### PR TITLE
refactor(core): remove stream-level retry from ReasonAtom, classify LLM errors

### DIFF
--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -37,7 +37,7 @@ use crate::llm_driver_registry::{
     DriverRegistry, LlmCallConfigBuilder, LlmCompletionMetadata, LlmMessage, LlmMessageContent,
     LlmMessageRole, LlmStreamEvent, ProviderConfig, ProviderType,
 };
-use crate::llm_retry::{LlmRetryConfig, RetryMetadata, is_transient_error_message};
+use crate::llm_retry::is_transient_error_message;
 use crate::message::{Message, MessageRole};
 use crate::message_retriever::MessageRetriever;
 use crate::openresponses_protocol::{
@@ -101,41 +101,6 @@ fn extract_locale_override(messages: &[Message]) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned)
-}
-
-fn should_retry_stream_error(
-    err: &str,
-    retry_attempts: u32,
-    max_retries: u32,
-    text: &str,
-    thinking: &str,
-    thinking_signature: Option<&str>,
-    tool_calls: &[ToolCall],
-) -> bool {
-    retry_attempts < max_retries
-        && text.is_empty()
-        && thinking.is_empty()
-        && thinking_signature.is_none()
-        && tool_calls.is_empty()
-        && is_transient_error_message(err)
-}
-
-fn merge_retry_metadata(
-    existing: Option<RetryMetadata>,
-    additional: &RetryMetadata,
-) -> Option<RetryMetadata> {
-    if !additional.had_retries() {
-        return existing;
-    }
-
-    let mut merged = existing.unwrap_or_default();
-    merged.attempts += additional.attempts;
-    merged.total_retry_wait += additional.total_retry_wait;
-    if additional.last_rate_limit_info.is_some() {
-        merged.last_rate_limit_info = additional.last_rate_limit_info.clone();
-    }
-
-    Some(merged)
 }
 
 // ============================================================================
@@ -457,23 +422,8 @@ where
 
                 let error_msg = e.to_string();
 
-                // User-facing error message
-                // Provide specific guidance based on error type
-                let user_error_text = if let Some(model_id) = e.model_not_available_id() {
-                    format!(
-                        "The model `{}` is not available. It may have been removed, \
-                         renamed, or your API key may not have access to it. \
-                         Please select a different model.",
-                        model_id
-                    )
-                } else if e.is_request_too_large() {
-                    "The conversation has become too long for the model to process. \
-                     Please start a new session or reduce the context size."
-                        .to_string()
-                } else {
-                    "I encountered an error while processing your request. Please try again later."
-                        .to_string()
-                };
+                // User-facing error message based on error classification
+                let user_error_text = e.user_facing_message();
 
                 // Only emit user-facing error events for non-transient errors.
                 // Transient errors (server errors, rate limits, timeouts) will be
@@ -865,10 +815,8 @@ where
         let llm_start = Instant::now();
 
         // Try LLM call with automatic compaction on RequestTooLarge.
-        // Stream-level provider errors can still arrive inside a 200/SSE response, so
-        // we also allow a bounded retry before any output is emitted.
-        let retry_config = LlmRetryConfig::default();
-        let mut stream_retry_metadata = RetryMetadata::default();
+        // Transient errors (429, 5xx) are retried at the driver level.
+        // Stream-level errors are not retried here to avoid duplicate user-visible messages.
         let mut compaction_info: Option<LlmCompactionInfo> = None;
         let mut llm_messages_for_call = llm_messages.clone();
 
@@ -880,9 +828,9 @@ where
             thinking,
             thinking_signature,
             tool_calls,
-            mut completion_metadata,
+            completion_metadata,
             time_to_first_token_ms,
-        ) = 'stream_attempt: loop {
+        ) = {
             let mut stream = match llm_driver
                 .chat_completion_stream(llm_messages_for_call.clone(), &llm_config)
                 .await
@@ -1180,31 +1128,6 @@ where
                         break;
                     }
                     LlmStreamEvent::Error(err) => {
-                        if should_retry_stream_error(
-                            &err,
-                            stream_retry_metadata.attempts,
-                            retry_config.max_retries,
-                            &text,
-                            &thinking,
-                            thinking_signature.as_deref(),
-                            &tool_calls,
-                        ) {
-                            let wait_duration =
-                                retry_config.calculate_backoff(stream_retry_metadata.attempts);
-                            tracing::warn!(
-                                session_id = %session_id,
-                                turn_id = %context.turn_id,
-                                attempt = stream_retry_metadata.attempts + 1,
-                                max_retries = retry_config.max_retries,
-                                wait_secs = wait_duration.as_secs_f64(),
-                                error = %err,
-                                "ReasonAtom: transient stream error before first token, retrying"
-                            );
-                            stream_retry_metadata.record_retry(wait_duration, None);
-                            tokio::time::sleep(wait_duration).await;
-                            continue 'stream_attempt;
-                        }
-
                         // Emit llm.generation failure event (child of reason span)
                         let llm_duration_ms = llm_start.elapsed().as_millis() as u64;
                         let event_context = EventContext::from_atom_context(context).with_span(
@@ -1214,7 +1137,7 @@ where
                         );
                         let tools_summary: Vec<ToolDefinitionSummary> =
                             runtime_agent.tools.iter().map(|t| t.into()).collect();
-                        let mut generation_data = LlmGenerationData::failure(
+                        let generation_data = LlmGenerationData::failure(
                             messages_for_event.clone(),
                             tools_summary,
                             runtime_agent.model.clone(),
@@ -1223,13 +1146,6 @@ where
                             Some(llm_duration_ms),
                             time_to_first_token_ms,
                         );
-                        if stream_retry_metadata.had_retries() {
-                            generation_data = generation_data.with_retry(LlmRetryInfo {
-                                attempts: stream_retry_metadata.attempts,
-                                total_wait_ms: stream_retry_metadata.total_retry_wait.as_millis()
-                                    as u64,
-                            });
-                        }
                         let _ = self
                             .event_emitter
                             .emit(EventRequest::new(
@@ -1242,20 +1158,15 @@ where
                     }
                 }
             }
-            break 'stream_attempt (
+            (
                 text,
                 thinking,
                 thinking_signature,
                 tool_calls,
                 completion_metadata,
                 time_to_first_token_ms,
-            );
+            )
         };
-
-        if let Some(metadata) = completion_metadata.as_mut() {
-            metadata.retry_metadata =
-                merge_retry_metadata(metadata.retry_metadata.take(), &stream_retry_metadata);
-        }
 
         let llm_duration_ms = llm_start.elapsed().as_millis() as u64;
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -147,6 +147,66 @@ impl AgentLoopError {
             _ => None,
         }
     }
+
+    /// Check if this is a rate-limit error (HTTP 429 or rate-limit keywords)
+    pub fn is_rate_limited(&self) -> bool {
+        match self {
+            AgentLoopError::Llm(msg) => {
+                let msg_lower = msg.to_ascii_lowercase();
+                msg_lower.contains("(429)")
+                    || msg_lower.contains("rate limit")
+                    || msg_lower.contains("too many requests")
+            }
+            _ => false,
+        }
+    }
+
+    /// Check if this is an authentication/authorization error (HTTP 401/403)
+    pub fn is_auth_error(&self) -> bool {
+        match self {
+            AgentLoopError::Llm(msg) => msg.contains("(401)") || msg.contains("(403)"),
+            _ => false,
+        }
+    }
+
+    /// Check if this is a server error (HTTP 5xx or transient provider issue)
+    pub fn is_server_error(&self) -> bool {
+        match self {
+            AgentLoopError::Llm(msg) => {
+                msg.contains("(500)")
+                    || msg.contains("(502)")
+                    || msg.contains("(503)")
+                    || msg.contains("(504)")
+                    || msg.contains("(529)")
+            }
+            _ => false,
+        }
+    }
+
+    /// Get user-facing error message based on error classification
+    pub fn user_facing_message(&self) -> String {
+        if let Some(model_id) = self.model_not_available_id() {
+            format!(
+                "The model `{}` is not available. It may have been removed, \
+                 renamed, or your API key may not have access to it. \
+                 Please select a different model.",
+                model_id
+            )
+        } else if self.is_request_too_large() {
+            "The conversation has become too long for the model to process. \
+             Please start a new session or reduce the context size."
+                .to_string()
+        } else if self.is_rate_limited() {
+            "Rate limited by the AI provider. Please wait a moment.".to_string()
+        } else if self.is_auth_error() {
+            "There is a misconfiguration with the AI provider. Please contact support.".to_string()
+        } else if self.is_server_error() {
+            "The AI provider is experiencing issues. Please try again shortly.".to_string()
+        } else {
+            "I encountered an error while processing your request. Please try again later."
+                .to_string()
+        }
+    }
 }
 
 #[cfg(test)]
@@ -205,5 +265,97 @@ mod tests {
     fn test_model_not_available_error_display() {
         let err = AgentLoopError::model_not_available("gpt-99");
         assert_eq!(err.to_string(), "Model not available: gpt-99");
+    }
+
+    #[test]
+    fn test_is_rate_limited_detects_429() {
+        let err = AgentLoopError::llm("Anthropic API error (429): rate limit exceeded");
+        assert!(err.is_rate_limited());
+    }
+
+    #[test]
+    fn test_is_rate_limited_detects_rate_limit_keyword() {
+        let err =
+            AgentLoopError::llm("Rate limit exceeded (after 2 retries, last error: too many)");
+        assert!(err.is_rate_limited());
+    }
+
+    #[test]
+    fn test_is_rate_limited_false_for_server_error() {
+        let err = AgentLoopError::llm("Anthropic API error (500): internal server error");
+        assert!(!err.is_rate_limited());
+    }
+
+    #[test]
+    fn test_is_auth_error_detects_401() {
+        let err = AgentLoopError::llm("Anthropic API error (401): invalid api key");
+        assert!(err.is_auth_error());
+    }
+
+    #[test]
+    fn test_is_auth_error_detects_403() {
+        let err = AgentLoopError::llm("OpenAI API error (403): forbidden");
+        assert!(err.is_auth_error());
+    }
+
+    #[test]
+    fn test_is_server_error_detects_500() {
+        let err = AgentLoopError::llm("Anthropic API error (500): internal server error");
+        assert!(err.is_server_error());
+    }
+
+    #[test]
+    fn test_is_server_error_detects_503() {
+        let err = AgentLoopError::llm("OpenAI API error (503): service unavailable");
+        assert!(err.is_server_error());
+    }
+
+    #[test]
+    fn test_user_facing_message_rate_limited() {
+        let err = AgentLoopError::llm("Anthropic API error (429): rate limit exceeded");
+        assert_eq!(
+            err.user_facing_message(),
+            "Rate limited by the AI provider. Please wait a moment."
+        );
+    }
+
+    #[test]
+    fn test_user_facing_message_auth_error() {
+        let err = AgentLoopError::llm("Anthropic API error (401): invalid api key");
+        assert_eq!(
+            err.user_facing_message(),
+            "There is a misconfiguration with the AI provider. Please contact support."
+        );
+    }
+
+    #[test]
+    fn test_user_facing_message_server_error() {
+        let err = AgentLoopError::llm("Anthropic API error (500): internal server error");
+        assert_eq!(
+            err.user_facing_message(),
+            "The AI provider is experiencing issues. Please try again shortly."
+        );
+    }
+
+    #[test]
+    fn test_user_facing_message_generic_fallback() {
+        let err = AgentLoopError::llm("Failed to send request: connection refused");
+        assert_eq!(
+            err.user_facing_message(),
+            "I encountered an error while processing your request. Please try again later."
+        );
+    }
+
+    #[test]
+    fn test_user_facing_message_model_not_available() {
+        let err = AgentLoopError::model_not_available("gpt-99");
+        assert!(err.user_facing_message().contains("gpt-99"));
+        assert!(err.user_facing_message().contains("not available"));
+    }
+
+    #[test]
+    fn test_user_facing_message_request_too_large() {
+        let err = AgentLoopError::request_too_large("context length exceeded");
+        assert!(err.user_facing_message().contains("too long"));
     }
 }

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -945,7 +945,10 @@ async fn test_reason_atom_emits_output_message_completed_on_success() {
 }
 
 #[tokio::test]
-async fn test_reason_atom_retries_transient_stream_error_before_first_token() {
+async fn test_reason_atom_does_not_retry_transient_stream_error() {
+    // Stream-level errors are NOT retried at the atom level.
+    // Transient retries happen at the driver level (HTTP 429/5xx).
+    // The atom reports the error as a failure to avoid duplicate user-visible messages.
     use everruns_core::memory::InMemoryEventEmitter;
 
     let (
@@ -999,11 +1002,14 @@ async fn test_reason_atom_retries_transient_stream_error_before_first_token() {
     let result = atom
         .execute(input)
         .await
-        .expect("ReasonAtom should succeed after retry");
+        .expect("ReasonAtom should return Ok with failure result");
 
-    assert!(result.success, "Transient stream error should be retried");
-    assert_eq!(result.text, "Recovered after retry.");
-    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    assert!(
+        !result.success,
+        "Stream error should not be retried at atom level"
+    );
+    // Only one attempt — no retry
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
 
     let events = event_emitter.events().await;
     let llm_event = events
@@ -1012,13 +1018,7 @@ async fn test_reason_atom_retries_transient_stream_error_before_first_token() {
         .expect("llm.generation event should be emitted");
 
     if let everruns_core::EventData::LlmGeneration(data) = &llm_event.data {
-        let retry = data
-            .metadata
-            .retry
-            .as_ref()
-            .expect("retry metadata should be present");
-        assert_eq!(retry.attempts, 1);
-        assert!(data.metadata.success);
+        assert!(!data.metadata.success, "Should report failure");
     } else {
         panic!("Expected llm.generation event data");
     }

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -245,11 +245,21 @@ sequenceDiagram
     alt Request Too Large
         D->>D: Detect via is_*_request_too_large()
         D-->>R: Err(RequestTooLarge(msg))
-        R->>R: is_request_too_large() = true
         R-->>User: "Conversation too long..."
+    else Rate Limited (429)
+        D-->>R: Err(Llm(msg))
+        R->>R: is_rate_limited() = true
+        R-->>User: "Rate limited by the AI provider..."
+    else Auth Error (401/403)
+        D-->>R: Err(Llm(msg))
+        R->>R: is_auth_error() = true
+        R-->>User: "Misconfiguration, contact support..."
+    else Server Error (5xx)
+        D-->>R: Err(Llm(msg))
+        R->>R: is_server_error() = true
+        R-->>User: "Provider experiencing issues..."
     else Other Error
         D-->>R: Err(Llm(msg))
-        R->>R: is_request_too_large() = false
         R-->>User: "Error processing request..."
     end
 
@@ -306,11 +316,7 @@ The following HTTP status codes trigger automatic retry:
 - `429` - Too Many Requests (Rate Limited)
 - `5xx` - Server Errors (except 501 Not Implemented)
 
-For streaming providers, Everruns also retries a narrow class of **in-band stream errors** when:
-- the provider emits a transient server/rate-limit style error event inside an accepted stream
-- no text, thinking content, tool calls, or completion metadata have been emitted yet
-
-Once any output has been surfaced to the user, the generation is not retried automatically. This avoids duplicated partial output and preserves deterministic event history.
+In-band stream errors (provider errors inside an accepted SSE stream) are **not** retried at the atom level to avoid duplicate user-visible error messages. The driver-level HTTP retry handles transient failures before the stream is established.
 
 ### Rate Limit Header Support
 


### PR DESCRIPTION
## What
Remove atom-level stream retry from ReasonAtom and add error classification for user-facing LLM error messages.

## Why
When the LLM provider was down, each user message independently showed a generic "I encountered an error" message. Stream-level retries at the atom level were redundant with driver-level retries and risked duplicate user-visible error events.

## How
1. **Removed stream retry loop** from ReasonAtom. Transient errors (429, 5xx) are already retried at the HTTP driver level with exponential backoff.
2. **Added error classification** to `AgentLoopError` with methods: `is_rate_limited()`, `is_auth_error()`, `is_server_error()`, and `user_facing_message()`.
3. **Updated error messages**:
   - Rate limited (429) -> "Rate limited by the AI provider. Please wait a moment."
   - Auth error (401/403) -> "There is a misconfiguration with the AI provider. Please contact support."
   - Server error (5xx) -> "The AI provider is experiencing issues. Please try again shortly."
   - Generic fallback preserved for unclassified errors.
4. **Updated test** to verify stream errors are no longer retried at atom level.
5. **Updated spec** to reflect removal of stream retry and new error classification flow.

## Risk
- Low
- Only affects error messaging and retry behavior for LLM stream errors
- Driver-level retry (HTTP 429/5xx) is unchanged

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered