### PR TITLE
fix(scripts): handle empty ui_dev_args under set -u

### DIFF
--- a/scripts/lib/services.sh
+++ b/scripts/lib/services.sh
@@ -170,7 +170,7 @@ if [ -n "${UI_DEV_ARGS:-}" ]; then
 fi
 
 run_ui_dev() {
-  PORT="$UI_PORT" ./node_modules/.bin/next dev --port "$UI_PORT" "${ui_dev_args[@]}"
+  PORT="$UI_PORT" ./node_modules/.bin/next dev --port "$UI_PORT" ${ui_dev_args[@]+"${ui_dev_args[@]}"}
 }
 
 run_ui_start() {


### PR DESCRIPTION
## What
Fix unbound variable error in `scripts/lib/services.sh` when starting UI dev server via `just start-all`.

## Why
`ui_dev_args` is initialized as an empty array and only populated conditionally (symlinked `node_modules` or `UI_DEV_ARGS` env var). Under `set -u` (from `common.sh`), `"${ui_dev_args[@]}"` on an empty array triggers `unbound variable`, preventing UI startup.

## How
Use the standard bash idiom `${arr[@]+"${arr[@]}"}` which safely expands to nothing when empty and to quoted elements when non-empty.

## Risk
- Low
- Only affects the `run_ui_dev` function in services.sh. Verified both empty and non-empty cases work correctly.

## Checklist
- [x] Tests added or updated (verified manually: empty array → no args, non-empty → passes --webpack)
- [x] Backward compatibility considered (no breaking change, purely a bugfix)