### PR TITLE
feat(ui): replace archive checkboxes with filter dropdown on all list pages

### DIFF
--- a/apps/ui/src/__tests__/archive-filter.test.tsx
+++ b/apps/ui/src/__tests__/archive-filter.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ArchiveFilter } from "@/components/archive-filter";
+
+describe("ArchiveFilter", () => {
+  it("renders a Filter button", () => {
+    render(<ArchiveFilter showArchived={false} onShowArchivedChange={jest.fn()} />);
+
+    expect(screen.getByRole("button", { name: /filter/i })).toBeInTheDocument();
+  });
+
+  it("does not show badge when filter is inactive", () => {
+    render(<ArchiveFilter showArchived={false} onShowArchivedChange={jest.fn()} />);
+
+    expect(screen.queryByText("1")).not.toBeInTheDocument();
+  });
+
+  it("shows badge with count when filter is active", () => {
+    render(<ArchiveFilter showArchived={true} onShowArchivedChange={jest.fn()} />);
+
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+
+  it("uses the default label when none provided", () => {
+    render(<ArchiveFilter showArchived={false} onShowArchivedChange={jest.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /filter/i }));
+
+    expect(screen.getByText("Show archived")).toBeInTheDocument();
+  });
+
+  it("uses a custom label when provided", () => {
+    render(
+      <ArchiveFilter
+        showArchived={false}
+        onShowArchivedChange={jest.fn()}
+        label="Show archived agents"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /filter/i }));
+
+    expect(screen.getByText("Show archived agents")).toBeInTheDocument();
+  });
+
+  it("calls onShowArchivedChange when checkbox item is clicked", () => {
+    const onChange = jest.fn();
+    render(<ArchiveFilter showArchived={false} onShowArchivedChange={onChange} />);
+
+    // Open dropdown
+    fireEvent.click(screen.getByRole("button", { name: /filter/i }));
+
+    // Click the checkbox item
+    fireEvent.click(screen.getByText("Show archived"));
+
+    expect(onChange).toHaveBeenCalled();
+    expect(onChange.mock.calls[0][0]).toBe(true);
+  });
+
+  it("shows Filters label in dropdown header", () => {
+    render(<ArchiveFilter showArchived={false} onShowArchivedChange={jest.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /filter/i }));
+
+    expect(screen.getByText("Filters")).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/app/(main)/agents/page.tsx
+++ b/apps/ui/src/app/(main)/agents/page.tsx
@@ -6,10 +6,10 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Plus, Upload } from "lucide-react";
 import { AgentCard } from "@/components/agents";
+import { ArchiveFilter } from "@/components/archive-filter";
 
 export default function AgentsPage() {
   const router = useRouter();
@@ -59,14 +59,13 @@ export default function AgentsPage() {
   return (
     <div className="container mx-auto p-6">
       <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-bold">Agents</h1>
-          <label className="mt-2 inline-flex items-center gap-2 text-sm text-muted-foreground">
-            <Checkbox checked={showArchived} onCheckedChange={setShowArchived} />
-            Show archived agents
-          </label>
-        </div>
-        <div className="flex gap-2">
+        <h1 className="text-2xl font-bold">Agents</h1>
+        <div className="flex items-center gap-2">
+          <ArchiveFilter
+            showArchived={showArchived}
+            onShowArchivedChange={setShowArchived}
+            label="Show archived agents"
+          />
           <input
             type="file"
             ref={fileInputRef}

--- a/apps/ui/src/app/(main)/apps/page.tsx
+++ b/apps/ui/src/app/(main)/apps/page.tsx
@@ -6,8 +6,8 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Plus, Rocket, Globe, GlobeLock, Copy } from "lucide-react";
+import { ArchiveFilter } from "@/components/archive-filter";
 import { CopyButton } from "@/components/ui/copy-button";
 import Link from "next/link";
 import type { App } from "@/lib/api/types";
@@ -29,22 +29,23 @@ export default function AppsPage() {
   return (
     <div className="container mx-auto p-6">
       <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-bold flex items-center gap-3">
-            Apps
-            <ExperimentalPageBadge />
-          </h1>
-          <label className="mt-2 inline-flex items-center gap-2 text-sm text-muted-foreground">
-            <Checkbox checked={showArchived} onCheckedChange={setShowArchived} />
-            Show archived apps
-          </label>
+        <h1 className="text-2xl font-bold flex items-center gap-3">
+          Apps
+          <ExperimentalPageBadge />
+        </h1>
+        <div className="flex items-center gap-2">
+          <ArchiveFilter
+            showArchived={showArchived}
+            onShowArchivedChange={setShowArchived}
+            label="Show archived apps"
+          />
+          <Link href="/apps/new">
+            <Button variant="accent">
+              <Plus className="w-4 h-4 mr-2" />
+              New App
+            </Button>
+          </Link>
         </div>
-        <Link href="/apps/new">
-          <Button variant="accent">
-            <Plus className="w-4 h-4 mr-2" />
-            New App
-          </Button>
-        </Link>
       </div>
 
       {isLoading ? (

--- a/apps/ui/src/app/(main)/harnesses/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/page.tsx
@@ -3,11 +3,20 @@
 import { useState } from "react";
 import { useHarnesses, useCapabilities } from "@/hooks";
 import Link from "next/link";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { Checkbox } from "@/components/ui/checkbox";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuPositioner,
+  DropdownMenuContent,
+  DropdownMenuCheckboxItem,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+} from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Plus } from "lucide-react";
+import { Filter, Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { HarnessCard } from "@/components/harnesses";
 
 export default function HarnessesPage() {
@@ -26,19 +35,41 @@ export default function HarnessesPage() {
   return (
     <div className="container mx-auto p-6">
       <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-bold">Harnesses</h1>
-          <label className="mt-2 inline-flex items-center gap-2 text-sm text-muted-foreground">
-            <Checkbox checked={showArchived} onCheckedChange={setShowArchived} />
-            Show archived harnesses
-          </label>
+        <h1 className="text-2xl font-bold">Harnesses</h1>
+        <div className="flex items-center gap-2">
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              className={cn(buttonVariants({ variant: "outline", size: "sm" }), "gap-1.5")}
+            >
+              <Filter className="size-3.5" />
+              Filter
+              {showArchived && (
+                <span className="bg-primary text-primary-foreground rounded-full px-1.5 text-xs">
+                  1
+                </span>
+              )}
+            </DropdownMenuTrigger>
+            <DropdownMenuPositioner align="end">
+              <DropdownMenuContent className="w-56">
+                <DropdownMenuGroup>
+                  <DropdownMenuLabel>Filters</DropdownMenuLabel>
+                  <DropdownMenuCheckboxItem
+                    checked={showArchived}
+                    onCheckedChange={setShowArchived}
+                  >
+                    Show archived harnesses
+                  </DropdownMenuCheckboxItem>
+                </DropdownMenuGroup>
+              </DropdownMenuContent>
+            </DropdownMenuPositioner>
+          </DropdownMenu>
+          <Link href="/harnesses/new">
+            <Button variant="accent">
+              <Plus className="w-4 h-4 mr-2" />
+              New Harness
+            </Button>
+          </Link>
         </div>
-        <Link href="/harnesses/new">
-          <Button variant="accent">
-            <Plus className="w-4 h-4 mr-2" />
-            New Harness
-          </Button>
-        </Link>
       </div>
 
       {isLoading ? (

--- a/apps/ui/src/app/(main)/harnesses/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/page.tsx
@@ -3,21 +3,12 @@
 import { useState } from "react";
 import { useHarnesses, useCapabilities } from "@/hooks";
 import Link from "next/link";
-import { Button, buttonVariants } from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuPositioner,
-  DropdownMenuContent,
-  DropdownMenuCheckboxItem,
-  DropdownMenuGroup,
-  DropdownMenuLabel,
-} from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Filter, Plus } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { Plus } from "lucide-react";
 import { HarnessCard } from "@/components/harnesses";
+import { ArchiveFilter } from "@/components/archive-filter";
 
 export default function HarnessesPage() {
   const [showArchived, setShowArchived] = useState(false);
@@ -37,32 +28,11 @@ export default function HarnessesPage() {
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold">Harnesses</h1>
         <div className="flex items-center gap-2">
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              className={cn(buttonVariants({ variant: "outline", size: "sm" }), "gap-1.5")}
-            >
-              <Filter className="size-3.5" />
-              Filter
-              {showArchived && (
-                <span className="bg-primary text-primary-foreground rounded-full px-1.5 text-xs">
-                  1
-                </span>
-              )}
-            </DropdownMenuTrigger>
-            <DropdownMenuPositioner align="end">
-              <DropdownMenuContent className="w-56">
-                <DropdownMenuGroup>
-                  <DropdownMenuLabel>Filters</DropdownMenuLabel>
-                  <DropdownMenuCheckboxItem
-                    checked={showArchived}
-                    onCheckedChange={setShowArchived}
-                  >
-                    Show archived harnesses
-                  </DropdownMenuCheckboxItem>
-                </DropdownMenuGroup>
-              </DropdownMenuContent>
-            </DropdownMenuPositioner>
-          </DropdownMenu>
+          <ArchiveFilter
+            showArchived={showArchived}
+            onShowArchivedChange={setShowArchived}
+            label="Show archived harnesses"
+          />
           <Link href="/harnesses/new">
             <Button variant="accent">
               <Plus className="w-4 h-4 mr-2" />

--- a/apps/ui/src/app/(main)/mcp-servers/page.tsx
+++ b/apps/ui/src/app/(main)/mcp-servers/page.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -27,6 +26,7 @@ import { usePolicies } from "@/hooks/use-policies";
 import { Plus, Plug, Trash2, Key, Globe } from "lucide-react";
 import type { McpServer, CreateMcpServerRequest } from "@/lib/api/types";
 import { getEntityNameClassName, getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
+import { ArchiveFilter } from "@/components/archive-filter";
 
 function McpServerCard({
   server,
@@ -308,15 +308,18 @@ export default function McpServersPage() {
             Configure Model Context Protocol (MCP) servers to extend agent capabilities with
             external tools and resources.
           </p>
-          <label className="mt-2 inline-flex items-center gap-2 text-sm text-muted-foreground">
-            <Checkbox checked={showArchived} onCheckedChange={setShowArchived} />
-            Show archived MCP servers
-          </label>
         </div>
-        <Button onClick={() => setAddServerOpen(true)}>
-          <Plus className="mr-2 h-4 w-4" />
-          Add Server
-        </Button>
+        <div className="flex items-center gap-2">
+          <ArchiveFilter
+            showArchived={showArchived}
+            onShowArchivedChange={setShowArchived}
+            label="Show archived MCP servers"
+          />
+          <Button onClick={() => setAddServerOpen(true)}>
+            <Plus className="mr-2 h-4 w-4" />
+            Add Server
+          </Button>
+        </div>
       </div>
 
       {error && (

--- a/apps/ui/src/app/(main)/skills/page.tsx
+++ b/apps/ui/src/app/(main)/skills/page.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -27,6 +26,7 @@ import { usePolicies } from "@/hooks/use-policies";
 import { Plus, BookOpen, Trash2, Upload, FileText, Archive, Box } from "lucide-react";
 import type { Skill } from "@/lib/api/types";
 import { getEntityNameClassName, getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
+import { ArchiveFilter } from "@/components/archive-filter";
 
 function SkillCard({
   skill,
@@ -252,14 +252,13 @@ export default function SkillsPage() {
   return (
     <div className="container mx-auto p-6">
       <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-bold">Skills</h1>
-          <label className="mt-2 inline-flex items-center gap-2 text-sm text-muted-foreground">
-            <Checkbox checked={showArchived} onCheckedChange={setShowArchived} />
-            Show archived skills
-          </label>
-        </div>
-        <div className="flex gap-2">
+        <h1 className="text-2xl font-bold">Skills</h1>
+        <div className="flex items-center gap-2">
+          <ArchiveFilter
+            showArchived={showArchived}
+            onShowArchivedChange={setShowArchived}
+            label="Show archived skills"
+          />
           <Button variant="outline" onClick={() => setUploadSkillOpen(true)}>
             <Upload className="h-4 w-4 mr-2" />
             Upload ZIP

--- a/apps/ui/src/components/archive-filter.tsx
+++ b/apps/ui/src/components/archive-filter.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Filter } from "lucide-react";
+import { buttonVariants } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuPositioner,
+  DropdownMenuContent,
+  DropdownMenuCheckboxItem,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+interface ArchiveFilterProps {
+  showArchived: boolean;
+  onShowArchivedChange: (show: boolean) => void;
+  /** Label for the checkbox item, e.g. "Show archived agents" */
+  label?: string;
+}
+
+export function ArchiveFilter({
+  showArchived,
+  onShowArchivedChange,
+  label = "Show archived",
+}: ArchiveFilterProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        className={cn(buttonVariants({ variant: "outline", size: "sm" }), "gap-1.5")}
+      >
+        <Filter className="size-3.5" />
+        Filter
+        {showArchived && (
+          <span className="bg-primary text-primary-foreground rounded-full px-1.5 text-xs">
+            1
+          </span>
+        )}
+      </DropdownMenuTrigger>
+      <DropdownMenuPositioner align="end">
+        <DropdownMenuContent className="w-56">
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>Filters</DropdownMenuLabel>
+            <DropdownMenuCheckboxItem
+              checked={showArchived}
+              onCheckedChange={onShowArchivedChange}
+            >
+              {label}
+            </DropdownMenuCheckboxItem>
+          </DropdownMenuGroup>
+        </DropdownMenuContent>
+      </DropdownMenuPositioner>
+    </DropdownMenu>
+  );
+}

--- a/apps/ui/src/components/archive-filter.tsx
+++ b/apps/ui/src/components/archive-filter.tsx
@@ -33,19 +33,14 @@ export function ArchiveFilter({
         <Filter className="size-3.5" />
         Filter
         {showArchived && (
-          <span className="bg-primary text-primary-foreground rounded-full px-1.5 text-xs">
-            1
-          </span>
+          <span className="bg-primary text-primary-foreground rounded-full px-1.5 text-xs">1</span>
         )}
       </DropdownMenuTrigger>
       <DropdownMenuPositioner align="end">
         <DropdownMenuContent className="w-56">
           <DropdownMenuGroup>
             <DropdownMenuLabel>Filters</DropdownMenuLabel>
-            <DropdownMenuCheckboxItem
-              checked={showArchived}
-              onCheckedChange={onShowArchivedChange}
-            >
+            <DropdownMenuCheckboxItem checked={showArchived} onCheckedChange={onShowArchivedChange}>
               {label}
             </DropdownMenuCheckboxItem>
           </DropdownMenuGroup>


### PR DESCRIPTION
## What
Replace bare "Show archived" checkboxes with a shared `ArchiveFilter` dropdown button on all 5 list pages: agents, apps, harnesses, MCP servers, and skills.

## Why
The standalone checkbox looked out of place. The events page already uses a filter dropdown pattern — this brings all list pages in line with that design.

## How
- Extracted a reusable `ArchiveFilter` component (`components/archive-filter.tsx`) that renders a Filter icon button with a dropdown containing checkbox items and an active-filter count badge.
- Updated all 5 list pages to use the shared component instead of inline `<Checkbox>` + `<label>`.
- Added 7 unit tests covering rendering, badge visibility, custom labels, and callback behavior.

## Risk
- Low
- UI-only change; no API, auth, or data model changes. All 496 existing tests pass.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered