### PR TITLE
fix(ui): unify API error handling through centralized client

### DIFF
--- a/apps/ui/src/__tests__/throw-api-error.test.ts
+++ b/apps/ui/src/__tests__/throw-api-error.test.ts
@@ -1,0 +1,87 @@
+import { throwApiError, ApiError } from "@/lib/api/client";
+
+function mockResponse(
+  status: number,
+  statusText: string,
+  body?: string,
+): { status: number; statusText: string; text: () => Promise<string> } {
+  return {
+    status,
+    statusText,
+    text: () => Promise.resolve(body ?? ""),
+  };
+}
+
+describe("throwApiError", () => {
+  it("extracts error field from JSON body", async () => {
+    const response = mockResponse(400, "Bad Request", JSON.stringify({ error: "invalid input" }));
+    try {
+      await throwApiError(response as unknown as Response);
+      fail("should throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError);
+      expect((e as ApiError).status).toBe(400);
+      expect((e as ApiError).message).toBe("invalid input");
+    }
+  });
+
+  it("extracts message field from JSON body", async () => {
+    const response = mockResponse(404, "Not Found", JSON.stringify({ message: "not found" }));
+    try {
+      await throwApiError(response as unknown as Response);
+      fail("should throw");
+    } catch (e) {
+      expect((e as ApiError).status).toBe(404);
+      expect((e as ApiError).message).toBe("not found");
+    }
+  });
+
+  it("falls back to stringified JSON when no error/message field", async () => {
+    const body = { code: "ERR_UNKNOWN", details: "something" };
+    const response = mockResponse(500, "Internal Server Error", JSON.stringify(body));
+    try {
+      await throwApiError(response as unknown as Response);
+      fail("should throw");
+    } catch (e) {
+      expect((e as ApiError).status).toBe(500);
+      expect((e as ApiError).message).toBe(JSON.stringify(body));
+    }
+  });
+
+  it("uses plain text body when not JSON", async () => {
+    const response = mockResponse(502, "Bad Gateway", "upstream timeout");
+    try {
+      await throwApiError(response as unknown as Response);
+      fail("should throw");
+    } catch (e) {
+      expect((e as ApiError).status).toBe(502);
+      expect((e as ApiError).message).toBe("upstream timeout");
+    }
+  });
+
+  it("handles empty body", async () => {
+    const response = mockResponse(503, "Service Unavailable", "");
+    try {
+      await throwApiError(response as unknown as Response);
+      fail("should throw");
+    } catch (e) {
+      expect((e as ApiError).status).toBe(503);
+      expect((e as ApiError).statusText).toBe("Service Unavailable");
+    }
+  });
+
+  it("handles text() throwing", async () => {
+    const response = {
+      status: 500,
+      statusText: "Internal Server Error",
+      text: () => Promise.reject(new Error("body consumed")),
+    };
+    try {
+      await throwApiError(response as unknown as Response);
+      fail("should throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError);
+      expect((e as ApiError).status).toBe(500);
+    }
+  });
+});

--- a/apps/ui/src/lib/api/agents.ts
+++ b/apps/ui/src/lib/api/agents.ts
@@ -1,7 +1,7 @@
 // Agent API functions (M2)
 // Org is sent via everruns_org cookie (set by OrgProvider via /v1/users/me/switch-org)
 
-import { api } from "./client";
+import { api, throwApiError } from "./client";
 import type {
   Agent,
   AgentPreviewResponse,
@@ -41,20 +41,18 @@ export async function destroyAgent(agentId: string): Promise<void> {
 }
 
 export async function exportAgent(agentId: string): Promise<string> {
-  // Use fetch directly since we need to return text, not JSON
-  // Org is sent via cookie automatically (credentials: "include")
+  // Raw fetch needed: returns text/markdown, not JSON
   const response = await fetch(`/api/v1/agents/${agentId}/export`, {
     credentials: "include",
   });
   if (!response.ok) {
-    throw new Error(`Export failed: ${response.statusText}`);
+    await throwApiError(response);
   }
   return response.text();
 }
 
 export async function importAgent(markdown: string): Promise<Agent> {
-  // Use fetch directly since we need to send text/markdown content type
-  // Org is sent via cookie automatically (credentials: "include")
+  // Raw fetch needed: sends text/markdown Content-Type
   const response = await fetch("/api/v1/agents/import", {
     method: "POST",
     credentials: "include",
@@ -64,8 +62,7 @@ export async function importAgent(markdown: string): Promise<Agent> {
     body: markdown,
   });
   if (!response.ok) {
-    const error = await response.text();
-    throw new Error(error || `Import failed: ${response.statusText}`);
+    await throwApiError(response);
   }
   return response.json();
 }

--- a/apps/ui/src/lib/api/client.ts
+++ b/apps/ui/src/lib/api/client.ts
@@ -64,15 +64,7 @@ async function request<T>(endpoint: string, options: RequestInit = {}): Promise<
   }
 
   if (!response.ok) {
-    // Try to get error details from response body
-    let errorMessage: string | undefined;
-    try {
-      const errorBody = await response.json();
-      errorMessage = errorBody.error || errorBody.message || JSON.stringify(errorBody);
-    } catch {
-      // Response body is not JSON or empty
-    }
-    throw new ApiError(response.status, response.statusText, errorMessage);
+    await throwApiError(response);
   }
 
   // Handle empty responses (204 No Content or empty body)
@@ -127,14 +119,19 @@ export const api = {
 export async function throwApiError(response: Response): Promise<never> {
   let errorMessage: string | undefined;
   try {
-    const errorBody = await response.json();
-    errorMessage = errorBody.error || errorBody.message || JSON.stringify(errorBody);
-  } catch {
-    try {
-      errorMessage = await response.text();
-    } catch {
-      // No body at all
+    // Read body as text first to avoid consuming the stream with response.json()
+    const text = await response.text();
+    if (text) {
+      try {
+        const errorBody = JSON.parse(text);
+        errorMessage = errorBody.error || errorBody.message || JSON.stringify(errorBody);
+      } catch {
+        // Not JSON — use the raw text as the error message
+        errorMessage = text;
+      }
     }
+  } catch {
+    // No body at all
   }
   throw new ApiError(response.status, response.statusText, errorMessage);
 }

--- a/apps/ui/src/lib/api/client.ts
+++ b/apps/ui/src/lib/api/client.ts
@@ -119,6 +119,26 @@ export const api = {
   delete: <T>(url: string) => request<T>(url, { method: "DELETE" }),
 };
 
+/**
+ * Extract an ApiError from a failed fetch Response.
+ * Use this in callsites that need raw fetch() (FormData, text responses,
+ * header access) but still want centralized error handling.
+ */
+export async function throwApiError(response: Response): Promise<never> {
+  let errorMessage: string | undefined;
+  try {
+    const errorBody = await response.json();
+    errorMessage = errorBody.error || errorBody.message || JSON.stringify(errorBody);
+  } catch {
+    try {
+      errorMessage = await response.text();
+    } catch {
+      // No body at all
+    }
+  }
+  throw new ApiError(response.status, response.statusText, errorMessage);
+}
+
 export function getApiBaseUrl(): string {
   return API_BASE;
 }

--- a/apps/ui/src/lib/api/events.ts
+++ b/apps/ui/src/lib/api/events.ts
@@ -2,7 +2,7 @@
 // Events are SSE notifications for real-time updates
 // Org is sent via everruns_org cookie (set by OrgProvider via /v1/users/me/switch-org)
 
-import { api, ApiError, getApiBaseUrl } from "./client";
+import { getApiBaseUrl, throwApiError } from "./client";
 import type { Event, ListResponse } from "./types";
 
 // Default event types to exclude in UI contexts (streaming delta events are noise)
@@ -68,7 +68,7 @@ export async function listEventsPaginated(
   });
 
   if (!response.ok) {
-    throw new ApiError(response.status, response.statusText);
+    await throwApiError(response);
   }
 
   const body: ListResponse<Event> = await response.json();

--- a/apps/ui/src/lib/api/images.ts
+++ b/apps/ui/src/lib/api/images.ts
@@ -4,7 +4,7 @@
 // API functions for uploading, retrieving, and deleting images.
 // Images can be attached to messages as image_file content parts.
 
-import { getApiBaseUrl } from "./client";
+import { api, getApiBaseUrl, throwApiError } from "./client";
 import type { ImageUploadResponse, ImageInfo } from "./types";
 import { ALLOWED_IMAGE_TYPES, MAX_IMAGE_SIZE } from "./types";
 
@@ -53,16 +53,15 @@ export async function uploadImage(file: File, sessionId?: string): Promise<Image
   const params = sessionId ? `?session_id=${sessionId}` : "";
   const url = `${baseUrl}/v1/images${params}`;
 
-  // Org is sent via cookie automatically (credentials: "include")
+  // Raw fetch needed for FormData (no Content-Type header — browser sets multipart boundary)
   const response = await fetch(url, {
     method: "POST",
     body: formData,
-    credentials: "include", // Include cookies for auth (access_token, everruns_org)
+    credentials: "include",
   });
 
   if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`Failed to upload image: ${text}`);
+    await throwApiError(response);
   }
 
   return response.json();
@@ -86,34 +85,15 @@ export function getThumbnailUrl(imageId: string): string {
  * Delete an image
  */
 export async function deleteImage(imageId: string): Promise<void> {
-  // Org is sent via cookie automatically (credentials: "include")
-  const response = await fetch(`${getApiBaseUrl()}/v1/images/${imageId}`, {
-    method: "DELETE",
-    credentials: "include", // Include cookies for auth (access_token, everruns_org)
-  });
-
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`Failed to delete image: ${text}`);
-  }
+  await api.delete(`/v1/images/${imageId}`);
 }
 
 /**
  * List images
  */
 export async function listImages(limit: number = 50, offset: number = 0): Promise<ImageInfo[]> {
-  // Org is sent via cookie automatically (credentials: "include")
-  const response = await fetch(
-    `${getApiBaseUrl()}/v1/images?limit=${limit}&offset=${offset}`,
-    { credentials: "include" }, // Include cookies for auth (access_token, everruns_org)
-  );
-
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`Failed to list images: ${text}`);
-  }
-
-  return response.json();
+  const response = await api.get<ImageInfo[]>(`/v1/images?limit=${limit}&offset=${offset}`);
+  return response.data;
 }
 
 /**

--- a/apps/ui/src/lib/api/skills.ts
+++ b/apps/ui/src/lib/api/skills.ts
@@ -1,7 +1,7 @@
 // Skills registry API functions
 // Org is sent via everruns_org cookie (set by OrgProvider via /v1/users/me/switch-org)
 
-import { api } from "./client";
+import { api, throwApiError } from "./client";
 import type {
   Skill,
   SkillContent,
@@ -57,6 +57,7 @@ export async function uploadSkillArchive(file: File): Promise<Skill> {
   const formData = new FormData();
   formData.append("file", file);
 
+  // Raw fetch needed for FormData (no Content-Type header — browser sets multipart boundary)
   const response = await fetch("/api/v1/skills/upload", {
     method: "POST",
     credentials: "include",
@@ -64,14 +65,7 @@ export async function uploadSkillArchive(file: File): Promise<Skill> {
   });
 
   if (!response.ok) {
-    let errorMessage: string | undefined;
-    try {
-      const errorBody = await response.json();
-      errorMessage = errorBody.error || errorBody.message || JSON.stringify(errorBody);
-    } catch {
-      // Response body is not JSON or empty
-    }
-    throw new Error(errorMessage || `Upload failed: ${response.status} ${response.statusText}`);
+    await throwApiError(response);
   }
 
   return response.json();


### PR DESCRIPTION
## What
Route all raw-fetch API callsites through centralized error handling using the existing `ApiError` class.

## Why
Several API functions (image upload, agent export/import, skill upload, event listing) used raw `fetch()` but threw generic `Error` objects instead of `ApiError`, losing status codes and structured error messages. This made error handling inconsistent across the UI. Fixes EVE-122.

## How
- Added `throwApiError()` helper to `client.ts` that extracts error details from response body and throws `ApiError`
- Updated 5 files to use `throwApiError()` instead of ad-hoc error construction:
  - `images.ts`: `uploadImage()` now uses `throwApiError()`; `deleteImage()` and `listImages()` converted to use centralized `api` client
  - `agents.ts`: `exportAgent()` and `importAgent()` use `throwApiError()`
  - `skills.ts`: `uploadSkillArchive()` uses `throwApiError()`, removed duplicated error extraction
  - `events.ts`: `listEventsPaginated()` uses `throwApiError()`

## Risk
- Low
- Error messages may differ slightly in format (now consistently `ApiError` with status code)

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered