### PR TITLE
fix(auth-sync): support authoritative org membership updates and removals

### DIFF
--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -1319,6 +1319,16 @@ impl StorageBackend {
         dispatch!(self, ensure_membership, user_id, org_id, role)
     }
 
+    /// Reconcile org memberships to match an authoritative list from an external
+    /// identity provider. Returns `(added, updated, removed)` counts.
+    pub async fn reconcile_memberships(
+        &self,
+        org_id: i64,
+        authoritative: &[(Uuid, String)],
+    ) -> Result<(usize, usize, usize)> {
+        dispatch!(self, reconcile_memberships, org_id, authoritative)
+    }
+
     // ============================================
     // Session Storage (Key-Value & Secrets)
     // ============================================

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -3554,17 +3554,65 @@ impl InMemoryDatabase {
         Ok(row)
     }
 
-    /// Ensure user is a member of organization (idempotent)
+    /// Ensure user is a member of organization with the given role (upsert).
+    /// Updates the role if the membership already exists.
     pub async fn ensure_membership(&self, user_id: Uuid, org_id: i64, role: &str) -> Result<()> {
         let key = (org_id, user_id);
         let mut members = self.organization_members.write();
-        members.entry(key).or_insert_with(|| OrganizationMemberRow {
-            org_id,
-            user_id,
-            role: role.to_string(),
-            created_at: Self::now(),
-        });
+        members
+            .entry(key)
+            .and_modify(|m| m.role = role.to_string())
+            .or_insert_with(|| OrganizationMemberRow {
+                org_id,
+                user_id,
+                role: role.to_string(),
+                created_at: Self::now(),
+            });
         Ok(())
+    }
+
+    /// Reconcile org memberships to match an authoritative list.
+    /// Returns `(added, updated, removed)` counts.
+    pub async fn reconcile_memberships(
+        &self,
+        org_id: i64,
+        authoritative: &[(Uuid, String)],
+    ) -> Result<(usize, usize, usize)> {
+        let current = self.list_organization_members(org_id).await?;
+        let current_map: std::collections::HashMap<Uuid, String> =
+            current.into_iter().map(|m| (m.user_id, m.role)).collect();
+        let auth_map: std::collections::HashMap<Uuid, &str> = authoritative
+            .iter()
+            .map(|(uid, role)| (*uid, role.as_str()))
+            .collect();
+
+        let mut added = 0usize;
+        let mut updated = 0usize;
+        let mut removed = 0usize;
+
+        for (user_id, role) in authoritative {
+            match current_map.get(user_id) {
+                None => {
+                    self.add_organization_member(org_id, *user_id, role).await?;
+                    added += 1;
+                }
+                Some(existing_role) if existing_role != role => {
+                    self.update_organization_member_role(org_id, *user_id, role)
+                        .await?;
+                    updated += 1;
+                }
+                _ => {}
+            }
+        }
+
+        for user_id in current_map.keys() {
+            if !auth_map.contains_key(user_id) {
+                self.remove_organization_member(org_id, *user_id).await?;
+                removed += 1;
+            }
+        }
+
+        Ok((added, updated, removed))
     }
 
     // ============================================

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -3572,42 +3572,63 @@ impl InMemoryDatabase {
     }
 
     /// Reconcile org memberships to match an authoritative list.
+    /// Operates under a single write lock for atomicity.
+    /// Duplicate user_ids in the authoritative list are deduplicated (last wins).
     /// Returns `(added, updated, removed)` counts.
     pub async fn reconcile_memberships(
         &self,
         org_id: i64,
         authoritative: &[(Uuid, String)],
     ) -> Result<(usize, usize, usize)> {
-        let current = self.list_organization_members(org_id).await?;
-        let current_map: std::collections::HashMap<Uuid, String> =
-            current.into_iter().map(|m| (m.user_id, m.role)).collect();
+        // Deduplicate authoritative input (last occurrence wins)
         let auth_map: std::collections::HashMap<Uuid, &str> = authoritative
             .iter()
             .map(|(uid, role)| (*uid, role.as_str()))
+            .collect();
+
+        let mut members = self.organization_members.write();
+        let now = Self::now();
+
+        // Build current state under the write lock
+        let current_map: std::collections::HashMap<Uuid, String> = members
+            .iter()
+            .filter(|((oid, _), _)| *oid == org_id)
+            .map(|((_, uid), row)| (*uid, row.role.clone()))
             .collect();
 
         let mut added = 0usize;
         let mut updated = 0usize;
         let mut removed = 0usize;
 
-        for (user_id, role) in authoritative {
+        // Add or update from the deduped map
+        for (user_id, role) in &auth_map {
             match current_map.get(user_id) {
                 None => {
-                    self.add_organization_member(org_id, *user_id, role).await?;
+                    members.insert(
+                        (org_id, *user_id),
+                        OrganizationMemberRow {
+                            org_id,
+                            user_id: *user_id,
+                            role: role.to_string(),
+                            created_at: now,
+                        },
+                    );
                     added += 1;
                 }
                 Some(existing_role) if existing_role != role => {
-                    self.update_organization_member_role(org_id, *user_id, role)
-                        .await?;
+                    if let Some(row) = members.get_mut(&(org_id, *user_id)) {
+                        row.role = role.to_string();
+                    }
                     updated += 1;
                 }
-                _ => {}
+                _ => {} // unchanged
             }
         }
 
+        // Remove members not in authoritative list
         for user_id in current_map.keys() {
             if !auth_map.contains_key(user_id) {
-                self.remove_organization_member(org_id, *user_id).await?;
+                members.remove(&(org_id, *user_id));
                 removed += 1;
             }
         }

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -4329,7 +4329,10 @@ impl Database {
     /// Updates the role if the membership already exists.
     pub async fn ensure_membership(&self, user_id: Uuid, org_id: i64, role: &str) -> Result<()> {
         sqlx::query(
-            "INSERT INTO organization_members (org_id, user_id, role) VALUES ($1, $2, $3) ON CONFLICT (org_id, user_id) DO UPDATE SET role = EXCLUDED.role",
+            "INSERT INTO organization_members (org_id, user_id, role) VALUES ($1, $2, $3) \
+             ON CONFLICT (org_id, user_id) DO UPDATE \
+             SET role = EXCLUDED.role \
+             WHERE organization_members.role IS DISTINCT FROM EXCLUDED.role",
         )
         .bind(org_id)
         .bind(user_id)
@@ -4344,34 +4347,63 @@ impl Database {
     /// identity provider. Adds missing members, updates changed roles, and
     /// removes members not present in the authoritative list.
     ///
+    /// Runs inside a transaction for atomicity. Duplicate user_ids in the
+    /// authoritative list are deduplicated (last wins).
+    ///
     /// Returns `(added, updated, removed)` counts.
     pub async fn reconcile_memberships(
         &self,
         org_id: i64,
         authoritative: &[(Uuid, String)],
     ) -> Result<(usize, usize, usize)> {
-        let current = self.list_organization_members(org_id).await?;
-        let current_map: std::collections::HashMap<Uuid, String> =
-            current.into_iter().map(|m| (m.user_id, m.role)).collect();
+        // Deduplicate authoritative input (last occurrence wins)
         let auth_map: std::collections::HashMap<Uuid, &str> = authoritative
             .iter()
             .map(|(uid, role)| (*uid, role.as_str()))
             .collect();
 
+        let mut tx = self.pool.begin().await?;
+
+        // Read current memberships inside the transaction (lock rows)
+        let current: Vec<OrganizationMemberRow> = sqlx::query_as(
+            "SELECT org_id, user_id, role, created_at \
+             FROM organization_members WHERE org_id = $1 FOR UPDATE",
+        )
+        .bind(org_id)
+        .fetch_all(&mut *tx)
+        .await?;
+
+        let current_map: std::collections::HashMap<Uuid, String> =
+            current.into_iter().map(|m| (m.user_id, m.role)).collect();
+
         let mut added = 0usize;
         let mut updated = 0usize;
         let mut removed = 0usize;
 
-        // Add or update
-        for (user_id, role) in authoritative {
+        // Add or update from the deduped map
+        for (user_id, role) in &auth_map {
             match current_map.get(user_id) {
                 None => {
-                    self.add_organization_member(org_id, *user_id, role).await?;
+                    sqlx::query(
+                        "INSERT INTO organization_members (org_id, user_id, role) VALUES ($1, $2, $3)",
+                    )
+                    .bind(org_id)
+                    .bind(user_id)
+                    .bind(role)
+                    .execute(&mut *tx)
+                    .await?;
                     added += 1;
                 }
                 Some(existing_role) if existing_role != role => {
-                    self.update_organization_member_role(org_id, *user_id, role)
-                        .await?;
+                    sqlx::query(
+                        "UPDATE organization_members SET role = $1 \
+                         WHERE org_id = $2 AND user_id = $3",
+                    )
+                    .bind(role)
+                    .bind(org_id)
+                    .bind(user_id)
+                    .execute(&mut *tx)
+                    .await?;
                     updated += 1;
                 }
                 _ => {} // unchanged
@@ -4381,10 +4413,16 @@ impl Database {
         // Remove members not in authoritative list
         for user_id in current_map.keys() {
             if !auth_map.contains_key(user_id) {
-                self.remove_organization_member(org_id, *user_id).await?;
+                sqlx::query("DELETE FROM organization_members WHERE org_id = $1 AND user_id = $2")
+                    .bind(org_id)
+                    .bind(user_id)
+                    .execute(&mut *tx)
+                    .await?;
                 removed += 1;
             }
         }
+
+        tx.commit().await?;
 
         Ok((added, updated, removed))
     }

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -4325,10 +4325,11 @@ impl Database {
         Ok(row)
     }
 
-    /// Ensure user is a member of organization (idempotent)
+    /// Ensure user is a member of organization with the given role (upsert).
+    /// Updates the role if the membership already exists.
     pub async fn ensure_membership(&self, user_id: Uuid, org_id: i64, role: &str) -> Result<()> {
         sqlx::query(
-            "INSERT INTO organization_members (org_id, user_id, role) VALUES ($1, $2, $3) ON CONFLICT (org_id, user_id) DO NOTHING"
+            "INSERT INTO organization_members (org_id, user_id, role) VALUES ($1, $2, $3) ON CONFLICT (org_id, user_id) DO UPDATE SET role = EXCLUDED.role",
         )
         .bind(org_id)
         .bind(user_id)
@@ -4337,6 +4338,55 @@ impl Database {
         .await?;
 
         Ok(())
+    }
+
+    /// Reconcile org memberships to match an authoritative list from an external
+    /// identity provider. Adds missing members, updates changed roles, and
+    /// removes members not present in the authoritative list.
+    ///
+    /// Returns `(added, updated, removed)` counts.
+    pub async fn reconcile_memberships(
+        &self,
+        org_id: i64,
+        authoritative: &[(Uuid, String)],
+    ) -> Result<(usize, usize, usize)> {
+        let current = self.list_organization_members(org_id).await?;
+        let current_map: std::collections::HashMap<Uuid, String> =
+            current.into_iter().map(|m| (m.user_id, m.role)).collect();
+        let auth_map: std::collections::HashMap<Uuid, &str> = authoritative
+            .iter()
+            .map(|(uid, role)| (*uid, role.as_str()))
+            .collect();
+
+        let mut added = 0usize;
+        let mut updated = 0usize;
+        let mut removed = 0usize;
+
+        // Add or update
+        for (user_id, role) in authoritative {
+            match current_map.get(user_id) {
+                None => {
+                    self.add_organization_member(org_id, *user_id, role).await?;
+                    added += 1;
+                }
+                Some(existing_role) if existing_role != role => {
+                    self.update_organization_member_role(org_id, *user_id, role)
+                        .await?;
+                    updated += 1;
+                }
+                _ => {} // unchanged
+            }
+        }
+
+        // Remove members not in authoritative list
+        for user_id in current_map.keys() {
+            if !auth_map.contains_key(user_id) {
+                self.remove_organization_member(org_id, *user_id).await?;
+                removed += 1;
+            }
+        }
+
+        Ok((added, updated, removed))
     }
 
     // ============================================

--- a/crates/server/tests/org_creation_test.rs
+++ b/crates/server/tests/org_creation_test.rs
@@ -345,3 +345,144 @@ fn test_generate_org_public_id_format() {
         assert_eq!(id.len(), 36); // "org_" + 32 hex chars
     }
 }
+
+// ============================================
+// Membership Sync / Reconciliation Tests
+// ============================================
+
+#[tokio::test]
+async fn test_ensure_membership_updates_role() {
+    let db = InMemoryDatabase::default();
+    let user_id = Uuid::now_v7();
+
+    let org = db
+        .create_organization(CreateOrganizationRow {
+            public_id: format!("org_{}", Uuid::now_v7().simple()),
+            name: "Role Update Test".to_string(),
+            created_by: None,
+        })
+        .await
+        .unwrap();
+
+    // Insert as member
+    db.ensure_membership(user_id, org.org_id, "member")
+        .await
+        .unwrap();
+    let members = db.list_organization_members(org.org_id).await.unwrap();
+    assert_eq!(members[0].role, "member");
+
+    // Ensure again with different role — should update
+    db.ensure_membership(user_id, org.org_id, "admin")
+        .await
+        .unwrap();
+    let members = db.list_organization_members(org.org_id).await.unwrap();
+    assert_eq!(members.len(), 1, "should still have one member");
+    assert_eq!(members[0].role, "admin");
+}
+
+#[tokio::test]
+async fn test_reconcile_memberships_add_update_remove() {
+    let db = InMemoryDatabase::default();
+    let user_a = Uuid::now_v7();
+    let user_b = Uuid::now_v7();
+    let user_c = Uuid::now_v7();
+
+    let org = db
+        .create_organization(CreateOrganizationRow {
+            public_id: format!("org_{}", Uuid::now_v7().simple()),
+            name: "Reconcile Test".to_string(),
+            created_by: None,
+        })
+        .await
+        .unwrap();
+
+    // Seed: A=owner, B=member
+    db.add_organization_member(org.org_id, user_a, "owner")
+        .await
+        .unwrap();
+    db.add_organization_member(org.org_id, user_b, "member")
+        .await
+        .unwrap();
+
+    // Authoritative: A=admin (role change), C=member (new), B absent (remove)
+    let authoritative = vec![
+        (user_a, "admin".to_string()),
+        (user_c, "member".to_string()),
+    ];
+
+    let (added, updated, removed) = db
+        .reconcile_memberships(org.org_id, &authoritative)
+        .await
+        .unwrap();
+
+    assert_eq!(added, 1, "user_c should be added");
+    assert_eq!(updated, 1, "user_a role should be updated");
+    assert_eq!(removed, 1, "user_b should be removed");
+
+    // Verify final state
+    let members = db.list_organization_members(org.org_id).await.unwrap();
+    assert_eq!(members.len(), 2);
+
+    let member_map: std::collections::HashMap<Uuid, String> =
+        members.into_iter().map(|m| (m.user_id, m.role)).collect();
+    assert_eq!(member_map.get(&user_a).unwrap(), "admin");
+    assert_eq!(member_map.get(&user_c).unwrap(), "member");
+    assert!(!member_map.contains_key(&user_b));
+}
+
+#[tokio::test]
+async fn test_reconcile_memberships_empty_authoritative_removes_all() {
+    let db = InMemoryDatabase::default();
+    let user_id = Uuid::now_v7();
+
+    let org = db
+        .create_organization(CreateOrganizationRow {
+            public_id: format!("org_{}", Uuid::now_v7().simple()),
+            name: "Reconcile Empty Test".to_string(),
+            created_by: None,
+        })
+        .await
+        .unwrap();
+
+    db.add_organization_member(org.org_id, user_id, "owner")
+        .await
+        .unwrap();
+
+    let (added, updated, removed) = db.reconcile_memberships(org.org_id, &[]).await.unwrap();
+
+    assert_eq!(added, 0);
+    assert_eq!(updated, 0);
+    assert_eq!(removed, 1);
+
+    let members = db.list_organization_members(org.org_id).await.unwrap();
+    assert!(members.is_empty());
+}
+
+#[tokio::test]
+async fn test_reconcile_memberships_no_changes() {
+    let db = InMemoryDatabase::default();
+    let user_id = Uuid::now_v7();
+
+    let org = db
+        .create_organization(CreateOrganizationRow {
+            public_id: format!("org_{}", Uuid::now_v7().simple()),
+            name: "Reconcile Noop Test".to_string(),
+            created_by: None,
+        })
+        .await
+        .unwrap();
+
+    db.add_organization_member(org.org_id, user_id, "owner")
+        .await
+        .unwrap();
+
+    let authoritative = vec![(user_id, "owner".to_string())];
+    let (added, updated, removed) = db
+        .reconcile_memberships(org.org_id, &authoritative)
+        .await
+        .unwrap();
+
+    assert_eq!(added, 0);
+    assert_eq!(updated, 0);
+    assert_eq!(removed, 0);
+}


### PR DESCRIPTION
## What
Fix `ensure_membership` to update roles on conflict (was `DO NOTHING`), and add `reconcile_memberships()` for authoritative membership sync from external identity providers.

## Why
External auth integrations (PropelAuth, Auth0) need to sync org memberships authoritatively — adding missing members, updating changed roles, and removing stale memberships. The existing `ensure_membership` silently dropped role changes, and there was no reconciliation method.

Closes EVE-71

## How
- Changed `ensure_membership` SQL from `ON CONFLICT DO NOTHING` to `ON CONFLICT DO UPDATE SET role`
- Updated in-memory backend to use `and_modify` for role upsert
- Added `reconcile_memberships(org_id, authoritative_list)` to postgres, in-memory, and StorageBackend dispatch
- Returns `(added, updated, removed)` counts for observability
- 4 new tests: role upsert, full add/update/remove reconciliation, empty authoritative list, no-op case

## Risk
- Low
- `ensure_membership` callers (seed code) are unaffected by the upsert change — seeds run once
- `reconcile_memberships` is a new method not yet called from any endpoint — provides building block for SaaS auth sync
- No API surface change, no migration needed

## Checklist
- [x] Tests added or updated (4 new tests, all passing)
- [x] Backward compatibility considered (upsert is strictly more correct than DO NOTHING)