### PR TITLE
fix(ui): show harness names instead of raw IDs in settings dropdowns

### DIFF
--- a/apps/ui/src/components/harness/harness-select.tsx
+++ b/apps/ui/src/components/harness/harness-select.tsx
@@ -41,7 +41,11 @@ export function HarnessSelect({
     return new Map<string, Harness>(harnesses.map((h) => [h.id, h]));
   }, [harnesses]);
 
-  const displayValue = value ? harnessMap.get(value)?.name : undefined;
+  // Resolve ID → name. When harnesses haven't loaded yet (org switch race),
+  // show "Loading…" instead of the raw ID (EVE-142).
+  const displayValue = value
+    ? (harnessMap.get(value)?.name ?? (harnesses.length === 0 ? "Loading…" : value))
+    : undefined;
 
   return (
     <Select value={value} onValueChange={onValueChange} disabled={disabled}>


### PR DESCRIPTION
## Summary
- Fix race condition where harness dropdowns show raw IDs during org switch
- Show "Loading…" while harnesses are fetching instead of raw ID

## Changes
- `harness-select.tsx`: Resolve ID→name with loading fallback when harnesses havent loaded yet

## Test plan
- [x] Verified logic handles: no value (placeholder), value+loaded (name), value+loading ("Loading…")
- [x] UI-only change, no backend changes needed

Fixes EVE-142