### PR TITLE
feat(server): wire PermissionResolver into AuthState and config endpoints

### DIFF
--- a/crates/core/src/permissions.rs
+++ b/crates/core/src/permissions.rs
@@ -448,6 +448,7 @@ pub type PolicyConfigResponse = ResourceConfigResponse;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
 
     fn owner_caller() -> Caller {
         Caller {
@@ -669,6 +670,29 @@ mod tests {
 
         assert_eq!(result.get("harness.manage"), Some(&false));
         assert_eq!(result.get("harness.dangerous"), Some(&false));
+    }
+
+    #[test]
+    fn arc_resolver_works_as_trait_object() {
+        // Validates the pattern used in AuthState: Arc<dyn PermissionResolver>
+        let resolver: Arc<dyn PermissionResolver> = Arc::new(DenyManageResolver);
+        let caller = owner_caller();
+
+        // Policy::evaluate_with accepts &dyn PermissionResolver
+        assert!(
+            TEST_MANAGE
+                .evaluate_with(resolver.as_ref(), &caller)
+                .is_err()
+        );
+
+        // evaluate_policies_with accepts &dyn PermissionResolver
+        let result =
+            evaluate_policies_with(resolver.as_ref(), &caller, &[&TEST_MANAGE, &TEST_DANGEROUS]);
+        assert_eq!(result.get("harness.manage"), Some(&false));
+
+        // Default resolver works the same way
+        let default: Arc<dyn PermissionResolver> = Arc::new(DefaultPermissionResolver);
+        assert!(TEST_MANAGE.evaluate_with(default.as_ref(), &caller).is_ok());
     }
 
     // -- Permission display --

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -17,7 +17,7 @@ use chrono::Utc;
 use everruns_core::typed_id::{AgentId, ModelId};
 use everruns_core::{
     Agent, AgentCapabilityConfig, AgentStatus, Caller, InitialFile, OrgRole,
-    ResourceConfigResponse, ToolDefinition, evaluate_policies,
+    ResourceConfigResponse, ToolDefinition, evaluate_policies_with,
 };
 
 use super::common::{
@@ -242,9 +242,16 @@ impl FromRef<AppState> for AuthState {
     ),
     tag = "agents"
 )]
-pub async fn agent_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
+pub async fn agent_config(
+    State(auth): State<AuthState>,
+    org: ResolvedOrg,
+) -> Json<ResourceConfigResponse> {
     let caller = Caller::from(&org);
-    let policies = evaluate_policies(&caller, &[&AGENT_VIEW, &AGENT_MANAGE, &AGENT_DANGEROUS]);
+    let policies = evaluate_policies_with(
+        auth.permission_resolver.as_ref(),
+        &caller,
+        &[&AGENT_VIEW, &AGENT_MANAGE, &AGENT_DANGEROUS],
+    );
     Json(ResourceConfigResponse { policies })
 }
 

--- a/crates/server/src/api/apps.rs
+++ b/crates/server/src/api/apps.rs
@@ -14,7 +14,7 @@ use axum::{
 };
 use everruns_core::typed_id::{AgentId, AppId, HarnessId};
 use everruns_core::{
-    App, AppStatus, Caller, ChannelType, ResourceConfigResponse, evaluate_policies,
+    App, AppStatus, Caller, ChannelType, ResourceConfigResponse, evaluate_policies_with,
 };
 
 use super::common::{ApiOptionExt, ApiPolicyResultExt, ErrorResponse, ListResponse};
@@ -130,9 +130,16 @@ pub fn routes(state: AppState) -> Router {
     ),
     tag = "apps"
 )]
-pub async fn app_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
+pub async fn app_config(
+    State(auth): State<AuthState>,
+    org: ResolvedOrg,
+) -> Json<ResourceConfigResponse> {
     let caller = Caller::from(&org);
-    let policies = evaluate_policies(&caller, &[&APP_VIEW, &APP_MANAGE, &APP_DANGEROUS]);
+    let policies = evaluate_policies_with(
+        auth.permission_resolver.as_ref(),
+        &caller,
+        &[&APP_VIEW, &APP_MANAGE, &APP_DANGEROUS],
+    );
     Json(ResourceConfigResponse { policies })
 }
 

--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -15,7 +15,7 @@ use axum::{
 use everruns_core::typed_id::{HarnessId, ModelId};
 use everruns_core::{
     AgentCapabilityConfig, Caller, Harness, HarnessStatus, InitialFile, ResourceConfigResponse,
-    ToolDefinition, evaluate_policies,
+    ToolDefinition, evaluate_policies_with,
 };
 
 use super::common::{ApiOptionExt, ApiPolicyResultExt, ErrorResponse, ListResponse};
@@ -162,9 +162,13 @@ pub fn routes(state: AppState) -> Router {
     ),
     tag = "harnesses"
 )]
-pub async fn harness_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
+pub async fn harness_config(
+    State(auth): State<AuthState>,
+    org: ResolvedOrg,
+) -> Json<ResourceConfigResponse> {
     let caller = Caller::from(&org);
-    let policies = evaluate_policies(
+    let policies = evaluate_policies_with(
+        auth.permission_resolver.as_ref(),
         &caller,
         &[&HARNESS_VIEW, &HARNESS_MANAGE, &HARNESS_DANGEROUS],
     );

--- a/crates/server/src/api/llm_models.rs
+++ b/crates/server/src/api/llm_models.rs
@@ -15,7 +15,7 @@ use axum::{
 use everruns_core::typed_id::{ModelId, ProviderId};
 use everruns_core::{
     Caller, LlmModel, LlmModelSource, LlmModelStatus, LlmModelWithProvider, ResourceConfigResponse,
-    evaluate_policies,
+    evaluate_policies_with,
 };
 use serde::Deserialize;
 use std::sync::Arc;
@@ -362,9 +362,16 @@ pub async fn delete_model(
     ),
     tag = "llm-models"
 )]
-pub async fn llm_model_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
+pub async fn llm_model_config(
+    State(auth): State<AuthState>,
+    org: ResolvedOrg,
+) -> Json<ResourceConfigResponse> {
     let caller = Caller::from(&org);
-    let policies = evaluate_policies(&caller, &[&LLM_MODEL_VIEW, &LLM_MODEL_MANAGE]);
+    let policies = evaluate_policies_with(
+        auth.permission_resolver.as_ref(),
+        &caller,
+        &[&LLM_MODEL_VIEW, &LLM_MODEL_MANAGE],
+    );
     Json(ResourceConfigResponse { policies })
 }
 

--- a/crates/server/src/api/llm_providers.rs
+++ b/crates/server/src/api/llm_providers.rs
@@ -16,7 +16,7 @@ use everruns_core::llm_models::LlmProvider;
 use everruns_core::typed_id::ProviderId;
 use everruns_core::{
     Caller, DriverRegistry, LlmProviderStatus, LlmProviderType, ResourceConfigResponse,
-    evaluate_policies,
+    evaluate_policies_with,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -379,9 +379,16 @@ pub async fn sync_models(
     ),
     tag = "llm-providers"
 )]
-pub async fn llm_provider_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
+pub async fn llm_provider_config(
+    State(auth): State<AuthState>,
+    org: ResolvedOrg,
+) -> Json<ResourceConfigResponse> {
     let caller = Caller::from(&org);
-    let policies = evaluate_policies(&caller, &[&LLM_PROVIDER_VIEW, &LLM_PROVIDER_MANAGE]);
+    let policies = evaluate_policies_with(
+        auth.permission_resolver.as_ref(),
+        &caller,
+        &[&LLM_PROVIDER_VIEW, &LLM_PROVIDER_MANAGE],
+    );
     Json(ResourceConfigResponse { policies })
 }
 

--- a/crates/server/src/api/mcp_servers.rs
+++ b/crates/server/src/api/mcp_servers.rs
@@ -15,7 +15,7 @@ use axum::{
 use everruns_core::typed_id::McpServerId;
 use everruns_core::{
     Caller, McpServer, McpServerStatus, McpServerTransportType, ResourceConfigResponse,
-    evaluate_policies, validate_safe_url,
+    evaluate_policies_with, validate_safe_url,
 };
 
 use super::common::{ApiOptionExt, ApiPolicyResultExt, ErrorResponse, ListResponse};
@@ -158,9 +158,13 @@ pub fn routes(state: AppState) -> Router {
     ),
     tag = "mcp-servers"
 )]
-pub async fn mcp_server_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
+pub async fn mcp_server_config(
+    State(auth): State<AuthState>,
+    org: ResolvedOrg,
+) -> Json<ResourceConfigResponse> {
     let caller = Caller::from(&org);
-    let policies = evaluate_policies(
+    let policies = evaluate_policies_with(
+        auth.permission_resolver.as_ref(),
         &caller,
         &[&MCP_SERVER_VIEW, &MCP_SERVER_MANAGE, &MCP_SERVER_DANGEROUS],
     );

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -17,7 +17,7 @@ use axum::{
 use everruns_core::capability_types::AgentCapabilityConfig;
 use everruns_core::events::{EventContext, EventRequest, InputMessageData, TurnCancelledData};
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, ModelId, SessionId, TurnId};
-use everruns_core::{Caller, Message, ResourceConfigResponse, Session, evaluate_policies};
+use everruns_core::{Caller, Message, ResourceConfigResponse, Session, evaluate_policies_with};
 use everruns_worker::AgentRunner;
 
 use super::common::{
@@ -197,9 +197,16 @@ pub fn routes(state: AppState) -> Router {
 }
 
 /// GET /v1/sessions/config
-pub async fn session_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
+pub async fn session_config(
+    State(auth): State<AuthState>,
+    org: ResolvedOrg,
+) -> Json<ResourceConfigResponse> {
     let caller = Caller::from(&org);
-    let policies = evaluate_policies(&caller, &[&SESSION_VIEW, &SESSION_MANAGE]);
+    let policies = evaluate_policies_with(
+        auth.permission_resolver.as_ref(),
+        &caller,
+        &[&SESSION_VIEW, &SESSION_MANAGE],
+    );
     Json(ResourceConfigResponse { policies })
 }
 

--- a/crates/server/src/api/skills.rs
+++ b/crates/server/src/api/skills.rs
@@ -19,7 +19,7 @@ use axum::{
 use axum_extra::extract::Multipart;
 use everruns_core::{
     Caller, ResourceConfigResponse, Skill, SkillContent, SkillId, SkillStatus,
-    SkillValidationResult, evaluate_policies,
+    SkillValidationResult, evaluate_policies_with,
 };
 use serde::Deserialize;
 use std::sync::Arc;
@@ -111,9 +111,16 @@ impl FromRef<AppState> for AuthState {
     ),
     tag = "skills"
 )]
-pub async fn skill_config(org: ResolvedOrg) -> Json<ResourceConfigResponse> {
+pub async fn skill_config(
+    State(auth): State<AuthState>,
+    org: ResolvedOrg,
+) -> Json<ResourceConfigResponse> {
     let caller = Caller::from(&org);
-    let policies = evaluate_policies(&caller, &[&SKILL_VIEW, &SKILL_MANAGE, &SKILL_DANGEROUS]);
+    let policies = evaluate_policies_with(
+        auth.permission_resolver.as_ref(),
+        &caller,
+        &[&SKILL_VIEW, &SKILL_MANAGE, &SKILL_DANGEROUS],
+    );
     Json(ResourceConfigResponse { policies })
 }
 

--- a/crates/server/src/auth/middleware.rs
+++ b/crates/server/src/auth/middleware.rs
@@ -11,7 +11,8 @@ use axum::{
 use axum_extra::extract::CookieJar;
 use everruns_core::{
     ANONYMOUS_USER_EMAIL, ANONYMOUS_USER_ID, ANONYMOUS_USER_NAME, Caller, DEFAULT_ORG_ID,
-    DEFAULT_ORG_PUBLIC_ID, OrgMembership, OrgRole, validate_org_public_id,
+    DEFAULT_ORG_PUBLIC_ID, DefaultPermissionResolver, OrgMembership, OrgRole, PermissionResolver,
+    validate_org_public_id,
 };
 use serde::Serialize;
 use std::sync::Arc;
@@ -137,17 +138,42 @@ pub enum AuthMethod {
 pub struct AuthState {
     pub config: AuthConfig,
     pub backend: Arc<dyn AuthBackend>,
+    /// Permission resolver for policy evaluation. Defaults to `DefaultPermissionResolver`.
+    /// Downstream consumers can inject a custom resolver to enforce billing-tier rules,
+    /// database-backed grants, or external RBAC decisions.
+    pub permission_resolver: Arc<dyn PermissionResolver>,
 }
 
 impl AuthState {
     pub fn new(config: AuthConfig, backend: Arc<dyn AuthBackend>) -> Self {
-        Self { config, backend }
+        Self {
+            config,
+            backend,
+            permission_resolver: Arc::new(DefaultPermissionResolver),
+        }
+    }
+
+    /// Create with a custom permission resolver.
+    pub fn with_resolver(
+        config: AuthConfig,
+        backend: Arc<dyn AuthBackend>,
+        resolver: Arc<dyn PermissionResolver>,
+    ) -> Self {
+        Self {
+            config,
+            backend,
+            permission_resolver: resolver,
+        }
     }
 
     /// Convenience: create with built-in backend (OSS default)
     pub fn builtin(config: AuthConfig, db: Arc<StorageBackend>) -> Self {
         let backend = Arc::new(super::builtin::BuiltinAuthBackend::new(config.clone(), db));
-        Self { config, backend }
+        Self {
+            config,
+            backend,
+            permission_resolver: Arc::new(DefaultPermissionResolver),
+        }
     }
 }
 

--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -103,6 +103,20 @@ Example custom resolvers:
 - Resolver backed by a per-user grants table
 - Adapter that maps external RBAC roles into OSS `Permission` values
 
+### Server Integration
+
+`AuthState` carries the active `PermissionResolver` as `Arc<dyn PermissionResolver>`. All config endpoints (`GET /v1/{resource}/config`) use `evaluate_policies_with(auth.permission_resolver.as_ref(), ...)` so they automatically respect the injected resolver.
+
+```rust
+// OSS default (uses DefaultPermissionResolver)
+AuthState::new(config, backend)
+
+// Custom resolver
+AuthState::with_resolver(config, backend, Arc::new(MyResolver))
+```
+
+The `#[policy]` macro continues to call `Policy::evaluate()`, which uses `DefaultPermissionResolver`. Custom resolvers are opt-in at explicit call sites (config endpoints, or manual `evaluate_with()` calls); the macro behavior does not change.
+
 ## Enforcement
 
 ### Service Layer


### PR DESCRIPTION
## What
Wire the existing `PermissionResolver` trait into the server's `AuthState` so downstream consumers can inject custom permission resolvers (billing-tier, DB-backed grants, external RBAC) without patching policy definitions or config endpoints.

## Why
The `PermissionResolver` trait existed in `everruns-core` but was unused in the server — all 8 config endpoints hardcoded `evaluate_policies()` with `DefaultPermissionResolver`. There was no injection point for downstream consumers to override permission resolution.

## How
- Added `permission_resolver: Arc<dyn PermissionResolver>` to `AuthState`, defaulting to `DefaultPermissionResolver`
- Added `AuthState::with_resolver()` constructor for custom resolver injection
- Updated all 8 resource config endpoints to use `evaluate_policies_with(auth.permission_resolver.as_ref(), ...)` instead of `evaluate_policies()`
- Added `arc_resolver_works_as_trait_object` test validating the `Arc<dyn PermissionResolver>` pattern
- Updated `specs/permissions.md` with server integration documentation

## Risk
- Low
- Behavioral no-op for OSS: all constructors default to `DefaultPermissionResolver`, preserving identical behavior
- Config handler signatures changed (added `State<AuthState>` parameter) but `AuthState` is already available via `FromRef` on every `AppState`

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

Closes EVE-90