### PR TITLE
fix(ui): constrain ScrollArea max-height overflow

### DIFF
--- a/apps/ui/src/__tests__/scroll-area.test.tsx
+++ b/apps/ui/src/__tests__/scroll-area.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+describe("ScrollArea", () => {
+  it("keeps viewport constrained when callers use max-height wrappers", () => {
+    render(
+      <ScrollArea className="max-h-[40vh]" data-testid="scroll-area">
+        <div>content</div>
+      </ScrollArea>,
+    );
+
+    const root = screen.getByTestId("scroll-area");
+    const viewport = root.querySelector('[data-slot="scroll-area-viewport"]');
+
+    expect(root).toHaveClass("overflow-hidden");
+    expect(viewport).not.toBeNull();
+    expect(viewport as HTMLElement).toHaveClass("[max-height:inherit]");
+  });
+});

--- a/apps/ui/src/components/ui/scroll-area.tsx
+++ b/apps/ui/src/components/ui/scroll-area.tsx
@@ -11,13 +11,13 @@ function ScrollArea({ className, children, ref, ...props }: ScrollAreaProps) {
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
-      className={cn("relative", className)}
+      className={cn("relative overflow-hidden", className)}
       ref={ref}
       {...props}
     >
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
-        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+        className="focus-visible:ring-ring/50 size-full rounded-[inherit] [max-height:inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-inset focus-visible:outline-1"
       >
         <ScrollAreaPrimitive.Content>{children}</ScrollAreaPrimitive.Content>
       </ScrollAreaPrimitive.Viewport>


### PR DESCRIPTION
## What
Constrain shared UI scroll areas so sections that rely on `max-h-*` stay clipped and scroll internally, instead of letting long content spill into the next section.

## Why
A long tools list in the LLM history viewer could render past the end of the Tools section and overlap the following Input Messages section.

## How
- hide overflow at the shared `ScrollArea` root
- let the viewport inherit the parent max height
- add a regression test for the `max-h-*` usage pattern

## Risk
- Low
- Shared `ScrollArea` behavior changes for callers that use `max-h-*`; explicit-height callers should continue to work.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
