### PR TITLE
docs: extend all short meta descriptions to 150+ chars for SEO

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -31,7 +31,7 @@ export default defineConfig({
     starlight({
       title: "Everruns",
       description:
-        "Documentation for Everruns, a durable agentic harness engine for AI agents",
+        "Documentation for Everruns, a durable agentic harness engine for AI agents. Guides for deploying, configuring, and building agent applications with the API.",
       routeMiddleware: "./src/routeData.ts",
       logo: {
         src: "./src/assets/logo.svg",

--- a/apps/docs/src/routeData.ts
+++ b/apps/docs/src/routeData.ts
@@ -143,7 +143,7 @@ function deriveDescription(slug: string, title: string): string {
 
   // API overview page
   if (slug === "api") {
-    return "Complete API reference for Everruns, including endpoints, schemas, and authentication";
+    return "Complete REST API reference for Everruns, including all endpoints, request and response schemas, authentication, and interactive usage examples.";
   }
 
   // API schema pages

--- a/docs/capabilities/agent-instructions.md
+++ b/docs/capabilities/agent-instructions.md
@@ -1,6 +1,6 @@
 ---
 title: AGENTS.md
-description: Dynamic project instructions from AGENTS.md in the session workspace
+description: Dynamic project instructions loaded from AGENTS.md files in the session workspace. Agents inherit coding style, tool preferences, and workflow rules automatically.
 ---
 
 | | |

--- a/docs/capabilities/agent-skills.md
+++ b/docs/capabilities/agent-skills.md
@@ -1,6 +1,6 @@
 ---
 title: Agent Skills
-description: Discover and activate portable instruction packages from the session workspace
+description: Discover and activate portable skill packages from the session workspace. Agents gain specialized knowledge and workflows by loading skill definitions at runtime.
 ---
 
 | | |

--- a/docs/capabilities/browserless.md
+++ b/docs/capabilities/browserless.md
@@ -1,6 +1,6 @@
 ---
 title: Browserless
-description: Cloud browser automation for screenshots, DOM reading, scraping, and interactions
+description: Cloud browser automation for screenshots, DOM reading, scraping, and page interactions. Agents browse the web headlessly using Browserless cloud infrastructure.
 ---
 
 | | |

--- a/docs/capabilities/current-time.md
+++ b/docs/capabilities/current-time.md
@@ -1,6 +1,6 @@
 ---
 title: Current Time
-description: Get the current date and time in various formats and timezones
+description: Get the current date and time in various formats and timezones. Agents can check wall-clock time for scheduling decisions, logging, and time-aware responses.
 ---
 
 | | |

--- a/docs/capabilities/daytona.md
+++ b/docs/capabilities/daytona.md
@@ -1,6 +1,6 @@
 ---
 title: Daytona
-description: Run code in isolated cloud sandboxes with Daytona, including command execution, file access, and session-scoped environments.
+description: Run code in isolated Daytona cloud sandboxes with secure command execution, file access, and session-scoped environments for safe multi-tenant agent workloads.
 ---
 
 | | |

--- a/docs/capabilities/fake-aws.md
+++ b/docs/capabilities/fake-aws.md
@@ -1,6 +1,6 @@
 ---
 title: Fake AWS
-description: Demo capability with simulated AWS infrastructure management tools
+description: Demo capability with simulated AWS infrastructure management tools. Use this built-in demo to test agent workflows with mock EC2, S3, and Lambda operations.
 ---
 
 | | |

--- a/docs/capabilities/fake-crm.md
+++ b/docs/capabilities/fake-crm.md
@@ -1,6 +1,6 @@
 ---
 title: Fake CRM
-description: Demo capability with simulated CRM and customer support tools
+description: Demo capability with simulated CRM and customer support tools. Use this built-in demo to test agent workflows with mock contacts, tickets, and customer data.
 ---
 
 | | |

--- a/docs/capabilities/fake-warehouse.md
+++ b/docs/capabilities/fake-warehouse.md
@@ -1,6 +1,6 @@
 ---
 title: Fake Warehouse
-description: Demo capability with simulated warehouse management tools
+description: Demo capability with simulated warehouse management tools. Use this built-in demo to test agent workflows with mock inventory, orders, and shipping operations.
 ---
 
 | | |

--- a/docs/capabilities/file-system.md
+++ b/docs/capabilities/file-system.md
@@ -1,6 +1,6 @@
 ---
 title: File System
-description: Read, write, search, and manage files in an isolated per-session workspace
+description: Read, write, search, and manage files in an isolated per-session workspace. Agents get sandboxed file access with glob, grep, and directory operations.
 ---
 
 | | |

--- a/docs/capabilities/index.md
+++ b/docs/capabilities/index.md
@@ -1,6 +1,6 @@
 ---
 title: Capabilities Overview
-description: Modular functionality units that extend agent behavior with tools, system prompts, and execution features
+description: Modular capabilities that extend agent behavior with tools, system prompts, and execution features. Browse all built-in and custom capabilities available.
 ---
 
 Capabilities are modular units that extend what an agent can do. Each capability can contribute:

--- a/docs/capabilities/infinity-context.md
+++ b/docs/capabilities/infinity-context.md
@@ -1,6 +1,6 @@
 ---
 title: Infinity Context
-description: Keep long conversations manageable by trimming live prompt history and querying older messages on demand
+description: Keep long conversations manageable by trimming live prompt history and querying older messages on demand. Unlimited conversation length for complex agent tasks.
 sidebar:
   order: 85
 ---

--- a/docs/capabilities/openai-tool-search.md
+++ b/docs/capabilities/openai-tool-search.md
@@ -1,6 +1,6 @@
 ---
 title: OpenAI Tool Search
-description: Deferred tool loading for agents with many tools, reducing token usage on OpenAI GPT-5.4+ models
+description: Deferred tool loading for agents with many tools, reducing prompt token usage on OpenAI GPT-5.4+ models. Tools are loaded on demand based on semantic search.
 sidebar:
   order: 90
 ---

--- a/docs/capabilities/platform-management.md
+++ b/docs/capabilities/platform-management.md
@@ -1,6 +1,6 @@
 ---
 title: Platform Management
-description: Programmatic management of harnesses, agents, and sessions
+description: Programmatic management of harnesses, agents, and sessions from within a running session. Agents can create, list, update, and delete platform resources via tools.
 ---
 
 | | |

--- a/docs/capabilities/session-schedules.md
+++ b/docs/capabilities/session-schedules.md
@@ -1,6 +1,6 @@
 ---
 title: Schedules
-description: Schedule one-shot and recurring tasks within a session
+description: Schedule one-shot and recurring cron-based tasks within a session. Agents can set timers, run periodic checks, and automate follow-up actions on a schedule.
 ---
 
 | | |

--- a/docs/capabilities/session-storage.md
+++ b/docs/capabilities/session-storage.md
@@ -1,6 +1,6 @@
 ---
 title: Storage
-description: Key/value storage and encrypted secret storage within a session
+description: Key/value storage and encrypted secret storage scoped to a session. Agents can persist state, cache results, and store sensitive data securely across turns.
 ---
 
 | | |

--- a/docs/capabilities/session.md
+++ b/docs/capabilities/session.md
@@ -1,6 +1,6 @@
 ---
 title: Session
-description: Read and update current session metadata, including titles, agent information, and other session-scoped context for active conversations.
+description: Read and update current session metadata — titles, agent information, and session-scoped context. Agents can inspect and modify their own session during execution.
 ---
 
 | | |

--- a/docs/capabilities/sql-database.md
+++ b/docs/capabilities/sql-database.md
@@ -1,6 +1,6 @@
 ---
 title: SQL Database
-description: Session-scoped SQLite databases for structured data storage and querying
+description: Session-scoped SQLite databases for structured data storage and querying. Agents can create tables, run SQL queries, and persist relational data per session.
 ---
 
 | | |

--- a/docs/capabilities/sub-agents.md
+++ b/docs/capabilities/sub-agents.md
@@ -1,6 +1,6 @@
 ---
 title: Sub Agents
-description: Spawn and manage subagents for parallel task execution in isolated context windows.
+description: Spawn and manage subagents for parallel task execution in isolated context windows. Orchestrate multi-agent workflows with message passing and lifecycle control.
 ---
 
 | | |

--- a/docs/capabilities/task-management.md
+++ b/docs/capabilities/task-management.md
@@ -1,6 +1,6 @@
 ---
 title: Task Management
-description: Structured task lists for tracking multi-step work progress
+description: Structured task lists for tracking multi-step work progress. Agents can create, update, and complete tasks to organize complex workflows within a session.
 ---
 
 | | |

--- a/docs/capabilities/virtual-bash.md
+++ b/docs/capabilities/virtual-bash.md
@@ -1,6 +1,6 @@
 ---
 title: Virtual Bash
-description: Sandboxed bash command execution in an isolated environment
+description: Sandboxed Bash command execution in an isolated environment. Agents can run shell commands safely with process isolation, timeouts, and output capture.
 ---
 
 | | |

--- a/docs/capabilities/web-fetch.md
+++ b/docs/capabilities/web-fetch.md
@@ -1,6 +1,6 @@
 ---
 title: Web Fetch
-description: Fetch web content from URLs with HTML-to-markdown conversion
+description: Fetch web content from any URL and convert HTML to clean markdown. Agents can read web pages, extract text, and follow links in their session workspace.
 ---
 
 | | |

--- a/docs/ecosystem/bashkit.md
+++ b/docs/ecosystem/bashkit.md
@@ -1,6 +1,6 @@
 ---
 title: Bashkit
-description: Sandboxed virtual Bash interpreter for multi-tenant agent environments.
+description: Sandboxed virtual Bash interpreter for multi-tenant agent environments. Run shell commands safely with process isolation, filesystem limits, and timeouts.
 ---
 
 [Bashkit](https://github.com/everruns/bashkit) is a virtual Bash interpreter written in Rust. It provides sandboxed, in-process execution with no real filesystem access by default — purpose-built for running untrusted bash scripts in multi-tenant agent environments.

--- a/docs/event-reference.md
+++ b/docs/event-reference.md
@@ -1,6 +1,6 @@
 ---
 title: Event Reference
-description: Complete reference for all Everruns event types, including input, output, tool, and lifecycle events emitted during execution.
+description: Complete reference for all Everruns event types — input, output, tool, lifecycle, and error events emitted during execution. Includes schemas and SSE examples.
 ---
 
 This page documents all event types in the Everruns event protocol.

--- a/docs/features/agent-instructions.md
+++ b/docs/features/agent-instructions.md
@@ -1,6 +1,6 @@
 ---
 title: AGENTS.md
-description: Provide project-level instructions to agents via AGENTS.md
+description: Provide project-level instructions to agents via AGENTS.md files. Define coding style, tool preferences, and workflow rules that agents follow automatically.
 ---
 
 The **AGENTS.md** capability reads an `AGENTS.md` file from the session workspace and automatically includes it in the agent's system prompt on every turn. This gives you a simple, standard way to provide project-level context — coding conventions, style guides, build instructions, or any other guidance — to your agents.

--- a/docs/features/apps.md
+++ b/docs/features/apps.md
@@ -1,6 +1,6 @@
 ---
 title: Apps
-description: Deploy agents to external channels like Slack, WhatsApp, and more
+description: Deploy Everruns agents to external channels like Slack, WhatsApp, and custom webhooks. Configure distribution, authentication, and message routing per app.
 ---
 
 An App binds a Harness and Agent to a distribution channel, turning your agent into a deployed service that responds to external messages. Apps provide a publish/unpublish lifecycle — only published apps accept incoming requests.

--- a/docs/features/capabilities.md
+++ b/docs/features/capabilities.md
@@ -1,6 +1,6 @@
 ---
 title: Capabilities
-description: Modular functionality units that extend Agent behavior
+description: Modular capabilities that extend agent behavior with tools, system prompts, and execution features. Add file access, web browsing, code execution, and more.
 ---
 
 Capabilities are modular functionality units that extend Agent behavior. A Capability can contribute additions to the system prompt, provide tools, and modify execution behavior. Users can enable multiple capabilities on an Agent to compose functionality.

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -1,6 +1,6 @@
 ---
 title: CLI
-description: Command-line interface for managing agents, sessions, and conversations
+description: Command-line interface for managing agents, creating sessions, streaming real-time events, and running interactive conversations with the Everruns platform.
 ---
 
 The `everruns` CLI provides a command-line interface for managing agents, sessions, and conversations. It's useful for scripting, automation, and quick interactions without using the web UI.

--- a/docs/features/events.md
+++ b/docs/features/events.md
@@ -1,6 +1,6 @@
 ---
 title: Events
-description: Real-time event streaming for session observability
+description: Real-time SSE event streaming for full session observability. Monitor agent execution, tool calls, token usage, and all lifecycle events as they happen.
 ---
 
 Events are the core communication protocol in Everruns. They provide real-time visibility into session execution via Server-Sent Events (SSE) streaming.

--- a/docs/features/harnesses.md
+++ b/docs/features/harnesses.md
@@ -1,6 +1,6 @@
 ---
 title: Harnesses
-description: Pre-configured environments that define base capabilities for sessions
+description: Pre-configured environments that define base capabilities, tools, and execution settings for agent sessions. Built-in and custom harness types available.
 ---
 
 A harness defines the base environment for sessions — the system prompt, default model, and capabilities that every session starts with. Think of a harness as a "starter kit" that agents and sessions build on top of.

--- a/docs/features/skills-registry.md
+++ b/docs/features/skills-registry.md
@@ -1,6 +1,6 @@
 ---
 title: Skills Registry
-description: API-managed skill registry for creating, uploading, and sharing skills across your organization
+description: API-managed skill registry for creating, uploading, and sharing portable instruction packages across your organization with versioning and search support.
 ---
 
 The Skills Registry provides API endpoints for managing organization-wide skills. Registry skills persist across sessions and can be assigned to any agent as capabilities.

--- a/docs/features/skills.mdx
+++ b/docs/features/skills.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent Skills
-description: Portable instruction packages that extend agent capabilities with specialized knowledge and workflows
+description: Portable instruction packages that extend agent capabilities with specialized knowledge, workflows, and tools. Create, share, and activate skills per session.
 ---
 
 Agent Skills are portable instruction packages following the [Agent Skills](https://agentskills.io/) open specification. They enable agents to discover and activate specialized knowledge on demand, keeping the agent's context efficient through progressive disclosure.

--- a/docs/features/ui.md
+++ b/docs/features/ui.md
@@ -1,6 +1,6 @@
 ---
 title: Management UI
-description: Optional web interface for managing agents, sessions, and monitoring operations
+description: Optional web interface for managing agents, creating sessions, monitoring real-time events, and viewing conversation history in the Everruns platform.
 ---
 
 While Everruns is a headless agent platform designed for API-first integration, it provides an optional management UI for administrative tasks and session monitoring.

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -1,6 +1,6 @@
 ---
 title: Concepts
-description: Learn the core Everruns entities, runtime relationships, and execution model across harnesses, agents, sessions, turns, and events.
+description: Learn the core Everruns entities and execution model — harnesses, agents, sessions, turns, events, and capabilities, and how they all relate at runtime.
 ---
 
 This page describes the core entities in Everruns and how they relate to each other, organized into three layers: the high-level execution model, session internals, and settings.

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: Get started with Everruns - A durable agentic harness engine
+description: Get started with Everruns, a durable agentic harness engine built on Rust. Deploy, configure, and orchestrate AI agents with built-in persistence and tools.
 ---
 
 Everruns is a durable agentic harness engine built on Rust with a PostgreSQL-backed durable execution engine. It provides APIs for managing agents, sessions, and runs with streaming event output via SSE.

--- a/docs/integrations/brave-search.md
+++ b/docs/integrations/brave-search.md
@@ -1,6 +1,6 @@
 ---
 title: Brave Search
-description: Give agents live web search with Brave Search, including ranked results, freshness filters, pagination, and source attribution.
+description: Give agents live web search with Brave Search — ranked results, freshness filters, pagination, source attribution, and safe search. Requires a Brave API key.
 ---
 
 Everruns integrates with [Brave Search](https://brave.com/search/api/) to give agents full web search capabilities. Agents can search the web and get relevant results including titles, URLs, and descriptions — perfect for research, fact-checking, and finding current information.

--- a/docs/integrations/browserless.md
+++ b/docs/integrations/browserless.md
@@ -1,6 +1,6 @@
 ---
 title: Browserless
-description: Cloud browser automation for screenshots, scraping, and testing with Browserless
+description: Integrate Browserless for cloud browser automation — screenshots, scraping, and testing. Configure API keys, connection pooling, and headless Chrome for agents.
 ---
 
 Everruns integrates with [Browserless](https://www.browserless.io/) to provide cloud-based browser automation. Agents can navigate web pages, take screenshots, read DOM content, scrape structured data, and interact with UI elements (click, type, keyboard, mouse, touch).

--- a/docs/integrations/daytona.md
+++ b/docs/integrations/daytona.md
@@ -1,6 +1,6 @@
 ---
 title: Daytona
-description: Cloud sandbox environments for secure code execution with Daytona
+description: Integrate Daytona cloud sandbox environments for secure, isolated code execution. Configure API keys, workspace templates, and session-scoped sandbox lifecycle.
 ---
 
 ![Daytona Integration](daytona.png)

--- a/docs/integrations/duckduckgo.md
+++ b/docs/integrations/duckduckgo.md
@@ -1,6 +1,6 @@
 ---
 title: DuckDuckGo
-description: Free instant answers, definitions, and topic summaries via DuckDuckGo
+description: Give agents free instant answers, definitions, and topic summaries via DuckDuckGo. No API key required — lightweight search for general knowledge queries.
 ---
 
 Everruns integrates with [DuckDuckGo](https://duckduckgo.com/) to provide instant answers via the [DuckDuckGo Instant Answer API](https://api.duckduckgo.com/api). Agents can look up facts, definitions, topic summaries (from Wikipedia and other sources), and related topics — all without an API key.

--- a/docs/integrations/slack.md
+++ b/docs/integrations/slack.md
@@ -1,6 +1,6 @@
 ---
 title: Slack
-description: Deploy Everruns agents as Slack bots that respond to messages
+description: Deploy Everruns agents as Slack bots that respond to messages, threads, and mentions. Configure OAuth, event subscriptions, and channel routing for your workspace.
 ---
 
 Everruns integrates with [Slack](https://slack.com) to deploy agents as bots that respond to messages in channels and threads. Messages are received via Slack's Events API, processed by the agent, and responses are posted back to the conversation.

--- a/docs/observability/braintrust.md
+++ b/docs/observability/braintrust.md
@@ -1,6 +1,6 @@
 ---
 title: Braintrust
-description: LLM observability, evaluation, and trace visualization with Braintrust
+description: LLM observability, evaluation, and trace visualization with Braintrust. Monitor agent performance, inspect tool call chains, and compare model outputs over time.
 ---
 
 <img src="/images/observability/braintrust-logo.png" alt="Braintrust" width="64" style="float: right; margin-left: 16px;" />

--- a/docs/sre/admin-container.md
+++ b/docs/sre/admin-container.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Container
-description: Tools for checking migration status, key rotation, and other administrative tasks
+description: Admin container tools for checking database migration status, rotating encryption keys, running diagnostics, and performing operational maintenance tasks.
 ---
 
 The admin container provides tools for key rotation, migration status checks, and other administrative tasks in production environments.

--- a/docs/sre/runbooks/authentication.md
+++ b/docs/sre/runbooks/authentication.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication Configuration
-description: Configuring and managing authentication for Everruns
+description: Configure authentication for Everruns, including API key setup, OAuth integration, token validation, and multi-tenant access control for production deployments.
 ---
 
 ## Overview

--- a/docs/sre/runbooks/durable-mode-setup.md
+++ b/docs/sre/runbooks/durable-mode-setup.md
@@ -1,6 +1,6 @@
 ---
 title: Durable Execution Engine Setup
-description: How to run Everruns with the PostgreSQL-backed durable execution engine
+description: Step-by-step guide to running Everruns with the PostgreSQL-backed durable execution engine, including database setup, migrations, and worker configuration.
 ---
 
 This guide explains how to run Everruns with the custom PostgreSQL-backed durable execution engine.

--- a/docs/tutorials/building-agents-using-sdk/index.md
+++ b/docs/tutorials/building-agents-using-sdk/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Building Agents Using the Everruns SDK"
-description: "A hands-on guide to building, running, and orchestrating AI agents with the everruns-sdk Python package"
+description: "A hands-on guide to building, running, and orchestrating AI agents with the everruns-sdk Python package. Covers setup, tools, streaming, and multi-agent patterns."
 ---
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";


### PR DESCRIPTION
## What
Extended all short meta descriptions across 46 docs pages to meet the 150-160 character SEO target. Updated frontmatter `description` fields, the global Starlight description in `astro.config.mjs`, and the API overview fallback in `routeData.ts`.

## Why
Bing Webmaster Tools flagged 32 pages with meta descriptions too short (moderate severity). The `routeData.ts` middleware only generates fallback descriptions for pages with *no* description — it does not extend short ones. So content pages with 50-130 char frontmatter descriptions were still serving short meta tags.

## How
- Updated `description:` frontmatter in all 44 content markdown/mdx files to 150+ chars
- Extended the global fallback description in `astro.config.mjs` (76 → 157 chars)
- Extended the API overview fallback in `routeData.ts` (89 → 152 chars)

## Risk
- Low
- Docs-only change — no runtime code affected. Validated with full `npm run build` (158 pages, all pass). Spot-checked built HTML to confirm meta tags render correctly.

## Checklist
- [x] Tests added or updated (docs build validates all pages)
- [x] Backward compatibility considered (N/A — content-only change)