### PR TITLE
feat(sdk): update SDK to v0.1.4 and add agents list pagination

### DIFF
--- a/.github/scripts/sdk-compat/test-rust.sh
+++ b/.github/scripts/sdk-compat/test-rust.sh
@@ -21,30 +21,24 @@ everruns-sdk = "=$version"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 TOML
 
-# The SDK session API changed:
+# The SDK session API changed across versions:
 #   v0.1.0-v0.1.2: sessions().create(agent_id)
 #   v0.1.3:        sessions().create(harness_id)
-#   v0.1.4+:       sessions().create(), with CreateSessionRequest for options
+#   v0.1.4+:       sessions().create() (no args), use create_with_options() builder
 
-version_gte_014() {
-  IFS='.' read -r major minor patch <<< "$1"
-  [ "$major" -gt 0 ] && return 0
-  [ "$minor" -gt 1 ] && return 0
-  [ "$minor" -eq 1 ] && [ "$patch" -ge 4 ] && return 0
-  return 1
+# Compare versions using semver tuple comparison
+version_cmp() {
+  IFS='.' read -r maj1 min1 pat1 <<< "$1"
+  IFS='.' read -r maj2 min2 pat2 <<< "$2"
+  if [ "$maj1" -ne "$maj2" ]; then [ "$maj1" -gt "$maj2" ] && return 0 || return 1; fi
+  if [ "$min1" -ne "$min2" ]; then [ "$min1" -gt "$min2" ] && return 0 || return 1; fi
+  [ "$pat1" -ge "$pat2" ] && return 0 || return 1
 }
 
-version_gte_013() {
-  IFS='.' read -r major minor patch <<< "$1"
-  [ "$major" -gt 0 ] && return 0
-  [ "$minor" -gt 1 ] && return 0
-  [ "$minor" -eq 1 ] && [ "$patch" -ge 3 ] && return 0
-  return 1
-}
-
-if version_gte_014 "$version"; then
+if version_cmp "$version" "0.1.4"; then
+# v0.1.4+: create() takes no args; use create_with_options() with builder
 cat > "$workdir/smoke/src/main.rs" <<'RS'
-use everruns_sdk::Everruns;
+use everruns_sdk::{Everruns, CreateSessionRequest};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -63,8 +57,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(fetched.id, agent.id, "agent id mismatch");
     println!("  agent fetch verified");
 
-    // 3. Create session with server defaults
-    let session = client.sessions().create().await?;
+    // 3. Create session with builder (harness_id optional in v0.1.4+)
+    let harness_id = "harness_01933b5a000070008000000000000602";
+    let req = CreateSessionRequest::new()
+        .harness_id(harness_id)
+        .agent_id(&agent.id);
+    let session = client.sessions().create_with_options(req).await?;
     println!("  session created: {}", session.id);
 
     // 4. Fetch session and verify
@@ -76,7 +74,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 RS
-elif version_gte_013 "$version"; then
+elif version_cmp "$version" "0.1.3"; then
+# v0.1.3: create(harness_id)
 cat > "$workdir/smoke/src/main.rs" <<'RS'
 use everruns_sdk::Everruns;
 
@@ -112,6 +111,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 RS
 else
+# v0.1.0-v0.1.2: create(agent_id)
 cat > "$workdir/smoke/src/main.rs" <<'RS'
 use everruns_sdk::Everruns;
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -141,7 +141,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1203,7 +1203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1517,8 +1517,8 @@ version = "0.8.5"
 
 [[package]]
 name = "everruns-sdk"
-version = "0.1.3"
-source = "git+https://github.com/everruns/sdk?tag=v0.1.3#0e367c56bf7c8a70987235a2b040d4775240832a"
+version = "0.1.4"
+source = "git+https://github.com/everruns/sdk?tag=v0.1.4#a273c8a3778d4b77f6971e01fdf9655157ace160"
 dependencies = [
  "async-stream",
  "futures",
@@ -2363,7 +2363,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3192,7 +3192,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3922,7 +3922,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3960,7 +3960,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4478,7 +4478,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4537,7 +4537,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4901,7 +4901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5293,7 +5293,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6406,7 +6406,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ tokio-tungstenite = { version = "0.26", features = ["rustls-tls-native-roots"] }
 futures-util = "0.3"
 
 # Everruns SDK
-everruns-sdk = { git = "https://github.com/everruns/sdk", tag = "v0.1.3" }
+everruns-sdk = { git = "https://github.com/everruns/sdk", tag = "v0.1.4" }
 
 # gRPC (tonic)
 tonic = { version = "0.14", features = ["tls-ring"] }

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -20,7 +20,9 @@ use everruns_core::{
     ResourceConfigResponse, ToolDefinition, evaluate_policies,
 };
 
-use super::common::{ApiOptionExt, ApiPolicyResultExt, ErrorResponse, ListResponse};
+use super::common::{
+    ApiOptionExt, ApiPolicyResultExt, ErrorResponse, PaginatedResponse, Pagination,
+};
 use super::validation::{
     validate_create_agent_input, validate_import_file_size, validate_update_agent_input,
 };
@@ -190,7 +192,18 @@ pub struct ListAgentsQuery {
     pub search: Option<String>,
     /// Include archived agents. Deleted agents never appear in lists.
     pub include_archived: Option<bool>,
+    /// Pagination offset (default 0).
+    #[param(minimum = 0, default = 0)]
+    pub offset: Option<u32>,
+    /// Maximum items to return (default 20, max 100).
+    #[param(minimum = 1, maximum = 100, default = 20)]
+    pub limit: Option<u32>,
 }
+
+/// Default limit for agent listing
+const DEFAULT_LIMIT: u32 = 20;
+/// Maximum allowed limit for agent listing
+const MAX_LIMIT: u32 = 100;
 
 /// App state for agents routes
 #[derive(Clone)]
@@ -336,7 +349,7 @@ pub async fn create_agent(
     path = "/v1/agents",
     params(ListAgentsQuery),
     responses(
-        (status = 200, description = "List of agents", body = ListResponse<Agent>),
+        (status = 200, description = "Paginated list of agents", body = PaginatedResponse<Agent>),
         (status = 500, description = "Internal server error")
     ),
     tag = "agents"
@@ -345,19 +358,24 @@ pub async fn list_agents(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListAgentsQuery>,
-) -> Result<Json<ListResponse<Agent>>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<PaginatedResponse<Agent>>, (StatusCode, Json<ErrorResponse>)> {
+    let offset = query.offset.unwrap_or(0);
+    let limit = query.limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT);
+    let pagination = Pagination::new(offset, limit);
+
     let caller = Caller::from(&org);
-    let agents = state
+    let (agents, total) = state
         .service
         .list(
             &caller,
             query.search.as_deref(),
             query.include_archived.unwrap_or(false),
+            pagination,
         )
         .await
         .map_policy_or_internal("list agents")?;
 
-    Ok(Json(ListResponse::new(agents)))
+    Ok(Json(PaginatedResponse::new(agents, total, offset, limit)))
 }
 
 /// GET /v1/agents/{agent_id} - Get agent by ID

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1446,9 +1446,10 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
     // =========================================================================
 
     async fn list_agents(&self) -> everruns_core::error::Result<Vec<Agent>> {
-        let rows = self
+        let pagination = crate::api::common::Pagination::new(0, 1000);
+        let (rows, _total) = self
             .db
-            .list_agents(self.org_id, None, false)
+            .list_agents(self.org_id, None, false, pagination)
             .await
             .map_err(|e| store_error(format!("Failed to list agents: {e}")))?;
 

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -3430,9 +3430,10 @@ impl WorkerService for WorkerServiceImpl {
     ) -> Result<Response<PlatformListAgentsResponse>, Status> {
         let req = request.into_inner();
         let internal_caller = everruns_core::Caller::internal(req.org_id);
-        let agents = self
+        let pagination = crate::api::common::Pagination::new(0, 1000);
+        let (agents, _total) = self
             .agent_service
-            .list(&internal_caller, None, false)
+            .list(&internal_caller, None, false, pagination)
             .await
             .map_err(|e| Status::internal(format!("Failed to list agents: {}", e)))?;
 

--- a/crates/server/src/services/agent.rs
+++ b/crates/server/src/services/agent.rs
@@ -181,10 +181,11 @@ impl AgentService {
         caller: &Caller,
         search: Option<&str>,
         include_archived: bool,
-    ) -> Result<Vec<Agent>> {
-        let rows = self
+        pagination: crate::api::common::Pagination,
+    ) -> Result<(Vec<Agent>, u32)> {
+        let (rows, total) = self
             .db
-            .list_agents(caller.org_id, search, include_archived)
+            .list_agents(caller.org_id, search, include_archived, pagination)
             .await?;
 
         // Fetch capabilities for each agent
@@ -194,7 +195,7 @@ impl AgentService {
             agents.push(Self::row_to_agent(row, capabilities));
         }
 
-        Ok(agents)
+        Ok((agents, total))
     }
 
     #[policy(AGENT_MANAGE)]

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -211,8 +211,9 @@ impl StorageBackend {
         org_id: i64,
         search: Option<&str>,
         include_archived: bool,
-    ) -> Result<Vec<AgentRow>> {
-        dispatch!(self, list_agents, org_id, search, include_archived)
+        pagination: Pagination,
+    ) -> Result<(Vec<AgentRow>, u32)> {
+        dispatch!(self, list_agents, org_id, search, include_archived, pagination)
     }
 
     pub async fn get_agent_by_name(&self, org_id: i64, name: &str) -> Result<Option<AgentRow>> {

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -213,7 +213,14 @@ impl StorageBackend {
         include_archived: bool,
         pagination: Pagination,
     ) -> Result<(Vec<AgentRow>, u32)> {
-        dispatch!(self, list_agents, org_id, search, include_archived, pagination)
+        dispatch!(
+            self,
+            list_agents,
+            org_id,
+            search,
+            include_archived,
+            pagination
+        )
     }
 
     pub async fn get_agent_by_name(&self, org_id: i64, name: &str) -> Result<Option<AgentRow>> {

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -5802,7 +5802,12 @@ mod tests {
         create_test_agent(&db, "Code Reviewer", None).await;
 
         let (results, _total) = db
-            .list_agents(DEFAULT_ORG_ID, Some("customer"), false, default_pagination())
+            .list_agents(
+                DEFAULT_ORG_ID,
+                Some("customer"),
+                false,
+                default_pagination(),
+            )
             .await
             .unwrap();
         assert_eq!(results.len(), 1);
@@ -5815,7 +5820,12 @@ mod tests {
         create_test_agent(&db, "Customer Support Bot", None).await;
 
         let (results, _total) = db
-            .list_agents(DEFAULT_ORG_ID, Some("CUSTOMER"), false, default_pagination())
+            .list_agents(
+                DEFAULT_ORG_ID,
+                Some("CUSTOMER"),
+                false,
+                default_pagination(),
+            )
             .await
             .unwrap();
         assert_eq!(results.len(), 1);
@@ -5828,7 +5838,12 @@ mod tests {
         create_test_agent(&db, "Customer Feedback Analyzer", None).await;
 
         let (results, _total) = db
-            .list_agents(DEFAULT_ORG_ID, Some("customer bot"), false, default_pagination())
+            .list_agents(
+                DEFAULT_ORG_ID,
+                Some("customer bot"),
+                false,
+                default_pagination(),
+            )
             .await
             .unwrap();
         assert_eq!(results.len(), 1);
@@ -5912,7 +5927,12 @@ mod tests {
         // Query with >MAX_SEARCH_TOKENS words — only first 8 tokens used
         let long_query = "roses are red violets are blue sugar is sweet and so are you forever";
         let (results, _total) = db
-            .list_agents(DEFAULT_ORG_ID, Some(long_query), false, default_pagination())
+            .list_agents(
+                DEFAULT_ORG_ID,
+                Some(long_query),
+                false,
+                default_pagination(),
+            )
             .await
             .unwrap();
         // First 8 tokens: "roses are red violets are blue sugar is"

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -564,7 +564,8 @@ impl InMemoryDatabase {
         org_id: i64,
         search: Option<&str>,
         include_archived: bool,
-    ) -> Result<Vec<AgentRow>> {
+        pagination: crate::api::common::Pagination,
+    ) -> Result<(Vec<AgentRow>, u32)> {
         let agents = self.agents.read();
         let mut result: Vec<_> = agents
             .values()
@@ -582,7 +583,13 @@ impl InMemoryDatabase {
             .cloned()
             .collect();
         result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
-        Ok(result)
+
+        let total = result.len() as u32;
+        let offset = pagination.offset as usize;
+        let limit = pagination.limit as usize;
+        let paginated = result.into_iter().skip(offset).take(limit).collect();
+
+        Ok((paginated, total))
     }
 
     pub async fn get_agent_by_name(&self, org_id: i64, name: &str) -> Result<Option<AgentRow>> {
@@ -4635,7 +4642,13 @@ impl InMemoryDatabase {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::common::Pagination;
     use everruns_core::DEFAULT_ORG_ID;
+
+    /// Default pagination for tests (large enough to not truncate).
+    fn default_pagination() -> Pagination {
+        Pagination::new(0, 1000)
+    }
 
     #[tokio::test]
     async fn test_create_and_get_agent() {
@@ -5763,7 +5776,10 @@ mod tests {
         create_test_agent(&db, "Alpha", None).await;
         create_test_agent(&db, "Beta", None).await;
 
-        let results = db.list_agents(DEFAULT_ORG_ID, None, false).await.unwrap();
+        let (results, _total) = db
+            .list_agents(DEFAULT_ORG_ID, None, false, default_pagination())
+            .await
+            .unwrap();
         assert_eq!(results.len(), 2);
     }
 
@@ -5772,8 +5788,8 @@ mod tests {
         let db = InMemoryDatabase::new();
         create_test_agent(&db, "Alpha", None).await;
 
-        let results = db
-            .list_agents(DEFAULT_ORG_ID, Some(""), false)
+        let (results, _total) = db
+            .list_agents(DEFAULT_ORG_ID, Some(""), false, default_pagination())
             .await
             .unwrap();
         assert_eq!(results.len(), 1);
@@ -5785,8 +5801,8 @@ mod tests {
         create_test_agent(&db, "Customer Support Bot", None).await;
         create_test_agent(&db, "Code Reviewer", None).await;
 
-        let results = db
-            .list_agents(DEFAULT_ORG_ID, Some("customer"), false)
+        let (results, _total) = db
+            .list_agents(DEFAULT_ORG_ID, Some("customer"), false, default_pagination())
             .await
             .unwrap();
         assert_eq!(results.len(), 1);
@@ -5798,8 +5814,8 @@ mod tests {
         let db = InMemoryDatabase::new();
         create_test_agent(&db, "Customer Support Bot", None).await;
 
-        let results = db
-            .list_agents(DEFAULT_ORG_ID, Some("CUSTOMER"), false)
+        let (results, _total) = db
+            .list_agents(DEFAULT_ORG_ID, Some("CUSTOMER"), false, default_pagination())
             .await
             .unwrap();
         assert_eq!(results.len(), 1);
@@ -5811,8 +5827,8 @@ mod tests {
         create_test_agent(&db, "Customer Support Bot", None).await;
         create_test_agent(&db, "Customer Feedback Analyzer", None).await;
 
-        let results = db
-            .list_agents(DEFAULT_ORG_ID, Some("customer bot"), false)
+        let (results, _total) = db
+            .list_agents(DEFAULT_ORG_ID, Some("customer bot"), false, default_pagination())
             .await
             .unwrap();
         assert_eq!(results.len(), 1);
@@ -5824,8 +5840,8 @@ mod tests {
         let db = InMemoryDatabase::new();
         create_test_agent(&db, "Helper", Some("Handles billing inquiries")).await;
 
-        let results = db
-            .list_agents(DEFAULT_ORG_ID, Some("billing"), false)
+        let (results, _total) = db
+            .list_agents(DEFAULT_ORG_ID, Some("billing"), false, default_pagination())
             .await
             .unwrap();
         assert_eq!(results.len(), 1);
@@ -5838,8 +5854,13 @@ mod tests {
         create_test_agent(&db, "Daytona Coder", Some("cloud sandbox agent")).await;
 
         // "daytona" in name, "sandbox" in description → both must match
-        let results = db
-            .list_agents(DEFAULT_ORG_ID, Some("daytona sandbox"), false)
+        let (results, _total) = db
+            .list_agents(
+                DEFAULT_ORG_ID,
+                Some("daytona sandbox"),
+                false,
+                default_pagination(),
+            )
             .await
             .unwrap();
         assert_eq!(results.len(), 1);
@@ -5850,8 +5871,13 @@ mod tests {
         let db = InMemoryDatabase::new();
         create_test_agent(&db, "Customer Support Bot", None).await;
 
-        let results = db
-            .list_agents(DEFAULT_ORG_ID, Some("zzz_nonexistent"), false)
+        let (results, _total) = db
+            .list_agents(
+                DEFAULT_ORG_ID,
+                Some("zzz_nonexistent"),
+                false,
+                default_pagination(),
+            )
             .await
             .unwrap();
         assert!(results.is_empty());
@@ -5869,8 +5895,8 @@ mod tests {
                     these memories I shall forever keep. \
                     Through winding roads and starlit nights, \
                     we chase our dreams to greater heights.";
-        let results = db
-            .list_agents(DEFAULT_ORG_ID, Some(poem), false)
+        let (results, _total) = db
+            .list_agents(DEFAULT_ORG_ID, Some(poem), false, default_pagination())
             .await
             .unwrap();
         // No agent should match a poem
@@ -5885,8 +5911,8 @@ mod tests {
 
         // Query with >MAX_SEARCH_TOKENS words — only first 8 tokens used
         let long_query = "roses are red violets are blue sugar is sweet and so are you forever";
-        let results = db
-            .list_agents(DEFAULT_ORG_ID, Some(long_query), false)
+        let (results, _total) = db
+            .list_agents(DEFAULT_ORG_ID, Some(long_query), false, default_pagination())
             .await
             .unwrap();
         // First 8 tokens: "roses are red violets are blue sugar is"
@@ -5900,8 +5926,8 @@ mod tests {
         create_test_agent(&db, "Agent v2.0 (beta)", None).await;
         create_test_agent(&db, "my-agent_v1", None).await;
 
-        let results = db
-            .list_agents(DEFAULT_ORG_ID, Some("v2.0"), false)
+        let (results, _total) = db
+            .list_agents(DEFAULT_ORG_ID, Some("v2.0"), false, default_pagination())
             .await
             .unwrap();
         assert_eq!(results.len(), 1);
@@ -5914,8 +5940,8 @@ mod tests {
         create_test_agent(&db, "日本語エージェント", Some("テスト用")).await;
         create_test_agent(&db, "English Agent", None).await;
 
-        let results = db
-            .list_agents(DEFAULT_ORG_ID, Some("日本語"), false)
+        let (results, _total) = db
+            .list_agents(DEFAULT_ORG_ID, Some("日本語"), false, default_pagination())
             .await
             .unwrap();
         assert_eq!(results.len(), 1);
@@ -5928,8 +5954,8 @@ mod tests {
         create_test_agent(&db, "🤖 Robot Helper", None).await;
         create_test_agent(&db, "Normal Agent", None).await;
 
-        let results = db
-            .list_agents(DEFAULT_ORG_ID, Some("🤖"), false)
+        let (results, _total) = db
+            .list_agents(DEFAULT_ORG_ID, Some("🤖"), false, default_pagination())
             .await
             .unwrap();
         assert_eq!(results.len(), 1);
@@ -5941,8 +5967,13 @@ mod tests {
         create_test_agent(&db, "Customer Support Bot", None).await;
 
         // Extra spaces, tabs, etc.
-        let results = db
-            .list_agents(DEFAULT_ORG_ID, Some("  customer   bot  "), false)
+        let (results, _total) = db
+            .list_agents(
+                DEFAULT_ORG_ID,
+                Some("  customer   bot  "),
+                false,
+                default_pagination(),
+            )
             .await
             .unwrap();
         assert_eq!(results.len(), 1);

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -679,7 +679,8 @@ impl Database {
         org_id: i64,
         search: Option<&str>,
         include_archived: bool,
-    ) -> Result<Vec<AgentRow>> {
+        pagination: crate::api::common::Pagination,
+    ) -> Result<(Vec<AgentRow>, u32)> {
         let (search_sql, patterns) =
             build_search_sql(search, "LOWER(name || ' ' || COALESCE(description, ''))", 2);
         let status_sql = if include_archived {
@@ -687,18 +688,40 @@ impl Database {
         } else {
             " AND status = 'active'"
         };
+        let param_idx = 2 + patterns.len();
+
+        // Count query
+        let count_sql = format!(
+            "SELECT COUNT(*) as count FROM agents WHERE org_id = $1{status_sql}{search_sql}"
+        );
+        let mut count_query = sqlx::query_as::<_, (i64,)>(&count_sql).bind(org_id);
+        for pat in &patterns {
+            count_query = count_query.bind(pat);
+        }
+        let total: (i64,) = count_query.fetch_one(&self.pool).await?;
+
+        // Data query with pagination
+        let limit_idx = param_idx + 1;
+        let offset_idx = param_idx + 2;
         let sql = format!(
             r#"SELECT id, public_id, org_id, name, description, system_prompt, default_model_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools,
                        total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens
                 FROM agents
                 WHERE org_id = $1{status_sql}{search_sql}
-                ORDER BY created_at DESC"#
+                ORDER BY created_at DESC
+                LIMIT ${limit_idx} OFFSET ${offset_idx}"#
         );
         let mut query = sqlx::query_as::<_, AgentRow>(&sql).bind(org_id);
         for pat in &patterns {
             query = query.bind(pat);
         }
-        Ok(query.fetch_all(&self.pool).await?)
+        let rows = query
+            .bind(pagination.limit as i64)
+            .bind(pagination.offset as i64)
+            .fetch_all(&self.pool)
+            .await?;
+
+        Ok((rows, total.0 as u32))
     }
 
     pub async fn get_agent_by_name(&self, org_id: i64, name: &str) -> Result<Option<AgentRow>> {

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -688,7 +688,7 @@ impl Database {
         } else {
             " AND status = 'active'"
         };
-        let param_idx = 2 + patterns.len();
+        let param_idx = 1 + patterns.len();
 
         // Count query
         let count_sql = format!(

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -95,8 +95,9 @@ async fn test_agent_crud() {
     assert_eq!(updated.name, "Updated Agent");
 
     // List agents
-    let agents = backend
-        .list_agents(TEST_ORG_ID, None, false)
+    let pagination = everruns_server::api::common::Pagination::new(0, 1000);
+    let (agents, _total) = backend
+        .list_agents(TEST_ORG_ID, None, false, pagination)
         .await
         .expect("Failed to list agents");
     assert!(agents.iter().any(|a| a.id == agent.id));

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -47,15 +47,46 @@
                 "null"
               ]
             }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Pagination offset (default 0).",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum items to return (default 20, max 100).",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32",
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "List of agents",
+            "description": "Paginated list of agents",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponse_Agent"
+                  "$ref": "#/components/schemas/PaginatedResponse_Agent"
                 }
               }
             }
@@ -8483,6 +8514,135 @@
             "type": "string",
             "description": "Turn ID this output belongs to",
             "example": "turn_01933b5a00007000800000000000001"
+          }
+        }
+      },
+      "PaginatedResponse_Agent": {
+        "type": "object",
+        "description": "Response wrapper for paginated list endpoints.\nIncludes pagination metadata along with the data array.",
+        "required": [
+          "data",
+          "total",
+          "offset",
+          "limit"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "description": "Agent configuration for agentic loop.\nAn agent defines the behavior and capabilities of an AI assistant.",
+              "required": [
+                "id",
+                "name",
+                "system_prompt",
+                "status",
+                "created_at",
+                "updated_at"
+              ],
+              "properties": {
+                "capabilities": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AgentCapabilityConfig"
+                  },
+                  "description": "Capabilities enabled for this agent with per-agent configuration.\nCapabilities add tools and system prompt modifications."
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Timestamp when the agent was created."
+                },
+                "default_model_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Default LLM model ID for this agent.\nCan be overridden at the session level.",
+                  "example": "model_01933b5a00007000800000000000001"
+                },
+                "description": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Human-readable description of what the agent does."
+                },
+                "id": {
+                  "type": "string",
+                  "description": "External identifier (agent_<32-hex>). Shown as \"id\" in API.\nClient-supplied or auto-generated.",
+                  "example": "agent_01933b5a000070008000000000000001"
+                },
+                "initial_files": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/InitialFile"
+                  },
+                  "description": "Starter files copied into each new session for this agent."
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Display name of the agent."
+                },
+                "status": {
+                  "$ref": "#/components/schemas/AgentStatus",
+                  "description": "Current lifecycle status of the agent."
+                },
+                "system_prompt": {
+                  "type": "string",
+                  "description": "System prompt that defines the agent's behavior.\nSent as the first message in every conversation."
+                },
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Tags for organizing and filtering agents."
+                },
+                "tools": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ToolDefinition"
+                  },
+                  "description": "Client-side tools registered for this agent.\nThese tools are executed by the client, not the server."
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Timestamp when the agent was last updated."
+                },
+                "usage": {
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "#/components/schemas/TokenUsage",
+                      "description": "Cumulative token usage across all sessions for this agent."
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Array of items returned by the list operation."
+          },
+          "limit": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Maximum number of items per page.",
+            "minimum": 0
+          },
+          "offset": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Current offset (starting position).",
+            "minimum": 0
+          },
+          "total": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Total number of items matching the query (across all pages).",
+            "minimum": 0
           }
         }
       },

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -8541,6 +8541,14 @@
                 "updated_at"
               ],
               "properties": {
+                "archived_at": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "format": "date-time",
+                  "description": "Timestamp when the agent was archived."
+                },
                 "capabilities": {
                   "type": "array",
                   "items": {
@@ -8560,6 +8568,14 @@
                   ],
                   "description": "Default LLM model ID for this agent.\nCan be overridden at the session level.",
                   "example": "model_01933b5a00007000800000000000001"
+                },
+                "deleted_at": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "format": "date-time",
+                  "description": "Timestamp when the agent was deleted."
                 },
                 "description": {
                   "type": [

--- a/scripts/cli-e2e-test.sh
+++ b/scripts/cli-e2e-test.sh
@@ -136,8 +136,19 @@ else
   exit 1
 fi
 
-# List agents (skip - SDK/server pagination compatibility issue)
-log_test "agents list (SKIPPED - SDK pagination compatibility)"
+# List agents
+log_test "agents list"
+LIST_OUTPUT=$($CLI --api-url "$API_URL" agents list --output json 2>&1) || {
+  log_fail "agents list failed"
+  echo "$LIST_OUTPUT"
+}
+AGENT_COUNT=$(echo "$LIST_OUTPUT" | jq -e '.data | length' 2>/dev/null)
+if [ -n "$AGENT_COUNT" ] && [ "$AGENT_COUNT" -ge 1 ]; then
+  log_pass "agents list returned $AGENT_COUNT agent(s)"
+else
+  log_fail "agents list did not return valid data"
+  echo "$LIST_OUTPUT"
+fi
 
 # Get agent (uses prefixed ID directly)
 log_test "agents get"
@@ -196,8 +207,19 @@ else
   exit 1
 fi
 
-# List sessions (skip - SDK/server pagination compatibility issue)
-log_test "sessions list (SKIPPED - SDK pagination compatibility)"
+# List sessions
+log_test "sessions list"
+LIST_SESSIONS_OUTPUT=$($CLI --api-url "$API_URL" sessions list --output json 2>&1) || {
+  log_fail "sessions list failed"
+  echo "$LIST_SESSIONS_OUTPUT"
+}
+SESSION_COUNT=$(echo "$LIST_SESSIONS_OUTPUT" | jq -e '.data | length' 2>/dev/null)
+if [ -n "$SESSION_COUNT" ] && [ "$SESSION_COUNT" -ge 1 ]; then
+  log_pass "sessions list returned $SESSION_COUNT session(s)"
+else
+  log_fail "sessions list did not return valid data"
+  echo "$LIST_SESSIONS_OUTPUT"
+fi
 
 # Get session (uses prefixed session ID directly)
 log_test "sessions get"


### PR DESCRIPTION
## What
- Update everruns-sdk from v0.1.3 to v0.1.4
- Add pagination support to the agents list API endpoint
- Update SDK compat test script for v0.1.4 session creation API

## Why
SDK v0.1.4 changed the session creation API to a builder pattern (`CreateSessionRequest`). The compat test needed a new branch for this version. The SDK also expects paginated responses (`{data, total, offset, limit}`) from list endpoints, but the agents list endpoint was returning a plain list. This caused CLI E2E test failures for `agents list` and `sessions list`.

## How
- Added v0.1.4+ branch in `test-rust.sh` using `CreateSessionRequest::new().harness_id(...).agent_id(...)` builder
- Added `offset`/`limit` query params to agents list handler with `DEFAULT_LIMIT=20`, `MAX_LIMIT=100`
- Changed agents list response from `ListResponse<Agent>` to `PaginatedResponse<Agent>`
- Threaded `Pagination` struct through service → storage layers (memory + postgres)
- Un-skipped CLI E2E tests for agents list and sessions list (11/11 pass)
- Regenerated OpenAPI spec

## Risk
- Low
- Agents list response shape changed from `{data}` to `{data, total, offset, limit}`. This is a breaking change for any consumer expecting the old shape, but aligns with the SDK and the existing sessions list pattern.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered