### PR TITLE
feat(core): add permission resolver contract

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -254,8 +254,9 @@ pub use typed_id::{
 
 // Permissions re-exports
 pub use permissions::{
-    Caller, Permission, Policy, PolicyConfigResponse, PolicyError, ResourceConfigResponse, Rule,
-    evaluate_policies, role_has_permission, role_permissions,
+    Caller, DefaultPermissionResolver, Permission, PermissionResolver, Policy,
+    PolicyConfigResponse, PolicyError, ResourceConfigResponse, Rule, evaluate_policies,
+    evaluate_policies_with, role_has_permission, role_permissions,
 };
 
 // URL validation re-exports

--- a/crates/core/src/permissions.rs
+++ b/crates/core/src/permissions.rs
@@ -1,6 +1,6 @@
 // Permissions model for fine-grained access control
 //
-// Decision: Permissions are hardcoded per OrgRole (no DB storage in phase 1).
+// Decision: Default permissions are hardcoded per OrgRole; custom resolvers can override evaluation.
 // Decision: Policies are const values evaluated at service method entry via #[policy] macro.
 // Decision: Permission format is `org:<resource>:<action>`.
 // See specs/permissions.md for full design.
@@ -149,6 +149,80 @@ pub fn role_permissions(role: OrgRole) -> &'static [Permission] {
     }
 }
 
+/// Contract for resolving which permissions a caller has.
+///
+/// `DefaultPermissionResolver` preserves the OSS role-based mapping, while downstream
+/// consumers can implement this trait to inject billing-tier rules, database-backed
+/// grants, or external RBAC systems without patching policy evaluation itself.
+///
+/// # Contract
+///
+/// Implementations must:
+///
+/// - Fail closed. Return `true` from `has_permission()` only when the caller is
+///   actually authorized.
+/// - Be consistent. If `has_permission(caller, permission)` returns `true`, then
+///   `caller_permissions(caller)` must include that same permission.
+/// - Be safe to call from async request paths (`Send + Sync`).
+///
+/// # Example
+///
+/// ```no_run
+/// use everruns_core::{Caller, Permission, PermissionResolver};
+///
+/// struct TierAwareResolver;
+///
+/// impl PermissionResolver for TierAwareResolver {
+///     fn has_permission(&self, caller: &Caller, permission: &Permission) -> bool {
+///         caller.role == everruns_core::organization::OrgRole::Owner
+///             && permission == &Permission::OrgHarnessesDangerous
+///     }
+///
+///     fn caller_permissions(&self, caller: &Caller) -> Vec<Permission> {
+///         Permission::ALL
+///             .iter()
+///             .copied()
+///             .filter(|permission| self.has_permission(caller, permission))
+///             .collect()
+///     }
+/// }
+/// ```
+pub trait PermissionResolver: Send + Sync {
+    /// Return whether the caller currently has `permission`.
+    ///
+    /// This method is used by `Policy::evaluate_with()` for
+    /// `Rule::UserHasPermission` checks.
+    fn has_permission(&self, caller: &Caller, permission: &Permission) -> bool;
+
+    /// Return the full set of permissions currently granted to `caller`.
+    ///
+    /// Config endpoints and downstream policy-reporting code use this to expose
+    /// evaluated capabilities to a UI. Prefer deterministic ordering so callers
+    /// can compare results reliably.
+    fn caller_permissions(&self, caller: &Caller) -> Vec<Permission>;
+}
+
+/// Default `PermissionResolver` backed by the built-in role-to-permission map.
+///
+/// This preserves the existing OSS behavior by delegating to
+/// `role_has_permission()` and `role_permissions()`.
+///
+/// # Safety
+///
+/// This resolver is stateless and can be shared freely across threads.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DefaultPermissionResolver;
+
+impl PermissionResolver for DefaultPermissionResolver {
+    fn has_permission(&self, caller: &Caller, permission: &Permission) -> bool {
+        role_has_permission(caller.role, permission)
+    }
+
+    fn caller_permissions(&self, caller: &Caller) -> Vec<Permission> {
+        role_permissions(caller.role).to_vec()
+    }
+}
+
 // ============================================================================
 // Rule
 // ============================================================================
@@ -195,10 +269,23 @@ impl Policy {
     /// Evaluate all rules against the caller. Returns `Ok(())` if all pass,
     /// or `Err(PolicyError)` on the first failing rule.
     pub fn evaluate(&self, caller: &Caller) -> Result<(), PolicyError> {
+        let resolver = DefaultPermissionResolver;
+        self.evaluate_with(&resolver, caller)
+    }
+
+    /// Evaluate all rules against the caller using a custom permission resolver.
+    ///
+    /// `Rule::UserHasPermission` checks are delegated to `resolver`, while other
+    /// rule types keep their current built-in behavior.
+    pub fn evaluate_with(
+        &self,
+        resolver: &dyn PermissionResolver,
+        caller: &Caller,
+    ) -> Result<(), PolicyError> {
         for rule in self.rules {
             match rule {
                 Rule::UserHasPermission(perm) => {
-                    if !role_has_permission(caller.role, perm) {
+                    if !resolver.has_permission(caller, perm) {
                         return Err(PolicyError::denied(self.id, perm.as_str()));
                     }
                 }
@@ -297,9 +384,26 @@ impl std::error::Error for PolicyError {}
 /// Evaluate multiple policies against a caller and return a map of results.
 /// Used by `/config` endpoints to expose policy results to the UI.
 pub fn evaluate_policies(caller: &Caller, policies: &[&Policy]) -> HashMap<String, bool> {
+    let resolver = DefaultPermissionResolver;
+    evaluate_policies_with(&resolver, caller, policies)
+}
+
+/// Evaluate multiple policies using a custom permission resolver.
+///
+/// This is the config-endpoint companion to `Policy::evaluate_with()`.
+pub fn evaluate_policies_with(
+    resolver: &dyn PermissionResolver,
+    caller: &Caller,
+    policies: &[&Policy],
+) -> HashMap<String, bool> {
     policies
         .iter()
-        .map(|p| (p.id.to_string(), p.evaluate(caller).is_ok()))
+        .map(|policy| {
+            (
+                policy.id.to_string(),
+                policy.evaluate_with(resolver, caller).is_ok(),
+            )
+        })
         .collect()
 }
 
@@ -490,6 +594,61 @@ mod tests {
         let result = evaluate_policies(&caller, &[&TEST_MANAGE, &TEST_DANGEROUS, &TEST_ROLE_ADMIN]);
 
         assert!(result.values().all(|&v| !v));
+    }
+
+    #[test]
+    fn default_permission_resolver_matches_hardcoded_role_mapping() {
+        let resolver = DefaultPermissionResolver;
+
+        for caller in [owner_caller(), admin_caller(), member_caller()] {
+            for permission in Permission::ALL {
+                assert_eq!(
+                    resolver.has_permission(&caller, permission),
+                    role_has_permission(caller.role, permission)
+                );
+            }
+
+            assert_eq!(
+                resolver.caller_permissions(&caller),
+                role_permissions(caller.role).to_vec()
+            );
+        }
+    }
+
+    struct DenyManageResolver;
+
+    impl PermissionResolver for DenyManageResolver {
+        fn has_permission(&self, _caller: &Caller, permission: &Permission) -> bool {
+            permission != &Permission::OrgHarnessesManage
+        }
+
+        fn caller_permissions(&self, _caller: &Caller) -> Vec<Permission> {
+            Permission::ALL
+                .iter()
+                .copied()
+                .filter(|permission| permission != &Permission::OrgHarnessesManage)
+                .collect()
+        }
+    }
+
+    #[test]
+    fn evaluate_with_uses_custom_permission_resolver() {
+        let caller = owner_caller();
+        let resolver = DenyManageResolver;
+
+        assert!(TEST_MANAGE.evaluate(&caller).is_ok());
+        assert!(TEST_MANAGE.evaluate_with(&resolver, &caller).is_err());
+    }
+
+    #[test]
+    fn evaluate_policies_with_uses_custom_permission_resolver() {
+        let caller = owner_caller();
+        let resolver = DenyManageResolver;
+
+        let result = evaluate_policies_with(&resolver, &caller, &[&TEST_MANAGE, &TEST_DANGEROUS]);
+
+        assert_eq!(result.get("harness.manage"), Some(&false));
+        assert_eq!(result.get("harness.dangerous"), Some(&false));
     }
 
     // -- Permission display --

--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Fine-grained permission system built on top of existing OrgRole hierarchy. Roles grant default permission sets. Policies (sets of rules) enforce access at the service layer. Policy results are exposed to UI via per-resource config endpoints.
+Fine-grained permission system built on top of existing OrgRole hierarchy. Roles grant default permission sets through `DefaultPermissionResolver`. Policies (sets of rules) enforce access at the service layer. Policy results are exposed to UI via per-resource config endpoints. Downstream consumers can override permission resolution with `PermissionResolver` without changing policy definitions.
 
 ## Concepts
 
@@ -66,7 +66,7 @@ Policy {
 
 ## Role → Permission Mapping
 
-Hardcoded. No DB storage (phase 1).
+Default OSS mapping is hardcoded. No DB storage (phase 1).
 
 | Permission | Owner | Admin | Member |
 |------------|-------|-------|--------|
@@ -86,6 +86,22 @@ Hardcoded. No DB storage (phase 1).
 Owner inherits all Admin permissions. Admin inherits all Member permissions.
 
 **Default role:** `Owner` (phase 1). All users get full permissions by default. Future phases will assign roles via invitation/admin UI.
+
+## Permission Resolver Contract
+
+`PermissionResolver` is the extensibility contract between policy evaluation and the source of truth for caller permissions.
+
+- `DefaultPermissionResolver` preserves current OSS behavior by delegating to the hardcoded role map in `crates/core/src/permissions.rs`.
+- Downstream consumers can provide a custom resolver to enforce subscription limits, per-user grants, or external RBAC decisions while reusing the same `Policy` and `Rule` types.
+- Implementations must fail closed: `has_permission()` returns `true` only for real grants.
+- Implementations must stay consistent: if `has_permission(caller, p)` is `true`, then `caller_permissions(caller)` must include `p`.
+- Implementations must be `Send + Sync` so request handlers can share them safely.
+
+Example custom resolvers:
+
+- Billing-tier aware resolver that removes dangerous or premium permissions for lower plans
+- Resolver backed by a per-user grants table
+- Adapter that maps external RBAC roles into OSS `Permission` values
 
 ## Enforcement
 
@@ -123,10 +139,19 @@ pub struct Policy {
 impl Policy {
     /// Returns Ok(()) or Err(PolicyDenied).
     pub fn evaluate(&self, caller: &Caller) -> Result<(), PolicyError> {
+        self.evaluate_with(&DefaultPermissionResolver, caller)
+    }
+
+    /// Evaluate with a custom resolver.
+    pub fn evaluate_with(
+        &self,
+        resolver: &dyn PermissionResolver,
+        caller: &Caller,
+    ) -> Result<(), PolicyError> {
         for rule in self.rules {
             match rule {
                 Rule::UserHasPermission(perm) => {
-                    if !caller.role.has_permission(perm) {
+                    if !resolver.has_permission(caller, perm) {
                         return Err(PolicyError::denied(self.id, rule));
                     }
                 }
@@ -141,6 +166,8 @@ impl Policy {
     }
 }
 ```
+
+Config endpoints can use `evaluate_policies_with(resolver, caller, policies)` when they need policy results derived from a custom resolver instead of the default role map.
 
 ### Declarative Enforcement via `#[policy]` Macro
 
@@ -204,6 +231,8 @@ The proc macro:
 2. Scans the function signature for a parameter with type `&Caller` — extracts its name (usually `caller`)
 3. Prepends `#policy_path.evaluate(#caller_ident)?;` to the function body
 4. Compile error if no `&Caller` parameter found
+
+The macro continues to call `Policy::evaluate()`, which uses `DefaultPermissionResolver`. Custom resolvers are opt-in at explicit call sites; the macro behavior does not change.
 
 ```rust
 // crates/macros/src/lib.rs


### PR DESCRIPTION
## What
- add `PermissionResolver` and `DefaultPermissionResolver` as the public policy-evaluation contract
- add `Policy::evaluate_with()` and `evaluate_policies_with()` while keeping default behavior unchanged
- document the contract in the permissions spec and add resolver-focused unit coverage

## Why
Fixes EVE-90.

Downstream consumers need to customize policy grants without patching the OSS role-to-permission map.

## How
- route permission checks through a resolver trait and keep `evaluate()` on the default role-based resolver
- re-export the new types and helper from `everruns-core`
- prove backward compatibility with tests that compare the default resolver to the existing hardcoded mapping and exercise a mock custom resolver

## Risk
- Low
- Main risk is behavior drift in existing policy checks; covered by the default-resolver equivalence test, custom-resolver tests, and `just pre-push`

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered