### PR TITLE
feat(skills): add model frontmatter field for per-skill model override

### DIFF
--- a/crates/core/src/capabilities/skills.rs
+++ b/crates/core/src/capabilities/skills.rs
@@ -496,6 +496,9 @@ impl Tool for ActivateSkillFromVfsTool {
                     result["context"] = serde_json::json!("fork");
                     result["agent"] =
                         serde_json::json!(parsed.agent.as_deref().unwrap_or("general-purpose"));
+                    if let Some(ref model) = parsed.model {
+                        result["model"] = serde_json::json!(model);
+                    }
                 }
 
                 if !bundled_files.is_empty() {
@@ -1214,6 +1217,58 @@ mod tests {
                 // No context or agent fields for inline skills
                 assert!(val.get("context").is_none());
                 assert!(val.get("agent").is_none());
+            }
+            other => panic!("Expected Success, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_activate_skill_fork_with_model() {
+        let fs = Arc::new(MockFileStore::new());
+        let session_id = SessionId::new();
+        fs.add_file(
+            session_id,
+            "/.agents/skills/quick-lint/SKILL.md",
+            "---\nname: quick-lint\ndescription: Fast lint.\ncontext: fork\nmodel: claude-haiku-4-5-20251001\n---\n\nLint check.",
+        );
+
+        let context = ToolContext::with_file_store(session_id, fs);
+        let tool = ActivateSkillFromVfsTool;
+
+        let result = tool
+            .execute_with_context(serde_json::json!({"name": "quick-lint"}), &context)
+            .await;
+        match result {
+            ToolExecutionResult::Success(val) => {
+                assert_eq!(val["context"], "fork");
+                assert_eq!(val["agent"], "general-purpose");
+                assert_eq!(val["model"], "claude-haiku-4-5-20251001");
+            }
+            other => panic!("Expected Success, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_activate_skill_inline_no_model_in_result() {
+        let fs = Arc::new(MockFileStore::new());
+        let session_id = SessionId::new();
+        fs.add_file(
+            session_id,
+            "/.agents/skills/my-skill/SKILL.md",
+            "---\nname: my-skill\ndescription: A skill.\nmodel: gpt-4o\n---\n\nBody.",
+        );
+
+        let context = ToolContext::with_file_store(session_id, fs);
+        let tool = ActivateSkillFromVfsTool;
+
+        let result = tool
+            .execute_with_context(serde_json::json!({"name": "my-skill"}), &context)
+            .await;
+        match result {
+            ToolExecutionResult::Success(val) => {
+                // Inline skill: no model field in result (model only applies with fork)
+                assert!(val.get("context").is_none());
+                assert!(val.get("model").is_none());
             }
             other => panic!("Expected Success, got: {:?}", other),
         }

--- a/crates/core/src/skill.rs
+++ b/crates/core/src/skill.rs
@@ -167,6 +167,8 @@ pub struct ParsedSkillMd {
     pub context: SkillContext,
     /// Subagent type when context is fork (e.g., "Explore", "Plan"). Default: "general-purpose"
     pub agent: Option<String>,
+    /// LLM model override for this skill (e.g., "claude-haiku-4-5-20251001")
+    pub model: Option<String>,
 }
 
 /// YAML frontmatter structure
@@ -193,6 +195,8 @@ struct SkillFrontmatter {
     context: Option<String>,
     /// Subagent type when context is fork (e.g., "Explore", "Plan")
     agent: Option<String>,
+    /// LLM model override for this skill
+    model: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -335,6 +339,7 @@ pub fn parse_skill_md(content: &str) -> Result<ParsedSkillMd, Vec<String>> {
         argument_hint: fm.argument_hint,
         context,
         agent: fm.agent,
+        model: fm.model,
     })
 }
 
@@ -359,6 +364,13 @@ pub fn validate_skill_md(content: &str) -> SkillValidationResult {
             if parsed.context == SkillContext::Fork && parsed.agent.is_none() {
                 warnings.push(
                     "context: fork without agent field — will use default \"general-purpose\" agent."
+                        .to_string(),
+                );
+            }
+            if parsed.model.is_some() && parsed.context != SkillContext::Fork {
+                warnings.push(
+                    "model: field is only supported with context: fork. \
+                     Inline skills ignore the model override."
                         .to_string(),
                 );
             }
@@ -1061,6 +1073,94 @@ Body.
     #[test]
     fn test_skill_context_default() {
         assert_eq!(SkillContext::default(), SkillContext::Inline);
+    }
+
+    // -- model frontmatter tests --
+
+    #[test]
+    fn test_parse_model_with_fork() {
+        let content = r#"---
+name: quick-lint
+description: Fast lint check.
+context: fork
+model: claude-haiku-4-5-20251001
+---
+
+Lint instructions.
+"#;
+        let parsed = parse_skill_md(content).unwrap();
+        assert_eq!(parsed.model.as_deref(), Some("claude-haiku-4-5-20251001"));
+        assert_eq!(parsed.context, SkillContext::Fork);
+    }
+
+    #[test]
+    fn test_parse_model_without_fork() {
+        let content = r#"---
+name: my-skill
+description: A skill.
+model: gpt-4o
+---
+
+Body.
+"#;
+        let parsed = parse_skill_md(content).unwrap();
+        assert_eq!(parsed.model.as_deref(), Some("gpt-4o"));
+        assert_eq!(parsed.context, SkillContext::Inline);
+    }
+
+    #[test]
+    fn test_parse_no_model_field() {
+        let content = r#"---
+name: my-skill
+description: A skill.
+---
+
+Body.
+"#;
+        let parsed = parse_skill_md(content).unwrap();
+        assert!(parsed.model.is_none());
+    }
+
+    #[test]
+    fn test_validate_warns_model_without_fork() {
+        let content = r#"---
+name: my-skill
+description: A skill.
+model: gpt-4o
+---
+
+Body.
+"#;
+        let result = validate_skill_md(content);
+        assert!(result.valid);
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("model:") && w.contains("context: fork"))
+        );
+    }
+
+    #[test]
+    fn test_validate_no_warning_model_with_fork() {
+        let content = r#"---
+name: my-skill
+description: A skill.
+context: fork
+agent: Explore
+model: claude-haiku-4-5-20251001
+---
+
+Body.
+"#;
+        let result = validate_skill_md(content);
+        assert!(result.valid);
+        assert!(
+            !result
+                .warnings
+                .iter()
+                .any(|w| w.contains("model:") && w.contains("context: fork"))
+        );
     }
 
     // ========================================================================


### PR DESCRIPTION
## What
Add `model` frontmatter field to SKILL.md for per-skill LLM model override.

## Why
Different skills have different capability/cost requirements (EVE-139). A lint skill can use a cheap model while an architect skill needs the most capable one. Per-skill model override enables cost optimization and capability matching.

## How
- Added `model: Option<String>` to `ParsedSkillMd` and `SkillFrontmatter` in `crates/core/src/skill.rs`
- Passed through in `parse_skill_md()`
- Added warning in `validate_skill_md()` when model is used without `context: fork` (inline skills ignore the override)
- Included `model` in `activate_skill` result for fork-mode skills in `crates/core/src/capabilities/skills.rs`
- 7 new tests: parsing with/without fork, missing model, validation warnings, activation result

## Risk
- Low
- Additive field, no breaking changes
- Model is only passed through for fork-mode skills; inline skills get a validation warning

## Checklist
- [x] Tests added or updated (7 new tests)
- [x] Backward compatibility considered (additive only, Optional field)