### PR TITLE
Ensure ScrollArea respects max-height wrappers and add unit test

### DIFF
--- a/apps/ui/src/__tests__/scroll-area.test.tsx
+++ b/apps/ui/src/__tests__/scroll-area.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+describe("ScrollArea", () => {
+  it("keeps viewport constrained when callers use max-height wrappers", () => {
+    render(
+      <ScrollArea className="max-h-[40vh]" data-testid="scroll-area">
+        <div>content</div>
+      </ScrollArea>,
+    );
+
+    const root = screen.getByTestId("scroll-area");
+    const viewport = root.querySelector('[data-slot="scroll-area-viewport"]');
+
+    expect(root).toHaveClass("overflow-hidden");
+    expect(viewport).not.toBeNull();
+    expect(viewport as HTMLElement).toHaveClass("[max-height:inherit]");
+  });
+});

--- a/apps/ui/src/components/ui/scroll-area.tsx
+++ b/apps/ui/src/components/ui/scroll-area.tsx
@@ -11,13 +11,13 @@ function ScrollArea({ className, children, ref, ...props }: ScrollAreaProps) {
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
-      className={cn("relative", className)}
+      className={cn("relative overflow-hidden", className)}
       ref={ref}
       {...props}
     >
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
-        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+        className="focus-visible:ring-ring/50 size-full rounded-[inherit] [max-height:inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-inset focus-visible:outline-1"
       >
         <ScrollAreaPrimitive.Content>{children}</ScrollAreaPrimitive.Content>
       </ScrollAreaPrimitive.Viewport>


### PR DESCRIPTION
### Motivation

- Constrain the scroll viewport so that callers who wrap `ScrollArea` with `max-height` utilities get a properly constrained scrolling region. 

### Description

- Add `overflow-hidden` to the `ScrollAreaPrimitive.Root` wrapper to prevent the root from overflowing its container. 
- Add `[max-height:inherit]` and `focus-visible:ring-inset` to the `ScrollAreaPrimitive.Viewport` so the viewport inherits max-height from wrappers and focus ring is inset. 
- Add a unit test `apps/ui/src/__tests__/scroll-area.test.tsx` that renders `ScrollArea` with a `max-h-[40vh]` wrapper and asserts the root has `overflow-hidden` and the viewport has `[max-height:inherit]`.

### Testing

- Ran the UI unit test suite including the new `scroll-area.test.tsx` which asserts class presence and viewport selection, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcbd8ac94c832b9088584811c21254)