### PR TITLE
fix(ui): refresh org dropdown after creating new org

### DIFF
--- a/apps/ui/src/__tests__/use-organizations.test.tsx
+++ b/apps/ui/src/__tests__/use-organizations.test.tsx
@@ -1,0 +1,163 @@
+import { renderHook, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { useCreateOrganization, useUpdateOrganization } from "@/hooks/use-organizations";
+import { authKeys } from "@/hooks/use-auth";
+import { queryKeys } from "@/lib/query-keys";
+
+jest.mock("@/lib/api/organizations", () => ({
+  createOrganization: jest.fn(),
+  getOrganization: jest.fn(),
+  updateOrganization: jest.fn(),
+}));
+
+const mockUseOrg = jest.fn();
+jest.mock("@/providers/org-provider", () => ({
+  useOrg: () => mockUseOrg(),
+}));
+
+import * as orgsApi from "@/lib/api/organizations";
+
+const mockCreateOrganization = orgsApi.createOrganization as jest.MockedFunction<
+  typeof orgsApi.createOrganization
+>;
+const mockUpdateOrganization = orgsApi.updateOrganization as jest.MockedFunction<
+  typeof orgsApi.updateOrganization
+>;
+
+describe("useCreateOrganization", () => {
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    jest.clearAllMocks();
+    mockUseOrg.mockReturnValue({
+      currentOrg: { public_id: "org-123", name: "Existing Org", role: "owner" },
+      isLoading: false,
+    });
+  });
+
+  it("invalidates auth user query after creating org", async () => {
+    const newOrg = { id: "org-456", name: "New Org" };
+    mockCreateOrganization.mockResolvedValueOnce(newOrg as never);
+
+    const invalidateSpy = jest.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreateOrganization(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: "New Org" });
+    });
+
+    // Must invalidate authKeys.user() so the sidebar org dropdown refreshes
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: authKeys.user() });
+  });
+
+  it("invalidates organizations query after creating org", async () => {
+    const newOrg = { id: "org-456", name: "New Org" };
+    mockCreateOrganization.mockResolvedValueOnce(newOrg as never);
+
+    const invalidateSpy = jest.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreateOrganization(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: "New Org" });
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.organizations.all });
+  });
+
+  it("awaits invalidation before resolving mutateAsync", async () => {
+    const newOrg = { id: "org-456", name: "New Org" };
+    mockCreateOrganization.mockResolvedValueOnce(newOrg as never);
+
+    // Track invalidation call order
+    const callOrder: string[] = [];
+    const originalInvalidate = queryClient.invalidateQueries.bind(queryClient);
+    jest.spyOn(queryClient, "invalidateQueries").mockImplementation(async (opts) => {
+      callOrder.push("invalidate");
+      return originalInvalidate(opts);
+    });
+
+    const { result } = renderHook(() => useCreateOrganization(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: "New Org" });
+      callOrder.push("resolved");
+    });
+
+    // Invalidation calls must happen before mutateAsync resolves
+    const invalidateIndices = callOrder
+      .map((c, i) => (c === "invalidate" ? i : -1))
+      .filter((i) => i >= 0);
+    const resolvedIndex = callOrder.indexOf("resolved");
+    for (const idx of invalidateIndices) {
+      expect(idx).toBeLessThan(resolvedIndex);
+    }
+  });
+});
+
+describe("useUpdateOrganization", () => {
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    jest.clearAllMocks();
+    mockUseOrg.mockReturnValue({
+      currentOrg: { public_id: "org-123", name: "Existing Org", role: "owner" },
+      isLoading: false,
+    });
+  });
+
+  it("invalidates auth user query after updating org", async () => {
+    const updatedOrg = { id: "org-123", name: "Updated Org" };
+    mockUpdateOrganization.mockResolvedValueOnce(updatedOrg as never);
+
+    const invalidateSpy = jest.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useUpdateOrganization(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: "Updated Org" });
+    });
+
+    // Must invalidate authKeys.user() so org dropdown reflects name changes
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: authKeys.user() });
+  });
+
+  it("invalidates org detail query after updating org", async () => {
+    const updatedOrg = { id: "org-123", name: "Updated Org" };
+    mockUpdateOrganization.mockResolvedValueOnce(updatedOrg as never);
+
+    const invalidateSpy = jest.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useUpdateOrganization(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: "Updated Org" });
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: queryKeys.organizations.detail("org-123"),
+    });
+  });
+});

--- a/apps/ui/src/hooks/use-organizations.ts
+++ b/apps/ui/src/hooks/use-organizations.ts
@@ -3,6 +3,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { createOrganization, getOrganization, updateOrganization } from "@/lib/api/organizations";
 import { queryKeys } from "@/lib/query-keys";
+import { authKeys } from "@/hooks/use-auth";
 import type { UpdateOrganizationRequest } from "@/lib/api/types";
 import { useOrg } from "@/providers/org-provider";
 
@@ -29,10 +30,17 @@ export function useCreateOrganization() {
 
   return useMutation({
     mutationFn: createOrganization,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.organizations.all });
-      // Refresh user's org list so the new org appears in the dropdown
-      queryClient.invalidateQueries({ queryKey: queryKeys.users.me() });
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.organizations.all }),
+        // Refresh user's org list so the new org appears in the sidebar dropdown.
+        // The org list is sourced from the auth user query (["auth", "user"]),
+        // not queryKeys.users.me, so we must invalidate authKeys.user().
+        // Awaiting ensures the org list is up-to-date before mutateAsync resolves,
+        // preventing race conditions where setCurrentOrg runs before the new org
+        // appears in the organizations array (which would reset to the old org).
+        queryClient.invalidateQueries({ queryKey: authKeys.user() }),
+      ]);
     },
   });
 }
@@ -51,8 +59,8 @@ export function useUpdateOrganization() {
           queryKey: queryKeys.organizations.detail(org),
         });
       }
-      // Also invalidate auth session to refresh user's org list
-      queryClient.invalidateQueries({ queryKey: queryKeys.users.me() });
+      // Refresh auth user query so the sidebar org dropdown reflects updates
+      queryClient.invalidateQueries({ queryKey: authKeys.user() });
     },
   });
 }


### PR DESCRIPTION
## Summary
- Fix org dropdown not refreshing after creating a new organisation
- Root cause: `useCreateOrganization` invalidated wrong query key (`queryKeys.users.me()` = `["user", "me"]`) instead of `authKeys.user()` (`["auth", "user"]`) which is the actual key used by the auth user query that supplies the org list
- Also `await` the invalidation in `onSuccess` so `mutateAsync` callers see fresh data before proceeding

## Linear Issue
Fixes EVE-143

## Test plan
- [x] Added `use-organizations.test.tsx` with 5 tests covering cache invalidation behavior
- [ ] Create new org — dropdown should show it immediately
- [ ] Verify existing orgs still display correctly
- [ ] Multiple rapid org creations — all should appear