### PR TITLE
Constrain ScrollArea viewport to parent max-height and add unit test

### DIFF
--- a/apps/ui/src/__tests__/scroll-area.test.tsx
+++ b/apps/ui/src/__tests__/scroll-area.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+describe("ScrollArea", () => {
+  it("keeps viewport constrained when callers use max-height wrappers", () => {
+    render(
+      <ScrollArea className="max-h-[40vh]" data-testid="scroll-area">
+        <div>content</div>
+      </ScrollArea>,
+    );
+
+    const root = screen.getByTestId("scroll-area");
+    const viewport = root.querySelector('[data-slot="scroll-area-viewport"]');
+
+    expect(root).toHaveClass("overflow-hidden");
+    expect(viewport).toHaveClass("[max-height:inherit]");
+  });
+});

--- a/apps/ui/src/components/ui/scroll-area.tsx
+++ b/apps/ui/src/components/ui/scroll-area.tsx
@@ -11,13 +11,13 @@ function ScrollArea({ className, children, ref, ...props }: ScrollAreaProps) {
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
-      className={cn("relative", className)}
+      className={cn("relative overflow-hidden", className)}
       ref={ref}
       {...props}
     >
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
-        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+        className="focus-visible:ring-ring/50 size-full rounded-[inherit] [max-height:inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
       >
         <ScrollAreaPrimitive.Content>{children}</ScrollAreaPrimitive.Content>
       </ScrollAreaPrimitive.Viewport>


### PR DESCRIPTION
### Motivation

- Ensure `ScrollArea` respects caller-provided `max-height` wrappers so inner content doesn't exceed parent constraints. 
- Prevent visual/scroll leakage by making the root container clip overflow when wrappers constrain height.

### Description

- Add `overflow-hidden` to the `ScrollArea` root element's class list to clip overflowing content. 
- Add `[max-height:inherit]` to the `ScrollAreaPrimitive.Viewport` classes so the viewport inherits its container's `max-height`. 
- Add a unit test at `apps/ui/src/__tests__/scroll-area.test.tsx` that verifies the root has `overflow-hidden` and the viewport has `[max-height:inherit]` when rendered with a `max-h-[]` wrapper.

### Testing

- Ran the component unit test `apps/ui/src/__tests__/scroll-area.test.tsx` which asserts the new classes are present, and it passed. 
- Ran the UI test suite locally and there were no regressions detected in the changed area.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcbd8ac94c832b9088584811c21254)