### PR TITLE
fix(ui): improve connection-required banner readability

### DIFF
--- a/apps/ui/src/components/chat/setup-connection-tool-call.tsx
+++ b/apps/ui/src/components/chat/setup-connection-tool-call.tsx
@@ -98,20 +98,20 @@ export function SetupConnectionToolCall({
 
   return (
     <>
-      <div className="flex items-center gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-900 dark:bg-amber-950/30">
-        <ProviderIcon iconName={icon} className="h-5 w-5 text-amber-600 dark:text-amber-400" />
+      <div className="flex items-center gap-3 rounded-lg border border-border bg-muted/50 px-4 py-3">
+        <ProviderIcon iconName={icon} className="h-5 w-5 text-foreground" />
         <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
+          <p className="text-sm font-medium text-foreground">
             {displayName} connection required
           </p>
-          <p className="text-xs text-amber-600 dark:text-amber-400">
+          <p className="text-xs text-muted-foreground">
             Connect your {displayName} account to continue
           </p>
         </div>
         <div className="flex items-center gap-2">
           <Button
             size="sm"
-            variant="outline"
+            variant="ghost"
             onClick={handleCancelled}
             disabled={status === "submitting"}
             className="text-muted-foreground"

--- a/apps/ui/src/components/chat/setup-connection-tool-call.tsx
+++ b/apps/ui/src/components/chat/setup-connection-tool-call.tsx
@@ -101,9 +101,7 @@ export function SetupConnectionToolCall({
       <div className="flex items-center gap-3 rounded-lg border border-border bg-muted/50 px-4 py-3">
         <ProviderIcon iconName={icon} className="h-5 w-5 text-foreground" />
         <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium text-foreground">
-            {displayName} connection required
-          </p>
+          <p className="text-sm font-medium text-foreground">{displayName} connection required</p>
           <p className="text-xs text-muted-foreground">
             Connect your {displayName} account to continue
           </p>


### PR DESCRIPTION
## What
Replace low-contrast amber-on-amber styling in the connection-required banner with neutral theme colors.

## Why
The amber text on amber background was hard to read, especially in light mode. Users reported the Daytona connection prompt was not visually clear.

## How
- Use `border-border`, `bg-muted/50`, `text-foreground`, `text-muted-foreground` instead of amber color variants
- Switch Skip button from `outline` to `ghost` variant for less visual noise
- Removed separate dark-mode overrides (theme tokens handle it automatically)

## Risk
- Low
- Cosmetic-only change to one component. No logic changes.

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered