### PR TITLE
fix(skills): enforce /ship delegation in process-issues skill

### DIFF
--- a/.claude/skills/process-issues/SKILL.md
+++ b/.claude/skills/process-issues/SKILL.md
@@ -30,21 +30,20 @@ Use this skill when the user asks to:
 1. **One PR per issue, always.**
    - Every issue gets its own branch and PR. No batch PRs. No partial fixes.
    - Branch naming: `{issue-id}-{short-description}` from `origin/main` (lowercase kebab-case).
-   - Each PR must satisfy the full `/ship` outcomes: goal met, validation matches risk, artifacts updated, CI green, PR merged safely.
 
-2. **Issues are fully resolved or explicitly skipped.**
-   - Resolved: PR merged, issue marked **Done** in Linear with a comment linking the merged PR.
+2. **Each PR ships via the `/ship` skill.**
+   - Always invoke `/ship` using the Skill tool — never duplicate its logic (validation, PR creation, CI checks, merge).
+   - `/ship` owns the full shipping lifecycle: diff review, simplification, security review, artifact sync, evidence gathering, PR creation, CI wait, and squash merge.
+   - Each PR must satisfy all `/ship` required outcomes: goal met, validation matches risk, artifacts updated, CI green, PR merged safely.
+
+3. **Issues are fully resolved or explicitly skipped.**
+   - Resolved: PR merged via `/ship`, issue marked **Done** in Linear with a comment linking the merged PR.
    - Skipped: Linear comment explaining why (blocked, ambiguous requirements, missing access). Issue left as **In Progress** or unchanged.
 
-3. **Sequential merging prevents conflicts.**
-   - After merging each PR, rebase remaining open PRs onto updated `main` before merging the next.
+4. **Sequential merging prevents conflicts.**
+   - After `/ship` merges each PR, rebase remaining open PRs onto updated `main` before shipping the next.
    - When multiple PRs touch `Cargo.toml` workspace deps, the second merge can create duplicate key errors — rebase catches this.
-   - Never merge a PR whose CI ran against a stale base.
-
-4. **Extensive test coverage.**
-   - **Unit tests:** test changed function/module directly; cover happy path, error cases, edge cases; for bug fixes, test must fail without fix; for features, cover all acceptance criteria.
-   - **Integration tests:** test through service layer or API boundary; verify side effects (database state, events emitted); test adjacent component interaction; for API changes, test request validation, response shape, error codes.
-   - **Test naming:** `test_{function}_{scenario}_{expected}` (e.g., `test_create_agent_duplicate_name_returns_conflict`); tests must be deterministic and independent.
+   - Never ship a PR whose CI ran against a stale base.
 
 5. **A summary report is delivered.**
    - Issues completed (with PR links)
@@ -78,18 +77,21 @@ For each issue, process up to 5 concurrently using subagents:
 1. **Pick up** — mark as **In Progress** in Linear, assign if unassigned
 2. **Analyze** — parse requirements, search codebase, identify root cause or scope. If ambiguous: comment in Linear requesting clarification, skip
 3. **Branch** — `git fetch origin main && git checkout -b {issue-id}-{short-description} origin/main`
-4. **Ship** — delegate to [`/ship`](../ship/SKILL.md) with the issue context:
-   - What to implement: issue description and acceptance criteria
-   - PR links back to the Linear issue (e.g., `Fixes ENG-123`)
+4. **Implement** — write the code change:
+   - Parse issue description and acceptance criteria
    - Write failing test first for bugs; validate acceptance criteria for features
-5. **Close** — after PR merge: mark issue **Done**, add Linear comment with PR link
+   - Commit with conventional-commit messages referencing the issue (e.g., `fix(core): resolve X — Fixes EVE-123`)
+5. **Ship via `/ship` skill** — invoke `/ship` using the Skill tool to handle validation, PR creation, CI, and merge. **Do NOT** duplicate `/ship` logic (validation, PR creation, merge sequencing) inline — always delegate.
+   - Pass context: what was implemented, which issue it resolves, the branch name
+   - `/ship` owns: diff review, simplification, security review, artifact sync, evidence gathering, PR creation, CI wait, and merge
+6. **Close** — after `/ship` completes merge: mark issue **Done** in Linear, add comment with merged PR link
 
 ### Merge Sequencing
 
-When multiple issues produce PRs, merge one at a time:
+When multiple issues produce PRs, merge sequentially (not in parallel):
 
-1. Merge first PR (CI must be green)
-2. Rebase next PR onto updated `main`, push, wait for CI
+1. Let `/ship` merge the first PR (CI must be green)
+2. Rebase next PR onto updated `main`, push, then invoke `/ship` for that PR
 3. Repeat until all PRs are merged
 
 ### Skip Rules
@@ -109,3 +111,4 @@ Always add a Linear comment explaining why.
 - No partial fixes — fully resolve or skip
 - No manual deployment steps (CI/CD handles deployment)
 - No backward compatibility shims (internal code, just change it)
+- **No shipping shortcuts** — always invoke `/ship` via the Skill tool for validation, PR, CI, and merge. Never inline `/ship` logic or skip shipping steps


### PR DESCRIPTION
## What
Clarify that the `process-issues` skill must invoke `/ship` via the Skill tool for all shipping concerns, rather than duplicating shipping logic inline.

## Why
The previous wording was ambiguous — it said "delegate to /ship" but could be interpreted as just following the ship guidelines manually. This led to risk of duplicated logic and shipping shortcuts.

## How
- Added explicit Required Outcome #2 ("Each PR ships via the `/ship` skill") requiring Skill tool invocation
- Separated implementation (step 4) from shipping (step 5) in per-issue execution
- Removed duplicated "Extensive test coverage" prescriptions (owned by `/ship`)
- Added "No shipping shortcuts" constraint
- Updated merge sequencing to reference `/ship` as the merge driver

## Risk
- Low
- Docs-only change to a skill definition — no runtime code affected

## Checklist
- [x] Tests added or updated (N/A — no runtime code)
- [x] Backward compatibility considered (N/A — internal skill definition)