### PR TITLE
fix(ui): add confirmation dialog for MCP server archive

### DIFF
--- a/apps/ui/src/__tests__/mcp-servers-page.test.tsx
+++ b/apps/ui/src/__tests__/mcp-servers-page.test.tsx
@@ -111,9 +111,7 @@ describe("McpServersPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Archive" }));
 
     expect(screen.getByText("Archive MCP Server")).toBeInTheDocument();
-    expect(
-      screen.getByText(/Are you sure you want to archive the MCP server/),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Are you sure you want to archive the MCP server/)).toBeInTheDocument();
   });
 
   it("does not archive when cancel is clicked in the confirmation dialog", () => {

--- a/apps/ui/src/__tests__/mcp-servers-page.test.tsx
+++ b/apps/ui/src/__tests__/mcp-servers-page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within, fireEvent } from "@testing-library/react";
 import McpServersPage from "@/app/(main)/mcp-servers/page";
 
 const mockUseMcpServers = jest.fn();
@@ -103,5 +103,52 @@ describe("McpServersPage", () => {
     render(<McpServersPage />);
 
     expect(screen.getByText(/Failed to load MCP servers/)).toBeInTheDocument();
+  });
+
+  it("shows confirmation dialog when clicking Archive", () => {
+    render(<McpServersPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Archive" }));
+
+    expect(screen.getByText("Archive MCP Server")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Are you sure you want to archive the MCP server/),
+    ).toBeInTheDocument();
+  });
+
+  it("does not archive when cancel is clicked in the confirmation dialog", () => {
+    const mockMutateAsync = jest.fn();
+    mockUseUpdateMcpServer.mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    });
+
+    render(<McpServersPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Archive" }));
+
+    const dialog = screen.getByRole("dialog");
+    const cancelButton = within(dialog).getByRole("button", { name: "Cancel" });
+    fireEvent.click(cancelButton);
+
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("archives server when confirmed in the dialog", () => {
+    const mockMutateAsync = jest.fn().mockResolvedValue({});
+    mockUseUpdateMcpServer.mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    });
+
+    render(<McpServersPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Archive" }));
+
+    const dialog = screen.getByRole("dialog");
+    const archiveButton = within(dialog).getByRole("button", { name: "Archive" });
+    fireEvent.click(archiveButton);
+
+    expect(mockMutateAsync).toHaveBeenCalledWith({ status: "archived" });
   });
 });

--- a/apps/ui/src/app/(main)/mcp-servers/page.tsx
+++ b/apps/ui/src/app/(main)/mcp-servers/page.tsx
@@ -86,11 +86,7 @@ function McpServerCard({
             {server.api_key_set ? "Update Key" : "Set Key"}
           </Button>
           {!isArchived && !isDeleted && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onArchive(server)}
-            >
+            <Button variant="outline" size="sm" onClick={() => onArchive(server)}>
               Archive
             </Button>
           )}
@@ -285,18 +281,15 @@ function ArchiveConfirmDialog({
           <DialogTitle>Archive MCP Server</DialogTitle>
           <DialogDescription>
             Are you sure you want to archive the MCP server{" "}
-            <span className="font-medium">{server?.name}</span>? Archived
-            servers will no longer be available to agents.
+            <span className="font-medium">{server?.name}</span>? Archived servers will no longer be
+            available to agents.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          <Button
-            onClick={handleArchive}
-            disabled={updateServer.isPending}
-          >
+          <Button onClick={handleArchive} disabled={updateServer.isPending}>
             {updateServer.isPending ? "Archiving..." : "Archive"}
           </Button>
         </DialogFooter>

--- a/apps/ui/src/app/(main)/mcp-servers/page.tsx
+++ b/apps/ui/src/app/(main)/mcp-servers/page.tsx
@@ -32,14 +32,15 @@ function McpServerCard({
   server,
   canDestroy,
   onDelete,
+  onArchive,
   onSetApiKey,
 }: {
   server: McpServer;
   canDestroy: boolean;
   onDelete: (server: McpServer) => void;
+  onArchive: (server: McpServer) => void;
   onSetApiKey: (server: McpServer) => void;
 }) {
-  const updateServer = useUpdateMcpServer(server.id);
   const isArchived = server.status === "archived";
   const isDeleted = server.status === "deleted";
 
@@ -88,10 +89,9 @@ function McpServerCard({
             <Button
               variant="outline"
               size="sm"
-              onClick={() => updateServer.mutate({ status: "archived" })}
-              disabled={updateServer.isPending}
+              onClick={() => onArchive(server)}
             >
-              {updateServer.isPending ? "Archiving..." : "Archive"}
+              Archive
             </Button>
           )}
           {isArchived && canDestroy && (
@@ -261,6 +261,50 @@ function SetApiKeyDialog({
   );
 }
 
+function ArchiveConfirmDialog({
+  server,
+  open,
+  onOpenChange,
+}: {
+  server: McpServer | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const updateServer = useUpdateMcpServer(server?.id || "");
+
+  const handleArchive = async () => {
+    if (!server) return;
+    await updateServer.mutateAsync({ status: "archived" });
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Archive MCP Server</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to archive the MCP server{" "}
+            <span className="font-medium">{server?.name}</span>? Archived
+            servers will no longer be available to agents.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleArchive}
+            disabled={updateServer.isPending}
+          >
+            {updateServer.isPending ? "Archiving..." : "Archive"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 function McpServerCardSkeleton() {
   return (
     <Card>
@@ -292,6 +336,7 @@ export default function McpServersPage() {
   const [addServerOpen, setAddServerOpen] = useState(false);
   const [apiKeyServer, setApiKeyServer] = useState<McpServer | null>(null);
   const [pendingDeleteServer, setPendingDeleteServer] = useState<McpServer | null>(null);
+  const [pendingArchiveServer, setPendingArchiveServer] = useState<McpServer | null>(null);
 
   const handleDeleteServer = async () => {
     if (!pendingDeleteServer) return;
@@ -350,6 +395,7 @@ export default function McpServersPage() {
               server={server}
               canDestroy={canDestroy}
               onDelete={setPendingDeleteServer}
+              onArchive={setPendingArchiveServer}
               onSetApiKey={setApiKeyServer}
             />
           ))}
@@ -358,6 +404,11 @@ export default function McpServersPage() {
 
       {/* Dialogs */}
       <AddMcpServerDialog open={addServerOpen} onOpenChange={setAddServerOpen} />
+      <ArchiveConfirmDialog
+        server={pendingArchiveServer}
+        open={pendingArchiveServer !== null}
+        onOpenChange={(open) => !open && setPendingArchiveServer(null)}
+      />
       <SetApiKeyDialog
         server={apiKeyServer}
         open={apiKeyServer !== null}


### PR DESCRIPTION
## Summary
- Added confirmation dialog before archiving MCP servers
- Prevents accidental archive actions from single misclick

## Linear Issue
Fixes EVE-146

## Test plan
- [ ] Click Archive on MCP server — confirmation dialog should appear
- [ ] Confirm archive — server should be archived
- [ ] Cancel archive — server should remain unchanged