### PR TITLE
chore(specs): add toolkit library contract for external tool libraries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,7 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 - `specs/browserless.md` - Browserless browser automation integration
 - `specs/subagents.md` - Subagent orchestration (spawn, message, cancel child sessions)
 - `specs/subagent-architecture-analysis.md` - Subagent architecture analysis across top coding agents
+- `specs/toolkit-library-contract.md` - Convention for external toolkit libraries (bashkit, fetchkit, etc.)
 
 ### Test Cases
 

--- a/specs/toolkit-library-contract.md
+++ b/specs/toolkit-library-contract.md
@@ -16,33 +16,39 @@ bashkit and fetchkit diverged in how they expose tool metadata and execution:
 
 This means each new toolkit requires bespoke integration code in `crates/core/src/capabilities/`. The contract below standardizes the public API shape so the integration side is predictable.
 
+## Contract overview
+
+Three objects with clear responsibilities:
+
+```
+ToolBuilder (config)  →  Tool (metadata)  →  ToolExecution (runtime)
+```
+
+- **`ToolBuilder`** — kit-specific configuration, produces a `Tool`
+- **`Tool`** — immutable metadata (name, description, schema, system prompt), produces a `ToolExecution`
+- **`ToolExecution`** — stateful, single-use execution of one tool call
+
 ## Contract
 
-### 1. `ToolBuilder` and `Tool`
+### 1. `ToolBuilder`
 
-Every `*kit` library exposes a `ToolBuilder` for configuration and a `Tool` as the built artifact.
+Every `*kit` library exposes a `ToolBuilder` for configuration:
 
 ```rust
-// ToolBuilder: config only
 let builder = mykit::ToolBuilder::new()
     .some_feature(true)
     .some_limit(1000);
 
-// build() produces an immutable Tool
 let tool = builder.build();
-
-// Metadata lives on Tool (not builder)
-let schema = tool.input_schema();
-let prompt = tool.system_prompt();
 ```
 
 `ToolBuilder` methods are chainable. `build()` consumes the builder and returns a `Tool`.
 
-`Tool` is `Send + Sync`. `ToolBuilder` need not be.
+`ToolBuilder` need not be `Send + Sync`.
 
-### 2. Tool metadata methods
+### 2. `Tool` — metadata
 
-All metadata lives on `Tool`:
+`Tool` is immutable and holds all metadata baked in from the builder config:
 
 ```rust
 impl Tool {
@@ -66,38 +72,92 @@ impl Tool {
 }
 ```
 
-Builder config bakes into `Tool` at `build()` time. The consumer builds the `Tool` once and reads metadata + executes from the same object.
+`Tool` is `Send + Sync` and cheap to clone (typically `Arc` internals or static data).
 
 **Rationale:** `input_schema()` was missing from bashkit, forcing the consumer to hardcode the schema and keep it in sync manually. All metadata methods must live on `Tool` so the consumer can delegate without duplication.
 
-### 3. `Tool` — execution
+### 3. `ToolExecution` — runtime
 
-`Tool` is the built, immutable, executable artifact. Every `Tool` provides an async execute method:
-
-```rust
-impl Tool {
-    /// Execute the tool with JSON arguments matching `input_schema()`.
-    /// Returns a kit-specific result type (see §5).
-    async fn execute(&self, args: serde_json::Value) -> Result<ToolOutput, ToolError>;
-}
-```
-
-If the tool needs an adapter (filesystem, file saver, etc.), provide a second method:
+`ToolExecution` represents a single in-flight tool call. Created from `Tool`, it is stateful and single-use.
 
 ```rust
 impl Tool {
-    /// Execute with an injected adapter.
-    async fn execute_with<A: SomeAdapter>(
-        &self,
-        args: serde_json::Value,
-        adapter: &A,
-    ) -> Result<ToolOutput, ToolError>;
+    /// Create an execution for the given arguments.
+    /// Validates args against input_schema() before returning.
+    fn execution(&self, args: serde_json::Value) -> Result<ToolExecution, ToolError>;
 }
 ```
 
-The base `execute()` must work without adapters (returning an error or degraded result if the adapter-dependent feature is requested). This lets the consumer call `execute()` in context-free paths and `execute_with()` when context is available.
+#### Required: `execute()`
 
-**bashkit note:** bashkit currently uses a separate `Bash` interpreter struct for execution. Under this contract, `Tool::execute()` would create the interpreter internally. Per-execution config (filesystem adapter, working directory) flows through the args or through `execute_with()`.
+```rust
+impl ToolExecution {
+    /// Run to completion. Consumes the execution.
+    async fn execute(self) -> Result<ToolOutput, ToolError>;
+}
+```
+
+If the tool needs an adapter (filesystem, file saver, etc.), provide a variant:
+
+```rust
+impl ToolExecution {
+    /// Run to completion with an injected adapter.
+    async fn execute_with<A: SomeAdapter>(self, adapter: &A) -> Result<ToolOutput, ToolError>;
+}
+```
+
+The base `execute()` must work without adapters (returning an error if an adapter-dependent feature was requested in args). This lets the consumer call `execute()` in context-free paths and `execute_with()` when context is available.
+
+#### Optional: cancellation
+
+Toolkits with long-running operations (bash scripts, multi-step fetches) may support cancellation:
+
+```rust
+impl ToolExecution {
+    /// Cancel the running execution.
+    /// Returns partial results collected so far, or None if nothing was produced yet.
+    async fn cancel(&self) -> Option<ToolOutput>;
+}
+```
+
+Design rules:
+- `cancel()` is safe to call multiple times (idempotent)
+- `cancel()` is safe to call concurrently with `execute()` — it signals cancellation, `execute()` returns promptly
+- Partial output follows the same `ToolOutput` shape (e.g. bashkit returns stdout collected so far, exit code -1)
+- If the kit does not support cancellation, omit the method entirely — the consumer falls back to dropping the future
+
+**bashkit example:** bash command running for 30s, user cancels at 5s. `cancel()` returns `ToolOutput { result: json!({"stdout": "partial output...", "exit_code": -1, "cancelled": true}), images: vec![] }`.
+
+#### Optional: streaming
+
+Toolkits that produce incremental output may expose a stream:
+
+```rust
+impl ToolExecution {
+    /// Stream incremental output chunks during execution.
+    /// The stream completes when execution finishes.
+    /// Final result is still returned from execute().
+    fn output_stream(&self) -> impl Stream<Item = ToolOutputChunk>;
+}
+
+pub struct ToolOutputChunk {
+    /// Incremental content (e.g. stdout line, fetched bytes, progress update)
+    pub data: serde_json::Value,
+    /// Chunk type for consumer routing (e.g. "stdout", "stderr", "progress")
+    pub kind: String,
+}
+```
+
+Design rules:
+- Streaming is opt-in — if the kit doesn't support it, omit the method
+- `output_stream()` must be called **before** `execute()` — it returns a receiver, `execute()` drives the sender
+- The stream is informational — the consumer uses it for live UI updates (e.g. streaming bash output to the terminal panel)
+- The final `ToolOutput` from `execute()` is the authoritative result, not the concatenation of chunks
+- If `cancel()` is called, the stream ends and `execute()` returns the partial result
+
+**bashkit example:** streaming stdout/stderr line by line as the bash command runs.
+
+**fetchkit example:** streaming download progress (`{"bytes_received": 1024, "total": 50000}`).
 
 ### 4. Adapter traits
 
@@ -171,7 +231,7 @@ Toolkit crates re-export all types needed to implement adapter traits and handle
 
 ```rust
 // mykit/src/lib.rs
-pub use tool::{ToolBuilder, Tool, ToolOutput, ToolImage};
+pub use tool::{ToolBuilder, Tool, ToolExecution, ToolOutput, ToolOutputChunk, ToolImage};
 pub use error::ToolError;
 pub use adapters::{AdapterTrait, AdapterError, DefaultAdapter};
 // Any types needed to implement AdapterTrait:
@@ -183,15 +243,16 @@ pub use adapters::{SaveResult, Metadata, DirEntry, ...};
 Toolkit crates must not depend on `everruns-core` or any everruns crate. They are standalone libraries. The integration boundary is:
 
 ```
-toolkit crate (standalone)     everruns-core
-├── ToolBuilder (config)       ├── XxxCapability (implements Capability trait)
-├── Tool (metadata+execute)    │   └── builds Tool, reads metadata for system prompt
-├── AdapterTrait               ├── XxxTool (implements everruns Tool trait)
-├── Error types                │   ├── delegates metadata to toolkit Tool
-└── Output types               │   ├── delegates execution to toolkit Tool
-                               │   └── maps errors/output to ToolExecutionResult
-                               └── AdapterImpl (implements toolkit::AdapterTrait)
-                                   └── bridges to SessionFileStore, etc.
+toolkit crate (standalone)       everruns-core
+├── ToolBuilder (config)         ├── XxxCapability (implements Capability trait)
+├── Tool (metadata)              │   └── builds Tool, reads metadata for system prompt
+├── ToolExecution (runtime)      ├── XxxTool (implements everruns Tool trait)
+│   ├── execute()                │   ├── delegates metadata to toolkit Tool
+│   ├── cancel() [optional]      │   ├── creates ToolExecution per call
+│   └── output_stream() [opt]    │   ├── wires cancel/stream to everruns runtime
+├── AdapterTrait                 │   └── maps errors/output to ToolExecutionResult
+├── Error types                  └── AdapterImpl (implements toolkit::AdapterTrait)
+└── Output types                     └── bridges to SessionFileStore, etc.
 ```
 
 ## Consumer integration pattern
@@ -215,7 +276,6 @@ impl Capability for XxxCapability {
     }
 
     fn system_prompt_preview(&self) -> Option<String> {
-        // Build with all features enabled for preview
         let tool = mykit::ToolBuilder::new().some_feature(true).build();
         Some(tool.system_prompt())
     }
@@ -251,19 +311,42 @@ impl Tool for XxxTool {
     fn parameters_schema(&self) -> Value { self.kit_tool.input_schema() }
 
     async fn execute(&self, args: Value) -> ToolExecutionResult {
-        match self.kit_tool.execute(args).await {
-            Ok(output) => ToolExecutionResult::success(output.result),
-            Err(e) if e.is_user_facing() => ToolExecutionResult::tool_error(e.to_string()),
-            Err(e) => ToolExecutionResult::internal_error_msg(e.to_string()),
+        let execution = match self.kit_tool.execution(args) {
+            Ok(exec) => exec,
+            Err(e) => return map_error(e),
+        };
+        match execution.execute().await {
+            Ok(output) => map_output(output),
+            Err(e) => map_error(e),
         }
     }
 
     async fn execute_with_context(&self, args: Value, ctx: &ToolContext) -> ToolExecutionResult {
+        let execution = match self.kit_tool.execution(args) {
+            Ok(exec) => exec,
+            Err(e) => return map_error(e),
+        };
         let adapter = MyAdapter::from_context(ctx);
-        match self.kit_tool.execute_with(args, &adapter).await {
+        match execution.execute_with(&adapter).await {
             Ok(output) => map_output(output),
             Err(e) => map_error(e),
         }
+    }
+}
+
+fn map_output(output: mykit::ToolOutput) -> ToolExecutionResult {
+    if output.images.is_empty() {
+        ToolExecutionResult::success(output.result)
+    } else {
+        ToolExecutionResult::success_with_images(output.result, /* map images */)
+    }
+}
+
+fn map_error(e: mykit::ToolError) -> ToolExecutionResult {
+    if e.is_user_facing() {
+        ToolExecutionResult::tool_error(e.to_string())
+    } else {
+        ToolExecutionResult::internal_error_msg(e.to_string())
     }
 }
 ```
@@ -274,16 +357,18 @@ impl Tool for XxxTool {
 |---------|-----|-----------|
 | bashkit | No `ToolBuilder` — uses `BashTool::builder()` (naming) | Rename to `ToolBuilder` for consistency |
 | bashkit | No `input_schema()` on Tool | Add method; remove hardcoded schema from `virtual_bash.rs` |
-| bashkit | No `execute()` on Tool — uses separate `Bash` struct | Add `execute()` / `execute_with()` that wraps `Bash` internally |
+| bashkit | No `ToolExecution` — uses separate `Bash` struct | Wrap `Bash` in `ToolExecution`; `execute()` creates interpreter internally |
 | bashkit | `system_prompt()` naming OK — fetchkit uses `llmtxt()` | Standardize on `system_prompt()` for both |
 | bashkit | No `name()` on Tool | Add; return `"bash"` |
 | bashkit | No structured `ToolOutput` — returns raw stdout/stderr | Wrap in `ToolOutput { result: json!({...}), images: vec![] }` |
+| bashkit | Has natural cancel/stream support (interpreter is stateful) | Expose via `ToolExecution::cancel()` and `output_stream()` |
 | fetchkit | `Tool::builder()` naming OK but returns unnamed builder type | Expose as `ToolBuilder` |
 | fetchkit | Uses `llmtxt()` instead of `system_prompt()` | Rename (or alias) to `system_prompt()` |
-| fetchkit | `execute()` takes `FetchRequest`, not `Value` | Add `Value`-based overload or keep `FetchRequest` and document parse step |
+| fetchkit | `execute()` takes `FetchRequest`, not `Value` | Parse `Value` → `FetchRequest` inside `ToolExecution::execute()` |
 | fetchkit | Error enum doesn't have `is_user_facing()` | Add method; currently all errors are user-facing |
 | fetchkit | No `name()` on Tool | Add; return `"web_fetch"` |
 | fetchkit | No structured `ToolOutput` | Wrap response in `ToolOutput` |
+| fetchkit | No `ToolExecution` — `execute()` lives on `Tool` | Move to `ToolExecution`; streaming progress is a natural fit |
 
 ## Non-goals
 

--- a/specs/toolkit-library-contract.md
+++ b/specs/toolkit-library-contract.md
@@ -152,18 +152,21 @@ impl Tool {
     /// Consumer can use this for diagnostics, logging, or compatibility checks.
     fn version(&self) -> &str;
 
-    /// Human-readable description of the tool for the LLM.
-    /// Baked in at build() time from builder config. Localized per builder locale.
+    /// Short, token-efficient description for the LLM.
+    /// One sentence. No filler. Localized per builder locale.
     fn description(&self) -> &str;
 
     /// JSON Schema for the tool's input parameters.
     /// Must be a valid JSON Schema object with `"type": "object"`.
     /// Adapts to builder config (e.g. optional params appear/disappear).
+    /// See §2a for schema authoring rules.
     fn input_schema(&self) -> serde_json::Value;
 
-    /// System prompt content (LLM instructions for using this tool).
+    /// Terse system prompt addition for the LLM.
+    /// Must start with tool name (e.g. "web_fetch: ..."). No title/header.
+    /// Minimal tokens — only behavior the LLM can't infer from the schema.
     /// Returned as plain text — the consumer wraps it in XML tags.
-    /// Returns empty string if no system prompt contribution.
+    /// Empty string if no system prompt contribution needed.
     /// Localized per builder locale.
     fn system_prompt(&self) -> String;
 
@@ -181,6 +184,66 @@ impl Tool {
 `Tool` is `Send + Sync` and cheap to clone (typically `Arc` internals or static data).
 
 **Rationale:** `input_schema()` was missing from bashkit, forcing the consumer to hardcode the schema and keep it in sync manually. All metadata methods must live on `Tool` so the consumer can delegate without duplication.
+
+#### Token budget rules
+
+Every token in `description()` and `system_prompt()` costs money on every LLM call. Be ruthless.
+
+**`description()`** — one sentence, no articles, no filler:
+- Good: `"Fetch a URL and return content as text or markdown"`
+- Bad: `"This tool allows you to fetch content from a specified URL and return it in various formats including plain text or markdown"`
+
+**`system_prompt()`** — starts with tool name, no markdown headers, only what the LLM can't infer from the schema:
+- Good: `"web_fetch: returns truncated content if response exceeds 50KB. Use as_markdown for HTML pages. Blocked: private IPs, cloud metadata endpoints."`
+- Bad: `"# Web Fetch Tool\n\nThe web_fetch tool is used to fetch content from URLs. It supports GET and HEAD methods.\n\n## Usage\n..."`
+
+If the schema is self-explanatory, `system_prompt()` can return `""`.
+
+#### 2a. Input schema authoring rules
+
+The schema is sent to the LLM on every call. Minimize token cost:
+
+1. **Argument names carry intent** — if the name is clear, omit `description`. `url`, `command`, `timeout_ms` need no description. `as_markdown` needs no description.
+
+2. **Use `enum` for fixed values** — don't describe allowed values in text:
+   ```json
+   // Good
+   {"method": {"type": "string", "enum": ["GET", "HEAD"]}}
+   // Bad
+   {"method": {"type": "string", "description": "HTTP method. Must be GET or HEAD."}}
+   ```
+
+3. **Specify `default` in schema** — don't describe defaults in text:
+   ```json
+   // Good
+   {"timeout_ms": {"type": "integer", "default": 30000}}
+   // Bad
+   {"timeout_ms": {"type": "integer", "description": "Timeout in milliseconds. Defaults to 30000."}}
+   ```
+
+4. **Short descriptions only when needed** — format, constraints, non-obvious behavior:
+   ```json
+   {"working_dir": {"type": "string", "default": "/workspace", "description": "Absolute path"}}
+   ```
+
+5. **Use `format` for known types** — `"format": "uri"`, `"format": "date-time"`, etc.
+
+**fetchkit example** (before/after):
+```json
+// Before (verbose)
+{
+  "url": {"type": "string", "description": "The URL to fetch content from. Must start with http:// or https://."},
+  "method": {"type": "string", "description": "HTTP method to use. Supported: GET, HEAD. Default: GET."},
+  "as_markdown": {"type": "boolean", "description": "If true, converts HTML content to markdown format. Default: false."}
+}
+
+// After (token-efficient)
+{
+  "url": {"type": "string", "format": "uri"},
+  "method": {"type": "string", "enum": ["GET", "HEAD"], "default": "GET"},
+  "as_markdown": {"type": "boolean", "default": false}
+}
+```
 
 #### `help()` content
 
@@ -358,21 +421,22 @@ Rules:
 
 ### 5. Error types
 
-Every toolkit defines its own error enum:
+Every toolkit defines its own error enum. Errors must be **actionable** (tell the LLM/user what to do differently) and **never expose internals** (no stack traces, no internal paths, no library names).
 
 ```rust
 #[derive(Debug, thiserror::Error)]
 pub enum ToolError {
-    /// Errors safe to show to the LLM (validation, not found, etc.)
+    /// Errors safe to show to the LLM — actionable, no internal details.
+    /// Localized per builder locale.
     #[error("...")]
     UserFacing(String),
 
-    /// Errors that should be hidden from the LLM (internal failures)
+    /// Internal failures — logged by consumer, never shown to LLM.
+    /// Not localized (English-only, for operator logs).
     #[error("...")]
     Internal(String),
 
-    // Kit-specific variants are fine, but must be classifiable as
-    // user-facing or internal via a method:
+    // Kit-specific variants are fine, but must be classifiable:
 }
 
 impl ToolError {
@@ -383,25 +447,104 @@ impl ToolError {
 
 The consumer maps these to `ToolExecutionResult::ToolError` or `ToolExecutionResult::InternalError` using `is_user_facing()`.
 
+#### Error message rules
+
+**User-facing errors** (shown to LLM):
+- Actionable: say what went wrong and how to fix it
+- No internal details: no file paths, no library names, no stack traces
+- Localized per builder locale
+- Short — one sentence
+
+```
+// Good
+"url is required"
+"URL scheme must be http or https"
+"Server did not respond within 1s. Retry or try a different URL."
+"Cannot save file: save_to_file requires the FileSaver adapter"
+
+// Bad
+"reqwest::Error: connection refused at 10.0.0.1:443"
+"NullPointerException in FetchHandler.java:142"
+"Error: Os { code: 2, kind: NotFound, message: \"No such file\" }"
+```
+
+**Internal errors** (logged, hidden from LLM):
+- Full details for debugging (stack traces, internal paths, etc.)
+- Always English (operator logs)
+- Consumer replaces with generic message before returning to LLM
+
 ### 6. Output type
 
-Execution returns a structured output:
+Execution returns a structured output with a clear split between what goes to the LLM and what stays with the consumer:
 
 ```rust
 pub struct ToolOutput {
-    /// JSON result value
+    /// JSON result sent to the LLM.
     pub result: serde_json::Value,
-    /// Optional images (base64 + media type)
+
+    /// Optional images sent to the LLM as native image content blocks.
     pub images: Vec<ToolImage>,
+
+    /// Metadata for the consumer/platform — never sent to the LLM.
+    /// Toolkits attach diagnostics, metrics, and operational data here.
+    pub metadata: ToolOutputMetadata,
 }
 
 pub struct ToolImage {
     pub base64: String,
     pub media_type: String,
 }
+
+/// Operational metadata that stays with the consumer.
+/// None of this reaches the LLM context window.
+pub struct ToolOutputMetadata {
+    /// Execution wall-clock duration.
+    pub duration: std::time::Duration,
+
+    /// Kit-specific metadata as JSON.
+    /// Examples: HTTP status code, response headers, bytes transferred,
+    /// commands executed, exit codes, filesystem operations count.
+    pub extra: serde_json::Value,
+}
 ```
 
 If the tool never returns images, `images` is always empty. The consumer maps `ToolOutput` to `ToolExecutionResult::Success` or `ToolExecutionResult::SuccessWithImages`.
+
+**Metadata contract:** `metadata` is for the consumer (logging, billing, UI, analytics) — never serialized into the LLM tool result. The consumer decides what to do with it:
+
+```rust
+// Consumer side — metadata goes to tracing/events, not to LLM
+fn map_output(output: mykit::ToolOutput) -> ToolExecutionResult {
+    tracing::info!(
+        duration_ms = output.metadata.duration.as_millis(),
+        extra = %output.metadata.extra,
+        "tool execution complete"
+    );
+    // Only result + images go to the LLM
+    ToolExecutionResult::success(output.result)
+}
+```
+
+**Kit-specific metadata examples:**
+
+```rust
+// fetchkit
+json!({
+    "http_status": 200,
+    "content_type": "text/html",
+    "content_length": 48230,
+    "redirects": 1,
+    "truncated": true
+})
+
+// bashkit
+json!({
+    "exit_code": 0,
+    "commands_executed": 3,
+    "fs_reads": 5,
+    "fs_writes": 2
+})
+```
 
 ### 7. Re-exports
 
@@ -523,6 +666,11 @@ impl Tool for XxxTool {
 }
 
 fn map_output(output: mykit::ToolOutput) -> ToolExecutionResult {
+    // Metadata stays with consumer — log, emit events, never send to LLM
+    tracing::debug!(
+        duration_ms = output.metadata.duration.as_millis(),
+        extra = %output.metadata.extra,
+    );
     if output.images.is_empty() {
         ToolExecutionResult::success(output.result)
     } else {
@@ -543,14 +691,16 @@ fn map_error(e: mykit::ToolError) -> ToolExecutionResult {
 
 | Library | Gap | Migration |
 |---------|-----|-----------|
-| Library | Gap | Migration |
-|---------|-----|-----------|
 | both | No `locale()` on builder | Add; default `"en-US"`, thread through to description/system_prompt/errors |
 | both | No `display_name()` on Tool | Add; return localized human-readable name |
 | both | No `version()` on Tool | Add; return `env!("CARGO_PKG_VERSION")` |
 | both | No `build_tool_definition()` | Add; return OpenAI function call JSON |
 | both | No `build_output_schema()` | Add; describe shape of result JSON |
 | both | No `build_service()` | Add; return `impl Service<Value>` for generic callable usage |
+| both | No `help()` on Tool | Add; render comprehensive Markdown |
+| both | No `ToolOutputMetadata` | Add; return duration + kit-specific extras |
+| both | Verbose descriptions/schemas | Trim per token budget rules |
+| both | Error messages expose internals | Rewrite to be actionable, no internal details |
 | bashkit | No `ToolBuilder` — uses `BashTool::builder()` (naming) | Rename to `ToolBuilder` for consistency |
 | bashkit | No `input_schema()` on Tool | Add method; remove hardcoded schema from `virtual_bash.rs` |
 | bashkit | No `ToolExecution` — uses separate `Bash` struct | Wrap `Bash` in `ToolExecution`; `execute()` creates interpreter internally |

--- a/specs/toolkit-library-contract.md
+++ b/specs/toolkit-library-contract.md
@@ -32,7 +32,7 @@ ToolBuilder (config)  →  Tool (metadata)  →  ToolExecution (runtime)
 
 ### 1. `ToolBuilder`
 
-Every `*kit` library exposes a `ToolBuilder` for configuration:
+Every `*kit` library exposes a `ToolBuilder` for configuration. The builder is a factory that can produce different artifacts depending on what the consumer needs.
 
 ```rust
 let builder = mykit::ToolBuilder::new()
@@ -40,16 +40,21 @@ let builder = mykit::ToolBuilder::new()
     .some_feature(true)
     .some_limit(1000);
 
+// Full object — metadata + execution factory
 let tool = builder.build();
+
+// Or produce individual artifacts without building the full Tool:
+let definition = builder.build_tool_definition();   // OpenAI function call JSON
+let input_schema = builder.build_input_schema();     // JSON Schema for args
+let output_schema = builder.build_output_schema();   // JSON Schema for result
+let executor = builder.build_executor();             // generic Value → Value executor
 ```
 
-`ToolBuilder` methods are chainable. `build()` consumes the builder and returns a `Tool`.
+Config methods are chainable. Build methods take `&self` (non-consuming) — you can call multiple on the same builder.
 
 `ToolBuilder` need not be `Send + Sync`.
 
-#### Required builder methods
-
-Every `ToolBuilder` must accept:
+#### Required config methods
 
 ```rust
 impl ToolBuilder {
@@ -61,6 +66,59 @@ impl ToolBuilder {
 ```
 
 Kit-specific config methods are added alongside `locale()`.
+
+#### Build methods
+
+```rust
+impl ToolBuilder {
+    /// Build the full Tool (metadata + execution factory).
+    fn build(&self) -> Tool;
+
+    /// Build a standalone executor: accepts JSON args, returns JSON result.
+    /// No metadata attached — useful for embedding in generic pipelines,
+    /// test harnesses, or consumers that manage tool definitions separately.
+    fn build_executor(&self) -> ToolExecutor;
+
+    /// Build an OpenAI-compatible function tool definition.
+    /// Returns JSON matching the OpenAI `tools` array element format:
+    /// `{"type": "function", "function": {"name": "...", "description": "...", "parameters": {...}}}`
+    fn build_tool_definition(&self) -> serde_json::Value;
+
+    /// Build the JSON Schema for the tool's input parameters.
+    /// Same as `Tool::input_schema()` but without building the full Tool.
+    fn build_input_schema(&self) -> serde_json::Value;
+
+    /// Build the JSON Schema for the tool's output.
+    /// Describes the shape of `ToolOutput::result` so consumers can
+    /// validate results or generate types.
+    fn build_output_schema(&self) -> serde_json::Value;
+}
+```
+
+**`ToolExecutor`** is a minimal, stateless executor:
+
+```rust
+pub struct ToolExecutor { /* internal */ }
+
+impl ToolExecutor {
+    /// Execute with JSON args, return JSON result.
+    /// No ToolExecution indirection — fire-and-forget for simple consumers.
+    async fn execute(&self, args: serde_json::Value) -> Result<serde_json::Value, ToolError>;
+
+    /// Execute with an adapter.
+    async fn execute_with<A: SomeAdapter>(
+        &self,
+        args: serde_json::Value,
+        adapter: &A,
+    ) -> Result<serde_json::Value, ToolError>;
+}
+```
+
+**When to use which:**
+- `build()` → everruns integration (full metadata + `ToolExecution` with cancel/stream)
+- `build_executor()` → test harnesses, scripts, pipelines that just need `Value` in → `Value` out
+- `build_tool_definition()` → registering tools with OpenAI-compatible APIs
+- `build_input_schema()` / `build_output_schema()` → codegen, validation, documentation
 
 ### 2. `Tool` — metadata
 
@@ -290,7 +348,7 @@ Toolkit crates re-export all types needed to implement adapter traits and handle
 
 ```rust
 // mykit/src/lib.rs
-pub use tool::{ToolBuilder, Tool, ToolExecution, ToolOutput, ToolOutputChunk, ToolImage};
+pub use tool::{ToolBuilder, Tool, ToolExecutor, ToolExecution, ToolOutput, ToolOutputChunk, ToolImage};
 pub use error::ToolError;
 pub use adapters::{AdapterTrait, AdapterError, DefaultAdapter};
 // Any types needed to implement AdapterTrait:
@@ -302,16 +360,22 @@ pub use adapters::{SaveResult, Metadata, DirEntry, ...};
 Toolkit crates must not depend on `everruns-core` or any everruns crate. They are standalone libraries. The integration boundary is:
 
 ```
-toolkit crate (standalone)       everruns-core
-├── ToolBuilder (config+locale)  ├── XxxCapability (implements Capability trait)
-├── Tool (metadata+version)      │   └── builds Tool, reads metadata for system prompt
-├── ToolExecution (runtime)      ├── XxxTool (implements everruns Tool trait)
-│   ├── execute()                │   ├── delegates metadata to toolkit Tool
-│   ├── cancel() [optional]      │   ├── creates ToolExecution per call
-│   └── output_stream() [opt]    │   ├── wires cancel/stream to everruns runtime
-├── AdapterTrait                 │   └── maps errors/output to ToolExecutionResult
-├── Error types                  └── AdapterImpl (implements toolkit::AdapterTrait)
-└── Output types                     └── bridges to SessionFileStore, etc.
+toolkit crate (standalone)       everruns-core             other consumers
+├── ToolBuilder                  ├── XxxCapability          ├── build_executor()
+│   ├── build() → Tool           │   └── builds Tool        │   └── Value in → Value out
+│   ├── build_executor()         ├── XxxTool                ├── build_tool_definition()
+│   ├── build_tool_definition()  │   ├── delegates metadata │   └── OpenAI function JSON
+│   ├── build_input_schema()     │   ├── creates Execution  ├── build_input_schema()
+│   └── build_output_schema()    │   ├── wires cancel/stream└── build_output_schema()
+├── Tool (metadata+version)      │   └── maps to everruns
+├── ToolExecutor (Value→Value)   └── AdapterImpl
+├── ToolExecution (stateful)         └── bridges to SessionFileStore
+│   ├── execute()
+│   ├── cancel() [optional]
+│   └── output_stream() [opt]
+├── AdapterTrait
+├── Error types
+└── Output types
 ```
 
 ## Consumer integration pattern
@@ -423,6 +487,9 @@ fn map_error(e: mykit::ToolError) -> ToolExecutionResult {
 | both | No `locale()` on builder | Add; default `"en-US"`, thread through to description/system_prompt/errors |
 | both | No `display_name()` on Tool | Add; return localized human-readable name |
 | both | No `version()` on Tool | Add; return `env!("CARGO_PKG_VERSION")` |
+| both | No `build_tool_definition()` | Add; return OpenAI function call JSON |
+| both | No `build_output_schema()` | Add; describe shape of result JSON |
+| both | No `build_executor()` | Add; return `ToolExecutor` for generic Value→Value usage |
 | bashkit | No `ToolBuilder` — uses `BashTool::builder()` (naming) | Rename to `ToolBuilder` for consistency |
 | bashkit | No `input_schema()` on Tool | Add method; remove hardcoded schema from `virtual_bash.rs` |
 | bashkit | No `ToolExecution` — uses separate `Bash` struct | Wrap `Bash` in `ToolExecution`; `execute()` creates interpreter internally |

--- a/specs/toolkit-library-contract.md
+++ b/specs/toolkit-library-contract.md
@@ -687,34 +687,10 @@ fn map_error(e: mykit::ToolError) -> ToolExecutionResult {
 }
 ```
 
-## Current gaps
+## Existing implementations
 
-| Library | Gap | Migration |
-|---------|-----|-----------|
-| both | No `locale()` on builder | Add; default `"en-US"`, thread through to description/system_prompt/errors |
-| both | No `display_name()` on Tool | Add; return localized human-readable name |
-| both | No `version()` on Tool | Add; return `env!("CARGO_PKG_VERSION")` |
-| both | No `build_tool_definition()` | Add; return OpenAI function call JSON |
-| both | No `build_output_schema()` | Add; describe shape of result JSON |
-| both | No `build_service()` | Add; return `impl Service<Value>` for generic callable usage |
-| both | No `help()` on Tool | Add; render comprehensive Markdown |
-| both | No `ToolOutputMetadata` | Add; return duration + kit-specific extras |
-| both | Verbose descriptions/schemas | Trim per token budget rules |
-| both | Error messages expose internals | Rewrite to be actionable, no internal details |
-| bashkit | No `ToolBuilder` — uses `BashTool::builder()` (naming) | Rename to `ToolBuilder` for consistency |
-| bashkit | No `input_schema()` on Tool | Add method; remove hardcoded schema from `virtual_bash.rs` |
-| bashkit | No `ToolExecution` — uses separate `Bash` struct | Wrap `Bash` in `ToolExecution`; `execute()` creates interpreter internally |
-| bashkit | `system_prompt()` naming OK — fetchkit uses `llmtxt()` | Standardize on `system_prompt()` for both |
-| bashkit | No `name()` on Tool | Add; return `"bash"` |
-| bashkit | No structured `ToolOutput` — returns raw stdout/stderr | Wrap in `ToolOutput { result: json!({...}), images: vec![] }` |
-| bashkit | Has natural cancel/stream support (interpreter is stateful) | Expose via `ToolExecution::cancel()` and `output_stream()` |
-| fetchkit | `Tool::builder()` naming OK but returns unnamed builder type | Expose as `ToolBuilder` |
-| fetchkit | Uses `llmtxt()` instead of `system_prompt()` | Rename (or alias) to `system_prompt()` |
-| fetchkit | `execute()` takes `FetchRequest`, not `Value` | Parse `Value` → `FetchRequest` inside `ToolExecution::execute()` |
-| fetchkit | Error enum doesn't have `is_user_facing()` | Add method; currently all errors are user-facing |
-| fetchkit | No `name()` on Tool | Add; return `"web_fetch"` |
-| fetchkit | No structured `ToolOutput` | Wrap response in `ToolOutput` |
-| fetchkit | No `ToolExecution` — `execute()` lives on `Tool` | Move to `ToolExecution`; streaming progress is a natural fit |
+- **bashkit** — `github.com/everruns/bashkit` (bash sandbox tool, cancel + streaming)
+- **fetchkit** — `crates.io/crates/fetchkit` (HTTP fetch tool, file saver adapter)
 
 ## Non-goals
 

--- a/specs/toolkit-library-contract.md
+++ b/specs/toolkit-library-contract.md
@@ -36,6 +36,7 @@ Every `*kit` library exposes a `ToolBuilder` for configuration:
 
 ```rust
 let builder = mykit::ToolBuilder::new()
+    .locale("en-US")
     .some_feature(true)
     .some_limit(1000);
 
@@ -45,6 +46,21 @@ let tool = builder.build();
 `ToolBuilder` methods are chainable. `build()` consumes the builder and returns a `Tool`.
 
 `ToolBuilder` need not be `Send + Sync`.
+
+#### Required builder methods
+
+Every `ToolBuilder` must accept:
+
+```rust
+impl ToolBuilder {
+    /// Set the locale for user-facing text (description, system prompt, error messages).
+    /// BCP 47 language tag (e.g. "en-US", "uk-UA").
+    /// Default: "en-US".
+    fn locale(self, locale: &str) -> Self;
+}
+```
+
+Kit-specific config methods are added alongside `locale()`.
 
 ### 2. `Tool` — metadata
 
@@ -56,8 +72,17 @@ impl Tool {
     /// Snake_case, stable across versions.
     fn name(&self) -> &str;
 
+    /// Human-readable display name for UI (e.g. "Bash", "Web Fetch").
+    /// Localized per builder locale.
+    fn display_name(&self) -> &str;
+
+    /// Semantic version of the toolkit library (e.g. "0.1.8").
+    /// Defaults to the crate version (`env!("CARGO_PKG_VERSION")`).
+    /// Consumer can use this for diagnostics, logging, or compatibility checks.
+    fn version(&self) -> &str;
+
     /// Human-readable description of the tool for the LLM.
-    /// Baked in at build() time from builder config.
+    /// Baked in at build() time from builder config. Localized per builder locale.
     fn description(&self) -> &str;
 
     /// JSON Schema for the tool's input parameters.
@@ -68,13 +93,47 @@ impl Tool {
     /// System prompt content (LLM instructions for using this tool).
     /// Returned as plain text — the consumer wraps it in XML tags.
     /// Returns empty string if no system prompt contribution.
+    /// Localized per builder locale.
     fn system_prompt(&self) -> String;
+
+    /// The locale this tool was built with (e.g. "en-US").
+    fn locale(&self) -> &str;
 }
 ```
 
 `Tool` is `Send + Sync` and cheap to clone (typically `Arc` internals or static data).
 
 **Rationale:** `input_schema()` was missing from bashkit, forcing the consumer to hardcode the schema and keep it in sync manually. All metadata methods must live on `Tool` so the consumer can delegate without duplication.
+
+#### Locale affects
+
+Locale controls the language of human-readable text:
+- `description()` — tool description sent to LLM
+- `display_name()` — UI label
+- `system_prompt()` — LLM instructions
+- Error messages from `ToolError` (user-facing variants)
+
+Locale does **not** affect:
+- `name()` — always English snake_case (LLM contract)
+- `input_schema()` — property names and types are locale-independent
+- `version()` — always semver
+
+#### Examples
+
+```rust
+// English (default)
+let tool = mykit::ToolBuilder::new().build();
+assert_eq!(tool.name(), "web_fetch");
+assert_eq!(tool.display_name(), "Web Fetch");
+assert_eq!(tool.version(), "0.1.3");
+assert!(tool.description().starts_with("Fetch content from a URL"));
+
+// Ukrainian
+let tool_ua = mykit::ToolBuilder::new().locale("uk-UA").build();
+assert_eq!(tool_ua.name(), "web_fetch"); // unchanged
+assert_eq!(tool_ua.display_name(), "Веб-завантаження");
+assert!(tool_ua.description().starts_with("Завантажити вміст за URL"));
+```
 
 ### 3. `ToolExecution` — runtime
 
@@ -244,8 +303,8 @@ Toolkit crates must not depend on `everruns-core` or any everruns crate. They ar
 
 ```
 toolkit crate (standalone)       everruns-core
-├── ToolBuilder (config)         ├── XxxCapability (implements Capability trait)
-├── Tool (metadata)              │   └── builds Tool, reads metadata for system prompt
+├── ToolBuilder (config+locale)  ├── XxxCapability (implements Capability trait)
+├── Tool (metadata+version)      │   └── builds Tool, reads metadata for system prompt
 ├── ToolExecution (runtime)      ├── XxxTool (implements everruns Tool trait)
 │   ├── execute()                │   ├── delegates metadata to toolkit Tool
 │   ├── cancel() [optional]      │   ├── creates ToolExecution per call
@@ -289,9 +348,12 @@ impl Capability for XxxCapability {
 }
 
 /// Helper: config JSON → built Tool
-fn tool_from_config(config: &Value) -> mykit::Tool {
+fn tool_from_config(config: &Value, locale: &str) -> mykit::Tool {
     let feature = config.get("some_feature").and_then(|v| v.as_bool()).unwrap_or(false);
-    mykit::ToolBuilder::new().some_feature(feature).build()
+    mykit::ToolBuilder::new()
+        .locale(locale)
+        .some_feature(feature)
+        .build()
 }
 
 pub struct XxxTool {
@@ -307,6 +369,7 @@ impl XxxTool {
 #[async_trait]
 impl Tool for XxxTool {
     fn name(&self) -> &str { self.kit_tool.name() }
+    fn display_name(&self) -> Option<&str> { Some(self.kit_tool.display_name()) }
     fn description(&self) -> &str { self.kit_tool.description() }
     fn parameters_schema(&self) -> Value { self.kit_tool.input_schema() }
 
@@ -355,6 +418,11 @@ fn map_error(e: mykit::ToolError) -> ToolExecutionResult {
 
 | Library | Gap | Migration |
 |---------|-----|-----------|
+| Library | Gap | Migration |
+|---------|-----|-----------|
+| both | No `locale()` on builder | Add; default `"en-US"`, thread through to description/system_prompt/errors |
+| both | No `display_name()` on Tool | Add; return localized human-readable name |
+| both | No `version()` on Tool | Add; return `env!("CARGO_PKG_VERSION")` |
 | bashkit | No `ToolBuilder` — uses `BashTool::builder()` (naming) | Rename to `ToolBuilder` for consistency |
 | bashkit | No `input_schema()` on Tool | Add method; remove hardcoded schema from `virtual_bash.rs` |
 | bashkit | No `ToolExecution` — uses separate `Bash` struct | Wrap `Bash` in `ToolExecution`; `execute()` creates interpreter internally |

--- a/specs/toolkit-library-contract.md
+++ b/specs/toolkit-library-contract.md
@@ -169,6 +169,12 @@ impl Tool {
 
     /// The locale this tool was built with (e.g. "en-US").
     fn locale(&self) -> &str;
+
+    /// Comprehensive help rendered as Markdown.
+    /// Includes: description, all parameters with types/defaults/constraints,
+    /// usage examples, adapter requirements, error cases, and version.
+    /// Localized per builder locale.
+    fn help(&self) -> String;
 }
 ```
 
@@ -176,11 +182,53 @@ impl Tool {
 
 **Rationale:** `input_schema()` was missing from bashkit, forcing the consumer to hardcode the schema and keep it in sync manually. All metadata methods must live on `Tool` so the consumer can delegate without duplication.
 
+#### `help()` content
+
+`help()` returns a self-contained Markdown document. Expected sections:
+
+```markdown
+# Web Fetch
+
+Fetch content from a URL and return it as text or markdown.
+
+**Version:** 0.1.3
+**Name:** `web_fetch`
+
+## Parameters
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `url` | string | yes | — | URL to fetch (http/https) |
+| `method` | string | no | `"GET"` | HTTP method (`GET` or `HEAD`) |
+| `as_markdown` | boolean | no | `false` | Convert HTML to markdown |
+| `save_to_file` | string | no | — | Path to save response to |
+
+## Examples
+
+\```json
+{"url": "https://example.com", "as_markdown": true}
+\```
+
+## Adapters
+
+- **FileSaver** (optional): Required when `save_to_file` is set.
+  Without it, `save_to_file` returns an error.
+
+## Errors
+
+- `MissingUrl` — `url` parameter not provided
+- `BlockedUrl` — URL blocked by SSRF policy
+- `FirstByteTimeout` — server did not respond within 1 second
+```
+
+The exact sections vary by tool — the contract is that `help()` is comprehensive enough to use the tool without reading source code.
+
 #### Locale affects
 
 Locale controls the language of human-readable text:
 - `description()` — tool description sent to LLM
 - `display_name()` — UI label
+- `help()` — comprehensive help document
 - `system_prompt()` — LLM instructions
 - Error messages from `ToolError` (user-facing variants)
 

--- a/specs/toolkit-library-contract.md
+++ b/specs/toolkit-library-contract.md
@@ -1,0 +1,263 @@
+# Toolkit Library Contract
+
+> Convention for external libraries (bashkit, fetchkit, future *-kit) that expose tools for everruns integration.
+> Not a shared crate — just a contract so all toolkit libraries feel the same to integrate.
+
+## Problem
+
+bashkit and fetchkit diverged in how they expose tool metadata and execution:
+
+| Concern | bashkit | fetchkit |
+|---------|---------|----------|
+| Schema | Not exposed — wrapper hardcodes JSON | `tool.input_schema()` → `Value` |
+| System prompt | `tool.system_prompt()` | `tool.llmtxt()` |
+| Execution | Separate `Bash` struct, not on `Tool` | `tool.execute(req)` on `Tool` |
+| Builder config | `.username()`, `.hostname()`, `.limits()`, `.env()` | `.enable_save_to_file()`, `.block_private_ips()` |
+
+This means each new toolkit requires bespoke integration code in `crates/core/src/capabilities/`. The contract below standardizes the public API shape so the integration side is predictable.
+
+## Contract
+
+### 1. `Tool` struct with builder
+
+Every toolkit library exposes a `Tool` struct constructed via builder:
+
+```rust
+let tool = mykit::Tool::builder()
+    // kit-specific config methods
+    .build();
+```
+
+Builder is the only public constructor. `Tool` is `Send + Sync`.
+
+### 2. Tool metadata methods
+
+Every `Tool` must provide these methods:
+
+```rust
+impl Tool {
+    /// Tool name for LLM invocation (e.g. "bash", "web_fetch").
+    /// Snake_case, stable across versions.
+    fn name(&self) -> &str;
+
+    /// Human-readable description of the tool for the LLM.
+    /// May vary based on builder config (e.g. enabled features change the description).
+    fn description(&self) -> String;
+
+    /// JSON Schema for the tool's input parameters.
+    /// Must be a valid JSON Schema object with `"type": "object"`.
+    /// Adapts to builder config (e.g. optional params appear/disappear).
+    fn input_schema(&self) -> serde_json::Value;
+
+    /// System prompt content (LLM instructions for using this tool).
+    /// Returned as plain text — the consumer wraps it in XML tags.
+    /// Returns empty string if no system prompt contribution.
+    fn system_prompt(&self) -> String;
+}
+```
+
+**Rationale:** `input_schema()` was missing from bashkit, forcing the consumer to hardcode the schema and keep it in sync manually. All three metadata methods must live on the `Tool` so the consumer can delegate without duplication.
+
+### 3. Execution
+
+Every `Tool` provides an async execute method:
+
+```rust
+impl Tool {
+    /// Execute the tool with JSON arguments matching `input_schema()`.
+    /// Returns a kit-specific result type (see §5).
+    async fn execute(&self, args: serde_json::Value) -> Result<ToolOutput, ToolError>;
+}
+```
+
+If the tool needs an adapter (filesystem, file saver, etc.), provide a second method:
+
+```rust
+impl Tool {
+    /// Execute with an injected adapter.
+    async fn execute_with<A: SomeAdapter>(
+        &self,
+        args: serde_json::Value,
+        adapter: &A,
+    ) -> Result<ToolOutput, ToolError>;
+}
+```
+
+The base `execute()` must work without adapters (returning an error or degraded result if the adapter-dependent feature is requested). This lets the consumer call `execute()` in context-free paths and `execute_with()` when context is available.
+
+**bashkit note:** bashkit currently uses a separate `Bash` interpreter struct for execution. Under this contract, `Tool::execute()` would create the interpreter internally. Per-execution config (filesystem adapter, working directory) flows through the args or through `execute_with()`.
+
+### 4. Adapter traits
+
+When a toolkit needs a consumer-provided integration point (filesystem, file saver, HTTP client, etc.), it defines an adapter trait:
+
+```rust
+/// Trait name describes the capability, not the consumer.
+/// e.g. `FileSaver`, `FileSystem` — not `SessionFileSaver`.
+#[async_trait]
+pub trait AdapterTrait: Send + Sync {
+    async fn method(&self, ...) -> Result<..., AdapterError>;
+}
+```
+
+Rules:
+- Trait is defined in the toolkit crate, implemented by the consumer
+- Trait is `Send + Sync` (adapters are shared across async tasks)
+- Trait uses the toolkit's own error type or a dedicated adapter error type
+- Toolkit may ship a default implementation for common cases (e.g. `LocalFileSaver` in fetchkit)
+
+### 5. Error types
+
+Every toolkit defines its own error enum:
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum ToolError {
+    /// Errors safe to show to the LLM (validation, not found, etc.)
+    #[error("...")]
+    UserFacing(String),
+
+    /// Errors that should be hidden from the LLM (internal failures)
+    #[error("...")]
+    Internal(String),
+
+    // Kit-specific variants are fine, but must be classifiable as
+    // user-facing or internal via a method:
+}
+
+impl ToolError {
+    /// Whether this error is safe to show to the LLM.
+    fn is_user_facing(&self) -> bool;
+}
+```
+
+The consumer maps these to `ToolExecutionResult::ToolError` or `ToolExecutionResult::InternalError` using `is_user_facing()`.
+
+### 6. Output type
+
+Execution returns a structured output:
+
+```rust
+pub struct ToolOutput {
+    /// JSON result value
+    pub result: serde_json::Value,
+    /// Optional images (base64 + media type)
+    pub images: Vec<ToolImage>,
+}
+
+pub struct ToolImage {
+    pub base64: String,
+    pub media_type: String,
+}
+```
+
+If the tool never returns images, `images` is always empty. The consumer maps `ToolOutput` to `ToolExecutionResult::Success` or `ToolExecutionResult::SuccessWithImages`.
+
+### 7. Re-exports
+
+Toolkit crates re-export all types needed to implement adapter traits and handle results from `lib.rs`. Consumer code should only need `use mykit::{...}` — no reaching into submodules.
+
+```rust
+// mykit/src/lib.rs
+pub use tool::{Tool, ToolBuilder, ToolOutput, ToolImage};
+pub use error::ToolError;
+pub use adapters::{AdapterTrait, AdapterError, DefaultAdapter};
+// Any types needed to implement AdapterTrait:
+pub use adapters::{SaveResult, Metadata, DirEntry, ...};
+```
+
+### 8. No everruns dependency
+
+Toolkit crates must not depend on `everruns-core` or any everruns crate. They are standalone libraries. The integration boundary is:
+
+```
+toolkit crate (standalone)     everruns-core
+├── Tool (builder, metadata)   ├── XxxCapability (implements Capability trait)
+├── execute()                  ├── XxxTool (implements everruns Tool trait)
+├── AdapterTrait               │   ├── delegates metadata to toolkit::Tool
+├── Error types                │   ├── delegates execution to toolkit::Tool
+└── Output types               │   └── maps errors/output to ToolExecutionResult
+                               └── AdapterImpl (implements toolkit::AdapterTrait)
+                                   └── bridges to SessionFileStore, etc.
+```
+
+## Consumer integration pattern
+
+With this contract, every capability wrapper follows the same structure:
+
+```rust
+// crates/core/src/capabilities/xxx.rs
+
+use mykit;
+
+pub struct XxxCapability;
+
+impl Capability for XxxCapability {
+    fn id(&self) -> &str { "xxx" }
+    fn name(&self) -> &str { "Xxx" }
+    fn description(&self) -> &str { mykit::TOOL_DESCRIPTION } // or constant
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![Box::new(XxxTool::new())]
+    }
+
+    fn system_prompt_preview(&self) -> Option<String> {
+        Some(mykit::Tool::builder().build().system_prompt())
+    }
+
+    async fn system_prompt_contribution_with_config(
+        &self, _ctx: &SystemPromptContext, config: &Value,
+    ) -> Option<String> {
+        let tool = build_from_config(config);
+        Some(format!("<capability id=\"{}\">\n{}\n</capability>", self.id(), tool.system_prompt()))
+    }
+}
+
+pub struct XxxTool {
+    kit_tool: mykit::Tool,
+}
+
+#[async_trait]
+impl Tool for XxxTool {
+    fn name(&self) -> &str { self.kit_tool.name() }
+    fn description(&self) -> &str { &self.description }
+    fn parameters_schema(&self) -> Value { self.kit_tool.input_schema() }
+
+    async fn execute(&self, args: Value) -> ToolExecutionResult {
+        match self.kit_tool.execute(args).await {
+            Ok(output) => ToolExecutionResult::success(output.result),
+            Err(e) if e.is_user_facing() => ToolExecutionResult::tool_error(e.to_string()),
+            Err(e) => ToolExecutionResult::internal_error_msg(e.to_string()),
+        }
+    }
+
+    async fn execute_with_context(&self, args: Value, ctx: &ToolContext) -> ToolExecutionResult {
+        let adapter = MyAdapter::from_context(ctx);
+        match self.kit_tool.execute_with(args, &adapter).await {
+            Ok(output) => map_output(output),
+            Err(e) => map_error(e),
+        }
+    }
+}
+```
+
+## Current gaps
+
+| Library | Gap | Migration |
+|---------|-----|-----------|
+| bashkit | No `input_schema()` on Tool | Add method; remove hardcoded schema from `virtual_bash.rs` |
+| bashkit | No `execute()` on Tool — uses separate `Bash` struct | Add `execute()` / `execute_with()` that wraps `Bash` internally |
+| bashkit | `system_prompt()` naming OK — fetchkit uses `llmtxt()` | Standardize on `system_prompt()` for both |
+| bashkit | No `name()` on Tool | Add; return `"bash"` |
+| bashkit | No structured `ToolOutput` — returns raw stdout/stderr | Wrap in `ToolOutput { result: json!({...}), images: vec![] }` |
+| fetchkit | Uses `llmtxt()` instead of `system_prompt()` | Rename (or alias) to `system_prompt()` |
+| fetchkit | `execute()` takes `FetchRequest`, not `Value` | Add `Value`-based overload or keep `FetchRequest` and document parse step |
+| fetchkit | Error enum doesn't have `is_user_facing()` | Add method; currently all errors are user-facing |
+| fetchkit | No `name()` on Tool | Add; return `"web_fetch"` |
+| fetchkit | No structured `ToolOutput` | Wrap response in `ToolOutput` |
+
+## Non-goals
+
+- **Shared trait crate**: No `toolkit-common` dependency. Each kit defines its own types following the same shape. This avoids coupling kit release cycles.
+- **Generic tool registration**: The consumer still writes a thin `XxxCapability` + `XxxTool` wrapper. The contract just makes that wrapper predictable and mechanical.
+- **Versioning contract**: Kits version independently. Breaking changes to the contract surface are communicated via this spec, not semver of a shared crate.

--- a/specs/toolkit-library-contract.md
+++ b/specs/toolkit-library-contract.md
@@ -74,10 +74,11 @@ impl ToolBuilder {
     /// Build the full Tool (metadata + execution factory).
     fn build(&self) -> Tool;
 
-    /// Build a standalone executor: accepts JSON args, returns JSON result.
+    /// Build a `tower::Service` that accepts JSON args and returns JSON result.
     /// No metadata attached — useful for embedding in generic pipelines,
     /// test harnesses, or consumers that manage tool definitions separately.
-    fn build_executor(&self) -> ToolExecutor;
+    /// Implements `tower::Service<Value, Response = Value, Error = ToolError>`.
+    fn build_service(&self) -> impl Service<Value, Response = Value, Error = ToolError>;
 
     /// Build an OpenAI-compatible function tool definition.
     /// Returns JSON matching the OpenAI `tools` array element format:
@@ -95,28 +96,40 @@ impl ToolBuilder {
 }
 ```
 
-**`ToolExecutor`** is a minimal, stateless executor:
+**`build_service()`** returns a standard `tower::Service` — the Rust equivalent of Python's callable protocol (`__call__`). This is the community-standard async request→response interface. Any tower middleware (timeout, retry, rate-limit, tracing) works out of the box.
 
 ```rust
-pub struct ToolExecutor { /* internal */ }
+use tower::Service;
 
-impl ToolExecutor {
-    /// Execute with JSON args, return JSON result.
-    /// No ToolExecution indirection — fire-and-forget for simple consumers.
-    async fn execute(&self, args: serde_json::Value) -> Result<serde_json::Value, ToolError>;
+let mut svc = mykit::ToolBuilder::new()
+    .some_feature(true)
+    .build_service();
 
-    /// Execute with an adapter.
-    async fn execute_with<A: SomeAdapter>(
+// Standard Service::call — just like Python's callable
+let result: Value = svc.call(json!({"url": "https://example.com"})).await?;
+
+// Compose with tower middleware
+use tower::ServiceBuilder;
+let svc = ServiceBuilder::new()
+    .timeout(Duration::from_secs(30))
+    .service(mykit::ToolBuilder::new().build_service());
+```
+
+Toolkits that need adapter injection provide a `ServiceBuilder`-style layer or a second factory method:
+
+```rust
+impl ToolBuilder {
+    /// Build a service with an adapter injected.
+    fn build_service_with<A: SomeAdapter>(
         &self,
-        args: serde_json::Value,
-        adapter: &A,
-    ) -> Result<serde_json::Value, ToolError>;
+        adapter: A,
+    ) -> impl Service<Value, Response = Value, Error = ToolError>;
 }
 ```
 
 **When to use which:**
 - `build()` → everruns integration (full metadata + `ToolExecution` with cancel/stream)
-- `build_executor()` → test harnesses, scripts, pipelines that just need `Value` in → `Value` out
+- `build_service()` → generic async callable, tower middleware composition, test harnesses
 - `build_tool_definition()` → registering tools with OpenAI-compatible APIs
 - `build_input_schema()` / `build_output_schema()` → codegen, validation, documentation
 
@@ -348,7 +361,7 @@ Toolkit crates re-export all types needed to implement adapter traits and handle
 
 ```rust
 // mykit/src/lib.rs
-pub use tool::{ToolBuilder, Tool, ToolExecutor, ToolExecution, ToolOutput, ToolOutputChunk, ToolImage};
+pub use tool::{ToolBuilder, Tool, ToolExecution, ToolOutput, ToolOutputChunk, ToolImage};
 pub use error::ToolError;
 pub use adapters::{AdapterTrait, AdapterError, DefaultAdapter};
 // Any types needed to implement AdapterTrait:
@@ -489,7 +502,7 @@ fn map_error(e: mykit::ToolError) -> ToolExecutionResult {
 | both | No `version()` on Tool | Add; return `env!("CARGO_PKG_VERSION")` |
 | both | No `build_tool_definition()` | Add; return OpenAI function call JSON |
 | both | No `build_output_schema()` | Add; describe shape of result JSON |
-| both | No `build_executor()` | Add; return `ToolExecutor` for generic Value→Value usage |
+| both | No `build_service()` | Add; return `impl Service<Value>` for generic callable usage |
 | bashkit | No `ToolBuilder` — uses `BashTool::builder()` (naming) | Rename to `ToolBuilder` for consistency |
 | bashkit | No `input_schema()` on Tool | Add method; remove hardcoded schema from `virtual_bash.rs` |
 | bashkit | No `ToolExecution` — uses separate `Bash` struct | Wrap `Bash` in `ToolExecution`; `execute()` creates interpreter internally |

--- a/specs/toolkit-library-contract.md
+++ b/specs/toolkit-library-contract.md
@@ -18,44 +18,41 @@ This means each new toolkit requires bespoke integration code in `crates/core/sr
 
 ## Contract
 
-### 1. `ToolBuilder` — the primary API for everruns
+### 1. `ToolBuilder` and `Tool`
 
-The `ToolBuilder` is the main integration surface. everruns constructs tool builders (often at init time), configures them, and calls metadata/execution methods directly on the builder or on the `Tool` it produces.
-
-Every `*kit` library exposes a `ToolBuilder` with kit-specific config methods:
+Every `*kit` library exposes a `ToolBuilder` for configuration and a `Tool` as the built artifact.
 
 ```rust
+// ToolBuilder: config only
 let builder = mykit::ToolBuilder::new()
-    // kit-specific config methods
     .some_feature(true)
     .some_limit(1000);
 
-// Metadata is available on the builder (no need to build first)
-let schema = builder.input_schema();
-let prompt = builder.system_prompt();
-
-// Build produces an immutable, executable Tool
+// build() produces an immutable Tool
 let tool = builder.build();
+
+// Metadata lives on Tool (not builder)
+let schema = tool.input_schema();
+let prompt = tool.system_prompt();
 ```
 
 `ToolBuilder` methods are chainable. `build()` consumes the builder and returns a `Tool`.
 
-Both `ToolBuilder` and `Tool` are `Send + Sync`.
+`Tool` is `Send + Sync`. `ToolBuilder` need not be.
 
 ### 2. Tool metadata methods
 
-Available on both `ToolBuilder` (for pre-build introspection) and `Tool` (post-build):
+All metadata lives on `Tool`:
 
 ```rust
-// On ToolBuilder and Tool
-impl {
+impl Tool {
     /// Tool name for LLM invocation (e.g. "bash", "web_fetch").
     /// Snake_case, stable across versions.
     fn name(&self) -> &str;
 
     /// Human-readable description of the tool for the LLM.
-    /// May vary based on builder config (e.g. enabled features change the description).
-    fn description(&self) -> String;
+    /// Baked in at build() time from builder config.
+    fn description(&self) -> &str;
 
     /// JSON Schema for the tool's input parameters.
     /// Must be a valid JSON Schema object with `"type": "object"`.
@@ -69,9 +66,9 @@ impl {
 }
 ```
 
-**Why on builder too:** everruns needs metadata at capability-collection time to generate system prompts and tool definitions. The builder config affects metadata (e.g. `enable_save_to_file` changes the schema and description). Having metadata on the builder avoids building a throwaway `Tool` just to read the schema.
+Builder config bakes into `Tool` at `build()` time. The consumer builds the `Tool` once and reads metadata + executes from the same object.
 
-**Rationale:** `input_schema()` was missing from bashkit, forcing the consumer to hardcode the schema and keep it in sync manually. All metadata methods must live on the builder/tool so the consumer can delegate without duplication.
+**Rationale:** `input_schema()` was missing from bashkit, forcing the consumer to hardcode the schema and keep it in sync manually. All metadata methods must live on `Tool` so the consumer can delegate without duplication.
 
 ### 3. `Tool` — execution
 
@@ -187,12 +184,11 @@ Toolkit crates must not depend on `everruns-core` or any everruns crate. They ar
 
 ```
 toolkit crate (standalone)     everruns-core
-├── ToolBuilder (config+meta)  ├── XxxCapability (implements Capability trait)
-├── Tool (execute)             │   ├── uses ToolBuilder for metadata + system prompt
-├── AdapterTrait               │   └── builds Tool for execution
-├── Error types                ├── XxxTool (implements everruns Tool trait)
-└── Output types               │   ├── delegates metadata to toolkit ToolBuilder/Tool
-                               │   ├── delegates execution to toolkit Tool
+├── ToolBuilder (config)       ├── XxxCapability (implements Capability trait)
+├── Tool (metadata+execute)    │   └── builds Tool, reads metadata for system prompt
+├── AdapterTrait               ├── XxxTool (implements everruns Tool trait)
+├── Error types                │   ├── delegates metadata to toolkit Tool
+└── Output types               │   ├── delegates execution to toolkit Tool
                                │   └── maps errors/output to ToolExecutionResult
                                └── AdapterImpl (implements toolkit::AdapterTrait)
                                    └── bridges to SessionFileStore, etc.
@@ -219,43 +215,39 @@ impl Capability for XxxCapability {
     }
 
     fn system_prompt_preview(&self) -> Option<String> {
-        // Builder metadata without building a Tool — preview with all features enabled
-        Some(mykit::ToolBuilder::new().some_feature(true).system_prompt())
+        // Build with all features enabled for preview
+        let tool = mykit::ToolBuilder::new().some_feature(true).build();
+        Some(tool.system_prompt())
     }
 
     async fn system_prompt_contribution_with_config(
         &self, _ctx: &SystemPromptContext, config: &Value,
     ) -> Option<String> {
-        // Builder reads config, generates config-aware system prompt
-        let builder = builder_from_config(config);
-        Some(format!("<capability id=\"{}\">\n{}\n</capability>", self.id(), builder.system_prompt()))
+        let tool = tool_from_config(config);
+        Some(format!("<capability id=\"{}\">\n{}\n</capability>", self.id(), tool.system_prompt()))
     }
 }
 
-/// Helper: config JSON → ToolBuilder
-fn builder_from_config(config: &Value) -> mykit::ToolBuilder {
+/// Helper: config JSON → built Tool
+fn tool_from_config(config: &Value) -> mykit::Tool {
     let feature = config.get("some_feature").and_then(|v| v.as_bool()).unwrap_or(false);
-    mykit::ToolBuilder::new().some_feature(feature)
+    mykit::ToolBuilder::new().some_feature(feature).build()
 }
 
 pub struct XxxTool {
     kit_tool: mykit::Tool,
-    description: String,
 }
 
 impl XxxTool {
     fn new(config: &Value) -> Self {
-        let builder = builder_from_config(config);
-        let description = builder.description();
-        let kit_tool = builder.build();
-        Self { kit_tool, description }
+        Self { kit_tool: tool_from_config(config) }
     }
 }
 
 #[async_trait]
 impl Tool for XxxTool {
     fn name(&self) -> &str { self.kit_tool.name() }
-    fn description(&self) -> &str { &self.description }
+    fn description(&self) -> &str { self.kit_tool.description() }
     fn parameters_schema(&self) -> Value { self.kit_tool.input_schema() }
 
     async fn execute(&self, args: Value) -> ToolExecutionResult {
@@ -281,16 +273,16 @@ impl Tool for XxxTool {
 | Library | Gap | Migration |
 |---------|-----|-----------|
 | bashkit | No `ToolBuilder` — uses `BashTool::builder()` (naming) | Rename to `ToolBuilder` for consistency |
-| bashkit | No `input_schema()` on builder or Tool | Add method; remove hardcoded schema from `virtual_bash.rs` |
+| bashkit | No `input_schema()` on Tool | Add method; remove hardcoded schema from `virtual_bash.rs` |
 | bashkit | No `execute()` on Tool — uses separate `Bash` struct | Add `execute()` / `execute_with()` that wraps `Bash` internally |
 | bashkit | `system_prompt()` naming OK — fetchkit uses `llmtxt()` | Standardize on `system_prompt()` for both |
-| bashkit | No `name()` on builder or Tool | Add; return `"bash"` |
+| bashkit | No `name()` on Tool | Add; return `"bash"` |
 | bashkit | No structured `ToolOutput` — returns raw stdout/stderr | Wrap in `ToolOutput { result: json!({...}), images: vec![] }` |
 | fetchkit | `Tool::builder()` naming OK but returns unnamed builder type | Expose as `ToolBuilder` |
 | fetchkit | Uses `llmtxt()` instead of `system_prompt()` | Rename (or alias) to `system_prompt()` |
 | fetchkit | `execute()` takes `FetchRequest`, not `Value` | Add `Value`-based overload or keep `FetchRequest` and document parse step |
 | fetchkit | Error enum doesn't have `is_user_facing()` | Add method; currently all errors are user-facing |
-| fetchkit | No `name()` on builder or Tool | Add; return `"web_fetch"` |
+| fetchkit | No `name()` on Tool | Add; return `"web_fetch"` |
 | fetchkit | No structured `ToolOutput` | Wrap response in `ToolOutput` |
 
 ## Non-goals

--- a/specs/toolkit-library-contract.md
+++ b/specs/toolkit-library-contract.md
@@ -1,6 +1,6 @@
 # Toolkit Library Contract
 
-> Convention for external libraries (bashkit, fetchkit, future *-kit) that expose tools for everruns integration.
+> Convention for external `*kit` libraries (bashkit, fetchkit, future kits) that expose tools for everruns integration.
 > Not a shared crate — just a contract so all toolkit libraries feel the same to integrate.
 
 ## Problem
@@ -18,24 +18,37 @@ This means each new toolkit requires bespoke integration code in `crates/core/sr
 
 ## Contract
 
-### 1. `Tool` struct with builder
+### 1. `ToolBuilder` — the primary API for everruns
 
-Every toolkit library exposes a `Tool` struct constructed via builder:
+The `ToolBuilder` is the main integration surface. everruns constructs tool builders (often at init time), configures them, and calls metadata/execution methods directly on the builder or on the `Tool` it produces.
+
+Every `*kit` library exposes a `ToolBuilder` with kit-specific config methods:
 
 ```rust
-let tool = mykit::Tool::builder()
+let builder = mykit::ToolBuilder::new()
     // kit-specific config methods
-    .build();
+    .some_feature(true)
+    .some_limit(1000);
+
+// Metadata is available on the builder (no need to build first)
+let schema = builder.input_schema();
+let prompt = builder.system_prompt();
+
+// Build produces an immutable, executable Tool
+let tool = builder.build();
 ```
 
-Builder is the only public constructor. `Tool` is `Send + Sync`.
+`ToolBuilder` methods are chainable. `build()` consumes the builder and returns a `Tool`.
+
+Both `ToolBuilder` and `Tool` are `Send + Sync`.
 
 ### 2. Tool metadata methods
 
-Every `Tool` must provide these methods:
+Available on both `ToolBuilder` (for pre-build introspection) and `Tool` (post-build):
 
 ```rust
-impl Tool {
+// On ToolBuilder and Tool
+impl {
     /// Tool name for LLM invocation (e.g. "bash", "web_fetch").
     /// Snake_case, stable across versions.
     fn name(&self) -> &str;
@@ -56,11 +69,13 @@ impl Tool {
 }
 ```
 
-**Rationale:** `input_schema()` was missing from bashkit, forcing the consumer to hardcode the schema and keep it in sync manually. All three metadata methods must live on the `Tool` so the consumer can delegate without duplication.
+**Why on builder too:** everruns needs metadata at capability-collection time to generate system prompts and tool definitions. The builder config affects metadata (e.g. `enable_save_to_file` changes the schema and description). Having metadata on the builder avoids building a throwaway `Tool` just to read the schema.
 
-### 3. Execution
+**Rationale:** `input_schema()` was missing from bashkit, forcing the consumer to hardcode the schema and keep it in sync manually. All metadata methods must live on the builder/tool so the consumer can delegate without duplication.
 
-Every `Tool` provides an async execute method:
+### 3. `Tool` — execution
+
+`Tool` is the built, immutable, executable artifact. Every `Tool` provides an async execute method:
 
 ```rust
 impl Tool {
@@ -159,7 +174,7 @@ Toolkit crates re-export all types needed to implement adapter traits and handle
 
 ```rust
 // mykit/src/lib.rs
-pub use tool::{Tool, ToolBuilder, ToolOutput, ToolImage};
+pub use tool::{ToolBuilder, Tool, ToolOutput, ToolImage};
 pub use error::ToolError;
 pub use adapters::{AdapterTrait, AdapterError, DefaultAdapter};
 // Any types needed to implement AdapterTrait:
@@ -172,11 +187,13 @@ Toolkit crates must not depend on `everruns-core` or any everruns crate. They ar
 
 ```
 toolkit crate (standalone)     everruns-core
-├── Tool (builder, metadata)   ├── XxxCapability (implements Capability trait)
-├── execute()                  ├── XxxTool (implements everruns Tool trait)
-├── AdapterTrait               │   ├── delegates metadata to toolkit::Tool
-├── Error types                │   ├── delegates execution to toolkit::Tool
-└── Output types               │   └── maps errors/output to ToolExecutionResult
+├── ToolBuilder (config+meta)  ├── XxxCapability (implements Capability trait)
+├── Tool (execute)             │   ├── uses ToolBuilder for metadata + system prompt
+├── AdapterTrait               │   └── builds Tool for execution
+├── Error types                ├── XxxTool (implements everruns Tool trait)
+└── Output types               │   ├── delegates metadata to toolkit ToolBuilder/Tool
+                               │   ├── delegates execution to toolkit Tool
+                               │   └── maps errors/output to ToolExecutionResult
                                └── AdapterImpl (implements toolkit::AdapterTrait)
                                    └── bridges to SessionFileStore, etc.
 ```
@@ -195,26 +212,44 @@ pub struct XxxCapability;
 impl Capability for XxxCapability {
     fn id(&self) -> &str { "xxx" }
     fn name(&self) -> &str { "Xxx" }
-    fn description(&self) -> &str { mykit::TOOL_DESCRIPTION } // or constant
+    fn description(&self) -> &str { "..." }
 
-    fn tools(&self) -> Vec<Box<dyn Tool>> {
-        vec![Box::new(XxxTool::new())]
+    fn tools_with_config(&self, config: &Value) -> Vec<Box<dyn Tool>> {
+        vec![Box::new(XxxTool::new(config))]
     }
 
     fn system_prompt_preview(&self) -> Option<String> {
-        Some(mykit::Tool::builder().build().system_prompt())
+        // Builder metadata without building a Tool — preview with all features enabled
+        Some(mykit::ToolBuilder::new().some_feature(true).system_prompt())
     }
 
     async fn system_prompt_contribution_with_config(
         &self, _ctx: &SystemPromptContext, config: &Value,
     ) -> Option<String> {
-        let tool = build_from_config(config);
-        Some(format!("<capability id=\"{}\">\n{}\n</capability>", self.id(), tool.system_prompt()))
+        // Builder reads config, generates config-aware system prompt
+        let builder = builder_from_config(config);
+        Some(format!("<capability id=\"{}\">\n{}\n</capability>", self.id(), builder.system_prompt()))
     }
+}
+
+/// Helper: config JSON → ToolBuilder
+fn builder_from_config(config: &Value) -> mykit::ToolBuilder {
+    let feature = config.get("some_feature").and_then(|v| v.as_bool()).unwrap_or(false);
+    mykit::ToolBuilder::new().some_feature(feature)
 }
 
 pub struct XxxTool {
     kit_tool: mykit::Tool,
+    description: String,
+}
+
+impl XxxTool {
+    fn new(config: &Value) -> Self {
+        let builder = builder_from_config(config);
+        let description = builder.description();
+        let kit_tool = builder.build();
+        Self { kit_tool, description }
+    }
 }
 
 #[async_trait]
@@ -245,15 +280,17 @@ impl Tool for XxxTool {
 
 | Library | Gap | Migration |
 |---------|-----|-----------|
-| bashkit | No `input_schema()` on Tool | Add method; remove hardcoded schema from `virtual_bash.rs` |
+| bashkit | No `ToolBuilder` — uses `BashTool::builder()` (naming) | Rename to `ToolBuilder` for consistency |
+| bashkit | No `input_schema()` on builder or Tool | Add method; remove hardcoded schema from `virtual_bash.rs` |
 | bashkit | No `execute()` on Tool — uses separate `Bash` struct | Add `execute()` / `execute_with()` that wraps `Bash` internally |
 | bashkit | `system_prompt()` naming OK — fetchkit uses `llmtxt()` | Standardize on `system_prompt()` for both |
-| bashkit | No `name()` on Tool | Add; return `"bash"` |
+| bashkit | No `name()` on builder or Tool | Add; return `"bash"` |
 | bashkit | No structured `ToolOutput` — returns raw stdout/stderr | Wrap in `ToolOutput { result: json!({...}), images: vec![] }` |
+| fetchkit | `Tool::builder()` naming OK but returns unnamed builder type | Expose as `ToolBuilder` |
 | fetchkit | Uses `llmtxt()` instead of `system_prompt()` | Rename (or alias) to `system_prompt()` |
 | fetchkit | `execute()` takes `FetchRequest`, not `Value` | Add `Value`-based overload or keep `FetchRequest` and document parse step |
 | fetchkit | Error enum doesn't have `is_user_facing()` | Add method; currently all errors are user-facing |
-| fetchkit | No `name()` on Tool | Add; return `"web_fetch"` |
+| fetchkit | No `name()` on builder or Tool | Add; return `"web_fetch"` |
 | fetchkit | No structured `ToolOutput` | Wrap response in `ToolOutput` |
 
 ## Non-goals


### PR DESCRIPTION
## What
New spec `specs/toolkit-library-contract.md` defining the public API contract for external `*kit` toolkit libraries (bashkit, fetchkit, future kits).

## Why
bashkit and fetchkit diverged in how they expose tool metadata and execution, requiring bespoke integration code for each. This spec standardizes the shape so integration is predictable and mechanical.

## How
Defines a three-object contract: `ToolBuilder` (config) → `Tool` (metadata) → `ToolExecution` (runtime). Key design decisions:
- Token budget rules for `description()`, `system_prompt()`, and `input_schema()` to minimize LLM cost
- `ToolOutputMetadata` for consumer-side data (duration, http_status, exit_code) that never reaches the LLM
- Actionable, localized error messages with no internal details exposed
- `tower::Service` integration via `build_service()`
- Cancel + streaming support for long-running tools
- Adapter traits for consumer-provided integrations (filesystem, file saver)
- Links to bashkit and fetchkit as reference implementations

## Risk
- Low
- Spec only — no code changes. Existing toolkits are not yet migrated.

## Checklist
- [x] Tests added or updated — N/A (spec only)
- [x] Backward compatibility considered — N/A (new spec, no existing contract)