### PR TITLE
fix(api): return 404 for missing harness IDs in update and destroy

### DIFF
--- a/crates/server/src/services/harness.rs
+++ b/crates/server/src/services/harness.rs
@@ -780,10 +780,7 @@ mod tests {
         let service = HarnessService::new(db.clone());
         let caller = Caller::internal(DEFAULT_ORG_ID);
 
-        let err = service
-            .destroy(&caller, Uuid::nil())
-            .await
-            .unwrap_err();
+        let err = service.destroy(&caller, Uuid::nil()).await.unwrap_err();
 
         assert!(err.downcast_ref::<ResourceNotFoundError>().is_some());
         assert_eq!(err.to_string(), "Harness not found");

--- a/crates/server/src/services/harness.rs
+++ b/crates/server/src/services/harness.rs
@@ -169,7 +169,7 @@ impl HarnessService {
             .db
             .get_harness(caller.org_id, HarnessId::from_uuid(id))
             .await?
-            .ok_or_else(|| anyhow::anyhow!("Harness not found"))?;
+            .ok_or_else(|| ResourceNotFoundError::new("Harness"))?;
         if existing.status != "active" {
             anyhow::bail!("Archived or deleted harnesses cannot be edited");
         }
@@ -292,7 +292,7 @@ impl HarnessService {
             .db
             .get_harness(caller.org_id, HarnessId::from_uuid(id))
             .await?
-            .ok_or_else(|| anyhow::anyhow!("Harness not found"))?;
+            .ok_or_else(|| ResourceNotFoundError::new("Harness"))?;
         if existing.status != "archived" {
             anyhow::bail!("Harness must be archived before deletion");
         }
@@ -757,5 +757,35 @@ mod tests {
                 .contains("child harnesses still inherit from it"),
             "unexpected error: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn update_nonexistent_harness_returns_not_found() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let service = HarnessService::new(db.clone());
+        let caller = Caller::internal(DEFAULT_ORG_ID);
+
+        let err = service
+            .update(&caller, Uuid::nil(), build_update_request(None))
+            .await
+            .unwrap_err();
+
+        assert!(err.downcast_ref::<ResourceNotFoundError>().is_some());
+        assert_eq!(err.to_string(), "Harness not found");
+    }
+
+    #[tokio::test]
+    async fn destroy_nonexistent_harness_returns_not_found() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let service = HarnessService::new(db.clone());
+        let caller = Caller::internal(DEFAULT_ORG_ID);
+
+        let err = service
+            .destroy(&caller, Uuid::nil())
+            .await
+            .unwrap_err();
+
+        assert!(err.downcast_ref::<ResourceNotFoundError>().is_some());
+        assert_eq!(err.to_string(), "Harness not found");
     }
 }

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -1530,6 +1530,32 @@ async fn test_update_harness_missing_default_model_returns_not_found() {
 }
 
 #[tokio::test]
+async fn test_update_nonexistent_harness_returns_not_found() {
+    let server = TestServer::in_memory().await;
+
+    server
+        .patch(
+            "/v1/harnesses/harness_ffffffffffffffffffffffffffffffff",
+            json!({ "name": "Updated" }),
+        )
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_destroy_nonexistent_harness_returns_not_found() {
+    let server = TestServer::in_memory().await;
+
+    server
+        .post(
+            "/v1/harnesses/harness_ffffffffffffffffffffffffffffffff/delete",
+            json!({}),
+        )
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
 async fn test_copy_harness_not_found() {
     let server = TestServer::new().await;
 


### PR DESCRIPTION
## What
Replace stringly-typed `anyhow!("Harness not found")` with typed `ResourceNotFoundError::new("Harness")` in `HarnessService::update()` and `HarnessService::destroy()`.

## Why
The `map_policy_or_internal()` error mapper could not downcast the untyped `anyhow::Error` to `ResourceNotFoundError`, so missing/cross-org harness IDs in update and destroy flows returned `500 Internal Server Error` instead of `404 Not Found`. Fixes EVE-152.

## How
- Two one-line changes in `crates/server/src/services/harness.rs` (lines 172, 295)
- Two unit tests asserting `ResourceNotFoundError` is returned
- Two integration tests asserting HTTP 404 for nonexistent harness IDs

## Risk
- Low
- Error path only; no changes to success flows

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered