### PR TITLE
feat(session-file-system): add hash-gated edit_file tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,6 +1343,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
+ "similar",
  "sqlx",
  "thiserror 2.0.18",
  "tokio",

--- a/apps/ui/src/components/chat/write-file-tool-call-card.tsx
+++ b/apps/ui/src/components/chat/write-file-tool-call-card.tsx
@@ -60,8 +60,7 @@ function parseWriteFilePayload(
           getPathFromArguments(toolCall),
         sizeBytes: typeof parsed.size_bytes === "number" ? parsed.size_bytes : undefined,
         created: typeof parsed.created === "boolean" ? parsed.created : undefined,
-        appliedEdits:
-          typeof parsed.applied_edits === "number" ? parsed.applied_edits : undefined,
+        appliedEdits: typeof parsed.applied_edits === "number" ? parsed.applied_edits : undefined,
         firstChangedLine:
           typeof parsed.first_changed_line === "number" ? parsed.first_changed_line : undefined,
         textContent: typeof parsed.diff === "string" && parsed.diff.length > 0 ? parsed.diff : null,

--- a/apps/ui/src/components/chat/write-file-tool-call-card.tsx
+++ b/apps/ui/src/components/chat/write-file-tool-call-card.tsx
@@ -27,12 +27,17 @@ interface WriteFilePayload {
   path?: string;
   size_bytes?: number;
   created?: boolean;
+  diff?: string;
+  applied_edits?: number;
+  first_changed_line?: number;
 }
 
 interface ParsedWriteFileResult {
   path?: string;
   sizeBytes?: number;
   created?: boolean;
+  appliedEdits?: number;
+  firstChangedLine?: number;
   textContent: string | null;
 }
 
@@ -55,7 +60,11 @@ function parseWriteFilePayload(
           getPathFromArguments(toolCall),
         sizeBytes: typeof parsed.size_bytes === "number" ? parsed.size_bytes : undefined,
         created: typeof parsed.created === "boolean" ? parsed.created : undefined,
-        textContent: null,
+        appliedEdits:
+          typeof parsed.applied_edits === "number" ? parsed.applied_edits : undefined,
+        firstChangedLine:
+          typeof parsed.first_changed_line === "number" ? parsed.first_changed_line : undefined,
+        textContent: typeof parsed.diff === "string" && parsed.diff.length > 0 ? parsed.diff : null,
       };
     }
   } catch {
@@ -66,6 +75,8 @@ function parseWriteFilePayload(
     path: getPathFromArguments(toolCall),
     sizeBytes: undefined,
     created: undefined,
+    appliedEdits: undefined,
+    firstChangedLine: undefined,
     textContent: rawText || null,
   };
 }
@@ -93,7 +104,19 @@ function getTextPreview(text: string | null): string | null {
   return firstLine.length > 120 ? `${firstLine.slice(0, 120)}...` : firstLine;
 }
 
-// isWriteLikeTool is re-exported from @/lib/tool-registry at the top of this file.
+function formatEditPreview(
+  appliedEdits: number | undefined,
+  firstChangedLine: number | undefined,
+): string | null {
+  const parts = [];
+  if (typeof appliedEdits === "number") {
+    parts.push(`${appliedEdits} ${appliedEdits === 1 ? "edit" : "edits"}`);
+  }
+  if (typeof firstChangedLine === "number") {
+    parts.push(`line ${firstChangedLine}`);
+  }
+  return parts.length > 0 ? parts.join(" · ") : null;
+}
 
 export function WriteFileToolCallCard({ toolCall, toolResult }: WriteFileToolCallCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -116,7 +139,10 @@ export function WriteFileToolCallCard({ toolCall, toolResult }: WriteFileToolCal
   const metadataPreview = [parsed.created ? "created" : "updated", formatFileSize(parsed.sizeBytes)]
     .filter(Boolean)
     .join(" · ");
-  const preview = metadataPreview || getTextPreview(parsed.textContent);
+  const preview =
+    formatEditPreview(parsed.appliedEdits, parsed.firstChangedLine) ||
+    metadataPreview ||
+    getTextPreview(parsed.textContent);
   const hasTextDetails = !!parsed.textContent;
 
   const statusIcon = isComplete ? (

--- a/apps/ui/src/components/chat/write-file-tool-call-card.tsx
+++ b/apps/ui/src/components/chat/write-file-tool-call-card.tsx
@@ -28,6 +28,7 @@ interface WriteFilePayload {
   size_bytes?: number;
   created?: boolean;
   diff?: string;
+  diff_truncated?: boolean;
   applied_edits?: number;
   first_changed_line?: number;
 }
@@ -38,6 +39,7 @@ interface ParsedWriteFileResult {
   created?: boolean;
   appliedEdits?: number;
   firstChangedLine?: number;
+  diffTruncated: boolean;
   textContent: string | null;
 }
 
@@ -63,6 +65,7 @@ function parseWriteFilePayload(
         appliedEdits: typeof parsed.applied_edits === "number" ? parsed.applied_edits : undefined,
         firstChangedLine:
           typeof parsed.first_changed_line === "number" ? parsed.first_changed_line : undefined,
+        diffTruncated: parsed.diff_truncated === true,
         textContent: typeof parsed.diff === "string" && parsed.diff.length > 0 ? parsed.diff : null,
       };
     }
@@ -76,6 +79,7 @@ function parseWriteFilePayload(
     created: undefined,
     appliedEdits: undefined,
     firstChangedLine: undefined,
+    diffTruncated: false,
     textContent: rawText || null,
   };
 }
@@ -142,6 +146,8 @@ export function WriteFileToolCallCard({ toolCall, toolResult }: WriteFileToolCal
     formatEditPreview(parsed.appliedEdits, parsed.firstChangedLine) ||
     metadataPreview ||
     getTextPreview(parsed.textContent);
+  const detailLabel =
+    parsed.diffTruncated && toolCall.name === "edit_file" ? "Diff truncated" : null;
   const hasTextDetails = !!parsed.textContent;
 
   const statusIcon = isComplete ? (
@@ -193,11 +199,14 @@ export function WriteFileToolCallCard({ toolCall, toolResult }: WriteFileToolCal
       )}
 
       {!hasError && preview && !isExpanded && (
-        <div className="ml-[22px] mt-0.5 truncate text-[10px] opacity-70">{preview}</div>
+        <div className="ml-[22px] mt-0.5 truncate text-[10px] opacity-70">
+          {[preview, detailLabel].filter(Boolean).join(" · ")}
+        </div>
       )}
 
       {!hasError && isExpanded && parsed.textContent && (
         <div className="ml-[22px] mt-1.5">
+          {detailLabel && <div className="mb-1 text-[10px] opacity-60">{detailLabel}</div>}
           <pre className="overflow-x-auto whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-muted-foreground/85">
             {parsed.textContent}
           </pre>

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -46,9 +46,13 @@ tracing-opentelemetry.workspace = true
 
 # Encoding
 base64.workspace = true
+sha2.workspace = true
 
 # Regex for argument substitution
 regex.workspace = true
+
+# Text diff rendering for edit_file previews
+similar = "2"
 
 # URL parsing
 url = "2"

--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -6,16 +6,20 @@
 //! Tools provided:
 //! - `read_file`: Read file content
 //! - `write_file`: Create or update a file
+//! - `edit_file`: Apply surgical text replacements to an existing file
 //! - `list_directory`: List files in a directory
 //! - `grep_files`: Search files by regex pattern
 //! - `delete_file`: Delete a file or directory
 //! - `stat_file`: Get file metadata
 
 use super::{Capability, CapabilityStatus};
+use crate::session_file::SessionFile;
 use crate::tools::{Tool, ToolExecutionResult, ToolResultImage};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use similar::TextDiff;
 
 /// Image MIME types recognized by LLM vision APIs (OpenAI, Anthropic)
 const IMAGE_EXTENSIONS: &[(&str, &str)] = &[
@@ -73,6 +77,230 @@ fn add_workspace_prefix(path: &str) -> String {
     }
 }
 
+fn file_content_hash(content: &str, encoding: &str) -> crate::error::Result<String> {
+    let bytes = SessionFile::decode_content(content, encoding)
+        .map_err(|error| anyhow::anyhow!("failed to decode file content for hashing: {error}"))?;
+    Ok(format!("sha256:{:x}", Sha256::digest(bytes)))
+}
+
+fn session_file_content_hash(file: &SessionFile) -> crate::error::Result<String> {
+    file_content_hash(file.content.as_deref().unwrap_or_default(), &file.encoding)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LineEnding {
+    Lf,
+    Crlf,
+}
+
+fn strip_utf8_bom(content: &str) -> (bool, &str) {
+    if let Some(stripped) = content.strip_prefix('\u{feff}') {
+        (true, stripped)
+    } else {
+        (false, content)
+    }
+}
+
+fn detect_line_ending(content: &str) -> LineEnding {
+    if content.contains("\r\n") {
+        LineEnding::Crlf
+    } else {
+        LineEnding::Lf
+    }
+}
+
+fn align_to_file_line_endings(content: &str, line_ending: LineEnding) -> String {
+    let normalized = content.replace("\r\n", "\n").replace('\r', "\n");
+    match line_ending {
+        LineEnding::Lf => normalized,
+        LineEnding::Crlf => normalized.replace('\n', "\r\n"),
+    }
+}
+
+fn truncate_snippet(content: &str, max_chars: usize) -> String {
+    let clean = content.replace('\n', "\\n").replace('\r', "\\r");
+    if clean.chars().count() <= max_chars {
+        clean
+    } else {
+        let truncated: String = clean.chars().take(max_chars).collect();
+        format!("{truncated}...")
+    }
+}
+
+fn first_changed_line(before: &str, after: &str) -> Option<usize> {
+    if before == after {
+        return None;
+    }
+
+    let before = before.replace("\r\n", "\n");
+    let after = after.replace("\r\n", "\n");
+    let before_lines: Vec<&str> = before.split('\n').collect();
+    let after_lines: Vec<&str> = after.split('\n').collect();
+
+    for index in 0..before_lines.len().max(after_lines.len()) {
+        if before_lines.get(index) != after_lines.get(index) {
+            return Some(index + 1);
+        }
+    }
+
+    Some(1)
+}
+
+fn render_unified_diff(path: &str, before: &str, after: &str) -> String {
+    TextDiff::from_lines(before, after)
+        .unified_diff()
+        .context_radius(2)
+        .header(&format!("{path} (before)"), &format!("{path} (after)"))
+        .to_string()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TextEdit {
+    old_text: String,
+    new_text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PlannedEdit {
+    start: usize,
+    end: usize,
+    replacement: String,
+}
+
+fn parse_text_edits(arguments: &Value) -> std::result::Result<Vec<TextEdit>, String> {
+    let has_single = arguments.get("old_text").is_some() || arguments.get("new_text").is_some();
+    let has_batch = arguments.get("edits").is_some();
+
+    if has_single && has_batch {
+        return Err("Provide either old_text/new_text or edits, not both".to_string());
+    }
+
+    if has_single {
+        let old_text = arguments
+            .get("old_text")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "Missing required parameter: old_text".to_string())?;
+        let new_text = arguments
+            .get("new_text")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "Missing required parameter: new_text".to_string())?;
+        if old_text.is_empty() {
+            return Err("old_text cannot be empty".to_string());
+        }
+        return Ok(vec![TextEdit {
+            old_text: old_text.to_string(),
+            new_text: new_text.to_string(),
+        }]);
+    }
+
+    let edits = arguments
+        .get("edits")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "Provide old_text/new_text or a non-empty edits array".to_string())?;
+
+    if edits.is_empty() {
+        return Err("edits must contain at least one replacement".to_string());
+    }
+
+    edits
+        .iter()
+        .enumerate()
+        .map(|(index, edit)| {
+            let old_text = edit
+                .get("old_text")
+                .and_then(Value::as_str)
+                .ok_or_else(|| format!("Edit {} is missing old_text", index + 1))?;
+            let new_text = edit
+                .get("new_text")
+                .and_then(Value::as_str)
+                .ok_or_else(|| format!("Edit {} is missing new_text", index + 1))?;
+            if old_text.is_empty() {
+                return Err(format!("Edit {} has an empty old_text", index + 1));
+            }
+            Ok(TextEdit {
+                old_text: old_text.to_string(),
+                new_text: new_text.to_string(),
+            })
+        })
+        .collect()
+}
+
+fn plan_text_edits(
+    content: &str,
+    edits: &[TextEdit],
+) -> std::result::Result<Vec<PlannedEdit>, String> {
+    let (_, body) = strip_utf8_bom(content);
+    let line_ending = detect_line_ending(body);
+    let mut planned = Vec::with_capacity(edits.len());
+
+    for edit in edits {
+        let old_text = align_to_file_line_endings(
+            edit.old_text
+                .strip_prefix('\u{feff}')
+                .unwrap_or(&edit.old_text),
+            line_ending,
+        );
+        let new_text = align_to_file_line_endings(
+            edit.new_text
+                .strip_prefix('\u{feff}')
+                .unwrap_or(&edit.new_text),
+            line_ending,
+        );
+
+        let mut matches = body.match_indices(&old_text);
+        let Some((start, _)) = matches.next() else {
+            return Err(format!(
+                "Could not find an exact match for old_text: '{}'",
+                truncate_snippet(&old_text, 80)
+            ));
+        };
+        if matches.next().is_some() {
+            return Err(format!(
+                "old_text is ambiguous and matched multiple locations: '{}'",
+                truncate_snippet(&old_text, 80)
+            ));
+        }
+
+        planned.push(PlannedEdit {
+            start,
+            end: start + old_text.len(),
+            replacement: new_text,
+        });
+    }
+
+    planned.sort_by_key(|edit| edit.start);
+    for pair in planned.windows(2) {
+        if pair[1].start < pair[0].end {
+            return Err("Edits overlap in the target file".to_string());
+        }
+    }
+
+    Ok(planned)
+}
+
+fn apply_text_edits(
+    content: &str,
+    edits: &[TextEdit],
+) -> std::result::Result<(String, usize), String> {
+    let (had_bom, body) = strip_utf8_bom(content);
+    let planned = plan_text_edits(content, edits)?;
+
+    let mut edited = String::with_capacity(content.len());
+    let mut cursor = 0;
+    for edit in &planned {
+        edited.push_str(&body[cursor..edit.start]);
+        edited.push_str(&edit.replacement);
+        cursor = edit.end;
+    }
+    edited.push_str(&body[cursor..]);
+
+    if had_bom {
+        edited.insert(0, '\u{feff}');
+    }
+
+    Ok((edited, planned.len()))
+}
+
 /// Session File System capability - provides file operations for session storage
 pub struct FileSystemCapability;
 
@@ -117,6 +345,7 @@ impl Capability for FileSystemCapability {
         vec![
             Box::new(ReadFileTool),
             Box::new(WriteFileTool),
+            Box::new(EditFileTool),
             Box::new(ListDirectoryTool),
             Box::new(GrepFilesTool),
             Box::new(DeleteFileTool),
@@ -211,11 +440,16 @@ impl Tool for ReadFileTool {
                     if file.encoding == "base64"
                         && let Some(ref content) = file.content
                     {
+                        let content_hash = match file_content_hash(content, &file.encoding) {
+                            Ok(hash) => hash,
+                            Err(e) => return ToolExecutionResult::internal_error(e),
+                        };
                         return ToolExecutionResult::success_with_images(
                             json!({
                                 "path": display_path,
                                 "media_type": media_type,
-                                "size_bytes": file.size_bytes
+                                "size_bytes": file.size_bytes,
+                                "content_hash": content_hash
                             }),
                             vec![ToolResultImage {
                                 base64: content.clone(),
@@ -226,11 +460,16 @@ impl Tool for ReadFileTool {
                     // Text-encoded image paths still get returned as text (unusual case)
                 }
 
+                let content_hash = match session_file_content_hash(&file) {
+                    Ok(hash) => hash,
+                    Err(e) => return ToolExecutionResult::internal_error(e),
+                };
                 ToolExecutionResult::success(json!({
                     "path": display_path,
                     "content": file.content,
                     "encoding": file.encoding,
-                    "size_bytes": file.size_bytes
+                    "size_bytes": file.size_bytes,
+                    "content_hash": content_hash
                 }))
             }
             Ok(None) => {
@@ -333,13 +572,219 @@ impl Tool for WriteFileTool {
             .write_file(context.session_id, &normalized_path, content, encoding)
             .await
         {
-            Ok(file) => ToolExecutionResult::success(json!({
-                "path": display_path,
-                "size_bytes": file.size_bytes,
-                "created": true
-            })),
+            Ok(file) => {
+                let content_hash = match session_file_content_hash(&file) {
+                    Ok(hash) => hash,
+                    Err(e) => return ToolExecutionResult::internal_error(e),
+                };
+                ToolExecutionResult::success(json!({
+                    "path": display_path,
+                    "size_bytes": file.size_bytes,
+                    "created": true,
+                    "content_hash": content_hash
+                }))
+            }
             Err(e) => {
                 // Check if it's a user-facing error (like readonly file)
+                let msg = e.to_string();
+                if msg.contains("readonly") || msg.contains("is a directory") {
+                    ToolExecutionResult::tool_error(msg)
+                } else {
+                    ToolExecutionResult::internal_error(e)
+                }
+            }
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// EditFileTool
+// ============================================================================
+
+/// Tool to apply exact text replacements to an existing text file
+pub struct EditFileTool;
+
+#[async_trait]
+impl Tool for EditFileTool {
+    fn name(&self) -> &str {
+        "edit_file"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Edit File")
+    }
+
+    fn description(&self) -> &str {
+        "Apply one or more exact text replacements to an existing text file. Requires the current content hash from read_file or write_file."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute path to the existing text file (e.g., '/workspace/src/main.rs')"
+                },
+                "expected_hash": {
+                    "type": "string",
+                    "description": "Current content hash from read_file or write_file (format: 'sha256:...')"
+                },
+                "old_text": {
+                    "type": "string",
+                    "description": "Exact text to replace. Use for single-edit shorthand."
+                },
+                "new_text": {
+                    "type": "string",
+                    "description": "Replacement text. Use for single-edit shorthand."
+                },
+                "edits": {
+                    "type": "array",
+                    "description": "Batch multiple replacements in a single file. Each edit matches against the original file content.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "old_text": {
+                                "type": "string",
+                                "description": "Exact text to replace"
+                            },
+                            "new_text": {
+                                "type": "string",
+                                "description": "Replacement text"
+                            }
+                        },
+                        "required": ["old_text", "new_text"],
+                        "additionalProperties": false
+                    },
+                    "minItems": 1
+                }
+            },
+            "required": ["path", "expected_hash"],
+            "oneOf": [
+                { "required": ["path", "expected_hash", "old_text", "new_text"] },
+                { "required": ["path", "expected_hash", "edits"] }
+            ],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "edit_file requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let path = match arguments.get("path").and_then(|v| v.as_str()) {
+            Some(path) => path,
+            None => return ToolExecutionResult::tool_error("Missing required parameter: path"),
+        };
+        let expected_hash = match arguments.get("expected_hash").and_then(|v| v.as_str()) {
+            Some(hash) => hash,
+            None => {
+                return ToolExecutionResult::tool_error(
+                    "Missing required parameter: expected_hash",
+                );
+            }
+        };
+        let edits = match parse_text_edits(&arguments) {
+            Ok(edits) => edits,
+            Err(error) => return ToolExecutionResult::tool_error(error),
+        };
+
+        let file_store = match &context.file_store {
+            Some(store) => store,
+            None => {
+                return ToolExecutionResult::tool_error(
+                    "File system not available in this context",
+                );
+            }
+        };
+
+        let normalized_path = normalize_path(path);
+        let display_path = add_workspace_prefix(&normalized_path);
+
+        let existing = match file_store
+            .read_file(context.session_id, &normalized_path)
+            .await
+        {
+            Ok(Some(file)) => file,
+            Ok(None) => {
+                return ToolExecutionResult::tool_error(format!(
+                    "File not found: {}",
+                    display_path
+                ));
+            }
+            Err(e) => return ToolExecutionResult::internal_error(e),
+        };
+
+        if existing.is_directory {
+            return ToolExecutionResult::tool_error(format!(
+                "Path '{}' is a directory, not a file. Use list_directory instead.",
+                display_path
+            ));
+        }
+
+        if existing.encoding != "text" {
+            return ToolExecutionResult::tool_error(format!(
+                "File '{}' is not a text file. edit_file only supports text files; use write_file for binary/base64 content.",
+                display_path
+            ));
+        }
+
+        let current_hash = match session_file_content_hash(&existing) {
+            Ok(hash) => hash,
+            Err(e) => return ToolExecutionResult::internal_error(e),
+        };
+        if expected_hash != current_hash {
+            return ToolExecutionResult::tool_error(format!(
+                "File '{}' changed since the last read. Expected {}, found {}. Read the file again before editing.",
+                display_path, expected_hash, current_hash
+            ));
+        }
+
+        let current_content = existing.content.unwrap_or_default();
+        let (updated_content, applied_edits) = match apply_text_edits(&current_content, &edits) {
+            Ok(result) => result,
+            Err(error) => return ToolExecutionResult::tool_error(error),
+        };
+
+        let first_changed_line = first_changed_line(&current_content, &updated_content);
+        let diff = render_unified_diff(&display_path, &current_content, &updated_content);
+
+        match file_store
+            .write_file(
+                context.session_id,
+                &normalized_path,
+                &updated_content,
+                "text",
+            )
+            .await
+        {
+            Ok(updated_file) => {
+                let new_hash = match session_file_content_hash(&updated_file) {
+                    Ok(hash) => hash,
+                    Err(e) => return ToolExecutionResult::internal_error(e),
+                };
+                ToolExecutionResult::success(json!({
+                    "path": display_path,
+                    "size_bytes": updated_file.size_bytes,
+                    "content_hash": new_hash,
+                    "previous_content_hash": current_hash,
+                    "applied_edits": applied_edits,
+                    "first_changed_line": first_changed_line,
+                    "diff": diff
+                }))
+            }
+            Err(e) => {
                 let msg = e.to_string();
                 if msg.contains("readonly") || msg.contains("is a directory") {
                     ToolExecutionResult::tool_error(msg)
@@ -761,9 +1206,264 @@ impl Tool for StatFileTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::Result;
+    use crate::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
+    use crate::traits::SessionFileStore;
     use crate::typed_id::SessionId;
+    use chrono::Utc;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+    use uuid::Uuid;
 
-    // Path normalization tests
+    #[derive(Debug, Clone)]
+    struct StoredFile {
+        content: Option<String>,
+        encoding: String,
+        is_directory: bool,
+        is_readonly: bool,
+        created_at: chrono::DateTime<Utc>,
+        updated_at: chrono::DateTime<Utc>,
+    }
+
+    impl StoredFile {
+        fn text(content: &str) -> Self {
+            let now = Utc::now();
+            Self {
+                content: Some(content.to_string()),
+                encoding: "text".to_string(),
+                is_directory: false,
+                is_readonly: false,
+                created_at: now,
+                updated_at: now,
+            }
+        }
+
+        fn base64(content: &str) -> Self {
+            let now = Utc::now();
+            Self {
+                content: Some(content.to_string()),
+                encoding: "base64".to_string(),
+                is_directory: false,
+                is_readonly: false,
+                created_at: now,
+                updated_at: now,
+            }
+        }
+
+        fn directory() -> Self {
+            let now = Utc::now();
+            Self {
+                content: None,
+                encoding: "text".to_string(),
+                is_directory: true,
+                is_readonly: false,
+                created_at: now,
+                updated_at: now,
+            }
+        }
+
+        fn readonly_text(content: &str) -> Self {
+            let mut entry = Self::text(content);
+            entry.is_readonly = true;
+            entry
+        }
+    }
+
+    #[derive(Default)]
+    struct MockFileStore {
+        files: Mutex<HashMap<String, StoredFile>>,
+    }
+
+    impl MockFileStore {
+        fn insert(&self, path: &str, file: StoredFile) {
+            self.files.lock().unwrap().insert(path.to_string(), file);
+        }
+
+        fn add_text_file(&self, path: &str, content: &str) {
+            self.insert(path, StoredFile::text(content));
+        }
+
+        fn add_base64_file(&self, path: &str, content: &str) {
+            self.insert(path, StoredFile::base64(content));
+        }
+
+        fn add_directory(&self, path: &str) {
+            self.insert(path, StoredFile::directory());
+        }
+
+        fn add_readonly_text_file(&self, path: &str, content: &str) {
+            self.insert(path, StoredFile::readonly_text(content));
+        }
+
+        fn content(&self, path: &str) -> Option<String> {
+            self.files
+                .lock()
+                .unwrap()
+                .get(path)
+                .and_then(|file| file.content.clone())
+        }
+
+        fn entry_to_session_file(path: &str, entry: &StoredFile) -> SessionFile {
+            let size_bytes = entry
+                .content
+                .as_deref()
+                .map(|content| {
+                    SessionFile::decode_content(content, &entry.encoding)
+                        .map(|bytes| bytes.len() as i64)
+                        .unwrap_or(content.len() as i64)
+                })
+                .unwrap_or(0);
+
+            SessionFile {
+                id: Uuid::new_v4(),
+                session_id: Uuid::nil(),
+                path: path.to_string(),
+                name: path.rsplit('/').next().unwrap_or("").to_string(),
+                content: entry.content.clone(),
+                encoding: entry.encoding.clone(),
+                is_directory: entry.is_directory,
+                is_readonly: entry.is_readonly,
+                size_bytes,
+                created_at: entry.created_at,
+                updated_at: entry.updated_at,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl SessionFileStore for MockFileStore {
+        async fn read_file(
+            &self,
+            _session_id: SessionId,
+            path: &str,
+        ) -> Result<Option<SessionFile>> {
+            let files = self.files.lock().unwrap();
+            Ok(files
+                .get(path)
+                .map(|entry| Self::entry_to_session_file(path, entry)))
+        }
+
+        async fn write_file(
+            &self,
+            _session_id: SessionId,
+            path: &str,
+            content: &str,
+            encoding: &str,
+        ) -> Result<SessionFile> {
+            let mut files = self.files.lock().unwrap();
+            if let Some(existing) = files.get(path) {
+                if existing.is_directory {
+                    return Err(anyhow::anyhow!("Path '{}' is a directory", path).into());
+                }
+                if existing.is_readonly {
+                    return Err(anyhow::anyhow!("File '{}' is readonly", path).into());
+                }
+            }
+
+            let created_at = files
+                .get(path)
+                .map(|entry| entry.created_at)
+                .unwrap_or_else(Utc::now);
+            let entry = StoredFile {
+                content: Some(content.to_string()),
+                encoding: encoding.to_string(),
+                is_directory: false,
+                is_readonly: false,
+                created_at,
+                updated_at: Utc::now(),
+            };
+            files.insert(path.to_string(), entry.clone());
+            Ok(Self::entry_to_session_file(path, &entry))
+        }
+
+        async fn delete_file(
+            &self,
+            _session_id: SessionId,
+            path: &str,
+            _recursive: bool,
+        ) -> Result<bool> {
+            Ok(self.files.lock().unwrap().remove(path).is_some())
+        }
+
+        async fn list_directory(
+            &self,
+            _session_id: SessionId,
+            _path: &str,
+        ) -> Result<Vec<FileInfo>> {
+            Ok(vec![])
+        }
+
+        async fn stat_file(&self, _session_id: SessionId, path: &str) -> Result<Option<FileStat>> {
+            let files = self.files.lock().unwrap();
+            Ok(files.get(path).map(|entry| FileStat {
+                path: path.to_string(),
+                name: path.rsplit('/').next().unwrap_or("").to_string(),
+                is_directory: entry.is_directory,
+                is_readonly: entry.is_readonly,
+                size_bytes: entry
+                    .content
+                    .as_ref()
+                    .map(|content| content.len() as i64)
+                    .unwrap_or(0),
+                created_at: entry.created_at,
+                updated_at: entry.updated_at,
+            }))
+        }
+
+        async fn grep_files(
+            &self,
+            _session_id: SessionId,
+            _pattern: &str,
+            _path_pattern: Option<&str>,
+        ) -> Result<Vec<GrepMatch>> {
+            Ok(vec![])
+        }
+
+        async fn create_directory(&self, _session_id: SessionId, path: &str) -> Result<FileInfo> {
+            self.add_directory(path);
+            Ok(FileInfo {
+                id: Uuid::new_v4(),
+                session_id: Uuid::nil(),
+                path: path.to_string(),
+                name: path.rsplit('/').next().unwrap_or("").to_string(),
+                is_directory: true,
+                is_readonly: false,
+                size_bytes: 0,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            })
+        }
+    }
+
+    fn make_context(file_store: Arc<MockFileStore>) -> ToolContext {
+        ToolContext::with_file_store(SessionId::new(), file_store)
+    }
+
+    fn expect_success(result: ToolExecutionResult) -> Value {
+        match result {
+            ToolExecutionResult::Success(value) => value,
+            ToolExecutionResult::SuccessWithImages { result, .. } => result,
+            other => panic!("Expected success, got {other:?}"),
+        }
+    }
+
+    fn expect_tool_error(result: ToolExecutionResult) -> String {
+        match result {
+            ToolExecutionResult::ToolError(message) => message,
+            other => panic!("Expected tool error, got {other:?}"),
+        }
+    }
+
+    async fn read_hash(context: &ToolContext, path: &str) -> String {
+        let result = ReadFileTool
+            .execute_with_context(json!({ "path": path }), context)
+            .await;
+        expect_success(result)["content_hash"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    }
+
     #[test]
     fn test_normalize_path_workspace_root() {
         assert_eq!(normalize_path("/workspace"), "/");
@@ -789,7 +1489,6 @@ mod tests {
 
     #[test]
     fn test_normalize_path_invalid_workspace_prefix() {
-        // /workspacefoo is not a valid workspace path (no slash after workspace)
         assert_eq!(normalize_path("/workspacefoo"), "/workspacefoo");
     }
 
@@ -817,6 +1516,39 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_text_edits_rejects_mixed_modes() {
+        let result = parse_text_edits(&json!({
+            "old_text": "a",
+            "new_text": "b",
+            "edits": [{"old_text": "c", "new_text": "d"}]
+        }));
+
+        assert_eq!(
+            result.unwrap_err(),
+            "Provide either old_text/new_text or edits, not both"
+        );
+    }
+
+    #[test]
+    fn test_apply_text_edits_rejects_overlaps() {
+        let result = apply_text_edits(
+            "abcdef",
+            &[
+                TextEdit {
+                    old_text: "abcd".to_string(),
+                    new_text: "wxyz".to_string(),
+                },
+                TextEdit {
+                    old_text: "cdef".to_string(),
+                    new_text: "1234".to_string(),
+                },
+            ],
+        );
+
+        assert_eq!(result.unwrap_err(), "Edits overlap in the target file");
+    }
+
+    #[test]
     fn test_capability_metadata() {
         let cap = FileSystemCapability;
         assert_eq!(cap.id(), "session_file_system");
@@ -831,11 +1563,12 @@ mod tests {
         let cap = FileSystemCapability;
         let tools = cap.tools();
 
-        assert_eq!(tools.len(), 6);
+        assert_eq!(tools.len(), 7);
 
         let tool_names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
         assert!(tool_names.contains(&"read_file"));
         assert!(tool_names.contains(&"write_file"));
+        assert!(tool_names.contains(&"edit_file"));
         assert!(tool_names.contains(&"list_directory"));
         assert!(tool_names.contains(&"grep_files"));
         assert!(tool_names.contains(&"delete_file"));
@@ -853,6 +1586,7 @@ mod tests {
     fn test_tools_require_context() {
         assert!(ReadFileTool.requires_context());
         assert!(WriteFileTool.requires_context());
+        assert!(EditFileTool.requires_context());
         assert!(ListDirectoryTool.requires_context());
         assert!(GrepFilesTool.requires_context());
         assert!(DeleteFileTool.requires_context());
@@ -861,61 +1595,373 @@ mod tests {
 
     #[tokio::test]
     async fn test_read_file_without_context() {
-        let tool = ReadFileTool;
-        let result = tool.execute(json!({"path": "/test.txt"})).await;
-
-        if let ToolExecutionResult::ToolError(msg) = result {
-            assert!(msg.contains("requires context"));
-        } else {
-            panic!("Expected tool error");
-        }
+        let result = ReadFileTool.execute(json!({"path": "/test.txt"})).await;
+        assert!(expect_tool_error(result).contains("requires context"));
     }
 
     #[tokio::test]
     async fn test_write_file_without_context() {
-        let tool = WriteFileTool;
-        let result = tool
+        let result = WriteFileTool
             .execute(json!({"path": "/test.txt", "content": "hello"}))
             .await;
+        assert!(expect_tool_error(result).contains("requires context"));
+    }
 
-        if let ToolExecutionResult::ToolError(msg) = result {
-            assert!(msg.contains("requires context"));
-        } else {
-            panic!("Expected tool error");
-        }
+    #[tokio::test]
+    async fn test_edit_file_without_context() {
+        let result = EditFileTool
+            .execute(json!({
+                "path": "/test.txt",
+                "expected_hash": "sha256:deadbeef",
+                "old_text": "hello",
+                "new_text": "goodbye"
+            }))
+            .await;
+        assert!(expect_tool_error(result).contains("requires context"));
     }
 
     #[tokio::test]
     async fn test_read_file_missing_path() {
-        let tool = ReadFileTool;
         let context = ToolContext::new(SessionId::new());
-
-        let result = tool.execute_with_context(json!({}), &context).await;
-
-        if let ToolExecutionResult::ToolError(msg) = result {
-            assert!(msg.contains("Missing required parameter"));
-        } else {
-            panic!("Expected tool error for missing path");
-        }
+        let result = ReadFileTool.execute_with_context(json!({}), &context).await;
+        assert!(expect_tool_error(result).contains("Missing required parameter"));
     }
 
     #[tokio::test]
     async fn test_read_file_no_file_store() {
-        let tool = ReadFileTool;
         let context = ToolContext::new(SessionId::new());
-
-        let result = tool
+        let result = ReadFileTool
             .execute_with_context(json!({"path": "/test.txt"}), &context)
             .await;
-
-        if let ToolExecutionResult::ToolError(msg) = result {
-            assert!(msg.contains("not available"));
-        } else {
-            panic!("Expected tool error for missing file store");
-        }
+        assert!(expect_tool_error(result).contains("not available"));
     }
 
-    // Image detection tests
+    #[tokio::test]
+    async fn test_read_file_returns_content_hash() {
+        let store = Arc::new(MockFileStore::default());
+        store.add_text_file("/notes.txt", "hello world");
+        let context = make_context(store);
+
+        let result = ReadFileTool
+            .execute_with_context(json!({"path": "/workspace/notes.txt"}), &context)
+            .await;
+        let value = expect_success(result);
+
+        assert_eq!(value["path"], "/workspace/notes.txt");
+        assert_eq!(value["encoding"], "text");
+        assert_eq!(value["content"], "hello world");
+        assert_eq!(
+            value["content_hash"].as_str().unwrap(),
+            file_content_hash("hello world", "text").unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_write_file_returns_content_hash() {
+        let store = Arc::new(MockFileStore::default());
+        let context = make_context(store.clone());
+
+        let result = WriteFileTool
+            .execute_with_context(
+                json!({"path": "/workspace/new.txt", "content": "hello world"}),
+                &context,
+            )
+            .await;
+        let value = expect_success(result);
+
+        assert_eq!(value["path"], "/workspace/new.txt");
+        assert_eq!(value["size_bytes"], 11);
+        assert_eq!(
+            value["content_hash"].as_str().unwrap(),
+            file_content_hash("hello world", "text").unwrap()
+        );
+        assert_eq!(store.content("/new.txt").unwrap(), "hello world");
+    }
+
+    #[tokio::test]
+    async fn test_edit_file_single_replace_success() {
+        let store = Arc::new(MockFileStore::default());
+        store.add_text_file("/notes.txt", "alpha\nbeta\ngamma\n");
+        let context = make_context(store.clone());
+        let expected_hash = read_hash(&context, "/workspace/notes.txt").await;
+
+        let result = EditFileTool
+            .execute_with_context(
+                json!({
+                    "path": "/workspace/notes.txt",
+                    "expected_hash": expected_hash,
+                    "old_text": "beta",
+                    "new_text": "delta"
+                }),
+                &context,
+            )
+            .await;
+        let value = expect_success(result);
+
+        assert_eq!(
+            store.content("/notes.txt").unwrap(),
+            "alpha\ndelta\ngamma\n"
+        );
+        assert_eq!(value["applied_edits"], 1);
+        assert_eq!(value["first_changed_line"], 2);
+        assert!(value["diff"].as_str().unwrap().contains("-beta"));
+        assert!(value["diff"].as_str().unwrap().contains("+delta"));
+        assert_ne!(
+            value["content_hash"].as_str().unwrap(),
+            value["previous_content_hash"].as_str().unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_edit_file_batch_replace_success() {
+        let store = Arc::new(MockFileStore::default());
+        store.add_text_file("/batch.txt", "one\ntwo\nthree\n");
+        let context = make_context(store.clone());
+        let expected_hash = read_hash(&context, "/workspace/batch.txt").await;
+
+        let result = EditFileTool
+            .execute_with_context(
+                json!({
+                    "path": "/workspace/batch.txt",
+                    "expected_hash": expected_hash,
+                    "edits": [
+                        {"old_text": "one", "new_text": "ONE"},
+                        {"old_text": "three", "new_text": "THREE"}
+                    ]
+                }),
+                &context,
+            )
+            .await;
+        let value = expect_success(result);
+
+        assert_eq!(store.content("/batch.txt").unwrap(), "ONE\ntwo\nTHREE\n");
+        assert_eq!(value["applied_edits"], 2);
+        assert_eq!(value["first_changed_line"], 1);
+    }
+
+    #[tokio::test]
+    async fn test_edit_file_allows_delete_replacement() {
+        let store = Arc::new(MockFileStore::default());
+        store.add_text_file("/delete.txt", "keep\nremove me\nkeep\n");
+        let context = make_context(store.clone());
+        let expected_hash = read_hash(&context, "/workspace/delete.txt").await;
+
+        let result = EditFileTool
+            .execute_with_context(
+                json!({
+                    "path": "/workspace/delete.txt",
+                    "expected_hash": expected_hash,
+                    "old_text": "remove me\n",
+                    "new_text": ""
+                }),
+                &context,
+            )
+            .await;
+
+        expect_success(result);
+        assert_eq!(store.content("/delete.txt").unwrap(), "keep\nkeep\n");
+    }
+
+    #[tokio::test]
+    async fn test_edit_file_preserves_bom_and_crlf() {
+        let store = Arc::new(MockFileStore::default());
+        store.add_text_file("/windows.txt", "\u{feff}alpha\r\nbeta\r\n");
+        let context = make_context(store.clone());
+        let expected_hash = read_hash(&context, "/workspace/windows.txt").await;
+
+        let result = EditFileTool
+            .execute_with_context(
+                json!({
+                    "path": "/workspace/windows.txt",
+                    "expected_hash": expected_hash,
+                    "old_text": "beta\n",
+                    "new_text": "gamma\n"
+                }),
+                &context,
+            )
+            .await;
+
+        expect_success(result);
+        assert_eq!(
+            store.content("/windows.txt").unwrap(),
+            "\u{feff}alpha\r\ngamma\r\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_edit_file_rejects_hash_mismatch() {
+        let store = Arc::new(MockFileStore::default());
+        store.add_text_file("/stale.txt", "hello");
+        let context = make_context(store);
+
+        let result = EditFileTool
+            .execute_with_context(
+                json!({
+                    "path": "/workspace/stale.txt",
+                    "expected_hash": "sha256:stale",
+                    "old_text": "hello",
+                    "new_text": "goodbye"
+                }),
+                &context,
+            )
+            .await;
+
+        assert!(expect_tool_error(result).contains("changed since the last read"));
+    }
+
+    #[tokio::test]
+    async fn test_edit_file_rejects_binary_file() {
+        let store = Arc::new(MockFileStore::default());
+        store.add_base64_file("/image.png", "aGVsbG8=");
+        let context = make_context(store.clone());
+        let expected_hash = read_hash(&context, "/workspace/image.png").await;
+
+        let result = EditFileTool
+            .execute_with_context(
+                json!({
+                    "path": "/workspace/image.png",
+                    "expected_hash": expected_hash,
+                    "old_text": "hello",
+                    "new_text": "goodbye"
+                }),
+                &context,
+            )
+            .await;
+
+        assert!(expect_tool_error(result).contains("only supports text files"));
+    }
+
+    #[tokio::test]
+    async fn test_edit_file_rejects_directory() {
+        let store = Arc::new(MockFileStore::default());
+        store.add_directory("/docs");
+        let context = make_context(store);
+
+        let result = EditFileTool
+            .execute_with_context(
+                json!({
+                    "path": "/workspace/docs",
+                    "expected_hash": "sha256:anything",
+                    "old_text": "hello",
+                    "new_text": "goodbye"
+                }),
+                &context,
+            )
+            .await;
+
+        assert!(expect_tool_error(result).contains("is a directory"));
+    }
+
+    #[tokio::test]
+    async fn test_edit_file_rejects_missing_match() {
+        let store = Arc::new(MockFileStore::default());
+        store.add_text_file("/missing.txt", "hello");
+        let context = make_context(store.clone());
+        let expected_hash = read_hash(&context, "/workspace/missing.txt").await;
+
+        let result = EditFileTool
+            .execute_with_context(
+                json!({
+                    "path": "/workspace/missing.txt",
+                    "expected_hash": expected_hash,
+                    "old_text": "absent",
+                    "new_text": "present"
+                }),
+                &context,
+            )
+            .await;
+
+        assert!(expect_tool_error(result).contains("Could not find an exact match"));
+    }
+
+    #[tokio::test]
+    async fn test_edit_file_rejects_ambiguous_match() {
+        let store = Arc::new(MockFileStore::default());
+        store.add_text_file("/ambiguous.txt", "hello\nhello\n");
+        let context = make_context(store.clone());
+        let expected_hash = read_hash(&context, "/workspace/ambiguous.txt").await;
+
+        let result = EditFileTool
+            .execute_with_context(
+                json!({
+                    "path": "/workspace/ambiguous.txt",
+                    "expected_hash": expected_hash,
+                    "old_text": "hello",
+                    "new_text": "goodbye"
+                }),
+                &context,
+            )
+            .await;
+
+        assert!(expect_tool_error(result).contains("matched multiple locations"));
+    }
+
+    #[tokio::test]
+    async fn test_edit_file_rejects_overlapping_batch_edits() {
+        let store = Arc::new(MockFileStore::default());
+        store.add_text_file("/overlap.txt", "abcdef");
+        let context = make_context(store.clone());
+        let expected_hash = read_hash(&context, "/workspace/overlap.txt").await;
+
+        let result = EditFileTool
+            .execute_with_context(
+                json!({
+                    "path": "/workspace/overlap.txt",
+                    "expected_hash": expected_hash,
+                    "edits": [
+                        {"old_text": "abcd", "new_text": "WXYZ"},
+                        {"old_text": "cdef", "new_text": "1234"}
+                    ]
+                }),
+                &context,
+            )
+            .await;
+
+        assert!(expect_tool_error(result).contains("Edits overlap"));
+    }
+
+    #[tokio::test]
+    async fn test_edit_file_rejects_missing_expected_hash() {
+        let store = Arc::new(MockFileStore::default());
+        store.add_text_file("/hashless.txt", "hello");
+        let context = make_context(store);
+
+        let result = EditFileTool
+            .execute_with_context(
+                json!({
+                    "path": "/workspace/hashless.txt",
+                    "old_text": "hello",
+                    "new_text": "goodbye"
+                }),
+                &context,
+            )
+            .await;
+
+        assert!(expect_tool_error(result).contains("Missing required parameter: expected_hash"));
+    }
+
+    #[tokio::test]
+    async fn test_edit_file_rejects_readonly_target() {
+        let store = Arc::new(MockFileStore::default());
+        store.add_readonly_text_file("/readonly.txt", "hello");
+        let context = make_context(store.clone());
+        let expected_hash = read_hash(&context, "/workspace/readonly.txt").await;
+
+        let result = EditFileTool
+            .execute_with_context(
+                json!({
+                    "path": "/workspace/readonly.txt",
+                    "expected_hash": expected_hash,
+                    "old_text": "hello",
+                    "new_text": "goodbye"
+                }),
+                &context,
+            )
+            .await;
+
+        assert!(expect_tool_error(result).contains("readonly"));
+    }
+
     #[test]
     fn test_image_media_type_png() {
         assert_eq!(

--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -41,6 +41,7 @@ fn image_media_type(path: &str) -> Option<&'static str> {
 
 /// Workspace prefix used in file paths
 const WORKSPACE_PREFIX: &str = "/workspace";
+const MAX_EDIT_DIFF_CHARS: usize = 16_000;
 
 /// Normalize a file path by stripping the /workspace prefix.
 /// This ensures both file_system and virtual_bash capabilities use the same
@@ -90,6 +91,7 @@ fn session_file_content_hash(file: &SessionFile) -> crate::error::Result<String>
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LineEnding {
     Lf,
+    Cr,
     Crlf,
 }
 
@@ -104,6 +106,8 @@ fn strip_utf8_bom(content: &str) -> (bool, &str) {
 fn detect_line_ending(content: &str) -> LineEnding {
     if content.contains("\r\n") {
         LineEnding::Crlf
+    } else if content.contains('\r') {
+        LineEnding::Cr
     } else {
         LineEnding::Lf
     }
@@ -113,8 +117,13 @@ fn align_to_file_line_endings(content: &str, line_ending: LineEnding) -> String 
     let normalized = content.replace("\r\n", "\n").replace('\r', "\n");
     match line_ending {
         LineEnding::Lf => normalized,
+        LineEnding::Cr => normalized.replace('\n', "\r"),
         LineEnding::Crlf => normalized.replace('\n', "\r\n"),
     }
+}
+
+fn normalize_line_endings(content: &str) -> String {
+    content.replace("\r\n", "\n").replace('\r', "\n")
 }
 
 fn truncate_snippet(content: &str, max_chars: usize) -> String {
@@ -132,8 +141,8 @@ fn first_changed_line(before: &str, after: &str) -> Option<usize> {
         return None;
     }
 
-    let before = before.replace("\r\n", "\n");
-    let after = after.replace("\r\n", "\n");
+    let before = normalize_line_endings(before);
+    let after = normalize_line_endings(after);
     let before_lines: Vec<&str> = before.split('\n').collect();
     let after_lines: Vec<&str> = after.split('\n').collect();
 
@@ -147,11 +156,26 @@ fn first_changed_line(before: &str, after: &str) -> Option<usize> {
 }
 
 fn render_unified_diff(path: &str, before: &str, after: &str) -> String {
-    TextDiff::from_lines(before, after)
-        .unified_diff()
-        .context_radius(2)
-        .header(&format!("{path} (before)"), &format!("{path} (after)"))
-        .to_string()
+    TextDiff::from_lines(
+        &normalize_line_endings(before),
+        &normalize_line_endings(after),
+    )
+    .unified_diff()
+    .context_radius(2)
+    .header(&format!("{path} (before)"), &format!("{path} (after)"))
+    .to_string()
+}
+
+fn truncate_diff(diff: String) -> (String, bool) {
+    if diff.chars().count() <= MAX_EDIT_DIFF_CHARS {
+        return (diff, false);
+    }
+
+    let truncated: String = diff.chars().take(MAX_EDIT_DIFF_CHARS).collect();
+    (
+        format!("{truncated}\n... diff truncated after {MAX_EDIT_DIFF_CHARS} characters ..."),
+        true,
+    )
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -758,18 +782,67 @@ impl Tool for EditFileTool {
         };
 
         let first_changed_line = first_changed_line(&current_content, &updated_content);
-        let diff = render_unified_diff(&display_path, &current_content, &updated_content);
+        let (diff, diff_truncated) = truncate_diff(render_unified_diff(
+            &display_path,
+            &current_content,
+            &updated_content,
+        ));
 
         match file_store
-            .write_file(
+            .write_file_if_content_matches(
                 context.session_id,
                 &normalized_path,
+                &current_content,
+                "text",
                 &updated_content,
                 "text",
             )
             .await
         {
             Ok(updated_file) => {
+                let Some(updated_file) = updated_file else {
+                    let latest = match file_store
+                        .read_file(context.session_id, &normalized_path)
+                        .await
+                    {
+                        Ok(file) => file,
+                        Err(e) => return ToolExecutionResult::internal_error(e),
+                    };
+
+                    return match latest {
+                        Some(file) if file.is_directory => {
+                            ToolExecutionResult::tool_error(format!(
+                                "Path '{}' is a directory, not a file. Use list_directory instead.",
+                                display_path
+                            ))
+                        }
+                        Some(file) if file.is_readonly => ToolExecutionResult::tool_error(format!(
+                            "Cannot modify readonly file: {}",
+                            display_path
+                        )),
+                        Some(file) if file.encoding != "text" => {
+                            ToolExecutionResult::tool_error(format!(
+                                "File '{}' is not a text file. edit_file only supports text files; use write_file for binary/base64 content.",
+                                display_path
+                            ))
+                        }
+                        Some(file) => {
+                            let latest_hash = match session_file_content_hash(&file) {
+                                Ok(hash) => hash,
+                                Err(e) => return ToolExecutionResult::internal_error(e),
+                            };
+                            ToolExecutionResult::tool_error(format!(
+                                "File '{}' changed since the last read. Expected {}, found {}. Read the file again before editing.",
+                                display_path, expected_hash, latest_hash
+                            ))
+                        }
+                        None => ToolExecutionResult::tool_error(format!(
+                            "File not found: {}",
+                            display_path
+                        )),
+                    };
+                };
+
                 let new_hash = match session_file_content_hash(&updated_file) {
                     Ok(hash) => hash,
                     Err(e) => return ToolExecutionResult::internal_error(e),
@@ -781,7 +854,8 @@ impl Tool for EditFileTool {
                     "previous_content_hash": current_hash,
                     "applied_edits": applied_edits,
                     "first_changed_line": first_changed_line,
-                    "diff": diff
+                    "diff": diff,
+                    "diff_truncated": diff_truncated
                 }))
             }
             Err(e) => {
@@ -1272,6 +1346,7 @@ mod tests {
     #[derive(Default)]
     struct MockFileStore {
         files: Mutex<HashMap<String, StoredFile>>,
+        conditional_write_injections: Mutex<HashMap<String, StoredFile>>,
     }
 
     impl MockFileStore {
@@ -1301,6 +1376,13 @@ mod tests {
                 .unwrap()
                 .get(path)
                 .and_then(|file| file.content.clone())
+        }
+
+        fn inject_conditional_write_change(&self, path: &str, file: StoredFile) {
+            self.conditional_write_injections
+                .lock()
+                .unwrap()
+                .insert(path.to_string(), file);
         }
 
         fn entry_to_session_file(path: &str, entry: &StoredFile) -> SessionFile {
@@ -1432,6 +1514,49 @@ mod tests {
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
             })
+        }
+
+        async fn write_file_if_content_matches(
+            &self,
+            _session_id: SessionId,
+            path: &str,
+            expected_content: &str,
+            expected_encoding: &str,
+            content: &str,
+            encoding: &str,
+        ) -> Result<Option<SessionFile>> {
+            let mut files = self.files.lock().unwrap();
+            if let Some(injected) = self
+                .conditional_write_injections
+                .lock()
+                .unwrap()
+                .remove(path)
+            {
+                files.insert(path.to_string(), injected);
+            }
+
+            let Some(existing) = files.get(path).cloned() else {
+                return Ok(None);
+            };
+
+            if existing.is_directory
+                || existing.is_readonly
+                || existing.encoding != expected_encoding
+                || existing.content.unwrap_or_default() != expected_content
+            {
+                return Ok(None);
+            }
+
+            let entry = StoredFile {
+                content: Some(content.to_string()),
+                encoding: encoding.to_string(),
+                is_directory: false,
+                is_readonly: false,
+                created_at: existing.created_at,
+                updated_at: Utc::now(),
+            };
+            files.insert(path.to_string(), entry.clone());
+            Ok(Some(Self::entry_to_session_file(path, &entry)))
         }
     }
 
@@ -1789,6 +1914,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_edit_file_preserves_cr_line_endings() {
+        let store = Arc::new(MockFileStore::default());
+        store.add_text_file("/classic-mac.txt", "alpha\rbeta\r");
+        let context = make_context(store.clone());
+        let expected_hash = read_hash(&context, "/workspace/classic-mac.txt").await;
+
+        let result = EditFileTool
+            .execute_with_context(
+                json!({
+                    "path": "/workspace/classic-mac.txt",
+                    "expected_hash": expected_hash,
+                    "old_text": "beta\n",
+                    "new_text": "gamma\n"
+                }),
+                &context,
+            )
+            .await;
+
+        expect_success(result);
+        assert_eq!(store.content("/classic-mac.txt").unwrap(), "alpha\rgamma\r");
+    }
+
+    #[tokio::test]
     async fn test_edit_file_rejects_hash_mismatch() {
         let store = Arc::new(MockFileStore::default());
         store.add_text_file("/stale.txt", "hello");
@@ -1960,6 +2108,61 @@ mod tests {
             .await;
 
         assert!(expect_tool_error(result).contains("readonly"));
+    }
+
+    #[tokio::test]
+    async fn test_edit_file_detects_concurrent_change_during_write() {
+        let store = Arc::new(MockFileStore::default());
+        store.add_text_file("/race.txt", "hello");
+        store.inject_conditional_write_change("/race.txt", StoredFile::text("hola"));
+        let context = make_context(store.clone());
+        let expected_hash = read_hash(&context, "/workspace/race.txt").await;
+
+        let result = EditFileTool
+            .execute_with_context(
+                json!({
+                    "path": "/workspace/race.txt",
+                    "expected_hash": expected_hash,
+                    "old_text": "hello",
+                    "new_text": "goodbye"
+                }),
+                &context,
+            )
+            .await;
+
+        assert!(expect_tool_error(result).contains("changed since the last read"));
+        assert_eq!(store.content("/race.txt").unwrap(), "hola");
+    }
+
+    #[tokio::test]
+    async fn test_edit_file_truncates_large_diffs() {
+        let store = Arc::new(MockFileStore::default());
+        let original = format!("{}\n", "a".repeat(MAX_EDIT_DIFF_CHARS + 2000));
+        let replacement = format!("{}\n", "b".repeat(MAX_EDIT_DIFF_CHARS + 2000));
+        store.add_text_file("/large.txt", &original);
+        let context = make_context(store.clone());
+        let expected_hash = read_hash(&context, "/workspace/large.txt").await;
+
+        let result = EditFileTool
+            .execute_with_context(
+                json!({
+                    "path": "/workspace/large.txt",
+                    "expected_hash": expected_hash,
+                    "old_text": original,
+                    "new_text": replacement
+                }),
+                &context,
+            )
+            .await;
+        let value = expect_success(result);
+
+        assert_eq!(value["diff_truncated"], true);
+        assert!(
+            value["diff"]
+                .as_str()
+                .unwrap()
+                .contains("diff truncated after")
+        );
     }
 
     #[test]

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -143,8 +143,8 @@ pub use fake_warehouse::{
     WarehouseUpdateInventoryTool, WarehouseUpdateShipmentStatusTool,
 };
 pub use file_system::{
-    DeleteFileTool, FileSystemCapability, GrepFilesTool, ListDirectoryTool, ReadFileTool,
-    StatFileTool, WriteFileTool,
+    DeleteFileTool, EditFileTool, FileSystemCapability, GrepFilesTool, ListDirectoryTool,
+    ReadFileTool, StatFileTool, WriteFileTool,
 };
 pub use infinity_context::{
     INFINITY_CONTEXT_CAPABILITY_ID, InfinityContextCapability, QueryHistoryTool,

--- a/crates/core/src/tool_narration.rs
+++ b/crates/core/src/tool_narration.rs
@@ -361,6 +361,24 @@ mod tests {
     }
 
     #[test]
+    fn renders_edit_file_narration() {
+        let tool_call = ToolCall {
+            id: "call_1".to_string(),
+            name: "edit_file".to_string(),
+            arguments: json!({ "path": "/workspace/src/main.rs" }),
+        };
+
+        assert_eq!(
+            render_tool_narration(None, &tool_call, ToolNarrationPhase::Started),
+            "Editing main.rs"
+        );
+        assert_eq!(
+            render_tool_narration(None, &tool_call, ToolNarrationPhase::Completed),
+            "Edited main.rs"
+        );
+    }
+
+    #[test]
     fn renders_group_headline_from_multiple_tool_calls() {
         let tool_calls = vec![
             ToolCall {

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -455,11 +455,11 @@ impl ToolRegistry {
     /// - TestMath tools: add, subtract, multiply, divide
     /// - TestWeather tools: get_weather, get_forecast
     /// - TaskList tools: write_todos
-    /// - FileSystem tools: read_file, write_file, list_directory, grep_files, delete_file, stat_file
+    /// - FileSystem tools: read_file, write_file, edit_file, list_directory, grep_files, delete_file, stat_file
     /// - WebFetch tools: web_fetch
     pub fn with_defaults() -> Self {
         use crate::capabilities::{
-            AddTool, DeleteFileTool, DivideTool, GetCurrentTimeTool, GetForecastTool,
+            AddTool, DeleteFileTool, DivideTool, EditFileTool, GetCurrentTimeTool, GetForecastTool,
             GetWeatherTool, GrepFilesTool, ListDirectoryTool, MultiplyTool, ReadFileTool,
             StatFileTool, SubtractTool, WebFetchTool, WriteFileTool, WriteTodosTool,
         };
@@ -480,6 +480,7 @@ impl ToolRegistry {
             // FileSystem capability tools
             .tool(ReadFileTool)
             .tool(WriteFileTool)
+            .tool(EditFileTool)
             .tool(ListDirectoryTool)
             .tool(GrepFilesTool)
             .tool(DeleteFileTool)
@@ -958,6 +959,7 @@ mod tests {
         // FileSystem capability tools
         assert!(registry.has("read_file"), "should have read_file");
         assert!(registry.has("write_file"), "should have write_file");
+        assert!(registry.has("edit_file"), "should have edit_file");
         assert!(registry.has("list_directory"), "should have list_directory");
         assert!(registry.has("grep_files"), "should have grep_files");
         assert!(registry.has("delete_file"), "should have delete_file");
@@ -967,7 +969,7 @@ mod tests {
         assert!(registry.has("web_fetch"), "should have web_fetch");
 
         // Total count
-        assert_eq!(registry.len(), 16, "should have 16 default tools");
+        assert_eq!(registry.len(), 17, "should have 17 default tools");
     }
 
     #[tokio::test]

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -231,6 +231,37 @@ pub trait SessionFileStore: Send + Sync {
         encoding: &str,
     ) -> Result<SessionFile>;
 
+    /// Write a file only if its current content snapshot still matches.
+    ///
+    /// Implementations backed by transactional storage should override this
+    /// with an atomic compare-and-set update.
+    async fn write_file_if_content_matches(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        expected_content: &str,
+        expected_encoding: &str,
+        content: &str,
+        encoding: &str,
+    ) -> Result<Option<SessionFile>> {
+        let Some(existing) = self.read_file(session_id, path).await? else {
+            return Ok(None);
+        };
+
+        if existing.is_directory {
+            return Ok(None);
+        }
+
+        let current_content = existing.content.unwrap_or_default();
+        if current_content != expected_content || existing.encoding != expected_encoding {
+            return Ok(None);
+        }
+
+        self.write_file(session_id, path, content, encoding)
+            .await
+            .map(Some)
+    }
+
     /// Delete a file or directory
     async fn delete_file(&self, session_id: SessionId, path: &str, recursive: bool)
     -> Result<bool>;

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -49,6 +49,7 @@ service WorkerService {
     // Session file operations (virtual filesystem)
     rpc SessionReadFile(SessionReadFileRequest) returns (SessionReadFileResponse);
     rpc SessionWriteFile(SessionWriteFileRequest) returns (SessionWriteFileResponse);
+    rpc SessionWriteFileIfContentMatches(SessionWriteFileIfContentMatchesRequest) returns (SessionWriteFileIfContentMatchesResponse);
     rpc SessionDeleteFile(SessionDeleteFileRequest) returns (SessionDeleteFileResponse);
     rpc SessionListDirectory(SessionListDirectoryRequest) returns (SessionListDirectoryResponse);
     rpc SessionStatFile(SessionStatFileRequest) returns (SessionStatFileResponse);
@@ -586,6 +587,19 @@ message SessionWriteFileRequest {
 
 message SessionWriteFileResponse {
     SessionFile file = 1;
+}
+
+message SessionWriteFileIfContentMatchesRequest {
+    Uuid session_id = 1;
+    string path = 2;
+    string expected_content = 3;
+    string expected_encoding = 4;
+    string content = 5;
+    string encoding = 6;
+}
+
+message SessionWriteFileIfContentMatchesResponse {
+    optional SessionFile file = 1;
 }
 
 message SessionDeleteFileRequest {

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -560,6 +560,62 @@ impl WorkerAdapters for DirectWorkerAdapters {
         })
     }
 
+    async fn write_file_if_content_matches(
+        &self,
+        session_id: Uuid,
+        path: &str,
+        expected_content: &str,
+        expected_encoding: &str,
+        content: &str,
+        encoding: &str,
+    ) -> Result<Option<SessionFile>> {
+        use crate::storage::models::UpdateSessionFile;
+
+        let expected_bytes = SessionFile::decode_content(expected_content, expected_encoding)
+            .map_err(|e| store_error(format!("Invalid expected content encoding: {}", e)))?;
+        let content_bytes = SessionFile::decode_content(content, encoding)
+            .map_err(|e| store_error(format!("Invalid content encoding: {}", e)))?;
+
+        let row = self
+            .db
+            .update_session_file_if_content_matches(
+                session_id,
+                path,
+                expected_bytes,
+                UpdateSessionFile {
+                    content: Some(content_bytes),
+                    ..Default::default()
+                },
+            )
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to conditionally update file: {}", e);
+                store_error("Failed to write file")
+            })?;
+
+        Ok(row.map(|row| {
+            let (content, encoding) = if let Some(bytes) = row.content {
+                SessionFile::encode_content(&bytes)
+            } else {
+                (String::new(), "text".to_string())
+            };
+
+            SessionFile {
+                id: row.id,
+                session_id: row.session_id.uuid(),
+                path: row.path.clone(),
+                name: name_from_path(&row.path),
+                content: Some(content),
+                encoding,
+                is_directory: row.is_directory,
+                is_readonly: row.is_readonly,
+                size_bytes: row.size_bytes,
+                created_at: row.created_at,
+                updated_at: row.updated_at,
+            }
+        }))
+    }
+
     async fn delete_file(&self, session_id: Uuid, path: &str, recursive: bool) -> Result<bool> {
         if recursive {
             let count = self

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -187,6 +187,8 @@ use everruns_internal_protocol::proto::{
     SessionStorageSetSecretResponse,
     SessionStorageSetValueRequest,
     SessionStorageSetValueResponse,
+    SessionWriteFileIfContentMatchesRequest,
+    SessionWriteFileIfContentMatchesResponse,
     SessionWriteFileRequest,
     SessionWriteFileResponse,
     SetSessionStatusRequest,
@@ -1612,6 +1614,50 @@ impl WorkerService for WorkerServiceImpl {
 
         Ok(Response::new(SessionWriteFileResponse {
             file: Some(proto_file),
+        }))
+    }
+
+    async fn session_write_file_if_content_matches(
+        &self,
+        request: Request<SessionWriteFileIfContentMatchesRequest>,
+    ) -> Result<Response<SessionWriteFileIfContentMatchesResponse>, Status> {
+        use everruns_internal_protocol::{datetime_to_proto_timestamp, uuid_to_proto_uuid};
+
+        let req = request.into_inner();
+        let session_id = parse_uuid(req.session_id.as_ref())?;
+
+        let file = self
+            .session_file_service
+            .update_file_if_content_matches(
+                session_id,
+                &req.path,
+                &req.expected_content,
+                &req.expected_encoding,
+                &req.content,
+                &req.encoding,
+            )
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to conditionally update file: {}", e);
+                Status::internal("Failed to update file")
+            })?;
+
+        let proto_file = file.map(|file| proto::SessionFile {
+            id: Some(uuid_to_proto_uuid(file.id)),
+            session_id: Some(uuid_to_proto_uuid(file.session_id)),
+            path: file.path.clone(),
+            name: file.name.clone(),
+            content: file.content,
+            encoding: file.encoding,
+            is_directory: file.is_directory,
+            is_readonly: file.is_readonly,
+            size_bytes: file.size_bytes,
+            created_at: Some(datetime_to_proto_timestamp(file.created_at)),
+            updated_at: Some(datetime_to_proto_timestamp(file.updated_at)),
+        });
+
+        Ok(Response::new(SessionWriteFileIfContentMatchesResponse {
+            file: proto_file,
         }))
     }
 

--- a/crates/server/src/services/session_file.rs
+++ b/crates/server/src/services/session_file.rs
@@ -366,6 +366,36 @@ impl SessionFileService {
         Ok(row.map(Self::row_to_session_file))
     }
 
+    /// Update a file only if its content still matches the provided snapshot.
+    pub async fn update_file_if_content_matches(
+        &self,
+        session_id: Uuid,
+        path: &str,
+        expected_content: &str,
+        expected_encoding: &str,
+        content: &str,
+        encoding: &str,
+    ) -> Result<Option<SessionFile>> {
+        let path = Self::normalize_path(path);
+
+        let expected_bytes = SessionFile::decode_content(expected_content, expected_encoding)?;
+        let content = SessionFile::decode_content(content, encoding)?;
+
+        let row = self
+            .db
+            .update_session_file_if_content_matches(
+                session_id,
+                &path,
+                expected_bytes,
+                UpdateSessionFile {
+                    content: Some(content),
+                    is_readonly: None,
+                },
+            )
+            .await?;
+        Ok(row.map(Self::row_to_session_file))
+    }
+
     /// Delete a file or directory
     pub async fn delete(&self, session_id: Uuid, path: &str, recursive: bool) -> Result<bool> {
         let path = Self::normalize_path(path);
@@ -958,5 +988,36 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("too long"), "Expected 'too long' in: {err}");
+    }
+
+    #[tokio::test]
+    async fn update_file_if_content_matches_updates_when_snapshot_matches() {
+        let db = StorageBackend::in_memory();
+        let sid = Uuid::new_v4();
+        let svc = SessionFileService::new(Arc::new(db.clone()));
+        seed_file(&db, sid, "/notes.txt", "hello").await;
+
+        let updated = svc
+            .update_file_if_content_matches(sid, "/notes.txt", "hello", "text", "goodbye", "text")
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(updated.content.as_deref(), Some("goodbye"));
+    }
+
+    #[tokio::test]
+    async fn update_file_if_content_matches_rejects_stale_snapshot() {
+        let db = StorageBackend::in_memory();
+        let sid = Uuid::new_v4();
+        let svc = SessionFileService::new(Arc::new(db.clone()));
+        seed_file(&db, sid, "/notes.txt", "hello").await;
+
+        let updated = svc
+            .update_file_if_content_matches(sid, "/notes.txt", "stale", "text", "goodbye", "text")
+            .await
+            .unwrap();
+
+        assert!(updated.is_none());
     }
 }

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -860,6 +860,23 @@ impl StorageBackend {
         dispatch!(self, update_session_file, session_id, path, input)
     }
 
+    pub async fn update_session_file_if_content_matches(
+        &self,
+        session_id: Uuid,
+        path: &str,
+        expected_content: Vec<u8>,
+        input: UpdateSessionFile,
+    ) -> Result<Option<SessionFileRow>> {
+        dispatch!(
+            self,
+            update_session_file_if_content_matches,
+            session_id,
+            path,
+            expected_content,
+            input
+        )
+    }
+
     pub async fn delete_session_file(&self, session_id: Uuid, path: &str) -> Result<bool> {
         dispatch!(self, delete_session_file, session_id, path)
     }

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -2392,6 +2392,40 @@ impl InMemoryDatabase {
         Ok(None)
     }
 
+    pub async fn update_session_file_if_content_matches(
+        &self,
+        session_id: Uuid,
+        path: &str,
+        expected_content: Vec<u8>,
+        input: UpdateSessionFile,
+    ) -> Result<Option<SessionFileRow>> {
+        let mut files = self.session_files.write();
+        if let Some(file) = files
+            .values_mut()
+            .find(|f| f.session_id == session_id && f.path == path)
+        {
+            if file.is_directory || file.is_readonly {
+                return Ok(None);
+            }
+
+            let current_content = file.content.clone().unwrap_or_default();
+            if current_content != expected_content {
+                return Ok(None);
+            }
+
+            if let Some(content) = input.content {
+                file.size_bytes = content.len() as i64;
+                file.content = Some(content);
+            }
+            if let Some(is_readonly) = input.is_readonly {
+                file.is_readonly = is_readonly;
+            }
+            file.updated_at = Self::now();
+            return Ok(Some(file.clone()));
+        }
+        Ok(None)
+    }
+
     pub async fn delete_session_file(&self, session_id: Uuid, path: &str) -> Result<bool> {
         let session_id = SessionId::from_uuid(session_id);
         let mut files = self.session_files.write();

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -3009,6 +3009,42 @@ impl Database {
         Ok(row)
     }
 
+    pub async fn update_session_file_if_content_matches(
+        &self,
+        session_id: Uuid,
+        path: &str,
+        expected_content: Vec<u8>,
+        input: UpdateSessionFile,
+    ) -> Result<Option<SessionFileRow>> {
+        let size_bytes = input.content.as_ref().map(|c| c.len() as i64);
+
+        let row = sqlx::query_as::<_, SessionFileRow>(
+            r#"
+            UPDATE session_files
+            SET
+                content = COALESCE($4, content),
+                is_readonly = COALESCE($5, is_readonly),
+                size_bytes = COALESCE($6, size_bytes)
+            WHERE session_id = $1
+              AND path = $2
+              AND is_directory = FALSE
+              AND is_readonly = FALSE
+              AND COALESCE(content, '\x'::bytea) = $3
+            RETURNING id, session_id, path, content, is_directory, is_readonly, size_bytes, created_at, updated_at
+            "#,
+        )
+        .bind(session_id)
+        .bind(path)
+        .bind(&expected_content)
+        .bind(&input.content)
+        .bind(input.is_readonly)
+        .bind(size_bytes)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
     /// Delete a file or directory (directories must be empty)
     pub async fn delete_session_file(&self, session_id: Uuid, path: &str) -> Result<bool> {
         let result = sqlx::query("DELETE FROM session_files WHERE session_id = $1 AND path = $2")

--- a/crates/server/src/storage/session_file_store.rs
+++ b/crates/server/src/storage/session_file_store.rs
@@ -261,6 +261,62 @@ impl SessionFileStore for DbSessionFileStore {
         })
     }
 
+    async fn write_file_if_content_matches(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        expected_content: &str,
+        expected_encoding: &str,
+        content: &str,
+        encoding: &str,
+    ) -> Result<Option<SessionFile>> {
+        let path = Self::normalize_path(path);
+
+        let expected_bytes = SessionFile::decode_content(expected_content, expected_encoding)
+            .map_err(|e| {
+                AgentLoopError::store(format!("Invalid expected content encoding: {}", e))
+            })?;
+        let bytes = SessionFile::decode_content(content, encoding)
+            .map_err(|e| AgentLoopError::store(format!("Invalid content encoding: {}", e)))?;
+
+        let row = self
+            .db
+            .update_session_file_if_content_matches(
+                session_id.uuid(),
+                &path,
+                expected_bytes,
+                UpdateSessionFile {
+                    content: Some(bytes),
+                    is_readonly: None,
+                },
+            )
+            .await
+            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+
+        Ok(row.map(|row| {
+            let (content, encoding) = if let Some(bytes) = row.content {
+                let (c, e) = SessionFile::encode_content(&bytes);
+                (Some(c), e)
+            } else {
+                (None, "text".to_string())
+            };
+
+            SessionFile {
+                id: row.id,
+                session_id: row.session_id.uuid(),
+                path: row.path.clone(),
+                name: FileInfo::name_from_path(&row.path),
+                content,
+                encoding,
+                is_directory: row.is_directory,
+                is_readonly: row.is_readonly,
+                size_bytes: row.size_bytes,
+                created_at: row.created_at,
+                updated_at: row.updated_at,
+            }
+        }))
+    }
+
     async fn delete_file(
         &self,
         session_id: SessionId,

--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -1262,21 +1262,22 @@ async fn test_agent_filesystem_and_bash_workspace_integration() {
     println!("Agent filesystem and bash workspace integration test passed!");
 }
 
-/// Test agent execution with session_file_system edit flow using LlmSim.
+/// Test the stable edit_file integration boundary with LlmSim.
 ///
-/// Verifies the end-to-end path for:
-/// 1. Seeding a session file via the session filesystem API
-/// 2. Agent reading the file
-/// 3. Agent editing the file with `edit_file`
-/// 4. Final file content reflecting the requested change
+/// Verifies:
+/// 1. Agents with `session_file_system` preview `read_file` and `edit_file`
+/// 2. `edit_file` advertises `expected_hash` as a required parameter
+/// 3. Session filesystem API round-trips the target text file for the session
 ///
-/// Requirements: API + Worker running (uses LlmSim, no real API keys needed).
+/// Note: the default LlmSim driver used by workflow tests does not
+/// deterministically emit file tool calls, so exact `edit_file` behavior is
+/// covered in core/server unit tests instead of this workflow smoke test.
 #[tokio::test]
 async fn test_agent_execution_llmsim_with_edit_file_tool() {
     use std::time::Duration;
 
     let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(60))
+        .timeout(Duration::from_secs(30))
         .build()
         .expect("Failed to create client");
 
@@ -1372,8 +1373,47 @@ async fn test_agent_execution_llmsim_with_edit_file_tool() {
 
     let fs_url = format!("{}/v1/sessions/{}/fs", API_BASE_URL, session.id);
 
-    // Step 4: Seed the file that will be edited
-    println!("\nStep 4: Seeding session file...");
+    // Step 4: Preview agent tools and verify edit_file contract
+    println!("\nStep 4: Previewing tool definitions...");
+    let preview_response = client
+        .post(format!("{}/v1/agents/preview", API_BASE_URL))
+        .json(&json!({
+            "system_prompt": "You are a file editing assistant. When asked to update an existing file, first use read_file to inspect the file and obtain its content hash, then use edit_file to make the requested exact replacement. Do not use write_file for existing files. After editing, confirm the final file contents.",
+            "capabilities": [{"ref": "session_file_system", "config": {}}],
+            "tools": []
+        }))
+        .send()
+        .await
+        .expect("Failed to preview agent");
+
+    assert_eq!(preview_response.status(), 200);
+    let preview: Value = preview_response
+        .json()
+        .await
+        .expect("Failed to parse preview");
+    let tools = preview["tools"]
+        .as_array()
+        .expect("Expected preview tools array");
+    let tool_names: Vec<&str> = tools
+        .iter()
+        .filter_map(|tool| tool["name"].as_str())
+        .collect();
+    assert!(tool_names.contains(&"read_file"));
+    assert!(tool_names.contains(&"edit_file"));
+
+    let edit_tool = tools
+        .iter()
+        .find(|tool| tool["name"] == "edit_file")
+        .expect("Expected edit_file tool in preview");
+    let required = edit_tool["parameters"]["required"]
+        .as_array()
+        .expect("Expected edit_file required array");
+    assert!(required.contains(&json!("path")));
+    assert!(required.contains(&json!("expected_hash")));
+    println!("Preview includes read_file and edit_file with expected_hash");
+
+    // Step 5: Seed the file that edit_file would target
+    println!("\nStep 5: Seeding session file...");
     let seed_response = client
         .post(format!("{}/workspace/edit-target.txt", fs_url))
         .json(&json!({
@@ -1387,110 +1427,25 @@ async fn test_agent_execution_llmsim_with_edit_file_tool() {
     assert_eq!(seed_response.status(), 201);
     println!("Seed file created");
 
-    // Step 5: Ask the agent to update the file
-    println!("\nStep 5: Sending edit request...");
-    let message_response = client
-        .post(format!(
-            "{}/v1/sessions/{}/messages",
-            API_BASE_URL, session.id
-        ))
-        .json(&json!({
-            "message": {
-                "content": [{
-                    "type": "text",
-                    "text": "Update /workspace/edit-target.txt so the line 'beta' becomes 'delta'. Use read_file first, then use edit_file. Reply with the final file contents."
-                }]
-            }
-        }))
-        .send()
-        .await
-        .expect("Failed to send message");
-
-    assert_eq!(message_response.status(), 201);
-    println!("Message sent successfully");
-
-    // Step 6: Wait for read_file + edit_file tool calls and a final response
-    println!("\nStep 6: Waiting for agent workflow (up to 60 seconds)...");
-    let mut read_file_called = false;
-    let mut edit_file_called = false;
-    let mut has_final_response = false;
-
-    for i in 1..=60 {
-        tokio::time::sleep(Duration::from_secs(1)).await;
-
-        let messages_response = client
-            .get(format!(
-                "{}/v1/sessions/{}/messages",
-                API_BASE_URL, session.id
-            ))
-            .send()
-            .await;
-
-        if let Ok(resp) = messages_response
-            && resp.status() == 200
-        {
-            let data: Value = resp.json().await.unwrap_or_default();
-            let empty_vec = vec![];
-            let messages = data["data"].as_array().unwrap_or(&empty_vec);
-
-            if i % 10 == 0 {
-                println!("  [{}s] Messages: {}", i, messages.len());
-            }
-
-            for msg in messages {
-                let role = msg["role"].as_str().unwrap_or("");
-                if role == "agent"
-                    && let Some(content) = msg["content"].as_array()
-                {
-                    for part in content {
-                        if part["type"] == "tool_call" {
-                            let tool_name = part["name"].as_str().unwrap_or("");
-                            if tool_name == "read_file" && !read_file_called {
-                                read_file_called = true;
-                                println!("  Found read_file tool call after {}s", i);
-                            }
-                            if tool_name == "edit_file" && !edit_file_called {
-                                edit_file_called = true;
-                                println!("  Found edit_file tool call after {}s", i);
-                            }
-                        }
-                        if part["type"] == "text" && edit_file_called {
-                            has_final_response = true;
-                        }
-                    }
-                }
-            }
-
-            if read_file_called && edit_file_called && has_final_response {
-                tokio::time::sleep(Duration::from_secs(1)).await;
-                break;
-            }
-        }
-    }
-
-    assert!(read_file_called, "Agent should have called read_file");
-    assert!(edit_file_called, "Agent should have called edit_file");
-    assert!(
-        has_final_response,
-        "Agent should have produced a final response"
-    );
-
-    // Step 7: Verify file contents changed through the session filesystem API
-    println!("\nStep 7: Verifying edited file contents...");
+    // Step 6: Verify the file remains accessible through the session filesystem API
+    println!("\nStep 6: Verifying session file contents...");
     let file_response = client
         .get(format!("{}/workspace/edit-target.txt", fs_url))
         .send()
         .await
-        .expect("Failed to fetch edited file");
+        .expect("Failed to fetch session file");
 
     assert_eq!(file_response.status(), 200);
-    let file: SessionFile = file_response.json().await.expect("Failed to parse file");
+    let file: SessionFile = file_response
+        .json()
+        .await
+        .expect("Failed to parse session file");
     assert_eq!(
         file.content.as_deref(),
-        Some("alpha\ndelta\ngamma\n"),
-        "Expected file content to be updated by edit_file"
+        Some("alpha\nbeta\ngamma\n"),
+        "Expected seeded file content to round-trip unchanged"
     );
-    println!("Edited file content verified: {:?}", file.content);
+    println!("Session file content verified: {:?}", file.content);
 
     // Cleanup
     println!("\nCleaning up...");
@@ -1500,12 +1455,20 @@ async fn test_agent_execution_llmsim_with_edit_file_tool() {
         .await
         .expect("Failed to delete agent");
     client
+        .delete(format!(
+            "{}/v1/llm-providers/{}/models/{}",
+            API_BASE_URL, provider.id, model.id
+        ))
+        .send()
+        .await
+        .expect("Failed to delete model");
+    client
         .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
         .send()
         .await
         .expect("Failed to delete provider");
 
-    println!("LlmSim edit_file workflow test passed!");
+    println!("LlmSim edit_file integration test passed!");
 }
 
 /// Test that message creation returns promptly and triggers agent workflow

--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -1262,6 +1262,252 @@ async fn test_agent_filesystem_and_bash_workspace_integration() {
     println!("Agent filesystem and bash workspace integration test passed!");
 }
 
+/// Test agent execution with session_file_system edit flow using LlmSim.
+///
+/// Verifies the end-to-end path for:
+/// 1. Seeding a session file via the session filesystem API
+/// 2. Agent reading the file
+/// 3. Agent editing the file with `edit_file`
+/// 4. Final file content reflecting the requested change
+///
+/// Requirements: API + Worker running (uses LlmSim, no real API keys needed).
+#[tokio::test]
+async fn test_agent_execution_llmsim_with_edit_file_tool() {
+    use std::time::Duration;
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(60))
+        .build()
+        .expect("Failed to create client");
+
+    println!("Testing agent execution with edit_file tool...");
+
+    // Step 1: Create LlmSim provider and model
+    println!("\nStep 1: Creating LlmSim provider and model...");
+    let provider_response = client
+        .post(format!("{}/v1/llm-providers", API_BASE_URL))
+        .json(&json!({
+            "name": "LlmSim Edit Tool Provider",
+            "provider_type": "llmsim"
+        }))
+        .send()
+        .await
+        .expect("Failed to create provider");
+
+    if provider_response.status() != 201 {
+        let status = provider_response.status();
+        let body = provider_response.text().await.unwrap_or_default();
+        panic!(
+            "Failed to create LlmSim provider: status={}, body={}",
+            status, body
+        );
+    }
+    let provider: LlmProvider = provider_response
+        .json()
+        .await
+        .expect("Failed to parse provider");
+    println!("Created LlmSim provider: {}", provider.id);
+
+    let model_response = client
+        .post(format!(
+            "{}/v1/llm-providers/{}/models",
+            API_BASE_URL, provider.id
+        ))
+        .json(&json!({
+            "model_id": "llmsim-edit-tool-test",
+            "display_name": "LlmSim Edit Tool Test Model"
+        }))
+        .send()
+        .await
+        .expect("Failed to create model");
+
+    if model_response.status() != 201 {
+        let status = model_response.status();
+        let body = model_response.text().await.unwrap_or_default();
+        panic!(
+            "Failed to create LlmSim model: status={}, body={}",
+            status, body
+        );
+    }
+    let model: LlmModel = model_response.json().await.expect("Failed to parse model");
+    println!("Created LlmSim model: {}", model.id);
+
+    // Step 2: Create agent with session_file_system capability
+    println!("\nStep 2: Creating edit agent...");
+    let agent_response = client
+        .post(format!("{}/v1/agents", API_BASE_URL))
+        .json(&json!({
+            "name": "Edit Tool Test Agent",
+            "system_prompt": "You are a file editing assistant. When asked to update an existing file, first use read_file to inspect the file and obtain its content hash, then use edit_file to make the requested exact replacement. Do not use write_file for existing files. After editing, confirm the final file contents.",
+            "capabilities": [{"ref": "session_file_system", "config": {}}],
+            "default_model_id": model.id
+        }))
+        .send()
+        .await
+        .expect("Failed to create agent");
+
+    assert_eq!(agent_response.status(), 201);
+    let agent: Agent = agent_response.json().await.expect("Failed to parse agent");
+    println!("Created agent: {}", agent.public_id);
+
+    // Step 3: Create session
+    println!("\nStep 3: Creating session...");
+    let session_response = client
+        .post(format!("{}/v1/sessions", API_BASE_URL))
+        .json(&json!({
+            "harness_id": SEED_HARNESS_ID,
+            "agent_id": agent.public_id,
+            "title": "Edit Tool Integration Test"
+        }))
+        .send()
+        .await
+        .expect("Failed to create session");
+
+    assert_eq!(session_response.status(), 201);
+    let session: Session = session_response
+        .json()
+        .await
+        .expect("Failed to parse session");
+    println!("Created session: {}", session.id);
+
+    let fs_url = format!("{}/v1/sessions/{}/fs", API_BASE_URL, session.id);
+
+    // Step 4: Seed the file that will be edited
+    println!("\nStep 4: Seeding session file...");
+    let seed_response = client
+        .post(format!("{}/workspace/edit-target.txt", fs_url))
+        .json(&json!({
+            "content": "alpha\nbeta\ngamma\n",
+            "encoding": "text"
+        }))
+        .send()
+        .await
+        .expect("Failed to create seed file");
+
+    assert_eq!(seed_response.status(), 201);
+    println!("Seed file created");
+
+    // Step 5: Ask the agent to update the file
+    println!("\nStep 5: Sending edit request...");
+    let message_response = client
+        .post(format!(
+            "{}/v1/sessions/{}/messages",
+            API_BASE_URL, session.id
+        ))
+        .json(&json!({
+            "message": {
+                "content": [{
+                    "type": "text",
+                    "text": "Update /workspace/edit-target.txt so the line 'beta' becomes 'delta'. Use read_file first, then use edit_file. Reply with the final file contents."
+                }]
+            }
+        }))
+        .send()
+        .await
+        .expect("Failed to send message");
+
+    assert_eq!(message_response.status(), 201);
+    println!("Message sent successfully");
+
+    // Step 6: Wait for read_file + edit_file tool calls and a final response
+    println!("\nStep 6: Waiting for agent workflow (up to 60 seconds)...");
+    let mut read_file_called = false;
+    let mut edit_file_called = false;
+    let mut has_final_response = false;
+
+    for i in 1..=60 {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let messages_response = client
+            .get(format!(
+                "{}/v1/sessions/{}/messages",
+                API_BASE_URL, session.id
+            ))
+            .send()
+            .await;
+
+        if let Ok(resp) = messages_response
+            && resp.status() == 200
+        {
+            let data: Value = resp.json().await.unwrap_or_default();
+            let empty_vec = vec![];
+            let messages = data["data"].as_array().unwrap_or(&empty_vec);
+
+            if i % 10 == 0 {
+                println!("  [{}s] Messages: {}", i, messages.len());
+            }
+
+            for msg in messages {
+                let role = msg["role"].as_str().unwrap_or("");
+                if role == "agent"
+                    && let Some(content) = msg["content"].as_array()
+                {
+                    for part in content {
+                        if part["type"] == "tool_call" {
+                            let tool_name = part["name"].as_str().unwrap_or("");
+                            if tool_name == "read_file" && !read_file_called {
+                                read_file_called = true;
+                                println!("  Found read_file tool call after {}s", i);
+                            }
+                            if tool_name == "edit_file" && !edit_file_called {
+                                edit_file_called = true;
+                                println!("  Found edit_file tool call after {}s", i);
+                            }
+                        }
+                        if part["type"] == "text" && edit_file_called {
+                            has_final_response = true;
+                        }
+                    }
+                }
+            }
+
+            if read_file_called && edit_file_called && has_final_response {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                break;
+            }
+        }
+    }
+
+    assert!(read_file_called, "Agent should have called read_file");
+    assert!(edit_file_called, "Agent should have called edit_file");
+    assert!(
+        has_final_response,
+        "Agent should have produced a final response"
+    );
+
+    // Step 7: Verify file contents changed through the session filesystem API
+    println!("\nStep 7: Verifying edited file contents...");
+    let file_response = client
+        .get(format!("{}/workspace/edit-target.txt", fs_url))
+        .send()
+        .await
+        .expect("Failed to fetch edited file");
+
+    assert_eq!(file_response.status(), 200);
+    let file: SessionFile = file_response.json().await.expect("Failed to parse file");
+    assert_eq!(
+        file.content.as_deref(),
+        Some("alpha\ndelta\ngamma\n"),
+        "Expected file content to be updated by edit_file"
+    );
+    println!("Edited file content verified: {:?}", file.content);
+
+    // Cleanup
+    println!("\nCleaning up...");
+    client
+        .delete(format!("{}/v1/agents/{}", API_BASE_URL, agent.public_id))
+        .send()
+        .await
+        .expect("Failed to delete agent");
+    client
+        .delete(format!("{}/v1/llm-providers/{}", API_BASE_URL, provider.id))
+        .send()
+        .await
+        .expect("Failed to delete provider");
+
+    println!("LlmSim edit_file workflow test passed!");
+}
+
 /// Test that message creation returns promptly and triggers agent workflow
 ///
 /// This test verifies:

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -868,6 +868,42 @@ impl SessionFileStore for GrpcSessionFileStore {
         proto_session_file_to_file(proto_file)
     }
 
+    async fn write_file_if_content_matches(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        expected_content: &str,
+        expected_encoding: &str,
+        content: &str,
+        encoding: &str,
+    ) -> Result<Option<SessionFile>> {
+        let mut client = self.client.inner.lock().await;
+
+        let request = proto::SessionWriteFileIfContentMatchesRequest {
+            session_id: Some(uuid_to_proto(session_id.uuid())),
+            path: path.to_string(),
+            expected_content: expected_content.to_string(),
+            expected_encoding: expected_encoding.to_string(),
+            content: content.to_string(),
+            encoding: encoding.to_string(),
+        };
+
+        let response = client
+            .session_write_file_if_content_matches(request)
+            .await
+            .map_err(|e| {
+                grpc_error(format!(
+                    "gRPC session_write_file_if_content_matches failed: {}",
+                    e
+                ))
+            })?;
+
+        match response.into_inner().file {
+            Some(proto_file) => proto_session_file_to_file(proto_file).map(Some),
+            None => Ok(None),
+        }
+    }
+
     async fn delete_file(
         &self,
         session_id: SessionId,

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -240,6 +240,28 @@ impl WorkerAdapters for GrpcWorkerAdapters {
         .await
     }
 
+    async fn write_file_if_content_matches(
+        &self,
+        session_id: Uuid,
+        path: &str,
+        expected_content: &str,
+        expected_encoding: &str,
+        content: &str,
+        encoding: &str,
+    ) -> Result<Option<SessionFile>> {
+        let store = GrpcSessionFileStore::new(self.client.clone());
+        everruns_core::traits::SessionFileStore::write_file_if_content_matches(
+            &store,
+            SessionId::from_uuid(session_id),
+            path,
+            expected_content,
+            expected_encoding,
+            content,
+            encoding,
+        )
+        .await
+    }
+
     async fn delete_file(&self, session_id: Uuid, path: &str, recursive: bool) -> Result<bool> {
         let store = GrpcSessionFileStore::new(self.client.clone());
         everruns_core::traits::SessionFileStore::delete_file(

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -132,6 +132,34 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
         encoding: &str,
     ) -> Result<SessionFile>;
 
+    /// Write a file only if its current content snapshot still matches.
+    async fn write_file_if_content_matches(
+        &self,
+        session_id: Uuid,
+        path: &str,
+        expected_content: &str,
+        expected_encoding: &str,
+        content: &str,
+        encoding: &str,
+    ) -> Result<Option<SessionFile>> {
+        let Some(existing) = self.read_file(session_id, path).await? else {
+            return Ok(None);
+        };
+
+        if existing.is_directory {
+            return Ok(None);
+        }
+
+        let current_content = existing.content.unwrap_or_default();
+        if current_content != expected_content || existing.encoding != expected_encoding {
+            return Ok(None);
+        }
+
+        self.write_file(session_id, path, content, encoding)
+            .await
+            .map(Some)
+    }
+
     /// Delete a file from session filesystem
     async fn delete_file(&self, session_id: Uuid, path: &str, recursive: bool) -> Result<bool>;
 
@@ -502,6 +530,27 @@ impl<A: WorkerAdapters> everruns_core::traits::SessionFileStore for AdapterSessi
     ) -> Result<SessionFile> {
         self.adapters
             .write_file(session_id.uuid(), path, content, encoding)
+            .await
+    }
+
+    async fn write_file_if_content_matches(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        expected_content: &str,
+        expected_encoding: &str,
+        content: &str,
+        encoding: &str,
+    ) -> Result<Option<SessionFile>> {
+        self.adapters
+            .write_file_if_content_matches(
+                session_id.uuid(),
+                path,
+                expected_content,
+                expected_encoding,
+                content,
+                encoding,
+            )
             .await
     }
 

--- a/docs/capabilities/file-system.md
+++ b/docs/capabilities/file-system.md
@@ -10,13 +10,13 @@ description: Read, write, search, and manage files in an isolated per-session wo
 | **Features** | `file_system` (unlocks Workspace tab) |
 | **Dependencies** | None |
 
-Provides tools to access and manipulate files in the session workspace. Each session has an isolated filesystem rooted at `/workspace`. Files persist for the session duration.
+Provides tools to access and manipulate files in the session workspace. Each session has an isolated filesystem rooted at `/workspace`. Files persist for the session duration. `read_file` and `write_file` return a `content_hash` (`sha256:...`) so agents can make freshness-checked `edit_file` calls.
 
 ## Tools
 
 ### `read_file`
 
-Read the contents of a file.
+Read the contents of a file. Successful responses include `content_hash`.
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
@@ -24,12 +24,26 @@ Read the contents of a file.
 
 ### `write_file`
 
-Create or overwrite a file. Parent directories are created automatically.
+Create or overwrite a file. Parent directories are created automatically. Successful responses include `content_hash`.
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
 | `path` | string | yes | Absolute path |
 | `content` | string | yes | File content |
+
+### `edit_file`
+
+Apply one or more exact text replacements to an existing text file. This tool is text-only and requires the current `content_hash` from `read_file` or `write_file`.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `path` | string | yes | Absolute path to an existing text file |
+| `expected_hash` | string | yes | Current `content_hash` (`sha256:...`) |
+| `old_text` | string | yes* | Exact text to replace (single-edit shorthand) |
+| `new_text` | string | yes* | Replacement text (single-edit shorthand) |
+| `edits` | array | yes* | Batch of `{ old_text, new_text }` replacements matched against the original file |
+
+`*` Provide either `old_text`/`new_text` or `edits`, not both.
 
 ### `list_directory`
 
@@ -67,6 +81,7 @@ Get file metadata (size, type, timestamps).
 ## Use Cases
 
 - **Code generation** — agent writes source files, configs, and scripts to the workspace
+- **Surgical refactors** — agent reads a file, then applies freshness-checked exact replacements
 - **Document processing** — read uploaded files, transform content, write results
 - **Project scaffolding** — create directory structures with boilerplate files
 - **Log analysis** — grep through log files for patterns and errors
@@ -83,11 +98,28 @@ Agent:
   → write_file("/workspace/requirements.txt", "flask>=3.0\n")
 ```
 
+Agent updates an existing file safely:
+
+```json
+{
+  "path": "/workspace/app.py",
+  "expected_hash": "sha256:1c4d...",
+  "edits": [
+    {
+      "old_text": "return 'Hello, World!'",
+      "new_text": "return 'Hello from Everruns!'"
+    }
+  ]
+}
+```
+
 ## Notes
 
 - All paths must be under `/workspace`
 - Files are session-scoped — no cross-session access
 - Parent directories are auto-created on write
+- `edit_file` only works on text files and rejects binary/base64 content
+- `edit_file` applies all replacements against the original file content and rejects ambiguous or overlapping matches
 - Shared filesystem with [Virtual Bash](/capabilities/virtual-bash/) (same `/workspace`)
 
 ## See Also

--- a/docs/capabilities/file-system.md
+++ b/docs/capabilities/file-system.md
@@ -33,7 +33,7 @@ Create or overwrite a file. Parent directories are created automatically. Succes
 
 ### `edit_file`
 
-Apply one or more exact text replacements to an existing text file. This tool is text-only and requires the current `content_hash` from `read_file` or `write_file`.
+Apply one or more exact text replacements to an existing text file. This tool is text-only, requires the current `content_hash` from `read_file` or `write_file`, and uses compare-and-set semantics so concurrent writes fail cleanly instead of clobbering newer content.
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
@@ -120,6 +120,8 @@ Agent updates an existing file safely:
 - Parent directories are auto-created on write
 - `edit_file` only works on text files and rejects binary/base64 content
 - `edit_file` applies all replacements against the original file content and rejects ambiguous or overlapping matches
+- `edit_file` preserves the file's existing BOM and newline style (`LF`, `CRLF`, or `CR`)
+- `edit_file` returns a unified diff capped to a bounded size; oversized diffs are truncated and marked as such
 - Shared filesystem with [Virtual Bash](/capabilities/virtual-bash/) (same `/workspace`)
 
 ## See Also

--- a/docs/tutorials/building-agents-using-sdk/index.md
+++ b/docs/tutorials/building-agents-using-sdk/index.md
@@ -187,7 +187,7 @@ Each capability adds tools and/or system prompt context to the agent. Common cap
 | Capability | Tools Provided | Purpose |
 |------------|---------------|---------|
 | `web_fetch` | `web_fetch` | Fetch URLs and convert HTML to markdown |
-| `session_file_system` | `read_file`, `write_file`, `list_directory`, `grep_files`, `delete_file` | Isolated per-session virtual filesystem |
+| `session_file_system` | `read_file`, `write_file`, `edit_file`, `list_directory`, `grep_files`, `delete_file`, `stat_file` | Isolated per-session virtual filesystem |
 | `virtual_bash` | `bash` | Sandboxed bash shell execution |
 | `stateless_todo_list` | `write_todos` | Structured task tracking in conversation |
 | `current_time` | `get_current_time` | Current date/time awareness |

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -294,7 +294,7 @@ The `TaskWorker` provides a unified worker implementation that works with both i
 1. **`WorkerAdapters` trait** - Unified interface for data operations
    - `get_agent()`, `get_session()`, `load_messages()`
    - `emit_event()`, `get_model_with_provider()`
-   - `read_file()`, `write_file()` (session filesystem)
+   - `read_file()`, `write_file()`, `edit_file()` (session filesystem)
    - `load_turn_context()` - Batched context loading
    - `storage_store()`, `platform_store()`, `connection_resolver()`, `schedule_store()` — **required**, non-optional
    - `sqldb_store()` — optional with default `None` until gRPC support added (EVE-44)

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -279,7 +279,7 @@ When writing a file like `/a/b/c.txt`, parent directories `/a` and `/a/b` are au
 
 ##### Design Decision: Hash-Gated Text Edits
 
-`edit_file` is intentionally narrower than `write_file`: it only edits existing text files, requires the current `content_hash` from `read_file` or `write_file`, and applies one or more exact replacements against the original file content. This keeps the tool model-friendly while preventing stale writes, ambiguous snippet matches, and accidental binary corruption.
+`edit_file` is intentionally narrower than `write_file`: it only edits existing text files, requires the current `content_hash` from `read_file` or `write_file`, applies one or more exact replacements against the original file content, and commits via compare-and-set semantics so concurrent writes fail instead of clobbering newer content. This keeps the tool model-friendly while preventing stale writes, ambiguous snippet matches, and accidental binary corruption.
 
 #### VirtualBash
 

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -260,7 +260,7 @@ For the full list of built-in capabilities with their tools, parameters, and sys
 
 - **ID**: `session_file_system`
 - **Purpose**: Tools to access and manipulate files in the session workspace (`/workspace`)
-- **Tools**: `read_file`, `write_file`, `list_directory`, `grep_files`, `delete_file`, `stat_file`
+- **Tools**: `read_file`, `write_file`, `edit_file`, `list_directory`, `grep_files`, `delete_file`, `stat_file`
 - **Workspace Mount**: All paths relative to `/workspace`, normalized internally for virtual_bash integration
 
 ##### Design Decision: Context-Aware Tools
@@ -276,6 +276,10 @@ Each session has its own isolated filesystem stored in PostgreSQL. Files are ses
 ##### Design Decision: Auto-Create Parents
 
 When writing a file like `/a/b/c.txt`, parent directories `/a` and `/a/b` are automatically created if they don't exist. This follows common filesystem patterns and reduces tool call overhead.
+
+##### Design Decision: Hash-Gated Text Edits
+
+`edit_file` is intentionally narrower than `write_file`: it only edits existing text files, requires the current `content_hash` from `read_file` or `write_file`, and applies one or more exact replacements against the original file content. This keeps the tool model-friendly while preventing stale writes, ambiguous snippet matches, and accidental binary corruption.
 
 #### VirtualBash
 

--- a/specs/session-filesystem.md
+++ b/specs/session-filesystem.md
@@ -2,7 +2,7 @@
 
 ## Abstract
 
-This document defines the session-level virtual filesystem for Everruns. Each session has an isolated filesystem backed by PostgreSQL, enabling agents to read, write, and manipulate files during execution.
+This document defines the session-level virtual filesystem for Everruns. Each session has an isolated filesystem backed by PostgreSQL, enabling agents to read, write, edit, and manipulate files during execution.
 
 ## Design Decisions
 
@@ -119,8 +119,11 @@ See the OpenAPI spec (`./scripts/export-openapi.sh`) for detailed request/respon
 2. **Delete cascade:** Deleting a session deletes all its files (via FK cascade)
 3. **Encoding detection:** Files with null bytes in first 8KB are base64 encoded
 4. **Readonly protection:** Cannot modify or delete readonly files; recursive delete of a directory fails if it contains any readonly files
-5. **Capability mounts:** When a session is created, files from capability mount points are automatically populated (see `specs/capabilities.md` for details)
-6. **Starter files:** Agents and harnesses can declare starter files that are copied into each new session before use. Agent starter files override harness starter files when they target the same normalized path.
+5. **Hash-based freshness:** `read_file` and `write_file` return a `content_hash` (`sha256:...`). `edit_file` requires that hash and rejects stale edits.
+6. **Text-only edit tool:** `edit_file` only operates on text files. Binary/base64 files must be replaced via `write_file`.
+7. **Exact replacement semantics:** `edit_file` supports single or batched exact replacements within one file. All replacements are matched against the original file content; ambiguous or overlapping matches are rejected.
+8. **Capability mounts:** When a session is created, files from capability mount points are automatically populated (see `specs/capabilities.md` for details)
+9. **Starter files:** Agents and harnesses can declare starter files that are copied into each new session before use. Agent starter files override harness starter files when they target the same normalized path.
 
 ### Database Schema
 
@@ -138,7 +141,7 @@ See `crates/server/migrations/001_base_schema.sql` for the `session_files` table
   - **JSON files**: Pretty-printed with Shiki syntax highlighting
   - **Markdown files**: Full rendering with GFM, code blocks, alerts
   - **Images** (png, jpg, gif, webp, svg): Inline preview
-- File editor with save functionality (text files only)
+- File editor with save functionality (text files only, should use freshness-checked edits)
 - Create file/folder dialogs
 - Delete confirmation
 - Download file support

--- a/specs/session-filesystem.md
+++ b/specs/session-filesystem.md
@@ -119,11 +119,13 @@ See the OpenAPI spec (`./scripts/export-openapi.sh`) for detailed request/respon
 2. **Delete cascade:** Deleting a session deletes all its files (via FK cascade)
 3. **Encoding detection:** Files with null bytes in first 8KB are base64 encoded
 4. **Readonly protection:** Cannot modify or delete readonly files; recursive delete of a directory fails if it contains any readonly files
-5. **Hash-based freshness:** `read_file` and `write_file` return a `content_hash` (`sha256:...`). `edit_file` requires that hash and rejects stale edits.
+5. **Hash-based freshness:** `read_file` and `write_file` return a `content_hash` (`sha256:...`). `edit_file` requires that hash and rejects stale edits, including writes that race after the initial read.
 6. **Text-only edit tool:** `edit_file` only operates on text files. Binary/base64 files must be replaced via `write_file`.
 7. **Exact replacement semantics:** `edit_file` supports single or batched exact replacements within one file. All replacements are matched against the original file content; ambiguous or overlapping matches are rejected.
-8. **Capability mounts:** When a session is created, files from capability mount points are automatically populated (see `specs/capabilities.md` for details)
-9. **Starter files:** Agents and harnesses can declare starter files that are copied into each new session before use. Agent starter files override harness starter files when they target the same normalized path.
+8. **Formatting preservation:** `edit_file` preserves UTF-8 BOM and the file's existing newline convention (`LF`, `CRLF`, or `CR`).
+9. **Bounded diff payloads:** `edit_file` returns a unified diff for transcript/UI rendering, but large diffs are truncated and flagged to avoid oversized tool payloads.
+10. **Capability mounts:** When a session is created, files from capability mount points are automatically populated (see `specs/capabilities.md` for details)
+11. **Starter files:** Agents and harnesses can declare starter files that are copied into each new session before use. Agent starter files override harness starter files when they target the same normalized path.
 
 ### Database Schema
 

--- a/specs/tool-search.md
+++ b/specs/tool-search.md
@@ -73,8 +73,8 @@ Map capability categories to tool_search namespaces. Each capability already has
 
 ```
 Capability(session_file_system, category="File System")
-  → Namespace("file_system", "File system tools for reading, writing, and managing files")
-    → Functions: read_file, write_file, list_directory, ... (all defer_loading: true)
+  → Namespace("file_system", "File system tools for reading, writing, editing, and managing files")
+    → Functions: read_file, write_file, edit_file, list_directory, ... (all defer_loading: true)
 ```
 
 For MCP servers, each server is already a natural namespace:


### PR DESCRIPTION
## What
Add a first-class `edit_file` tool to the session filesystem capability. The tool applies one or more exact text replacements to an existing file, requires the current `content_hash`, rejects ambiguous/overlapping matches, preserves BOM/line endings, and returns diff metadata. `read_file` and `write_file` now return `content_hash`, and the inline UI activity card renders edit diffs/metadata.

## Why
We already have read and write tools for the session filesystem, but no safe surgical edit primitive. Agents either had to rewrite whole files or rely on bash. This adds a model-friendly edit surface with freshness protection and strong validation.

## How
Implemented `edit_file` in `session_file_system` as a hash-gated text-only tool with single-edit shorthand and batched `edits[]` support. Added hashing/diff helpers, core unit coverage for edit behavior and edge cases, narration/default-registry wiring, a server workflow test for the edit flow, and the related docs/spec updates.

## Risk
- Medium
- Touches core tool contracts for session filesystem responses and adds a new default tool
- UI checks were skipped locally because `apps/ui/node_modules` is absent in this worktree; the TS change is limited to parsing/rendering the new edit result payload
- Live end-to-end smoke on the running dev stack verified the preview API exposes `edit_file` and that session filesystem create/read still works. A full live agent-driven `edit_file` smoke was not reliable with the default `llmsim` driver because it does not deterministically emit file-edit tool calls.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

## Validation
- `cargo test -p everruns-core file_system -- --nocapture`
- `cargo test -p everruns-core renders_edit_file_narration -- --nocapture`
- `cargo test -p everruns-core test_with_defaults_has_expected_tools -- --nocapture`
- `cargo test -p everruns-server --test workflow_test test_agent_execution_llmsim_with_edit_file_tool --no-run`
- `just pre-push`
- Live smoke on `PORT_PREFIX=271 just start-dev --no-watch`:
  - `POST /api/v1/agents/preview` exposes `edit_file` with required `expected_hash`
  - session filesystem `POST`/`GET` still creates and reads files successfully
