### PR TITLE
fix(worker): skip retries for non-retryable durable task errors

### DIFF
--- a/crates/core/src/atoms/input.rs
+++ b/crates/core/src/atoms/input.rs
@@ -152,6 +152,13 @@ mod tests {
 
         let result = atom.execute(InputAtomInput { context }).await;
 
-        assert!(result.is_err());
+        let err = result.unwrap_err();
+        // Error message must contain "User message not found" so the durable
+        // worker can classify it as non-retryable (see is_non_retryable_task_error).
+        assert!(
+            err.to_string().contains("User message not found"),
+            "Expected 'User message not found' in error: {}",
+            err
+        );
     }
 }

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -489,6 +489,17 @@ impl ShutdownHandle {
     }
 }
 
+/// Check if a task error is deterministic and should never be retried.
+///
+/// Deterministic errors reference data that is permanently gone (e.g. a deleted
+/// message). Retrying will never succeed and only burns attempts while keeping
+/// the workflow in `Pending` status, blocking the entire session.
+fn is_non_retryable_task_error(error: &str) -> bool {
+    let lower = error.to_ascii_lowercase();
+    lower.contains("user message not found")
+        || lower.contains("inputatom execution failed") && lower.contains("not found")
+}
+
 impl DurableWorker {
     /// Poll for tasks and execute them concurrently
     async fn poll_and_execute(self: &Arc<Self>) -> Result<usize> {
@@ -551,47 +562,87 @@ impl DurableWorker {
                         "Task execution failed"
                     );
 
-                    // Report failure to store
-                    let mut store = worker.store.lock().await;
-                    match store.fail_task(task.id, &e.to_string()).await {
-                        Ok(will_retry) => {
-                            if !will_retry {
-                                // Task exhausted all retries (DLQ). Mark workflow as
-                                // completed so the session doesn't get stuck.
-                                if let Some(wf_id) = task.workflow_id {
-                                    warn!(
-                                        task_id = %task.id,
-                                        workflow_id = %wf_id,
-                                        "Task moved to DLQ, completing workflow with failure"
-                                    );
-                                    let _ = store
-                                        .update_workflow_status(
-                                            wf_id,
-                                            WorkflowStatus::Completed,
-                                            None,
-                                            Some(e.to_string()),
-                                        )
-                                        .await;
-                                }
+                    let error_msg = e.to_string();
+                    let force_dlq = is_non_retryable_task_error(&error_msg);
 
-                                // Emit a single user-facing error event now that all
-                                // retries are exhausted. Transient errors skip event
-                                // emission during each attempt to avoid duplicates;
-                                // this is the one place we surface the final failure.
-                                if matches!(
-                                    task.activity_type.as_str(),
-                                    "reason" | "process_input" | "act"
-                                ) {
-                                    worker.emit_dlq_error_event(&task).await;
+                    if force_dlq {
+                        // Deterministic error — retrying will never succeed.
+                        // Skip the retry loop and go straight to DLQ.
+                        warn!(
+                            task_id = %task.id,
+                            activity_type = %task.activity_type,
+                            error = %error_msg,
+                            "Non-retryable error detected, skipping retries"
+                        );
+
+                        let mut store = worker.store.lock().await;
+
+                        // Mark task as failed (will still count the attempt, but
+                        // we immediately handle the DLQ path regardless).
+                        let _ = store.fail_task(task.id, &error_msg).await;
+
+                        if let Some(wf_id) = task.workflow_id {
+                            let _ = store
+                                .update_workflow_status(
+                                    wf_id,
+                                    WorkflowStatus::Completed,
+                                    None,
+                                    Some(error_msg),
+                                )
+                                .await;
+                        }
+
+                        if matches!(
+                            task.activity_type.as_str(),
+                            "reason" | "process_input" | "act"
+                        ) {
+                            drop(store);
+                            worker.emit_dlq_error_event(&task).await;
+                        }
+                    } else {
+                        // Report failure to store (may retry)
+                        let mut store = worker.store.lock().await;
+                        match store.fail_task(task.id, &error_msg).await {
+                            Ok(will_retry) => {
+                                if !will_retry {
+                                    // Task exhausted all retries (DLQ). Mark workflow as
+                                    // completed so the session doesn't get stuck.
+                                    if let Some(wf_id) = task.workflow_id {
+                                        warn!(
+                                            task_id = %task.id,
+                                            workflow_id = %wf_id,
+                                            "Task moved to DLQ, completing workflow with failure"
+                                        );
+                                        let _ = store
+                                            .update_workflow_status(
+                                                wf_id,
+                                                WorkflowStatus::Completed,
+                                                None,
+                                                Some(error_msg),
+                                            )
+                                            .await;
+                                    }
+
+                                    // Emit a single user-facing error event now that all
+                                    // retries are exhausted. Transient errors skip event
+                                    // emission during each attempt to avoid duplicates;
+                                    // this is the one place we surface the final failure.
+                                    if matches!(
+                                        task.activity_type.as_str(),
+                                        "reason" | "process_input" | "act"
+                                    ) {
+                                        drop(store);
+                                        worker.emit_dlq_error_event(&task).await;
+                                    }
                                 }
                             }
-                        }
-                        Err(fail_err) => {
-                            error!(
-                                task_id = %task.id,
-                                error = %fail_err,
-                                "Failed to report task failure"
-                            );
+                            Err(fail_err) => {
+                                error!(
+                                    task_id = %task.id,
+                                    error = %fail_err,
+                                    "Failed to report task failure"
+                                );
+                            }
                         }
                     }
                 }
@@ -1422,5 +1473,26 @@ mod tests {
         assert!(config.worker_id.starts_with("worker-"));
         assert_eq!(config.max_concurrent_tasks, 1000);
         assert_eq!(config.grpc_address, "127.0.0.1:9001");
+    }
+
+    #[test]
+    fn test_is_non_retryable_task_error_detects_missing_message() {
+        assert!(is_non_retryable_task_error(
+            "Message store error: User message not found: msg_abc123"
+        ));
+        assert!(is_non_retryable_task_error(
+            "InputAtom execution failed: Message store error: User message not found: msg_xyz"
+        ));
+    }
+
+    #[test]
+    fn test_is_non_retryable_task_error_allows_transient_errors() {
+        assert!(!is_non_retryable_task_error(
+            "Transient LLM error (will retry at task level): server_error"
+        ));
+        assert!(!is_non_retryable_task_error("Failed to connect to gRPC"));
+        assert!(!is_non_retryable_task_error(
+            "LLM provider temporarily unavailable (circuit breaker open)"
+        ));
     }
 }

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -497,7 +497,7 @@ impl ShutdownHandle {
 fn is_non_retryable_task_error(error: &str) -> bool {
     let lower = error.to_ascii_lowercase();
     lower.contains("user message not found")
-        || lower.contains("inputatom execution failed") && lower.contains("not found")
+        || (lower.contains("inputatom execution failed") && lower.contains("not found"))
 }
 
 impl DurableWorker {
@@ -567,20 +567,40 @@ impl DurableWorker {
 
                     if force_dlq {
                         // Deterministic error — retrying will never succeed.
-                        // Skip the retry loop and go straight to DLQ.
+                        // Exhaust all retry attempts immediately so the task
+                        // reaches DLQ, then complete the workflow.
                         warn!(
                             task_id = %task.id,
                             activity_type = %task.activity_type,
                             error = %error_msg,
-                            "Non-retryable error detected, skipping retries"
+                            "Non-retryable error detected, exhausting retries"
                         );
 
                         let mut store = worker.store.lock().await;
 
-                        // Mark task as failed (will still count the attempt, but
-                        // we immediately handle the DLQ path regardless).
-                        let _ = store.fail_task(task.id, &error_msg).await;
+                        // Loop fail_task until the store says no more retries
+                        // (task is in DLQ). This ensures we don't complete the
+                        // workflow while the task is still retryable.
+                        loop {
+                            match store.fail_task(task.id, &error_msg).await {
+                                Ok(will_retry) => {
+                                    if !will_retry {
+                                        break;
+                                    }
+                                    // Consume another attempt immediately.
+                                }
+                                Err(fail_err) => {
+                                    error!(
+                                        task_id = %task.id,
+                                        error = %fail_err,
+                                        "Failed to force task into DLQ via fail_task"
+                                    );
+                                    break;
+                                }
+                            }
+                        }
 
+                        // Task is now in DLQ — safe to complete the workflow.
                         if let Some(wf_id) = task.workflow_id {
                             let _ = store
                                 .update_workflow_status(

--- a/crates/worker/src/main.rs
+++ b/crates/worker/src/main.rs
@@ -14,7 +14,10 @@ async fn main() -> Result<()> {
     }
     if telemetry_config.log_filter.is_none() {
         let log_level = std::env::var("LOG_LEVEL").unwrap_or_else(|_| "debug".to_string());
-        telemetry_config.log_filter = Some(format!("everruns_worker={}", log_level));
+        telemetry_config.log_filter = Some(format!(
+            "everruns_worker={},everruns_core={}",
+            log_level, log_level
+        ));
     }
     let _telemetry_guard = init_telemetry(telemetry_config);
 


### PR DESCRIPTION
## Summary

- Detect deterministic errors (e.g. "User message not found") and immediately DLQ the task instead of retrying 5 times while blocking the session
- Widen worker default log filter from `everruns_worker={LOG_LEVEL}` to include `everruns_core={LOG_LEVEL}` so atom-level warnings are visible
- Add test asserting InputAtom error message contains the pattern the worker uses for non-retryable classification

## Problem

When a `process_input` durable task references an input message that no longer exists (e.g. after a restart that loses in-flight data), the task retries up to 5 times. Each retry fails identically because the data is permanently gone. The workflow stays in `Pending` status, and `durable_runner.rs` times out after 10 seconds waiting for it to complete, permanently blocking the session.

## Test plan

- [x] `cargo test -p everruns-core --lib atoms::input` — InputAtom error message assertion
- [x] `cargo test -p everruns-worker --lib durable_worker::tests` — non-retryable classification tests
- [x] `cargo clippy -p everruns-worker -p everruns-core -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Closes EVE-156
