### PR TITLE
feat(anthropic): adopt model metadata from /v1/models API

### DIFF
--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -765,14 +765,18 @@ impl LlmDriver for AnthropicLlmDriver {
         let discovered: Vec<DiscoveredModel> = models_response
             .data
             .into_iter()
-            .map(|m| DiscoveredModel {
-                model_id: m.id,
-                display_name: Some(m.display_name),
-                created_at: m
-                    .created_at
-                    .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
-                    .map(|dt| dt.with_timezone(&chrono::Utc)),
-                owned_by: Some("anthropic".to_string()),
+            .map(|m| {
+                let profile = Some(m.to_discovered_profile());
+                DiscoveredModel {
+                    model_id: m.id,
+                    display_name: Some(m.display_name),
+                    created_at: m
+                        .created_at
+                        .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
+                        .map(|dt| dt.with_timezone(&chrono::Utc)),
+                    owned_by: Some("anthropic".to_string()),
+                    discovered_profile: profile,
+                }
             })
             .collect();
 
@@ -1120,6 +1124,9 @@ struct AnthropicModelsResponse {
 }
 
 /// Individual model info from Anthropic's models API
+///
+/// Includes structured capabilities and token limits returned by the
+/// `/v1/models` endpoint, used to build `LlmModelProfile` at discovery time.
 #[derive(Debug, Deserialize)]
 struct AnthropicModelInfo {
     /// Model identifier (e.g., "claude-opus-4-5-20251101")
@@ -1129,6 +1136,265 @@ struct AnthropicModelInfo {
     /// ISO 8601 timestamp when the model was created
     #[serde(default)]
     created_at: Option<String>,
+    /// Maximum input context window size in tokens
+    #[serde(default)]
+    max_input_tokens: Option<u32>,
+    /// Maximum output tokens
+    #[serde(default)]
+    max_tokens: Option<u32>,
+    /// Model capabilities
+    #[serde(default)]
+    capabilities: Option<AnthropicModelCapabilities>,
+}
+
+/// Capability support flag from Anthropic's models API
+#[derive(Debug, Deserialize, Default)]
+struct CapabilitySupport {
+    #[serde(default)]
+    supported: bool,
+}
+
+/// Effort capability with per-level support
+#[derive(Debug, Deserialize, Default)]
+struct EffortCapability {
+    #[serde(default)]
+    supported: bool,
+    #[serde(default)]
+    low: Option<CapabilitySupport>,
+    #[serde(default)]
+    medium: Option<CapabilitySupport>,
+    #[serde(default)]
+    high: Option<CapabilitySupport>,
+    #[serde(default)]
+    max: Option<CapabilitySupport>,
+}
+
+/// Thinking capability with type configurations
+#[derive(Debug, Deserialize, Default)]
+struct ThinkingCapability {
+    #[serde(default)]
+    supported: bool,
+    #[serde(default)]
+    types: Option<ThinkingTypes>,
+}
+
+/// Supported thinking type configurations
+#[derive(Debug, Deserialize, Default)]
+#[allow(dead_code)] // Fields deserialized from API; stored as metadata
+struct ThinkingTypes {
+    #[serde(default)]
+    enabled: Option<CapabilitySupport>,
+    #[serde(default)]
+    adaptive: Option<CapabilitySupport>,
+}
+
+/// Model capabilities from Anthropic's models API
+#[derive(Debug, Deserialize, Default)]
+#[allow(dead_code)] // Fields deserialized from API; not all used yet but stored as metadata
+struct AnthropicModelCapabilities {
+    #[serde(default)]
+    image_input: Option<CapabilitySupport>,
+    #[serde(default)]
+    pdf_input: Option<CapabilitySupport>,
+    #[serde(default)]
+    structured_outputs: Option<CapabilitySupport>,
+    #[serde(default)]
+    thinking: Option<ThinkingCapability>,
+    #[serde(default)]
+    effort: Option<EffortCapability>,
+    #[serde(default)]
+    citations: Option<CapabilitySupport>,
+    #[serde(default)]
+    code_execution: Option<CapabilitySupport>,
+    #[serde(default)]
+    batch: Option<CapabilitySupport>,
+}
+
+impl AnthropicModelInfo {
+    /// Build an `LlmModelProfile` from the API-provided metadata.
+    ///
+    /// This profile contains limits and capability flags discovered from the API.
+    /// Cost data is NOT available from the API and remains in hardcoded profiles.
+    fn to_discovered_profile(&self) -> everruns_core::llm_models::LlmModelProfile {
+        use everruns_core::llm_models::*;
+
+        let caps = self.capabilities.as_ref();
+
+        // Build token limits from API fields
+        let limits = match (self.max_input_tokens, self.max_tokens) {
+            (Some(input), Some(output)) => Some(LlmModelLimits {
+                context: input as i32,
+                input: None,
+                output: output as i32,
+                max_media: None,
+            }),
+            _ => None,
+        };
+
+        // Determine if model supports image input (implies attachment support)
+        let image_input = caps
+            .and_then(|c| c.image_input.as_ref())
+            .is_some_and(|c| c.supported);
+
+        // Build modalities from capabilities
+        let modalities = {
+            let mut input_mods = vec![Modality::Text];
+            if image_input {
+                input_mods.push(Modality::Image);
+            }
+            Some(LlmModelModalities {
+                input: input_mods,
+                output: vec![Modality::Text],
+            })
+        };
+
+        // Build reasoning effort config from thinking + effort capabilities
+        let reasoning = caps
+            .and_then(|c| c.thinking.as_ref())
+            .is_some_and(|t| t.supported);
+
+        let reasoning_effort = if reasoning {
+            self.build_reasoning_effort(caps)
+        } else {
+            None
+        };
+
+        let structured_output = caps
+            .and_then(|c| c.structured_outputs.as_ref())
+            .is_some_and(|c| c.supported);
+
+        LlmModelProfile {
+            name: self.display_name.clone(),
+            family: self.id.clone(),
+            release_date: self
+                .created_at
+                .as_ref()
+                .and_then(|s| s.get(..10))
+                .map(|s| s.to_string()),
+            last_updated: None,
+            attachment: image_input,
+            reasoning,
+            temperature: true, // All Claude models support temperature
+            knowledge: None,   // Not available from API
+            tool_call: true,   // All Claude models support tool use
+            structured_output,
+            open_weights: false,
+            cost: None, // Not available from API; hardcoded profiles provide this
+            limits,
+            modalities,
+            reasoning_effort,
+            tool_search: false,
+            supports_phases: false,
+        }
+    }
+
+    fn build_reasoning_effort(
+        &self,
+        caps: Option<&AnthropicModelCapabilities>,
+    ) -> Option<everruns_core::llm_models::ReasoningEffortConfig> {
+        use everruns_core::llm_models::*;
+
+        let thinking = caps?.thinking.as_ref()?;
+        if !thinking.supported {
+            return None;
+        }
+
+        let types = thinking.types.as_ref();
+        let supports_adaptive = types
+            .and_then(|t| t.adaptive.as_ref())
+            .is_some_and(|c| c.supported);
+
+        // Check effort capability for supported levels
+        let effort_cap = caps?.effort.as_ref();
+        let effort_supported = effort_cap.is_some_and(|e| e.supported);
+
+        if !effort_supported {
+            // Thinking supported but no effort levels — basic extended thinking
+            return Some(ReasoningEffortConfig {
+                values: vec![
+                    ReasoningEffortValue {
+                        value: ReasoningEffort::Low,
+                        name: "Low (1K tokens)".into(),
+                    },
+                    ReasoningEffortValue {
+                        value: ReasoningEffort::Medium,
+                        name: "Medium (4K tokens)".into(),
+                    },
+                    ReasoningEffortValue {
+                        value: ReasoningEffort::High,
+                        name: "High (16K tokens)".into(),
+                    },
+                    ReasoningEffortValue {
+                        value: ReasoningEffort::Xhigh,
+                        name: "Extra High (32K tokens)".into(),
+                    },
+                ],
+                default: ReasoningEffort::Medium,
+            });
+        }
+
+        // Build effort values from per-level support flags
+        let ec = effort_cap.unwrap();
+        let mut values = Vec::new();
+
+        if ec.low.as_ref().is_some_and(|c| c.supported) {
+            let name = if supports_adaptive {
+                "Low"
+            } else {
+                "Low (1K tokens)"
+            };
+            values.push(ReasoningEffortValue {
+                value: ReasoningEffort::Low,
+                name: name.into(),
+            });
+        }
+        if ec.medium.as_ref().is_some_and(|c| c.supported) {
+            let name = if supports_adaptive {
+                "Medium"
+            } else {
+                "Medium (4K tokens)"
+            };
+            values.push(ReasoningEffortValue {
+                value: ReasoningEffort::Medium,
+                name: name.into(),
+            });
+        }
+        if ec.high.as_ref().is_some_and(|c| c.supported) {
+            let name = if supports_adaptive {
+                "High"
+            } else {
+                "High (16K tokens)"
+            };
+            values.push(ReasoningEffortValue {
+                value: ReasoningEffort::High,
+                name: name.into(),
+            });
+        }
+        if ec.max.as_ref().is_some_and(|c| c.supported) {
+            let name = if supports_adaptive {
+                "Max"
+            } else {
+                "Extra High (32K tokens)"
+            };
+            values.push(ReasoningEffortValue {
+                value: ReasoningEffort::Xhigh,
+                name: name.into(),
+            });
+        }
+
+        if values.is_empty() {
+            return None;
+        }
+
+        // Default: High for adaptive, Medium for budget-based
+        let default = if supports_adaptive {
+            ReasoningEffort::High
+        } else {
+            ReasoningEffort::Medium
+        };
+
+        Some(ReasoningEffortConfig { values, default })
+    }
 }
 
 // ============================================================================

--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -1210,6 +1210,23 @@ struct AnthropicModelCapabilities {
     batch: Option<CapabilitySupport>,
 }
 
+/// Normalize Anthropic model ID to a family base name by stripping trailing
+/// date suffix (e.g., "claude-opus-4-5-20251101" -> "claude-opus-4-5").
+fn normalize_anthropic_id(model_id: &str) -> &str {
+    // Anthropic date suffixes are always -YYYYMMDD (8 digits after a dash)
+    if model_id.len() > 9 {
+        let suffix_start = model_id.len() - 9; // "-YYYYMMDD" is 9 chars
+        let (base, suffix) = model_id.split_at(suffix_start);
+        if suffix.starts_with('-')
+            && suffix[1..].len() == 8
+            && suffix[1..].chars().all(|c| c.is_ascii_digit())
+        {
+            return base;
+        }
+    }
+    model_id
+}
+
 impl AnthropicModelInfo {
     /// Build an `LlmModelProfile` from the API-provided metadata.
     ///
@@ -1231,10 +1248,14 @@ impl AnthropicModelInfo {
             _ => None,
         };
 
-        // Determine if model supports image input (implies attachment support)
+        // Determine if model supports image/PDF input (implies attachment support)
         let image_input = caps
             .and_then(|c| c.image_input.as_ref())
             .is_some_and(|c| c.supported);
+        let pdf_input = caps
+            .and_then(|c| c.pdf_input.as_ref())
+            .is_some_and(|c| c.supported);
+        let supports_attachments = image_input || pdf_input;
 
         // Build modalities from capabilities
         let modalities = {
@@ -1265,14 +1286,14 @@ impl AnthropicModelInfo {
 
         LlmModelProfile {
             name: self.display_name.clone(),
-            family: self.id.clone(),
+            family: normalize_anthropic_id(&self.id).to_string(),
             release_date: self
                 .created_at
                 .as_ref()
                 .and_then(|s| s.get(..10))
                 .map(|s| s.to_string()),
             last_updated: None,
-            attachment: image_input,
+            attachment: supports_attachments,
             reasoning,
             temperature: true, // All Claude models support temperature
             knowledge: None,   // Not available from API
@@ -1820,5 +1841,113 @@ mod tests {
             reqwest::StatusCode::BAD_REQUEST,
             error
         ));
+    }
+
+    // ========================================================================
+    // Model ID normalization tests
+    // ========================================================================
+
+    #[test]
+    fn test_normalize_anthropic_id_strips_date_suffix() {
+        assert_eq!(
+            normalize_anthropic_id("claude-opus-4-5-20251101"),
+            "claude-opus-4-5"
+        );
+        assert_eq!(
+            normalize_anthropic_id("claude-sonnet-4-6-20260217"),
+            "claude-sonnet-4-6"
+        );
+    }
+
+    #[test]
+    fn test_normalize_anthropic_id_preserves_base_ids() {
+        assert_eq!(normalize_anthropic_id("claude-opus-4-5"), "claude-opus-4-5");
+        assert_eq!(
+            normalize_anthropic_id("claude-3-5-sonnet"),
+            "claude-3-5-sonnet"
+        );
+    }
+
+    // ========================================================================
+    // Discovered profile construction tests
+    // ========================================================================
+
+    #[test]
+    fn test_to_discovered_profile_basic() {
+        let info = AnthropicModelInfo {
+            id: "claude-sonnet-4-6-20260217".into(),
+            display_name: "Claude Sonnet 4.6".into(),
+            created_at: Some("2026-02-17T00:00:00Z".into()),
+            max_input_tokens: Some(200_000),
+            max_tokens: Some(64_000),
+            capabilities: None,
+        };
+
+        let profile = info.to_discovered_profile();
+        assert_eq!(profile.name, "Claude Sonnet 4.6");
+        assert_eq!(profile.family, "claude-sonnet-4-6");
+        assert!(profile.limits.is_some());
+        let limits = profile.limits.unwrap();
+        assert_eq!(limits.context, 200_000);
+        assert_eq!(limits.output, 64_000);
+        assert!(profile.cost.is_none()); // Never from API
+    }
+
+    #[test]
+    fn test_to_discovered_profile_with_capabilities() {
+        let info = AnthropicModelInfo {
+            id: "claude-opus-4-6-20260205".into(),
+            display_name: "Claude Opus 4.6".into(),
+            created_at: None,
+            max_input_tokens: Some(1_000_000),
+            max_tokens: Some(128_000),
+            capabilities: Some(AnthropicModelCapabilities {
+                image_input: Some(CapabilitySupport { supported: true }),
+                pdf_input: Some(CapabilitySupport { supported: true }),
+                structured_outputs: Some(CapabilitySupport { supported: true }),
+                thinking: Some(ThinkingCapability {
+                    supported: true,
+                    types: Some(ThinkingTypes {
+                        enabled: Some(CapabilitySupport { supported: true }),
+                        adaptive: Some(CapabilitySupport { supported: true }),
+                    }),
+                }),
+                effort: Some(EffortCapability {
+                    supported: true,
+                    low: Some(CapabilitySupport { supported: true }),
+                    medium: Some(CapabilitySupport { supported: true }),
+                    high: Some(CapabilitySupport { supported: true }),
+                    max: Some(CapabilitySupport { supported: true }),
+                }),
+                ..Default::default()
+            }),
+        };
+
+        let profile = info.to_discovered_profile();
+        assert!(profile.attachment); // image + PDF
+        assert!(profile.reasoning);
+        assert!(profile.structured_output);
+        assert!(profile.reasoning_effort.is_some());
+        let effort = profile.reasoning_effort.unwrap();
+        assert_eq!(effort.values.len(), 4); // low, medium, high, max
+    }
+
+    #[test]
+    fn test_to_discovered_profile_pdf_only_is_attachment() {
+        let info = AnthropicModelInfo {
+            id: "claude-test".into(),
+            display_name: "Test".into(),
+            created_at: None,
+            max_input_tokens: None,
+            max_tokens: None,
+            capabilities: Some(AnthropicModelCapabilities {
+                image_input: Some(CapabilitySupport { supported: false }),
+                pdf_input: Some(CapabilitySupport { supported: true }),
+                ..Default::default()
+            }),
+        };
+
+        let profile = info.to_discovered_profile();
+        assert!(profile.attachment, "PDF-only should still be attachment");
     }
 }

--- a/crates/core/src/llm_driver_registry.rs
+++ b/crates/core/src/llm_driver_registry.rs
@@ -54,6 +54,12 @@ pub enum LlmStreamEvent {
 ///
 /// Represents a model available from a provider. Used for dynamic model discovery
 /// to sync available models from provider APIs into the database.
+///
+/// The `discovered_profile` field carries structured capability/limit metadata
+/// parsed from the provider's API response (e.g., Anthropic's capabilities object).
+/// During model sync, this profile is merged with hardcoded profiles: hardcoded
+/// values take precedence (they include cost data not available from APIs),
+/// but discovered data fills gaps for models without hardcoded profiles.
 #[derive(Debug, Clone)]
 pub struct DiscoveredModel {
     /// Model identifier (e.g., "gpt-5.2", "claude-opus-4-5-20251101")
@@ -64,6 +70,9 @@ pub struct DiscoveredModel {
     pub created_at: Option<DateTime<Utc>>,
     /// Owner or organization (e.g., "openai", "system")
     pub owned_by: Option<String>,
+    /// Structured profile built from provider API metadata (capabilities, limits).
+    /// Populated by drivers that return rich model metadata (e.g., Anthropic /v1/models).
+    pub discovered_profile: Option<crate::llm_models::LlmModelProfile>,
 }
 
 /// Metadata about LLM completion

--- a/crates/gemini/src/driver.rs
+++ b/crates/gemini/src/driver.rs
@@ -741,6 +741,7 @@ impl LlmDriver for GeminiLlmDriver {
                     display_name: Some(m.display_name),
                     created_at: None,
                     owned_by: Some("google".to_string()),
+                    discovered_profile: None,
                 }
             })
             .collect();

--- a/crates/openai/src/driver.rs
+++ b/crates/openai/src/driver.rs
@@ -300,6 +300,7 @@ async fn list_openai_models(
             display_name: None, // OpenAI doesn't provide display names
             created_at: chrono::Utc.timestamp_opt(m.created, 0).single(),
             owned_by: Some(m.owned_by),
+            discovered_profile: None,
         })
         .collect();
 

--- a/crates/server/src/services/llm_model.rs
+++ b/crates/server/src/services/llm_model.rs
@@ -11,8 +11,8 @@ use crate::storage::{
 };
 use anyhow::Result;
 use everruns_core::{
-    Caller, LlmModel, LlmModelSource, LlmModelStatus, LlmModelWithProvider, LlmProviderType,
-    Permission, Policy, Rule, get_model_profile,
+    Caller, LlmModel, LlmModelProfile, LlmModelSource, LlmModelStatus, LlmModelWithProvider,
+    LlmProviderType, Permission, Policy, Rule, get_model_profile,
 };
 use everruns_macros::policy;
 use std::sync::Arc;
@@ -314,8 +314,22 @@ impl LlmModelService {
         let provider_type: LlmProviderType =
             row.provider_type.parse().unwrap_or(LlmProviderType::Openai);
 
-        // Look up profile based on provider_type and model_id (readonly, not from DB)
-        let profile = get_model_profile(&provider_type, &row.model_id);
+        // Look up hardcoded profile, then try discovered profile from provider_metadata.
+        // Hardcoded profiles take precedence (they have cost data), but discovered
+        // profiles fill gaps for models without hardcoded entries.
+        let hardcoded = get_model_profile(&provider_type, &row.model_id);
+        let profile = if hardcoded.is_some() {
+            // Merge: hardcoded base with discovered limits/capabilities as fallback
+            let discovered = Self::extract_discovered_profile(row);
+            match (hardcoded, discovered) {
+                (Some(h), Some(d)) => Some(Self::merge_profiles(h, d)),
+                (Some(h), None) => Some(h),
+                _ => unreachable!(),
+            }
+        } else {
+            // No hardcoded profile — use discovered if available
+            Self::extract_discovered_profile(row)
+        };
 
         LlmModelWithProvider {
             id: row.id,
@@ -335,6 +349,39 @@ impl LlmModelService {
             provider_name: row.provider_name.clone(),
             provider_type,
             profile,
+        }
+    }
+
+    /// Extract the discovered profile from provider_metadata JSON.
+    fn extract_discovered_profile(row: &LlmModelWithProviderRow) -> Option<LlmModelProfile> {
+        let metadata = row.provider_metadata.as_ref()?;
+        let profile_val = metadata.get("discovered_profile")?;
+        serde_json::from_value(profile_val.clone()).ok()
+    }
+
+    /// Merge a hardcoded profile with a discovered profile.
+    /// Hardcoded values take precedence; discovered values fill gaps.
+    fn merge_profiles(hardcoded: LlmModelProfile, discovered: LlmModelProfile) -> LlmModelProfile {
+        LlmModelProfile {
+            // Hardcoded always wins for curated fields
+            name: hardcoded.name,
+            family: hardcoded.family,
+            release_date: hardcoded.release_date.or(discovered.release_date),
+            last_updated: hardcoded.last_updated.or(discovered.last_updated),
+            attachment: hardcoded.attachment,
+            reasoning: hardcoded.reasoning,
+            temperature: hardcoded.temperature,
+            knowledge: hardcoded.knowledge, // Not available from API
+            tool_call: hardcoded.tool_call,
+            structured_output: hardcoded.structured_output,
+            open_weights: hardcoded.open_weights,
+            cost: hardcoded.cost, // Never from API
+            // Limits: prefer hardcoded, fall back to discovered (API is authoritative for limits)
+            limits: hardcoded.limits.or(discovered.limits),
+            modalities: hardcoded.modalities.or(discovered.modalities),
+            reasoning_effort: hardcoded.reasoning_effort.or(discovered.reasoning_effort),
+            tool_search: hardcoded.tool_search,
+            supports_phases: hardcoded.supports_phases,
         }
     }
 }

--- a/crates/server/src/services/llm_model.rs
+++ b/crates/server/src/services/llm_model.rs
@@ -376,7 +376,7 @@ impl LlmModelService {
             structured_output: hardcoded.structured_output,
             open_weights: hardcoded.open_weights,
             cost: hardcoded.cost, // Never from API
-            // Limits: prefer hardcoded, fall back to discovered (API is authoritative for limits)
+            // Limits: hardcoded values are authoritative; use discovered values only as fallback
             limits: hardcoded.limits.or(discovered.limits),
             modalities: hardcoded.modalities.or(discovered.modalities),
             reasoning_effort: hardcoded.reasoning_effort.or(discovered.reasoning_effort),
@@ -447,5 +447,168 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(err.to_string(), "Provider not found");
+    }
+
+    // ========================================================================
+    // Profile merge tests
+    // ========================================================================
+
+    fn base_profile() -> LlmModelProfile {
+        LlmModelProfile {
+            name: "Test".into(),
+            family: "test".into(),
+            release_date: None,
+            last_updated: None,
+            attachment: true,
+            reasoning: false,
+            temperature: true,
+            knowledge: None,
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: None,
+            limits: None,
+            modalities: None,
+            reasoning_effort: None,
+            tool_search: false,
+            supports_phases: false,
+        }
+    }
+
+    #[test]
+    fn merge_hardcoded_wins_for_curated_fields() {
+        let hardcoded = LlmModelProfile {
+            name: "Hardcoded Name".into(),
+            family: "hardcoded-family".into(),
+            cost: Some(everruns_core::LlmModelCost {
+                input: 5.0,
+                output: 25.0,
+                cache_read: None,
+            }),
+            ..base_profile()
+        };
+        let discovered = LlmModelProfile {
+            name: "Discovered Name".into(),
+            family: "discovered-family".into(),
+            cost: None,
+            ..base_profile()
+        };
+
+        let merged = LlmModelService::merge_profiles(hardcoded, discovered);
+        assert_eq!(merged.name, "Hardcoded Name");
+        assert_eq!(merged.family, "hardcoded-family");
+        assert!(merged.cost.is_some());
+    }
+
+    #[test]
+    fn merge_discovered_fills_gaps() {
+        use everruns_core::llm_models::LlmModelLimits;
+
+        let hardcoded = LlmModelProfile {
+            limits: None,
+            ..base_profile()
+        };
+        let discovered = LlmModelProfile {
+            limits: Some(LlmModelLimits {
+                context: 200_000,
+                input: None,
+                output: 64_000,
+                max_media: None,
+            }),
+            ..base_profile()
+        };
+
+        let merged = LlmModelService::merge_profiles(hardcoded, discovered);
+        assert!(merged.limits.is_some());
+        assert_eq!(merged.limits.unwrap().context, 200_000);
+    }
+
+    #[test]
+    fn merge_hardcoded_limits_take_precedence() {
+        use everruns_core::llm_models::LlmModelLimits;
+
+        let hardcoded = LlmModelProfile {
+            limits: Some(LlmModelLimits {
+                context: 128_000,
+                input: None,
+                output: 16_384,
+                max_media: None,
+            }),
+            ..base_profile()
+        };
+        let discovered = LlmModelProfile {
+            limits: Some(LlmModelLimits {
+                context: 200_000,
+                input: None,
+                output: 64_000,
+                max_media: None,
+            }),
+            ..base_profile()
+        };
+
+        let merged = LlmModelService::merge_profiles(hardcoded, discovered);
+        assert_eq!(merged.limits.unwrap().context, 128_000);
+    }
+
+    #[test]
+    fn extract_discovered_profile_from_metadata() {
+        use crate::storage::models::LlmModelWithProviderRow;
+        use chrono::Utc;
+
+        let profile = base_profile();
+        let metadata = serde_json::json!({
+            "discovered_profile": profile,
+        });
+
+        let row = LlmModelWithProviderRow {
+            id: everruns_core::ModelId::new(),
+            org_id: 1,
+            provider_id: everruns_core::ProviderId::new(),
+            model_id: "test-model".into(),
+            display_name: "Test".into(),
+            capabilities: serde_json::json!([]),
+            is_favorite: false,
+            installed: true,
+            status: "active".into(),
+            source: "discovered".into(),
+            last_seen_at: None,
+            provider_metadata: Some(metadata),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            provider_name: "TestProvider".into(),
+            provider_type: "anthropic".into(),
+        };
+
+        let extracted = LlmModelService::extract_discovered_profile(&row);
+        assert!(extracted.is_some());
+        assert_eq!(extracted.unwrap().name, "Test");
+    }
+
+    #[test]
+    fn extract_discovered_profile_returns_none_without_metadata() {
+        use crate::storage::models::LlmModelWithProviderRow;
+        use chrono::Utc;
+
+        let row = LlmModelWithProviderRow {
+            id: everruns_core::ModelId::new(),
+            org_id: 1,
+            provider_id: everruns_core::ProviderId::new(),
+            model_id: "test-model".into(),
+            display_name: "Test".into(),
+            capabilities: serde_json::json!([]),
+            is_favorite: false,
+            installed: true,
+            status: "active".into(),
+            source: "manual".into(),
+            last_seen_at: None,
+            provider_metadata: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            provider_name: "TestProvider".into(),
+            provider_type: "openai".into(),
+        };
+
+        let extracted = LlmModelService::extract_discovered_profile(&row);
+        assert!(extracted.is_none());
     }
 }

--- a/crates/server/src/services/model_sync.rs
+++ b/crates/server/src/services/model_sync.rs
@@ -206,11 +206,12 @@ impl ModelSyncService {
         for model in discovered {
             seen_model_ids.insert(model.model_id.clone());
 
-            // Build provider metadata
+            // Build provider metadata (includes discovered_profile when available)
             let metadata = serde_json::json!({
                 "display_name": model.display_name,
                 "created_at": model.created_at,
                 "owned_by": model.owned_by,
+                "discovered_profile": model.discovered_profile,
             });
 
             if existing_ids.contains(model.model_id.as_str()) {


### PR DESCRIPTION
## Summary

- Parse rich metadata from Anthropic `/v1/models` endpoint: `max_input_tokens`, `max_tokens`, and `capabilities` (thinking, effort levels, image_input, structured_outputs, citations, code_execution, batch)
- Add `discovered_profile` field to `DiscoveredModel` so drivers can pass structured metadata through model sync
- Build `LlmModelProfile` from Anthropic API response at discovery time, eliminating the need for hardcoded profiles for new models
- Merge discovered profiles with hardcoded profiles in `LlmModelService` — hardcoded values take precedence (they include cost data not available from APIs), discovered values fill gaps

This means newly released Claude models will automatically get correct token limits and capability flags without requiring a code change to `llm_model_profiles.rs`.

## Test plan

- [x] All 24 existing `everruns-anthropic` tests pass
- [x] `just pre-push` passes (fmt, clippy, lockfile)
- [ ] CI green
- [ ] Smoke test: trigger model sync for Anthropic provider, verify discovered models have profiles with limits and capabilities populated