### PR TITLE
feat(apps): add slack report-progress reply mode

### DIFF
--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -42,7 +42,12 @@ import {
 import { ArrowLeft, Globe, GlobeLock, Copy, Trash2, Pencil, Check, X, Rocket } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import { SlackSetupGuidance } from "@/components/apps/slack-setup-guidance";
-import type { SessionStrategy, SlackChannelConfig, UpdateAppRequest } from "@/lib/api/types";
+import type {
+  SessionStrategy,
+  SlackChannelConfig,
+  SlackReplyMode,
+  UpdateAppRequest,
+} from "@/lib/api/types";
 import {
   getEntityNameClassName,
   getEntityReferenceClassName,
@@ -80,6 +85,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
   const [editChannelId, setEditChannelId] = useState("");
   const [editTeamId, setEditTeamId] = useState("");
   const [editSessionStrategy, setEditSessionStrategy] = useState<SessionStrategy>("per_thread");
+  const [editReplyMode, setEditReplyMode] = useState<SlackReplyMode>("all_messages");
 
   const [creatingSlackApp, setCreatingSlackApp] = useState(false);
 
@@ -143,6 +149,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
     setEditChannelId(slackConfig?.channel_id ?? "");
     setEditTeamId(slackConfig?.team_id ?? "");
     setEditSessionStrategy(slackConfig?.session_strategy ?? "per_thread");
+    setEditReplyMode(slackConfig?.reply_mode ?? "all_messages");
     setEditingSlack(true);
   };
 
@@ -152,6 +159,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
       signing_secret: editSigningSecret,
       bot_token: editBotToken,
       session_strategy: editSessionStrategy,
+      reply_mode: editReplyMode,
       ...(editChannelId ? { channel_id: editChannelId } : {}),
       ...(editTeamId ? { team_id: editTeamId } : {}),
     };
@@ -365,6 +373,33 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                     </p>
                   </div>
 
+                  <div>
+                    <Label htmlFor="reply_mode">Reply Mode</Label>
+                    <Select
+                      value={editReplyMode}
+                      onValueChange={(v) => setEditReplyMode(v as SlackReplyMode)}
+                    >
+                      <SelectTrigger>
+                        <SelectValue>
+                          {
+                            {
+                              all_messages: "All Assistant Messages",
+                              report_progress_only: "Report Progress Only",
+                            }[editReplyMode]
+                          }
+                        </SelectValue>
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all_messages">All Assistant Messages</SelectItem>
+                        <SelectItem value="report_progress_only">Report Progress Only</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      Report-progress mode sends a fast handoff acknowledgement and only forwards
+                      deterministic `report_progress` updates to Slack.
+                    </p>
+                  </div>
+
                   <div className="flex gap-2 pt-2">
                     <Button
                       size="sm"
@@ -422,6 +457,15 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                         : slackConfig?.session_strategy === "per_channel"
                           ? "Per Channel"
                           : "Per User"}
+                    </p>
+                  </div>
+
+                  <div>
+                    <p className="text-sm font-medium">Reply Mode</p>
+                    <p className="text-sm text-muted-foreground">
+                      {slackConfig?.reply_mode === "report_progress_only"
+                        ? "Report Progress Only"
+                        : "All Assistant Messages"}
                     </p>
                   </div>
 

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -1875,6 +1875,7 @@ export interface CommandsResponse {
 export type AppStatus = "draft" | "published" | "archived" | "deleted";
 export type ChannelType = "slack";
 export type SessionStrategy = "per_thread" | "per_channel" | "per_user";
+export type SlackReplyMode = "all_messages" | "report_progress_only";
 
 export interface SlackChannelConfig {
   signing_secret: string;
@@ -1882,6 +1883,7 @@ export interface SlackChannelConfig {
   channel_id?: string;
   team_id?: string;
   session_strategy: SessionStrategy;
+  reply_mode?: SlackReplyMode;
   webhook_verified_at?: string | null;
   first_message_received_at?: string | null;
 }

--- a/crates/core/src/app.rs
+++ b/crates/core/src/app.rs
@@ -131,7 +131,7 @@ pub struct App {
 }
 
 /// Session strategy for incoming messages (how messages map to sessions).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum SessionStrategy {
@@ -142,6 +142,18 @@ pub enum SessionStrategy {
     PerChannel,
     /// One session per user.
     PerUser,
+}
+
+/// How replies are delivered back to Slack.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum SlackReplyMode {
+    /// Forward completed assistant messages directly to Slack.
+    #[default]
+    AllMessages,
+    /// Only send deterministic updates emitted via `report_progress`.
+    ReportProgressOnly,
 }
 
 /// Typed Slack channel configuration.
@@ -162,6 +174,9 @@ pub struct SlackChannelConfig {
     /// How incoming messages map to sessions.
     #[serde(default)]
     pub session_strategy: SessionStrategy,
+    /// How replies are delivered back to Slack.
+    #[serde(default)]
+    pub reply_mode: SlackReplyMode,
     /// Set when Slack successfully verifies the webhook URL (url_verification challenge).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub webhook_verified_at: Option<DateTime<Utc>>,
@@ -254,7 +269,8 @@ mod tests {
             "bot_token": "xoxb-tok",
             "channel_id": "C123",
             "team_id": "T123",
-            "session_strategy": "per_channel"
+            "session_strategy": "per_channel",
+            "reply_mode": "report_progress_only"
         }"#;
         let config: SlackChannelConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.signing_secret, "sec123");
@@ -262,6 +278,7 @@ mod tests {
         assert_eq!(config.channel_id.as_deref(), Some("C123"));
         assert_eq!(config.team_id.as_deref(), Some("T123"));
         assert_eq!(config.session_strategy, SessionStrategy::PerChannel);
+        assert_eq!(config.reply_mode, SlackReplyMode::ReportProgressOnly);
     }
 
     #[test]
@@ -271,6 +288,7 @@ mod tests {
         assert!(config.channel_id.is_none());
         assert!(config.team_id.is_none());
         assert_eq!(config.session_strategy, SessionStrategy::PerThread);
+        assert_eq!(config.reply_mode, SlackReplyMode::AllMessages);
         assert!(config.webhook_verified_at.is_none());
         assert!(config.first_message_received_at.is_none());
     }
@@ -301,12 +319,21 @@ mod tests {
             channel_id: None,
             team_id: None,
             session_strategy: SessionStrategy::PerThread,
+            reply_mode: SlackReplyMode::AllMessages,
             webhook_verified_at: None,
             first_message_received_at: None,
         };
         let json = serde_json::to_value(&config).unwrap();
         assert!(json.get("webhook_verified_at").is_none());
         assert!(json.get("first_message_received_at").is_none());
+    }
+
+    #[test]
+    fn test_slack_reply_mode_serde_roundtrip() {
+        let json = serde_json::to_string(&SlackReplyMode::ReportProgressOnly).unwrap();
+        assert_eq!(json, r#""report_progress_only""#);
+        let parsed: SlackReplyMode = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, SlackReplyMode::ReportProgressOnly);
     }
 
     #[test]

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -639,7 +639,10 @@ where
             builder = builder.tools(session.tools.clone());
         }
 
-        let runtime_agent = builder.build();
+        let mut runtime_agent = builder.build();
+        if crate::progress_reporting::session_uses_report_progress(&session.tags) {
+            runtime_agent = crate::progress_reporting::apply_report_progress_mode(runtime_agent);
+        }
 
         // 6b. Extract compaction config from agent/harness/session capabilities
         let compaction_config = {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -61,6 +61,7 @@ pub mod skill;
 
 // Permissions model (policies, rules, caller context)
 pub mod permissions;
+pub mod progress_reporting;
 
 // URL validation for SSRF prevention (shared utility)
 pub mod url_validation;
@@ -204,7 +205,7 @@ pub use tool_types::{
 // Domain entity re-exports
 // Note: LlmProvider entity is in llm_models module. Import as: everruns_core::llm_models::LlmProvider
 pub use agent::{Agent, AgentStatus, generate_agent_public_id, validate_agent_public_id};
-pub use app::{App, AppStatus, ChannelType, SessionStrategy, SlackChannelConfig};
+pub use app::{App, AppStatus, ChannelType, SessionStrategy, SlackChannelConfig, SlackReplyMode};
 pub use capability_dto::{AgentCapability, CapabilityInfo};
 pub use events::{
     ACT_COMPLETED, ACT_STARTED, ActCompletedData, ActStartedData, CONTEXT_COMPACTED,

--- a/crates/core/src/progress_reporting.rs
+++ b/crates/core/src/progress_reporting.rs
@@ -1,0 +1,289 @@
+// Deterministic progress-reporting helpers for external handoff channels.
+//
+// Design Decision: The agent-facing tool is generic (`report_progress`) while
+// delivery remains channel-specific. Slack handoff sessions opt in via a
+// session tag, which lets ReasonAtom expose the tool and prompt without
+// leaking Slack-specific behavior into the wider runtime.
+
+use crate::RuntimeAgent;
+use crate::app::SlackReplyMode;
+use crate::tool_types::ToolDefinition;
+use crate::tools::{Tool, ToolExecutionResult};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+pub const REPORT_PROGRESS_TOOL_NAME: &str = "report_progress";
+pub const SLACK_REPLY_MODE_TAG_PREFIX: &str = "slack:reply_mode:";
+pub const SLACK_REPORT_PROGRESS_ONLY_TAG: &str = "slack:reply_mode:report_progress_only";
+const REPORT_PROGRESS_PROMPT_MARKER: &str = "# External Progress Reporting";
+const REPORT_PROGRESS_SYSTEM_PROMPT: &str = r#"# External Progress Reporting
+
+This session is attached to an external handoff thread.
+
+The external user does not see normal assistant messages. They only see updates sent through `report_progress`.
+
+Rules:
+- Use `report_progress` for meaningful user-facing updates only.
+- Use status `progress` for material milestones, `blocked` when waiting or stuck, and `completed` before the turn ends.
+- Keep summaries concise, deterministic, and focused on outcomes.
+- Do not mirror low-level tool chatter into `report_progress`."#;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProgressReportStatus {
+    Progress,
+    Blocked,
+    Completed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProgressReportPayload {
+    pub status: ProgressReportStatus,
+    pub summary: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub details: Vec<String>,
+}
+
+impl ProgressReportPayload {
+    fn validate(self) -> Result<Self, String> {
+        let summary = self.summary.trim();
+        if summary.is_empty() {
+            return Err("Missing required field: 'summary'".to_string());
+        }
+
+        let mut details = Vec::with_capacity(self.details.len());
+        for (idx, detail) in self.details.iter().enumerate() {
+            let trimmed = detail.trim();
+            if trimmed.is_empty() {
+                return Err(format!("details[{}] must not be empty", idx));
+            }
+            details.push(trimmed.to_string());
+        }
+
+        Ok(Self {
+            status: self.status,
+            summary: summary.to_string(),
+            details,
+        })
+    }
+}
+
+pub fn session_uses_report_progress(tags: &[String]) -> bool {
+    tags.iter().any(|tag| tag == SLACK_REPORT_PROGRESS_ONLY_TAG)
+}
+
+pub fn sync_slack_reply_mode_tags(tags: &mut Vec<String>, reply_mode: SlackReplyMode) {
+    tags.retain(|tag| !tag.starts_with(SLACK_REPLY_MODE_TAG_PREFIX));
+    if reply_mode == SlackReplyMode::ReportProgressOnly {
+        tags.push(SLACK_REPORT_PROGRESS_ONLY_TAG.to_string());
+    }
+}
+
+pub fn report_progress_tool_definition() -> ToolDefinition {
+    ReportProgressTool.to_definition()
+}
+
+pub fn apply_report_progress_mode(mut runtime_agent: RuntimeAgent) -> RuntimeAgent {
+    if !runtime_agent
+        .tools
+        .iter()
+        .any(|tool| tool.name() == REPORT_PROGRESS_TOOL_NAME)
+    {
+        runtime_agent.tools.push(report_progress_tool_definition());
+    }
+
+    if !runtime_agent
+        .system_prompt
+        .contains(REPORT_PROGRESS_PROMPT_MARKER)
+    {
+        runtime_agent.system_prompt = if runtime_agent.system_prompt.is_empty() {
+            REPORT_PROGRESS_SYSTEM_PROMPT.to_string()
+        } else {
+            format!(
+                "{}\n\n{}",
+                REPORT_PROGRESS_SYSTEM_PROMPT, runtime_agent.system_prompt
+            )
+        };
+    }
+
+    runtime_agent
+}
+
+pub fn format_progress_report_for_slack(report: &ProgressReportPayload) -> String {
+    let heading = match report.status {
+        ProgressReportStatus::Progress => "Update",
+        ProgressReportStatus::Blocked => "Blocked",
+        ProgressReportStatus::Completed => "Done",
+    };
+
+    let mut lines = vec![format!("{}: {}", heading, report.summary)];
+    for detail in &report.details {
+        lines.push(format!("- {}", detail));
+    }
+    lines.join("\n")
+}
+
+pub struct ReportProgressTool;
+
+#[async_trait]
+impl Tool for ReportProgressTool {
+    fn name(&self) -> &str {
+        REPORT_PROGRESS_TOOL_NAME
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Report Progress")
+    }
+
+    fn description(&self) -> &str {
+        "Send a deterministic, user-facing progress update for an external handoff thread. Use status 'completed' before ending the turn."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "enum": ["progress", "blocked", "completed"],
+                    "description": "Kind of progress update being reported."
+                },
+                "summary": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Short user-facing summary of the current milestone or outcome."
+                },
+                "details": {
+                    "type": "array",
+                    "description": "Optional short bullet points with concrete outcomes or blockers.",
+                    "items": {
+                        "type": "string",
+                        "minLength": 1
+                    }
+                }
+            },
+            "required": ["status", "summary"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+        let payload = match serde_json::from_value::<ProgressReportPayload>(arguments) {
+            Ok(payload) => payload,
+            Err(error) => {
+                return ToolExecutionResult::tool_error(format!(
+                    "Invalid report_progress arguments: {}",
+                    error
+                ));
+            }
+        };
+
+        match payload.validate() {
+            Ok(validated) => ToolExecutionResult::success(serde_json::to_value(validated).unwrap()),
+            Err(error) => ToolExecutionResult::tool_error(error),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_report_progress_tool_success() {
+        let tool = ReportProgressTool;
+        let result = tool
+            .execute(serde_json::json!({
+                "status": "completed",
+                "summary": "Fixed the failing Slack session routing",
+                "details": ["added reply-mode tags", "wired deterministic progress delivery"]
+            }))
+            .await;
+
+        match result {
+            ToolExecutionResult::Success(value) => {
+                let payload: ProgressReportPayload = serde_json::from_value(value).unwrap();
+                assert_eq!(payload.status, ProgressReportStatus::Completed);
+                assert_eq!(payload.summary, "Fixed the failing Slack session routing");
+                assert_eq!(payload.details.len(), 2);
+            }
+            other => panic!("Expected success, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_report_progress_tool_rejects_empty_summary() {
+        let tool = ReportProgressTool;
+        let result = tool
+            .execute(serde_json::json!({
+                "status": "progress",
+                "summary": "   "
+            }))
+            .await;
+
+        match result {
+            ToolExecutionResult::ToolError(message) => {
+                assert_eq!(message, "Missing required field: 'summary'");
+            }
+            other => panic!("Expected tool error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_sync_slack_reply_mode_tags() {
+        let mut tags = vec![
+            "slack:app:app_123".to_string(),
+            "slack:thread:123.456".to_string(),
+            "slack:reply_mode:all_messages".to_string(),
+        ];
+
+        sync_slack_reply_mode_tags(&mut tags, SlackReplyMode::ReportProgressOnly);
+
+        assert!(tags.iter().any(|tag| tag == SLACK_REPORT_PROGRESS_ONLY_TAG));
+        assert_eq!(
+            tags.iter()
+                .filter(|tag| tag.starts_with(SLACK_REPLY_MODE_TAG_PREFIX))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_apply_report_progress_mode_adds_tool_and_prompt_once() {
+        let runtime_agent = RuntimeAgent::new("Base prompt.", "gpt-5.4");
+
+        let runtime_agent = apply_report_progress_mode(runtime_agent);
+        let runtime_agent = apply_report_progress_mode(runtime_agent);
+
+        assert_eq!(
+            runtime_agent
+                .tools
+                .iter()
+                .filter(|tool| tool.name() == REPORT_PROGRESS_TOOL_NAME)
+                .count(),
+            1
+        );
+        assert_eq!(
+            runtime_agent
+                .system_prompt
+                .matches(REPORT_PROGRESS_PROMPT_MARKER)
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_format_progress_report_for_slack() {
+        let text = format_progress_report_for_slack(&ProgressReportPayload {
+            status: ProgressReportStatus::Blocked,
+            summary: "Waiting on credentials".to_string(),
+            details: vec!["need Slack bot token".to_string()],
+        });
+
+        assert_eq!(
+            text,
+            "Blocked: Waiting on credentials\n- need Slack bot token"
+        );
+    }
+}

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -452,6 +452,7 @@ impl ToolRegistry {
     /// This includes:
     /// - `get_current_time`: Returns the current date and time
     /// - `echo`: Echoes back the provided message
+    /// - `report_progress`: Emits deterministic external progress updates
     /// - TestMath tools: add, subtract, multiply, divide
     /// - TestWeather tools: get_weather, get_forecast
     /// - TaskList tools: write_todos
@@ -463,10 +464,12 @@ impl ToolRegistry {
             GetWeatherTool, GrepFilesTool, ListDirectoryTool, MultiplyTool, ReadFileTool,
             StatFileTool, SubtractTool, WebFetchTool, WriteFileTool, WriteTodosTool,
         };
+        use crate::progress_reporting::ReportProgressTool;
 
         ToolRegistry::builder()
             .tool(GetCurrentTimeTool)
             .tool(EchoTool)
+            .tool(ReportProgressTool)
             // TestMath capability tools
             .tool(AddTool)
             .tool(SubtractTool)

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -945,6 +945,10 @@ mod tests {
             "should have get_current_time"
         );
         assert!(registry.has("echo"), "should have echo");
+        assert!(
+            registry.has("report_progress"),
+            "should have report_progress"
+        );
 
         // TestMath capability tools
         assert!(registry.has("add"), "should have add");
@@ -972,7 +976,7 @@ mod tests {
         assert!(registry.has("web_fetch"), "should have web_fetch");
 
         // Total count
-        assert_eq!(registry.len(), 17, "should have 17 default tools");
+        assert_eq!(registry.len(), 18, "should have 18 default tools");
     }
 
     #[tokio::test]

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -359,6 +359,8 @@ message Session {
     optional Uuid harness_id = 10;
     // Session locale (BCP 47, e.g. "uk-UA")
     string locale = 11;
+    // Session tags (used for routing and channel-specific behavior)
+    repeated string tags = 12;
 }
 
 message GetSessionRequest {

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -377,7 +377,7 @@ pub fn proto_harness_to_schema(
 pub fn proto_session_to_schema(
     value: proto::Session,
 ) -> Result<everruns_core::Session, ConversionError> {
-    let tags: Vec<String> = vec![];
+    let tags = value.tags.clone();
     let started_at: Option<String> = None;
     let finished_at: Option<String> = None;
 
@@ -444,6 +444,7 @@ pub fn schema_session_to_proto(value: &everruns_core::Session) -> proto::Session
             .filter_map(|c| serde_json::to_string(c).ok())
             .collect(),
         harness_id: Some(uuid_to_proto_uuid(value.harness_id.uuid())),
+        tags: value.tags.clone(),
     }
 }
 
@@ -1083,7 +1084,7 @@ mod tests {
             description: Some("Test description".to_string()),
             system_prompt: "You are a helpful assistant".to_string(),
             default_model_id: None,
-            tags: vec![],
+            tags: vec!["slack:thread:123.456".to_string()],
             capabilities: vec![
                 AgentCapabilityConfig::new("tools:read_file"),
                 AgentCapabilityConfig::new("tools:write_file"),
@@ -1141,7 +1142,7 @@ mod tests {
             description: None,
             system_prompt: "You are a helpful assistant".to_string(),
             default_model_id: None,
-            tags: vec![],
+            tags: vec!["slack:thread:123.456".to_string()],
             capabilities: vec![],
             initial_files: vec![],
             tools: vec![],
@@ -1330,7 +1331,7 @@ mod tests {
             locale: None,
             preview: None,
             output_preview: None,
-            tags: vec![],
+            tags: vec!["slack:thread:123.456".to_string()],
             model_id: None,
             capabilities: vec![AgentCapabilityConfig::new("session")],
             tools: vec![],
@@ -1356,6 +1357,7 @@ mod tests {
             "org_00000000000000000000000000000001"
         );
         assert_eq!(proto_session.capabilities.len(), 1);
+        assert_eq!(proto_session.tags, vec!["slack:thread:123.456".to_string()]);
 
         // Convert back to schema
         let schema_session = proto_session_to_schema(proto_session).unwrap();
@@ -1365,6 +1367,10 @@ mod tests {
         );
         assert_eq!(schema_session.id, session.id);
         assert_eq!(schema_session.harness_id, session.harness_id);
+        assert_eq!(
+            schema_session.tags,
+            vec!["slack:thread:123.456".to_string()]
+        );
         assert_eq!(schema_session.capabilities.len(), 1);
         assert_eq!(schema_session.capabilities[0].capability_id(), "session");
     }

--- a/crates/server/specs/slack-integration.md
+++ b/crates/server/specs/slack-integration.md
@@ -40,6 +40,7 @@ The events endpoint verifies HMAC-SHA256 signing secret, finds/creates session b
 - **Startup recovery**: On server restart, `SlackDeliveryDispatcher::recover()` queries sessions with `status = 'active'` and `slack:*` tags, looks up the corresponding app for the bot_token, finds the last unfinished turn, and re-registers deliveries.
 - **Slack event dedup**: Slack sends both `app_mention` and `message` events for @mentions. DB-level dedup via `has_event_with_slack_ts()` prevents duplicate processing (uses JSONB `@>` containment on input.message events).
 - **Thread context injection**: When the bot is first mentioned mid-thread (`PerThread` strategy, new session, `thread_ts` present), prior messages are fetched via Slack's `conversations.replies` API and injected as `input.message` events (without triggering agent workflows). This gives the agent full conversational context. Bot messages become assistant-role; human messages get user-role with `ExternalActor` attribution. Failures are non-fatal — the agent proceeds without history. Required scopes (`channels:history`, `groups:history`, `im:history`, `mpim:history`) are already in the manifest.
+- **Reply modes**: Slack apps can either forward completed assistant messages (`all_messages`) or run in `report_progress_only` handoff mode. In handoff mode the webhook posts an immediate deterministic acknowledgement (`On it.`), the session is tagged with the reply mode, ReasonAtom exposes a `report_progress` tool + prompt instructions, and Slack delivery ignores normal assistant messages in favor of explicit `tool.completed` events from that tool.
 
 ## Channel Config
 
@@ -51,6 +52,7 @@ Key fields:
 - `channel_id`: Optional channel to listen on
 - `team_id`: Slack workspace ID
 - `session_strategy`: `per_thread` (default), `per_channel`, `per_user`
+- `reply_mode`: `all_messages` (default) or `report_progress_only`
 
 ## Session Strategies
 
@@ -59,6 +61,13 @@ Key fields:
 | `per_thread` | `slack:thread:{thread_ts}` | Each Slack thread = separate session |
 | `per_channel` | `slack:channel:{channel}` | One session per channel |
 | `per_user` | `slack:user:{user}` | One session per user |
+
+## Reply Modes
+
+| Mode | Slack-visible behavior |
+|------|------------------------|
+| `all_messages` | Every completed assistant message is posted back to Slack |
+| `report_progress_only` | Slack gets `On it.` immediately, then only deterministic `report_progress` updates |
 
 ## API
 

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -25,7 +25,10 @@ use axum::{
     routing::{get, post},
 };
 use chrono::Utc;
-use everruns_core::{App, AppStatus, Caller, ChannelType, SessionStrategy, SlackChannelConfig};
+use everruns_core::progress_reporting::sync_slack_reply_mode_tags;
+use everruns_core::{
+    App, AppStatus, Caller, ChannelType, SessionStrategy, SlackChannelConfig, SlackReplyMode,
+};
 use everruns_worker::AgentRunner;
 use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
@@ -39,7 +42,7 @@ use crate::api::sessions::CreateSessionRequest;
 use crate::services::{AppService, EventService, MessageService, SessionService};
 use crate::slack_delivery::SlackDeliveryDispatcher;
 use crate::storage::StorageBackend;
-use crate::storage::models::UpdateApp;
+use crate::storage::models::{UpdateApp, UpdateSession};
 
 use super::common::ErrorResponse;
 
@@ -442,22 +445,45 @@ async fn process_slack_message(
     let org_public_id = org_row.public_id;
 
     // Build session tags based on strategy
-    let session_tags = build_session_tags(app, slack_config, event);
+    let routing_tags = build_session_tags(app, slack_config, event);
+    let desired_tags = desired_session_tags(&routing_tags, slack_config.reply_mode);
 
     // Find or create session
     let (session, is_new_session) =
-        match state.db.find_session_by_tags(org_id, &session_tags).await? {
+        match state.db.find_session_by_tags(org_id, &routing_tags).await? {
             Some(row) => {
                 tracing::debug!(
                     session_id = %row.id,
-                    tags = ?session_tags,
+                    tags = ?routing_tags,
                     "Found existing Slack session"
                 );
-                (SessionService::row_to_session(row, &org_public_id), false)
+                let session = SessionService::row_to_session(row, &org_public_id);
+                let mut synced_tags = session.tags.clone();
+                sync_slack_reply_mode_tags(&mut synced_tags, slack_config.reply_mode);
+                if synced_tags != session.tags
+                    && let Err(error) = state
+                        .db
+                        .update_session(
+                            org_id,
+                            session.id,
+                            UpdateSession {
+                                tags: Some(synced_tags),
+                                ..Default::default()
+                            },
+                        )
+                        .await
+                {
+                    tracing::warn!(
+                        session_id = %session.id,
+                        error = %error,
+                        "Failed to sync Slack reply-mode session tags"
+                    );
+                }
+                (session, false)
             }
             None => {
                 tracing::info!(
-                    tags = ?session_tags,
+                    tags = ?desired_tags,
                     "Creating new Slack session"
                 );
                 let title = build_session_title(slack_config, event);
@@ -466,7 +492,7 @@ async fn process_slack_message(
                     agent_id: Some(app.agent_id),
                     title: Some(title),
                     locale: None,
-                    tags: session_tags.clone(),
+                    tags: desired_tags.clone(),
                     model_id: None,
                     capabilities: vec![],
                     tools: vec![],
@@ -599,6 +625,19 @@ async fn process_slack_message(
     let session_id = session.id.uuid();
     let message_id = message.id;
 
+    if slack_config.reply_mode == SlackReplyMode::ReportProgressOnly
+        && !channel.is_empty()
+        && !thread_ts.is_empty()
+        && let Err(error) =
+            crate::slack_delivery::post_to_slack(&bot_token, &channel, &thread_ts, "On it.").await
+    {
+        tracing::warn!(
+            session_id = %session.id,
+            error = %error,
+            "Failed to post initial Slack handoff acknowledgement"
+        );
+    }
+
     if let Some(ref dispatcher) = state.delivery_dispatcher {
         // Event-driven delivery: no deadline, handles arbitrarily long turns
         dispatcher
@@ -608,15 +647,17 @@ async fn process_slack_message(
                 bot_token,
                 channel,
                 thread_ts,
+                slack_config.reply_mode,
             )
             .await;
     } else {
         // Fallback for DEV_MODE without EventNotificationBroadcaster:
         // use the legacy polling approach
         let db = state.db.clone();
+        let reply_mode = slack_config.reply_mode;
         tokio::spawn(async move {
             if let Err(e) = wait_and_post_response(
-                &db, session_id, message_id, &bot_token, &channel, &thread_ts,
+                &db, session_id, message_id, &bot_token, &channel, &thread_ts, reply_mode,
             )
             .await
             {
@@ -737,6 +778,12 @@ fn build_session_tags(
         }
     }
 
+    tags
+}
+
+fn desired_session_tags(routing_tags: &[String], reply_mode: SlackReplyMode) -> Vec<String> {
+    let mut tags = routing_tags.to_vec();
+    sync_slack_reply_mode_tags(&mut tags, reply_mode);
     tags
 }
 
@@ -970,6 +1017,7 @@ async fn wait_and_post_response(
     bot_token: &str,
     channel: &str,
     thread_ts: &str,
+    reply_mode: SlackReplyMode,
 ) -> anyhow::Result<()> {
     use everruns_core::typed_id::{EventId, SessionId};
 
@@ -1004,9 +1052,12 @@ async fn wait_and_post_response(
             // Post each assistant message to Slack as it arrives. This gives
             // users progress visibility during multi-step agent turns (e.g.
             // "Let me search for that..." before tool execution).
-            if event_row.event_type == "output.message.completed"
-                && is_our_turn
-                && let Some(text) = extract_response_text(&event_row.data)
+            if is_our_turn
+                && let Some(text) = crate::slack_delivery::extract_delivery_text(
+                    &event_row.event_type,
+                    reply_mode,
+                    &event_row.data,
+                )
             {
                 post_to_slack(bot_token, channel, thread_ts, &text).await?;
             }
@@ -1030,6 +1081,7 @@ async fn wait_and_post_response(
 
 /// Extract text content from an output.message.completed event's data.
 /// Delegates to the shared implementation in `slack_delivery`.
+#[cfg(test)]
 fn extract_response_text(data: &serde_json::Value) -> Option<String> {
     crate::slack_delivery::extract_response_text(data)
 }
@@ -1513,6 +1565,7 @@ mod tests {
         let json = r#"{"signing_secret": "sec", "bot_token": "tok"}"#;
         let config: SlackChannelConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.session_strategy, SessionStrategy::PerThread);
+        assert_eq!(config.reply_mode, SlackReplyMode::AllMessages);
         assert!(config.channel_id.is_none());
         assert!(config.team_id.is_none());
     }
@@ -1558,6 +1611,26 @@ mod tests {
 
         let tags = build_session_tags(&app, &config, &event);
         assert_eq!(tags[1], "slack:user:U999");
+    }
+
+    #[test]
+    fn test_desired_session_tags_adds_reply_mode_for_report_progress_only() {
+        let tags = desired_session_tags(
+            &[
+                "slack:app:app_123".to_string(),
+                "slack:thread:1234.0000".to_string(),
+            ],
+            SlackReplyMode::ReportProgressOnly,
+        );
+
+        assert_eq!(
+            tags,
+            vec![
+                "slack:app:app_123".to_string(),
+                "slack:thread:1234.0000".to_string(),
+                "slack:reply_mode:report_progress_only".to_string(),
+            ]
+        );
     }
 
     #[test]
@@ -1713,6 +1786,7 @@ mod tests {
             channel_id: None,
             team_id: None,
             session_strategy: strategy,
+            reply_mode: SlackReplyMode::AllMessages,
             webhook_verified_at: None,
             first_message_received_at: None,
         }

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -845,6 +845,7 @@ impl WorkerService for WorkerServiceImpl {
                 .iter()
                 .filter_map(|c| serde_json::to_string(c).ok())
                 .collect(),
+            tags: session.tags.clone(),
         };
 
         // Load messages from events using EventService with limit
@@ -1094,6 +1095,7 @@ impl WorkerService for WorkerServiceImpl {
                 .iter()
                 .filter_map(|c| serde_json::to_string(c).ok())
                 .collect(),
+            tags: s.tags.clone(),
         });
 
         Ok(Response::new(GetSessionResponse {
@@ -1146,6 +1148,7 @@ impl WorkerService for WorkerServiceImpl {
                 .iter()
                 .filter_map(|c| serde_json::to_string(c).ok())
                 .collect(),
+            tags: session.tags.clone(),
         };
 
         Ok(Response::new(SetSessionStatusResponse {
@@ -1197,6 +1200,7 @@ impl WorkerService for WorkerServiceImpl {
                 .iter()
                 .filter_map(|c| serde_json::to_string(c).ok())
                 .collect(),
+            tags: session.tags.clone(),
         };
 
         Ok(Response::new(SetSessionTitleResponse {

--- a/crates/server/src/slack_delivery.rs
+++ b/crates/server/src/slack_delivery.rs
@@ -12,6 +12,10 @@
 // Design Decision: Delivery context is keyed by (session_id, input_message_id)
 // to support concurrent turns in the same session.
 
+use everruns_core::SlackReplyMode;
+use everruns_core::progress_reporting::{
+    ProgressReportPayload, REPORT_PROGRESS_TOOL_NAME, format_progress_report_for_slack,
+};
 use everruns_core::typed_id::{EventId, SessionId};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -29,6 +33,7 @@ struct DeliveryContext {
     channel: String,
     thread_ts: String,
     input_message_id: String,
+    reply_mode: SlackReplyMode,
     /// Last event ID we've processed (for cursor-based pagination).
     since_event_id: Option<EventId>,
 }
@@ -91,6 +96,7 @@ impl SlackDeliveryDispatcher {
         bot_token: String,
         channel: String,
         thread_ts: String,
+        reply_mode: SlackReplyMode,
     ) {
         let key = DeliveryKey {
             session_id,
@@ -102,6 +108,7 @@ impl SlackDeliveryDispatcher {
             channel,
             thread_ts,
             input_message_id,
+            reply_mode,
             since_event_id: None,
         };
 
@@ -229,8 +236,8 @@ impl SlackDeliveryDispatcher {
                 }
 
                 // Post output messages to Slack
-                if event.event_type == "output.message.completed"
-                    && let Some(text) = extract_response_text(&event.data)
+                if let Some(text) =
+                    extract_delivery_text(&event.event_type, ctx.reply_mode, &event.data)
                     && let Err(e) = post_to_slack_with_retry(
                         &ctx.bot_token,
                         &ctx.channel,
@@ -454,6 +461,7 @@ impl SlackDeliveryDispatcher {
                 slack_config.bot_token.clone(),
                 channel,
                 thread_ts,
+                slack_config.reply_mode,
             )
             .await;
         }
@@ -481,6 +489,47 @@ pub(crate) fn extract_response_text(data: &serde_json::Value) -> Option<String> 
         None
     } else {
         Some(text_parts.join("\n"))
+    }
+}
+
+pub(crate) fn extract_progress_report_text(data: &serde_json::Value) -> Option<String> {
+    if data.get("tool_name")?.as_str()? != REPORT_PROGRESS_TOOL_NAME {
+        return None;
+    }
+    if !data
+        .get("success")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        return None;
+    }
+
+    let result = data.get("result")?.as_array()?;
+    let json_text = result.iter().find_map(|part| {
+        if part.get("type")?.as_str()? == "text" {
+            part.get("text").and_then(|text| text.as_str())
+        } else {
+            None
+        }
+    })?;
+
+    let payload: ProgressReportPayload = serde_json::from_str(json_text).ok()?;
+    Some(format_progress_report_for_slack(&payload))
+}
+
+pub(crate) fn extract_delivery_text(
+    event_type: &str,
+    reply_mode: SlackReplyMode,
+    data: &serde_json::Value,
+) -> Option<String> {
+    match reply_mode {
+        SlackReplyMode::AllMessages if event_type == "output.message.completed" => {
+            extract_response_text(data)
+        }
+        SlackReplyMode::ReportProgressOnly if event_type == "tool.completed" => {
+            extract_progress_report_text(data)
+        }
+        _ => None,
     }
 }
 
@@ -701,6 +750,71 @@ mod tests {
         // doesn't match "text" and the `&&` short-circuits. Both text parts
         // should be captured.
         assert_eq!(result, Some("Part 1\nPart 2".to_string()));
+    }
+
+    #[test]
+    fn test_extract_progress_report_text_formats_payload() {
+        let data = serde_json::json!({
+            "tool_name": "report_progress",
+            "success": true,
+            "result": [
+                {
+                    "type": "text",
+                    "text": r#"{"status":"completed","summary":"Shipped the fix","details":["updated Slack reply mode"]}"#
+                }
+            ]
+        });
+
+        assert_eq!(
+            extract_progress_report_text(&data),
+            Some("Done: Shipped the fix\n- updated Slack reply mode".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_delivery_text_respects_reply_mode() {
+        let output = serde_json::json!({
+            "message": {
+                "content": [
+                    {"type": "text", "text": "Normal assistant reply"}
+                ]
+            }
+        });
+        let tool = serde_json::json!({
+            "tool_name": "report_progress",
+            "success": true,
+            "result": [
+                {
+                    "type": "text",
+                    "text": r#"{"status":"progress","summary":"Investigating","details":[]}"#
+                }
+            ]
+        });
+
+        assert_eq!(
+            extract_delivery_text(
+                "output.message.completed",
+                SlackReplyMode::AllMessages,
+                &output
+            ),
+            Some("Normal assistant reply".to_string())
+        );
+        assert_eq!(
+            extract_delivery_text("tool.completed", SlackReplyMode::AllMessages, &tool),
+            None
+        );
+        assert_eq!(
+            extract_delivery_text("tool.completed", SlackReplyMode::ReportProgressOnly, &tool),
+            Some("Update: Investigating".to_string())
+        );
+        assert_eq!(
+            extract_delivery_text(
+                "output.message.completed",
+                SlackReplyMode::ReportProgressOnly,
+                &output
+            ),
+            None
+        );
     }
 
     #[test]

--- a/crates/server/tests/slack_integration_test.rs
+++ b/crates/server/tests/slack_integration_test.rs
@@ -320,6 +320,77 @@ async fn test_slack_message_creates_session() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_slack_report_progress_only_tags_session() {
+    let server = TestServer::new().await;
+    let agent_id = create_test_agent(&server).await;
+    let app: App = server
+        .post(
+            "/v1/apps",
+            json!({
+                "name": "Slack Report Progress Bot",
+                "harness_id": SEED_BASE_HARNESS_ID,
+                "agent_id": agent_id,
+                "channel_type": "slack",
+                "channel_config": {
+                    "signing_secret": TEST_SIGNING_SECRET,
+                    "bot_token": "xoxb-test-token-for-integration",
+                    "team_id": "T_TEST",
+                    "session_strategy": "per_thread",
+                    "reply_mode": "report_progress_only"
+                }
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    server
+        .post(&format!("/v1/apps/{}/publish", app.public_id), json!({}))
+        .await
+        .assert_success();
+
+    let ts = unique_ts();
+    let payload = json!({
+        "type": "event_callback",
+        "team_id": "T_TEST",
+        "event": {
+            "type": "message",
+            "text": "Please fix this",
+            "user": "U_TESTUSER",
+            "ts": ts,
+            "thread_ts": null
+        }
+    });
+
+    let resp = send_slack_event(&server, &app.public_id, TEST_SIGNING_SECRET, &payload).await;
+    let body: Value = resp.assert_status(StatusCode::OK).json();
+    assert_eq!(body["ok"], true);
+
+    let expected_thread_tag = format!("slack:thread:{}", ts);
+    let sessions = wait_for_sessions_with_tag(&server, &expected_thread_tag, 1).await;
+    let session = &sessions[0];
+
+    let tags: Vec<&str> = session["tags"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|t| t.as_str())
+        .collect();
+
+    let expected_app_tag = format!("slack:app:{}", app.public_id);
+    assert!(
+        tags.contains(&expected_app_tag.as_str()),
+        "Session should have slack:app tag, got: {:?}",
+        tags
+    );
+    assert!(
+        tags.contains(&"slack:reply_mode:report_progress_only"),
+        "Session should have slack reply-mode tag, got: {:?}",
+        tags
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_slack_threaded_message_reuses_session() {
     let server = TestServer::new().await;
     let app = create_published_slack_app(&server, TEST_SIGNING_SECRET).await;

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -690,7 +690,7 @@ fn proto_session_to_session(proto_session: proto::Session) -> Result<Session> {
         locale: non_empty_string(proto_session.locale),
         preview: None,
         output_preview: None,
-        tags: vec![],
+        tags: proto_session.tags,
         model_id: model_id.map(|u| u.into()),
         capabilities,
         tools: vec![],

--- a/specs/apps.md
+++ b/specs/apps.md
@@ -29,7 +29,8 @@ Channel config is stored as JSONB and validated at the application layer per cha
   "channel_id": "C0123456789",
   "channel_name": "#support",
   "team_id": "T0123456789",
-  "session_strategy": "per_thread"
+  "session_strategy": "per_thread",
+  "reply_mode": "all_messages"
 }
 ```
 
@@ -39,6 +40,12 @@ Controls how incoming messages map to sessions:
 - `per_thread` — each thread gets its own session (default)
 - `per_channel` — one session per channel
 - `per_user` — one session per user
+
+### Slack Reply Mode
+
+Controls what gets posted back to Slack:
+- `all_messages` — forward completed assistant messages directly to Slack (default)
+- `report_progress_only` — send an immediate handoff acknowledgement, then only forward explicit `report_progress` tool updates
 
 ### Lifecycle
 
@@ -66,6 +73,7 @@ Key fields:
 - `agent_id`: Required FK to agent
 - `channel_type`: Enum string (`slack`, etc.)
 - `channel_config`: JSONB with channel-specific settings
+- Slack `channel_config.reply_mode`: `all_messages` or `report_progress_only`
 - `status`: `draft` | `published` | `archived` | `deleted`
 - `archived_at`, `deleted_at`: Lifecycle timestamps
 - `published_at`: Timestamp when last published


### PR DESCRIPTION
## What
Add a Slack app reply mode that hands work off to the agent without streaming normal assistant chatter back into the Slack thread.

## Why
Some Slack app flows need deterministic external updates instead of low-level agent commentary. This adds a channel setting that turns Slack into a handoff surface: users get an immediate acknowledgement, the agent receives the thread context, and only explicit progress reports are posted back.

## How
- add `reply_mode` to Slack app config with `all_messages` and `report_progress_only`
- add a generic `report_progress` tool plus prompt injection for report-only sessions
- tag Slack sessions with reply mode, propagate tags through the worker protocol, and deliver only `report_progress` tool completions in report-only mode
- add UI controls/spec updates and a Slack webhook integration test for the new mode

## Risk
- Medium
- Slack report-only delivery now depends on explicit `report_progress` tool calls and session tag propagation across server/worker boundaries

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

## Validation
- `cargo test -p everruns-internal-protocol test_proto_session_roundtrip_includes_organization_id --lib`
- `cargo test -p everruns-core progress_reporting --lib`
- `cargo test -p everruns-core slack_reply_mode --lib`
- `cargo test -p everruns-server test_extract_delivery_text_respects_reply_mode --lib`
- `cargo test -p everruns-server test_desired_session_tags_adds_reply_mode_for_report_progress_only --lib`
- `cargo test -p everruns-server --test slack_integration_test test_slack_report_progress_only_tags_session -- --test-threads=1` with local Postgres + migrations
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `just pre-push`

## Notes
- `npm run lint` still reports three existing warnings in unrelated UI files (`capability-dialog.tsx`, `file-previews.tsx`, `src/lib/api/events.ts`) but no errors.