### PR TITLE
refactor(core): remove system prompt duplication with tool definitions

### DIFF
--- a/crates/core/src/capabilities/fake_aws.rs
+++ b/crates/core/src/capabilities/fake_aws.rs
@@ -698,29 +698,7 @@ impl Capability for FakeAwsCapability {
 
     fn system_prompt_addition(&self) -> Option<&str> {
         Some(
-            r#"You have access to AWS infrastructure management tools. All AWS data is stored in /aws/ directory.
-
-Available tools:
-- `aws_list_ec2_instances`: List all EC2 instances with their status
-- `aws_create_ec2_instance`: Launch a new EC2 instance
-- `aws_stop_ec2_instance`: Stop a running EC2 instance
-- `aws_list_rds_databases`: List RDS database instances
-- `aws_create_rds_database`: Create a new RDS database
-- `aws_list_s3_buckets`: List all S3 buckets
-- `aws_create_s3_bucket`: Create a new S3 bucket
-- `aws_list_iam_users`: List IAM users and their permissions
-- `aws_create_iam_user`: Create a new IAM user
-- `aws_list_security_groups`: List security groups and rules
-- `aws_get_cloudwatch_metrics`: Get CloudWatch metrics for resources
-
-Data structure:
-- /aws/ec2_instances.json - EC2 instance records
-- /aws/rds_databases.json - RDS database records
-- /aws/s3_buckets.json - S3 bucket records
-- /aws/iam_users.json - IAM user records
-- /aws/security_groups.json - Security group records
-
-API calls have realistic latency. All mutations are persisted."#,
+            "AWS data is stored in /aws/ (ec2_instances.json, rds_databases.json, s3_buckets.json, iam_users.json, security_groups.json). API calls have realistic latency.",
         )
     }
 

--- a/crates/core/src/capabilities/fake_crm.rs
+++ b/crates/core/src/capabilities/fake_crm.rs
@@ -49,24 +49,7 @@ impl Capability for FakeCrmCapability {
     }
 
     fn system_prompt_addition(&self) -> Option<&str> {
-        Some(
-            r#"You have access to CRM and customer support tools. All CRM data is stored in /crm/ directory.
-
-Available tools:
-- `crm_list_customers`: List all customers with pagination
-- `crm_get_customer`: Get detailed customer information by ID
-- `crm_create_customer`: Create a new customer record
-- `crm_list_tickets`: List support tickets (filter by status/priority)
-- `crm_create_ticket`: Create a new support ticket
-- `crm_update_ticket`: Update ticket status and assign to agents
-- `crm_add_interaction`: Add a customer interaction note (call, email, meeting)
-- `crm_search_customers`: Search customers by name, email, or company
-
-Data structure:
-- /crm/customers.json - Customer records
-- /crm/tickets.json - Support ticket records
-- /crm/interactions.json - Customer interaction history"#,
-        )
+        Some("CRM data is stored in /crm/ (customers.json, tickets.json, interactions.json).")
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {

--- a/crates/core/src/capabilities/fake_financial.rs
+++ b/crates/core/src/capabilities/fake_financial.rs
@@ -50,22 +50,7 @@ impl Capability for FakeFinancialCapability {
 
     fn system_prompt_addition(&self) -> Option<&str> {
         Some(
-            r#"You have access to financial management tools. All financial data is stored in /finance/ directory.
-
-Available tools:
-- `finance_list_transactions`: List financial transactions (filter by type/category)
-- `finance_create_transaction`: Record a new transaction (income/expense)
-- `finance_get_balance`: Get current account balances
-- `finance_list_budgets`: List budgets by category
-- `finance_create_budget`: Create or update a budget
-- `finance_get_expense_report`: Generate expense report by period
-- `finance_get_revenue_report`: Generate revenue report by period
-- `finance_forecast_cash_flow`: Forecast cash flow for upcoming months
-
-Data structure:
-- /finance/transactions.json - Transaction records
-- /finance/budgets.json - Budget definitions
-- /finance/accounts.json - Account balances"#,
+            "Financial data is stored in /finance/ (transactions.json, budgets.json, accounts.json).",
         )
     }
 

--- a/crates/core/src/capabilities/fake_warehouse.rs
+++ b/crates/core/src/capabilities/fake_warehouse.rs
@@ -52,26 +52,7 @@ impl Capability for FakeWarehouseCapability {
 
     fn system_prompt_addition(&self) -> Option<&str> {
         Some(
-            r#"You have access to warehouse management tools. All warehouse data is stored in /warehouse/ directory.
-
-Available tools:
-- `warehouse_get_inventory`: Get current inventory levels for products
-- `warehouse_update_inventory`: Update inventory quantities (add/remove stock)
-- `warehouse_create_shipment`: Create a new shipment with products
-- `warehouse_list_shipments`: List all shipments with status tracking
-- `warehouse_update_shipment_status`: Update shipment status (pending/in_transit/delivered)
-- `warehouse_create_order`: Create a new customer order
-- `warehouse_list_orders`: List all customer orders
-- `warehouse_create_invoice`: Generate an invoice for an order
-- `warehouse_process_return`: Process a product return and update inventory
-- `warehouse_inventory_report`: Generate comprehensive inventory report
-
-Data structure:
-- /warehouse/inventory.json - Product inventory levels
-- /warehouse/shipments.json - Shipment records
-- /warehouse/orders.json - Customer orders
-- /warehouse/invoices.json - Generated invoices
-- /warehouse/returns.json - Return records"#,
+            "Warehouse data is stored in /warehouse/ (inventory.json, shipments.json, orders.json, invoices.json, returns.json).",
         )
     }
 

--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -109,26 +109,7 @@ impl Capability for FileSystemCapability {
 
     fn system_prompt_addition(&self) -> Option<&str> {
         Some(
-            r#"You have access to file system tools for working with the session workspace. Each session has its own isolated workspace stored in the database.
-
-**Workspace Location:** `/workspace`
-
-All session files are stored under `/workspace`. This is the root of your persistent storage.
-
-Available tools:
-- `read_file`: Read the content of a file by path
-- `write_file`: Create a new file or update existing file content
-- `list_directory`: List files and directories at a given path
-- `grep_files`: Search file contents using regex patterns
-- `delete_file`: Delete a file or directory
-- `stat_file`: Get metadata about a file (size, dates, etc.)
-
-Best practices:
-- All paths should start with `/workspace` (e.g., `/workspace/myfile.txt`)
-- Use `list_directory` with path `/workspace` to explore the workspace
-- Use `stat_file` to check if a file exists before reading/writing
-- Use `grep_files` to search across multiple files efficiently
-- Directories are created automatically when writing files"#,
+            r#"Session workspace root: `/workspace`. All file paths must start with `/workspace`. Directories are created automatically when writing files."#,
         )
     }
 
@@ -865,9 +846,7 @@ mod tests {
     fn test_capability_has_system_prompt() {
         let cap = FileSystemCapability;
         let prompt = cap.system_prompt_addition().unwrap();
-        assert!(prompt.contains("read_file"));
-        assert!(prompt.contains("write_file"));
-        assert!(prompt.contains("list_directory"));
+        assert!(prompt.contains("/workspace"));
     }
 
     #[test]

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -279,6 +279,20 @@ pub trait Capability: Send + Sync {
     /// This is the simple sync path for capabilities with static prompts.
     /// For dynamic content that requires filesystem access, override
     /// `system_prompt_contribution()` instead.
+    ///
+    /// **Contract: no duplication with tool definitions.** System prompt
+    /// additions must NOT repeat information already present in tool names,
+    /// descriptions, or parameter schemas. Only include content that cannot
+    /// be inferred from tool definitions alone:
+    ///
+    /// - High-level semantics (when to use which tool, behavioral guidance)
+    /// - Constraints the model cannot discover from schemas (row limits,
+    ///   naming rules, workspace root paths, scheduling limits)
+    /// - Data layout (filesystem paths for state files)
+    /// - Cross-tool relationships or ordering not evident from descriptions
+    ///
+    /// If every piece of information in the prompt is already covered by the
+    /// tool definitions, return `None` instead.
     fn system_prompt_addition(&self) -> Option<&str> {
         None
     }
@@ -1435,33 +1449,19 @@ mod tests {
         )
         .await;
 
-        // TestMath has system prompt addition and 4 tools
-        assert!(applied.runtime_agent.system_prompt.contains("math tools"));
-        // Capability prompt wrapped in XML tags
+        // TestMath has no system prompt addition (tool defs are sufficient)
         assert!(
-            applied
+            !applied
                 .runtime_agent
                 .system_prompt
                 .contains("<capability id=\"test_math\">")
         );
+        // No capability prompt prefix, so base prompt is used as-is (no XML wrapping)
         assert!(
             applied
                 .runtime_agent
                 .system_prompt
-                .contains("</capability>")
-        );
-        // Base prompt wrapped in <system-prompt> tags
-        assert!(
-            applied
-                .runtime_agent
-                .system_prompt
-                .contains("<system-prompt>")
-        );
-        assert!(
-            applied
-                .runtime_agent
-                .system_prompt
-                .contains("</system-prompt>")
+                .contains("You are a helpful assistant.")
         );
         assert!(applied.tool_registry.has("add"));
         assert!(applied.tool_registry.has("subtract"));
@@ -1483,15 +1483,9 @@ mod tests {
         )
         .await;
 
-        // TestWeather has system prompt addition and 2 tools
+        // TestWeather has no system prompt addition (tool defs are sufficient)
         assert!(
-            applied
-                .runtime_agent
-                .system_prompt
-                .contains("weather tools")
-        );
-        assert!(
-            applied
+            !applied
                 .runtime_agent
                 .system_prompt
                 .contains("<capability id=\"test_weather\">")
@@ -1578,28 +1572,36 @@ mod tests {
     async fn test_xml_tags_wrap_capability_prompts() {
         let registry = CapabilityRegistry::with_builtins();
         let collected =
-            collect_capabilities(&["test_math".to_string()], &registry, &test_ctx()).await;
+            collect_capabilities(&["stateless_todo_list".to_string()], &registry, &test_ctx())
+                .await;
 
         assert_eq!(collected.system_prompt_parts.len(), 1);
         let part = &collected.system_prompt_parts[0];
-        assert!(part.starts_with("<capability id=\"test_math\">"));
+        assert!(part.starts_with("<capability id=\"stateless_todo_list\">"));
         assert!(part.ends_with("</capability>"));
-        assert!(part.contains("math tools"));
+        assert!(part.contains("Task Management"));
     }
 
     #[tokio::test]
     async fn test_xml_tags_multiple_capabilities() {
         let registry = CapabilityRegistry::with_builtins();
         let collected = collect_capabilities(
-            &["test_math".to_string(), "test_weather".to_string()],
+            &[
+                "stateless_todo_list".to_string(),
+                "session_schedule".to_string(),
+            ],
             &registry,
             &test_ctx(),
         )
         .await;
 
         assert_eq!(collected.system_prompt_parts.len(), 2);
-        assert!(collected.system_prompt_parts[0].starts_with("<capability id=\"test_math\">"));
-        assert!(collected.system_prompt_parts[1].starts_with("<capability id=\"test_weather\">"));
+        assert!(
+            collected.system_prompt_parts[0].starts_with("<capability id=\"stateless_todo_list\">")
+        );
+        assert!(
+            collected.system_prompt_parts[1].starts_with("<capability id=\"session_schedule\">")
+        );
 
         let prefix = collected.system_prompt_prefix().unwrap();
         // Both capability sections separated by double newline
@@ -1611,12 +1613,17 @@ mod tests {
         let registry = CapabilityRegistry::with_builtins();
         let base = RuntimeAgent::new("You are helpful.", "gpt-5.2");
 
-        let applied =
-            apply_capabilities(base, &["test_math".to_string()], &registry, &test_ctx()).await;
+        let applied = apply_capabilities(
+            base,
+            &["stateless_todo_list".to_string()],
+            &registry,
+            &test_ctx(),
+        )
+        .await;
 
         let prompt = &applied.runtime_agent.system_prompt;
         // Capability wrapped
-        assert!(prompt.contains("<capability id=\"test_math\">"));
+        assert!(prompt.contains("<capability id=\"stateless_todo_list\">"));
         assert!(prompt.contains("</capability>"));
         // Base prompt wrapped
         assert!(prompt.contains("<system-prompt>\nYou are helpful.\n</system-prompt>"));

--- a/crates/core/src/capabilities/platform_management.rs
+++ b/crates/core/src/capabilities/platform_management.rs
@@ -45,48 +45,7 @@ impl Capability for PlatformManagementCapability {
 
     fn system_prompt_addition(&self) -> Option<&str> {
         Some(
-            r#"You have platform management tools to manage Everruns entities:
-
-## Capabilities
-
-Capabilities are the primary way to extend agent and harness functionality. Each capability provides tools, system prompt additions, or both. There are three types:
-- **Built-in**: Core capabilities like file system, bash, web fetch, research, etc.
-- **MCP Servers**: External tool providers connected via the Model Context Protocol.
-- **Skills**: Reusable instruction sets that teach agents domain-specific workflows.
-
-When creating or updating agents/harnesses, use `list_capabilities` to discover available capability IDs, then pass them in the `capabilities` parameter.
-
-`list_capabilities` - Discover available capabilities:
-- search: Optional filter by name, description, category, or ID
-- Returns: capability ID, name, description, type, tools, dependencies
-
-`manage_harnesses` - Harness CRUD operations:
-- operation: "list" - List all harnesses
-- operation: "get" - Get a harness by ID (requires: harness_id)
-- operation: "create" - Create a harness (requires: name, system_prompt; optional: description, capabilities)
-- operation: "update" - Update a harness (requires: harness_id; optional: name, description, system_prompt)
-- operation: "delete" - Archive a harness (requires: harness_id)
-- operation: "copy" - Copy a harness (requires: harness_id; optional: new_name)
-
-`manage_agents` - Agent CRUD operations:
-- operation: "list" - List all agents
-- operation: "get" - Get an agent by ID (requires: agent_id)
-- operation: "create" - Create an agent (requires: name, system_prompt; optional: description, capabilities)
-- operation: "update" - Update an agent (requires: agent_id; optional: name, description, system_prompt)
-- operation: "delete" - Archive an agent (requires: agent_id)
-
-`manage_sessions` - Session operations:
-- operation: "list" - List sessions (optional: limit, agent_id)
-- operation: "create" - Create a session (requires: harness_id; optional: agent_id, title)
-- operation: "get" - Get a session by ID (requires: session_id)
-- operation: "delete" - Archive a session (requires: session_id)
-
-`session_interact` - Session messaging and turn management:
-- operation: "send_message" - Send a user message to a session (requires: session_id, content)
-- operation: "get_messages" - Get messages from a session (requires: session_id; optional: limit, default 10)
-- operation: "wait_for_idle" - Wait for turn to complete (requires: session_id; optional: timeout_secs, default 120)
-
-All results include UI links to view entities in the web interface."#,
+            r#"Capabilities extend agent/harness functionality. Three types: built-in, MCP servers, and skills. Use `list_capabilities` to discover IDs before creating agents/harnesses. All results include UI links."#,
         )
     }
 
@@ -1835,12 +1794,6 @@ mod tests {
         let cap = PlatformManagementCapability;
         let prompt = cap.system_prompt_addition().expect("should have prompt");
         assert!(prompt.contains("list_capabilities"));
-        assert!(prompt.contains("manage_harnesses"));
-        assert!(prompt.contains("manage_agents"));
-        assert!(prompt.contains("manage_sessions"));
-        assert!(prompt.contains("session_interact"));
-        // Capabilities section should be mentioned
         assert!(prompt.contains("Capabilities"));
-        assert!(prompt.contains("primary way to extend"));
     }
 }

--- a/crates/core/src/capabilities/session.rs
+++ b/crates/core/src/capabilities/session.rs
@@ -38,15 +38,6 @@ impl Capability for SessionCapability {
         Some("Session")
     }
 
-    fn system_prompt_addition(&self) -> Option<&str> {
-        Some(
-            r#"You can manage session metadata with these tools:
-
-- `write_session_title`: Set/update the current session title
-- `get_session_info`: Get session ID, title, and assigned agent name (if present)"#,
-        )
-    }
-
     fn tools(&self) -> Vec<Box<dyn Tool>> {
         vec![
             Box::new(WriteSessionTitleTool),

--- a/crates/core/src/capabilities/session_schedule.rs
+++ b/crates/core/src/capabilities/session_schedule.rs
@@ -44,17 +44,7 @@ impl Capability for SessionScheduleCapability {
 
     fn system_prompt_addition(&self) -> Option<&str> {
         Some(
-            r#"You can schedule future tasks within this session:
-
-- `create_schedule`: Schedule work to happen later. Provide a `description` of what to do, and either:
-  - `scheduled_at` (ISO 8601 datetime) for a one-shot task, or
-  - `cron_expression` (standard 5-field cron) for recurring tasks.
-  Optional: `timezone` (IANA timezone, default UTC).
-- `cancel_schedule`: Cancel a schedule by its `schedule_id`.
-- `list_schedules`: List all schedules for this session.
-
-When a schedule fires, you will receive a message with the task description and should execute it.
-Maximum 5 active schedules per session."#,
+            "When a schedule fires, you will receive a message with the task description and should execute it. Maximum 5 active schedules per session.",
         )
     }
 

--- a/crates/core/src/capabilities/session_sql_database.rs
+++ b/crates/core/src/capabilities/session_sql_database.rs
@@ -42,19 +42,7 @@ impl Capability for SessionSqlDatabaseCapability {
 
     fn system_prompt_addition(&self) -> Option<&str> {
         Some(
-            r#"You have access to session-scoped SQL databases. Use these tools to create tables, insert data, and query data using standard SQLite SQL syntax.
-
-**Tools:**
-- `sql_execute`: Create tables, insert/update/delete data. Auto-creates the database if needed.
-- `sql_query`: Run SELECT queries. Returns columns and rows as JSON.
-- `sql_schema`: Inspect database schema (tables, columns, types).
-
-**Guidelines:**
-- Database names must be alphanumeric with underscores (e.g., "analytics", "user_data")
-- Use `sql_schema` to inspect existing tables before querying
-- Results are limited to 1000 rows per query
-- Databases are session-scoped and isolated
-- Standard SQLite SQL syntax is supported"#,
+            r#"Database names must be alphanumeric with underscores. Results limited to 1000 rows per query. Standard SQLite SQL syntax."#,
         )
     }
 
@@ -395,10 +383,8 @@ mod tests {
     fn test_capability_has_system_prompt() {
         let cap = SessionSqlDatabaseCapability;
         let prompt = cap.system_prompt_addition().unwrap();
-        assert!(prompt.contains("sql_execute"));
-        assert!(prompt.contains("sql_query"));
-        assert!(prompt.contains("sql_schema"));
         assert!(prompt.contains("SQLite"));
+        assert!(prompt.contains("1000 rows"));
     }
 
     #[test]

--- a/crates/core/src/capabilities/session_storage.rs
+++ b/crates/core/src/capabilities/session_storage.rs
@@ -49,24 +49,7 @@ impl Capability for SessionStorageCapability {
 
     fn system_prompt_addition(&self) -> Option<&str> {
         Some(
-            r#"You have access to session storage tools for persisting data within the session.
-
-`kv_store` - Key/value storage (plain text):
-- operation: "set" - Store a key/value pair (key, value required)
-- operation: "get" - Retrieve a value (key required)
-- operation: "delete" - Delete a key/value pair (key required)
-- operation: "list" - List all stored keys
-
-`secret_store` - Secret storage (encrypted at rest):
-- operation: "set" - Store a secret (name, value required)
-- operation: "get" - Retrieve a secret (name required)
-- operation: "delete" - Delete a secret (name required)
-- operation: "list" - List all secret names
-
-Best practices:
-- Use kv_store for general data like state, preferences, or intermediate results
-- Use secret_store for sensitive data like API keys, tokens, or credentials
-- Keys and names are unique per session - storing with the same key/name overwrites"#,
+            "Use `kv_store` for general data. Use `secret_store` for sensitive data (API keys, tokens, credentials) — secrets are encrypted at rest. Keys are unique per session; storing with the same key overwrites.",
         )
     }
 
@@ -495,7 +478,7 @@ mod tests {
         let prompt = cap.system_prompt_addition().unwrap();
         assert!(prompt.contains("kv_store"));
         assert!(prompt.contains("secret_store"));
-        assert!(prompt.contains("encrypted at rest"));
+        assert!(prompt.contains("encrypted"));
     }
 
     #[test]

--- a/crates/core/src/capabilities/skills.rs
+++ b/crates/core/src/capabilities/skills.rs
@@ -61,11 +61,7 @@ fn workspace_path(path: &str) -> String {
 pub struct SkillsCapability;
 
 /// Static skills system prompt (used by sync callers and as fallback)
-const SKILLS_SYSTEM_PROMPT: &str = "You have access to an agent skills system. Skills are instruction packages \
-that can be discovered from the session filesystem.\n\n\
-Skills location: `/workspace/.agents/skills/{skill-name}/SKILL.md`\n\n\
-Use `list_skills` to discover available skills. When a skill is relevant to the \
-user's task, use `activate_skill` to load its full instructions into your context. \
+const SKILLS_SYSTEM_PROMPT: &str = "Skills location: `/workspace/.agents/skills/{skill-name}/SKILL.md`. \
 Only activate skills that are relevant to the current task.";
 
 #[async_trait]
@@ -717,8 +713,6 @@ mod tests {
         let prompt = cap.system_prompt_addition().unwrap();
 
         assert!(prompt.contains("/workspace/.agents/skills/"));
-        assert!(prompt.contains("list_skills"));
-        assert!(prompt.contains("activate_skill"));
     }
 
     #[test]
@@ -1175,8 +1169,10 @@ mod tests {
 
         // System prompt should include skills capability section
         assert!(
-            runtime_agent.system_prompt.contains("list_skills"),
-            "System prompt should mention list_skills tool"
+            runtime_agent
+                .system_prompt
+                .contains("/workspace/.agents/skills/"),
+            "System prompt should mention skills path"
         );
         assert!(
             runtime_agent
@@ -1241,7 +1237,7 @@ mod tests {
 
         let result = cap.system_prompt_contribution(&ctx).await.unwrap();
         assert!(result.contains("<capability id=\"skills\">"));
-        assert!(result.contains("list_skills"));
+        assert!(result.contains("/workspace/.agents/skills/"));
         // No "Available skills:" section
         assert!(!result.contains("Available skills:"));
     }
@@ -1259,7 +1255,7 @@ mod tests {
 
         let result = cap.system_prompt_contribution(&ctx).await.unwrap();
         assert!(result.contains("<capability id=\"skills\">"));
-        assert!(result.contains("list_skills"));
+        assert!(result.contains("/workspace/.agents/skills/"));
         // No "Available skills:" section (dir doesn't exist)
         assert!(!result.contains("Available skills:"));
     }

--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -63,25 +63,7 @@ impl Capability for SubagentCapability {
     }
 }
 
-const SUBAGENT_SYSTEM_PROMPT: &str = r#"You can delegate tasks to subagents that run in their own context window.
-
-## Tools
-
-- `spawn_subagent`: Create a named subagent to handle a specific task.
-  - Foreground (default): blocks until the subagent completes and returns its result.
-  - Each subagent has a human-readable name (e.g. "Test Runner", "Auth Explorer").
-  - Names must be unique within the current session.
-
-- `get_subagents`: List all subagents or get detailed status of a specific one.
-  - No arguments: returns all subagents with status summary.
-  - With name_or_id: returns detailed status and result of that subagent.
-
-- `message_subagent`: Send a message to a subagent by name or ID.
-  - Running subagent: injects message as steering (subagent sees it on next turn).
-  - Completed/failed subagent: resumes with the message as new input.
-  - With cancel=true: delivers message then gracefully stops the subagent.
-
-## When to use subagents
+const SUBAGENT_SYSTEM_PROMPT: &str = r#"Delegate tasks to subagents running in their own context window.
 
 - Move noisy/verbose work off the main conversation (test runs, large searches).
 - Run independent tasks in parallel (multiple spawn_subagent calls in one response).

--- a/crates/core/src/capabilities/test_math.rs
+++ b/crates/core/src/capabilities/test_math.rs
@@ -33,12 +33,6 @@ impl Capability for TestMathCapability {
         Some("Testing")
     }
 
-    fn system_prompt_addition(&self) -> Option<&str> {
-        Some(
-            "You have access to math tools. Use them for calculations: add, subtract, multiply, divide.",
-        )
-    }
-
     fn tools(&self) -> Vec<Box<dyn Tool>> {
         vec![
             Box::new(AddTool),
@@ -296,10 +290,9 @@ mod tests {
     }
 
     #[test]
-    fn test_capability_has_system_prompt() {
+    fn test_capability_no_system_prompt() {
         let cap = TestMathCapability;
-        let prompt = cap.system_prompt_addition().unwrap();
-        assert!(prompt.contains("math tools"));
+        assert!(cap.system_prompt_addition().is_none());
     }
 
     #[test]

--- a/crates/core/src/capabilities/test_weather.rs
+++ b/crates/core/src/capabilities/test_weather.rs
@@ -33,12 +33,6 @@ impl Capability for TestWeatherCapability {
         Some("Testing")
     }
 
-    fn system_prompt_addition(&self) -> Option<&str> {
-        Some(
-            "You have access to weather tools. Use get_weather for current conditions and get_forecast for multi-day forecasts.",
-        )
-    }
-
     fn tools(&self) -> Vec<Box<dyn Tool>> {
         vec![Box::new(GetWeatherTool), Box::new(GetForecastTool)]
     }
@@ -264,10 +258,9 @@ mod tests {
     }
 
     #[test]
-    fn test_capability_has_system_prompt() {
+    fn test_capability_no_system_prompt() {
         let cap = TestWeatherCapability;
-        let prompt = cap.system_prompt_addition().unwrap();
-        assert!(prompt.contains("weather tools"));
+        assert!(cap.system_prompt_addition().is_none());
     }
 
     #[test]

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -454,11 +454,11 @@ mod tests {
         let registry = CapabilityRegistry::with_builtins();
         let runtime_agent = RuntimeAgentBuilder::new()
             .system_prompt("Base prompt.")
-            .with_capabilities(&["test_math".to_string()], &registry, &test_ctx())
+            .with_capabilities(&["session_file_system".to_string()], &registry, &test_ctx())
             .await
             .build();
 
-        assert!(runtime_agent.system_prompt.contains("math tools"));
+        assert!(runtime_agent.system_prompt.contains("/workspace"));
         // Base prompt wrapped in <system-prompt> tags
         assert!(runtime_agent.system_prompt.contains("<system-prompt>"));
         assert!(
@@ -539,8 +539,8 @@ mod tests {
             "Should include File System capability in XML tags"
         );
         assert!(
-            runtime_agent.system_prompt.contains("read_file"),
-            "Should include File System system prompt (mentions read_file tool)"
+            runtime_agent.system_prompt.contains("/workspace"),
+            "Should include File System system prompt (mentions workspace root)"
         );
         // Should also include Sample Data's contribution in XML tags
         assert!(
@@ -729,8 +729,8 @@ mod tests {
             usage: None,
         };
 
-        // Session adds test_math capability (additive — has system prompt addition)
-        let session_capability_ids = vec!["test_math".to_string()];
+        // Session adds stateless_todo_list capability (additive — has system prompt addition)
+        let session_capability_ids = vec!["stateless_todo_list".to_string()];
 
         let runtime_agent = RuntimeAgentBuilder::new()
             .with_agent(&agent, &registry, &test_ctx())
@@ -744,15 +744,15 @@ mod tests {
         assert!(runtime_agent.tools.len() >= 2);
         let tool_names: Vec<&str> = runtime_agent.tools.iter().map(|t| t.name()).collect();
         assert!(tool_names.contains(&"get_current_time"));
-        assert!(tool_names.contains(&"add"));
+        assert!(tool_names.contains(&"write_todos"));
 
         // System prompt should contain both capability additions and agent prompt
         assert!(runtime_agent.system_prompt.contains("Agent prompt."));
-        assert!(runtime_agent.system_prompt.contains("math tools"));
+        assert!(runtime_agent.system_prompt.contains("Task Management"));
         assert!(
             runtime_agent
                 .system_prompt
-                .contains("<capability id=\"test_math\">")
+                .contains("<capability id=\"stateless_todo_list\">")
         );
         // Base prompt should be wrapped in <system-prompt> tags (no double wrapping)
         let system_prompt_count = runtime_agent

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -133,6 +133,17 @@ See `crates/core/src/capabilities/mod.rs` for the `Capability` trait and `Capabi
 - **`system_prompt_contribution(ctx)`** — Async, receives `SystemPromptContext` with session filesystem access. Default wraps `system_prompt_addition()` in XML tags. Capabilities needing dynamic content (e.g., `agent_instructions`, `skills`) override to read from session filesystem.
 - **`system_prompt_contribution_with_config(ctx, config)`** — Async, receives per-capability config JSON. Default delegates to `system_prompt_contribution(ctx)`. Used by `collect_capabilities_with_configs()`.
 
+##### System Prompt Content Contract
+
+System prompt additions must **not duplicate** information already present in tool definitions (names, descriptions, parameter schemas). Only include content that the model cannot infer from tool definitions alone:
+
+- **Behavioral semantics**: when to use which tool, ordering constraints, cross-tool relationships
+- **Non-schema constraints**: row limits, naming rules, workspace root paths, scheduling limits
+- **Data layout**: filesystem paths where state is persisted (e.g., `/crm/customers.json`)
+- **Execution semantics**: what happens when a schedule fires, nesting restrictions
+
+If every piece of information in the prompt is already covered by tool definitions, return `None`. Listing tool names and descriptions in the system prompt is redundant because the model receives tool definitions as structured metadata alongside the prompt.
+
 ##### Config-Aware Methods
 
 - **`tools_with_config(config)`** — Returns tools adapted to per-capability config. Default delegates to `tools()`. Example: `WebFetchCapability` enables `save_to_file` when config has `enable_file_download: true`.


### PR DESCRIPTION
## What
Remove duplicated tool information from capability `system_prompt_addition()` returns. Trim 15 capabilities to only contain information not already present in tool definitions (names, descriptions, parameter schemas).

## Why
Tool definitions already provide structured metadata (name, description, parameters) to the model. Repeating this in system prompts wastes context tokens and creates drift risk between two sources of truth.

## How
- Removed `system_prompt_addition()` entirely from `test_math`, `test_weather`, `session` (tool definitions are self-explanatory)
- Trimmed 10 capabilities to only retain: data file paths, behavioral constraints, cross-tool relationships, non-schema limits
- Documented the no-duplication contract in `specs/capabilities.md` and Rust doc comments on the trait method
- Updated 8 tests in `mod.rs`, `runtime_agent.rs`, `skills.rs`, `platform_management.rs`

## Risk
- Low
- Capability prompts are shorter; model may need to rely more on tool definitions for understanding tools (this is the intended design)

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (internal code, no external API change)