### PR TITLE
feat(embedding): add PlatformDefinition for embeddable runtimes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ Always make sure you are working on top of latest main from remote.
 
 - `specs/concepts.md` - Core entities, relationships, and concept diagram
 - `specs/architecture.md` - System architecture, crate structure, infrastructure
+- `specs/embedding.md` - Embedding contract and `PlatformDefinition`
 - `specs/code-organization.md` - Naming conventions, type flow, testing, error handling
 - `specs/models.md` - Data models (Agent, Session, Message, etc.)
 - `specs/apis.md` - HTTP API endpoints, error handling

--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -1287,6 +1287,7 @@ impl AnthropicModelInfo {
         LlmModelProfile {
             name: self.display_name.clone(),
             family: normalize_anthropic_id(&self.id).to_string(),
+            description: None,
             release_date: self
                 .created_at
                 .as_ref()

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -599,6 +599,11 @@ impl CapabilityRegistry {
         self.capabilities.get(id)
     }
 
+    /// Remove a capability from the registry.
+    pub fn unregister(&mut self, id: &str) -> Option<Arc<dyn Capability>> {
+        self.capabilities.remove(id)
+    }
+
     /// Check if a capability is registered
     pub fn has(&self, id: &str) -> bool {
         self.capabilities.contains_key(id)

--- a/crates/core/src/connection_provider.rs
+++ b/crates/core/src/connection_provider.rs
@@ -8,6 +8,8 @@
 
 use async_trait::async_trait;
 use serde::Serialize;
+use std::collections::HashMap;
+use std::sync::Arc;
 
 // ============================================================================
 // Plugin Registration
@@ -76,6 +78,124 @@ pub trait ConnectionProvider: Send + Sync {
     /// Validate a credential before saving. Called for API key providers.
     /// Returns Ok with optional metadata on success, Err with user-facing message on failure.
     async fn validate(&self, credential: &str) -> Result<ConnectionValidation, String>;
+}
+
+// ============================================================================
+// ConnectionProvider Registry
+// ============================================================================
+
+/// Registry of connection providers available to a platform.
+///
+/// This is the explicit counterpart to `ConnectionProviderPlugin`. Inventory-based
+/// discovery remains useful for the default OSS platform, but embedders need a
+/// concrete registry they can edit before handing the platform to the server.
+#[derive(Clone, Default)]
+pub struct ConnectionProviderRegistry {
+    providers: HashMap<String, Arc<dyn ConnectionProvider>>,
+}
+
+impl ConnectionProviderRegistry {
+    /// Create an empty provider registry.
+    pub fn new() -> Self {
+        Self {
+            providers: HashMap::new(),
+        }
+    }
+
+    /// Register a connection provider.
+    ///
+    /// If a provider with the same `provider_id()` already exists, it is replaced.
+    pub fn register(&mut self, provider: impl ConnectionProvider + 'static) {
+        self.providers
+            .insert(provider.provider_id().to_string(), Arc::new(provider));
+    }
+
+    /// Register a boxed connection provider.
+    pub fn register_boxed(&mut self, provider: Box<dyn ConnectionProvider>) {
+        self.providers
+            .insert(provider.provider_id().to_string(), Arc::from(provider));
+    }
+
+    /// Register an `Arc`-wrapped connection provider.
+    pub fn register_arc(&mut self, provider: Arc<dyn ConnectionProvider>) {
+        self.providers
+            .insert(provider.provider_id().to_string(), provider);
+    }
+
+    /// Remove a provider by ID.
+    pub fn unregister(&mut self, provider_id: &str) -> Option<Arc<dyn ConnectionProvider>> {
+        self.providers.remove(provider_id)
+    }
+
+    /// Get a provider by ID.
+    pub fn get(&self, provider_id: &str) -> Option<&Arc<dyn ConnectionProvider>> {
+        self.providers.get(provider_id)
+    }
+
+    /// Check whether a provider is registered.
+    pub fn has(&self, provider_id: &str) -> bool {
+        self.providers.contains_key(provider_id)
+    }
+
+    /// List all registered providers.
+    pub fn list(&self) -> Vec<&Arc<dyn ConnectionProvider>> {
+        self.providers.values().collect()
+    }
+
+    /// Number of registered providers.
+    pub fn len(&self) -> usize {
+        self.providers.len()
+    }
+
+    /// Whether the registry is empty.
+    pub fn is_empty(&self) -> bool {
+        self.providers.is_empty()
+    }
+
+    /// Create a builder for fluent registration.
+    pub fn builder() -> ConnectionProviderRegistryBuilder {
+        ConnectionProviderRegistryBuilder::new()
+    }
+}
+
+impl std::fmt::Debug for ConnectionProviderRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let ids: Vec<_> = self.providers.keys().collect();
+        f.debug_struct("ConnectionProviderRegistry")
+            .field("providers", &ids)
+            .finish()
+    }
+}
+
+/// Builder for creating a `ConnectionProviderRegistry`.
+pub struct ConnectionProviderRegistryBuilder {
+    registry: ConnectionProviderRegistry,
+}
+
+impl ConnectionProviderRegistryBuilder {
+    /// Create a new empty builder.
+    pub fn new() -> Self {
+        Self {
+            registry: ConnectionProviderRegistry::new(),
+        }
+    }
+
+    /// Add a connection provider to the registry.
+    pub fn provider(mut self, provider: impl ConnectionProvider + 'static) -> Self {
+        self.registry.register(provider);
+        self
+    }
+
+    /// Build the registry.
+    pub fn build(self) -> ConnectionProviderRegistry {
+        self.registry
+    }
+}
+
+impl Default for ConnectionProviderRegistryBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 // ============================================================================

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -77,6 +77,7 @@ pub mod message_retriever;
 pub mod openai_protocol;
 pub mod openresponses_protocol;
 pub mod openresponses_types;
+pub mod platform_definition;
 pub mod platform_store;
 pub mod runtime_agent;
 pub mod tools;
@@ -155,8 +156,12 @@ pub use tools::{
 // Capability re-exports
 // Connection provider plugin system (API key connections like Daytona)
 pub use connection_provider::{
-    ConnectionFormSchema, ConnectionProvider, ConnectionProviderPlugin, ConnectionType,
-    ConnectionValidation, FieldType, FormField,
+    ConnectionFormSchema, ConnectionProvider, ConnectionProviderPlugin, ConnectionProviderRegistry,
+    ConnectionProviderRegistryBuilder, ConnectionType, ConnectionValidation, FieldType, FormField,
+};
+pub use platform_definition::{
+    BuiltInCapabilityDefinition, BuiltInHarnessDefinition, BuiltInHarnessRole, PlatformDefinition,
+    PlatformDefinitionBuilder,
 };
 
 pub use capabilities::SystemPromptContext;

--- a/crates/core/src/platform_definition.rs
+++ b/crates/core/src/platform_definition.rs
@@ -1,0 +1,464 @@
+//! Platform definition for embeddable Everruns deployments.
+//!
+//! `PlatformDefinition` is the shared composition root for server and worker
+//! runtime surface. Embedders can add or remove capabilities, LLM drivers,
+//! connection providers, and built-in harness templates without patching
+//! internal startup code.
+//!
+//! Server-only concerns such as route wiring, auth backends, and background
+//! task scheduling stay outside this module so the type can be reused from any
+//! binary crate.
+
+use crate::{
+    Capability, CapabilityRegistry, ConnectionProvider, ConnectionProviderRegistry, DriverRegistry,
+};
+use serde_json::Value;
+use uuid::Uuid;
+
+/// Stable role assigned to a built-in harness template.
+///
+/// Roles let the server resolve special harness behavior without assuming a
+/// specific harness name. For example, a platform can provide a base harness
+/// named "Minimal" and still mark it as the `Base` harness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BuiltInHarnessRole {
+    /// Harness used when session creation omits `harness_id` and the org has no
+    /// explicit `base_harness_id` configured yet.
+    Base,
+    /// Harness selected as the default in organization settings when the org is
+    /// first initialized.
+    Default,
+    /// Harness used by the global chat endpoint.
+    Chat,
+}
+
+/// Capability entry for a built-in harness template.
+#[derive(Debug, Clone)]
+pub struct BuiltInCapabilityDefinition {
+    /// Capability identifier.
+    pub id: String,
+    /// Per-harness capability config passed to capability resolution.
+    pub config: Value,
+}
+
+impl BuiltInCapabilityDefinition {
+    /// Create a capability entry with an empty config object.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            config: serde_json::json!({}),
+        }
+    }
+
+    /// Create a capability entry with explicit config.
+    pub fn with_config(id: impl Into<String>, config: Value) -> Self {
+        Self {
+            id: id.into(),
+            config,
+        }
+    }
+}
+
+/// Built-in harness template provisioned by a platform definition.
+#[derive(Debug, Clone)]
+pub struct BuiltInHarnessDefinition {
+    /// Stable key for the template inside the platform definition.
+    ///
+    /// This key is for code-level identification and should not be shown to
+    /// users. Use values like `base`, `generic`, or `platform_chat`.
+    pub key: String,
+    /// Fixed UUID used for the default org when backward compatibility matters.
+    ///
+    /// Other organizations still receive fresh UUIDs; the template name and
+    /// `is_built_in` flag are used to reconcile them.
+    pub seed_id: Option<Uuid>,
+    /// Display name shown in the UI and API.
+    pub name: String,
+    /// Human-readable description.
+    pub description: String,
+    /// Base system prompt for the harness.
+    pub system_prompt: String,
+    /// Tags applied to the harness.
+    pub tags: Vec<String>,
+    /// Capabilities enabled by default for the harness.
+    pub capabilities: Vec<BuiltInCapabilityDefinition>,
+    /// Special roles for platform behavior.
+    pub roles: Vec<BuiltInHarnessRole>,
+}
+
+impl BuiltInHarnessDefinition {
+    /// Create a built-in harness template.
+    pub fn new(
+        key: impl Into<String>,
+        name: impl Into<String>,
+        description: impl Into<String>,
+        system_prompt: impl Into<String>,
+    ) -> Self {
+        Self {
+            key: key.into(),
+            seed_id: None,
+            name: name.into(),
+            description: description.into(),
+            system_prompt: system_prompt.into(),
+            tags: Vec::new(),
+            capabilities: Vec::new(),
+            roles: Vec::new(),
+        }
+    }
+
+    /// Set the default-org seed UUID used for backward compatibility.
+    pub fn with_seed_id(mut self, seed_id: Uuid) -> Self {
+        self.seed_id = Some(seed_id);
+        self
+    }
+
+    /// Replace the harness tags.
+    pub fn with_tags<I, S>(mut self, tags: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.tags = tags.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Replace the harness capabilities.
+    pub fn with_capabilities<I>(mut self, capabilities: I) -> Self
+    where
+        I: IntoIterator<Item = BuiltInCapabilityDefinition>,
+    {
+        self.capabilities = capabilities.into_iter().collect();
+        self
+    }
+
+    /// Replace the harness roles.
+    pub fn with_roles<I>(mut self, roles: I) -> Self
+    where
+        I: IntoIterator<Item = BuiltInHarnessRole>,
+    {
+        self.roles = roles.into_iter().collect();
+        self
+    }
+
+    /// Check whether this harness has a specific role.
+    pub fn has_role(&self, role: BuiltInHarnessRole) -> bool {
+        self.roles.contains(&role)
+    }
+}
+
+/// Shared definition of the Everruns platform surface.
+///
+/// `PlatformDefinition` lets an embedder decide which capabilities, LLM
+/// drivers, connection providers, and built-in harness templates exist at
+/// runtime. Server and worker code should consume the same definition so the
+/// control plane and execution plane stay aligned.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use everruns_core::{
+///     BuiltInCapabilityDefinition, BuiltInHarnessDefinition, BuiltInHarnessRole,
+///     DriverRegistry, PlatformDefinition,
+/// };
+///
+/// let mut drivers = DriverRegistry::new();
+/// everruns_openai::register_driver(&mut drivers);
+///
+/// let platform = PlatformDefinition::builder()
+///     .driver_registry(drivers)
+///     .capability(everruns_core::CurrentTimeCapability)
+///     .add_built_in_harness(
+///         BuiltInHarnessDefinition::new(
+///             "minimal",
+///             "Minimal",
+///             "Small default harness for an embedded deployment.",
+///             "You are a helpful assistant.",
+///         )
+///         .with_roles([BuiltInHarnessRole::Base, BuiltInHarnessRole::Default])
+///         .with_capabilities([BuiltInCapabilityDefinition::new("current_time")]),
+///     )
+///     .build();
+/// ```
+#[derive(Clone)]
+pub struct PlatformDefinition {
+    capability_registry: CapabilityRegistry,
+    driver_registry: DriverRegistry,
+    connection_providers: ConnectionProviderRegistry,
+    built_in_harnesses: Vec<BuiltInHarnessDefinition>,
+}
+
+impl PlatformDefinition {
+    /// Create a platform definition from explicit registries.
+    pub fn new(capability_registry: CapabilityRegistry, driver_registry: DriverRegistry) -> Self {
+        Self {
+            capability_registry,
+            driver_registry,
+            connection_providers: ConnectionProviderRegistry::new(),
+            built_in_harnesses: Vec::new(),
+        }
+    }
+
+    /// Create a builder for fluent platform composition.
+    pub fn builder() -> PlatformDefinitionBuilder {
+        PlatformDefinitionBuilder::new()
+    }
+
+    /// Immutable access to the capability registry.
+    pub fn capability_registry(&self) -> &CapabilityRegistry {
+        &self.capability_registry
+    }
+
+    /// Mutable access to the capability registry.
+    pub fn capability_registry_mut(&mut self) -> &mut CapabilityRegistry {
+        &mut self.capability_registry
+    }
+
+    /// Immutable access to the driver registry.
+    pub fn driver_registry(&self) -> &DriverRegistry {
+        &self.driver_registry
+    }
+
+    /// Mutable access to the driver registry.
+    pub fn driver_registry_mut(&mut self) -> &mut DriverRegistry {
+        &mut self.driver_registry
+    }
+
+    /// Immutable access to the connection-provider registry.
+    pub fn connection_providers(&self) -> &ConnectionProviderRegistry {
+        &self.connection_providers
+    }
+
+    /// Mutable access to the connection-provider registry.
+    pub fn connection_providers_mut(&mut self) -> &mut ConnectionProviderRegistry {
+        &mut self.connection_providers
+    }
+
+    /// Built-in harness templates provisioned by this platform.
+    pub fn built_in_harnesses(&self) -> &[BuiltInHarnessDefinition] {
+        &self.built_in_harnesses
+    }
+
+    /// Mutable access to the built-in harness templates.
+    pub fn built_in_harnesses_mut(&mut self) -> &mut Vec<BuiltInHarnessDefinition> {
+        &mut self.built_in_harnesses
+    }
+
+    /// Append a built-in harness template.
+    pub fn add_built_in_harness(&mut self, harness: BuiltInHarnessDefinition) {
+        self.built_in_harnesses.push(harness);
+    }
+
+    /// Find the first built-in harness with the requested role.
+    pub fn harness_for_role(&self, role: BuiltInHarnessRole) -> Option<&BuiltInHarnessDefinition> {
+        self.built_in_harnesses.iter().find(|h| h.has_role(role))
+    }
+}
+
+impl Default for PlatformDefinition {
+    fn default() -> Self {
+        Self::new(CapabilityRegistry::new(), DriverRegistry::new())
+    }
+}
+
+impl std::fmt::Debug for PlatformDefinition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let harness_keys: Vec<_> = self.built_in_harnesses.iter().map(|h| &h.key).collect();
+        f.debug_struct("PlatformDefinition")
+            .field("capabilities", &self.capability_registry)
+            .field("drivers", &self.driver_registry.registered_providers())
+            .field("connection_providers", &self.connection_providers)
+            .field("built_in_harnesses", &harness_keys)
+            .finish()
+    }
+}
+
+/// Builder for `PlatformDefinition`.
+pub struct PlatformDefinitionBuilder {
+    platform: PlatformDefinition,
+}
+
+impl PlatformDefinitionBuilder {
+    /// Create a new empty builder.
+    pub fn new() -> Self {
+        Self {
+            platform: PlatformDefinition::default(),
+        }
+    }
+
+    /// Replace the capability registry.
+    pub fn capability_registry(mut self, registry: CapabilityRegistry) -> Self {
+        self.platform.capability_registry = registry;
+        self
+    }
+
+    /// Register a capability on the platform.
+    pub fn capability(mut self, capability: impl Capability + 'static) -> Self {
+        self.platform.capability_registry.register(capability);
+        self
+    }
+
+    /// Replace the driver registry.
+    pub fn driver_registry(mut self, registry: DriverRegistry) -> Self {
+        self.platform.driver_registry = registry;
+        self
+    }
+
+    /// Replace the connection-provider registry.
+    pub fn connection_providers(mut self, registry: ConnectionProviderRegistry) -> Self {
+        self.platform.connection_providers = registry;
+        self
+    }
+
+    /// Register a connection provider on the platform.
+    pub fn connection_provider(mut self, provider: impl ConnectionProvider + 'static) -> Self {
+        self.platform.connection_providers.register(provider);
+        self
+    }
+
+    /// Replace the built-in harness templates.
+    pub fn built_in_harnesses<I>(mut self, harnesses: I) -> Self
+    where
+        I: IntoIterator<Item = BuiltInHarnessDefinition>,
+    {
+        self.platform.built_in_harnesses = harnesses.into_iter().collect();
+        self
+    }
+
+    /// Append a built-in harness template.
+    pub fn add_built_in_harness(mut self, harness: BuiltInHarnessDefinition) -> Self {
+        self.platform.built_in_harnesses.push(harness);
+        self
+    }
+
+    /// Build the platform definition.
+    pub fn build(self) -> PlatformDefinition {
+        self.platform
+    }
+}
+
+impl Default for PlatformDefinitionBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connection_provider::{
+        ConnectionFormSchema, ConnectionType, ConnectionValidation, FieldType, FormField,
+    };
+    use crate::{CapabilityStatus, CurrentTimeCapability};
+    use async_trait::async_trait;
+
+    struct TestProvider;
+
+    #[async_trait]
+    impl ConnectionProvider for TestProvider {
+        fn provider_id(&self) -> &str {
+            "test_provider"
+        }
+
+        fn display_name(&self) -> &str {
+            "Test Provider"
+        }
+
+        fn description(&self) -> &str {
+            "Test connection provider"
+        }
+
+        fn icon(&self) -> &str {
+            "plug"
+        }
+
+        fn connection_type(&self) -> ConnectionType {
+            ConnectionType::ApiKey
+        }
+
+        fn form_schema(&self) -> Option<ConnectionFormSchema> {
+            Some(ConnectionFormSchema {
+                fields: vec![FormField {
+                    name: "api_key".to_string(),
+                    label: "API Key".to_string(),
+                    field_type: FieldType::Password,
+                    required: true,
+                    placeholder: None,
+                    help_text: None,
+                }],
+                instructions_markdown: "Enter the API key.".to_string(),
+            })
+        }
+
+        async fn validate(&self, _credential: &str) -> Result<ConnectionValidation, String> {
+            Ok(ConnectionValidation {
+                provider_username: Some("test-user".to_string()),
+            })
+        }
+    }
+
+    #[test]
+    fn test_platform_definition_builder() {
+        let mut drivers = DriverRegistry::new();
+        crate::llmsim_driver::register_driver(&mut drivers);
+
+        let platform = PlatformDefinition::builder()
+            .driver_registry(drivers.clone())
+            .capability(CurrentTimeCapability)
+            .connection_provider(TestProvider)
+            .add_built_in_harness(
+                BuiltInHarnessDefinition::new(
+                    "minimal",
+                    "Minimal",
+                    "Minimal harness",
+                    "You are helpful.",
+                )
+                .with_roles([BuiltInHarnessRole::Base, BuiltInHarnessRole::Default]),
+            )
+            .build();
+
+        assert!(platform.capability_registry().has("current_time"));
+        assert!(platform.connection_providers().has("test_provider"));
+        assert_eq!(
+            platform
+                .harness_for_role(BuiltInHarnessRole::Base)
+                .unwrap()
+                .name,
+            "Minimal"
+        );
+        assert!(
+            platform
+                .driver_registry()
+                .has_driver(&crate::ProviderType::LlmSim)
+        );
+    }
+
+    #[test]
+    fn test_platform_definition_mutation() {
+        let mut platform = PlatformDefinition::default();
+        platform
+            .capability_registry_mut()
+            .register(CurrentTimeCapability);
+        platform.connection_providers_mut().register(TestProvider);
+        platform.add_built_in_harness(
+            BuiltInHarnessDefinition::new("chat", "Chat", "Chat harness", "You are helpful.")
+                .with_roles([BuiltInHarnessRole::Chat]),
+        );
+
+        let info = crate::CapabilityInfo::from_core(
+            platform
+                .capability_registry()
+                .get("current_time")
+                .expect("current_time registered")
+                .as_ref(),
+        );
+        assert_eq!(info.status, CapabilityStatus::Available);
+        assert!(platform.connection_providers().has("test_provider"));
+        assert_eq!(
+            platform
+                .harness_for_role(BuiltInHarnessRole::Chat)
+                .unwrap()
+                .key,
+            "chat"
+        );
+    }
+}

--- a/crates/server/src/api/organizations.rs
+++ b/crates/server/src/api/organizations.rs
@@ -13,7 +13,8 @@ use axum::{
     routing::get,
 };
 use everruns_core::{
-    DEFAULT_ORG_ID, OrgRole, Organization, generate_org_public_id, validate_org_public_id,
+    BuiltInHarnessDefinition, DEFAULT_ORG_ID, OrgRole, Organization, generate_org_public_id,
+    validate_org_public_id,
 };
 
 use super::common::{ApiOptionExt, ApiResultExt, ErrorResponse, ListResponse};
@@ -26,11 +27,24 @@ use utoipa::ToSchema;
 pub struct AppState {
     pub db: Arc<StorageBackend>,
     pub auth: AuthState,
+    pub built_in_harnesses: Vec<BuiltInHarnessDefinition>,
 }
 
 impl AppState {
     pub fn new(db: Arc<StorageBackend>, auth: AuthState) -> Self {
-        Self { db, auth }
+        Self::with_built_in_harnesses(db, auth, crate::platform::oss_built_in_harnesses())
+    }
+
+    pub fn with_built_in_harnesses(
+        db: Arc<StorageBackend>,
+        auth: AuthState,
+        built_in_harnesses: Vec<BuiltInHarnessDefinition>,
+    ) -> Self {
+        Self {
+            db,
+            auth,
+            built_in_harnesses,
+        }
     }
 }
 
@@ -214,7 +228,13 @@ pub async fn create_organization(
         .log_internal_error_json("add organization member")?;
 
     // Initialize built-in harnesses for the new organization
-    if let Err(e) = crate::org_init::initialize_org_harnesses(&state.db, row.org_id).await {
+    if let Err(e) = crate::org_init::initialize_org_harnesses_with_definitions(
+        &state.db,
+        row.org_id,
+        &state.built_in_harnesses,
+    )
+    .await
+    {
         tracing::warn!(
             org_id = row.org_id,
             error = %e,

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -3,10 +3,10 @@
 // Policy enforcement happens at the service layer via #[policy] macro.
 
 use crate::auth::{AuthState, ResolvedOrg};
-use crate::org_init::BASE_HARNESS_ID;
 use crate::services::session::{SESSION_MANAGE, SESSION_VIEW};
 use crate::services::{EventService, SessionService};
 use crate::storage::StorageBackend;
+use anyhow::Context;
 use axum::extract::FromRef;
 use axum::{
     Json, Router,
@@ -17,7 +17,10 @@ use axum::{
 use everruns_core::capability_types::AgentCapabilityConfig;
 use everruns_core::events::{EventContext, EventRequest, InputMessageData, TurnCancelledData};
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, ModelId, SessionId, TurnId};
-use everruns_core::{Caller, Message, ResourceConfigResponse, Session, evaluate_policies_with};
+use everruns_core::{
+    BuiltInHarnessRole, Caller, Message, PlatformDefinition, ResourceConfigResponse, Session,
+    evaluate_policies_with,
+};
 use everruns_worker::AgentRunner;
 
 use super::common::{
@@ -134,16 +137,45 @@ pub struct AppState {
     pub event_service: EventService,
     pub runner: Arc<dyn AgentRunner>,
     pub auth: AuthState,
+    pub fallback_base_harness_name: Option<String>,
+    pub chat_harness_name: Option<String>,
+    pub chat_session_title: Option<String>,
 }
 
 impl AppState {
     pub fn new(db: Arc<StorageBackend>, runner: Arc<dyn AgentRunner>, auth: AuthState) -> Self {
+        Self::with_platform_definition(
+            db,
+            runner,
+            auth,
+            &crate::platform::oss_platform_definition(),
+        )
+    }
+
+    pub fn with_platform_definition(
+        db: Arc<StorageBackend>,
+        runner: Arc<dyn AgentRunner>,
+        auth: AuthState,
+        platform_definition: &PlatformDefinition,
+    ) -> Self {
         Self {
-            session_service: Arc::new(SessionService::new(db.clone())),
+            session_service: Arc::new(SessionService::with_registry(
+                db.clone(),
+                platform_definition.capability_registry().clone(),
+            )),
             event_service: EventService::new(db.clone()),
             db,
             runner,
             auth,
+            fallback_base_harness_name: platform_definition
+                .harness_for_role(BuiltInHarnessRole::Base)
+                .map(|h| h.name.clone()),
+            chat_harness_name: platform_definition
+                .harness_for_role(BuiltInHarnessRole::Chat)
+                .map(|h| h.name.clone()),
+            chat_session_title: platform_definition
+                .harness_for_role(BuiltInHarnessRole::Chat)
+                .map(|h| h.name.clone()),
         }
     }
 }
@@ -230,9 +262,14 @@ pub async fn create_session(
     req.locale = normalize_locale(req.locale)
         .map_err(|err| -> (StatusCode, Json<ErrorResponse>) { err.into() })?;
 
-    let harness_id = resolve_session_harness_id(&state.db, org.org_id, req.harness_id)
-        .await
-        .log_internal_error_json("resolve session harness fallback")?;
+    let harness_id = resolve_session_harness_id(
+        &state.db,
+        org.org_id,
+        req.harness_id,
+        state.fallback_base_harness_name.as_deref(),
+    )
+    .await
+    .log_internal_error_json("resolve session harness fallback")?;
     req.harness_id = Some(harness_id);
 
     // Validate harness exists and belongs to this org
@@ -292,6 +329,7 @@ async fn resolve_session_harness_id(
     db: &StorageBackend,
     org_id: i64,
     requested_harness_id: Option<HarnessId>,
+    fallback_base_harness_name: Option<&str>,
 ) -> anyhow::Result<HarnessId> {
     if let Some(harness_id) = requested_harness_id {
         return Ok(harness_id);
@@ -302,12 +340,19 @@ async fn resolve_session_harness_id(
         return Ok(harness_id);
     }
 
-    let harnesses = db.list_harnesses(org_id, Some("Base"), false).await?;
-    Ok(harnesses
+    let fallback_name = fallback_base_harness_name.context(
+        "Session creation requires a base harness but no base harness role is configured",
+    )?;
+    let harnesses = db
+        .list_harnesses(org_id, Some(fallback_name), false)
+        .await?;
+    harnesses
         .into_iter()
-        .find(|h| h.is_built_in && h.name == "Base")
+        .find(|h| h.is_built_in && h.name == fallback_name)
         .map(|h| h.id)
-        .unwrap_or_else(|| HarnessId::from_uuid(BASE_HARNESS_ID)))
+        .context(format!(
+            "Built-in base harness '{fallback_name}' is not provisioned for org {org_id}"
+        ))
 }
 
 /// POST /v1/sessions/chat - Get or create global chat session
@@ -330,15 +375,48 @@ pub async fn get_or_create_chat_session(
 ) -> Result<Json<Session>, (StatusCode, Json<ErrorResponse>)> {
     // Use authenticated user_id, or fall back to anonymous user (auth=none mode)
     let user_id = org.user_id.unwrap_or(everruns_core::ANONYMOUS_USER_ID);
+    let chat_harness_name = state.chat_harness_name.clone().ok_or((
+        StatusCode::NOT_FOUND,
+        Json(ErrorResponse::new(
+            "Global chat is not configured for this platform",
+        )),
+    ))?;
+    let chat_harness_id =
+        resolve_named_built_in_harness_id(&state.db, org.org_id, &chat_harness_name)
+            .await
+            .log_internal_error_json("resolve chat harness")?;
 
     let caller = Caller::from(&org);
     let session = state
         .session_service
-        .get_or_create_chat_session(&caller, user_id, crate::seed::CHAT_HARNESS_ID)
+        .get_or_create_chat_session(
+            &caller,
+            user_id,
+            chat_harness_id.uuid(),
+            state
+                .chat_session_title
+                .as_deref()
+                .unwrap_or(chat_harness_name.as_str()),
+        )
         .await
         .map_policy_or_internal("get or create chat session")?;
 
     Ok(Json(session))
+}
+
+async fn resolve_named_built_in_harness_id(
+    db: &StorageBackend,
+    org_id: i64,
+    harness_name: &str,
+) -> anyhow::Result<HarnessId> {
+    let harnesses = db.list_harnesses(org_id, Some(harness_name), false).await?;
+    harnesses
+        .into_iter()
+        .find(|h| h.is_built_in && h.name == harness_name)
+        .map(|h| h.id)
+        .context(format!(
+            "Built-in harness '{harness_name}' is not provisioned for org {org_id}"
+        ))
 }
 
 /// GET /v1/sessions - List sessions in organization
@@ -762,7 +840,10 @@ pub async fn cancel_turn(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::{StorageBackend, models::UpdateOrganizationSettings};
+    use crate::storage::{
+        StorageBackend,
+        models::{CreateHarnessRow, UpdateOrganizationSettings},
+    };
 
     const TEST_HARNESS_ID: &str = "harness_550e8400e29b41d4a716446655440000";
     const TEST_AGENT_ID: &str = "agent_550e8400e29b41d4a716446655440000";
@@ -884,9 +965,26 @@ mod tests {
     #[tokio::test]
     async fn test_resolve_session_harness_id_defaults_to_base() {
         let db = StorageBackend::in_memory();
+        let row = db
+            .create_harness(
+                42,
+                CreateHarnessRow {
+                    name: "Base".to_string(),
+                    description: Some("Base".to_string()),
+                    system_prompt: "You are helpful.".to_string(),
+                    default_model_id: None,
+                    tags: vec!["base".to_string()],
+                    initial_files: serde_json::json!([]),
+                    is_built_in: true,
+                },
+            )
+            .await
+            .unwrap();
 
-        let harness_id = resolve_session_harness_id(&db, 42, None).await.unwrap();
-        assert_eq!(harness_id.uuid(), BASE_HARNESS_ID);
+        let harness_id = resolve_session_harness_id(&db, 42, None, Some("Base"))
+            .await
+            .unwrap();
+        assert_eq!(harness_id, row.id);
     }
 
     #[tokio::test]
@@ -904,7 +1002,9 @@ mod tests {
         .await
         .unwrap();
 
-        let harness_id = resolve_session_harness_id(&db, 42, None).await.unwrap();
+        let harness_id = resolve_session_harness_id(&db, 42, None, Some("Base"))
+            .await
+            .unwrap();
         assert_eq!(harness_id, base_harness_id);
     }
 }

--- a/crates/server/src/api/user_connections.rs
+++ b/crates/server/src/api/user_connections.rs
@@ -18,9 +18,8 @@ use axum::{
 use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use chrono::{DateTime, Utc};
 use everruns_core::connection_provider::{
-    ConnectionFormSchema as CoreFormSchema, ConnectionProviderPlugin, ConnectionType,
+    ConnectionFormSchema as CoreFormSchema, ConnectionProviderRegistry, ConnectionType,
 };
-use everruns_core::deployment::DeploymentGrade;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -35,6 +34,25 @@ pub struct AppState {
     pub encryption: Option<Arc<EncryptionService>>,
     pub auth: AuthState,
     pub auth_config: AuthConfig,
+    pub connection_providers: ConnectionProviderRegistry,
+}
+
+impl AppState {
+    pub fn new(
+        db: Arc<StorageBackend>,
+        encryption: Option<Arc<EncryptionService>>,
+        auth: AuthState,
+        auth_config: AuthConfig,
+        connection_providers: ConnectionProviderRegistry,
+    ) -> Self {
+        Self {
+            db,
+            encryption,
+            auth,
+            auth_config,
+            connection_providers,
+        }
+    }
 }
 
 impl FromRef<AppState> for AuthState {
@@ -186,7 +204,6 @@ pub async fn list_connection_providers(
     State(state): State<AppState>,
     _auth: AuthUser,
 ) -> Json<Vec<ProviderResponse>> {
-    let grade = DeploymentGrade::from_env();
     let mut providers = Vec::new();
 
     // Hardcoded GitHub OAuth provider (only if configured)
@@ -201,12 +218,8 @@ pub async fn list_connection_providers(
         });
     }
 
-    // Plugin-registered providers (API-key based)
-    for plugin in inventory::iter::<ConnectionProviderPlugin> {
-        if plugin.experimental_only && !grade.experimental_features_enabled() {
-            continue;
-        }
-        let provider = (plugin.factory)();
+    // Platform-registered providers (API-key based)
+    for provider in state.connection_providers.list() {
         let form_schema = provider.form_schema().map(|s| form_schema_to_response(&s));
         let conn_type = match provider.connection_type() {
             ConnectionType::OAuth => "oauth",
@@ -235,22 +248,15 @@ pub async fn create_api_key_connection(
     Path(provider_id): Path<String>,
     Json(body): Json<CreateApiKeyConnectionRequest>,
 ) -> Result<(StatusCode, Json<ConnectionResponse>), (StatusCode, String)> {
-    let grade = DeploymentGrade::from_env();
-
-    // Find the registered ConnectionProvider for this provider_id
-    let provider: Option<Box<dyn everruns_core::connection_provider::ConnectionProvider>> =
-        inventory::iter::<ConnectionProviderPlugin>
-            .into_iter()
-            .filter(|p| !p.experimental_only || grade.experimental_features_enabled())
-            .map(|p| (p.factory)())
-            .find(|p| p.provider_id() == provider_id);
-
-    let provider = provider.ok_or_else(|| {
-        (
-            StatusCode::NOT_FOUND,
-            format!("Unknown connection provider: {provider_id}"),
-        )
-    })?;
+    let provider = state
+        .connection_providers
+        .get(&provider_id)
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                format!("Unknown connection provider: {provider_id}"),
+            )
+        })?;
 
     // Only API-key providers support direct creation
     if provider.connection_type() != ConnectionType::ApiKey {
@@ -360,8 +366,6 @@ pub async fn verify_connection(
     auth: AuthUser,
     Path(provider_id): Path<String>,
 ) -> Result<Json<VerifyConnectionResponse>, (StatusCode, String)> {
-    let grade = DeploymentGrade::from_env();
-
     // Look up the stored connection
     let row = state
         .db
@@ -411,20 +415,15 @@ pub async fn verify_connection(
         )
     })?;
 
-    // Find the provider plugin
-    let provider: Option<Box<dyn everruns_core::connection_provider::ConnectionProvider>> =
-        inventory::iter::<ConnectionProviderPlugin>
-            .into_iter()
-            .filter(|p| !p.experimental_only || grade.experimental_features_enabled())
-            .map(|p| (p.factory)())
-            .find(|p| p.provider_id() == provider_id);
-
-    let provider = provider.ok_or_else(|| {
-        (
-            StatusCode::NOT_FOUND,
-            format!("Unknown connection provider: {provider_id}"),
-        )
-    })?;
+    let provider = state
+        .connection_providers
+        .get(&provider_id)
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                format!("Unknown connection provider: {provider_id}"),
+            )
+        })?;
 
     // Call provider's validate()
     match provider.validate(&credential).await {

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -21,14 +21,12 @@ use crate::{api, seed, services};
 use anyhow::{Context, Result};
 use axum::http::{Method, header};
 use axum::{Json, Router, extract::State, routing::get};
-use everruns_core::CapabilityRegistry;
-use everruns_core::{BraintrustListener, EventListener, OtelEventListener};
+use everruns_core::{BraintrustListener, EventListener, OtelEventListener, PlatformDefinition};
 use everruns_durable::{
     InMemoryWorkflowEventStore, PostgresWorkflowEventStore, WorkflowEventStore,
 };
 use everruns_worker::{
-    AgentRunner, RunnerBackend, TaskWorker, TaskWorkerConfig, create_driver_registry,
-    create_runner_with_backend,
+    AgentRunner, RunnerBackend, TaskWorker, TaskWorkerConfig, create_runner_with_backend,
 };
 use serde::Serialize;
 use sqlx::PgPool;
@@ -67,6 +65,7 @@ pub struct ServerContext {
     pub encryption: Option<Arc<EncryptionService>>,
     pub runner: Arc<dyn AgentRunner>,
     pub driver_registry: Arc<everruns_core::DriverRegistry>,
+    pub platform_definition: Arc<PlatformDefinition>,
 }
 
 // =========================================================================
@@ -124,6 +123,7 @@ struct HealthState {
 pub struct ServerAppBuilder {
     config: ServerConfig,
     auth_factory: Option<AuthFactoryFn>,
+    platform_definition: Option<PlatformDefinition>,
     extra_routes: Vec<Router>,
     event_listeners: Vec<Arc<dyn EventListener>>,
     migrations: Vec<MigrationFn>,
@@ -136,6 +136,7 @@ impl ServerAppBuilder {
         Self {
             config,
             auth_factory: None,
+            platform_definition: None,
             extra_routes: Vec::new(),
             event_listeners: Vec::new(),
             migrations: Vec::new(),
@@ -152,6 +153,12 @@ impl ServerAppBuilder {
         factory: impl FnOnce(Arc<StorageBackend>) -> Arc<dyn AuthBackend> + Send + 'static,
     ) -> Self {
         self.auth_factory = Some(Box::new(factory));
+        self
+    }
+
+    /// Replace the default OSS runtime surface with an explicit platform definition.
+    pub fn platform_definition(mut self, platform_definition: PlatformDefinition) -> Self {
+        self.platform_definition = Some(platform_definition);
         self
     }
 
@@ -203,6 +210,11 @@ impl ServerAppBuilder {
     /// Build and run the server. Blocks until shutdown.
     pub async fn run(self) -> Result<()> {
         tracing::info!("everrun-api starting...");
+        let platform_definition = Arc::new(
+            self.platform_definition
+                .clone()
+                .unwrap_or_else(crate::platform::oss_platform_definition),
+        );
 
         // =====================================================================
         // Phase 1: Storage backend & runner
@@ -285,12 +297,13 @@ impl ServerAppBuilder {
         // Phase 2: Seed & infrastructure services
         // =====================================================================
         let auth_config = auth::AuthConfig::from_env();
-        seed::spawn_seed_task(
+        seed::spawn_seed_task_with_platform_definition(
             db.clone(),
             seed::SeedAuthContext {
                 mode: auth_config.mode.clone(),
                 admin: auth_config.admin.clone(),
             },
+            platform_definition.as_ref().clone(),
         );
 
         let sqldb_backend = Arc::new(everruns_session_sqldb::InMemorySqlDbBackend::new());
@@ -419,8 +432,12 @@ impl ServerAppBuilder {
         // =====================================================================
         // Phase 5: API state construction
         // =====================================================================
-        let sessions_state =
-            api::sessions::AppState::new(db.clone(), runner.clone(), auth_state.clone());
+        let sessions_state = api::sessions::AppState::with_platform_definition(
+            db.clone(),
+            runner.clone(),
+            auth_state.clone(),
+            platform_definition.as_ref(),
+        );
         let messages_state = api::messages::AppState::new(
             db.clone(),
             runner.clone(),
@@ -444,7 +461,10 @@ impl ServerAppBuilder {
         };
 
         let events_state = api::events::AppState {
-            session_service: Arc::new(services::SessionService::new(db.clone())),
+            session_service: Arc::new(services::SessionService::with_registry(
+                db.clone(),
+                platform_definition.capability_registry().clone(),
+            )),
             event_service: event_service.clone(),
             sse_tracker: sse_tracker.clone(),
             event_broadcaster,
@@ -458,7 +478,7 @@ impl ServerAppBuilder {
                 auth: auth_state.clone(),
             }
         });
-        let driver_registry = Arc::new(create_driver_registry());
+        let driver_registry = Arc::new(platform_definition.driver_registry().clone());
         let llm_resolver = Arc::new(services::LlmResolverService::new(
             db.clone(),
             encryption.clone(),
@@ -477,9 +497,10 @@ impl ServerAppBuilder {
         );
         let mcp_servers_state =
             api::mcp_servers::AppState::new(db.clone(), encryption.clone(), auth_state.clone());
-        let capability_service = Arc::new(services::CapabilityService::new(
+        let capability_service = Arc::new(services::CapabilityService::with_registry(
             db.clone(),
             encryption.clone(),
+            platform_definition.capability_registry().clone(),
         ));
         let capabilities_state =
             api::capabilities::AppState::new(capability_service.clone(), auth_state.clone());
@@ -531,14 +552,19 @@ impl ServerAppBuilder {
         ));
         let skills_state = api::skills::AppState::new(db.clone(), auth_state.clone());
         let images_state = api::images::AppState::new(db.clone(), auth_state.clone());
-        let organizations_state = api::organizations::AppState::new(db.clone(), auth_state.clone());
+        let organizations_state = api::organizations::AppState::with_built_in_harnesses(
+            db.clone(),
+            auth_state.clone(),
+            platform_definition.built_in_harnesses().to_vec(),
+        );
         let audit_logs_state = api::audit_logs::AppState::new(db.clone(), auth_state.clone());
-        let user_connections_state = api::user_connections::AppState {
-            db: db.clone(),
-            encryption: encryption.clone(),
-            auth: auth_state.clone(),
-            auth_config: auth_config.clone(),
-        };
+        let user_connections_state = api::user_connections::AppState::new(
+            db.clone(),
+            encryption.clone(),
+            auth_state.clone(),
+            auth_config.clone(),
+            platform_definition.connection_providers().clone(),
+        );
         let session_schedule_service =
             Arc::new(crate::services::SessionScheduleService::new(db.clone()));
         let session_schedules_state = api::session_schedules::AppState::new(
@@ -695,6 +721,7 @@ impl ServerAppBuilder {
             encryption: encryption.clone(),
             runner: runner.clone(),
             driver_registry: driver_registry.clone(),
+            platform_definition: platform_definition.clone(),
         };
 
         if !self.config.dev_mode {
@@ -704,6 +731,7 @@ impl ServerAppBuilder {
             let grpc_event_service = event_service.clone();
             let grpc_runner = runner.clone();
             let grpc_addr = self.config.grpc_addr.clone();
+            let grpc_platform_definition = platform_definition.clone();
 
             let task_broadcaster = if let Some(pool) = db.pool() {
                 let broadcaster = TaskNotificationBroadcaster::new(pool.clone()).await;
@@ -722,6 +750,7 @@ impl ServerAppBuilder {
                     grpc_db,
                     grpc_encryption,
                     Some(grpc_runner),
+                    grpc_platform_definition.as_ref().clone(),
                 );
                 if let Some(broadcaster) = task_broadcaster {
                     grpc_svc.set_task_broadcaster(broadcaster);
@@ -883,8 +912,6 @@ impl ServerAppBuilder {
                     db.clone(),
                     encryption.clone(),
                 ));
-                let capability_registry = CapabilityRegistry::with_builtins();
-
                 let session_storage_store: Arc<dyn everruns_core::traits::SessionStorageStore> =
                     match db.as_ref() {
                         crate::storage::StorageBackend::Postgres(database) => {
@@ -909,7 +936,8 @@ impl ServerAppBuilder {
                     event_service.clone(),
                     llm_resolver,
                     mcp_server_service,
-                    capability_registry,
+                    platform_definition.capability_registry().clone(),
+                    platform_definition.driver_registry().clone(),
                     sqldb_store.clone(),
                 )
                 .with_storage_store(session_storage_store)

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -21,7 +21,6 @@ use everruns_core::{
     LlmProviderType, Message, MessageRole, Session, SessionStatus, ToolDefinition, ToolRegistry,
     ToolResultContentPart,
 };
-use everruns_worker::create_driver_registry;
 use everruns_worker::mcp_executor::McpServerInfo;
 use everruns_worker::worker_adapters::{TurnContext, WorkerAdapters};
 use std::collections::HashMap;
@@ -62,6 +61,7 @@ pub struct DirectWorkerAdapters {
     llm_resolver: Arc<LlmResolverService>,
     mcp_server_service: Arc<McpServerService>,
     capability_registry: CapabilityRegistry,
+    driver_registry: DriverRegistry,
     sqldb_store: everruns_core::traits::SessionSqlDbStoreRef,
     storage_store: Option<Arc<dyn everruns_core::traits::SessionStorageStore>>,
     connection_resolver: Option<Arc<dyn everruns_core::traits::UserConnectionResolver>>,
@@ -76,6 +76,7 @@ impl DirectWorkerAdapters {
         llm_resolver: Arc<LlmResolverService>,
         mcp_server_service: Arc<McpServerService>,
         capability_registry: CapabilityRegistry,
+        driver_registry: DriverRegistry,
         sqldb_store: everruns_core::traits::SessionSqlDbStoreRef,
     ) -> Self {
         Self {
@@ -84,6 +85,7 @@ impl DirectWorkerAdapters {
             llm_resolver,
             mcp_server_service,
             capability_registry,
+            driver_registry,
             sqldb_store,
             storage_store: None,
             connection_resolver: None,
@@ -798,7 +800,7 @@ impl WorkerAdapters for DirectWorkerAdapters {
     }
 
     fn driver_registry(&self) -> DriverRegistry {
-        create_driver_registry()
+        self.driver_registry.clone()
     }
 
     fn sqldb_store(&self) -> everruns_core::traits::SessionSqlDbStoreRef {
@@ -1901,6 +1903,7 @@ mod tests {
         let llm_resolver = Arc::new(crate::services::LlmResolverService::new(db.clone(), None));
         let mcp_server_service = Arc::new(crate::services::McpServerService::new(db.clone(), None));
         let cap_registry = CapabilityRegistry::new();
+        let driver_registry = everruns_worker::create_driver_registry();
         let sqldb_backend = Arc::new(everruns_session_sqldb::InMemorySqlDbBackend::new());
         let sqldb_store: everruns_core::traits::SessionSqlDbStoreRef = Arc::new(
             everruns_session_sqldb::InMemorySqlDbStore::new(sqldb_backend),
@@ -1912,6 +1915,7 @@ mod tests {
             llm_resolver,
             mcp_server_service,
             cap_registry,
+            driver_registry,
             sqldb_store,
         )
     }
@@ -2219,6 +2223,7 @@ mod tests {
             Some(encryption),
         ));
         let cap_registry = CapabilityRegistry::new();
+        let driver_registry = everruns_worker::create_driver_registry();
         let sqldb_backend = Arc::new(everruns_session_sqldb::InMemorySqlDbBackend::new());
         let sqldb_store: everruns_core::traits::SessionSqlDbStoreRef = Arc::new(
             everruns_session_sqldb::InMemorySqlDbStore::new(sqldb_backend),
@@ -2230,6 +2235,7 @@ mod tests {
             llm_resolver,
             mcp_server_service,
             cap_registry,
+            driver_registry,
             sqldb_store,
         )
     }

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -13,6 +13,7 @@ use crate::services::{
 use crate::storage::{EncryptionService, StorageBackend};
 use crate::task_notifications::TaskNotificationBroadcaster;
 use base64::Engine;
+use everruns_core::PlatformDefinition;
 use everruns_durable::{
     ActivityOptions, CircuitBreakerConfig, CircuitState, DistributedCircuitBreaker,
     PostgresWorkflowEventStore, StoreError, TaskDefinition, TaskFailureOutcome, WorkerInfo,
@@ -338,14 +339,18 @@ impl WorkerServiceImpl {
         db: Arc<StorageBackend>,
         encryption: Option<Arc<EncryptionService>>,
         runner: Option<Arc<dyn everruns_worker::AgentRunner>>,
+        platform_definition: PlatformDefinition,
     ) -> Self {
         let agent_service = AgentService::new(db.clone());
         let harness_service = HarnessService::new(db.clone());
-        let session_service = SessionService::new(db.clone());
+        let capability_registry = platform_definition.capability_registry().clone();
+        let session_service =
+            SessionService::with_registry(db.clone(), capability_registry.clone());
         let session_file_service = SessionFileService::new(db.clone());
         let llm_resolver_service = LlmResolverService::new(db.clone(), encryption.clone());
         let mcp_server_service = McpServerService::new(db.clone(), encryption.clone());
-        let capability_service = CapabilityService::new(db.clone(), encryption.clone());
+        let capability_service =
+            CapabilityService::with_registry(db.clone(), encryption.clone(), capability_registry);
 
         // Create durable store using the pool if available (PostgreSQL mode only)
         // In dev mode (in-memory), durable execution is handled differently

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -30,6 +30,11 @@ pub mod storage;
 
 // OpenAPI spec generation
 pub mod openapi;
+pub mod platform;
+pub use platform::{
+    oss_built_in_harnesses, oss_connection_provider_registry, oss_platform_definition,
+    oss_platform_definition_for_grade,
+};
 
 // Direct worker adapters for in-process task worker
 pub mod direct_worker_adapters;

--- a/crates/server/src/org_init.rs
+++ b/crates/server/src/org_init.rs
@@ -67,14 +67,10 @@ pub async fn initialize_org_harnesses_with_definitions(
             is_built_in: true,
         };
 
-        if is_default_org && harness.seed_id.is_some() {
+        if is_default_org && let Some(seed_id) = harness.seed_id {
             // Default org: use fixed seed UUIDs for backward compat
             match db
-                .create_harness_with_id(
-                    org_id,
-                    harness.seed_id.expect("seed_id checked above").into(),
-                    input,
-                )
+                .create_harness_with_id(org_id, seed_id.into(), input)
                 .await?
             {
                 Some(row) => {
@@ -88,12 +84,8 @@ pub async fn initialize_org_harnesses_with_definitions(
                     }
                 }
                 None => {
-                    let caps_changed = sync_harness_capabilities(
-                        db,
-                        harness.seed_id.expect("seed_id checked above"),
-                        &harness.capabilities,
-                    )
-                    .await?;
+                    let caps_changed =
+                        sync_harness_capabilities(db, seed_id, &harness.capabilities).await?;
                     if caps_changed {
                         tracing::info!(
                             name = harness.name,

--- a/crates/server/src/org_init.rs
+++ b/crates/server/src/org_init.rs
@@ -11,43 +11,8 @@ use crate::storage::{
     models::{CreateHarnessRow, UpdateOrganizationSettings},
 };
 use anyhow::{Context, Result};
+use everruns_core::{BuiltInCapabilityDefinition, BuiltInHarnessDefinition, BuiltInHarnessRole};
 use uuid::Uuid;
-
-/// Capability entry with optional per-capability config for built-in harnesses.
-pub struct BuiltInCapability {
-    pub id: &'static str,
-    pub config: Option<fn() -> serde_json::Value>,
-}
-
-impl BuiltInCapability {
-    const fn new(id: &'static str) -> Self {
-        Self { id, config: None }
-    }
-
-    const fn with_config(id: &'static str, config: fn() -> serde_json::Value) -> Self {
-        Self {
-            id,
-            config: Some(config),
-        }
-    }
-}
-
-impl std::fmt::Display for BuiltInCapability {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.id)
-    }
-}
-
-/// Built-in harness definition (static, system-managed)
-pub struct BuiltInHarness {
-    /// Fixed UUID used only for the default org (backward compat)
-    pub seed_id: Uuid,
-    pub name: &'static str,
-    pub description: &'static str,
-    pub system_prompt: &'static str,
-    pub tags: &'static [&'static str],
-    pub capabilities: &'static [BuiltInCapability],
-}
 
 /// Well-known seed IDs for default org harnesses (backward compat)
 mod harness_ids {
@@ -66,60 +31,9 @@ pub const BASE_HARNESS_ID: Uuid = harness_ids::BASE;
 /// Well-known UUID for the Chat harness (used by global chat endpoint)
 pub const CHAT_HARNESS_ID: Uuid = harness_ids::CHAT;
 
-/// Built-in harnesses provisioned for every organization
-pub const BUILT_IN_HARNESSES: &[BuiltInHarness] = &[
-    BuiltInHarness {
-        seed_id: harness_ids::BASE,
-        name: "Base",
-        description: "Empty harness with no capabilities. Provides a blank canvas for custom configurations.",
-        system_prompt: "You are a helpful assistant.",
-        tags: &["base", "built-in"],
-        capabilities: &[] as &[BuiltInCapability],
-    },
-    BuiltInHarness {
-        seed_id: harness_ids::GENERIC,
-        name: "Generic",
-        description: "General-purpose harness with file system, bash, web fetch, secrets, session management, long-context support, and agent skills. Recommended default for most use cases.",
-        system_prompt: "You are a helpful assistant.",
-        tags: &["generic", "default", "built-in"],
-        capabilities: &[
-            BuiltInCapability::new("session_file_system"),
-            BuiltInCapability::new("virtual_bash"),
-            BuiltInCapability::with_config(
-                "web_fetch",
-                || serde_json::json!({"enable_file_download": true}),
-            ),
-            BuiltInCapability::new("session_storage"),
-            BuiltInCapability::new("session"),
-            BuiltInCapability::new("agent_instructions"),
-            BuiltInCapability::new("skills"),
-            BuiltInCapability::new("infinity_context"),
-            BuiltInCapability::new("openai_tool_search"),
-        ],
-    },
-    BuiltInHarness {
-        seed_id: harness_ids::CHAT,
-        name: "Platform Chat",
-        description: "Conversational harness for the global chat interface with platform management capabilities.",
-        system_prompt: "You are a helpful assistant on the Everruns platform.\n\nCapabilities are the primary way to extend agent functionality. Use `list_capabilities` to discover available capabilities (built-in, MCP servers, and skills), then assign them when creating agents or harnesses.\n\nWhen creating agents, always use `list_capabilities` first to find relevant capability IDs to include.\n\n## Rendering entity references\n\nAll tool results include `name` and `ui_link` fields. When referencing entities (agents, harnesses, sessions) in your responses, always render them as clickable markdown links with the entity name — never show raw IDs.\n\nExamples:\n- Use: [My Agent](/agents/agent_abc123)\n- Not: agent_abc123\n- Use: Created [Research Bot](/agents/agent_xyz) successfully\n- Not: Created agent agent_xyz successfully\n\n## Running agents\n\nWhen asked to \"run an agent\" or \"run X with agent Y\", follow these steps:\n1. Create a session for the agent (use `manage_sessions` with operation \"create\")\n2. Send the user's message/task to the session (use `session_interact` with operation \"send_message\")\n3. Wait for the turn to complete (use `session_interact` with operation \"wait_for_idle\")\n4. Retrieve and relay the results (use `session_interact` with operation \"get_messages\")\n\n## Harness creation\n\nAvoid creating new harnesses unless the user explicitly needs a custom one. For most tasks, use the built-in \"Generic\" harness (find it via `manage_harnesses` with operation \"list\") which already includes file system, bash, storage, long-context support, session, agent instructions, and skills capabilities.\n\n## Confirmation guidelines\n\n- **Always confirm** before creating a harness or agent — these are reusable org-wide entities.\n- **Sessions**: Use common sense. Routine requests (\"run agent X on this task\") can proceed without confirmation. Unusual or high-impact requests (destructive operations, large-scale actions, unclear intent) should be confirmed first.",
-        tags: &["chat", "built-in"],
-        capabilities: &[
-            BuiltInCapability::new("session_file_system"),
-            BuiltInCapability::new("virtual_bash"),
-            BuiltInCapability::with_config(
-                "web_fetch",
-                || serde_json::json!({"enable_file_download": true}),
-            ),
-            BuiltInCapability::new("session_storage"),
-            BuiltInCapability::new("session"),
-            BuiltInCapability::new("agent_instructions"),
-            BuiltInCapability::new("skills"),
-            BuiltInCapability::new("infinity_context"),
-            BuiltInCapability::new("platform_management"),
-            BuiltInCapability::new("openai_tool_search"),
-        ],
-    },
-];
+pub(crate) fn default_harness_definitions() -> Vec<BuiltInHarnessDefinition> {
+    crate::platform::oss_built_in_harnesses()
+}
 
 /// Initialize built-in harnesses for a specific organization.
 ///
@@ -128,30 +42,43 @@ pub const BUILT_IN_HARNESSES: &[BuiltInHarness] = &[
 ///
 /// Uses upsert semantics: creates if missing, updates if definition changed.
 pub async fn initialize_org_harnesses(db: &StorageBackend, org_id: i64) -> Result<InitResult> {
+    initialize_org_harnesses_with_definitions(db, org_id, &default_harness_definitions()).await
+}
+
+/// Initialize built-in harnesses using an explicit set of harness definitions.
+pub async fn initialize_org_harnesses_with_definitions(
+    db: &StorageBackend,
+    org_id: i64,
+    harnesses: &[BuiltInHarnessDefinition],
+) -> Result<InitResult> {
     use everruns_core::DEFAULT_ORG_ID;
 
     let mut result = InitResult::default();
     let is_default_org = org_id == DEFAULT_ORG_ID;
 
-    for harness in BUILT_IN_HARNESSES {
+    for harness in harnesses {
         let input = CreateHarnessRow {
             name: harness.name.to_string(),
             description: Some(harness.description.to_string()),
             system_prompt: harness.system_prompt.to_string(),
             default_model_id: None,
-            tags: harness.tags.iter().map(|s| s.to_string()).collect(),
+            tags: harness.tags.clone(),
             initial_files: serde_json::json!([]),
             is_built_in: true,
         };
 
-        if is_default_org {
+        if is_default_org && harness.seed_id.is_some() {
             // Default org: use fixed seed UUIDs for backward compat
             match db
-                .create_harness_with_id(org_id, harness.seed_id.into(), input)
+                .create_harness_with_id(
+                    org_id,
+                    harness.seed_id.expect("seed_id checked above").into(),
+                    input,
+                )
                 .await?
             {
                 Some(row) => {
-                    sync_harness_capabilities(db, row.id.uuid(), harness.capabilities).await?;
+                    sync_harness_capabilities(db, row.id.uuid(), &harness.capabilities).await?;
                     if row.created_at == row.updated_at {
                         tracing::info!(name = harness.name, org_id, "Created built-in harness");
                         result.created += 1;
@@ -161,9 +88,12 @@ pub async fn initialize_org_harnesses(db: &StorageBackend, org_id: i64) -> Resul
                     }
                 }
                 None => {
-                    let caps_changed =
-                        sync_harness_capabilities(db, harness.seed_id, harness.capabilities)
-                            .await?;
+                    let caps_changed = sync_harness_capabilities(
+                        db,
+                        harness.seed_id.expect("seed_id checked above"),
+                        &harness.capabilities,
+                    )
+                    .await?;
                     if caps_changed {
                         tracing::info!(
                             name = harness.name,
@@ -179,7 +109,9 @@ pub async fn initialize_org_harnesses(db: &StorageBackend, org_id: i64) -> Resul
             }
         } else {
             // Non-default org: check if built-in harness already exists by name
-            let existing = db.list_harnesses(org_id, Some(harness.name), false).await?;
+            let existing = db
+                .list_harnesses(org_id, Some(&harness.name), false)
+                .await?;
             let already_exists = existing
                 .iter()
                 .any(|h| h.name == harness.name && h.is_built_in);
@@ -196,8 +128,12 @@ pub async fn initialize_org_harnesses(db: &StorageBackend, org_id: i64) -> Resul
                     .await?
                 {
                     Some(_) => {
-                        sync_harness_capabilities(db, existing_row.id.uuid(), harness.capabilities)
-                            .await?;
+                        sync_harness_capabilities(
+                            db,
+                            existing_row.id.uuid(),
+                            &harness.capabilities,
+                        )
+                        .await?;
                         tracing::info!(name = harness.name, org_id, "Updated built-in harness");
                         result.updated += 1;
                     }
@@ -205,7 +141,7 @@ pub async fn initialize_org_harnesses(db: &StorageBackend, org_id: i64) -> Resul
                         let caps_changed = sync_harness_capabilities(
                             db,
                             existing_row.id.uuid(),
-                            harness.capabilities,
+                            &harness.capabilities,
                         )
                         .await?;
                         if caps_changed {
@@ -218,7 +154,7 @@ pub async fn initialize_org_harnesses(db: &StorageBackend, org_id: i64) -> Resul
             } else {
                 // Fresh org — create with new UUID
                 let row = db.create_harness(org_id, input).await?;
-                sync_harness_capabilities(db, row.id.uuid(), harness.capabilities).await?;
+                sync_harness_capabilities(db, row.id.uuid(), &harness.capabilities).await?;
                 tracing::info!(
                     name = harness.name,
                     org_id,
@@ -230,7 +166,7 @@ pub async fn initialize_org_harnesses(db: &StorageBackend, org_id: i64) -> Resul
         }
     }
 
-    sync_org_harness_settings(db, org_id).await?;
+    sync_org_harness_settings_with_definitions(db, org_id, harnesses).await?;
 
     Ok(result)
 }
@@ -240,11 +176,20 @@ pub async fn initialize_org_harnesses(db: &StorageBackend, org_id: i64) -> Resul
 /// Ensures every org has up-to-date built-in harnesses. Called during seeding
 /// and can be triggered for upgrades when built-in definitions change.
 pub async fn reconcile_built_in_harnesses(db: &StorageBackend) -> Result<InitResult> {
+    reconcile_built_in_harnesses_with_definitions(db, &default_harness_definitions()).await
+}
+
+/// Reconcile built-in harnesses with an explicit set of harness definitions.
+pub async fn reconcile_built_in_harnesses_with_definitions(
+    db: &StorageBackend,
+    harnesses: &[BuiltInHarnessDefinition],
+) -> Result<InitResult> {
     let orgs = db.list_organizations().await?;
     let mut total = InitResult::default();
 
     for org in &orgs {
-        let org_result = initialize_org_harnesses(db, org.org_id).await?;
+        let org_result =
+            initialize_org_harnesses_with_definitions(db, org.org_id, harnesses).await?;
         tracing::debug!(
             org_id = org.org_id,
             created = org_result.created,
@@ -268,6 +213,15 @@ pub async fn reconcile_built_in_harnesses(db: &StorageBackend) -> Result<InitRes
 
 /// Ensure org settings point at built-in default/base harnesses without overriding user changes.
 pub async fn sync_org_harness_settings(db: &StorageBackend, org_id: i64) -> Result<()> {
+    sync_org_harness_settings_with_definitions(db, org_id, &default_harness_definitions()).await
+}
+
+/// Ensure org settings point at platform-provided default/base harnesses without overriding user changes.
+pub async fn sync_org_harness_settings_with_definitions(
+    db: &StorageBackend,
+    org_id: i64,
+    harness_definitions: &[BuiltInHarnessDefinition],
+) -> Result<()> {
     let settings = db.get_organization_settings(org_id).await?;
     let needs_default = settings
         .as_ref()
@@ -280,26 +234,42 @@ pub async fn sync_org_harness_settings(db: &StorageBackend, org_id: i64) -> Resu
     }
 
     let harnesses = db.list_harnesses(org_id, None, false).await?;
+    let default_harness_name = harness_definitions
+        .iter()
+        .find(|h| h.has_role(BuiltInHarnessRole::Default))
+        .map(|h| h.name.as_str());
+    let base_harness_name = harness_definitions
+        .iter()
+        .find(|h| h.has_role(BuiltInHarnessRole::Base))
+        .map(|h| h.name.as_str());
     let default_harness_id = harnesses
         .iter()
-        .find(|h| h.is_built_in && h.name == "Generic")
+        .find(|h| default_harness_name.is_some_and(|name| h.is_built_in && h.name == name))
         .map(|h| h.id);
     let base_harness_id = harnesses
         .iter()
-        .find(|h| h.is_built_in && h.name == "Base")
+        .find(|h| base_harness_name.is_some_and(|name| h.is_built_in && h.name == name))
         .map(|h| h.id);
 
     let default_harness_id = if needs_default {
-        Some(Some(default_harness_id.context(
-            "missing built-in Generic harness during org init",
-        )?))
+        default_harness_name
+            .map(|name| {
+                default_harness_id
+                    .context(format!("missing built-in {name} harness during org init"))
+                    .map(Some)
+            })
+            .transpose()?
     } else {
         None
     };
     let base_harness_id = if needs_base {
-        Some(Some(
-            base_harness_id.context("missing built-in Base harness during org init")?,
-        ))
+        base_harness_name
+            .map(|name| {
+                base_harness_id
+                    .context(format!("missing built-in {name} harness during org init"))
+                    .map(Some)
+            })
+            .transpose()?
     } else {
         None
     };
@@ -322,11 +292,11 @@ pub async fn sync_org_harness_settings(db: &StorageBackend, org_id: i64) -> Resu
 async fn sync_harness_capabilities(
     db: &StorageBackend,
     harness_id: Uuid,
-    desired: &[BuiltInCapability],
+    desired: &[BuiltInCapabilityDefinition],
 ) -> Result<bool> {
     let current = db.get_harness_capabilities(harness_id).await?;
     let current_ids: Vec<&str> = current.iter().map(|c| c.capability_id.as_str()).collect();
-    let desired_ids: Vec<&str> = desired.iter().map(|c| c.id).collect();
+    let desired_ids: Vec<&str> = desired.iter().map(|c| c.id.as_str()).collect();
 
     if current_ids == desired_ids {
         return Ok(false);
@@ -335,10 +305,7 @@ async fn sync_harness_capabilities(
     let cap_tuples: Vec<(String, i32, serde_json::Value)> = desired
         .iter()
         .enumerate()
-        .map(|(idx, cap)| {
-            let config = cap.config.map_or_else(|| serde_json::json!({}), |f| f());
-            (cap.id.to_string(), idx as i32, config)
-        })
+        .map(|(idx, cap)| (cap.id.clone(), idx as i32, cap.config.clone()))
         .collect();
     db.set_harness_capabilities(harness_id, cap_tuples).await?;
     Ok(true)
@@ -375,9 +342,14 @@ mod tests {
         StorageBackend::in_memory()
     }
 
+    fn harnesses() -> Vec<BuiltInHarnessDefinition> {
+        default_harness_definitions()
+    }
+
     #[test]
     fn test_built_in_harness_names_unique() {
-        let names: Vec<&str> = BUILT_IN_HARNESSES.iter().map(|h| h.name).collect();
+        let built_in_harnesses = harnesses();
+        let names: Vec<&str> = built_in_harnesses.iter().map(|h| h.name.as_str()).collect();
         let mut unique = names.clone();
         unique.sort();
         unique.dedup();
@@ -390,7 +362,14 @@ mod tests {
 
     #[test]
     fn test_built_in_harness_seed_ids_unique() {
-        let ids: Vec<Uuid> = BUILT_IN_HARNESSES.iter().map(|h| h.seed_id).collect();
+        let built_in_harnesses = harnesses();
+        let ids: Vec<Uuid> = built_in_harnesses
+            .iter()
+            .map(|h| {
+                h.seed_id
+                    .expect("OSS built-in harness should have a seed id")
+            })
+            .collect();
         let mut unique = ids.clone();
         unique.sort();
         unique.dedup();
@@ -407,17 +386,17 @@ mod tests {
         seed_default_org(&db).await;
 
         let result = initialize_org_harnesses(&db, DEFAULT_ORG_ID).await.unwrap();
-        assert_eq!(result.created, BUILT_IN_HARNESSES.len());
+        assert_eq!(result.created, harnesses().len());
 
         // All harnesses should be listed
-        let harnesses = db
+        let provisioned_harnesses = db
             .list_harnesses(DEFAULT_ORG_ID, None, false)
             .await
             .unwrap();
-        assert_eq!(harnesses.len(), BUILT_IN_HARNESSES.len());
+        assert_eq!(provisioned_harnesses.len(), harnesses().len());
 
         // All should be marked as built-in
-        for h in &harnesses {
+        for h in &provisioned_harnesses {
             assert!(h.is_built_in, "Harness {} should be built-in", h.name);
         }
 
@@ -439,11 +418,11 @@ mod tests {
         seed_default_org(&db).await;
 
         let r1 = initialize_org_harnesses(&db, DEFAULT_ORG_ID).await.unwrap();
-        assert_eq!(r1.created, BUILT_IN_HARNESSES.len());
+        assert_eq!(r1.created, harnesses().len());
 
         let r2 = initialize_org_harnesses(&db, DEFAULT_ORG_ID).await.unwrap();
         assert_eq!(r2.created, 0);
-        assert_eq!(r2.unchanged, BUILT_IN_HARNESSES.len());
+        assert_eq!(r2.unchanged, harnesses().len());
     }
 
     #[tokio::test]
@@ -462,11 +441,11 @@ mod tests {
             .unwrap();
 
         let result = initialize_org_harnesses(&db, org2.org_id).await.unwrap();
-        assert_eq!(result.created, BUILT_IN_HARNESSES.len());
+        assert_eq!(result.created, harnesses().len());
 
         // Verify harnesses exist for org 2
         let h_org2 = db.list_harnesses(org2.org_id, None, false).await.unwrap();
-        assert_eq!(h_org2.len(), BUILT_IN_HARNESSES.len());
+        assert_eq!(h_org2.len(), harnesses().len());
         for h in &h_org2 {
             assert!(h.is_built_in);
         }
@@ -544,12 +523,12 @@ mod tests {
 
         let result = reconcile_built_in_harnesses(&db).await.unwrap();
         // Should create harnesses for both orgs
-        assert_eq!(result.created, BUILT_IN_HARNESSES.len() * 2);
+        assert_eq!(result.created, harnesses().len() * 2);
 
         // Second reconcile should be no-op
         let result2 = reconcile_built_in_harnesses(&db).await.unwrap();
         assert_eq!(result2.created, 0);
-        assert_eq!(result2.unchanged, BUILT_IN_HARNESSES.len() * 2);
+        assert_eq!(result2.unchanged, harnesses().len() * 2);
 
         let _ = org2; // silence unused
     }
@@ -562,9 +541,12 @@ mod tests {
         initialize_org_harnesses(&db, DEFAULT_ORG_ID).await.unwrap();
 
         // Verify default org harnesses use the fixed seed UUIDs
-        for harness_def in BUILT_IN_HARNESSES {
+        for harness_def in harnesses() {
+            let seed_id = harness_def
+                .seed_id
+                .expect("OSS built-in harness should have a seed id");
             let row = db
-                .get_harness(DEFAULT_ORG_ID, harness_def.seed_id.into())
+                .get_harness(DEFAULT_ORG_ID, seed_id.into())
                 .await
                 .unwrap();
             assert!(
@@ -596,7 +578,14 @@ mod tests {
 
         // Non-default org should NOT use seed UUIDs
         let h_org2 = db.list_harnesses(org2.org_id, None, false).await.unwrap();
-        let seed_ids: Vec<Uuid> = BUILT_IN_HARNESSES.iter().map(|h| h.seed_id).collect();
+        let built_in_harnesses = harnesses();
+        let seed_ids: Vec<Uuid> = built_in_harnesses
+            .iter()
+            .map(|h| {
+                h.seed_id
+                    .expect("OSS built-in harness should have a seed id")
+            })
+            .collect();
         for h in &h_org2 {
             assert!(
                 !seed_ids.contains(&h.id.uuid()),
@@ -614,24 +603,38 @@ mod tests {
         initialize_org_harnesses(&db, DEFAULT_ORG_ID).await.unwrap();
 
         // Check that Generic harness has the expected capabilities
-        let generic = BUILT_IN_HARNESSES
+        let built_in_harnesses = harnesses();
+        let generic = built_in_harnesses
             .iter()
             .find(|h| h.name == "Generic")
             .unwrap();
-        let caps = db.get_harness_capabilities(generic.seed_id).await.unwrap();
+        let caps = db
+            .get_harness_capabilities(
+                generic
+                    .seed_id
+                    .expect("OSS built-in harness should have a seed id"),
+            )
+            .await
+            .unwrap();
         let cap_ids: Vec<&str> = caps.iter().map(|c| c.capability_id.as_str()).collect();
-        let expected_ids: Vec<&str> = generic.capabilities.iter().map(|c| c.id).collect();
+        let expected_ids: Vec<&str> = generic.capabilities.iter().map(|c| c.id.as_str()).collect();
         assert_eq!(
             cap_ids, expected_ids,
             "Generic harness capabilities should match definition"
         );
 
         // Base harness should have no capabilities
-        let base = BUILT_IN_HARNESSES
+        let base = built_in_harnesses
             .iter()
             .find(|h| h.name == "Base")
             .unwrap();
-        let base_caps = db.get_harness_capabilities(base.seed_id).await.unwrap();
+        let base_caps = db
+            .get_harness_capabilities(
+                base.seed_id
+                    .expect("OSS built-in harness should have a seed id"),
+            )
+            .await
+            .unwrap();
         assert!(
             base_caps.is_empty(),
             "Base harness should have no capabilities"

--- a/crates/server/src/platform.rs
+++ b/crates/server/src/platform.rs
@@ -1,0 +1,116 @@
+//! Default OSS platform definition helpers.
+//!
+//! The default OSS platform stays centralized here so server startup, org
+//! initialization, and docs can all point to the same preset. Inventory-based
+//! integration discovery is intentionally confined to this module; embedders
+//! can start from the OSS preset or construct a `PlatformDefinition` manually
+//! without depending on inventory registration.
+
+use everruns_core::connection_provider::{ConnectionProviderPlugin, ConnectionProviderRegistry};
+use everruns_core::deployment::DeploymentGrade;
+use everruns_core::{
+    BuiltInCapabilityDefinition, BuiltInHarnessDefinition, BuiltInHarnessRole, CapabilityRegistry,
+    PlatformDefinition,
+};
+
+/// Build the default OSS `PlatformDefinition` for the current deployment grade.
+pub fn oss_platform_definition() -> PlatformDefinition {
+    oss_platform_definition_for_grade(DeploymentGrade::from_env())
+}
+
+/// Build the default OSS `PlatformDefinition` for an explicit deployment grade.
+pub fn oss_platform_definition_for_grade(grade: DeploymentGrade) -> PlatformDefinition {
+    let capability_registry = CapabilityRegistry::with_builtins_for_grade(grade);
+    let driver_registry = everruns_worker::create_driver_registry();
+    let connection_providers = oss_connection_provider_registry_for_grade(grade);
+
+    PlatformDefinition::builder()
+        .capability_registry(capability_registry)
+        .driver_registry(driver_registry)
+        .connection_providers(connection_providers)
+        .built_in_harnesses(oss_built_in_harnesses())
+        .build()
+}
+
+/// Build the default OSS connection-provider registry.
+pub fn oss_connection_provider_registry() -> ConnectionProviderRegistry {
+    oss_connection_provider_registry_for_grade(DeploymentGrade::from_env())
+}
+
+/// Build the default OSS connection-provider registry for an explicit grade.
+pub fn oss_connection_provider_registry_for_grade(
+    grade: DeploymentGrade,
+) -> ConnectionProviderRegistry {
+    let mut registry = ConnectionProviderRegistry::new();
+
+    for plugin in inventory::iter::<ConnectionProviderPlugin> {
+        if plugin.experimental_only && !grade.experimental_features_enabled() {
+            continue;
+        }
+        registry.register_boxed((plugin.factory)());
+    }
+
+    registry
+}
+
+/// Built-in harness templates for the default OSS platform.
+pub fn oss_built_in_harnesses() -> Vec<BuiltInHarnessDefinition> {
+    vec![
+        BuiltInHarnessDefinition::new(
+            "base",
+            "Base",
+            "Empty harness with no capabilities. Provides a blank canvas for custom configurations.",
+            "You are a helpful assistant.",
+        )
+        .with_seed_id(crate::org_init::BASE_HARNESS_ID)
+        .with_tags(["base", "built-in"])
+        .with_roles([BuiltInHarnessRole::Base]),
+        BuiltInHarnessDefinition::new(
+            "generic",
+            "Generic",
+            "General-purpose harness with file system, bash, web fetch, secrets, session management, long-context support, and agent skills. Recommended default for most use cases.",
+            "You are a helpful assistant.",
+        )
+        .with_seed_id(crate::org_init::GENERIC_HARNESS_ID)
+        .with_tags(["generic", "default", "built-in"])
+        .with_roles([BuiltInHarnessRole::Default])
+        .with_capabilities([
+            BuiltInCapabilityDefinition::new("session_file_system"),
+            BuiltInCapabilityDefinition::new("virtual_bash"),
+            BuiltInCapabilityDefinition::with_config(
+                "web_fetch",
+                serde_json::json!({"enable_file_download": true}),
+            ),
+            BuiltInCapabilityDefinition::new("session_storage"),
+            BuiltInCapabilityDefinition::new("session"),
+            BuiltInCapabilityDefinition::new("agent_instructions"),
+            BuiltInCapabilityDefinition::new("skills"),
+            BuiltInCapabilityDefinition::new("infinity_context"),
+            BuiltInCapabilityDefinition::new("openai_tool_search"),
+        ]),
+        BuiltInHarnessDefinition::new(
+            "platform_chat",
+            "Platform Chat",
+            "Conversational harness for the global chat interface with platform management capabilities.",
+            "You are a helpful assistant on the Everruns platform.\n\nCapabilities are the primary way to extend agent functionality. Use `list_capabilities` to discover available capabilities (built-in, MCP servers, and skills), then assign them when creating agents or harnesses.\n\nWhen creating agents, always use `list_capabilities` first to find relevant capability IDs to include.\n\n## Rendering entity references\n\nAll tool results include `name` and `ui_link` fields. When referencing entities (agents, harnesses, sessions) in your responses, always render them as clickable markdown links with the entity name — never show raw IDs.\n\nExamples:\n- Use: [My Agent](/agents/agent_abc123)\n- Not: agent_abc123\n- Use: Created [Research Bot](/agents/agent_xyz) successfully\n- Not: Created agent agent_xyz successfully\n\n## Running agents\n\nWhen asked to \"run an agent\" or \"run X with agent Y\", follow these steps:\n1. Create a session for the agent (use `manage_sessions` with operation \"create\")\n2. Send the user's message/task to the session (use `session_interact` with operation \"send_message\")\n3. Wait for the turn to complete (use `session_interact` with operation \"wait_for_idle\")\n4. Retrieve and relay the results (use `session_interact` with operation \"get_messages\")\n\n## Harness creation\n\nAvoid creating new harnesses unless the user explicitly needs a custom one. For most tasks, use the built-in \"Generic\" harness (find it via `manage_harnesses` with operation \"list\") which already includes file system, bash, storage, long-context support, session, agent instructions, and skills capabilities.\n\n## Confirmation guidelines\n\n- **Always confirm** before creating a harness or agent — these are reusable org-wide entities.\n- **Sessions**: Use common sense. Routine requests (\"run agent X on this task\") can proceed without confirmation. Unusual or high-impact requests (destructive operations, large-scale actions, unclear intent) should be confirmed first.",
+        )
+        .with_seed_id(crate::org_init::CHAT_HARNESS_ID)
+        .with_tags(["chat", "built-in"])
+        .with_roles([BuiltInHarnessRole::Chat])
+        .with_capabilities([
+            BuiltInCapabilityDefinition::new("session_file_system"),
+            BuiltInCapabilityDefinition::new("virtual_bash"),
+            BuiltInCapabilityDefinition::with_config(
+                "web_fetch",
+                serde_json::json!({"enable_file_download": true}),
+            ),
+            BuiltInCapabilityDefinition::new("session_storage"),
+            BuiltInCapabilityDefinition::new("session"),
+            BuiltInCapabilityDefinition::new("agent_instructions"),
+            BuiltInCapabilityDefinition::new("skills"),
+            BuiltInCapabilityDefinition::new("infinity_context"),
+            BuiltInCapabilityDefinition::new("platform_management"),
+            BuiltInCapabilityDefinition::new("openai_tool_search"),
+        ]),
+    ]
+}

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -18,8 +18,9 @@ use crate::storage::{
 };
 use everruns_core::{
     ANONYMOUS_USER_EMAIL, ANONYMOUS_USER_ID, ANONYMOUS_USER_NAME, DEFAULT_ORG_ID,
-    DEFAULT_ORG_PUBLIC_ID, DeploymentGrade,
+    DEFAULT_ORG_PUBLIC_ID, DeploymentGrade, PlatformDefinition,
 };
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 use uuid::Uuid;
@@ -1021,7 +1022,11 @@ User: "Analyze my codebase and suggest improvements"
 /// Seed agents into the database (upserts, only when changed).
 ///
 /// Filters out dev-only agents when not in dev environment.
-async fn seed_agents(db: &StorageBackend, grade: DeploymentGrade) -> anyhow::Result<SeedResult> {
+async fn seed_agents_with_platform_definition(
+    db: &StorageBackend,
+    grade: DeploymentGrade,
+    platform_definition: &PlatformDefinition,
+) -> anyhow::Result<SeedResult> {
     let mut result = SeedResult::default();
     let include_dev_only = grade.experimental_features_enabled();
 
@@ -1033,6 +1038,21 @@ async fn seed_agents(db: &StorageBackend, grade: DeploymentGrade) -> anyhow::Res
                 id = %seed.id,
                 "Skipping dev-only agent (deployment_grade={})",
                 grade
+            );
+            continue;
+        }
+        let missing_capabilities: Vec<&str> = seed
+            .capabilities
+            .iter()
+            .map(|capability| capability.id)
+            .filter(|capability_id| !platform_definition.capability_registry().has(capability_id))
+            .collect();
+        if !missing_capabilities.is_empty() {
+            tracing::debug!(
+                name = seed.name,
+                id = %seed.id,
+                missing_capabilities = ?missing_capabilities,
+                "Skipping seed agent because platform definition does not register all required capabilities"
             );
             continue;
         }
@@ -1114,11 +1134,38 @@ const SEED_PROVIDERS: &[SeedProvider] = &[
     },
 ];
 
-/// Seed LLM providers into the database (upserts, only when changed)
-async fn seed_providers(db: &StorageBackend) -> anyhow::Result<SeedResult> {
+fn enabled_seed_provider_ids(platform_definition: &PlatformDefinition) -> HashSet<Uuid> {
+    let registered_provider_types: HashSet<String> = platform_definition
+        .driver_registry()
+        .registered_providers()
+        .into_iter()
+        .map(|provider_type| provider_type.to_string())
+        .collect();
+
+    SEED_PROVIDERS
+        .iter()
+        .filter(|seed| registered_provider_types.contains(seed.provider_type))
+        .map(|seed| seed.id)
+        .collect()
+}
+
+async fn seed_providers_with_platform_definition(
+    db: &StorageBackend,
+    platform_definition: &PlatformDefinition,
+) -> anyhow::Result<SeedResult> {
     let mut result = SeedResult::default();
+    let enabled_provider_ids = enabled_seed_provider_ids(platform_definition);
 
     for seed in SEED_PROVIDERS {
+        if !enabled_provider_ids.contains(&seed.id) {
+            tracing::debug!(
+                name = seed.name,
+                id = %seed.id,
+                provider_type = seed.provider_type,
+                "Skipping seed provider because platform definition does not register its driver"
+            );
+            continue;
+        }
         let input = CreateLlmProviderRow {
             name: seed.name.to_string(),
             provider_type: seed.provider_type.to_string(),
@@ -1606,10 +1653,22 @@ async fn seed_organization_settings(db: &StorageBackend) -> anyhow::Result<SeedR
 }
 
 /// Seed LLM models into the database (upserts, only when changed)
-async fn seed_models(db: &StorageBackend) -> anyhow::Result<SeedResult> {
+async fn seed_models_with_platform_definition(
+    db: &StorageBackend,
+    platform_definition: &PlatformDefinition,
+) -> anyhow::Result<SeedResult> {
     let mut result = SeedResult::default();
+    let enabled_provider_ids = enabled_seed_provider_ids(platform_definition);
 
     for seed in SEED_MODELS {
+        if !enabled_provider_ids.contains(&seed.provider_id) {
+            tracing::debug!(
+                model_id = seed.model_id,
+                id = %seed.id,
+                "Skipping seed model because its provider driver is not registered by the platform definition"
+            );
+            continue;
+        }
         let input = CreateLlmModelRow {
             provider_id: seed.provider_id.into(),
             model_id: seed.model_id.to_string(),
@@ -1740,6 +1799,19 @@ pub struct SeedAuthContext {
 ///
 /// Uses `DeploymentGrade::from_env()` to determine which agents to seed.
 pub fn spawn_seed_task(db: Arc<StorageBackend>, auth_ctx: SeedAuthContext) {
+    spawn_seed_task_with_platform_definition(
+        db,
+        auth_ctx,
+        crate::platform::oss_platform_definition_for_grade(DeploymentGrade::from_env()),
+    );
+}
+
+/// Spawn seeding as a background task using an explicit platform definition.
+pub fn spawn_seed_task_with_platform_definition(
+    db: Arc<StorageBackend>,
+    auth_ctx: SeedAuthContext,
+    platform_definition: PlatformDefinition,
+) {
     let grade = DeploymentGrade::from_env();
     tracing::info!(deployment_grade = %grade, "Starting seeding task");
 
@@ -1747,7 +1819,7 @@ pub fn spawn_seed_task(db: Arc<StorageBackend>, auth_ctx: SeedAuthContext) {
         // Small delay to let the server start first
         tokio::time::sleep(Duration::from_millis(500)).await;
 
-        match run_seed_with_retry(&db, grade, &auth_ctx).await {
+        match run_seed_with_retry(&db, grade, &auth_ctx, &platform_definition).await {
             Ok(result) => {
                 if result.has_changes() {
                     tracing::info!(
@@ -1780,12 +1852,13 @@ async fn run_seed_with_retry(
     db: &StorageBackend,
     grade: DeploymentGrade,
     auth_ctx: &SeedAuthContext,
+    platform_definition: &PlatformDefinition,
 ) -> Result<SeedResult, String> {
     let mut retry_count = 0;
     let mut delay = INITIAL_RETRY_DELAY;
 
     loop {
-        match seed_all(db, grade, auth_ctx).await {
+        match seed_all_with_platform_definition(db, grade, auth_ctx, platform_definition).await {
             Ok(result) => return Ok(result),
             Err(e) => {
                 let error_str = e.to_string();
@@ -1834,6 +1907,17 @@ pub async fn seed_all(
     grade: DeploymentGrade,
     auth_ctx: &SeedAuthContext,
 ) -> anyhow::Result<SeedResult> {
+    let platform_definition = crate::platform::oss_platform_definition_for_grade(grade);
+    seed_all_with_platform_definition(db, grade, auth_ctx, &platform_definition).await
+}
+
+/// Run all seeders in order using an explicit platform definition.
+pub async fn seed_all_with_platform_definition(
+    db: &StorageBackend,
+    grade: DeploymentGrade,
+    auth_ctx: &SeedAuthContext,
+    platform_definition: &PlatformDefinition,
+) -> anyhow::Result<SeedResult> {
     let mut result = SeedResult::default();
 
     // Seed default organization first (all other resources depend on it)
@@ -1871,7 +1955,7 @@ pub async fn seed_all(
     }
 
     // Seed providers (models depend on them)
-    let provider_result = seed_providers(db).await?;
+    let provider_result = seed_providers_with_platform_definition(db, platform_definition).await?;
     tracing::debug!(
         created = provider_result.created,
         updated = provider_result.updated,
@@ -1881,7 +1965,7 @@ pub async fn seed_all(
     result.merge(provider_result);
 
     // Seed models (depend on providers)
-    let model_result = seed_models(db).await?;
+    let model_result = seed_models_with_platform_definition(db, platform_definition).await?;
     tracing::debug!(
         created = model_result.created,
         updated = model_result.updated,
@@ -1911,7 +1995,11 @@ pub async fn seed_all(
     result.merge(mcp_result);
 
     // Reconcile built-in harnesses across all orgs (before agents, sessions may reference them)
-    let harness_result = org_init::reconcile_built_in_harnesses(db).await?;
+    let harness_result = org_init::reconcile_built_in_harnesses_with_definitions(
+        db,
+        platform_definition.built_in_harnesses(),
+    )
+    .await?;
     tracing::debug!(
         created = harness_result.created,
         updated = harness_result.updated,
@@ -1923,7 +2011,7 @@ pub async fn seed_all(
     result.unchanged += harness_result.unchanged;
 
     // Seed agents (respects deployment grade for dev-only agents)
-    let agent_result = seed_agents(db, grade).await?;
+    let agent_result = seed_agents_with_platform_definition(db, grade, platform_definition).await?;
     tracing::debug!(
         created = agent_result.created,
         updated = agent_result.updated,
@@ -1947,13 +2035,20 @@ mod tests {
         StorageBackend::in_memory()
     }
 
+    fn built_in_harnesses() -> Vec<everruns_core::BuiltInHarnessDefinition> {
+        org_init::default_harness_definitions()
+    }
+
     // --- Harness seed data ---
 
     #[test]
     fn test_seed_harness_ids_are_unique() {
-        let ids: Vec<Uuid> = org_init::BUILT_IN_HARNESSES
+        let ids: Vec<Uuid> = built_in_harnesses()
             .iter()
-            .map(|h| h.seed_id)
+            .map(|h| {
+                h.seed_id
+                    .expect("OSS built-in harness should have a seed id")
+            })
             .collect();
         let mut unique_ids = ids.clone();
         unique_ids.sort();
@@ -1967,10 +2062,8 @@ mod tests {
 
     #[test]
     fn test_seed_harness_names_are_unique() {
-        let names: Vec<&str> = org_init::BUILT_IN_HARNESSES
-            .iter()
-            .map(|h| h.name)
-            .collect();
+        let built_in_harnesses = built_in_harnesses();
+        let names: Vec<&str> = built_in_harnesses.iter().map(|h| h.name.as_str()).collect();
         let mut unique_names = names.clone();
         unique_names.sort();
         unique_names.dedup();
@@ -1983,7 +2076,8 @@ mod tests {
 
     #[test]
     fn test_base_harness_has_no_capabilities() {
-        let base = org_init::BUILT_IN_HARNESSES
+        let built_in_harnesses = built_in_harnesses();
+        let base = built_in_harnesses
             .iter()
             .find(|h| h.name == "Base")
             .expect("Base harness should exist");
@@ -1991,17 +2085,18 @@ mod tests {
             base.capabilities.is_empty(),
             "Base harness must have no capabilities"
         );
-        assert!(base.tags.contains(&"base"));
+        assert!(base.tags.iter().any(|tag| tag == "base"));
     }
 
     #[test]
     fn test_generic_harness_has_expected_capabilities() {
-        let generic = org_init::BUILT_IN_HARNESSES
+        let built_in_harnesses = built_in_harnesses();
+        let generic = built_in_harnesses
             .iter()
             .find(|h| h.name == "Generic")
             .expect("Generic harness should exist");
 
-        let cap_ids: Vec<&str> = generic.capabilities.iter().map(|c| c.id).collect();
+        let cap_ids: Vec<&str> = generic.capabilities.iter().map(|c| c.id.as_str()).collect();
         assert_eq!(cap_ids.len(), 9);
         assert!(cap_ids.contains(&"session_file_system"));
         assert!(cap_ids.contains(&"virtual_bash"));
@@ -2012,8 +2107,8 @@ mod tests {
         assert!(cap_ids.contains(&"skills"));
         assert!(cap_ids.contains(&"infinity_context"));
         assert!(cap_ids.contains(&"openai_tool_search"));
-        assert!(generic.tags.contains(&"generic"));
-        assert!(generic.tags.contains(&"default"));
+        assert!(generic.tags.iter().any(|tag| tag == "generic"));
+        assert!(generic.tags.iter().any(|tag| tag == "default"));
     }
 
     #[test]
@@ -2023,14 +2118,15 @@ mod tests {
             everruns_core::DeploymentGrade::Dev,
         );
 
-        let generic = org_init::BUILT_IN_HARNESSES
+        let built_in_harnesses = built_in_harnesses();
+        let generic = built_in_harnesses
             .iter()
             .find(|h| h.name == "Generic")
             .expect("Generic harness should exist");
 
-        for cap in generic.capabilities {
+        for cap in &generic.capabilities {
             assert!(
-                registry.has(cap.id),
+                registry.has(&cap.id),
                 "Capability '{}' referenced by Generic harness must be registered",
                 cap.id
             );
@@ -2051,12 +2147,13 @@ mod tests {
             everruns_core::DeploymentGrade::Dev,
         );
 
-        let generic = org_init::BUILT_IN_HARNESSES
+        let built_in_harnesses = built_in_harnesses();
+        let generic = built_in_harnesses
             .iter()
             .find(|h| h.name == "Generic")
             .expect("Generic harness should exist");
 
-        let cap_ids: Vec<String> = generic.capabilities.iter().map(|s| s.to_string()).collect();
+        let cap_ids: Vec<String> = generic.capabilities.iter().map(|s| s.id.clone()).collect();
         let ctx = SystemPromptContext::without_file_store(everruns_core::SessionId::new());
         let collected = collect_capabilities(&cap_ids, &registry, &ctx).await;
 
@@ -2095,12 +2192,13 @@ mod tests {
             everruns_core::DeploymentGrade::Dev,
         );
 
-        let generic = org_init::BUILT_IN_HARNESSES
+        let built_in_harnesses = built_in_harnesses();
+        let generic = built_in_harnesses
             .iter()
             .find(|h| h.name == "Generic")
             .expect("Generic harness should exist");
 
-        let cap_ids: Vec<String> = generic.capabilities.iter().map(|s| s.to_string()).collect();
+        let cap_ids: Vec<String> = generic.capabilities.iter().map(|s| s.id.clone()).collect();
         let ctx = SystemPromptContext::without_file_store(everruns_core::SessionId::new());
         let collected = collect_capabilities(&cap_ids, &registry, &ctx).await;
 
@@ -2140,12 +2238,13 @@ mod tests {
             everruns_core::DeploymentGrade::Dev,
         );
 
-        let generic = org_init::BUILT_IN_HARNESSES
+        let built_in_harnesses = built_in_harnesses();
+        let generic = built_in_harnesses
             .iter()
             .find(|h| h.name == "Generic")
             .expect("Generic harness should exist");
 
-        let cap_ids: Vec<String> = generic.capabilities.iter().map(|s| s.to_string()).collect();
+        let cap_ids: Vec<String> = generic.capabilities.iter().map(|s| s.id.clone()).collect();
         let ctx = SystemPromptContext::without_file_store(everruns_core::SessionId::new());
         let collected = collect_capabilities(&cap_ids, &registry, &ctx).await;
 
@@ -2367,12 +2466,14 @@ mod tests {
             .unwrap();
 
         // Mutate harness description via public API
+        let built_in_harnesses = built_in_harnesses();
         let harness_id = everruns_core::HarnessId::from_uuid(
-            org_init::BUILT_IN_HARNESSES
+            built_in_harnesses
                 .iter()
                 .find(|h| h.name == "Base")
                 .unwrap()
-                .seed_id,
+                .seed_id
+                .expect("OSS built-in harness should have a seed id"),
         );
         db.update_harness(
             DEFAULT_ORG_ID,

--- a/crates/server/src/services/capability.rs
+++ b/crates/server/src/services/capability.rs
@@ -32,9 +32,17 @@ pub struct CapabilityService {
 
 impl CapabilityService {
     pub fn new(db: Arc<StorageBackend>, encryption: Option<Arc<EncryptionService>>) -> Self {
+        Self::with_registry(db, encryption, CapabilityRegistry::with_builtins())
+    }
+
+    pub fn with_registry(
+        db: Arc<StorageBackend>,
+        encryption: Option<Arc<EncryptionService>>,
+        registry: CapabilityRegistry,
+    ) -> Self {
         Self {
             db: db.clone(),
-            registry: CapabilityRegistry::with_builtins(),
+            registry,
             mcp_service: McpServerService::new(db.clone(), encryption),
             skill_service: Arc::new(SkillService::new(db)),
         }

--- a/crates/server/src/services/llm_model.rs
+++ b/crates/server/src/services/llm_model.rs
@@ -366,6 +366,7 @@ impl LlmModelService {
             // Hardcoded always wins for curated fields
             name: hardcoded.name,
             family: hardcoded.family,
+            description: hardcoded.description.or(discovered.description),
             release_date: hardcoded.release_date.or(discovered.release_date),
             last_updated: hardcoded.last_updated.or(discovered.last_updated),
             attachment: hardcoded.attachment,
@@ -457,6 +458,7 @@ mod tests {
         LlmModelProfile {
             name: "Test".into(),
             family: "test".into(),
+            description: None,
             release_date: None,
             last_updated: None,
             attachment: true,
@@ -484,6 +486,7 @@ mod tests {
                 input: 5.0,
                 output: 25.0,
                 cache_read: None,
+                cost_tiers: vec![],
             }),
             ..base_profile()
         };

--- a/crates/server/src/services/session.rs
+++ b/crates/server/src/services/session.rs
@@ -478,6 +478,7 @@ impl SessionService {
         caller: &Caller,
         user_id: Uuid,
         harness_id: Uuid,
+        title: &str,
     ) -> Result<Session> {
         let org_id = caller.org_id;
         let org_public_id = &caller.org_public_id;
@@ -498,7 +499,7 @@ impl SessionService {
             org_id,
             harness_id: Some(harness_id_typed),
             agent_id: None,
-            title: Some("Platform Chat".to_string()),
+            title: Some(title.to_string()),
             locale: None,
             tags: vec!["global-chat".to_string(), user_tag],
             model_id: None,

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -36,7 +36,7 @@ use everruns_server::{
     api, auth, seed, services,
     storage::{EncryptionService, StorageBackend},
 };
-use everruns_worker::{RunnerBackend, create_driver_registry, create_runner_with_backend};
+use everruns_worker::{RunnerBackend, create_runner_with_backend};
 
 /// Get test database URL from environment or use default
 pub fn get_database_url() -> String {
@@ -102,6 +102,7 @@ impl TestServer {
 
         // Seed default data synchronously (harnesses, agents, providers, etc.)
         let grade = everruns_core::DeploymentGrade::from_env();
+        let platform_definition = everruns_server::oss_platform_definition_for_grade(grade);
         seed::seed_all(&db, grade, &seed::SeedAuthContext::default())
             .await
             .expect("Failed to seed test data");
@@ -132,15 +133,19 @@ impl TestServer {
         };
 
         // Create driver registry
-        let driver_registry = Arc::new(create_driver_registry());
+        let driver_registry = Arc::new(platform_definition.driver_registry().clone());
 
         // Create event listeners (minimal for tests)
         let event_service = Arc::new(services::EventService::with_listeners(db.clone(), vec![]));
         let feature_flags = everruns_core::FeatureFlags::from_env(&grade);
 
         // Create module-specific states
-        let sessions_state =
-            api::sessions::AppState::new(db.clone(), runner.clone(), auth_state.clone());
+        let sessions_state = api::sessions::AppState::with_platform_definition(
+            db.clone(),
+            runner.clone(),
+            auth_state.clone(),
+            &platform_definition,
+        );
         let messages_state = api::messages::AppState::new(
             db.clone(),
             runner.clone(),
@@ -151,7 +156,10 @@ impl TestServer {
             everruns_server::api::sse::SseConnectionLimits::default(),
         ));
         let events_state = api::events::AppState {
-            session_service: Arc::new(services::SessionService::new(db.clone())),
+            session_service: Arc::new(services::SessionService::with_registry(
+                db.clone(),
+                platform_definition.capability_registry().clone(),
+            )),
             event_service: event_service.clone(),
             sse_tracker: sse_tracker.clone(),
             event_broadcaster: None,
@@ -167,9 +175,10 @@ impl TestServer {
         let llm_models_state = api::llm_models::AppState::new(db.clone(), auth_state.clone(), None);
         let mcp_servers_state =
             api::mcp_servers::AppState::new(db.clone(), encryption.clone(), auth_state.clone());
-        let capability_service = Arc::new(services::CapabilityService::new(
+        let capability_service = Arc::new(services::CapabilityService::with_registry(
             db.clone(),
             encryption.clone(),
+            platform_definition.capability_registry().clone(),
         ));
         let capabilities_state =
             api::capabilities::AppState::new(capability_service.clone(), auth_state.clone());
@@ -200,7 +209,11 @@ impl TestServer {
             api::schedules::ScheduleAppState::new(Some(durable_store), auth_state.clone());
         let skills_state = api::skills::AppState::new(db.clone(), auth_state.clone());
         let images_state = api::images::AppState::new(db.clone(), auth_state.clone());
-        let organizations_state = api::organizations::AppState::new(db.clone(), auth_state.clone());
+        let organizations_state = api::organizations::AppState::with_built_in_harnesses(
+            db.clone(),
+            auth_state.clone(),
+            platform_definition.built_in_harnesses().to_vec(),
+        );
         let session_schedules_state = api::session_schedules::AppState::new(
             Arc::new(services::SessionScheduleService::new(db.clone())),
             auth_state.clone(),
@@ -218,12 +231,13 @@ impl TestServer {
         let feature_flags_state = api::feature_flags::AppState {
             flags: feature_flags.clone(),
         };
-        let user_connections_state = api::user_connections::AppState {
-            db: db.clone(),
-            encryption: encryption.clone(),
-            auth: auth_state.clone(),
-            auth_config: auth_config.clone(),
-        };
+        let user_connections_state = api::user_connections::AppState::new(
+            db.clone(),
+            encryption.clone(),
+            auth_state.clone(),
+            auth_config.clone(),
+            platform_definition.connection_providers().clone(),
+        );
 
         let apps_state = api::apps::AppState::new(db.clone(), auth_state.clone());
         let slack_state = api::slack_events::SlackState::new(

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -15,14 +15,11 @@
 use anyhow::{Context, Result};
 use everruns_core::ToolRegistry;
 use everruns_core::atoms::{ActAtom, Atom, InputAtom, ReasonAtom};
-use everruns_core::capabilities::{
-    CapabilityRegistry, SystemPromptContext, collect_capabilities, is_mcp_capability,
-};
+use everruns_core::capabilities::{SystemPromptContext, collect_capabilities, is_mcp_capability};
 use everruns_core::traits::{AgentStore, HarnessStore};
-use everruns_core::{AgentStatus, HarnessStatus, Message};
+use everruns_core::{AgentStatus, HarnessStatus, Message, PlatformDefinition};
 use std::sync::Arc;
 
-use crate::adapters::create_driver_registry;
 use crate::grpc_adapters::{
     GrpcAgentStore, GrpcClient, GrpcConnectionResolver, GrpcEventEmitter, GrpcHarnessStore,
     GrpcImageResolver, GrpcLeasedResourceStore, GrpcLlmProviderStore, GrpcMessageRetriever,
@@ -262,6 +259,7 @@ pub async fn reason_activity(
     grpc_client: GrpcClient,
     org_id: i64,
     input: ReasonInput,
+    platform_definition: &PlatformDefinition,
 ) -> Result<ReasonResult> {
     use everruns_core::MessageRetriever;
     use everruns_core::events::{
@@ -304,8 +302,8 @@ pub async fn reason_activity(
     let session_store = GrpcSessionStore::new(grpc_client.clone(), org_id);
     let message_retriever = GrpcMessageRetriever::new(grpc_client.clone());
     let provider_store = GrpcLlmProviderStore::new(grpc_client.clone(), org_id);
-    let capability_registry = CapabilityRegistry::with_builtins();
-    let driver_registry = create_driver_registry();
+    let capability_registry = platform_definition.capability_registry().clone();
+    let driver_registry = platform_definition.driver_registry().clone();
     let event_emitter = GrpcEventEmitter::new(grpc_client.clone());
 
     // Create image resolver for multimodal image support
@@ -424,6 +422,7 @@ pub async fn act_activity(
     grpc_client: GrpcClient,
     org_id: i64,
     input: ActInput,
+    platform_definition: &PlatformDefinition,
 ) -> Result<ActResult> {
     tracing::info!(
         org_id = org_id,
@@ -483,7 +482,7 @@ pub async fn act_activity(
     };
 
     if !cap_ids.is_empty() {
-        let capability_registry = CapabilityRegistry::with_builtins();
+        let capability_registry = platform_definition.capability_registry().clone();
         let ctx = SystemPromptContext::without_file_store(input.context.session_id);
         let collected = collect_capabilities(&cap_ids, &capability_registry, &ctx).await;
         for tool in collected.tools {

--- a/crates/worker/src/app_builder.rs
+++ b/crates/worker/src/app_builder.rs
@@ -4,6 +4,7 @@
 // Decision: Encapsulates telemetry, shutdown, and worker lifecycle
 
 use anyhow::{Context, Result};
+use everruns_core::PlatformDefinition;
 use tracing::info;
 
 use crate::durable_worker::{DurableWorker, DurableWorkerConfig};
@@ -25,26 +26,47 @@ use crate::durable_worker::{DurableWorker, DurableWorkerConfig};
 /// ```
 pub struct WorkerAppBuilder {
     config: DurableWorkerConfig,
+    platform_definition: Option<PlatformDefinition>,
 }
 
 impl WorkerAppBuilder {
     /// Create a new worker app builder with the given configuration.
     pub fn new(config: DurableWorkerConfig) -> Self {
-        Self { config }
+        Self {
+            config,
+            platform_definition: None,
+        }
+    }
+
+    /// Replace the default worker runtime surface with an explicit platform definition.
+    pub fn platform_definition(mut self, platform_definition: PlatformDefinition) -> Self {
+        self.platform_definition = Some(platform_definition);
+        self
     }
 
     /// Build and run the worker. Blocks until shutdown signal.
     pub async fn run(self) -> Result<()> {
+        let Self {
+            config,
+            platform_definition,
+        } = self;
         info!(
-            grpc_address = %self.config.grpc_address,
-            worker_id = %self.config.worker_id,
-            max_concurrent = self.config.max_concurrent_tasks,
+            grpc_address = %config.grpc_address,
+            worker_id = %config.worker_id,
+            max_concurrent = config.max_concurrent_tasks,
             "Starting Durable worker"
         );
 
-        let worker = DurableWorker::new(self.config)
-            .await
-            .context("Failed to create Durable worker")?;
+        let worker = match platform_definition {
+            Some(platform_definition) => {
+                DurableWorker::with_platform_definition(config, platform_definition)
+                    .await
+                    .context("Failed to create Durable worker")?
+            }
+            None => DurableWorker::new(config)
+                .await
+                .context("Failed to create Durable worker")?,
+        };
 
         let shutdown_handle = worker.shutdown_handle();
 

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -3,7 +3,6 @@
 // Decision: Uses gRPC adapters for control-plane communication (no direct DB access)
 
 use anyhow::Result;
-use everruns_core::Message;
 use everruns_core::atoms::AtomContext;
 use everruns_core::events::{
     EventContext, EventRequest, OutputMessageCompletedData, SessionIdledData, ToolCallRequestedData,
@@ -11,6 +10,7 @@ use everruns_core::events::{
 use everruns_core::tool_types::ToolCall;
 use everruns_core::traits::EventEmitter;
 use everruns_core::typed_id::{ExecId, MessageId, SessionId, TurnId};
+use everruns_core::{Message, PlatformDefinition};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
@@ -184,6 +184,7 @@ pub struct DurableWorker {
     config: DurableWorkerConfig,
     store: Arc<Mutex<GrpcDurableStore>>,
     grpc_address: String,
+    platform_definition: Arc<PlatformDefinition>,
     shutdown_tx: watch::Sender<bool>,
     shutdown_rx: watch::Receiver<bool>,
     /// Count of tasks currently being executed
@@ -193,6 +194,14 @@ pub struct DurableWorker {
 impl DurableWorker {
     /// Create a new durable worker
     pub async fn new(config: DurableWorkerConfig) -> Result<Self> {
+        Self::with_platform_definition(config, crate::platform::default_platform_definition()).await
+    }
+
+    /// Create a new durable worker with an explicit platform definition.
+    pub async fn with_platform_definition(
+        config: DurableWorkerConfig,
+        platform_definition: PlatformDefinition,
+    ) -> Result<Self> {
         info!(
             worker_id = %config.worker_id,
             grpc_address = %config.grpc_address,
@@ -213,6 +222,7 @@ impl DurableWorker {
             config,
             store: Arc::new(Mutex::new(store)),
             grpc_address,
+            platform_definition: Arc::new(platform_definition),
             shutdown_tx,
             shutdown_rx,
             in_flight: Arc::new(AtomicUsize::new(0)),
@@ -765,8 +775,9 @@ impl DurableWorker {
                 let cleanup_input: crate::leased_resource_cleanup::LeasedResourceCleanupInput =
                     serde_json::from_value(task.input.clone())
                         .map_err(|e| anyhow::anyhow!("Failed to parse cleanup input: {}", e))?;
-                let adapters = crate::grpc_worker_adapters::GrpcWorkerAdapters::from_client(
+                let adapters = crate::grpc_worker_adapters::GrpcWorkerAdapters::from_client_with_platform_definition(
                     grpc_client.clone(),
+                    self.platform_definition.as_ref().clone(),
                 );
                 let res = crate::leased_resource_cleanup::execute_cleanup_activity(
                     &adapters,
@@ -1102,7 +1113,13 @@ impl DurableWorker {
         };
 
         // Use the existing reason_activity function with gRPC adapters
-        let result = reason_activity(grpc_client, input.org_id, reason_input).await;
+        let result = reason_activity(
+            grpc_client,
+            input.org_id,
+            reason_input,
+            self.platform_definition.as_ref(),
+        )
+        .await;
 
         // Record circuit breaker outcome
         // LLM failures are wrapped as Ok(ReasonResult { success: false }) by the atom,
@@ -1173,7 +1190,13 @@ impl DurableWorker {
         );
 
         // Use the existing act_activity function with gRPC adapters
-        let result = act_activity(grpc_client, org_id, act_input).await?;
+        let result = act_activity(
+            grpc_client,
+            org_id,
+            act_input,
+            self.platform_definition.as_ref(),
+        )
+        .await?;
 
         Ok(serde_json::to_value(&result)?)
     }

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -15,12 +15,13 @@ use everruns_core::traits::{AgentStore, ModelWithProvider, ResolvedImage};
 use everruns_core::typed_id::{
     AgentId, HarnessId, LeasedResourceId, MessageId, ModelId, SessionId,
 };
-use everruns_core::{Agent, DriverRegistry, Harness, Message, Session, ToolRegistry};
+use everruns_core::{
+    Agent, DriverRegistry, Harness, Message, PlatformDefinition, Session, ToolRegistry,
+};
 use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;
 
-use crate::adapters::create_driver_registry;
 use crate::grpc_adapters::{
     GrpcAgentStore, GrpcClient, GrpcEventEmitter, GrpcHarnessStore, GrpcImageResolver,
     GrpcLeasedResourceStore, GrpcLlmProviderStore, GrpcMessageRetriever, GrpcSessionFileStore,
@@ -37,18 +38,48 @@ use crate::worker_adapters::{TurnContext, WorkerAdapters};
 #[derive(Clone)]
 pub struct GrpcWorkerAdapters {
     client: GrpcClient,
+    platform_definition: PlatformDefinition,
 }
 
 impl GrpcWorkerAdapters {
     /// Create new gRPC adapters by connecting to control-plane
     pub async fn connect(grpc_address: &str) -> Result<Self> {
+        Self::connect_with_platform_definition(
+            grpc_address,
+            crate::platform::default_platform_definition(),
+        )
+        .await
+    }
+
+    /// Create new gRPC adapters with an explicit platform definition.
+    pub async fn connect_with_platform_definition(
+        grpc_address: &str,
+        platform_definition: PlatformDefinition,
+    ) -> Result<Self> {
         let client = GrpcClient::connect(grpc_address).await?;
-        Ok(Self { client })
+        Ok(Self {
+            client,
+            platform_definition,
+        })
     }
 
     /// Create from an existing GrpcClient
     pub fn from_client(client: GrpcClient) -> Self {
-        Self { client }
+        Self::from_client_with_platform_definition(
+            client,
+            crate::platform::default_platform_definition(),
+        )
+    }
+
+    /// Create from an existing GrpcClient with an explicit platform definition.
+    pub fn from_client_with_platform_definition(
+        client: GrpcClient,
+        platform_definition: PlatformDefinition,
+    ) -> Self {
+        Self {
+            client,
+            platform_definition,
+        }
     }
 
     /// Get the underlying GrpcClient (for MCP executor)
@@ -305,11 +336,11 @@ impl WorkerAdapters for GrpcWorkerAdapters {
     // =========================================================================
 
     fn capability_registry(&self) -> CapabilityRegistry {
-        CapabilityRegistry::with_builtins()
+        self.platform_definition.capability_registry().clone()
     }
 
     fn driver_registry(&self) -> DriverRegistry {
-        create_driver_registry()
+        self.platform_definition.driver_registry().clone()
     }
 
     fn sqldb_store(&self) -> everruns_core::traits::SessionSqlDbStoreRef {

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -15,6 +15,7 @@ pub mod grpc_durable_store;
 pub mod grpc_worker_adapters;
 pub mod leased_resource_cleanup;
 pub mod mcp_executor;
+pub mod platform;
 pub mod runner;
 pub mod unified_worker;
 pub mod worker_adapters;
@@ -33,6 +34,7 @@ pub use runner::{AgentRunner, RunnerBackend, create_runner, create_runner_with_b
 
 // Re-export LLM driver factory helpers
 pub use adapters::{create_driver_registry, create_llm_driver};
+pub use platform::{default_platform_definition, default_platform_definition_for_grade};
 
 // Re-export gRPC adapters for worker communication with control plane
 pub use grpc_adapters::{

--- a/crates/worker/src/platform.rs
+++ b/crates/worker/src/platform.rs
@@ -1,0 +1,21 @@
+//! Worker runtime platform helpers.
+//!
+//! Workers honor the same `PlatformDefinition` shape as the server so
+//! embedders can keep execution and control-plane runtime surfaces aligned.
+//! The worker default only includes capabilities and LLM drivers because
+//! connection providers and harness templates are server-owned by default.
+
+use everruns_core::{CapabilityRegistry, DeploymentGrade, PlatformDefinition};
+
+/// Build the default worker-side platform definition for the current deployment grade.
+pub fn default_platform_definition() -> PlatformDefinition {
+    default_platform_definition_for_grade(DeploymentGrade::from_env())
+}
+
+/// Build the default worker-side platform definition for an explicit grade.
+pub fn default_platform_definition_for_grade(grade: DeploymentGrade) -> PlatformDefinition {
+    PlatformDefinition::builder()
+        .capability_registry(CapabilityRegistry::with_builtins_for_grade(grade))
+        .driver_registry(crate::create_driver_registry())
+        .build()
+}

--- a/docs/advanced/embedding-everruns.md
+++ b/docs/advanced/embedding-everruns.md
@@ -1,0 +1,178 @@
+---
+title: Embedding Everruns
+description: Build a custom Rust service on top of Everruns by composing your own PlatformDefinition, server, and worker
+sidebar:
+  order: 20
+---
+
+Everruns can be embedded into another Rust service instead of only running as the stock OSS binaries. The composition root is `PlatformDefinition`: a shared bundle of runtime components that both the control plane and worker can honor.
+
+This lets you:
+
+- Add your own API routes with `ServerAppBuilder`
+- Add your own capabilities
+- Remove built-in capabilities or connection providers you do not want
+- Replace built-in harness templates
+- Run the stock worker with the same runtime surface as your server
+
+## What PlatformDefinition Controls
+
+`PlatformDefinition` currently owns:
+
+- Capability registry
+- LLM driver registry
+- Connection-provider registry
+- Built-in harness templates
+
+The type lives in `everruns-core`, so you can build it without depending on server internals.
+
+## Start From The OSS Preset
+
+If you want "Everruns, but customized", start from the OSS preset and mutate it:
+
+```rust
+use std::sync::Arc;
+
+use axum::{Router, routing::get};
+use everruns_core::{
+    BuiltInCapabilityDefinition, BuiltInHarnessDefinition, BuiltInHarnessRole,
+};
+use everruns_server::{ServerAppBuilder, ServerConfig, oss_platform_definition};
+use everruns_worker::{WorkerAppBuilder, DurableWorkerConfig};
+
+fn custom_routes() -> Router {
+    Router::new().route("/v1/ping", get(|| async { "pong" }))
+}
+
+fn platform() -> everruns_core::PlatformDefinition {
+    let mut platform = oss_platform_definition();
+
+    // Remove built-in components you do not want.
+    platform.capability_registry_mut().unregister("daytona");
+    platform.connection_providers_mut().unregister("daytona");
+
+    // Replace the stock default/base harnesses with a smaller embedded preset.
+    platform.built_in_harnesses_mut().retain(|harness| {
+        !harness.has_role(BuiltInHarnessRole::Base)
+            && !harness.has_role(BuiltInHarnessRole::Default)
+    });
+    platform.built_in_harnesses_mut().push(
+        BuiltInHarnessDefinition::new(
+            "minimal",
+            "Minimal",
+            "Small default harness for an embedded deployment.",
+            "You are a helpful assistant.",
+        )
+        .with_roles([BuiltInHarnessRole::Base, BuiltInHarnessRole::Default])
+        .with_tags(["minimal", "built-in"])
+        .with_capabilities([BuiltInCapabilityDefinition::new("current_time")]),
+    );
+
+    platform
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let platform = platform();
+
+    let server_platform = platform.clone();
+    let worker_platform = platform.clone();
+
+    tokio::spawn(async move {
+        WorkerAppBuilder::new(DurableWorkerConfig::from_env())
+            .platform_definition(worker_platform)
+            .run()
+            .await
+            .expect("worker failed");
+    });
+
+    ServerAppBuilder::new(ServerConfig::from_env())
+        .platform_definition(server_platform)
+        .routes(custom_routes())
+        .run()
+        .await
+}
+```
+
+## Build From Scratch
+
+If you want a fully custom deployment, construct `PlatformDefinition` directly:
+
+```rust
+use everruns_core::{
+    BuiltInCapabilityDefinition, BuiltInHarnessDefinition, BuiltInHarnessRole,
+    CapabilityRegistry, DriverRegistry, PlatformDefinition,
+};
+
+fn platform() -> PlatformDefinition {
+    let mut capabilities = CapabilityRegistry::new();
+    capabilities.register(everruns_core::CurrentTimeCapability);
+
+    let mut drivers = DriverRegistry::new();
+    everruns_openai::register_driver(&mut drivers);
+
+    PlatformDefinition::builder()
+        .capability_registry(capabilities)
+        .driver_registry(drivers)
+        .built_in_harnesses([
+            BuiltInHarnessDefinition::new(
+                "minimal",
+                "Minimal",
+                "Minimal embedded harness",
+                "You are a helpful assistant.",
+            )
+            .with_roles([BuiltInHarnessRole::Base, BuiltInHarnessRole::Default])
+            .with_capabilities([BuiltInCapabilityDefinition::new("current_time")]),
+        ])
+        .build()
+}
+```
+
+When you build from scratch, only the components you register exist. Seeded providers, models, harnesses, and agents are filtered against that definition.
+
+## Built-in Harness Roles
+
+Special harness behavior is driven by explicit roles, not fixed names:
+
+- `Base`: used when session creation omits a harness and the org has no explicit base harness configured yet
+- `Default`: set as the org default harness during initialization
+- `Chat`: used by the global chat session endpoint
+
+That means you can rename the harnesses freely. A platform can ship a base harness called `Minimal` or `Internal Default` as long as it carries the correct role.
+
+## Seeding Behavior
+
+Startup seeding now respects the supplied platform definition:
+
+- Built-in harness reconciliation uses your harness templates
+- Providers are only seeded when their driver exists
+- Models are only seeded when their provider driver exists
+- Agents are skipped when they require capabilities your platform removed
+
+This is the mechanism that lets you remove Daytona from the platform without leaving broken seeded agents or connection-provider UI behind.
+
+## Custom Routes
+
+`ServerAppBuilder::routes()` still merges your routes into the stock API router. That is the simplest way to add platform-specific endpoints such as billing, internal admin APIs, or product-specific workflows.
+
+```rust
+use axum::{Json, Router, routing::post};
+use serde_json::json;
+
+fn routes() -> Router {
+    Router::new().route(
+        "/v1/internal/reindex",
+        post(|| async { Json(json!({ "queued": true })) }),
+    )
+}
+```
+
+## Current Boundary
+
+The current embedding contract is strong around runtime surface composition, but it does not yet cover everything:
+
+- Stock HTTP modules are still mounted by default
+- Custom routes do not contribute to OpenAPI automatically
+- Harnesses are data templates, not runtime code plugins
+
+For most embedders, that is enough to build a custom control plane on top of Everruns while still reusing the durable execution engine, workers, and platform services.

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -109,6 +109,24 @@ graph TD
     worker -.->|gRPC| server
 ```
 
+### Platform Composition
+
+Everruns runtime composition is centered on `PlatformDefinition` in `crates/core/src/platform_definition.rs`.
+
+`PlatformDefinition` is the shared bundle for:
+
+- Capabilities
+- LLM drivers
+- Connection providers
+- Built-in harness templates
+
+The server and worker builders both accept an explicit `PlatformDefinition`. If none is supplied, they fall back to crate-local presets:
+
+- `everruns_server::oss_platform_definition()`
+- `everruns_worker::default_platform_definition()`
+
+This keeps the existing OSS runtime as the default while allowing embedders to remove integrations, add custom capabilities, replace harness templates, or register different LLM drivers without forking Everruns internals.
+
 ### Integration Plugin Force-Linking
 
 Integration crates (`docker`, `daytona`) register capabilities at startup via `inventory::submit!`. The `inventory` crate uses linker sections — if the crate is not explicitly referenced, Rust's linker will optimize it out and the `submit!` registrations silently disappear.
@@ -122,11 +140,15 @@ Adding a new integration crate requires:
 
 Without step 3, the crate compiles but its capabilities are never registered. There is no compile-time error — the integration simply does not appear at runtime.
 
+Important: inventory discovery is now confined to default presets. Embedders can bypass those presets entirely by constructing `PlatformDefinition` directly.
+
 ### Server Entrypoint
 
-The server binary (`main.rs`) uses `ServerAppBuilder` from the library crate. The builder pattern enables SaaS wrappers to compose their own binary with custom auth, routes, event listeners, and background tasks.
+The server binary (`main.rs`) uses `ServerAppBuilder` from the library crate. The builder pattern enables SaaS wrappers and embedders to compose their own binary with custom auth, routes, event listeners, background tasks, and a custom `PlatformDefinition`.
 
-See `crates/server/src/app_builder.rs` for `ServerAppBuilder` — composable builder with `auth()`, `routes()`, `run()` methods. Key modules in lib crate: `app_builder`, `server` (config + router), `seed` (database seeding), `grpc_service` (WorkerService).
+See `crates/server/src/app_builder.rs` for `ServerAppBuilder` — composable builder with `auth()`, `platform_definition()`, `routes()`, and `run()` methods. Key modules in lib crate: `app_builder`, `server` (config + router), `seed` (database seeding), `grpc_service` (WorkerService), `platform` (default OSS preset).
+
+The worker binary mirrors this pattern through `WorkerAppBuilder` in `crates/worker/src/app_builder.rs`, which also accepts `platform_definition()`.
 
 ### Data Layer
 

--- a/specs/embedding.md
+++ b/specs/embedding.md
@@ -1,0 +1,154 @@
+# Embedding Specification
+
+## Abstract
+
+Everruns is embeddable through a shared `PlatformDefinition` composition root. An embedder can assemble a custom runtime surface, then pass the same definition to the control plane and worker so capabilities, LLM drivers, connection providers, and built-in harness templates stay aligned.
+
+This spec defines the contract for embedding. See `crates/core/src/platform_definition.rs` for the public Rust API.
+
+## Goals
+
+1. Let downstream Rust services start from `ServerAppBuilder` and `WorkerAppBuilder` instead of forking Everruns binaries.
+2. Let embedders add or remove built-in runtime components without patching internal call sites.
+3. Keep server startup, worker execution, org initialization, and seeding consistent by reading from the same definition.
+4. Preserve the existing OSS experience through default presets.
+
+## PlatformDefinition
+
+`PlatformDefinition` is the shared runtime bundle consumed by both server and worker. It currently owns:
+
+- Capability registry
+- LLM driver registry
+- Connection-provider registry
+- Built-in harness templates
+
+The type lives in `everruns-core` so any binary can construct or mutate it without depending on `everruns-server`.
+
+### Built-in Harness Templates
+
+Built-in harness templates are data, not code plugins. Each template carries:
+
+- Stable internal key
+- Optional default-org seed UUID
+- Name, description, system prompt, tags
+- Built-in capability definitions with optional per-capability config
+- Explicit roles
+
+Roles replace hard-coded harness names for platform behavior:
+
+- `Base`: fallback harness for session creation
+- `Default`: org default harness for new orgs
+- `Chat`: global chat harness
+
+## Presets
+
+Everruns provides default presets so OSS behavior remains unchanged unless an embedder overrides it.
+
+### Server preset
+
+`crates/server/src/platform.rs` defines:
+
+- `oss_platform_definition()`
+- `oss_platform_definition_for_grade()`
+- `oss_connection_provider_registry()`
+- `oss_built_in_harnesses()`
+
+This preset centralizes the current OSS runtime surface, including inventory-discovered connection providers and built-in harness templates.
+
+### Worker preset
+
+`crates/worker/src/platform.rs` defines:
+
+- `default_platform_definition()`
+- `default_platform_definition_for_grade()`
+
+The worker preset includes built-in capabilities and built-in LLM drivers. It intentionally leaves connection providers and harness templates empty because those are server-owned unless an embedder passes a fully shared definition.
+
+## Consumption Rules
+
+### Server
+
+`ServerAppBuilder` accepts an optional `PlatformDefinition`. When absent, it uses the OSS preset.
+
+The server must derive the following from the platform definition:
+
+- Capability service registry
+- Session service capability registry
+- LLM driver registry for provider resolution and model sync
+- Connection providers for user connection APIs
+- Built-in harness templates for org initialization
+- Seed behavior for providers, models, harnesses, and agents
+- gRPC worker service capability/session registries
+- DEV_MODE in-process worker registries
+
+### Worker
+
+`WorkerAppBuilder` accepts an optional `PlatformDefinition`. When absent, it uses the worker preset.
+
+The worker must derive the following from the platform definition:
+
+- Capability registry used during `reason` and `act`
+- LLM driver registry used during `reason`
+- gRPC worker adapter registries when adapter-based execution paths are used
+
+## Seeding Contract
+
+Seeding must honor the supplied platform definition.
+
+### Required behavior
+
+1. Built-in harness reconciliation must use the platform's built-in harness templates.
+2. Provider seeding must skip providers whose driver type is not registered by the platform.
+3. Model seeding must skip models whose provider driver is not registered by the platform.
+4. Agent seeding must skip agents whose required capabilities are not registered by the platform.
+
+This prevents broken seeded data such as agents referencing Daytona when Daytona was intentionally removed from the platform.
+
+## Org Initialization Contract
+
+Organization initialization must provision built-in harnesses from the supplied harness templates and resolve default/base settings through harness roles, not hard-coded harness names or global constants.
+
+Default-org fixed UUIDs remain allowed for backward compatibility when a template includes `seed_id`.
+
+## Builder Contract
+
+### ServerAppBuilder
+
+Embedders may extend the control plane by:
+
+- Replacing the `PlatformDefinition`
+- Adding routes
+- Adding auth backends
+- Adding event listeners
+- Adding migrations
+- Adding background tasks
+
+### WorkerAppBuilder
+
+Embedders may extend execution by:
+
+- Replacing the `PlatformDefinition`
+- Reusing Everruns worker runtime and lifecycle handling
+
+## Non-goals
+
+This spec does not require:
+
+- Selective removal of built-in HTTP route modules
+- Route-level OpenAPI composition for embedder routes
+- Code-plugin harness implementations
+
+Those may be added later, but they are outside the current embedding contract.
+
+## Source Index
+
+- `crates/core/src/platform_definition.rs`
+- `crates/core/src/connection_provider.rs`
+- `crates/server/src/app_builder.rs`
+- `crates/server/src/platform.rs`
+- `crates/server/src/seed.rs`
+- `crates/server/src/org_init.rs`
+- `crates/worker/src/app_builder.rs`
+- `crates/worker/src/platform.rs`
+- `crates/worker/src/durable_worker.rs`
+- `crates/worker/src/activities.rs`


### PR DESCRIPTION
## What
Add a shared `PlatformDefinition` composition root so Everruns can be embedded into custom Rust services while keeping server, worker, seeding, and org init aligned.

## Why
Everruns had extension points, but the runtime surface was still hardcoded in multiple places. That made it difficult to remove built-ins like Daytona, add custom harness templates, or keep server and worker behavior consistent in embedded deployments.

## How
- add `PlatformDefinition` plus connection-provider and built-in harness definition types in `everruns-core`
- add default server and worker platform presets
- thread the platform definition through `ServerAppBuilder`, `WorkerAppBuilder`, durable worker execution, gRPC worker service, DEV_MODE adapters, org init, and seeding
- make seed data respect the chosen platform by filtering providers, models, agents, and built-in harnesses
- document the embedding contract in `specs/embedding.md` and add an advanced embedding guide in `docs/advanced/embedding-everruns.md`

## Risk
- Medium
- Startup, seeding, session fallback harness resolution, and worker/runtime registry wiring now depend on the shared platform definition. Regressions would most likely show up during app boot, chat session creation, or seeded default data.

## Validation
- `cargo check -q -p everruns-server -p everruns-worker`
- `cargo test -q -p everruns-server -p everruns-worker --no-run`
- `cargo test -q -p everruns-server org_init`
- `cargo test -q -p everruns-server seed_all_first_run`
- `just pre-push`
- smoke: `WORKER_GRPC_AUTH_TOKEN=ship-smoke-token PORT_PREFIX=382 just start-all --no-watch`
- smoke endpoints: `/health`, `/api/v1/harnesses`, `/api/v1/capabilities`, `/api/v1/user/connections/providers`, `POST /api/v1/sessions/chat`

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
