### PR TITLE
fix(security): encrypt app channel_config secrets at rest

### DIFF
--- a/crates/server/migrations/009_encrypt_app_channel_config.sql
+++ b/crates/server/migrations/009_encrypt_app_channel_config.sql
@@ -1,0 +1,12 @@
+-- Encrypt app channel credentials (EVE-158)
+--
+-- channel_config JSONB contains secrets (e.g. Slack signing_secret, bot_token).
+-- Move to an encrypted column following the envelope encryption pattern.
+-- Keep the old column temporarily for migration reads; new writes go only to
+-- channel_config_encrypted.
+
+ALTER TABLE apps ADD COLUMN channel_config_encrypted BYTEA;
+
+-- Backfill: mark existing rows as needing migration by leaving
+-- channel_config_encrypted NULL. The app service reads from encrypted first,
+-- falls back to plaintext, and writes encrypted on any update.

--- a/crates/server/src/api/apps.rs
+++ b/crates/server/src/api/apps.rs
@@ -92,9 +92,13 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn new(db: Arc<StorageBackend>, auth: AuthState) -> Self {
+    pub fn new(
+        db: Arc<StorageBackend>,
+        encryption: Option<Arc<crate::storage::EncryptionService>>,
+        auth: AuthState,
+    ) -> Self {
         Self {
-            service: Arc::new(AppService::new(db)),
+            service: Arc::new(AppService::new(db, encryption)),
             auth,
         }
     }

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -198,12 +198,13 @@ pub struct SlackState {
 impl SlackState {
     pub fn new(
         db: Arc<StorageBackend>,
+        encryption: Option<Arc<crate::storage::EncryptionService>>,
         runner: Arc<dyn AgentRunner>,
         delivery_dispatcher: Option<Arc<SlackDeliveryDispatcher>>,
         notifications_enabled: bool,
     ) -> Self {
         Self {
-            app_service: Arc::new(AppService::new(db.clone())),
+            app_service: Arc::new(AppService::new(db.clone(), encryption)),
             session_service: Arc::new(SessionService::new(db.clone())),
             message_service: Arc::new(MessageService::new(
                 db.clone(),
@@ -2552,7 +2553,7 @@ mod tests {
         // When fetch returns empty, inject_thread_context should succeed as no-op
         let db = Arc::new(StorageBackend::in_memory());
         let runner: Arc<dyn AgentRunner> = Arc::new(NoopRunner);
-        let state = SlackState::new(db, runner, None, false);
+        let state = SlackState::new(db, None, runner, None, false);
         let session_id = setup_test_session(&state.db).await;
 
         // inject with no network (fetch will fail gracefully → empty replies → Ok)

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -513,9 +513,11 @@ impl ServerAppBuilder {
             api::commands::AppState::new(capability_service.clone(), auth_state.clone());
         let agents_state =
             api::agents::AppState::new(db.clone(), capability_service, auth_state.clone());
-        let apps_state = api::apps::AppState::new(db.clone(), auth_state.clone());
+        let apps_state =
+            api::apps::AppState::new(db.clone(), encryption.clone(), auth_state.clone());
         let slack_state = api::slack_events::SlackState::new(
             db.clone(),
+            encryption.clone(),
             runner.clone(),
             slack_dispatcher.clone(),
             notifications_enabled,
@@ -977,8 +979,9 @@ impl ServerAppBuilder {
         if let Some(ref dispatcher) = slack_dispatcher {
             let dispatcher = dispatcher.clone();
             let recovery_db = db.clone();
+            let recovery_enc = encryption.clone();
             tokio::spawn(async move {
-                let app_service = crate::services::AppService::new(recovery_db);
+                let app_service = crate::services::AppService::new(recovery_db, recovery_enc);
                 dispatcher.recover(&app_service).await;
             });
         }

--- a/crates/server/src/services/app.rs
+++ b/crates/server/src/services/app.rs
@@ -1,8 +1,10 @@
 // App service for business logic
+// Decision: channel_config secrets encrypted via EncryptionService (EVE-158)
+// Decision: encrypt on write, decrypt in row_to_app; fallback to plaintext for migration
 
 use crate::errors::ResourceNotFoundError;
 use crate::storage::{
-    AppRow, StorageBackend,
+    AppRow, EncryptionService, StorageBackend,
     models::{CreateAppRow, UpdateApp},
 };
 use anyhow::Result;
@@ -39,11 +41,44 @@ pub const APP_DANGEROUS: Policy = Policy {
 
 pub struct AppService {
     db: Arc<StorageBackend>,
+    encryption: Option<Arc<EncryptionService>>,
 }
 
 impl AppService {
-    pub fn new(db: Arc<StorageBackend>) -> Self {
-        Self { db }
+    pub fn new(db: Arc<StorageBackend>, encryption: Option<Arc<EncryptionService>>) -> Self {
+        Self { db, encryption }
+    }
+
+    /// Encrypt channel_config JSON to bytes. Returns None if encryption is not
+    /// configured (dev/test mode) or the config is empty.
+    fn encrypt_channel_config(&self, config: &serde_json::Value) -> Result<Option<Vec<u8>>> {
+        if config.is_null() || (config.is_object() && config.as_object().unwrap().is_empty()) {
+            return Ok(None);
+        }
+        let encryption = match self.encryption.as_ref() {
+            Some(e) => e,
+            None => return Ok(None), // No encryption in dev mode
+        };
+        let json = serde_json::to_string(config)?;
+        Ok(Some(encryption.encrypt_string(&json)?))
+    }
+
+    /// Decrypt channel_config from encrypted bytes. Falls back to the plaintext
+    /// column for rows that haven't been migrated yet.
+    fn decrypt_channel_config(
+        &self,
+        encrypted: Option<&[u8]>,
+        plaintext_fallback: &serde_json::Value,
+    ) -> serde_json::Value {
+        if let Some(data) = encrypted
+            && let Some(ref enc) = self.encryption
+            && let Ok(json) = enc.decrypt_to_string(data)
+            && let Ok(val) = serde_json::from_str(&json)
+        {
+            return val;
+        }
+        // Fallback to plaintext column (pre-migration rows or dev mode)
+        plaintext_fallback.clone()
     }
 
     #[policy(APP_MANAGE)]
@@ -69,6 +104,9 @@ impl AppService {
             anyhow::bail!("Archived or deleted agents cannot be assigned");
         }
 
+        let channel_config = req.channel_config.unwrap_or_default();
+        let channel_config_encrypted = self.encrypt_channel_config(&channel_config)?;
+
         let input = CreateAppRow {
             public_id: public_id.to_string(),
             name: req.name,
@@ -76,7 +114,8 @@ impl AppService {
             harness_id: harness_row.id.uuid(),
             agent_id: agent_row.id.uuid(),
             channel_type: req.channel_type.to_string(),
-            channel_config: req.channel_config.unwrap_or_default(),
+            channel_config,
+            channel_config_encrypted,
         };
 
         let row = self.db.create_app(caller.org_id, input).await?;
@@ -177,6 +216,13 @@ impl AppService {
             None
         };
 
+        // Encrypt channel_config if provided
+        let channel_config_encrypted = if let Some(ref config) = req.channel_config {
+            self.encrypt_channel_config(config)?
+        } else {
+            None
+        };
+
         let input = UpdateApp {
             name: req.name,
             description: req.description,
@@ -184,6 +230,7 @@ impl AppService {
             agent_id,
             channel_type: req.channel_type.map(|ct| ct.to_string()),
             channel_config: req.channel_config,
+            channel_config_encrypted,
             status: req.status.map(|s| s.to_string()),
             published_at: UpdateField::Unchanged,
         };
@@ -305,7 +352,10 @@ impl AppService {
             agent_id,
             channel_type: ChannelType::from_str_opt(&row.channel_type)
                 .unwrap_or(ChannelType::Slack),
-            channel_config: row.channel_config,
+            channel_config: self.decrypt_channel_config(
+                row.channel_config_encrypted.as_deref(),
+                &row.channel_config,
+            ),
             status: AppStatus::from(row.status.as_str()),
             published_at: row.published_at,
             created_at: row.created_at,

--- a/crates/server/src/services/app.rs
+++ b/crates/server/src/services/app.rs
@@ -64,21 +64,42 @@ impl AppService {
     }
 
     /// Decrypt channel_config from encrypted bytes. Falls back to the plaintext
-    /// column for rows that haven't been migrated yet.
+    /// column only for rows that haven't been migrated yet or when encryption
+    /// is not configured (dev/test mode). If encrypted data is present but
+    /// decryption/parsing fails, log and return null instead of silently
+    /// reading from the plaintext column.
     fn decrypt_channel_config(
         &self,
         encrypted: Option<&[u8]>,
         plaintext_fallback: &serde_json::Value,
     ) -> serde_json::Value {
-        if let Some(data) = encrypted
-            && let Some(ref enc) = self.encryption
-            && let Ok(json) = enc.decrypt_to_string(data)
-            && let Ok(val) = serde_json::from_str(&json)
-        {
-            return val;
+        match (encrypted, self.encryption.as_ref()) {
+            // Pre-migration rows or dev/test mode: use plaintext column.
+            (None, _) | (_, None) => plaintext_fallback.clone(),
+            // Encrypted data with an available encryption service.
+            (Some(data), Some(enc)) => {
+                let json = match enc.decrypt_to_string(data) {
+                    Ok(json) => json,
+                    Err(err) => {
+                        tracing::error!(
+                            error = %err,
+                            "Failed to decrypt channel_config; returning null instead of plaintext fallback"
+                        );
+                        return serde_json::Value::Null;
+                    }
+                };
+                match serde_json::from_str(&json) {
+                    Ok(val) => val,
+                    Err(err) => {
+                        tracing::error!(
+                            error = %err,
+                            "Failed to parse decrypted channel_config JSON; returning null"
+                        );
+                        serde_json::Value::Null
+                    }
+                }
+            }
         }
-        // Fallback to plaintext column (pre-migration rows or dev mode)
-        plaintext_fallback.clone()
     }
 
     #[policy(APP_MANAGE)]
@@ -107,6 +128,14 @@ impl AppService {
         let channel_config = req.channel_config.unwrap_or_default();
         let channel_config_encrypted = self.encrypt_channel_config(&channel_config)?;
 
+        // When encryption produced ciphertext, redact the plaintext column
+        // so secrets are not stored in both columns.
+        let stored_plaintext = if channel_config_encrypted.is_some() {
+            serde_json::Value::Object(Default::default())
+        } else {
+            channel_config
+        };
+
         let input = CreateAppRow {
             public_id: public_id.to_string(),
             name: req.name,
@@ -114,7 +143,7 @@ impl AppService {
             harness_id: harness_row.id.uuid(),
             agent_id: agent_row.id.uuid(),
             channel_type: req.channel_type.to_string(),
-            channel_config,
+            channel_config: stored_plaintext,
             channel_config_encrypted,
         };
 
@@ -216,11 +245,29 @@ impl AppService {
             None
         };
 
-        // Encrypt channel_config if provided
-        let channel_config_encrypted = if let Some(ref config) = req.channel_config {
-            self.encrypt_channel_config(config)?
+        // Encrypt channel_config. If the request provides a new config, encrypt it.
+        // Otherwise, opportunistically encrypt the existing plaintext config for
+        // pre-migration rows (when encryption is configured but encrypted column is NULL).
+        let (channel_config, channel_config_encrypted) = if let Some(config) = req.channel_config {
+            let encrypted = self.encrypt_channel_config(&config)?;
+            // Redact plaintext when encryption produced ciphertext
+            let stored_plaintext = if encrypted.is_some() {
+                Some(serde_json::Value::Object(Default::default()))
+            } else {
+                Some(config)
+            };
+            (stored_plaintext, encrypted)
+        } else if existing.channel_config_encrypted.is_none() && self.encryption.is_some() {
+            // Opportunistic migration: encrypt existing plaintext on any update
+            let encrypted = self.encrypt_channel_config(&existing.channel_config)?;
+            let stored_plaintext = if encrypted.is_some() {
+                Some(serde_json::Value::Object(Default::default()))
+            } else {
+                None
+            };
+            (stored_plaintext, encrypted)
         } else {
-            None
+            (None, None)
         };
 
         let input = UpdateApp {
@@ -229,7 +276,7 @@ impl AppService {
             harness_id,
             agent_id,
             channel_type: req.channel_type.map(|ct| ct.to_string()),
-            channel_config: req.channel_config,
+            channel_config,
             channel_config_encrypted,
             status: req.status.map(|s| s.to_string()),
             published_at: UpdateField::Unchanged,

--- a/crates/server/src/storage/encryption.rs
+++ b/crates/server/src/storage/encryption.rs
@@ -395,6 +395,12 @@ pub const ENCRYPTED_COLUMNS: &[EncryptedColumn] = &[
         column: "refresh_token_encrypted",
         id_column: "id",
     },
+    // App channel config contains secrets (e.g. Slack signing_secret, bot_token)
+    EncryptedColumn {
+        table: "apps",
+        column: "channel_config_encrypted",
+        id_column: "id",
+    },
 ];
 
 #[cfg(test)]

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -4677,6 +4677,7 @@ impl InMemoryDatabase {
             agent_id: input.agent_id,
             channel_type: input.channel_type,
             channel_config: input.channel_config,
+            channel_config_encrypted: input.channel_config_encrypted,
             status: "draft".to_string(),
             published_at: None,
             created_at: now,
@@ -4762,6 +4763,9 @@ impl InMemoryDatabase {
         }
         if let Some(channel_config) = input.channel_config {
             app.channel_config = channel_config;
+        }
+        if let Some(encrypted) = input.channel_config_encrypted {
+            app.channel_config_encrypted = Some(encrypted);
         }
         if let Some(status) = input.status {
             app.status = status;
@@ -6364,6 +6368,7 @@ mod tests {
                 agent_id: agent.id.into(),
                 channel_type: "slack".to_string(),
                 channel_config: serde_json::json!({}),
+                channel_config_encrypted: None,
             },
         )
         .await
@@ -6379,6 +6384,7 @@ mod tests {
                 agent_id: agent.id.into(),
                 channel_type: "web".to_string(),
                 channel_config: serde_json::json!({}),
+                channel_config_encrypted: None,
             },
         )
         .await

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -1128,6 +1128,7 @@ pub struct AppRow {
     pub agent_id: Uuid,
     pub channel_type: String,
     pub channel_config: serde_json::Value,
+    pub channel_config_encrypted: Option<Vec<u8>>,
     pub status: String,
     pub published_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
@@ -1146,6 +1147,8 @@ pub struct CreateAppRow {
     pub agent_id: Uuid,
     pub channel_type: String,
     pub channel_config: serde_json::Value,
+    /// Encrypted channel_config bytes (envelope-encrypted JSON).
+    pub channel_config_encrypted: Option<Vec<u8>>,
 }
 
 /// Input for updating an app
@@ -1157,6 +1160,8 @@ pub struct UpdateApp {
     pub agent_id: Option<Uuid>,
     pub channel_type: Option<String>,
     pub channel_config: Option<serde_json::Value>,
+    /// Encrypted channel_config bytes (envelope-encrypted JSON).
+    pub channel_config_encrypted: Option<Vec<u8>>,
     pub status: Option<String>,
     pub published_at: UpdateField<DateTime<Utc>>,
 }

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -5308,9 +5308,9 @@ impl Database {
     pub async fn create_app(&self, org_id: i64, input: CreateAppRow) -> Result<AppRow> {
         let row = sqlx::query_as::<_, AppRow>(
             r#"
-            INSERT INTO apps (org_id, public_id, name, description, harness_id, agent_id, channel_type, channel_config, status)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'draft')
-            RETURNING id, org_id, public_id, name, description, harness_id, agent_id, channel_type, channel_config, status, published_at, created_at, updated_at, archived_at, deleted_at
+            INSERT INTO apps (org_id, public_id, name, description, harness_id, agent_id, channel_type, channel_config, channel_config_encrypted, status)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'draft')
+            RETURNING id, org_id, public_id, name, description, harness_id, agent_id, channel_type, channel_config, channel_config_encrypted, status, published_at, created_at, updated_at, archived_at, deleted_at
             "#,
         )
         .bind(org_id)
@@ -5321,6 +5321,7 @@ impl Database {
         .bind(input.agent_id)
         .bind(&input.channel_type)
         .bind(&input.channel_config)
+        .bind(&input.channel_config_encrypted)
         .fetch_one(&self.pool)
         .await?;
 
@@ -5334,7 +5335,7 @@ impl Database {
     ) -> Result<Option<AppRow>> {
         let row = sqlx::query_as::<_, AppRow>(
             r#"
-            SELECT id, org_id, public_id, name, description, harness_id, agent_id, channel_type, channel_config, status, published_at, created_at, updated_at, archived_at, deleted_at
+            SELECT id, org_id, public_id, name, description, harness_id, agent_id, channel_type, channel_config, channel_config_encrypted, status, published_at, created_at, updated_at, archived_at, deleted_at
             FROM apps
             WHERE org_id = $1 AND public_id = $2
             "#,
@@ -5351,7 +5352,7 @@ impl Database {
     pub async fn get_app_by_public_id_unscoped(&self, public_id: &str) -> Result<Option<AppRow>> {
         let row = sqlx::query_as::<_, AppRow>(
             r#"
-            SELECT id, org_id, public_id, name, description, harness_id, agent_id, channel_type, channel_config, status, published_at, created_at, updated_at, archived_at, deleted_at
+            SELECT id, org_id, public_id, name, description, harness_id, agent_id, channel_type, channel_config, channel_config_encrypted, status, published_at, created_at, updated_at, archived_at, deleted_at
             FROM apps
             WHERE public_id = $1
             "#,
@@ -5377,7 +5378,7 @@ impl Database {
             " AND status NOT IN ('archived', 'deleted')"
         };
         let sql = format!(
-            r#"SELECT id, org_id, public_id, name, description, harness_id, agent_id, channel_type, channel_config, status, published_at, created_at, updated_at, archived_at, deleted_at
+            r#"SELECT id, org_id, public_id, name, description, harness_id, agent_id, channel_type, channel_config, channel_config_encrypted, status, published_at, created_at, updated_at, archived_at, deleted_at
                 FROM apps
                 WHERE org_id = $1{status_sql}{search_sql}
                 ORDER BY created_at DESC"#
@@ -5405,11 +5406,12 @@ impl Database {
                 agent_id = COALESCE($6, agent_id),
                 channel_type = COALESCE($7, channel_type),
                 channel_config = COALESCE($8, channel_config),
-                status = COALESCE($9, status),
-                published_at = CASE WHEN $10 THEN $11 ELSE published_at END,
+                channel_config_encrypted = COALESCE($9, channel_config_encrypted),
+                status = COALESCE($10, status),
+                published_at = CASE WHEN $11 THEN $12 ELSE published_at END,
                 updated_at = NOW()
             WHERE org_id = $1 AND id = $2
-            RETURNING id, org_id, public_id, name, description, harness_id, agent_id, channel_type, channel_config, status, published_at, created_at, updated_at, archived_at, deleted_at
+            RETURNING id, org_id, public_id, name, description, harness_id, agent_id, channel_type, channel_config, channel_config_encrypted, status, published_at, created_at, updated_at, archived_at, deleted_at
             "#,
         )
         .bind(org_id)
@@ -5420,6 +5422,7 @@ impl Database {
         .bind(input.agent_id)
         .bind(&input.channel_type)
         .bind(&input.channel_config)
+        .bind(&input.channel_config_encrypted)
         .bind(&input.status)
         .bind(input.published_at.is_changed())
         .bind(input.published_at.into_value())

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -239,9 +239,10 @@ impl TestServer {
             platform_definition.connection_providers().clone(),
         );
 
-        let apps_state = api::apps::AppState::new(db.clone(), auth_state.clone());
+        let apps_state = api::apps::AppState::new(db.clone(), None, auth_state.clone());
         let slack_state = api::slack_events::SlackState::new(
             db.clone(),
+            None, // No encryption in tests
             runner.clone(),
             None, // No delivery dispatcher in tests
             feature_flags.notifications,


### PR DESCRIPTION
## What
Encrypt app channel_config JSONB at rest using the existing envelope encryption system. Slack signing_secret and bot_token are now stored encrypted in channel_config_encrypted instead of plaintext JSONB.

## Why
App channel credentials (Slack bot tokens, signing secrets) were stored as plaintext JSONB, meaning database compromise or backup leaks would expose live channel credentials. EVE-158.

## How
- Added migration 009_encrypt_app_channel_config.sql with new channel_config_encrypted BYTEA column
- AppService now injects EncryptionService, encrypts channel_config on create/update, decrypts on read
- Falls back to plaintext column for pre-migration rows (gradual migration on next update)
- Registered new column in ENCRYPTED_COLUMNS for key rotation coverage
- Updated all call sites: AppState, SlackState, app_builder.rs, test harness

## Risk
- Medium
- Migration adds nullable column (no data loss)
- Fallback to plaintext ensures backward compatibility during rollout
- Dev mode (no encryption key) continues to work with plaintext

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered