### PR TITLE
fix(ui-security): fail closed on auth bootstrap errors

### DIFF
--- a/apps/ui/src/__tests__/auth-provider.test.tsx
+++ b/apps/ui/src/__tests__/auth-provider.test.tsx
@@ -2,20 +2,15 @@ import { renderHook, act } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode } from "react";
 import { AuthProvider, useAuth } from "@/providers/auth-provider";
+import { ApiError } from "@/lib/api/client";
 
 // Mock the auth hooks used by AuthProvider
 const mockLogoutMutateAsync = jest.fn();
+const mockUseAuthConfig = jest.fn();
+const mockUseCurrentUser = jest.fn();
 jest.mock("@/hooks/use-auth", () => ({
-  useAuthConfig: () => ({
-    data: { mode: "password", oauth_providers: [] },
-    isLoading: false,
-    error: null,
-  }),
-  useCurrentUser: () => ({
-    data: { id: "user-1", email: "test@example.com", name: "Test User", roles: ["user"] },
-    isLoading: false,
-    error: null,
-  }),
+  useAuthConfig: () => mockUseAuthConfig(),
+  useCurrentUser: () => mockUseCurrentUser(),
   useLogout: () => ({
     mutateAsync: mockLogoutMutateAsync,
     isPending: false,
@@ -31,6 +26,16 @@ describe("AuthProvider pluggable actions", () => {
     });
     jest.clearAllMocks();
     mockLogoutMutateAsync.mockResolvedValue(undefined);
+    mockUseAuthConfig.mockReturnValue({
+      data: { mode: "password", oauth_providers: [] },
+      isLoading: false,
+      error: null,
+    });
+    mockUseCurrentUser.mockReturnValue({
+      data: { id: "user-1", email: "test@example.com", name: "Test User", roles: ["user"] },
+      isLoading: false,
+      error: null,
+    });
   });
 
   function makeWrapper(providerProps?: {
@@ -92,5 +97,50 @@ describe("AuthProvider pluggable actions", () => {
     });
 
     expect(result.current.logoutPending).toBe(false);
+  });
+
+  it("marks auth as unavailable when auth config bootstrap fails", () => {
+    mockUseAuthConfig.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("config failed"),
+    });
+    mockUseCurrentUser.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useAuth(), { wrapper: makeWrapper() });
+
+    expect(result.current.authUnavailable).toBe(true);
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it("marks auth as unavailable when current user bootstrap fails with a transport error", () => {
+    mockUseCurrentUser.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new ApiError(503, "Service Unavailable", "backend down"),
+    });
+
+    const { result } = renderHook(() => useAuth(), { wrapper: makeWrapper() });
+
+    expect(result.current.authUnavailable).toBe(true);
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it("keeps unauthenticated 401 distinct from auth-unavailable failures", () => {
+    mockUseCurrentUser.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new ApiError(401, "Unauthorized", "not logged in"),
+    });
+
+    const { result } = renderHook(() => useAuth(), { wrapper: makeWrapper() });
+
+    expect(result.current.authUnavailable).toBe(false);
+    expect(result.current.requiresAuth).toBe(true);
+    expect(result.current.isAuthenticated).toBe(false);
   });
 });

--- a/apps/ui/src/__tests__/main-layout-auth.test.tsx
+++ b/apps/ui/src/__tests__/main-layout-auth.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { ApiError } from "@/lib/api/client";
+import MainLayout from "@/app/(main)/layout";
+
+const mockReplace = jest.fn();
+const mockPathname = jest.fn();
+const mockSearchParams = jest.fn();
+
+const authState = {
+  config: { mode: "password", oauth_providers: [] },
+  configLoading: false,
+  configError: null as Error | null,
+  user: { id: "user-1", email: "test@example.com", name: "Test User", roles: ["user"] },
+  userLoading: false,
+  userError: null as Error | null,
+  isAuthenticated: true,
+  requiresAuth: true,
+  isLoading: false,
+  authUnavailable: false,
+  logout: jest.fn(),
+  logoutPending: false,
+};
+
+const orgState = {
+  isLoading: false,
+};
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  usePathname: () => mockPathname(),
+  useSearchParams: () => mockSearchParams(),
+}));
+
+jest.mock("@/components/layout/sidebar", () => ({
+  Sidebar: () => <div data-testid="sidebar">Sidebar</div>,
+}));
+
+jest.mock("@/components/command-palette", () => ({
+  CommandPalette: () => <div data-testid="command-palette">Command Palette</div>,
+}));
+
+jest.mock("@/hooks/use-command-palette", () => ({
+  CommandPaletteContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useCommandPaletteState: () => ({}),
+}));
+
+jest.mock("@/providers/auth-provider", () => ({
+  useAuth: () => authState,
+}));
+
+jest.mock("@/providers/org-provider", () => ({
+  useOrg: () => orgState,
+}));
+
+jest.mock("@/providers/notifications-provider", () => ({
+  NotificationsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("@/providers/feature-flags-provider", () => ({
+  useFeatureFlag: () => false,
+}));
+
+describe("MainLayout auth availability", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPathname.mockReturnValue("/settings/providers");
+    mockSearchParams.mockReturnValue(new URLSearchParams("tab=models"));
+
+    authState.config = { mode: "password", oauth_providers: [] };
+    authState.configLoading = false;
+    authState.configError = null;
+    authState.user = {
+      id: "user-1",
+      email: "test@example.com",
+      name: "Test User",
+      roles: ["user"],
+    };
+    authState.userLoading = false;
+    authState.userError = null;
+    authState.isAuthenticated = true;
+    authState.requiresAuth = true;
+    authState.isLoading = false;
+    authState.authUnavailable = false;
+    orgState.isLoading = false;
+  });
+
+  it("blocks the protected shell when auth config bootstrap fails", () => {
+    authState.config = undefined;
+    authState.configError = new Error("config failed");
+    authState.user = null;
+    authState.isAuthenticated = false;
+    authState.requiresAuth = false;
+    authState.authUnavailable = true;
+
+    render(
+      <MainLayout>
+        <div>Secret App</div>
+      </MainLayout>,
+    );
+
+    expect(screen.getByText("Authentication unavailable")).toBeInTheDocument();
+    expect(screen.queryByTestId("sidebar")).not.toBeInTheDocument();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("blocks the protected shell when current user bootstrap fails", () => {
+    authState.user = null;
+    authState.userError = new ApiError(503, "Service Unavailable", "backend down");
+    authState.isAuthenticated = false;
+    authState.authUnavailable = true;
+
+    render(
+      <MainLayout>
+        <div>Secret App</div>
+      </MainLayout>,
+    );
+
+    expect(screen.getByText("Authentication unavailable")).toBeInTheDocument();
+    expect(screen.queryByTestId("sidebar")).not.toBeInTheDocument();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("still redirects to login for ordinary unauthenticated 401 responses", async () => {
+    authState.user = null;
+    authState.userError = new ApiError(401, "Unauthorized", "not logged in");
+    authState.isAuthenticated = false;
+    authState.authUnavailable = false;
+
+    render(
+      <MainLayout>
+        <div>Secret App</div>
+      </MainLayout>,
+    );
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith(
+        "/login?return_to=%2Fsettings%2Fproviders%3Ftab%3Dmodels",
+      );
+    });
+    expect(screen.queryByText("Authentication unavailable")).not.toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/app/(main)/layout.tsx
+++ b/apps/ui/src/app/(main)/layout.tsx
@@ -3,24 +3,48 @@
 // Main app layout with sidebar, auth guard, and global command palette
 import { Suspense, useEffect } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import { AlertTriangle, Loader2 } from "lucide-react";
 import { Sidebar } from "@/components/layout/sidebar";
 import { CommandPalette } from "@/components/command-palette";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { CommandPaletteContext, useCommandPaletteState } from "@/hooks/use-command-palette";
 import { useAuth } from "@/providers/auth-provider";
 import { useOrg } from "@/providers/org-provider";
 import { NotificationsProvider } from "@/providers/notifications-provider";
 import { useFeatureFlag } from "@/providers/feature-flags-provider";
-import { Loader2 } from "lucide-react";
 
 interface MainLayoutProps {
   children: React.ReactNode;
+}
+
+function AuthUnavailableState() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4">
+      <Card className="w-full max-w-lg">
+        <CardHeader className="items-center text-center">
+          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+            <AlertTriangle className="h-6 w-6 text-destructive" />
+          </div>
+          <CardTitle>Authentication unavailable</CardTitle>
+          <CardDescription>
+            We couldn&apos;t verify your authentication state. Protected routes stay blocked until
+            auth bootstrap succeeds.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex justify-center">
+          <Button onClick={() => window.location.reload()}>Retry</Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
 }
 
 function MainLayoutInner({ children }: MainLayoutProps) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const { isAuthenticated, isLoading: authLoading, requiresAuth } = useAuth();
+  const { isAuthenticated, isLoading: authLoading, requiresAuth, authUnavailable } = useAuth();
   const { isLoading: orgLoading } = useOrg();
   const notificationsEnabled = useFeatureFlag("notifications");
   const commandPalette = useCommandPaletteState();
@@ -30,25 +54,25 @@ function MainLayoutInner({ children }: MainLayoutProps) {
 
   // Redirect to login if auth is required but user is not authenticated
   useEffect(() => {
-    if (!authLoading && requiresAuth && !isAuthenticated) {
+    if (!authLoading && !authUnavailable && requiresAuth && !isAuthenticated) {
       // Preserve current location so login can redirect back
       const currentUrl = pathname + (searchParams.toString() ? `?${searchParams.toString()}` : "");
       const returnTo =
         currentUrl !== "/dashboard" ? `?return_to=${encodeURIComponent(currentUrl)}` : "";
       router.replace(`/login${returnTo}`);
     }
-  }, [authLoading, requiresAuth, isAuthenticated, router, pathname, searchParams]);
+  }, [authLoading, authUnavailable, requiresAuth, isAuthenticated, router, pathname, searchParams]);
 
   // After OAuth login, check sessionStorage for a pending return_to redirect
   useEffect(() => {
-    if (!authLoading && isAuthenticated) {
+    if (!authLoading && !authUnavailable && isAuthenticated) {
       const pendingReturnTo = sessionStorage.getItem("everruns_return_to");
       if (pendingReturnTo) {
         sessionStorage.removeItem("everruns_return_to");
         router.replace(pendingReturnTo);
       }
     }
-  }, [authLoading, isAuthenticated, router]);
+  }, [authLoading, authUnavailable, isAuthenticated, router]);
 
   // Show loading state while checking auth and initializing org
   if (isLoading) {
@@ -57,6 +81,10 @@ function MainLayoutInner({ children }: MainLayoutProps) {
         <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
       </div>
     );
+  }
+
+  if (authUnavailable) {
+    return <AuthUnavailableState />;
   }
 
   // If auth required but not authenticated, show nothing (will redirect)

--- a/apps/ui/src/providers/auth-provider.tsx
+++ b/apps/ui/src/providers/auth-provider.tsx
@@ -8,6 +8,7 @@
 
 import { createContext, useContext, useCallback, type ReactNode } from "react";
 import { useAuthConfig, useCurrentUser, useLogout as useLogoutMutation } from "@/hooks/use-auth";
+import { ApiError } from "@/lib/api/client";
 import type { AuthConfigResponse, UserInfoResponse } from "@/lib/api/types";
 
 export interface AuthContextValue {
@@ -25,6 +26,7 @@ export interface AuthContextValue {
   isAuthenticated: boolean;
   requiresAuth: boolean;
   isLoading: boolean;
+  authUnavailable: boolean;
 
   // Pluggable actions — defaults call OSS endpoints; SaaS can override at provider level
   logout: () => Promise<void>;
@@ -33,6 +35,10 @@ export interface AuthContextValue {
 }
 
 export const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+function isUnauthenticatedError(error: Error | null): boolean {
+  return error instanceof ApiError && error.status === 401;
+}
 
 interface AuthProviderProps {
   children: ReactNode;
@@ -61,11 +67,12 @@ export function AuthProvider({
 
   // Determine if authentication is required based on mode
   const requiresAuth = config ? config.mode !== "none" : false;
+  const authUnavailable = !!configError || (!!userError && !isUnauthenticatedError(userError));
 
   // User is authenticated if:
   // 1. Auth is not required (mode=none), OR
   // 2. User data exists
-  const isAuthenticated = !requiresAuth || !!user;
+  const isAuthenticated = !authUnavailable && (!requiresAuth || !!user);
 
   // Overall loading state - always wait for user fetch (sets org cookie)
   const isLoading = configLoading || userLoading;
@@ -80,6 +87,7 @@ export function AuthProvider({
     isAuthenticated,
     requiresAuth,
     isLoading,
+    authUnavailable,
     logout: logoutOverride ?? defaultLogout,
     logoutPending: logoutOverride ? false : logoutMutation.isPending,
     createOrganization,

--- a/specs/authentication.md
+++ b/specs/authentication.md
@@ -130,6 +130,7 @@ Based on `mode`:
 - **none**: Skip authentication entirely, show app directly
 - **admin/full**: Require login before accessing protected routes
 - **external**: Auth required (like full), but login/signup managed by external provider
+- Protected routes fail closed while auth bootstrap state is unknown: if `/v1/auth/config` fails, or `/v1/auth/me` fails for reasons other than `401 Unauthorized`, the UI shows a blocking auth-unavailable state instead of rendering the app shell or redirecting to login
 
 ### UI Components
 
@@ -145,10 +146,11 @@ Based on `mode`:
 1. App loads, fetches `/v1/auth/config`
 2. If `mode === "none"`, render app without auth
 3. Otherwise, check if user is authenticated via `/v1/auth/me`
-4. If not authenticated, redirect to `/login?return_to=<current_path>` (preserving the user's location)
-5. After login, cookies are set automatically (HTTP-only) and the user is redirected back to `return_to` (default: `/dashboard`)
-6. Subsequent requests include cookies via `credentials: "include"`
-7. On 401 response, the API client silently attempts `POST /v1/auth/refresh` (using the HttpOnly `refresh_token` cookie) and retries the request
+4. If auth bootstrap fails (`/v1/auth/config` error or non-401 `/v1/auth/me` error), block protected routes with an auth-unavailable state
+5. If `/v1/auth/me` returns `401 Unauthorized`, redirect to `/login?return_to=<current_path>` (preserving the user's location)
+6. After login, cookies are set automatically (HTTP-only) and the user is redirected back to `return_to` (default: `/dashboard`)
+7. Subsequent requests include cookies via `credentials: "include"`
+8. On 401 response, the API client silently attempts `POST /v1/auth/refresh` (using the HttpOnly `refresh_token` cookie) and retries the request
 
 ### Token Refresh
 


### PR DESCRIPTION
## What
- add an explicit `authUnavailable` state in the UI auth provider for bootstrap failures
- block the protected main layout with an auth-unavailable screen when `/v1/auth/config` fails or `/v1/auth/me` fails with a non-401 error
- add regression tests for auth-provider state derivation and protected layout behavior
- document the fail-closed bootstrap behavior in the authentication spec

## Why
Fixes EVE-65.

The protected UI previously treated auth bootstrap failures as either auth-disabled or ordinary unauthenticated state. That could render the app shell when `/v1/auth/config` failed, or mis-handle `/v1/auth/me` transport/server failures instead of failing closed.

## How
- classify only `ApiError(401)` as a normal unauthenticated state
- treat config bootstrap errors and non-401 current-user errors as auth-unavailable
- render a blocking retry state before the app shell mounts, and keep the normal login redirect path for real 401 responses

## Risk
- Medium
- Auth bootstrap flows on protected routes changed; a misclassification here could block valid sessions or redirect incorrectly. Targeted tests cover config failure, current-user failure, and ordinary 401 redirect behavior.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
