### PR TITLE
fix(api): return 404 for missing app harness and agent references

### DIFF
--- a/crates/server/src/services/app.rs
+++ b/crates/server/src/services/app.rs
@@ -1,10 +1,10 @@
 // App service for business logic
 
+use crate::errors::ResourceNotFoundError;
 use crate::storage::{
     AppRow, StorageBackend,
     models::{CreateAppRow, UpdateApp},
 };
-use crate::errors::ResourceNotFoundError;
 use anyhow::Result;
 use chrono::Utc;
 use everruns_core::typed_id::{AgentId, HarnessId};

--- a/crates/server/src/services/app.rs
+++ b/crates/server/src/services/app.rs
@@ -4,6 +4,7 @@ use crate::storage::{
     AppRow, StorageBackend,
     models::{CreateAppRow, UpdateApp},
 };
+use crate::errors::ResourceNotFoundError;
 use anyhow::Result;
 use chrono::Utc;
 use everruns_core::typed_id::{AgentId, HarnessId};
@@ -55,7 +56,7 @@ impl AppService {
             .db
             .get_harness(caller.org_id, req.harness_id)
             .await?
-            .ok_or_else(|| anyhow::anyhow!("Harness not found"))?;
+            .ok_or_else(|| ResourceNotFoundError::new("Harness"))?;
         if harness_row.status != "active" {
             anyhow::bail!("Archived or deleted harnesses cannot be assigned");
         }
@@ -63,7 +64,7 @@ impl AppService {
             .db
             .get_agent_by_public_id(caller.org_id, &req.agent_id.to_string())
             .await?
-            .ok_or_else(|| anyhow::anyhow!("Agent not found"))?;
+            .ok_or_else(|| ResourceNotFoundError::new("Agent"))?;
         if agent_row.status != "active" {
             anyhow::bail!("Archived or deleted agents cannot be assigned");
         }
@@ -153,7 +154,7 @@ impl AppService {
                 .db
                 .get_harness(caller.org_id, hid)
                 .await?
-                .ok_or_else(|| anyhow::anyhow!("Harness not found"))?;
+                .ok_or_else(|| ResourceNotFoundError::new("Harness"))?;
             if h.status != "active" {
                 anyhow::bail!("Archived or deleted harnesses cannot be assigned");
             }
@@ -167,7 +168,7 @@ impl AppService {
                 .db
                 .get_agent_by_public_id(caller.org_id, &aid.to_string())
                 .await?
-                .ok_or_else(|| anyhow::anyhow!("Agent not found"))?;
+                .ok_or_else(|| ResourceNotFoundError::new("Agent"))?;
             if a.status != "active" {
                 anyhow::bail!("Archived or deleted agents cannot be assigned");
             }

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -2649,12 +2649,12 @@ async fn test_create_app_missing_agent_returns_not_found() {
     let server = TestServer::new().await;
 
     // List harnesses to get a valid harness_id
-    let harnesses: Vec<Value> = server
+    let harnesses: Value = server
         .get("/v1/harnesses")
         .await
         .assert_status(StatusCode::OK)
         .json();
-    let harness_id = harnesses[0]["id"].as_str().unwrap();
+    let harness_id = harnesses["data"][0]["id"].as_str().unwrap();
 
     server
         .post(

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -2609,6 +2609,67 @@ async fn test_verify_connection_providers_listed() {
     assert!(resp.is_array());
 }
 
+// ============================================
+// App Reference Validation Tests
+// ============================================
+
+#[tokio::test]
+async fn test_create_app_missing_harness_returns_not_found() {
+    let server = TestServer::new().await;
+
+    // Create an agent to use
+    let agent: Value = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": "Test Agent",
+                "system_prompt": "Test"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    server
+        .post(
+            "/v1/apps",
+            json!({
+                "name": "Test App",
+                "harness_id": "harness_ffffffffffffffffffffffffffffffff",
+                "agent_id": agent["id"],
+                "channel_type": "slack"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_create_app_missing_agent_returns_not_found() {
+    let server = TestServer::new().await;
+
+    // List harnesses to get a valid harness_id
+    let harnesses: Vec<Value> = server
+        .get("/v1/harnesses")
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    let harness_id = harnesses[0]["id"].as_str().unwrap();
+
+    server
+        .post(
+            "/v1/apps",
+            json!({
+                "name": "Test App",
+                "harness_id": harness_id,
+                "agent_id": "agent_ffffffffffffffffffffffffffffffff",
+                "channel_type": "slack"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}
+
 #[tokio::test]
 async fn test_list_connections_initially_empty() {
     let server = TestServer::in_memory().await;

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -2648,23 +2648,87 @@ async fn test_create_app_missing_harness_returns_not_found() {
 async fn test_create_app_missing_agent_returns_not_found() {
     let server = TestServer::new().await;
 
-    // List harnesses to get a valid harness_id
-    let harnesses: Value = server
-        .get("/v1/harnesses")
-        .await
-        .assert_status(StatusCode::OK)
-        .json();
-    let harness_id = harnesses["data"][0]["id"].as_str().unwrap();
-
     server
         .post(
             "/v1/apps",
             json!({
                 "name": "Test App",
-                "harness_id": harness_id,
+                "harness_id": SEED_GENERIC_HARNESS_ID,
                 "agent_id": "agent_ffffffffffffffffffffffffffffffff",
                 "channel_type": "slack"
             }),
+        )
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_update_app_missing_harness_returns_not_found() {
+    let server = TestServer::new().await;
+
+    // Create agent and app
+    let agent: Value = server
+        .post(
+            "/v1/agents",
+            json!({ "name": "Test Agent", "system_prompt": "Test" }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    let app: Value = server
+        .post(
+            "/v1/apps",
+            json!({
+                "name": "Test App",
+                "harness_id": SEED_GENERIC_HARNESS_ID,
+                "agent_id": agent["id"],
+                "channel_type": "slack"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    server
+        .patch(
+            &format!("/v1/apps/{}", app["public_id"].as_str().unwrap()),
+            json!({ "harness_id": "harness_ffffffffffffffffffffffffffffffff" }),
+        )
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_update_app_missing_agent_returns_not_found() {
+    let server = TestServer::new().await;
+
+    // Create agent and app
+    let agent: Value = server
+        .post(
+            "/v1/agents",
+            json!({ "name": "Test Agent", "system_prompt": "Test" }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    let app: Value = server
+        .post(
+            "/v1/apps",
+            json!({
+                "name": "Test App",
+                "harness_id": SEED_GENERIC_HARNESS_ID,
+                "agent_id": agent["id"],
+                "channel_type": "slack"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    server
+        .patch(
+            &format!("/v1/apps/{}", app["public_id"].as_str().unwrap()),
+            json!({ "agent_id": "agent_ffffffffffffffffffffffffffffffff" }),
         )
         .await
         .assert_status(StatusCode::NOT_FOUND);

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -2691,7 +2691,7 @@ async fn test_update_app_missing_harness_returns_not_found() {
 
     server
         .patch(
-            &format!("/v1/apps/{}", app["public_id"].as_str().unwrap()),
+            &format!("/v1/apps/{}", app["id"].as_str().unwrap()),
             json!({ "harness_id": "harness_ffffffffffffffffffffffffffffffff" }),
         )
         .await
@@ -2727,7 +2727,7 @@ async fn test_update_app_missing_agent_returns_not_found() {
 
     server
         .patch(
-            &format!("/v1/apps/{}", app["public_id"].as_str().unwrap()),
+            &format!("/v1/apps/{}", app["id"].as_str().unwrap()),
             json!({ "agent_id": "agent_ffffffffffffffffffffffffffffffff" }),
         )
         .await


### PR DESCRIPTION
## What
Replace untyped `anyhow!("Harness not found")` and `anyhow!("Agent not found")` with typed `ResourceNotFoundError` in `AppService::create()` and `AppService::update()`.

## Why
The `map_policy_or_internal()` error mapper could not downcast the untyped errors, so missing/cross-org harness or agent IDs in app create and update flows returned `500 Internal Server Error` instead of `404 Not Found`. Fixes EVE-151.

## How
- Four error sites changed in `crates/server/src/services/app.rs` (create: harness+agent, update: harness+agent)
- Two integration tests asserting HTTP 404 for nonexistent harness/agent IDs on app creation

## Risk
- Low
- Error path only; no changes to success flows

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered