### PR TITLE
chore(shipping): require final review sweep before merge

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -47,6 +47,10 @@ Use this skill when the user asks to:
 6. The PR is mergeable and merged safely.
    - Push the branch.
    - Create or update the PR with `.github/pull_request_template.md`.
+   - Check the PR conversation, review threads, and review state from all reviewers, including bots.
+   - After each push and again after CI turns green, wait briefly for async reviewer bots to finish, then re-check for new comments before merge.
+   - Address actionable review comments with code or doc changes, or reply with the resolution when no code change is needed.
+   - Do not merge while substantive review feedback is still outstanding.
    - Wait for CI to go green.
    - Merge with squash only after green CI.
 
@@ -56,6 +60,7 @@ Use this skill when the user asks to:
 - Choose the highest-signal path first: targeted diff review, focused tests, relevant builds, then smoke tests if gaps remain.
 - "Fix and ship" means implement first, then switch into shipping mode.
 - Docs or config-only changes can skip code tests when you explain why and run the relevant docs, lint, or build proof.
+- Do not enable auto-merge until reviewer feedback is settled; async review bots can post after the last push or after CI turns green.
 - If `just fmt` can auto-fix a failing formatting check, use it once and retry.
 - Stop only for blockers you cannot safely resolve alone: merge conflicts, missing credentials, ambiguous product intent, or CI failures you cannot reproduce or fix.
 
@@ -79,5 +84,9 @@ Pick only what matches the changed surface:
 - In the PR body, explain what changed, why it changed, how it was validated, and notable risks or follow-ups.
 - Use `gh pr view --json url` to detect an existing PR.
 - Create a PR with `gh pr create` if needed.
+- Use `gh pr view --comments` to inspect the PR conversation, including bot comments.
+- Use `gh pr view --json reviews,latestReviews` to inspect reviewer state.
+- If review-thread status is unclear, inspect the review threads in the GitHub UI or via `gh api graphql` before merge.
+- After the final push and after CI is green, wait briefly for async reviewer bots, then do one last comment sweep before merge.
 - Use `gh pr checks` to watch CI.
-- Merge with `gh pr merge --squash --auto` only after CI is green.
+- Merge with `gh pr merge --squash` only after CI is green and the final review sweep is clean.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -48,11 +48,11 @@ Use this skill when the user asks to:
    - Push the branch.
    - Create or update the PR with `.github/pull_request_template.md`.
    - Check the PR conversation, review threads, and review state from all reviewers, including bots.
-   - After each push and again after CI turns green, wait briefly for async reviewer bots to finish, then re-check for new comments before merge.
+   - After each push and again after CI turns green, wait at least 2 minutes for async reviewer bots to finish, then re-check for new comments before merge.
    - Address actionable review comments with code or doc changes, or reply with the resolution when no code change is needed.
    - Do not merge while substantive review feedback is still outstanding.
    - Wait for CI to go green.
-   - Merge with squash only after green CI.
+   - Merge with squash only after CI is green and the final review/comment sweep above is clean.
 
 ## Operating Model
 
@@ -60,7 +60,7 @@ Use this skill when the user asks to:
 - Choose the highest-signal path first: targeted diff review, focused tests, relevant builds, then smoke tests if gaps remain.
 - "Fix and ship" means implement first, then switch into shipping mode.
 - Docs or config-only changes can skip code tests when you explain why and run the relevant docs, lint, or build proof.
-- Do not enable auto-merge until reviewer feedback is settled; async review bots can post after the last push or after CI turns green.
+- Do not use auto-merge or `gh pr merge --auto`; merge manually only after the final review sweep is clean because async review bots can post after the last push or after CI turns green.
 - If `just fmt` can auto-fix a failing formatting check, use it once and retry.
 - Stop only for blockers you cannot safely resolve alone: merge conflicts, missing credentials, ambiguous product intent, or CI failures you cannot reproduce or fix.
 
@@ -87,6 +87,6 @@ Pick only what matches the changed surface:
 - Use `gh pr view --comments` to inspect the PR conversation, including bot comments.
 - Use `gh pr view --json reviews,latestReviews` to inspect reviewer state.
 - If review-thread status is unclear, inspect the review threads in the GitHub UI or via `gh api graphql` before merge.
-- After the final push and after CI is green, wait briefly for async reviewer bots, then do one last comment sweep before merge.
+- After the final push and after CI is green, wait at least 2 minutes for async reviewer bots, then do one last comment sweep before merge.
 - Use `gh pr checks` to watch CI.
 - Merge with `gh pr merge --squash` only after CI is green and the final review sweep is clean.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,7 +230,7 @@ Use the smallest set that gives high confidence. `/ship` should pick from this m
 10. Capture UI screenshots for UI changes in validation or PR comments only
 11. Ensure test coverage proves the fix or acceptance criteria, including important negative paths
 12. Update relevant specs, docs, test cases, threat model, OpenAPI, and `AGENTS.md`
-13. Merge only with green CI and resolved PR comments
+13. Merge only with green CI and a final clean PR comment sweep, including async reviewer bots
 
 ### CI
 

--- a/specs/shipping.md
+++ b/specs/shipping.md
@@ -37,7 +37,7 @@ Relevant references:
 3. Merge-ready code: touched code is reviewed for avoidable complexity plus security and performance risk, and issues found during that review are addressed or explicitly blocked.
 4. Synced artifacts: only the affected artifacts are updated, including specs, threat model, docs, OpenAPI, test cases, and agent instructions when relevant.
 5. Smoke test impacted functionality: always smoke test the flows affected by the change end-to-end. This is mandatory, not conditional on risk assessment. Docs-only or config-only changes that do not affect runtime behavior may skip smoke testing with explicit justification.
-6. Safe merge: the PR uses the repo template, CI is green, review comments are resolved, and merge happens with squash only.
+6. Safe merge: the PR uses the repo template, CI is green, review comments from all reviewers, including async bot reviewers, are addressed after a final post-green sweep, and merge happens with squash only.
 
 ## Constraints
 
@@ -45,6 +45,7 @@ Relevant references:
 - Validation should start with the smallest high-signal proof and deepen only when risk or weak signals require it.
 - Bug fixes should prefer a failing test before the fix when practical, but the validation strategy may vary when a smaller or stronger proof exists.
 - Docs-only or config-only changes may skip code tests if that choice is justified and the relevant docs or build checks were run.
+- Auto-merge must not bypass the final review pass; shipping should give async reviewer bots time to comment after the last push and after CI turns green, then re-check before merge.
 - If a blocker cannot be resolved safely by the agent alone, shipping must stop and report the blocker rather than guess.
 
 ## Reporting Standard


### PR DESCRIPTION
## What
Extend `/ship` so merge requires a final review/comment sweep after CI is green, including async bot feedback. Sync the shipping spec and AGENTS guidance to match.

## Why
Reviewer bots can post after the last push or after CI turns green. The previous `/ship` guidance still allowed `gh pr merge --squash --auto`, which could merge before that feedback landed.

## How
Updated `.claude/skills/ship/SKILL.md` to require checking PR conversation, review threads, and reviewer state, to wait briefly after pushes and post-green CI for async bot feedback, and to merge with manual squash only after a clean final sweep.
Updated `specs/shipping.md` and `AGENTS.md` so repo guidance matches the skill.

## Risk
- Low
- Docs/instructions only. Main risk is slightly slower merges in exchange for safer review handling.

## Validation
- `just pre-push`
- Runtime smoke test skipped: no product/runtime code changed; this is shipping guidance only.

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered
