### PR TITLE
chore(maintenance): review stale in-progress linear issues

### DIFF
--- a/.claude/skills/maintenance/SKILL.md
+++ b/.claude/skills/maintenance/SKILL.md
@@ -43,7 +43,7 @@ Use this skill when the task is about repo maintenance rather than a single feat
 
 - Start from goals and risk surface, not checklist order.
 - Prefer the highest-signal path first: recent diffs, flaky areas, failing checks, stale specs, outdated dependencies, or known security/performance hotspots.
-- Check OSS/EVE Linear issues already in `In Progress` when maintenance covers release readiness or workflow hygiene. Treat issues with no meaningful update for more than 2 days as stale by default, then triage or report them.
+- Check Linear issues in the OSS project (EVE team) already in `In Progress` when maintenance covers release readiness or workflow hygiene. Treat issues whose `updatedAt` is older than 2 days as stale by default, then triage or report them.
 - Skip untouched areas when there is a clear reason. Say why they were skipped.
 - Prefer fixing over reporting.
 - For bugs uncovered during maintenance, prefer a failing test before the fix when practical.
@@ -114,8 +114,8 @@ Good evidence:
 Goal: Linear reflects reality closely enough that active work is visible, stalled work is noticed, and release planning is not distorted by stale execution state.
 
 Good evidence:
-- OSS/EVE issues already in `In Progress` were reviewed for stale ownership or stalled execution
-- issues with no meaningful update for more than 2 days were triaged, commented, re-scoped, or moved out of `In Progress`
+- OSS project issues already in `In Progress` were reviewed for stale ownership or stalled execution
+- issues whose `updatedAt` was older than 2 days were triaged, commented, re-scoped, or moved out of `In Progress`
 - maintenance findings that should not be fixed immediately were captured as actionable Linear issues or comments instead of left implicit
 
 ### Repo Workflow Hygiene
@@ -140,7 +140,7 @@ Pick only what matches the task:
 - `./scripts/export-openapi.sh`
 - `doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" gh api repos/everruns/everruns/dependabot/alerts --jq "[.[] | select(.state==\"open\")] | length"'` — open Dependabot alert count
 - `doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" gh api repos/everruns/everruns/secret-scanning/alerts --jq "[.[] | select(.state==\"open\")] | length"'` — open secret scanning alert count
-- Linear MCP: list OSS project issues in `In Progress`, compare `updatedAt` to current time, and flag items older than 2 days for triage
+- Linear MCP: list OSS project issues in `In Progress`, compare each issue's `updatedAt` to current time, and flag items older than 2 days for triage
 
 ## Deliverable
 

--- a/.claude/skills/maintenance/SKILL.md
+++ b/.claude/skills/maintenance/SKILL.md
@@ -43,6 +43,7 @@ Use this skill when the task is about repo maintenance rather than a single feat
 
 - Start from goals and risk surface, not checklist order.
 - Prefer the highest-signal path first: recent diffs, flaky areas, failing checks, stale specs, outdated dependencies, or known security/performance hotspots.
+- Check OSS/EVE Linear issues already in `In Progress` when maintenance covers release readiness or workflow hygiene. Treat issues with no meaningful update for more than 2 days as stale by default, then triage or report them.
 - Skip untouched areas when there is a clear reason. Say why they were skipped.
 - Prefer fixing over reporting.
 - For bugs uncovered during maintenance, prefer a failing test before the fix when practical.
@@ -108,6 +109,15 @@ Good evidence:
 - hacks, shortcuts, and open vulnerabilities surfaced with code references
 - large files (>2K lines non-test) catalogued with the structural reason they grew
 
+### Issue Tracking Hygiene
+
+Goal: Linear reflects reality closely enough that active work is visible, stalled work is noticed, and release planning is not distorted by stale execution state.
+
+Good evidence:
+- OSS/EVE issues already in `In Progress` were reviewed for stale ownership or stalled execution
+- issues with no meaningful update for more than 2 days were triaged, commented, re-scoped, or moved out of `In Progress`
+- maintenance findings that should not be fixed immediately were captured as actionable Linear issues or comments instead of left implicit
+
 ### Repo Workflow Hygiene
 
 Goal: agent instructions, commands, skills, examples, and release helpers still match reality.
@@ -130,6 +140,7 @@ Pick only what matches the task:
 - `./scripts/export-openapi.sh`
 - `doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" gh api repos/everruns/everruns/dependabot/alerts --jq "[.[] | select(.state==\"open\")] | length"'` — open Dependabot alert count
 - `doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" gh api repos/everruns/everruns/secret-scanning/alerts --jq "[.[] | select(.state==\"open\")] | length"'` — open secret scanning alert count
+- Linear MCP: list OSS project issues in `In Progress`, compare `updatedAt` to current time, and flag items older than 2 days for triage
 
 ## Deliverable
 
@@ -138,6 +149,7 @@ Report:
 - what scope was covered
 - what was fixed or found
 - what evidence was gathered
+- which stale `In Progress` Linear issues were triaged, if that check was in scope
 - what was intentionally skipped and why
 
 If the user asks to ship after maintenance, hand off to [`/ship`](../ship/SKILL.md).

--- a/specs/maintenance.md
+++ b/specs/maintenance.md
@@ -27,6 +27,7 @@ Relevant references:
 - [`specs/code-organization.md`](./code-organization.md)
 - [`specs/commands.md`](./commands.md)
 - [`specs/skills-registry.md`](./skills-registry.md)
+- [`specs/issue-tracking.md`](./issue-tracking.md)
 - [GitHub Security Overview](https://github.com/everruns/everruns/security)
 - [Dependabot Alerts](https://github.com/everruns/everruns/security/dependabot)
 - [Secret Scanning Alerts](https://github.com/everruns/everruns/security/secret-scanning?query=is%3Aopen+results%3Ageneric)
@@ -46,6 +47,7 @@ Before a release, maintenance should cover:
 - areas changed since the last release
 - historically fragile or high-risk surfaces
 - release artifacts affected by those changes
+- Linear issues already marked `In Progress` but left stale long enough to signal execution drift; use 2 days without meaningful progress as the default review threshold unless the task sets a stricter bar
 - GitHub Security tab: security overview, Dependabot alerts, and open secret scanning alerts
 
 A full-repo sweep is not mandatory if the evidence is already strong. The bar is confidence, not checklist completion theater.

--- a/specs/maintenance.md
+++ b/specs/maintenance.md
@@ -47,7 +47,7 @@ Before a release, maintenance should cover:
 - areas changed since the last release
 - historically fragile or high-risk surfaces
 - release artifacts affected by those changes
-- Linear issues already marked `In Progress` but left stale long enough to signal execution drift; use 2 days without meaningful progress as the default review threshold unless the task sets a stricter bar
+- Linear issues already marked `In Progress` whose `updatedAt` is older than 2 days, signaling execution drift; use that `updatedAt` threshold as the default review threshold unless the task sets a stricter bar
 - GitHub Security tab: security overview, Dependabot alerts, and open secret scanning alerts
 
 A full-repo sweep is not mandatory if the evidence is already strong. The bar is confidence, not checklist completion theater.


### PR DESCRIPTION
## What
Update the maintenance workflow and spec so maintenance reviews stale Linear work already marked `In Progress`.

## Why
Release-readiness and workflow hygiene can be distorted when work sits in `In Progress` too long without a meaningful update. The maintenance guidance did not previously require that check.

## How
- add the stale `In Progress` Linear review requirement to `specs/maintenance.md`
- update `.claude/skills/maintenance/SKILL.md` with a default 2-day threshold, an Issue Tracking Hygiene section, and expected reporting/evidence
- validate that the Linear query needed for this check exposes `updatedAt`, and run `just pre-push`

## Risk
- Low
- Docs/skill-only change; risk is limited to maintenance workflow guidance

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered
