### PR TITLE
fix(ui): match filter button size with sibling buttons

### DIFF
--- a/apps/ui/src/components/archive-filter.tsx
+++ b/apps/ui/src/components/archive-filter.tsx
@@ -28,9 +28,9 @@ export function ArchiveFilter({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
-        className={cn(buttonVariants({ variant: "outline", size: "sm" }), "gap-1.5")}
+        className={cn(buttonVariants({ variant: "outline" }), "gap-1.5")}
       >
-        <Filter className="size-3.5" />
+        <Filter className="size-4" />
         Filter
         {showArchived && (
           <span className="bg-primary text-primary-foreground rounded-full px-1.5 text-xs">1</span>

--- a/apps/ui/src/components/archive-filter.tsx
+++ b/apps/ui/src/components/archive-filter.tsx
@@ -27,9 +27,7 @@ export function ArchiveFilter({
 }: ArchiveFilterProps) {
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger
-        className={cn(buttonVariants({ variant: "outline" }), "gap-1.5")}
-      >
+      <DropdownMenuTrigger className={cn(buttonVariants({ variant: "outline" }), "gap-1.5")}>
         <Filter className="size-4" />
         Filter
         {showArchived && (


### PR DESCRIPTION
## What
Fix inconsistent button sizes in toolbar across all list pages (agents, MCP servers, apps, harnesses, skills).

## Why
The `ArchiveFilter` trigger used `size="sm"` (`h-8` / 32px) while sibling buttons (Import, New Agent, etc.) used the default size (`h-9` / 36px), causing a visible height mismatch.

## How
- Removed `size: "sm"` from the `ArchiveFilter` button variant, defaulting to `h-9`
- Updated icon from `size-3.5` to `size-4` to match default button icon convention

## Risk
- Low
- Pure cosmetic change to a shared component; no logic changes

## Checklist
- [x] Tests added or updated (existing tests pass; change is cosmetic)
- [x] Backward compatibility considered (N/A — internal UI)