### PR TITLE
test(ui): add global chat test cases for agent creation and execution

### DIFF
--- a/test_cases/ui/global_chat/TC001_global_chat_loads.md
+++ b/test_cases/ui/global_chat/TC001_global_chat_loads.md
@@ -1,0 +1,31 @@
+# TC001: Global Chat - Page Loads
+
+## Description
+
+Verify that the global chat page loads successfully, creates a singleton session, and displays the chat interface.
+
+## Preconditions
+
+- Server running (`just start-dev`)
+- User logged in
+- Feature flag `global_chat` enabled (`FEATURE_GLOBAL_CHAT=true`)
+
+## Test Data
+
+None.
+
+## Steps
+
+1. Navigate to `/chat` in the sidebar
+2. Wait for the loading spinner to disappear
+3. Observe the page header and chat panel
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Page header | Shows "Chat" with experimental badge |
+| Chat panel | Renders with message input area |
+| No error | No "Failed to load chat" message |
+| Session created | `POST /v1/sessions/chat` returns 200/201 |
+| Revisiting `/chat` | Same session reused (singleton) |

--- a/test_cases/ui/global_chat/TC002_create_agent_via_chat.md
+++ b/test_cases/ui/global_chat/TC002_create_agent_via_chat.md
@@ -1,0 +1,37 @@
+# TC002: Global Chat - Create Agent via Chat
+
+## Description
+
+Verify that the global chat agent can create a new agent when asked, using the `manage_agents` platform management tool.
+
+## Preconditions
+
+- Server running (`just start-dev`)
+- User logged in
+- Feature flag `global_chat` enabled
+- LLM API keys configured
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| User Message | Create an agent called "Weather Bot" with system prompt "You answer weather questions." |
+
+## Steps
+
+1. Navigate to `/chat`
+2. Type: `Create an agent called "Weather Bot" with system prompt "You answer weather questions."`
+3. Send the message
+4. Wait for the agent to respond (may ask for confirmation, confirm if so)
+5. Observe the response — should contain a clickable link to the new agent
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Agent created | Response mentions agent creation success |
+| Agent link | Response contains markdown link `[Weather Bot](/agents/agent_...)` |
+| Navigate to link | Agent detail page loads with name "Weather Bot" |
+| Agent prompt | System prompt is "You answer weather questions." |
+| Agent status | `active` |
+| Agents list | New agent visible at `/agents` |

--- a/test_cases/ui/global_chat/TC003_create_10_random_agents.md
+++ b/test_cases/ui/global_chat/TC003_create_10_random_agents.md
@@ -1,0 +1,44 @@
+# TC003: Global Chat - Create 10 Random Agents
+
+## Description
+
+Verify that the global chat agent can create 10 distinct agents in a single conversation when asked. Each agent should have a unique name and system prompt.
+
+## Preconditions
+
+- Server running (`just start-dev`)
+- User logged in
+- Feature flag `global_chat` enabled
+- LLM API keys configured
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| User Message | Create 10 agents with different purposes. Name them: Code Reviewer, Data Analyst, Writing Editor, Math Tutor, DevOps Helper, Security Auditor, API Designer, Test Writer, Debug Assistant, and Doc Generator. Give each a relevant system prompt. |
+
+## Steps
+
+1. Navigate to `/chat`
+2. Send the message from test data above
+3. Confirm when the chat agent asks for confirmation
+4. Wait for the agent to finish creating all 10 agents (may take 30-60 seconds)
+5. Observe the response — should list all created agents with links
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| All 10 created | Response confirms 10 agents created |
+| Unique names | Each agent has a distinct name matching the requested names |
+| Agent links | Response contains 10 clickable agent links |
+| Agents list | Navigate to `/agents` — all 10 visible |
+| Each agent active | Each agent has `status: active` |
+| System prompts | Each agent has a system prompt relevant to its name |
+
+## Validation Commands
+
+```bash
+# Assert: 10 agents exist (excluding any pre-existing agents)
+curl -s "http://localhost:9300/api/v1/agents" | jq '[.data[] | select(.name | test("Code Reviewer|Data Analyst|Writing Editor|Math Tutor|DevOps Helper|Security Auditor|API Designer|Test Writer|Debug Assistant|Doc Generator"))] | length == 10'
+```

--- a/test_cases/ui/global_chat/TC004_run_agent_via_chat.md
+++ b/test_cases/ui/global_chat/TC004_run_agent_via_chat.md
@@ -1,0 +1,40 @@
+# TC004: Global Chat - Run Agent via Chat
+
+## Description
+
+Verify that the global chat agent can run a previously created agent by creating a session, sending a message, waiting for completion, and relaying results.
+
+## Preconditions
+
+- Server running (`just start-dev`)
+- User logged in
+- Feature flag `global_chat` enabled
+- LLM API keys configured
+- At least one agent exists (e.g., "Math Tutor" from TC003)
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| User Message | Run the Math Tutor agent with the task: "What is the square root of 144?" |
+
+## Steps
+
+1. Navigate to `/chat`
+2. Send the message from test data above
+3. Wait for the chat agent to:
+   - Create a session for Math Tutor
+   - Send the task message
+   - Wait for the turn to complete
+   - Retrieve and relay the results
+4. Observe the response
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Session created | Chat agent creates session for Math Tutor |
+| Message sent | Task forwarded to the session |
+| Result relayed | Response includes the Math Tutor's answer (mentions "12") |
+| Session link | Response contains link to the session |
+| Session visible | New session appears at `/sessions` with Math Tutor agent |

--- a/test_cases/ui/global_chat/TC005_run_all_10_agents.md
+++ b/test_cases/ui/global_chat/TC005_run_all_10_agents.md
@@ -1,0 +1,54 @@
+# TC005: Global Chat - Run All 10 Agents
+
+## Description
+
+Verify that the global chat agent can run all 10 previously created agents sequentially, each with a relevant task, and relay all results.
+
+## Preconditions
+
+- Server running (`just start-dev`)
+- User logged in
+- Feature flag `global_chat` enabled
+- LLM API keys configured
+- All 10 agents from TC003 exist
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| User Message | Run each of these agents with a short test task: Code Reviewer ("Review this function: def add(a,b): return a+b"), Data Analyst ("What is the mean of [10, 20, 30]?"), Writing Editor ("Fix: 'Their going to the store'"), Math Tutor ("What is 15% of 200?"), DevOps Helper ("What port does HTTPS use?"), Security Auditor ("Is eval() safe in Python?"), API Designer ("Suggest a REST endpoint for user creation"), Test Writer ("Write a test for an add function"), Debug Assistant ("Why might a null pointer exception occur?"), Doc Generator ("Write a one-line docstring for a sort function"). |
+
+## Steps
+
+1. Navigate to `/chat`
+2. Send the message from test data above
+3. Wait for the chat agent to create sessions and run each agent (may take 2-5 minutes)
+4. Observe the response
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| All 10 run | Chat agent reports results from all 10 agents |
+| Sessions created | 10 new sessions appear at `/sessions` |
+| Each agent responded | Each result contains a non-empty answer |
+| Code Reviewer | Response references the `add` function |
+| Data Analyst | Response mentions `20` (mean) |
+| Writing Editor | Response corrects to "They're" |
+| Math Tutor | Response mentions `30` |
+| DevOps Helper | Response mentions `443` |
+| Security Auditor | Response warns against `eval()` |
+| API Designer | Response suggests a `POST /users` or similar |
+| Test Writer | Response contains test code |
+| Debug Assistant | Response explains null pointer causes |
+| Doc Generator | Response contains a docstring |
+
+## Validation Commands
+
+```bash
+# Assert: 10 sessions with agent assignments exist
+curl -s "http://localhost:9300/api/v1/sessions" | jq '[.data[] | select(.agent_id != null)] | length >= 10'
+
+# Assert: each session reached idle
+curl -s "http://localhost:9300/api/v1/sessions" | jq '[.data[] | select(.agent_id != null and .status == "idle")] | length >= 10'
+```

--- a/test_cases/ui/global_chat/TC006_verify_agents_in_agents_page.md
+++ b/test_cases/ui/global_chat/TC006_verify_agents_in_agents_page.md
@@ -1,0 +1,43 @@
+# TC006: Global Chat - Verify Agents in Agents Page
+
+## Description
+
+After creating agents via global chat, verify they appear correctly in the Agents listing page with proper names, status, and details.
+
+## Preconditions
+
+- Server running (`just start-dev`)
+- User logged in
+- 10 agents created via global chat (TC003 completed)
+
+## Test Data
+
+| Agent Name | Expected Status |
+|------------|----------------|
+| Code Reviewer | active |
+| Data Analyst | active |
+| Writing Editor | active |
+| Math Tutor | active |
+| DevOps Helper | active |
+| Security Auditor | active |
+| API Designer | active |
+| Test Writer | active |
+| Debug Assistant | active |
+| Doc Generator | active |
+
+## Steps
+
+1. Navigate to `/agents`
+2. Observe the agents list
+3. Click on each agent to view its detail page
+4. Verify name, system prompt, and status for each
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| All 10 visible | All 10 agents appear in the list |
+| Names match | Each agent name matches what was requested |
+| Status | All show `active` status |
+| System prompts | Each has a non-empty system prompt relevant to its purpose |
+| Detail pages load | Clicking each agent navigates to `/agents/{id}` without errors |

--- a/test_cases/ui/global_chat/TC007_verify_sessions_created.md
+++ b/test_cases/ui/global_chat/TC007_verify_sessions_created.md
@@ -1,0 +1,34 @@
+# TC007: Global Chat - Verify Sessions Created by Agent Runs
+
+## Description
+
+After running agents via global chat, verify that sessions were created and are visible in the Sessions page with correct agent associations and idle status.
+
+## Preconditions
+
+- Server running (`just start-dev`)
+- User logged in
+- 10 agents run via global chat (TC005 completed)
+
+## Test Data
+
+None (uses sessions created by TC005).
+
+## Steps
+
+1. Navigate to `/sessions`
+2. Observe the sessions list
+3. For each of the 10 agent-linked sessions:
+   - Verify agent name is displayed
+   - Click into the session
+   - Check session status and messages
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| 10 agent sessions | At least 10 sessions with agent assignments visible |
+| Agent names | Each session shows the correct agent name |
+| Status | All sessions are `idle` (turn completed) |
+| Messages | Each session has >= 2 messages (user + agent response) |
+| Chat history | Clicking a session shows the conversation with task and response |

--- a/test_cases/ui/global_chat/TC008_chat_multi_turn_agent_management.md
+++ b/test_cases/ui/global_chat/TC008_chat_multi_turn_agent_management.md
@@ -1,0 +1,43 @@
+# TC008: Global Chat - Multi-turn Agent Management
+
+## Description
+
+Verify that global chat supports multi-turn conversation for agent management: create an agent, run it, check results, then update the agent — all in one conversation.
+
+## Preconditions
+
+- Server running (`just start-dev`)
+- User logged in
+- Feature flag `global_chat` enabled
+- LLM API keys configured
+
+## Test Data
+
+| Turn | User Message |
+|------|-------------|
+| 1 | Create an agent called "Joke Bot" with system prompt "You tell short, clean jokes." |
+| 2 | Run Joke Bot with the task: "Tell me a joke about programming." |
+| 3 | What did Joke Bot say? |
+| 4 | List all my agents. |
+
+## Steps
+
+1. Navigate to `/chat`
+2. Send turn 1 message, confirm creation if asked
+3. Wait for response, verify agent created
+4. Send turn 2 message
+5. Wait for response, verify Joke Bot ran and returned a joke
+6. Send turn 3 message
+7. Verify chat agent recalls the Joke Bot's response from context
+8. Send turn 4 message
+9. Verify chat agent lists all agents including Joke Bot
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Turn 1 | Agent "Joke Bot" created with link |
+| Turn 2 | Session created, joke returned |
+| Turn 3 | Chat agent recalls the joke from previous turn |
+| Turn 4 | Agent list returned, includes Joke Bot |
+| Conversation continuity | All turns share the same global chat session |

--- a/test_cases/ui/global_chat/TC009_chat_error_handling.md
+++ b/test_cases/ui/global_chat/TC009_chat_error_handling.md
@@ -1,0 +1,39 @@
+# TC009: Global Chat - Error Handling for Agent Operations
+
+## Description
+
+Verify that global chat handles error cases gracefully: running a nonexistent agent, creating a duplicate agent name, and interacting with invalid references.
+
+## Preconditions
+
+- Server running (`just start-dev`)
+- User logged in
+- Feature flag `global_chat` enabled
+- LLM API keys configured
+
+## Test Data
+
+| Turn | User Message |
+|------|-------------|
+| 1 | Run an agent called "Nonexistent Bot 999" with task "hello" |
+| 2 | Create an agent with an empty name |
+| 3 | List all agents and tell me how many there are |
+
+## Steps
+
+1. Navigate to `/chat`
+2. Send turn 1 — attempt to run a nonexistent agent
+3. Observe the response: should indicate the agent was not found
+4. Send turn 2 — attempt invalid creation
+5. Observe the response: should indicate validation error or refuse
+6. Send turn 3 — verify the chat agent can still function after errors
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Nonexistent agent | Chat agent reports agent not found or offers to create it |
+| Empty name | Chat agent refuses or reports validation error |
+| Recovery | Turn 3 succeeds — chat agent lists agents correctly |
+| No crash | Chat interface remains functional throughout |
+| No orphan sessions | No broken sessions created for nonexistent agent |

--- a/test_cases/ui/global_chat/TC010_chat_disabled_feature_flag.md
+++ b/test_cases/ui/global_chat/TC010_chat_disabled_feature_flag.md
@@ -1,0 +1,32 @@
+# TC010: Global Chat - Disabled Feature Flag
+
+## Description
+
+Verify that the global chat page shows a disabled message when the `global_chat` feature flag is off, and that the sidebar hides or disables the chat entry.
+
+## Preconditions
+
+- Server running (`just start-dev`)
+- User logged in
+- Feature flag `global_chat` **disabled** (`FEATURE_GLOBAL_CHAT` unset or `false`)
+
+## Test Data
+
+None.
+
+## Steps
+
+1. Ensure `global_chat` feature flag is disabled
+2. Check the sidebar for the "Chat" entry
+3. Navigate directly to `/chat`
+4. Observe the page content
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Sidebar | "Chat" entry hidden or not present |
+| `/chat` page | Shows "Global Chat is not enabled" message |
+| Sub-message | Shows "This feature is currently disabled." |
+| No session created | No `POST /v1/sessions/chat` call made |
+| No errors | No console errors or unhandled exceptions |


### PR DESCRIPTION
## What
Add 10 manual UI test cases for the global chat feature covering agent creation, execution, and cross-page verification.

## Why
Global chat with platform management capabilities (create/run agents) needs test coverage to ensure the feature works end-to-end.

## How
10 test cases in `test_cases/ui/global_chat/`:
- **TC001**: Page load and singleton session creation
- **TC002**: Single agent creation via chat
- **TC003**: Bulk creation of 10 agents with distinct names/prompts
- **TC004**: Run a single agent via chat (create session → send → wait → relay)
- **TC005**: Run all 10 agents with task-specific inputs and verify responses
- **TC006**: Cross-verify agents on `/agents` page
- **TC007**: Cross-verify sessions on `/sessions` page
- **TC008**: Multi-turn agent management conversation
- **TC009**: Error handling (nonexistent agent, invalid input, recovery)
- **TC010**: Feature flag disabled behavior

## Risk
- Low
- Markdown-only; no code changes

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered