### PR TITLE
fix(api): return empty results for unknown agent_id in session list

### DIFF
--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -439,14 +439,21 @@ pub async fn list_sessions(
     let limit = query.limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT);
     let pagination = Pagination::new(offset, limit);
 
-    // Resolve agent public_id to internal UUID if filtering by agent
+    // Resolve agent public_id to internal UUID if filtering by agent.
+    // If agent_id is provided but not found, return empty results rather than
+    // silently dropping the filter and returning unfiltered sessions.
     let agent_internal_id = if let Some(ref agent_id) = query.agent_id {
         let row = state
             .db
             .get_agent_by_public_id(org.org_id, &agent_id.to_string())
             .await
             .log_internal_error_json("resolve agent for filter")?;
-        row.map(|r| r.id.uuid())
+        match row {
+            Some(r) => Some(r.id.uuid()),
+            None => {
+                return Ok(Json(PaginatedResponse::new(vec![], 0, offset, limit)));
+            }
+        }
     } else {
         None
     };

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -712,6 +712,47 @@ async fn test_sessions_pagination() {
     assert_eq!(body["data"].as_array().unwrap().len(), 5); // Only 5 remaining
 }
 
+#[tokio::test]
+async fn test_list_sessions_unknown_agent_returns_empty() {
+    let server = TestServer::new().await;
+
+    // Create a session so we know unfiltered results would be non-empty
+    let agent: Agent = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": "Test Agent",
+                "system_prompt": "Test"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let _session: Value = server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": SEED_BASE_HARNESS_ID,
+                "agent_id": agent.public_id,
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    // Filter by nonexistent agent_id should return empty results, not unfiltered
+    let body: Value = server
+        .get("/v1/sessions?agent_id=agent_ffffffffffffffffffffffffffffffff")
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    assert_eq!(body["total"], 0);
+    assert_eq!(body["data"].as_array().unwrap().len(), 0);
+    assert_eq!(body["offset"], 0);
+    assert_eq!(body["limit"], 20);
+}
+
 // ============================================
 // Message Tests
 // ============================================


### PR DESCRIPTION
## What
Return empty paginated results when `GET /v1/sessions?agent_id=...` references an unknown or cross-org agent, instead of silently dropping the filter.

## Why
Previously, an unknown `agent_id` filter resolved to `None`, which was passed to `SessionService::list()` as "no filter", returning unfiltered sessions. Callers believed their filter was applied but received unrelated sessions.

Fixes EVE-153

## How
When the agent lookup misses, return an early `200` with `data=[], total=0` instead of falling through with `agent_internal_id=None`.

## Risk
- Low
- Behavioral change: callers that relied on unknown agent_id returning all sessions will now get empty results. This is the correct behavior — the previous behavior was a bug.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered