### PR TITLE
chore(maintenance): add GitHub security checks to maintenance requirements

### DIFF
--- a/.claude/skills/maintenance/SKILL.md
+++ b/.claude/skills/maintenance/SKILL.md
@@ -76,6 +76,9 @@ Goal: new or changed attack surface is understood, and mitigations/docs match re
 Good evidence:
 - threat model updated when behavior or trust boundaries changed
 - obvious gaps in auth, validation, secret handling, or data exposure were reviewed
+- [GitHub Security Overview](https://github.com/everruns/everruns/security) checked for advisories
+- [Dependabot alerts](https://github.com/everruns/everruns/security/dependabot) reviewed and triaged
+- [Secret scanning alerts](https://github.com/everruns/everruns/security/secret-scanning?query=is%3Aopen+results%3Ageneric) reviewed — no open generic secret leaks
 
 ### Test And Runtime Confidence
 
@@ -125,6 +128,8 @@ Pick only what matches the task:
 - `cd apps/ui && npm run lint && npm run build`
 - `cd apps/docs && npm run build`
 - `./scripts/export-openapi.sh`
+- `doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" gh api repos/everruns/everruns/dependabot/alerts --jq "[.[] | select(.state==\"open\")] | length"'` — open Dependabot alert count
+- `doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" gh api repos/everruns/everruns/secret-scanning/alerts --jq "[.[] | select(.state==\"open\")] | length"'` — open secret scanning alert count
 
 ## Deliverable
 

--- a/specs/maintenance.md
+++ b/specs/maintenance.md
@@ -27,6 +27,9 @@ Relevant references:
 - [`specs/code-organization.md`](./code-organization.md)
 - [`specs/commands.md`](./commands.md)
 - [`specs/skills-registry.md`](./skills-registry.md)
+- [GitHub Security Overview](https://github.com/everruns/everruns/security)
+- [Dependabot Alerts](https://github.com/everruns/everruns/security/dependabot)
+- [Secret Scanning Alerts](https://github.com/everruns/everruns/security/secret-scanning?query=is%3Aopen+results%3Ageneric)
 
 ## Constraints
 
@@ -43,6 +46,7 @@ Before a release, maintenance should cover:
 - areas changed since the last release
 - historically fragile or high-risk surfaces
 - release artifacts affected by those changes
+- GitHub Security tab: security overview, Dependabot alerts, and open secret scanning alerts
 
 A full-repo sweep is not mandatory if the evidence is already strong. The bar is confidence, not checklist completion theater.
 


### PR DESCRIPTION
## What
Add GitHub security tab checks (security overview, Dependabot alerts, secret scanning) to the maintenance spec and skill.

## Why
Maintenance reviews should include GitHub-native security signals — Dependabot vulnerability alerts and secret scanning — to catch dependency CVEs and leaked secrets before release.

## How
- Added references to the three GitHub security pages in `specs/maintenance.md`
- Added them as release readiness checklist items
- Added evidence items under Security And Threat Posture in the maintenance skill
- Added CLI commands using `gh api` for programmatic alert counting

## Risk
- Low
- Docs-only change; no code behavior affected

## Checklist
- [x] Tests added or updated — N/A (docs only)
- [x] Backward compatibility considered — N/A