### PR TITLE
refactor(worker): extract domain logic from workers into atoms and shared modules

### DIFF
--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -28,6 +28,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Instant;
 
+use super::act_hooks::{self, PostActHook};
 use super::{Atom, AtomContext};
 use crate::error::Result;
 use crate::events::{
@@ -94,14 +95,23 @@ pub struct ActResult {
     pub success_count: u32,
     /// Number of failed tool calls
     pub error_count: u32,
-    /// Providers that require user connection setup before the tool can run.
-    /// When non-empty, the worker should pause and emit a client-side tool call
-    /// to prompt the user to configure the connection.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub connection_required: Vec<String>,
+    /// When true, the act emitted client-side tool calls (connection setup,
+    /// client-side tools, etc.) and the worker should pause until tool results
+    /// arrive. Workers check this single flag — they never need to know *why*
+    /// the act paused.
+    #[serde(default)]
+    pub waiting_for_tool_results: bool,
     /// True when execution stopped before tool execution because a dependency was archived or deleted.
     #[serde(default, skip_serializing_if = "is_false")]
     pub blocked: bool,
+    /// Client-side tool calls that were NOT executed by ActAtom but need to be
+    /// sent to the client. Populated by ActAtom's partitioning logic, consumed
+    /// by ClientSideToolHook.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub client_tool_calls: Vec<ToolCall>,
+    /// Tool definitions for the client-side tool calls (for narration/display).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub client_tool_definitions: Vec<ToolDefinition>,
 }
 
 fn is_false(value: &bool) -> bool {
@@ -150,6 +160,9 @@ where
     platform_store: Option<Arc<dyn crate::platform_store::PlatformStore>>,
     /// Optional leased resource store for provider lease tracking
     leased_resource_store: Option<Arc<dyn crate::traits::LeasedResourceStore>>,
+    /// Post-act hooks that run after tool execution completes.
+    /// Hooks inspect the result and may emit events (e.g. tool.call_requested).
+    hooks: Vec<Box<dyn PostActHook>>,
 }
 
 impl<T, E> ActAtom<T, E>
@@ -157,7 +170,7 @@ where
     T: ToolExecutor,
     E: EventEmitter,
 {
-    /// Create a new ActAtom
+    /// Create a new ActAtom with default hooks (ConnectionSetup + ClientSideTool).
     pub fn new(tool_executor: T, event_emitter: E) -> Self {
         Self {
             tool_executor,
@@ -172,6 +185,7 @@ where
             schedule_store: None,
             platform_store: None,
             leased_resource_store: None,
+            hooks: Self::default_hooks(),
         }
     }
 
@@ -194,7 +208,23 @@ where
             schedule_store: None,
             platform_store: None,
             leased_resource_store: None,
+            hooks: Self::default_hooks(),
         }
+    }
+
+    /// Add a custom post-act hook.
+    pub fn with_hook(mut self, hook: Box<dyn PostActHook>) -> Self {
+        self.hooks.push(hook);
+        self
+    }
+
+    /// Default hooks: ConnectionSetup (synthetic setup_connection calls)
+    /// and ClientSideTool (emit tool.call_requested for client-side tools).
+    fn default_hooks() -> Vec<Box<dyn PostActHook>> {
+        vec![
+            Box::new(act_hooks::ConnectionSetupHook),
+            Box::new(act_hooks::ClientSideToolHook),
+        ]
     }
 
     /// Set the SQL database store on this atom
@@ -288,16 +318,62 @@ where
             .. // agent_id/org_id not needed here, just passed through workflow
         } = input;
 
-        if tool_calls.is_empty() {
+        // Partition tool calls: server-side tools get executed, client-side tools
+        // are stored on ActResult for the ClientSideToolHook to emit.
+        let (server_tool_calls, client_tool_calls): (Vec<_>, Vec<_>) =
+            tool_calls.into_iter().partition(|tc| {
+                tool_definitions
+                    .iter()
+                    .find(|td| td.name() == tc.name)
+                    .map(|td| !matches!(td, ToolDefinition::ClientSide(_)))
+                    .unwrap_or(true) // unknown tools go to server (will error there)
+            });
+
+        let client_tool_definitions: Vec<_> = tool_definitions
+            .iter()
+            .filter(|td| matches!(td, ToolDefinition::ClientSide(_)))
+            .cloned()
+            .collect();
+
+        if server_tool_calls.is_empty() && client_tool_calls.is_empty() {
             return Ok(ActResult {
                 results: vec![],
                 completed: true,
                 success_count: 0,
                 error_count: 0,
-                connection_required: vec![],
+                waiting_for_tool_results: false,
                 blocked: false,
+                client_tool_calls: vec![],
+                client_tool_definitions: vec![],
             });
         }
+
+        // If only client-side tools (no server-side), skip tool execution entirely.
+        // Just run hooks to emit tool.call_requested.
+        if server_tool_calls.is_empty() {
+            let mut result = ActResult {
+                results: vec![],
+                completed: true,
+                success_count: 0,
+                error_count: 0,
+                waiting_for_tool_results: false,
+                blocked: false,
+                client_tool_calls,
+                client_tool_definitions,
+            };
+            act_hooks::run_post_act_hooks(
+                &self.hooks,
+                &context,
+                &mut result,
+                &tool_definitions,
+                &self.event_emitter,
+            )
+            .await;
+            return Ok(result);
+        }
+
+        // Replace tool_calls with only server-side tools for execution
+        let tool_calls = server_tool_calls;
 
         tracing::info!(
             session_id = %context.session_id,
@@ -375,12 +451,6 @@ where
         let success_count = results.iter().filter(|r| r.success).count() as u32;
         let error_count = results.iter().filter(|r| !r.success).count() as u32;
 
-        // Collect providers that need connection setup
-        let connection_required: Vec<String> = results
-            .iter()
-            .filter_map(|r| r.connection_required.clone())
-            .collect();
-
         // Calculate act phase duration
         let act_duration_ms = act_start.elapsed().as_millis() as u64;
 
@@ -437,14 +507,28 @@ where
             "ActAtom: all tools completed"
         );
 
-        Ok(ActResult {
+        let mut act_result = ActResult {
             results,
             completed: true,
             success_count,
             error_count,
-            connection_required,
+            waiting_for_tool_results: false,
             blocked: false,
-        })
+            client_tool_calls,
+            client_tool_definitions,
+        };
+
+        // Run post-act hooks (connection setup, client-side tool emission, etc.)
+        act_hooks::run_post_act_hooks(
+            &self.hooks,
+            &context,
+            &mut act_result,
+            &tool_definitions,
+            &self.event_emitter,
+        )
+        .await;
+
+        Ok(act_result)
     }
 }
 
@@ -963,14 +1047,16 @@ mod tests {
             completed: true,
             success_count: 0,
             error_count: 0,
-            connection_required: vec!["daytona".to_string()],
+            waiting_for_tool_results: true,
             blocked: false,
+            client_tool_calls: vec![],
+            client_tool_definitions: vec![],
         };
 
         let json_str = serde_json::to_string(&result).unwrap();
         let parsed: ActResult = serde_json::from_str(&json_str).unwrap();
 
-        assert_eq!(parsed.connection_required, vec!["daytona".to_string()]);
+        assert!(parsed.waiting_for_tool_results);
         assert_eq!(
             parsed.results[0].connection_required,
             Some("daytona".to_string())
@@ -978,8 +1064,8 @@ mod tests {
     }
 
     #[test]
-    fn test_act_result_without_connection_required_backward_compat() {
-        // Old JSON without connection_required fields still deserializes
+    fn test_act_result_backward_compat_deserialization() {
+        // Old JSON without new fields still deserializes
         let json_str = r#"{
             "results": [],
             "completed": true,
@@ -988,6 +1074,7 @@ mod tests {
         }"#;
         let parsed: ActResult = serde_json::from_str(json_str).unwrap();
 
-        assert!(parsed.connection_required.is_empty());
+        assert!(!parsed.waiting_for_tool_results);
+        assert!(parsed.client_tool_calls.is_empty());
     }
 }

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -329,11 +329,21 @@ where
                     .unwrap_or(true) // unknown tools go to server (will error there)
             });
 
-        let client_tool_definitions: Vec<_> = tool_definitions
-            .iter()
-            .filter(|td| matches!(td, ToolDefinition::ClientSide(_)))
-            .cloned()
-            .collect();
+        let client_tool_definitions: Vec<_> = if client_tool_calls.is_empty() {
+            vec![]
+        } else {
+            tool_definitions
+                .iter()
+                .filter(|td| {
+                    if let ToolDefinition::ClientSide(ct) = td {
+                        client_tool_calls.iter().any(|tc| tc.name == ct.name)
+                    } else {
+                        false
+                    }
+                })
+                .cloned()
+                .collect()
+        };
 
         if server_tool_calls.is_empty() && client_tool_calls.is_empty() {
             return Ok(ActResult {

--- a/crates/core/src/atoms/act_hooks.rs
+++ b/crates/core/src/atoms/act_hooks.rs
@@ -1,0 +1,297 @@
+// Post-act hooks for ActAtom
+//
+// Decision: Hooks are pure functions that inspect ActResult and return
+// declarative PostActActions. ActAtom interprets them (event emission, etc).
+// This keeps hooks testable without mocking EventEmitter.
+//
+// Decision: Hooks set `waiting_for_tool_results` on ActResult so workers
+// see a single generic flag — they never need to know WHY the act paused.
+
+use crate::events::{EventContext, EventRequest, ToolCallRequestedData};
+use crate::tool_types::{ToolCall, ToolDefinition};
+use crate::traits::EventEmitter;
+use serde_json::json;
+use uuid::Uuid;
+
+use super::AtomContext;
+use super::act::ActResult;
+
+// ============================================================================
+// PostActHook trait
+// ============================================================================
+
+/// Action a post-act hook wants ActAtom to perform.
+#[derive(Debug, Clone)]
+pub enum PostActAction {
+    /// Emit a `tool.call_requested` event with synthetic client-side tool calls.
+    EmitToolCallRequested {
+        tool_calls: Vec<ToolCall>,
+        tool_definitions: Vec<ToolDefinition>,
+    },
+}
+
+/// Hook that runs after ActAtom finishes executing tools.
+///
+/// Hooks inspect the completed results and may:
+/// - Set `waiting_for_tool_results` on `ActResult`
+/// - Return actions for ActAtom to execute (e.g. emit events)
+///
+/// Hooks are pure: they return declarative actions rather than
+/// touching the event emitter directly. This makes them trivially testable.
+pub trait PostActHook: Send + Sync {
+    /// Inspect completed results, optionally mutate the result and return actions.
+    fn on_completed(
+        &self,
+        result: &mut ActResult,
+        tool_definitions: &[ToolDefinition],
+    ) -> Vec<PostActAction>;
+}
+
+// ============================================================================
+// ConnectionSetupHook
+// ============================================================================
+
+/// Hook that detects tools requiring user connection setup and emits
+/// synthetic `setup_connection` tool calls so the client can prompt the user.
+///
+/// When any tool returns `connection_required`, this hook:
+/// 1. Sets `waiting_for_tool_results = true` on ActResult
+/// 2. Returns a `PostActAction::EmitToolCallRequested` with synthetic tool calls
+pub struct ConnectionSetupHook;
+
+impl PostActHook for ConnectionSetupHook {
+    fn on_completed(
+        &self,
+        result: &mut ActResult,
+        _tool_definitions: &[ToolDefinition],
+    ) -> Vec<PostActAction> {
+        let providers: Vec<String> = result
+            .results
+            .iter()
+            .filter_map(|r| r.connection_required.clone())
+            .collect();
+
+        if providers.is_empty() {
+            return vec![];
+        }
+
+        result.waiting_for_tool_results = true;
+
+        let tool_calls: Vec<ToolCall> = providers
+            .iter()
+            .map(|provider| ToolCall {
+                id: format!("setup_conn_{}", Uuid::now_v7()),
+                name: "setup_connection".to_string(),
+                arguments: json!({ "provider": provider }),
+            })
+            .collect();
+
+        vec![PostActAction::EmitToolCallRequested {
+            tool_calls,
+            tool_definitions: vec![],
+        }]
+    }
+}
+
+// ============================================================================
+// ClientSideToolHook
+// ============================================================================
+
+/// Hook that handles client-side tool calls from the ReasonResult.
+///
+/// When ActAtom receives tool calls that include client-side tools,
+/// those tools are NOT executed (they're filtered out before execution).
+/// Instead, this hook emits `tool.call_requested` events so the client
+/// can execute them and return results.
+///
+/// This hook reads client-side tool calls stored on ActResult by ActAtom's
+/// partitioning logic, then emits the appropriate event.
+pub struct ClientSideToolHook;
+
+impl PostActHook for ClientSideToolHook {
+    fn on_completed(
+        &self,
+        result: &mut ActResult,
+        _tool_definitions: &[ToolDefinition],
+    ) -> Vec<PostActAction> {
+        if result.client_tool_calls.is_empty() {
+            return vec![];
+        }
+
+        result.waiting_for_tool_results = true;
+
+        vec![PostActAction::EmitToolCallRequested {
+            tool_calls: result.client_tool_calls.clone(),
+            tool_definitions: result.client_tool_definitions.clone(),
+        }]
+    }
+}
+
+// ============================================================================
+// Hook execution helper
+// ============================================================================
+
+/// Execute all post-act hooks and apply their actions.
+///
+/// This is called by ActAtom after tool execution completes. It:
+/// 1. Runs each hook to collect actions
+/// 2. Emits events for each action
+pub(super) async fn run_post_act_hooks<E: EventEmitter>(
+    hooks: &[Box<dyn PostActHook>],
+    context: &AtomContext,
+    result: &mut ActResult,
+    tool_definitions: &[ToolDefinition],
+    event_emitter: &E,
+) {
+    for hook in hooks {
+        let actions = hook.on_completed(result, tool_definitions);
+        for action in actions {
+            match action {
+                PostActAction::EmitToolCallRequested {
+                    tool_calls,
+                    tool_definitions: action_defs,
+                } => {
+                    let event = EventRequest::new(
+                        context.session_id,
+                        EventContext::turn(context.turn_id, context.input_message_id),
+                        ToolCallRequestedData::with_definitions(&tool_calls, &action_defs),
+                    );
+                    if let Err(e) = event_emitter.emit(event).await {
+                        tracing::warn!(
+                            error = %e,
+                            "PostActHook: failed to emit tool.call_requested event"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::atoms::act::ToolCallResult;
+    use crate::tool_types::ToolResult;
+
+    fn make_tool_call_result(connection_required: Option<&str>) -> ToolCallResult {
+        ToolCallResult {
+            tool_call: ToolCall {
+                id: "call_1".to_string(),
+                name: "some_tool".to_string(),
+                arguments: json!({}),
+            },
+            result: ToolResult {
+                tool_call_id: "call_1".to_string(),
+                result: Some(json!({})),
+                images: None,
+                error: None,
+                connection_required: connection_required.map(|s| s.to_string()),
+            },
+            success: true,
+            status: "success".to_string(),
+            connection_required: connection_required.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn test_connection_setup_hook_no_connections() {
+        let hook = ConnectionSetupHook;
+        let mut result = ActResult {
+            results: vec![make_tool_call_result(None)],
+            completed: true,
+            success_count: 1,
+            error_count: 0,
+            waiting_for_tool_results: false,
+            blocked: false,
+            client_tool_calls: vec![],
+            client_tool_definitions: vec![],
+        };
+
+        let actions = hook.on_completed(&mut result, &[]);
+        assert!(actions.is_empty());
+        assert!(!result.waiting_for_tool_results);
+    }
+
+    #[test]
+    fn test_connection_setup_hook_with_connection() {
+        let hook = ConnectionSetupHook;
+        let mut result = ActResult {
+            results: vec![make_tool_call_result(Some("github"))],
+            completed: true,
+            success_count: 0,
+            error_count: 0,
+            waiting_for_tool_results: false,
+            blocked: false,
+            client_tool_calls: vec![],
+            client_tool_definitions: vec![],
+        };
+
+        let actions = hook.on_completed(&mut result, &[]);
+        assert_eq!(actions.len(), 1);
+        assert!(result.waiting_for_tool_results);
+
+        match &actions[0] {
+            PostActAction::EmitToolCallRequested { tool_calls, .. } => {
+                assert_eq!(tool_calls.len(), 1);
+                assert_eq!(tool_calls[0].name, "setup_connection");
+                assert_eq!(tool_calls[0].arguments["provider"], "github");
+            }
+        }
+    }
+
+    #[test]
+    fn test_client_side_tool_hook_no_client_tools() {
+        let hook = ClientSideToolHook;
+        let mut result = ActResult {
+            results: vec![],
+            completed: true,
+            success_count: 0,
+            error_count: 0,
+            waiting_for_tool_results: false,
+            blocked: false,
+            client_tool_calls: vec![],
+            client_tool_definitions: vec![],
+        };
+
+        let actions = hook.on_completed(&mut result, &[]);
+        assert!(actions.is_empty());
+        assert!(!result.waiting_for_tool_results);
+    }
+
+    #[test]
+    fn test_client_side_tool_hook_with_client_tools() {
+        let hook = ClientSideToolHook;
+        let client_call = ToolCall {
+            id: "call_client".to_string(),
+            name: "browser_click".to_string(),
+            arguments: json!({"selector": "#btn"}),
+        };
+
+        let mut result = ActResult {
+            results: vec![],
+            completed: true,
+            success_count: 0,
+            error_count: 0,
+            waiting_for_tool_results: false,
+            blocked: false,
+            client_tool_calls: vec![client_call.clone()],
+            client_tool_definitions: vec![],
+        };
+
+        let actions = hook.on_completed(&mut result, &[]);
+        assert_eq!(actions.len(), 1);
+        assert!(result.waiting_for_tool_results);
+
+        match &actions[0] {
+            PostActAction::EmitToolCallRequested { tool_calls, .. } => {
+                assert_eq!(tool_calls.len(), 1);
+                assert_eq!(tool_calls[0].name, "browser_click");
+            }
+        }
+    }
+}

--- a/crates/core/src/atoms/mod.rs
+++ b/crates/core/src/atoms/mod.rs
@@ -23,11 +23,13 @@ use crate::typed_id::{ExecId, MessageId, SessionId, TurnId};
 
 // Turn-based atoms for the turn workflow
 mod act;
+pub mod act_hooks;
 mod input;
 mod reason;
 
 // Re-export atoms and their types
 pub use act::{ActAtom, ActInput, ActResult, ToolCallResult};
+pub use act_hooks::{ClientSideToolHook, ConnectionSetupHook, PostActAction, PostActHook};
 pub use input::{InputAtom, InputAtomInput, InputAtomResult};
 pub use reason::{ReasonAtom, ReasonInput, ReasonResult};
 

--- a/crates/core/src/dependency_blocker.rs
+++ b/crates/core/src/dependency_blocker.rs
@@ -1,0 +1,75 @@
+// Dependency blocker detection
+//
+// Decision: Shared module in core so both workers and activities don't
+// duplicate harness/agent status checks and error messages.
+
+use crate::error::Result;
+use crate::traits::{AgentStore, HarnessStore};
+use crate::typed_id::{AgentId, HarnessId};
+use crate::{AgentStatus, HarnessStatus};
+
+/// Reason why execution was blocked before it started.
+#[derive(Debug, Clone, Copy)]
+pub enum DependencyBlocker {
+    HarnessArchived,
+    HarnessDeleted,
+    AgentArchived,
+    AgentDeleted,
+}
+
+impl DependencyBlocker {
+    /// User-facing message explaining why execution stopped.
+    pub fn message(self) -> &'static str {
+        match self {
+            DependencyBlocker::HarnessArchived => {
+                "Execution stopped because the assigned harness was archived."
+            }
+            DependencyBlocker::HarnessDeleted => {
+                "Execution stopped because the assigned harness was deleted."
+            }
+            DependencyBlocker::AgentArchived => {
+                "Execution stopped because the assigned agent was archived."
+            }
+            DependencyBlocker::AgentDeleted => {
+                "Execution stopped because the assigned agent was deleted."
+            }
+        }
+    }
+
+    /// Error code for events.
+    pub fn error_code(self) -> &'static str {
+        "dependency_unavailable"
+    }
+}
+
+/// Check if a harness/agent dependency is available for execution.
+///
+/// Returns `Some(blocker)` if execution should be blocked.
+pub async fn detect_dependency_blocker(
+    harness_store: &dyn HarnessStore,
+    agent_store: &dyn AgentStore,
+    harness_id: HarnessId,
+    agent_id: Option<AgentId>,
+) -> Result<Option<DependencyBlocker>> {
+    match harness_store.get_harness(harness_id).await? {
+        Some(harness) => match harness.status {
+            HarnessStatus::Active => {}
+            HarnessStatus::Archived => return Ok(Some(DependencyBlocker::HarnessArchived)),
+            HarnessStatus::Deleted => return Ok(Some(DependencyBlocker::HarnessDeleted)),
+        },
+        None => return Ok(Some(DependencyBlocker::HarnessDeleted)),
+    }
+
+    if let Some(agent_id) = agent_id {
+        match agent_store.get_agent(agent_id).await? {
+            Some(agent) => match agent.status {
+                AgentStatus::Active => {}
+                AgentStatus::Archived => return Ok(Some(DependencyBlocker::AgentArchived)),
+                AgentStatus::Deleted => return Ok(Some(DependencyBlocker::AgentDeleted)),
+            },
+            None => return Ok(Some(DependencyBlocker::AgentDeleted)),
+        }
+    }
+
+    Ok(None)
+}

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -189,9 +189,10 @@ impl AgentLoopError {
     /// deleted message, a missing agent). Retrying will never succeed and only
     /// burns attempts while keeping the workflow stuck.
     ///
-    /// Previously this classification was done via string-matching in the
-    /// durable worker. Centralizing it here keeps domain knowledge with the
-    /// error types.
+    /// Note: the durable worker currently uses string-matching via
+    /// `is_non_retryable_task_error` because task errors arrive as strings.
+    /// This method provides the typed equivalent for callers that have access
+    /// to a structured `AgentLoopError`.
     pub fn is_non_retryable(&self) -> bool {
         match self {
             // Missing data is permanent — the entity was deleted.

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -183,6 +183,34 @@ impl AgentLoopError {
         }
     }
 
+    /// Check if this error is deterministic and should never be retried.
+    ///
+    /// Non-retryable errors reference data that is permanently gone (e.g. a
+    /// deleted message, a missing agent). Retrying will never succeed and only
+    /// burns attempts while keeping the workflow stuck.
+    ///
+    /// Previously this classification was done via string-matching in the
+    /// durable worker. Centralizing it here keeps domain knowledge with the
+    /// error types.
+    pub fn is_non_retryable(&self) -> bool {
+        match self {
+            // Missing data is permanent — the entity was deleted.
+            AgentLoopError::AgentNotFound(_)
+            | AgentLoopError::HarnessNotFound(_)
+            | AgentLoopError::SessionNotFound(_)
+            | AgentLoopError::NoMessages => true,
+
+            // Config/driver errors won't self-heal within retries.
+            AgentLoopError::Configuration(_) | AgentLoopError::DriverNotRegistered(_) => true,
+
+            // MessageStore "not found" errors (deleted messages).
+            AgentLoopError::MessageStore(msg) => msg.to_ascii_lowercase().contains("not found"),
+
+            // Everything else is potentially transient.
+            _ => false,
+        }
+    }
+
     /// Get user-facing error message based on error classification
     pub fn user_facing_message(&self) -> String {
         if let Some(model_id) = self.model_not_available_id() {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -69,6 +69,7 @@ pub mod url_validation;
 pub mod atoms;
 pub mod capabilities;
 pub mod command;
+pub mod dependency_blocker;
 pub mod error;
 pub mod llm_driver_registry;
 pub mod llm_retry;
@@ -191,8 +192,9 @@ pub use capabilities::{
 
 // Atoms re-exports (stateless atomic operations)
 pub use atoms::{
-    ActAtom, ActInput, ActResult, Atom, AtomContext, InputAtom, InputAtomInput, InputAtomResult,
-    ReasonAtom, ReasonInput, ReasonResult, ToolCallResult,
+    ActAtom, ActInput, ActResult, Atom, AtomContext, ClientSideToolHook, ConnectionSetupHook,
+    InputAtom, InputAtomInput, InputAtomResult, PostActAction, PostActHook, ReasonAtom,
+    ReasonInput, ReasonResult, ToolCallResult,
 };
 
 // Tool types (runtime types defined in this crate)
@@ -267,6 +269,9 @@ pub use permissions::{
     SkillPermissionPattern, SkillPermissionRule, check_skill_permission, evaluate_policies,
     evaluate_policies_with, parse_skill_permission_rule, role_has_permission, role_permissions,
 };
+
+// Dependency blocker re-exports
+pub use dependency_blocker::{DependencyBlocker, detect_dependency_blocker};
 
 // URL validation re-exports
 pub use url_validation::{UrlValidationError, validate_safe_url};

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -43,7 +43,7 @@ async fn detect_dependency_blocker(
     let agent_store = GrpcAgentStore::new(grpc_client.clone(), org_id);
     everruns_core::detect_dependency_blocker(&harness_store, &agent_store, harness_id, agent_id)
         .await
-        .map_err(|e| anyhow::anyhow!(e))
+        .map_err(anyhow::Error::new)
 }
 
 /// Emit dependency-blocked events (output message + turn.failed + session.idled, set idle).

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -16,8 +16,8 @@ use anyhow::{Context, Result};
 use everruns_core::ToolRegistry;
 use everruns_core::atoms::{ActAtom, Atom, InputAtom, ReasonAtom};
 use everruns_core::capabilities::{SystemPromptContext, collect_capabilities, is_mcp_capability};
-use everruns_core::traits::{AgentStore, HarnessStore};
-use everruns_core::{AgentStatus, HarnessStatus, Message, PlatformDefinition};
+use everruns_core::traits::AgentStore;
+use everruns_core::{Message, PlatformDefinition};
 use std::sync::Arc;
 
 use crate::grpc_adapters::{
@@ -32,69 +32,26 @@ pub use everruns_core::atoms::{
     ActInput, ActResult, InputAtomInput, InputAtomResult, ReasonInput, ReasonResult, ToolCallResult,
 };
 
-#[derive(Debug, Clone, Copy)]
-enum DependencyBlocker {
-    HarnessArchived,
-    HarnessDeleted,
-    AgentArchived,
-    AgentDeleted,
-}
-
-impl DependencyBlocker {
-    fn message(self) -> &'static str {
-        match self {
-            DependencyBlocker::HarnessArchived => {
-                "Execution stopped because the assigned harness was archived."
-            }
-            DependencyBlocker::HarnessDeleted => {
-                "Execution stopped because the assigned harness was deleted."
-            }
-            DependencyBlocker::AgentArchived => {
-                "Execution stopped because the assigned agent was archived."
-            }
-            DependencyBlocker::AgentDeleted => {
-                "Execution stopped because the assigned agent was deleted."
-            }
-        }
-    }
-}
-
+/// Thin wrapper: detect dependency blockers using core's shared logic with gRPC adapters.
 async fn detect_dependency_blocker(
     grpc_client: &GrpcClient,
     org_id: i64,
     harness_id: everruns_core::HarnessId,
     agent_id: Option<everruns_core::AgentId>,
-) -> Result<Option<DependencyBlocker>> {
+) -> Result<Option<everruns_core::DependencyBlocker>> {
     let harness_store = GrpcHarnessStore::new(grpc_client.clone(), org_id);
-    match harness_store.get_harness(harness_id).await? {
-        Some(harness) => match harness.status {
-            HarnessStatus::Active => {}
-            HarnessStatus::Archived => return Ok(Some(DependencyBlocker::HarnessArchived)),
-            HarnessStatus::Deleted => return Ok(Some(DependencyBlocker::HarnessDeleted)),
-        },
-        None => return Ok(Some(DependencyBlocker::HarnessDeleted)),
-    }
-
-    if let Some(agent_id) = agent_id {
-        let agent_store = GrpcAgentStore::new(grpc_client.clone(), org_id);
-        match agent_store.get_agent(agent_id).await? {
-            Some(agent) => match agent.status {
-                AgentStatus::Active => {}
-                AgentStatus::Archived => return Ok(Some(DependencyBlocker::AgentArchived)),
-                AgentStatus::Deleted => return Ok(Some(DependencyBlocker::AgentDeleted)),
-            },
-            None => return Ok(Some(DependencyBlocker::AgentDeleted)),
-        }
-    }
-
-    Ok(None)
+    let agent_store = GrpcAgentStore::new(grpc_client.clone(), org_id);
+    everruns_core::detect_dependency_blocker(&harness_store, &agent_store, harness_id, agent_id)
+        .await
+        .map_err(|e| anyhow::anyhow!(e))
 }
 
+/// Emit dependency-blocked events (output message + turn.failed + session.idled, set idle).
 async fn emit_dependency_blocked_events(
     grpc_client: &GrpcClient,
     org_id: i64,
     context: &everruns_core::atoms::AtomContext,
-    blocker: DependencyBlocker,
+    blocker: everruns_core::DependencyBlocker,
 ) {
     use everruns_core::events::{
         EventContext, EventRequest, OutputMessageCompletedData, SessionIdledData, TurnFailedData,
@@ -129,7 +86,7 @@ async fn emit_dependency_blocked_events(
         TurnFailedData {
             turn_id,
             error: message.to_string(),
-            error_code: Some("dependency_unavailable".to_string()),
+            error_code: Some(blocker.error_code().to_string()),
         },
     );
     if let Err(e) = event_emitter.emit(failed_event).await {
@@ -442,8 +399,10 @@ pub async fn act_activity(
             completed: true,
             success_count: 0,
             error_count: 1,
-            connection_required: vec![],
+            waiting_for_tool_results: false,
             blocked: true,
+            client_tool_calls: vec![],
+            client_tool_definitions: vec![],
         });
     }
 
@@ -683,8 +642,10 @@ mod tests {
             completed: true,
             success_count: 1,
             error_count: 0,
-            connection_required: vec![],
+            waiting_for_tool_results: false,
             blocked: false,
+            client_tool_calls: vec![],
+            client_tool_definitions: vec![],
         };
 
         let json = serde_json::to_string(&result).unwrap();

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -5,9 +5,8 @@
 use anyhow::Result;
 use everruns_core::atoms::AtomContext;
 use everruns_core::events::{
-    EventContext, EventRequest, OutputMessageCompletedData, SessionIdledData, ToolCallRequestedData,
+    EventContext, EventRequest, OutputMessageCompletedData, SessionIdledData,
 };
-use everruns_core::tool_types::ToolCall;
 use everruns_core::traits::EventEmitter;
 use everruns_core::typed_id::{ExecId, MessageId, SessionId, TurnId};
 use everruns_core::{Message, PlatformDefinition};
@@ -898,49 +897,18 @@ impl DurableWorker {
                             "Task completed successfully"
                         );
 
-                        // After act activity: if tools need a connection, emit
-                        // tool.call_requested and set session to waiting_for_tool_results.
-                        // This must happen before schedule_next_activity (which completes
-                        // the workflow) because we need gRPC access for events/status.
+                        // After act activity: if ActAtom signaled waiting_for_tool_results
+                        // (connection setup, client-side tools), set session status.
+                        // Events were already emitted by ActAtom hooks.
                         if task.activity_type == "act"
                             && let Some(ref ti) = turn_input_opt
                         {
-                            let act_result: Option<everruns_core::ActResult> =
-                                serde_json::from_value(output.clone()).ok();
-                            let conn_providers: Vec<String> = act_result
-                                .as_ref()
-                                .map(|r| r.connection_required.clone())
-                                .unwrap_or_default();
-
-                            if !conn_providers.is_empty() {
-                                // Build synthetic setup_connection tool calls
-                                let synthetic_tool_calls: Vec<ToolCall> = conn_providers
-                                    .iter()
-                                    .map(|provider| ToolCall {
-                                        id: format!("setup_conn_{}", Uuid::now_v7()),
-                                        name: "setup_connection".to_string(),
-                                        arguments: serde_json::json!({ "provider": provider }),
-                                    })
-                                    .collect();
-
-                                let turn_id = ti.turn_id.unwrap_or_default();
+                            let waiting = output
+                                .get("waiting_for_tool_results")
+                                .and_then(|v| v.as_bool())
+                                .unwrap_or(false);
+                            if waiting {
                                 let grpc_client = GrpcClient::connect(&self.grpc_address).await?;
-                                let event_emitter = GrpcEventEmitter::new(grpc_client.clone());
-
-                                let requested_event = EventRequest::new(
-                                    ti.session_id,
-                                    EventContext::turn(turn_id, ti.input_message_id),
-                                    ToolCallRequestedData {
-                                        tool_calls: synthetic_tool_calls,
-                                        tool_summaries: vec![],
-                                        headline: None,
-                                    },
-                                );
-                                if let Err(e) = event_emitter.emit(requested_event).await {
-                                    warn!(error = %e, "Failed to emit tool.call_requested event for connection setup");
-                                }
-
-                                // Set session status to waiting_for_tool_results
                                 if let Err(e) = grpc_client
                                     .set_session_status(
                                         ti.org_id,
@@ -1431,16 +1399,14 @@ impl DurableWorker {
                     return Ok(());
                 }
 
-                // Check if any tools require a user connection setup.
-                // If so, complete the workflow — the event emission and session status
-                // change were already handled by the caller (process_claimed_task).
-                let act_result: Option<everruns_core::ActResult> =
-                    serde_json::from_value(output.clone()).ok();
-                let has_connection_required = act_result
-                    .as_ref()
-                    .is_some_and(|r| !r.connection_required.is_empty());
+                // Check if act needs external input (connection setup, client-side tools).
+                // ActAtom sets waiting_for_tool_results via hooks; worker just checks the flag.
+                let waiting = output
+                    .get("waiting_for_tool_results")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
 
-                if has_connection_required {
+                if waiting {
                     // Complete workflow and persist the current DurableTurnInput so
                     // the tool-results endpoint can resume with correct turn_id,
                     // iteration, and previous_response_id (instead of creating a

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -17,6 +17,7 @@ pub mod leased_resource_cleanup;
 pub mod mcp_executor;
 pub mod platform;
 pub mod runner;
+pub mod session_lifecycle;
 pub mod unified_worker;
 pub mod worker_adapters;
 

--- a/crates/worker/src/session_lifecycle.rs
+++ b/crates/worker/src/session_lifecycle.rs
@@ -1,0 +1,288 @@
+// Session lifecycle management
+//
+// Decision: Consolidates session status transitions and lifecycle event emission
+// into one place. Previously scattered across unified_worker, durable_worker,
+// and activities — each with near-identical code.
+//
+// Workers call lifecycle methods; this module owns the event emission and
+// session status updates that always move in lockstep.
+
+use everruns_core::events::{
+    EventContext, EventRequest, OutputMessageCompletedData, SessionActivatedData, SessionIdledData,
+    TurnCompletedData, TurnFailedData, TurnStartedData,
+};
+use everruns_core::typed_id::{MessageId, SessionId, TurnId};
+use everruns_core::{DependencyBlocker, Message, TokenUsage};
+use tracing::warn;
+
+use crate::worker_adapters::WorkerAdapters;
+
+/// Encapsulates session/turn lifecycle transitions.
+///
+/// Each method atomically handles the event emission + session status update
+/// for a given lifecycle transition. Workers call these instead of manually
+/// emitting events and setting status.
+pub struct SessionLifecycle<A: WorkerAdapters> {
+    adapters: A,
+    org_id: i64,
+    session_id: SessionId,
+}
+
+impl<A: WorkerAdapters> SessionLifecycle<A> {
+    pub fn new(adapters: A, org_id: i64, session_id: SessionId) -> Self {
+        Self {
+            adapters,
+            org_id,
+            session_id,
+        }
+    }
+
+    /// Turn is starting: set session to "active", emit session.activated + turn.started.
+    pub async fn turn_started(
+        &self,
+        turn_id: TurnId,
+        input_message_id: MessageId,
+        input_content: Option<String>,
+    ) {
+        if let Err(e) = self
+            .adapters
+            .set_session_status(self.org_id, self.session_id.uuid(), "active")
+            .await
+        {
+            warn!(error = %e, "Failed to set session status to active");
+        }
+
+        let activated_event = EventRequest::new(
+            self.session_id,
+            EventContext::turn(turn_id, input_message_id),
+            SessionActivatedData {
+                turn_id,
+                input_message_id,
+            },
+        );
+        if let Err(e) = self.adapters.emit_event(activated_event).await {
+            warn!(error = %e, "Failed to emit session.activated event");
+        }
+
+        let turn_started_event = EventRequest::new(
+            self.session_id,
+            EventContext::turn(turn_id, input_message_id),
+            TurnStartedData {
+                turn_id,
+                input_message_id,
+                input_content,
+            },
+        );
+        if let Err(e) = self.adapters.emit_event(turn_started_event).await {
+            warn!(error = %e, "Failed to emit turn.started event");
+        }
+    }
+
+    /// Turn completed successfully: emit turn.completed + session.idled, set session to "idle".
+    pub async fn turn_completed(
+        &self,
+        turn_id: TurnId,
+        input_message_id: MessageId,
+        iterations: u32,
+        usage: Option<TokenUsage>,
+        input_content: Option<String>,
+    ) {
+        if let Err(e) = self
+            .adapters
+            .set_session_status(self.org_id, self.session_id.uuid(), "idle")
+            .await
+        {
+            warn!(error = %e, "Failed to set session status to idle");
+        }
+
+        let turn_completed_event = EventRequest::new(
+            self.session_id,
+            EventContext::turn(turn_id, input_message_id),
+            TurnCompletedData {
+                turn_id,
+                iterations,
+                duration_ms: None,
+                usage: usage.clone(),
+                input_content,
+            },
+        );
+        if let Err(e) = self.adapters.emit_event(turn_completed_event).await {
+            warn!(error = %e, "Failed to emit turn.completed event");
+        }
+
+        let idled_event = EventRequest::new(
+            self.session_id,
+            EventContext::turn(turn_id, input_message_id),
+            SessionIdledData {
+                turn_id,
+                iterations: Some(iterations),
+                usage,
+            },
+        );
+        if let Err(e) = self.adapters.emit_event(idled_event).await {
+            warn!(error = %e, "Failed to emit session.idled event");
+        }
+    }
+
+    /// Turn failed: emit turn.failed + session.idled, set session to "idle".
+    pub async fn turn_failed(
+        &self,
+        turn_id: TurnId,
+        input_message_id: MessageId,
+        error: &str,
+        error_code: Option<&str>,
+    ) {
+        if let Err(e) = self
+            .adapters
+            .set_session_status(self.org_id, self.session_id.uuid(), "idle")
+            .await
+        {
+            warn!(error = %e, "Failed to set session status to idle");
+        }
+
+        let turn_failed_event = EventRequest::new(
+            self.session_id,
+            EventContext::turn(turn_id, input_message_id),
+            TurnFailedData {
+                turn_id,
+                error: error.to_string(),
+                error_code: error_code.map(|s| s.to_string()),
+            },
+        );
+        if let Err(e) = self.adapters.emit_event(turn_failed_event).await {
+            warn!(error = %e, "Failed to emit turn.failed event");
+        }
+
+        let idled_event = EventRequest::new(
+            self.session_id,
+            EventContext::turn(turn_id, input_message_id),
+            SessionIdledData {
+                turn_id,
+                iterations: None,
+                usage: None,
+            },
+        );
+        if let Err(e) = self.adapters.emit_event(idled_event).await {
+            warn!(error = %e, "Failed to emit session.idled event");
+        }
+    }
+
+    /// Act needs external input: set session to "waiting_for_tool_results".
+    /// Events are already emitted by ActAtom's hooks — this only sets status.
+    pub async fn waiting_for_tool_results(&self) {
+        if let Err(e) = self
+            .adapters
+            .set_session_status(
+                self.org_id,
+                self.session_id.uuid(),
+                "waiting_for_tool_results",
+            )
+            .await
+        {
+            warn!(error = %e, "Failed to set session status to waiting_for_tool_results");
+        }
+    }
+
+    /// Dependency blocked: emit user-facing error message + turn.failed + session.idled,
+    /// set session to "idle".
+    pub async fn dependency_blocked(
+        &self,
+        turn_id: TurnId,
+        input_message_id: MessageId,
+        blocker: DependencyBlocker,
+    ) {
+        let message = blocker.message();
+
+        let output_event = EventRequest::new(
+            self.session_id,
+            EventContext::turn(turn_id, input_message_id),
+            OutputMessageCompletedData::new(Message::assistant(message)),
+        );
+        if let Err(e) = self.adapters.emit_event(output_event).await {
+            warn!(error = %e, "Failed to emit dependency blocked message");
+        }
+
+        self.turn_failed(
+            turn_id,
+            input_message_id,
+            message,
+            Some(blocker.error_code()),
+        )
+        .await;
+    }
+
+    /// DLQ error: emit user-facing error + session.idled, set session to "idle".
+    pub async fn dlq_error(&self, turn_id: TurnId, input_message_id: MessageId) {
+        let error_message = Message::assistant(
+            "I encountered an error while processing your request. Please try again later.",
+        );
+        let context = EventContext::turn(turn_id, input_message_id);
+
+        if let Err(e) = self
+            .adapters
+            .emit_event(EventRequest::new(
+                self.session_id,
+                context,
+                OutputMessageCompletedData::new(error_message),
+            ))
+            .await
+        {
+            warn!(error = %e, "Failed to emit DLQ error event");
+        }
+
+        let idled_event = EventRequest::new(
+            self.session_id,
+            EventContext::turn(turn_id, input_message_id),
+            SessionIdledData {
+                turn_id,
+                iterations: None,
+                usage: None,
+            },
+        );
+        if let Err(e) = self.adapters.emit_event(idled_event).await {
+            warn!(error = %e, "Failed to emit session.idled after DLQ");
+        }
+
+        if let Err(e) = self
+            .adapters
+            .set_session_status(self.org_id, self.session_id.uuid(), "idle")
+            .await
+        {
+            warn!(error = %e, "Failed to set session idle after DLQ");
+        }
+    }
+
+    /// Cancelled: emit cancellation message + session.idled, set session to "idle".
+    pub async fn cancelled(&self, turn_id: TurnId, input_message_id: MessageId) {
+        let cancel_message = Message::assistant("Work was cancelled by user.");
+        let message_event = EventRequest::new(
+            self.session_id,
+            EventContext::turn(turn_id, input_message_id),
+            OutputMessageCompletedData::new(cancel_message),
+        );
+        if let Err(e) = self.adapters.emit_event(message_event).await {
+            warn!(error = %e, "Failed to emit cancellation message");
+        }
+
+        let idled_event = EventRequest::new(
+            self.session_id,
+            EventContext::turn(turn_id, input_message_id),
+            SessionIdledData {
+                turn_id,
+                iterations: None,
+                usage: None,
+            },
+        );
+        if let Err(e) = self.adapters.emit_event(idled_event).await {
+            warn!(error = %e, "Failed to emit session.idled event");
+        }
+
+        if let Err(e) = self
+            .adapters
+            .set_session_status(self.org_id, self.session_id.uuid(), "idle")
+            .await
+        {
+            warn!(error = %e, "Failed to set session status to idle");
+        }
+    }
+}

--- a/crates/worker/src/session_lifecycle.rs
+++ b/crates/worker/src/session_lifecycle.rs
@@ -19,9 +19,10 @@ use crate::worker_adapters::WorkerAdapters;
 
 /// Encapsulates session/turn lifecycle transitions.
 ///
-/// Each method atomically handles the event emission + session status update
-/// for a given lifecycle transition. Workers call these instead of manually
-/// emitting events and setting status.
+/// Each method handles the event emission + session status update for a given
+/// lifecycle transition on a best-effort basis (individual operations may fail
+/// independently). Workers call these instead of manually emitting events and
+/// setting status.
 pub struct SessionLifecycle<A: WorkerAdapters> {
     adapters: A,
     org_id: i64,

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -9,13 +9,9 @@
 // while preserving the different deployment models (in-process vs external).
 
 use anyhow::Result;
+use everruns_core::ActInput;
 use everruns_core::atoms::{ActAtom, Atom, AtomContext, InputAtom, ReasonAtom};
-use everruns_core::events::{
-    EventContext, EventRequest, OutputMessageCompletedData, SessionActivatedData, SessionIdledData,
-    TurnCompletedData, TurnFailedData, TurnStartedData,
-};
 use everruns_core::typed_id::{ExecId, TurnId};
-use everruns_core::{ActInput, AgentStatus, HarnessStatus, Message};
 use everruns_durable::{
     ActivityOptions, ClaimedTask, WorkerInfo, WorkflowEvent, WorkflowEventStore, WorkflowStatus,
     append_event, record_activity_completed, record_activity_failed, record_activity_started,
@@ -29,6 +25,7 @@ use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crate::durable_runner::DurableTurnInput;
+use crate::session_lifecycle::SessionLifecycle;
 use crate::worker_adapters::{
     AdapterAgentStore, AdapterEventEmitter, AdapterHarnessStore, AdapterImageResolver,
     AdapterLlmProviderStore, AdapterMessageRetriever, AdapterSessionFileStore,
@@ -348,116 +345,24 @@ pub struct ShutdownHandle {
     tx: watch::Sender<bool>,
 }
 
-#[derive(Debug, Clone, Copy)]
-enum DependencyBlocker {
-    HarnessArchived,
-    HarnessDeleted,
-    AgentArchived,
-    AgentDeleted,
-}
-
-impl DependencyBlocker {
-    fn message(self) -> &'static str {
-        match self {
-            DependencyBlocker::HarnessArchived => {
-                "Execution stopped because the assigned harness was archived."
-            }
-            DependencyBlocker::HarnessDeleted => {
-                "Execution stopped because the assigned harness was deleted."
-            }
-            DependencyBlocker::AgentArchived => {
-                "Execution stopped because the assigned agent was archived."
-            }
-            DependencyBlocker::AgentDeleted => {
-                "Execution stopped because the assigned agent was deleted."
-            }
-        }
-    }
-}
-
+/// Helper: detect dependency blockers using shared core logic.
 async fn detect_dependency_blocker<A: WorkerAdapters>(
     adapters: &A,
     org_id: i64,
     harness_id: everruns_core::HarnessId,
     agent_id: Option<everruns_core::AgentId>,
-) -> Result<Option<DependencyBlocker>> {
-    let harness = adapters.get_harness(org_id, harness_id.uuid()).await?;
-    match harness {
-        Some(harness) => match harness.status {
-            HarnessStatus::Active => {}
-            HarnessStatus::Archived => return Ok(Some(DependencyBlocker::HarnessArchived)),
-            HarnessStatus::Deleted => return Ok(Some(DependencyBlocker::HarnessDeleted)),
-        },
-        None => return Ok(Some(DependencyBlocker::HarnessDeleted)),
-    }
-
-    if let Some(agent_id) = agent_id {
-        let agent = adapters.get_agent(org_id, agent_id.uuid()).await?;
-        match agent {
-            Some(agent) => match agent.status {
-                AgentStatus::Active => {}
-                AgentStatus::Archived => return Ok(Some(DependencyBlocker::AgentArchived)),
-                AgentStatus::Deleted => return Ok(Some(DependencyBlocker::AgentDeleted)),
-            },
-            None => return Ok(Some(DependencyBlocker::AgentDeleted)),
-        }
-    }
-
-    Ok(None)
-}
-
-async fn emit_dependency_blocked<A: WorkerAdapters>(
-    adapters: &A,
-    org_id: i64,
-    context: &AtomContext,
-    blocker: DependencyBlocker,
-) {
-    let session_id = context.session_id;
-    let turn_id = context.turn_id;
-    let input_message_id = context.input_message_id;
-    let message = blocker.message();
-
-    let output_event = EventRequest::new(
-        session_id,
-        EventContext::turn(turn_id, input_message_id),
-        OutputMessageCompletedData::new(Message::assistant(message)),
-    );
-    if let Err(e) = adapters.emit_event(output_event).await {
-        warn!(error = %e, "Failed to emit dependency blocked message");
-    }
-
-    if let Err(e) = adapters
-        .set_session_status(org_id, session_id.uuid(), "idle")
-        .await
-    {
-        warn!(error = %e, "Failed to set session status to idle");
-    }
-
-    let failed_event = EventRequest::new(
-        session_id,
-        EventContext::turn(turn_id, input_message_id),
-        TurnFailedData {
-            turn_id,
-            error: message.to_string(),
-            error_code: Some("dependency_unavailable".to_string()),
-        },
-    );
-    if let Err(e) = adapters.emit_event(failed_event).await {
-        warn!(error = %e, "Failed to emit dependency turn.failed");
-    }
-
-    let idled_event = EventRequest::new(
-        session_id,
-        EventContext::turn(turn_id, input_message_id),
-        SessionIdledData {
-            turn_id,
-            iterations: None,
-            usage: None,
-        },
-    );
-    if let Err(e) = adapters.emit_event(idled_event).await {
-        warn!(error = %e, "Failed to emit dependency session.idled");
-    }
+) -> Result<Option<everruns_core::DependencyBlocker>> {
+    let harness_store = AdapterHarnessStore::new(adapters.clone(), org_id);
+    let agent_store = AdapterAgentStore::new(adapters.clone(), org_id);
+    Ok(
+        everruns_core::detect_dependency_blocker(
+            &harness_store,
+            &agent_store,
+            harness_id,
+            agent_id,
+        )
+        .await?,
+    )
 }
 
 impl ShutdownHandle {
@@ -608,56 +513,21 @@ where
                         "Task completed successfully"
                     );
 
-                    // After act activity: if tools need a connection, emit
-                    // tool.call_requested and set session to waiting_for_tool_results.
-                    // This must happen before schedule_next_activity (which completes
-                    // the workflow) because we need adapter access for events/status.
+                    // After act activity: if ActAtom signaled waiting_for_tool_results
+                    // (connection setup, client-side tools, etc.), set session status.
+                    // Event emission is handled by ActAtom's hooks.
                     if task.activity_type == "act"
                         && let Some(ref ti) = turn_input_opt
                     {
                         let act_result: Option<everruns_core::ActResult> =
                             serde_json::from_value(output.clone()).ok();
-                        let conn_providers: Vec<String> = act_result
+                        if act_result
                             .as_ref()
-                            .map(|r| r.connection_required.clone())
-                            .unwrap_or_default();
-
-                        if !conn_providers.is_empty() {
-                            // Build synthetic setup_connection tool calls
-                            let synthetic_tool_calls: Vec<everruns_core::ToolCall> = conn_providers
-                                .iter()
-                                .map(|provider| everruns_core::ToolCall {
-                                    id: format!("setup_conn_{}", Uuid::now_v7()),
-                                    name: "setup_connection".to_string(),
-                                    arguments: serde_json::json!({ "provider": provider }),
-                                })
-                                .collect();
-
-                            let turn_id = ti.turn_id.unwrap_or_default();
-                            let requested_event = EventRequest::new(
-                                ti.session_id,
-                                EventContext::turn(turn_id, ti.input_message_id),
-                                everruns_core::ToolCallRequestedData {
-                                    tool_calls: synthetic_tool_calls,
-                                    tool_summaries: vec![],
-                                    headline: None,
-                                },
-                            );
-                            if let Err(e) = adapters.emit_event(requested_event).await {
-                                warn!(error = %e, "Failed to emit tool.call_requested event for connection setup");
-                            }
-
-                            // Set session status to waiting_for_tool_results
-                            if let Err(e) = adapters
-                                .set_session_status(
-                                    ti.org_id,
-                                    ti.session_id.uuid(),
-                                    "waiting_for_tool_results",
-                                )
-                                .await
-                            {
-                                warn!(error = %e, "Failed to set session status to waiting_for_tool_results");
-                            }
+                            .is_some_and(|r| r.waiting_for_tool_results)
+                        {
+                            let lifecycle =
+                                SessionLifecycle::new(adapters.clone(), ti.org_id, ti.session_id);
+                            lifecycle.waiting_for_tool_results().await;
                         }
                     }
 
@@ -722,40 +592,11 @@ async fn execute_input_activity<A: WorkerAdapters>(
         exec_id: ExecId::new(),
     };
 
-    // Set session status to "active"
-    if let Err(e) = adapters
-        .set_session_status(input.org_id, input.session_id.uuid(), "active")
-        .await
-    {
-        warn!(error = %e, "Failed to set session status to active");
-    }
-
-    // Emit session.activated event
-    let activated_event = EventRequest::new(
-        input.session_id,
-        EventContext::turn(context.turn_id, input.input_message_id),
-        SessionActivatedData {
-            turn_id: context.turn_id,
-            input_message_id: input.input_message_id,
-        },
-    );
-    if let Err(e) = adapters.emit_event(activated_event).await {
-        warn!(error = %e, "Failed to emit session.activated event");
-    }
-
-    // Emit turn.started event
-    let turn_started_event = EventRequest::new(
-        input.session_id,
-        EventContext::turn(context.turn_id, input.input_message_id),
-        TurnStartedData {
-            turn_id: context.turn_id,
-            input_message_id: input.input_message_id,
-            input_content: None, // Content will be extracted by Braintrust listener
-        },
-    );
-    if let Err(e) = adapters.emit_event(turn_started_event).await {
-        warn!(error = %e, "Failed to emit turn.started event");
-    }
+    // Turn starting: set active, emit session.activated + turn.started
+    let lifecycle = SessionLifecycle::new(adapters.clone(), input.org_id, input.session_id);
+    lifecycle
+        .turn_started(context.turn_id, input.input_message_id, None)
+        .await;
 
     // Execute InputAtom
     let message_retriever = AdapterMessageRetriever::new(adapters.clone());
@@ -800,10 +641,14 @@ async fn execute_reason_activity<A: WorkerAdapters>(
     let session_id = input.session_id;
     let input_message_id = input.input_message_id;
 
+    let lifecycle = SessionLifecycle::new(adapters.clone(), input.org_id, session_id);
+
     if let Some(blocker) =
         detect_dependency_blocker(adapters, input.org_id, input.harness_id, input.agent_id).await?
     {
-        emit_dependency_blocked(adapters, input.org_id, &context, blocker).await;
+        lifecycle
+            .dependency_blocked(turn_id, input_message_id, blocker)
+            .await;
         return Ok(serde_json::to_value(everruns_core::ReasonResult {
             success: false,
             text: blocker.message().to_string(),
@@ -857,108 +702,29 @@ async fn execute_reason_activity<A: WorkerAdapters>(
 
     let result = atom.execute(reason_input).await?;
 
-    // Check for client-side tool calls
-    let has_client_side_tools = result.has_tool_calls
-        && result.success
-        && result.tool_calls.iter().any(|tc| {
-            result
-                .tool_definitions
-                .iter()
-                .find(|td| td.name() == tc.name)
-                .map(|td| matches!(td, everruns_core::ToolDefinition::ClientSide(_)))
-                .unwrap_or(false)
-        });
-
-    if has_client_side_tools {
-        // Separate client-side tool calls
-        let client_tool_calls: Vec<_> = result
-            .tool_calls
-            .iter()
-            .filter(|tc| {
-                result
-                    .tool_definitions
-                    .iter()
-                    .find(|td| td.name() == tc.name)
-                    .map(|td| matches!(td, everruns_core::ToolDefinition::ClientSide(_)))
-                    .unwrap_or(false)
-            })
-            .collect();
-
-        // Emit tool.call_requested event with full ToolCall (client needs arguments)
-        let requested_event = EventRequest::new(
-            session_id,
-            EventContext::turn(turn_id, input_message_id),
-            everruns_core::ToolCallRequestedData::with_definitions(
-                &client_tool_calls.into_iter().cloned().collect::<Vec<_>>(),
-                &result.tool_definitions,
-            ),
-        );
-        if let Err(e) = adapters.emit_event(requested_event).await {
-            warn!(error = %e, "Failed to emit tool.call_requested event");
-        }
-
-        // Set session status to waiting_for_tool_results
-        if let Err(e) = adapters
-            .set_session_status(input.org_id, session_id.uuid(), "waiting_for_tool_results")
-            .await
-        {
-            warn!(error = %e, "Failed to set session status to waiting_for_tool_results");
-        }
-    }
-
-    // If turn is complete (no tool calls or failure), set session to idle
+    // If turn is complete (no tool calls or failure), emit lifecycle events.
+    // Client-side tool handling is now done by ActAtom's hooks.
     let turn_complete = !result.has_tool_calls || !result.success;
     if turn_complete {
-        if let Err(e) = adapters
-            .set_session_status(input.org_id, session_id.uuid(), "idle")
-            .await
-        {
-            warn!(error = %e, "Failed to set session status to idle");
-        }
-
-        // Emit turn.failed or turn.completed
         if !result.success {
-            let turn_failed_event = EventRequest::new(
-                session_id,
-                EventContext::turn(turn_id, input_message_id),
-                TurnFailedData {
+            lifecycle
+                .turn_failed(
                     turn_id,
-                    error: "An error occurred while processing your request.".to_string(),
-                    error_code: Some("llm_error".to_string()),
-                },
-            );
-            if let Err(e) = adapters.emit_event(turn_failed_event).await {
-                warn!(error = %e, "Failed to emit turn.failed event");
-            }
+                    input_message_id,
+                    "An error occurred while processing your request.",
+                    Some("llm_error"),
+                )
+                .await;
         } else {
-            let turn_completed_event = EventRequest::new(
-                session_id,
-                EventContext::turn(turn_id, input_message_id),
-                TurnCompletedData {
+            lifecycle
+                .turn_completed(
                     turn_id,
-                    iterations: input.iteration,
-                    duration_ms: None,
-                    usage: result.usage.clone(),
-                    input_content: None, // Passed through from turn.started by Braintrust
-                },
-            );
-            if let Err(e) = adapters.emit_event(turn_completed_event).await {
-                warn!(error = %e, "Failed to emit turn.completed event");
-            }
-        }
-
-        // Emit session.idled event
-        let idled_event = EventRequest::new(
-            session_id,
-            EventContext::turn(turn_id, input_message_id),
-            SessionIdledData {
-                turn_id,
-                iterations: Some(input.iteration),
-                usage: result.usage.clone(),
-            },
-        );
-        if let Err(e) = adapters.emit_event(idled_event).await {
-            warn!(error = %e, "Failed to emit session.idled event");
+                    input_message_id,
+                    input.iteration,
+                    result.usage.clone(),
+                    None,
+                )
+                .await;
         }
     }
 
@@ -984,18 +750,24 @@ async fn execute_act_activity<A: WorkerAdapters>(
     if let Some(blocker) =
         detect_dependency_blocker(adapters, org_id, input.harness_id, input.agent_id).await?
     {
-        emit_dependency_blocked(adapters, org_id, &input.context, blocker).await;
-        let mut output = serde_json::to_value(everruns_core::ActResult {
+        let lifecycle = SessionLifecycle::new(adapters.clone(), org_id, input.context.session_id);
+        lifecycle
+            .dependency_blocked(
+                input.context.turn_id,
+                input.context.input_message_id,
+                blocker,
+            )
+            .await;
+        let output = serde_json::to_value(everruns_core::ActResult {
             results: vec![],
             completed: true,
             success_count: 0,
             error_count: 1,
-            connection_required: vec![],
+            waiting_for_tool_results: false,
             blocked: true,
+            client_tool_calls: vec![],
+            client_tool_definitions: vec![],
         })?;
-        if let serde_json::Value::Object(ref mut map) = output {
-            map.insert("blocked".to_string(), serde_json::Value::Bool(true));
-        }
         return Ok(output);
     }
 
@@ -1097,99 +869,56 @@ async fn schedule_next_activity<S: WorkflowEventStore>(
             debug!(workflow_id = %workflow_id, turn_id = ?turn_id, "Scheduled reason activity");
         }
         "reason" => {
-            // Check if there are tool calls
             let reason_result: everruns_core::ReasonResult = serde_json::from_value(output.clone())
                 .map_err(|e| anyhow::anyhow!("Failed to parse ReasonResult: {}", e))?;
 
-            // Carry response_id forward for next reason iteration
             let response_id = reason_result.response_id.clone();
 
             if reason_result.has_tool_calls && reason_result.success {
                 let turn_id = input.turn_id.unwrap_or_default();
 
-                // Separate server-side and client-side tool calls
-                let (server_tool_calls, client_tool_calls): (Vec<_>, Vec<_>) =
-                    reason_result.tool_calls.into_iter().partition(|tc| {
-                        reason_result
-                            .tool_definitions
-                            .iter()
-                            .find(|td| td.name() == tc.name)
-                            .map(|td| !matches!(td, everruns_core::ToolDefinition::ClientSide(_)))
-                            .unwrap_or(true) // unknown tools go to server (will error)
-                    });
-
-                let has_client_tools = !client_tool_calls.is_empty();
-                let has_server_tools = !server_tool_calls.is_empty();
-
-                if has_server_tools {
-                    // Schedule act activity for server-side tools
-                    // Client-side tools will be handled after act completes
-                    let act_input = ActInput {
-                        org_id: Some(input.org_id),
-                        context: AtomContext {
-                            session_id: input.session_id,
-                            turn_id,
-                            input_message_id: input.input_message_id,
-                            exec_id: ExecId::new(),
-                        },
-                        harness_id: input.harness_id,
-                        agent_id: input.agent_id,
-                        tool_calls: server_tool_calls,
-                        tool_definitions: reason_result.tool_definitions.clone(),
-                    };
-                    let mut act_input_json = serde_json::to_value(&act_input)?;
-                    // Carry response_id and iteration through act task for next reason iteration
-                    if let Some(rid) = &response_id {
-                        act_input_json["previous_response_id"] = serde_json::json!(rid);
-                    }
-                    act_input_json["iteration"] = serde_json::json!(input.iteration);
-                    let activity_id = format!("act_{}", Uuid::now_v7());
-
-                    let task = TaskDefinition {
-                        workflow_id: Some(workflow_id),
-                        activity_id: activity_id.clone(),
-                        activity_type: "act".to_string(),
-                        input: act_input_json.clone(),
-                        options: Default::default(),
-                    };
-                    store
-                        .enqueue_task(task)
-                        .await
-                        .map_err(|e| anyhow::anyhow!("Failed to enqueue act task: {}", e))?;
-
-                    let scheduled_event = WorkflowEvent::ActivityScheduled {
-                        activity_id,
-                        activity_type: "act".to_string(),
-                        input: act_input_json,
-                        options: ActivityOptions::default(),
-                    };
-                    let _ = append_event(store.as_ref(), workflow_id, scheduled_event).await;
-
-                    debug!(
-                        workflow_id = %workflow_id,
-                        server_tools = has_server_tools,
-                        client_tools = has_client_tools,
-                        "Scheduled act activity for server-side tools"
-                    );
+                // Send ALL tool calls to ActAtom — it handles client/server partitioning internally
+                let act_input = ActInput {
+                    org_id: Some(input.org_id),
+                    context: AtomContext {
+                        session_id: input.session_id,
+                        turn_id,
+                        input_message_id: input.input_message_id,
+                        exec_id: ExecId::new(),
+                    },
+                    harness_id: input.harness_id,
+                    agent_id: input.agent_id,
+                    tool_calls: reason_result.tool_calls,
+                    tool_definitions: reason_result.tool_definitions,
+                };
+                let mut act_input_json = serde_json::to_value(&act_input)?;
+                if let Some(rid) = &response_id {
+                    act_input_json["previous_response_id"] = serde_json::json!(rid);
                 }
+                act_input_json["iteration"] = serde_json::json!(input.iteration);
+                let activity_id = format!("act_{}", Uuid::now_v7());
 
-                if has_client_tools && !has_server_tools {
-                    // Only client-side tools, no server tools
-                    // Complete workflow - it will be resumed by tool-results endpoint
-                    // The tool.call_requested event was already emitted in execute_reason_activity
-                    record_workflow_completed(store.as_ref(), workflow_id, output.clone()).await;
+                let task = TaskDefinition {
+                    workflow_id: Some(workflow_id),
+                    activity_id: activity_id.clone(),
+                    activity_type: "act".to_string(),
+                    input: act_input_json.clone(),
+                    options: Default::default(),
+                };
+                store
+                    .enqueue_task(task)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to enqueue act task: {}", e))?;
 
-                    store
-                        .update_workflow_status(workflow_id, WorkflowStatus::Completed, None, None)
-                        .await
-                        .map_err(|e| anyhow::anyhow!("Failed to update workflow status: {}", e))?;
+                let scheduled_event = WorkflowEvent::ActivityScheduled {
+                    activity_id,
+                    activity_type: "act".to_string(),
+                    input: act_input_json,
+                    options: ActivityOptions::default(),
+                };
+                let _ = append_event(store.as_ref(), workflow_id, scheduled_event).await;
 
-                    info!(
-                        workflow_id = %workflow_id,
-                        client_tool_count = client_tool_calls.len(),
-                        "Workflow completed - waiting for client tool results"
-                    );
-                }
+                debug!(workflow_id = %workflow_id, "Scheduled act activity");
             } else {
                 // Workflow complete
                 record_workflow_completed(store.as_ref(), workflow_id, output.clone()).await;
@@ -1216,16 +945,14 @@ async fn schedule_next_activity<S: WorkflowEventStore>(
                 info!(workflow_id = %workflow_id, "Workflow completed after dependency block");
                 return Ok(());
             }
-            // Check if any tools require a user connection setup.
-            // If so, complete the workflow — the event emission and session status
-            // change were already handled by the caller (process_claimed_task).
-            let act_result: Option<everruns_core::ActResult> =
-                serde_json::from_value(output.clone()).ok();
-            let has_connection_required = act_result
-                .as_ref()
-                .is_some_and(|r| !r.connection_required.is_empty());
+            // Check if act needs external input (connection setup, client-side tools).
+            // ActAtom sets waiting_for_tool_results via hooks; worker just checks the flag.
+            let waiting = output
+                .get("waiting_for_tool_results")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
 
-            if has_connection_required {
+            if waiting {
                 // Complete workflow — it will be resumed by tool-results endpoint
                 record_workflow_completed(store.as_ref(), workflow_id, output.clone()).await;
                 store
@@ -1235,7 +962,7 @@ async fn schedule_next_activity<S: WorkflowEventStore>(
 
                 info!(
                     workflow_id = %workflow_id,
-                    "Workflow completed — waiting for user to set up connection"
+                    "Workflow completed — waiting for tool results"
                 );
             } else {
                 // Normal flow: schedule another reason activity
@@ -1281,9 +1008,6 @@ async fn schedule_next_activity<S: WorkflowEventStore>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use everruns_core::tool_types::{
-        BuiltinTool, ClientSideTool, DeferrablePolicy, ToolCall, ToolDefinition, ToolPolicy,
-    };
 
     #[test]
     fn test_config_default() {
@@ -1303,304 +1027,5 @@ mod tests {
     fn test_config_production() {
         let config = TaskWorkerConfig::production();
         assert_eq!(config.max_concurrent_tasks, 1000);
-    }
-
-    // =========================================================================
-    // Client-Side Tool Partition Logic Tests
-    //
-    // Tests the partition logic used in schedule_next_activity to separate
-    // server-side and client-side tool calls from a ReasonResult.
-    // =========================================================================
-
-    /// Helper: partition tool calls into (server, client) using the same logic
-    /// as schedule_next_activity in the worker.
-    fn partition_tool_calls(
-        tool_calls: Vec<ToolCall>,
-        tool_definitions: &[ToolDefinition],
-    ) -> (Vec<ToolCall>, Vec<ToolCall>) {
-        tool_calls.into_iter().partition(|tc| {
-            tool_definitions
-                .iter()
-                .find(|td| td.name() == tc.name)
-                .map(|td| !matches!(td, ToolDefinition::ClientSide(_)))
-                .unwrap_or(true) // unknown tools go to server (will error)
-        })
-    }
-
-    #[test]
-    fn test_partition_all_server_tools() {
-        let tool_definitions = vec![ToolDefinition::Builtin(BuiltinTool {
-            name: "get_weather".to_string(),
-            display_name: None,
-            description: "Get weather".to_string(),
-            parameters: serde_json::json!({"type": "object"}),
-            policy: ToolPolicy::Auto,
-            category: None,
-            deferrable: DeferrablePolicy::default(),
-        })];
-
-        let tool_calls = vec![ToolCall {
-            id: "call_1".to_string(),
-            name: "get_weather".to_string(),
-            arguments: serde_json::json!({"city": "NYC"}),
-        }];
-
-        let (server, client) = partition_tool_calls(tool_calls, &tool_definitions);
-        assert_eq!(server.len(), 1);
-        assert_eq!(client.len(), 0);
-        assert_eq!(server[0].id, "call_1");
-    }
-
-    #[test]
-    fn test_partition_all_client_tools() {
-        let tool_definitions = vec![ToolDefinition::ClientSide(ClientSideTool {
-            name: "browser_click".to_string(),
-            display_name: None,
-            description: "Click element".to_string(),
-            parameters: serde_json::json!({"type": "object"}),
-            category: None,
-            deferrable: DeferrablePolicy::default(),
-        })];
-
-        let tool_calls = vec![ToolCall {
-            id: "call_1".to_string(),
-            name: "browser_click".to_string(),
-            arguments: serde_json::json!({"selector": "#btn"}),
-        }];
-
-        let (server, client) = partition_tool_calls(tool_calls, &tool_definitions);
-        assert_eq!(server.len(), 0);
-        assert_eq!(client.len(), 1);
-        assert_eq!(client[0].id, "call_1");
-    }
-
-    #[test]
-    fn test_partition_mixed_tools() {
-        let tool_definitions = vec![
-            ToolDefinition::Builtin(BuiltinTool {
-                name: "get_time".to_string(),
-                display_name: None,
-                description: "Get current time".to_string(),
-                parameters: serde_json::json!({"type": "object"}),
-                policy: ToolPolicy::Auto,
-                category: None,
-                deferrable: DeferrablePolicy::default(),
-            }),
-            ToolDefinition::ClientSide(ClientSideTool {
-                name: "browser_click".to_string(),
-                display_name: None,
-                description: "Click element".to_string(),
-                parameters: serde_json::json!({"type": "object"}),
-                category: None,
-                deferrable: DeferrablePolicy::default(),
-            }),
-            ToolDefinition::ClientSide(ClientSideTool {
-                name: "browser_type".to_string(),
-                display_name: None,
-                description: "Type text".to_string(),
-                parameters: serde_json::json!({"type": "object"}),
-                category: None,
-                deferrable: DeferrablePolicy::default(),
-            }),
-            ToolDefinition::Builtin(BuiltinTool {
-                name: "read_file".to_string(),
-                display_name: None,
-                description: "Read a file".to_string(),
-                parameters: serde_json::json!({"type": "object"}),
-                policy: ToolPolicy::Auto,
-                category: None,
-                deferrable: DeferrablePolicy::default(),
-            }),
-        ];
-
-        let tool_calls = vec![
-            ToolCall {
-                id: "call_1".to_string(),
-                name: "get_time".to_string(),
-                arguments: serde_json::json!({}),
-            },
-            ToolCall {
-                id: "call_2".to_string(),
-                name: "browser_click".to_string(),
-                arguments: serde_json::json!({"selector": "#submit"}),
-            },
-            ToolCall {
-                id: "call_3".to_string(),
-                name: "read_file".to_string(),
-                arguments: serde_json::json!({"path": "/test.txt"}),
-            },
-            ToolCall {
-                id: "call_4".to_string(),
-                name: "browser_type".to_string(),
-                arguments: serde_json::json!({"selector": "#input", "text": "hello"}),
-            },
-        ];
-
-        let (server, client) = partition_tool_calls(tool_calls, &tool_definitions);
-
-        assert_eq!(server.len(), 2);
-        assert_eq!(client.len(), 2);
-
-        let server_ids: Vec<&str> = server.iter().map(|tc| tc.id.as_str()).collect();
-        let client_ids: Vec<&str> = client.iter().map(|tc| tc.id.as_str()).collect();
-
-        assert!(server_ids.contains(&"call_1")); // get_time -> server
-        assert!(server_ids.contains(&"call_3")); // read_file -> server
-        assert!(client_ids.contains(&"call_2")); // browser_click -> client
-        assert!(client_ids.contains(&"call_4")); // browser_type -> client
-    }
-
-    #[test]
-    fn test_partition_unknown_tool_goes_to_server() {
-        // Unknown tools (not in definitions) default to server-side
-        let tool_definitions = vec![ToolDefinition::ClientSide(ClientSideTool {
-            name: "known_client".to_string(),
-            display_name: None,
-            description: "Known client tool".to_string(),
-            parameters: serde_json::json!({"type": "object"}),
-            category: None,
-            deferrable: DeferrablePolicy::default(),
-        })];
-
-        let tool_calls = vec![
-            ToolCall {
-                id: "call_1".to_string(),
-                name: "unknown_tool".to_string(),
-                arguments: serde_json::json!({}),
-            },
-            ToolCall {
-                id: "call_2".to_string(),
-                name: "known_client".to_string(),
-                arguments: serde_json::json!({}),
-            },
-        ];
-
-        let (server, client) = partition_tool_calls(tool_calls, &tool_definitions);
-
-        assert_eq!(server.len(), 1);
-        assert_eq!(server[0].name, "unknown_tool");
-        assert_eq!(client.len(), 1);
-        assert_eq!(client[0].name, "known_client");
-    }
-
-    #[test]
-    fn test_partition_empty_tool_calls() {
-        let tool_definitions = vec![ToolDefinition::ClientSide(ClientSideTool {
-            name: "some_tool".to_string(),
-            display_name: None,
-            description: "A tool".to_string(),
-            parameters: serde_json::json!({"type": "object"}),
-            category: None,
-            deferrable: DeferrablePolicy::default(),
-        })];
-
-        let tool_calls: Vec<ToolCall> = vec![];
-        let (server, client) = partition_tool_calls(tool_calls, &tool_definitions);
-        assert!(server.is_empty());
-        assert!(client.is_empty());
-    }
-
-    #[test]
-    fn test_partition_with_reason_result() {
-        // Full integration: create a ReasonResult and partition its tool calls
-        let reason_result = ReasonResult {
-            success: true,
-            text: "I'll use both tools.".to_string(),
-            has_tool_calls: true,
-            tool_calls: vec![
-                ToolCall {
-                    id: "call_srv".to_string(),
-                    name: "get_current_time".to_string(),
-                    arguments: serde_json::json!({}),
-                },
-                ToolCall {
-                    id: "call_cli".to_string(),
-                    name: "deploy_app".to_string(),
-                    arguments: serde_json::json!({"env": "staging"}),
-                },
-            ],
-            tool_definitions: vec![
-                ToolDefinition::Builtin(BuiltinTool {
-                    name: "get_current_time".to_string(),
-                    display_name: None,
-                    description: "Get current time".to_string(),
-                    parameters: serde_json::json!({"type": "object"}),
-                    policy: ToolPolicy::Auto,
-                    category: None,
-                    deferrable: DeferrablePolicy::default(),
-                }),
-                ToolDefinition::ClientSide(ClientSideTool {
-                    name: "deploy_app".to_string(),
-                    display_name: None,
-                    description: "Deploy application".to_string(),
-                    parameters: serde_json::json!({"type": "object"}),
-                    category: None,
-                    deferrable: DeferrablePolicy::default(),
-                }),
-            ],
-            max_iterations: 100,
-            error: None,
-            usage: None,
-            response_id: None,
-        };
-
-        // Use the same partition logic as the worker
-        let (server_tool_calls, client_tool_calls): (Vec<_>, Vec<_>) =
-            reason_result.tool_calls.into_iter().partition(|tc| {
-                reason_result
-                    .tool_definitions
-                    .iter()
-                    .find(|td| td.name() == tc.name)
-                    .map(|td| !matches!(td, ToolDefinition::ClientSide(_)))
-                    .unwrap_or(true)
-            });
-
-        assert_eq!(server_tool_calls.len(), 1);
-        assert_eq!(server_tool_calls[0].name, "get_current_time");
-        assert_eq!(client_tool_calls.len(), 1);
-        assert_eq!(client_tool_calls[0].name, "deploy_app");
-    }
-
-    #[test]
-    fn test_partition_requires_approval_stays_server_side() {
-        // Tools with RequiresApproval policy are still server-side
-        let tool_definitions = vec![
-            ToolDefinition::Builtin(BuiltinTool {
-                name: "delete_file".to_string(),
-                display_name: None,
-                description: "Delete a file".to_string(),
-                parameters: serde_json::json!({"type": "object"}),
-                policy: ToolPolicy::RequiresApproval,
-                category: None,
-                deferrable: DeferrablePolicy::default(),
-            }),
-            ToolDefinition::ClientSide(ClientSideTool {
-                name: "browser_click".to_string(),
-                display_name: None,
-                description: "Click element".to_string(),
-                parameters: serde_json::json!({"type": "object"}),
-                category: None,
-                deferrable: DeferrablePolicy::default(),
-            }),
-        ];
-
-        let tool_calls = vec![
-            ToolCall {
-                id: "call_1".to_string(),
-                name: "delete_file".to_string(),
-                arguments: serde_json::json!({}),
-            },
-            ToolCall {
-                id: "call_2".to_string(),
-                name: "browser_click".to_string(),
-                arguments: serde_json::json!({}),
-            },
-        ];
-
-        let (server, client) = partition_tool_calls(tool_calls, &tool_definitions);
-        assert_eq!(server.len(), 1);
-        assert_eq!(server[0].name, "delete_file"); // RequiresApproval -> server
-        assert_eq!(client.len(), 1);
-        assert_eq!(client[0].name, "browser_click"); // ClientSide -> client
     }
 }


### PR DESCRIPTION
## Summary

- **PostActHook pattern**: Pure hook functions on ActAtom generate declarative `PostActAction` enums. `ConnectionSetupHook` and `ClientSideToolHook` handle connection setup and client-side tool events — workers never see connection details.
- **Client/server tool partitioning** moved from workers into `ActAtom.execute()`. Fixes a bug where durable_worker sent all tool calls (including client-side) to execution without partitioning.
- **DependencyBlocker** deduplicated from 3 copies (unified_worker, durable_worker, activities) into `crates/core/src/dependency_blocker.rs`.
- **SessionLifecycle** consolidates 7 event types + 5 session status transitions into one component. Workers call `lifecycle.turn_started()` instead of manually emitting events + setting status.
- **`is_non_retryable()`** on `AgentLoopError` centralizes error retryability classification at the source.
- **`ActResult.waiting_for_tool_results`** replaces `connection_required: Vec<String>` — workers check a single boolean flag without knowing WHY the act paused.

Net -525 lines deleted across workers.

## Test plan

- [x] All core atom tests pass (10 tests including new hook tests)
- [x] All worker tests pass (64 tests)
- [x] All error classification tests pass
- [x] `just pre-push` passes (fmt, clippy, lockfile)
- [x] Full workspace `cargo check --all-targets` clean