### PR TITLE
fix(reason): preserve partial output on trailing stream errors

### DIFF
--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -90,6 +90,30 @@ fn patch_dangling_tool_calls(messages: &[Message]) -> Vec<Message> {
     result
 }
 
+/// Known error placeholder texts emitted by the DLQ handler and user_facing_message().
+/// These add no conversational value and inflate subsequent LLM requests.
+const ERROR_PLACEHOLDER_MESSAGES: &[&str] = &[
+    "I encountered an error while processing your request. Please try again later.",
+    "The AI provider is experiencing issues. Please try again shortly.",
+    "Rate limited by the AI provider. Please wait a moment.",
+    "The conversation has become too long for the model to process. Please start a new session or reduce the context size.",
+    "There is a misconfiguration with the AI provider. Please contact support.",
+];
+
+/// Returns true if the message is an error placeholder that should be stripped
+/// from the conversation history before sending to the LLM.
+fn is_error_placeholder_message(msg: &Message) -> bool {
+    if msg.role != MessageRole::Agent {
+        return false;
+    }
+    // Must have no tool calls (pure text-only error message)
+    if msg.has_tool_calls() {
+        return false;
+    }
+    let text = msg.text().unwrap_or("");
+    ERROR_PLACEHOLDER_MESSAGES.contains(&text)
+}
+
 fn extract_locale_override(messages: &[Message]) -> Option<String> {
     messages
         .iter()
@@ -699,7 +723,14 @@ where
         // Add conversation messages with resolved images.
         // For user messages with an external_actor, prefix the first text part
         // with the actor's display label so the LLM knows who is speaking.
+        // Skip error placeholder messages from prior failed turns — they add
+        // no conversational value and inflate the request.
+        let mut stripped_error_count = 0u32;
         for msg in &patched_messages {
+            if is_error_placeholder_message(msg) {
+                stripped_error_count += 1;
+                continue;
+            }
             let mut llm_msg = LlmMessage::from_message_with_images(msg, &resolved_images);
             if msg.role == MessageRole::User
                 && let Some(ref actor) = msg.external_actor
@@ -707,6 +738,13 @@ where
                 llm_msg.prepend_text_prefix(&format!("[{}] ", actor.display_label()));
             }
             llm_messages.push(llm_msg);
+        }
+        if stripped_error_count > 0 {
+            tracing::info!(
+                session_id = %session_id,
+                stripped_error_count,
+                "ReasonAtom: stripped error placeholder messages from LLM input"
+            );
         }
 
         // 12. Build LLM call config with reasoning effort and metadata
@@ -1128,7 +1166,27 @@ where
                         break;
                     }
                     LlmStreamEvent::Error(err) => {
-                        // Emit llm.generation failure event (child of reason span)
+                        // If we already collected valid tool calls or text before
+                        // the error arrived, treat it as a partial success. This
+                        // handles OpenAI Responses API behaviour where a trailing
+                        // server_error can follow fully-streamed function calls.
+                        let has_partial_output = !tool_calls.is_empty() || !text.is_empty();
+
+                        if has_partial_output {
+                            tracing::warn!(
+                                session_id = %session_id,
+                                error = %err,
+                                tool_call_count = tool_calls.len(),
+                                text_len = text.len(),
+                                "ReasonAtom: trailing stream error after valid output — treating as partial success"
+                            );
+                            // Break out of the stream loop and use the output
+                            // we already collected. completion_metadata will be
+                            // None since we never got a Done event.
+                            break;
+                        }
+
+                        // No useful output collected — treat as a real failure.
                         let llm_duration_ms = llm_start.elapsed().as_millis() as u64;
                         let event_context = EventContext::from_atom_context(context).with_span(
                             trace_id.to_string(),

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -1369,3 +1369,354 @@ async fn test_llm_call_config_previous_response_id() {
     let config_default = LlmCallConfigBuilder::from(&agent).build();
     assert_eq!(config_default.previous_response_id, None);
 }
+
+// ============================================================================
+// Trailing stream error with partial output (OpenAI server_error after tool calls)
+// ============================================================================
+
+/// Driver that emits tool calls followed by a trailing error event.
+/// Simulates OpenAI Responses API behaviour where a server_error can
+/// follow fully-streamed function calls.
+#[derive(Clone, Debug)]
+struct ToolCallsThenErrorDriver;
+
+#[async_trait]
+impl everruns_core::LlmDriver for ToolCallsThenErrorDriver {
+    async fn chat_completion_stream(
+        &self,
+        _messages: Vec<everruns_core::LlmMessage>,
+        _config: &everruns_core::LlmCallConfig,
+    ) -> everruns_core::Result<everruns_core::LlmResponseStream> {
+        Ok(Box::pin(stream::iter(vec![
+            // Tool calls arrive first (fully streamed)
+            Ok(everruns_core::LlmStreamEvent::ToolCalls(vec![ToolCall {
+                id: "call_session_1".to_string(),
+                name: "manage_sessions".to_string(),
+                arguments: json!({"operation": "create", "agent_id": "agent_123"}),
+            }])),
+            // Trailing server error after valid output
+            Ok(everruns_core::LlmStreamEvent::Error(
+                "server_error: An error occurred while processing your request.".to_string(),
+            )),
+        ])))
+    }
+}
+
+#[tokio::test]
+async fn test_reason_atom_preserves_tool_calls_on_trailing_stream_error() {
+    use everruns_core::memory::InMemoryEventEmitter;
+
+    let (
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever,
+        provider_store,
+        harness_id,
+        agent_id,
+        session_id,
+    ) = setup_test_environment().await;
+
+    message_retriever
+        .seed(session_id.into(), vec![Message::user("Run builder agent")])
+        .await;
+
+    let mut driver_registry = DriverRegistry::new();
+    driver_registry.register(ProviderType::LlmSim, |_api_key, _base_url| {
+        Box::new(ToolCallsThenErrorDriver)
+    });
+
+    let event_emitter = InMemoryEventEmitter::new();
+
+    let atom = ReasonAtom::new(
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever.clone(),
+        provider_store,
+        CapabilityRegistry::new(),
+        driver_registry,
+        event_emitter.clone(),
+    );
+
+    let context = create_context(session_id);
+    let input = ReasonInput {
+        context,
+        harness_id,
+        agent_id: Some(agent_id.into()),
+        org_id: 0,
+        mcp_tool_definitions: vec![],
+        previous_response_id: None,
+        iteration: 1,
+    };
+
+    let result = atom
+        .execute(input)
+        .await
+        .expect("ReasonAtom should return Ok for partial success");
+
+    // Tool calls should be preserved despite the trailing error
+    assert!(
+        result.success,
+        "Partial success with tool calls should be treated as success"
+    );
+    assert!(result.has_tool_calls, "Tool calls should be present");
+    assert_eq!(result.tool_calls.len(), 1);
+    assert_eq!(result.tool_calls[0].name, "manage_sessions");
+    assert_eq!(result.tool_calls[0].id, "call_session_1");
+
+    // No response_id since we never got a Done event
+    assert!(result.response_id.is_none());
+}
+
+/// Driver that emits text content followed by a trailing error event.
+#[derive(Clone, Debug)]
+struct TextThenErrorDriver;
+
+#[async_trait]
+impl everruns_core::LlmDriver for TextThenErrorDriver {
+    async fn chat_completion_stream(
+        &self,
+        _messages: Vec<everruns_core::LlmMessage>,
+        _config: &everruns_core::LlmCallConfig,
+    ) -> everruns_core::Result<everruns_core::LlmResponseStream> {
+        Ok(Box::pin(stream::iter(vec![
+            Ok(everruns_core::LlmStreamEvent::TextDelta(
+                "Here are the links:\n\n- Research Agent:".to_string(),
+            )),
+            Ok(everruns_core::LlmStreamEvent::Error(
+                "server_error: internal failure".to_string(),
+            )),
+        ])))
+    }
+}
+
+#[tokio::test]
+async fn test_reason_atom_preserves_text_on_trailing_stream_error() {
+    use everruns_core::memory::InMemoryEventEmitter;
+
+    let (
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever,
+        provider_store,
+        harness_id,
+        agent_id,
+        session_id,
+    ) = setup_test_environment().await;
+
+    message_retriever
+        .seed(session_id.into(), vec![Message::user("Give me links")])
+        .await;
+
+    let mut driver_registry = DriverRegistry::new();
+    driver_registry.register(ProviderType::LlmSim, |_api_key, _base_url| {
+        Box::new(TextThenErrorDriver)
+    });
+
+    let event_emitter = InMemoryEventEmitter::new();
+
+    let atom = ReasonAtom::new(
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever.clone(),
+        provider_store,
+        CapabilityRegistry::new(),
+        driver_registry,
+        event_emitter.clone(),
+    );
+
+    let context = create_context(session_id);
+    let input = ReasonInput {
+        context,
+        harness_id,
+        agent_id: Some(agent_id.into()),
+        org_id: 0,
+        mcp_tool_definitions: vec![],
+        previous_response_id: None,
+        iteration: 1,
+    };
+
+    let result = atom
+        .execute(input)
+        .await
+        .expect("ReasonAtom should return Ok for partial success");
+
+    // Text should be preserved despite the trailing error
+    assert!(
+        result.success,
+        "Partial success with text should be treated as success"
+    );
+    assert!(
+        result.text.contains("Research Agent"),
+        "Partial text should be preserved: got '{}'",
+        result.text
+    );
+    assert!(!result.has_tool_calls);
+}
+
+/// Driver that emits an error without any prior output (pure failure).
+/// This should still fail as before — no partial output to recover.
+#[derive(Clone, Debug)]
+struct PureErrorDriver;
+
+#[async_trait]
+impl everruns_core::LlmDriver for PureErrorDriver {
+    async fn chat_completion_stream(
+        &self,
+        _messages: Vec<everruns_core::LlmMessage>,
+        _config: &everruns_core::LlmCallConfig,
+    ) -> everruns_core::Result<everruns_core::LlmResponseStream> {
+        Ok(Box::pin(stream::iter(vec![Ok(
+            everruns_core::LlmStreamEvent::Error("server_error: total failure".to_string()),
+        )])))
+    }
+}
+
+#[tokio::test]
+async fn test_reason_atom_still_fails_on_pure_stream_error() {
+    use everruns_core::memory::InMemoryEventEmitter;
+
+    let (
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever,
+        provider_store,
+        harness_id,
+        agent_id,
+        session_id,
+    ) = setup_test_environment().await;
+
+    message_retriever
+        .seed(session_id.into(), vec![Message::user("Hello!")])
+        .await;
+
+    let mut driver_registry = DriverRegistry::new();
+    driver_registry.register(ProviderType::LlmSim, |_api_key, _base_url| {
+        Box::new(PureErrorDriver)
+    });
+
+    let event_emitter = InMemoryEventEmitter::new();
+
+    let atom = ReasonAtom::new(
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever.clone(),
+        provider_store,
+        CapabilityRegistry::new(),
+        driver_registry,
+        event_emitter.clone(),
+    );
+
+    let context = create_context(session_id);
+    let input = ReasonInput {
+        context,
+        harness_id,
+        agent_id: Some(agent_id.into()),
+        org_id: 0,
+        mcp_tool_definitions: vec![],
+        previous_response_id: None,
+        iteration: 1,
+    };
+
+    let result = atom
+        .execute(input)
+        .await
+        .expect("ReasonAtom should handle pure error gracefully");
+
+    // Pure error (no partial output) should still fail
+    assert!(
+        !result.success,
+        "Pure stream error should still be a failure"
+    );
+    assert!(result.error.is_some());
+    assert!(!result.has_tool_calls);
+}
+
+// ============================================================================
+// Error placeholder message stripping
+// ============================================================================
+
+#[tokio::test]
+async fn test_reason_atom_strips_error_placeholder_messages() {
+    use everruns_core::memory::InMemoryEventEmitter;
+
+    let (
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever,
+        provider_store,
+        harness_id,
+        agent_id,
+        session_id,
+    ) = setup_test_environment().await;
+
+    // Seed with a conversation that includes error placeholder messages
+    // (simulates accumulated DLQ errors from prior failed turns)
+    message_retriever
+        .seed(
+            session_id.into(),
+            vec![
+                Message::user("Create agents for me"),
+                Message::assistant(
+                    "I encountered an error while processing your request. Please try again later.",
+                ),
+                Message::assistant(
+                    "I encountered an error while processing your request. Please try again later.",
+                ),
+                Message::assistant(
+                    "I encountered an error while processing your request. Please try again later.",
+                ),
+                Message::user("Try again"),
+            ],
+        )
+        .await;
+
+    // Use echo driver to see what the LLM receives
+    let driver_registry = create_custom_driver_registry(LlmSimConfig::echo());
+
+    let event_emitter = InMemoryEventEmitter::new();
+
+    let atom = ReasonAtom::new(
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever.clone(),
+        provider_store,
+        CapabilityRegistry::new(),
+        driver_registry,
+        event_emitter.clone(),
+    );
+
+    let context = create_context(session_id);
+    let input = ReasonInput {
+        context,
+        harness_id,
+        agent_id: Some(agent_id.into()),
+        org_id: 0,
+        mcp_tool_definitions: vec![],
+        previous_response_id: None,
+        iteration: 1,
+    };
+
+    let result = atom
+        .execute(input)
+        .await
+        .expect("ReasonAtom should succeed");
+
+    assert!(result.success);
+
+    // The echo driver echoes back the user messages it received.
+    // The error placeholder messages should NOT appear in the echo output
+    // because they were stripped before sending to the LLM.
+    assert!(
+        !result.text.contains("I encountered an error"),
+        "Error placeholder messages should be stripped from LLM input, got: '{}'",
+        result.text
+    );
+}


### PR DESCRIPTION
## What
Two fixes to the ReasonAtom streaming error handler:
1. Preserve partial output (tool calls or text) when a trailing stream error arrives after valid content
2. Strip error placeholder messages from conversation history before sending to the LLM

## Why
OpenAI Responses API can send a trailing server_error event after fully-streamed function calls. The previous code treated ALL stream errors as fatal, discarding already-collected tool calls and text. This caused agents to fail even when valid output was received.

Additionally, repeated DLQ error placeholder messages accumulated in conversation history, inflating subsequent LLM requests with no conversational value.

## How
- In the stream error handler, check if tool calls or text have already been collected before treating the error as fatal. If partial output exists, log a warning and break out of the stream loop (partial success).
- Added is_error_placeholder_message() helper that identifies known error placeholder texts. These are skipped when building LLM messages.

## Risk
- Low
- Regression: pure stream errors (no partial output) still fail as before, verified by dedicated test
- Edge case: a stream with both valid output AND a meaningful error will now succeed with partial output rather than failing. This matches the observed OpenAI behavior where the output is complete despite the error.

## Checklist
- [x] Tests added or updated (4 new tests: tool calls + error, text + error, pure error, placeholder stripping)
- [x] Backward compatibility considered (pure errors still fail identically)