### PR TITLE
fix(ui): deduplicate single-row tool activity timeline display

### DIFF
--- a/apps/ui/src/__tests__/tool-activity-timeline-group.test.tsx
+++ b/apps/ui/src/__tests__/tool-activity-timeline-group.test.tsx
@@ -2,6 +2,20 @@ import { render, screen } from "@testing-library/react";
 import { ToolActivityTimelineGroup } from "@/components/chat/tool-activity-timeline-group";
 
 describe("ToolActivityTimelineGroup", () => {
+  it("renders single row inline without duplicate headline", () => {
+    render(
+      <ToolActivityTimelineGroup
+        headline="Ran List Capabilities"
+        completedHeadline="Ran List Capabilities"
+        rows={[{ id: "tool-1", label: "List Capabilities", state: "completed" }]}
+      />,
+    );
+
+    // Headline should appear exactly once (as the row label)
+    const matches = screen.getAllByText("Ran List Capabilities");
+    expect(matches).toHaveLength(1);
+  });
+
   it("renders narrated group headline and child rows", () => {
     render(
       <ToolActivityTimelineGroup

--- a/apps/ui/src/components/chat/tool-activity-timeline-group.tsx
+++ b/apps/ui/src/components/chat/tool-activity-timeline-group.tsx
@@ -115,11 +115,7 @@ export function ToolActivityTimelineGroup({
   // Single row: render inline with headline as label, no nested wrapper
   if (rows.length === 1) {
     const row = rows[0];
-    return (
-      <TimelineRow
-        row={{ ...row, label: displayHeadline }}
-      />
-    );
+    return <TimelineRow row={{ ...row, label: displayHeadline }} />;
   }
 
   return (

--- a/apps/ui/src/components/chat/tool-activity-timeline-group.tsx
+++ b/apps/ui/src/components/chat/tool-activity-timeline-group.tsx
@@ -112,6 +112,16 @@ export function ToolActivityTimelineGroup({
   const [expanded, setExpanded] = useState(() => isActive);
   const displayHeadline = isActive ? headline : (completedHeadline ?? headline);
 
+  // Single row: render inline with headline as label, no nested wrapper
+  if (rows.length === 1) {
+    const row = rows[0];
+    return (
+      <TimelineRow
+        row={{ ...row, label: displayHeadline }}
+      />
+    );
+  }
+
   return (
     <div className="space-y-2">
       <button


### PR DESCRIPTION
## What
When a tool activity group contains only one tool call (e.g. `list_capabilities`), the UI rendered both a group headline and an identical child row, showing "Ran List Capabilities" twice.

## Why
The narration system correctly generates both a group-level headline and per-tool narrations. For single-tool groups these are identical, causing visual duplication in the timeline.

## How
When a group has exactly one row, render it inline as a single `TimelineRow` using the headline as the label, skipping the nested group wrapper entirely.

## Risk
- Low
- Only affects rendering of single-tool groups. Multi-tool groups are unchanged. Existing test updated to cover this path.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered