### PR TITLE
feat(skills): add context: fork and agent frontmatter fields

### DIFF
--- a/crates/core/src/capabilities/skills.rs
+++ b/crates/core/src/capabilities/skills.rs
@@ -491,6 +491,13 @@ impl Tool for ActivateSkillFromVfsTool {
                     "description": parsed.description,
                 });
 
+                // Include context and agent fields for fork-mode skills
+                if parsed.context == crate::skill::SkillContext::Fork {
+                    result["context"] = serde_json::json!("fork");
+                    result["agent"] =
+                        serde_json::json!(parsed.agent.as_deref().unwrap_or("general-purpose"));
+                }
+
                 if !bundled_files.is_empty() {
                     result["bundled_files"] = serde_json::json!(bundled_files);
                 }
@@ -1126,6 +1133,87 @@ mod tests {
                 let paths: Vec<&str> = bundled.iter().map(|f| f.as_str().unwrap()).collect();
                 assert!(paths.contains(&"/workspace/.agents/skills/data-tool/README.md"));
                 // scripts/run.py is nested so won't be a direct child
+            }
+            other => panic!("Expected Success, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_activate_skill_with_context_fork() {
+        let fs = Arc::new(MockFileStore::new());
+        let session_id = SessionId::new();
+        fs.add_file(
+            session_id,
+            "/.agents/skills/research/SKILL.md",
+            "---\nname: research\ndescription: Deep research.\ncontext: fork\nagent: Explore\n---\n\nResearch the topic.",
+        );
+
+        let context = ToolContext::with_file_store(session_id, fs);
+        let tool = ActivateSkillFromVfsTool;
+
+        let result = tool
+            .execute_with_context(serde_json::json!({"name": "research"}), &context)
+            .await;
+        match result {
+            ToolExecutionResult::Success(val) => {
+                assert_eq!(val["skill"], "research");
+                assert_eq!(val["context"], "fork");
+                assert_eq!(val["agent"], "Explore");
+                // Instructions are still included (caller decides how to use them)
+                let instructions = val["instructions"].as_str().unwrap();
+                assert!(instructions.contains("Research the topic"));
+            }
+            other => panic!("Expected Success, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_activate_skill_fork_default_agent() {
+        let fs = Arc::new(MockFileStore::new());
+        let session_id = SessionId::new();
+        fs.add_file(
+            session_id,
+            "/.agents/skills/analyze/SKILL.md",
+            "---\nname: analyze\ndescription: Analyze code.\ncontext: fork\n---\n\nAnalyze the code.",
+        );
+
+        let context = ToolContext::with_file_store(session_id, fs);
+        let tool = ActivateSkillFromVfsTool;
+
+        let result = tool
+            .execute_with_context(serde_json::json!({"name": "analyze"}), &context)
+            .await;
+        match result {
+            ToolExecutionResult::Success(val) => {
+                assert_eq!(val["context"], "fork");
+                assert_eq!(val["agent"], "general-purpose");
+            }
+            other => panic!("Expected Success, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_activate_skill_inline_no_context_field() {
+        let fs = Arc::new(MockFileStore::new());
+        let session_id = SessionId::new();
+        fs.add_file(
+            session_id,
+            "/.agents/skills/inline-skill/SKILL.md",
+            &valid_skill_md("inline-skill", "An inline skill"),
+        );
+
+        let context = ToolContext::with_file_store(session_id, fs);
+        let tool = ActivateSkillFromVfsTool;
+
+        let result = tool
+            .execute_with_context(serde_json::json!({"name": "inline-skill"}), &context)
+            .await;
+        match result {
+            ToolExecutionResult::Success(val) => {
+                assert_eq!(val["skill"], "inline-skill");
+                // No context or agent fields for inline skills
+                assert!(val.get("context").is_none());
+                assert!(val.get("agent").is_none());
             }
             other => panic!("Expected Success, got: {:?}", other),
         }

--- a/crates/core/src/skill.rs
+++ b/crates/core/src/skill.rs
@@ -114,6 +114,30 @@ pub struct Skill {
     pub deleted_at: Option<DateTime<Utc>>,
 }
 
+/// Skill execution context mode.
+///
+/// Determines whether the skill runs inline in the current session
+/// or in an isolated subagent context.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[derive(Default)]
+pub enum SkillContext {
+    /// Run inline in the current session (default)
+    #[default]
+    Inline,
+    /// Run in an isolated subagent session
+    Fork,
+}
+
+impl std::fmt::Display for SkillContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SkillContext::Inline => write!(f, "inline"),
+            SkillContext::Fork => write!(f, "fork"),
+        }
+    }
+}
+
 /// Parsed SKILL.md content
 #[derive(Debug, Clone)]
 pub struct ParsedSkillMd {
@@ -139,6 +163,10 @@ pub struct ParsedSkillMd {
     pub disable_model_invocation: bool,
     /// Hint string for autocomplete (e.g., "<issue-number>")
     pub argument_hint: Option<String>,
+    /// Execution context: inline (default) or fork (subagent)
+    pub context: SkillContext,
+    /// Subagent type when context is fork (e.g., "Explore", "Plan"). Default: "general-purpose"
+    pub agent: Option<String>,
 }
 
 /// YAML frontmatter structure
@@ -161,6 +189,10 @@ struct SkillFrontmatter {
     /// Hint string shown in autocomplete for expected arguments
     #[serde(rename = "argument-hint")]
     argument_hint: Option<String>,
+    /// Execution context: "fork" runs in isolated subagent, absent/other = inline
+    context: Option<String>,
+    /// Subagent type when context is fork (e.g., "Explore", "Plan")
+    agent: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -257,6 +289,23 @@ pub fn parse_skill_md(content: &str) -> Result<ParsedSkillMd, Vec<String>> {
         errors.push("argument-hint: exceeds 128 character limit".to_string());
     }
 
+    // Parse context field
+    let context = match fm.context.as_deref() {
+        Some("fork") => SkillContext::Fork,
+        Some("inline") | None => SkillContext::Inline,
+        Some(other) => {
+            errors.push(format!(
+                "context: invalid value \"{other}\", must be \"fork\" or \"inline\""
+            ));
+            SkillContext::Inline
+        }
+    };
+
+    // Validate agent field only meaningful with context: fork
+    if fm.agent.is_some() && context != SkillContext::Fork {
+        errors.push("agent: field is only meaningful when context is \"fork\"".to_string());
+    }
+
     if body.len() > 100 * 1024 {
         errors.push("instructions: exceeds 100 KB limit".to_string());
     }
@@ -284,6 +333,8 @@ pub fn parse_skill_md(content: &str) -> Result<ParsedSkillMd, Vec<String>> {
         user_invocable: fm.user_invocable,
         disable_model_invocation: fm.disable_model_invocation,
         argument_hint: fm.argument_hint,
+        context,
+        agent: fm.agent,
     })
 }
 
@@ -302,6 +353,12 @@ pub fn validate_skill_md(content: &str) -> SkillValidationResult {
                 warnings.push(
                     "Skill is unreachable: user-invocable is false and disable-model-invocation is true. \
                      Neither users nor the model can invoke this skill."
+                        .to_string(),
+                );
+            }
+            if parsed.context == SkillContext::Fork && parsed.agent.is_none() {
+                warnings.push(
+                    "context: fork without agent field — will use default \"general-purpose\" agent."
                         .to_string(),
                 );
             }
@@ -879,6 +936,131 @@ Body.
 "#;
         let parsed = parse_skill_md(content).unwrap();
         assert!(parsed.argument_hint.is_none());
+    }
+
+    // ========================================================================
+    // context and agent frontmatter tests
+    // ========================================================================
+
+    #[test]
+    fn test_parse_context_fork() {
+        let content = r#"---
+name: deep-research
+description: Research a topic thoroughly.
+context: fork
+---
+
+Research $ARGUMENTS.
+"#;
+        let parsed = parse_skill_md(content).unwrap();
+        assert_eq!(parsed.context, SkillContext::Fork);
+        assert!(parsed.agent.is_none());
+    }
+
+    #[test]
+    fn test_parse_context_fork_with_agent() {
+        let content = r#"---
+name: explore-code
+description: Explore codebase.
+context: fork
+agent: Explore
+---
+
+Explore $ARGUMENTS.
+"#;
+        let parsed = parse_skill_md(content).unwrap();
+        assert_eq!(parsed.context, SkillContext::Fork);
+        assert_eq!(parsed.agent.as_deref(), Some("Explore"));
+    }
+
+    #[test]
+    fn test_parse_context_inline_explicit() {
+        let content = r#"---
+name: my-skill
+description: A skill.
+context: inline
+---
+
+Body.
+"#;
+        let parsed = parse_skill_md(content).unwrap();
+        assert_eq!(parsed.context, SkillContext::Inline);
+    }
+
+    #[test]
+    fn test_parse_context_default_inline() {
+        let content = r#"---
+name: my-skill
+description: A skill.
+---
+
+Body.
+"#;
+        let parsed = parse_skill_md(content).unwrap();
+        assert_eq!(parsed.context, SkillContext::Inline);
+        assert!(parsed.agent.is_none());
+    }
+
+    #[test]
+    fn test_parse_context_invalid_value() {
+        let content = r#"---
+name: my-skill
+description: A skill.
+context: parallel
+---
+
+Body.
+"#;
+        let err = parse_skill_md(content).unwrap_err();
+        assert!(err.iter().any(|e| e.contains("context: invalid value")));
+    }
+
+    #[test]
+    fn test_parse_agent_without_fork_is_error() {
+        let content = r#"---
+name: my-skill
+description: A skill.
+agent: Explore
+---
+
+Body.
+"#;
+        let err = parse_skill_md(content).unwrap_err();
+        assert!(
+            err.iter()
+                .any(|e| e.contains("agent: field is only meaningful"))
+        );
+    }
+
+    #[test]
+    fn test_validate_warns_fork_without_agent() {
+        let content = r#"---
+name: my-skill
+description: A skill.
+context: fork
+---
+
+Body.
+"#;
+        let result = validate_skill_md(content);
+        assert!(result.valid);
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("general-purpose"))
+        );
+    }
+
+    #[test]
+    fn test_skill_context_display() {
+        assert_eq!(SkillContext::Inline.to_string(), "inline");
+        assert_eq!(SkillContext::Fork.to_string(), "fork");
+    }
+
+    #[test]
+    fn test_skill_context_default() {
+        assert_eq!(SkillContext::default(), SkillContext::Inline);
     }
 
     // ========================================================================


### PR DESCRIPTION
## What
Add `context: fork` and `agent` frontmatter fields to SKILL.md. Fork-mode skills declare they should run in an isolated subagent session rather than inline.

## Why
Some skills (research, analysis, code review) benefit from running in isolation — they don't need conversation history, shouldn't pollute the main context, and can use a specialized agent type. This enables the pattern used by Claude Code's subagent system.

Fixes EVE-137

## How
- Added `SkillContext` enum (`Inline` / `Fork`) in `crates/core/src/skill.rs`
- Added `context` and `agent` fields to `ParsedSkillMd` and `SkillFrontmatter`
- Parser validates: `context` must be "fork" or "inline", `agent` is only valid with `context: fork`
- Validation warns when `context: fork` without explicit `agent` (defaults to "general-purpose")
- Skill activation includes `context` and `agent` in result for fork-mode skills, enabling the harness to spawn the appropriate subagent

## Risk
- Low
- Additive: new optional frontmatter fields, existing skills unaffected
- No behavior change for inline skills (the default)

## Checklist
- [x] Tests added or updated (10 new parser tests + 3 activation tests)
- [x] Backward compatibility considered (fully backward compatible)