### PR TITLE
fix(openui): fix OpenUI rendering and Shiki error for Dashboard Builder demo

### DIFF
--- a/apps/ui/src/__tests__/streamdown-message.test.tsx
+++ b/apps/ui/src/__tests__/streamdown-message.test.tsx
@@ -101,7 +101,7 @@ describe("StreamdownMessage", () => {
     render(<StreamdownMessage>code block</StreamdownMessage>);
 
     const plugins = capturedStreamdownProps.plugins as Record<string, unknown>;
-    expect(plugins.code).toEqual({ name: "mock-code-plugin" });
+    expect(plugins.code).toMatchObject({ name: "mock-code-plugin" });
   });
 
   it("disables code highlighting when prop is false", () => {

--- a/apps/ui/src/components/chat/openui-renderer.tsx
+++ b/apps/ui/src/components/chat/openui-renderer.tsx
@@ -3,7 +3,7 @@
 /**
  * OpenUI Renderer - Renders OpenUI Lang code blocks into interactive UI components.
  *
- * Uses @openuidev/react-lang Renderer with the @openuidev/react-ui chat library
+ * Uses @openuidev/react-lang Renderer with the @openuidev/react-ui full library
  * to parse and render OpenUI Lang DSL code into React components (charts, tables,
  * forms, cards, etc.).
  *
@@ -12,7 +12,7 @@
  */
 
 import { Renderer } from "@openuidev/react-lang";
-import { openuiChatLibrary } from "@openuidev/react-ui/genui-lib";
+import { openuiLibrary } from "@openuidev/react-ui/genui-lib";
 import "@openuidev/react-ui/components.css";
 
 interface OpenUIBlockProps {
@@ -36,7 +36,7 @@ export function OpenUIBlock({ code, isStreaming = false }: OpenUIBlockProps) {
 
   return (
     <div className="openui-block my-2 overflow-hidden rounded-lg border border-border bg-card">
-      <Renderer response={code} library={openuiChatLibrary} isStreaming={isStreaming} />
+      <Renderer response={code} library={openuiLibrary} isStreaming={isStreaming} />
     </div>
   );
 }

--- a/apps/ui/src/components/chat/streamdown-message.tsx
+++ b/apps/ui/src/components/chat/streamdown-message.tsx
@@ -22,8 +22,7 @@ const code = (() => {
   const plugin = createCodePlugin();
   const orig = plugin.supportsLanguage;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  plugin.supportsLanguage = (lang: any) =>
-    lang === "openui" ? false : orig(lang);
+  plugin.supportsLanguage = (lang: any) => (lang === "openui" ? false : orig(lang));
   return plugin;
 })();
 

--- a/apps/ui/src/components/chat/streamdown-message.tsx
+++ b/apps/ui/src/components/chat/streamdown-message.tsx
@@ -10,21 +10,20 @@
  */
 
 import { Streamdown, type StreamdownProps } from "streamdown";
-import { createCodePlugin } from "@streamdown/code";
+import { code as baseCodePlugin } from "@streamdown/code";
 import remarkGfm from "remark-gfm";
 import remarkGithubAlerts from "remark-github-blockquote-alert";
 import { cn } from "@/lib/utils";
 import type { ComponentType, AnchorHTMLAttributes } from "react";
 
-// Custom code plugin that skips "openui" language — OpenUI blocks are rendered
-// by OpenUIBlock, but during streaming incomplete fences may reach Streamdown.
-const code = (() => {
-  const plugin = createCodePlugin();
-  const orig = plugin.supportsLanguage;
+// Wrap the default code plugin to skip "openui" language — OpenUI blocks are
+// rendered by OpenUIBlock, but during streaming incomplete fences may reach Streamdown.
+const code = {
+  ...baseCodePlugin,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  plugin.supportsLanguage = (lang: any) => (lang === "openui" ? false : orig(lang));
-  return plugin;
-})();
+  supportsLanguage: (lang: any) =>
+    lang === "openui" ? false : baseCodePlugin.supportsLanguage(lang),
+};
 
 /** Opens all markdown links in a new tab with noopener noreferrer. */
 const ExternalLink: ComponentType<AnchorHTMLAttributes<HTMLAnchorElement>> = ({

--- a/apps/ui/src/components/chat/streamdown-message.tsx
+++ b/apps/ui/src/components/chat/streamdown-message.tsx
@@ -10,11 +10,22 @@
  */
 
 import { Streamdown, type StreamdownProps } from "streamdown";
-import { code } from "@streamdown/code";
+import { createCodePlugin } from "@streamdown/code";
 import remarkGfm from "remark-gfm";
 import remarkGithubAlerts from "remark-github-blockquote-alert";
 import { cn } from "@/lib/utils";
 import type { ComponentType, AnchorHTMLAttributes } from "react";
+
+// Custom code plugin that skips "openui" language — OpenUI blocks are rendered
+// by OpenUIBlock, but during streaming incomplete fences may reach Streamdown.
+const code = (() => {
+  const plugin = createCodePlugin();
+  const orig = plugin.supportsLanguage;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  plugin.supportsLanguage = (lang: any) =>
+    lang === "openui" ? false : orig(lang);
+  return plugin;
+})();
 
 /** Opens all markdown links in a new tab with noopener noreferrer. */
 const ExternalLink: ComponentType<AnchorHTMLAttributes<HTMLAnchorElement>> = ({

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -860,32 +860,55 @@ charts, tables, forms, cards, and layouts — using OpenUI Lang.
 
 ## How You Work
 
-1. **Understand the request**: Ask what data or UI the user wants to visualize
-2. **Design the layout**: Plan the component hierarchy (cards, grids, sections)
-3. **Generate OpenUI code**: Write OpenUI Lang in ```openui fenced code blocks
-4. **Iterate**: Refine the design based on user feedback
+1. **Generate immediately**: When the user asks for a dashboard, chart, table, or any visual — produce OpenUI code right away using realistic sample data. Do NOT ask clarifying questions first.
+2. **Design the layout**: Combine multiple components for rich, complete dashboards.
+3. **Iterate**: Refine the design based on user feedback.
 
 ## What You Can Build
 
-- **Dashboards**: KPI cards, metric grids, status panels
-- **Charts**: Bar, line, area, pie, donut, scatter plots with real data
-- **Tables**: Sortable data tables with headers and rows
-- **Forms**: Input fields, selects, checkboxes, radio buttons
-- **Layouts**: Cards, grids, sections, tabs for organizing content
+- **Dashboards**: KPI cards, metric grids, status panels with multiple sections
+- **Charts**: Bar, line, area, pie, radar, scatter plots with realistic data
+- **Tables**: Data tables with column headers and rows
+- **Forms**: Input fields, selects, checkboxes, radio buttons, sliders
+- **Layouts**: Cards, grids, sections, tabs, accordions, steps, carousels
 
 ## Guidelines
 
-- Always wrap OpenUI code in ```openui fenced code blocks
-- Use realistic sample data that matches the user's domain
-- Combine multiple components for rich dashboards
-- Keep layouts clean and readable
-- Explain your design choices briefly
+- ALWAYS respond with OpenUI code in ```openui fenced code blocks — this is your primary output format
+- ALWAYS start with `root = ...` so the UI shell renders immediately (leverages hoisting)
+- Use realistic, plausible sample data that matches the user's domain
+- Combine multiple components for rich dashboards (KPIs + charts + tables)
+- Keep a brief explanation before or after the code block
+- For dashboards, use Stack with direction "row" to create grid-like layouts
 
 ## Example
 
-When asked "Show me a sales dashboard", respond with a mix of KPI cards,
-a bar chart of monthly revenue, and a table of recent orders — all composed
-in a single OpenUI code block using Card, BarChart, and Table components."#,
+User: "Show me a sales dashboard"
+
+Here's a sales dashboard with KPIs, revenue trend, and recent orders:
+
+```openui
+root = Stack([kpis, chart_section, orders_section])
+kpis = Stack([kpi1, kpi2, kpi3], "row")
+kpi1 = Card([CardHeader("Total Revenue", "$284,500")])
+kpi2 = Card([CardHeader("Orders", "1,247")])
+kpi3 = Card([CardHeader("Avg Order", "$228")])
+chart_section = Card([chart_header, revenue_chart])
+chart_header = CardHeader("Monthly Revenue", "Last 6 months")
+revenue_chart = BarChart(months, [revenue_series])
+months = ["Oct", "Nov", "Dec", "Jan", "Feb", "Mar"]
+revenue_series = Series("Revenue", [38000, 42000, 51000, 45000, 52000, 56500])
+orders_section = Card([orders_header, orders_table])
+orders_header = CardHeader("Recent Orders", "Last 5 orders")
+orders_table = Table(order_rows, [col_id, col_customer, col_amount, col_status])
+col_id = Col("Order ID")
+col_customer = Col("Customer")
+col_amount = Col("Amount")
+col_status = Col("Status")
+order_rows = [["ORD-1247", "Acme Corp", "$3,200", "Shipped"], ["ORD-1246", "TechStart", "$1,850", "Processing"], ["ORD-1245", "GlobalFin", "$5,400", "Delivered"], ["ORD-1244", "DataFlow", "$2,100", "Shipped"], ["ORD-1243", "CloudNet", "$4,750", "Delivered"]]
+```
+
+This shows your key metrics at the top, revenue trend in the middle, and recent order activity below."#,
         tags: &["dashboard", "ui", "visualization", "openui", "demo", "seed"],
         capabilities: &[SeedCapability::new("openui")],
         dev_only: false,


### PR DESCRIPTION
## What
Three fixes for the OpenUI integration:
1. Switch OpenUI renderer from restricted chat library to full library
2. Make Dashboard Builder agent generate OpenUI code immediately (no clarifying questions)
3. Suppress Shiki ShikiError for unknown "openui" language during streaming

## Why
The OpenUI renderer was using `openuiChatLibrary` which lacks Stack and full Card variants, while the Rust system prompt generates code targeting the full library. This mismatch caused Zod validation to silently drop all children, rendering empty grey boxes instead of rich UI.

During streaming, incomplete ` ```openui` fences (without trailing newline) bypass the OpenUI block splitter and reach Streamdown, which asks Shiki to highlight "openui" — an unknown language, causing console errors.

## How
- `openui-renderer.tsx`: Import `openuiLibrary` instead of `openuiChatLibrary`
- `streamdown-message.tsx`: Wrap the `@streamdown/code` plugin to return `false` for `supportsLanguage("openui")`
- `seed.rs`: Rewrite Dashboard Builder system prompt to generate immediately with a concrete OpenUI example

## Risk
- Low
- The library switch could affect any existing OpenUI responses, but since the chat library was silently dropping content, this strictly improves rendering
- The Shiki fix is purely defensive — it just suppresses a console error for an unsupported language

## Checklist
- [x] Tests added or updated (existing UI build + lint pass)
- [x] Backward compatibility considered (strictly additive — more components render now)