### PR TITLE
fix(protocol): include missing fields in proto session conversion

### DIFF
--- a/crates/core/src/capabilities/platform_management.rs
+++ b/crates/core/src/capabilities/platform_management.rs
@@ -735,6 +735,7 @@ impl Tool for ManageSessionsTool {
                             .map(|s| {
                                 json!({
                                     "id": s.id.to_string(),
+                                    "organization_id": s.organization_id,
                                     "title": s.title,
                                     "status": format!("{:?}", s.status),
                                     "agent_id": s.agent_id.as_ref().map(|a| a.to_string()),
@@ -778,6 +779,7 @@ impl Tool for ManageSessionsTool {
                 {
                     Ok(s) => ToolExecutionResult::success(json!({
                         "id": s.id.to_string(),
+                        "organization_id": s.organization_id,
                         "title": s.title,
                         "locale": s.locale,
                         "status": format!("{:?}", s.status),
@@ -808,6 +810,7 @@ impl Tool for ManageSessionsTool {
                 match store.get_session_by_id(id).await {
                     Ok(Some(s)) => ToolExecutionResult::success(json!({
                         "id": s.id.to_string(),
+                        "organization_id": s.organization_id,
                         "title": s.title,
                         "status": format!("{:?}", s.status),
                         "agent_id": s.agent_id.as_ref().map(|a| a.to_string()),

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -388,16 +388,25 @@ pub fn proto_session_to_schema(
         .as_ref()
         .map(|u| format!("model_{}", u.value.replace("-", "")));
 
+    let capabilities: Vec<serde_json::Value> = value
+        .capabilities
+        .iter()
+        .filter_map(|c| serde_json::from_str(c).ok())
+        .collect();
+
     let json = serde_json::json!({
         "id": id_str,
+        "organization_id": value.organization_id,
         "harness_id": harness_id_str,
         "agent_id": agent_id_str,
         "title": if value.title.is_empty() { None } else { Some(&value.title) },
         "locale": if value.locale.is_empty() { None } else { Some(&value.locale) },
         "tags": tags,
         "model_id": model_id_str,
+        "capabilities": capabilities,
         "status": value.status,
         "created_at": value.created_at.as_ref().map(|t| proto_timestamp_to_datetime(t).to_rfc3339()),
+        "updated_at": value.updated_at.as_ref().map(|t| proto_timestamp_to_datetime(t).to_rfc3339()),
         "started_at": started_at,
         "finished_at": finished_at,
     });
@@ -1291,5 +1300,59 @@ mod tests {
 
         let schema_message = proto_message_to_schema(proto_message).unwrap();
         assert!(schema_message.external_actor.is_none());
+    }
+
+    #[test]
+    fn test_proto_session_roundtrip_includes_organization_id() {
+        use chrono::Utc;
+        use everruns_core::AgentCapabilityConfig;
+
+        let now = Utc::now();
+        let session = everruns_core::Session {
+            id: everruns_core::SessionId::new(),
+            organization_id: "org_00000000000000000000000000000001".to_string(),
+            harness_id: everruns_core::HarnessId::new(),
+            agent_id: None,
+            title: Some("Test Session".to_string()),
+            locale: None,
+            preview: None,
+            output_preview: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: vec![AgentCapabilityConfig::new("session")],
+            tools: vec![],
+            status: everruns_core::SessionStatus::Idle,
+            created_at: now,
+            updated_at: now,
+            started_at: None,
+            finished_at: None,
+            usage: None,
+            is_pinned: None,
+            active_schedule_count: None,
+            features: vec![],
+            parent_session_id: None,
+            subagent_name: None,
+            subagent_task: None,
+            subagent_status: None,
+        };
+
+        // Convert to proto
+        let proto_session = schema_session_to_proto(&session);
+        assert_eq!(
+            proto_session.organization_id,
+            "org_00000000000000000000000000000001"
+        );
+        assert_eq!(proto_session.capabilities.len(), 1);
+
+        // Convert back to schema
+        let schema_session = proto_session_to_schema(proto_session).unwrap();
+        assert_eq!(
+            schema_session.organization_id,
+            "org_00000000000000000000000000000001"
+        );
+        assert_eq!(schema_session.id, session.id);
+        assert_eq!(schema_session.harness_id, session.harness_id);
+        assert_eq!(schema_session.capabilities.len(), 1);
+        assert_eq!(schema_session.capabilities[0].capability_id(), "session");
     }
 }


### PR DESCRIPTION
## What
Fix `proto_session_to_schema()` in `crates/internal-protocol/src/lib.rs` to include `organization_id`, `updated_at`, and `capabilities` in the intermediate JSON. Also surface `organization_id` in platform management tool responses (list, create, get sessions).

## Why
The gRPC worker path was failing with `"JSON error: missing field organization_id"` when deserializing proto Session to core Session. The JSON intermediate was missing three fields:
- `organization_id` (required) — caused the crash
- `updated_at` (required) — would crash after fixing org_id
- `capabilities` (defaulted) — silent data loss

This only affected the gRPC worker path (production). DEV_MODE and API responses were unaffected because they construct Session structs directly.

Additionally, platform management tool responses were not including `organization_id`, creating an inconsistency with the REST API and missing audit trail context.

## How
- Added the three missing fields to the JSON construction in `proto_session_to_schema()`
- Added `organization_id` to session tool responses in `platform_management.rs` (list, create, get)
- Added a round-trip test verifying `organization_id` and `capabilities` survive proto conversion

## Risk
- Low
- Additive change to serialization; no existing behavior removed
- Org isolation unaffected (enforced at SQL/auth layer, not at DTO level)

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered