### PR TITLE
fix(ui): remove chat composer divider

### DIFF
--- a/apps/ui/src/__tests__/chat-panel.test.tsx
+++ b/apps/ui/src/__tests__/chat-panel.test.tsx
@@ -171,4 +171,16 @@ describe("ChatPanel placeholder", () => {
       screen.getByPlaceholderText("Type a message or / for commands... (Enter to send)"),
     ).toBeInTheDocument();
   });
+
+  it("does not render a top border between messages and composer", () => {
+    mockUseSessionCommands.mockReturnValue({ data: { commands: [] } });
+
+    render(<ChatPanel />);
+
+    const composer = screen.getByPlaceholderText("Type a message... (Enter to send)");
+    const composerShell = composer.closest("form")?.parentElement;
+
+    expect(composerShell).not.toBeNull();
+    expect(composerShell).not.toHaveClass("border-t");
+  });
 });

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -780,7 +780,7 @@ export function ChatPanel() {
         )}
       </div>
 
-      <div className="border-t border-border bg-muted/30 p-4 sm:p-5">
+      <div className="bg-muted/30 p-4 sm:p-5">
         <form onSubmit={handleSubmit} className="space-y-3">
           <input
             ref={fileInputRef}


### PR DESCRIPTION
## What
Remove the horizontal divider between the session message list and the composer.

## Why
The split line adds visual separation where the composer already has its own bordered surface, so it creates unnecessary clutter in chat.

## How
Dropped the `border-t` wrapper styles from the composer container in `ChatPanel` and added a regression test that asserts the composer shell no longer renders a top border.

## Risk
- Low
- Limited to chat composer styling in the session UI

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
