### PR TITLE
fix(ui): make org switching atomic with cookie sync and query invalidation

### DIFF
--- a/apps/ui/src/__tests__/org-provider.test.tsx
+++ b/apps/ui/src/__tests__/org-provider.test.tsx
@@ -57,10 +57,14 @@ const NEW_ORG: OrganizationMembership = {
   role: "owner",
 };
 
-function wrapper({ children }: { children: ReactNode }) {
-  const queryClient = new QueryClient({
+let queryClient: QueryClient;
+beforeEach(() => {
+  queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
+});
+
+function wrapper({ children }: { children: ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
       <OrgProvider>{children}</OrgProvider>
@@ -128,13 +132,16 @@ describe("OrgProvider", () => {
     mockUser = { organizations: [DEFAULT_ORG, SECOND_ORG] };
     mockAuthLoading = false;
 
-    // Make switchOrg hang until we resolve it
+    // Make switchOrg hang for SECOND_ORG until we resolve it; allow init sync for DEFAULT_ORG
     let resolveSwitch!: () => void;
-    mockSwitchOrg.mockReturnValueOnce(
-      new Promise<void>((resolve) => {
-        resolveSwitch = resolve;
-      }),
-    );
+    mockSwitchOrg.mockImplementation((orgId: string) => {
+      if (orgId === SECOND_ORG.public_id) {
+        return new Promise<void>((resolve) => {
+          resolveSwitch = resolve;
+        });
+      }
+      return Promise.resolve(undefined);
+    });
 
     const { result } = renderHook(() => useOrg(), { wrapper });
 

--- a/apps/ui/src/__tests__/org-provider.test.tsx
+++ b/apps/ui/src/__tests__/org-provider.test.tsx
@@ -1,5 +1,6 @@
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, waitFor } from "@testing-library/react";
 import { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { OrgProvider, useOrg } from "@/providers/org-provider";
 import type { OrganizationMembership } from "@/lib/api/types";
 
@@ -11,9 +12,10 @@ jest.mock("next/navigation", () => ({
   usePathname: () => mockPathname(),
 }));
 
-// Mock switchOrg API
+// Mock switchOrg API — controllable per test
+const mockSwitchOrg = jest.fn().mockResolvedValue(undefined);
 jest.mock("@/lib/api/users", () => ({
-  switchOrg: jest.fn().mockResolvedValue(undefined),
+  switchOrg: (...args: unknown[]) => mockSwitchOrg(...args),
 }));
 
 // Mock auth provider — mutable so we can change the user mid-test
@@ -33,6 +35,7 @@ beforeEach(() => {
     .mockImplementation((key, val) => storageMap.set(key, val));
   jest.spyOn(Storage.prototype, "removeItem").mockImplementation((key) => storageMap.delete(key));
   mockPush.mockClear();
+  mockSwitchOrg.mockClear().mockResolvedValue(undefined);
   mockPathname.mockReturnValue("/dashboard");
 });
 
@@ -55,7 +58,14 @@ const NEW_ORG: OrganizationMembership = {
 };
 
 function wrapper({ children }: { children: ReactNode }) {
-  return <OrgProvider>{children}</OrgProvider>;
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <OrgProvider>{children}</OrgProvider>
+    </QueryClientProvider>
+  );
 }
 
 describe("OrgProvider", () => {
@@ -68,7 +78,7 @@ describe("OrgProvider", () => {
     expect(result.current.currentOrg?.public_id).toBe(DEFAULT_ORG.public_id);
   });
 
-  it("switches to a different existing org", () => {
+  it("switches to a different existing org after cookie sync", async () => {
     mockUser = { organizations: [DEFAULT_ORG, SECOND_ORG] };
     mockAuthLoading = false;
 
@@ -78,44 +88,108 @@ describe("OrgProvider", () => {
       result.current.setCurrentOrg(SECOND_ORG);
     });
 
-    expect(result.current.currentOrg?.public_id).toBe(SECOND_ORG.public_id);
+    // Org switch is async — wait for cookie sync to complete
+    await waitFor(() => {
+      expect(result.current.currentOrg?.public_id).toBe(SECOND_ORG.public_id);
+    });
     expect(storageMap.get("everruns_current_org")).toBe(SECOND_ORG.public_id);
+    expect(mockSwitchOrg).toHaveBeenCalledWith(SECOND_ORG.public_id);
   });
 
-  it("keeps newly created org even when organizations list hasn't caught up", () => {
+  it("rolls back on failed org switch", async () => {
+    mockUser = { organizations: [DEFAULT_ORG, SECOND_ORG] };
+    mockAuthLoading = false;
+    // Reject only for SECOND_ORG; allow init sync for DEFAULT_ORG
+    mockSwitchOrg.mockImplementation((orgId: string) => {
+      if (orgId === SECOND_ORG.public_id) {
+        return Promise.reject(new Error("network error"));
+      }
+      return Promise.resolve(undefined);
+    });
+
+    const { result } = renderHook(() => useOrg(), { wrapper });
+
+    act(() => {
+      result.current.setCurrentOrg(SECOND_ORG);
+    });
+
+    // Wait for the failed switch to settle
+    await waitFor(() => {
+      expect(result.current.isSwitching).toBe(false);
+    });
+
+    // Should stay on original org
+    expect(result.current.currentOrg?.public_id).toBe(DEFAULT_ORG.public_id);
+    // localStorage should NOT have been updated
+    expect(storageMap.get("everruns_current_org")).toBeUndefined();
+  });
+
+  it("shows isSwitching during org switch", async () => {
+    mockUser = { organizations: [DEFAULT_ORG, SECOND_ORG] };
+    mockAuthLoading = false;
+
+    // Make switchOrg hang until we resolve it
+    let resolveSwitch!: () => void;
+    mockSwitchOrg.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveSwitch = resolve;
+      }),
+    );
+
+    const { result } = renderHook(() => useOrg(), { wrapper });
+
+    act(() => {
+      result.current.setCurrentOrg(SECOND_ORG);
+    });
+
+    // Should be switching
+    expect(result.current.isSwitching).toBe(true);
+    // Should still be on old org until cookie sync completes
+    expect(result.current.currentOrg?.public_id).toBe(DEFAULT_ORG.public_id);
+
+    // Complete the switch
+    await act(async () => {
+      resolveSwitch();
+    });
+
+    expect(result.current.isSwitching).toBe(false);
+    expect(result.current.currentOrg?.public_id).toBe(SECOND_ORG.public_id);
+  });
+
+  it("keeps newly created org even when organizations list hasn't caught up", async () => {
     // Start with only the default org
     mockUser = { organizations: [DEFAULT_ORG] };
     mockAuthLoading = false;
 
     const { result, rerender } = renderHook(() => useOrg(), { wrapper });
 
-    // Simulate: user creates a new org and calls setCurrentOrg before
-    // the organizations list is refreshed.
     act(() => {
       result.current.setCurrentOrg(NEW_ORG);
     });
 
-    // The new org is NOT yet in the organizations array (query hasn't refetched).
-    // Without the fix, the sync useEffect would reset currentOrg to default.
-    expect(result.current.currentOrg?.public_id).toBe(NEW_ORG.public_id);
+    // Wait for the async switch to complete
+    await waitFor(() => {
+      expect(result.current.currentOrg?.public_id).toBe(NEW_ORG.public_id);
+    });
 
     // Rerender to trigger effects again — should still hold the new org.
     rerender();
     expect(result.current.currentOrg?.public_id).toBe(NEW_ORG.public_id);
   });
 
-  it("clears explicit flag once organizations list catches up", () => {
+  it("clears explicit flag once organizations list catches up", async () => {
     mockUser = { organizations: [DEFAULT_ORG] };
     mockAuthLoading = false;
 
     const { result, rerender } = renderHook(() => useOrg(), { wrapper });
 
-    // Set current org to a new org not yet in the list
     act(() => {
       result.current.setCurrentOrg(NEW_ORG);
     });
 
-    expect(result.current.currentOrg?.public_id).toBe(NEW_ORG.public_id);
+    await waitFor(() => {
+      expect(result.current.currentOrg?.public_id).toBe(NEW_ORG.public_id);
+    });
 
     // Now simulate the organizations list catching up (auth query refetched)
     mockUser = { organizations: [DEFAULT_ORG, NEW_ORG] };
@@ -125,7 +199,7 @@ describe("OrgProvider", () => {
     expect(result.current.currentOrg?.public_id).toBe(NEW_ORG.public_id);
   });
 
-  it("redirects entity detail pages on org switch", () => {
+  it("redirects entity detail pages on org switch", async () => {
     mockUser = { organizations: [DEFAULT_ORG, SECOND_ORG] };
     mockAuthLoading = false;
     mockPathname.mockReturnValue("/agents/agent-123");
@@ -136,10 +210,12 @@ describe("OrgProvider", () => {
       result.current.setCurrentOrg(SECOND_ORG);
     });
 
-    expect(mockPush).toHaveBeenCalledWith("/agents");
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/agents");
+    });
   });
 
-  it("does not redirect non-entity pages on org switch", () => {
+  it("does not redirect non-entity pages on org switch", async () => {
     mockUser = { organizations: [DEFAULT_ORG, SECOND_ORG] };
     mockAuthLoading = false;
     mockPathname.mockReturnValue("/dashboard");
@@ -148,6 +224,10 @@ describe("OrgProvider", () => {
 
     act(() => {
       result.current.setCurrentOrg(SECOND_ORG);
+    });
+
+    await waitFor(() => {
+      expect(result.current.currentOrg?.public_id).toBe(SECOND_ORG.public_id);
     });
 
     expect(mockPush).not.toHaveBeenCalled();

--- a/apps/ui/src/providers/org-provider.tsx
+++ b/apps/ui/src/providers/org-provider.tsx
@@ -141,30 +141,39 @@ export function OrgProvider({ children }: OrgProviderProps) {
     }
   }, [organizations, currentOrg, isInitialized]);
 
-  // Sync currentOrg cookie on mount/init (fire-and-forget, not user-initiated)
+  // Sync currentOrg cookie on init only (fire-and-forget, not user-initiated).
+  // Guard with ref to avoid redundant calls after user-initiated switches.
+  const didInitSyncRef = useRef(false);
   useEffect(() => {
-    if (currentOrg && isInitialized) {
+    if (currentOrg && isInitialized && !didInitSyncRef.current) {
+      didInitSyncRef.current = true;
       void switchOrgApi(currentOrg.public_id).catch((error) => {
         console.warn("Failed to sync org cookie on init:", error);
       });
     }
   }, [currentOrg, isInitialized]);
 
+  // Track latest switch to handle concurrent calls (last one wins)
+  const switchCounterRef = useRef(0);
+
   // Atomic org switch: await cookie sync → commit state → invalidate queries
   const setCurrentOrg = useCallback(
     (org: OrganizationMembership) => {
+      // Skip if already on this org
+      if (currentOrg?.public_id === org.public_id) return;
+
       // Mark as explicitly selected so the sync effect doesn't reset it
       // before the organizations list is refreshed.
       explicitOrgRef.current = org.public_id;
 
-      // Skip if already on this org
-      if (currentOrg?.public_id === org.public_id) return;
-
+      const switchId = ++switchCounterRef.current;
       setIsSwitching(true);
 
       // Await server cookie before committing client state
       switchOrgApi(org.public_id)
         .then(() => {
+          // Only commit if this is still the latest switch request
+          if (switchCounterRef.current !== switchId) return;
           setCurrentOrgState(org);
           localStorage.setItem(ORG_STORAGE_KEY, org.public_id);
           // Invalidate all org-scoped queries so stale data is refetched
@@ -176,12 +185,16 @@ export function OrgProvider({ children }: OrgProviderProps) {
           }
         })
         .catch((error) => {
+          // Only rollback if this is still the latest switch request
+          if (switchCounterRef.current !== switchId) return;
           // Rollback: clear explicit flag, stay on current org
           explicitOrgRef.current = null;
           console.error("Org switch failed, staying on current org:", error);
         })
         .finally(() => {
-          setIsSwitching(false);
+          if (switchCounterRef.current === switchId) {
+            setIsSwitching(false);
+          }
         });
     },
     [currentOrg?.public_id, queryClient, pathname, router],

--- a/apps/ui/src/providers/org-provider.tsx
+++ b/apps/ui/src/providers/org-provider.tsx
@@ -18,6 +18,7 @@ import {
   type ReactNode,
 } from "react";
 import { usePathname, useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "./auth-provider";
 import { switchOrg as switchOrgApi } from "@/lib/api/users";
 import type { OrganizationMembership, OrgRole } from "@/lib/api/types";
@@ -61,12 +62,14 @@ export interface OrgContextValue {
   currentOrg: OrganizationMembership | null;
   /** All organizations the user belongs to */
   organizations: OrganizationMembership[];
-  /** Set the current organization */
+  /** Set the current organization (awaits server cookie sync before committing) */
   setCurrentOrg: (org: OrganizationMembership) => void;
   /** Check if current user has at least the given role in the current org */
   hasRole: (role: OrgRole) => boolean;
   /** Loading state */
   isLoading: boolean;
+  /** True while an org switch is in progress (cookie sync pending) */
+  isSwitching: boolean;
 }
 
 export const OrgContext = createContext<OrgContextValue | undefined>(undefined);
@@ -79,11 +82,13 @@ export function OrgProvider({ children }: OrgProviderProps) {
   const { user, isLoading: authLoading } = useAuth();
   const [currentOrg, setCurrentOrgState] = useState<OrganizationMembership | null>(null);
   const [isInitialized, setIsInitialized] = useState(false);
+  const [isSwitching, setIsSwitching] = useState(false);
   // Track explicit org selection to prevent useEffect from resetting it
   // before the organizations list catches up (e.g. after creating a new org).
   const explicitOrgRef = useRef<string | null>(null);
   const router = useRouter();
   const pathname = usePathname();
+  const queryClient = useQueryClient();
 
   // Memoize organizations to prevent infinite re-renders
   // User is always fetched (even in none mode) and includes organizations
@@ -136,40 +141,51 @@ export function OrgProvider({ children }: OrgProviderProps) {
     }
   }, [organizations, currentOrg, isInitialized]);
 
-  // Call API to switch org (sets server-side cookie)
-  const syncOrgCookie = useCallback(async (orgId: string) => {
-    try {
-      await switchOrgApi(orgId);
-    } catch (error) {
-      // Log but don't throw - org switching should be resilient
-      console.warn("Failed to sync org cookie:", error);
+  // Sync currentOrg cookie on mount/init (fire-and-forget, not user-initiated)
+  useEffect(() => {
+    if (currentOrg && isInitialized) {
+      void switchOrgApi(currentOrg.public_id).catch((error) => {
+        console.warn("Failed to sync org cookie on init:", error);
+      });
     }
-  }, []);
+  }, [currentOrg, isInitialized]);
 
+  // Atomic org switch: await cookie sync → commit state → invalidate queries
   const setCurrentOrg = useCallback(
     (org: OrganizationMembership) => {
       // Mark as explicitly selected so the sync effect doesn't reset it
       // before the organizations list is refreshed.
       explicitOrgRef.current = org.public_id;
-      setCurrentOrgState(org);
-      localStorage.setItem(ORG_STORAGE_KEY, org.public_id);
-      // Set server-side cookie via API
-      void syncOrgCookie(org.public_id);
-      // Redirect entity detail pages to their list page to avoid 404
-      const listPath = getEntityListPath(pathname);
-      if (listPath) {
-        router.push(listPath);
-      }
-    },
-    [syncOrgCookie, pathname, router],
-  );
 
-  // Sync currentOrg to server cookie on mount/change
-  useEffect(() => {
-    if (currentOrg && isInitialized) {
-      void syncOrgCookie(currentOrg.public_id);
-    }
-  }, [currentOrg, isInitialized, syncOrgCookie]);
+      // Skip if already on this org
+      if (currentOrg?.public_id === org.public_id) return;
+
+      setIsSwitching(true);
+
+      // Await server cookie before committing client state
+      switchOrgApi(org.public_id)
+        .then(() => {
+          setCurrentOrgState(org);
+          localStorage.setItem(ORG_STORAGE_KEY, org.public_id);
+          // Invalidate all org-scoped queries so stale data is refetched
+          void queryClient.invalidateQueries();
+          // Redirect entity detail pages to their list page to avoid 404
+          const listPath = getEntityListPath(pathname);
+          if (listPath) {
+            router.push(listPath);
+          }
+        })
+        .catch((error) => {
+          // Rollback: clear explicit flag, stay on current org
+          explicitOrgRef.current = null;
+          console.error("Org switch failed, staying on current org:", error);
+        })
+        .finally(() => {
+          setIsSwitching(false);
+        });
+    },
+    [currentOrg?.public_id, queryClient, pathname, router],
+  );
 
   const hasRole = useCallback(
     (role: OrgRole) => {
@@ -185,6 +201,7 @@ export function OrgProvider({ children }: OrgProviderProps) {
     setCurrentOrg,
     hasRole,
     isLoading: authLoading || !isInitialized,
+    isSwitching,
   };
 
   return <OrgContext.Provider value={value}>{children}</OrgContext.Provider>;


### PR DESCRIPTION
## What
Make org switching await the server-side cookie sync before committing client state, with rollback on failure and query invalidation on success.

## Why
Org switching was optimistic and non-atomic — `currentOrg` and `localStorage` updated immediately while `switchOrgApi()` ran in the background. This meant responses from org A could be fetched and cached under org B during the transition. Fixes EVE-67.

## How
- `setCurrentOrg` now calls `switchOrgApi()` first, then commits state on success
- On API failure: rolls back `explicitOrgRef`, stays on current org, logs error
- On success: updates state, localStorage, invalidates all queries, redirects detail pages
- Added `isSwitching` to `OrgContextValue` for UI loading indicators
- Updated tests: async switch flow, rollback on failure, isSwitching lifecycle

## Risk
- Low-Medium
- Org switch now has a brief delay (network round-trip) before UI updates
- If the API is slow, users see the old org until the switch completes

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered