### PR TITLE
feat(server): implement 5-minute timeout for waiting_for_tool_results sessions

### DIFF
--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -1004,6 +1004,9 @@ impl ServerAppBuilder {
             tracing::info!("Durable task scheduler started");
         }
 
+        // -- Tool result timeout sweep (both prod and dev) --
+        crate::tool_result_timeout::spawn_tool_result_timeout_sweep(db.clone(), runner.clone());
+
         // -- Session schedule poller (both prod and dev) --
         crate::session_scheduler::spawn_session_scheduler(
             db.clone(),

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -68,6 +68,9 @@ pub mod seed;
 pub mod leased_resource_scheduler;
 pub mod session_scheduler;
 
+// Background sweep: time out sessions stuck in waiting_for_tool_results
+pub mod tool_result_timeout;
+
 // Server configuration and router helpers
 pub mod server;
 pub use server::ServerConfig;

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -350,6 +350,15 @@ impl StorageBackend {
         dispatch!(self, find_active_slack_sessions)
     }
 
+    /// Find sessions in `waiting_for_tool_results` with updated_at before the
+    /// given cutoff. Returns `(session_id, org_id)` pairs.
+    pub async fn list_sessions_waiting_tool_results_before(
+        &self,
+        cutoff: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Vec<(SessionId, i64)>> {
+        dispatch!(self, list_sessions_waiting_tool_results_before, cutoff)
+    }
+
     /// Find a single session matching ALL given tags within an org.
     pub async fn find_session_by_tags(
         &self,

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -6586,6 +6586,83 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_list_sessions_waiting_tool_results_before() {
+        let db = InMemoryDatabase::new();
+        let now = Utc::now();
+        let cutoff = now - chrono::Duration::minutes(5);
+
+        // Create 3 sessions: one waiting+old, one waiting+recent, one active+old
+        let s1 = db
+            .create_session(CreateSessionRow {
+                org_id: DEFAULT_ORG_ID,
+                harness_id: None,
+                agent_id: None,
+                title: None,
+                locale: None,
+                tags: vec![],
+                model_id: None,
+                capabilities: serde_json::json!({}),
+                tools: serde_json::json!([]),
+            })
+            .await
+            .unwrap();
+        let s2 = db
+            .create_session(CreateSessionRow {
+                org_id: DEFAULT_ORG_ID,
+                harness_id: None,
+                agent_id: None,
+                title: None,
+                locale: None,
+                tags: vec![],
+                model_id: None,
+                capabilities: serde_json::json!({}),
+                tools: serde_json::json!([]),
+            })
+            .await
+            .unwrap();
+        let s3 = db
+            .create_session(CreateSessionRow {
+                org_id: DEFAULT_ORG_ID,
+                harness_id: None,
+                agent_id: None,
+                title: None,
+                locale: None,
+                tags: vec![],
+                model_id: None,
+                capabilities: serde_json::json!({}),
+                tools: serde_json::json!([]),
+            })
+            .await
+            .unwrap();
+
+        // Manually set statuses and updated_at
+        {
+            let mut sessions = db.sessions.write();
+            if let Some(s) = sessions.get_mut(&s1.id) {
+                s.status = "waiting_for_tool_results".to_string();
+                s.updated_at = now - chrono::Duration::minutes(10); // old, should match
+            }
+            if let Some(s) = sessions.get_mut(&s2.id) {
+                s.status = "waiting_for_tool_results".to_string();
+                s.updated_at = now - chrono::Duration::minutes(1); // recent, should NOT match
+            }
+            if let Some(s) = sessions.get_mut(&s3.id) {
+                s.status = "active".to_string();
+                s.updated_at = now - chrono::Duration::minutes(10); // old but active, should NOT match
+            }
+        }
+
+        let result = db
+            .list_sessions_waiting_tool_results_before(cutoff)
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].0, s1.id);
+        assert_eq!(result[0].1, DEFAULT_ORG_ID);
+    }
+
+    #[tokio::test]
     async fn test_search_filter_empty_string_matches_all() {
         let db = InMemoryDatabase::new();
         let session_id = create_session_with_content_events(&db).await;

--- a/crates/server/src/storage/memory.rs
+++ b/crates/server/src/storage/memory.rs
@@ -1052,6 +1052,20 @@ impl InMemoryDatabase {
         Ok(result)
     }
 
+    /// Find sessions in `waiting_for_tool_results` with updated_at before cutoff.
+    pub async fn list_sessions_waiting_tool_results_before(
+        &self,
+        cutoff: DateTime<Utc>,
+    ) -> Result<Vec<(SessionId, i64)>> {
+        let sessions = self.sessions.read();
+        let result: Vec<_> = sessions
+            .values()
+            .filter(|s| s.status == "waiting_for_tool_results" && s.updated_at < cutoff)
+            .map(|s| (s.id, s.org_id))
+            .collect();
+        Ok(result)
+    }
+
     /// Find a single session matching ALL given tags within an org.
     pub async fn find_session_by_tags(
         &self,

--- a/crates/server/src/storage/repositories.rs
+++ b/crates/server/src/storage/repositories.rs
@@ -1271,6 +1271,27 @@ impl Database {
         Ok(rows)
     }
 
+    /// Find sessions in `waiting_for_tool_results` with updated_at before the
+    /// given cutoff. Returns lightweight `(session_id, org_id)` pairs.
+    pub async fn list_sessions_waiting_tool_results_before(
+        &self,
+        cutoff: DateTime<Utc>,
+    ) -> Result<Vec<(SessionId, i64)>> {
+        let rows = sqlx::query_as::<_, (SessionId, i64)>(
+            r#"
+            SELECT id, org_id
+            FROM sessions
+            WHERE status = 'waiting_for_tool_results'
+              AND updated_at < $1
+            "#,
+        )
+        .bind(cutoff)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
     /// Update session by org and session id
     pub async fn update_session(
         &self,

--- a/crates/server/src/tool_result_timeout.rs
+++ b/crates/server/src/tool_result_timeout.rs
@@ -48,7 +48,9 @@ async fn sweep_timed_out_sessions(
     runner: &Arc<dyn AgentRunner>,
     timeout_secs: u64,
 ) -> anyhow::Result<()> {
-    let cutoff = Utc::now() - chrono::Duration::seconds(timeout_secs as i64);
+    let duration = chrono::Duration::try_seconds(timeout_secs.min(i64::MAX as u64) as i64)
+        .unwrap_or(chrono::Duration::seconds(DEFAULT_TIMEOUT_SECS as i64));
+    let cutoff = Utc::now() - duration;
 
     let timed_out = db.list_sessions_waiting_tool_results_before(cutoff).await?;
 
@@ -101,7 +103,7 @@ async fn timeout_session(
         let error_result = ToolCompletedData::failure(
             tool_call_id.clone(),
             String::new(),
-            "error".to_string(),
+            "timeout".to_string(),
             "Timed out waiting for client tool results".to_string(),
             None,
         );

--- a/crates/server/src/tool_result_timeout.rs
+++ b/crates/server/src/tool_result_timeout.rs
@@ -1,0 +1,182 @@
+// Background sweep: time out sessions stuck in `waiting_for_tool_results`.
+// Decision: periodic sweep (every 30s) rather than per-session timers; survives restarts.
+// Decision: timeout is 5 minutes per specs/client-side-tools.md, configurable via env var.
+
+use crate::services::EventService;
+use crate::storage::StorageBackend;
+use chrono::Utc;
+use everruns_core::events::{
+    EventContext, EventData, EventRequest, ToolCompletedData, deserialize_event_data,
+};
+use everruns_core::typed_id::{MessageId, SessionId, TurnId};
+use everruns_worker::AgentRunner;
+use std::sync::Arc;
+
+/// Default timeout for waiting_for_tool_results sessions (5 minutes).
+const DEFAULT_TIMEOUT_SECS: u64 = 300;
+
+/// How often the sweep runs (30 seconds).
+const SWEEP_INTERVAL_SECS: u64 = 30;
+
+/// Spawn a background task that periodically times out stale
+/// `waiting_for_tool_results` sessions.
+pub fn spawn_tool_result_timeout_sweep(db: Arc<StorageBackend>, runner: Arc<dyn AgentRunner>) {
+    let timeout_secs = std::env::var("TOOL_RESULT_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_TIMEOUT_SECS);
+
+    tokio::spawn(async move {
+        tracing::info!(
+            timeout_secs,
+            sweep_interval_secs = SWEEP_INTERVAL_SECS,
+            "Tool result timeout sweep started"
+        );
+
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(SWEEP_INTERVAL_SECS)).await;
+
+            if let Err(e) = sweep_timed_out_sessions(&db, &runner, timeout_secs).await {
+                tracing::warn!(error = %e, "Tool result timeout sweep error");
+            }
+        }
+    });
+}
+
+async fn sweep_timed_out_sessions(
+    db: &Arc<StorageBackend>,
+    runner: &Arc<dyn AgentRunner>,
+    timeout_secs: u64,
+) -> anyhow::Result<()> {
+    let cutoff = Utc::now() - chrono::Duration::seconds(timeout_secs as i64);
+
+    let timed_out = db.list_sessions_waiting_tool_results_before(cutoff).await?;
+
+    if timed_out.is_empty() {
+        return Ok(());
+    }
+
+    tracing::info!(
+        count = timed_out.len(),
+        "Found timed-out waiting_for_tool_results sessions"
+    );
+
+    let event_service = EventService::new(db.clone());
+
+    for (session_id, org_id) in timed_out {
+        if let Err(e) = timeout_session(db, &event_service, runner, session_id, org_id).await {
+            tracing::warn!(
+                session_id = %session_id,
+                error = %e,
+                "Failed to timeout session"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+async fn timeout_session(
+    db: &Arc<StorageBackend>,
+    event_service: &EventService,
+    runner: &Arc<dyn AgentRunner>,
+    session_id: SessionId,
+    org_id: i64,
+) -> anyhow::Result<()> {
+    // Find pending tool call IDs from the most recent tool.call_requested event
+    let tool_call_ids = find_pending_tool_call_ids(db, session_id).await?;
+
+    if tool_call_ids.is_empty() {
+        tracing::warn!(
+            session_id = %session_id,
+            "No tool.call_requested event found for timed-out session, resetting status"
+        );
+    }
+
+    let turn_id = TurnId::from_uuid(session_id.uuid());
+    let message_id = MessageId::from_uuid(session_id.uuid());
+
+    // Emit timeout error events for each pending tool call
+    for tool_call_id in &tool_call_ids {
+        let error_result = ToolCompletedData::failure(
+            tool_call_id.clone(),
+            String::new(),
+            "error".to_string(),
+            "Timed out waiting for client tool results".to_string(),
+            None,
+        );
+
+        let event = EventRequest::new(
+            session_id,
+            EventContext::turn(turn_id, message_id),
+            error_result,
+        );
+
+        if let Err(e) = event_service.emit(event).await {
+            tracing::warn!(
+                session_id = %session_id,
+                tool_call_id = %tool_call_id,
+                error = %e,
+                "Failed to emit timeout tool.completed event"
+            );
+        }
+    }
+
+    // Update session status to active
+    let caller = everruns_core::Caller::internal(org_id);
+    let session_service = crate::services::SessionService::new(db.clone());
+    if let Err(e) = session_service
+        .update_status(&caller, session_id.uuid(), "active".to_string())
+        .await
+    {
+        tracing::warn!(session_id = %session_id, error = %e, "Failed to reset session status");
+    }
+
+    // Resume the workflow
+    let runner = runner.clone();
+    let sid = session_id;
+    tokio::spawn(async move {
+        if let Err(e) = runner.resume_after_tool_results(sid).await {
+            tracing::warn!(
+                session_id = %sid,
+                error = %e,
+                "Failed to resume workflow after tool result timeout"
+            );
+        } else {
+            tracing::info!(
+                session_id = %sid,
+                "Workflow resumed after tool result timeout"
+            );
+        }
+    });
+
+    Ok(())
+}
+
+/// Find pending tool call IDs from the most recent tool.call_requested event.
+async fn find_pending_tool_call_ids(
+    db: &Arc<StorageBackend>,
+    session_id: SessionId,
+) -> anyhow::Result<Vec<String>> {
+    let events = db
+        .list_events(
+            session_id,
+            None,
+            None,
+            &["tool.call_requested".to_string()],
+            &[],
+            None,
+            Some(1), // Only need the most recent one
+        )
+        .await?;
+
+    // list_events with limit returns the LAST N events, so this is the most recent
+    if let Some(event) = events.last() {
+        let data = deserialize_event_data(&event.event_type, event.data.clone());
+        if let EventData::ToolCallRequested(req) = data {
+            return Ok(req.tool_calls.iter().map(|tc| tc.id.clone()).collect());
+        }
+    }
+
+    Ok(vec![])
+}


### PR DESCRIPTION
## What
Background sweep that times out sessions stuck in `waiting_for_tool_results` status beyond a configurable timeout (default 5 minutes).

## Why
Per `specs/client-side-tools.md`, sessions waiting for client-side tool results should not wait indefinitely. Without a timeout, a client crash or network failure leaves the session permanently stuck.

## How
- New `tool_result_timeout` module with a periodic sweep (every 30s)
- `list_sessions_waiting_tool_results_before(cutoff)` query in Postgres, in-memory, and dispatch backend
- For each timed-out session: synthesizes error `tool.completed` events, resets status to `active`, resumes the workflow
- Timeout configurable via `TOOL_RESULT_TIMEOUT_SECS` env var
- Wired into `app_builder.rs` for both prod and dev modes

## Risk
- Low
- Only affects sessions already stuck in waiting_for_tool_results beyond the timeout. Normal sessions unaffected.

## Checklist
- [x] Tests added or updated (storage layer methods tested via existing patterns)
- [x] Backward compatibility considered (new additive feature, no breaking changes)