### PR TITLE
fix(core): revert tool_search auto-enable, keep capability-driven

### DIFF
--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -293,39 +293,26 @@ impl RuntimeAgentBuilder {
 
     /// Build the runtime agent.
     ///
-    /// Validates and auto-enables tool_search based on model support.
+    /// Validates that tool_search is only enabled for models that support it
+    /// (currently GPT-5.4+). Clears tool_search for unsupported models to
+    /// prevent 400 errors from the OpenAI API.
     ///
-    /// - If tool_search is explicitly configured but the model doesn't support it,
-    ///   clears it to prevent 400 errors from the OpenAI API.
-    /// - If tool_search is NOT configured but the model supports it natively
-    ///   (GPT-5.4+), auto-enables it with the default threshold. This ensures
-    ///   agents using GPT-5.4 benefit from deferred tool loading without
-    ///   requiring the explicit `openai_tool_search` capability.
+    /// tool_search is capability-driven: it is only set when the
+    /// `openai_tool_search` capability is explicitly added to the agent
+    /// or harness. This method does NOT auto-enable it.
     pub fn build(mut self) -> RuntimeAgent {
-        let model_supports = get_model_profile(&LlmProviderType::Openai, &self.runtime_agent.model)
-            .is_some_and(|p| p.tool_search);
-
-        match self.runtime_agent.tool_search {
-            Some(_) if !model_supports => {
+        if self.runtime_agent.tool_search.is_some() {
+            let model_supports =
+                get_model_profile(&LlmProviderType::Openai, &self.runtime_agent.model)
+                    .is_some_and(|p| p.tool_search);
+            if !model_supports {
                 tracing::debug!(
                     model = %self.runtime_agent.model,
                     "tool_search capability configured but model does not support it; disabling"
                 );
                 self.runtime_agent.tool_search = None;
             }
-            None if model_supports => {
-                tracing::debug!(
-                    model = %self.runtime_agent.model,
-                    "model supports tool_search natively; auto-enabling"
-                );
-                self.runtime_agent.tool_search = Some(ToolSearchConfig {
-                    enabled: true,
-                    threshold: crate::capabilities::DEFAULT_TOOL_SEARCH_THRESHOLD,
-                });
-            }
-            _ => {} // Already configured and model supports it, or not configured and model doesn't support it
         }
-
         self.runtime_agent
     }
 }
@@ -827,40 +814,26 @@ mod tests {
     }
 
     #[test]
-    fn test_build_auto_enables_tool_search_for_gpt54() {
+    fn test_build_no_auto_enable_tool_search_without_capability() {
+        // tool_search requires explicit openai_tool_search capability.
+        // Even GPT-5.4 (which supports it) should not get it automatically.
         let agent = RuntimeAgentBuilder::new().model("gpt-5.4").build();
 
         assert!(
-            agent.tool_search.is_some(),
-            "tool_search should be auto-enabled for gpt-5.4 (native support)"
-        );
-        let ts = agent.tool_search.unwrap();
-        assert!(ts.enabled);
-        assert_eq!(
-            ts.threshold,
-            crate::capabilities::DEFAULT_TOOL_SEARCH_THRESHOLD
-        );
-    }
-
-    #[test]
-    fn test_build_does_not_auto_enable_tool_search_for_unsupported_model() {
-        let agent = RuntimeAgentBuilder::new().model("gpt-5.2").build();
-
-        assert!(
             agent.tool_search.is_none(),
-            "tool_search should not be auto-enabled for gpt-5.2 (unsupported)"
+            "tool_search must not be auto-enabled; it is capability-driven"
         );
     }
 
     #[test]
     fn test_build_preserves_explicit_tool_search_config_for_supported_model() {
-        // Simulates Generic harness setting openai_tool_search with custom threshold.
-        // Auto-enable must NOT overwrite the explicit config.
+        // Simulates Generic harness setting openai_tool_search capability
+        // with custom threshold — build() must preserve it.
         let agent = RuntimeAgentBuilder::new()
             .model("gpt-5.4")
             .tool_search(ToolSearchConfig {
                 enabled: true,
-                threshold: 5, // custom threshold from capability
+                threshold: 5,
             })
             .build();
 
@@ -870,7 +843,7 @@ mod tests {
         assert!(ts.enabled);
         assert_eq!(
             ts.threshold, 5,
-            "custom threshold from capability must not be overwritten by auto-enable default"
+            "custom threshold from capability must be preserved"
         );
     }
 }


### PR DESCRIPTION
## What
Reverts the auto-enable of `tool_search` for GPT-5.4+ models introduced in #859. Restores capability-driven behavior: `tool_search` only activates when the `openai_tool_search` capability is explicitly added.

The Daytona system prompt cleanup from #859 is kept (that was correct).

## Why
`tool_search` is an opt-in capability, not a model-level default. The Generic harness already includes `openai_tool_search` — agents/harnesses that want it should add the capability explicitly.

## How
- Restored original `build()` logic: only clears `tool_search` for unsupported models, never auto-enables.
- Replaced auto-enable test with `test_build_no_auto_enable_tool_search_without_capability` that asserts GPT-5.4 does NOT get `tool_search` without the capability.
- Kept `test_build_preserves_explicit_tool_search_config_for_supported_model` for the harness scenario.

## Risk
- Low — restores previous behavior
- No functional change for Generic harness users (capability already present)

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered