### PR TITLE
chore(specs): enforce mandatory smoke testing in shipping requirements

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -22,6 +22,8 @@ Use this skill when the user asks to:
 
 ## Required Outcomes
 
+**ALL outcomes below are MANDATORY. These are not suggestions — do not skip or weaken any requirement.**
+
 1. The branch state is safe.
    - Do not ship from `main` or `master`.
    - The working tree must be clean before the final push.
@@ -36,11 +38,12 @@ Use this skill when the user asks to:
    - Fix issues you find and refresh the evidence.
 4. Relevant artifacts stay in sync.
    - Update only the artifacts affected by the change: `specs/`, `specs/threat-model.md`, `AGENTS.md`, `test_cases/`, `apps/docs/`, and OpenAPI exports when applicable.
-5. Runtime confidence matches the change.
-   - Use smoke tests when static checks or automated tests are not enough.
+5. Smoke test impacted functionality.
+   - **Always** smoke test the flows affected by the change end-to-end. This is mandatory, not conditional on risk assessment.
    - Prefer `just start-dev --no-watch` for fast checks.
    - Use `just start-all --no-watch` when database, migration, infra, or API integration risk exists.
    - Stop any servers you started.
+   - Docs-only or config-only changes that do not affect runtime behavior may skip smoke testing with explicit justification.
 6. The PR is mergeable and merged safely.
    - Push the branch.
    - Create or update the PR with `.github/pull_request_template.md`.

--- a/specs/shipping.md
+++ b/specs/shipping.md
@@ -30,13 +30,13 @@ Relevant references:
 
 ## Required Outcomes
 
-Every shipped change must satisfy these outcomes:
+**Every shipped change MUST satisfy ALL of these outcomes. These are mandatory requirements, not optional suggestions. Do not skip or weaken any requirement.**
 
 1. Safe branch state: no shipping from `main` or `master`; working tree clean before final push; rebased onto the latest `origin/main` before merge.
 2. Goal achieved with evidence: the requested behavior is implemented and validated with proof that matches the risk.
 3. Merge-ready code: touched code is reviewed for avoidable complexity plus security and performance risk, and issues found during that review are addressed or explicitly blocked.
 4. Synced artifacts: only the affected artifacts are updated, including specs, threat model, docs, OpenAPI, test cases, and agent instructions when relevant.
-5. Runtime confidence: smoke tests or live verification supplement builds and automated tests when the risk surface justifies it.
+5. Smoke test impacted functionality: always smoke test the flows affected by the change end-to-end. This is mandatory, not conditional on risk assessment. Docs-only or config-only changes that do not affect runtime behavior may skip smoke testing with explicit justification.
 6. Safe merge: the PR uses the repo template, CI is green, review comments are resolved, and merge happens with squash only.
 
 ## Constraints


### PR DESCRIPTION
## What
Strengthen shipping spec and ship skill to make smoke testing mandatory for all shipped changes, rather than conditional on risk assessment.

## Why
Smoke testing was previously worded as optional ("when the risk surface justifies it"), which allowed agents to skip it. Making it mandatory ensures every shipped change gets end-to-end validation, with an explicit escape hatch only for docs/config-only changes.

## How
- Updated `specs/shipping.md` outcome #5 and intro paragraph
- Updated `.claude/skills/ship/SKILL.md` to match the spec language

## Risk
- Low
- Spec/docs-only change. No code affected. Worst case: agents run more smoke tests than before (a net positive).

## Checklist
- [x] Tests added or updated (N/A — no code changes)
- [x] Backward compatibility considered (N/A — internal spec)