### PR TITLE
fix(auth): query DB for org memberships in /v1/auth/me (none mode)

### DIFF
--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -556,26 +556,52 @@ pub async fn logout(jar: CookieJar) -> CookieJar {
 
 /// GET /v1/auth/me - Get current user info
 /// Also sets everruns_org cookie if missing (using user's first org)
+///
+/// Queries the database for the user's actual organization memberships so that
+/// newly created orgs appear immediately (the auth middleware may cache a stale
+/// or hardcoded list, e.g. AuthUser::anonymous() in none mode).
 pub async fn get_current_user(
+    State(state): State<BuiltinAuthBackend>,
     user: AuthUser,
     jar: CookieJar,
 ) -> (CookieJar, Json<UserInfoResponse>) {
-    // Always return organizations array (middleware ensures at least default org)
-    let organizations = Some(
-        user.organizations
-            .iter()
-            .map(|o| OrgMembershipResponse {
-                public_id: o.public_id.clone(),
-                name: o.name.clone(),
-                role: o.role.as_str().to_string(),
-            })
-            .collect(),
-    );
+    // Query DB for fresh organization memberships instead of using the
+    // potentially stale list from the auth middleware / anonymous() default.
+    let organizations = match state.db.list_user_organizations(user.id).await {
+        Ok(rows) => Some(
+            rows.iter()
+                .map(|o| OrgMembershipResponse {
+                    public_id: o.public_id.clone(),
+                    name: o.name.clone(),
+                    role: o.role.clone(),
+                })
+                .collect::<Vec<_>>(),
+        ),
+        Err(e) => {
+            tracing::warn!(user_id = %user.id, error = %e, "Failed to query user organizations, falling back to auth context");
+            Some(
+                user.organizations
+                    .iter()
+                    .map(|o| OrgMembershipResponse {
+                        public_id: o.public_id.clone(),
+                        name: o.name.clone(),
+                        role: o.role.as_str().to_string(),
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        }
+    };
+
+    // Determine first org for cookie (prefer DB result)
+    let first_org_public_id: Option<String> = organizations
+        .as_ref()
+        .and_then(|orgs| orgs.first().map(|o| o.public_id.clone()))
+        .or_else(|| user.organizations.first().map(|o| o.public_id.clone()));
 
     // Set org cookie if missing (ensures subsequent API calls have org context)
     let jar = if jar.get(ORG_COOKIE_NAME).is_none() {
-        if let Some(org) = user.organizations.first() {
-            let cookie = Cookie::build((ORG_COOKIE_NAME, org.public_id.clone()))
+        if let Some(public_id) = &first_org_public_id {
+            let cookie = Cookie::build((ORG_COOKIE_NAME, public_id.clone()))
                 .path("/")
                 .http_only(false) // Allow JS to read for UI state
                 .secure(true)

--- a/crates/server/tests/org_lifecycle_test.rs
+++ b/crates/server/tests/org_lifecycle_test.rs
@@ -120,6 +120,58 @@ async fn test_multiple_created_orgs_all_visible() {
 }
 
 // ============================================
+// Bug regression: /v1/auth/me must return newly created org (auth=none)
+// ============================================
+
+#[tokio::test]
+async fn test_auth_me_includes_newly_created_org() {
+    let server = TestServer::in_memory().await;
+
+    // Before creation, /v1/auth/me should show at least the default org
+    let me_before: Value = server
+        .get("/v1/auth/me")
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    let orgs_before = me_before["organizations"]
+        .as_array()
+        .expect("organizations array");
+    assert_eq!(orgs_before.len(), 1, "should start with one default org");
+
+    // Create a new org
+    let created: Value = server
+        .post("/v1/orgs", json!({"name": "AuthMe Corp"}))
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    let new_org_id = created["id"].as_str().expect("org id");
+
+    // After creation, /v1/auth/me must include the new org
+    let me_after: Value = server
+        .get("/v1/auth/me")
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    let orgs_after = me_after["organizations"]
+        .as_array()
+        .expect("organizations array");
+    assert_eq!(
+        orgs_after.len(),
+        2,
+        "auth/me should now show two orgs (default + new)"
+    );
+
+    let org_ids: Vec<&str> = orgs_after
+        .iter()
+        .map(|o| o["public_id"].as_str().unwrap())
+        .collect();
+    assert!(
+        org_ids.contains(&new_org_id),
+        "newly created org must appear in /v1/auth/me organizations"
+    );
+}
+
+// ============================================
 // Validation: empty name rejected
 // ============================================
 


### PR DESCRIPTION
## What
`GET /v1/auth/me` now queries the database for the user's actual organization
memberships instead of returning the hardcoded list from the auth middleware.

## Why
In `auth=none` mode, `AuthUser::anonymous()` returns a hardcoded org list with
only the default org. After creating a new org via `POST /v1/orgs`, the UI
refetches `/v1/auth/me` which still returned only the default org — the newly
created org never appeared in the sidebar, making it look like creation failed.

## How
- Added `State(state): State<BuiltinAuthBackend>` to `get_current_user` to
  access the DB.
- Call `db.list_user_organizations(user.id)` for fresh membership data.
- Fall back to the auth context list on DB errors (graceful degradation).
- Added regression test `test_auth_me_includes_newly_created_org`.

## Risk
- Low
- The change only affects `/v1/auth/me`. Adds one DB query per call (same query
  `list_organizations` already uses). Falls back to previous behavior on error.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered