### PR TITLE
fix(api): scope agent and harness default model ids

### DIFF
--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -2,6 +2,7 @@
 // Routes use ResolvedOrg: org derived from auth context (API key or cookie)
 
 use crate::auth::{AuthState, ResolvedOrg};
+use crate::errors::ResourceNotFoundError;
 use crate::storage::StorageBackend;
 use axum::extract::FromRef;
 use axum::{
@@ -314,6 +315,9 @@ pub async fn create_agent(
             let msg = e.to_string();
             if msg.contains("duplicate key") || msg.contains("already exists") {
                 return Err(ErrorResponse::conflict("Agent with this ID already exists"));
+            }
+            if let Some(not_found) = e.downcast_ref::<ResourceNotFoundError>() {
+                return Err(ErrorResponse::not_found(not_found.resource()));
             }
             tracing::error!("Failed to create agent: {}", msg);
             return Err(ErrorResponse::internal_error());

--- a/crates/server/src/api/common.rs
+++ b/crates/server/src/api/common.rs
@@ -67,7 +67,9 @@ impl<T> ApiPolicyResultExt<T> for Result<T, anyhow::Error> {
         operation: &str,
     ) -> Result<T, (StatusCode, Json<ErrorResponse>)> {
         self.map_err(|e| {
-            if let Some(policy_err) = e.downcast_ref::<everruns_core::PolicyError>() {
+            if let Some(not_found) = e.downcast_ref::<crate::errors::ResourceNotFoundError>() {
+                ErrorResponse::not_found(not_found.resource())
+            } else if let Some(policy_err) = e.downcast_ref::<everruns_core::PolicyError>() {
                 (
                     StatusCode::FORBIDDEN,
                     Json(ErrorResponse::new(&policy_err.message)),

--- a/crates/server/src/errors.rs
+++ b/crates/server/src/errors.rs
@@ -1,0 +1,21 @@
+// Shared application error types.
+// Decision: keep resource-level errors typed so API handlers can map them
+// to precise HTTP responses instead of collapsing validation failures to 500s.
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[error("{resource} not found")]
+pub struct ResourceNotFoundError {
+    resource: &'static str,
+}
+
+impl ResourceNotFoundError {
+    pub const fn new(resource: &'static str) -> Self {
+        Self { resource }
+    }
+
+    pub const fn resource(&self) -> &'static str {
+        self.resource
+    }
+}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -17,6 +17,9 @@ pub mod api;
 pub mod auth;
 pub use auth::{AuthBackend, BuiltinAuthBackend};
 
+// Shared application errors
+pub mod errors;
+
 // Services layer
 pub mod services;
 pub use services::CapabilityService;

--- a/crates/server/src/services/agent.rs
+++ b/crates/server/src/services/agent.rs
@@ -4,6 +4,7 @@
 // Agent creation events are not yet implemented but would be handled
 // by event listeners rather than direct spans.
 
+use crate::errors::ResourceNotFoundError;
 use crate::storage::{
     AgentRow, StorageBackend,
     models::{CreateAgentRow, UpdateAgent},
@@ -63,6 +64,9 @@ impl AgentService {
     ) -> Result<Agent> {
         let capabilities_to_store =
             ensure_file_system_capability(req.capabilities.clone(), !req.initial_files.is_empty());
+        let default_model_id = self
+            .validate_default_model_id(caller.org_id, req.default_model_id)
+            .await?;
 
         // When no client_id, generate internal UUID and derive public_id from it.
         // This keeps public_id == AgentId::from_uuid(internal_id), so session FKs
@@ -74,7 +78,7 @@ impl AgentService {
                 name: req.name.clone(),
                 description: req.description.clone(),
                 system_prompt: req.system_prompt.clone(),
-                default_model_id: req.default_model_id,
+                default_model_id,
                 tags: req.tags.clone(),
                 initial_files: serde_json::to_value(&req.initial_files).unwrap_or_default(),
                 tools: serde_json::to_value(&req.tools).unwrap_or_default(),
@@ -90,7 +94,7 @@ impl AgentService {
                 name: req.name.clone(),
                 description: req.description.clone(),
                 system_prompt: req.system_prompt.clone(),
-                default_model_id: req.default_model_id,
+                default_model_id,
                 tags: req.tags.clone(),
                 initial_files: serde_json::to_value(&req.initial_files).unwrap_or_default(),
                 tools: serde_json::to_value(&req.tools).unwrap_or_default(),
@@ -207,12 +211,15 @@ impl AgentService {
             )),
             None => None,
         };
+        let default_model_id = self
+            .validate_default_model_id(caller.org_id, req.default_model_id)
+            .await?;
 
         let input = UpdateAgent {
             name: req.name,
             description: req.description,
             system_prompt: req.system_prompt,
-            default_model_id: req.default_model_id,
+            default_model_id,
             tags: req.tags,
             status: req.status.map(|s| s.to_string()),
             initial_files: req
@@ -353,6 +360,23 @@ impl AgentService {
             .collect())
     }
 
+    async fn validate_default_model_id(
+        &self,
+        org_id: i64,
+        default_model_id: Option<everruns_core::ModelId>,
+    ) -> Result<Option<everruns_core::ModelId>> {
+        let Some(model_id) = default_model_id else {
+            return Ok(None);
+        };
+
+        self.db
+            .get_llm_model(org_id, model_id.uuid())
+            .await?
+            .ok_or_else(|| ResourceNotFoundError::new("Model"))?;
+
+        Ok(Some(model_id))
+    }
+
     fn row_to_agent(row: AgentRow, capabilities: Vec<AgentCapabilityConfig>) -> Agent {
         // Convert database usage columns to TokenUsage
         let usage = if row.total_input_tokens > 0 || row.total_output_tokens > 0 {
@@ -397,5 +421,137 @@ impl AgentService {
             updated_at: row.updated_at,
             usage,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{CreateLlmModelRow, CreateLlmProviderRow, CreateOrganizationRow};
+    use everruns_core::DEFAULT_ORG_ID;
+
+    fn build_create_request(
+        default_model_id: Option<everruns_core::ModelId>,
+    ) -> CreateAgentRequest {
+        CreateAgentRequest {
+            id: None,
+            name: "Test Agent".to_string(),
+            description: None,
+            system_prompt: "Test".to_string(),
+            default_model_id,
+            tags: vec![],
+            capabilities: vec![],
+            initial_files: vec![],
+            tools: vec![],
+        }
+    }
+
+    fn build_update_request(
+        default_model_id: Option<everruns_core::ModelId>,
+    ) -> UpdateAgentRequest {
+        UpdateAgentRequest {
+            name: None,
+            description: None,
+            system_prompt: None,
+            default_model_id,
+            tags: None,
+            capabilities: None,
+            initial_files: None,
+            status: None,
+            tools: None,
+        }
+    }
+
+    async fn create_second_org(db: &StorageBackend) -> i64 {
+        db.create_organization_with_id(
+            2,
+            CreateOrganizationRow {
+                public_id: "org_2".to_string(),
+                name: "Org 2".to_string(),
+                created_by: None,
+            },
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        .org_id
+    }
+
+    async fn create_model(
+        db: &StorageBackend,
+        org_id: i64,
+        model_id: &str,
+    ) -> everruns_core::ModelId {
+        let provider = db
+            .create_llm_provider(
+                org_id,
+                CreateLlmProviderRow {
+                    name: format!("Provider {org_id}"),
+                    provider_type: "openai".to_string(),
+                    base_url: None,
+                    api_key_encrypted: None,
+                    settings: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        db.create_llm_model(
+            org_id,
+            CreateLlmModelRow {
+                provider_id: provider.id,
+                model_id: model_id.to_string(),
+                display_name: model_id.to_string(),
+                capabilities: vec![],
+                installed: true,
+                is_favorite: false,
+                source: "manual".to_string(),
+                provider_metadata: None,
+            },
+        )
+        .await
+        .unwrap()
+        .id
+    }
+
+    #[tokio::test]
+    async fn create_rejects_default_model_from_another_org() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let service = AgentService::new(db.clone());
+        let caller = Caller::internal(DEFAULT_ORG_ID);
+        let other_org_id = create_second_org(&db).await;
+        let other_model_id = create_model(&db, other_org_id, "cross-org-model").await;
+
+        let err = service
+            .create(&caller, None, build_create_request(Some(other_model_id)))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), "Model not found");
+    }
+
+    #[tokio::test]
+    async fn update_rejects_default_model_from_another_org() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let service = AgentService::new(db.clone());
+        let caller = Caller::internal(DEFAULT_ORG_ID);
+        let other_org_id = create_second_org(&db).await;
+        let other_model_id = create_model(&db, other_org_id, "cross-org-model").await;
+
+        let agent = service
+            .create(&caller, None, build_create_request(None))
+            .await
+            .unwrap();
+
+        let err = service
+            .update(
+                &caller,
+                &agent.public_id.to_string(),
+                build_update_request(Some(other_model_id)),
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), "Model not found");
     }
 }

--- a/crates/server/src/services/harness.rs
+++ b/crates/server/src/services/harness.rs
@@ -4,6 +4,7 @@
 // Policy enforcement via #[policy] macro — see specs/permissions.md.
 
 use crate::api::harnesses::{CreateHarnessRequest, UpdateHarnessRequest};
+use crate::errors::ResourceNotFoundError;
 use crate::storage::{
     HarnessRow, StorageBackend,
     models::{CreateHarnessRow, UpdateHarness},
@@ -65,12 +66,15 @@ impl HarnessService {
     pub async fn create(&self, caller: &Caller, req: CreateHarnessRequest) -> Result<Harness> {
         let capabilities_to_store =
             ensure_file_system_capability(req.capabilities.clone(), !req.initial_files.is_empty());
+        let default_model_id = self
+            .validate_default_model_id(caller.org_id, req.default_model_id)
+            .await?;
 
         let input = CreateHarnessRow {
             name: req.name,
             description: req.description,
             system_prompt: req.system_prompt,
-            default_model_id: req.default_model_id,
+            default_model_id,
             tags: req.tags,
             initial_files: serde_json::to_value(&req.initial_files).unwrap_or_default(),
             is_built_in: false,
@@ -164,12 +168,15 @@ impl HarnessService {
             )),
             None => None,
         };
+        let default_model_id = self
+            .validate_default_model_id(caller.org_id, req.default_model_id)
+            .await?;
 
         let input = UpdateHarness {
             name: req.name,
             description: req.description,
             system_prompt: req.system_prompt,
-            default_model_id: req.default_model_id,
+            default_model_id,
             tags: req.tags,
             initial_files: req
                 .initial_files
@@ -259,6 +266,23 @@ impl HarnessService {
             .collect())
     }
 
+    async fn validate_default_model_id(
+        &self,
+        org_id: i64,
+        default_model_id: Option<everruns_core::ModelId>,
+    ) -> Result<Option<everruns_core::ModelId>> {
+        let Some(model_id) = default_model_id else {
+            return Ok(None);
+        };
+
+        self.db
+            .get_llm_model(org_id, model_id.uuid())
+            .await?
+            .ok_or_else(|| ResourceNotFoundError::new("Model"))?;
+
+        Ok(Some(model_id))
+    }
+
     fn row_to_harness(row: HarnessRow, capabilities: Vec<AgentCapabilityConfig>) -> Harness {
         Harness {
             id: row.id,
@@ -275,5 +299,134 @@ impl HarnessService {
             created_at: row.created_at,
             updated_at: row.updated_at,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{CreateLlmModelRow, CreateLlmProviderRow, CreateOrganizationRow};
+    use everruns_core::DEFAULT_ORG_ID;
+
+    fn build_create_request(
+        default_model_id: Option<everruns_core::ModelId>,
+    ) -> CreateHarnessRequest {
+        CreateHarnessRequest {
+            name: "Test Harness".to_string(),
+            description: None,
+            system_prompt: "Test".to_string(),
+            default_model_id,
+            tags: vec![],
+            capabilities: vec![],
+            initial_files: vec![],
+        }
+    }
+
+    fn build_update_request(
+        default_model_id: Option<everruns_core::ModelId>,
+    ) -> UpdateHarnessRequest {
+        UpdateHarnessRequest {
+            name: None,
+            description: None,
+            system_prompt: None,
+            default_model_id,
+            tags: None,
+            capabilities: None,
+            initial_files: None,
+            status: None,
+        }
+    }
+
+    async fn create_second_org(db: &StorageBackend) -> i64 {
+        db.create_organization_with_id(
+            2,
+            CreateOrganizationRow {
+                public_id: "org_2".to_string(),
+                name: "Org 2".to_string(),
+                created_by: None,
+            },
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        .org_id
+    }
+
+    async fn create_model(
+        db: &StorageBackend,
+        org_id: i64,
+        model_id: &str,
+    ) -> everruns_core::ModelId {
+        let provider = db
+            .create_llm_provider(
+                org_id,
+                CreateLlmProviderRow {
+                    name: format!("Provider {org_id}"),
+                    provider_type: "openai".to_string(),
+                    base_url: None,
+                    api_key_encrypted: None,
+                    settings: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        db.create_llm_model(
+            org_id,
+            CreateLlmModelRow {
+                provider_id: provider.id,
+                model_id: model_id.to_string(),
+                display_name: model_id.to_string(),
+                capabilities: vec![],
+                installed: true,
+                is_favorite: false,
+                source: "manual".to_string(),
+                provider_metadata: None,
+            },
+        )
+        .await
+        .unwrap()
+        .id
+    }
+
+    #[tokio::test]
+    async fn create_rejects_default_model_from_another_org() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let service = HarnessService::new(db.clone());
+        let caller = Caller::internal(DEFAULT_ORG_ID);
+        let other_org_id = create_second_org(&db).await;
+        let other_model_id = create_model(&db, other_org_id, "cross-org-model").await;
+
+        let err = service
+            .create(&caller, build_create_request(Some(other_model_id)))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), "Model not found");
+    }
+
+    #[tokio::test]
+    async fn update_rejects_default_model_from_another_org() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let service = HarnessService::new(db.clone());
+        let caller = Caller::internal(DEFAULT_ORG_ID);
+        let other_org_id = create_second_org(&db).await;
+        let other_model_id = create_model(&db, other_org_id, "cross-org-model").await;
+
+        let harness = service
+            .create(&caller, build_create_request(None))
+            .await
+            .unwrap();
+
+        let err = service
+            .update(
+                &caller,
+                harness.id.uuid(),
+                build_update_request(Some(other_model_id)),
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), "Model not found");
     }
 }

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -194,6 +194,50 @@ async fn test_update_agent() {
 }
 
 #[tokio::test]
+async fn test_create_agent_missing_default_model_returns_not_found() {
+    let server = TestServer::in_memory().await;
+
+    server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": "Missing Model Agent",
+                "system_prompt": "Test",
+                "default_model_id": "model_019563a3000070008000000000000001"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_update_agent_missing_default_model_returns_not_found() {
+    let server = TestServer::in_memory().await;
+
+    let agent: Agent = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": "Update Missing Model Agent",
+                "system_prompt": "Test"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    server
+        .patch(
+            &format!("/v1/agents/{}", agent.public_id),
+            json!({
+                "default_model_id": "model_019563a3000070008000000000000002"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
 async fn test_delete_agent() {
     let server = TestServer::new().await;
 
@@ -1141,6 +1185,50 @@ async fn test_copy_harness() {
     assert_eq!(copied.capabilities[0].capability_id(), "current_time");
     // New ID
     assert_ne!(copied.id, harness.id);
+}
+
+#[tokio::test]
+async fn test_create_harness_missing_default_model_returns_not_found() {
+    let server = TestServer::in_memory().await;
+
+    server
+        .post(
+            "/v1/harnesses",
+            json!({
+                "name": "Missing Model Harness",
+                "system_prompt": "Test",
+                "default_model_id": "model_019563a3000070008000000000000003"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_update_harness_missing_default_model_returns_not_found() {
+    let server = TestServer::in_memory().await;
+
+    let harness: Harness = server
+        .post(
+            "/v1/harnesses",
+            json!({
+                "name": "Update Missing Model Harness",
+                "system_prompt": "Test"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    server
+        .patch(
+            &format!("/v1/harnesses/{}", harness.id),
+            json!({
+                "default_model_id": "model_019563a3000070008000000000000004"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -26,7 +26,7 @@ use axum::{
 use http_body_util::BodyExt;
 use serde::{Serialize, de::DeserializeOwned};
 use serde_json::Value;
-use sqlx::PgPool;
+use sqlx::{PgPool, postgres::PgPoolOptions};
 use tower::ServiceExt;
 
 use everruns_durable::{
@@ -87,9 +87,11 @@ impl TestServer {
             TestMode::InMemory => {
                 let db = Arc::new(StorageBackend::in_memory());
                 let shared_store = Arc::new(InMemoryWorkflowEventStore::new());
-                // For in-memory mode, we still need a pool for the return type
-                // but we won't use it - create a dummy connection
-                let pool = create_test_pool().await;
+                // In-memory tests do not use PostgreSQL; keep a lazy pool only
+                // to satisfy the test harness return type.
+                let pool = PgPoolOptions::new()
+                    .connect_lazy(&get_database_url())
+                    .expect("Failed to create lazy PostgreSQL pool");
                 (
                     db,
                     pool,


### PR DESCRIPTION
## What
- validate `default_model_id` inside the caller org before agent and harness create/update writes
- map the new typed not-found path to HTTP 404 instead of falling through to 500
- add regression coverage for cross-org service calls and API 404 behavior

## Why
Fixes EVE-91. Agent and harness write paths accepted arbitrary model UUIDs, so missing IDs could fail late and cross-org model IDs could be persisted.

## How
- introduce a shared `ResourceNotFoundError` for precise API mapping
- resolve agent and harness default models with org-scoped lookups before persisting
- make in-memory API tests independent from PostgreSQL by using a lazy pool in the test harness

## Risk
- Low
- touches agent/harness create and update validation plus shared API error mapping

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered