### PR TITLE
fix(ui): simplify archive filter label to "Show archived"

### DIFF
--- a/apps/ui/src/__tests__/archive-filter.test.tsx
+++ b/apps/ui/src/__tests__/archive-filter.test.tsx
@@ -20,26 +20,12 @@ describe("ArchiveFilter", () => {
     expect(screen.getByText("1")).toBeInTheDocument();
   });
 
-  it("uses the default label when none provided", () => {
+  it("shows 'Show archived' label in dropdown", () => {
     render(<ArchiveFilter showArchived={false} onShowArchivedChange={jest.fn()} />);
 
     fireEvent.click(screen.getByRole("button", { name: /filter/i }));
 
     expect(screen.getByText("Show archived")).toBeInTheDocument();
-  });
-
-  it("uses a custom label when provided", () => {
-    render(
-      <ArchiveFilter
-        showArchived={false}
-        onShowArchivedChange={jest.fn()}
-        label="Show archived agents"
-      />,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: /filter/i }));
-
-    expect(screen.getByText("Show archived agents")).toBeInTheDocument();
   });
 
   it("calls onShowArchivedChange when checkbox item is clicked", () => {

--- a/apps/ui/src/app/(main)/agents/page.tsx
+++ b/apps/ui/src/app/(main)/agents/page.tsx
@@ -61,10 +61,7 @@ export default function AgentsPage() {
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold">Agents</h1>
         <div className="flex items-center gap-2">
-          <ArchiveFilter
-            showArchived={showArchived}
-            onShowArchivedChange={setShowArchived}
-          />
+          <ArchiveFilter showArchived={showArchived} onShowArchivedChange={setShowArchived} />
           <input
             type="file"
             ref={fileInputRef}

--- a/apps/ui/src/app/(main)/agents/page.tsx
+++ b/apps/ui/src/app/(main)/agents/page.tsx
@@ -64,7 +64,6 @@ export default function AgentsPage() {
           <ArchiveFilter
             showArchived={showArchived}
             onShowArchivedChange={setShowArchived}
-            label="Show archived agents"
           />
           <input
             type="file"

--- a/apps/ui/src/app/(main)/apps/page.tsx
+++ b/apps/ui/src/app/(main)/apps/page.tsx
@@ -37,7 +37,6 @@ export default function AppsPage() {
           <ArchiveFilter
             showArchived={showArchived}
             onShowArchivedChange={setShowArchived}
-            label="Show archived apps"
           />
           <Link href="/apps/new">
             <Button variant="accent">

--- a/apps/ui/src/app/(main)/apps/page.tsx
+++ b/apps/ui/src/app/(main)/apps/page.tsx
@@ -34,10 +34,7 @@ export default function AppsPage() {
           <ExperimentalPageBadge />
         </h1>
         <div className="flex items-center gap-2">
-          <ArchiveFilter
-            showArchived={showArchived}
-            onShowArchivedChange={setShowArchived}
-          />
+          <ArchiveFilter showArchived={showArchived} onShowArchivedChange={setShowArchived} />
           <Link href="/apps/new">
             <Button variant="accent">
               <Plus className="w-4 h-4 mr-2" />

--- a/apps/ui/src/app/(main)/harnesses/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/page.tsx
@@ -28,10 +28,7 @@ export default function HarnessesPage() {
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold">Harnesses</h1>
         <div className="flex items-center gap-2">
-          <ArchiveFilter
-            showArchived={showArchived}
-            onShowArchivedChange={setShowArchived}
-          />
+          <ArchiveFilter showArchived={showArchived} onShowArchivedChange={setShowArchived} />
           <Link href="/harnesses/new">
             <Button variant="accent">
               <Plus className="w-4 h-4 mr-2" />

--- a/apps/ui/src/app/(main)/harnesses/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/page.tsx
@@ -31,7 +31,6 @@ export default function HarnessesPage() {
           <ArchiveFilter
             showArchived={showArchived}
             onShowArchivedChange={setShowArchived}
-            label="Show archived harnesses"
           />
           <Link href="/harnesses/new">
             <Button variant="accent">

--- a/apps/ui/src/app/(main)/mcp-servers/page.tsx
+++ b/apps/ui/src/app/(main)/mcp-servers/page.tsx
@@ -313,7 +313,6 @@ export default function McpServersPage() {
           <ArchiveFilter
             showArchived={showArchived}
             onShowArchivedChange={setShowArchived}
-            label="Show archived MCP servers"
           />
           <Button onClick={() => setAddServerOpen(true)}>
             <Plus className="mr-2 h-4 w-4" />

--- a/apps/ui/src/app/(main)/mcp-servers/page.tsx
+++ b/apps/ui/src/app/(main)/mcp-servers/page.tsx
@@ -310,10 +310,7 @@ export default function McpServersPage() {
           </p>
         </div>
         <div className="flex items-center gap-2">
-          <ArchiveFilter
-            showArchived={showArchived}
-            onShowArchivedChange={setShowArchived}
-          />
+          <ArchiveFilter showArchived={showArchived} onShowArchivedChange={setShowArchived} />
           <Button onClick={() => setAddServerOpen(true)}>
             <Plus className="mr-2 h-4 w-4" />
             Add Server

--- a/apps/ui/src/app/(main)/skills/page.tsx
+++ b/apps/ui/src/app/(main)/skills/page.tsx
@@ -257,7 +257,6 @@ export default function SkillsPage() {
           <ArchiveFilter
             showArchived={showArchived}
             onShowArchivedChange={setShowArchived}
-            label="Show archived skills"
           />
           <Button variant="outline" onClick={() => setUploadSkillOpen(true)}>
             <Upload className="h-4 w-4 mr-2" />

--- a/apps/ui/src/app/(main)/skills/page.tsx
+++ b/apps/ui/src/app/(main)/skills/page.tsx
@@ -254,10 +254,7 @@ export default function SkillsPage() {
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold">Skills</h1>
         <div className="flex items-center gap-2">
-          <ArchiveFilter
-            showArchived={showArchived}
-            onShowArchivedChange={setShowArchived}
-          />
+          <ArchiveFilter showArchived={showArchived} onShowArchivedChange={setShowArchived} />
           <Button variant="outline" onClick={() => setUploadSkillOpen(true)}>
             <Upload className="h-4 w-4 mr-2" />
             Upload ZIP

--- a/apps/ui/src/components/archive-filter.tsx
+++ b/apps/ui/src/components/archive-filter.tsx
@@ -18,10 +18,7 @@ interface ArchiveFilterProps {
   onShowArchivedChange: (show: boolean) => void;
 }
 
-export function ArchiveFilter({
-  showArchived,
-  onShowArchivedChange,
-}: ArchiveFilterProps) {
+export function ArchiveFilter({ showArchived, onShowArchivedChange }: ArchiveFilterProps) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger className={cn(buttonVariants({ variant: "outline" }), "gap-1.5")}>

--- a/apps/ui/src/components/archive-filter.tsx
+++ b/apps/ui/src/components/archive-filter.tsx
@@ -16,14 +16,11 @@ import { cn } from "@/lib/utils";
 interface ArchiveFilterProps {
   showArchived: boolean;
   onShowArchivedChange: (show: boolean) => void;
-  /** Label for the checkbox item, e.g. "Show archived agents" */
-  label?: string;
 }
 
 export function ArchiveFilter({
   showArchived,
   onShowArchivedChange,
-  label = "Show archived",
 }: ArchiveFilterProps) {
   return (
     <DropdownMenu>
@@ -39,7 +36,7 @@ export function ArchiveFilter({
           <DropdownMenuGroup>
             <DropdownMenuLabel>Filters</DropdownMenuLabel>
             <DropdownMenuCheckboxItem checked={showArchived} onCheckedChange={onShowArchivedChange}>
-              {label}
+              Show archived
             </DropdownMenuCheckboxItem>
           </DropdownMenuGroup>
         </DropdownMenuContent>

--- a/specs/models.md
+++ b/specs/models.md
@@ -32,7 +32,7 @@ Applies to:
 - Apps
 
 Contract:
-- `archived` means read-only, not assignable, not executable, hidden from lists by default, visible when explicitly filtered in.
+- `archived` means read-only, not assignable, not executable, hidden from lists by default, visible when explicitly filtered in. The filter label is always "Show archived" (no entity suffix) — the page context already communicates what entity type is listed.
 - `deleted` is a tombstone state used only to preserve historical references. Normal detail APIs return `404`, normal lists exclude deleted items, and runtime execution must not use them.
 - Existing references are preserved by ID. UI/API reference surfaces render tombstones like `<Deleted Agent>` instead of resolving the deleted entity normally.
 - If a session or app references an archived or deleted dependency, execution must stop gracefully on the next atom with a user-visible explanation instead of crashing.


### PR DESCRIPTION
## What
Remove entity-specific suffixes from the archive filter dropdown label. All pages now show "Show archived" instead of "Show archived agents", "Show archived harnesses", etc.

## Why
The page context already communicates what entity type is listed, making the suffix redundant.

## How
- Removed the `label` prop from `ArchiveFilter` component, hardcoded "Show archived"
- Removed `label` prop from all 5 call sites (agents, harnesses, skills, mcp-servers, apps)
- Updated test to reflect the simplified API
- Updated `specs/models.md` to document the convention

## Risk
- Low
- Pure UI label change, no logic affected

## Checklist
- [x] Tests added or updated
- [ ] Backward compatibility considered — N/A, internal component