### PR TITLE
fix(worker): track actual workflow iteration count

### DIFF
--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -280,6 +280,7 @@ pub async fn reason_activity(
     let session_id = input.context.session_id;
     let turn_id = input.context.turn_id;
     let input_message_id = input.context.input_message_id;
+    let iteration = input.iteration;
 
     if let Some(blocker) =
         detect_dependency_blocker(&grpc_client, org_id, input.harness_id, input.agent_id).await?
@@ -378,7 +379,7 @@ pub async fn reason_activity(
                 EventContext::turn(turn_id, input_message_id),
                 TurnCompletedData {
                     turn_id,
-                    iterations: 1, // TODO: Track actual iterations when workflow supports it
+                    iterations: iteration,
                     duration_ms: None,
                     usage: result.usage.clone(),
                     input_content,
@@ -397,7 +398,7 @@ pub async fn reason_activity(
             EventContext::turn(turn_id, input_message_id),
             SessionIdledData {
                 turn_id,
-                iterations: None, // We don't track iterations in the activity
+                iterations: Some(iteration),
                 usage: result.usage.clone(),
             },
         );

--- a/crates/worker/src/durable_runner.rs
+++ b/crates/worker/src/durable_runner.rs
@@ -43,6 +43,14 @@ pub struct DurableTurnInput {
     /// Previous LLM response ID for stateful continuation across reason iterations.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub previous_response_id: Option<String>,
+    /// Current iteration number within this turn (1-based).
+    /// Incremented each time a new reason activity is scheduled after act.
+    #[serde(default = "default_iteration")]
+    pub iteration: u32,
+}
+
+fn default_iteration() -> u32 {
+    1
 }
 
 /// Output from the turn workflow
@@ -495,6 +503,7 @@ impl AgentRunner for DurableRunner {
             input_message_id,
             turn_id: None,
             previous_response_id: None,
+            iteration: 1,
         };
 
         // Create workflow instance
@@ -680,6 +689,7 @@ mod tests {
             input_message_id: MessageId::new(),
             turn_id: None,
             previous_response_id: None,
+            iteration: 1,
         };
 
         let json = serde_json::to_string(&input).unwrap();

--- a/crates/worker/src/durable_runner.rs
+++ b/crates/worker/src/durable_runner.rs
@@ -700,6 +700,31 @@ mod tests {
         assert_eq!(input.agent_id, parsed.agent_id);
         assert_eq!(input.input_message_id, parsed.input_message_id);
         assert_eq!(input.turn_id, parsed.turn_id);
+        assert_eq!(input.iteration, parsed.iteration);
+    }
+
+    /// Test that iteration defaults to 1 when missing from JSON (backward compat)
+    #[test]
+    fn test_durable_turn_input_iteration_default() {
+        use everruns_core::DEFAULT_ORG_ID;
+
+        // Build a valid input and serialize it
+        let input = DurableTurnInput {
+            org_id: DEFAULT_ORG_ID,
+            session_id: SessionId::new(),
+            harness_id: HarnessId::new(),
+            agent_id: None,
+            input_message_id: MessageId::new(),
+            turn_id: None,
+            previous_response_id: None,
+            iteration: 3,
+        };
+        let mut json_val: serde_json::Value = serde_json::to_value(&input).unwrap();
+        // Remove iteration to simulate pre-existing persisted data
+        json_val.as_object_mut().unwrap().remove("iteration");
+
+        let parsed: DurableTurnInput = serde_json::from_value(json_val).unwrap();
+        assert_eq!(parsed.iteration, 1); // defaults to 1
     }
 
     /// Test that start_run works for a new session (first message)

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -743,6 +743,12 @@ impl DurableWorker {
                     .get("previous_response_id")
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string());
+                // Extract iteration count from act task input (carried through from reason)
+                let iteration = task
+                    .input
+                    .get("iteration")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(1) as u32;
                 let turn_input = DurableTurnInput {
                     org_id: act_task_input.org_id,
                     session_id: act_task_input.act_input.context.session_id,
@@ -751,6 +757,7 @@ impl DurableWorker {
                     input_message_id: act_task_input.act_input.context.input_message_id,
                     turn_id: Some(act_task_input.act_input.context.turn_id),
                     previous_response_id,
+                    iteration,
                 };
                 let res = self
                     .execute_act_activity(
@@ -1098,7 +1105,7 @@ impl DurableWorker {
             org_id: input.org_id,
             mcp_tool_definitions: turn_context.mcp_tool_definitions,
             previous_response_id: input.previous_response_id.clone(),
-            iteration: 1,
+            iteration: input.iteration,
         };
 
         // Use the existing reason_activity function with gRPC adapters
@@ -1233,6 +1240,7 @@ impl DurableWorker {
                     input_message_id: input.input_message_id,
                     turn_id,
                     previous_response_id: None,
+                    iteration: 1,
                 };
                 let input_json = serde_json::to_value(&input_with_turn)?;
 
@@ -1281,10 +1289,11 @@ impl DurableWorker {
                         },
                     };
                     let mut act_input_json = serde_json::to_value(&act_task_input)?;
-                    // Carry response_id through act task for next reason iteration
+                    // Carry response_id and iteration through act task for next reason iteration
                     if let Some(rid) = &chained_input.previous_response_id {
                         act_input_json["previous_response_id"] = serde_json::json!(rid);
                     }
+                    act_input_json["iteration"] = serde_json::json!(input.iteration);
 
                     store
                         .enqueue_task(
@@ -1351,6 +1360,8 @@ impl DurableWorker {
 
                 // After action, schedule another reason activity (continue the loop)
                 // Use chained_input which carries previous_response_id from last reason
+                // Increment iteration count for the next reason step
+                chained_input.iteration = chained_input.iteration.saturating_add(1);
                 let chained_json = serde_json::to_value(&chained_input)?;
                 store
                     .enqueue_task(

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -748,7 +748,9 @@ impl DurableWorker {
                     .input
                     .get("iteration")
                     .and_then(|v| v.as_u64())
-                    .unwrap_or(1) as u32;
+                    .and_then(|raw| u32::try_from(raw).ok())
+                    .filter(|&it| it > 0)
+                    .unwrap_or(1);
                 let turn_input = DurableTurnInput {
                     org_id: act_task_input.org_id,
                     session_id: act_task_input.act_input.context.session_id,

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -540,6 +540,13 @@ where
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
 
+            // Extract iteration count from act task input (carried through from reason)
+            let iteration = task
+                .input
+                .get("iteration")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(1) as u32;
+
             // Create DurableTurnInput from ActInput context
             let turn_input = DurableTurnInput {
                 org_id: act_input
@@ -551,6 +558,7 @@ where
                 input_message_id: act_input.context.input_message_id,
                 turn_id: Some(act_input.context.turn_id),
                 previous_response_id,
+                iteration,
             };
 
             let res = execute_act_activity(adapters, &act_input).await;
@@ -842,7 +850,7 @@ async fn execute_reason_activity<A: WorkerAdapters>(
         org_id: input.org_id,
         mcp_tool_definitions: turn_context.mcp_tool_definitions,
         previous_response_id: input.previous_response_id.clone(),
-        iteration: 1,
+        iteration: input.iteration,
     };
 
     let result = atom.execute(reason_input).await?;
@@ -926,7 +934,7 @@ async fn execute_reason_activity<A: WorkerAdapters>(
                 EventContext::turn(turn_id, input_message_id),
                 TurnCompletedData {
                     turn_id,
-                    iterations: 1,
+                    iterations: input.iteration,
                     duration_ms: None,
                     usage: result.usage.clone(),
                     input_content: None, // Passed through from turn.started by Braintrust
@@ -943,7 +951,7 @@ async fn execute_reason_activity<A: WorkerAdapters>(
             EventContext::turn(turn_id, input_message_id),
             SessionIdledData {
                 turn_id,
-                iterations: None,
+                iterations: Some(input.iteration),
                 usage: result.usage.clone(),
             },
         );
@@ -1057,6 +1065,7 @@ async fn schedule_next_activity<S: WorkflowEventStore>(
                 input_message_id: input.input_message_id,
                 turn_id,
                 previous_response_id: None,
+                iteration: 1,
             };
             let input_json = serde_json::to_value(&input_with_turn)?;
 
@@ -1127,10 +1136,11 @@ async fn schedule_next_activity<S: WorkflowEventStore>(
                         tool_definitions: reason_result.tool_definitions.clone(),
                     };
                     let mut act_input_json = serde_json::to_value(&act_input)?;
-                    // Carry response_id through act task for next reason iteration
+                    // Carry response_id and iteration through act task for next reason iteration
                     if let Some(rid) = &response_id {
                         act_input_json["previous_response_id"] = serde_json::json!(rid);
                     }
+                    act_input_json["iteration"] = serde_json::json!(input.iteration);
                     let activity_id = format!("act_{}", Uuid::now_v7());
 
                     let task = TaskDefinition {
@@ -1227,7 +1237,10 @@ async fn schedule_next_activity<S: WorkflowEventStore>(
                 );
             } else {
                 // Normal flow: schedule another reason activity
-                let input_json = serde_json::to_value(input)?;
+                // Increment iteration count for the next reason step
+                let mut next_input = input.clone();
+                next_input.iteration = next_input.iteration.saturating_add(1);
+                let input_json = serde_json::to_value(&next_input)?;
                 let activity_id = format!("reason_{}", Uuid::now_v7());
                 let task = TaskDefinition {
                     workflow_id: Some(workflow_id),

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -545,7 +545,9 @@ where
                 .input
                 .get("iteration")
                 .and_then(|v| v.as_u64())
-                .unwrap_or(1) as u32;
+                .and_then(|raw| u32::try_from(raw).ok())
+                .filter(|&it| it > 0)
+                .unwrap_or(1);
 
             // Create DurableTurnInput from ActInput context
             let turn_input = DurableTurnInput {


### PR DESCRIPTION
## What
Track the actual number of reason→act iterations in the durable workflow loop instead of reporting hardcoded defaults (`1` for `TurnCompletedData`, `None` for `SessionIdledData`).

## Why
Iteration metrics reported defaults, making monitoring unreliable. The TODO at `activities.rs:381` explicitly called this out.

Fixes EVE-116

## How
- Added `iteration: u32` field to `DurableTurnInput` (defaults to `1` via serde)
- Increment iteration each time a new reason activity is scheduled after act completion
- Carry iteration through act task input JSON (alongside `previous_response_id`)
- Use actual iteration count in `TurnCompletedData` and `SessionIdledData` events
- Applied consistently across both `durable_worker` and `unified_worker`

## Risk
- Low
- Backward compatible: `serde(default)` ensures existing serialized inputs without `iteration` default to 1
- No API surface changes; only internal event payloads gain accurate values

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered