### PR TITLE
fix(openui): add error boundary around Renderer for malformed ElementNode objects

### DIFF
--- a/apps/ui/src/components/chat/openui-renderer.tsx
+++ b/apps/ui/src/components/chat/openui-renderer.tsx
@@ -7,6 +7,12 @@
  * to parse and render OpenUI Lang DSL code into React components (charts, tables,
  * forms, cards, etc.).
  *
+ * Wraps the Renderer in an error boundary to catch "Objects are not valid as a
+ * React child" errors that occur when the LLM generates malformed OpenUI code
+ * (e.g. passing an element where a string prop is expected). The parser doesn't
+ * validate prop types, so these objects leak through as raw {type, typeName,
+ * props, partial} ElementNode objects.
+ *
  * @see specs/openui.md
  * @see https://github.com/thesysdev/openui
  */
@@ -14,12 +20,55 @@
 import { Renderer } from "@openuidev/react-lang";
 import { openuiLibrary } from "@openuidev/react-ui/genui-lib";
 import "@openuidev/react-ui/components.css";
+import { Component, type ErrorInfo, type ReactNode } from "react";
 
 interface OpenUIBlockProps {
   /** Raw OpenUI Lang code (without the ```openui fences) */
   code: string;
   /** Whether the LLM is still streaming this content */
   isStreaming?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Error boundary – catches render errors from the Renderer (e.g. untyped
+// ElementNode objects rendered as React children).
+// ---------------------------------------------------------------------------
+
+interface EBProps {
+  children: ReactNode;
+  fallback: ReactNode;
+}
+interface EBState {
+  hasError: boolean;
+}
+
+class OpenUIErrorBoundary extends Component<EBProps, EBState> {
+  constructor(props: EBProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): EBState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.warn("[openui] Render error caught by boundary:", error.message, info.componentStack);
+  }
+
+  componentDidUpdate(prevProps: EBProps) {
+    // Reset when children change (new code / streaming update)
+    if (this.state.hasError && prevProps.children !== this.props.children) {
+      this.setState({ hasError: false });
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+    return this.props.children;
+  }
 }
 
 /**
@@ -34,9 +83,17 @@ interface OpenUIBlockProps {
 export function OpenUIBlock({ code, isStreaming = false }: OpenUIBlockProps) {
   if (!code.trim()) return null;
 
+  const fallback = (
+    <pre className="overflow-x-auto p-4 text-xs text-muted-foreground">
+      <code>{code}</code>
+    </pre>
+  );
+
   return (
     <div className="openui-block my-2 overflow-hidden rounded-lg border border-border bg-card">
-      <Renderer response={code} library={openuiLibrary} isStreaming={isStreaming} />
+      <OpenUIErrorBoundary fallback={fallback}>
+        <Renderer response={code} library={openuiLibrary} isStreaming={isStreaming} />
+      </OpenUIErrorBoundary>
     </div>
   );
 }


### PR DESCRIPTION
## What
Add an `OpenUIErrorBoundary` around the `<Renderer>` in `OpenUIBlock` to catch render errors caused by malformed OpenUI Lang output.

## Why
The `@openuidev/react-lang` parser validates only required prop *presence*, not prop *types*. When the LLM generates code placing a component element where a string prop is expected (e.g. `Callout("info", CardHeader("Title"), "desc")`), the raw `{type, typeName, props, partial}` ElementNode object leaks through as a React child. React throws "Objects are not valid as a React child", surfacing in the dev error overlay.

The library internal per-node `ElementErrorBoundary` catches some cases but not all — the error still propagates to the page.

## How
- Added a class-based `OpenUIErrorBoundary` wrapping `<Renderer>` in `OpenUIBlock`
- On error, falls back to displaying the raw OpenUI code in a `<pre>` block
- Resets automatically when children change (new streaming chunk / new code)
- Logs `console.warn` instead of `console.error` since it is a known library limitation

## Risk
- Low
- Worst case: the fallback shows raw code instead of rendered UI for a malformed block. No impact on non-OpenUI rendering paths.

## Checklist
- [x] Tests added or updated — N/A (error boundary is a defensive guard; the trigger depends on LLM output)
- [x] Backward compatibility considered — additive only, no API changes