### PR TITLE
fix(worker): skip InputAtom when resuming after connection_required

### DIFF
--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -2552,6 +2552,13 @@ mod tests {
             Ok(())
         }
 
+        async fn resume_after_tool_results(
+            &self,
+            _session_id: everruns_core::typed_id::SessionId,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
         async fn cancel_run(
             &self,
             _run_id: everruns_core::typed_id::SessionId,

--- a/crates/server/src/api/tool_results.rs
+++ b/crates/server/src/api/tool_results.rs
@@ -164,7 +164,8 @@ pub async fn submit_tool_results(
 
     // Use session_id as turn_id (matches how DurableRunner uses workflow_id = session_id)
     let turn_id = TurnId::from_uuid(session_id.uuid());
-    let input_message_id = MessageId::new();
+    // Use a deterministic MessageId for event context only (not passed to InputAtom).
+    let event_message_id = MessageId::from_uuid(session_id.uuid());
 
     let accepted = req.tool_results.len();
 
@@ -194,7 +195,7 @@ pub async fn submit_tool_results(
 
         let event = EventRequest::new(
             session_id,
-            EventContext::turn(turn_id, input_message_id),
+            EventContext::turn(turn_id, event_message_id),
             tool_result,
         );
 
@@ -217,16 +218,12 @@ pub async fn submit_tool_results(
         tracing::warn!(error = %e, "Failed to set session status to active");
     }
 
-    // Resume the workflow by starting another run
+    // Resume the workflow by enqueueing a reason activity directly.
+    // This skips InputAtom (there is no new user message) and uses the
+    // DurableTurnInput saved when the workflow paused for connection_required.
     let runner = state.runner.clone();
-    let harness_id = session.harness_id;
-    let agent_id = session.agent_id;
-    let org_id = org.org_id;
     tokio::spawn(async move {
-        if let Err(e) = runner
-            .start_run(org_id, session_id, harness_id, agent_id, input_message_id)
-            .await
-        {
+        if let Err(e) = runner.resume_after_tool_results(session_id).await {
             tracing::error!(
                 session_id = %session_id,
                 error = %e,

--- a/crates/worker/src/durable_runner.rs
+++ b/crates/worker/src/durable_runner.rs
@@ -648,9 +648,12 @@ impl AgentRunner for DurableRunner {
             .await
             .map_err(|e| anyhow::anyhow!("Failed to get workflow status: {}", e))?;
 
-        if !status.is_terminal() {
+        // Only resume workflows that completed normally (i.e. due to
+        // connection_required). Failed/Cancelled/ContinuedAsNew workflows
+        // should not be resumed via this path.
+        if status != WorkflowStatus::Completed {
             return Err(anyhow::anyhow!(
-                "Cannot resume: workflow {} is still running (status: {:?})",
+                "Cannot resume: workflow {} is not in Completed status (status: {:?})",
                 workflow_id,
                 status
             ));
@@ -670,21 +673,33 @@ impl AgentRunner for DurableRunner {
 
         // Reset workflow to Pending and enqueue a reason activity directly
         // (skipping process_input / InputAtom — there is no new user message).
+        let input_json = serde_json::to_value(&turn_input)?;
         store
             .update_workflow_status(workflow_id, WorkflowStatus::Pending, None, None)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to reset workflow status: {}", e))?;
 
-        let input_json = serde_json::to_value(&turn_input)?;
-        store
+        if let Err(e) = store
             .enqueue_task(
                 workflow_id,
                 format!("reason_{}", Uuid::now_v7()),
                 "reason".to_string(),
-                input_json,
+                input_json.clone(),
             )
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to enqueue reason task: {}", e))?;
+        {
+            // Enqueue failed — restore workflow to Completed with saved input
+            // so a subsequent resume attempt can still succeed.
+            let _ = store
+                .update_workflow_status(
+                    workflow_id,
+                    WorkflowStatus::Completed,
+                    Some(serde_json::to_value(&turn_input).unwrap_or_default()),
+                    None,
+                )
+                .await;
+            return Err(anyhow::anyhow!("Failed to enqueue reason task: {}", e));
+        }
 
         info!(
             session_id = %session_id,
@@ -1133,8 +1148,8 @@ mod tests {
             .await
             .unwrap_err();
         assert!(
-            err.to_string().contains("still running"),
-            "Error should mention running workflow, got: {}",
+            err.to_string().contains("not in Completed status"),
+            "Error should reject non-Completed workflow, got: {}",
             err
         );
     }

--- a/crates/worker/src/durable_runner.rs
+++ b/crates/worker/src/durable_runner.rs
@@ -630,6 +630,73 @@ impl AgentRunner for DurableRunner {
         Ok(())
     }
 
+    async fn resume_after_tool_results(&self, session_id: SessionId) -> Result<()> {
+        let workflow_id = session_id.uuid();
+
+        info!(
+            session_id = %session_id,
+            workflow_id = %workflow_id,
+            "Resuming workflow after client tool results"
+        );
+
+        let mut store = self.store.lock().await;
+
+        // Retrieve saved DurableTurnInput from the workflow result.
+        // schedule_next_activity stores it when completing due to connection_required.
+        let (status, result_json, _) = store
+            .get_workflow_status(workflow_id)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to get workflow status: {}", e))?;
+
+        if !status.is_terminal() {
+            return Err(anyhow::anyhow!(
+                "Cannot resume: workflow {} is still running (status: {:?})",
+                workflow_id,
+                status
+            ));
+        }
+
+        let turn_input: DurableTurnInput = result_json
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Cannot resume: workflow {} has no saved turn input in result",
+                    workflow_id
+                )
+            })
+            .and_then(|v| {
+                serde_json::from_value(v)
+                    .map_err(|e| anyhow::anyhow!("Failed to parse saved turn input: {}", e))
+            })?;
+
+        // Reset workflow to Pending and enqueue a reason activity directly
+        // (skipping process_input / InputAtom — there is no new user message).
+        store
+            .update_workflow_status(workflow_id, WorkflowStatus::Pending, None, None)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to reset workflow status: {}", e))?;
+
+        let input_json = serde_json::to_value(&turn_input)?;
+        store
+            .enqueue_task(
+                workflow_id,
+                format!("reason_{}", Uuid::now_v7()),
+                "reason".to_string(),
+                input_json,
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to enqueue reason task: {}", e))?;
+
+        info!(
+            session_id = %session_id,
+            workflow_id = %workflow_id,
+            turn_id = ?turn_input.turn_id,
+            iteration = turn_input.iteration,
+            "Workflow resumed — reason activity enqueued (skipped InputAtom)"
+        );
+
+        Ok(())
+    }
+
     async fn cancel_run(&self, session_id: SessionId) -> Result<()> {
         info!(session_id = %session_id, "Cancelling durable workflow");
 
@@ -936,5 +1003,139 @@ mod tests {
             .expect("Second start_run should reset failed workflow");
 
         assert!(runner.is_running(session_id).await);
+    }
+
+    /// Test that resume_after_tool_results enqueues a reason activity directly
+    /// (skipping InputAtom) using the saved DurableTurnInput from the workflow result.
+    #[tokio::test]
+    async fn test_resume_after_tool_results_skips_input_atom() {
+        use everruns_core::DEFAULT_ORG_ID;
+        use everruns_core::typed_id::TurnId;
+
+        let runner = DurableRunner::new_in_memory();
+
+        let session_id = SessionId::new();
+        let harness_id = HarnessId::new();
+        let agent_id = AgentId::new();
+        let message_id = MessageId::new();
+        let turn_id = TurnId::new();
+
+        // Create a workflow via start_run (simulates the initial user message)
+        runner
+            .start_run(
+                DEFAULT_ORG_ID,
+                session_id,
+                harness_id,
+                Some(agent_id),
+                message_id,
+            )
+            .await
+            .expect("start_run should succeed");
+
+        // Simulate the workflow completing with connection_required:
+        // save a DurableTurnInput as the workflow result (as schedule_next_activity does).
+        let saved_input = DurableTurnInput {
+            org_id: DEFAULT_ORG_ID,
+            session_id,
+            harness_id,
+            agent_id: Some(agent_id),
+            input_message_id: message_id,
+            turn_id: Some(turn_id),
+            previous_response_id: Some("resp_abc".to_string()),
+            iteration: 3,
+        };
+        {
+            let mut store = runner.store.lock().await;
+            store
+                .update_workflow_status(
+                    session_id.uuid(),
+                    WorkflowStatus::Completed,
+                    Some(serde_json::to_value(&saved_input).unwrap()),
+                    None,
+                )
+                .await
+                .expect("Should complete workflow with saved input");
+        }
+
+        assert!(!runner.is_running(session_id).await, "Should be completed");
+
+        // Resume after tool results — should enqueue reason directly
+        runner
+            .resume_after_tool_results(session_id)
+            .await
+            .expect("resume_after_tool_results should succeed");
+
+        // Workflow should be running again (reset to Pending with reason task)
+        assert!(
+            runner.is_running(session_id).await,
+            "Workflow should be running after resume"
+        );
+    }
+
+    /// Test that resume_after_tool_results fails when workflow has no saved turn input
+    #[tokio::test]
+    async fn test_resume_after_tool_results_no_saved_input() {
+        use everruns_core::DEFAULT_ORG_ID;
+
+        let runner = DurableRunner::new_in_memory();
+
+        let session_id = SessionId::new();
+        let harness_id = HarnessId::new();
+        let message_id = MessageId::new();
+
+        // Create and complete a workflow without saving turn input in result
+        runner
+            .start_run(DEFAULT_ORG_ID, session_id, harness_id, None, message_id)
+            .await
+            .expect("start_run should succeed");
+
+        {
+            let mut store = runner.store.lock().await;
+            store
+                .update_workflow_status(session_id.uuid(), WorkflowStatus::Completed, None, None)
+                .await
+                .expect("Should complete workflow");
+        }
+
+        // Should fail because no saved turn input
+        let err = runner
+            .resume_after_tool_results(session_id)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("no saved turn input"),
+            "Error should mention missing turn input, got: {}",
+            err
+        );
+    }
+
+    /// Test that resume_after_tool_results fails on a still-running workflow
+    #[tokio::test]
+    async fn test_resume_after_tool_results_rejects_running_workflow() {
+        use everruns_core::DEFAULT_ORG_ID;
+
+        let runner = DurableRunner::new_in_memory();
+
+        let session_id = SessionId::new();
+        let harness_id = HarnessId::new();
+        let message_id = MessageId::new();
+
+        runner
+            .start_run(DEFAULT_ORG_ID, session_id, harness_id, None, message_id)
+            .await
+            .expect("start_run should succeed");
+
+        assert!(runner.is_running(session_id).await);
+
+        // Should fail because workflow is still running
+        let err = runner
+            .resume_after_tool_results(session_id)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("still running"),
+            "Error should mention running workflow, got: {}",
+            err
+        );
     }
 }

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -1441,9 +1441,22 @@ impl DurableWorker {
                     .is_some_and(|r| !r.connection_required.is_empty());
 
                 if has_connection_required {
-                    // Complete workflow — it will be resumed by tool-results endpoint
+                    // Complete workflow and persist the current DurableTurnInput so
+                    // the tool-results endpoint can resume with correct turn_id,
+                    // iteration, and previous_response_id (instead of creating a
+                    // phantom MessageId that InputAtom cannot find).
+                    let resumed_input = DurableTurnInput {
+                        iteration: chained_input.iteration.saturating_add(1),
+                        ..chained_input.clone()
+                    };
+                    let result_json = serde_json::to_value(&resumed_input).ok();
                     store
-                        .update_workflow_status(workflow_id, WorkflowStatus::Completed, None, None)
+                        .update_workflow_status(
+                            workflow_id,
+                            WorkflowStatus::Completed,
+                            result_json,
+                            None,
+                        )
                         .await
                         .map_err(|e| anyhow::anyhow!("Failed to update workflow status: {}", e))?;
 

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -1449,12 +1449,18 @@ impl DurableWorker {
                         iteration: chained_input.iteration.saturating_add(1),
                         ..chained_input.clone()
                     };
-                    let result_json = serde_json::to_value(&resumed_input).ok();
+                    let result_json = serde_json::to_value(&resumed_input)
+                        .map_err(|e| {
+                            anyhow::anyhow!(
+                                "Failed to serialize DurableTurnInput for connection_required resume: {}",
+                                e
+                            )
+                        })?;
                     store
                         .update_workflow_status(
                             workflow_id,
                             WorkflowStatus::Completed,
-                            result_json,
+                            Some(result_json),
                             None,
                         )
                         .await

--- a/crates/worker/src/runner.rs
+++ b/crates/worker/src/runner.rs
@@ -45,6 +45,13 @@ pub trait AgentRunner: Send + Sync {
         input_message_id: MessageId,
     ) -> Result<()>;
 
+    /// Resume a workflow after client-side tool results (e.g. connection_required).
+    ///
+    /// Unlike `start_run`, this skips `InputAtom` (there is no new user message)
+    /// and enqueues a `reason` activity directly using the turn context saved
+    /// when the workflow paused for tool results.
+    async fn resume_after_tool_results(&self, session_id: SessionId) -> Result<()>;
+
     /// Cancel a running workflow
     async fn cancel_run(&self, run_id: SessionId) -> Result<()>;
 


### PR DESCRIPTION
## Summary

- **Root cause**: `submit_tool_results` called `start_run` with a phantom `MessageId::new()` that had no corresponding stored message. `InputAtom` would fail to find this message → 5 deterministic retries → workflow stuck permanently in `Pending`.
- **Fix**: Add `AgentRunner::resume_after_tool_results()` that retrieves the `DurableTurnInput` saved when the workflow paused for `connection_required` and enqueues a `reason` activity directly, skipping `InputAtom` entirely.
- When `schedule_next_activity` completes a workflow due to `connection_required`, it now persists the current `DurableTurnInput` (with incremented iteration) as the workflow result, so it can be retrieved on resumption.
- Preserves `turn_id`, `iteration`, and `previous_response_id` from the original turn for correct trace correlation.

Closes EVE-157

## Test plan

- [x] Unit test: `test_resume_after_tool_results_skips_input_atom` — verifies workflow resumes correctly with saved turn input
- [x] Unit test: `test_resume_after_tool_results_no_saved_input` — verifies graceful error when no saved input exists
- [x] Unit test: `test_resume_after_tool_results_rejects_running_workflow` — verifies guard against resuming a still-running workflow
- [x] `just pre-push` passes (fmt, clippy, lockfile)
- [ ] Smoke test: configure agent with `connection_required` tool, verify workflow resumes after connection