### PR TITLE
fix(ui-security): clear all React Query caches and localStorage on logout

### DIFF
--- a/apps/ui/src/__tests__/use-auth.test.tsx
+++ b/apps/ui/src/__tests__/use-auth.test.tsx
@@ -43,6 +43,7 @@ describe("Auth Hooks", () => {
       },
     });
     jest.clearAllMocks();
+    localStorage.clear();
   });
 
   // Helper to initialize the user query so refetchQueries has something to refetch
@@ -310,8 +311,8 @@ describe("Auth Hooks", () => {
   });
 
   describe("useLogout", () => {
-    it("should call logout API and remove user data from cache", async () => {
-      // Pre-populate cache with user data
+    it("should call logout API and clear all cached data", async () => {
+      // Pre-populate cache with user data and org-sensitive data
       const mockUser = {
         id: "user-1",
         email: "test@example.com",
@@ -320,6 +321,10 @@ describe("Auth Hooks", () => {
       };
       queryClient.setQueryData(authKeys.user(), mockUser);
       queryClient.setQueryData(authKeys.apiKeys(), [{ id: "key-1", name: "Test Key" }]);
+      // Simulate org-sensitive cached data (e.g., durable workflows)
+      queryClient.setQueryData(["durable", "workflows"], [{ id: "wf-1" }]);
+
+      localStorage.setItem("everruns_current_org", "org_123");
 
       mockLogout.mockResolvedValueOnce();
 
@@ -331,13 +336,19 @@ describe("Auth Hooks", () => {
 
       expect(mockLogout).toHaveBeenCalled();
 
-      // Verify user data is removed from cache
+      // Verify ALL cached data is cleared, not just auth keys
       const cachedUser = queryClient.getQueryData(authKeys.user());
       expect(cachedUser).toBeUndefined();
 
-      // Verify API keys are also removed
       const cachedApiKeys = queryClient.getQueryData(authKeys.apiKeys());
       expect(cachedApiKeys).toBeUndefined();
+
+      // Verify org-sensitive data is also cleared
+      const cachedWorkflows = queryClient.getQueryData(["durable", "workflows"]);
+      expect(cachedWorkflows).toBeUndefined();
+
+      // Verify localStorage org selection is cleared
+      expect(localStorage.getItem("everruns_current_org")).toBeNull();
     });
 
     it("should clear user cache even if user was previously set", async () => {

--- a/apps/ui/src/hooks/use-auth.ts
+++ b/apps/ui/src/hooks/use-auth.ts
@@ -11,6 +11,7 @@ import {
   deleteApiKey,
 } from "@/lib/api/auth";
 import { updateProfile } from "@/lib/api/users";
+import { ORG_STORAGE_KEY } from "@/lib/constants";
 import type {
   LoginRequest,
   RegisterRequest,
@@ -98,7 +99,7 @@ export function useLogout() {
       // (durable, admin, sessions, etc.) cached for the next user.
       queryClient.clear();
       // Clear persisted org selection
-      localStorage.removeItem("everruns_current_org");
+      localStorage.removeItem(ORG_STORAGE_KEY);
     },
   });
 }

--- a/apps/ui/src/hooks/use-auth.ts
+++ b/apps/ui/src/hooks/use-auth.ts
@@ -93,9 +93,12 @@ export function useLogout() {
   return useMutation({
     mutationFn: logout,
     onSuccess: () => {
-      // Clear all auth-related queries
-      queryClient.removeQueries({ queryKey: authKeys.user() });
-      queryClient.removeQueries({ queryKey: authKeys.apiKeys() });
+      // Clear ALL cached queries to prevent data leaking across users.
+      // Selective removal (only auth keys) left org-sensitive data
+      // (durable, admin, sessions, etc.) cached for the next user.
+      queryClient.clear();
+      // Clear persisted org selection
+      localStorage.removeItem("everruns_current_org");
     },
   });
 }

--- a/apps/ui/src/lib/constants.ts
+++ b/apps/ui/src/lib/constants.ts
@@ -1,0 +1,5 @@
+// Shared constants used across providers and hooks.
+// Avoids circular imports between org-provider and use-auth.
+
+/** localStorage key for persisted org selection */
+export const ORG_STORAGE_KEY = "everruns_current_org";

--- a/apps/ui/src/providers/org-provider.tsx
+++ b/apps/ui/src/providers/org-provider.tsx
@@ -24,7 +24,7 @@ import type { OrganizationMembership, OrgRole } from "@/lib/api/types";
 
 // Default organization public ID (matches backend DEFAULT_ORG_PUBLIC_ID)
 const DEFAULT_ORG_PUBLIC_ID = "org_00000000000000000000000000000001";
-const STORAGE_KEY = "everruns_current_org";
+import { ORG_STORAGE_KEY } from "@/lib/constants";
 
 /** Check if a role has permission for a required role level */
 const ROLE_HIERARCHY: Record<OrgRole, number> = { owner: 3, admin: 2, member: 1 };
@@ -94,7 +94,7 @@ export function OrgProvider({ children }: OrgProviderProps) {
     if (authLoading || isInitialized) return;
 
     // Try to restore from localStorage
-    const storedOrgId = localStorage.getItem(STORAGE_KEY);
+    const storedOrgId = localStorage.getItem(ORG_STORAGE_KEY);
 
     if (storedOrgId && organizations.length > 0) {
       // Find the stored org in user's organizations
@@ -152,7 +152,7 @@ export function OrgProvider({ children }: OrgProviderProps) {
       // before the organizations list is refreshed.
       explicitOrgRef.current = org.public_id;
       setCurrentOrgState(org);
-      localStorage.setItem(STORAGE_KEY, org.public_id);
+      localStorage.setItem(ORG_STORAGE_KEY, org.public_id);
       // Set server-side cookie via API
       void syncOrgCookie(org.public_id);
       // Redirect entity detail pages to their list page to avoid 404


### PR DESCRIPTION
## What
Replace selective auth-key cache removal on logout with `queryClient.clear()`, and clear persisted org selection from localStorage.

## Why
Logout only removed `auth.user` and `auth.apiKeys` queries, leaving org-sensitive data (durable workflows, sessions, admin queries) cached in the React Query store. A subsequent user in the same browser session could see the previous user's cached data.

Closes EVE-66

## How
- `useLogout` `onSuccess` now calls `queryClient.clear()` instead of two selective `removeQueries()` calls
- Also clears `everruns_current_org` from localStorage to prevent org selection persistence across identities
- Updated test to verify non-auth queries (e.g. durable workflows) and localStorage are cleared on logout

## Risk
- Low
- Strictly more secure than the previous selective approach
- No backend changes; UI-only
- Existing logout flow unchanged — just clears more state

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (additive security improvement)