### PR TITLE
fix(browserless): block internal network targets

### DIFF
--- a/integrations/browserless/src/lib.rs
+++ b/integrations/browserless/src/lib.rs
@@ -21,6 +21,7 @@ pub mod connection;
 pub mod session_tools;
 pub mod state;
 mod tools;
+mod validation;
 
 use everruns_core::LEASED_RESOURCES_FEATURE;
 use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin, RiskLevel};

--- a/integrations/browserless/src/session_tools.rs
+++ b/integrations/browserless/src/session_tools.rs
@@ -19,6 +19,7 @@ use crate::state::{
     BrowserSessionState, browser_session_external_id, delete_browser_session, get_api_token,
     get_browser_session, save_browser_session,
 };
+use crate::validation::validate_browserless_url;
 
 const BROWSER_SESSION_LEASE_DURATION_SECONDS: u32 = 20 * 60;
 
@@ -198,11 +199,17 @@ impl Tool for BrowserlessOpenBrowserTool {
         };
 
         // Navigate to initial URL if provided
-        if let Some(url) = arguments.get("url").and_then(|v| v.as_str())
-            && let Err(e) = session.navigate(url).await
-        {
-            session.disconnect().await;
-            return ToolExecutionResult::tool_error(format!("Failed to navigate to {url}: {e}"));
+        if let Some(url) = arguments.get("url").and_then(|v| v.as_str()) {
+            if let Err(e) = validate_browserless_url(url) {
+                session.disconnect().await;
+                return e;
+            }
+            if let Err(e) = session.navigate(url).await {
+                session.disconnect().await;
+                return ToolExecutionResult::tool_error(format!(
+                    "Failed to navigate to {url}: {e}"
+                ));
+            }
         }
 
         let title = session.get_title().await.unwrap_or_default();

--- a/integrations/browserless/src/tools.rs
+++ b/integrations/browserless/src/tools.rs
@@ -21,6 +21,7 @@ use tracing::debug;
 use crate::client::BrowserlessClient;
 use crate::session_tools::{keep_session_alive, try_get_cdp_session};
 use crate::state::{get_api_token, required_str};
+use crate::validation::{validate_browserless_url, validate_interaction_steps};
 
 const MAX_HTML_BYTES: usize = 100_000;
 const MAX_WAIT_MS: u64 = 120_000;
@@ -45,15 +46,8 @@ fn truncate_html(html: String) -> (String, bool) {
     }
 }
 
-/// Validate that a URL uses http or https scheme. // THREAT[TM-TOOL-015]
 fn validate_url(url: &str) -> Result<(), ToolExecutionResult> {
-    if url.starts_with("http://") || url.starts_with("https://") {
-        Ok(())
-    } else {
-        Err(ToolExecutionResult::tool_error(
-            "Invalid URL scheme. Only http:// and https:// URLs are allowed.",
-        ))
-    }
+    validate_browserless_url(url)
 }
 
 /// Cap a wait/timeout value to MAX_WAIT_MS. // THREAT[TM-TOOL-016]
@@ -675,6 +669,9 @@ impl Tool for BrowserlessInteractTool {
                 );
             }
         };
+        if let Err(e) = validate_interaction_steps(&steps) {
+            return e;
+        }
 
         let return_screenshot = arguments
             .get("return_screenshot")
@@ -1012,7 +1009,61 @@ impl Tool for BrowserlessNavigateTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::validation::validate_interaction_steps;
     use everruns_core::capabilities::Capability;
+
+    #[test]
+    fn test_validate_url_accepts_public_https_url() {
+        assert!(validate_url("https://example.com").is_ok());
+    }
+
+    #[test]
+    fn test_validate_url_rejects_localhost() {
+        let err = validate_url("http://localhost:3000").unwrap_err();
+        match err {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("blocked"));
+            }
+            other => panic!("Expected ToolError, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_validate_url_rejects_private_ip() {
+        let err = validate_url("http://10.0.0.5/admin").unwrap_err();
+        match err {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("blocked"));
+            }
+            other => panic!("Expected ToolError, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_validate_url_rejects_cloud_metadata_ip() {
+        let err = validate_url("http://169.254.169.254/latest/meta-data/").unwrap_err();
+        match err {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("blocked"));
+            }
+            other => panic!("Expected ToolError, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_validate_interaction_steps_rejects_blocked_navigate_url() {
+        let steps = vec![json!({
+            "action": "navigate",
+            "value": "http://127.0.0.1:8080"
+        })];
+        let err = validate_interaction_steps(&steps).unwrap_err();
+        match err {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("blocked"));
+            }
+            other => panic!("Expected ToolError, got: {other:?}"),
+        }
+    }
 
     #[test]
     fn test_screenshot_tool_metadata() {

--- a/integrations/browserless/src/validation.rs
+++ b/integrations/browserless/src/validation.rs
@@ -1,0 +1,34 @@
+//! Browserless URL validation helpers.
+//!
+//! Decision: Reuse everruns-core SSRF validation for all user-provided Browserless
+//! URLs so Browserless tools match the threat model and share one policy with MCP
+//! and provider base URL validation.
+
+use everruns_core::tools::ToolExecutionResult;
+use serde_json::Value;
+
+/// THREAT[TM-TOOL-015]: Block Browserless navigation to internal/private hosts.
+/// Mitigation: Reuse shared URL validation so localhost, RFC1918, link-local,
+/// and metadata endpoints are rejected before any Browserless API call.
+pub(crate) fn validate_browserless_url(url: &str) -> Result<(), ToolExecutionResult> {
+    everruns_core::validate_safe_url(url)
+        .map(|_| ())
+        .map_err(|e| ToolExecutionResult::tool_error(format!("URL is blocked by policy: {e}")))
+}
+
+/// THREAT[TM-TOOL-015]: Validate all nested navigate actions in interaction steps.
+/// Mitigation: Reject Browserless interact payloads that attempt to navigate to
+/// blocked hosts after the initial page load.
+pub(crate) fn validate_interaction_steps(steps: &[Value]) -> Result<(), ToolExecutionResult> {
+    for step in steps {
+        if step.get("action").and_then(|v| v.as_str()) == Some("navigate") {
+            let url = step
+                .get("value")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| ToolExecutionResult::tool_error("navigate requires value (URL)"))?;
+            validate_browserless_url(url)?;
+        }
+    }
+
+    Ok(())
+}

--- a/specs/mcp-servers.md
+++ b/specs/mcp-servers.md
@@ -120,6 +120,7 @@ Delete an MCP server.
 1. **API Key Encryption**: API keys are encrypted at rest using envelope encryption (see `specs/encryption.md`)
 2. **API Key Not Exposed**: The `api_key_encrypted` field is never returned in API responses
 3. **Unique Names**: Server names must be unique to prevent configuration conflicts
+4. **SSRF Protection**: MCP server URLs are validated on create/update and re-validated at execution time. Private IPs, loopback, link-local, and cloud metadata endpoints are blocked by shared URL validation.
 
 ## MCP as Virtual Capabilities
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -403,9 +403,10 @@ fn authorizer(action: AuthAction) -> Authorization {
 | TM-TOOL-012 | Skill archive zip bomb | High | Decompressed size capped at 10 MB; file count capped at 100; individual file size capped at 1 MB | MITIGATED |
 | TM-TOOL-013 | Skill name collision across orgs | Medium | Skill names are unique per organization; capability IDs include UUID for global uniqueness | MITIGATED |
 | TM-TOOL-014 | Disabled skill still activatable | Medium | `CapabilityService.list_all()` filters out disabled skills; disabled skills not included in `<available_skills>` | MITIGATED |
-| TM-TOOL-015 | Browserless SSRF via tool URL | Medium | URL scheme validation: only `http://` and `https://` allowed; `file://`, `javascript:`, internal IPs blocked at URL level | MITIGATED |
+| TM-TOOL-015 | Browserless SSRF via tool URL | Medium | Shared `validate_safe_url()` blocks private/internal hosts for all Browserless navigation entry points, including interaction-step redirects | MITIGATED |
 | TM-TOOL-016 | Browserless timeout DoS | Medium | All wait/timeout values capped at 120s; prevents unbounded resource consumption | MITIGATED |
 | TM-TOOL-017 | Browserless API token in logs | Medium | CDP debug logging redacts token from WebSocket URLs before logging | MITIGATED |
+| TM-TOOL-018 | MCP server SSRF via configured server URL | High | MCP server URLs are validated on create/update and re-validated at execution time; private/internal hosts and metadata endpoints blocked | MITIGATED |
 
 ### Mitigation Details
 
@@ -431,6 +432,25 @@ ZIP archive extraction in `SkillService::create_from_archive()` enforces:
 3. Per-file size limit: 1 MB per individual file
 4. Total decompressed size limit: 10 MB
 5. Files extracted into `skill_files` table as individual rows (no runtime ZIP extraction)
+
+**TM-TOOL-015 — Browserless URL Validation (MITIGATED):**
+Browserless tools now reuse the shared `validate_safe_url()` policy from core. This blocks:
+- loopback and `localhost`
+- RFC1918 private ranges
+- link-local and cloud metadata endpoints
+- IPv6 loopback/link-local/private ranges
+
+Validation runs for:
+- direct Browserless tool URLs (`navigate`, `content`, `screenshot`, `scrape`)
+- `browserless_open_browser` initial navigation
+- nested `navigate` actions inside `browserless_interact`
+
+**TM-TOOL-018 — MCP Server SSRF (MITIGATED):**
+MCP server URLs are validated twice:
+1. On create/update in the control plane to reject unsafe configuration
+2. Again in the worker just before execution to catch TOCTOU or stale cached configuration
+
+The shared validator blocks loopback, RFC1918, link-local, and cloud metadata targets. This prevents an MCP capability from being used to probe worker-local or cluster-internal HTTP services via a malicious server URL.
 
 ## 8. LLM Integration (TM-LLM)
 
@@ -596,6 +616,7 @@ The agent loop is a core trust boundary: an LLM decides which tools to call with
 | TM-AGENT-016 | Plaintext secrets in chat history | Medium | When agent asks user for API key in chat, plaintext value stored in events table as message content; session secrets encrypt separately but chat retains plaintext | **OPEN** |
 | TM-AGENT-017 | Agent-initiated entity management | High | Agents with `platform_management` can create/update/delete harnesses, agents, sessions org-wide; no fine-grained RBAC within org; capability must be explicitly assigned | **OPEN** |
 | TM-AGENT-018 | No outbound URL filtering on web_fetch | Medium | Agent with `web_fetch` can POST session data to any URL; no allowlist/blocklist for outbound destinations; prompt injection could chain file read + web_fetch for exfiltration | **OPEN** |
+| TM-AGENT-019 | Internal network probing via high-risk execution capabilities | High | `daytona` provides full network access by design; `docker_container` uses host networking in dev mode; both rely on Admin-only assignment plus infrastructure egress isolation | **ACCEPTED** |
 
 ### Mitigation Details
 
@@ -675,6 +696,17 @@ An agent influenced by prompt injection (via tool results or user messages) coul
   4. Log all outbound `web_fetch` calls with URL + payload size for audit
 - **Complements:** fetchkit's DnsPolicy already blocks private IPs (TM-API-008). This adds application-layer URL policy on top.
 - **Priority:** Medium
+
+**TM-AGENT-019 — Internal Network Probing via High-Risk Execution Capabilities (ACCEPTED):**
+Some execution capabilities intentionally originate network traffic outside the worker process:
+- `daytona` sandboxes have full Linux and network access by design
+- `docker_container` uses host networking and is experimental/dev-only
+
+This means an agent with one of these capabilities can probe whatever network the sandbox/container can reach. Current mitigations are:
+- Admin-only assignment for high-risk capabilities (TM-AGENT-005)
+- `docker_container` is gated to development-grade deployments
+
+Residual risk remains with the deployment topology. Production operators must enforce egress filtering and network segmentation for any execution environment that can reach internal services.
 
 ## 14. Bash Sandbox (TM-BASH)
 
@@ -875,6 +907,7 @@ Search results from Brave Search are returned as tool results. Adversarial conte
 | TM-AGENT-002 | Indirect prompt injection via tool results | Tool results role-separated; no complete defense exists |
 | TM-AGENT-003 | MCP tool description poisoning | MCP servers org-configured; descriptions used as schemas only |
 | TM-AGENT-013 | Data exfiltration via web_fetch | Opt-in capability; org members trusted; intended functionality |
+| TM-AGENT-019 | Internal network probing via high-risk execution capabilities | High-risk capabilities are Admin-gated; residual exposure depends on deployment network isolation |
 | TM-DURABLE-006 | DLQ growth | Tasks preserved for debugging; manual cleanup |
 | TM-DAYTONA-001 | Git token on sandbox disk | Same trust boundary as exec; `/tmp` cleared on stop; short-lived token |
 
@@ -890,10 +923,11 @@ Search results from Brave Search are returned as tool results. Adversarial conte
 | Evaluate Braintrust | TM-OBS-001 | Assess data classification before enabling |
 | Secure OTLP endpoint | TM-OBS-003 | Use trusted internal infrastructure only |
 | OAuth provider trust | TM-AUTH-012 | Verify email ownership at OAuth providers |
-| Review agent capabilities | TM-AGENT-005, TM-AGENT-013 | High-risk capabilities require Admin role; audit capability assignments for org admin accounts |
+| Review agent capabilities | TM-AGENT-005, TM-AGENT-013, TM-AGENT-019 | High-risk capabilities require Admin role; audit capability assignments for org admin accounts |
 | System prompt review | TM-AGENT-004 | Review agent system prompts for jailbreak patterns before deployment |
 | Block cloud metadata | TM-API-009 | Defense-in-depth: enable IMDSv2 (AWS), metadata concealment (GCP), or equivalent; fetchkit v0.1.2 blocks 169.254.0.0/16 at application level |
 | Worker network isolation | TM-API-008, TM-API-010, TM-API-011 | Defense-in-depth: restrict worker container egress; fetchkit v0.1.2 blocks private IPs at application level |
+| Sandbox/container egress isolation | TM-AGENT-019 | Restrict Daytona sandbox and any Docker-backed execution environment from reaching internal networks unless explicitly intended |
 | Review GitHub App permissions | TM-DAYTONA-003 | Audit which repositories the GitHub App installation can access; Everruns does not enforce per-repo restrictions |
 
 ## Security Controls Matrix


### PR DESCRIPTION
## What
Block Browserless navigation to internal/private network targets and align the threat model with the actual network exposure surface.

## Why
Browserless tool URLs were only validated for scheme, which left a gap where Browserless could be used to probe `localhost`, RFC1918 addresses, or cloud metadata endpoints from the browser automation environment. The threat model also did not explicitly model MCP SSRF and high-risk execution capability network exposure.

## How
Reuse shared `validate_safe_url()` for all Browserless navigation entry points, including `browserless_open_browser` and nested `navigate` steps inside `browserless_interact`. Add regression tests for blocked targets. Update the threat model and MCP spec to document Browserless SSRF protection, MCP URL SSRF validation, and the accepted residual risk for `daytona` / `docker_container` internal network reachability.

## Risk
- Medium
- Browserless requests that previously reached private/internal hosts are now rejected. This is the intended behavior change.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
