### PR TITLE
fix(core): deduplicate ModelWithProvider type across crates

### DIFF
--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -14,7 +14,7 @@ use everruns_core::capabilities::{
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::events::{Event, EventRequest};
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
-use everruns_core::traits::ResolvedImage;
+use everruns_core::traits::{ModelWithProvider, ResolvedImage};
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId};
 use everruns_core::{
     Agent, AgentStatus, Caller, ContentPart, DriverRegistry, EventData, Harness, HarnessStatus,
@@ -23,7 +23,7 @@ use everruns_core::{
 };
 use everruns_worker::create_driver_registry;
 use everruns_worker::mcp_executor::McpServerInfo;
-use everruns_worker::worker_adapters::{ModelWithProvider, TurnContext, WorkerAdapters};
+use everruns_worker::worker_adapters::{TurnContext, WorkerAdapters};
 use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -11,7 +11,7 @@ use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::events::{Event, EventRequest};
 use everruns_core::leased_resource::LeasedResource;
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
-use everruns_core::traits::{AgentStore, ResolvedImage};
+use everruns_core::traits::{AgentStore, ModelWithProvider, ResolvedImage};
 use everruns_core::typed_id::{
     AgentId, HarnessId, LeasedResourceId, MessageId, ModelId, SessionId,
 };
@@ -27,7 +27,7 @@ use crate::grpc_adapters::{
     GrpcSessionSqlDbStore, GrpcSessionStorageStore, GrpcSessionStore,
 };
 use crate::mcp_executor::McpServerInfo;
-use crate::worker_adapters::{ModelWithProvider, TurnContext, WorkerAdapters};
+use crate::worker_adapters::{TurnContext, WorkerAdapters};
 
 // =============================================================================
 // GrpcWorkerAdapters Implementation
@@ -144,28 +144,16 @@ impl WorkerAdapters for GrpcWorkerAdapters {
         model_id: Uuid,
     ) -> Result<Option<ModelWithProvider>> {
         let store = GrpcLlmProviderStore::new(self.client.clone(), org_id);
-        let result = everruns_core::traits::LlmProviderStore::get_model_with_provider(
+        everruns_core::traits::LlmProviderStore::get_model_with_provider(
             &store,
             ModelId::from_uuid(model_id),
         )
-        .await?;
-        Ok(result.map(|m| ModelWithProvider {
-            model: m.model,
-            provider_type: m.provider_type,
-            api_key: m.api_key,
-            base_url: m.base_url,
-        }))
+        .await
     }
 
     async fn get_default_model(&self, org_id: i64) -> Result<Option<ModelWithProvider>> {
         let store = GrpcLlmProviderStore::new(self.client.clone(), org_id);
-        let result = everruns_core::traits::LlmProviderStore::get_default_model(&store).await?;
-        Ok(result.map(|m| ModelWithProvider {
-            model: m.model,
-            provider_type: m.provider_type,
-            api_key: m.api_key,
-            base_url: m.base_url,
-        }))
+        everruns_core::traits::LlmProviderStore::get_default_model(&store).await
     }
 
     // =========================================================================
@@ -307,12 +295,7 @@ impl WorkerAdapters for GrpcWorkerAdapters {
             agent: ctx.agent,
             session: ctx.session,
             messages: ctx.messages,
-            model: ctx.model.map(|m| ModelWithProvider {
-                model: m.model,
-                provider_type: m.provider_type,
-                api_key: m.api_key,
-                base_url: m.base_url,
-            }),
+            model: ctx.model,
             mcp_tool_definitions: ctx.mcp_tool_definitions,
         })
     }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -45,8 +45,7 @@ pub use grpc_worker_adapters::GrpcWorkerAdapters;
 pub use unified_worker::{TaskWorker, TaskWorkerConfig};
 pub use worker_adapters::{
     AdapterAgentStore, AdapterEventEmitter, AdapterLlmProviderStore, AdapterMessageRetriever,
-    AdapterSessionFileStore, AdapterSessionStore, ModelWithProvider as WorkerModelWithProvider,
-    TurnContext as WorkerTurnContext, WorkerAdapters,
+    AdapterSessionFileStore, AdapterSessionStore, TurnContext as WorkerTurnContext, WorkerAdapters,
 };
 
 // Re-export OpenAI driver from the openai crate

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -13,12 +13,12 @@ use everruns_core::error::Result;
 use everruns_core::events::{Event, EventRequest};
 use everruns_core::leased_resource::LeasedResource;
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
-use everruns_core::traits::{ImageResolver, LeasedResourceStore, ResolvedImage};
+use everruns_core::traits::{ImageResolver, LeasedResourceStore, ModelWithProvider, ResolvedImage};
 use everruns_core::typed_id::{
     AgentId, HarnessId, LeasedResourceId, MessageId, ModelId, SessionId,
 };
 use everruns_core::{
-    Agent, DriverRegistry, Harness, LlmProviderType, Message, Session, ToolDefinition, ToolRegistry,
+    Agent, DriverRegistry, Harness, Message, Session, ToolDefinition, ToolRegistry,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -290,15 +290,6 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
 // Supporting Types
 // =============================================================================
 
-/// Model with provider configuration
-#[derive(Debug, Clone)]
-pub struct ModelWithProvider {
-    pub model: String,
-    pub provider_type: LlmProviderType,
-    pub api_key: Option<String>,
-    pub base_url: Option<String>,
-}
-
 /// Turn context loaded in one batched call
 #[derive(Debug, Clone)]
 pub struct TurnContext {
@@ -437,27 +428,14 @@ impl<A: WorkerAdapters> everruns_core::traits::LlmProviderStore for AdapterLlmPr
     async fn get_model_with_provider(
         &self,
         model_id: ModelId,
-    ) -> Result<Option<everruns_core::traits::ModelWithProvider>> {
-        let result = self
-            .adapters
+    ) -> Result<Option<ModelWithProvider>> {
+        self.adapters
             .get_model_with_provider(self.org_id, model_id.uuid())
-            .await?;
-        Ok(result.map(|m| everruns_core::traits::ModelWithProvider {
-            model: m.model,
-            provider_type: m.provider_type,
-            api_key: m.api_key,
-            base_url: m.base_url,
-        }))
+            .await
     }
 
-    async fn get_default_model(&self) -> Result<Option<everruns_core::traits::ModelWithProvider>> {
-        let result = self.adapters.get_default_model(self.org_id).await?;
-        Ok(result.map(|m| everruns_core::traits::ModelWithProvider {
-            model: m.model,
-            provider_type: m.provider_type,
-            api_key: m.api_key,
-            base_url: m.base_url,
-        }))
+    async fn get_default_model(&self) -> Result<Option<ModelWithProvider>> {
+        self.adapters.get_default_model(self.org_id).await
     }
 }
 


### PR DESCRIPTION
## What
Remove the duplicate `ModelWithProvider` struct from the worker crate and use the core crate definition everywhere.

## Why
Identical `ModelWithProvider` was defined in both `crates/core/src/traits.rs` and `crates/worker/src/worker_adapters.rs`, with manual field-by-field conversions between them (EVE-104).

## How
- Removed duplicate struct from `worker_adapters.rs`
- Imported `ModelWithProvider` from `everruns_core::traits` in worker crate
- Replaced manual field-by-field conversions with direct pass-through in `AdapterLlmProviderStore`
- Updated imports in `grpc_worker_adapters.rs`
- Removed unnecessary re-export from `lib.rs`

Net: -54 lines, +14 lines.

## Risk
- Low
- Both structs were identical. Removing duplication and pass-through conversions. Compilation verifies correctness.

## Checklist
- [x] Tests added or updated (compilation proves type compatibility)
- [x] Backward compatibility considered (internal code, no public API change)

Fixes EVE-104