### PR TITLE
fix(api): validate harness_id and model_id in session creation

### DIFF
--- a/.github/scripts/sdk-compat/test-python.sh
+++ b/.github/scripts/sdk-compat/test-python.sh
@@ -51,8 +51,8 @@ async def main() -> None:
     params = list(sig.parameters.keys())
 
     if "harness_id" in params:
-        from everruns_sdk import generate_harness_id
-        harness_id = generate_harness_id()
+        # Use the well-known Generic harness (seeded in every org)
+        harness_id = "harness_01933b5a000070008000000000000602"
         session = await client.sessions.create(harness_id, agent_id=agent.id)
     else:
         session = await client.sessions.create(agent_id=agent.id)

--- a/.github/scripts/sdk-compat/test-rust.sh
+++ b/.github/scripts/sdk-compat/test-rust.sh
@@ -55,9 +55,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(fetched.id, agent.id, "agent id mismatch");
     println!("  agent fetch verified");
 
-    // 3. Create session with harness_id
-    let harness_id = everruns_sdk::generate_harness_id();
-    let session = client.sessions().create(&harness_id).await?;
+    // 3. Create session with the well-known Generic harness (seeded in every org)
+    let harness_id = "harness_01933b5a000070008000000000000602";
+    let session = client.sessions().create(harness_id).await?;
     println!("  session created: {}", session.id);
 
     // 4. Fetch session and verify

--- a/.github/scripts/sdk-compat/test-typescript.sh
+++ b/.github/scripts/sdk-compat/test-typescript.sh
@@ -44,11 +44,8 @@ if (fetchedAgent.id !== agent.id) {
 console.log("  agent fetch verified");
 
 // 3. Create session
-// v0.1.0 only sends agent_id; server auto-generates harness_id.
-// Newer versions may also pass harnessId.
-const harnessId = `harness_${[...Array(32)]
-  .map(() => Math.floor(Math.random() * 16).toString(16))
-  .join("")}`;
+// Use the well-known Generic harness (seeded in every org).
+const harnessId = "harness_01933b5a000070008000000000000602";
 const session = await client.sessions.create({ harnessId, agentId: agent.id });
 console.log(`  session created: ${session.id}`);
 

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -3,6 +3,7 @@
 // Policy enforcement happens at the service layer via #[policy] macro.
 
 use crate::auth::{AuthState, ResolvedOrg};
+use crate::seed::GENERIC_HARNESS_ID;
 use crate::services::session::{SESSION_MANAGE, SESSION_VIEW};
 use crate::services::{EventService, SessionService};
 use crate::storage::StorageBackend;
@@ -30,8 +31,8 @@ use utoipa::{IntoParams, ToSchema};
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct CreateSessionRequest {
     /// ID of the harness for this session (format: harness_{32-hex}).
-    /// Auto-generated if omitted (backward compatibility with older SDKs).
-    #[serde(default = "HarnessId::new")]
+    /// Defaults to the Generic harness if omitted (backward compat with older SDKs).
+    #[serde(default = "default_harness_id")]
     #[schema(value_type = String, example = "harness_01933b5a00007000800000000000001")]
     pub harness_id: HarnessId,
     /// ID of the agent to work in this session (optional, format: agent_{32-hex}).
@@ -59,6 +60,11 @@ pub struct CreateSessionRequest {
     /// These tools are sent to the LLM but executed by the client.
     #[serde(default)]
     pub tools: Vec<everruns_core::ToolDefinition>,
+}
+
+/// Default harness_id for sessions: uses the built-in Generic harness.
+fn default_harness_id() -> HarnessId {
+    HarnessId::from_uuid(GENERIC_HARNESS_ID)
 }
 
 /// Response from cancel turn endpoint
@@ -200,7 +206,7 @@ pub async fn session_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
     request_body = CreateSessionRequest,
     responses(
         (status = 201, description = "Session created successfully", body = Session),
-        (status = 400, description = "Invalid agent ID"),
+        (status = 404, description = "Harness, Agent, or Model not found"),
         (status = 500, description = "Internal server error")
     ),
     tag = "sessions"
@@ -210,6 +216,24 @@ pub async fn create_session(
     State(state): State<AppState>,
     Json(req): Json<CreateSessionRequest>,
 ) -> Result<(StatusCode, Json<Session>), (StatusCode, Json<ErrorResponse>)> {
+    // Validate harness exists and belongs to this org
+    state
+        .db
+        .get_harness(org.org_id, req.harness_id)
+        .await
+        .log_internal_error_json("resolve harness")?
+        .ok_or_not_found_json("Harness")?;
+
+    // Validate model exists and belongs to this org (if specified)
+    if let Some(ref model_id) = req.model_id {
+        state
+            .db
+            .get_llm_model(org.org_id, model_id.uuid())
+            .await
+            .log_internal_error_json("resolve model")?
+            .ok_or_not_found_json("Model")?;
+    }
+
     // Resolve agent public_id to internal UUID for FK storage (if agent specified)
     let (agent_internal_id, agent_public_id) = if let Some(ref agent_id) = req.agent_id {
         let agent_row = state
@@ -712,11 +736,12 @@ mod tests {
     }
 
     #[test]
-    fn test_create_session_request_missing_harness_id_auto_generates() {
-        // harness_id is optional — auto-generated for backward compat with older SDKs
+    fn test_create_session_request_missing_harness_id_defaults_to_generic() {
+        // harness_id defaults to Generic seed harness for backward compat with older SDKs
         let json = r#"{}"#;
         let req: CreateSessionRequest = serde_json::from_str(json).unwrap();
-        assert!(req.harness_id.to_string().starts_with("harness_"));
+        let expected = HarnessId::from_uuid(crate::seed::GENERIC_HARNESS_ID);
+        assert_eq!(req.harness_id, expected);
     }
 
     #[test]

--- a/crates/server/src/org_init.rs
+++ b/crates/server/src/org_init.rs
@@ -53,6 +53,9 @@ mod harness_ids {
     pub const CHAT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000603);
 }
 
+/// Well-known UUID for the Generic harness (default for sessions without explicit harness)
+pub const GENERIC_HARNESS_ID: Uuid = harness_ids::GENERIC;
+
 /// Well-known UUID for the Chat harness (used by global chat endpoint)
 pub const CHAT_HARNESS_ID: Uuid = harness_ids::CHAT;
 

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -22,6 +22,9 @@ use std::sync::Arc;
 use std::time::Duration;
 use uuid::Uuid;
 
+/// Well-known UUID for the Generic harness (default for sessions without explicit harness)
+pub const GENERIC_HARNESS_ID: Uuid = org_init::GENERIC_HARNESS_ID;
+
 /// Well-known UUID for the Chat harness (used by global chat endpoint)
 pub const CHAT_HARNESS_ID: Uuid = org_init::CHAT_HARNESS_ID;
 

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -265,6 +265,56 @@ async fn test_create_session() {
 }
 
 #[tokio::test]
+async fn test_create_session_nonexistent_harness_returns_404() {
+    let server = TestServer::new().await;
+
+    server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": "harness_00000000000000000000000000000000",
+                "title": "Should fail"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_create_session_nonexistent_model_returns_404() {
+    let server = TestServer::new().await;
+
+    server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": SEED_BASE_HARNESS_ID,
+                "model_id": "model_00000000000000000000000000000000",
+                "title": "Should fail"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_create_session_nonexistent_agent_returns_404() {
+    let server = TestServer::new().await;
+
+    server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": SEED_BASE_HARNESS_ID,
+                "agent_id": "agent_00000000000000000000000000000000",
+                "title": "Should fail"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
 async fn test_get_session() {
     let server = TestServer::new().await;
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2436,8 +2436,8 @@
               }
             }
           },
-          "400": {
-            "description": "Invalid agent ID"
+          "404": {
+            "description": "Harness, Agent, or Model not found"
           },
           "500": {
             "description": "Internal server error"
@@ -5217,7 +5217,7 @@
           },
           "harness_id": {
             "type": "string",
-            "description": "ID of the harness for this session (format: harness_{32-hex}).\nAuto-generated if omitted (backward compatibility with older SDKs).",
+            "description": "ID of the harness for this session (format: harness_{32-hex}).\nDefaults to the Generic harness if omitted (backward compat with older SDKs).",
             "example": "harness_01933b5a00007000800000000000001"
           },
           "model_id": {


### PR DESCRIPTION
## Summary
- Fix default `harness_id` to use the built-in Generic harness instead of generating a random UUID that doesn't exist in the database
- Add upfront validation in `create_session` that the referenced harness, model, and agent all exist and belong to the requesting org
- Return 404 with descriptive error messages for missing resources

## Changes
- `crates/server/src/api/sessions.rs`: Add harness + model validation before session creation; default to Generic harness
- `crates/server/src/org_init.rs`: Export `GENERIC_HARNESS_ID` constant
- `crates/server/src/seed.rs`: Re-export `GENERIC_HARNESS_ID`
- `crates/server/tests/api_integration_test.rs`: Add negative tests for nonexistent harness/model/agent
- `docs/api/openapi.json`: Update response codes

## Test plan
- [x] Unit tests pass (725 lib tests)
- [x] `just pre-push` passes
- [ ] Integration tests validate 404 for nonexistent harness, model, agent
- [ ] CI green