### PR TITLE
fix(server): downgrade temporary debug logging in event service

### DIFF
--- a/crates/server/src/services/event.rs
+++ b/crates/server/src/services/event.rs
@@ -116,12 +116,12 @@ impl EventService {
         // Validate event type consistency
         Self::validate_event_type_consistency(&request)?;
 
-        // Log streaming/generation events at info level (temporary for debugging)
+        // Log high-frequency streaming/generation events at debug level
         if request.event_type == "output.message.started"
             || request.event_type == "output.message.delta"
             || request.event_type == "llm.generation"
         {
-            tracing::info!(
+            tracing::debug!(
                 session_id = %request.session_id,
                 event_type = %request.event_type,
                 "EventService: storing event"


### PR DESCRIPTION
## What
Downgrade high-frequency streaming/generation event logs from `info!` to `debug!` level in `EventService`. Update comment to remove "temporary for debugging" phrasing.

## Why
These logs (`output.message.started`, `output.message.delta`, `llm.generation`) fire on every streaming token and are too noisy at `info` level in production. They were originally added as temporary debugging aids (EVE-114).

## How
Single-line change: `tracing::info!` → `tracing::debug!` in `crates/server/src/services/event.rs:124`.

## Risk
- Low
- No functional behavior change. Only log verbosity affected.

## Checklist
- [x] Tests added or updated (n/a — log level change only)
- [x] Backward compatibility considered (n/a — internal logging)

Fixes EVE-114