### PR TITLE
refactor(ui): extract QueryStateWrapper for list page boilerplate

### DIFF
--- a/apps/ui/src/app/(main)/agents/page.tsx
+++ b/apps/ui/src/app/(main)/agents/page.tsx
@@ -5,9 +5,8 @@ import { useAgents, useCapabilities, useImportAgent } from "@/hooks";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
 import { Plus, Upload } from "lucide-react";
+import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { AgentCard } from "@/components/agents";
 import { ArchiveFilter } from "@/components/archive-filter";
 
@@ -48,14 +47,6 @@ export default function AgentsPage() {
     [importAgent, router],
   );
 
-  if (error) {
-    return (
-      <div className="container mx-auto p-6">
-        <div className="text-red-500">Error loading agents: {error.message}</div>
-      </div>
-    );
-  }
-
   return (
     <div className="container mx-auto p-6">
       <div className="flex items-center justify-between mb-6">
@@ -88,42 +79,35 @@ export default function AgentsPage() {
         </div>
       )}
 
-      {isLoading ? (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {[...Array(6)].map((_, i) => (
-            <Card key={i}>
-              <CardHeader>
-                <Skeleton className="h-6 w-3/4" />
-              </CardHeader>
-              <CardContent>
-                <Skeleton className="h-4 w-full mb-2" />
-                <Skeleton className="h-4 w-2/3" />
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      ) : agents?.length === 0 ? (
-        <div className="text-center py-12">
-          <p className="text-muted-foreground mb-4">No agents yet</p>
-          <Link href="/agents/new">
-            <Button>
-              <Plus className="w-4 h-4 mr-2" />
-              Create your first agent
-            </Button>
-          </Link>
-        </div>
-      ) : (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {agents?.map((agent) => (
-            <AgentCard
-              key={agent.id}
-              agent={agent}
-              allCapabilities={allCapabilities}
-              showEditButton
-            />
-          ))}
-        </div>
-      )}
+      <QueryStateWrapper
+        isLoading={isLoading}
+        error={error}
+        data={agents}
+        emptyState={
+          <div className="text-center py-12">
+            <p className="text-muted-foreground mb-4">No agents yet</p>
+            <Link href="/agents/new">
+              <Button>
+                <Plus className="w-4 h-4 mr-2" />
+                Create your first agent
+              </Button>
+            </Link>
+          </div>
+        }
+      >
+        {(items) => (
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {items.map((agent) => (
+              <AgentCard
+                key={agent.id}
+                agent={agent}
+                allCapabilities={allCapabilities}
+                showEditButton
+              />
+            ))}
+          </div>
+        )}
+      </QueryStateWrapper>
     </div>
   );
 }

--- a/apps/ui/src/app/(main)/agents/page.tsx
+++ b/apps/ui/src/app/(main)/agents/page.tsx
@@ -83,6 +83,7 @@ export default function AgentsPage() {
         isLoading={isLoading}
         error={error}
         data={agents}
+        errorMessagePrefix="Failed to load agents"
         emptyState={
           <div className="text-center py-12">
             <p className="text-muted-foreground mb-4">No agents yet</p>

--- a/apps/ui/src/app/(main)/apps/page.tsx
+++ b/apps/ui/src/app/(main)/apps/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useApps, usePublishApp, useUnpublishApp } from "@/hooks/use-apps";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { Plus, Rocket, Globe, GlobeLock, Copy } from "lucide-react";

--- a/apps/ui/src/app/(main)/apps/page.tsx
+++ b/apps/ui/src/app/(main)/apps/page.tsx
@@ -40,6 +40,7 @@ export default function AppsPage() {
         isLoading={isLoading}
         error={error}
         data={apps}
+        errorMessagePrefix="Failed to load apps"
         skeletonCount={3}
         emptyState={<EmptyState />}
       >

--- a/apps/ui/src/app/(main)/apps/page.tsx
+++ b/apps/ui/src/app/(main)/apps/page.tsx
@@ -3,9 +3,9 @@
 import { useState } from "react";
 import { useApps, usePublishApp, useUnpublishApp } from "@/hooks/use-apps";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { Plus, Rocket, Globe, GlobeLock, Copy } from "lucide-react";
 import { ArchiveFilter } from "@/components/archive-filter";
 import { CopyButton } from "@/components/ui/copy-button";
@@ -17,14 +17,6 @@ import { getEntityNameClassName, getEntityStatusBadgeVariant } from "@/lib/entit
 export default function AppsPage() {
   const [showArchived, setShowArchived] = useState(false);
   const { data: apps, isLoading, error } = useApps({ includeArchived: showArchived });
-
-  if (error) {
-    return (
-      <div className="container mx-auto p-6">
-        <div className="text-red-500">Error loading apps: {error.message}</div>
-      </div>
-    );
-  }
 
   return (
     <div className="container mx-auto p-6">
@@ -44,29 +36,21 @@ export default function AppsPage() {
         </div>
       </div>
 
-      {isLoading ? (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {[...Array(3)].map((_, i) => (
-            <Card key={i}>
-              <CardHeader>
-                <Skeleton className="h-6 w-3/4" />
-              </CardHeader>
-              <CardContent>
-                <Skeleton className="h-4 w-full mb-2" />
-                <Skeleton className="h-4 w-2/3" />
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      ) : apps && apps.length > 0 ? (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {apps.map((app) => (
-            <AppCard key={app.id} app={app} />
-          ))}
-        </div>
-      ) : (
-        <EmptyState />
-      )}
+      <QueryStateWrapper
+        isLoading={isLoading}
+        error={error}
+        data={apps}
+        skeletonCount={3}
+        emptyState={<EmptyState />}
+      >
+        {(items) => (
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {items.map((app) => (
+              <AppCard key={app.id} app={app} />
+            ))}
+          </div>
+        )}
+      </QueryStateWrapper>
     </div>
   );
 }

--- a/apps/ui/src/app/(main)/harnesses/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/page.tsx
@@ -4,9 +4,8 @@ import { useState } from "react";
 import { useHarnesses, useCapabilities } from "@/hooks";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
 import { Plus } from "lucide-react";
+import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { HarnessCard } from "@/components/harnesses";
 import { ArchiveFilter } from "@/components/archive-filter";
 
@@ -14,14 +13,6 @@ export default function HarnessesPage() {
   const [showArchived, setShowArchived] = useState(false);
   const { data: harnesses, isLoading, error } = useHarnesses({ includeArchived: showArchived });
   const { data: allCapabilities } = useCapabilities();
-
-  if (error) {
-    return (
-      <div className="container mx-auto p-6">
-        <div className="text-red-500">Error loading harnesses: {error.message}</div>
-      </div>
-    );
-  }
 
   return (
     <div className="container mx-auto p-6">
@@ -38,42 +29,35 @@ export default function HarnessesPage() {
         </div>
       </div>
 
-      {isLoading ? (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {[...Array(6)].map((_, i) => (
-            <Card key={i}>
-              <CardHeader>
-                <Skeleton className="h-6 w-3/4" />
-              </CardHeader>
-              <CardContent>
-                <Skeleton className="h-4 w-full mb-2" />
-                <Skeleton className="h-4 w-2/3" />
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      ) : harnesses?.length === 0 ? (
-        <div className="text-center py-12">
-          <p className="text-muted-foreground mb-4">No harnesses yet</p>
-          <Link href="/harnesses/new">
-            <Button>
-              <Plus className="w-4 h-4 mr-2" />
-              Create your first harness
-            </Button>
-          </Link>
-        </div>
-      ) : (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {harnesses?.map((harness) => (
-            <HarnessCard
-              key={harness.id}
-              harness={harness}
-              allCapabilities={allCapabilities}
-              showEditButton
-            />
-          ))}
-        </div>
-      )}
+      <QueryStateWrapper
+        isLoading={isLoading}
+        error={error}
+        data={harnesses}
+        emptyState={
+          <div className="text-center py-12">
+            <p className="text-muted-foreground mb-4">No harnesses yet</p>
+            <Link href="/harnesses/new">
+              <Button>
+                <Plus className="w-4 h-4 mr-2" />
+                Create your first harness
+              </Button>
+            </Link>
+          </div>
+        }
+      >
+        {(items) => (
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {items.map((harness) => (
+              <HarnessCard
+                key={harness.id}
+                harness={harness}
+                allCapabilities={allCapabilities}
+                showEditButton
+              />
+            ))}
+          </div>
+        )}
+      </QueryStateWrapper>
     </div>
   );
 }

--- a/apps/ui/src/app/(main)/harnesses/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/page.tsx
@@ -33,6 +33,7 @@ export default function HarnessesPage() {
         isLoading={isLoading}
         error={error}
         data={harnesses}
+        errorMessagePrefix="Failed to load harnesses"
         emptyState={
           <div className="text-center py-12">
             <p className="text-muted-foreground mb-4">No harnesses yet</p>

--- a/apps/ui/src/app/(main)/mcp-servers/page.tsx
+++ b/apps/ui/src/app/(main)/mcp-servers/page.tsx
@@ -361,13 +361,7 @@ export default function McpServersPage() {
         isLoading={isLoading}
         error={error}
         data={servers}
-        errorState={
-          error && (
-            <div className="rounded-lg bg-destructive/10 p-4 text-destructive">
-              Failed to load MCP servers: {error.message}
-            </div>
-          )
-        }
+        errorMessagePrefix="Failed to load MCP servers"
         loadingSkeleton={
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
             {[...Array(3)].map((_, i) => (

--- a/apps/ui/src/app/(main)/mcp-servers/page.tsx
+++ b/apps/ui/src/app/(main)/mcp-servers/page.tsx
@@ -361,6 +361,13 @@ export default function McpServersPage() {
         isLoading={isLoading}
         error={error}
         data={servers}
+        errorState={
+          error && (
+            <div className="rounded-lg bg-destructive/10 p-4 text-destructive">
+              Failed to load MCP servers: {error.message}
+            </div>
+          )
+        }
         loadingSkeleton={
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
             {[...Array(3)].map((_, i) => (

--- a/apps/ui/src/app/(main)/mcp-servers/page.tsx
+++ b/apps/ui/src/app/(main)/mcp-servers/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -321,7 +322,7 @@ function McpServerCardSkeleton() {
 
 export default function McpServersPage() {
   const [showArchived, setShowArchived] = useState(false);
-  const { data: servers = [], isLoading, error } = useMcpServers({ includeArchived: showArchived });
+  const { data: servers, isLoading, error } = useMcpServers({ includeArchived: showArchived });
   const destroyServer = useDestroyMcpServer();
   const { can: canPolicies } = usePolicies("mcp-servers");
   const canDestroy = canPolicies("mcp_server.dangerous");
@@ -356,44 +357,46 @@ export default function McpServersPage() {
         </div>
       </div>
 
-      {error && (
-        <div className="rounded-lg bg-destructive/10 p-4 text-destructive">
-          Failed to load MCP servers: {error.message}
-        </div>
-      )}
-
-      {isLoading ? (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {[...Array(3)].map((_, i) => (
-            <McpServerCardSkeleton key={i} />
-          ))}
-        </div>
-      ) : servers.length === 0 ? (
-        <Card className="p-8 text-center">
-          <Plug className="mx-auto mb-4 h-12 w-12 text-muted-foreground" />
-          <h2 className="mb-2 text-lg font-medium">No MCP servers configured</h2>
-          <p className="mb-4 text-muted-foreground">
-            Add an MCP server to extend your agents with external tools and resources.
-          </p>
-          <Button onClick={() => setAddServerOpen(true)}>
-            <Plus className="mr-2 h-4 w-4" />
-            Add Server
-          </Button>
-        </Card>
-      ) : (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {servers.map((server) => (
-            <McpServerCard
-              key={server.id}
-              server={server}
-              canDestroy={canDestroy}
-              onDelete={setPendingDeleteServer}
-              onArchive={setPendingArchiveServer}
-              onSetApiKey={setApiKeyServer}
-            />
-          ))}
-        </div>
-      )}
+      <QueryStateWrapper
+        isLoading={isLoading}
+        error={error}
+        data={servers}
+        loadingSkeleton={
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {[...Array(3)].map((_, i) => (
+              <McpServerCardSkeleton key={i} />
+            ))}
+          </div>
+        }
+        emptyState={
+          <Card className="p-8 text-center">
+            <Plug className="mx-auto mb-4 h-12 w-12 text-muted-foreground" />
+            <h2 className="mb-2 text-lg font-medium">No MCP servers configured</h2>
+            <p className="mb-4 text-muted-foreground">
+              Add an MCP server to extend your agents with external tools and resources.
+            </p>
+            <Button onClick={() => setAddServerOpen(true)}>
+              <Plus className="mr-2 h-4 w-4" />
+              Add Server
+            </Button>
+          </Card>
+        }
+      >
+        {(items) => (
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {items.map((server) => (
+              <McpServerCard
+                key={server.id}
+                server={server}
+                canDestroy={canDestroy}
+                onDelete={setPendingDeleteServer}
+                onArchive={setPendingArchiveServer}
+                onSetApiKey={setApiKeyServer}
+              />
+            ))}
+          </div>
+        )}
+      </QueryStateWrapper>
 
       {/* Dialogs */}
       <AddMcpServerDialog open={addServerOpen} onOpenChange={setAddServerOpen} />

--- a/apps/ui/src/app/(main)/settings/api-keys/page.tsx
+++ b/apps/ui/src/app/(main)/settings/api-keys/page.tsx
@@ -254,13 +254,7 @@ export default function ApiKeysPage() {
           isLoading={apiKeysLoading}
           error={apiKeysError}
           data={userApiKeys}
-          errorState={
-            apiKeysError && (
-              <div className="bg-destructive/10 text-destructive p-4 rounded-lg mb-4">
-                Failed to load API keys: {apiKeysError.message}
-              </div>
-            )
-          }
+          errorMessagePrefix="Failed to load API keys"
           loadingSkeleton={
             <div className="space-y-2">
               {[...Array(2)].map((_, i) => (

--- a/apps/ui/src/app/(main)/settings/api-keys/page.tsx
+++ b/apps/ui/src/app/(main)/settings/api-keys/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -192,7 +193,7 @@ function ShowApiKeyDialog({
 
 export default function ApiKeysPage() {
   const { requiresAuth } = useAuth();
-  const { data: userApiKeys = [], isLoading: apiKeysLoading, error: apiKeysError } = useApiKeys();
+  const { data: userApiKeys, isLoading: apiKeysLoading, error: apiKeysError } = useApiKeys();
   const deleteApiKey = useDeleteApiKey();
 
   const [createApiKeyOpen, setCreateApiKeyOpen] = useState(false);
@@ -249,37 +250,39 @@ export default function ApiKeysPage() {
           </Button>
         </div>
 
-        {apiKeysError && (
-          <div className="bg-destructive/10 text-destructive p-4 rounded-lg mb-4">
-            Failed to load API keys: {apiKeysError.message}
-          </div>
-        )}
-
-        {apiKeysLoading ? (
-          <div className="space-y-2">
-            {[...Array(2)].map((_, i) => (
-              <Skeleton key={i} className="h-16 w-full" />
-            ))}
-          </div>
-        ) : userApiKeys.length === 0 ? (
-          <Card className="p-8 text-center">
-            <Key className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-            <h3 className="text-lg font-medium mb-2">No API keys</h3>
-            <p className="text-muted-foreground mb-4">
-              Create an API key to access the Everruns API programmatically.
-            </p>
-            <Button onClick={() => setCreateApiKeyOpen(true)}>
-              <Plus className="h-4 w-4 mr-2" />
-              Create API Key
-            </Button>
-          </Card>
-        ) : (
-          <div className="space-y-2">
-            {userApiKeys.map((apiKey) => (
-              <ApiKeyRow key={apiKey.id} apiKey={apiKey} onDelete={handleDeleteApiKey} />
-            ))}
-          </div>
-        )}
+        <QueryStateWrapper
+          isLoading={apiKeysLoading}
+          error={apiKeysError}
+          data={userApiKeys}
+          loadingSkeleton={
+            <div className="space-y-2">
+              {[...Array(2)].map((_, i) => (
+                <Skeleton key={i} className="h-16 w-full" />
+              ))}
+            </div>
+          }
+          emptyState={
+            <Card className="p-8 text-center">
+              <Key className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+              <h3 className="text-lg font-medium mb-2">No API keys</h3>
+              <p className="text-muted-foreground mb-4">
+                Create an API key to access the Everruns API programmatically.
+              </p>
+              <Button onClick={() => setCreateApiKeyOpen(true)}>
+                <Plus className="h-4 w-4 mr-2" />
+                Create API Key
+              </Button>
+            </Card>
+          }
+        >
+          {(items) => (
+            <div className="space-y-2">
+              {items.map((apiKey) => (
+                <ApiKeyRow key={apiKey.id} apiKey={apiKey} onDelete={handleDeleteApiKey} />
+              ))}
+            </div>
+          )}
+        </QueryStateWrapper>
       </section>
 
       {/* Dialogs */}

--- a/apps/ui/src/app/(main)/settings/api-keys/page.tsx
+++ b/apps/ui/src/app/(main)/settings/api-keys/page.tsx
@@ -254,6 +254,13 @@ export default function ApiKeysPage() {
           isLoading={apiKeysLoading}
           error={apiKeysError}
           data={userApiKeys}
+          errorState={
+            apiKeysError && (
+              <div className="bg-destructive/10 text-destructive p-4 rounded-lg mb-4">
+                Failed to load API keys: {apiKeysError.message}
+              </div>
+            )
+          }
           loadingSkeleton={
             <div className="space-y-2">
               {[...Array(2)].map((_, i) => (

--- a/apps/ui/src/app/(main)/settings/members/page.tsx
+++ b/apps/ui/src/app/(main)/settings/members/page.tsx
@@ -207,13 +207,7 @@ export default function MembersPage() {
           isLoading={isLoading}
           error={error}
           data={members}
-          errorState={
-            error && (
-              <div className="bg-destructive/10 text-destructive p-4 rounded-lg mb-4">
-                Failed to load members: {error.message}
-              </div>
-            )
-          }
+          errorMessagePrefix="Failed to load members"
           loadingSkeleton={
             <div className="space-y-2">
               {[...Array(3)].map((_, i) => (

--- a/apps/ui/src/app/(main)/settings/members/page.tsx
+++ b/apps/ui/src/app/(main)/settings/members/page.tsx
@@ -5,6 +5,7 @@ import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   Select,
@@ -183,7 +184,7 @@ function MemberCardSkeleton() {
 export default function MembersPage() {
   const { user } = useAuth();
   const { currentOrg, hasRole } = useOrg();
-  const { data: members = [], isLoading, error } = useMembers();
+  const { data: members, isLoading, error } = useMembers();
 
   const canManage = hasRole("admin");
   const isOwner = hasRole("owner");
@@ -202,42 +203,44 @@ export default function MembersPage() {
           </div>
         </div>
 
-        {error && (
-          <div className="bg-destructive/10 text-destructive p-4 rounded-lg mb-4">
-            Failed to load members: {error.message}
-          </div>
-        )}
-
-        {isLoading ? (
-          <div className="space-y-2">
-            {[...Array(3)].map((_, i) => (
-              <MemberCardSkeleton key={i} />
-            ))}
-          </div>
-        ) : members.length === 0 ? (
-          <Card className="p-8 text-center">
-            <Users className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-            <h3 className="text-lg font-medium mb-2">No members</h3>
-            <p className="text-muted-foreground">
-              No members have been added to this organization yet.
-            </p>
-          </Card>
-        ) : (
-          <div className="space-y-2">
-            <div className="text-sm text-muted-foreground mb-2">
-              {members.length} member{members.length !== 1 ? "s" : ""}
+        <QueryStateWrapper
+          isLoading={isLoading}
+          error={error}
+          data={members}
+          loadingSkeleton={
+            <div className="space-y-2">
+              {[...Array(3)].map((_, i) => (
+                <MemberCardSkeleton key={i} />
+              ))}
             </div>
-            {members.map((member) => (
-              <MemberCard
-                key={member.user_id}
-                member={member}
-                currentUserId={currentUserId}
-                canManage={canManage}
-                isOwner={isOwner}
-              />
-            ))}
-          </div>
-        )}
+          }
+          emptyState={
+            <Card className="p-8 text-center">
+              <Users className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+              <h3 className="text-lg font-medium mb-2">No members</h3>
+              <p className="text-muted-foreground">
+                No members have been added to this organization yet.
+              </p>
+            </Card>
+          }
+        >
+          {(items) => (
+            <div className="space-y-2">
+              <div className="text-sm text-muted-foreground mb-2">
+                {items.length} member{items.length !== 1 ? "s" : ""}
+              </div>
+              {items.map((member) => (
+                <MemberCard
+                  key={member.user_id}
+                  member={member}
+                  currentUserId={currentUserId}
+                  canManage={canManage}
+                  isOwner={isOwner}
+                />
+              ))}
+            </div>
+          )}
+        </QueryStateWrapper>
       </section>
     </div>
   );

--- a/apps/ui/src/app/(main)/settings/members/page.tsx
+++ b/apps/ui/src/app/(main)/settings/members/page.tsx
@@ -207,6 +207,13 @@ export default function MembersPage() {
           isLoading={isLoading}
           error={error}
           data={members}
+          errorState={
+            error && (
+              <div className="bg-destructive/10 text-destructive p-4 rounded-lg mb-4">
+                Failed to load members: {error.message}
+              </div>
+            )
+          }
           loadingSkeleton={
             <div className="space-y-2">
               {[...Array(3)].map((_, i) => (

--- a/apps/ui/src/app/(main)/skills/page.tsx
+++ b/apps/ui/src/app/(main)/skills/page.tsx
@@ -271,6 +271,7 @@ export default function SkillsPage() {
         isLoading={isLoading}
         error={error}
         data={skills}
+        errorMessagePrefix="Failed to load skills"
         loadingSkeleton={
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
             {[...Array(6)].map((_, i) => (

--- a/apps/ui/src/app/(main)/skills/page.tsx
+++ b/apps/ui/src/app/(main)/skills/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -234,7 +235,7 @@ function SkillCardSkeleton() {
 
 export default function SkillsPage() {
   const [showArchived, setShowArchived] = useState(false);
-  const { data: skills = [], isLoading, error } = useSkills({ includeArchived: showArchived });
+  const { data: skills, isLoading, error } = useSkills({ includeArchived: showArchived });
   const destroySkillMutation = useDestroySkill();
   const { can: canPolicies } = usePolicies("skills");
   const canDestroy = canPolicies("skill.dangerous");
@@ -266,45 +267,47 @@ export default function SkillsPage() {
         </div>
       </div>
 
-      {error && (
-        <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-md text-red-600 text-sm">
-          Failed to load skills: {error.message}
-        </div>
-      )}
-
-      {isLoading ? (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {[...Array(6)].map((_, i) => (
-            <SkillCardSkeleton key={i} />
-          ))}
-        </div>
-      ) : skills.length === 0 ? (
-        <div className="text-center py-12">
-          <BookOpen className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-          <p className="text-muted-foreground mb-4">No skills yet</p>
-          <div className="flex justify-center gap-2">
-            <Button variant="outline" onClick={() => setUploadSkillOpen(true)}>
-              <Upload className="h-4 w-4 mr-2" />
-              Upload ZIP
-            </Button>
-            <Button onClick={() => setAddSkillOpen(true)}>
-              <Plus className="h-4 w-4 mr-2" />
-              Add Skill
-            </Button>
+      <QueryStateWrapper
+        isLoading={isLoading}
+        error={error}
+        data={skills}
+        loadingSkeleton={
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {[...Array(6)].map((_, i) => (
+              <SkillCardSkeleton key={i} />
+            ))}
           </div>
-        </div>
-      ) : (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {skills.map((skill) => (
-            <SkillCard
-              key={skill.id}
-              skill={skill}
-              canDestroy={canDestroy}
-              onDelete={setPendingDeleteSkill}
-            />
-          ))}
-        </div>
-      )}
+        }
+        emptyState={
+          <div className="text-center py-12">
+            <BookOpen className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+            <p className="text-muted-foreground mb-4">No skills yet</p>
+            <div className="flex justify-center gap-2">
+              <Button variant="outline" onClick={() => setUploadSkillOpen(true)}>
+                <Upload className="h-4 w-4 mr-2" />
+                Upload ZIP
+              </Button>
+              <Button onClick={() => setAddSkillOpen(true)}>
+                <Plus className="h-4 w-4 mr-2" />
+                Add Skill
+              </Button>
+            </div>
+          </div>
+        }
+      >
+        {(items) => (
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {items.map((skill) => (
+              <SkillCard
+                key={skill.id}
+                skill={skill}
+                canDestroy={canDestroy}
+                onDelete={setPendingDeleteSkill}
+              />
+            ))}
+          </div>
+        )}
+      </QueryStateWrapper>
 
       <AddSkillDialog open={addSkillOpen} onOpenChange={setAddSkillOpen} />
       <UploadSkillDialog open={uploadSkillOpen} onOpenChange={setUploadSkillOpen} />

--- a/apps/ui/src/components/query-state-wrapper.tsx
+++ b/apps/ui/src/components/query-state-wrapper.tsx
@@ -30,8 +30,12 @@ function DefaultLoadingSkeleton({ count = 6 }: { count?: number }) {
 
 /* ---------- default error ---------- */
 
-function DefaultError({ message }: { message: string }) {
-  return <div className="text-red-500">Error: {message}</div>;
+function DefaultError({ prefix, message }: { prefix: string; message: string }) {
+  return (
+    <div className="rounded-lg bg-destructive/10 p-4 text-destructive">
+      {prefix}: {message}
+    </div>
+  );
 }
 
 /* ---------- default empty ---------- */
@@ -63,7 +67,9 @@ export interface QueryStateWrapperProps<T> {
   loadingSkeleton?: ReactNode;
   /** Number of skeleton cards when using the default skeleton. Default: 6 */
   skeletonCount?: number;
-  /** Custom error element. Overrides the default red text error. */
+  /** Prefix for the default error banner (e.g. "Failed to load agents"). Default: "Error" */
+  errorMessagePrefix?: string;
+  /** Custom error element. Overrides the default error banner when provided. */
   errorState?: ReactNode;
 }
 
@@ -76,10 +82,11 @@ export function QueryStateWrapper<T>({
   emptyState,
   loadingSkeleton,
   skeletonCount = 6,
+  errorMessagePrefix = "Error",
   errorState,
 }: QueryStateWrapperProps<T>) {
   if (error) {
-    return errorState ?? <DefaultError message={error.message} />;
+    return errorState ?? <DefaultError prefix={errorMessagePrefix} message={error.message} />;
   }
 
   if (isLoading) {

--- a/apps/ui/src/components/query-state-wrapper.tsx
+++ b/apps/ui/src/components/query-state-wrapper.tsx
@@ -1,0 +1,94 @@
+/**
+ * Generic wrapper for React Query list pages.
+ * Handles loading, error, and empty states so each page
+ * only needs to supply its skeleton, empty placeholder, and data render.
+ */
+
+import type { ReactNode } from "react";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+/* ---------- default loading skeleton (card grid) ---------- */
+
+function DefaultLoadingSkeleton({ count = 6 }: { count?: number }) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {[...Array(count)].map((_, i) => (
+        <Card key={i}>
+          <CardHeader>
+            <Skeleton className="h-6 w-3/4" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-4 w-full mb-2" />
+            <Skeleton className="h-4 w-2/3" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+/* ---------- default error ---------- */
+
+function DefaultError({ message }: { message: string }) {
+  return <div className="text-red-500">Error: {message}</div>;
+}
+
+/* ---------- default empty ---------- */
+
+function DefaultEmpty({ message }: { message: string }) {
+  return (
+    <div className="text-center py-12">
+      <p className="text-muted-foreground">{message}</p>
+    </div>
+  );
+}
+
+/* ---------- main component ---------- */
+
+export interface QueryStateWrapperProps<T> {
+  /** React Query `isLoading` / `isPending` flag */
+  isLoading: boolean;
+  /** React Query `error` */
+  error: Error | null;
+  /** The fetched data (array for list pages) */
+  data: T[] | undefined;
+  /** Render function called when data is available and non-empty */
+  children: (data: T[]) => ReactNode;
+  /** Message shown when data is an empty array. Default: "No items found" */
+  emptyMessage?: string;
+  /** Custom empty state element. Overrides emptyMessage when provided. */
+  emptyState?: ReactNode;
+  /** Custom loading skeleton element */
+  loadingSkeleton?: ReactNode;
+  /** Number of skeleton cards when using the default skeleton. Default: 6 */
+  skeletonCount?: number;
+  /** Custom error element. Overrides the default red text error. */
+  errorState?: ReactNode;
+}
+
+export function QueryStateWrapper<T>({
+  isLoading,
+  error,
+  data,
+  children,
+  emptyMessage = "No items found",
+  emptyState,
+  loadingSkeleton,
+  skeletonCount = 6,
+  errorState,
+}: QueryStateWrapperProps<T>) {
+  if (error) {
+    return errorState ?? <DefaultError message={error.message} />;
+  }
+
+  if (isLoading) {
+    return loadingSkeleton ?? <DefaultLoadingSkeleton count={skeletonCount} />;
+  }
+
+  if (!data || data.length === 0) {
+    return emptyState ?? <DefaultEmpty message={emptyMessage} />;
+  }
+
+  return <>{children(data)}</>;
+}


### PR DESCRIPTION
## What
Extract a shared `QueryStateWrapper<T>` component that handles loading, error, and empty states for React Query list pages.

## Why
Five list pages (agents, apps, harnesses, mcp-servers, skills) each duplicated the same loading skeleton / error / empty-state pattern. This creates maintenance burden and inconsistency risk.

## How
- Created `apps/ui/src/components/query-state-wrapper.tsx` with a generic `QueryStateWrapper<T>` component
- Props: `isLoading`, `error`, `data`, `children` (render function), plus optional `emptyMessage`, `emptyState`, `loadingSkeleton`, `skeletonCount`, `errorState`
- Updated all 5 list pages to use `QueryStateWrapper` instead of inline conditionals
- Pages with custom skeletons (skills, mcp-servers) pass `loadingSkeleton`; pages with custom empty states pass `emptyState`

## Risk
- Low
- Pure UI refactor — no data fetching, auth, or API changes
- Build and lint verified

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered

Fixes EVE-127