### PR TITLE
feat(ui): add model install/uninstall toggle and org default model selector

### DIFF
--- a/apps/ui/src/__tests__/settings-providers.test.tsx
+++ b/apps/ui/src/__tests__/settings-providers.test.tsx
@@ -62,6 +62,41 @@ jest.mock("@/hooks/use-llm-providers", () => ({
   useSyncProviderModels: () => mockUseSyncProviderModels(),
 }));
 
+jest.mock("@/hooks/use-organizations", () => ({
+  useOrganization: () => ({
+    data: {
+      id: "org_1",
+      name: "Test Org",
+      default_model_id: "model-1",
+      default_harness_id: null,
+      base_harness_id: null,
+      created_at: "2024-01-01",
+      updated_at: "2024-01-01",
+    },
+    isLoading: false,
+    error: null,
+  }),
+  useUpdateOrganization: () => ({
+    mutateAsync: jest.fn(),
+    isPending: false,
+  }),
+}));
+
+jest.mock("@/lib/api/llm-providers", () => ({
+  updateLlmModel: jest.fn(),
+}));
+
+jest.mock("@/lib/query-keys", () => ({
+  queryKeys: {
+    llmModels: {
+      all: ["llm-models"],
+      list: () => ["llm-models"],
+      detail: (id: string) => ["llm-models", id],
+    },
+    organizations: { all: ["organizations"], detail: (id: string) => ["organization", id] },
+  },
+}));
+
 describe("ProvidersPage", () => {
   let queryClient: QueryClient;
 
@@ -149,7 +184,8 @@ describe("ProvidersPage", () => {
   it("renders model rows with correct data", () => {
     render(<ProvidersPage />, { wrapper });
 
-    expect(screen.getByText("GPT-4")).toBeInTheDocument();
+    // Model name may appear in both the row and org settings selector
+    expect(screen.getAllByText("GPT-4").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("gpt-5.2 - OpenAI Production")).toBeInTheDocument();
   });
 
@@ -247,15 +283,18 @@ describe("ProvidersPage", () => {
     expect(headerButton).toBeDisabled();
   });
 
-  it("shows default star icon for default model", () => {
+  it("shows Installed badge for installed model", () => {
     render(<ProvidersPage />, { wrapper });
 
-    // GPT-4 is the default model
-    const modelRow = screen.getByText("GPT-4").closest("div");
-    expect(modelRow).toBeInTheDocument();
-    // Check for the star icon (it has fill-yellow-500 class)
-    const starIcons = document.querySelectorAll('[class*="fill-yellow-500"]');
-    expect(starIcons.length).toBeGreaterThan(0);
+    // GPT-4 is installed
+    expect(screen.getByText("Installed")).toBeInTheDocument();
+  });
+
+  it("shows Install/Uninstall button for models", () => {
+    render(<ProvidersPage />, { wrapper });
+
+    // Installed model should show Uninstall button
+    expect(screen.getByRole("button", { name: /Uninstall/i })).toBeInTheDocument();
   });
 
   it("shows API Key status correctly", () => {

--- a/apps/ui/src/app/(main)/settings/providers/page.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/page.tsx
@@ -16,6 +16,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   useLlmProviders,
   useLlmModels,
@@ -26,12 +27,14 @@ import {
   useCreateLlmModel,
   useDeleteLlmModel,
 } from "@/hooks/use-llm-providers";
+import { updateLlmModel } from "@/lib/api/llm-providers";
+import { useOrganization, useUpdateOrganization } from "@/hooks/use-organizations";
+import { queryKeys } from "@/lib/query-keys";
 import {
   Plus,
   Server,
   Trash2,
   Key,
-  Star,
   Cpu,
   Brain,
   Wrench,
@@ -42,8 +45,9 @@ import {
   ChevronDown,
   ChevronUp,
   RefreshCw,
+  Download,
+  X,
 } from "lucide-react";
-// Note: Star is still used in ModelRow for default model indicator
 import { ProviderIcon, getProviderLabel } from "@/components/providers/provider-icon";
 import type {
   LlmProvider,
@@ -178,9 +182,13 @@ function formatCost(cost: number): string {
 function ModelRow({
   model,
   onDelete,
+  onToggleInstalled,
+  isTogglingInstalled,
 }: {
   model: LlmModelWithProvider;
   onDelete: (id: string) => void;
+  onToggleInstalled: (id: string, installed: boolean) => void;
+  isTogglingInstalled: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
   const profile = model.profile;
@@ -198,7 +206,11 @@ function ModelRow({
           <div>
             <div className="font-medium flex items-center gap-2">
               {model.display_name}
-              {model.installed && <Star className="h-3 w-3 text-yellow-500 fill-yellow-500" />}
+              {model.installed && (
+                <Badge variant="outline" className="text-xs bg-green-50 text-green-700 border-green-200">
+                  Installed
+                </Badge>
+              )}
               {profile && (
                 <Badge
                   variant="outline"
@@ -262,6 +274,26 @@ function ModelRow({
           >
             {model.status}
           </Badge>
+          {/* Install / Uninstall toggle */}
+          <Button
+            variant={model.installed ? "outline" : "default"}
+            size="sm"
+            onClick={() => onToggleInstalled(model.id, !model.installed)}
+            disabled={isTogglingInstalled}
+            title={model.installed ? "Uninstall model (remove from UI pickers)" : "Install model (make available in UI pickers)"}
+          >
+            {model.installed ? (
+              <>
+                <X className="h-4 w-4 mr-1" />
+                Uninstall
+              </>
+            ) : (
+              <>
+                <Download className="h-4 w-4 mr-1" />
+                Install
+              </>
+            )}
+          </Button>
           {profile && (
             <Button
               variant="ghost"
@@ -541,7 +573,7 @@ function AddModelDialog({
   const [providerId, setProviderId] = useState("");
   const [modelId, setModelId] = useState("");
   const [displayName, setDisplayName] = useState("");
-  const [isDefault, setIsDefault] = useState(false);
+  const [installed, setInstalled] = useState(true);
 
   const createModel = useCreateLlmModel(providerId);
 
@@ -550,14 +582,14 @@ function AddModelDialog({
     const data: CreateLlmModelRequest = {
       model_id: modelId,
       display_name: displayName,
-      installed: isDefault,
+      installed,
     };
     await createModel.mutateAsync(data);
     onOpenChange(false);
     setProviderId("");
     setModelId("");
     setDisplayName("");
-    setIsDefault(false);
+    setInstalled(true);
   };
 
   return (
@@ -610,12 +642,12 @@ function AddModelDialog({
           <div className="flex items-center gap-2">
             <input
               type="checkbox"
-              id="model-is-default"
-              checked={isDefault}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setIsDefault(e.target.checked)}
+              id="model-installed"
+              checked={installed}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setInstalled(e.target.checked)}
               className="h-4 w-4"
             />
-            <Label htmlFor="model-is-default">Set as default model</Label>
+            <Label htmlFor="model-installed">Install model (available in UI model pickers)</Label>
           </div>
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
@@ -656,15 +688,19 @@ function ProviderCardSkeleton() {
 }
 
 export default function ProvidersPage() {
+  const queryClient = useQueryClient();
   const {
     data: providers = [],
     isLoading: providersLoading,
     error: providersError,
   } = useLlmProviders();
   const { data: models = [], isLoading: modelsLoading, error: modelsError } = useLlmModels();
+  const { data: org } = useOrganization();
+  const updateOrg = useUpdateOrganization();
   const deleteProvider = useDeleteLlmProvider();
   const deleteModel = useDeleteLlmModel();
   const syncModels = useSyncProviderModels();
+  const [togglingModelId, setTogglingModelId] = useState<string | null>(null);
 
   const [addProviderOpen, setAddProviderOpen] = useState(false);
   const [addModelOpen, setAddModelOpen] = useState(false);
@@ -674,6 +710,8 @@ export default function ProvidersPage() {
     type: "success" | "error";
     text: string;
   } | null>(null);
+
+  const installedModels = models.filter((m) => m.installed);
 
   const handleDeleteProvider = async (id: string) => {
     if (
@@ -689,6 +727,24 @@ export default function ProvidersPage() {
     if (confirm("Are you sure you want to delete this model?")) {
       await deleteModel.mutateAsync(id);
     }
+  };
+
+  const handleToggleInstalled = async (modelId: string, installed: boolean) => {
+    setTogglingModelId(modelId);
+    try {
+      await updateLlmModel(modelId, { installed });
+      await queryClient.invalidateQueries({ queryKey: queryKeys.llmModels.all });
+      // If uninstalling, also refresh org in case it was the default
+      if (!installed) {
+        await queryClient.invalidateQueries({ queryKey: queryKeys.organizations.all });
+      }
+    } finally {
+      setTogglingModelId(null);
+    }
+  };
+
+  const handleSetDefaultModel = async (modelId: string) => {
+    await updateOrg.mutateAsync({ default_model_id: modelId || undefined });
   };
 
   const handleSyncModels = async (providerId: string) => {
@@ -834,11 +890,62 @@ export default function ProvidersPage() {
         ) : (
           <div className="space-y-2">
             {models.map((model) => (
-              <ModelRow key={model.id} model={model} onDelete={handleDeleteModel} />
+              <ModelRow
+                key={model.id}
+                model={model}
+                onDelete={handleDeleteModel}
+                onToggleInstalled={handleToggleInstalled}
+                isTogglingInstalled={togglingModelId === model.id}
+              />
             ))}
           </div>
         )}
       </section>
+
+      {/* Organization Default Model Section */}
+      {installedModels.length > 0 && (
+        <section>
+          <div className="mb-4">
+            <h2 className="text-xl font-semibold">Organization Settings</h2>
+            <p className="text-sm text-muted-foreground">
+              Configure the default model for your organization. This is used when no model is specified at the agent or session level.
+            </p>
+          </div>
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center gap-4">
+                <Label htmlFor="default-model" className="whitespace-nowrap font-medium">
+                  Default Model
+                </Label>
+                <Select
+                  value={org?.default_model_id ?? "none"}
+                  onValueChange={(val) => handleSetDefaultModel(val === "none" ? "" : val)}
+                  disabled={updateOrg.isPending}
+                >
+                  <SelectTrigger className="w-full max-w-md" id="default-model">
+                    <span>
+                      {org?.default_model_id
+                        ? installedModels.find((m) => m.id === org.default_model_id)?.display_name ?? "Unknown model"
+                        : "No default model"}
+                    </span>
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">No default model</SelectItem>
+                    {installedModels.map((model) => (
+                      <SelectItem key={model.id} value={model.id}>
+                        <div className="flex items-center gap-2">
+                          <ProviderIcon providerType={model.provider_type} size="sm" showBackground={false} />
+                          <span>{model.display_name} ({model.provider_name})</span>
+                        </div>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </CardContent>
+          </Card>
+        </section>
+      )}
 
       {/* Dialogs */}
       <AddProviderDialog open={addProviderOpen} onOpenChange={setAddProviderOpen} />

--- a/apps/ui/src/app/(main)/settings/providers/page.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/page.tsx
@@ -207,7 +207,10 @@ function ModelRow({
             <div className="font-medium flex items-center gap-2">
               {model.display_name}
               {model.installed && (
-                <Badge variant="outline" className="text-xs bg-green-50 text-green-700 border-green-200">
+                <Badge
+                  variant="outline"
+                  className="text-xs bg-green-50 text-green-700 border-green-200"
+                >
                   Installed
                 </Badge>
               )}
@@ -280,7 +283,11 @@ function ModelRow({
             size="sm"
             onClick={() => onToggleInstalled(model.id, !model.installed)}
             disabled={isTogglingInstalled}
-            title={model.installed ? "Uninstall model (remove from UI pickers)" : "Install model (make available in UI pickers)"}
+            title={
+              model.installed
+                ? "Uninstall model (remove from UI pickers)"
+                : "Install model (make available in UI pickers)"
+            }
           >
             {model.installed ? (
               <>
@@ -908,7 +915,8 @@ export default function ProvidersPage() {
           <div className="mb-4">
             <h2 className="text-xl font-semibold">Organization Settings</h2>
             <p className="text-sm text-muted-foreground">
-              Configure the default model for your organization. This is used when no model is specified at the agent or session level.
+              Configure the default model for your organization. This is used when no model is
+              specified at the agent or session level.
             </p>
           </div>
           <Card>
@@ -925,7 +933,8 @@ export default function ProvidersPage() {
                   <SelectTrigger className="w-full max-w-md" id="default-model">
                     <span>
                       {org?.default_model_id
-                        ? installedModels.find((m) => m.id === org.default_model_id)?.display_name ?? "Unknown model"
+                        ? (installedModels.find((m) => m.id === org.default_model_id)
+                            ?.display_name ?? "Unknown model")
                         : "No default model"}
                     </span>
                   </SelectTrigger>
@@ -934,8 +943,14 @@ export default function ProvidersPage() {
                     {installedModels.map((model) => (
                       <SelectItem key={model.id} value={model.id}>
                         <div className="flex items-center gap-2">
-                          <ProviderIcon providerType={model.provider_type} size="sm" showBackground={false} />
-                          <span>{model.display_name} ({model.provider_name})</span>
+                          <ProviderIcon
+                            providerType={model.provider_type}
+                            size="sm"
+                            showBackground={false}
+                          />
+                          <span>
+                            {model.display_name} ({model.provider_name})
+                          </span>
                         </div>
                       </SelectItem>
                     ))}

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -854,6 +854,7 @@ export interface OrganizationMembership {
 export interface Organization {
   id: string;
   name: string;
+  default_model_id: string | null;
   default_harness_id: string | null;
   base_harness_id: string | null;
   created_at: string;
@@ -868,6 +869,7 @@ export interface CreateOrganizationRequest {
 /** Request to update an organization */
 export interface UpdateOrganizationRequest {
   name?: string;
+  default_model_id?: string;
   default_harness_id?: string;
   base_harness_id?: string;
 }

--- a/crates/server/src/api/organizations.rs
+++ b/crates/server/src/api/organizations.rs
@@ -55,6 +55,10 @@ pub struct UpdateOrganizationRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(example = "Acme Corporation")]
     pub name: Option<String>,
+    /// Default LLM model for this organization. Must be an installed model.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>, example = "model_01933b5a00007000800000000000001")]
+    pub default_model_id: Option<everruns_core::ModelId>,
     /// Default harness to preselect in the UI for new sessions.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(value_type = Option<String>, example = "harness_01933b5a000070008000000000000602")]
@@ -72,6 +76,9 @@ pub struct OrganizationResponse {
     pub id: String,
     /// Display name
     pub name: String,
+    /// Default LLM model for the organization.
+    #[schema(value_type = Option<String>)]
+    pub default_model_id: Option<everruns_core::ModelId>,
     /// Default harness to preselect in the UI.
     #[schema(value_type = Option<String>)]
     pub default_harness_id: Option<everruns_core::HarnessId>,
@@ -336,10 +343,34 @@ pub async fn update_organization(
 
     let UpdateOrganizationRequest {
         name,
+        default_model_id,
         default_harness_id,
         base_harness_id,
     } = req;
 
+    // Validate referenced IDs exist
+    if let Some(ref model_id) = default_model_id {
+        // Verify the model exists and is installed
+        let model = state
+            .db
+            .get_llm_model_with_provider(org_row.org_id, model_id.uuid())
+            .await
+            .log_internal_error_json("resolve default model")?
+            .ok_or_else(|| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    Json(ErrorResponse::new("Model not found")),
+                )
+            })?;
+        if !model.installed {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse::new(
+                    "Default model must be an installed model",
+                )),
+            ));
+        }
+    }
     if let Some(default_harness_id) = default_harness_id {
         state
             .db
@@ -367,15 +398,15 @@ pub async fn update_organization(
         .log_internal_error_json("update organization")?
         .ok_or_not_found_json("Organization")?;
 
-    if default_harness_id.is_some() || base_harness_id.is_some() {
+    if default_model_id.is_some() || default_harness_id.is_some() || base_harness_id.is_some() {
         state
             .db
             .patch_organization_settings(
                 org_row.org_id,
                 UpdateOrganizationSettings {
+                    default_model_id: default_model_id.map(Some),
                     default_harness_id: default_harness_id.map(Some),
                     base_harness_id: base_harness_id.map(Some),
-                    ..Default::default()
                 },
             )
             .await
@@ -420,6 +451,7 @@ async fn build_organization_response(
     Ok(OrganizationResponse {
         id: org.public_id,
         name: org.name,
+        default_model_id: settings.as_ref().and_then(|s| s.default_model_id),
         default_harness_id: settings.as_ref().and_then(|s| s.default_harness_id),
         base_harness_id: settings.as_ref().and_then(|s| s.base_harness_id),
         created_at: org.created_at,
@@ -729,6 +761,7 @@ mod tests {
         let response = OrganizationResponse {
             id: "org_00000000000000000000000000000001".to_string(),
             name: "Test Org".to_string(),
+            default_model_id: None,
             default_harness_id: Some("harness_01933b5a000070008000000000000602".parse().unwrap()),
             base_harness_id: Some("harness_01933b5a000070008000000000000601".parse().unwrap()),
             created_at: chrono::Utc::now(),

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -7250,6 +7250,13 @@
                   ],
                   "description": "Default harness to preselect in the UI."
                 },
+                "default_model_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Default LLM model for the organization."
+                },
                 "id": {
                   "type": "string",
                   "description": "External identifier (org_<32-hex-chars>)"
@@ -8446,6 +8453,13 @@
               "null"
             ],
             "description": "Default harness to preselect in the UI."
+          },
+          "default_model_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Default LLM model for the organization."
           },
           "id": {
             "type": "string",
@@ -11050,6 +11064,14 @@
             ],
             "description": "Default harness to preselect in the UI for new sessions.",
             "example": "harness_01933b5a000070008000000000000602"
+          },
+          "default_model_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Default LLM model for this organization. Must be an installed model.",
+            "example": "model_01933b5a00007000800000000000001"
           },
           "name": {
             "type": [


### PR DESCRIPTION
## Summary

- Add **Install/Uninstall** buttons to model rows in Settings > Providers, allowing users to toggle model visibility in UI model pickers
- Replace the star indicator with an explicit **"Installed" badge** for clarity
- Add **Organization Settings** section with a **Default Model** dropdown (populated from installed models only)
- Expose `default_model_id` in the org API response (`GET /v1/orgs/{org}`) and update request (`PATCH /v1/orgs/{org}`)
- Validate that the default model must be installed before it can be set — returns 400 otherwise
- Auto-elect a new default when the current default model is uninstalled or deleted
- Fix the AddModelDialog checkbox label from misleading "Set as default model" to "Install model (available in UI model pickers)"

## Test plan

- [x] Smoke-tested API: only 4 models installed by default (GPT-5.4, Opus 4.6, Sonnet 4.6, Haiku 4.6)
- [x] Verified install/uninstall toggle via `PATCH /v1/llm-models/{id}` with `installed` field
- [x] Verified org default model set/get via `PATCH /v1/orgs/{org}` with `default_model_id`
- [x] Verified rejection when setting non-installed model as default (400 error)
- [x] Verified auto-election when uninstalling the current default model
- [x] `cargo test` — all 10 default model tests + unit tests pass
- [x] `cargo clippy` — clean
- [x] `just pre-push` — all checks pass
- [ ] CI green