### PR TITLE
chore(core): bump bashkit v0.1.8 → v0.1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -141,7 +141,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -405,8 +405,8 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.1.8"
-source = "git+https://github.com/everruns/bashkit?tag=v0.1.8#ac184be82b1aca84c0d3cdd7b7dd93eb18a7531e"
+version = "0.1.10"
+source = "git+https://github.com/everruns/bashkit?tag=v0.1.10#f83e518a11dd904401f6c5403d4a96f02525a585"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -427,6 +427,7 @@ dependencies = [
  "sha2",
  "thiserror 2.0.18",
  "tokio",
+ "tower",
  "url",
 ]
 
@@ -1203,7 +1204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2383,7 +2384,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -3192,7 +3193,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3962,7 +3963,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4478,7 +4479,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4537,7 +4538,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4901,7 +4902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5293,7 +5294,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6618,15 +6619,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6673,28 +6665,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6725,12 +6700,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6747,12 +6716,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6773,22 +6736,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6809,12 +6760,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6831,12 +6776,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6857,12 +6796,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6879,12 +6812,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -54,7 +54,7 @@ url = "2"
 fetchkit = "0.1.3"
 
 # Virtual bash interpreter
-bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.1.8" }
+bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.1.10" }
 
 # OpenAPI schema generation (optional, enabled by everruns-server)
 utoipa = { workspace = true, optional = true }

--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -2057,4 +2057,91 @@ mod tests {
             panic!("Expected success on read");
         }
     }
+
+    // ========================================================================
+    // bashkit API smoke tests (v0.1.10 surface)
+    // ========================================================================
+
+    #[test]
+    fn test_bashkit_tool_description_is_nonempty() {
+        let desc = BASHKIT_TOOL.description();
+        assert!(
+            !desc.is_empty(),
+            "bashkit tool description should not be empty"
+        );
+        // Should mention bash or command execution
+        assert!(
+            desc.to_lowercase().contains("bash") || desc.to_lowercase().contains("command"),
+            "description should mention bash or command, got: {}",
+            desc
+        );
+    }
+
+    #[test]
+    fn test_bashkit_tool_system_prompt_is_nonempty() {
+        let prompt = BASHKIT_TOOL.system_prompt();
+        assert!(
+            !prompt.is_empty(),
+            "bashkit system prompt should not be empty"
+        );
+        assert!(
+            prompt.contains("everruns"),
+            "system prompt should contain configured identity 'everruns', got: {}",
+            prompt
+        );
+    }
+
+    #[test]
+    fn test_bashkit_static_description_matches_tool() {
+        // Verify the LazyLock statics produce the same values as direct calls
+        let direct_desc = BASHKIT_TOOL.description();
+        let static_desc: &str = &TOOL_DESCRIPTION;
+        assert_eq!(static_desc, direct_desc);
+
+        let direct_prompt = BASHKIT_TOOL.system_prompt();
+        let static_prompt: &str = &TOOL_SYSTEM_PROMPT;
+        assert_eq!(static_prompt, direct_prompt);
+    }
+
+    #[test]
+    fn test_bashkit_tool_builder_configuration() {
+        // Verify the static BASHKIT_TOOL was built with our custom settings
+        // by checking that description/system_prompt are accessible (non-panicking)
+        let _desc = BASHKIT_TOOL.description();
+        let _prompt = BASHKIT_TOOL.system_prompt();
+        // If we got here without panic, the builder configuration is valid
+    }
+
+    #[test]
+    fn test_bash_tool_display_name() {
+        let tool = BashTool;
+        assert_eq!(tool.display_name(), Some("Bash"));
+    }
+
+    #[test]
+    fn test_bash_tool_parameters_schema_structure() {
+        let tool = BashTool;
+        let schema = tool.parameters_schema();
+
+        // Verify required fields
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"]["command"].is_object());
+        assert_eq!(schema["properties"]["command"]["type"], "string");
+
+        // Verify optional fields
+        assert!(schema["properties"]["working_dir"].is_object());
+        assert!(schema["properties"]["timeout_ms"].is_object());
+
+        // Verify "command" is required
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.contains(&json!("command")));
+    }
+
+    #[test]
+    fn test_execution_limits_configuration() {
+        let limits = execution_limits();
+        // Just verify it doesn't panic and returns a valid object
+        // The limits are used by both BASHKIT_TOOL and per-execution Bash instances
+        let _ = limits;
+    }
 }

--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -55,10 +55,12 @@ static BASHKIT_TOOL: LazyLock<BashkitTool> = LazyLock::new(|| {
 });
 
 /// Tool description from bashkit library.
-static TOOL_DESCRIPTION: LazyLock<String> = LazyLock::new(|| BASHKIT_TOOL.description());
+static TOOL_DESCRIPTION: LazyLock<String> =
+    LazyLock::new(|| BASHKIT_TOOL.description().to_string());
 
 /// System prompt addition from bashkit library.
-static TOOL_SYSTEM_PROMPT: LazyLock<String> = LazyLock::new(|| BASHKIT_TOOL.system_prompt());
+static TOOL_SYSTEM_PROMPT: LazyLock<String> =
+    LazyLock::new(|| BASHKIT_TOOL.system_prompt().to_string());
 
 /// Virtual Bash capability - execute bash commands in a sandboxed environment
 pub struct VirtualBashCapability;


### PR DESCRIPTION
## Summary

- Bump bashkit dependency from v0.1.8 to v0.1.10 (latest)
- Adapt to API change: `description()` and `system_prompt()` now return `&str` instead of `String`
- Add 7 new smoke tests for the bashkit v0.1.10 API surface

## Test plan

- [x] All 67 virtual_bash tests pass (60 existing + 7 new)
- [x] `cargo clippy -p everruns-core --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean