### PR TITLE
fix(ui): always show session title edit button

### DIFF
--- a/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
@@ -161,7 +161,7 @@ function EditableSessionTitle({
       {title || fallback}
       <button
         onClick={() => setEditing(true)}
-        className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground opacity-0 group-hover/title:opacity-100 transition-opacity"
+        className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground"
         aria-label="Edit session title"
       >
         <Pencil className="w-3.5 h-3.5" />


### PR DESCRIPTION
## What
Remove hover-only opacity classes from the session title edit (pencil) button so it is always visible.

## Why
The edit button was hidden by default (`opacity-0`) and only appeared on hover (`group-hover/title:opacity-100`). This made it easy to miss and confusing when it disappeared.

## How
Removed `opacity-0 group-hover/title:opacity-100 transition-opacity` from the button className. The button now renders at full opacity at all times.

## Risk
- Low
- Purely cosmetic change; no logic, state, or API changes

## Checklist
- [x] Tests added or updated (N/A — CSS-only change, UI build passes)
- [x] Backward compatibility considered (N/A — no API or data changes)