### PR TITLE
feat(chat): add server-authored tool activity narration

### DIFF
--- a/apps/ui/src/__tests__/chat-panel.test.tsx
+++ b/apps/ui/src/__tests__/chat-panel.test.tsx
@@ -121,6 +121,10 @@ jest.mock("@/components/chat/tool-activity-group", () => ({
   ToolActivityGroup: () => null,
 }));
 
+jest.mock("@/components/chat/tool-activity-timeline-group", () => ({
+  ToolActivityTimelineGroup: () => null,
+}));
+
 beforeAll(() => {
   Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
     configurable: true,

--- a/apps/ui/src/__tests__/tool-activity-timeline-group.test.tsx
+++ b/apps/ui/src/__tests__/tool-activity-timeline-group.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { ToolActivityTimelineGroup } from "@/components/chat/tool-activity-timeline-group";
+
+describe("ToolActivityTimelineGroup", () => {
+  it("renders narrated group headline and child rows", () => {
+    render(
+      <ToolActivityTimelineGroup
+        headline="Reading AGENTS.md and searching files"
+        completedHeadline="Read AGENTS.md and searched files"
+        rows={[
+          { id: "tool-1", label: "Read AGENTS.md", state: "completed" },
+          { id: "tool-2", label: "Searched files for Doppler", state: "running" },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Reading AGENTS.md and searching files")).toBeInTheDocument();
+    expect(screen.queryByText("2/2")).not.toBeInTheDocument();
+    expect(screen.queryByText("1/2")).not.toBeInTheDocument();
+    expect(screen.getByText("Read AGENTS.md")).toBeInTheDocument();
+    expect(screen.getByText("Searched files for Doppler")).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
@@ -345,6 +345,9 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
           (e) =>
             e.type === "input.message" ||
             e.type === "output.message.completed" ||
+            e.type === "act.started" ||
+            e.type === "act.completed" ||
+            e.type === "tool.started" ||
             e.type === "tool.completed" ||
             e.type === "tool.call_requested",
         )

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -22,12 +22,17 @@ import {
   ArrowDown,
 } from "lucide-react";
 import type {
+  ActCompletedData,
+  ActStartedData,
   Controls,
   InputMessageData,
   OutputMessageCompletedData,
-  ToolCallRequestedData,
   ContentPart,
   CommandDescriptor,
+  ToolCallRequestedData,
+  ToolCallSummary,
+  ToolCompletedData,
+  ToolStartedData,
 } from "@/lib/api/types";
 import { isImageFilePart } from "@/lib/api/types";
 import { MessageInfoIcon } from "@/components/chat/message-info-icon";
@@ -40,6 +45,10 @@ import { ThinkingIndicator } from "@/components/thinking-indicator";
 import { StreamingMessage } from "@/components/streaming-message";
 import { MessageContent } from "@/components/chat/message-content";
 import { ToolActivityGroup } from "@/components/chat/tool-activity-group";
+import {
+  ToolActivityTimelineGroup,
+  type TimelineToolRow,
+} from "@/components/chat/tool-activity-timeline-group";
 import {
   formatWorkedDuration,
   getCompletedTurnDurationsByEvent,
@@ -134,6 +143,97 @@ export function ChatPanel() {
     () => getCompletedTurnDurationsByEvent(events ?? []),
     [events],
   );
+
+  const hasNarratedActEvents = useMemo(
+    () => chatEvents.some((event) => event.type === "act.started"),
+    [chatEvents],
+  );
+
+  const actGroupsByStartEventId = useMemo(() => {
+    type GroupState = {
+      startEventId: string;
+      headline: string;
+      completedHeadline?: string;
+      rows: TimelineToolRow[];
+    };
+
+    const groupsByExecId = new Map<string, GroupState>();
+
+    const ensureRow = (
+      group: GroupState,
+      id: string,
+      fallbackLabel: string,
+      state: TimelineToolRow["state"],
+    ) => {
+      const existing = group.rows.find((row) => row.id === id);
+      if (existing) {
+        existing.label = existing.label || fallbackLabel;
+        existing.state = state;
+        return existing;
+      }
+
+      const row: TimelineToolRow = { id, label: fallbackLabel, state };
+      group.rows.push(row);
+      return row;
+    };
+
+    for (const event of chatEvents) {
+      const execId = event.context?.exec_id;
+      if (!execId) continue;
+
+      if (event.type === "act.started") {
+        const data = event.data as ActStartedData;
+        groupsByExecId.set(execId, {
+          startEventId: event.id,
+          headline: data.headline ?? "Working",
+          rows: (data.tool_calls ?? []).map((toolCall: ToolCallSummary) => ({
+            id: toolCall.id,
+            label: toolCall.narration ?? toolCall.display_name ?? toolCall.name,
+            state: "running",
+          })),
+        });
+        continue;
+      }
+
+      const group = groupsByExecId.get(execId);
+      if (!group) continue;
+
+      if (event.type === "tool.started") {
+        const data = event.data as ToolStartedData;
+        const row = ensureRow(
+          group,
+          data.tool_call.id,
+          data.narration ?? data.display_name ?? data.tool_call.name,
+          "running",
+        );
+        row.label = data.narration ?? row.label;
+        continue;
+      }
+
+      if (event.type === "tool.completed") {
+        const data = event.data as ToolCompletedData;
+        const row = ensureRow(
+          group,
+          data.tool_call_id,
+          data.narration ?? data.display_name ?? data.tool_name ?? "Tool call",
+          data.success ? "completed" : "error",
+        );
+        row.label = data.narration ?? row.label;
+        row.result = data;
+        row.state = data.success ? "completed" : "error";
+        continue;
+      }
+
+      if (event.type === "act.completed") {
+        const data = event.data as ActCompletedData;
+        group.completedHeadline = data.headline;
+      }
+    }
+
+    return new Map(
+      Array.from(groupsByExecId.values()).map((group) => [group.startEventId, group] as const),
+    );
+  }, [chatEvents]);
 
   const handleCommandSelect = useCallback(
     (cmd: CommandDescriptor) => {
@@ -458,13 +558,57 @@ export function ChatPanel() {
               </div>
             )}
             {chatEvents.map((event) => {
-              if (event.type === "tool.completed") {
+              if (event.type === "tool.started" || event.type === "tool.completed") {
                 return null;
+              }
+
+              if (event.type === "act.completed") {
+                return null;
+              }
+
+              if (event.type === "act.started") {
+                const group = actGroupsByStartEventId.get(event.id);
+                if (!group || group.rows.length === 0) return null;
+                return (
+                  <div key={event.id} className="space-y-3">
+                    <div className="ml-9 space-y-1">
+                      <ToolActivityTimelineGroup
+                        headline={group.headline}
+                        completedHeadline={group.completedHeadline}
+                        rows={group.rows}
+                      />
+                    </div>
+                    {renderTurnDivider(event.id)}
+                  </div>
+                );
               }
 
               if (event.type === "tool.call_requested") {
                 const reqData = event.data as ToolCallRequestedData;
                 if (!reqData.tool_calls || reqData.tool_calls.length === 0) return null;
+
+                if (reqData.headline || reqData.tool_summaries?.length) {
+                  const rows: TimelineToolRow[] = (reqData.tool_summaries ?? []).map((summary) => ({
+                    id: summary.id,
+                    label: summary.narration ?? summary.display_name ?? summary.name,
+                    state: "waiting",
+                  }));
+
+                  if (rows.length > 0) {
+                    return (
+                      <div key={event.id} className="space-y-3">
+                        <div className="ml-9 space-y-1">
+                          <ToolActivityTimelineGroup
+                            headline={reqData.headline ?? "Waiting on tools"}
+                            rows={rows}
+                          />
+                        </div>
+                        {renderTurnDivider(event.id)}
+                      </div>
+                    );
+                  }
+                }
+
                 return (
                   <div key={event.id} className="space-y-3">
                     <div className="ml-9 space-y-1">
@@ -493,6 +637,10 @@ export function ChatPanel() {
                 !isUser && toolCalls.length > 0 && !textContent && images.length === 0;
 
               if (isToolOnlyMessage) {
+                if (hasNarratedActEvents) {
+                  return null;
+                }
+
                 return (
                   <div key={event.id} className="space-y-3">
                     <div className="ml-9 space-y-1">
@@ -560,7 +708,7 @@ export function ChatPanel() {
                     </div>
                   )}
 
-                  {toolCalls.length > 0 && (
+                  {toolCalls.length > 0 && !hasNarratedActEvents && (
                     <div className="ml-9 space-y-1">
                       <ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />
                     </div>

--- a/apps/ui/src/components/chat/tool-activity-timeline-group.tsx
+++ b/apps/ui/src/components/chat/tool-activity-timeline-group.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { AlertCircle, Check, ChevronDown, ChevronRight, Loader2 } from "lucide-react";
+import type { ToolCompletedData } from "@/lib/api/types";
+import { cn } from "@/lib/utils";
+import { getFullText } from "./tool-call-utils";
+
+export interface TimelineToolRow {
+  id: string;
+  label: string;
+  result?: ToolCompletedData;
+  state: "running" | "waiting" | "completed" | "error";
+}
+
+interface ToolActivityTimelineGroupProps {
+  headline: string;
+  completedHeadline?: string;
+  rows: TimelineToolRow[];
+}
+
+function resultPreview(result?: ToolCompletedData): string | null {
+  if (!result) return null;
+  if (result.error) return result.error;
+
+  const fullText = getFullText(result.result);
+  if (!fullText) return null;
+
+  const preview = fullText
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+
+  return preview ?? null;
+}
+
+function TimelineRow({ row }: { row: TimelineToolRow }) {
+  const [expanded, setExpanded] = useState(false);
+  const fullText = getFullText(row.result?.result);
+  const preview = resultPreview(row.result);
+  const hasDetails = fullText.length > 0;
+
+  return (
+    <div className="py-1.5">
+      <div className="flex items-start gap-2">
+        <div className="mt-0.5 flex h-4 w-4 items-center justify-center">
+          {row.state === "error" ? (
+            <AlertCircle className="h-3.5 w-3.5 text-red-500" />
+          ) : row.state === "completed" ? (
+            <Check className="h-3.5 w-3.5 text-muted-foreground/75" />
+          ) : (
+            <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground/80" />
+          )}
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="text-[15px] text-muted-foreground">{row.label}</div>
+
+          {preview && !expanded && (
+            <div className="mt-0.5 truncate text-xs text-muted-foreground/75">{preview}</div>
+          )}
+
+          {row.result?.error && (
+            <div className="mt-0.5 text-xs text-red-600 dark:text-red-400">{row.result.error}</div>
+          )}
+
+          {hasDetails && (
+            <button
+              type="button"
+              onClick={() => setExpanded((current) => !current)}
+              className="mt-1 inline-flex items-center gap-1 text-[10px] uppercase tracking-[0.18em] text-muted-foreground/70 transition-colors hover:text-foreground"
+            >
+              {expanded ? (
+                <ChevronDown className="h-3 w-3" />
+              ) : (
+                <ChevronRight className="h-3 w-3" />
+              )}
+              {expanded ? "hide details" : "details"}
+            </button>
+          )}
+
+          <div
+            className={cn(
+              "grid transition-all duration-200 ease-out",
+              expanded ? "mt-1 grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0",
+            )}
+          >
+            <div className="min-h-0 overflow-hidden">
+              {hasDetails && (
+                <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-muted-foreground/90">
+                  {fullText}
+                </pre>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ToolActivityTimelineGroup({
+  headline,
+  completedHeadline,
+  rows,
+}: ToolActivityTimelineGroupProps) {
+  const completedCount = useMemo(
+    () => rows.filter((row) => row.state === "completed" || row.state === "error").length,
+    [rows],
+  );
+  const isActive = completedCount < rows.length;
+  const [expanded, setExpanded] = useState(() => isActive);
+  const displayHeadline = isActive ? headline : (completedHeadline ?? headline);
+
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        onClick={() => setExpanded((current) => !current)}
+        className="inline-flex items-start gap-2 text-left text-muted-foreground transition-colors hover:text-foreground"
+        aria-label={expanded ? "Collapse activity group" : "Expand activity group"}
+      >
+        {expanded ? (
+          <ChevronDown className="mt-[2px] h-4 w-4 flex-shrink-0" />
+        ) : (
+          <ChevronRight className="mt-[2px] h-4 w-4 flex-shrink-0" />
+        )}
+        <span className="text-[15px] leading-6">{displayHeadline}</span>
+      </button>
+
+      <div
+        className={cn(
+          "grid transition-all duration-200 ease-out",
+          expanded ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0",
+        )}
+      >
+        <div className="min-h-0 overflow-hidden">
+          <div className="ml-2 space-y-0.5 border-l border-border/60 pl-3">
+            {rows.map((row) => (
+              <TimelineRow key={row.id} row={row} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/chat/turn-delimiter.ts
+++ b/apps/ui/src/components/chat/turn-delimiter.ts
@@ -3,6 +3,7 @@
 // can take over as the last visible item when embedded tool calls are hidden.
 
 import type {
+  ActStartedData,
   Event,
   InputMessageData,
   OutputMessageCompletedData,
@@ -47,6 +48,11 @@ function isVisibleChatEvent(event: Event, clientRequestedToolCallIds: Set<string
 
   if (event.type === "tool.call_requested") {
     const data = event.data as ToolCallRequestedData;
+    return (data.tool_calls?.length ?? 0) > 0;
+  }
+
+  if (event.type === "act.started") {
+    const data = event.data as ActStartedData;
     return (data.tool_calls?.length ?? 0) > 0;
   }
 

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -545,11 +545,14 @@ export interface ToolCallSummary {
   name: string;
   /** Human-readable display name for UI rendering */
   display_name?: string;
+  /** Human-readable narration for timeline rendering */
+  narration?: string;
 }
 
 /** Data for act.started event */
 export interface ActStartedData {
   tool_calls: ToolCallSummary[];
+  headline?: string;
 }
 
 /** Data for act.completed event */
@@ -558,6 +561,7 @@ export interface ActCompletedData {
   success_count: number;
   error_count: number;
   duration_ms?: number;
+  headline?: string;
 }
 
 /** Tool call from LLM response */
@@ -572,6 +576,8 @@ export interface ToolStartedData {
   tool_call: ToolCall;
   /** Human-readable display name for UI rendering */
   display_name?: string;
+  /** Human-readable narration for timeline rendering */
+  narration?: string;
 }
 
 /** Data for tool.call_requested event (client-side tool calls awaiting results) */
@@ -581,6 +587,8 @@ export interface ToolCallRequestedData {
     name: string;
     arguments: Record<string, unknown>;
   }>;
+  tool_summaries?: ToolCallSummary[];
+  headline?: string;
 }
 
 /** Data for tool.completed event */
@@ -594,6 +602,7 @@ export interface ToolCompletedData {
   result?: ContentPart[];
   error?: string;
   duration_ms?: number;
+  narration?: string;
 }
 
 /** LLM generation output */

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -35,6 +35,7 @@ use crate::events::{
     ToolStartedData,
 };
 use crate::message::ContentPart;
+use crate::tool_narration::{ToolNarrationPhase, render_group_headline, render_tool_narration};
 use crate::tool_types::{ToolCall, ToolDefinition, ToolResult};
 use crate::traits::{
     AgentStore, EventEmitter, SessionFileStore, SessionMutator, SessionStore, ToolContext,
@@ -366,6 +367,23 @@ where
             act_span_id.clone(), // Same span_id as started
             Some(parent_span_id.clone()),
         );
+        let mut completed_headline = render_group_headline(
+            &tool_calls,
+            &tool_definitions,
+            ToolNarrationPhase::Completed,
+        );
+        if error_count > 0 {
+            let suffix = format!(
+                " with {} error{}",
+                error_count,
+                if error_count == 1 { "" } else { "s" }
+            );
+            completed_headline = Some(match completed_headline {
+                Some(text) => format!("{text}{suffix}"),
+                None => format!("Completed tool batch{suffix}"),
+            });
+        }
+
         if let Err(e) = self
             .event_emitter
             .emit(EventRequest::new(
@@ -376,6 +394,7 @@ where
                     success_count,
                     error_count,
                     duration_ms: Some(act_duration_ms),
+                    headline: completed_headline,
                 },
             ))
             .await
@@ -455,6 +474,11 @@ where
                 ToolStartedData {
                     tool_call: tool_call.clone(),
                     display_name: display_name.clone(),
+                    narration: Some(render_tool_narration(
+                        tool_def,
+                        &tool_call,
+                        ToolNarrationPhase::Started,
+                    )),
                 },
             ))
             .await
@@ -484,7 +508,12 @@ where
                         "error".to_string(),
                         error_msg.clone(),
                         Some(tool_duration_ms),
-                    ),
+                    )
+                    .with_narration(Some(render_tool_narration(
+                        None,
+                        &tool_call,
+                        ToolNarrationPhase::Failed,
+                    ))),
                 ))
                 .await
             {
@@ -592,6 +621,11 @@ where
                         Some(tool_duration_ms),
                     )
                     .with_display_name(display_name.clone())
+                    .with_narration(Some(render_tool_narration(
+                        Some(tool_def),
+                        &tool_call,
+                        ToolNarrationPhase::Completed,
+                    )))
                 } else {
                     ToolCompletedData::failure(
                         tool_call.id.clone(),
@@ -601,6 +635,11 @@ where
                         Some(tool_duration_ms),
                     )
                     .with_display_name(display_name.clone())
+                    .with_narration(Some(render_tool_narration(
+                        Some(tool_def),
+                        &tool_call,
+                        ToolNarrationPhase::Failed,
+                    )))
                 };
 
                 if let Err(e) = self
@@ -652,7 +691,12 @@ where
                             error_msg.clone(),
                             Some(tool_duration_ms),
                         )
-                        .with_display_name(display_name.clone()),
+                        .with_display_name(display_name.clone())
+                        .with_narration(Some(render_tool_narration(
+                            Some(tool_def),
+                            &tool_call,
+                            ToolNarrationPhase::Failed,
+                        ))),
                     ))
                     .await
                 {

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -368,6 +368,7 @@ impl Event {
 // ============================================================================
 
 use crate::message::{ContentPart, Message};
+use crate::tool_narration::{ToolNarrationPhase, render_group_headline, render_tool_narration};
 use crate::tool_types::ToolCall;
 
 /// Metadata about the model used for generation
@@ -642,6 +643,9 @@ pub struct ToolCallSummary {
     /// Human-readable display name for UI rendering
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+    /// Human-readable narration for timeline rendering
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub narration: Option<String>,
 }
 
 impl From<&ToolCall> for ToolCallSummary {
@@ -650,6 +654,7 @@ impl From<&ToolCall> for ToolCallSummary {
             id: tc.id.clone(),
             name: tc.name.clone(),
             display_name: None,
+            narration: None,
         }
     }
 }
@@ -683,12 +688,16 @@ impl From<&crate::tool_types::ToolDefinition> for ToolDefinitionSummary {
 pub struct ActStartedData {
     /// Tool calls to be executed
     pub tool_calls: Vec<ToolCallSummary>,
+    /// Human-readable headline for the batch
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub headline: Option<String>,
 }
 
 impl ActStartedData {
     pub fn new(tool_calls: &[ToolCall]) -> Self {
         Self {
             tool_calls: tool_calls.iter().map(ToolCallSummary::from).collect(),
+            headline: render_group_headline(tool_calls, &[], ToolNarrationPhase::Started),
         }
     }
 
@@ -703,16 +712,22 @@ impl ActStartedData {
             tool_calls: tool_calls
                 .iter()
                 .map(|tc| {
-                    let display_name = def_map
-                        .get(tc.name.as_str())
-                        .and_then(|d| d.display_name().map(|s| s.to_string()));
+                    let tool_def = def_map.get(tc.name.as_str()).copied();
+                    let display_name =
+                        tool_def.and_then(|d| d.display_name().map(|s| s.to_string()));
                     ToolCallSummary {
                         id: tc.id.clone(),
                         name: tc.name.clone(),
                         display_name,
+                        narration: Some(render_tool_narration(
+                            tool_def,
+                            tc,
+                            ToolNarrationPhase::Started,
+                        )),
                     }
                 })
                 .collect(),
+            headline: render_group_headline(tool_calls, tool_defs, ToolNarrationPhase::Started),
         }
     }
 }
@@ -733,6 +748,9 @@ pub struct ActCompletedData {
     /// Duration of the act phase in milliseconds
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duration_ms: Option<u64>,
+    /// Human-readable headline for the completed batch
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub headline: Option<String>,
 }
 
 /// Data for tool.started event
@@ -744,6 +762,9 @@ pub struct ToolStartedData {
     /// Human-readable display name for UI rendering
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+    /// Human-readable narration for timeline rendering
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub narration: Option<String>,
 }
 
 /// Data for tool.completed event
@@ -777,6 +798,9 @@ pub struct ToolCompletedData {
     /// Duration of the tool call in milliseconds
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duration_ms: Option<u64>,
+    /// Human-readable narration for timeline rendering
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub narration: Option<String>,
 }
 
 impl ToolCompletedData {
@@ -795,6 +819,7 @@ impl ToolCompletedData {
             result: Some(result),
             error: None,
             duration_ms,
+            narration: None,
         }
     }
 
@@ -814,12 +839,19 @@ impl ToolCompletedData {
             result: None,
             error: Some(error),
             duration_ms,
+            narration: None,
         }
     }
 
     /// Set display name on this event data
     pub fn with_display_name(mut self, display_name: Option<String>) -> Self {
         self.display_name = display_name;
+        self
+    }
+
+    /// Set narration on this event data
+    pub fn with_narration(mut self, narration: Option<String>) -> Self {
+        self.narration = narration;
         self
     }
 }
@@ -833,6 +865,46 @@ impl ToolCompletedData {
 pub struct ToolCallRequestedData {
     /// Tool calls that need to be executed by the client
     pub tool_calls: Vec<ToolCall>,
+    /// Optional summaries with display names and narration for UI rendering
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tool_summaries: Vec<ToolCallSummary>,
+    /// Human-readable headline for the requested batch
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub headline: Option<String>,
+}
+
+impl ToolCallRequestedData {
+    pub fn with_definitions(
+        tool_calls: &[ToolCall],
+        tool_defs: &[crate::tool_types::ToolDefinition],
+    ) -> Self {
+        let def_map: std::collections::HashMap<&str, &crate::tool_types::ToolDefinition> =
+            tool_defs.iter().map(|d| (d.name(), d)).collect();
+
+        let tool_summaries = tool_calls
+            .iter()
+            .map(|tool_call| {
+                let tool_def = def_map.get(tool_call.name.as_str()).copied();
+                ToolCallSummary {
+                    id: tool_call.id.clone(),
+                    name: tool_call.name.clone(),
+                    display_name: tool_def
+                        .and_then(|def| def.display_name().map(|value| value.to_string())),
+                    narration: Some(render_tool_narration(
+                        tool_def,
+                        tool_call,
+                        ToolNarrationPhase::Waiting,
+                    )),
+                }
+            })
+            .collect();
+
+        Self {
+            tool_calls: tool_calls.to_vec(),
+            tool_summaries,
+            headline: render_group_headline(tool_calls, tool_defs, ToolNarrationPhase::Waiting),
+        }
+    }
 }
 
 // ============================================================================
@@ -2487,7 +2559,9 @@ mod contract_tests {
                 id: "tc_1".to_string(),
                 name: "get_weather".to_string(),
                 display_name: None,
+                narration: None,
             }],
+            headline: None,
         };
         with_settings!({
             sort_maps => true,
@@ -2503,6 +2577,7 @@ mod contract_tests {
             success_count: 2,
             error_count: 0,
             duration_ms: Some(500),
+            headline: None,
         };
         with_settings!({
             sort_maps => true,
@@ -2520,6 +2595,7 @@ mod contract_tests {
                 arguments: serde_json::json!({"city": "London"}),
             },
             display_name: None,
+            narration: None,
         };
         with_settings!({
             sort_maps => true,
@@ -2663,6 +2739,7 @@ mod contract_tests {
             id: "tc_1".to_string(),
             name: "get_weather".to_string(),
             display_name: Some("Get Weather".to_string()),
+            narration: None,
         };
         let json = serde_json::to_value(&summary).unwrap();
         assert_eq!(json["display_name"], "Get Weather");
@@ -2678,6 +2755,7 @@ mod contract_tests {
             id: "tc_1".to_string(),
             name: "get_weather".to_string(),
             display_name: None,
+            narration: None,
         };
         let json = serde_json::to_string(&summary).unwrap();
         assert!(!json.contains("display_name"));
@@ -2751,6 +2829,7 @@ mod contract_tests {
                 arguments: serde_json::json!({"command": "ls"}),
             },
             display_name: Some("Bash".to_string()),
+            narration: None,
         };
 
         let json = serde_json::to_value(&data).unwrap();
@@ -2927,7 +3006,14 @@ mod contract_tests {
                 REASON_COMPLETED,
                 ReasonCompletedData::success("", false, 0, None, None).into(),
             ),
-            (ACT_STARTED, ActStartedData { tool_calls: vec![] }.into()),
+            (
+                ACT_STARTED,
+                ActStartedData {
+                    tool_calls: vec![],
+                    headline: None,
+                }
+                .into(),
+            ),
             (
                 ACT_COMPLETED,
                 ActCompletedData {
@@ -2935,6 +3021,7 @@ mod contract_tests {
                     success_count: 0,
                     error_count: 0,
                     duration_ms: None,
+                    headline: None,
                 }
                 .into(),
             ),

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -28,6 +28,7 @@ pub mod feature_flags;
 
 // Telemetry (OpenTelemetry with gen-ai semantic conventions)
 pub mod telemetry;
+pub mod tool_narration;
 
 // Event listeners (pluggable observability backends)
 pub mod event_listeners;

--- a/crates/core/src/observation/braintrust.rs
+++ b/crates/core/src/observation/braintrust.rs
@@ -1684,13 +1684,16 @@ mod tests {
                     id: "call_1".to_string(),
                     name: "search".to_string(),
                     display_name: None,
+                    narration: None,
                 },
                 ToolCallSummary {
                     id: "call_2".to_string(),
                     name: "fetch".to_string(),
                     display_name: None,
+                    narration: None,
                 },
             ],
+            headline: None,
         };
         let event = Event::new(
             SessionId::new(),
@@ -1741,6 +1744,7 @@ mod tests {
             result: None,
             error: None,
             duration_ms: Some(200),
+            narration: None,
         };
         let event = Event::new(
             SessionId::new(),
@@ -1928,7 +1932,9 @@ mod tests {
                 id: "call_1".to_string(),
                 name: "search".to_string(),
                 display_name: None,
+                narration: None,
             }],
+            headline: None,
         };
         let act_event = Event::new(
             SessionId::new(),
@@ -1957,6 +1963,7 @@ mod tests {
             result: None,
             error: None,
             duration_ms: Some(75),
+            narration: None,
         };
         let tool_event = Event::new(
             SessionId::new(),
@@ -2124,7 +2131,9 @@ mod tests {
                 id: "call_1".to_string(),
                 name: "search".to_string(),
                 display_name: None,
+                narration: None,
             }],
+            headline: None,
         };
         let started_event = Event::new(
             SessionId::new(),
@@ -2145,6 +2154,7 @@ mod tests {
             success_count: 1,
             error_count: 0,
             duration_ms: Some(200),
+            headline: None,
         };
         let completed_event = Event::new(
             SessionId::new(),
@@ -2183,6 +2193,7 @@ mod tests {
                 arguments: serde_json::json!({"query": "test"}),
             },
             display_name: None,
+            narration: None,
         };
         let started_event = Event::new(
             SessionId::new(),
@@ -2207,6 +2218,7 @@ mod tests {
             result: None,
             error: None,
             duration_ms: Some(100),
+            narration: None,
         };
         let completed_event = Event::new(
             SessionId::new(),

--- a/crates/core/src/observation/otel.rs
+++ b/crates/core/src/observation/otel.rs
@@ -1126,7 +1126,10 @@ mod tests {
         let session_id = make_session_id();
         let act_span_id = "act_001";
 
-        let started = ActStartedData { tool_calls: vec![] };
+        let started = ActStartedData {
+            tool_calls: vec![],
+            headline: None,
+        };
         let event = event_with_context(
             session_id,
             turn_id,
@@ -1142,6 +1145,7 @@ mod tests {
             success_count: 2,
             error_count: 0,
             duration_ms: Some(300),
+            headline: None,
         };
         let event = event_with_context(
             session_id,
@@ -1170,6 +1174,7 @@ mod tests {
                 arguments: json!({"x": 42}),
             },
             display_name: None,
+            narration: None,
         };
         listener
             .on_event(&Event::new(
@@ -1189,6 +1194,7 @@ mod tests {
             result: None,
             error: None,
             duration_ms: Some(100),
+            narration: None,
         };
         listener
             .on_event(&Event::new(
@@ -1213,6 +1219,7 @@ mod tests {
             result: None,
             error: Some("Connection timeout".to_string()),
             duration_ms: None,
+            narration: None,
         };
         // Should not panic
         listener
@@ -1238,6 +1245,7 @@ mod tests {
                     arguments: json!({}),
                 },
                 display_name: None,
+                narration: None,
             };
             listener
                 .on_event(&Event::new(
@@ -1260,6 +1268,7 @@ mod tests {
                 result: None,
                 error: None,
                 duration_ms: Some(50),
+                narration: None,
             };
             listener
                 .on_event(&Event::new(
@@ -1555,6 +1564,7 @@ mod tests {
                 arguments: json!({"query": "rust programming", "limit": 10}),
             },
             display_name: None,
+            narration: None,
         };
         listener
             .on_event(&Event::new(
@@ -1573,6 +1583,7 @@ mod tests {
             result: None,
             error: None,
             duration_ms: Some(200),
+            narration: None,
         };
         listener
             .on_event(&Event::new(
@@ -1756,7 +1767,10 @@ mod tests {
                 turn_id,
                 Some(a1),
                 Some(&turn_id.to_string()),
-                EventData::ActStarted(ActStartedData { tool_calls: vec![] }),
+                EventData::ActStarted(ActStartedData {
+                    tool_calls: vec![],
+                    headline: None,
+                }),
             ))
             .await;
         listener
@@ -1770,6 +1784,7 @@ mod tests {
                     success_count: 1,
                     error_count: 0,
                     duration_ms: Some(50),
+                    headline: None,
                 }),
             ))
             .await;
@@ -1930,7 +1945,10 @@ mod tests {
                 turn_id,
                 Some(a1),
                 Some(&turn_key),
-                EventData::ActStarted(ActStartedData { tool_calls: vec![] }),
+                EventData::ActStarted(ActStartedData {
+                    tool_calls: vec![],
+                    headline: None,
+                }),
             ))
             .await;
 
@@ -1948,6 +1966,7 @@ mod tests {
                         arguments: json!({"query": "rust documentation"}),
                     },
                     display_name: None,
+                    narration: None,
                 }),
             ))
             .await;
@@ -1968,6 +1987,7 @@ mod tests {
                     result: None,
                     error: None,
                     duration_ms: Some(200),
+                    narration: None,
                 }),
             ))
             .await;
@@ -1984,6 +2004,7 @@ mod tests {
                     success_count: 1,
                     error_count: 0,
                     duration_ms: Some(250),
+                    headline: None,
                 }),
             ))
             .await;

--- a/crates/core/src/tool_narration.rs
+++ b/crates/core/src/tool_narration.rs
@@ -1,0 +1,391 @@
+use serde_json::Value;
+
+use crate::tool_types::{ToolCall, ToolDefinition};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolNarrationPhase {
+    Started,
+    Waiting,
+    Completed,
+    Failed,
+}
+
+fn title_case(name: &str) -> String {
+    name.split(['_', ' '])
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            let mut chars = part.chars();
+            match chars.next() {
+                Some(first) => {
+                    let mut value = String::new();
+                    value.extend(first.to_uppercase());
+                    value.push_str(chars.as_str());
+                    value
+                }
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn display_name(tool_def: Option<&ToolDefinition>, tool_call: &ToolCall) -> String {
+    tool_def
+        .and_then(|def| def.display_name())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| title_case(&tool_call.name))
+}
+
+fn arg_str<'a>(arguments: &'a Value, keys: &[&str]) -> Option<&'a str> {
+    keys.iter()
+        .find_map(|key| arguments.get(*key))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn arg_bool(arguments: &Value, key: &str) -> Option<bool> {
+    arguments.get(key).and_then(Value::as_bool)
+}
+
+fn basename(path: &str) -> &str {
+    let trimmed = path.trim_end_matches('/');
+    trimmed
+        .rsplit('/')
+        .next()
+        .filter(|part| !part.is_empty())
+        .unwrap_or(path)
+}
+
+fn truncate(value: &str, max_len: usize) -> String {
+    let clean = value.trim();
+    if clean.chars().count() <= max_len {
+        return clean.to_string();
+    }
+
+    let truncated: String = clean.chars().take(max_len).collect();
+    format!("{truncated}...")
+}
+
+fn location_phrase(arguments: &Value) -> String {
+    arg_str(arguments, &["path", "directory", "working_dir"])
+        .map(|value| {
+            if value == "." || value == "/workspace" {
+                "current directory".to_string()
+            } else {
+                value.to_string()
+            }
+        })
+        .unwrap_or_else(|| "current directory".to_string())
+}
+
+fn generic_phrase(
+    verb_started: &str,
+    verb_completed: &str,
+    verb_failed: &str,
+    target: Option<String>,
+    phase: ToolNarrationPhase,
+) -> String {
+    let verb = match phase {
+        ToolNarrationPhase::Started => verb_started,
+        ToolNarrationPhase::Waiting => verb_started,
+        ToolNarrationPhase::Completed => verb_completed,
+        ToolNarrationPhase::Failed => verb_failed,
+    };
+
+    match target {
+        Some(target) if !target.is_empty() => format!("{verb} {target}"),
+        _ => verb.to_string(),
+    }
+}
+
+pub fn render_tool_narration(
+    tool_def: Option<&ToolDefinition>,
+    tool_call: &ToolCall,
+    phase: ToolNarrationPhase,
+) -> String {
+    let args = &tool_call.arguments;
+    let fallback_name = display_name(tool_def, tool_call);
+
+    match tool_call.name.as_str() {
+        "bash" => {
+            let command = arg_str(args, &["command"])
+                .map(|value| format!("`{}`", truncate(value, 48)))
+                .unwrap_or_else(|| fallback_name.clone());
+            generic_phrase("Running", "Ran", "Failed to run", Some(command), phase)
+        }
+        "read_file" | "session_read_file" => {
+            let target = arg_str(args, &["path"]).map(|path| basename(path).to_string());
+            generic_phrase("Reading", "Read", "Failed to read", target, phase)
+        }
+        "read_many_files" => generic_phrase(
+            "Reading",
+            "Read",
+            "Failed to read",
+            Some("multiple files".to_string()),
+            phase,
+        ),
+        "list_directory" | "list_files" => generic_phrase(
+            "Listing files in",
+            "Listed files in",
+            "Failed to list files in",
+            Some(location_phrase(args)),
+            phase,
+        ),
+        "grep_files" => {
+            let target = arg_str(args, &["pattern"])
+                .map(|pattern| format!("files for {}", truncate(pattern, 36)))
+                .unwrap_or_else(|| "files".to_string());
+            generic_phrase(
+                "Searching",
+                "Searched",
+                "Failed to search",
+                Some(target),
+                phase,
+            )
+        }
+        "search" | "search_web" => {
+            let target = arg_str(args, &["query", "q", "search"])
+                .map(|query| format!("web for {}", truncate(query, 48)))
+                .unwrap_or_else(|| "web".to_string());
+            generic_phrase(
+                "Searching",
+                "Searched",
+                "Failed to search",
+                Some(target),
+                phase,
+            )
+        }
+        name if name.ends_with("__search") => {
+            let target = arg_str(args, &["query", "q", "search"])
+                .map(|query| truncate(query, 48))
+                .unwrap_or_else(|| "query".to_string());
+            generic_phrase(
+                "Searching",
+                "Searched",
+                "Failed to search",
+                Some(target),
+                phase,
+            )
+        }
+        "write_file" => {
+            let target = arg_str(args, &["path"]).map(|path| basename(path).to_string());
+            generic_phrase("Writing", "Wrote", "Failed to write", target, phase)
+        }
+        "edit_file" | "replace_in_file" => {
+            let target = arg_str(args, &["path"]).map(|path| basename(path).to_string());
+            generic_phrase("Editing", "Edited", "Failed to edit", target, phase)
+        }
+        "append_file" => {
+            let target = arg_str(args, &["path"]).map(|path| basename(path).to_string());
+            generic_phrase(
+                "Appending to",
+                "Appended to",
+                "Failed to append to",
+                target,
+                phase,
+            )
+        }
+        "move_file" => {
+            let target = arg_str(args, &["to", "destination", "new_path"])
+                .or_else(|| arg_str(args, &["path"]))
+                .map(|path| basename(path).to_string());
+            generic_phrase("Moving", "Moved", "Failed to move", target, phase)
+        }
+        "delete_file" => {
+            let target = arg_str(args, &["path"]).map(|path| basename(path).to_string());
+            generic_phrase("Deleting", "Deleted", "Failed to delete", target, phase)
+        }
+        "mkdir" => {
+            let target = arg_str(args, &["path"]).map(|path| basename(path).to_string());
+            generic_phrase(
+                "Creating directory",
+                "Created directory",
+                "Failed to create directory",
+                target,
+                phase,
+            )
+        }
+        "stat_file" => {
+            let target = arg_str(args, &["path"]).map(|path| basename(path).to_string());
+            generic_phrase("Checking", "Checked", "Failed to check", target, phase)
+        }
+        "secret_store" | "kv_store" => {
+            let operation = arg_str(args, &["operation"]).unwrap_or("use");
+            let target = arg_str(args, &["name", "key"])
+                .map(str::to_string)
+                .or_else(|| Some(fallback_name.clone()));
+            let started = format!("{}ing", title_case(operation));
+            let completed = if operation.eq_ignore_ascii_case("list") {
+                format!(
+                    "Listed {target}",
+                    target = target.clone().unwrap_or_default()
+                )
+            } else {
+                format!(
+                    "{} {}",
+                    title_case(operation),
+                    target.clone().unwrap_or_default()
+                )
+            };
+            match phase {
+                ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => {
+                    format!("{} {}", started, target.unwrap_or_default())
+                        .trim()
+                        .to_string()
+                }
+                ToolNarrationPhase::Completed => completed.trim().to_string(),
+                ToolNarrationPhase::Failed => format!(
+                    "Failed to {} {}",
+                    operation.to_lowercase(),
+                    target.unwrap_or_default()
+                )
+                .trim()
+                .to_string(),
+            }
+        }
+        "spawn_subagent" => {
+            let target = arg_str(args, &["name"])
+                .map(|name| format!("{name} subagent"))
+                .or_else(|| Some("subagent".to_string()));
+            generic_phrase("Launching", "Launched", "Failed to launch", target, phase)
+        }
+        "get_subagents" => {
+            let target = arg_str(args, &["name_or_id"])
+                .map(|value| format!("subagent {value}"))
+                .unwrap_or_else(|| "subagent status".to_string());
+            generic_phrase(
+                "Checking",
+                "Checked",
+                "Failed to check",
+                Some(target),
+                phase,
+            )
+        }
+        "message_subagent" => {
+            let target = arg_str(args, &["name_or_id"])
+                .map(|value| format!("message for {value}"))
+                .unwrap_or_else(|| "subagent message".to_string());
+            if matches!(phase, ToolNarrationPhase::Completed)
+                && arg_bool(args, "cancel").unwrap_or(false)
+            {
+                format!(
+                    "Queued stop request for {}",
+                    target.trim_start_matches("message for ")
+                )
+            } else {
+                generic_phrase("Queueing", "Queued", "Failed to queue", Some(target), phase)
+            }
+        }
+        "write_todos" => generic_phrase(
+            "Updating",
+            "Updated",
+            "Failed to update",
+            Some("task list".to_string()),
+            phase,
+        ),
+        _ => generic_phrase(
+            "Running",
+            "Ran",
+            "Failed to run",
+            Some(fallback_name),
+            phase,
+        ),
+    }
+}
+
+fn join_phrases(phrases: &[String], total_count: usize) -> String {
+    match phrases {
+        [] => "Working".to_string(),
+        [only] => only.clone(),
+        [first, second] => format!("{first} and {second}"),
+        [first, second, ..] => {
+            format!(
+                "{first}, {second}, and {} more actions",
+                total_count.saturating_sub(2)
+            )
+        }
+    }
+}
+
+pub fn render_group_headline(
+    tool_calls: &[ToolCall],
+    tool_defs: &[ToolDefinition],
+    phase: ToolNarrationPhase,
+) -> Option<String> {
+    if tool_calls.is_empty() {
+        return None;
+    }
+
+    let tool_map: std::collections::HashMap<&str, &ToolDefinition> =
+        tool_defs.iter().map(|def| (def.name(), def)).collect();
+
+    let phrases = tool_calls
+        .iter()
+        .map(|tool_call| {
+            render_tool_narration(
+                tool_map.get(tool_call.name.as_str()).copied(),
+                tool_call,
+                phase,
+            )
+        })
+        .take(3)
+        .collect::<Vec<_>>();
+
+    Some(join_phrases(&phrases, tool_calls.len()))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{ToolNarrationPhase, render_group_headline, render_tool_narration};
+    use crate::tool_types::ToolCall;
+
+    #[test]
+    fn renders_read_file_narration() {
+        let tool_call = ToolCall {
+            id: "call_1".to_string(),
+            name: "read_file".to_string(),
+            arguments: json!({ "path": "/workspace/AGENTS.md" }),
+        };
+
+        assert_eq!(
+            render_tool_narration(None, &tool_call, ToolNarrationPhase::Started),
+            "Reading AGENTS.md"
+        );
+        assert_eq!(
+            render_tool_narration(None, &tool_call, ToolNarrationPhase::Completed),
+            "Read AGENTS.md"
+        );
+    }
+
+    #[test]
+    fn renders_group_headline_from_multiple_tool_calls() {
+        let tool_calls = vec![
+            ToolCall {
+                id: "call_1".to_string(),
+                name: "list_directory".to_string(),
+                arguments: json!({ "path": "/workspace" }),
+            },
+            ToolCall {
+                id: "call_2".to_string(),
+                name: "read_file".to_string(),
+                arguments: json!({ "path": "/workspace/AGENTS.md" }),
+            },
+            ToolCall {
+                id: "call_3".to_string(),
+                name: "grep_files".to_string(),
+                arguments: json!({ "pattern": "Doppler" }),
+            },
+        ];
+
+        let headline =
+            render_group_headline(&tool_calls, &[], ToolNarrationPhase::Completed).unwrap();
+
+        assert_eq!(
+            headline,
+            "Listed files in current directory, Read AGENTS.md, and 1 more actions"
+        );
+    }
+}

--- a/crates/server/tests/client_side_tools_test.rs
+++ b/crates/server/tests/client_side_tools_test.rs
@@ -227,6 +227,8 @@ fn test_tool_call_requested_data_serialization() {
                 arguments: json!({"selector": "#input", "text": "hello"}),
             },
         ],
+        tool_summaries: vec![],
+        headline: None,
     };
 
     let json = serde_json::to_value(&data).unwrap();
@@ -250,6 +252,8 @@ fn test_tool_call_requested_data_roundtrip() {
             name: "deploy_staging".to_string(),
             arguments: json!({"env": "staging", "version": "1.2.3"}),
         }],
+        tool_summaries: vec![],
+        headline: None,
     };
 
     let json_str = serde_json::to_string(&original).unwrap();
@@ -265,7 +269,11 @@ fn test_tool_call_requested_data_roundtrip() {
 fn test_tool_call_requested_data_empty_tool_calls() {
     use everruns_core::events::ToolCallRequestedData;
 
-    let data = ToolCallRequestedData { tool_calls: vec![] };
+    let data = ToolCallRequestedData {
+        tool_calls: vec![],
+        tool_summaries: vec![],
+        headline: None,
+    };
 
     let json = serde_json::to_value(&data).unwrap();
     assert_eq!(json["tool_calls"].as_array().unwrap().len(), 0);

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -696,9 +696,10 @@ async fn execute_reason_activity<A: WorkerAdapters>(
         let requested_event = EventRequest::new(
             session_id,
             EventContext::turn(turn_id, input_message_id),
-            everruns_core::ToolCallRequestedData {
-                tool_calls: client_tool_calls.into_iter().cloned().collect(),
-            },
+            everruns_core::ToolCallRequestedData::with_definitions(
+                &client_tool_calls.into_iter().cloned().collect::<Vec<_>>(),
+                &result.tool_definitions,
+            ),
         );
         if let Err(e) = adapters.emit_event(requested_event).await {
             warn!(error = %e, "Failed to emit tool.call_requested event");

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4273,6 +4273,13 @@
             "description": "Number of failed tool calls",
             "minimum": 0
           },
+          "headline": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable headline for the completed batch"
+          },
           "success_count": {
             "type": "integer",
             "format": "int32",
@@ -4288,6 +4295,13 @@
           "tool_calls"
         ],
         "properties": {
+          "headline": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable headline for the batch"
+          },
           "tool_calls": {
             "type": "array",
             "items": {
@@ -9885,12 +9899,26 @@
           "tool_calls"
         ],
         "properties": {
+          "headline": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable headline for the requested batch"
+          },
           "tool_calls": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ToolCall"
             },
             "description": "Tool calls that need to be executed by the client"
+          },
+          "tool_summaries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ToolCallSummary"
+            },
+            "description": "Optional summaries with display names and narration for UI rendering"
           }
         }
       },
@@ -9914,6 +9942,13 @@
           },
           "name": {
             "type": "string"
+          },
+          "narration": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable narration for timeline rendering"
           }
         }
       },
@@ -9949,6 +9984,13 @@
               "null"
             ],
             "description": "Error message if failed"
+          },
+          "narration": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable narration for timeline rendering"
           },
           "result": {
             "type": [
@@ -10096,6 +10138,13 @@
               "null"
             ],
             "description": "Human-readable display name for UI rendering"
+          },
+          "narration": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable narration for timeline rendering"
           },
           "tool_call": {
             "$ref": "#/components/schemas/ToolCall",

--- a/specs/client-side-tools.md
+++ b/specs/client-side-tools.md
@@ -150,7 +150,16 @@ data: {
         "name": "lookup_crm",
         "arguments": { "customer_id": "CUST-42" }
       }
-    ]
+    ],
+    "tool_summaries": [
+      {
+        "id": "call_abc123",
+        "name": "lookup_crm",
+        "display_name": "Lookup CRM",
+        "narration": "Looking up customer CUST-42"
+      }
+    ],
+    "headline": "Looking up customer CUST-42"
   }
 }
 ```
@@ -243,6 +252,8 @@ Emitted when the LLM requests one or more client-side tool calls. The agent loop
 | `tool_calls[].id` | string | Unique tool call ID (from LLM response) |
 | `tool_calls[].name` | string | Tool name |
 | `tool_calls[].arguments` | object | Tool arguments (parsed JSON) |
+| `tool_summaries` | array | Optional server-authored display summaries for timeline UIs |
+| `headline` | string | Optional server-authored readable summary for the requested batch |
 
 ### Session Status: `waiting_for_tool_results`
 

--- a/specs/events.md
+++ b/specs/events.md
@@ -487,8 +487,14 @@ ActAtom lifecycle - tool batch execution.
   "context": { "turn_id": "...", "exec_id": "..." },
   "data": {
     "tool_calls": [
-      { "id": "call_123", "name": "get_weather", "display_name": "Get Weather" }
-    ]
+      {
+        "id": "call_123",
+        "name": "get_weather",
+        "display_name": "Get Weather",
+        "narration": "Checking weather for Tokyo"
+      }
+    ],
+    "headline": "Checking weather for Tokyo"
   }
 }
 ```
@@ -501,10 +507,13 @@ ActAtom lifecycle - tool batch execution.
   "data": {
     "completed": true,
     "success_count": 2,
-    "error_count": 0
+    "error_count": 0,
+    "headline": "Checked weather for Tokyo"
   }
 }
 ```
+
+**`headline`** (optional, string): Server-authored readable summary for the tool batch. UI should render this directly when present instead of synthesizing group copy from tool names.
 
 #### `tool.started` / `tool.completed`
 
@@ -521,7 +530,8 @@ Individual tool execution within ActAtom.
       "name": "get_weather",
       "arguments": { "city": "Tokyo" }
     },
-    "display_name": "Get Weather"
+    "display_name": "Get Weather",
+    "narration": "Checking weather for Tokyo"
   }
 }
 ```
@@ -537,12 +547,15 @@ Individual tool execution within ActAtom.
     "display_name": "Get Weather",
     "success": true,
     "status": "success",
+    "narration": "Checked weather for Tokyo",
     "result": [
       { "type": "text", "text": "Temperature: 22C, Sunny" }
     ]
   }
 }
 ```
+
+**`narration`** (optional, string): Server-authored readable summary for an individual tool step. Intended for transcript/timeline rendering. Clients may fall back to local formatting when absent.
 
 For failed tool calls:
 


### PR DESCRIPTION
## What
Add server-authored narration for tool activity and render narrated act groups in the chat UI.

## Why
Tool-call activity was previously summarized with client-side heuristics, which made copy inconsistent across clients and too log-like. This change moves narration ownership to the server so tool rows and group headlines are deterministic, human-readable, and closer to the transcript style in the target screenshot.

## How
- add deterministic narration generation in `crates/core/src/tool_narration.rs`
- extend `act.*`, `tool.*`, and `tool.call_requested` events with optional `headline` / `narration` fields
- emit narrated group and row data from server-side act execution and client-side tool request plumbing
- update the chat UI to render narrated activity timeline groups with minimal transcript-style styling and keep the old summarizer as fallback
- update event and client-side tool specs to document the new fields

## Risk
- Medium
- Risks are mainly transcript regressions in chat rendering and event consumers that assume older shapes. The new event fields are additive and the UI keeps fallback behavior for older events.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --lib --bins`
- `cd apps/ui && npm run format:check`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm test -- --runInBand --runTestsByPath src/__tests__/chat-panel.test.tsx src/__tests__/tool-activity-group.test.tsx src/__tests__/tool-activity-timeline-group.test.tsx`
- `just pre-push`
