### PR TITLE
fix(api): bind session schedule routes to parent session

### DIFF
--- a/crates/server/src/api/session_schedules.rs
+++ b/crates/server/src/api/session_schedules.rs
@@ -113,14 +113,11 @@ pub async fn list_schedules(
 pub async fn get_schedule(
     org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_session_id, schedule_id)): Path<(SessionId, ScheduleId)>,
+    Path((session_id, schedule_id)): Path<(SessionId, ScheduleId)>,
 ) -> Result<Json<SessionSchedule>, (StatusCode, Json<ErrorResponse>)> {
-    let schedule = state
-        .schedule_service
-        .get(org.org_id, schedule_id)
-        .await
-        .log_internal_error_json("get schedule")?
-        .ok_or_not_found_json("Schedule")?;
+    let schedule =
+        get_schedule_in_session(&state, org.org_id, session_id, schedule_id, "get schedule")
+            .await?;
 
     Ok(Json(schedule))
 }
@@ -139,10 +136,18 @@ pub async fn get_schedule(
 pub async fn update_schedule(
     org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_session_id, schedule_id)): Path<(SessionId, ScheduleId)>,
+    Path((session_id, schedule_id)): Path<(SessionId, ScheduleId)>,
     Json(req): Json<UpdateScheduleRequest>,
 ) -> Result<Json<SessionSchedule>, (StatusCode, Json<ErrorResponse>)> {
     let enabled = req.enabled.unwrap_or(true);
+    get_schedule_in_session(
+        &state,
+        org.org_id,
+        session_id,
+        schedule_id,
+        "update schedule parent",
+    )
+    .await?;
 
     let schedule = state
         .schedule_service
@@ -167,8 +172,17 @@ pub async fn update_schedule(
 pub async fn delete_schedule(
     org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_session_id, schedule_id)): Path<(SessionId, ScheduleId)>,
+    Path((session_id, schedule_id)): Path<(SessionId, ScheduleId)>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    get_schedule_in_session(
+        &state,
+        org.org_id,
+        session_id,
+        schedule_id,
+        "delete schedule parent",
+    )
+    .await?;
+
     let deleted = state
         .schedule_service
         .delete(org.org_id, schedule_id)
@@ -200,8 +214,17 @@ pub async fn delete_schedule(
 pub async fn trigger_schedule(
     org: ResolvedOrg,
     State(state): State<AppState>,
-    Path((_session_id, schedule_id)): Path<(SessionId, ScheduleId)>,
+    Path((session_id, schedule_id)): Path<(SessionId, ScheduleId)>,
 ) -> Result<Json<SessionSchedule>, (StatusCode, Json<ErrorResponse>)> {
+    get_schedule_in_session(
+        &state,
+        org.org_id,
+        session_id,
+        schedule_id,
+        "trigger schedule parent",
+    )
+    .await?;
+
     let schedule = state
         .schedule_service
         .mark_triggered(org.org_id, schedule_id)
@@ -210,4 +233,20 @@ pub async fn trigger_schedule(
         .ok_or_not_found_json("Schedule")?;
 
     Ok(Json(schedule))
+}
+
+async fn get_schedule_in_session(
+    state: &AppState,
+    org_id: i64,
+    session_id: SessionId,
+    schedule_id: ScheduleId,
+    log_context: &'static str,
+) -> Result<SessionSchedule, (StatusCode, Json<ErrorResponse>)> {
+    state
+        .schedule_service
+        .get(org_id, schedule_id)
+        .await
+        .log_internal_error_json(log_context)?
+        .filter(|schedule| schedule.session_id == session_id)
+        .ok_or_not_found_json("Schedule")
 }

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -13,11 +13,14 @@
 mod test_harness;
 
 use axum::http::StatusCode;
+use chrono::{Duration, Utc};
 use serde_json::{Value, json};
 use test_harness::TestServer;
 
 use everruns_core::llm_models::LlmProvider;
+use everruns_core::typed_id::ScheduleId;
 use everruns_core::{Agent, Harness, LlmModel, Session, SessionFile};
+use everruns_server::storage::models::CreateSessionScheduleRow;
 
 /// Seed harness ID from seed.rs (BASE_HARNESS = 0x01933b5a_0000_7000_8000_000000000601)
 const SEED_BASE_HARNESS_ID: &str = "harness_01933b5a000070008000000000000601";
@@ -463,6 +466,144 @@ async fn test_create_session_nonexistent_agent_returns_404() {
         )
         .await
         .assert_status(StatusCode::NOT_FOUND);
+}
+
+async fn create_schedule_test_session(server: &TestServer, title: &str) -> Session {
+    server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": SEED_BASE_HARNESS_ID,
+                "title": title
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json()
+}
+
+async fn seed_session_schedule(server: &TestServer, session: &Session) -> ScheduleId {
+    let scheduled_at = Utc::now() + Duration::hours(1);
+    let row = server
+        .db
+        .create_session_schedule(CreateSessionScheduleRow {
+            org_id: 1,
+            session_id: session.id,
+            description: "Mismatch test schedule".to_string(),
+            cron_expression: None,
+            scheduled_at: Some(scheduled_at),
+            timezone: "UTC".to_string(),
+            next_trigger_at: Some(scheduled_at),
+        })
+        .await
+        .unwrap();
+    row.id
+}
+
+// ============================================
+// Session Schedule API Tests
+// ============================================
+
+#[tokio::test]
+async fn test_get_session_schedule_wrong_parent_returns_not_found() {
+    let server = TestServer::in_memory().await;
+    let session = create_schedule_test_session(&server, "Schedule Owner").await;
+    let other_session = create_schedule_test_session(&server, "Wrong Parent").await;
+    let schedule_id = seed_session_schedule(&server, &session).await;
+
+    let body: Value = server
+        .get(&format!(
+            "/v1/sessions/{}/schedules/{}",
+            other_session.id, schedule_id
+        ))
+        .await
+        .assert_status(StatusCode::NOT_FOUND)
+        .json();
+
+    assert_eq!(body["error"], "Schedule not found");
+}
+
+#[tokio::test]
+async fn test_update_session_schedule_wrong_parent_returns_not_found() {
+    let server = TestServer::in_memory().await;
+    let session = create_schedule_test_session(&server, "Schedule Owner").await;
+    let other_session = create_schedule_test_session(&server, "Wrong Parent").await;
+    let schedule_id = seed_session_schedule(&server, &session).await;
+
+    let body: Value = server
+        .patch(
+            &format!(
+                "/v1/sessions/{}/schedules/{}",
+                other_session.id, schedule_id
+            ),
+            json!({ "enabled": false }),
+        )
+        .await
+        .assert_status(StatusCode::NOT_FOUND)
+        .json();
+    assert_eq!(body["error"], "Schedule not found");
+
+    let persisted = server
+        .db
+        .get_session_schedule(1, schedule_id)
+        .await
+        .unwrap();
+    assert!(persisted.unwrap().enabled);
+}
+
+#[tokio::test]
+async fn test_delete_session_schedule_wrong_parent_returns_not_found() {
+    let server = TestServer::in_memory().await;
+    let session = create_schedule_test_session(&server, "Schedule Owner").await;
+    let other_session = create_schedule_test_session(&server, "Wrong Parent").await;
+    let schedule_id = seed_session_schedule(&server, &session).await;
+
+    let body: Value = server
+        .delete(&format!(
+            "/v1/sessions/{}/schedules/{}",
+            other_session.id, schedule_id
+        ))
+        .await
+        .assert_status(StatusCode::NOT_FOUND)
+        .json();
+    assert_eq!(body["error"], "Schedule not found");
+
+    let persisted = server
+        .db
+        .get_session_schedule(1, schedule_id)
+        .await
+        .unwrap();
+    assert!(persisted.is_some());
+}
+
+#[tokio::test]
+async fn test_trigger_session_schedule_wrong_parent_returns_not_found() {
+    let server = TestServer::in_memory().await;
+    let session = create_schedule_test_session(&server, "Schedule Owner").await;
+    let other_session = create_schedule_test_session(&server, "Wrong Parent").await;
+    let schedule_id = seed_session_schedule(&server, &session).await;
+
+    let body: Value = server
+        .post(
+            &format!(
+                "/v1/sessions/{}/schedules/{}/trigger",
+                other_session.id, schedule_id
+            ),
+            json!({}),
+        )
+        .await
+        .assert_status(StatusCode::NOT_FOUND)
+        .json();
+    assert_eq!(body["error"], "Schedule not found");
+
+    let persisted = server
+        .db
+        .get_session_schedule(1, schedule_id)
+        .await
+        .unwrap();
+    let persisted = persisted.unwrap();
+    assert_eq!(persisted.trigger_count, 0);
+    assert!(persisted.last_triggered_at.is_none());
 }
 
 #[tokio::test]

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -201,6 +201,10 @@ impl TestServer {
         let skills_state = api::skills::AppState::new(db.clone(), auth_state.clone());
         let images_state = api::images::AppState::new(db.clone(), auth_state.clone());
         let organizations_state = api::organizations::AppState::new(db.clone(), auth_state.clone());
+        let session_schedules_state = api::session_schedules::AppState::new(
+            Arc::new(services::SessionScheduleService::new(db.clone())),
+            auth_state.clone(),
+        );
         let notifications_state = if feature_flags.notifications {
             Some(api::notifications::AppState {
                 notification_service: Arc::new(services::NotificationService::new(db.clone())),
@@ -250,6 +254,7 @@ impl TestServer {
             .merge(api::skills::routes(skills_state))
             .merge(api::images::routes(images_state))
             .merge(api::organizations::routes(organizations_state))
+            .merge(api::session_schedules::routes(session_schedules_state))
             .merge(api::feature_flags::routes(feature_flags_state))
             .merge(api::user_connections::routes(user_connections_state))
             .merge(api::slack_events::routes(slack_state))


### PR DESCRIPTION
## What
Bind nested session-schedule routes to the parent `session_id` instead of operating on `schedule_id` alone.

## Why
Callers could get, update, delete, or trigger a schedule through the wrong session URL as long as the schedule belonged to the same org.

## How
Load the schedule in each nested handler, require `schedule.session_id == {session_id}`, and return the existing 404 path on parent mismatch. Add API regressions for get/update/delete/trigger mismatch cases and mount the session-schedule routes in the in-memory API test harness.

## Risk
- Low
- Nested session schedule routes now reject mismatched parent paths with 404, which is the intended containment behavior.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered