### PR TITLE
fix(ui): replace unsafe type casts with type guards (EVE-126)

### DIFF
--- a/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
@@ -24,14 +24,10 @@ import type {
   ToolCompletedData,
   InputMessageData,
   OutputMessageCompletedData,
-  OutputMessageStartedData,
   Message,
   TokenUsage,
-  LlmGenerationData,
-  ReasonThinkingStartedData,
-  OutputMessageDeltaData,
 } from "@/lib/api/types";
-import { getTextFromContent, isToolCallPart } from "@/lib/api/types";
+import { getTextFromContent, isToolCallPart, getEventData } from "@/lib/api/types";
 import type { UseMutationResult } from "@tanstack/react-query";
 
 interface SessionContextValue {
@@ -259,33 +255,37 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
       }
 
       // output.message.delta provides incremental text updates
-      if (event.type === "output.message.delta") {
-        const data = event.data as OutputMessageDeltaData;
-        setIsThinking(false); // No longer just thinking, now we have text
-        setStreamingText(data.accumulated);
-        setStreamingTurnId(data.turn_id);
-        break;
+      {
+        const deltaData = getEventData(event, "output.message.delta");
+        if (deltaData) {
+          setIsThinking(false); // No longer just thinking, now we have text
+          setStreamingText(deltaData.accumulated);
+          setStreamingTurnId(deltaData.turn_id);
+          break;
+        }
       }
 
       // output.message.started tracks iteration number
-      if (event.type === "output.message.started") {
-        const data = event.data as OutputMessageStartedData;
-        if (data.iteration) {
-          setStreamingIteration(data.iteration);
+      {
+        const startedData = getEventData(event, "output.message.started");
+        if (startedData?.iteration) {
+          setStreamingIteration(startedData.iteration);
         }
         // Don't break - continue looking for delta/thinking events
       }
 
       // reason.thinking.started indicates LLM is generating (before first text)
-      if (event.type === "reason.thinking.started") {
-        const data = event.data as ReasonThinkingStartedData;
-        // Only set thinking if we don't already have streaming text for this turn
-        if (!streamingText || streamingTurnId !== data.turn_id) {
-          setIsThinking(true);
-          setStreamingText(null);
-          setStreamingTurnId(data.turn_id);
+      {
+        const thinkData = getEventData(event, "reason.thinking.started");
+        if (thinkData) {
+          // Only set thinking if we don't already have streaming text for this turn
+          if (!streamingText || streamingTurnId !== thinkData.turn_id) {
+            setIsThinking(true);
+            setStreamingText(null);
+            setStreamingTurnId(thinkData.turn_id);
+          }
+          break;
         }
-        break;
       }
     }
   }, [events, streamingTurnId, streamingText]);
@@ -320,14 +320,14 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
     const realUserMessages = events
       .filter((e) => e.type === "input.message")
       .map((e) => {
-        const data = e.data as InputMessageData;
-        return getTextFromContent(data.message?.content || []);
+        const data = getEventData(e, "input.message");
+        return getTextFromContent(data?.message?.content || []);
       });
 
     // Remove optimistic events that have matching real events
     const optimisticToRemove = optimisticEvents.filter((optEvent) => {
-      const data = optEvent.data as InputMessageData;
-      const optText = getTextFromContent(data.message?.content || []);
+      const data = getEventData(optEvent, "input.message");
+      const optText = getTextFromContent(data?.message?.content || []);
       return realUserMessages.includes(optText);
     });
 
@@ -359,16 +359,16 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
       realChatEvents
         .filter((e) => e.type === "input.message")
         .map((e) => {
-          const data = e.data as InputMessageData;
-          return getTextFromContent(data.message?.content || []);
+          const data = getEventData(e, "input.message");
+          return getTextFromContent(data?.message?.content || []);
         }),
     );
 
     // Filter out optimistic events that already have a real counterpart
     const pendingOptimisticEvents = optimisticEvents.filter((optEvent) => {
       if (optEvent.type !== "input.message") return true;
-      const data = optEvent.data as InputMessageData;
-      const optText = getTextFromContent(data.message?.content || []);
+      const data = getEventData(optEvent, "input.message");
+      const optText = getTextFromContent(data?.message?.content || []);
       return !realUserTexts.has(optText);
     });
 
@@ -380,8 +380,8 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
     const map = new Map<string, ToolCompletedData>();
     if (!events) return map;
     for (const event of events) {
-      if (event.type === "tool.completed") {
-        const data = event.data as ToolCompletedData;
+      const data = getEventData(event, "tool.completed");
+      if (data) {
         map.set(data.tool_call_id, data);
       }
     }
@@ -421,15 +421,13 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
     // Only scan events we haven't processed yet
     for (let i = acc.processed; i < events.length; i++) {
       const event = events[i];
-      if (event.type === "llm.generation") {
-        const data = event.data as LlmGenerationData;
-        if (data.metadata?.usage) {
-          acc.hasLlmEvents = true;
-          acc.inputTokens += data.metadata.usage.input_tokens;
-          acc.outputTokens += data.metadata.usage.output_tokens;
-          acc.cacheReadTokens += data.metadata.usage.cache_read_tokens ?? 0;
-          acc.cacheCreationTokens += data.metadata.usage.cache_creation_tokens ?? 0;
-        }
+      const llmData = getEventData(event, "llm.generation");
+      if (llmData?.metadata?.usage) {
+        acc.hasLlmEvents = true;
+        acc.inputTokens += llmData.metadata.usage.input_tokens;
+        acc.outputTokens += llmData.metadata.usage.output_tokens;
+        acc.cacheReadTokens += llmData.metadata.usage.cache_read_tokens ?? 0;
+        acc.cacheCreationTokens += llmData.metadata.usage.cache_creation_tokens ?? 0;
       }
     }
     acc.processed = events.length;

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -21,20 +21,8 @@ import {
   CalendarClock,
   ArrowDown,
 } from "lucide-react";
-import type {
-  ActCompletedData,
-  ActStartedData,
-  Controls,
-  InputMessageData,
-  OutputMessageCompletedData,
-  ContentPart,
-  CommandDescriptor,
-  ToolCallRequestedData,
-  ToolCallSummary,
-  ToolCompletedData,
-  ToolStartedData,
-} from "@/lib/api/types";
-import { isImageFilePart } from "@/lib/api/types";
+import type { Controls, ContentPart, CommandDescriptor, ToolCallSummary } from "@/lib/api/types";
+import { isImageFilePart, getEventData } from "@/lib/api/types";
 import { MessageInfoIcon } from "@/components/chat/message-info-icon";
 import { ImageAttachments, MessageImage } from "@/components/chat/image-attachments";
 import {
@@ -191,8 +179,8 @@ export function ChatPanel() {
   const clientRequestedToolCallIds = useMemo(() => {
     const ids = new Set<string>();
     for (const event of chatEvents) {
-      if (event.type !== "tool.call_requested") continue;
-      const data = event.data as ToolCallRequestedData;
+      const data = getEventData(event, "tool.call_requested");
+      if (!data) continue;
       for (const toolCall of data.tool_calls ?? []) {
         ids.add(toolCall.id);
       }
@@ -242,52 +230,63 @@ export function ChatPanel() {
       const execId = event.context?.exec_id;
       if (!execId) continue;
 
-      if (event.type === "act.started") {
-        const data = event.data as ActStartedData;
-        groupsByExecId.set(execId, {
-          startEventId: event.id,
-          headline: data.headline ?? "Working",
-          rows: (data.tool_calls ?? []).map((toolCall: ToolCallSummary) => ({
-            id: toolCall.id,
-            label: toolCall.narration ?? toolCall.display_name ?? toolCall.name,
-            state: "running",
-          })),
-        });
-        continue;
+      {
+        const actStarted = getEventData(event, "act.started");
+        if (actStarted) {
+          groupsByExecId.set(execId, {
+            startEventId: event.id,
+            headline: actStarted.headline ?? "Working",
+            rows: (actStarted.tool_calls ?? []).map((toolCall: ToolCallSummary) => ({
+              id: toolCall.id,
+              label: toolCall.narration ?? toolCall.display_name ?? toolCall.name,
+              state: "running",
+            })),
+          });
+          continue;
+        }
       }
 
       const group = groupsByExecId.get(execId);
       if (!group) continue;
 
-      if (event.type === "tool.started") {
-        const data = event.data as ToolStartedData;
-        const row = ensureRow(
-          group,
-          data.tool_call.id,
-          data.narration ?? data.display_name ?? data.tool_call.name,
-          "running",
-        );
-        row.label = data.narration ?? row.label;
-        continue;
+      {
+        const toolStarted = getEventData(event, "tool.started");
+        if (toolStarted) {
+          const row = ensureRow(
+            group,
+            toolStarted.tool_call.id,
+            toolStarted.narration ?? toolStarted.display_name ?? toolStarted.tool_call.name,
+            "running",
+          );
+          row.label = toolStarted.narration ?? row.label;
+          continue;
+        }
       }
 
-      if (event.type === "tool.completed") {
-        const data = event.data as ToolCompletedData;
-        const row = ensureRow(
-          group,
-          data.tool_call_id,
-          data.narration ?? data.display_name ?? data.tool_name ?? "Tool call",
-          data.success ? "completed" : "error",
-        );
-        row.label = data.narration ?? row.label;
-        row.result = data;
-        row.state = data.success ? "completed" : "error";
-        continue;
+      {
+        const toolCompleted = getEventData(event, "tool.completed");
+        if (toolCompleted) {
+          const row = ensureRow(
+            group,
+            toolCompleted.tool_call_id,
+            toolCompleted.narration ??
+              toolCompleted.display_name ??
+              toolCompleted.tool_name ??
+              "Tool call",
+            toolCompleted.success ? "completed" : "error",
+          );
+          row.label = toolCompleted.narration ?? row.label;
+          row.result = toolCompleted;
+          row.state = toolCompleted.success ? "completed" : "error";
+          continue;
+        }
       }
 
-      if (event.type === "act.completed") {
-        const data = event.data as ActCompletedData;
-        group.completedHeadline = data.headline;
+      {
+        const actCompleted = getEventData(event, "act.completed");
+        if (actCompleted) {
+          group.completedHeadline = actCompleted.headline;
+        }
       }
     }
 
@@ -540,7 +539,8 @@ export function ChatPanel() {
               }
 
               if (event.type === "context.compacted") {
-                const compactedData = event.data as import("@/lib/api/types").ContextCompactedData;
+                const compactedData = getEventData(event, "context.compacted");
+                if (!compactedData) return null;
                 return <CompactionDivider key={event.id} data={compactedData} />;
               }
 
@@ -562,7 +562,8 @@ export function ChatPanel() {
               }
 
               if (event.type === "tool.call_requested") {
-                const reqData = event.data as ToolCallRequestedData;
+                const reqData = getEventData(event, "tool.call_requested");
+                if (!reqData) return null;
                 if (!reqData.tool_calls || reqData.tool_calls.length === 0) return null;
 
                 if (reqData.headline || reqData.tool_summaries?.length) {
@@ -621,13 +622,18 @@ export function ChatPanel() {
               }
 
               const isUser = event.type === "input.message";
-              const data = event.data as InputMessageData | OutputMessageCompletedData;
+              const inputData = getEventData(event, "input.message");
+              const outputData = getEventData(event, "output.message.completed");
+              const data = inputData ?? outputData;
+              if (!data) return null;
               const textContent = getMessageText(data);
               const toolCalls = isUser
                 ? []
-                : getToolCalls(data as OutputMessageCompletedData).filter(
-                    (toolCall) => !clientRequestedToolCallIds.has(toolCall.id),
-                  );
+                : outputData
+                  ? getToolCalls(outputData).filter(
+                      (toolCall) => !clientRequestedToolCallIds.has(toolCall.id),
+                    )
+                  : [];
               const images = data.message?.content ? getMessageImages(data.message.content) : [];
               const isScheduleTriggered = isUser && data.message?.metadata?.source === "schedule";
               const isToolOnlyMessage =

--- a/apps/ui/src/components/chat/message-info-icon.tsx
+++ b/apps/ui/src/components/chat/message-info-icon.tsx
@@ -4,7 +4,8 @@ import { Info } from "lucide-react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { CopyButton } from "@/components/ui/copy-button";
 import { cn } from "@/lib/utils";
-import type { Event, OutputMessageCompletedData, TokenUsage } from "@/lib/api/types";
+import type { Event, TokenUsage } from "@/lib/api/types";
+import { getEventData, isRecord } from "@/lib/api/types";
 
 interface MessageInfoIconProps {
   /** The event containing message data */
@@ -18,14 +19,20 @@ interface MessageInfoIconProps {
  * Shows: message ID, model, reasoning effort, timestamp, and token usage.
  */
 export function MessageInfoIcon({ event, variant = "default" }: MessageInfoIconProps) {
-  const isAgentMessage = event.type === "output.message.completed";
-  const agentData = isAgentMessage ? (event.data as OutputMessageCompletedData) : null;
+  const agentData = getEventData(event, "output.message.completed");
 
   // Model and reasoning are stored on message.metadata (set by ReasonAtom)
   // Fallback to agentData.metadata for backward compatibility
-  const messageMetadata = agentData?.message?.metadata as Record<string, unknown> | undefined;
-  const model = (messageMetadata?.model as string) ?? agentData?.metadata?.model;
-  const reasoningEffort = messageMetadata?.reasoning_effort as string | undefined;
+  const messageMetadata = isRecord(agentData?.message?.metadata)
+    ? agentData.message.metadata
+    : undefined;
+  const model =
+    (typeof messageMetadata?.model === "string" ? messageMetadata.model : undefined) ??
+    agentData?.metadata?.model;
+  const reasoningEffort =
+    typeof messageMetadata?.reasoning_effort === "string"
+      ? messageMetadata.reasoning_effort
+      : undefined;
   const phase = agentData?.message?.phase;
 
   // Token usage from OutputMessageCompletedData (if populated)

--- a/apps/ui/src/components/chat/tool-activity-group.tsx
+++ b/apps/ui/src/components/chat/tool-activity-group.tsx
@@ -19,6 +19,7 @@ import {
   MonitorSmartphone,
 } from "lucide-react";
 import type { ToolCompletedData } from "@/lib/api/types";
+import { isRecord } from "@/lib/api/types";
 import { cn } from "@/lib/utils";
 import { basename } from "@/lib/path-utils";
 import {
@@ -183,32 +184,26 @@ function parseStructuredText(text: string): unknown | null {
 }
 
 function maskSensitiveFields(toolName: string, value: unknown): unknown {
-  if (
-    toolName !== "secret_store" ||
-    typeof value !== "object" ||
-    value === null ||
-    Array.isArray(value)
-  ) {
+  if (toolName !== "secret_store" || !isRecord(value)) {
     return value;
   }
 
-  const record = value as Record<string, unknown>;
-  if (!("value" in record) || record.value == null) {
+  if (!("value" in value) || value.value == null) {
     return value;
   }
 
   return {
-    ...record,
+    ...value,
     value: "[hidden]",
   };
 }
 
 function summarizeStructuredResult(toolCall: ToolCallContent, parsed: unknown): string | null {
-  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+  if (!isRecord(parsed)) {
     return null;
   }
 
-  const record = parsed as Record<string, unknown>;
+  const record = parsed;
 
   if (toolCall.name === "secret_store") {
     const operation = record.operation;

--- a/apps/ui/src/components/chat/tool-call-card.tsx
+++ b/apps/ui/src/components/chat/tool-call-card.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import type { Message } from "@/lib/api/types";
+import { isToolCallContent, isToolResultContent } from "@/lib/api/types";
 import { TodoListRenderer, isWriteTodosTool } from "./todo-list-renderer";
 import {
   extractToolCallContent,
@@ -21,15 +22,19 @@ interface ToolCallCardProps {
 export function ToolCallCard({ toolCall, toolResult }: ToolCallCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
 
-  // Handle new ContentPart[] format
+  // Handle new ContentPart[] format; fall back to runtime guard for legacy shapes
   const content = Array.isArray(toolCall.content)
     ? extractToolCallContent(toolCall.content)
-    : (toolCall.content as unknown as ToolCallContent);
+    : isToolCallContent(toolCall.content)
+      ? (toolCall.content as ToolCallContent)
+      : null;
 
   const resultContent =
     toolResult?.content && Array.isArray(toolResult.content)
       ? extractToolResultContent(toolResult.content)
-      : (toolResult?.content as unknown as ToolResultContent | undefined);
+      : isToolResultContent(toolResult?.content)
+        ? (toolResult!.content as ToolResultContent)
+        : undefined;
 
   const isComplete = !!toolResult;
   const hasError = resultContent?.error !== undefined && resultContent?.error !== null;

--- a/apps/ui/src/components/chat/turn-delimiter.ts
+++ b/apps/ui/src/components/chat/turn-delimiter.ts
@@ -2,24 +2,20 @@
 // optimistic input rows never show a fake duration and client tool requests
 // can take over as the last visible item when embedded tool calls are hidden.
 
-import type {
-  ActStartedData,
-  Event,
-  InputMessageData,
-  OutputMessageCompletedData,
-  ToolCallRequestedData,
-  TurnCompletedData,
-  TurnStartedData,
+import type { Event } from "@/lib/api/types";
+import {
+  getTextFromContent,
+  getToolCallsFromContent,
+  isImageFilePart,
+  getEventData,
 } from "@/lib/api/types";
-import { getTextFromContent, getToolCallsFromContent, isImageFilePart } from "@/lib/api/types";
 
 function getClientRequestedToolCallIds(events: Event[]): Set<string> {
   const ids = new Set<string>();
 
   for (const event of events) {
-    if (event.type !== "tool.call_requested") continue;
-
-    const data = event.data as ToolCallRequestedData;
+    const data = getEventData(event, "tool.call_requested");
+    if (!data) continue;
     for (const toolCall of data.tool_calls ?? []) {
       ids.add(toolCall.id);
     }
@@ -32,9 +28,8 @@ function getInputMessageTurnIds(events: Event[]): Map<string, string> {
   const turnIds = new Map<string, string>();
 
   for (const event of events) {
-    if (event.type !== "turn.started") continue;
-
-    const data = event.data as TurnStartedData;
+    const data = getEventData(event, "turn.started");
+    if (!data) continue;
     turnIds.set(data.input_message_id, data.turn_id);
   }
 
@@ -46,22 +41,22 @@ function isVisibleChatEvent(event: Event, clientRequestedToolCallIds: Set<string
     return true;
   }
 
-  if (event.type === "tool.call_requested") {
-    const data = event.data as ToolCallRequestedData;
-    return (data.tool_calls?.length ?? 0) > 0;
+  const reqData = getEventData(event, "tool.call_requested");
+  if (reqData) {
+    return (reqData.tool_calls?.length ?? 0) > 0;
   }
 
-  if (event.type === "act.started") {
-    const data = event.data as ActStartedData;
-    return (data.tool_calls?.length ?? 0) > 0;
+  const actData = getEventData(event, "act.started");
+  if (actData) {
+    return (actData.tool_calls?.length ?? 0) > 0;
   }
 
-  if (event.type !== "output.message.completed") {
+  const outData = getEventData(event, "output.message.completed");
+  if (!outData) {
     return false;
   }
 
-  const data = event.data as OutputMessageCompletedData;
-  const content = data.message?.content ?? [];
+  const content = outData.message?.content ?? [];
   const text = getTextFromContent(content);
   const hasImages = content.some(isImageFilePart);
   const visibleToolCalls = getToolCallsFromContent(content).filter(
@@ -79,11 +74,8 @@ function getEventTurnId(
     return event.context.turn_id;
   }
 
-  if (event.type !== "input.message") {
-    return undefined;
-  }
-
-  const data = event.data as InputMessageData;
+  const data = getEventData(event, "input.message");
+  if (!data) return undefined;
   return data.message?.id ? inputMessageTurnIds.get(data.message.id) : undefined;
 }
 
@@ -101,11 +93,9 @@ export function getCompletedTurnDurationsByEvent(events: Event[]): Map<string, n
       }
     }
 
-    if (event.type === "turn.completed") {
-      const data = event.data as TurnCompletedData;
-      if (data.duration_ms != null) {
-        durationMsByTurn.set(data.turn_id, data.duration_ms);
-      }
+    const tcData = getEventData(event, "turn.completed");
+    if (tcData && tcData.duration_ms != null) {
+      durationMsByTurn.set(tcData.turn_id, tcData.duration_ms);
     }
   }
 

--- a/apps/ui/src/components/connections/provider-icon.tsx
+++ b/apps/ui/src/components/connections/provider-icon.tsx
@@ -1,10 +1,10 @@
 "use client";
 
+import type { ComponentType } from "react";
 import { Github, Cloud, Search, LinkIcon } from "lucide-react";
-import type { LucideIcon } from "lucide-react";
 import { getCapabilityIcon } from "@/lib/capability-icons";
 
-const iconMap: Record<string, LucideIcon> = {
+const iconMap: Record<string, ComponentType<{ className?: string }>> = {
   github: Github,
   cloud: Cloud,
   search: Search,

--- a/apps/ui/src/components/durable/metrics-charts.tsx
+++ b/apps/ui/src/components/durable/metrics-charts.tsx
@@ -91,9 +91,12 @@ function getCounter(p: MetricsPoint, field: CounterField): number {
   return p[field];
 }
 
-/** Set a counter value on a mutable metrics point record */
-function setCounter(p: Record<string, unknown>, field: CounterField, value: number): void {
-  p[field] = value;
+/** Set a counter value on a mutable metrics point */
+function setCounter(p: MetricsPoint, field: CounterField, value: number): void {
+  // All CounterField keys are valid MetricsPoint numeric fields.
+  // Use indexed access on a type-safe mapped helper to avoid double cast.
+  const mutable: { -readonly [K in CounterField]: number } = p;
+  mutable[field] = value;
 }
 
 /** Create a zero-valued MetricsPoint at a given timestamp */
@@ -159,7 +162,7 @@ function buildTimeWindow(points: MetricsPoint[]): MetricsPoint[] {
       }
     } else if (Object.keys(lastCounters).length > 0) {
       // Fill empty slot with last known counter values
-      const slot = slots[i] as unknown as Record<string, unknown>;
+      const slot = slots[i];
       for (const field of COUNTER_FIELDS) {
         if (field in lastCounters) {
           setCounter(slot, field, lastCounters[field]!);
@@ -174,7 +177,7 @@ function buildTimeWindow(points: MetricsPoint[]): MetricsPoint[] {
   if (firstRealIdx > 0) {
     const firstReal = slots[firstRealIdx];
     for (let i = 0; i < firstRealIdx; i++) {
-      const slot = slots[i] as unknown as Record<string, unknown>;
+      const slot = slots[i];
       for (const field of COUNTER_FIELDS) {
         setCounter(slot, field, getCounter(firstReal, field));
       }

--- a/apps/ui/src/components/trajectory/trajectory-utils.ts
+++ b/apps/ui/src/components/trajectory/trajectory-utils.ts
@@ -10,19 +10,8 @@
 //   NOT on every SSE delta event (which fires 10-30x per second during streaming).
 
 import type { Node, Edge } from "@xyflow/react";
-import type {
-  Event,
-  InputMessageData,
-  OutputMessageCompletedData,
-  TurnStartedData,
-  TurnCompletedData,
-  TurnFailedData,
-  ReasonCompletedData,
-  ActStartedData,
-  ActCompletedData,
-  ToolCompletedData,
-} from "@/lib/api/types";
-import { getTextFromContent } from "@/lib/api/types";
+import type { Event, ToolCompletedData } from "@/lib/api/types";
+import { getTextFromContent, getEventData } from "@/lib/api/types";
 
 // --- Node data types ---
 
@@ -192,9 +181,9 @@ export function buildTurns(events: Event[]): TurnAccumulator[] {
 
   const toolResults = new Map<string, ToolCompletedData>();
   for (const event of events) {
-    if (event.type === "tool.completed") {
-      const data = event.data as ToolCompletedData;
-      toolResults.set(data.tool_call_id, data);
+    const tcData = getEventData(event, "tool.completed");
+    if (tcData) {
+      toolResults.set(tcData.tool_call_id, tcData);
     }
   }
 
@@ -203,7 +192,8 @@ export function buildTurns(events: Event[]): TurnAccumulator[] {
 
     switch (event.type) {
       case "turn.started": {
-        const data = event.data as TurnStartedData;
+        const data = getEventData(event, "turn.started");
+        if (!data) break;
 
         // Check if previous turn is an orphan (input.message arrived before turn.started).
         // Adopt it by updating its turnId instead of creating a duplicate turn.
@@ -234,7 +224,8 @@ export function buildTurns(events: Event[]): TurnAccumulator[] {
       }
 
       case "input.message": {
-        const data = event.data as InputMessageData;
+        const data = getEventData(event, "input.message");
+        if (!data) break;
         const text = getTextFromContent(data.message?.content || []);
         const messageId = data.message?.id;
         if (currentTurn) {
@@ -256,7 +247,8 @@ export function buildTurns(events: Event[]): TurnAccumulator[] {
 
       case "reason.completed": {
         if (!currentTurn) break;
-        const data = event.data as ReasonCompletedData;
+        const data = getEventData(event, "reason.completed");
+        if (!data) break;
         currentIteration = {
           reasoning: {
             eventId: event.id,
@@ -272,7 +264,8 @@ export function buildTurns(events: Event[]): TurnAccumulator[] {
 
       case "act.started": {
         if (!currentTurn || !currentIteration) break;
-        const data = event.data as ActStartedData;
+        const data = getEventData(event, "act.started");
+        if (!data) break;
         currentIteration.toolGroup = {
           eventId: event.id,
           ts: event.ts,
@@ -295,7 +288,8 @@ export function buildTurns(events: Event[]): TurnAccumulator[] {
 
       case "act.completed": {
         if (!currentTurn || !currentIteration?.toolGroup) break;
-        const data = event.data as ActCompletedData;
+        const data = getEventData(event, "act.completed");
+        if (!data) break;
         currentIteration.toolGroup.successCount = data.success_count;
         currentIteration.toolGroup.errorCount = data.error_count;
         currentIteration.toolGroup.durationMs = data.duration_ms;
@@ -304,7 +298,8 @@ export function buildTurns(events: Event[]): TurnAccumulator[] {
 
       case "output.message.completed": {
         if (!currentTurn) break;
-        const data = event.data as OutputMessageCompletedData;
+        const data = getEventData(event, "output.message.completed");
+        if (!data) break;
         const text = getTextFromContent(data.message?.content || []);
         const hasToolCalls = data.message?.content?.some((p) => p.type === "tool_call") ?? false;
         currentTurn.agentMessage = {
@@ -319,7 +314,8 @@ export function buildTurns(events: Event[]): TurnAccumulator[] {
 
       case "turn.completed": {
         if (!currentTurn) break;
-        const data = event.data as TurnCompletedData;
+        const data = getEventData(event, "turn.completed");
+        if (!data) break;
         currentTurn.completed = true;
         currentTurn.durationMs = data.duration_ms;
         currentTurn.iterationCount = data.iterations;
@@ -330,7 +326,8 @@ export function buildTurns(events: Event[]): TurnAccumulator[] {
 
       case "turn.failed": {
         if (!currentTurn) break;
-        const data = event.data as TurnFailedData;
+        const data = getEventData(event, "turn.failed");
+        if (!data) break;
         currentTurn.completed = true;
         currentTurn.failed = true;
         currentTurn.errorMessage = data.error;
@@ -412,13 +409,16 @@ export function buildTrajectory(events: Event[]): {
     let lastChildId: string | null = null;
 
     function addChild(id: string, type: TrajectoryNodeType, data: TrajectoryNodeData) {
+      // TrajectoryNodeData variants are plain objects with string keys.
+      // React Flow Node requires Record<string, unknown>; TS interfaces lack
+      // implicit index signatures, so a single narrowing cast is needed here.
       nodes.push({
         id,
         type,
         position: { x: CHILD_X, y: childY },
         parentId: groupId,
         extent: "parent" as const,
-        data: data as unknown as Record<string, unknown>,
+        data: data as TrajectoryNodeData & Record<string, unknown>,
       });
       if (!firstChildId) firstChildId = id;
       if (lastChildId) addEdge(lastChildId, id);
@@ -501,7 +501,7 @@ export function buildTrajectory(events: Event[]): {
         failed: turn.failed,
         errorMessage: turn.errorMessage,
         timestamp: turn.startTs,
-      } as unknown as Record<string, unknown>,
+      } as TurnGroupNodeData & Record<string, unknown>, // single cast: TS interface -> Record
       style: {
         width: GROUP_WIDTH,
         height: Math.max(groupHeight, GROUP_PAD_TOP + 40),

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -794,6 +794,94 @@ export type EventData =
   | ContextCompactedData
   | Record<string, unknown>; // Raw/unknown event data
 
+// ============================================
+// Event type guard helpers
+// ============================================
+// These narrow Event.data to the correct payload type based on Event.type,
+// replacing unsafe `as` casts with runtime-checked type predicates.
+
+/** Map from event type string to its data type */
+export interface EventTypeMap {
+  "input.message": InputMessageData;
+  "output.message.started": OutputMessageStartedData;
+  "output.message.delta": OutputMessageDeltaData;
+  "output.message.completed": OutputMessageCompletedData;
+  "turn.started": TurnStartedData;
+  "turn.completed": TurnCompletedData;
+  "turn.failed": TurnFailedData;
+  "reason.started": ReasonStartedData;
+  "reason.completed": ReasonCompletedData;
+  "act.started": ActStartedData;
+  "act.completed": ActCompletedData;
+  "tool.started": ToolStartedData;
+  "tool.call_requested": ToolCallRequestedData;
+  "tool.completed": ToolCompletedData;
+  "llm.generation": LlmGenerationData;
+  "session.started": SessionStartedData;
+  "session.activated": SessionActivatedData;
+  "session.idled": SessionIdledData;
+  "reason.thinking.started": ReasonThinkingStartedData;
+  "reason.thinking.delta": ReasonThinkingDeltaData;
+  "reason.thinking.completed": ReasonThinkingCompletedData;
+  "context.compacting": ContextCompactingData;
+  "context.compacted": ContextCompactedData;
+}
+
+export type KnownEventType = keyof EventTypeMap;
+
+/** Type predicate: narrows an Event to one with a known type and correctly-typed data. */
+export function isEventOfType<T extends KnownEventType>(
+  event: Event,
+  type: T,
+): event is Event & { type: T; data: EventTypeMap[T] } {
+  return event.type === type;
+}
+
+/** Narrow event data after a switch/if on event.type (returns typed data or null). */
+export function getEventData<T extends KnownEventType>(
+  event: Event,
+  type: T,
+): EventTypeMap[T] | null {
+  return event.type === type ? (event.data as EventTypeMap[T]) : null;
+}
+
+/**
+ * Type guard: narrows an unknown object value to Record<string, unknown>.
+ * Use after checking `typeof value === 'object' && value !== null && !Array.isArray(value)`.
+ */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Type guard for ToolCallContent shape (tool-call-card, tool-activity-group).
+ * Validates the essential fields at runtime.
+ */
+export function isToolCallContent(value: unknown): value is {
+  id: string;
+  name: string;
+  display_name?: string;
+  arguments: Record<string, unknown>;
+} {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.name === "string" &&
+    isRecord(value.arguments)
+  );
+}
+
+/**
+ * Type guard for ToolResultContent shape.
+ */
+export function isToolResultContent(value: unknown): value is {
+  tool_call_id: string;
+  result?: unknown;
+  error?: string;
+} {
+  return isRecord(value) && typeof value.tool_call_id === "string";
+}
+
 export interface CreateEventRequest {
   event_type: string;
   data: Record<string, unknown>;

--- a/apps/ui/src/lib/capability-icons.tsx
+++ b/apps/ui/src/lib/capability-icons.tsx
@@ -1,4 +1,9 @@
-import { forwardRef, type SVGProps } from "react";
+import {
+  forwardRef,
+  type SVGProps,
+  type ForwardRefExoticComponent,
+  type RefAttributes,
+} from "react";
 import {
   CircleOff,
   Clock,
@@ -21,6 +26,14 @@ import {
   Infinity as InfinityIcon,
   type LucideIcon,
 } from "lucide-react";
+
+/**
+ * Icon component type that accepts both LucideIcon and custom SVG forwardRef components.
+ * Avoids `as unknown as LucideIcon` double casts for custom icons.
+ */
+type IconComponent =
+  | LucideIcon
+  | ForwardRefExoticComponent<SVGProps<SVGSVGElement> & RefAttributes<SVGSVGElement>>;
 
 /**
  * Custom MCP (Model Context Protocol) icon.
@@ -102,7 +115,7 @@ DaytonaIcon.displayName = "DaytonaIcon";
  * Centralized mapping of capability icon names to Lucide React components.
  * Icon names are defined in the backend capability implementations.
  */
-export const capabilityIconMap: Record<string, LucideIcon> = {
+export const capabilityIconMap: Record<string, IconComponent> = {
   // Core capabilities
   "circle-off": CircleOff,
   clock: Clock,
@@ -124,16 +137,16 @@ export const capabilityIconMap: Record<string, LucideIcon> = {
   users: Users,
   "dollar-sign": DollarSign,
   package: Package,
-  // Custom icons
-  mcp: McpIcon as unknown as LucideIcon,
-  daytona: DaytonaIcon as unknown as LucideIcon,
+  // Custom icons (ForwardRefExoticComponent<SVGProps> — no double cast needed)
+  mcp: McpIcon,
+  daytona: DaytonaIcon,
 };
 
 /**
  * Get the icon component for a capability.
  * Falls back to CircleOff if the icon is not found.
  */
-export function getCapabilityIcon(iconName?: string | null): LucideIcon {
+export function getCapabilityIcon(iconName?: string | null): IconComponent {
   if (!iconName) return CircleOff;
   return capabilityIconMap[iconName] ?? CircleOff;
 }


### PR DESCRIPTION
## Summary

- Add type guard helpers (`isEventOfType`, `getEventData`, `isRecord`, `isToolCallContent`, `isToolResultContent`) to `types.ts` with an `EventTypeMap` for compile-time event type narrowing
- Replace 11 `as unknown as` double casts and 20+ bare `as` event data casts across 10 UI files with guarded narrowing via `getEventData()`
- Remove `as unknown as LucideIcon` double casts in capability-icons by introducing an `IconComponent` union type
- Fix `setCounter` in metrics-charts to accept `MetricsPoint` directly, eliminating double casts in `buildTimeWindow`
- Replace `as Record<string, unknown>` in tool-activity-group with `isRecord()` type guard

## Test plan

- [x] `npm run lint` passes (0 errors)
- [x] `npm run build` passes (TypeScript type checks)
- [x] `npx jest` — all 533 tests pass
- [x] `just pre-push` — all 6 checks green
- [ ] CI green