### PR TITLE
refactor(ui): extract useScrollManager and useImageDropZone hooks

### DIFF
--- a/apps/ui/src/__tests__/chat-panel.test.tsx
+++ b/apps/ui/src/__tests__/chat-panel.test.tsx
@@ -48,6 +48,24 @@ jest.mock("@/hooks", () => ({
     isUploading: false,
   }),
   useSessionCommands: (...args: unknown[]) => mockUseSessionCommands(...args),
+  useScrollManager: () => ({
+    scrollContainerRef: { current: null },
+    messagesEndRef: { current: null },
+    hasNewMessages: false,
+    dismissNewMessages: jest.fn(),
+    handleScrollUp: jest.fn(),
+    scrollToBottom: jest.fn(),
+  }),
+  useImageDropZone: () => ({
+    isDraggingOver: false,
+    dropZoneProps: {
+      onDragOver: jest.fn(),
+      onDragEnter: jest.fn(),
+      onDragLeave: jest.fn(),
+      onDrop: jest.fn(),
+    },
+    handlePaste: jest.fn(),
+  }),
 }));
 
 jest.mock("@tanstack/react-query", () => ({

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useMemo, useCallback, useLayoutEffect } from "react";
+import { useState, useRef, useEffect, useMemo, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
@@ -55,7 +55,13 @@ import {
   getCompletedTurnDurationsByEvent,
 } from "@/components/chat/turn-delimiter";
 import { useSessionContext } from "@/app/(main)/sessions/[sessionId]/session-context";
-import { useLlmModels, useImageAttachments, useSessionCommands } from "@/hooks";
+import {
+  useLlmModels,
+  useImageAttachments,
+  useSessionCommands,
+  useScrollManager,
+  useImageDropZone,
+} from "@/hooks";
 import { sendUserMessageWithImages } from "@/lib/api/messages";
 import { useMutation } from "@tanstack/react-query";
 import { ALLOWED_IMAGE_TYPES } from "@/lib/api/types";
@@ -136,18 +142,8 @@ export function ChatPanel() {
 
   const [inputValue, setInputValue] = useState("");
   const [selectedModelId, setSelectedModelId] = useState("");
-  const [isDraggingOver, setIsDraggingOver] = useState(false);
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const messagesEndRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const isNearBottomRef = useRef(true);
-  const [hasNewMessages, setHasNewMessages] = useState(false);
-  const prevChatEventsLengthRef = useRef(0);
-  const initialScrollDoneRef = useRef(false);
-
-  // Track scroll height before prepending older events for position preservation
-  const prevScrollHeightRef = useRef<number | null>(null);
   const hasUserSelectedModel = useRef(false);
   const modelSelectionStorageKey = useMemo(
     () => `everruns:chat:model-selection:${agentId}:${sessionId}`,
@@ -165,6 +161,23 @@ export function ChatPanel() {
     hasImages,
     isUploading,
   } = useImageAttachments({ sessionId });
+
+  // Scroll management
+  const { scrollContainerRef, messagesEndRef, hasNewMessages, dismissNewMessages, handleScrollUp } =
+    useScrollManager({
+      eventCount: chatEvents.length,
+      eventsLoaded: !eventsLoading,
+      hasMoreEvents,
+      loadingOlderEvents,
+      loadOlderEvents,
+      sessionId,
+      scrollDeps: [streamingText, isThinking],
+    });
+
+  // Image drag-drop and paste
+  const { isDraggingOver, dropZoneProps, handlePaste } = useImageDropZone({
+    onImageFiles: addFiles,
+  });
 
   // Commands autocomplete
   const { data: commandsData } = useSessionCommands(sessionId);
@@ -362,98 +375,6 @@ export function ChatPanel() {
     }
   }, [supportsReasoning, reasoningEffortConfig, reasoningEffort, setReasoningEffort]);
 
-  // Track whether user is near the bottom of the scroll container
-  const NEAR_BOTTOM_THRESHOLD = 100;
-
-  const checkIsNearBottom = useCallback(() => {
-    const container = scrollContainerRef.current;
-    if (!container) return true;
-    const { scrollTop, scrollHeight, clientHeight } = container;
-    return scrollHeight - scrollTop - clientHeight <= NEAR_BOTTOM_THRESHOLD;
-  }, []);
-
-  const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
-    messagesEndRef.current?.scrollIntoView({ behavior });
-  }, []);
-
-  // Listen for scroll events to track near-bottom state and trigger older event loading
-  useEffect(() => {
-    const container = scrollContainerRef.current;
-    if (!container) return;
-
-    const handleScroll = () => {
-      const nearBottom = checkIsNearBottom();
-      isNearBottomRef.current = nearBottom;
-      // Clear "new messages" indicator when user scrolls back to bottom
-      if (nearBottom) {
-        setHasNewMessages(false);
-      }
-    };
-
-    container.addEventListener("scroll", handleScroll, { passive: true });
-    return () => container.removeEventListener("scroll", handleScroll);
-  }, [checkIsNearBottom]);
-
-  // Scroll to bottom immediately on initial load (once events are ready)
-  useEffect(() => {
-    if (!eventsLoading && chatEvents.length > 0 && !initialScrollDoneRef.current) {
-      initialScrollDoneRef.current = true;
-      // Use requestAnimationFrame to ensure DOM is painted
-      requestAnimationFrame(() => {
-        scrollToBottom("instant");
-      });
-    }
-  }, [eventsLoading, chatEvents.length, scrollToBottom]);
-
-  // Reset initial scroll flag when session changes
-  useEffect(() => {
-    initialScrollDoneRef.current = false;
-    isNearBottomRef.current = true;
-    setHasNewMessages(false);
-    prevChatEventsLengthRef.current = 0;
-  }, [sessionId]);
-
-  // Auto-scroll on new events or streaming updates (only when near bottom)
-  // Skip if older events were prepended (prevScrollHeightRef is set)
-  useEffect(() => {
-    if (!initialScrollDoneRef.current) return;
-    if (prevScrollHeightRef.current !== null) return;
-
-    const hasNewChatEvents = chatEvents.length > prevChatEventsLengthRef.current;
-    prevChatEventsLengthRef.current = chatEvents.length;
-
-    if (isNearBottomRef.current) {
-      scrollToBottom("smooth");
-    } else if (hasNewChatEvents) {
-      setHasNewMessages(true);
-    }
-  }, [chatEvents, streamingText, isThinking, scrollToBottom]);
-
-  // Scroll position preservation: when older events are prepended,
-  // adjust scrollTop so the viewport stays in the same visual position
-  useLayoutEffect(() => {
-    const container = scrollContainerRef.current;
-    const prevHeight = prevScrollHeightRef.current;
-    if (container && prevHeight !== null) {
-      const newHeight = container.scrollHeight;
-      container.scrollTop += newHeight - prevHeight;
-      prevScrollHeightRef.current = null;
-    }
-  }, [chatEvents]);
-
-  // Scroll-up detection: trigger loading older events
-  const handleScroll = useCallback(() => {
-    const container = scrollContainerRef.current;
-    if (!container || !hasMoreEvents || loadingOlderEvents) return;
-
-    // Trigger when user scrolls within 200px of the top
-    if (container.scrollTop < 200) {
-      // Save scroll height before prepend for position preservation
-      prevScrollHeightRef.current = container.scrollHeight;
-      loadOlderEvents();
-    }
-  }, [hasMoreEvents, loadingOlderEvents, loadOlderEvents]);
-
   // Auto-focus message input when session loads
   useEffect(() => {
     if (!eventsLoading) {
@@ -577,7 +498,7 @@ export function ChatPanel() {
     <>
       <div
         ref={scrollContainerRef}
-        onScroll={handleScroll}
+        onScroll={handleScrollUp}
         className={cn(
           "relative flex-1 overflow-y-auto bg-background bg-brand-dots px-4 py-5 sm:px-6",
           !eventsLoading && chatEvents.length === 0 && "flex flex-col justify-end",
@@ -824,10 +745,7 @@ export function ChatPanel() {
         {hasNewMessages && (
           <button
             type="button"
-            onClick={() => {
-              scrollToBottom("smooth");
-              setHasNewMessages(false);
-            }}
+            onClick={dismissNewMessages}
             className={chatSurfaceStyles.floatingNotice}
           >
             <ArrowDown className="h-3 w-3" />
@@ -854,34 +772,7 @@ export function ChatPanel() {
               chatSurfaceStyles.composerInputShell,
               isDraggingOver && "bg-[hsl(var(--accent)/0.07)] ring-1 ring-accent/60",
             )}
-            onDragOver={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-            onDragEnter={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              setIsDraggingOver(true);
-            }}
-            onDragLeave={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-                setIsDraggingOver(false);
-              }
-            }}
-            onDrop={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              setIsDraggingOver(false);
-              const files = e.dataTransfer?.files;
-              if (files && files.length > 0) {
-                const imageFiles = Array.from(files).filter((f) => f.type.startsWith("image/"));
-                if (imageFiles.length > 0) {
-                  addFiles(imageFiles);
-                }
-              }
-            }}
+            {...dropZoneProps}
           >
             <CommandAutocomplete
               commands={commands}
@@ -899,21 +790,7 @@ export function ChatPanel() {
                 setShowCommands(hasCommands && shouldShowCommandAutocomplete(val));
               }}
               onKeyDown={handleKeyDown}
-              onPaste={(e) => {
-                const items = e.clipboardData?.items;
-                if (!items) return;
-                const imageFiles: File[] = [];
-                for (const item of Array.from(items)) {
-                  if (item.type.startsWith("image/")) {
-                    const file = item.getAsFile();
-                    if (file) imageFiles.push(file);
-                  }
-                }
-                if (imageFiles.length > 0) {
-                  e.preventDefault();
-                  addFiles(imageFiles);
-                }
-              }}
+              onPaste={handlePaste}
               placeholder={inputPlaceholder}
               className={chatSurfaceStyles.composerTextarea}
             />

--- a/apps/ui/src/hooks/index.ts
+++ b/apps/ui/src/hooks/index.ts
@@ -15,3 +15,5 @@ export * from "./use-global-chat";
 export * from "./use-commands";
 export * from "./use-notifications";
 export * from "./use-mount-effect";
+export * from "./use-scroll-manager";
+export * from "./use-image-drop-zone";

--- a/apps/ui/src/hooks/use-image-drop-zone.ts
+++ b/apps/ui/src/hooks/use-image-drop-zone.ts
@@ -1,0 +1,80 @@
+// Image drag-drop and paste handling hook for chat composer
+//
+// Decision: Extracts drag-drop and paste event handlers from ChatPanel into a reusable hook.
+// Returns event handlers and drag state — the consumer wires them to the DOM elements.
+
+import { useState, useCallback } from "react";
+
+interface UseImageDropZoneOptions {
+  /** Callback to handle dropped/pasted image files */
+  onImageFiles: (files: File[]) => void;
+}
+
+export function useImageDropZone({ onImageFiles }: UseImageDropZoneOptions) {
+  const [isDraggingOver, setIsDraggingOver] = useState(false);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+  }, []);
+
+  const handleDragEnter = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDraggingOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+      setIsDraggingOver(false);
+    }
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsDraggingOver(false);
+      const files = e.dataTransfer?.files;
+      if (files && files.length > 0) {
+        const imageFiles = Array.from(files).filter((f) => f.type.startsWith("image/"));
+        if (imageFiles.length > 0) {
+          onImageFiles(imageFiles);
+        }
+      }
+    },
+    [onImageFiles],
+  );
+
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent) => {
+      const items = e.clipboardData?.items;
+      if (!items) return;
+      const imageFiles: File[] = [];
+      for (const item of Array.from(items)) {
+        if (item.type.startsWith("image/")) {
+          const file = item.getAsFile();
+          if (file) imageFiles.push(file);
+        }
+      }
+      if (imageFiles.length > 0) {
+        e.preventDefault();
+        onImageFiles(imageFiles);
+      }
+    },
+    [onImageFiles],
+  );
+
+  return {
+    isDraggingOver,
+    dropZoneProps: {
+      onDragOver: handleDragOver,
+      onDragEnter: handleDragEnter,
+      onDragLeave: handleDragLeave,
+      onDrop: handleDrop,
+    },
+    handlePaste,
+  };
+}

--- a/apps/ui/src/hooks/use-image-drop-zone.ts
+++ b/apps/ui/src/hooks/use-image-drop-zone.ts
@@ -27,7 +27,8 @@ export function useImageDropZone({ onImageFiles }: UseImageDropZoneOptions) {
   const handleDragLeave = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+    const { relatedTarget, currentTarget } = e;
+    if (!(relatedTarget instanceof Node) || !currentTarget.contains(relatedTarget)) {
       setIsDraggingOver(false);
     }
   }, []);

--- a/apps/ui/src/hooks/use-scroll-manager.ts
+++ b/apps/ui/src/hooks/use-scroll-manager.ts
@@ -1,0 +1,143 @@
+// Scroll management hook for chat panels
+//
+// Decision: Consolidates 6 scroll-related refs and all scroll logic into a single hook.
+// Handles: auto-scroll on new content, "new messages" indicator, scroll position
+// preservation when older events are prepended, and infinite scroll-up detection.
+
+import { useRef, useState, useCallback, useEffect, useLayoutEffect } from "react";
+
+const NEAR_BOTTOM_THRESHOLD = 100;
+const SCROLL_UP_TRIGGER_PX = 200;
+
+interface UseScrollManagerOptions {
+  /** Total event count — used to detect new events vs prepended older ones */
+  eventCount: number;
+  /** Whether initial event loading is complete */
+  eventsLoaded: boolean;
+  /** Whether there are more older events to load */
+  hasMoreEvents: boolean;
+  /** Whether older events are currently loading */
+  loadingOlderEvents: boolean;
+  /** Load older events callback */
+  loadOlderEvents: () => void;
+  /** Session ID — resets state on change */
+  sessionId: string;
+  /** Dependencies that trigger auto-scroll when near bottom (e.g., streaming text) */
+  scrollDeps?: unknown[];
+}
+
+export function useScrollManager({
+  eventCount,
+  eventsLoaded,
+  hasMoreEvents,
+  loadingOlderEvents,
+  loadOlderEvents,
+  sessionId,
+  scrollDeps = [],
+}: UseScrollManagerOptions) {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const isNearBottomRef = useRef(true);
+  const prevEventCountRef = useRef(0);
+  const initialScrollDoneRef = useRef(false);
+  const prevScrollHeightRef = useRef<number | null>(null);
+  const [hasNewMessages, setHasNewMessages] = useState(false);
+
+  const checkIsNearBottom = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return true;
+    const { scrollTop, scrollHeight, clientHeight } = container;
+    return scrollHeight - scrollTop - clientHeight <= NEAR_BOTTOM_THRESHOLD;
+  }, []);
+
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
+    messagesEndRef.current?.scrollIntoView({ behavior });
+  }, []);
+
+  // Track near-bottom state on scroll
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const handleScroll = () => {
+      const nearBottom = checkIsNearBottom();
+      isNearBottomRef.current = nearBottom;
+      if (nearBottom) {
+        setHasNewMessages(false);
+      }
+    };
+
+    container.addEventListener("scroll", handleScroll, { passive: true });
+    return () => container.removeEventListener("scroll", handleScroll);
+  }, [checkIsNearBottom]);
+
+  // Initial scroll to bottom once events load
+  useEffect(() => {
+    if (eventsLoaded && eventCount > 0 && !initialScrollDoneRef.current) {
+      initialScrollDoneRef.current = true;
+      requestAnimationFrame(() => {
+        scrollToBottom("instant");
+      });
+    }
+  }, [eventsLoaded, eventCount, scrollToBottom]);
+
+  // Reset on session change
+  useEffect(() => {
+    initialScrollDoneRef.current = false;
+    isNearBottomRef.current = true;
+    setHasNewMessages(false);
+    prevEventCountRef.current = 0;
+  }, [sessionId]);
+
+  // Auto-scroll on new events or streaming (only when near bottom)
+  useEffect(() => {
+    if (!initialScrollDoneRef.current) return;
+    if (prevScrollHeightRef.current !== null) return;
+
+    const hasNewEvents = eventCount > prevEventCountRef.current;
+    prevEventCountRef.current = eventCount;
+
+    if (isNearBottomRef.current) {
+      scrollToBottom("smooth");
+    } else if (hasNewEvents) {
+      setHasNewMessages(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [eventCount, scrollToBottom, ...scrollDeps]);
+
+  // Preserve scroll position when older events are prepended
+  useLayoutEffect(() => {
+    const container = scrollContainerRef.current;
+    const prevHeight = prevScrollHeightRef.current;
+    if (container && prevHeight !== null) {
+      const newHeight = container.scrollHeight;
+      container.scrollTop += newHeight - prevHeight;
+      prevScrollHeightRef.current = null;
+    }
+  }, [eventCount]);
+
+  // Scroll-up detection for loading older events
+  const handleScrollUp = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container || !hasMoreEvents || loadingOlderEvents) return;
+
+    if (container.scrollTop < SCROLL_UP_TRIGGER_PX) {
+      prevScrollHeightRef.current = container.scrollHeight;
+      loadOlderEvents();
+    }
+  }, [hasMoreEvents, loadingOlderEvents, loadOlderEvents]);
+
+  const dismissNewMessages = useCallback(() => {
+    scrollToBottom("smooth");
+    setHasNewMessages(false);
+  }, [scrollToBottom]);
+
+  return {
+    scrollContainerRef,
+    messagesEndRef,
+    hasNewMessages,
+    dismissNewMessages,
+    handleScrollUp,
+    scrollToBottom,
+  };
+}

--- a/apps/ui/src/hooks/use-scroll-manager.ts
+++ b/apps/ui/src/hooks/use-scroll-manager.ts
@@ -92,10 +92,13 @@ export function useScrollManager({
   // Auto-scroll on new events or streaming (only when near bottom)
   useEffect(() => {
     if (!initialScrollDoneRef.current) return;
-    if (prevScrollHeightRef.current !== null) return;
 
+    // Always track event count so prepend-only updates don't cause
+    // a stale hasNewEvents on the next scrollDeps change.
     const hasNewEvents = eventCount > prevEventCountRef.current;
     prevEventCountRef.current = eventCount;
+
+    if (prevScrollHeightRef.current !== null) return;
 
     if (isNearBottomRef.current) {
       scrollToBottom("smooth");


### PR DESCRIPTION
## What
Extract scroll management and image drag-drop/paste handling from ChatPanel into dedicated hooks.

## Why
ChatPanel had 6 scroll-related refs with interleaved logic and inline drag-drop/paste handlers (EVE-128). This made the component harder to maintain and prevented reuse of scroll behavior.

## How
- **`useScrollManager`** (`apps/ui/src/hooks/use-scroll-manager.ts`): Consolidates `scrollContainerRef`, `messagesEndRef`, `isNearBottomRef`, `prevEventCountRef`, `initialScrollDoneRef`, `prevScrollHeightRef`, and all scroll effects (auto-scroll, new messages indicator, position preservation on prepend, infinite scroll-up detection) into a single hook
- **`useImageDropZone`** (`apps/ui/src/hooks/use-image-drop-zone.ts`): Extracts drag-over/enter/leave/drop and paste handlers with `isDraggingOver` state into a reusable hook returning `dropZoneProps` spread and `handlePaste`
- ChatPanel wires both hooks, reducing from ~1035 to ~920 lines
- Both hooks exported from `apps/ui/src/hooks/index.ts`

## Risk
- Low
- Pure refactoring — no behavioral changes
- UI build and lint pass

## Checklist
- [x] Tests added or updated (existing UI tests unaffected — mocked hooks)
- [x] Backward compatibility considered (internal refactor only)