### PR TITLE
fix(docs): render correct sidebar on API reference pages

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
 import starlightOpenAPI, { openAPISidebarGroups } from "starlight-openapi";
 import starlightSidebarTopics from "starlight-sidebar-topics";
+import apiSidebarFix from "./plugins/api-sidebar-fix.ts";
 import sitemapEnhance from "./integrations/sitemap-enhance.mjs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
@@ -199,6 +200,7 @@ export default defineConfig({
             exclude: ["/", "/api/**"],
           },
         ),
+        apiSidebarFix(),
       ],
       editLink: {
         baseUrl: "https://github.com/everruns/everruns/edit/main/apps/docs/",

--- a/apps/docs/plugins/api-sidebar-fix-middleware.ts
+++ b/apps/docs/plugins/api-sidebar-fix-middleware.ts
@@ -1,0 +1,34 @@
+// Post-order middleware that fixes sidebar-topics for API pages.
+// Runs after starlight-openapi has populated the sidebar with real items.
+
+import { defineRouteMiddleware } from "@astrojs/starlight/route-data";
+
+// The Reference topic index in the sidebar-topics config array.
+const REFERENCE_TOPIC_INDEX = 4;
+
+export const onRequest = defineRouteMiddleware((context) => {
+  const { starlightRoute } = context.locals;
+  const slug = starlightRoute.entry?.id;
+  if (!slug?.startsWith("api/") && slug !== "api") return;
+
+  // Only fix pages that sidebar-topics excluded (isPageWithTopic === false).
+  const topicsData = context.locals.starlightSidebarTopics;
+  if (!topicsData || topicsData.isPageWithTopic) return;
+
+  // Find the Reference topic's sidebar group (numbered by index).
+  const referenceGroup = starlightRoute.sidebar.find(
+    (item) =>
+      item.type === "group" && item.label === String(REFERENCE_TOPIC_INDEX),
+  );
+
+  if (referenceGroup?.type === "group") {
+    // Replace the full sidebar with just the Reference topic's items.
+    starlightRoute.sidebar = referenceGroup.entries;
+  }
+
+  // Patch sidebar-topics locals so the topic tabs render correctly.
+  topicsData.isPageWithTopic = true;
+  for (const topic of topicsData.topics) {
+    topic.isCurrent = topic.link === "/api/";
+  }
+});

--- a/apps/docs/plugins/api-sidebar-fix.ts
+++ b/apps/docs/plugins/api-sidebar-fix.ts
@@ -14,10 +14,6 @@
 
 import type { StarlightPlugin } from "@astrojs/starlight/types";
 
-// The Reference topic is at this index in the topics config array.
-// Must match the position in astro.config.mjs starlightSidebarTopics() call.
-const REFERENCE_TOPIC_INDEX = 4;
-
 export default function apiSidebarFix(): StarlightPlugin {
   return {
     name: "api-sidebar-fix",

--- a/apps/docs/plugins/api-sidebar-fix.ts
+++ b/apps/docs/plugins/api-sidebar-fix.ts
@@ -1,0 +1,34 @@
+// Fix sidebar-topics + starlight-openapi middleware ordering for API pages.
+//
+// Problem: starlight-sidebar-topics (pre) runs before starlight-openapi (post).
+// When sidebar-topics processes API pages, the sidebar still has placeholder
+// items so it can't match them to the Reference topic. The workaround was to
+// exclude /api/** from topic matching, but that caused the sidebar to render
+// raw numbered groups instead of the Reference topic's sidebar.
+//
+// Solution: This plugin registers a post-order middleware that runs AFTER
+// starlight-openapi populates the sidebar. For API pages that sidebar-topics
+// excluded, it extracts the Reference topic's sidebar group and patches the
+// sidebar-topics locals so the page is treated as belonging to the Reference
+// topic.
+
+import type { StarlightPlugin } from "@astrojs/starlight/types";
+
+// The Reference topic is at this index in the topics config array.
+// Must match the position in astro.config.mjs starlightSidebarTopics() call.
+const REFERENCE_TOPIC_INDEX = 4;
+
+export default function apiSidebarFix(): StarlightPlugin {
+  return {
+    name: "api-sidebar-fix",
+    hooks: {
+      "config:setup"({ addRouteMiddleware }) {
+        addRouteMiddleware({
+          entrypoint: new URL("./api-sidebar-fix-middleware.ts", import.meta.url)
+            .pathname,
+          order: "post",
+        });
+      },
+    },
+  };
+}


### PR DESCRIPTION
## What
Fix the API reference sidebar rendering raw numbered topic groups ("0", "1", "2"...) instead of the proper API Reference sidebar with operation groups.

## Why
The `starlight-sidebar-topics` plugin registers a `pre`-order middleware while `starlight-openapi` registers a `post`-order middleware. When sidebar-topics processes API pages, the sidebar still has placeholder items (not real API operations), so it can't match them to the Reference topic. The existing `exclude: ["/", "/api/**"]` workaround caused API pages to fall through to the default sidebar with all topics as numbered groups.

## How
Added a lightweight Starlight plugin (`plugins/api-sidebar-fix.ts`) that registers a `post`-order middleware running after starlight-openapi populates the sidebar. For excluded API pages, the middleware:
1. Extracts the Reference topic's sidebar group (now populated with real API items)
2. Sets `starlightRoute.sidebar` to just those items
3. Patches `starlightSidebarTopics` locals so topic tabs render with Reference active

## Risk
- Low
- Only affects docs site API reference pages. Verified with full `npm run build` (158 pages, no errors). Non-API pages unaffected.

## Checklist
- [ ] Tests added or updated — N/A, docs-only change validated by successful build
- [x] Backward compatibility considered — no API or runtime changes
