### PR TITLE
fix(core): skip serializing default deferrable policy in tool types

### DIFF
--- a/crates/core/src/tool_types.rs
+++ b/crates/core/src/tool_types.rs
@@ -43,6 +43,13 @@ pub enum DeferrablePolicy {
     Always,
 }
 
+impl DeferrablePolicy {
+    /// Returns true when the value is the default (`Automatic`).
+    pub fn is_default(&self) -> bool {
+        matches!(self, DeferrablePolicy::Automatic)
+    }
+}
+
 /// Tool definition in agent configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
@@ -78,7 +85,7 @@ pub struct BuiltinTool {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub category: Option<String>,
     /// Whether this tool's schema can be deferred via tool_search
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "DeferrablePolicy::is_default")]
     pub deferrable: DeferrablePolicy,
 }
 
@@ -100,7 +107,7 @@ pub struct ClientSideTool {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub category: Option<String>,
     /// Whether this tool's schema can be deferred via tool_search
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "DeferrablePolicy::is_default")]
     pub deferrable: DeferrablePolicy,
 }
 


### PR DESCRIPTION
## What
Add `skip_serializing_if` for the `deferrable` field on `BuiltinTool` and `ClientSideTool` so the default `Automatic` value is omitted from serialized JSON.

## Why
The `deferrable` field was added with `#[serde(default)]` but no `skip_serializing_if`, causing serialization to always emit `"deferrable": "automatic"`. This broke the client-side tool JSON roundtrip test which expected the output to match input JSON (which omitted the field). Fixes EVE-78.

## How
- Added `DeferrablePolicy::is_default()` method
- Added `skip_serializing_if = "DeferrablePolicy::is_default"` to both structs
- Consistent with how other default-valued fields (`category`, `display_name`) are handled

## Risk
- Low
- Serialization output changes: default `deferrable` value no longer emitted. This is the correct behavior — consumers using `#[serde(default)]` on deserialization are unaffected.

## Checklist
- [x] Tests added or updated (existing roundtrip test now passes)
- [x] Backward compatibility considered (omitting default is backward-compatible)

Fixes EVE-78