### PR TITLE
fix(api): validate provider ownership for model create

### DIFF
--- a/crates/server/src/api/llm_models.rs
+++ b/crates/server/src/api/llm_models.rs
@@ -132,6 +132,7 @@ pub struct UpdateLlmModelRequest {
     responses(
         (status = 201, description = "Model created", body = LlmModel),
         (status = 400, description = "Invalid provider ID"),
+        (status = 404, description = "Provider not found"),
         (status = 500, description = "Internal error")
     ),
     tag = "llm-models"

--- a/crates/server/src/services/llm_model.rs
+++ b/crates/server/src/services/llm_model.rs
@@ -3,6 +3,7 @@
 // On create/update/delete, the LLM resolver cache is invalidated so that
 // subsequent model resolutions pick up the new model config.
 
+use crate::errors::ResourceNotFoundError;
 use crate::services::LlmResolverService;
 use crate::storage::{
     StorageBackend,
@@ -62,6 +63,10 @@ impl LlmModelService {
         provider_id: Uuid,
         req: CreateLlmModelRequest,
     ) -> Result<LlmModel> {
+        let provider_id = self
+            .validate_provider_id(caller.org_id, provider_id)
+            .await?;
+
         let input = CreateLlmModelRow {
             provider_id: provider_id.into(),
             model_id: req.model_id,
@@ -273,6 +278,15 @@ impl LlmModelService {
         Ok(())
     }
 
+    async fn validate_provider_id(&self, org_id: i64, provider_id: Uuid) -> Result<Uuid> {
+        self.db
+            .get_llm_provider(org_id, provider_id)
+            .await?
+            .ok_or_else(|| ResourceNotFoundError::new("Provider"))?;
+
+        Ok(provider_id)
+    }
+
     fn row_to_model(row: &LlmModelRow) -> LlmModel {
         let capabilities: Vec<String> =
             serde_json::from_value(row.capabilities.clone()).unwrap_or_default();
@@ -322,5 +336,69 @@ impl LlmModelService {
             provider_type,
             profile,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{CreateLlmProviderRow, CreateOrganizationRow};
+    use everruns_core::DEFAULT_ORG_ID;
+
+    fn build_create_request() -> CreateLlmModelRequest {
+        CreateLlmModelRequest {
+            model_id: "test-model".to_string(),
+            display_name: "Test Model".to_string(),
+            capabilities: vec!["chat".to_string()],
+            installed: true,
+            is_favorite: false,
+        }
+    }
+
+    async fn create_second_org(db: &StorageBackend) -> i64 {
+        db.create_organization_with_id(
+            2,
+            CreateOrganizationRow {
+                public_id: "org_2".to_string(),
+                name: "Org 2".to_string(),
+                created_by: None,
+            },
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        .org_id
+    }
+
+    async fn create_provider(db: &StorageBackend, org_id: i64) -> everruns_core::ProviderId {
+        db.create_llm_provider(
+            org_id,
+            CreateLlmProviderRow {
+                name: format!("Provider {org_id}"),
+                provider_type: "openai".to_string(),
+                base_url: None,
+                api_key_encrypted: None,
+                settings: None,
+            },
+        )
+        .await
+        .unwrap()
+        .id
+    }
+
+    #[tokio::test]
+    async fn create_rejects_provider_from_another_org() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let service = LlmModelService::new(db.clone());
+        let caller = Caller::internal(DEFAULT_ORG_ID);
+        let other_org_id = create_second_org(&db).await;
+        let other_provider_id = create_provider(&db, other_org_id).await;
+
+        let err = service
+            .create(&caller, other_provider_id.uuid(), build_create_request())
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), "Provider not found");
     }
 }

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -966,6 +966,24 @@ async fn test_llm_model_crud() {
         .assert_status(StatusCode::NO_CONTENT);
 }
 
+#[tokio::test]
+async fn test_create_llm_model_missing_provider_returns_not_found() {
+    let server = TestServer::in_memory().await;
+
+    server
+        .post(
+            "/v1/llm-providers/provider_019563a3000070008000000000000001/models",
+            json!({
+                "model_id": "missing-provider-model",
+                "display_name": "Missing Provider Model",
+                "capabilities": ["chat"],
+                "installed": true
+            }),
+        )
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}
+
 // ============================================
 // Session Model Inheritance Tests
 // ============================================

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1951,6 +1951,9 @@
           "400": {
             "description": "Invalid provider ID"
           },
+          "404": {
+            "description": "Provider not found"
+          },
           "500": {
             "description": "Internal error"
           }


### PR DESCRIPTION
## What
- validate the provider under the caller org before creating an LLM model
- return `404` when the provider is missing or belongs to another org
- add API and service regressions for missing and cross-org provider IDs

## Why
Fixes EVE-92. The model-create route accepted a caller-supplied provider UUID without an org-scoped lookup, so missing providers could fall through as storage errors and cross-org providers could be linked.

## How
- resolve provider ownership in `LlmModelService::create` before building the insert row
- reuse the shared typed not-found error path already mapped by the API layer
- cover the behavior with a focused in-memory API test and a service cross-org test

## Risk
- Low
- touches only the LLM model create validation path

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered