### PR TITLE
fix(org): add default and base harness settings

### DIFF
--- a/apps/ui/src/__tests__/agent-detail-model.test.tsx
+++ b/apps/ui/src/__tests__/agent-detail-model.test.tsx
@@ -150,6 +150,7 @@ const mockUseLlmModels = jest.fn();
 const mockUseExportAgent = jest.fn();
 const mockUseCopyAgent = jest.fn();
 const mockUseHarnesses = jest.fn();
+const mockUseOrganization = jest.fn();
 
 jest.mock("@/hooks", () => ({
   useAgent: (...args: unknown[]) => mockUseAgent(...args),
@@ -160,6 +161,10 @@ jest.mock("@/hooks", () => ({
   useExportAgent: () => mockUseExportAgent(),
   useCopyAgent: () => mockUseCopyAgent(),
   useHarnesses: () => mockUseHarnesses(),
+}));
+
+jest.mock("@/hooks/use-organizations", () => ({
+  useOrganization: () => mockUseOrganization(),
 }));
 
 // Helper to render with Suspense for React.use()
@@ -190,6 +195,7 @@ describe("AgentDetailPage - LLM Model Display in Sessions List", () => {
     mockUseExportAgent.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
     mockUseCopyAgent.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
     mockUseHarnesses.mockReturnValue({ data: [] });
+    mockUseOrganization.mockReturnValue({ data: null });
   });
 
   it("renders agent page structure", async () => {

--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -28,6 +28,7 @@ import { CopyButton } from "@/components/ui/copy-button";
 import type { Capability, LlmModelWithProvider, TokenUsage } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
 import { getEntityNameClassName, getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
+import { useOrganization } from "@/hooks/use-organizations";
 
 // Helper function to format token counts in a compact way
 function formatTokens(tokens: number): string {
@@ -60,6 +61,7 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
   const { data: allCapabilities } = useCapabilities();
   const { data: llmModels } = useLlmModels();
   const createSession = useCreateSession();
+  const { data: organization } = useOrganization();
   const exportAgent = useExportAgent();
   const copyAgent = useCopyAgent();
   const { data: harnesses } = useHarnesses();
@@ -74,7 +76,7 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
   const defaultModel = agent?.default_model_id ? modelMap.get(agent.default_model_id) : undefined;
 
   const handleNewSession = async () => {
-    const harnessId = harnesses?.[0]?.id;
+    const harnessId = organization?.default_harness_id || harnesses?.[0]?.id;
     if (!harnessId) return;
     try {
       const session = await createSession.mutateAsync({

--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/page.tsx
@@ -10,6 +10,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { SessionCard } from "@/components/session/session-card";
 import { ArrowLeft, Plus, ChevronLeft, ChevronRight } from "lucide-react";
 import type { LlmModelWithProvider } from "@/lib/api/types";
+import { useOrganization } from "@/hooks/use-organizations";
 
 const PAGE_SIZE = 20;
 
@@ -26,6 +27,7 @@ export default function SessionsListPage({ params }: { params: Promise<{ agentId
   });
   const { data: llmModels } = useLlmModels();
   const createSession = useCreateSession();
+  const { data: organization } = useOrganization();
   const { data: harnesses } = useHarnesses();
 
   const sessions = sessionsResponse?.data ?? [];
@@ -39,7 +41,7 @@ export default function SessionsListPage({ params }: { params: Promise<{ agentId
   }, [llmModels]);
 
   const handleNewSession = async () => {
-    const harnessId = harnesses?.[0]?.id;
+    const harnessId = organization?.default_harness_id || harnesses?.[0]?.id;
     if (!harnessId) return;
     try {
       const session = await createSession.mutateAsync({

--- a/apps/ui/src/app/(main)/dashboard/page.tsx
+++ b/apps/ui/src/app/(main)/dashboard/page.tsx
@@ -28,6 +28,7 @@ import { AgentSelect } from "@/components/agent/agent-select";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
+import { useOrganization } from "@/hooks/use-organizations";
 
 export default function DashboardPage() {
   const router = useRouter();
@@ -40,6 +41,7 @@ export default function DashboardPage() {
   const { data: sessionStats } = useSessionStats();
   const { data: llmModels } = useLlmModels();
   const createSession = useCreateSession();
+  const { data: organization } = useOrganization();
   const { data: harnesses } = useHarnesses();
 
   const [newSessionDialogOpen, setNewSessionDialogOpen] = useState(false);
@@ -51,7 +53,7 @@ export default function DashboardPage() {
   };
 
   const handleCreateSession = async () => {
-    const harnessId = harnesses?.[0]?.id;
+    const harnessId = organization?.default_harness_id || harnesses?.[0]?.id;
     if (!harnessId) return;
     try {
       const session = await createSession.mutateAsync({

--- a/apps/ui/src/app/(main)/sessions/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/page.tsx
@@ -30,6 +30,7 @@ import { Label } from "@/components/ui/label";
 import { Plus, ChevronLeft, ChevronRight } from "lucide-react";
 import type { LlmModelWithProvider, Agent } from "@/lib/api/types";
 import { getEntityReferenceLabel } from "@/lib/entity-lifecycle";
+import { useOrganization } from "@/hooks/use-organizations";
 
 const PAGE_SIZE = 20;
 
@@ -43,6 +44,7 @@ export default function SessionsPage() {
   const offset = page * PAGE_SIZE;
 
   const { data: agents, isLoading: agentsLoading } = useAgents({ includeArchived: true });
+  const { data: organization } = useOrganization();
   const { data: harnesses } = useHarnesses();
   const { data: sessionsResponse, isLoading: sessionsLoading } = useSessions(
     selectedAgentId || undefined, // Pass undefined to get all sessions
@@ -78,9 +80,9 @@ export default function SessionsPage() {
   }, [agents]);
 
   const handleOpenNewSessionDialog = () => {
-    // Pre-select the Generic harness, falling back to the first harness
+    const defaultHarnessId = organization?.default_harness_id;
     const genericHarness = harnesses?.find((h) => h.name === "Generic");
-    setNewSessionHarnessId(genericHarness?.id || harnesses?.[0]?.id || "");
+    setNewSessionHarnessId(defaultHarnessId || genericHarness?.id || harnesses?.[0]?.id || "");
     // Pre-select the filtered agent if one is selected, otherwise leave empty (optional)
     setNewSessionAgentId(selectedAgentId || "");
     setNewSessionDialogOpen(true);

--- a/apps/ui/src/app/(main)/settings/organisation/page.tsx
+++ b/apps/ui/src/app/(main)/settings/organisation/page.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { CopyButton } from "@/components/ui/copy-button";
+import { HarnessSelect } from "@/components/harness/harness-select";
 import {
   Dialog,
   DialogContent,
@@ -20,42 +21,65 @@ import {
   useUpdateOrganization,
   useCreateOrganization,
 } from "@/hooks/use-organizations";
+import { useHarnesses } from "@/hooks";
 import { useOrg } from "@/providers/org-provider";
 import { Building2, Save, AlertCircle, Plus, Check } from "lucide-react";
 
 export default function OrganisationPage() {
   const { currentOrg, organizations, setCurrentOrg } = useOrg();
   const { data: organization, isLoading, error } = useOrganization();
+  const { data: harnesses = [] } = useHarnesses();
   const updateOrganization = useUpdateOrganization();
   const createOrganization = useCreateOrganization();
 
   const [name, setName] = useState("");
+  const [defaultHarnessId, setDefaultHarnessId] = useState("");
+  const [baseHarnessId, setBaseHarnessId] = useState("");
   const [hasChanges, setHasChanges] = useState(false);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [newOrgName, setNewOrgName] = useState("");
 
-  // Sync name from fetched organization data
+  const syncHasChanges = (nextName: string, nextDefaultHarnessId: string, nextBaseHarnessId: string) => {
+    setHasChanges(
+      nextName !== (organization?.name || "") ||
+        nextDefaultHarnessId !== (organization?.default_harness_id || "") ||
+        nextBaseHarnessId !== (organization?.base_harness_id || ""),
+    );
+  };
+
   useEffect(() => {
-    if (organization?.name) {
-      setName(organization.name);
-      setHasChanges(false);
+    if (!organization) {
+      return;
     }
-  }, [organization?.name]);
+
+    const genericHarnessId = harnesses.find((h) => h.name === "Generic")?.id || "";
+    const baseHarnessFallbackId = harnesses.find((h) => h.name === "Base")?.id || "";
+
+    setName(organization.name);
+    setDefaultHarnessId(organization.default_harness_id || genericHarnessId);
+    setBaseHarnessId(organization.base_harness_id || baseHarnessFallbackId);
+    setHasChanges(false);
+  }, [organization, harnesses]);
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setName(e.target.value);
-    setHasChanges(e.target.value !== organization?.name);
+    const nextName = e.target.value;
+    setName(nextName);
+    syncHasChanges(nextName, defaultHarnessId, baseHarnessId);
   };
 
   const handleSave = async () => {
-    if (!hasChanges || !name.trim()) return;
+    if (!hasChanges || !name.trim() || !defaultHarnessId || !baseHarnessId) return;
 
-    await updateOrganization.mutateAsync({ name: name.trim() });
+    await updateOrganization.mutateAsync({
+      name: name.trim(),
+      default_harness_id: defaultHarnessId,
+      base_harness_id: baseHarnessId,
+    });
     setHasChanges(false);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter" && hasChanges && name.trim()) {
+    if (e.key === "Enter" && hasChanges && name.trim() && defaultHarnessId && baseHarnessId) {
       handleSave();
     }
   };
@@ -123,37 +147,77 @@ export default function OrganisationPage() {
             </div>
 
             <div className="space-y-6 max-w-md">
-              {/* Organisation Name */}
               <div className="space-y-2">
                 <Label htmlFor="org-name">Organisation Name</Label>
-                <div className="flex gap-2">
-                  <Input
-                    id="org-name"
-                    value={name}
-                    onChange={handleNameChange}
-                    onKeyDown={handleKeyDown}
-                    placeholder="Organisation name"
-                    className="flex-1"
-                  />
-                  <Button
-                    onClick={handleSave}
-                    disabled={!hasChanges || !name.trim() || updateOrganization.isPending}
-                  >
-                    <Save className="h-4 w-4 mr-2" />
-                    {updateOrganization.isPending ? "Saving..." : "Save"}
-                  </Button>
-                </div>
-                {updateOrganization.isError && (
-                  <p className="text-sm text-destructive">
-                    Failed to update: {updateOrganization.error.message}
-                  </p>
-                )}
-                {updateOrganization.isSuccess && !hasChanges && (
-                  <p className="text-sm text-green-600">Saved successfully</p>
+                <Input
+                  id="org-name"
+                  value={name}
+                  onChange={handleNameChange}
+                  onKeyDown={handleKeyDown}
+                  placeholder="Organisation name"
+                  className="flex-1"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="default-harness">Default Harness</Label>
+                <HarnessSelect
+                  value={defaultHarnessId}
+                  onValueChange={(value) => {
+                    setDefaultHarnessId(value);
+                    syncHasChanges(name, value, baseHarnessId);
+                  }}
+                  placeholder="Select default harness"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Used as the normal starting harness in the UI. New orgs default this to Generic.
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="base-harness">Base Harness</Label>
+                <HarnessSelect
+                  value={baseHarnessId}
+                  onValueChange={(value) => {
+                    setBaseHarnessId(value);
+                    syncHasChanges(name, defaultHarnessId, value);
+                  }}
+                  placeholder="Select base harness"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Used only when a session starts without an explicit harness. New orgs default this
+                  to Base.
+                </p>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <Button
+                  onClick={handleSave}
+                  disabled={
+                    !hasChanges ||
+                    !name.trim() ||
+                    !defaultHarnessId ||
+                    !baseHarnessId ||
+                    updateOrganization.isPending
+                  }
+                >
+                  <Save className="h-4 w-4 mr-2" />
+                  {updateOrganization.isPending ? "Saving..." : "Save"}
+                </Button>
+                {harnesses.length === 0 && (
+                  <p className="text-xs text-muted-foreground">Harnesses will appear after org init.</p>
                 )}
               </div>
 
-              {/* Organisation ID */}
+              {updateOrganization.isError && (
+                <p className="text-sm text-destructive">
+                  Failed to update: {updateOrganization.error.message}
+                </p>
+              )}
+              {updateOrganization.isSuccess && !hasChanges && (
+                <p className="text-sm text-green-600">Saved successfully</p>
+              )}
+
               <div className="space-y-2">
                 <Label htmlFor="org-id">Organisation ID</Label>
                 <div className="flex items-center gap-2">

--- a/apps/ui/src/app/(main)/settings/organisation/page.tsx
+++ b/apps/ui/src/app/(main)/settings/organisation/page.tsx
@@ -39,7 +39,11 @@ export default function OrganisationPage() {
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [newOrgName, setNewOrgName] = useState("");
 
-  const syncHasChanges = (nextName: string, nextDefaultHarnessId: string, nextBaseHarnessId: string) => {
+  const syncHasChanges = (
+    nextName: string,
+    nextDefaultHarnessId: string,
+    nextBaseHarnessId: string,
+  ) => {
     setHasChanges(
       nextName !== (organization?.name || "") ||
         nextDefaultHarnessId !== (organization?.default_harness_id || "") ||
@@ -205,7 +209,9 @@ export default function OrganisationPage() {
                   {updateOrganization.isPending ? "Saving..." : "Save"}
                 </Button>
                 {harnesses.length === 0 && (
-                  <p className="text-xs text-muted-foreground">Harnesses will appear after org init.</p>
+                  <p className="text-xs text-muted-foreground">
+                    Harnesses will appear after org init.
+                  </p>
                 )}
               </div>
 

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -197,8 +197,8 @@ export interface SessionStats {
 }
 
 export interface CreateSessionRequest {
-  /** Harness ID for this session (required) */
-  harness_id: string;
+  /** Harness ID for this session. If omitted, org base harness is used. */
+  harness_id?: string;
   /** Agent ID to work in this session (optional) */
   agent_id?: string;
   title?: string;
@@ -846,6 +846,8 @@ export interface OrganizationMembership {
 export interface Organization {
   id: string;
   name: string;
+  default_harness_id: string | null;
+  base_harness_id: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -858,6 +860,8 @@ export interface CreateOrganizationRequest {
 /** Request to update an organization */
 export interface UpdateOrganizationRequest {
   name?: string;
+  default_harness_id?: string;
+  base_harness_id?: string;
 }
 
 export interface UserInfoResponse {

--- a/crates/server/migrations/016_org_settings_harness_defaults.sql
+++ b/crates/server/migrations/016_org_settings_harness_defaults.sql
@@ -1,0 +1,19 @@
+ALTER TABLE organization_settings
+ADD COLUMN default_harness_id UUID REFERENCES harnesses(id) ON DELETE SET NULL,
+ADD COLUMN base_harness_id UUID REFERENCES harnesses(id) ON DELETE SET NULL;
+
+UPDATE organization_settings os
+SET default_harness_id = h.id
+FROM harnesses h
+WHERE os.default_harness_id IS NULL
+  AND h.org_id = os.org_id
+  AND h.is_built_in = TRUE
+  AND h.name = 'Generic';
+
+UPDATE organization_settings os
+SET base_harness_id = h.id
+FROM harnesses h
+WHERE os.base_harness_id IS NULL
+  AND h.org_id = os.org_id
+  AND h.is_built_in = TRUE
+  AND h.name = 'Base';

--- a/crates/server/src/api/organizations.rs
+++ b/crates/server/src/api/organizations.rs
@@ -4,7 +4,7 @@
 // because they manage organizations themselves.
 
 use crate::auth::middleware::{AuthState, AuthUser, OrgAdmin, OrgContext};
-use crate::storage::StorageBackend;
+use crate::storage::{StorageBackend, models::UpdateOrganizationSettings};
 use axum::extract::FromRef;
 use axum::{
     Json, Router,
@@ -55,6 +55,14 @@ pub struct UpdateOrganizationRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(example = "Acme Corporation")]
     pub name: Option<String>,
+    /// Default harness to preselect in the UI for new sessions.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>, example = "harness_01933b5a000070008000000000000602")]
+    pub default_harness_id: Option<everruns_core::HarnessId>,
+    /// Base harness to use when a session is started without an explicit harness_id.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>, example = "harness_01933b5a000070008000000000000601")]
+    pub base_harness_id: Option<everruns_core::HarnessId>,
 }
 
 /// Response for organization operations
@@ -64,21 +72,16 @@ pub struct OrganizationResponse {
     pub id: String,
     /// Display name
     pub name: String,
+    /// Default harness to preselect in the UI.
+    #[schema(value_type = Option<String>)]
+    pub default_harness_id: Option<everruns_core::HarnessId>,
+    /// Base harness used when session creation omits harness_id.
+    #[schema(value_type = Option<String>)]
+    pub base_harness_id: Option<everruns_core::HarnessId>,
     /// When the organization was created
     pub created_at: chrono::DateTime<chrono::Utc>,
     /// When the organization was last updated
     pub updated_at: chrono::DateTime<chrono::Utc>,
-}
-
-impl From<Organization> for OrganizationResponse {
-    fn from(org: Organization) -> Self {
-        Self {
-            id: org.public_id,
-            name: org.name,
-            created_at: org.created_at,
-            updated_at: org.updated_at,
-        }
-    }
 }
 
 /// Build organization routes
@@ -125,6 +128,8 @@ pub async fn list_organizations(
         .map(|m| OrganizationResponse {
             id: m.public_id.clone(),
             name: m.name.clone(),
+            default_harness_id: None,
+            base_harness_id: None,
             // These timestamps are not available in OrgMembership, use placeholder
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
@@ -203,14 +208,8 @@ pub async fn create_organization(
         );
     }
 
-    let org = Organization {
-        public_id: row.public_id,
-        name: row.name,
-        created_at: row.created_at,
-        updated_at: row.updated_at,
-    };
-
-    Ok((StatusCode::CREATED, Json(OrganizationResponse::from(org))))
+    let response = build_organization_response(&state.db, row.org_id, row).await?;
+    Ok((StatusCode::CREATED, Json(response)))
 }
 
 /// GET /v1/orgs/:org - Get organization details
@@ -253,14 +252,9 @@ pub async fn get_organization(
         .log_internal_error_json("get organization")?
         .ok_or_not_found_json("Organization")?;
 
-    let org = Organization {
-        public_id: row.public_id,
-        name: row.name,
-        created_at: row.created_at,
-        updated_at: row.updated_at,
-    };
-
-    Ok(Json(OrganizationResponse::from(org)))
+    Ok(Json(
+        build_organization_response(&state.db, row.org_id, row).await?,
+    ))
 }
 
 /// PATCH /v1/orgs/:org - Update organization
@@ -333,8 +327,31 @@ pub async fn update_organization(
         ));
     }
 
+    let UpdateOrganizationRequest {
+        name,
+        default_harness_id,
+        base_harness_id,
+    } = req;
+
+    if let Some(default_harness_id) = default_harness_id {
+        state
+            .db
+            .get_harness(org_row.org_id, default_harness_id)
+            .await
+            .log_internal_error_json("resolve default harness")?
+            .ok_or_not_found_json("Harness")?;
+    }
+    if let Some(base_harness_id) = base_harness_id {
+        state
+            .db
+            .get_harness(org_row.org_id, base_harness_id)
+            .await
+            .log_internal_error_json("resolve base harness")?
+            .ok_or_not_found_json("Harness")?;
+    }
+
     // Update organization
-    let input = UpdateOrganization { name: req.name };
+    let input = UpdateOrganization { name };
 
     let row = state
         .db
@@ -343,6 +360,36 @@ pub async fn update_organization(
         .log_internal_error_json("update organization")?
         .ok_or_not_found_json("Organization")?;
 
+    if default_harness_id.is_some() || base_harness_id.is_some() {
+        state
+            .db
+            .patch_organization_settings(
+                org_row.org_id,
+                UpdateOrganizationSettings {
+                    default_harness_id: default_harness_id.map(Some),
+                    base_harness_id: base_harness_id.map(Some),
+                    ..Default::default()
+                },
+            )
+            .await
+            .log_internal_error_json("update organization settings")?;
+    }
+
+    Ok(Json(
+        build_organization_response(&state.db, row.org_id, row).await?,
+    ))
+}
+
+async fn build_organization_response(
+    db: &StorageBackend,
+    org_id: i64,
+    row: crate::storage::OrganizationRow,
+) -> Result<OrganizationResponse, (StatusCode, Json<ErrorResponse>)> {
+    let settings = db
+        .get_organization_settings(org_id)
+        .await
+        .log_internal_error_json("get organization settings")?;
+
     let org = Organization {
         public_id: row.public_id,
         name: row.name,
@@ -350,7 +397,14 @@ pub async fn update_organization(
         updated_at: row.updated_at,
     };
 
-    Ok(Json(OrganizationResponse::from(org)))
+    Ok(OrganizationResponse {
+        id: org.public_id,
+        name: org.name,
+        default_harness_id: settings.as_ref().and_then(|s| s.default_harness_id),
+        base_harness_id: settings.as_ref().and_then(|s| s.base_harness_id),
+        created_at: org.created_at,
+        updated_at: org.updated_at,
+    })
 }
 
 // ============================================================================
@@ -651,17 +705,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_organization_response_from() {
-        let org = Organization {
-            public_id: "org_00000000000000000000000000000001".to_string(),
+    fn test_organization_response_fields() {
+        let response = OrganizationResponse {
+            id: "org_00000000000000000000000000000001".to_string(),
             name: "Test Org".to_string(),
+            default_harness_id: Some("harness_01933b5a000070008000000000000602".parse().unwrap()),
+            base_harness_id: Some("harness_01933b5a000070008000000000000601".parse().unwrap()),
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
 
-        let response = OrganizationResponse::from(org.clone());
-        assert_eq!(response.id, org.public_id);
-        assert_eq!(response.name, org.name);
+        assert_eq!(response.id, "org_00000000000000000000000000000001");
+        assert_eq!(response.name, "Test Org");
+        assert!(response.default_harness_id.is_some());
+        assert!(response.base_harness_id.is_some());
     }
 
     #[test]
@@ -683,9 +740,17 @@ mod tests {
         let json = r#"{}"#;
         let req: UpdateOrganizationRequest = serde_json::from_str(json).unwrap();
         assert!(req.name.is_none());
+        assert!(req.default_harness_id.is_none());
+        assert!(req.base_harness_id.is_none());
 
-        let json = r#"{"name": "New Name"}"#;
+        let json = r#"{
+            "name": "New Name",
+            "default_harness_id": "harness_01933b5a000070008000000000000602",
+            "base_harness_id": "harness_01933b5a000070008000000000000601"
+        }"#;
         let req: UpdateOrganizationRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.name.unwrap(), "New Name");
+        assert!(req.default_harness_id.is_some());
+        assert!(req.base_harness_id.is_some());
     }
 }

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -3,7 +3,7 @@
 // Policy enforcement happens at the service layer via #[policy] macro.
 
 use crate::auth::{AuthState, ResolvedOrg};
-use crate::seed::GENERIC_HARNESS_ID;
+use crate::org_init::BASE_HARNESS_ID;
 use crate::services::session::{SESSION_MANAGE, SESSION_VIEW};
 use crate::services::{EventService, SessionService};
 use crate::storage::StorageBackend;
@@ -32,10 +32,10 @@ use utoipa::{IntoParams, ToSchema};
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct CreateSessionRequest {
     /// ID of the harness for this session (format: harness_{32-hex}).
-    /// Defaults to the Generic harness if omitted (backward compat with older SDKs).
-    #[serde(default = "default_harness_id")]
-    #[schema(value_type = String, example = "harness_01933b5a00007000800000000000001")]
-    pub harness_id: HarnessId,
+    /// If omitted, the org base harness is used. New orgs default that to Base.
+    #[serde(default)]
+    #[schema(value_type = Option<String>, example = "harness_01933b5a00007000800000000000001")]
+    pub harness_id: Option<HarnessId>,
     /// ID of the agent to work in this session (optional, format: agent_{32-hex}).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(value_type = Option<String>, example = "agent_01933b5a00007000800000000000001")]
@@ -65,11 +65,6 @@ pub struct CreateSessionRequest {
     /// These tools are sent to the LLM but executed by the client.
     #[serde(default)]
     pub tools: Vec<everruns_core::ToolDefinition>,
-}
-
-/// Default harness_id for sessions: uses the built-in Generic harness.
-fn default_harness_id() -> HarnessId {
-    HarnessId::from_uuid(GENERIC_HARNESS_ID)
 }
 
 /// Response from cancel turn endpoint
@@ -228,10 +223,15 @@ pub async fn create_session(
     req.locale = normalize_locale(req.locale)
         .map_err(|err| -> (StatusCode, Json<ErrorResponse>) { err.into() })?;
 
+    let harness_id = resolve_session_harness_id(&state.db, org.org_id, req.harness_id)
+        .await
+        .log_internal_error_json("resolve session harness fallback")?;
+    req.harness_id = Some(harness_id);
+
     // Validate harness exists and belongs to this org
     state
         .db
-        .get_harness(org.org_id, req.harness_id)
+        .get_harness(org.org_id, harness_id)
         .await
         .log_internal_error_json("resolve harness")?
         .ok_or_not_found_json("Harness")?;
@@ -270,7 +270,7 @@ pub async fn create_session(
         .session_service
         .create(
             &caller,
-            req.harness_id.uuid(),
+            harness_id.uuid(),
             agent_internal_id,
             agent_public_id,
             req,
@@ -279,6 +279,28 @@ pub async fn create_session(
         .map_policy_or_internal("create session")?;
 
     Ok((StatusCode::CREATED, Json(session)))
+}
+
+async fn resolve_session_harness_id(
+    db: &StorageBackend,
+    org_id: i64,
+    requested_harness_id: Option<HarnessId>,
+) -> anyhow::Result<HarnessId> {
+    if let Some(harness_id) = requested_harness_id {
+        return Ok(harness_id);
+    }
+
+    let settings = db.get_organization_settings(org_id).await?;
+    if let Some(harness_id) = settings.and_then(|row| row.base_harness_id) {
+        return Ok(harness_id);
+    }
+
+    let harnesses = db.list_harnesses(org_id, Some("Base"), false).await?;
+    Ok(harnesses
+        .into_iter()
+        .find(|h| h.is_built_in && h.name == "Base")
+        .map(|h| h.id)
+        .unwrap_or_else(|| HarnessId::from_uuid(BASE_HARNESS_ID)))
 }
 
 /// POST /v1/sessions/chat - Get or create global chat session
@@ -733,16 +755,16 @@ pub async fn cancel_turn(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::storage::{StorageBackend, models::UpdateOrganizationSettings};
 
     const TEST_HARNESS_ID: &str = "harness_550e8400e29b41d4a716446655440000";
     const TEST_AGENT_ID: &str = "agent_550e8400e29b41d4a716446655440000";
 
     #[test]
     fn test_create_session_request_minimal() {
-        // Test with only required harness_id
         let json = format!(r#"{{"harness_id": "{}"}}"#, TEST_HARNESS_ID);
         let req: CreateSessionRequest = serde_json::from_str(&json).unwrap();
-        assert_eq!(req.harness_id.to_string(), TEST_HARNESS_ID);
+        assert_eq!(req.harness_id.unwrap().to_string(), TEST_HARNESS_ID);
         assert_eq!(req.agent_id, None);
         assert_eq!(req.title, None);
         assert_eq!(req.locale, None);
@@ -752,12 +774,10 @@ mod tests {
     }
 
     #[test]
-    fn test_create_session_request_missing_harness_id_defaults_to_generic() {
-        // harness_id defaults to Generic seed harness for backward compat with older SDKs
+    fn test_create_session_request_missing_harness_id_is_none() {
         let json = r#"{}"#;
         let req: CreateSessionRequest = serde_json::from_str(json).unwrap();
-        let expected = HarnessId::from_uuid(crate::seed::GENERIC_HARNESS_ID);
-        assert_eq!(req.harness_id, expected);
+        assert_eq!(req.harness_id, None);
     }
 
     #[test]
@@ -852,5 +872,32 @@ mod tests {
         let req: UpdateSessionRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.title, None);
         assert_eq!(req.tags, Some(vec!["new-tag".to_string()]));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_session_harness_id_defaults_to_base() {
+        let db = StorageBackend::in_memory();
+
+        let harness_id = resolve_session_harness_id(&db, 42, None).await.unwrap();
+        assert_eq!(harness_id.uuid(), BASE_HARNESS_ID);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_session_harness_id_uses_org_base_harness() {
+        let db = StorageBackend::in_memory();
+        let base_harness_id: HarnessId = TEST_HARNESS_ID.parse().unwrap();
+
+        db.patch_organization_settings(
+            42,
+            UpdateOrganizationSettings {
+                base_harness_id: Some(Some(base_harness_id)),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let harness_id = resolve_session_harness_id(&db, 42, None).await.unwrap();
+        assert_eq!(harness_id, base_harness_id);
     }
 }

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -462,7 +462,7 @@ async fn process_slack_message(
                 );
                 let title = build_session_title(slack_config, event);
                 let req = CreateSessionRequest {
-                    harness_id: app.harness_id,
+                    harness_id: Some(app.harness_id),
                     agent_id: Some(app.agent_id),
                     title: Some(title),
                     locale: None,

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -28,6 +28,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;
 
+use crate::org_init::BASE_HARNESS_ID;
 use crate::services::{EventService, LlmResolverService, McpServerService};
 use crate::storage::StorageBackend;
 use crate::storage::models::{AgentCapabilityRow, UpdateSession};
@@ -1248,7 +1249,9 @@ impl DirectPlatformStore {
         Session {
             id: row.id,
             organization_id: everruns_core::org_public_id_from_internal(self.org_id),
-            harness_id: row.harness_id.unwrap_or_else(|| HarnessId::from_seed(1)),
+            harness_id: row
+                .harness_id
+                .unwrap_or_else(|| HarnessId::from_uuid(BASE_HARNESS_ID)),
             agent_id: row.agent_id,
             title: row.title,
             locale: row.locale,

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -3596,7 +3596,7 @@ impl WorkerService for WorkerServiceImpl {
         };
 
         let create_req = crate::api::sessions::CreateSessionRequest {
-            harness_id: everruns_core::HarnessId::from_uuid(harness_id),
+            harness_id: Some(everruns_core::HarnessId::from_uuid(harness_id)),
             agent_id: agent_public_id,
             title: req.title,
             locale: req.locale,

--- a/crates/server/src/org_init.rs
+++ b/crates/server/src/org_init.rs
@@ -4,9 +4,13 @@
 // Decision: New orgs get built-in harnesses during creation
 // Decision: Reconciliation ensures all orgs stay up-to-date with built-in definitions
 // Decision: Default org uses fixed seed UUIDs for backward compat; other orgs get fresh UUIDs
+// Decision: Org settings keep separate default and base harness pointers
 
-use crate::storage::{StorageBackend, models::CreateHarnessRow};
-use anyhow::Result;
+use crate::storage::{
+    StorageBackend,
+    models::{CreateHarnessRow, UpdateOrganizationSettings},
+};
+use anyhow::{Context, Result};
 use uuid::Uuid;
 
 /// Capability entry with optional per-capability config for built-in harnesses.
@@ -53,8 +57,11 @@ mod harness_ids {
     pub const CHAT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000603);
 }
 
-/// Well-known UUID for the Generic harness (default for sessions without explicit harness)
+/// Well-known UUID for the Generic harness (org default harness for new orgs)
 pub const GENERIC_HARNESS_ID: Uuid = harness_ids::GENERIC;
+
+/// Well-known UUID for the Base harness (session fallback when no harness is provided)
+pub const BASE_HARNESS_ID: Uuid = harness_ids::BASE;
 
 /// Well-known UUID for the Chat harness (used by global chat endpoint)
 pub const CHAT_HARNESS_ID: Uuid = harness_ids::CHAT;
@@ -223,6 +230,8 @@ pub async fn initialize_org_harnesses(db: &StorageBackend, org_id: i64) -> Resul
         }
     }
 
+    sync_org_harness_settings(db, org_id).await?;
+
     Ok(result)
 }
 
@@ -255,6 +264,57 @@ pub async fn reconcile_built_in_harnesses(db: &StorageBackend) -> Result<InitRes
     );
 
     Ok(total)
+}
+
+/// Ensure org settings point at built-in default/base harnesses without overriding user changes.
+pub async fn sync_org_harness_settings(db: &StorageBackend, org_id: i64) -> Result<()> {
+    let settings = db.get_organization_settings(org_id).await?;
+    let needs_default = settings
+        .as_ref()
+        .and_then(|s| s.default_harness_id)
+        .is_none();
+    let needs_base = settings.as_ref().and_then(|s| s.base_harness_id).is_none();
+
+    if !needs_default && !needs_base {
+        return Ok(());
+    }
+
+    let harnesses = db.list_harnesses(org_id, None, false).await?;
+    let default_harness_id = harnesses
+        .iter()
+        .find(|h| h.is_built_in && h.name == "Generic")
+        .map(|h| h.id);
+    let base_harness_id = harnesses
+        .iter()
+        .find(|h| h.is_built_in && h.name == "Base")
+        .map(|h| h.id);
+
+    let default_harness_id = if needs_default {
+        Some(Some(default_harness_id.context(
+            "missing built-in Generic harness during org init",
+        )?))
+    } else {
+        None
+    };
+    let base_harness_id = if needs_base {
+        Some(Some(
+            base_harness_id.context("missing built-in Base harness during org init")?,
+        ))
+    } else {
+        None
+    };
+
+    db.patch_organization_settings(
+        org_id,
+        UpdateOrganizationSettings {
+            default_harness_id,
+            base_harness_id,
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    Ok(())
 }
 
 /// Sync capabilities for a harness, only writing if the set actually changed.
@@ -308,6 +368,7 @@ impl InitResult {
 mod tests {
     use super::*;
     use crate::storage::StorageBackend;
+    use crate::storage::models::UpdateOrganizationSettings;
     use everruns_core::DEFAULT_ORG_ID;
 
     fn make_db() -> StorageBackend {
@@ -359,6 +420,17 @@ mod tests {
         for h in &harnesses {
             assert!(h.is_built_in, "Harness {} should be built-in", h.name);
         }
+
+        let settings = db
+            .get_organization_settings(DEFAULT_ORG_ID)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            settings.default_harness_id.unwrap().uuid(),
+            GENERIC_HARNESS_ID
+        );
+        assert_eq!(settings.base_harness_id.unwrap().uuid(), BASE_HARNESS_ID);
     }
 
     #[tokio::test]
@@ -398,6 +470,61 @@ mod tests {
         for h in &h_org2 {
             assert!(h.is_built_in);
         }
+
+        let generic_id = h_org2.iter().find(|h| h.name == "Generic").unwrap().id;
+        let base_id = h_org2.iter().find(|h| h.name == "Base").unwrap().id;
+        let settings = db
+            .get_organization_settings(org2.org_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(settings.default_harness_id, Some(generic_id));
+        assert_eq!(settings.base_harness_id, Some(base_id));
+    }
+
+    #[tokio::test]
+    async fn test_initialize_does_not_override_existing_org_harness_settings() {
+        let db = make_db();
+        seed_default_org(&db).await;
+
+        let org2 = db
+            .create_organization(crate::storage::models::CreateOrganizationRow {
+                public_id: "org_00000000000000000000000000000002".to_string(),
+                name: "Test Org 2".to_string(),
+                created_by: None,
+            })
+            .await
+            .unwrap();
+
+        initialize_org_harnesses(&db, org2.org_id).await.unwrap();
+
+        let harnesses = db.list_harnesses(org2.org_id, None, false).await.unwrap();
+        let chat_id = harnesses
+            .iter()
+            .find(|h| h.name == "Platform Chat")
+            .unwrap()
+            .id;
+
+        db.patch_organization_settings(
+            org2.org_id,
+            UpdateOrganizationSettings {
+                default_harness_id: Some(Some(chat_id)),
+                base_harness_id: Some(Some(chat_id)),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        initialize_org_harnesses(&db, org2.org_id).await.unwrap();
+
+        let settings = db
+            .get_organization_settings(org2.org_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(settings.default_harness_id, Some(chat_id));
+        assert_eq!(settings.base_harness_id, Some(chat_id));
     }
 
     #[tokio::test]

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -2070,6 +2070,20 @@ mod tests {
 
         assert!(result.created > 0, "first run should create items");
         assert_eq!(result.updated, 0, "first run should not update anything");
+
+        let settings = db
+            .get_organization_settings(DEFAULT_ORG_ID)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            settings.default_harness_id.unwrap().uuid(),
+            org_init::GENERIC_HARNESS_ID
+        );
+        assert_eq!(
+            settings.base_harness_id.unwrap().uuid(),
+            org_init::BASE_HARNESS_ID
+        );
     }
 
     #[tokio::test]

--- a/crates/server/src/services/session.rs
+++ b/crates/server/src/services/session.rs
@@ -7,6 +7,7 @@
 // (additive behavior).
 
 use crate::api::common::Pagination;
+use crate::org_init::BASE_HARNESS_ID;
 use crate::services::session_file::{CreateFileInput, SessionFileService};
 use crate::storage::{
     StorageBackend,
@@ -611,7 +612,9 @@ impl SessionService {
         Session {
             id: row.id,
             organization_id: org_public_id.to_string(),
-            harness_id: row.harness_id.unwrap_or_else(|| HarnessId::from_seed(1)),
+            harness_id: row
+                .harness_id
+                .unwrap_or_else(|| HarnessId::from_uuid(BASE_HARNESS_ID)),
             agent_id: row.agent_id,
             title: row.title,
             locale: row.locale,
@@ -736,7 +739,7 @@ mod tests {
                 Some(agent.internal_id),
                 Some(agent.public_id),
                 CreateSessionRequest {
-                    harness_id: harness.id,
+                    harness_id: Some(harness.id),
                     agent_id: Some(agent.public_id),
                     title: Some("Starter files".to_string()),
                     locale: None,
@@ -829,7 +832,7 @@ mod tests {
                 Some(agent.internal_id),
                 Some(agent.public_id),
                 CreateSessionRequest {
-                    harness_id: harness.id,
+                    harness_id: Some(harness.id),
                     agent_id: Some(agent.public_id),
                     title: Some("Archived harness".to_string()),
                     locale: None,
@@ -874,7 +877,7 @@ mod tests {
                 Some(agent.internal_id),
                 Some(agent.public_id),
                 CreateSessionRequest {
-                    harness_id: harness.id,
+                    harness_id: Some(harness.id),
                     agent_id: Some(agent.public_id),
                     title: Some("Archived agent".to_string()),
                     locale: None,

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -686,6 +686,14 @@ impl StorageBackend {
         dispatch!(self, upsert_organization_settings, org_id, default_model_id)
     }
 
+    pub async fn patch_organization_settings(
+        &self,
+        org_id: i64,
+        input: UpdateOrganizationSettings,
+    ) -> Result<OrganizationSettingsRow> {
+        dispatch!(self, patch_organization_settings, org_id, input)
+    }
+
     pub async fn create_llm_model(
         &self,
         org_id: i64,

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -1793,10 +1793,44 @@ impl InMemoryDatabase {
             .or_insert_with(|| OrganizationSettingsRow {
                 org_id,
                 default_model_id: None,
+                default_harness_id: None,
+                base_harness_id: None,
                 created_at: now,
                 updated_at: now,
             });
         row.default_model_id = default_model_id.map(ModelId::from_uuid);
+        row.updated_at = now;
+        Ok(row.clone())
+    }
+
+    pub async fn patch_organization_settings(
+        &self,
+        org_id: i64,
+        input: UpdateOrganizationSettings,
+    ) -> Result<OrganizationSettingsRow> {
+        let now = Self::now();
+        let mut settings = self.org_settings.write();
+        let row = settings
+            .entry(org_id)
+            .or_insert_with(|| OrganizationSettingsRow {
+                org_id,
+                default_model_id: None,
+                default_harness_id: None,
+                base_harness_id: None,
+                created_at: now,
+                updated_at: now,
+            });
+
+        if let Some(default_model_id) = input.default_model_id {
+            row.default_model_id = default_model_id;
+        }
+        if let Some(default_harness_id) = input.default_harness_id {
+            row.default_harness_id = default_harness_id;
+        }
+        if let Some(base_harness_id) = input.base_harness_id {
+            row.base_harness_id = base_harness_id;
+        }
+
         row.updated_at = now;
         Ok(row.clone())
     }

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -76,8 +76,17 @@ pub struct UpdateOrganization {
 pub struct OrganizationSettingsRow {
     pub org_id: i64,
     pub default_model_id: Option<ModelId>,
+    pub default_harness_id: Option<HarnessId>,
+    pub base_harness_id: Option<HarnessId>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct UpdateOrganizationSettings {
+    pub default_model_id: Option<Option<ModelId>>,
+    pub default_harness_id: Option<Option<HarnessId>>,
+    pub base_harness_id: Option<Option<HarnessId>>,
 }
 
 /// Input for creating an organization member

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -2351,7 +2351,7 @@ impl Database {
         org_id: i64,
     ) -> Result<Option<OrganizationSettingsRow>> {
         let row = sqlx::query_as::<_, OrganizationSettingsRow>(
-            "SELECT org_id, default_model_id, created_at, updated_at FROM organization_settings WHERE org_id = $1",
+            "SELECT org_id, default_model_id, default_harness_id, base_harness_id, created_at, updated_at FROM organization_settings WHERE org_id = $1",
         )
         .bind(org_id)
         .fetch_optional(&self.pool)
@@ -2372,11 +2372,49 @@ impl Database {
             ON CONFLICT (org_id) DO UPDATE SET
                 default_model_id = EXCLUDED.default_model_id,
                 updated_at = NOW()
-            RETURNING org_id, default_model_id, created_at, updated_at
+            RETURNING org_id, default_model_id, default_harness_id, base_harness_id, created_at, updated_at
             "#,
         )
         .bind(org_id)
         .bind(default_model_id)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    pub async fn patch_organization_settings(
+        &self,
+        org_id: i64,
+        input: UpdateOrganizationSettings,
+    ) -> Result<OrganizationSettingsRow> {
+        let row = sqlx::query_as::<_, OrganizationSettingsRow>(
+            r#"
+            INSERT INTO organization_settings (org_id, default_model_id, default_harness_id, base_harness_id)
+            VALUES ($1, $2, $4, $6)
+            ON CONFLICT (org_id) DO UPDATE SET
+                default_model_id = CASE
+                    WHEN $3 THEN $2
+                    ELSE organization_settings.default_model_id
+                END,
+                default_harness_id = CASE
+                    WHEN $5 THEN $4
+                    ELSE organization_settings.default_harness_id
+                END,
+                base_harness_id = CASE
+                    WHEN $7 THEN $6
+                    ELSE organization_settings.base_harness_id
+                END,
+                updated_at = NOW()
+            RETURNING org_id, default_model_id, default_harness_id, base_harness_id, created_at, updated_at
+            "#,
+        )
+        .bind(org_id)
+        .bind(input.default_model_id.flatten().map(|id| id.uuid()))
+        .bind(input.default_model_id.is_some())
+        .bind(input.default_harness_id.flatten().map(|id| id.uuid()))
+        .bind(input.default_harness_id.is_some())
+        .bind(input.base_harness_id.flatten().map(|id| id.uuid()))
+        .bind(input.base_harness_id.is_some())
         .fetch_one(&self.pool)
         .await?;
         Ok(row)

--- a/crates/server/src/storage/session_store.rs
+++ b/crates/server/src/storage/session_store.rs
@@ -6,6 +6,7 @@
 // Decision: org_id and org_public_id are baked into the struct at
 // construction time, matching the Grpc/Adapter store pattern.
 
+use crate::org_init::BASE_HARNESS_ID;
 use async_trait::async_trait;
 use everruns_core::{
     AgentLoopError, HarnessId, Result, SessionId, TokenUsage,
@@ -77,7 +78,9 @@ impl SessionStore for DbSessionStore {
                 Ok(Some(Session {
                     id: row.id,
                     organization_id: self.org_public_id.clone(),
-                    harness_id: row.harness_id.unwrap_or_else(|| HarnessId::from_seed(1)),
+                    harness_id: row
+                        .harness_id
+                        .unwrap_or_else(|| HarnessId::from_uuid(BASE_HARNESS_ID)),
                     agent_id: row.agent_id,
                     title: row.title,
                     locale: row.locale,

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -17,11 +17,12 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use everruns_server::api::common::Pagination;
+use everruns_server::org_init;
 use everruns_server::storage::{
     CreateAgentCapabilityRow, CreateAgentRow, CreateEventRow, CreateImageRow, CreateLlmModelRow,
     CreateLlmProviderRow, CreateMcpServerRow, CreateOrganizationRow, CreateSessionFileRow,
     CreateSessionRow, Database, StorageBackend, UpdateAgent, UpdateLlmModel, UpdateLlmProvider,
-    UpdateOrganization, UpdateSession, UpdateSessionFile,
+    UpdateOrganization, UpdateOrganizationSettings, UpdateSession, UpdateSessionFile,
 };
 use test_harness::get_database_url;
 
@@ -1018,6 +1019,53 @@ async fn test_organization_crud() {
         .await
         .expect("Failed to delete organization");
     assert!(deleted);
+}
+
+#[tokio::test]
+async fn test_organization_settings_harness_roundtrip() {
+    let backend = create_test_backend().await;
+
+    let public_id = format!("org_{}", Uuid::now_v7().simple());
+    let org = backend
+        .create_organization(CreateOrganizationRow {
+            public_id,
+            name: format!("Test Org {}", Uuid::now_v7()),
+            created_by: None,
+        })
+        .await
+        .expect("Failed to create organization");
+
+    org_init::initialize_org_harnesses(&backend, org.org_id)
+        .await
+        .expect("Failed to initialize org harnesses");
+
+    let harnesses = backend
+        .list_harnesses(org.org_id, None, false)
+        .await
+        .expect("Failed to list harnesses");
+    let generic_id = harnesses.iter().find(|h| h.name == "Generic").unwrap().id;
+    let base_id = harnesses.iter().find(|h| h.name == "Base").unwrap().id;
+
+    backend
+        .patch_organization_settings(
+            org.org_id,
+            UpdateOrganizationSettings {
+                default_harness_id: Some(Some(generic_id)),
+                base_harness_id: Some(Some(base_id)),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("Failed to patch organization settings");
+
+    let settings = backend
+        .get_organization_settings(org.org_id)
+        .await
+        .expect("Failed to get organization settings")
+        .expect("Organization settings not found");
+
+    assert_eq!(settings.default_harness_id, Some(generic_id));
+    assert_eq!(settings.base_harness_id, Some(base_id));
 }
 
 // ============================================

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -5328,8 +5328,11 @@
             "description": "Session-level capabilities (additive to agent capabilities).\nApplied after agent capabilities when building RuntimeAgent."
           },
           "harness_id": {
-            "type": "string",
-            "description": "ID of the harness for this session (format: harness_{32-hex}).\nDefaults to the Generic harness if omitted (backward compat with older SDKs).",
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ID of the harness for this session (format: harness_{32-hex}).\nIf omitted, the org base harness is used. New orgs default that to Base.",
             "example": "harness_01933b5a00007000800000000000001"
           },
           "locale": {
@@ -7225,10 +7228,24 @@
                 "updated_at"
               ],
               "properties": {
+                "base_harness_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Base harness used when session creation omits harness_id."
+                },
                 "created_at": {
                   "type": "string",
                   "format": "date-time",
                   "description": "When the organization was created"
+                },
+                "default_harness_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Default harness to preselect in the UI."
                 },
                 "id": {
                   "type": "string",
@@ -8408,10 +8425,24 @@
           "updated_at"
         ],
         "properties": {
+          "base_harness_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Base harness used when session creation omits harness_id."
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
             "description": "When the organization was created"
+          },
+          "default_harness_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Default harness to preselect in the UI."
           },
           "id": {
             "type": "string",
@@ -11001,6 +11032,22 @@
         "type": "object",
         "description": "Request to update an organization",
         "properties": {
+          "base_harness_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Base harness to use when a session is started without an explicit harness_id.",
+            "example": "harness_01933b5a000070008000000000000601"
+          },
+          "default_harness_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Default harness to preselect in the UI for new sessions.",
+            "example": "harness_01933b5a000070008000000000000602"
+          },
           "name": {
             "type": [
               "string",

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -34,6 +34,21 @@ All endpoints are prefixed with `/v1/`.
 
 See [authentication.md](authentication.md) for full authentication specification.
 
+### Organizations
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/orgs` | List organizations for current user |
+| POST | `/v1/orgs` | Create organization |
+| GET | `/v1/orgs/{org}` | Get organization details |
+| PATCH | `/v1/orgs/{org}` | Update organization name and harness defaults |
+
+Organization details include two org-scoped harness settings:
+- `default_harness_id` - the harness the UI should preselect for normal new-session flows
+- `base_harness_id` - the harness used when `POST /v1/sessions` omits `harness_id`
+
+New organizations initialize these to the built-in `Generic` and `Base` harnesses respectively. Initialization fills missing values but does not overwrite user-selected values.
+
 ### Agents
 
 | Method | Path | Description |
@@ -138,6 +153,7 @@ See `specs/localization.md` for locale/timezone precedence and execution-context
 ```json
 POST /v1/sessions
 {
+  "harness_id": "harness_01234567-...",
   "agent_id": "agent_01234567-...",
   "title": "Optional title",
   "locale": "uk-UA",
@@ -150,7 +166,9 @@ POST /v1/sessions
 }
 ```
 
-The `agent_id` field is required and specifies which agent will work in this session.
+The `harness_id` field is optional. When omitted, the server uses the organization's `base_harness_id`. New organizations default that setting to the built-in `Base` harness.
+
+The `agent_id` field is optional and specifies which agent will work in this session when present.
 
 The optional `locale` field sets the session's default locale for agent responses and regional formatting. It is persisted on the session and reused across worker turns.
 The session API should also support an optional `timezone` field with an IANA timezone value. This is the durable fallback for unattended execution and scheduled/background turns.


### PR DESCRIPTION
## What
Add org-level default and base harness settings, wire them through org init/seed and the org settings UI, and make session creation fall back to the org base harness when `harness_id` is omitted.

## Why
We need orgs to default to Generic without requiring manual setup, preserve user-selected harness settings during org initialization, and consistently use Base as the session fallback in both dev and full modes.

## How
Store `default_harness_id` and `base_harness_id` in organization settings with a new migration, sync missing values during org initialization/seed without overwriting explicit user settings, expose both values through the org API/UI, and resolve missing session harnesses from the org base harness with a Base fallback.

## Risk
- Medium
- Affects org settings persistence, session creation defaults, and a new database migration

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered