### PR TITLE
fix(storage): scope llm model provider joins to org

### DIFF
--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -1747,6 +1747,9 @@ impl InMemoryDatabase {
         if let Some(model) = models.get(&default_model_id)
             && model.org_id == org_id
             && let Some(provider) = providers.get(&model.provider_id)
+            && provider.org_id == org_id
+            && model.status == "active"
+            && provider.status == "active"
         {
             return Ok(Some(LlmModelWithProviderRow {
                 id: model.id,
@@ -1939,6 +1942,7 @@ impl InMemoryDatabase {
         if let Some(model) = models.get(&id)
             && model.org_id == org_id
             && let Some(provider) = providers.get(&model.provider_id)
+            && provider.org_id == org_id
         {
             return Ok(Some(LlmModelWithProviderRow {
                 id: model.id,
@@ -1984,10 +1988,11 @@ impl InMemoryDatabase {
 
         let mut result: Vec<_> = models
             .values()
-            .filter(|model| model.org_id == org_id)
+            .filter(|model| model.org_id == org_id && model.status == "active")
             .filter_map(|model| {
                 providers
                     .get(&model.provider_id)
+                    .filter(|provider| provider.org_id == org_id && provider.status == "active")
                     .map(|provider| LlmModelWithProviderRow {
                         id: model.id,
                         org_id: model.org_id,
@@ -2074,7 +2079,10 @@ impl InMemoryDatabase {
         for model in models.values() {
             if model.model_id == model_id
                 && model.org_id == org_id
+                && model.status == "active"
                 && let Some(provider) = providers.get(&model.provider_id)
+                && provider.org_id == org_id
+                && provider.status == "active"
             {
                 return Ok(Some(LlmModelWithProviderRow {
                     id: model.id,

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -2329,8 +2329,8 @@ impl Database {
             SELECT m.id, m.org_id, m.provider_id, m.model_id, m.display_name, m.capabilities, m.is_favorite, m.installed, m.status, m.source, m.last_seen_at, m.provider_metadata, m.created_at, m.updated_at,
                    p.name as provider_name, p.provider_type
             FROM organization_settings os
-            JOIN llm_models m ON m.id = os.default_model_id
-            JOIN llm_providers p ON m.provider_id = p.id
+            JOIN llm_models m ON m.id = os.default_model_id AND m.org_id = os.org_id
+            JOIN llm_providers p ON m.provider_id = p.id AND p.org_id = m.org_id
             WHERE os.org_id = $1 AND m.status = 'active' AND p.status = 'active'
             "#,
         )
@@ -2550,7 +2550,7 @@ impl Database {
             SELECT m.id, m.org_id, m.provider_id, m.model_id, m.display_name, m.capabilities, m.is_favorite, m.installed, m.status, m.source, m.last_seen_at, m.provider_metadata, m.created_at, m.updated_at,
                    p.name as provider_name, p.provider_type
             FROM llm_models m
-            JOIN llm_providers p ON m.provider_id = p.id
+            JOIN llm_providers p ON m.provider_id = p.id AND p.org_id = m.org_id
             WHERE m.org_id = $1 AND m.id = $2
             "#,
         )
@@ -2589,7 +2589,7 @@ impl Database {
             SELECT m.id, m.org_id, m.provider_id, m.model_id, m.display_name, m.capabilities, m.is_favorite, m.installed, m.status, m.source, m.last_seen_at, m.provider_metadata, m.created_at, m.updated_at,
                    p.name as provider_name, p.provider_type
             FROM llm_models m
-            JOIN llm_providers p ON m.provider_id = p.id
+            JOIN llm_providers p ON m.provider_id = p.id AND p.org_id = m.org_id
             WHERE m.status = 'active' AND p.status = 'active' AND m.org_id = $1
             ORDER BY m.installed DESC, m.is_favorite DESC, p.name ASC, m.display_name ASC
             "#,
@@ -2666,7 +2666,7 @@ impl Database {
             SELECT m.id, m.org_id, m.provider_id, m.model_id, m.display_name, m.capabilities, m.is_favorite, m.installed, m.status, m.source, m.last_seen_at, m.provider_metadata, m.created_at, m.updated_at,
                    p.name as provider_name, p.provider_type
             FROM llm_models m
-            JOIN llm_providers p ON m.provider_id = p.id
+            JOIN llm_providers p ON m.provider_id = p.id AND p.org_id = m.org_id
             WHERE m.model_id = $1 AND m.status = 'active' AND p.status = 'active' AND m.org_id = $2
             "#,
         )

--- a/crates/server/tests/org_isolation_test.rs
+++ b/crates/server/tests/org_isolation_test.rs
@@ -433,6 +433,63 @@ async fn test_llm_model_negative_cross_org() {
     assert_eq!(original.display_name, "GPT-4");
 }
 
+#[tokio::test]
+async fn test_llm_model_provider_reads_fail_closed_for_corrupt_cross_org_reference() {
+    let db = InMemoryDatabase::default();
+    let org2 = create_second_org(&db).await;
+
+    let foreign_provider = db
+        .create_llm_provider(
+            org2,
+            CreateLlmProviderRow {
+                name: "Org2 Provider".to_string(),
+                provider_type: "openai".to_string(),
+                base_url: None,
+                api_key_encrypted: None,
+                settings: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let corrupt_model = db
+        .create_llm_model(
+            ORG1,
+            CreateLlmModelRow {
+                provider_id: foreign_provider.id,
+                model_id: "cross-org-provider-model".to_string(),
+                display_name: "Corrupt Model".to_string(),
+                capabilities: vec![],
+                installed: true,
+                is_favorite: false,
+                source: "manual".to_string(),
+                provider_metadata: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        db.get_llm_model(ORG1, corrupt_model.id.uuid())
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        db.get_llm_model_with_provider(ORG1, corrupt_model.id.uuid())
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        db.get_llm_model_by_model_id(ORG1, "cross-org-provider-model")
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(db.list_all_llm_models(ORG1).await.unwrap().is_empty());
+}
+
 // ============================================
 // Image Isolation Tests
 // ============================================
@@ -751,6 +808,49 @@ async fn test_default_model_org_isolation() {
 
     // Negative: org2 does not see org1's default model
     assert!(db.get_default_llm_model(org2).await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn test_default_llm_model_fails_closed_for_cross_org_provider_reference() {
+    let db = InMemoryDatabase::default();
+    let org2 = create_second_org(&db).await;
+
+    let foreign_provider = db
+        .create_llm_provider(
+            org2,
+            CreateLlmProviderRow {
+                name: "Org2 Provider".to_string(),
+                provider_type: "openai".to_string(),
+                base_url: None,
+                api_key_encrypted: None,
+                settings: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let corrupt_model = db
+        .create_llm_model(
+            ORG1,
+            CreateLlmModelRow {
+                provider_id: foreign_provider.id,
+                model_id: "cross-org-default-model".to_string(),
+                display_name: "Corrupt Default".to_string(),
+                capabilities: vec![],
+                installed: true,
+                is_favorite: false,
+                source: "manual".to_string(),
+                provider_metadata: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    db.upsert_organization_settings(ORG1, Some(corrupt_model.id.uuid()))
+        .await
+        .unwrap();
+
+    assert!(db.get_default_llm_model(ORG1).await.unwrap().is_none());
 }
 
 // ============================================

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -1562,6 +1562,94 @@ async fn test_llm_model_org_isolation_postgres() {
 }
 
 #[tokio::test]
+async fn test_llm_model_provider_reads_fail_closed_on_cross_org_provider_postgres() {
+    let backend = create_test_backend().await;
+    let org2 = create_test_org(&backend, "Cross-org Provider Isolation Org").await;
+
+    let foreign_provider = backend
+        .create_llm_provider(
+            org2,
+            CreateLlmProviderRow {
+                name: format!("Prov-{}", Uuid::now_v7()),
+                provider_type: "openai".to_string(),
+                base_url: None,
+                api_key_encrypted: None,
+                settings: None,
+            },
+        )
+        .await
+        .expect("create foreign provider");
+
+    let corrupt_model = backend
+        .create_llm_model(
+            TEST_ORG_ID,
+            CreateLlmModelRow {
+                provider_id: foreign_provider.id,
+                model_id: format!("cross-org-model-{}", Uuid::now_v7()),
+                display_name: "Corrupt Model".to_string(),
+                capabilities: vec![],
+                installed: true,
+                is_favorite: false,
+                source: "manual".to_string(),
+                provider_metadata: None,
+            },
+        )
+        .await
+        .expect("create corrupt model");
+
+    backend
+        .upsert_organization_settings(TEST_ORG_ID, Some(corrupt_model.id.uuid()))
+        .await
+        .expect("set default model");
+
+    assert!(
+        backend
+            .get_llm_model(TEST_ORG_ID, corrupt_model.id.uuid())
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        backend
+            .get_llm_model_with_provider(TEST_ORG_ID, corrupt_model.id.uuid())
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        backend
+            .list_all_llm_models(TEST_ORG_ID)
+            .await
+            .unwrap()
+            .into_iter()
+            .all(|model| model.id != corrupt_model.id)
+    );
+    assert!(
+        backend
+            .get_llm_model_by_model_id(TEST_ORG_ID, &corrupt_model.model_id)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        backend
+            .get_default_llm_model(TEST_ORG_ID)
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    backend
+        .delete_llm_model(TEST_ORG_ID, corrupt_model.id.uuid())
+        .await
+        .unwrap();
+    backend
+        .delete_llm_provider(org2, foreign_provider.id.uuid())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
 async fn test_image_org_isolation_postgres() {
     let backend = create_test_backend().await;
     let org2 = create_test_org(&backend, "Image Isolation Org").await;


### PR DESCRIPTION
## What
Fail closed when LLM model read paths encounter a model row whose `provider_id` points at another org.

## Why
Write-side validation fixes reduce the chance of bad rows, but these storage reads still joined provider metadata by UUID alone. If a corrupted cross-org `provider_id` or `default_model_id` existed, the read side could surface provider data from another org.

## How
- tighten the Postgres joins to require provider/model org consistency
- mirror the same fail-closed behavior in the in-memory backend
- add corruption regressions for `get_llm_model_with_provider`, `list_all_llm_models`, `get_llm_model_by_model_id`, and `get_default_llm_model`

## Risk
- Low
- Affects only read paths for corrupted cross-org model/provider references; valid same-org rows are unchanged

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
