### PR TITLE
fix(ui): fix schedule creation form silently failing

### DIFF
--- a/apps/ui/src/__tests__/schedules-list.test.tsx
+++ b/apps/ui/src/__tests__/schedules-list.test.tsx
@@ -490,6 +490,162 @@ describe("SchedulesPage", () => {
         expect(mockCreateMutate).toHaveBeenCalled();
       });
     });
+
+    it("sends correct request shape to API on submit", async () => {
+      const mockCreateMutate = jest.fn().mockResolvedValue({
+        id: "sched_new",
+        name: "My Schedule",
+      });
+      mockUseCreateSchedule.mockReturnValue({
+        mutateAsync: mockCreateMutate,
+        isPending: false,
+      });
+
+      render(<SchedulesPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole("button", { name: /New Schedule/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+
+      const nameInput = document.getElementById("name") as HTMLInputElement;
+      fireEvent.change(nameInput, { target: { value: "My Schedule" } });
+
+      const targetNameInput = document.getElementById("targetName") as HTMLInputElement;
+      fireEvent.change(targetNameInput, { target: { value: "my-workflow" } });
+
+      const submitButton = screen.getByRole("button", { name: /Create Schedule/i });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockCreateMutate).toHaveBeenCalledWith({
+          name: "My Schedule",
+          description: undefined,
+          cron_expression: "0 * * * * * *",
+          target: {
+            type: "workflow",
+            name: "my-workflow",
+            input: {},
+          },
+          enabled: true,
+        });
+      });
+    });
+
+    it("displays error message when schedule creation fails", async () => {
+      const mockCreateMutate = jest.fn().mockRejectedValue(
+        new Error("API Error: 400 Bad Request"),
+      );
+      mockUseCreateSchedule.mockReturnValue({
+        mutateAsync: mockCreateMutate,
+        isPending: false,
+      });
+
+      render(<SchedulesPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole("button", { name: /New Schedule/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+
+      const nameInput = document.getElementById("name") as HTMLInputElement;
+      fireEvent.change(nameInput, { target: { value: "Test Schedule" } });
+
+      const targetNameInput = document.getElementById("targetName") as HTMLInputElement;
+      fireEvent.change(targetNameInput, { target: { value: "test-workflow" } });
+
+      const submitButton = screen.getByRole("button", { name: /Create Schedule/i });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(screen.getByText("API Error: 400 Bad Request")).toBeInTheDocument();
+      });
+    });
+
+    it("displays error for invalid JSON in target input", async () => {
+      mockUseCreateSchedule.mockReturnValue({
+        mutateAsync: jest.fn(),
+        isPending: false,
+      });
+
+      render(<SchedulesPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole("button", { name: /New Schedule/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+
+      const nameInput = document.getElementById("name") as HTMLInputElement;
+      fireEvent.change(nameInput, { target: { value: "Test Schedule" } });
+
+      const targetNameInput = document.getElementById("targetName") as HTMLInputElement;
+      fireEvent.change(targetNameInput, { target: { value: "test-workflow" } });
+
+      const targetInputField = document.getElementById("targetInput") as HTMLTextAreaElement;
+      fireEvent.change(targetInputField, { target: { value: "not valid json" } });
+
+      const submitButton = screen.getByRole("button", { name: /Create Schedule/i });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(screen.getByText("Invalid JSON in target input")).toBeInTheDocument();
+      });
+    });
+
+    it("does not close dialog when creation fails", async () => {
+      const mockCreateMutate = jest.fn().mockRejectedValue(
+        new Error("Server error"),
+      );
+      mockUseCreateSchedule.mockReturnValue({
+        mutateAsync: mockCreateMutate,
+        isPending: false,
+      });
+
+      render(<SchedulesPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole("button", { name: /New Schedule/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+
+      const nameInput = document.getElementById("name") as HTMLInputElement;
+      fireEvent.change(nameInput, { target: { value: "Test Schedule" } });
+
+      const targetNameInput = document.getElementById("targetName") as HTMLInputElement;
+      fireEvent.change(targetNameInput, { target: { value: "test-workflow" } });
+
+      const submitButton = screen.getByRole("button", { name: /Create Schedule/i });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(screen.getByText("Server error")).toBeInTheDocument();
+      });
+
+      // Dialog should still be open
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    it("disables Cancel button while creation is pending", async () => {
+      mockUseCreateSchedule.mockReturnValue({
+        mutateAsync: jest.fn().mockImplementation(() => new Promise(() => {})),
+        isPending: true,
+      });
+
+      render(<SchedulesPage />, { wrapper });
+
+      fireEvent.click(screen.getByRole("button", { name: /New Schedule/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+
+      const cancelButton = screen.getByRole("button", { name: /Cancel/i });
+      expect(cancelButton).toBeDisabled();
+    });
   });
 
   // ============================================

--- a/apps/ui/src/__tests__/schedules-list.test.tsx
+++ b/apps/ui/src/__tests__/schedules-list.test.tsx
@@ -534,9 +534,7 @@ describe("SchedulesPage", () => {
     });
 
     it("displays error message when schedule creation fails", async () => {
-      const mockCreateMutate = jest.fn().mockRejectedValue(
-        new Error("API Error: 400 Bad Request"),
-      );
+      const mockCreateMutate = jest.fn().mockRejectedValue(new Error("API Error: 400 Bad Request"));
       mockUseCreateSchedule.mockReturnValue({
         mutateAsync: mockCreateMutate,
         isPending: false,
@@ -596,9 +594,7 @@ describe("SchedulesPage", () => {
     });
 
     it("does not close dialog when creation fails", async () => {
-      const mockCreateMutate = jest.fn().mockRejectedValue(
-        new Error("Server error"),
-      );
+      const mockCreateMutate = jest.fn().mockRejectedValue(new Error("Server error"));
       mockUseCreateSchedule.mockReturnValue({
         mutateAsync: mockCreateMutate,
         isPending: false,

--- a/apps/ui/src/app/(main)/durable/schedules/page.tsx
+++ b/apps/ui/src/app/(main)/durable/schedules/page.tsx
@@ -266,8 +266,7 @@ function CreateScheduleDialog({ onClose }: { onClose: () => void }) {
       await createMutation.mutateAsync(request);
       onClose();
     } catch (err) {
-      const message =
-        err instanceof Error ? err.message : "Failed to create schedule";
+      const message = err instanceof Error ? err.message : "Failed to create schedule";
       setErrorMessage(message);
     }
   };

--- a/apps/ui/src/app/(main)/durable/schedules/page.tsx
+++ b/apps/ui/src/app/(main)/durable/schedules/page.tsx
@@ -233,17 +233,20 @@ function CreateScheduleDialog({ onClose }: { onClose: () => void }) {
   const [targetName, setTargetName] = useState("");
   const [targetInput, setTargetInput] = useState("{}");
   const [enabled, setEnabled] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const createMutation = useCreateSchedule();
 
   const handleSubmit = async () => {
     if (!name || !cronExpression || !targetName) return;
 
+    setErrorMessage(null);
+
     let input: Record<string, unknown> = {};
     try {
       input = JSON.parse(targetInput);
     } catch {
-      alert("Invalid JSON in target input");
+      setErrorMessage("Invalid JSON in target input");
       return;
     }
 
@@ -263,7 +266,9 @@ function CreateScheduleDialog({ onClose }: { onClose: () => void }) {
       await createMutation.mutateAsync(request);
       onClose();
     } catch (err) {
-      console.error("Failed to create schedule:", err);
+      const message =
+        err instanceof Error ? err.message : "Failed to create schedule";
+      setErrorMessage(message);
     }
   };
 
@@ -346,8 +351,13 @@ function CreateScheduleDialog({ onClose }: { onClose: () => void }) {
           <Label htmlFor="enabled">Enable schedule immediately</Label>
         </div>
       </div>
+      {errorMessage && (
+        <div className="rounded-md bg-destructive/10 border border-destructive/20 p-3">
+          <p className="text-sm text-destructive">{errorMessage}</p>
+        </div>
+      )}
       <DialogFooter>
-        <Button variant="outline" onClick={onClose}>
+        <Button variant="outline" onClick={onClose} disabled={createMutation.isPending}>
           Cancel
         </Button>
         <Button


### PR DESCRIPTION
## Summary
- Fixed schedule creation dialog silently failing when submitting the form
- Added inline error message display in the create schedule dialog (replaces console-only error logging)
- Replaced `alert()` for JSON validation errors with inline error state
- Disabled Cancel button while mutation is pending to prevent accidental dismissal

## Linear Issue
Fixes EVE-149

## Test plan
- [ ] Create a new schedule via the UI dialog -- schedule should appear in list
- [ ] Submit form with invalid data -- error message should be displayed inline
- [ ] Verify existing schedules still display correctly
- [ ] Cancel button should be disabled while creation is in progress