### PR TITLE
fix(server): allow waiting_for_tool_results in gRPC set_session_status

### DIFF
--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -1106,7 +1106,7 @@ impl WorkerService for WorkerServiceImpl {
         let internal_caller = everruns_core::Caller::internal(req.org_id);
 
         // Validate status value
-        let valid_statuses = ["started", "active", "idle"];
+        let valid_statuses = ["started", "active", "idle", "waiting_for_tool_results"];
         if !valid_statuses.contains(&req.status.as_str()) {
             return Err(Status::invalid_argument(format!(
                 "Invalid status '{}'. Must be one of: started, active, idle",

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -1109,7 +1109,7 @@ impl WorkerService for WorkerServiceImpl {
         let valid_statuses = ["started", "active", "idle", "waiting_for_tool_results"];
         if !valid_statuses.contains(&req.status.as_str()) {
             return Err(Status::invalid_argument(format!(
-                "Invalid status '{}'. Must be one of: started, active, idle",
+                "Invalid status '{}'. Must be one of: started, active, idle, waiting_for_tool_results",
                 req.status
             )));
         }


### PR DESCRIPTION
## What
Add `waiting_for_tool_results` to the valid statuses whitelist in the gRPC `set_session_status` handler.

## Why
The durable worker sets session status to `waiting_for_tool_results` after client-side tool calls (e.g., `setup_connection`), but the gRPC handler rejected it because the validation only allowed `started`, `active`, `idle`. The DB schema and direct worker adapter already accept this status. This caused a WARN log on every client-side tool flow in durable mode.

## How
Added `"waiting_for_tool_results"` to the `valid_statuses` array and updated the error message to match.

## Risk
- Low
- Only widens an existing validation check to accept a status already supported by the DB and the rest of the codebase

## Checklist
- [x] Tests added or updated — existing test suite passes; no new test needed for a validation whitelist addition
- [x] Backward compatibility considered — additive change only