### PR TITLE
fix(core): auto-enable tool_search for GPT-5.4 and remove Daytona prompt duplication

### DIFF
--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -293,22 +293,39 @@ impl RuntimeAgentBuilder {
 
     /// Build the runtime agent.
     ///
-    /// Validates that tool_search is only enabled for models that support it
-    /// (currently GPT-5.4+). Clears tool_search for unsupported models to
-    /// prevent 400 errors from the OpenAI API.
+    /// Validates and auto-enables tool_search based on model support.
+    ///
+    /// - If tool_search is explicitly configured but the model doesn't support it,
+    ///   clears it to prevent 400 errors from the OpenAI API.
+    /// - If tool_search is NOT configured but the model supports it natively
+    ///   (GPT-5.4+), auto-enables it with the default threshold. This ensures
+    ///   agents using GPT-5.4 benefit from deferred tool loading without
+    ///   requiring the explicit `openai_tool_search` capability.
     pub fn build(mut self) -> RuntimeAgent {
-        if self.runtime_agent.tool_search.is_some() {
-            let model_supports =
-                get_model_profile(&LlmProviderType::Openai, &self.runtime_agent.model)
-                    .is_some_and(|p| p.tool_search);
-            if !model_supports {
+        let model_supports = get_model_profile(&LlmProviderType::Openai, &self.runtime_agent.model)
+            .is_some_and(|p| p.tool_search);
+
+        match self.runtime_agent.tool_search {
+            Some(_) if !model_supports => {
                 tracing::debug!(
                     model = %self.runtime_agent.model,
                     "tool_search capability configured but model does not support it; disabling"
                 );
                 self.runtime_agent.tool_search = None;
             }
+            None if model_supports => {
+                tracing::debug!(
+                    model = %self.runtime_agent.model,
+                    "model supports tool_search natively; auto-enabling"
+                );
+                self.runtime_agent.tool_search = Some(ToolSearchConfig {
+                    enabled: true,
+                    threshold: crate::capabilities::DEFAULT_TOOL_SEARCH_THRESHOLD,
+                });
+            }
+            _ => {} // Already configured and model supports it, or not configured and model doesn't support it
         }
+
         self.runtime_agent
     }
 }
@@ -806,6 +823,32 @@ mod tests {
         assert!(
             agent.tool_search.is_none(),
             "tool_search should be cleared for non-OpenAI models"
+        );
+    }
+
+    #[test]
+    fn test_build_auto_enables_tool_search_for_gpt54() {
+        let agent = RuntimeAgentBuilder::new().model("gpt-5.4").build();
+
+        assert!(
+            agent.tool_search.is_some(),
+            "tool_search should be auto-enabled for gpt-5.4 (native support)"
+        );
+        let ts = agent.tool_search.unwrap();
+        assert!(ts.enabled);
+        assert_eq!(
+            ts.threshold,
+            crate::capabilities::DEFAULT_TOOL_SEARCH_THRESHOLD
+        );
+    }
+
+    #[test]
+    fn test_build_does_not_auto_enable_tool_search_for_unsupported_model() {
+        let agent = RuntimeAgentBuilder::new().model("gpt-5.2").build();
+
+        assert!(
+            agent.tool_search.is_none(),
+            "tool_search should not be auto-enabled for gpt-5.2 (unsupported)"
         );
     }
 }

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -851,4 +851,26 @@ mod tests {
             "tool_search should not be auto-enabled for gpt-5.2 (unsupported)"
         );
     }
+
+    #[test]
+    fn test_build_preserves_explicit_tool_search_config_for_supported_model() {
+        // Simulates Generic harness setting openai_tool_search with custom threshold.
+        // Auto-enable must NOT overwrite the explicit config.
+        let agent = RuntimeAgentBuilder::new()
+            .model("gpt-5.4")
+            .tool_search(ToolSearchConfig {
+                enabled: true,
+                threshold: 5, // custom threshold from capability
+            })
+            .build();
+
+        let ts = agent
+            .tool_search
+            .expect("explicit tool_search should be preserved");
+        assert!(ts.enabled);
+        assert_eq!(
+            ts.threshold, 5,
+            "custom threshold from capability must not be overwritten by auto-enable default"
+        );
+    }
 }

--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -99,6 +99,10 @@ impl Capability for DaytonaCapability {
     }
 
     fn system_prompt_addition(&self) -> Option<&str> {
+        // Tool names and descriptions are NOT listed here — they are already
+        // provided via the tools parameter in the API request.  Duplicating
+        // them in the system prompt wastes tokens and can confuse models
+        // (especially GPT-5.4+ with tool_search).
         Some(
             r#"## Daytona
 
@@ -106,16 +110,6 @@ Cloud-based sandboxes via Daytona. Each sandbox is an isolated environment with 
 
 Authentication: Daytona API key is resolved automatically from Settings > Connections > Daytona.
 If not configured, guide the user to set up their key in Settings > Connections.
-
-Tools:
-- `daytona_create_sandbox` - Create and start a new sandbox
-- `daytona_exec` - Run a shell command (synchronous, returns output)
-- `daytona_read_file` / `daytona_write_file` - Read/write files in sandbox
-- `daytona_download_workspace` - Download sandbox workspace to session storage
-- `daytona_list_sandboxes` - List session sandboxes
-- `daytona_manage_sandbox` - Stop or delete a sandbox
-- `daytona_git_clone` - Clone a git repository into a sandbox (auto-uses connected GitHub credentials)
-- `daytona_git_credentials` - Configure git credentials for push/pull/fetch via daytona_exec
 
 All tools except `daytona_create_sandbox` and `daytona_list_sandboxes` require a `sandbox_id`.
 Sandboxes auto-stop after 5 minutes of inactivity.
@@ -198,11 +192,12 @@ mod tests {
     fn test_capability_has_system_prompt() {
         let cap = DaytonaCapability;
         let prompt = cap.system_prompt_addition().unwrap();
+        assert!(prompt.contains("Daytona"));
+        assert!(prompt.contains("Settings > Connections"));
+        // Tool names referenced in usage context (not as a tool list)
         assert!(prompt.contains("daytona_create_sandbox"));
         assert!(prompt.contains("daytona_git_clone"));
         assert!(prompt.contains("daytona_git_credentials"));
-        assert!(prompt.contains("Daytona"));
-        assert!(prompt.contains("Settings > Connections"));
     }
 
     #[test]


### PR DESCRIPTION
## What
Two fixes for GPT-5.4 tool recognition and Daytona system prompt duplication.

1. **Auto-enable `tool_search` for GPT-5.4+**: `RuntimeAgentBuilder::build()` now auto-enables `tool_search` with the default threshold when the model natively supports it (per profile `tool_search: true`), even without the explicit `openai_tool_search` capability.

2. **Remove tool list from Daytona system prompt**: Removed the "Tools:" block listing all 9 Daytona tool names/descriptions from `system_prompt_addition()`. These duplicated definitions already sent via the API `tools` parameter.

## Why
- GPT-5.4 is the default model. Agents using custom harnesses (without `openai_tool_search` capability) would send 17+ tools in standard format instead of the deferred `tool_search` format GPT-5.4 works best with.
- The Generic harness already includes `openai_tool_search`, so the standard path worked. But custom harnesses or direct agent usage missed the optimization.
- Daytona system prompt listed tool names/descriptions that were already in the `tools` parameter, wasting tokens and potentially confusing GPT-5.4 with `tool_search` (where the model discovers tools on-demand).

## How
- `RuntimeAgentBuilder::build()` now has a `match` on `(tool_search config, model support)`:
  - `Some + unsupported` → clear (existing behavior)
  - `None + supported` → auto-enable with default threshold (new)
  - `Some + supported` → preserve explicit config (existing, now tested)
- Daytona `system_prompt_addition()` keeps workflow/usage guidance but drops the tool inventory list.

## Risk
- Low
- The Generic harness path is unchanged (explicit config preserved). Auto-enable only affects custom harnesses or direct agent usage on GPT-5.4+.
- If a future model falsely has `tool_search: true` in its profile, the driver gracefully falls back below threshold (standard format).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered