### PR TITLE
feat(skills): positional argument substitution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "euclid"
-version = "0.22.13"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df61bf483e837f88d5c2291dcf55c67be7e676b3a51acc48db3a7b163b91ed63"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
 ]
@@ -1337,6 +1337,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "regex",
  "reqwest 0.13.1",
  "rstest",
  "serde",
@@ -2621,9 +2622,9 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
  "darling",
  "indoc",
@@ -3013,6 +3014,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
 
 [[package]]
+name = "memo-map"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3061,10 +3068,11 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.17.1"
+version = "2.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea5ea1e90055f200af6b8e52a4a34e05e77e7fee953a9fb40c631efdc43cab1"
+checksum = "328251e58ad8e415be6198888fc207502727dc77945806421ab34f35bf012e7d"
 dependencies = [
+ "memo-map",
  "serde",
 ]
 
@@ -5629,32 +5637,32 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.0.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.4+spec-1.1.0"
+version = "0.25.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
 dependencies = [
  "indexmap",
  "toml_datetime",
  "toml_parser",
- "winnow 0.7.15",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.0.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
- "winnow 0.7.15",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -6921,9 +6929,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
 ]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -47,6 +47,9 @@ tracing-opentelemetry.workspace = true
 # Encoding
 base64.workspace = true
 
+# Regex for argument substitution
+regex.workspace = true
+
 # URL parsing
 url = "2"
 

--- a/crates/core/src/capabilities/skills.rs
+++ b/crates/core/src/capabilities/skills.rs
@@ -220,6 +220,10 @@ Skills are instruction packages (SKILL.md files) that teach the agent new abilit
                         "name": {
                             "type": "string",
                             "description": "The skill directory name (e.g., 'pdf-processing')"
+                        },
+                        "arguments": {
+                            "type": "string",
+                            "description": "Optional arguments to pass to the skill for $ARGUMENTS substitution"
                         }
                     },
                     "required": ["name"]
@@ -378,6 +382,10 @@ impl Tool for ActivateSkillFromVfsTool {
                 "name": {
                     "type": "string",
                     "description": "The skill directory name (e.g., 'pdf-processing')"
+                },
+                "arguments": {
+                    "type": "string",
+                    "description": "Optional arguments to pass to the skill for $ARGUMENTS substitution"
                 }
             },
             "required": ["name"]
@@ -405,6 +413,11 @@ impl Tool for ActivateSkillFromVfsTool {
                 return ToolExecutionResult::tool_error("Missing required parameter: name");
             }
         };
+
+        let skill_args = arguments
+            .get("arguments")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
 
         // Validate name (prevent path traversal)
         if name.contains("..") || name.contains('/') || name.contains('\\') {
@@ -447,10 +460,11 @@ impl Tool for ActivateSkillFromVfsTool {
         let content = file.content.as_deref().unwrap_or("");
         match crate::skill::parse_skill_md(content) {
             Ok(parsed) => {
-                let instructions = format!(
-                    "<skill name=\"{}\">\n{}\n</skill>",
-                    parsed.name, parsed.instructions
-                );
+                // Apply argument substitution
+                let expanded =
+                    crate::skill::expand_skill_arguments(&parsed.instructions, skill_args);
+                let instructions =
+                    format!("<skill name=\"{}\">\n{}\n</skill>", parsed.name, expanded);
 
                 // List bundled files in the skill directory
                 let skill_dir = format!("{}/{}", SKILLS_PATH, name);

--- a/crates/core/src/skill.rs
+++ b/crates/core/src/skill.rs
@@ -136,6 +136,8 @@ pub struct ParsedSkillMd {
     pub user_invocable: bool,
     /// Whether the model is prevented from auto-invoking this skill (default: false)
     pub disable_model_invocation: bool,
+    /// Hint string for autocomplete (e.g., "<issue-number>")
+    pub argument_hint: Option<String>,
 }
 
 /// YAML frontmatter structure
@@ -155,6 +157,9 @@ struct SkillFrontmatter {
     /// Whether the model is prevented from auto-invoking this skill (default: false)
     #[serde(rename = "disable-model-invocation", default)]
     disable_model_invocation: bool,
+    /// Hint string shown in autocomplete for expected arguments
+    #[serde(rename = "argument-hint")]
+    argument_hint: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -245,6 +250,12 @@ pub fn parse_skill_md(content: &str) -> Result<ParsedSkillMd, Vec<String>> {
         errors.push("compatibility: exceeds 500 character limit".to_string());
     }
 
+    if let Some(ref hint) = fm.argument_hint
+        && hint.len() > 128
+    {
+        errors.push("argument-hint: exceeds 128 character limit".to_string());
+    }
+
     if body.len() > 100 * 1024 {
         errors.push("instructions: exceeds 100 KB limit".to_string());
     }
@@ -271,6 +282,7 @@ pub fn parse_skill_md(content: &str) -> Result<ParsedSkillMd, Vec<String>> {
         instructions: body,
         user_invocable: fm.user_invocable,
         disable_model_invocation: fm.disable_model_invocation,
+        argument_hint: fm.argument_hint,
     })
 }
 
@@ -367,6 +379,113 @@ fn extract_frontmatter(content: &str) -> Result<(String, String), Vec<String>> {
     };
 
     Ok((frontmatter.to_string(), body))
+}
+
+// ============================================================================
+// Skill Argument Substitution
+// ============================================================================
+
+/// Split arguments respecting quoted strings.
+///
+/// Splits on whitespace, treating `"hello world"` or `'hello world'` as single tokens.
+/// Quotes are stripped from the result.
+fn split_skill_args(raw: &str) -> Vec<String> {
+    let mut args = Vec::new();
+    let mut current = String::new();
+    let mut in_quote: Option<char> = None;
+    for c in raw.chars() {
+        match (c, in_quote) {
+            ('"' | '\'', None) => in_quote = Some(c),
+            (q, Some(open)) if q == open => in_quote = None,
+            (c, Some(_)) => current.push(c),
+            (c, None) if c.is_whitespace() => {
+                if !current.is_empty() {
+                    args.push(std::mem::take(&mut current));
+                }
+            }
+            (c, None) => current.push(c),
+        }
+    }
+    if !current.is_empty() {
+        args.push(current);
+    }
+    args
+}
+
+/// Expand positional argument placeholders in skill content.
+///
+/// Substitution variables (processed in this order):
+/// 1. `$ARGUMENTS[N]` → Nth positional argument (0-based)
+/// 2. `$ARGUMENTS` → full argument string
+/// 3. `$N` (single digit 0-9) → shorthand for `$ARGUMENTS[N]`
+///
+/// If no placeholders are found and arguments are non-empty, appends `ARGUMENTS: <value>`.
+/// Out-of-bounds indices resolve to empty string.
+pub fn expand_skill_arguments(content: &str, raw_args: &str) -> String {
+    if raw_args.is_empty() {
+        return content.to_string();
+    }
+
+    let args = split_skill_args(raw_args);
+    let mut result = content.to_string();
+    let mut had_placeholder = false;
+
+    // 1. Replace $ARGUMENTS[N] (must be before $ARGUMENTS to avoid partial match)
+    let indexed_re = regex::Regex::new(r"\$ARGUMENTS\[([0-9]+)\]").unwrap();
+    if indexed_re.is_match(&result) {
+        had_placeholder = true;
+        result = indexed_re
+            .replace_all(&result, |caps: &regex::Captures| {
+                let idx: usize = caps[1].parse().unwrap_or(usize::MAX);
+                args.get(idx).cloned().unwrap_or_default()
+            })
+            .to_string();
+    }
+
+    // 2. Replace $ARGUMENTS (full string)
+    if result.contains("$ARGUMENTS") {
+        had_placeholder = true;
+        result = result.replace("$ARGUMENTS", raw_args);
+    }
+
+    // 3. Replace $N shorthand (single digit, not followed by word chars)
+    let chars: Vec<char> = result.chars().collect();
+    let mut new_result = String::with_capacity(result.len());
+    let mut found_shorthand = false;
+    let mut i = 0;
+
+    while i < chars.len() {
+        if chars[i] == '$' && i + 1 < chars.len() && chars[i + 1].is_ascii_digit() {
+            let digit = chars[i + 1];
+            let next_is_word = i + 2 < chars.len()
+                && (chars[i + 2].is_ascii_alphanumeric() || chars[i + 2] == '_');
+
+            if !next_is_word {
+                found_shorthand = true;
+                let idx = (digit as u8 - b'0') as usize;
+                new_result.push_str(args.get(idx).map(|s| s.as_str()).unwrap_or(""));
+            } else {
+                new_result.push('$');
+                new_result.push(digit);
+            }
+            i += 2;
+        } else {
+            new_result.push(chars[i]);
+            i += 1;
+        }
+    }
+
+    if found_shorthand {
+        had_placeholder = true;
+        result = new_result;
+    }
+
+    // Fallback: append if no placeholders found
+    if !had_placeholder {
+        result.push_str(&format!("\n\nARGUMENTS: {}", raw_args));
+    }
+
+    result
 }
 
 #[cfg(test)]
@@ -602,5 +721,126 @@ Instructions.
         assert_eq!(SkillSourceType::from("archive"), SkillSourceType::Archive);
         assert_eq!(SkillSourceType::from("markdown"), SkillSourceType::Markdown);
         assert_eq!(SkillSourceType::from("other"), SkillSourceType::Markdown);
+    }
+
+    #[test]
+    fn test_parse_argument_hint() {
+        let content = r#"---
+name: fix-issue
+description: Fix a GitHub issue.
+argument-hint: "<issue-number>"
+---
+
+Fix issue $ARGUMENTS.
+"#;
+        let parsed = parse_skill_md(content).unwrap();
+        assert_eq!(parsed.argument_hint.as_deref(), Some("<issue-number>"));
+    }
+
+    #[test]
+    fn test_parse_argument_hint_default_none() {
+        let content = r#"---
+name: my-skill
+description: A skill.
+---
+
+Body.
+"#;
+        let parsed = parse_skill_md(content).unwrap();
+        assert!(parsed.argument_hint.is_none());
+    }
+
+    // ========================================================================
+    // expand_skill_arguments tests
+    // ========================================================================
+
+    #[test]
+    fn test_expand_full_arguments() {
+        let content = "Process $ARGUMENTS now.";
+        let result = expand_skill_arguments(content, "SearchBar React");
+        assert_eq!(result, "Process SearchBar React now.");
+    }
+
+    #[test]
+    fn test_expand_indexed_arguments() {
+        let content = "Migrate $ARGUMENTS[0] from $ARGUMENTS[1] to $ARGUMENTS[2].";
+        let result = expand_skill_arguments(content, "SearchBar React Vue");
+        assert_eq!(result, "Migrate SearchBar from React to Vue.");
+    }
+
+    #[test]
+    fn test_expand_shorthand_arguments() {
+        let content = "Component: $0, from: $1, to: $2.";
+        let result = expand_skill_arguments(content, "SearchBar React Vue");
+        assert_eq!(result, "Component: SearchBar, from: React, to: Vue.");
+    }
+
+    #[test]
+    fn test_expand_quoted_arguments() {
+        let content = "File: $0, message: $1.";
+        let result = expand_skill_arguments(content, "app.js \"hello world\"");
+        assert_eq!(result, "File: app.js, message: hello world.");
+    }
+
+    #[test]
+    fn test_expand_out_of_bounds() {
+        let content = "A: $0, B: $1, C: $5.";
+        let result = expand_skill_arguments(content, "only-one");
+        assert_eq!(result, "A: only-one, B: , C: .");
+    }
+
+    #[test]
+    fn test_expand_no_placeholders_appends() {
+        let content = "Do the thing.";
+        let result = expand_skill_arguments(content, "some args");
+        assert_eq!(result, "Do the thing.\n\nARGUMENTS: some args");
+    }
+
+    #[test]
+    fn test_expand_empty_args() {
+        let content = "Content with $ARGUMENTS placeholder.";
+        let result = expand_skill_arguments(content, "");
+        assert_eq!(result, "Content with $ARGUMENTS placeholder.");
+    }
+
+    #[test]
+    fn test_expand_shorthand_no_word_collision() {
+        // $NAME should NOT be replaced (not $0-$9 pattern)
+        let content = "Variable $NAME and $0.";
+        let result = expand_skill_arguments(content, "first");
+        assert_eq!(result, "Variable $NAME and first.");
+    }
+
+    #[test]
+    fn test_expand_dollar_followed_by_multi_digit() {
+        // $10 should NOT match $1 + "0" — only single-digit shorthand
+        let content = "Value: $10 and $1.";
+        let result = expand_skill_arguments(content, "a b");
+        // $10 is not a valid shorthand (digit followed by digit), $1 = "b"
+        assert_eq!(result, "Value: $10 and b.");
+    }
+
+    #[test]
+    fn test_split_skill_args_basic() {
+        let args = split_skill_args("a b c");
+        assert_eq!(args, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn test_split_skill_args_quoted() {
+        let args = split_skill_args("\"hello world\" foo 'bar baz'");
+        assert_eq!(args, vec!["hello world", "foo", "bar baz"]);
+    }
+
+    #[test]
+    fn test_split_skill_args_empty() {
+        let args = split_skill_args("");
+        assert!(args.is_empty());
+    }
+
+    #[test]
+    fn test_split_skill_args_extra_whitespace() {
+        let args = split_skill_args("  a   b  ");
+        assert_eq!(args, vec!["a", "b"]);
     }
 }


### PR DESCRIPTION
## Summary
- Add positional argument substitution (`$ARGUMENTS[N]` / `$N`) to skill content
- Add `argument-hint` frontmatter field for autocomplete hints
- Integrate into `activate_skill` tool with optional `arguments` parameter

## Changes
- `expand_skill_arguments()` with quote-aware arg splitting in `skill.rs`
- `activate_skill` tool accepts optional `arguments` param and applies substitution
- Parse `argument-hint` in frontmatter (max 128 chars)
- Fallback: append `ARGUMENTS:` when no placeholders found

## Test plan
- [x] 14 unit tests covering all substitution patterns
- [x] Quoted args, out-of-bounds, shorthand collision, multi-digit
- [x] argument-hint parsing tests
- [x] All 1152 core tests pass
- [x] `cargo clippy -- -D warnings` clean

Fixes EVE-132