### PR TITLE
fix(auth): resolve org cookie in no-auth mode for multi-org support

### DIFF
--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -343,7 +343,8 @@ impl ServerAppBuilder {
                 }
             }
         };
-        let auth_state = auth::AuthState::new(auth_config.clone(), auth_backend.clone());
+        let auth_state =
+            auth::AuthState::new(auth_config.clone(), auth_backend.clone()).with_db(db.clone());
         let feature_flags =
             everruns_core::FeatureFlags::from_env(&everruns_core::DeploymentGrade::from_env());
         let notifications_enabled = feature_flags.notifications;

--- a/crates/server/src/auth/middleware.rs
+++ b/crates/server/src/auth/middleware.rs
@@ -142,6 +142,10 @@ pub struct AuthState {
     /// Downstream consumers can inject a custom resolver to enforce billing-tier rules,
     /// database-backed grants, or external RBAC decisions.
     pub permission_resolver: Arc<dyn PermissionResolver>,
+    /// Storage backend for org lookups in no-auth mode.
+    /// In AuthMethod::None, the anonymous user only carries the default org,
+    /// so ResolvedOrg needs DB access to resolve the org cookie.
+    pub db: Option<Arc<StorageBackend>>,
 }
 
 impl AuthState {
@@ -150,6 +154,7 @@ impl AuthState {
             config,
             backend,
             permission_resolver: Arc::new(DefaultPermissionResolver),
+            db: None,
         }
     }
 
@@ -163,17 +168,28 @@ impl AuthState {
             config,
             backend,
             permission_resolver: resolver,
+            db: None,
         }
     }
 
     /// Convenience: create with built-in backend (OSS default)
     pub fn builtin(config: AuthConfig, db: Arc<StorageBackend>) -> Self {
-        let backend = Arc::new(super::builtin::BuiltinAuthBackend::new(config.clone(), db));
+        let backend = Arc::new(super::builtin::BuiltinAuthBackend::new(
+            config.clone(),
+            db.clone(),
+        ));
         Self {
             config,
             backend,
             permission_resolver: Arc::new(DefaultPermissionResolver),
+            db: Some(db),
         }
+    }
+
+    /// Set the storage backend (for org resolution in no-auth mode).
+    pub fn with_db(mut self, db: Arc<StorageBackend>) -> Self {
+        self.db = Some(db);
+        self
     }
 }
 
@@ -473,24 +489,51 @@ where
         let user = AuthUser::from_request_parts(parts, state).await?;
 
         match user.auth_method {
-            AuthMethod::ApiKey | AuthMethod::None => {
+            AuthMethod::ApiKey => {
                 // API key auth: user has exactly one org (from API key)
-                // None (anonymous): user has exactly one org (default org)
-                // In both cases, just use the single org - no cookie needed
                 let org = user
                     .organizations
                     .first()
                     .ok_or_else(|| AuthError::unauthorized("No organization available"))?;
-                let user_id = if user.auth_method == AuthMethod::None {
-                    None
-                } else {
-                    Some(user.id)
-                };
                 Ok(ResolvedOrg {
                     org_id: org.org_id,
                     public_id: org.public_id.clone(),
                     name: org.name.clone(),
-                    user_id,
+                    user_id: Some(user.id),
+                    role: org.role,
+                })
+            }
+            AuthMethod::None => {
+                // No-auth mode: anonymous user only carries the default org,
+                // but the user may have switched to a different org via cookie.
+                // Read the org cookie and resolve via DB if available.
+                let auth_state = AuthState::from_ref(state);
+                let jar = CookieJar::from_headers(&parts.headers);
+                let cookie_org_id = jar.get(ORG_COOKIE_NAME).map(|c| c.value().to_string());
+
+                if let (Some(org_public_id), Some(db)) = (&cookie_org_id, &auth_state.db)
+                    && validate_org_public_id(org_public_id)
+                    && let Ok(Some(org_row)) = db.get_organization_by_public_id(org_public_id).await
+                {
+                    return Ok(ResolvedOrg {
+                        org_id: org_row.org_id,
+                        public_id: org_row.public_id,
+                        name: org_row.name,
+                        user_id: None,
+                        role: OrgRole::Owner, // Anonymous user is owner of all orgs
+                    });
+                }
+
+                // Fall back to default org
+                let org = user
+                    .organizations
+                    .first()
+                    .ok_or_else(|| AuthError::unauthorized("No organization available"))?;
+                Ok(ResolvedOrg {
+                    org_id: org.org_id,
+                    public_id: org.public_id.clone(),
+                    name: org.name.clone(),
+                    user_id: None,
                     role: org.role,
                 })
             }


### PR DESCRIPTION
## Summary

- **Backend**: In dev/no-auth mode (`AuthMethod::None`), the `ResolvedOrg` extractor always returned the default org, ignoring the `everruns_org` cookie. After creating a new org and switching to it, all API calls (harnesses, settings, etc.) still returned data for the default org. Fixed by reading the org cookie and resolving via DB lookup, with fallback to the default org.
- **Frontend**: `HarnessSelect` showed raw harness IDs (e.g., `harness_019d...`) when the harnesses list hadn't loaded yet. Now shows "Loading..." during fetch.

## Test plan

- [x] Create a new org via Settings > Organisation > Create Organisation
- [x] Verify redirect to `/orgs/{orgId}/setup` with progress steps
- [x] Verify all 3 setup steps complete (org created, harnesses initialised, defaults configured)
- [x] Click "Go to dashboard" — lands on dashboard with new org selected
- [x] Navigate to Settings > Organisation — verify harness dropdowns show "Generic" and "Base" (not raw IDs)
- [x] Test error handling: navigate to `/orgs/org_nonexistent/setup` — shows "Organisation not found"
- [x] Direct navigation to setup page works correctly