### PR TITLE
feat(harness): add inheritance and effective previews

### DIFF
--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -397,6 +397,7 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
               <AgentPreview
                 systemPrompt={formData.system_prompt}
                 capabilities={selectedCapabilities}
+                tools={agent.tools ?? []}
               />
             </div>
 

--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -382,6 +382,7 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
               ref: cap.ref,
               config: cap.config,
             }))}
+            tools={agent.tools ?? []}
           />
         </TabsContent>
       </Tabs>

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import {
   useHarness,
+  useHarnesses,
   useUpdateHarness,
   useDeleteHarness,
   useDestroyHarness,
@@ -28,6 +29,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { CapabilitySelector } from "@/components/agents/capability-selector";
+import { HarnessSelect } from "@/components/harness/harness-select";
 import { HarnessPreview } from "@/components/harnesses/harness-preview";
 import { InitialFilesEditor } from "@/components/initial-files-editor";
 import { ModelPicker } from "@/components/models/model-picker";
@@ -39,6 +41,7 @@ interface FormData {
   name: string;
   description: string;
   system_prompt: string;
+  parent_harness_id: string;
   tags: string;
   default_model_id: string;
 }
@@ -48,6 +51,7 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
   const router = useRouter();
 
   const { data: harness, isLoading: harnessLoading } = useHarness(harnessId);
+  const { data: harnesses = [] } = useHarnesses();
   const updateHarness = useUpdateHarness();
   const deleteHarness = useDeleteHarness();
   const destroyHarness = useDestroyHarness();
@@ -65,6 +69,7 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
         name: "",
         description: "",
         system_prompt: "",
+        parent_harness_id: "",
         tags: "",
         default_model_id: "",
       };
@@ -73,6 +78,7 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
       name: harness.name,
       description: harness.description || "",
       system_prompt: harness.system_prompt,
+      parent_harness_id: harness.parent_harness_id || "",
       tags: harness.tags.join(", "),
       default_model_id: harness.default_model_id || "",
     };
@@ -81,6 +87,13 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
   const formData = useMemo(
     () => ({ ...initialFormData, ...formChanges }),
     [initialFormData, formChanges],
+  );
+  const selectedParentHarness = useMemo(
+    () =>
+      formData.parent_harness_id
+        ? harnesses.find((candidate) => candidate.id === formData.parent_harness_id)
+        : undefined,
+    [formData.parent_harness_id, harnesses],
   );
 
   const handleFormChange = useCallback((field: keyof FormData, value: string) => {
@@ -123,6 +136,7 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
           name: formData.name,
           description: formData.description || undefined,
           system_prompt: formData.system_prompt,
+          parent_harness_id: formData.parent_harness_id || null,
           tags,
           default_model_id: formData.default_model_id || undefined,
           ...(capabilitiesChanged && { capabilities: capabilitiesToSave }),
@@ -251,6 +265,23 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
                         disabled={isSaving || isReadOnly}
                         rows={2}
                       />
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label htmlFor="parent-harness">Parent Harness</Label>
+                      <HarnessSelect
+                        value={formData.parent_harness_id}
+                        onValueChange={(value) => handleFormChange("parent_harness_id", value)}
+                        placeholder="No parent harness"
+                        includeNoneOption
+                        noneLabel="No parent harness"
+                        excludeIds={[harnessId]}
+                        disabled={isSaving || isReadOnly}
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Inherit prompt, capabilities, initial files, and model fallback from a
+                        parent harness.
+                      </p>
                     </div>
 
                     <div className="space-y-2">
@@ -395,6 +426,7 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
               <HarnessPreview
                 systemPrompt={formData.system_prompt}
                 capabilities={selectedCapabilities}
+                parentHarnessId={formData.parent_harness_id || undefined}
               />
             </div>
 
@@ -414,6 +446,12 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
                     <p className="text-sm font-medium">Description</p>
                     <p className="text-sm text-muted-foreground">
                       {formData.description || "(not set)"}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium">Parent Harness</p>
+                    <p className="text-sm text-muted-foreground">
+                      {(selectedParentHarness?.name ?? formData.parent_harness_id) || "(none)"}
                     </p>
                   </div>
                   <div>

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
@@ -7,6 +7,7 @@ import {
   useLlmModels,
   useDeleteHarness,
   useCopyHarness,
+  useHarnesses,
 } from "@/hooks";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
@@ -30,6 +31,7 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
   const router = useRouter();
   const [activeTab, setActiveTab] = useState("overview");
   const { data: harness, isLoading: harnessLoading } = useHarness(harnessId);
+  const { data: harnesses = [] } = useHarnesses();
   const { data: allCapabilities } = useCapabilities();
   const { data: llmModels } = useLlmModels();
   const deleteHarness = useDeleteHarness();
@@ -42,6 +44,9 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
 
   const defaultModel = harness?.default_model_id
     ? modelMap.get(harness.default_model_id)
+    : undefined;
+  const parentHarness = harness?.parent_harness_id
+    ? harnesses.find((candidate) => candidate.id === harness.parent_harness_id)
     : undefined;
 
   const getCapabilityInfo = (capabilityId: string): Capability | undefined =>
@@ -171,13 +176,17 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
                 <CardContent>
                   {harnessCapabilities.length === 0 ? (
                     <p className="text-sm text-muted-foreground">
-                      No capabilities enabled.{" "}
-                      <Link
-                        href={`/harnesses/${harnessId}/edit`}
-                        className="text-primary hover:underline"
-                      >
-                        Add some
-                      </Link>
+                      {harness.parent_harness_id
+                        ? "No local capabilities configured on this harness. Preview shows inherited capabilities."
+                        : "No capabilities enabled. "}
+                      {!harness.parent_harness_id && (
+                        <Link
+                          href={`/harnesses/${harnessId}/edit`}
+                          className="text-primary hover:underline"
+                        >
+                          Add some
+                        </Link>
+                      )}
                     </p>
                   ) : (
                     <div className="space-y-2">
@@ -216,6 +225,22 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
                         <ProviderIcon providerType={defaultModel.provider_type} size="sm" />
                         <span className="text-sm">{defaultModel.display_name}</span>
                       </div>
+                    </div>
+                  )}
+
+                  {harness.parent_harness_id && (
+                    <div>
+                      <p className="text-sm font-medium">Inherits From</p>
+                      {parentHarness ? (
+                        <Link
+                          href={`/harnesses/${parentHarness.id}`}
+                          className="text-sm text-primary hover:underline"
+                        >
+                          {parentHarness.name}
+                        </Link>
+                      ) : (
+                        <p className="text-sm text-muted-foreground">{harness.parent_harness_id}</p>
+                      )}
                     </div>
                   )}
 
@@ -263,6 +288,7 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
         <TabsContent value="preview">
           <HarnessPreview
             systemPrompt={harness.system_prompt}
+            parentHarnessId={harness.parent_harness_id || undefined}
             capabilities={harnessCapabilities.map((cap) => ({
               ref: cap.ref,
               config: cap.config,

--- a/apps/ui/src/app/(main)/harnesses/new/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/new/page.tsx
@@ -20,6 +20,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { ProviderIcon } from "@/components/providers/provider-icon";
 import { CapabilitySelector } from "@/components/agents/capability-selector";
+import { HarnessSelect } from "@/components/harness/harness-select";
 import { InitialFilesEditor } from "@/components/initial-files-editor";
 import type { AgentCapabilityConfig, InitialFile } from "@/lib/api/types";
 
@@ -33,6 +34,7 @@ export default function NewHarnessPage() {
     name: "",
     description: "",
     system_prompt: "",
+    parent_harness_id: "",
     default_model_id: "",
     tags: "",
   });
@@ -57,6 +59,7 @@ export default function NewHarnessPage() {
         name: formData.name,
         description: formData.description || undefined,
         system_prompt: formData.system_prompt,
+        parent_harness_id: formData.parent_harness_id || undefined,
         default_model_id: formData.default_model_id || undefined,
         tags: tags.length > 0 ? tags : undefined,
         capabilities: selectedCapabilities.length > 0 ? selectedCapabilities : undefined,
@@ -116,6 +119,22 @@ export default function NewHarnessPage() {
                 onChange={(e) => setFormData({ ...formData, tags: e.target.value })}
               />
               <p className="text-xs text-muted-foreground">Comma-separated list of tags</p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="parent-harness">Parent Harness</Label>
+              <HarnessSelect
+                value={formData.parent_harness_id}
+                onValueChange={(value) => setFormData({ ...formData, parent_harness_id: value })}
+                placeholder="No parent harness"
+                includeNoneOption
+                noneLabel="No parent harness"
+                disabled={createHarness.isPending}
+              />
+              <p className="text-xs text-muted-foreground">
+                Inherit system prompt, capabilities, initial files, and default model from another
+                harness.
+              </p>
             </div>
 
             <div className="space-y-2">

--- a/apps/ui/src/components/agents/agent-preview.tsx
+++ b/apps/ui/src/components/agents/agent-preview.tsx
@@ -12,9 +12,10 @@ import { Wrench, FileText, AlertCircle } from "lucide-react";
 interface AgentPreviewProps {
   systemPrompt: string;
   capabilities: AgentCapabilityConfig[];
+  tools?: ToolDefinition[];
 }
 
-export function AgentPreview({ systemPrompt, capabilities }: AgentPreviewProps) {
+export function AgentPreview({ systemPrompt, capabilities, tools = [] }: AgentPreviewProps) {
   const previewMutation = usePreviewAgent();
   const [preview, setPreview] = useState<AgentPreviewResponse | null>(null);
 
@@ -24,6 +25,7 @@ export function AgentPreview({ systemPrompt, capabilities }: AgentPreviewProps) 
       {
         system_prompt: systemPrompt,
         capabilities,
+        tools,
       },
       {
         onSuccess: (data) => {
@@ -32,7 +34,7 @@ export function AgentPreview({ systemPrompt, capabilities }: AgentPreviewProps) 
       },
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [systemPrompt, JSON.stringify(capabilities)]);
+  }, [systemPrompt, JSON.stringify(capabilities), JSON.stringify(tools)]);
 
   if (previewMutation.isPending && !preview) {
     return (

--- a/apps/ui/src/components/harness/harness-select.tsx
+++ b/apps/ui/src/components/harness/harness-select.tsx
@@ -22,6 +22,12 @@ interface HarnessSelectProps {
   className?: string;
   /** Disable the select */
   disabled?: boolean;
+  /** Include a "no harness" option */
+  includeNoneOption?: boolean;
+  /** Label for the empty option */
+  noneLabel?: string;
+  /** Harness IDs to omit from the dropdown */
+  excludeIds?: string[];
 }
 
 /**
@@ -34,26 +40,39 @@ export function HarnessSelect({
   placeholder = "Select harness",
   className,
   disabled,
+  includeNoneOption = false,
+  noneLabel = "None",
+  excludeIds = [],
 }: HarnessSelectProps) {
+  const noneValue = "__none__";
   const { data: harnesses = [] } = useHarnesses();
+  const filteredHarnesses = useMemo(
+    () => harnesses.filter((harness) => !excludeIds.includes(harness.id)),
+    [excludeIds, harnesses],
+  );
 
   const harnessMap = useMemo(() => {
-    return new Map<string, Harness>(harnesses.map((h) => [h.id, h]));
-  }, [harnesses]);
+    return new Map<string, Harness>(filteredHarnesses.map((h) => [h.id, h]));
+  }, [filteredHarnesses]);
 
   // Resolve ID → name. When harnesses haven't loaded yet (org switch race),
   // show "Loading…" instead of the raw ID (EVE-142).
   const displayValue = value
-    ? (harnessMap.get(value)?.name ?? (harnesses.length === 0 ? "Loading…" : value))
+    ? (harnessMap.get(value)?.name ?? (filteredHarnesses.length === 0 ? "Loading…" : value))
     : undefined;
 
   return (
-    <Select value={value} onValueChange={onValueChange} disabled={disabled}>
+    <Select
+      value={value || (includeNoneOption ? noneValue : value)}
+      onValueChange={(nextValue) => onValueChange(nextValue === noneValue ? "" : nextValue)}
+      disabled={disabled}
+    >
       <SelectTrigger className={className}>
         <SelectValue placeholder={placeholder}>{displayValue}</SelectValue>
       </SelectTrigger>
       <SelectContent>
-        {harnesses.map((harness) => (
+        {includeNoneOption && <SelectItem value={noneValue}>{noneLabel}</SelectItem>}
+        {filteredHarnesses.map((harness) => (
           <SelectItem key={harness.id} value={harness.id}>
             {harness.name}
           </SelectItem>

--- a/apps/ui/src/components/harnesses/harness-preview.tsx
+++ b/apps/ui/src/components/harnesses/harness-preview.tsx
@@ -12,9 +12,14 @@ import { Wrench, FileText, AlertCircle } from "lucide-react";
 interface HarnessPreviewProps {
   systemPrompt: string;
   capabilities: AgentCapabilityConfig[];
+  parentHarnessId?: string;
 }
 
-export function HarnessPreview({ systemPrompt, capabilities }: HarnessPreviewProps) {
+export function HarnessPreview({
+  systemPrompt,
+  capabilities,
+  parentHarnessId,
+}: HarnessPreviewProps) {
   const previewMutation = usePreviewHarness();
   const [preview, setPreview] = useState<AgentPreviewResponse | null>(null);
 
@@ -22,6 +27,7 @@ export function HarnessPreview({ systemPrompt, capabilities }: HarnessPreviewPro
     previewMutation.mutate(
       {
         system_prompt: systemPrompt,
+        parent_harness_id: parentHarnessId,
         capabilities,
       },
       {
@@ -31,7 +37,7 @@ export function HarnessPreview({ systemPrompt, capabilities }: HarnessPreviewPro
       },
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [systemPrompt, JSON.stringify(capabilities)]);
+  }, [parentHarnessId, systemPrompt, JSON.stringify(capabilities)]);
 
   if (previewMutation.isPending && !preview) {
     return (

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -84,6 +84,7 @@ export interface Harness {
   name: string;
   description: string | null;
   system_prompt: string;
+  parent_harness_id: string | null;
   default_model_id: string | null;
   tags: string[];
   /** Capabilities with per-harness configuration */
@@ -102,6 +103,7 @@ export interface CreateHarnessRequest {
   name: string;
   description?: string;
   system_prompt: string;
+  parent_harness_id?: string;
   default_model_id?: string;
   tags?: string[];
   /** Capabilities with per-harness configuration */
@@ -113,6 +115,7 @@ export interface UpdateHarnessRequest {
   name?: string;
   description?: string;
   system_prompt?: string;
+  parent_harness_id?: string | null;
   default_model_id?: string;
   tags?: string[];
   /** Capabilities with per-harness configuration */
@@ -125,6 +128,8 @@ export interface UpdateHarnessRequest {
 export interface PreviewHarnessRequest {
   /** The base system prompt (before capability additions) */
   system_prompt: string;
+  /** Optional parent harness to inherit from before previewing local changes */
+  parent_harness_id?: string;
   /** Capability IDs to apply */
   capabilities?: AgentCapabilityConfig[];
 }
@@ -135,6 +140,8 @@ export interface PreviewAgentRequest {
   system_prompt: string;
   /** Capabilities to apply with per-agent configuration */
   capabilities?: AgentCapabilityConfig[];
+  /** Client-side tools to include in preview output */
+  tools?: ToolDefinition[];
 }
 
 /** Response showing the final agent shape after applying capabilities */

--- a/crates/core/examples/turn_based_execution.rs
+++ b/crates/core/examples/turn_based_execution.rs
@@ -118,6 +118,7 @@ async fn main() -> anyhow::Result<()> {
         name: "Default Harness".to_string(),
         description: None,
         system_prompt: "You are a helpful assistant.".to_string(),
+        parent_harness_id: None,
         default_model_id: None,
         tags: vec![],
         capabilities: vec![],

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -609,12 +609,6 @@ where
         // 6. Build runtime agent: harness (base) → agent (optional) → session caps
         //    Uses async builder methods so capabilities can resolve dynamic system
         //    prompt content (e.g., reading AGENTS.md, discovering skills).
-        let session_capability_ids: Vec<String> = session
-            .capabilities
-            .iter()
-            .map(|cap| cap.capability_id().to_string())
-            .collect();
-
         let prompt_ctx = crate::capabilities::SystemPromptContext {
             session_id,
             locale: extract_locale_override(&messages).or_else(|| session.locale.clone()),
@@ -630,8 +624,8 @@ where
                 .await;
         }
         builder = builder
-            .with_capabilities(
-                &session_capability_ids,
+            .with_capability_configs(
+                &session.capabilities,
                 &self.capability_registry,
                 &prompt_ctx,
             )

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -860,6 +860,38 @@ pub fn resolve_dependencies(
     })
 }
 
+/// Resolve dependency-expanded capability configs, preserving explicit config on selected IDs.
+///
+/// Dependencies are inserted with empty configs. If the same capability is provided more than
+/// once, the last explicit config wins.
+pub fn resolve_capability_configs(
+    selected_configs: &[AgentCapabilityConfig],
+    registry: &CapabilityRegistry,
+) -> Result<Vec<AgentCapabilityConfig>, DependencyError> {
+    let selected_ids: Vec<String> = selected_configs
+        .iter()
+        .map(|config| config.capability_id().to_string())
+        .collect();
+    let resolved = resolve_dependencies(&selected_ids, registry)?;
+
+    let explicit_configs: std::collections::HashMap<String, serde_json::Value> = selected_configs
+        .iter()
+        .map(|config| (config.capability_id().to_string(), config.config.clone()))
+        .collect();
+
+    Ok(resolved
+        .resolved_ids
+        .into_iter()
+        .map(|capability_id| {
+            explicit_configs
+                .get(&capability_id)
+                .cloned()
+                .map(|config| AgentCapabilityConfig::with_config(capability_id.clone(), config))
+                .unwrap_or_else(|| AgentCapabilityConfig::new(capability_id))
+        })
+        .collect())
+}
+
 /// Helper function to resolve a single capability and its dependencies recursively.
 fn resolve_single_capability(
     cap_id: &str,

--- a/crates/core/src/capabilities/platform_management.rs
+++ b/crates/core/src/capabilities/platform_management.rs
@@ -134,6 +134,10 @@ impl Tool for ManageHarnessesTool {
                     "type": "string",
                     "description": "System prompt for the harness. Defaults to 'You are a helpful assistant.' if omitted."
                 },
+                "parent_harness_id": {
+                    "type": ["string", "null"],
+                    "description": "Optional parent harness ID. Set to null on update to clear inheritance."
+                },
                 "capabilities": {
                     "type": "array",
                     "items": {"type": "string"},
@@ -231,6 +235,24 @@ impl Tool for ManageHarnessesTool {
                 let system_prompt =
                     get_str(&arguments, "system_prompt").unwrap_or("You are a helpful assistant.");
                 let description = get_str(&arguments, "description");
+                let parent_harness_id = match arguments.get("parent_harness_id") {
+                    Some(Value::String(id_str)) => {
+                        match id_str.parse::<crate::typed_id::HarnessId>() {
+                            Ok(id) => Some(id),
+                            Err(_) => {
+                                return ToolExecutionResult::tool_error(format!(
+                                    "Invalid parent_harness_id: {id_str}"
+                                ));
+                            }
+                        }
+                    }
+                    Some(Value::Null) | None => None,
+                    Some(_) => {
+                        return ToolExecutionResult::tool_error(
+                            "parent_harness_id must be a harness ID string or null",
+                        );
+                    }
+                };
                 let capabilities: Vec<String> = arguments
                     .get("capabilities")
                     .and_then(|v| v.as_array())
@@ -241,13 +263,20 @@ impl Tool for ManageHarnessesTool {
                     })
                     .unwrap_or_default();
                 match store
-                    .create_harness(name, description, system_prompt, &capabilities)
+                    .create_harness(
+                        name,
+                        description,
+                        system_prompt,
+                        parent_harness_id,
+                        &capabilities,
+                    )
                     .await
                 {
                     Ok(h) => ToolExecutionResult::success(json!({
                         "id": h.id.to_string(),
                         "name": h.name,
                         "description": h.description,
+                        "parent_harness_id": h.parent_harness_id.map(|id| id.to_string()),
                         "status": format!("{:?}", h.status),
                         "ui_link": format!("{}/harnesses/{}", base_url, h.id),
                         "message": "Harness created successfully"
@@ -274,14 +303,34 @@ impl Tool for ManageHarnessesTool {
                 let name = get_str(&arguments, "name");
                 let description = get_str(&arguments, "description");
                 let system_prompt = get_str(&arguments, "system_prompt");
+                let parent_harness_id = match arguments.get("parent_harness_id") {
+                    Some(Value::String(id_str)) => {
+                        match id_str.parse::<crate::typed_id::HarnessId>() {
+                            Ok(id) => Some(Some(id)),
+                            Err(_) => {
+                                return ToolExecutionResult::tool_error(format!(
+                                    "Invalid parent_harness_id: {id_str}"
+                                ));
+                            }
+                        }
+                    }
+                    Some(Value::Null) => Some(None),
+                    None => None,
+                    Some(_) => {
+                        return ToolExecutionResult::tool_error(
+                            "parent_harness_id must be a harness ID string or null",
+                        );
+                    }
+                };
                 match store
-                    .update_harness(id, name, description, system_prompt)
+                    .update_harness(id, name, description, system_prompt, parent_harness_id)
                     .await
                 {
                     Ok(h) => ToolExecutionResult::success(json!({
                         "id": h.id.to_string(),
                         "name": h.name,
                         "description": h.description,
+                        "parent_harness_id": h.parent_harness_id.map(|id| id.to_string()),
                         "status": format!("{:?}", h.status),
                         "ui_link": format!("{}/harnesses/{}", base_url, h.id),
                         "message": "Harness updated successfully"

--- a/crates/core/src/harness.rs
+++ b/crates/core/src/harness.rs
@@ -66,6 +66,10 @@ pub struct Harness {
     /// System prompt that defines the harness's base behavior.
     /// Forms the foundation of the prompt stack.
     pub system_prompt: String,
+    /// Optional parent harness that this harness inherits from.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "harness_01933b5a000070008000000000000602"))]
+    pub parent_harness_id: Option<HarnessId>,
     /// Default LLM model ID for this harness.
     /// Lowest priority in chain: controls > session > agent > harness.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -97,4 +101,195 @@ pub struct Harness {
     /// Timestamp when the harness was deleted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deleted_at: Option<DateTime<Utc>>,
+}
+
+/// Merge a parent harness into a child harness, producing the effective child harness.
+///
+/// Metadata remains child-owned (`id`, `name`, `tags`, status, timestamps). Runtime-affecting
+/// fields compose:
+/// - `system_prompt`: parent first, child appended
+/// - `default_model_id`: child wins, then parent fallback
+/// - `capabilities`: parent baseline, child overrides by capability id
+/// - `initial_files`: parent baseline, child overrides by normalized path
+pub fn merge_harness(parent: &Harness, child: &Harness) -> Harness {
+    Harness {
+        id: child.id,
+        name: child.name.clone(),
+        description: child.description.clone(),
+        system_prompt: merge_system_prompts(&parent.system_prompt, &child.system_prompt),
+        parent_harness_id: child.parent_harness_id,
+        default_model_id: child.default_model_id.or(parent.default_model_id),
+        tags: child.tags.clone(),
+        capabilities: merge_capabilities(&parent.capabilities, &child.capabilities),
+        initial_files: merge_initial_files(&parent.initial_files, &child.initial_files),
+        is_built_in: child.is_built_in,
+        status: child.status.clone(),
+        created_at: child.created_at,
+        updated_at: child.updated_at,
+        archived_at: child.archived_at,
+        deleted_at: child.deleted_at,
+    }
+}
+
+/// Merge a root-to-leaf chain of harnesses into one effective harness.
+pub fn merge_harness_chain(chain: &[Harness]) -> Option<Harness> {
+    let mut iter = chain.iter();
+    let first = iter.next()?.clone();
+    Some(iter.fold(first, |effective, layer| merge_harness(&effective, layer)))
+}
+
+fn merge_system_prompts(parent: &str, child: &str) -> String {
+    let parent = parent.trim();
+    let child = child.trim();
+
+    match (parent.is_empty(), child.is_empty()) {
+        (true, true) => String::new(),
+        (false, true) => parent.to_string(),
+        (true, false) => child.to_string(),
+        (false, false) => format!("{parent}\n\n{child}"),
+    }
+}
+
+fn merge_capabilities(
+    parent: &[AgentCapabilityConfig],
+    child: &[AgentCapabilityConfig],
+) -> Vec<AgentCapabilityConfig> {
+    let mut merged = parent.to_vec();
+
+    for child_cap in child {
+        if let Some(existing) = merged
+            .iter_mut()
+            .find(|existing| existing.capability_id() == child_cap.capability_id())
+        {
+            *existing = child_cap.clone();
+        } else {
+            merged.push(child_cap.clone());
+        }
+    }
+
+    merged
+}
+
+fn merge_initial_files(parent: &[InitialFile], child: &[InitialFile]) -> Vec<InitialFile> {
+    let mut merged = parent.to_vec();
+
+    for child_file in child {
+        let normalized_path = normalize_initial_file_path(&child_file.path);
+        if let Some(existing) = merged
+            .iter_mut()
+            .find(|existing| normalize_initial_file_path(&existing.path) == normalized_path)
+        {
+            *existing = child_file.clone();
+        } else {
+            merged.push(child_file.clone());
+        }
+    }
+
+    merged
+}
+
+fn normalize_initial_file_path(path: &str) -> String {
+    if path == "/workspace" {
+        "/".to_string()
+    } else if let Some(stripped) = path.strip_prefix("/workspace/") {
+        format!("/{}", stripped.trim_start_matches('/'))
+    } else if path.starts_with('/') {
+        path.to_string()
+    } else {
+        format!("/{}", path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_harness(id_seed: u128, system_prompt: &str) -> Harness {
+        Harness {
+            id: HarnessId::from_uuid(uuid::Uuid::from_u128(id_seed)),
+            name: format!("Harness {id_seed}"),
+            description: None,
+            system_prompt: system_prompt.to_string(),
+            parent_harness_id: None,
+            default_model_id: None,
+            tags: vec![],
+            capabilities: vec![],
+            initial_files: vec![],
+            is_built_in: false,
+            status: HarnessStatus::Active,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            archived_at: None,
+            deleted_at: None,
+        }
+    }
+
+    #[test]
+    fn merges_prompt_capabilities_and_initial_files() {
+        let mut parent = test_harness(1, "Parent prompt.");
+        parent.capabilities = vec![
+            AgentCapabilityConfig::new("session_file_system"),
+            AgentCapabilityConfig::with_config(
+                "web_fetch",
+                serde_json::json!({"enable_file_download": true}),
+            ),
+        ];
+        parent.initial_files = vec![InitialFile {
+            path: "/workspace/README.md".to_string(),
+            content: "parent".to_string(),
+            encoding: "text".to_string(),
+            is_readonly: true,
+        }];
+
+        let mut child = test_harness(2, "Child prompt.");
+        child.parent_harness_id = Some(parent.id);
+        child.capabilities = vec![
+            AgentCapabilityConfig::with_config(
+                "web_fetch",
+                serde_json::json!({"enable_file_download": false}),
+            ),
+            AgentCapabilityConfig::new("platform_management"),
+        ];
+        child.initial_files = vec![
+            InitialFile {
+                path: "README.md".to_string(),
+                content: "child".to_string(),
+                encoding: "text".to_string(),
+                is_readonly: false,
+            },
+            InitialFile {
+                path: "/notes.txt".to_string(),
+                content: "notes".to_string(),
+                encoding: "text".to_string(),
+                is_readonly: false,
+            },
+        ];
+
+        let merged = merge_harness(&parent, &child);
+
+        assert_eq!(merged.system_prompt, "Parent prompt.\n\nChild prompt.");
+        assert_eq!(merged.capabilities.len(), 3);
+        assert_eq!(
+            merged.capabilities[1],
+            AgentCapabilityConfig::with_config(
+                "web_fetch",
+                serde_json::json!({"enable_file_download": false}),
+            )
+        );
+        assert_eq!(merged.initial_files.len(), 2);
+        assert_eq!(merged.initial_files[0].content, "child");
+        assert_eq!(merged.initial_files[1].path, "/notes.txt");
+    }
+
+    #[test]
+    fn merges_chain_root_to_leaf() {
+        let root = test_harness(1, "Root");
+        let mut middle = test_harness(2, "Middle");
+        middle.parent_harness_id = Some(root.id);
+        let mut leaf = test_harness(3, "Leaf");
+        leaf.parent_harness_id = Some(middle.id);
+
+        let merged = merge_harness_chain(&[root, middle, leaf]).expect("merged harness");
+        assert_eq!(merged.system_prompt, "Root\n\nMiddle\n\nLeaf");
+    }
 }

--- a/crates/core/src/in_memory_loop.rs
+++ b/crates/core/src/in_memory_loop.rs
@@ -332,6 +332,7 @@ impl InMemoryAgenticLoopBuilder {
             name: "In-Memory Harness".to_string(),
             description: None,
             system_prompt: self.system_prompt.clone(),
+            parent_harness_id: None,
             default_model_id: None,
             tags: vec![],
             capabilities: vec![],

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -222,7 +222,7 @@ pub use events::{
     TokenUsage, ToolCallRequestedData, ToolCallSummary, ToolCompletedData, ToolStartedData,
     TurnCancelledData, TurnCompletedData, TurnFailedData, TurnStartedData, VALID_EVENT_TYPES,
 };
-pub use harness::{Harness, HarnessStatus};
+pub use harness::{Harness, HarnessStatus, merge_harness, merge_harness_chain};
 pub use leased_resource::{
     LEASED_RESOURCES_FEATURE, LeasedResource, LeasedResourceStatus, UpsertLeasedResource,
 };

--- a/crates/core/src/platform_definition.rs
+++ b/crates/core/src/platform_definition.rs
@@ -78,6 +78,8 @@ pub struct BuiltInHarnessDefinition {
     pub description: String,
     /// Base system prompt for the harness.
     pub system_prompt: String,
+    /// Optional parent harness key to inherit from during provisioning.
+    pub parent_key: Option<String>,
     /// Tags applied to the harness.
     pub tags: Vec<String>,
     /// Capabilities enabled by default for the harness.
@@ -100,6 +102,7 @@ impl BuiltInHarnessDefinition {
             name: name.into(),
             description: description.into(),
             system_prompt: system_prompt.into(),
+            parent_key: None,
             tags: Vec::new(),
             capabilities: Vec::new(),
             roles: Vec::new(),
@@ -119,6 +122,12 @@ impl BuiltInHarnessDefinition {
         S: Into<String>,
     {
         self.tags = tags.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Set the parent harness key used for inheritance during provisioning.
+    pub fn with_parent_key(mut self, parent_key: impl Into<String>) -> Self {
+        self.parent_key = Some(parent_key.into());
         self
     }
 

--- a/crates/core/src/platform_store.rs
+++ b/crates/core/src/platform_store.rs
@@ -46,6 +46,7 @@ pub trait PlatformStore: Send + Sync {
         name: &str,
         description: Option<&str>,
         system_prompt: &str,
+        parent_harness_id: Option<HarnessId>,
         capabilities: &[String],
     ) -> Result<Harness>;
 
@@ -56,6 +57,7 @@ pub trait PlatformStore: Send + Sync {
         name: Option<&str>,
         description: Option<&str>,
         system_prompt: Option<&str>,
+        parent_harness_id: Option<Option<HarnessId>>,
     ) -> Result<Harness>;
 
     /// Delete (archive) a harness.
@@ -201,6 +203,7 @@ pub mod tests {
                     name: "Test Harness".to_string(),
                     description: Some("test harness".to_string()),
                     system_prompt: "You are helpful.".to_string(),
+                    parent_harness_id: None,
                     default_model_id: None,
                     tags: vec![],
                     capabilities: vec![AgentCapabilityConfig::new("session")],
@@ -274,10 +277,12 @@ pub mod tests {
             name: &str,
             _desc: Option<&str>,
             _prompt: &str,
+            parent_harness_id: Option<HarnessId>,
             _caps: &[String],
         ) -> Result<Harness> {
             let mut h = self.harness.clone();
             h.name = name.to_string();
+            h.parent_harness_id = parent_harness_id;
             Ok(h)
         }
         async fn update_harness(
@@ -286,10 +291,14 @@ pub mod tests {
             name: Option<&str>,
             _desc: Option<&str>,
             _prompt: Option<&str>,
+            parent_harness_id: Option<Option<HarnessId>>,
         ) -> Result<Harness> {
             let mut h = self.harness.clone();
             if let Some(n) = name {
                 h.name = n.to_string();
+            }
+            if let Some(parent_harness_id) = parent_harness_id {
+                h.parent_harness_id = parent_harness_id;
             }
             Ok(h)
         }

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -12,7 +12,8 @@
 
 use crate::agent::Agent;
 use crate::capabilities::{
-    CapabilityRegistry, SystemPromptContext, collect_capabilities, resolve_dependencies,
+    CapabilityRegistry, SystemPromptContext, collect_capabilities_with_configs,
+    resolve_capability_configs,
 };
 use crate::harness::Harness;
 use crate::llm_driver_registry::ToolSearchConfig;
@@ -111,14 +112,8 @@ impl RuntimeAgentBuilder {
         registry: &CapabilityRegistry,
         ctx: &SystemPromptContext,
     ) -> Self {
-        let capability_ids: Vec<String> = harness
-            .capabilities
-            .iter()
-            .map(|cap| cap.capability_id().to_string())
-            .collect();
-
         self.system_prompt(&harness.system_prompt)
-            .with_capabilities(&capability_ids, registry, ctx)
+            .with_capability_configs(&harness.capabilities, registry, ctx)
             .await
     }
 
@@ -144,15 +139,9 @@ impl RuntimeAgentBuilder {
         registry: &CapabilityRegistry,
         ctx: &SystemPromptContext,
     ) -> Self {
-        let capability_ids: Vec<String> = agent
-            .capabilities
-            .iter()
-            .map(|cap| cap.capability_id().to_string())
-            .collect();
-
         let mut builder = self
             .system_prompt(&agent.system_prompt)
-            .with_capabilities(&capability_ids, registry, ctx)
+            .with_capability_configs(&agent.capabilities, registry, ctx)
             .await;
 
         // Add agent-level client-side tools
@@ -177,21 +166,35 @@ impl RuntimeAgentBuilder {
     /// * `registry` - The capability registry containing implementations
     /// * `ctx` - Session context for dynamic prompt resolution
     pub async fn with_capabilities(
-        mut self,
+        self,
         capability_ids: &[String],
         registry: &CapabilityRegistry,
         ctx: &SystemPromptContext,
     ) -> Self {
-        // Resolve dependencies first (dependencies come before dependents)
-        let resolved_ids = match resolve_dependencies(capability_ids, registry) {
-            Ok(resolved) => resolved.resolved_ids,
+        let capability_configs: Vec<crate::AgentCapabilityConfig> = capability_ids
+            .iter()
+            .map(|id| crate::AgentCapabilityConfig::new(id.clone()))
+            .collect();
+        self.with_capability_configs(&capability_configs, registry, ctx)
+            .await
+    }
+
+    /// Apply capability configs to this builder, preserving per-capability configuration.
+    pub async fn with_capability_configs(
+        mut self,
+        capability_configs: &[crate::AgentCapabilityConfig],
+        registry: &CapabilityRegistry,
+        ctx: &SystemPromptContext,
+    ) -> Self {
+        let resolved_configs = match resolve_capability_configs(capability_configs, registry) {
+            Ok(resolved) => resolved,
             Err(e) => {
                 tracing::warn!("Failed to resolve capability dependencies: {}", e);
-                capability_ids.to_vec()
+                capability_configs.to_vec()
             }
         };
 
-        let collected = collect_capabilities(&resolved_ids, registry, ctx).await;
+        let collected = collect_capabilities_with_configs(&resolved_configs, registry, ctx).await;
 
         // Apply system prompt additions (prepend to existing, wrap base in XML tags)
         if let Some(prefix) = collected.system_prompt_prefix() {

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -56,6 +56,7 @@ async fn setup_test_environment() -> (
         name: "Test Harness".to_string(),
         description: None,
         system_prompt: "You are a helpful assistant.".to_string(),
+        parent_harness_id: None,
         default_model_id: None,
         tags: vec![],
         capabilities: vec![],

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -324,6 +324,9 @@ message Harness {
     Timestamp created_at = 7;
     Timestamp updated_at = 8;
     repeated string capability_ids = 9;
+    repeated string tags = 10;
+    optional Uuid parent_harness_id = 11;
+    bool is_built_in = 12;
 }
 
 message GetHarnessRequest {
@@ -1382,6 +1385,7 @@ message PlatformCreateHarnessRequest {
     optional string description = 3;
     string system_prompt = 4;
     repeated string capabilities = 5;
+    optional Uuid parent_harness_id = 6;
 }
 
 message PlatformCreateHarnessResponse {
@@ -1394,6 +1398,8 @@ message PlatformUpdateHarnessRequest {
     optional string name = 3;
     optional string description = 4;
     optional string system_prompt = 5;
+    optional Uuid parent_harness_id = 6;
+    optional bool clear_parent_harness_id = 7;
 }
 
 message PlatformUpdateHarnessResponse {

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -324,6 +324,11 @@ pub fn schema_harness_to_proto(value: &everruns_core::Harness) -> proto::Harness
             .iter()
             .map(|c| c.capability_id().to_string())
             .collect(),
+        tags: value.tags.clone(),
+        parent_harness_id: value
+            .parent_harness_id
+            .map(|id| uuid_to_proto_uuid(id.uuid())),
+        is_built_in: value.is_built_in,
     }
 }
 
@@ -340,6 +345,10 @@ pub fn proto_harness_to_schema(
         .default_model_id
         .as_ref()
         .map(|u| format!("model_{}", u.value.replace("-", "")));
+    let parent_harness_id_str = value
+        .parent_harness_id
+        .as_ref()
+        .map(|u| format!("harness_{}", u.value.replace("-", "")));
 
     let capabilities: Vec<serde_json::Value> = value
         .capability_ids
@@ -352,9 +361,11 @@ pub fn proto_harness_to_schema(
         "name": value.name,
         "description": if value.description.is_empty() { None } else { Some(&value.description) },
         "system_prompt": value.system_prompt,
+        "parent_harness_id": parent_harness_id_str,
         "default_model_id": model_id_str,
-        "tags": Vec::<String>::new(),
+        "tags": value.tags,
         "capabilities": capabilities,
+        "is_built_in": value.is_built_in,
         "status": value.status,
         "created_at": value.created_at.as_ref().map(|t| proto_timestamp_to_datetime(t).to_rfc3339()),
         "updated_at": value.updated_at.as_ref().map(|t| proto_timestamp_to_datetime(t).to_rfc3339()),

--- a/crates/server/migrations/008_harness_inheritance.sql
+++ b/crates/server/migrations/008_harness_inheritance.sql
@@ -1,0 +1,9 @@
+-- Harness inheritance
+--
+-- Decision: schema-only migration; existing data is upgraded by startup reconciliation and
+-- service-layer logic, not by in-migration UPDATE statements.
+
+ALTER TABLE harnesses
+ADD COLUMN parent_harness_id UUID REFERENCES harnesses(id) ON DELETE RESTRICT;
+
+CREATE INDEX idx_harnesses_parent_harness_id ON harnesses(parent_harness_id);

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -122,6 +122,10 @@ pub struct PreviewAgentRequest {
     #[serde(default)]
     #[schema(example = json!([{"ref": "current_time", "config": {}}, {"ref": "test_math", "config": {}}]))]
     pub capabilities: Vec<AgentCapabilityConfig>,
+    /// Client-side tools to include in the preview.
+    #[serde(default)]
+    #[schema(value_type = Vec<Object>)]
+    pub tools: Vec<ToolDefinition>,
 }
 
 /// Response showing the final agent shape after applying capabilities
@@ -958,7 +962,7 @@ pub async fn preview_agent(
     State(state): State<AppState>,
     Json(req): Json<PreviewAgentRequest>,
 ) -> Result<Json<AgentPreviewResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let (system_prompt, tools) = state
+    let (system_prompt, mut tools) = state
         .capability_service
         .preview(org.org_id, &req.system_prompt, &req.capabilities)
         .await
@@ -967,6 +971,7 @@ pub async fn preview_agent(
             ErrorResponse::new("Internal server error")
                 .into_response(StatusCode::INTERNAL_SERVER_ERROR)
         })?;
+    tools.extend(req.tools);
 
     Ok(Json(AgentPreviewResponse {
         system_prompt,

--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -3,7 +3,9 @@
 // Policy enforcement happens at the service layer via #[policy] macro.
 
 use crate::auth::{AuthState, ResolvedOrg};
-use crate::services::harness::{HARNESS_DANGEROUS, HARNESS_MANAGE, HARNESS_VIEW};
+use crate::services::harness::{
+    HARNESS_DANGEROUS, HARNESS_MANAGE, HARNESS_VIEW, merge_preview_layer, resolve_effective_harness,
+};
 use crate::storage::StorageBackend;
 use axum::extract::FromRef;
 use axum::{
@@ -39,6 +41,10 @@ pub struct CreateHarnessRequest {
     /// The system prompt defining the harness's base behavior.
     #[schema(example = "You are a research assistant with deep analytical capabilities.")]
     pub system_prompt: String,
+    /// Optional parent harness to inherit from.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>, example = "harness_01933b5a000070008000000000000602")]
+    pub parent_harness_id: Option<HarnessId>,
     /// Default LLM model ID for this harness. Lowest priority in model chain.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(value_type = Option<String>, example = "model_01933b5a00007000800000000000001")]
@@ -67,6 +73,9 @@ pub struct UpdateHarnessRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_prompt: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>, nullable = true)]
+    pub parent_harness_id: Option<Option<HarnessId>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(value_type = Option<String>)]
     pub default_model_id: Option<ModelId>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -84,6 +93,9 @@ pub struct UpdateHarnessRequest {
 pub struct PreviewHarnessRequest {
     #[schema(example = "You are a research assistant.")]
     pub system_prompt: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>, example = "harness_01933b5a000070008000000000000602")]
+    pub parent_harness_id: Option<HarnessId>,
     #[serde(default)]
     pub capabilities: Vec<AgentCapabilityConfig>,
 }
@@ -478,9 +490,27 @@ pub async fn preview_harness(
     State(state): State<AppState>,
     Json(req): Json<PreviewHarnessRequest>,
 ) -> Result<Json<HarnessPreviewResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let parent = match req.parent_harness_id {
+        Some(parent_harness_id) => Some(
+            resolve_effective_harness(state.service.db().as_ref(), org.org_id, parent_harness_id)
+                .await
+                .map_err(|e| {
+                    tracing::error!("Failed to resolve harness preview parent: {}", e);
+                    ErrorResponse::new("Internal server error")
+                        .into_response(StatusCode::INTERNAL_SERVER_ERROR)
+                })?
+                .ok_or_else(|| {
+                    ErrorResponse::new("Parent harness not found")
+                        .into_response(StatusCode::NOT_FOUND)
+                })?,
+        ),
+        None => None,
+    };
+    let (system_prompt, capabilities) =
+        merge_preview_layer(parent.as_ref(), &req.system_prompt, &req.capabilities);
     let (system_prompt, tools) = state
         .capability_service
-        .preview(org.org_id, &req.system_prompt, &req.capabilities)
+        .preview(org.org_id, &system_prompt, &capabilities)
         .await
         .map_err(|e| {
             tracing::error!("Failed to generate harness preview: {}", e);

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -972,6 +972,7 @@ mod tests {
                     name: "Base".to_string(),
                     description: Some("Base".to_string()),
                     system_prompt: "You are helpful.".to_string(),
+                    parent_harness_id: None,
                     default_model_id: None,
                     tags: vec!["base".to_string()],
                     initial_files: serde_json::json!([]),

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -19,7 +19,7 @@ use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId};
 use everruns_core::{
     Agent, AgentStatus, Caller, ContentPart, DriverRegistry, EventData, Harness, HarnessStatus,
     LlmProviderType, Message, MessageRole, Session, SessionStatus, ToolDefinition, ToolRegistry,
-    ToolResultContentPart,
+    ToolResultContentPart, merge_harness,
 };
 use everruns_worker::mcp_executor::McpServerInfo;
 use everruns_worker::worker_adapters::{TurnContext, WorkerAdapters};
@@ -908,49 +908,72 @@ impl WorkerAdapters for DirectWorkerAdapters {
 impl DirectWorkerAdapters {
     /// Get a harness by ID (direct DB access)
     async fn get_harness_impl(&self, org_id: i64, harness_id: Uuid) -> Result<Option<Harness>> {
-        let harness_id_typed = HarnessId::from_uuid(harness_id);
-        let row = self
-            .db
-            .get_harness(org_id, harness_id_typed)
-            .await
-            .map_err(|e| {
-                tracing::error!("Failed to get harness: {}", e);
-                store_error("Failed to get harness")
-            })?;
+        let mut visited = std::collections::HashSet::new();
+        let mut chain = Vec::new();
+        let mut cursor = Some(HarnessId::from_uuid(harness_id));
 
-        let capabilities = if row.is_some() {
-            self.db
-                .get_harness_capabilities(harness_id)
+        while let Some(current_harness_id) = cursor {
+            if !visited.insert(current_harness_id) {
+                return Err(store_error("Harness inheritance cycle detected"));
+            }
+
+            let row = self
+                .db
+                .get_harness(org_id, current_harness_id)
+                .await
+                .map_err(|e| {
+                    tracing::error!("Failed to get harness: {}", e);
+                    store_error("Failed to get harness")
+                })?;
+            let Some(row) = row else {
+                if chain.is_empty() {
+                    return Ok(None);
+                }
+                return Err(store_error("Parent harness not found"));
+            };
+
+            let capabilities = self
+                .db
+                .get_harness_capabilities(current_harness_id.uuid())
                 .await
                 .unwrap_or_default()
-        } else {
-            vec![]
-        };
-
-        Ok(row.map(|r| Harness {
-            id: r.id,
-            name: r.name,
-            description: r.description,
-            system_prompt: r.system_prompt,
-            default_model_id: r.default_model_id,
-            tags: r.tags,
-            capabilities: capabilities
                 .into_iter()
-                .map(|c| AgentCapabilityConfig::with_config(c.capability_id, c.config))
-                .collect(),
-            initial_files: serde_json::from_value(r.initial_files).unwrap_or_default(),
-            is_built_in: r.is_built_in,
-            status: match r.status.as_str() {
-                "active" => HarnessStatus::Active,
-                "archived" => HarnessStatus::Archived,
-                "deleted" => HarnessStatus::Deleted,
-                _ => HarnessStatus::Active,
-            },
-            created_at: r.created_at,
-            updated_at: r.updated_at,
-            archived_at: r.archived_at,
-            deleted_at: r.deleted_at,
-        }))
+                .map(|cap| AgentCapabilityConfig::with_config(cap.capability_id, cap.config))
+                .collect();
+
+            cursor = row.parent_harness_id;
+            chain.push(Harness {
+                id: row.id,
+                name: row.name,
+                description: row.description,
+                system_prompt: row.system_prompt,
+                parent_harness_id: row.parent_harness_id,
+                default_model_id: row.default_model_id,
+                tags: row.tags,
+                capabilities,
+                initial_files: serde_json::from_value(row.initial_files).unwrap_or_default(),
+                is_built_in: row.is_built_in,
+                status: match row.status.as_str() {
+                    "active" => HarnessStatus::Active,
+                    "archived" => HarnessStatus::Archived,
+                    "deleted" => HarnessStatus::Deleted,
+                    _ => HarnessStatus::Active,
+                },
+                created_at: row.created_at,
+                updated_at: row.updated_at,
+                archived_at: row.archived_at,
+                deleted_at: row.deleted_at,
+            });
+        }
+
+        let Some(mut effective) = chain.pop() else {
+            return Ok(None);
+        };
+        while let Some(layer) = chain.pop() {
+            effective = merge_harness(&effective, &layer);
+        }
+
+        Ok(Some(effective))
     }
 
     /// Build an Agent from a DB row and pre-loaded capability rows.
@@ -1205,6 +1228,7 @@ impl DirectPlatformStore {
             name: row.name,
             description: row.description,
             system_prompt: row.system_prompt,
+            parent_harness_id: row.parent_harness_id,
             default_model_id: row.default_model_id,
             tags: row.tags,
             capabilities,
@@ -1340,6 +1364,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
         name: &str,
         description: Option<&str>,
         system_prompt: &str,
+        parent_harness_id: Option<HarnessId>,
         capabilities: &[String],
     ) -> everruns_core::error::Result<Harness> {
         use crate::storage::models::CreateHarnessRow;
@@ -1348,6 +1373,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
             name: name.to_string(),
             description: description.map(|s| s.to_string()),
             system_prompt: system_prompt.to_string(),
+            parent_harness_id,
             default_model_id: None,
             tags: vec!["managed".to_string()],
             initial_files: serde_json::json!([]),
@@ -1389,6 +1415,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
         name: Option<&str>,
         description: Option<&str>,
         system_prompt: Option<&str>,
+        parent_harness_id: Option<Option<HarnessId>>,
     ) -> everruns_core::error::Result<Harness> {
         use crate::storage::models::UpdateHarness;
 
@@ -1396,6 +1423,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
             name: name.map(|s| s.to_string()),
             description: description.map(|s| s.to_string()),
             system_prompt: system_prompt.map(|s| s.to_string()),
+            parent_harness_id,
             ..Default::default()
         };
         self.db
@@ -1441,6 +1469,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
             &copy_name,
             source.description.as_deref(),
             &source.system_prompt,
+            source.parent_harness_id,
             &cap_ids,
         )
         .await

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -1043,10 +1043,9 @@ impl WorkerService for WorkerServiceImpl {
         let req = request.into_inner();
         let harness_id = parse_uuid(req.harness_id.as_ref())?;
 
-        let internal_caller = everruns_core::Caller::internal(req.org_id);
         let harness = self
             .harness_service
-            .get(&internal_caller, harness_id)
+            .resolve_effective(req.org_id, everruns_core::HarnessId::from_uuid(harness_id))
             .await
             .map_err(|e| Status::internal(format!("Failed to get harness: {}", e)))?;
 
@@ -3323,6 +3322,12 @@ impl WorkerService for WorkerServiceImpl {
             name: req.name,
             description: req.description,
             system_prompt: req.system_prompt,
+            parent_harness_id: req
+                .parent_harness_id
+                .as_ref()
+                .map(|parent_id| parse_uuid(Some(parent_id)))
+                .transpose()?
+                .map(everruns_core::HarnessId::from_uuid),
             default_model_id: None,
             tags: vec![],
             capabilities,
@@ -3352,6 +3357,16 @@ impl WorkerService for WorkerServiceImpl {
             name: req.name,
             description: req.description,
             system_prompt: req.system_prompt,
+            parent_harness_id: if req.clear_parent_harness_id.unwrap_or(false) {
+                Some(None)
+            } else {
+                req.parent_harness_id
+                    .as_ref()
+                    .map(|parent_id| parse_uuid(Some(parent_id)))
+                    .transpose()?
+                    .map(everruns_core::HarnessId::from_uuid)
+                    .map(Some)
+            },
             default_model_id: None,
             tags: None,
             capabilities: None,
@@ -3409,6 +3424,7 @@ impl WorkerService for WorkerServiceImpl {
                 name: Some(new_name),
                 description: None,
                 system_prompt: None,
+                parent_harness_id: None,
                 default_model_id: None,
                 tags: None,
                 capabilities: None,

--- a/crates/server/src/org_init.rs
+++ b/crates/server/src/org_init.rs
@@ -13,7 +13,6 @@ use crate::storage::{
 use anyhow::{Context, Result};
 use everruns_core::{BuiltInCapabilityDefinition, BuiltInHarnessDefinition, BuiltInHarnessRole};
 use uuid::Uuid;
-
 /// Well-known seed IDs for default org harnesses (backward compat)
 mod harness_ids {
     use uuid::Uuid;
@@ -57,10 +56,15 @@ pub async fn initialize_org_harnesses_with_definitions(
     let is_default_org = org_id == DEFAULT_ORG_ID;
 
     for harness in harnesses {
+        let parent_harness_id =
+            resolve_built_in_parent_id(db, org_id, is_default_org, harnesses, harness)
+                .await
+                .with_context(|| format!("resolve parent for built-in harness {}", harness.name))?;
         let input = CreateHarnessRow {
             name: harness.name.to_string(),
             description: Some(harness.description.to_string()),
             system_prompt: harness.system_prompt.to_string(),
+            parent_harness_id,
             default_model_id: None,
             tags: harness.tags.clone(),
             initial_files: serde_json::json!([]),
@@ -161,6 +165,38 @@ pub async fn initialize_org_harnesses_with_definitions(
     sync_org_harness_settings_with_definitions(db, org_id, harnesses).await?;
 
     Ok(result)
+}
+
+async fn resolve_built_in_parent_id(
+    db: &StorageBackend,
+    org_id: i64,
+    is_default_org: bool,
+    harnesses: &[BuiltInHarnessDefinition],
+    harness: &BuiltInHarnessDefinition,
+) -> Result<Option<everruns_core::HarnessId>> {
+    let Some(parent_key) = harness.parent_key.as_deref() else {
+        return Ok(None);
+    };
+
+    let parent = harnesses
+        .iter()
+        .find(|candidate| candidate.key == parent_key)
+        .with_context(|| format!("unknown built-in parent {parent_key}"))?;
+
+    if is_default_org {
+        let parent_seed = parent
+            .seed_id
+            .with_context(|| format!("missing seed id for built-in parent {parent_key}"))?;
+        return Ok(Some(parent_seed.into()));
+    }
+
+    let parent_row = db
+        .list_harnesses(org_id, Some(&parent.name), true)
+        .await?
+        .into_iter()
+        .find(|candidate| candidate.is_built_in && candidate.name == parent.name)
+        .with_context(|| format!("missing built-in parent {} for org {org_id}", parent.name))?;
+    Ok(Some(parent_row.id))
 }
 
 /// Reconcile built-in harnesses across all organizations.
@@ -402,6 +438,23 @@ mod tests {
             GENERIC_HARNESS_ID
         );
         assert_eq!(settings.base_harness_id.unwrap().uuid(), BASE_HARNESS_ID);
+
+        let chat = provisioned_harnesses
+            .iter()
+            .find(|h| h.name == "Platform Chat")
+            .expect("chat harness");
+        let generic = provisioned_harnesses
+            .iter()
+            .find(|h| h.name == "Generic")
+            .expect("generic harness");
+        assert_eq!(chat.parent_harness_id, Some(generic.id));
+
+        let chat_caps = db.get_harness_capabilities(chat.id.uuid()).await.unwrap();
+        let chat_cap_ids = chat_caps
+            .iter()
+            .map(|cap| cap.capability_id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(chat_cap_ids, vec!["platform_management"]);
     }
 
     #[tokio::test]

--- a/crates/server/src/platform.rs
+++ b/crates/server/src/platform.rs
@@ -95,22 +95,11 @@ pub fn oss_built_in_harnesses() -> Vec<BuiltInHarnessDefinition> {
             "You are a helpful assistant on the Everruns platform.\n\nCapabilities are the primary way to extend agent functionality. Use `list_capabilities` to discover available capabilities (built-in, MCP servers, and skills), then assign them when creating agents or harnesses.\n\nWhen creating agents, always use `list_capabilities` first to find relevant capability IDs to include.\n\n## Rendering entity references\n\nAll tool results include `name` and `ui_link` fields. When referencing entities (agents, harnesses, sessions) in your responses, always render them as clickable markdown links with the entity name — never show raw IDs.\n\nExamples:\n- Use: [My Agent](/agents/agent_abc123)\n- Not: agent_abc123\n- Use: Created [Research Bot](/agents/agent_xyz) successfully\n- Not: Created agent agent_xyz successfully\n\n## Running agents\n\nWhen asked to \"run an agent\" or \"run X with agent Y\", follow these steps:\n1. Create a session for the agent (use `manage_sessions` with operation \"create\")\n2. Send the user's message/task to the session (use `session_interact` with operation \"send_message\")\n3. Wait for the turn to complete (use `session_interact` with operation \"wait_for_idle\")\n4. Retrieve and relay the results (use `session_interact` with operation \"get_messages\")\n\n## Harness creation\n\nAvoid creating new harnesses unless the user explicitly needs a custom one. For most tasks, use the built-in \"Generic\" harness (find it via `manage_harnesses` with operation \"list\") which already includes file system, bash, storage, long-context support, session, agent instructions, and skills capabilities.\n\n## Confirmation guidelines\n\n- **Always confirm** before creating a harness or agent — these are reusable org-wide entities.\n- **Sessions**: Use common sense. Routine requests (\"run agent X on this task\") can proceed without confirmation. Unusual or high-impact requests (destructive operations, large-scale actions, unclear intent) should be confirmed first.",
         )
         .with_seed_id(crate::org_init::CHAT_HARNESS_ID)
+        .with_parent_key("generic")
         .with_tags(["chat", "built-in"])
         .with_roles([BuiltInHarnessRole::Chat])
         .with_capabilities([
-            BuiltInCapabilityDefinition::new("session_file_system"),
-            BuiltInCapabilityDefinition::new("virtual_bash"),
-            BuiltInCapabilityDefinition::with_config(
-                "web_fetch",
-                serde_json::json!({"enable_file_download": true}),
-            ),
-            BuiltInCapabilityDefinition::new("session_storage"),
-            BuiltInCapabilityDefinition::new("session"),
-            BuiltInCapabilityDefinition::new("agent_instructions"),
-            BuiltInCapabilityDefinition::new("skills"),
-            BuiltInCapabilityDefinition::new("infinity_context"),
             BuiltInCapabilityDefinition::new("platform_management"),
-            BuiltInCapabilityDefinition::new("openai_tool_search"),
         ]),
     ]
 }

--- a/crates/server/src/services/capability.rs
+++ b/crates/server/src/services/capability.rs
@@ -320,7 +320,7 @@ impl CapabilityService {
         capability_configs: &[everruns_core::AgentCapabilityConfig],
     ) -> Result<(String, Vec<everruns_core::ToolDefinition>)> {
         use everruns_core::capabilities::{
-            SystemPromptContext, collect_capabilities, resolve_dependencies,
+            SystemPromptContext, collect_capabilities_with_configs, resolve_capability_configs,
         };
 
         let mut system_prompt_parts: Vec<String> = Vec::new();
@@ -328,8 +328,8 @@ impl CapabilityService {
 
         // Separate built-in capabilities from MCP capabilities
         // Skill capabilities (skill:{uuid}) are mount-only; skip in preview.
-        let mut builtin_cap_ids: Vec<String> = Vec::new();
         let mut mcp_cap_ids: Vec<uuid::Uuid> = Vec::new();
+        let mut builtin_cap_configs: Vec<everruns_core::AgentCapabilityConfig> = Vec::new();
 
         for cap_config in capability_configs {
             let cap_ref = &cap_config.capability_ref;
@@ -338,18 +338,18 @@ impl CapabilityService {
             } else if cap_ref.skill_id().is_some() {
                 // AttachSkillCapability: mount-only, no preview contribution
             } else {
-                builtin_cap_ids.push(cap_ref.to_string());
+                builtin_cap_configs.push(cap_config.clone());
             }
         }
 
         // Resolve dependencies for built-in capabilities
-        let resolved = resolve_dependencies(&builtin_cap_ids, &self.registry)
+        let resolved = resolve_capability_configs(&builtin_cap_configs, &self.registry)
             .map_err(|e| anyhow::anyhow!("Failed to resolve capability dependencies: {}", e))?;
 
         // Collect from resolved capabilities (includes dependencies in correct order)
         // Preview has no session context, so dynamic capabilities (agent_instructions) return None
         let ctx = SystemPromptContext::without_file_store(everruns_core::SessionId::new());
-        let collected = collect_capabilities(&resolved.resolved_ids, &self.registry, &ctx).await;
+        let collected = collect_capabilities_with_configs(&resolved, &self.registry, &ctx).await;
         if let Some(prefix) = collected.system_prompt_prefix() {
             system_prompt_parts.push(prefix);
         }

--- a/crates/server/src/services/harness.rs
+++ b/crates/server/src/services/harness.rs
@@ -12,9 +12,10 @@ use crate::storage::{
 use anyhow::Result;
 use everruns_core::{
     AgentCapabilityConfig, Caller, Harness, HarnessId, HarnessStatus, InitialFile, Permission,
-    Policy, Rule,
+    Policy, Rule, merge_harness,
 };
 use everruns_macros::policy;
+use std::collections::HashSet;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -62,10 +63,17 @@ impl HarnessService {
         Self { db }
     }
 
+    pub(crate) fn db(&self) -> &Arc<StorageBackend> {
+        &self.db
+    }
+
     #[policy(HARNESS_MANAGE)]
     pub async fn create(&self, caller: &Caller, req: CreateHarnessRequest) -> Result<Harness> {
         let capabilities_to_store =
             ensure_file_system_capability(req.capabilities.clone(), !req.initial_files.is_empty());
+        let parent_harness_id = self
+            .validate_parent_harness(caller.org_id, None, req.parent_harness_id)
+            .await?;
         let default_model_id = self
             .validate_default_model_id(caller.org_id, req.default_model_id)
             .await?;
@@ -74,6 +82,7 @@ impl HarnessService {
             name: req.name,
             description: req.description,
             system_prompt: req.system_prompt,
+            parent_harness_id,
             default_model_id,
             tags: req.tags,
             initial_files: serde_json::to_value(&req.initial_files).unwrap_or_default(),
@@ -183,11 +192,19 @@ impl HarnessService {
         let default_model_id = self
             .validate_default_model_id(caller.org_id, req.default_model_id)
             .await?;
+        let parent_harness_id = self
+            .validate_parent_harness(
+                caller.org_id,
+                Some(HarnessId::from_uuid(id)),
+                req.parent_harness_id.flatten(),
+            )
+            .await?;
 
         let input = UpdateHarness {
             name: req.name,
             description: req.description,
             system_prompt: req.system_prompt,
+            parent_harness_id: req.parent_harness_id.map(|_| parent_harness_id),
             default_model_id,
             tags: req.tags,
             initial_files: req
@@ -239,6 +256,7 @@ impl HarnessService {
             name: format!("{} (copy)", source.name),
             description: source.description,
             system_prompt: source.system_prompt,
+            parent_harness_id: source.parent_harness_id,
             default_model_id: source.default_model_id,
             tags: source.tags,
             capabilities: source.capabilities,
@@ -255,6 +273,8 @@ impl HarnessService {
         if self.is_built_in(caller.org_id, id).await? {
             anyhow::bail!("Cannot delete built-in harness.");
         }
+        self.ensure_no_child_harnesses(caller.org_id, HarnessId::from_uuid(id))
+            .await?;
 
         self.db
             .delete_harness(caller.org_id, HarnessId::from_uuid(id))
@@ -266,6 +286,8 @@ impl HarnessService {
         if self.is_built_in(caller.org_id, id).await? {
             anyhow::bail!("Cannot delete built-in harness.");
         }
+        self.ensure_no_child_harnesses(caller.org_id, HarnessId::from_uuid(id))
+            .await?;
         let existing = self
             .db
             .get_harness(caller.org_id, HarnessId::from_uuid(id))
@@ -277,6 +299,10 @@ impl HarnessService {
         self.db
             .destroy_harness(caller.org_id, HarnessId::from_uuid(id))
             .await
+    }
+
+    pub async fn resolve_effective(&self, org_id: i64, id: HarnessId) -> Result<Option<Harness>> {
+        resolve_effective_harness(self.db.as_ref(), org_id, id).await
     }
 
     /// Check if a harness is built-in (system-managed, readonly).
@@ -313,12 +339,65 @@ impl HarnessService {
         Ok(Some(model_id))
     }
 
+    async fn validate_parent_harness(
+        &self,
+        org_id: i64,
+        current_harness_id: Option<HarnessId>,
+        parent_harness_id: Option<HarnessId>,
+    ) -> Result<Option<HarnessId>> {
+        let Some(parent_harness_id) = parent_harness_id else {
+            return Ok(None);
+        };
+
+        if current_harness_id == Some(parent_harness_id) {
+            anyhow::bail!("Harness cannot inherit from itself");
+        }
+
+        let parent = self
+            .db
+            .get_harness(org_id, parent_harness_id)
+            .await?
+            .ok_or_else(|| ResourceNotFoundError::new("Parent harness"))?;
+        if parent.status != "active" {
+            anyhow::bail!("Parent harness must be active");
+        }
+
+        if let Some(current_harness_id) = current_harness_id {
+            ensure_no_parent_cycle(
+                self.db.as_ref(),
+                org_id,
+                current_harness_id,
+                parent_harness_id,
+            )
+            .await?;
+        }
+
+        Ok(Some(parent_harness_id))
+    }
+
+    async fn ensure_no_child_harnesses(&self, org_id: i64, parent_id: HarnessId) -> Result<()> {
+        let children = self.db.list_child_harnesses(org_id, parent_id).await?;
+        if children.is_empty() {
+            return Ok(());
+        }
+
+        let child_names = children
+            .iter()
+            .map(|child| child.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        anyhow::bail!(
+            "Cannot archive or delete harness while child harnesses still inherit from it: {child_names}"
+        );
+    }
+
     fn row_to_harness(row: HarnessRow, capabilities: Vec<AgentCapabilityConfig>) -> Harness {
         Harness {
             id: row.id,
             name: row.name,
             description: row.description,
             system_prompt: row.system_prompt,
+            parent_harness_id: row.parent_harness_id,
             default_model_id: row.default_model_id,
             tags: row.tags,
             capabilities,
@@ -334,6 +413,115 @@ impl HarnessService {
     }
 }
 
+pub(crate) async fn load_raw_harness(
+    db: &StorageBackend,
+    org_id: i64,
+    harness_id: HarnessId,
+) -> Result<Option<Harness>> {
+    let Some(row) = db.get_harness(org_id, harness_id).await? else {
+        return Ok(None);
+    };
+    let capabilities = db
+        .get_harness_capabilities(harness_id.uuid())
+        .await?
+        .into_iter()
+        .map(|row| AgentCapabilityConfig::with_config(row.capability_id, row.config))
+        .collect();
+    Ok(Some(HarnessService::row_to_harness(row, capabilities)))
+}
+
+pub(crate) async fn resolve_effective_harness(
+    db: &StorageBackend,
+    org_id: i64,
+    harness_id: HarnessId,
+) -> Result<Option<Harness>> {
+    let mut visited = HashSet::new();
+    let mut chain = Vec::new();
+    let mut cursor = Some(harness_id);
+
+    while let Some(current_harness_id) = cursor {
+        if !visited.insert(current_harness_id) {
+            anyhow::bail!("Harness inheritance cycle detected");
+        }
+
+        let Some(harness) = load_raw_harness(db, org_id, current_harness_id).await? else {
+            if chain.is_empty() {
+                return Ok(None);
+            }
+            anyhow::bail!("Parent harness not found");
+        };
+        cursor = harness.parent_harness_id;
+        chain.push(harness);
+    }
+
+    let Some(mut effective) = chain.pop() else {
+        return Ok(None);
+    };
+
+    while let Some(layer) = chain.pop() {
+        effective = merge_harness(&effective, &layer);
+    }
+
+    Ok(Some(effective))
+}
+
+pub(crate) fn merge_preview_layer(
+    parent: Option<&Harness>,
+    system_prompt: &str,
+    capabilities: &[AgentCapabilityConfig],
+) -> (String, Vec<AgentCapabilityConfig>) {
+    let Some(parent) = parent else {
+        return (system_prompt.to_string(), capabilities.to_vec());
+    };
+
+    let draft = Harness {
+        id: HarnessId::new(),
+        name: "preview".to_string(),
+        description: None,
+        system_prompt: system_prompt.to_string(),
+        parent_harness_id: None,
+        default_model_id: None,
+        tags: vec![],
+        capabilities: capabilities.to_vec(),
+        initial_files: vec![],
+        is_built_in: false,
+        status: HarnessStatus::Active,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+        archived_at: None,
+        deleted_at: None,
+    };
+    let merged = merge_harness(parent, &draft);
+    (merged.system_prompt, merged.capabilities)
+}
+
+async fn ensure_no_parent_cycle(
+    db: &StorageBackend,
+    org_id: i64,
+    current_harness_id: HarnessId,
+    candidate_parent_id: HarnessId,
+) -> Result<()> {
+    let mut cursor = Some(candidate_parent_id);
+    let mut visited = HashSet::new();
+
+    while let Some(harness_id) = cursor {
+        if harness_id == current_harness_id {
+            anyhow::bail!("Harness inheritance cycle detected");
+        }
+        if !visited.insert(harness_id) {
+            anyhow::bail!("Harness inheritance cycle detected");
+        }
+
+        let row = db
+            .get_harness(org_id, harness_id)
+            .await?
+            .ok_or_else(|| ResourceNotFoundError::new("Parent harness"))?;
+        cursor = row.parent_harness_id;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -347,6 +535,7 @@ mod tests {
             name: "Test Harness".to_string(),
             description: None,
             system_prompt: "Test".to_string(),
+            parent_harness_id: None,
             default_model_id,
             tags: vec![],
             capabilities: vec![],
@@ -361,6 +550,7 @@ mod tests {
             name: None,
             description: None,
             system_prompt: None,
+            parent_harness_id: None,
             default_model_id,
             tags: None,
             capabilities: None,
@@ -460,5 +650,112 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(err.to_string(), "Model not found");
+    }
+
+    #[tokio::test]
+    async fn resolves_effective_harness_from_parent() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let service = HarnessService::new(db.clone());
+        let caller = Caller::internal(DEFAULT_ORG_ID);
+
+        let parent = service
+            .create(
+                &caller,
+                CreateHarnessRequest {
+                    name: "Parent".to_string(),
+                    description: None,
+                    system_prompt: "Parent prompt".to_string(),
+                    parent_harness_id: None,
+                    default_model_id: None,
+                    tags: vec!["parent".to_string()],
+                    capabilities: vec![AgentCapabilityConfig::with_config(
+                        "web_fetch",
+                        serde_json::json!({"enable_file_download": true}),
+                    )],
+                    initial_files: vec![InitialFile {
+                        path: "/workspace/README.md".to_string(),
+                        content: "parent".to_string(),
+                        encoding: "text".to_string(),
+                        is_readonly: true,
+                    }],
+                },
+            )
+            .await
+            .unwrap();
+
+        let child = service
+            .create(
+                &caller,
+                CreateHarnessRequest {
+                    name: "Child".to_string(),
+                    description: None,
+                    system_prompt: "Child prompt".to_string(),
+                    parent_harness_id: Some(parent.id),
+                    default_model_id: None,
+                    tags: vec!["child".to_string()],
+                    capabilities: vec![AgentCapabilityConfig::new("platform_management")],
+                    initial_files: vec![InitialFile {
+                        path: "/README.md".to_string(),
+                        content: "child".to_string(),
+                        encoding: "text".to_string(),
+                        is_readonly: false,
+                    }],
+                },
+            )
+            .await
+            .unwrap();
+
+        let effective = service
+            .resolve_effective(DEFAULT_ORG_ID, child.id)
+            .await
+            .unwrap()
+            .expect("effective harness");
+
+        assert_eq!(effective.system_prompt, "Parent prompt\n\nChild prompt");
+        assert_eq!(
+            effective
+                .capabilities
+                .iter()
+                .map(|cap| cap.capability_id())
+                .collect::<Vec<_>>(),
+            vec!["session_file_system", "web_fetch", "platform_management"]
+        );
+        assert_eq!(effective.initial_files.len(), 1);
+        assert_eq!(effective.initial_files[0].content, "child");
+    }
+
+    #[tokio::test]
+    async fn rejects_archiving_parent_with_children() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let service = HarnessService::new(db.clone());
+        let caller = Caller::internal(DEFAULT_ORG_ID);
+
+        let parent = service
+            .create(&caller, build_create_request(None))
+            .await
+            .unwrap();
+        service
+            .create(
+                &caller,
+                CreateHarnessRequest {
+                    name: "Child".to_string(),
+                    description: None,
+                    system_prompt: "Child".to_string(),
+                    parent_harness_id: Some(parent.id),
+                    default_model_id: None,
+                    tags: vec![],
+                    capabilities: vec![],
+                    initial_files: vec![],
+                },
+            )
+            .await
+            .unwrap();
+
+        let err = service.delete(&caller, parent.id.uuid()).await.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("child harnesses still inherit from it"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/crates/server/src/services/session.rs
+++ b/crates/server/src/services/session.rs
@@ -9,6 +9,7 @@
 use crate::api::common::Pagination;
 use crate::errors::ResourceNotFoundError;
 use crate::org_init::BASE_HARNESS_ID;
+use crate::services::harness::resolve_effective_harness;
 use crate::services::session_file::{CreateFileInput, SessionFileService};
 use crate::storage::{
     StorageBackend,
@@ -94,6 +95,9 @@ impl SessionService {
         if harness.status != "active" {
             anyhow::bail!("Archived or deleted harnesses cannot be assigned");
         }
+        let effective_harness = resolve_effective_harness(self.db.as_ref(), org_id, harness_id)
+            .await?
+            .ok_or_else(|| ResourceNotFoundError::new("Harness"))?;
         let agent = if let Some(aid) = agent_id {
             let agent = self
                 .db
@@ -117,7 +121,7 @@ impl SessionService {
                 agent
                     .as_ref()
                     .and_then(|a| a.default_model_id)
-                    .or(harness.default_model_id)
+                    .or(effective_harness.default_model_id)
             });
 
         // Serialize capabilities to JSON for storage
@@ -255,12 +259,9 @@ impl SessionService {
         agent_id: Option<Uuid>,
     ) -> Result<Vec<InitialFile>> {
         let mut files = self
-            .db
-            .get_harness(org_id, HarnessId::from_uuid(harness_id))
+            .resolve_effective_harness(org_id, HarnessId::from_uuid(harness_id))
             .await?
-            .map(|row| {
-                serde_json::from_value::<Vec<InitialFile>>(row.initial_files).unwrap_or_default()
-            })
+            .map(|harness| harness.initial_files)
             .unwrap_or_default();
 
         if let Some(agent_id) = agent_id
@@ -565,17 +566,21 @@ impl SessionService {
         let mut capability_ids = Vec::new();
 
         if self
-            .db
-            .get_harness(org_id, HarnessId::from_uuid(harness_id))
+            .resolve_effective_harness(org_id, HarnessId::from_uuid(harness_id))
             .await?
             .is_some()
         {
             capability_ids.extend(
-                self.db
-                    .get_harness_capabilities(harness_id)
+                self.resolve_effective_harness(org_id, HarnessId::from_uuid(harness_id))
                     .await?
-                    .into_iter()
-                    .map(|row| row.capability_id),
+                    .map(|harness| {
+                        harness
+                            .capabilities
+                            .into_iter()
+                            .map(|cap| cap.capability_id().to_string())
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default(),
             );
         }
 
@@ -683,6 +688,14 @@ impl SessionService {
                 .map(|s| SubagentStatus::from(s.as_str())),
         }
     }
+
+    async fn resolve_effective_harness(
+        &self,
+        org_id: i64,
+        harness_id: HarnessId,
+    ) -> Result<Option<everruns_core::Harness>> {
+        resolve_effective_harness(self.db.as_ref(), org_id, harness_id).await
+    }
 }
 
 fn normalize_initial_file_path(path: &str) -> String {
@@ -787,6 +800,7 @@ mod tests {
                     name: "Harness".to_string(),
                     description: None,
                     system_prompt: "Harness prompt".to_string(),
+                    parent_harness_id: None,
                     default_model_id: None,
                     tags: vec![],
                     capabilities: vec![],
@@ -879,6 +893,92 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn inherited_harness_starter_files_are_copied_into_new_sessions() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let harness_service = HarnessService::new(db.clone());
+        let session_service = SessionService::new(db.clone());
+        let caller = Caller::internal(1);
+
+        let parent = harness_service
+            .create(
+                &caller,
+                CreateHarnessRequest {
+                    name: "Parent".to_string(),
+                    description: None,
+                    system_prompt: "Parent prompt".to_string(),
+                    parent_harness_id: None,
+                    default_model_id: None,
+                    tags: vec![],
+                    capabilities: vec![],
+                    initial_files: vec![
+                        InitialFile {
+                            path: "/workspace/config.txt".to_string(),
+                            content: "from parent".to_string(),
+                            encoding: "text".to_string(),
+                            is_readonly: false,
+                        },
+                        InitialFile {
+                            path: "/parent-only.txt".to_string(),
+                            content: "only parent".to_string(),
+                            encoding: "text".to_string(),
+                            is_readonly: true,
+                        },
+                    ],
+                },
+            )
+            .await
+            .unwrap();
+
+        let child = harness_service
+            .create(
+                &caller,
+                CreateHarnessRequest {
+                    name: "Child".to_string(),
+                    description: None,
+                    system_prompt: "Child prompt".to_string(),
+                    parent_harness_id: Some(parent.id),
+                    default_model_id: None,
+                    tags: vec![],
+                    capabilities: vec![],
+                    initial_files: vec![InitialFile {
+                        path: "/config.txt".to_string(),
+                        content: "from child".to_string(),
+                        encoding: "text".to_string(),
+                        is_readonly: true,
+                    }],
+                },
+            )
+            .await
+            .unwrap();
+
+        let session = session_service
+            .create(
+                &caller,
+                child.id.uuid(),
+                None,
+                None,
+                build_create_request(child.id, None, None),
+            )
+            .await
+            .unwrap();
+
+        let file_service = SessionFileService::new(db);
+        let config = file_service
+            .read_file(session.id.uuid(), "/config.txt")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(config.content.as_deref(), Some("from child"));
+
+        let parent_only = file_service
+            .read_file(session.id.uuid(), "/parent-only.txt")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(parent_only.content.as_deref(), Some("only parent"));
+    }
+
+    #[tokio::test]
     async fn archived_dependencies_cannot_be_assigned_in_dev_mode() {
         let db = Arc::new(StorageBackend::in_memory());
         let harness_service = HarnessService::new(db.clone());
@@ -893,6 +993,7 @@ mod tests {
                     name: "Harness".to_string(),
                     description: None,
                     system_prompt: "Harness prompt".to_string(),
+                    parent_harness_id: None,
                     default_model_id: None,
                     tags: vec![],
                     capabilities: vec![],
@@ -948,6 +1049,7 @@ mod tests {
                     name: "Harness 2".to_string(),
                     description: None,
                     system_prompt: "Harness prompt".to_string(),
+                    parent_harness_id: None,
                     default_model_id: None,
                     tags: vec![],
                     capabilities: vec![],
@@ -993,6 +1095,7 @@ mod tests {
                     name: "Other Harness".to_string(),
                     description: None,
                     system_prompt: "Other".to_string(),
+                    parent_harness_id: None,
                     default_model_id: None,
                     tags: vec![],
                     capabilities: vec![],
@@ -1033,6 +1136,7 @@ mod tests {
                     name: "Harness".to_string(),
                     description: None,
                     system_prompt: "Harness".to_string(),
+                    parent_harness_id: None,
                     default_model_id: None,
                     tags: vec![],
                     capabilities: vec![],
@@ -1073,6 +1177,7 @@ mod tests {
                     name: "Other Harness".to_string(),
                     description: None,
                     system_prompt: "Other".to_string(),
+                    parent_harness_id: None,
                     default_model_id: None,
                     tags: vec![],
                     capabilities: vec![AgentCapabilityConfig::new("sample_data")],
@@ -1159,6 +1264,7 @@ mod tests {
                     name: "Other Harness".to_string(),
                     description: None,
                     system_prompt: "Other".to_string(),
+                    parent_harness_id: None,
                     default_model_id: None,
                     tags: vec![],
                     capabilities: vec![AgentCapabilityConfig::new("sample_data")],

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -295,6 +295,14 @@ impl StorageBackend {
         dispatch!(self, update_harness, org_id, id, input)
     }
 
+    pub async fn list_child_harnesses(
+        &self,
+        org_id: i64,
+        parent_id: HarnessId,
+    ) -> Result<Vec<HarnessRow>> {
+        dispatch!(self, list_child_harnesses, org_id, parent_id)
+    }
+
     pub async fn delete_harness(&self, org_id: i64, id: HarnessId) -> Result<bool> {
         dispatch!(self, delete_harness, org_id, id)
     }

--- a/crates/server/src/storage/harness_store.rs
+++ b/crates/server/src/storage/harness_store.rs
@@ -10,8 +10,10 @@ use async_trait::async_trait;
 use everruns_core::{
     AgentCapabilityConfig, AgentLoopError, HarnessId, Result,
     harness::{Harness, HarnessStatus},
+    merge_harness,
     traits::HarnessStore,
 };
+use std::collections::HashSet;
 
 use super::repositories::Database;
 
@@ -38,44 +40,70 @@ impl DbHarnessStore {
 #[async_trait]
 impl HarnessStore for DbHarnessStore {
     async fn get_harness(&self, harness_id: HarnessId) -> Result<Option<Harness>> {
-        let harness_row = self
-            .db
-            .get_harness(self.org_id, harness_id)
-            .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+        let mut visited = HashSet::new();
+        let mut chain = Vec::new();
+        let mut cursor = Some(harness_id);
 
-        match harness_row {
-            Some(row) => {
-                let capability_rows = self
-                    .db
-                    .get_harness_capabilities(harness_id.uuid())
-                    .await
-                    .map_err(|e| AgentLoopError::store(e.to_string()))?;
-
-                let capabilities: Vec<AgentCapabilityConfig> = capability_rows
-                    .into_iter()
-                    .map(|c| AgentCapabilityConfig::with_config(c.capability_id, c.config))
-                    .collect();
-
-                Ok(Some(Harness {
-                    id: row.id,
-                    name: row.name,
-                    description: row.description,
-                    system_prompt: row.system_prompt,
-                    default_model_id: row.default_model_id,
-                    tags: row.tags,
-                    capabilities,
-                    initial_files: serde_json::from_value(row.initial_files).unwrap_or_default(),
-                    is_built_in: row.is_built_in,
-                    status: HarnessStatus::from(row.status.as_str()),
-                    created_at: row.created_at,
-                    updated_at: row.updated_at,
-                    archived_at: row.archived_at,
-                    deleted_at: row.deleted_at,
-                }))
+        while let Some(current_harness_id) = cursor {
+            if !visited.insert(current_harness_id) {
+                return Err(AgentLoopError::store(
+                    "Harness inheritance cycle detected".to_string(),
+                ));
             }
-            None => Ok(None),
+
+            let Some(row) = self
+                .db
+                .get_harness(self.org_id, current_harness_id)
+                .await
+                .map_err(|e| AgentLoopError::store(e.to_string()))?
+            else {
+                if chain.is_empty() {
+                    return Ok(None);
+                }
+                return Err(AgentLoopError::store(
+                    "Parent harness not found".to_string(),
+                ));
+            };
+
+            let capability_rows = self
+                .db
+                .get_harness_capabilities(current_harness_id.uuid())
+                .await
+                .map_err(|e| AgentLoopError::store(e.to_string()))?;
+
+            let capabilities: Vec<AgentCapabilityConfig> = capability_rows
+                .into_iter()
+                .map(|c| AgentCapabilityConfig::with_config(c.capability_id, c.config))
+                .collect();
+
+            cursor = row.parent_harness_id;
+            chain.push(Harness {
+                id: row.id,
+                name: row.name,
+                description: row.description,
+                system_prompt: row.system_prompt,
+                parent_harness_id: row.parent_harness_id,
+                default_model_id: row.default_model_id,
+                tags: row.tags,
+                capabilities,
+                initial_files: serde_json::from_value(row.initial_files).unwrap_or_default(),
+                is_built_in: row.is_built_in,
+                status: HarnessStatus::from(row.status.as_str()),
+                created_at: row.created_at,
+                updated_at: row.updated_at,
+                archived_at: row.archived_at,
+                deleted_at: row.deleted_at,
+            });
         }
+
+        let Some(mut effective) = chain.pop() else {
+            return Ok(None);
+        };
+        while let Some(layer) = chain.pop() {
+            effective = merge_harness(&effective, &layer);
+        }
+
+        Ok(Some(effective))
     }
 }
 

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -743,6 +743,7 @@ impl InMemoryDatabase {
             name: input.name,
             description: input.description,
             system_prompt: input.system_prompt,
+            parent_harness_id: input.parent_harness_id,
             default_model_id: input.default_model_id,
             tags: input.tags,
             initial_files: input.initial_files,
@@ -773,6 +774,7 @@ impl InMemoryDatabase {
             if existing.name == input.name
                 && existing.description == input.description
                 && existing.system_prompt == input.system_prompt
+                && existing.parent_harness_id == input.parent_harness_id
                 && existing.tags == input.tags
                 && existing.initial_files == input.initial_files
             {
@@ -782,6 +784,7 @@ impl InMemoryDatabase {
                 name: input.name,
                 description: input.description,
                 system_prompt: input.system_prompt,
+                parent_harness_id: input.parent_harness_id,
                 tags: input.tags,
                 initial_files: input.initial_files,
                 updated_at: now,
@@ -797,6 +800,7 @@ impl InMemoryDatabase {
             name: input.name,
             description: input.description,
             system_prompt: input.system_prompt,
+            parent_harness_id: input.parent_harness_id,
             default_model_id: input.default_model_id,
             tags: input.tags,
             initial_files: input.initial_files,
@@ -863,6 +867,9 @@ impl InMemoryDatabase {
             if let Some(system_prompt) = input.system_prompt {
                 harness.system_prompt = system_prompt;
             }
+            if let Some(parent_harness_id) = input.parent_harness_id {
+                harness.parent_harness_id = parent_harness_id;
+            }
             if let Some(default_model_id) = input.default_model_id {
                 harness.default_model_id = Some(default_model_id);
             }
@@ -893,6 +900,25 @@ impl InMemoryDatabase {
             return Ok(true);
         }
         Ok(false)
+    }
+
+    pub async fn list_child_harnesses(
+        &self,
+        org_id: i64,
+        parent_id: HarnessId,
+    ) -> Result<Vec<HarnessRow>> {
+        let harnesses = self.harnesses.read();
+        let mut result: Vec<_> = harnesses
+            .values()
+            .filter(|h| {
+                h.org_id == org_id
+                    && h.parent_harness_id == Some(parent_id)
+                    && h.status != "deleted"
+            })
+            .cloned()
+            .collect();
+        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(result)
     }
 
     pub async fn destroy_harness(&self, org_id: i64, id: HarnessId) -> Result<bool> {

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -283,6 +283,7 @@ pub struct HarnessRow {
     pub name: String,
     pub description: Option<String>,
     pub system_prompt: String,
+    pub parent_harness_id: Option<HarnessId>,
     pub default_model_id: Option<ModelId>,
     pub tags: Vec<String>,
     /// Starter files copied into new sessions (JSONB in DB)
@@ -301,6 +302,7 @@ pub struct CreateHarnessRow {
     pub name: String,
     pub description: Option<String>,
     pub system_prompt: String,
+    pub parent_harness_id: Option<HarnessId>,
     pub default_model_id: Option<ModelId>,
     pub tags: Vec<String>,
     /// Starter files copied into new sessions (JSONB in DB)
@@ -313,6 +315,7 @@ pub struct UpdateHarness {
     pub name: Option<String>,
     pub description: Option<String>,
     pub system_prompt: Option<String>,
+    pub parent_harness_id: Option<Option<HarnessId>>,
     pub default_model_id: Option<ModelId>,
     pub tags: Option<Vec<String>>,
     pub initial_files: Option<serde_json::Value>,

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -876,15 +876,16 @@ impl Database {
     pub async fn create_harness(&self, org_id: i64, input: CreateHarnessRow) -> Result<HarnessRow> {
         let row = sqlx::query_as::<_, HarnessRow>(
             r#"
-            INSERT INTO harnesses (org_id, name, description, system_prompt, default_model_id, tags, initial_files, is_built_in, status)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'active')
-            RETURNING id, org_id, name, description, system_prompt, default_model_id, tags, initial_files, is_built_in, status, created_at, updated_at, archived_at, deleted_at
+            INSERT INTO harnesses (org_id, name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, is_built_in, status)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'active')
+            RETURNING id, org_id, name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, is_built_in, status, created_at, updated_at, archived_at, deleted_at
             "#,
         )
         .bind(org_id)
         .bind(&input.name)
         .bind(&input.description)
         .bind(&input.system_prompt)
+        .bind(input.parent_harness_id.map(|id| id.uuid()))
         .bind(input.default_model_id.map(|m| m.uuid()))
         .bind(&input.tags)
         .bind(&input.initial_files)
@@ -907,12 +908,13 @@ impl Database {
     ) -> Result<Option<HarnessRow>> {
         let row = sqlx::query_as::<_, HarnessRow>(
             r#"
-            INSERT INTO harnesses (id, org_id, name, description, system_prompt, default_model_id, tags, initial_files, is_built_in, status)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'active')
+            INSERT INTO harnesses (id, org_id, name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, is_built_in, status)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'active')
             ON CONFLICT (id) DO UPDATE SET
                 name = EXCLUDED.name,
                 description = EXCLUDED.description,
                 system_prompt = EXCLUDED.system_prompt,
+                parent_harness_id = EXCLUDED.parent_harness_id,
                 tags = EXCLUDED.tags,
                 initial_files = EXCLUDED.initial_files,
                 is_built_in = EXCLUDED.is_built_in,
@@ -921,10 +923,11 @@ impl Database {
                 harnesses.name IS DISTINCT FROM EXCLUDED.name
                 OR harnesses.description IS DISTINCT FROM EXCLUDED.description
                 OR harnesses.system_prompt IS DISTINCT FROM EXCLUDED.system_prompt
+                OR harnesses.parent_harness_id IS DISTINCT FROM EXCLUDED.parent_harness_id
                 OR harnesses.tags IS DISTINCT FROM EXCLUDED.tags
                 OR harnesses.initial_files IS DISTINCT FROM EXCLUDED.initial_files
                 OR harnesses.is_built_in IS DISTINCT FROM EXCLUDED.is_built_in
-            RETURNING id, org_id, name, description, system_prompt, default_model_id, tags, initial_files, is_built_in, status, created_at, updated_at, archived_at, deleted_at
+            RETURNING id, org_id, name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, is_built_in, status, created_at, updated_at, archived_at, deleted_at
             "#,
         )
         .bind(id.uuid())
@@ -932,6 +935,7 @@ impl Database {
         .bind(&input.name)
         .bind(&input.description)
         .bind(&input.system_prompt)
+        .bind(input.parent_harness_id.map(|id| id.uuid()))
         .bind(input.default_model_id.map(|m| m.uuid()))
         .bind(&input.tags)
         .bind(&input.initial_files)
@@ -945,7 +949,7 @@ impl Database {
     pub async fn get_harness(&self, org_id: i64, id: HarnessId) -> Result<Option<HarnessRow>> {
         let row = sqlx::query_as::<_, HarnessRow>(
             r#"
-            SELECT id, org_id, name, description, system_prompt, default_model_id, tags, initial_files, is_built_in, status, created_at, updated_at, archived_at, deleted_at
+            SELECT id, org_id, name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, is_built_in, status, created_at, updated_at, archived_at, deleted_at
             FROM harnesses
             WHERE org_id = $1 AND id = $2
             "#,
@@ -972,7 +976,7 @@ impl Database {
             " AND status = 'active'"
         };
         let sql = format!(
-            r#"SELECT id, org_id, name, description, system_prompt, default_model_id, tags, initial_files, is_built_in, status, created_at, updated_at, archived_at, deleted_at
+            r#"SELECT id, org_id, name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, is_built_in, status, created_at, updated_at, archived_at, deleted_at
                 FROM harnesses
                 WHERE org_id = $1{status_sql}{search_sql}
                 ORDER BY created_at DESC"#
@@ -997,13 +1001,17 @@ impl Database {
                 name = COALESCE($3, name),
                 description = COALESCE($4, description),
                 system_prompt = COALESCE($5, system_prompt),
-                default_model_id = COALESCE($6, default_model_id),
-                tags = COALESCE($7, tags),
-                initial_files = COALESCE($8, initial_files),
-                status = COALESCE($9, status),
+                parent_harness_id = CASE
+                    WHEN $6 THEN $7
+                    ELSE parent_harness_id
+                END,
+                default_model_id = COALESCE($8, default_model_id),
+                tags = COALESCE($9, tags),
+                initial_files = COALESCE($10, initial_files),
+                status = COALESCE($11, status),
                 updated_at = NOW()
             WHERE org_id = $1 AND id = $2
-            RETURNING id, org_id, name, description, system_prompt, default_model_id, tags, initial_files, is_built_in, status, created_at, updated_at, archived_at, deleted_at
+            RETURNING id, org_id, name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, is_built_in, status, created_at, updated_at, archived_at, deleted_at
             "#,
         )
         .bind(org_id)
@@ -1011,6 +1019,8 @@ impl Database {
         .bind(&input.name)
         .bind(&input.description)
         .bind(&input.system_prompt)
+        .bind(input.parent_harness_id.is_some())
+        .bind(input.parent_harness_id.flatten().map(|id| id.uuid()))
         .bind(input.default_model_id.map(|m| m.uuid()))
         .bind(&input.tags)
         .bind(&input.initial_files)
@@ -1019,6 +1029,25 @@ impl Database {
         .await?;
 
         Ok(row)
+    }
+
+    pub async fn list_child_harnesses(
+        &self,
+        org_id: i64,
+        parent_id: HarnessId,
+    ) -> Result<Vec<HarnessRow>> {
+        Ok(sqlx::query_as::<_, HarnessRow>(
+            r#"
+            SELECT id, org_id, name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, is_built_in, status, created_at, updated_at, archived_at, deleted_at
+            FROM harnesses
+            WHERE org_id = $1 AND parent_harness_id = $2 AND status != 'deleted'
+            ORDER BY created_at DESC
+            "#,
+        )
+        .bind(org_id)
+        .bind(parent_id.uuid())
+        .fetch_all(&self.pool)
+        .await?)
     }
 
     pub async fn delete_harness(&self, org_id: i64, id: HarnessId) -> Result<bool> {

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -2221,6 +2221,11 @@ async fn test_chat_harness_has_platform_management() {
         .json();
 
     assert_eq!(harness.name, "Platform Chat");
+    assert_eq!(
+        harness.parent_harness_id.as_ref().map(ToString::to_string),
+        Some(SEED_GENERIC_HARNESS_ID.to_string()),
+        "Platform Chat should inherit from Generic"
+    );
 
     let cap_ids: Vec<&str> = harness
         .capabilities
@@ -2230,16 +2235,41 @@ async fn test_chat_harness_has_platform_management() {
 
     assert_eq!(
         cap_ids.len(),
-        10,
-        "Platform Chat harness should have 10 capabilities (Generic + platform_management)"
-    );
-    assert!(
-        cap_ids.contains(&"infinity_context"),
-        "Platform Chat harness should include infinity_context from Generic"
+        1,
+        "Platform Chat should only store its local capability set"
     );
     assert!(
         cap_ids.contains(&"platform_management"),
-        "Platform Chat harness should include platform_management capability"
+        "Platform Chat should store platform_management locally"
+    );
+
+    let preview: Value = server
+        .post(
+            "/v1/harnesses/preview",
+            json!({
+                "system_prompt": harness.system_prompt,
+                "parent_harness_id": harness.parent_harness_id,
+                "capabilities": harness.capabilities,
+            }),
+        )
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    let tool_names: Vec<&str> = preview["tools"]
+        .as_array()
+        .expect("preview tools should be an array")
+        .iter()
+        .filter_map(|tool| tool["name"].as_str())
+        .collect();
+
+    assert!(
+        tool_names.contains(&"web_fetch"),
+        "Platform Chat preview should include inherited Generic tools"
+    );
+    assert!(
+        tool_names.contains(&"manage_harnesses"),
+        "Platform Chat preview should include platform management tools"
     );
 }
 

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -2574,8 +2574,14 @@ mod tests {
         let harness = proto_harness_to_harness(proto).expect("proto harness should convert");
 
         assert_eq!(harness.id.uuid(), harness_id);
-        assert_eq!(harness.parent_harness_id.map(|id| id.uuid()), Some(parent_id));
-        assert_eq!(harness.tags, vec!["chat".to_string(), "built-in".to_string()]);
+        assert_eq!(
+            harness.parent_harness_id.map(|id| id.uuid()),
+            Some(parent_id)
+        );
+        assert_eq!(
+            harness.tags,
+            vec!["chat".to_string(), "built-in".to_string()]
+        );
         assert!(harness.is_built_in);
     }
 

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -565,6 +565,11 @@ fn proto_harness_to_harness(proto_harness: proto::Harness) -> Result<Harness> {
         .as_ref()
         .map(|u| proto_uuid_to_uuid(Some(u)))
         .transpose()?;
+    let parent_harness_id = proto_harness
+        .parent_harness_id
+        .as_ref()
+        .map(|u| proto_uuid_to_uuid(Some(u)))
+        .transpose()?;
 
     let status = match proto_harness.status.to_lowercase().as_str() {
         "active" => HarnessStatus::Active,
@@ -578,16 +583,16 @@ fn proto_harness_to_harness(proto_harness: proto::Harness) -> Result<Harness> {
         name: proto_harness.name,
         description: non_empty_string(proto_harness.description),
         system_prompt: proto_harness.system_prompt,
-        parent_harness_id: None,
+        parent_harness_id: parent_harness_id.map(|u| u.into()),
         default_model_id: default_model_id.map(|u| u.into()),
-        tags: vec![],
+        tags: proto_harness.tags,
         capabilities: proto_harness
             .capability_ids
             .into_iter()
             .map(everruns_core::AgentCapabilityConfig::new)
             .collect(),
         initial_files: vec![],
-        is_built_in: false,
+        is_built_in: proto_harness.is_built_in,
         status,
         created_at: proto_timestamp_or_now(proto_harness.created_at.as_ref()),
         updated_at: proto_timestamp_or_now(proto_harness.updated_at.as_ref()),
@@ -2545,6 +2550,34 @@ fn proto_value_to_json(value: prost_types::Value) -> serde_json::Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use uuid::Uuid;
+
+    #[test]
+    fn test_proto_harness_to_harness_preserves_metadata() {
+        let harness_id = Uuid::new_v4();
+        let parent_id = Uuid::new_v4();
+        let proto = proto::Harness {
+            id: Some(uuid_to_proto(harness_id)),
+            name: "Platform Chat".into(),
+            description: "Built-in chat harness".into(),
+            system_prompt: "prompt".into(),
+            default_model_id: None,
+            status: "active".into(),
+            created_at: None,
+            updated_at: None,
+            capability_ids: vec!["platform_management".into()],
+            tags: vec!["chat".into(), "built-in".into()],
+            parent_harness_id: Some(uuid_to_proto(parent_id)),
+            is_built_in: true,
+        };
+
+        let harness = proto_harness_to_harness(proto).expect("proto harness should convert");
+
+        assert_eq!(harness.id.uuid(), harness_id);
+        assert_eq!(harness.parent_harness_id.map(|id| id.uuid()), Some(parent_id));
+        assert_eq!(harness.tags, vec!["chat".to_string(), "built-in".to_string()]);
+        assert!(harness.is_built_in);
+    }
 
     #[test]
     fn test_proto_value_to_json_null() {

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -578,6 +578,7 @@ fn proto_harness_to_harness(proto_harness: proto::Harness) -> Result<Harness> {
         name: proto_harness.name,
         description: non_empty_string(proto_harness.description),
         system_prompt: proto_harness.system_prompt,
+        parent_harness_id: None,
         default_model_id: default_model_id.map(|u| u.into()),
         tags: vec![],
         capabilities: proto_harness
@@ -1878,6 +1879,7 @@ impl everruns_core::platform_store::PlatformStore for GrpcPlatformStore {
         name: &str,
         description: Option<&str>,
         system_prompt: &str,
+        parent_harness_id: Option<everruns_core::HarnessId>,
         capabilities: &[String],
     ) -> Result<Harness> {
         let mut client = self.client.inner.lock().await;
@@ -1888,6 +1890,7 @@ impl everruns_core::platform_store::PlatformStore for GrpcPlatformStore {
                 description: description.map(|s| s.to_string()),
                 system_prompt: system_prompt.to_string(),
                 capabilities: capabilities.to_vec(),
+                parent_harness_id: parent_harness_id.map(|id| uuid_to_proto(id.uuid())),
             })
             .await
             .map_err(|e| grpc_error(format!("gRPC platform_create_harness failed: {}", e)))?;
@@ -1907,6 +1910,7 @@ impl everruns_core::platform_store::PlatformStore for GrpcPlatformStore {
         name: Option<&str>,
         description: Option<&str>,
         system_prompt: Option<&str>,
+        parent_harness_id: Option<Option<everruns_core::HarnessId>>,
     ) -> Result<Harness> {
         let mut client = self.client.inner.lock().await;
         let response = client
@@ -1916,6 +1920,11 @@ impl everruns_core::platform_store::PlatformStore for GrpcPlatformStore {
                 name: name.map(|s| s.to_string()),
                 description: description.map(|s| s.to_string()),
                 system_prompt: system_prompt.map(|s| s.to_string()),
+                parent_harness_id: parent_harness_id
+                    .flatten()
+                    .map(|parent_id| uuid_to_proto(parent_id.uuid())),
+                clear_parent_harness_id: parent_harness_id
+                    .and_then(|value| value.is_none().then_some(true)),
             })
             .await
             .map_err(|e| grpc_error(format!("gRPC platform_update_harness failed: {}", e)))?;

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -9127,6 +9127,13 @@
             "type": "string",
             "description": "The base system prompt (before capability additions)",
             "example": "You are a helpful customer support agent."
+          },
+          "tools": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            },
+            "description": "Client-side tools to include in the preview."
           }
         }
       },

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -107,6 +107,8 @@ All agent create/update/import endpoints enforce input size limits as last-resor
 
 Harnesses define the base environment and capabilities for sessions. See [harness-types.md](harness-types.md) for built-in types.
 
+Harness create/update payloads include optional `parent_harness_id`. When present, preview and runtime resolve the effective harness from parent to child before applying any agent or session layers.
+
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/v1/harnesses` | Create harness |

--- a/specs/harness-types.md
+++ b/specs/harness-types.md
@@ -6,6 +6,8 @@ Harnesses define the base environment and capabilities for sessions. Everruns sh
 
 Harnesses may also define starter files. Starter files are copied into each new session created from the harness and can be marked editable or read-only per file.
 
+Harnesses support single-parent inheritance via `parent_harness_id`. Inheritance is live: the effective harness is resolved from parent to child at runtime and in preview.
+
 ## Built-in Harness Types
 
 ### Base
@@ -64,23 +66,17 @@ Conversational harness for the global chat interface. Extends Generic capabiliti
 |----------|-------|
 | Name | Platform Chat |
 | Seed ID | `harness_01933b5a000070008000000000000603` |
+| Parent | Generic |
 | System Prompt | See `crates/server/src/seed.rs` (CHAT_HARNESS) for full prompt |
 | Tags | `chat`, `seed` |
 
-**Capabilities:** Generic capabilities plus `platform_management`:
+**Local capabilities:** `platform_management`
 
 | Capability ID | Name | Purpose | Config |
 |---------------|------|---------|--------|
-| `session_file_system` | File System | Read, write, list, grep, delete files in `/workspace` | |
-| `virtual_bash` | Virtual Bash | Sandboxed bash shell for code execution and scripting | |
-| `web_fetch` | Web Fetch | Fetch web content with file download support | `{"enable_file_download": true}` |
-| `session_storage` | Storage | Key/value store and encrypted secret storage | |
-| `session` | Session | Session info access and title management | |
-| `agent_instructions` | AGENTS.md | Reads AGENTS.md from workspace and injects into system prompt | |
-| `skills` | Agent Skills | Discover and activate skills from `/.agents/skills/` in session filesystem | |
-| `infinity_context` | Infinity Context | Trims older prompt history while keeping it queryable | |
-| `openai_tool_search` | OpenAI Tool Search | Defers tool schema loading on supported OpenAI models | |
 | `platform_management` | Platform Management | Manage harnesses, agents, and sessions via tools | |
+
+**Effective capabilities:** Generic capabilities plus `platform_management`
 
 **System prompt guidance includes:**
 - "Run agent" workflow: create session → send message → wait for idle → get results
@@ -102,8 +98,9 @@ Conversational harness for the global chat interface. Extends Generic capabiliti
 | Why include `session` in Generic? | Session metadata (title, info) is commonly needed and has minimal overhead. |
 | Why include `agent_instructions` in Generic? | AGENTS.md is the standard way to provide project-level instructions. Including it by default means users get this functionality without extra configuration. |
 | Why include `skills` in Generic? | Skills extend agent abilities via portable instruction packages. Including discovery by default means agents can use skills uploaded to the session filesystem without extra capability setup. |
-<<<<<<< HEAD
 | Why include `infinity_context` in Generic? | General-purpose sessions often grow long. Including long-context support by default keeps the prompt bounded without permanently hiding earlier conversation state. |
+| Why support harness inheritance? | It lets users build on Generic or other shared harnesses without duplicating long capability lists, prompts, model defaults, or starter files. |
+| How does harness inheritance merge? | System prompt appends parent then child. Default model falls back parent then child override. Capabilities merge by capability ID with child config overriding parent. Starter files merge by normalized path with child overriding parent. |
 | Can users create additional harnesses? | Yes, via `POST /v1/harnesses`. Built-in harnesses are readonly; users can copy them for editable versions. |
 | Why are built-in harnesses readonly? | Prevents accidental modification of system-managed definitions. Copy-to-edit pattern gives users full control while keeping built-ins stable and upgradeable. |
 | How are built-in harnesses upgraded? | Reconciliation runs at startup — iterates all orgs and upserts built-in harness definitions. Changes to `org_init::BUILT_IN_HARNESSES` propagate automatically. |


### PR DESCRIPTION
## What
Add harness inheritance across storage, runtime, transport, and UI so harnesses can inherit a parent harness and previews show the effective merged result.

## Why
Harness configuration was duplicated across built-ins and user-created harnesses. Users could not build on top of Generic without copying capability lists, starter files, prompts, and model defaults. Preview UI also only showed local shape instead of the effective runtime result.

## How
- add `parent_harness_id` to harness storage, API, and transport layers with same-org and cycle validation
- resolve effective harnesses parent-to-child at runtime for prompts, capabilities, starter files, and model fallback
- update built-in OSS harness definitions so `Platform Chat` inherits `Generic`, and reconcile existing provisioned built-ins at startup instead of rewriting data in migrations
- make harness preview resolve inherited state before computing prompt/tools, and include agent client-side tools in agent preview output for parity
- update harness create/edit/detail UI to expose parent selection and show inherited preview/detail state
- carry the new parent field through platform-management tools, gRPC, and worker adapters

## Risk
- Medium
- Harness provisioning and session startup now depend on parent-chain resolution; regressions would affect built-in harness setup, preview output, or session capability/file inheritance.
- Transport changes touch internal gRPC harness payloads and platform-management tool wiring.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

Validation:
- `cargo check -p everruns-core -p everruns-internal-protocol -p everruns-worker -p everruns-server`
- `cargo test -p everruns-server resolves_effective_harness_from_parent --lib`
- `cargo test -p everruns-server inherited_harness_starter_files_are_copied_into_new_sessions --lib`
- `cargo test -p everruns-server test_initialize_default_org_creates_harnesses --lib`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run build`
- `just pre-push`
- Full-stack smoke on `PORT_PREFIX=333 just start-all --no-watch` with local gRPC token, including API + UI verification that a child harness inherits its parent and preview shows merged prompt/tools
