### PR TITLE
fix(config): enforce real user git identity via SessionStart hook

### DIFF
--- a/.claude/hooks/fix-git-identity.sh
+++ b/.claude/hooks/fix-git-identity.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# SessionStart hook: override agent-like git identity with real user.
+# Runs automatically when a Claude Code session starts.
+
+set -euo pipefail
+
+# Only act inside a git repo
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$REPO_ROOT/scripts/lib/common.sh"
+
+configure_commit_git_identity_if_needed 2>/dev/null || true

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,19 @@
 {
-  "gitAttribution": false,
   "attribution": {
     "commit": "",
     "pr": ""
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/fix-git-identity.sh"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## What

Add a `SessionStart` hook that automatically overrides agent-like git identities (e.g. `Claude <noreply@anthropic.com>`) with the real user from `GIT_USER_NAME`/`GIT_USER_EMAIL` at the start of every Claude Code session.

## Why

Despite AGENTS.md instructions and validation scripts, commits were still authored by "Claude" because:
1. Global git config has `user.name=Claude` in cloud environments
2. Instructions to override identity were not reliably followed by agents
3. When PRs were squash-merged, GitHub added `Co-authored-by: Claude <noreply@anthropic.com>` trailers automatically
4. Result: every commit showed "chaliy and claude authored"

## How

- **New `SessionStart` hook** (`.claude/hooks/fix-git-identity.sh`): calls existing `configure_commit_git_identity_if_needed` from `scripts/lib/common.sh` to detect and replace agent-like identities before any commits are made
- **Updated `.claude/settings.json`**: added the hook config, removed invalid `gitAttribution` field (not a real Claude Code setting — the correct `attribution` object was already present)

## Risk

- Low
- Uses existing identity resolution logic (`configure_commit_git_identity_if_needed`) that is already tested
- Hook is no-op when identity is already human
- No git hooks needed — works in cloud environments

## Checklist
- [x] Backward compatibility considered
- [x] Tests added or updated (existing `scripts/test-git-identity.sh` covers the identity logic)