### PR TITLE
feat(skills): add disable-model-invocation frontmatter field

### DIFF
--- a/crates/core/src/capabilities/attach_skill.rs
+++ b/crates/core/src/capabilities/attach_skill.rs
@@ -59,6 +59,9 @@ pub struct SkillMeta {
     /// Whether this skill appears as a /slash command for users
     #[serde(default = "default_true")]
     pub user_invocable: bool,
+    /// Whether the model is prevented from auto-invoking this skill
+    #[serde(default)]
+    pub disable_model_invocation: bool,
 }
 
 fn default_true() -> bool {
@@ -104,6 +107,8 @@ pub struct AttachSkillCapability {
     files: Vec<(String, String)>,
     /// Whether this skill is user-invocable as a /slash command
     user_invocable: bool,
+    /// Whether the model is prevented from auto-invoking this skill
+    disable_model_invocation: bool,
 }
 
 impl AttachSkillCapability {
@@ -118,7 +123,15 @@ impl AttachSkillCapability {
         instructions: String,
         files: Vec<(String, String)>,
     ) -> Self {
-        Self::from_registry_with_invocable(skill_id, name, description, instructions, files, true)
+        Self::from_registry_with_options(
+            skill_id,
+            name,
+            description,
+            instructions,
+            files,
+            true,
+            false,
+        )
     }
 
     pub fn from_registry_with_invocable(
@@ -129,8 +142,33 @@ impl AttachSkillCapability {
         files: Vec<(String, String)>,
         user_invocable: bool,
     ) -> Self {
-        let skill_md_content =
-            reconstruct_skill_md(&name, &description, &instructions, user_invocable);
+        Self::from_registry_with_options(
+            skill_id,
+            name,
+            description,
+            instructions,
+            files,
+            user_invocable,
+            false,
+        )
+    }
+
+    pub fn from_registry_with_options(
+        skill_id: Uuid,
+        name: String,
+        description: String,
+        instructions: String,
+        files: Vec<(String, String)>,
+        user_invocable: bool,
+        disable_model_invocation: bool,
+    ) -> Self {
+        let skill_md_content = reconstruct_skill_md(
+            &name,
+            &description,
+            &instructions,
+            user_invocable,
+            disable_model_invocation,
+        );
 
         Self {
             capability_id: skill_capability_id(skill_id),
@@ -139,6 +177,7 @@ impl AttachSkillCapability {
             skill_md_content,
             files,
             user_invocable,
+            disable_model_invocation,
         }
     }
 
@@ -150,6 +189,11 @@ impl AttachSkillCapability {
     /// Whether this skill is user-invocable as a /slash command
     pub fn user_invocable(&self) -> bool {
         self.user_invocable
+    }
+
+    /// Whether the model is prevented from auto-invoking this skill
+    pub fn disable_model_invocation(&self) -> bool {
+        self.disable_model_invocation
     }
 
     /// Build mount points for the skill directory.
@@ -217,6 +261,7 @@ fn reconstruct_skill_md(
     description: &str,
     instructions: &str,
     user_invocable: bool,
+    disable_model_invocation: bool,
 ) -> String {
     // Quote description to handle YAML-special characters (:, #, etc.)
     let safe_description = format!("\"{}\"", description.replace('"', "\\\""));
@@ -225,8 +270,13 @@ fn reconstruct_skill_md(
     } else {
         "user-invocable: false\n".to_string()
     };
+    let model_invocation_line = if disable_model_invocation {
+        "disable-model-invocation: true\n".to_string()
+    } else {
+        String::new()
+    };
     format!(
-        "---\nname: {name}\ndescription: {safe_description}\n{invocable_line}---\n\n{instructions}"
+        "---\nname: {name}\ndescription: {safe_description}\n{invocable_line}{model_invocation_line}---\n\n{instructions}"
     )
 }
 
@@ -247,6 +297,7 @@ pub fn discover_skills_from_entries(
                     description: parsed.description.clone(),
                     source: SkillSource::Filesystem { path: path.clone() },
                     user_invocable: parsed.user_invocable,
+                    disable_model_invocation: parsed.disable_model_invocation,
                 };
                 let instructions = SkillInstructions {
                     instructions: parsed.instructions,
@@ -437,6 +488,7 @@ mod tests {
             "A test skill",
             "# Instructions\nDo the thing.",
             true,
+            false,
         );
 
         // Should be parseable by parse_skill_md
@@ -454,6 +506,7 @@ mod tests {
             "Description with: colons and \"quotes\"",
             "# Body",
             true,
+            false,
         );
 
         let parsed = crate::skill::parse_skill_md(&content).unwrap();
@@ -466,11 +519,48 @@ mod tests {
 
     #[test]
     fn test_reconstruct_skill_md_not_invocable() {
-        let content = reconstruct_skill_md("bg-skill", "Background context", "# Body", false);
+        let content =
+            reconstruct_skill_md("bg-skill", "Background context", "# Body", false, false);
 
         let parsed = crate::skill::parse_skill_md(&content).unwrap();
         assert_eq!(parsed.name, "bg-skill");
         assert!(!parsed.user_invocable);
+    }
+
+    #[test]
+    fn test_reconstruct_skill_md_disable_model_invocation() {
+        let content = reconstruct_skill_md("manual-skill", "Manual only", "# Body", true, true);
+
+        let parsed = crate::skill::parse_skill_md(&content).unwrap();
+        assert_eq!(parsed.name, "manual-skill");
+        assert!(parsed.user_invocable);
+        assert!(parsed.disable_model_invocation);
+    }
+
+    #[test]
+    fn test_reconstruct_skill_md_both_flags() {
+        let content = reconstruct_skill_md("both-flags", "Both flags set", "# Body", false, true);
+
+        let parsed = crate::skill::parse_skill_md(&content).unwrap();
+        assert!(!parsed.user_invocable);
+        assert!(parsed.disable_model_invocation);
+    }
+
+    #[test]
+    fn test_attach_skill_with_disable_model_invocation() {
+        let skill_id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let cap = AttachSkillCapability::from_registry_with_options(
+            skill_id,
+            "manual-skill".to_string(),
+            "Manual only".to_string(),
+            "# Instructions".to_string(),
+            vec![],
+            true,
+            true,
+        );
+
+        assert_eq!(cap.name(), "manual-skill");
+        assert!(cap.user_invocable());
     }
 
     #[test]
@@ -494,6 +584,7 @@ mod tests {
                 skill_id: "abc".to_string(),
             },
             user_invocable: true,
+            disable_model_invocation: false,
         };
 
         let json = serde_json::to_string(&meta).unwrap();

--- a/crates/core/src/capabilities/skills.rs
+++ b/crates/core/src/capabilities/skills.rs
@@ -145,6 +145,7 @@ Skills are instruction packages (SKILL.md files) that teach the agent new abilit
                         parsed.name,
                         parsed.description,
                         parsed.user_invocable,
+                        parsed.disable_model_invocation,
                     ));
                 }
             }
@@ -153,10 +154,17 @@ Skills are instruction packages (SKILL.md files) that teach the agent new abilit
         let mut prompt = String::from(SKILLS_SYSTEM_PROMPT);
 
         if !discovered_skills.is_empty() {
-            let total = discovered_skills.len();
-            prompt.push_str("\n\nAvailable skills:\n");
-            for (name, description, user_invocable) in
-                discovered_skills.iter().take(MAX_SKILLS_IN_PROMPT)
+            // Filter out skills where disable_model_invocation is true
+            let model_visible_skills: Vec<_> = discovered_skills
+                .iter()
+                .filter(|(_, _, _, disable_model)| !disable_model)
+                .collect();
+            let total = model_visible_skills.len();
+            if total > 0 {
+                prompt.push_str("\n\nAvailable skills:\n");
+            }
+            for (name, description, user_invocable, _) in
+                model_visible_skills.iter().take(MAX_SKILLS_IN_PROMPT)
             {
                 let desc = truncate_description(description, MAX_DESCRIPTION_CHARS);
                 let invocable_hint = if *user_invocable { " (/{name})" } else { "" };
@@ -318,6 +326,7 @@ impl Tool for ListSkillsTool {
                             "path": workspace_path(&skill_md_path),
                             "version": parsed.version,
                             "user_invocable": parsed.user_invocable,
+                            "disable_model_invocation": parsed.disable_model_invocation,
                         }));
                     }
                     Err(errors) => {
@@ -1648,6 +1657,43 @@ mod tests {
             }
             other => panic!("Expected Success, got: {:?}", other),
         }
+    }
+
+    #[tokio::test]
+    async fn test_contribution_excludes_disable_model_invocation_skills() {
+        let cap = SkillsCapability;
+        let store = Arc::new(MockFileStore::new());
+        let session_id = SessionId::new();
+
+        // Normal skill
+        store.add_file(
+            session_id,
+            "/.agents/skills/normal-skill/SKILL.md",
+            &valid_skill_md("normal-skill", "A normal skill"),
+        );
+
+        // Skill with disable-model-invocation: true
+        store.add_file(
+            session_id,
+            "/.agents/skills/manual-skill/SKILL.md",
+            "---\nname: manual-skill\ndescription: Manual only skill\ndisable-model-invocation: true\n---\n\n# Instructions\nManual only.",
+        );
+
+        let ctx = SystemPromptContext {
+            session_id,
+            locale: None,
+            file_store: Some(store),
+        };
+
+        let result = cap.system_prompt_contribution(&ctx).await.unwrap();
+        assert!(
+            result.contains("normal-skill"),
+            "Normal skill should appear"
+        );
+        assert!(
+            !result.contains("manual-skill"),
+            "Skill with disable-model-invocation should not appear in system prompt"
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/skill.rs
+++ b/crates/core/src/skill.rs
@@ -102,6 +102,9 @@ pub struct Skill {
     /// Whether this skill appears as a /slash command for users
     #[serde(default = "default_true")]
     pub user_invocable: bool,
+    /// Whether the model is prevented from auto-invoking this skill
+    #[serde(default)]
+    pub disable_model_invocation: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -131,6 +134,8 @@ pub struct ParsedSkillMd {
     pub instructions: String,
     /// Whether this skill appears as a /slash command for users (default: true)
     pub user_invocable: bool,
+    /// Whether the model is prevented from auto-invoking this skill (default: false)
+    pub disable_model_invocation: bool,
 }
 
 /// YAML frontmatter structure
@@ -147,6 +152,9 @@ struct SkillFrontmatter {
     /// Whether this skill appears as a /slash command (default: true)
     #[serde(rename = "user-invocable", default = "default_true")]
     user_invocable: bool,
+    /// Whether the model is prevented from auto-invoking this skill (default: false)
+    #[serde(rename = "disable-model-invocation", default)]
+    disable_model_invocation: bool,
 }
 
 fn default_true() -> bool {
@@ -262,6 +270,7 @@ pub fn parse_skill_md(content: &str) -> Result<ParsedSkillMd, Vec<String>> {
         version,
         instructions: body,
         user_invocable: fm.user_invocable,
+        disable_model_invocation: fm.disable_model_invocation,
     })
 }
 
@@ -275,6 +284,13 @@ pub fn validate_skill_md(content: &str) -> SkillValidationResult {
                 warnings.push(format!(
                     "Instructions exceed 500 lines ({line_count} lines). Consider splitting into references."
                 ));
+            }
+            if !parsed.user_invocable && parsed.disable_model_invocation {
+                warnings.push(
+                    "Skill is unreachable: user-invocable is false and disable-model-invocation is true. \
+                     Neither users nor the model can invoke this skill."
+                        .to_string(),
+                );
             }
             SkillValidationResult {
                 valid: true,
@@ -517,6 +533,56 @@ Instructions.
 "#;
         let parsed = parse_skill_md(content).unwrap();
         assert!(!parsed.user_invocable);
+    }
+
+    #[test]
+    fn test_parse_disable_model_invocation_default_false() {
+        let content = r#"---
+name: my-skill
+description: A skill without disable-model-invocation field.
+---
+
+Instructions.
+"#;
+        let parsed = parse_skill_md(content).unwrap();
+        assert!(
+            !parsed.disable_model_invocation,
+            "disable_model_invocation should default to false"
+        );
+    }
+
+    #[test]
+    fn test_parse_disable_model_invocation_true() {
+        let content = r#"---
+name: manual-only
+description: A skill that cannot be auto-invoked by the model.
+disable-model-invocation: true
+---
+
+Instructions.
+"#;
+        let parsed = parse_skill_md(content).unwrap();
+        assert!(parsed.disable_model_invocation);
+        assert!(parsed.user_invocable); // default true
+    }
+
+    #[test]
+    fn test_validate_warns_unreachable_skill() {
+        let content = r#"---
+name: unreachable
+description: Neither user nor model can invoke.
+user-invocable: false
+disable-model-invocation: true
+---
+
+Instructions.
+"#;
+        let result = validate_skill_md(content);
+        assert!(result.valid);
+        assert!(
+            result.warnings.iter().any(|w| w.contains("unreachable")),
+            "Should warn about unreachable skill"
+        );
     }
 
     #[test]

--- a/crates/server/src/services/skill.rs
+++ b/crates/server/src/services/skill.rs
@@ -92,6 +92,12 @@ impl SkillService {
         if !parsed.user_invocable {
             metadata_map.insert("user_invocable".to_string(), serde_json::Value::Bool(false));
         }
+        if parsed.disable_model_invocation {
+            metadata_map.insert(
+                "disable_model_invocation".to_string(),
+                serde_json::Value::Bool(true),
+            );
+        }
         let metadata = serde_json::to_value(&metadata_map)?;
 
         let input = CreateSkillRow {
@@ -154,6 +160,12 @@ impl SkillService {
         let mut metadata_map = parsed.metadata.clone();
         if !parsed.user_invocable {
             metadata_map.insert("user_invocable".to_string(), serde_json::Value::Bool(false));
+        }
+        if parsed.disable_model_invocation {
+            metadata_map.insert(
+                "disable_model_invocation".to_string(),
+                serde_json::Value::Bool(true),
+            );
         }
         let metadata = serde_json::to_value(&metadata_map)?;
 
@@ -374,6 +386,12 @@ impl SkillService {
             .and_then(|v| v.as_bool())
             .unwrap_or(true);
 
+        // disable_model_invocation defaults to false; only true if explicitly set
+        let disable_model_invocation = metadata
+            .get("disable_model_invocation")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
         Skill {
             id: row.id,
             name: row.name.clone(),
@@ -386,6 +404,7 @@ impl SkillService {
             status: SkillStatus::from(row.status.as_str()),
             version: row.version.clone(),
             user_invocable,
+            disable_model_invocation,
             created_at: row.created_at,
             updated_at: row.updated_at,
             archived_at: row.archived_at,

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -7473,6 +7473,10 @@
                   "type": "string",
                   "example": "Extract text and tables from PDF files."
                 },
+                "disable_model_invocation": {
+                  "type": "boolean",
+                  "description": "Whether the model is prevented from auto-invoking this skill"
+                },
                 "id": {
                   "type": "string",
                   "example": "skill_01933b5a00007000800000000000001"
@@ -10020,6 +10024,10 @@
           "description": {
             "type": "string",
             "example": "Extract text and tables from PDF files."
+          },
+          "disable_model_invocation": {
+            "type": "boolean",
+            "description": "Whether the model is prevented from auto-invoking this skill"
           },
           "id": {
             "type": "string",

--- a/specs/skills-registry.md
+++ b/specs/skills-registry.md
@@ -28,7 +28,21 @@ description: What this skill does and when to use it.  # 1-1024 chars
 ---
 ```
 
-Optional frontmatter: `license`, `compatibility`, `metadata` (key-value map), `allowed-tools` (experimental), `user-invocable` (Everruns command visibility extension; see [`specs/commands.md`](./commands.md)).
+Optional frontmatter: `license`, `compatibility`, `metadata` (key-value map), `allowed-tools` (experimental), `user-invocable` (Everruns command visibility extension; see [`specs/commands.md`](./commands.md)), `disable-model-invocation` (prevents the model from auto-invoking the skill; see below).
+
+#### Invocation Control Fields
+
+Two independent boolean frontmatter fields control who can invoke a skill:
+
+| Frontmatter | User can invoke (/) | Model can invoke | In system prompt |
+|---|---|---|---|
+| *(defaults)* | Yes | Yes | Description listed |
+| `disable-model-invocation: true` | Yes | No | Description **not** listed |
+| `user-invocable: false` | No | Yes | Description listed |
+| Both set | No | No | **Unreachable** (validation warning) |
+
+- `user-invocable: false` — hides from `/` autocomplete menu (background knowledge only)
+- `disable-model-invocation: true` — prevents the model from seeing the skill in its system prompt, so it cannot auto-invoke it. The skill is still invocable via explicit `/name` slash command.
 
 **Progressive disclosure** is core to the design:
 1. **Discovery** (~100 tokens): Only name + description loaded at startup


### PR DESCRIPTION
## Summary
- Add `disable-model-invocation` boolean frontmatter field to SKILL.md
- Separates "hide from menu" (`user-invocable: false`) from "prevent model auto-invocation"
- Skills with `disable-model-invocation: true` are hidden from system prompt but still invocable via `/name`

## Changes
- Parse new field in `SkillFrontmatter` (default: false)
- Add to `ParsedSkillMd`, `Skill`, `SkillMeta`, `AttachSkillCapability`
- Filter skills with the flag from `system_prompt_contribution()`
- Store in metadata JSON alongside `user_invocable`
- Round-trip through `reconstruct_skill_md()`
- Validation warning if both `user-invocable: false` and `disable-model-invocation: true`
- Update `specs/skills-registry.md` with invocation control matrix

## Test plan
- [x] Unit tests for parsing `disable-model-invocation: true/false/default`
- [x] Validation test for unreachable skill warning
- [x] `reconstruct_skill_md` round-trip tests with new field
- [x] System prompt contribution excludes flagged skills
- [x] All 1144 core tests pass, all 741 server tests pass
- [x] `cargo fmt` and `cargo clippy -- -D warnings` clean

Fixes EVE-131