### PR TITLE
fix(ui): add missing SSE event types for connection setup and compaction

### DIFF
--- a/apps/ui/src/components/chat/setup-connection-tool-call.tsx
+++ b/apps/ui/src/components/chat/setup-connection-tool-call.tsx
@@ -83,10 +83,10 @@ export function SetupConnectionToolCall({
     return (
       <div
         className={cn(
-          "flex items-center gap-2 rounded-lg border px-3 py-2 text-sm",
+          "flex items-center gap-2 px-3 py-1.5 text-sm",
           wasSuccess
-            ? "border-green-200 bg-green-50 text-green-700 dark:border-green-900 dark:bg-green-950/30 dark:text-green-400"
-            : "border-border bg-muted/30 text-muted-foreground",
+            ? "text-green-700 dark:text-green-400"
+            : "text-muted-foreground",
         )}
       >
         {wasSuccess ? <Check className="h-4 w-4" /> : <X className="h-4 w-4" />}

--- a/apps/ui/src/components/chat/setup-connection-tool-call.tsx
+++ b/apps/ui/src/components/chat/setup-connection-tool-call.tsx
@@ -84,9 +84,7 @@ export function SetupConnectionToolCall({
       <div
         className={cn(
           "flex items-center gap-2 px-3 py-1.5 text-sm",
-          wasSuccess
-            ? "text-green-700 dark:text-green-400"
-            : "text-muted-foreground",
+          wasSuccess ? "text-green-700 dark:text-green-400" : "text-muted-foreground",
         )}
       >
         {wasSuccess ? <Check className="h-4 w-4" /> : <X className="h-4 w-4" />}

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -205,6 +205,7 @@ const SSE_EVENT_TYPES = [
   "act.completed",
   "tool.started",
   "tool.completed",
+  "tool.call_requested",
   "llm.generation",
   "session.started",
   "session.activated",
@@ -212,6 +213,7 @@ const SSE_EVENT_TYPES = [
   "reason.thinking.started",
   "reason.thinking.delta",
   "reason.thinking.completed",
+  "context.compacted",
 ];
 
 /** Default page size for paginated event loading */


### PR DESCRIPTION
## What
Add `tool.call_requested` and `context.compacted` to the SSE event type subscription list in `useEvents`. Clean up the completed connection banner styling.

## Why
The `setup_connection` inline card (Daytona, etc.) only appeared after a full page refresh because the SSE listener never subscribed to `tool.call_requested` events. The worker emits the synthetic `setup_connection` tool call correctly, but the client missed it in real-time. Similarly, `context.compacted` events were rendered in `chatEvents` but never received via SSE.

## How
- Added `tool.call_requested` and `context.compacted` to `SSE_EVENT_TYPES` in `use-sessions.ts`
- Simplified the completed connection state in `setup-connection-tool-call.tsx` — removed border, background, and rounded corners for a lightweight inline status

## Risk
- Low
- UI-only change to SSE event subscription. No backend changes. The event types already exist in the backend SSE emitter — this just subscribes the client to them.

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered