### PR TITLE
fix(ui): remove chat picker inset chrome

### DIFF
--- a/apps/ui/src/__tests__/chat-panel.test.tsx
+++ b/apps/ui/src/__tests__/chat-panel.test.tsx
@@ -8,12 +8,11 @@ const mockSelectTrigger = jest.fn(
     children,
     nativeButton: _nativeButton,
     render: _render,
-    ...props
   }: {
     children?: React.ReactNode;
     nativeButton?: boolean;
     render?: React.ReactElement;
-  }) => <div {...props}>{children}</div>,
+  }) => <div>{children}</div>,
 );
 
 const mockSessionContext = {

--- a/apps/ui/src/__tests__/chat-panel.test.tsx
+++ b/apps/ui/src/__tests__/chat-panel.test.tsx
@@ -3,6 +3,18 @@ import React from "react";
 import { ChatPanel } from "@/components/chat/chat-panel";
 
 const mockUseSessionCommands = jest.fn();
+const mockSelectTrigger = jest.fn(
+  ({
+    children,
+    nativeButton: _nativeButton,
+    render: _render,
+    ...props
+  }: {
+    children?: React.ReactNode;
+    nativeButton?: boolean;
+    render?: React.ReactElement;
+  }) => <div {...props}>{children}</div>,
+);
 
 const mockSessionContext = {
   agentId: "agent-1",
@@ -105,7 +117,11 @@ jest.mock("@/components/ui/select", () => ({
   Select: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   SelectItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  SelectTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectTrigger: (props: {
+    children?: React.ReactNode;
+    nativeButton?: boolean;
+    render?: React.ReactElement;
+  }) => mockSelectTrigger(props),
   SelectValue: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
 }));
 
@@ -157,6 +173,10 @@ beforeAll(() => {
 describe("ChatPanel compaction divider", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSelectTrigger.mockClear();
+    mockSessionContext.chatEvents = [];
+    mockSessionContext.llmModel = null;
+    mockSessionContext.reasoningEffort = "";
     mockUseSessionCommands.mockReturnValue({ data: { commands: [] } });
   });
 
@@ -289,5 +309,29 @@ describe("ChatPanel placeholder", () => {
 
     expect(composerShell).not.toBeNull();
     expect(composerShell).not.toHaveClass("border-t");
+  });
+
+  it("renders inline composer selects with non-native triggers to avoid nested picker chrome", () => {
+    mockUseSessionCommands.mockReturnValue({ data: { commands: [] } });
+    mockSessionContext.llmModel = {
+      display_name: "GPT-5.4",
+      profile: {
+        reasoning: true,
+        reasoning_effort: {
+          default: "medium",
+          values: [{ value: "medium", name: "Medium" }],
+        },
+      },
+    };
+
+    render(<ChatPanel />);
+
+    expect(mockSelectTrigger).toHaveBeenCalledTimes(2);
+
+    for (const [triggerProps] of mockSelectTrigger.mock.calls) {
+      expect(triggerProps?.nativeButton).toBe(false);
+      expect(React.isValidElement(triggerProps?.render)).toBe(true);
+      expect(triggerProps?.render.type).toBe("div");
+    }
   });
 });

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -822,7 +822,9 @@ export function ChatPanel() {
                 >
                   <SelectTrigger
                     size="sm"
-                    className="h-7 w-[156px] min-w-0 border-0 bg-transparent px-0 py-0 text-sm shadow-none focus-visible:ring-0 data-[size=sm]:h-7 [&_svg]:icon-sharp"
+                    nativeButton={false}
+                    render={<div />}
+                    className="h-7 w-[156px] min-w-0 cursor-pointer border-0 bg-transparent px-0 py-0 text-sm shadow-none focus-visible:ring-0 data-[size=sm]:h-7 [&_svg]:icon-sharp"
                   >
                     <SelectValue>{modelTriggerLabel}</SelectValue>
                   </SelectTrigger>
@@ -849,7 +851,9 @@ export function ChatPanel() {
                   >
                     <SelectTrigger
                       size="sm"
-                      className="h-7 w-[116px] min-w-0 border-0 bg-transparent px-0 py-0 text-sm shadow-none focus-visible:ring-0 data-[size=sm]:h-7 [&_svg]:icon-sharp"
+                      nativeButton={false}
+                      render={<div />}
+                      className="h-7 w-[116px] min-w-0 cursor-pointer border-0 bg-transparent px-0 py-0 text-sm shadow-none focus-visible:ring-0 data-[size=sm]:h-7 [&_svg]:icon-sharp"
                     >
                       <SelectValue>
                         {reasoningEffort ? getReasoningEffortName(reasoningEffort) : "Default"}


### PR DESCRIPTION
## What
Remove the inner native-looking gray field from the chat composer model and reasoning pickers.

## Why
The composer chip was rendering a second inset control inside the outer shell, which made the picker look visually broken.

## How
Use Base UI's non-native trigger path for the inline composer selects so the trigger stops painting native button chrome inside the chip. Added a regression test that asserts both inline composer selects use the non-native trigger configuration.

## Risk
- Low
- Limited to the chat composer model/reasoning selects. Main risk is keyboard/accessibility behavior regression, which was covered by using Base UI's built-in non-native trigger path and live smoke testing.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
