### PR TITLE
feat(cli): add file sync commands and comprehensive test coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ Always make sure you are working on top of latest main from remote.
 - `specs/otel-observability.md` - OpenTelemetry Gen-AI semantic convention tracing
 - `specs/encryption.md` - Envelope encryption for sensitive data
 - `specs/session-filesystem.md` - Per-session virtual filesystem
-- `specs/file-sync.md` - CLI bidirectional file sync with session workspace
+- `specs/cli.md` - CLI specification (commands, file sync, wire protocol)
 - `specs/usage-tracking.md` - LLM token usage tracking
 - `specs/documentation.md` - Documentation site (Astro Starlight)
 - `specs/brand.md` - Brand identity, colors, typography

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,7 @@ Always make sure you are working on top of latest main from remote.
 - `specs/otel-observability.md` - OpenTelemetry Gen-AI semantic convention tracing
 - `specs/encryption.md` - Envelope encryption for sensitive data
 - `specs/session-filesystem.md` - Per-session virtual filesystem
+- `specs/file-sync.md` - CLI bidirectional file sync with session workspace
 - `specs/usage-tracking.md` - LLM token usage tracking
 - `specs/documentation.md` - Documentation site (Astro Starlight)
 - `specs/brand.md` - Brand identity, colors, typography

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,6 +1317,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
+ "tempfile",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -165,7 +165,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1227,7 +1227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1306,12 +1306,17 @@ name = "everruns-cli"
 version = "0.8.6"
 dependencies = [
  "anyhow",
+ "base64",
+ "chrono",
  "clap",
  "everruns-sdk",
+ "ignore",
+ "notify",
  "reqwest 0.13.1",
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "tokio",
 ]
 
@@ -1769,6 +1774,17 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -2390,7 +2406,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2410,7 +2426,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2537,6 +2553,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2599,6 +2631,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2633,6 +2685,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2790,6 +2851,26 @@ dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -3212,6 +3293,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.11.0",
+ "filetime",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3226,7 +3334,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3956,7 +4064,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3994,7 +4102,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4512,7 +4620,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4571,7 +4679,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4935,7 +5043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5327,7 +5435,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6440,7 +6548,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,7 @@ moka = { version = "0.12", features = ["future", "sync"] }
 # Fault injection testing
 fail = "0.5"
 rstest = "0.25"
+tempfile = "3"
 
 # File watching and gitignore
 notify = { version = "7", default-features = false, features = ["macos_kqueue"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,11 @@ moka = { version = "0.12", features = ["future", "sync"] }
 fail = "0.5"
 rstest = "0.25"
 
+# File watching and gitignore
+notify = { version = "7", default-features = false, features = ["macos_kqueue"] }
+notify-debouncer-mini = { version = "0.5", default-features = false }
+ignore = "0.4"
+
 # Plugin system for external integrations
 inventory = "0.3"
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -30,3 +30,10 @@ serde_yaml.workspace = true
 
 # Error handling
 anyhow.workspace = true
+
+# File sync dependencies
+sha2.workspace = true
+base64.workspace = true
+chrono.workspace = true
+notify.workspace = true
+ignore.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -37,3 +37,6 @@ base64.workspace = true
 chrono.workspace = true
 notify.workspace = true
 ignore.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/cli/src/commands/capabilities.rs
+++ b/crates/cli/src/commands/capabilities.rs
@@ -1,5 +1,6 @@
 // Capabilities listing command
 //
+// TODO(sdk): Replace raw reqwest with SDK capabilities() methods once available.
 // Note: Capabilities endpoint is not yet supported by the SDK,
 // so we use reqwest directly here.
 

--- a/crates/cli/src/commands/files/ls.rs
+++ b/crates/cli/src/commands/files/ls.rs
@@ -1,0 +1,65 @@
+// `everruns files ls` — list remote session files.
+
+use crate::commands::files::remote::RemoteClient;
+use crate::output::{OutputFormat, print_table_header, print_table_row};
+use anyhow::Result;
+
+pub async fn run(
+    api_url: &str,
+    api_key: &str,
+    output: OutputFormat,
+    session_id: String,
+    path: String,
+    recursive: bool,
+    long: bool,
+) -> Result<()> {
+    let client = RemoteClient::new(api_url, api_key, &session_id);
+    let entries = client.list(&path, recursive).await?;
+
+    if output.is_text() {
+        if entries.is_empty() {
+            println!("(empty)");
+            return Ok(());
+        }
+
+        if long {
+            print_table_header(&[("SIZE", 10), ("UPDATED", 20), ("PATH", 60)]);
+            for entry in &entries {
+                let size = if entry.is_directory {
+                    "-".to_string()
+                } else {
+                    format_size(entry.size_bytes)
+                };
+                let updated = entry.updated_at.as_deref().unwrap_or("-");
+                let path_display = if entry.is_directory {
+                    format!("{}/", entry.path)
+                } else {
+                    entry.path.clone()
+                };
+                print_table_row(&[(&size, 10), (updated, 20), (&path_display, 60)]);
+            }
+        } else {
+            for entry in &entries {
+                if entry.is_directory {
+                    println!("{}/", entry.path);
+                } else {
+                    println!("{}", entry.path);
+                }
+            }
+        }
+    } else {
+        output.print_value(&serde_json::json!({ "entries": entries }));
+    }
+
+    Ok(())
+}
+
+fn format_size(bytes: i64) -> String {
+    if bytes < 1024 {
+        format!("{}B", bytes)
+    } else if bytes < 1024 * 1024 {
+        format!("{:.1}K", bytes as f64 / 1024.0)
+    } else {
+        format!("{:.1}M", bytes as f64 / (1024.0 * 1024.0))
+    }
+}

--- a/crates/cli/src/commands/files/ls.rs
+++ b/crates/cli/src/commands/files/ls.rs
@@ -63,3 +63,28 @@ fn format_size(bytes: i64) -> String {
         format!("{:.1}M", bytes as f64 / (1024.0 * 1024.0))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_size_bytes() {
+        assert_eq!(format_size(0), "0B");
+        assert_eq!(format_size(512), "512B");
+        assert_eq!(format_size(1023), "1023B");
+    }
+
+    #[test]
+    fn test_format_size_kilobytes() {
+        assert_eq!(format_size(1024), "1.0K");
+        assert_eq!(format_size(1536), "1.5K");
+        assert_eq!(format_size(10240), "10.0K");
+    }
+
+    #[test]
+    fn test_format_size_megabytes() {
+        assert_eq!(format_size(1024 * 1024), "1.0M");
+        assert_eq!(format_size(5 * 1024 * 1024), "5.0M");
+    }
+}

--- a/crates/cli/src/commands/files/mod.rs
+++ b/crates/cli/src/commands/files/mod.rs
@@ -1,5 +1,8 @@
 // File sync CLI commands
 //
+// TODO(sdk): Replace RemoteClient (raw reqwest) with SDK session_files() methods
+// once everruns-sdk ships support (see https://github.com/everruns/sdk/issues/60).
+//
 // Design Decision: All file operations grouped under `everruns files` subcommand.
 // Design Decision: Remote API client uses reqwest directly (session filesystem not in SDK yet).
 

--- a/crates/cli/src/commands/files/mod.rs
+++ b/crates/cli/src/commands/files/mod.rs
@@ -1,0 +1,181 @@
+// File sync CLI commands
+//
+// Design Decision: All file operations grouped under `everruns files` subcommand.
+// Design Decision: Remote API client uses reqwest directly (session filesystem not in SDK yet).
+
+pub mod ls;
+pub mod pull;
+pub mod push;
+pub mod remote;
+pub mod state;
+pub mod sync_cmd;
+pub mod sync_engine;
+
+use crate::output::OutputFormat;
+use anyhow::Result;
+use clap::Subcommand;
+
+#[derive(Subcommand)]
+pub enum FilesCommand {
+    /// Bidirectional live sync between local directory and session workspace
+    Sync {
+        /// Session ID (e.g. ses_xxx)
+        #[arg(long, short)]
+        session: String,
+
+        /// Local directory to sync (default: current directory)
+        #[arg(default_value = ".")]
+        local_dir: String,
+
+        /// Remote poll interval in seconds
+        #[arg(long, default_value = "3")]
+        interval: u64,
+
+        /// Conflict strategy
+        #[arg(long, default_value = "last-write-wins", value_parser = ["last-write-wins", "local-wins", "remote-wins"])]
+        conflict: String,
+
+        /// Additional exclude patterns (repeatable)
+        #[arg(long)]
+        exclude: Vec<String>,
+
+        /// Don't read .gitignore
+        #[arg(long)]
+        no_gitignore: bool,
+
+        /// Show what would sync without making changes
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Delete files on one side when deleted on the other
+        #[arg(long)]
+        delete: bool,
+
+        /// Show every file operation
+        #[arg(long, short)]
+        verbose: bool,
+    },
+
+    /// One-shot push local files to session workspace
+    Push {
+        /// Session ID (e.g. ses_xxx)
+        #[arg(long, short)]
+        session: String,
+
+        /// Local directory to push from (default: current directory)
+        #[arg(default_value = ".")]
+        local_dir: String,
+
+        /// Delete remote files not present locally
+        #[arg(long)]
+        delete: bool,
+
+        /// Show what would be pushed
+        #[arg(long)]
+        dry_run: bool,
+    },
+
+    /// One-shot pull session workspace files to local directory
+    Pull {
+        /// Session ID (e.g. ses_xxx)
+        #[arg(long, short)]
+        session: String,
+
+        /// Local directory to pull into (default: current directory)
+        #[arg(default_value = ".")]
+        local_dir: String,
+
+        /// Delete local files not present remotely
+        #[arg(long)]
+        delete: bool,
+
+        /// Show what would be pulled
+        #[arg(long)]
+        dry_run: bool,
+    },
+
+    /// List files in session workspace
+    Ls {
+        /// Session ID (e.g. ses_xxx)
+        #[arg(long, short)]
+        session: String,
+
+        /// Remote path to list (default: root)
+        #[arg(default_value = "/")]
+        path: String,
+
+        /// List recursively
+        #[arg(long, short)]
+        recursive: bool,
+
+        /// Show size and dates
+        #[arg(long, short)]
+        long: bool,
+    },
+}
+
+pub async fn run(
+    command: FilesCommand,
+    api_url: &str,
+    api_key: &str,
+    output: OutputFormat,
+    quiet: bool,
+) -> Result<()> {
+    match command {
+        FilesCommand::Sync {
+            session,
+            local_dir,
+            interval,
+            conflict,
+            exclude,
+            no_gitignore,
+            dry_run,
+            delete,
+            verbose,
+        } => {
+            sync_cmd::run(
+                api_url,
+                api_key,
+                quiet,
+                session,
+                local_dir,
+                interval,
+                conflict,
+                exclude,
+                no_gitignore,
+                dry_run,
+                delete,
+                verbose,
+            )
+            .await
+        }
+        FilesCommand::Push {
+            session,
+            local_dir,
+            delete,
+            dry_run,
+        } => {
+            push::run(
+                api_url, api_key, output, quiet, session, local_dir, delete, dry_run,
+            )
+            .await
+        }
+        FilesCommand::Pull {
+            session,
+            local_dir,
+            delete,
+            dry_run,
+        } => {
+            pull::run(
+                api_url, api_key, output, quiet, session, local_dir, delete, dry_run,
+            )
+            .await
+        }
+        FilesCommand::Ls {
+            session,
+            path,
+            recursive,
+            long,
+        } => ls::run(api_url, api_key, output, session, path, recursive, long).await,
+    }
+}

--- a/crates/cli/src/commands/files/pull.rs
+++ b/crates/cli/src/commands/files/pull.rs
@@ -1,0 +1,130 @@
+// `everruns files pull` — one-shot download remote → local.
+
+use crate::commands::files::remote::RemoteClient;
+use crate::commands::files::state::{SyncState, content_hash, state_dir};
+use crate::commands::files::sync_engine::scan_remote;
+use crate::output::OutputFormat;
+use anyhow::Result;
+use std::path::PathBuf;
+
+#[allow(clippy::too_many_arguments)]
+pub async fn run(
+    api_url: &str,
+    api_key: &str,
+    output: OutputFormat,
+    quiet: bool,
+    session_id: String,
+    local_dir: String,
+    delete: bool,
+    dry_run: bool,
+) -> Result<()> {
+    let local_dir = PathBuf::from(&local_dir).canonicalize()?;
+    let client = RemoteClient::new(api_url, api_key, &session_id);
+    let sd = state_dir(&local_dir);
+    let mut state = SyncState::load(&sd, &session_id)?;
+
+    let remote_files = scan_remote(&client).await?;
+
+    if !quiet && output.is_text() && !dry_run {
+        eprintln!(
+            "Pulling {} files from session {}...",
+            remote_files.len(),
+            session_id
+        );
+    }
+
+    let mut downloaded = 0u32;
+    let mut errors = 0u32;
+
+    for (path, entry) in &remote_files {
+        let remote_hash = entry.content_hash.as_deref().unwrap_or("");
+
+        // Check if changed since last sync
+        let prev_hash = state.files.get(path).and_then(|s| s.remote_hash.as_deref());
+        if prev_hash == Some(remote_hash) {
+            continue;
+        }
+
+        if dry_run {
+            println!("  ↓ {}", path);
+            downloaded += 1;
+            continue;
+        }
+
+        match client.read_file(&format!("/{}", path)).await {
+            Ok(content) => {
+                let bytes = RemoteClient::decode_content(&content)?;
+                let local_path = local_dir.join(path);
+                if let Some(parent) = local_path.parent() {
+                    std::fs::create_dir_all(parent)?;
+                }
+                std::fs::write(&local_path, &bytes)?;
+                let hash = content_hash(&bytes);
+
+                let file_state = state.files.entry(path.clone()).or_insert_with(|| {
+                    crate::commands::files::state::FileSyncState {
+                        local_hash: None,
+                        remote_hash: None,
+                        local_mtime: None,
+                        remote_updated_at: None,
+                    }
+                });
+                file_state.local_hash = Some(hash);
+                file_state.remote_hash = Some(remote_hash.to_string());
+                downloaded += 1;
+            }
+            Err(e) => {
+                eprintln!("  ✗ {}: {}", path, e);
+                errors += 1;
+            }
+        }
+    }
+
+    // Handle deletions
+    let mut deleted = 0u32;
+    if delete {
+        let remote_paths: std::collections::HashSet<&str> =
+            remote_files.keys().map(String::as_str).collect();
+        // Check previously synced files that are no longer remote
+        let prev_paths: Vec<String> = state.files.keys().cloned().collect();
+        for path in prev_paths {
+            if !remote_paths.contains(path.as_str()) {
+                let local_path = local_dir.join(&path);
+                if local_path.exists() {
+                    if dry_run {
+                        println!("  🗑 local {}", path);
+                    } else {
+                        let _ = std::fs::remove_file(&local_path);
+                    }
+                    deleted += 1;
+                }
+                state.files.remove(&path);
+            }
+        }
+    }
+
+    if !dry_run {
+        state.last_sync = Some(chrono::Utc::now().to_rfc3339());
+        state.save(&sd)?;
+    }
+
+    if output.is_text() {
+        if dry_run {
+            println!("Would pull: {} files, delete: {}", downloaded, deleted);
+        } else {
+            println!(
+                "Pulled: {} files, deleted: {}, errors: {}",
+                downloaded, deleted, errors
+            );
+        }
+    } else {
+        output.print_value(&serde_json::json!({
+            "downloaded": downloaded,
+            "deleted": deleted,
+            "errors": errors,
+            "dry_run": dry_run,
+        }));
+    }
+
+    Ok(())
+}

--- a/crates/cli/src/commands/files/pull.rs
+++ b/crates/cli/src/commands/files/pull.rs
@@ -2,7 +2,7 @@
 
 use crate::commands::files::remote::RemoteClient;
 use crate::commands::files::state::{SyncState, content_hash, state_dir};
-use crate::commands::files::sync_engine::scan_remote;
+use crate::commands::files::sync_engine::{safe_local_path, scan_remote};
 use crate::output::OutputFormat;
 use anyhow::Result;
 use std::path::PathBuf;
@@ -54,7 +54,7 @@ pub async fn run(
         match client.read_file(&format!("/{}", path)).await {
             Ok(content) => {
                 let bytes = RemoteClient::decode_content(&content)?;
-                let local_path = local_dir.join(path);
+                let local_path = safe_local_path(&local_dir, path)?;
                 if let Some(parent) = local_path.parent() {
                     std::fs::create_dir_all(parent)?;
                 }
@@ -89,8 +89,9 @@ pub async fn run(
         let prev_paths: Vec<String> = state.files.keys().cloned().collect();
         for path in prev_paths {
             if !remote_paths.contains(path.as_str()) {
-                let local_path = local_dir.join(&path);
-                if local_path.exists() {
+                if let Ok(local_path) = safe_local_path(&local_dir, &path)
+                    && local_path.exists()
+                {
                     if dry_run {
                         println!("  🗑 local {}", path);
                     } else {

--- a/crates/cli/src/commands/files/pull.rs
+++ b/crates/cli/src/commands/files/pull.rs
@@ -37,7 +37,11 @@ pub async fn run(
     let mut errors = 0u32;
 
     for (path, entry) in &remote_files {
-        let remote_hash = entry.content_hash.as_deref().unwrap_or("");
+        let remote_hash = entry
+            .content_hash
+            .as_deref()
+            .or(entry.updated_at.as_deref())
+            .unwrap_or("");
 
         // Check if changed since last sync
         let prev_hash = state.files.get(path).and_then(|s| s.remote_hash.as_deref());

--- a/crates/cli/src/commands/files/push.rs
+++ b/crates/cli/src/commands/files/push.rs
@@ -64,6 +64,9 @@ pub async fn run(
                     }
                 });
                 entry.local_hash = Some(hash.clone());
+                // Set remote_hash to local hash so subsequent pull/sync
+                // won't re-download content we just uploaded.
+                entry.remote_hash = Some(hash.clone());
             }
             Err(e) => {
                 eprintln!("  ✗ {}: {}", path, e);

--- a/crates/cli/src/commands/files/push.rs
+++ b/crates/cli/src/commands/files/push.rs
@@ -1,0 +1,116 @@
+// `everruns files push` — one-shot upload local → remote.
+
+use crate::commands::files::remote::RemoteClient;
+use crate::commands::files::state::{SyncState, state_dir};
+use crate::commands::files::sync_engine::scan_local;
+use crate::output::OutputFormat;
+use anyhow::Result;
+use std::path::PathBuf;
+
+#[allow(clippy::too_many_arguments)]
+pub async fn run(
+    api_url: &str,
+    api_key: &str,
+    output: OutputFormat,
+    quiet: bool,
+    session_id: String,
+    local_dir: String,
+    delete: bool,
+    dry_run: bool,
+) -> Result<()> {
+    let local_dir = PathBuf::from(&local_dir).canonicalize()?;
+    let client = RemoteClient::new(api_url, api_key, &session_id);
+    let sd = state_dir(&local_dir);
+    let mut state = SyncState::load(&sd, &session_id)?;
+
+    let local_files = scan_local(&local_dir, false, &[])?;
+
+    if !quiet && output.is_text() && !dry_run {
+        eprintln!(
+            "Pushing {} files to session {}...",
+            local_files.len(),
+            session_id
+        );
+    }
+
+    let mut uploaded = 0u32;
+    let mut errors = 0u32;
+
+    for (path, (content, hash)) in &local_files {
+        // Check if changed since last sync
+        let prev_hash = state.files.get(path).and_then(|s| s.local_hash.as_deref());
+        if prev_hash == Some(hash.as_str()) {
+            continue;
+        }
+
+        if dry_run {
+            println!("  ↑ {}", path);
+            uploaded += 1;
+            continue;
+        }
+
+        match client
+            .write_file(&format!("/{}", path), content, true)
+            .await
+        {
+            Ok(()) => {
+                uploaded += 1;
+                let entry = state.files.entry(path.clone()).or_insert_with(|| {
+                    crate::commands::files::state::FileSyncState {
+                        local_hash: None,
+                        remote_hash: None,
+                        local_mtime: None,
+                        remote_updated_at: None,
+                    }
+                });
+                entry.local_hash = Some(hash.clone());
+            }
+            Err(e) => {
+                eprintln!("  ✗ {}: {}", path, e);
+                errors += 1;
+            }
+        }
+    }
+
+    // Handle deletions
+    let mut deleted = 0u32;
+    if delete {
+        let remote_files = crate::commands::files::sync_engine::scan_remote(&client).await?;
+        for path in remote_files.keys() {
+            if !local_files.contains_key(path) {
+                if dry_run {
+                    println!("  🗑 remote {}", path);
+                } else {
+                    let _ = client.delete(&format!("/{}", path), false).await;
+                }
+                deleted += 1;
+                state.files.remove(path);
+            }
+        }
+    }
+
+    if !dry_run {
+        state.last_sync = Some(chrono::Utc::now().to_rfc3339());
+        state.save(&sd)?;
+    }
+
+    if output.is_text() {
+        if dry_run {
+            println!("Would push: {} files, delete: {}", uploaded, deleted);
+        } else {
+            println!(
+                "Pushed: {} files, deleted: {}, errors: {}",
+                uploaded, deleted, errors
+            );
+        }
+    } else {
+        output.print_value(&serde_json::json!({
+            "uploaded": uploaded,
+            "deleted": deleted,
+            "errors": errors,
+            "dry_run": dry_run,
+        }));
+    }
+
+    Ok(())
+}

--- a/crates/cli/src/commands/files/remote.rs
+++ b/crates/cli/src/commands/files/remote.rs
@@ -1,5 +1,9 @@
 // Remote session filesystem API client
 //
+// TODO(sdk): Replace all raw reqwest calls with SDK methods once everruns-sdk
+// ships session filesystem support (see https://github.com/everruns/sdk/issues/60).
+// Affected methods: list, read_file, write_file, create_dir, delete.
+//
 // Design Decision: Direct reqwest calls since session filesystem is not in the SDK yet.
 // Design Decision: Binary detection mirrors server logic (null bytes in first 8KB).
 
@@ -72,6 +76,7 @@ impl RemoteClient {
     }
 
     /// List files at a path. If recursive, lists the entire tree.
+    // TODO(sdk): Replace with sdk.session_files().list(session_id, path, recursive)
     pub async fn list(&self, path: &str, recursive: bool) -> Result<Vec<RemoteFileEntry>> {
         let mut url = self.fs_url(path);
         if recursive {
@@ -94,12 +99,16 @@ impl RemoteClient {
         }
 
         // The API returns either a file object or a directory listing.
-        // Directory listing has an "entries" array.
+        // Directory listing has a "data" array.
         let body: serde_json::Value = resp.json().await?;
 
-        if let Some(entries) = body.get("entries").and_then(|e| e.as_array()) {
+        if let Some(data) = body
+            .get("data")
+            .and_then(|d| d.as_array())
+            .or_else(|| body.get("entries").and_then(|e| e.as_array()))
+        {
             let files: Vec<RemoteFileEntry> =
-                serde_json::from_value(serde_json::Value::Array(entries.clone()))?;
+                serde_json::from_value(serde_json::Value::Array(data.clone()))?;
             Ok(files)
         } else {
             // Single file
@@ -109,6 +118,7 @@ impl RemoteClient {
     }
 
     /// Read file content.
+    // TODO(sdk): Replace with sdk.session_files().read(session_id, path)
     pub async fn read_file(&self, path: &str) -> Result<RemoteFileContent> {
         let url = self.fs_url(path);
         let resp = self
@@ -141,6 +151,7 @@ impl RemoteClient {
     }
 
     /// Create or update a file on remote.
+    // TODO(sdk): Replace with sdk.session_files().create() / .update()
     pub async fn write_file(&self, path: &str, content: &[u8], create: bool) -> Result<()> {
         let url = self.fs_url(path);
 
@@ -215,6 +226,7 @@ impl RemoteClient {
     }
 
     /// Create a directory on remote (used by sync for mkdir-on-demand).
+    // TODO(sdk): Replace with sdk.session_files().create_dir(session_id, path)
     #[allow(dead_code)]
     pub async fn create_dir(&self, path: &str) -> Result<()> {
         let url = self.fs_url(path);
@@ -241,6 +253,7 @@ impl RemoteClient {
     }
 
     /// Delete a file or directory on remote.
+    // TODO(sdk): Replace with sdk.session_files().delete(session_id, path, recursive)
     pub async fn delete(&self, path: &str, recursive: bool) -> Result<()> {
         let mut url = self.fs_url(path);
         if recursive {
@@ -262,5 +275,149 @@ impl RemoteClient {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_client() -> RemoteClient {
+        RemoteClient::new("https://api.example.com", "test-key", "ses_123")
+    }
+
+    #[test]
+    fn test_fs_url_root() {
+        let client = test_client();
+        assert_eq!(
+            client.fs_url("/"),
+            "https://api.example.com/v1/sessions/ses_123/fs"
+        );
+    }
+
+    #[test]
+    fn test_fs_url_empty() {
+        let client = test_client();
+        assert_eq!(
+            client.fs_url(""),
+            "https://api.example.com/v1/sessions/ses_123/fs"
+        );
+    }
+
+    #[test]
+    fn test_fs_url_file() {
+        let client = test_client();
+        assert_eq!(
+            client.fs_url("/src/main.rs"),
+            "https://api.example.com/v1/sessions/ses_123/fs/src/main.rs"
+        );
+    }
+
+    #[test]
+    fn test_fs_url_nested() {
+        let client = test_client();
+        assert_eq!(
+            client.fs_url("/a/b/c/d.txt"),
+            "https://api.example.com/v1/sessions/ses_123/fs/a/b/c/d.txt"
+        );
+    }
+
+    #[test]
+    fn test_fs_url_trailing_slash_stripped() {
+        let client = RemoteClient::new("https://api.example.com/", "key", "ses_1");
+        assert_eq!(
+            client.fs_url("/file.txt"),
+            "https://api.example.com/v1/sessions/ses_1/fs/file.txt"
+        );
+    }
+
+    #[test]
+    fn test_decode_content_text() {
+        let content = RemoteFileContent {
+            path: "/hello.txt".to_string(),
+            content: "hello world".to_string(),
+            encoding: "text".to_string(),
+            content_hash: None,
+            is_directory: false,
+            updated_at: None,
+        };
+        let bytes = RemoteClient::decode_content(&content).unwrap();
+        assert_eq!(bytes, b"hello world");
+    }
+
+    #[test]
+    fn test_decode_content_base64() {
+        let content = RemoteFileContent {
+            path: "/binary.bin".to_string(),
+            content: base64::engine::general_purpose::STANDARD.encode(b"\x00\x01\x02\x03"),
+            encoding: "base64".to_string(),
+            content_hash: None,
+            is_directory: false,
+            updated_at: None,
+        };
+        let bytes = RemoteClient::decode_content(&content).unwrap();
+        assert_eq!(bytes, &[0x00, 0x01, 0x02, 0x03]);
+    }
+
+    #[test]
+    fn test_decode_content_invalid_base64() {
+        let content = RemoteFileContent {
+            path: "/bad.bin".to_string(),
+            content: "not-valid-base64!!!".to_string(),
+            encoding: "base64".to_string(),
+            content_hash: None,
+            is_directory: false,
+            updated_at: None,
+        };
+        assert!(RemoteClient::decode_content(&content).is_err());
+    }
+
+    #[test]
+    fn test_default_encoding() {
+        assert_eq!(default_encoding(), "text");
+    }
+
+    #[test]
+    fn test_remote_file_entry_deserialize() {
+        let json = serde_json::json!({
+            "path": "/src/lib.rs",
+            "is_directory": false,
+            "size_bytes": 1024,
+            "content_hash": "sha256:abc123",
+            "updated_at": "2026-03-20T12:00:00Z"
+        });
+        let entry: RemoteFileEntry = serde_json::from_value(json).unwrap();
+        assert_eq!(entry.path, "/src/lib.rs");
+        assert!(!entry.is_directory);
+        assert_eq!(entry.size_bytes, 1024);
+        assert_eq!(entry.content_hash.as_deref(), Some("sha256:abc123"));
+        assert!(!entry.is_readonly);
+    }
+
+    #[test]
+    fn test_remote_file_entry_deserialize_minimal() {
+        let json = serde_json::json!({
+            "path": "/test",
+            "is_directory": true
+        });
+        let entry: RemoteFileEntry = serde_json::from_value(json).unwrap();
+        assert_eq!(entry.path, "/test");
+        assert!(entry.is_directory);
+        assert_eq!(entry.size_bytes, 0); // default
+        assert!(entry.content_hash.is_none());
+        assert!(entry.updated_at.is_none());
+    }
+
+    #[test]
+    fn test_remote_file_content_deserialize() {
+        let json = serde_json::json!({
+            "path": "/hello.txt",
+            "content": "hello world",
+        });
+        let content: RemoteFileContent = serde_json::from_value(json).unwrap();
+        assert_eq!(content.path, "/hello.txt");
+        assert_eq!(content.content, "hello world");
+        assert_eq!(content.encoding, "text"); // default
+        assert!(!content.is_directory);
     }
 }

--- a/crates/cli/src/commands/files/remote.rs
+++ b/crates/cli/src/commands/files/remote.rs
@@ -1,0 +1,266 @@
+// Remote session filesystem API client
+//
+// Design Decision: Direct reqwest calls since session filesystem is not in the SDK yet.
+// Design Decision: Binary detection mirrors server logic (null bytes in first 8KB).
+
+use anyhow::{Context, Result};
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+
+/// Represents a file entry returned by the remote API.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RemoteFileEntry {
+    pub path: String,
+    pub is_directory: bool,
+    #[serde(default)]
+    pub size_bytes: i64,
+    #[serde(default)]
+    pub content_hash: Option<String>,
+    #[serde(default)]
+    pub updated_at: Option<String>,
+    #[serde(default)]
+    pub is_readonly: bool,
+}
+
+/// File content with encoding info.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RemoteFileContent {
+    pub path: String,
+    pub content: String,
+    #[serde(default = "default_encoding")]
+    pub encoding: String,
+    #[serde(default)]
+    pub content_hash: Option<String>,
+    #[serde(default)]
+    pub is_directory: bool,
+    #[serde(default)]
+    pub updated_at: Option<String>,
+}
+
+fn default_encoding() -> String {
+    "text".to_string()
+}
+
+/// Client for the session filesystem API.
+pub struct RemoteClient {
+    http: reqwest::Client,
+    base_url: String,
+    session_id: String,
+    api_key: String,
+}
+
+impl RemoteClient {
+    pub fn new(api_url: &str, api_key: &str, session_id: &str) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            base_url: api_url.trim_end_matches('/').to_string(),
+            session_id: session_id.to_string(),
+            api_key: api_key.to_string(),
+        }
+    }
+
+    fn fs_url(&self, path: &str) -> String {
+        let clean = path.trim_start_matches('/');
+        if clean.is_empty() {
+            format!("{}/v1/sessions/{}/fs", self.base_url, self.session_id)
+        } else {
+            format!(
+                "{}/v1/sessions/{}/fs/{}",
+                self.base_url, self.session_id, clean
+            )
+        }
+    }
+
+    /// List files at a path. If recursive, lists the entire tree.
+    pub async fn list(&self, path: &str, recursive: bool) -> Result<Vec<RemoteFileEntry>> {
+        let mut url = self.fs_url(path);
+        if recursive {
+            let sep = if url.contains('?') { '&' } else { '?' };
+            url = format!("{}{}recursive=true", url, sep);
+        }
+
+        let resp = self
+            .http
+            .get(&url)
+            .header("Authorization", &self.api_key)
+            .send()
+            .await
+            .context("Failed to list remote files")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            anyhow::bail!("List remote files failed: {} {}", status, text);
+        }
+
+        // The API returns either a file object or a directory listing.
+        // Directory listing has an "entries" array.
+        let body: serde_json::Value = resp.json().await?;
+
+        if let Some(entries) = body.get("entries").and_then(|e| e.as_array()) {
+            let files: Vec<RemoteFileEntry> =
+                serde_json::from_value(serde_json::Value::Array(entries.clone()))?;
+            Ok(files)
+        } else {
+            // Single file
+            let entry: RemoteFileEntry = serde_json::from_value(body)?;
+            Ok(vec![entry])
+        }
+    }
+
+    /// Read file content.
+    pub async fn read_file(&self, path: &str) -> Result<RemoteFileContent> {
+        let url = self.fs_url(path);
+        let resp = self
+            .http
+            .get(&url)
+            .header("Authorization", &self.api_key)
+            .send()
+            .await
+            .context("Failed to read remote file")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            anyhow::bail!("Read remote file failed: {} {}", status, text);
+        }
+
+        let content: RemoteFileContent = resp.json().await?;
+        Ok(content)
+    }
+
+    /// Decode file content bytes from the remote response.
+    pub fn decode_content(content: &RemoteFileContent) -> Result<Vec<u8>> {
+        if content.encoding == "base64" {
+            base64::engine::general_purpose::STANDARD
+                .decode(&content.content)
+                .context("Failed to decode base64 content")
+        } else {
+            Ok(content.content.as_bytes().to_vec())
+        }
+    }
+
+    /// Create or update a file on remote.
+    pub async fn write_file(&self, path: &str, content: &[u8], create: bool) -> Result<()> {
+        let url = self.fs_url(path);
+
+        // Detect binary: null bytes in first 8KB
+        let is_binary = content.iter().take(8192).any(|&b| b == 0);
+        let (encoded, encoding) = if is_binary {
+            (
+                base64::engine::general_purpose::STANDARD.encode(content),
+                "base64",
+            )
+        } else {
+            (String::from_utf8_lossy(content).into_owned(), "text")
+        };
+
+        let body = serde_json::json!({
+            "content": encoded,
+            "encoding": encoding,
+        });
+
+        let resp = if create {
+            self.http
+                .post(&url)
+                .header("Authorization", &self.api_key)
+                .header("Content-Type", "application/json")
+                .json(&body)
+                .send()
+                .await
+                .context("Failed to create remote file")?
+        } else {
+            self.http
+                .put(&url)
+                .header("Authorization", &self.api_key)
+                .header("Content-Type", "application/json")
+                .json(&body)
+                .send()
+                .await
+                .context("Failed to update remote file")?
+        };
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            // If create fails with 409 (conflict/exists), fall back to update
+            if create && status == reqwest::StatusCode::CONFLICT {
+                return self.update_file(path, &body).await;
+            }
+            anyhow::bail!("Write remote file failed: {} {}", status, text);
+        }
+
+        Ok(())
+    }
+
+    /// Update-only helper (avoids async recursion in write_file).
+    async fn update_file(&self, path: &str, body: &serde_json::Value) -> Result<()> {
+        let url = self.fs_url(path);
+        let resp = self
+            .http
+            .put(&url)
+            .header("Authorization", &self.api_key)
+            .header("Content-Type", "application/json")
+            .json(body)
+            .send()
+            .await
+            .context("Failed to update remote file")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            anyhow::bail!("Update remote file failed: {} {}", status, text);
+        }
+        Ok(())
+    }
+
+    /// Create a directory on remote (used by sync for mkdir-on-demand).
+    #[allow(dead_code)]
+    pub async fn create_dir(&self, path: &str) -> Result<()> {
+        let url = self.fs_url(path);
+        let body = serde_json::json!({ "is_directory": true });
+
+        let resp = self
+            .http
+            .post(&url)
+            .header("Authorization", &self.api_key)
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .context("Failed to create remote directory")?;
+
+        // Ignore 409 (already exists)
+        if !resp.status().is_success() && resp.status() != reqwest::StatusCode::CONFLICT {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            anyhow::bail!("Create remote dir failed: {} {}", status, text);
+        }
+
+        Ok(())
+    }
+
+    /// Delete a file or directory on remote.
+    pub async fn delete(&self, path: &str, recursive: bool) -> Result<()> {
+        let mut url = self.fs_url(path);
+        if recursive {
+            url = format!("{}?recursive=true", url);
+        }
+
+        let resp = self
+            .http
+            .delete(&url)
+            .header("Authorization", &self.api_key)
+            .send()
+            .await
+            .context("Failed to delete remote file")?;
+
+        if !resp.status().is_success() && resp.status() != reqwest::StatusCode::NOT_FOUND {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            anyhow::bail!("Delete remote file failed: {} {}", status, text);
+        }
+
+        Ok(())
+    }
+}

--- a/crates/cli/src/commands/files/state.rs
+++ b/crates/cli/src/commands/files/state.rs
@@ -85,3 +85,127 @@ mod hex {
 pub fn state_dir(local_dir: &Path) -> PathBuf {
     local_dir.join(".everruns-sync")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_content_hash_deterministic() {
+        let h1 = content_hash(b"hello world");
+        let h2 = content_hash(b"hello world");
+        assert_eq!(h1, h2);
+        assert!(h1.starts_with("sha256:"));
+    }
+
+    #[test]
+    fn test_content_hash_different_content() {
+        let h1 = content_hash(b"hello");
+        let h2 = content_hash(b"world");
+        assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn test_content_hash_empty() {
+        let h = content_hash(b"");
+        assert!(h.starts_with("sha256:"));
+        // SHA256 of empty string is well-known
+        assert_eq!(
+            h,
+            "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn test_content_hash_binary() {
+        let h = content_hash(&[0x00, 0x01, 0xff, 0xfe]);
+        assert!(h.starts_with("sha256:"));
+        assert_eq!(h.len(), 7 + 64); // "sha256:" + 64 hex chars
+    }
+
+    #[test]
+    fn test_state_new() {
+        let state = SyncState::new("ses_123");
+        assert_eq!(state.session_id, "ses_123");
+        assert!(state.last_sync.is_none());
+        assert!(state.files.is_empty());
+    }
+
+    #[test]
+    fn test_state_save_and_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let sd = dir.path().join(".everruns-sync");
+
+        let mut state = SyncState::new("ses_abc");
+        state.last_sync = Some("2026-01-01T00:00:00Z".to_string());
+        state.files.insert(
+            "src/main.rs".to_string(),
+            FileSyncState {
+                local_hash: Some("sha256:aaa".to_string()),
+                remote_hash: Some("sha256:bbb".to_string()),
+                local_mtime: None,
+                remote_updated_at: None,
+            },
+        );
+
+        state.save(&sd).unwrap();
+
+        let loaded = SyncState::load(&sd, "ses_abc").unwrap();
+        assert_eq!(loaded.session_id, "ses_abc");
+        assert_eq!(loaded.last_sync, Some("2026-01-01T00:00:00Z".to_string()));
+        assert!(loaded.files.contains_key("src/main.rs"));
+        let file = &loaded.files["src/main.rs"];
+        assert_eq!(file.local_hash.as_deref(), Some("sha256:aaa"));
+        assert_eq!(file.remote_hash.as_deref(), Some("sha256:bbb"));
+    }
+
+    #[test]
+    fn test_state_load_missing_returns_fresh() {
+        let dir = tempfile::tempdir().unwrap();
+        let sd = dir.path().join(".nonexistent");
+
+        let state = SyncState::load(&sd, "ses_xyz").unwrap();
+        assert_eq!(state.session_id, "ses_xyz");
+        assert!(state.files.is_empty());
+    }
+
+    #[test]
+    fn test_state_load_session_mismatch_returns_fresh() {
+        let dir = tempfile::tempdir().unwrap();
+        let sd = dir.path().join(".everruns-sync");
+
+        let state = SyncState::new("ses_old");
+        state.save(&sd).unwrap();
+
+        // Load with different session_id
+        let loaded = SyncState::load(&sd, "ses_new").unwrap();
+        assert_eq!(loaded.session_id, "ses_new");
+        assert!(loaded.files.is_empty());
+    }
+
+    #[test]
+    fn test_state_load_corrupt_returns_fresh() {
+        let dir = tempfile::tempdir().unwrap();
+        let sd = dir.path().join(".everruns-sync");
+        fs::create_dir_all(&sd).unwrap();
+        fs::write(sd.join("state.json"), "not json at all").unwrap();
+
+        let state = SyncState::load(&sd, "ses_abc").unwrap();
+        assert_eq!(state.session_id, "ses_abc");
+        assert!(state.files.is_empty());
+    }
+
+    #[test]
+    fn test_state_dir_path() {
+        let p = state_dir(Path::new("/home/user/project"));
+        assert_eq!(p, PathBuf::from("/home/user/project/.everruns-sync"));
+    }
+
+    #[test]
+    fn test_hex_encode() {
+        assert_eq!(hex::encode([0xde, 0xad, 0xbe, 0xef]), "deadbeef");
+        assert_eq!(hex::encode([0x00, 0xff]), "00ff");
+        assert_eq!(hex::encode([]), "");
+    }
+}

--- a/crates/cli/src/commands/files/state.rs
+++ b/crates/cli/src/commands/files/state.rs
@@ -1,0 +1,87 @@
+// Sync state persistence
+//
+// Design Decision: State stored in <local-dir>/.everruns-sync/state.json.
+// Design Decision: Content hashes used for incremental sync (skip unchanged files).
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Per-file sync state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileSyncState {
+    pub local_hash: Option<String>,
+    pub remote_hash: Option<String>,
+    pub local_mtime: Option<String>,
+    pub remote_updated_at: Option<String>,
+}
+
+/// Root sync state persisted to disk.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncState {
+    pub session_id: String,
+    pub last_sync: Option<String>,
+    pub files: HashMap<String, FileSyncState>,
+}
+
+impl SyncState {
+    pub fn new(session_id: &str) -> Self {
+        Self {
+            session_id: session_id.to_string(),
+            last_sync: None,
+            files: HashMap::new(),
+        }
+    }
+
+    /// Load state from disk, or create fresh if missing/corrupt.
+    pub fn load(state_dir: &Path, session_id: &str) -> Result<Self> {
+        let path = state_dir.join("state.json");
+        if path.exists() {
+            let data = std::fs::read_to_string(&path).context("Read sync state")?;
+            match serde_json::from_str::<SyncState>(&data) {
+                Ok(state) if state.session_id == session_id => Ok(state),
+                _ => {
+                    eprintln!("Sync state mismatch or corrupt, starting fresh");
+                    Ok(Self::new(session_id))
+                }
+            }
+        } else {
+            Ok(Self::new(session_id))
+        }
+    }
+
+    /// Persist state to disk.
+    pub fn save(&self, state_dir: &Path) -> Result<()> {
+        std::fs::create_dir_all(state_dir).context("Create sync state dir")?;
+        let path = state_dir.join("state.json");
+        let data = serde_json::to_string_pretty(self)?;
+        std::fs::write(&path, data).context("Write sync state")?;
+        Ok(())
+    }
+}
+
+/// Compute sha256 hash of bytes, returning "sha256:<hex>" string.
+pub fn content_hash(data: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    let result = hasher.finalize();
+    format!("sha256:{}", hex::encode(result))
+}
+
+/// Hex encoding for sha256 (inline, avoids hex crate dep).
+mod hex {
+    pub fn encode(bytes: impl AsRef<[u8]>) -> String {
+        bytes
+            .as_ref()
+            .iter()
+            .map(|b| format!("{:02x}", b))
+            .collect()
+    }
+}
+
+/// Return the state directory path for a given local dir.
+pub fn state_dir(local_dir: &Path) -> PathBuf {
+    local_dir.join(".everruns-sync")
+}

--- a/crates/cli/src/commands/files/sync_cmd.rs
+++ b/crates/cli/src/commands/files/sync_cmd.rs
@@ -1,0 +1,147 @@
+// `everruns files sync` — long-running bidirectional file sync.
+//
+// Design Decision: Uses notify for local FS events + periodic remote polling.
+// Design Decision: Graceful shutdown on Ctrl+C with stats summary.
+
+use crate::commands::files::remote::RemoteClient;
+use crate::commands::files::state::{SyncState, state_dir};
+use crate::commands::files::sync_engine::{Conflict, reconcile};
+use anyhow::Result;
+use notify::{Event, RecursiveMode, Watcher};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+#[allow(clippy::too_many_arguments)]
+pub async fn run(
+    api_url: &str,
+    api_key: &str,
+    quiet: bool,
+    session_id: String,
+    local_dir: String,
+    interval: u64,
+    conflict: String,
+    exclude: Vec<String>,
+    no_gitignore: bool,
+    dry_run: bool,
+    delete: bool,
+    verbose: bool,
+) -> Result<()> {
+    let local_dir = PathBuf::from(&local_dir).canonicalize()?;
+    let client = RemoteClient::new(api_url, api_key, &session_id);
+    let conflict_strategy = Conflict::parse(&conflict);
+    let sd = state_dir(&local_dir);
+    let mut state = SyncState::load(&sd, &session_id)?;
+
+    if !quiet {
+        eprintln!(
+            "Syncing {} ↔ session {} (poll {}s, conflict: {})",
+            local_dir.display(),
+            session_id,
+            interval,
+            conflict,
+        );
+        if dry_run {
+            eprintln!("(dry-run mode)");
+        }
+    }
+
+    // Initial full reconciliation
+    if !quiet {
+        eprintln!("Initial sync...");
+    }
+    let stats = reconcile(
+        &client,
+        &local_dir,
+        &mut state,
+        conflict_strategy,
+        no_gitignore,
+        &exclude,
+        dry_run,
+        delete,
+        verbose,
+    )
+    .await?;
+    if !quiet {
+        eprintln!("Initial sync done: {}", stats);
+    }
+
+    // Set up local filesystem watcher
+    let local_changed = Arc::new(AtomicBool::new(false));
+    let changed_flag = local_changed.clone();
+
+    let local_dir_clone = local_dir.clone();
+    let mut watcher = notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
+        if let Ok(event) = res {
+            // Ignore changes in .everruns-sync directory
+            let dominated_by_sync = event
+                .paths
+                .iter()
+                .all(|p| p.starts_with(local_dir_clone.join(".everruns-sync")));
+            if !dominated_by_sync {
+                changed_flag.store(true, Ordering::Relaxed);
+            }
+        }
+    })?;
+
+    watcher.watch(&local_dir, RecursiveMode::Recursive)?;
+
+    // Shutdown signal
+    let running = Arc::new(AtomicBool::new(true));
+    let r = running.clone();
+    tokio::spawn(async move {
+        tokio::signal::ctrl_c().await.ok();
+        r.store(false, Ordering::Relaxed);
+    });
+
+    // Main sync loop
+    let poll_dur = Duration::from_secs(interval);
+    let mut total_up: u64 = 0;
+    let mut total_down: u64 = 0;
+
+    while running.load(Ordering::Relaxed) {
+        tokio::time::sleep(poll_dur).await;
+
+        if !running.load(Ordering::Relaxed) {
+            break;
+        }
+
+        // Always poll remote; also sync if local changed
+        let _local_dirty = local_changed.swap(false, Ordering::Relaxed);
+
+        let stats = reconcile(
+            &client,
+            &local_dir,
+            &mut state,
+            conflict_strategy,
+            no_gitignore,
+            &exclude,
+            dry_run,
+            delete,
+            verbose,
+        )
+        .await;
+
+        match stats {
+            Ok(s) => {
+                total_up += s.uploaded as u64;
+                total_down += s.downloaded as u64;
+                let has_activity =
+                    s.uploaded > 0 || s.downloaded > 0 || s.conflicts > 0 || s.errors > 0;
+                if has_activity && !quiet {
+                    eprintln!("{}", s);
+                }
+            }
+            Err(e) => {
+                eprintln!("Sync error: {}", e);
+            }
+        }
+    }
+
+    if !quiet {
+        eprintln!("\nSync stopped. Total: ↑{} ↓{}", total_up, total_down);
+    }
+
+    Ok(())
+}

--- a/crates/cli/src/commands/files/sync_engine.rs
+++ b/crates/cli/src/commands/files/sync_engine.rs
@@ -231,6 +231,7 @@ pub async fn reconcile(
                             continue;
                         }
                         stats.uploaded += 1;
+                        update_state(state, path, Some(local_hash), Some(remote_hash));
                     } else {
                         if !dry_run {
                             match download_file(client, local_dir, path).await {
@@ -274,7 +275,9 @@ pub async fn reconcile(
                         continue;
                     }
                     stats.uploaded += 1;
-                    update_state(state, path, Some(local_hash), None);
+                    // Use local hash as remote_hash so next cycle won't
+                    // treat the remote as changed (server may update hash).
+                    update_state(state, path, Some(local_hash), Some(local_hash));
                 }
             }
 

--- a/crates/cli/src/commands/files/sync_engine.rs
+++ b/crates/cli/src/commands/files/sync_engine.rs
@@ -1,0 +1,393 @@
+// Sync engine — reconciles local and remote file trees.
+//
+// Design Decision: Sync operates on normalized paths (forward slashes, no leading slash for local).
+// Design Decision: Conflict resolution is configurable (last-write, local, remote).
+
+use crate::commands::files::remote::{RemoteClient, RemoteFileEntry};
+use crate::commands::files::state::{FileSyncState, SyncState, content_hash, state_dir};
+use anyhow::{Context, Result};
+use ignore::WalkBuilder;
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+/// Conflict resolution strategy.
+#[derive(Debug, Clone, Copy)]
+pub enum Conflict {
+    LastWrite,
+    Local,
+    Remote,
+}
+
+impl Conflict {
+    pub fn parse(s: &str) -> Self {
+        match s {
+            "local-wins" => Self::Local,
+            "remote-wins" => Self::Remote,
+            _ => Self::LastWrite,
+        }
+    }
+}
+
+/// Summary of a sync cycle.
+#[derive(Debug, Default)]
+pub struct SyncStats {
+    pub uploaded: u32,
+    pub downloaded: u32,
+    pub deleted_local: u32,
+    pub deleted_remote: u32,
+    pub conflicts: u32,
+    pub skipped: u32,
+    pub errors: u32,
+}
+
+impl std::fmt::Display for SyncStats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "↑{} ↓{}", self.uploaded, self.downloaded)?;
+        if self.deleted_local > 0 || self.deleted_remote > 0 {
+            write!(f, " del:{}", self.deleted_local + self.deleted_remote)?;
+        }
+        if self.conflicts > 0 {
+            write!(f, " conflicts:{}", self.conflicts)?;
+        }
+        if self.errors > 0 {
+            write!(f, " errors:{}", self.errors)?;
+        }
+        Ok(())
+    }
+}
+
+/// Walk local directory and collect file paths with their content hashes.
+pub fn scan_local(
+    local_dir: &Path,
+    no_gitignore: bool,
+    extra_excludes: &[String],
+) -> Result<HashMap<String, (Vec<u8>, String)>> {
+    let mut files = HashMap::new();
+
+    let mut builder = WalkBuilder::new(local_dir);
+    builder
+        .hidden(false)
+        .git_ignore(!no_gitignore)
+        .git_global(false)
+        .git_exclude(false);
+
+    let default_excludes = [
+        ".git",
+        "node_modules",
+        "target",
+        "__pycache__",
+        ".env",
+        ".everruns-sync",
+    ];
+
+    let mut overrides = ignore::overrides::OverrideBuilder::new(local_dir);
+    for pattern in default_excludes {
+        overrides.add(&format!("!{}", pattern))?;
+    }
+    for pattern in extra_excludes {
+        overrides.add(&format!("!{}", pattern))?;
+    }
+
+    let syncignore_path = local_dir.join(".syncignore");
+    if syncignore_path.exists()
+        && let Ok(content) = std::fs::read_to_string(&syncignore_path)
+    {
+        for line in content.lines() {
+            let line = line.trim();
+            if !line.is_empty() && !line.starts_with('#') {
+                overrides.add(&format!("!{}", line))?;
+            }
+        }
+    }
+
+    builder.overrides(overrides.build()?);
+
+    for entry in builder.build() {
+        let entry = entry?;
+        let path = entry.path();
+
+        if path.is_dir() {
+            continue;
+        }
+
+        let rel = path.strip_prefix(local_dir).context("Strip local prefix")?;
+        let normalized = normalize_path(rel);
+
+        let content = std::fs::read(path).with_context(|| format!("Read {}", path.display()))?;
+        let hash = content_hash(&content);
+        files.insert(normalized, (content, hash));
+    }
+
+    Ok(files)
+}
+
+/// Scan remote files via API.
+pub async fn scan_remote(client: &RemoteClient) -> Result<HashMap<String, RemoteFileEntry>> {
+    let entries = client.list("/", true).await?;
+    let mut files = HashMap::new();
+    for entry in entries {
+        if !entry.is_directory {
+            let normalized = entry.path.trim_start_matches('/').to_string();
+            files.insert(normalized, entry);
+        }
+    }
+    Ok(files)
+}
+
+/// Run a full sync cycle: reconcile local and remote, apply changes.
+#[allow(clippy::too_many_arguments)]
+pub async fn reconcile(
+    client: &RemoteClient,
+    local_dir: &Path,
+    state: &mut SyncState,
+    conflict_strategy: Conflict,
+    no_gitignore: bool,
+    extra_excludes: &[String],
+    dry_run: bool,
+    delete: bool,
+    verbose: bool,
+) -> Result<SyncStats> {
+    let mut stats = SyncStats::default();
+
+    let local_files = scan_local(local_dir, no_gitignore, extra_excludes)?;
+    let remote_files = scan_remote(client).await?;
+
+    let all_paths: HashSet<&str> = local_files
+        .keys()
+        .chain(remote_files.keys())
+        .map(String::as_str)
+        .collect();
+
+    for path in all_paths {
+        let local = local_files.get(path);
+        let remote = remote_files.get(path);
+        let prev = state.files.get(path);
+
+        match (local, remote) {
+            (Some((local_content, local_hash)), Some(remote_entry)) => {
+                let prev_local = prev.and_then(|p| p.local_hash.as_deref());
+                let prev_remote = prev.and_then(|p| p.remote_hash.as_deref());
+                let remote_hash = remote_entry.content_hash.as_deref().unwrap_or("");
+
+                let local_changed = prev_local.is_none_or(|h| h != local_hash);
+                let remote_changed = prev_remote.is_none_or(|h| h != remote_hash);
+
+                if !local_changed && !remote_changed {
+                    stats.skipped += 1;
+                    continue;
+                }
+
+                if local_changed && !remote_changed {
+                    if verbose {
+                        eprintln!("  ↑ {}", path);
+                    }
+                    if !dry_run
+                        && let Err(e) = client
+                            .write_file(&format!("/{}", path), local_content, false)
+                            .await
+                    {
+                        eprintln!("  x upload {}: {}", path, e);
+                        stats.errors += 1;
+                        continue;
+                    }
+                    stats.uploaded += 1;
+                    update_state(state, path, Some(local_hash), Some(remote_hash));
+                } else if !local_changed && remote_changed {
+                    if verbose {
+                        eprintln!("  ↓ {}", path);
+                    }
+                    if !dry_run {
+                        match download_file(client, local_dir, path).await {
+                            Ok(hash) => {
+                                update_state(state, path, Some(&hash), Some(remote_hash));
+                            }
+                            Err(e) => {
+                                eprintln!("  x download {}: {}", path, e);
+                                stats.errors += 1;
+                                continue;
+                            }
+                        }
+                    }
+                    stats.downloaded += 1;
+                } else {
+                    // Both changed — conflict
+                    stats.conflicts += 1;
+                    let winner = resolve_conflict(conflict_strategy, local_dir, path, remote_entry);
+                    eprintln!("  ! conflict: {} ({} wins)", path, winner);
+
+                    if winner == "local" {
+                        if !dry_run
+                            && let Err(e) = client
+                                .write_file(&format!("/{}", path), local_content, false)
+                                .await
+                        {
+                            eprintln!("  x upload {}: {}", path, e);
+                            stats.errors += 1;
+                            continue;
+                        }
+                        stats.uploaded += 1;
+                    } else {
+                        if !dry_run {
+                            match download_file(client, local_dir, path).await {
+                                Ok(hash) => {
+                                    update_state(state, path, Some(&hash), Some(remote_hash));
+                                }
+                                Err(e) => {
+                                    eprintln!("  x download {}: {}", path, e);
+                                    stats.errors += 1;
+                                    continue;
+                                }
+                            }
+                        }
+                        stats.downloaded += 1;
+                    }
+                }
+            }
+
+            (Some((local_content, local_hash)), None) => {
+                let was_synced = prev.is_some();
+                if was_synced && delete {
+                    if verbose {
+                        eprintln!("  del local {}", path);
+                    }
+                    if !dry_run {
+                        let local_path = local_dir.join(path);
+                        let _ = std::fs::remove_file(&local_path);
+                    }
+                    state.files.remove(path);
+                    stats.deleted_local += 1;
+                } else {
+                    if verbose {
+                        eprintln!("  ↑ {}", path);
+                    }
+                    if !dry_run
+                        && let Err(e) = client
+                            .write_file(&format!("/{}", path), local_content, true)
+                            .await
+                    {
+                        eprintln!("  x upload {}: {}", path, e);
+                        stats.errors += 1;
+                        continue;
+                    }
+                    stats.uploaded += 1;
+                    update_state(state, path, Some(local_hash), None);
+                }
+            }
+
+            (None, Some(remote_entry)) => {
+                let was_synced = prev.is_some();
+                let remote_hash = remote_entry.content_hash.as_deref().unwrap_or("");
+
+                if was_synced && delete {
+                    if verbose {
+                        eprintln!("  del remote {}", path);
+                    }
+                    if !dry_run {
+                        let _ = client.delete(&format!("/{}", path), false).await;
+                    }
+                    state.files.remove(path);
+                    stats.deleted_remote += 1;
+                } else {
+                    if verbose {
+                        eprintln!("  ↓ {}", path);
+                    }
+                    if !dry_run {
+                        match download_file(client, local_dir, path).await {
+                            Ok(hash) => {
+                                update_state(state, path, Some(&hash), Some(remote_hash));
+                            }
+                            Err(e) => {
+                                eprintln!("  x download {}: {}", path, e);
+                                stats.errors += 1;
+                                continue;
+                            }
+                        }
+                    }
+                    stats.downloaded += 1;
+                }
+            }
+
+            (None, None) => unreachable!(),
+        }
+    }
+
+    state.last_sync = Some(chrono::Utc::now().to_rfc3339());
+
+    if !dry_run {
+        let sd = state_dir(local_dir);
+        state.save(&sd)?;
+    }
+
+    Ok(stats)
+}
+
+fn resolve_conflict(
+    strategy: Conflict,
+    local_dir: &Path,
+    path: &str,
+    remote_entry: &RemoteFileEntry,
+) -> &'static str {
+    match strategy {
+        Conflict::Local => "local",
+        Conflict::Remote => "remote",
+        Conflict::LastWrite => {
+            let local_mtime = std::fs::metadata(local_dir.join(path))
+                .ok()
+                .and_then(|m| m.modified().ok());
+            let remote_time = remote_entry
+                .updated_at
+                .as_deref()
+                .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
+                .map(|t| {
+                    std::time::SystemTime::UNIX_EPOCH
+                        + std::time::Duration::from_secs(t.timestamp() as u64)
+                });
+
+            match (local_mtime, remote_time) {
+                (Some(l), Some(r)) if l > r => "local",
+                (Some(_), Some(_)) => "remote",
+                _ => "local", // tie-break: local wins
+            }
+        }
+    }
+}
+
+async fn download_file(client: &RemoteClient, local_dir: &Path, path: &str) -> Result<String> {
+    let remote_content = client.read_file(&format!("/{}", path)).await?;
+    let bytes = RemoteClient::decode_content(&remote_content)?;
+    let local_path = local_dir.join(path);
+
+    if let Some(parent) = local_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    std::fs::write(&local_path, &bytes)?;
+    Ok(content_hash(&bytes))
+}
+
+fn update_state(
+    state: &mut SyncState,
+    path: &str,
+    local_hash: Option<&str>,
+    remote_hash: Option<&str>,
+) {
+    let entry = state
+        .files
+        .entry(path.to_string())
+        .or_insert_with(|| FileSyncState {
+            local_hash: None,
+            remote_hash: None,
+            local_mtime: None,
+            remote_updated_at: None,
+        });
+    if let Some(h) = local_hash {
+        entry.local_hash = Some(h.to_string());
+    }
+    if let Some(h) = remote_hash {
+        entry.remote_hash = Some(h.to_string());
+    }
+}
+
+fn normalize_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}

--- a/crates/cli/src/commands/files/sync_engine.rs
+++ b/crates/cli/src/commands/files/sync_engine.rs
@@ -255,8 +255,9 @@ pub async fn reconcile(
                     if verbose {
                         eprintln!("  del local {}", path);
                     }
-                    if !dry_run {
-                        let local_path = local_dir.join(path);
+                    if !dry_run
+                        && let Ok(local_path) = safe_local_path(local_dir, path)
+                    {
                         let _ = std::fs::remove_file(&local_path);
                     }
                     state.files.remove(path);
@@ -361,10 +362,41 @@ fn resolve_conflict(
     }
 }
 
+/// Validate that a path joined with local_dir stays within local_dir (prevents path traversal).
+pub fn safe_local_path(local_dir: &Path, path: &str) -> Result<std::path::PathBuf> {
+    // Reject absolute paths and traversal components
+    if path.starts_with('/') || path.starts_with('\\') || path.contains("..") {
+        anyhow::bail!("Unsafe path rejected (traversal or absolute): {}", path);
+    }
+    let joined = local_dir.join(path);
+    // Normalize and verify the result is under local_dir
+    // Use lexical check since the file may not exist yet
+    let normalized = joined
+        .components()
+        .fold(std::path::PathBuf::new(), |mut acc, c| {
+            match c {
+                std::path::Component::ParentDir => {
+                    acc.pop();
+                }
+                std::path::Component::CurDir => {}
+                _ => acc.push(c),
+            }
+            acc
+        });
+    if !normalized.starts_with(local_dir) {
+        anyhow::bail!(
+            "Path escapes sync directory: {} -> {}",
+            path,
+            normalized.display()
+        );
+    }
+    Ok(joined)
+}
+
 async fn download_file(client: &RemoteClient, local_dir: &Path, path: &str) -> Result<String> {
     let remote_content = client.read_file(&format!("/{}", path)).await?;
     let bytes = RemoteClient::decode_content(&remote_content)?;
-    let local_path = local_dir.join(path);
+    let local_path = safe_local_path(local_dir, path)?;
 
     if let Some(parent) = local_path.parent() {
         std::fs::create_dir_all(parent)?;
@@ -595,5 +627,26 @@ mod tests {
         let entry = &state.files["file.txt"];
         assert_eq!(entry.local_hash.as_deref(), Some("sha256:aaa")); // unchanged
         assert_eq!(entry.remote_hash.as_deref(), Some("sha256:bbb"));
+    }
+
+    #[test]
+    fn test_safe_local_path_normal() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = safe_local_path(dir.path(), "src/main.rs").unwrap();
+        assert_eq!(result, dir.path().join("src/main.rs"));
+    }
+
+    #[test]
+    fn test_safe_local_path_rejects_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(safe_local_path(dir.path(), "../../etc/passwd").is_err());
+        assert!(safe_local_path(dir.path(), "../secret").is_err());
+        assert!(safe_local_path(dir.path(), "a/../../b").is_err());
+    }
+
+    #[test]
+    fn test_safe_local_path_rejects_absolute() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(safe_local_path(dir.path(), "/etc/passwd").is_err());
     }
 }

--- a/crates/cli/src/commands/files/sync_engine.rs
+++ b/crates/cli/src/commands/files/sync_engine.rs
@@ -167,7 +167,12 @@ pub async fn reconcile(
             (Some((local_content, local_hash)), Some(remote_entry)) => {
                 let prev_local = prev.and_then(|p| p.local_hash.as_deref());
                 let prev_remote = prev.and_then(|p| p.remote_hash.as_deref());
-                let remote_hash = remote_entry.content_hash.as_deref().unwrap_or("");
+                // Use content_hash if available, fall back to updated_at for change detection
+                let remote_hash = remote_entry
+                    .content_hash
+                    .as_deref()
+                    .or(remote_entry.updated_at.as_deref())
+                    .unwrap_or("");
 
                 let local_changed = prev_local.is_none_or(|h| h != local_hash);
                 let remote_changed = prev_remote.is_none_or(|h| h != remote_hash);
@@ -276,7 +281,11 @@ pub async fn reconcile(
 
             (None, Some(remote_entry)) => {
                 let was_synced = prev.is_some();
-                let remote_hash = remote_entry.content_hash.as_deref().unwrap_or("");
+                let remote_hash = remote_entry
+                    .content_hash
+                    .as_deref()
+                    .or(remote_entry.updated_at.as_deref())
+                    .unwrap_or("");
 
                 if was_synced && delete {
                     if verbose {
@@ -390,4 +399,201 @@ fn update_state(
 
 fn normalize_path(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_conflict_parse() {
+        assert!(matches!(Conflict::parse("local-wins"), Conflict::Local));
+        assert!(matches!(Conflict::parse("remote-wins"), Conflict::Remote));
+        assert!(matches!(
+            Conflict::parse("last-write-wins"),
+            Conflict::LastWrite
+        ));
+        assert!(matches!(Conflict::parse("unknown"), Conflict::LastWrite));
+        assert!(matches!(Conflict::parse(""), Conflict::LastWrite));
+    }
+
+    #[test]
+    fn test_sync_stats_display_minimal() {
+        let stats = SyncStats {
+            uploaded: 2,
+            downloaded: 1,
+            ..Default::default()
+        };
+        assert_eq!(format!("{}", stats), "↑2 ↓1");
+    }
+
+    #[test]
+    fn test_sync_stats_display_with_deletes() {
+        let stats = SyncStats {
+            uploaded: 0,
+            downloaded: 0,
+            deleted_local: 1,
+            deleted_remote: 2,
+            ..Default::default()
+        };
+        assert_eq!(format!("{}", stats), "↑0 ↓0 del:3");
+    }
+
+    #[test]
+    fn test_sync_stats_display_full() {
+        let stats = SyncStats {
+            uploaded: 5,
+            downloaded: 3,
+            deleted_local: 1,
+            deleted_remote: 0,
+            conflicts: 2,
+            skipped: 10,
+            errors: 1,
+        };
+        assert_eq!(format!("{}", stats), "↑5 ↓3 del:1 conflicts:2 errors:1");
+    }
+
+    #[test]
+    fn test_sync_stats_display_zero() {
+        let stats = SyncStats::default();
+        assert_eq!(format!("{}", stats), "↑0 ↓0");
+    }
+
+    #[test]
+    fn test_normalize_path_unix() {
+        assert_eq!(normalize_path(Path::new("src/main.rs")), "src/main.rs");
+    }
+
+    #[test]
+    fn test_normalize_path_nested() {
+        assert_eq!(normalize_path(Path::new("a/b/c/d.txt")), "a/b/c/d.txt");
+    }
+
+    #[test]
+    fn test_scan_local_basic() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("hello.txt"), "hello").unwrap();
+        fs::create_dir_all(dir.path().join("src")).unwrap();
+        fs::write(dir.path().join("src/main.rs"), "fn main() {}").unwrap();
+
+        let files = scan_local(dir.path(), false, &[]).unwrap();
+        assert!(files.contains_key("hello.txt"));
+        assert!(files.contains_key("src/main.rs"));
+        assert_eq!(files.len(), 2);
+
+        // Verify content and hash
+        let (content, hash) = &files["hello.txt"];
+        assert_eq!(content, b"hello");
+        assert!(hash.starts_with("sha256:"));
+    }
+
+    #[test]
+    fn test_scan_local_excludes_default_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("keep.txt"), "keep").unwrap();
+        fs::create_dir_all(dir.path().join(".git")).unwrap();
+        fs::write(dir.path().join(".git/config"), "gitconfig").unwrap();
+        fs::create_dir_all(dir.path().join("node_modules")).unwrap();
+        fs::write(dir.path().join("node_modules/pkg.js"), "module").unwrap();
+        fs::create_dir_all(dir.path().join("target")).unwrap();
+        fs::write(dir.path().join("target/debug"), "binary").unwrap();
+        fs::create_dir_all(dir.path().join(".everruns-sync")).unwrap();
+        fs::write(dir.path().join(".everruns-sync/state.json"), "{}").unwrap();
+
+        let files = scan_local(dir.path(), false, &[]).unwrap();
+        assert!(files.contains_key("keep.txt"));
+        assert!(!files.contains_key(".git/config"));
+        assert!(!files.contains_key("node_modules/pkg.js"));
+        assert!(!files.contains_key("target/debug"));
+        assert!(!files.contains_key(".everruns-sync/state.json"));
+    }
+
+    #[test]
+    fn test_scan_local_extra_excludes() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("keep.txt"), "keep").unwrap();
+        fs::create_dir_all(dir.path().join("build")).unwrap();
+        fs::write(dir.path().join("build/out.js"), "output").unwrap();
+
+        let files = scan_local(dir.path(), false, &["build".to_string()]).unwrap();
+        assert!(files.contains_key("keep.txt"));
+        assert!(!files.contains_key("build/out.js"));
+    }
+
+    #[test]
+    fn test_scan_local_syncignore() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("keep.txt"), "keep").unwrap();
+        fs::write(dir.path().join("secret.key"), "secret").unwrap();
+        fs::write(dir.path().join(".syncignore"), "*.key\n# comment\n").unwrap();
+
+        let files = scan_local(dir.path(), false, &[]).unwrap();
+        assert!(files.contains_key("keep.txt"));
+        assert!(!files.contains_key("secret.key"));
+    }
+
+    #[test]
+    fn test_scan_local_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let files = scan_local(dir.path(), false, &[]).unwrap();
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_conflict_local_wins() {
+        let entry = RemoteFileEntry {
+            path: "/test.txt".to_string(),
+            is_directory: false,
+            size_bytes: 5,
+            content_hash: None,
+            updated_at: Some("2026-01-01T00:00:00Z".to_string()),
+            is_readonly: false,
+        };
+        let result = resolve_conflict(Conflict::Local, Path::new("/tmp"), "test.txt", &entry);
+        assert_eq!(result, "local");
+    }
+
+    #[test]
+    fn test_resolve_conflict_remote_wins() {
+        let entry = RemoteFileEntry {
+            path: "/test.txt".to_string(),
+            is_directory: false,
+            size_bytes: 5,
+            content_hash: None,
+            updated_at: Some("2026-01-01T00:00:00Z".to_string()),
+            is_readonly: false,
+        };
+        let result = resolve_conflict(Conflict::Remote, Path::new("/tmp"), "test.txt", &entry);
+        assert_eq!(result, "remote");
+    }
+
+    #[test]
+    fn test_update_state_new_entry() {
+        let mut state = SyncState::new("ses_test");
+        update_state(
+            &mut state,
+            "file.txt",
+            Some("sha256:aaa"),
+            Some("sha256:bbb"),
+        );
+        let entry = &state.files["file.txt"];
+        assert_eq!(entry.local_hash.as_deref(), Some("sha256:aaa"));
+        assert_eq!(entry.remote_hash.as_deref(), Some("sha256:bbb"));
+    }
+
+    #[test]
+    fn test_update_state_partial_update() {
+        let mut state = SyncState::new("ses_test");
+        update_state(&mut state, "file.txt", Some("sha256:aaa"), None);
+        let entry = &state.files["file.txt"];
+        assert_eq!(entry.local_hash.as_deref(), Some("sha256:aaa"));
+        assert!(entry.remote_hash.is_none());
+
+        // Now update remote only
+        update_state(&mut state, "file.txt", None, Some("sha256:bbb"));
+        let entry = &state.files["file.txt"];
+        assert_eq!(entry.local_hash.as_deref(), Some("sha256:aaa")); // unchanged
+        assert_eq!(entry.remote_hash.as_deref(), Some("sha256:bbb"));
+    }
 }

--- a/crates/cli/src/commands/files/sync_engine.rs
+++ b/crates/cli/src/commands/files/sync_engine.rs
@@ -255,9 +255,7 @@ pub async fn reconcile(
                     if verbose {
                         eprintln!("  del local {}", path);
                     }
-                    if !dry_run
-                        && let Ok(local_path) = safe_local_path(local_dir, path)
-                    {
+                    if !dry_run && let Ok(local_path) = safe_local_path(local_dir, path) {
                         let _ = std::fs::remove_file(&local_path);
                     }
                     state.files.remove(path);

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod agents;
 pub mod capabilities;
 pub mod chat;
+pub mod files;
 pub mod sessions;

--- a/crates/cli/src/commands/sessions.rs
+++ b/crates/cli/src/commands/sessions.rs
@@ -1,4 +1,6 @@
 // Session management commands
+//
+// TODO(sdk): Replace raw reqwest in create() with SDK once it supports harness_id parameter.
 
 use crate::output::{OutputFormat, print_field, print_table_header, print_table_row};
 use anyhow::Result;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -56,6 +56,12 @@ pub enum Commands {
         command: commands::sessions::SessionsCommand,
     },
 
+    /// File sync and management
+    Files {
+        #[command(subcommand)]
+        command: commands::files::FilesCommand,
+    },
+
     /// Send a message and stream the response
     Chat {
         /// Message text to send
@@ -113,6 +119,9 @@ async fn main() -> anyhow::Result<()> {
                 cli.quiet,
             )
             .await
+        }
+        Commands::Files { command } => {
+            commands::files::run(command, &api_url, &api_key, output_format, cli.quiet).await
         }
         Commands::Chat {
             message,
@@ -276,6 +285,130 @@ mod tests {
             assert_eq!(status, "all");
         } else {
             panic!("Expected Capabilities command");
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_files_sync() {
+        let cli = Cli::try_parse_from([
+            "everruns",
+            "files",
+            "sync",
+            "--session",
+            "ses_abc",
+            "--interval",
+            "5",
+            "--conflict",
+            "local-wins",
+            "--verbose",
+            "/tmp/mydir",
+        ])
+        .unwrap();
+        if let Commands::Files { command } = cli.command {
+            if let commands::files::FilesCommand::Sync {
+                session,
+                local_dir,
+                interval,
+                conflict,
+                verbose,
+                ..
+            } = command
+            {
+                assert_eq!(session, "ses_abc");
+                assert_eq!(local_dir, "/tmp/mydir");
+                assert_eq!(interval, 5);
+                assert_eq!(conflict, "local-wins");
+                assert!(verbose);
+            } else {
+                panic!("Expected Sync command");
+            }
+        } else {
+            panic!("Expected Files command");
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_files_push() {
+        let cli = Cli::try_parse_from([
+            "everruns",
+            "files",
+            "push",
+            "--session",
+            "ses_xyz",
+            "--dry-run",
+        ])
+        .unwrap();
+        if let Commands::Files { command } = cli.command {
+            if let commands::files::FilesCommand::Push {
+                session, dry_run, ..
+            } = command
+            {
+                assert_eq!(session, "ses_xyz");
+                assert!(dry_run);
+            } else {
+                panic!("Expected Push command");
+            }
+        } else {
+            panic!("Expected Files command");
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_files_pull() {
+        let cli = Cli::try_parse_from([
+            "everruns",
+            "files",
+            "pull",
+            "--session",
+            "ses_xyz",
+            "--delete",
+        ])
+        .unwrap();
+        if let Commands::Files { command } = cli.command {
+            if let commands::files::FilesCommand::Pull {
+                session, delete, ..
+            } = command
+            {
+                assert_eq!(session, "ses_xyz");
+                assert!(delete);
+            } else {
+                panic!("Expected Pull command");
+            }
+        } else {
+            panic!("Expected Files command");
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_files_ls() {
+        let cli = Cli::try_parse_from([
+            "everruns",
+            "files",
+            "ls",
+            "--session",
+            "ses_xyz",
+            "-r",
+            "-l",
+            "/src",
+        ])
+        .unwrap();
+        if let Commands::Files { command } = cli.command {
+            if let commands::files::FilesCommand::Ls {
+                session,
+                path,
+                recursive,
+                long,
+            } = command
+            {
+                assert_eq!(session, "ses_xyz");
+                assert_eq!(path, "/src");
+                assert!(recursive);
+                assert!(long);
+            } else {
+                panic!("Expected Ls command");
+            }
+        } else {
+            panic!("Expected Files command");
         }
     }
 

--- a/crates/cli/tests/files_integration_test.rs
+++ b/crates/cli/tests/files_integration_test.rs
@@ -1,0 +1,263 @@
+//! Integration tests for CLI file sync operations.
+//!
+//! Tests the full sync workflow with filesystem operations:
+//! scan, state persistence, and reconciliation logic.
+
+use std::fs;
+
+// Import via the crate's public modules
+// Since the CLI is a binary crate, we test via subprocess for CLI invocation
+// and via direct imports for library-like logic.
+
+/// Test helper: create a temp directory with files
+fn create_test_dir(files: &[(&str, &str)]) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    for (path, content) in files {
+        let full_path = dir.path().join(path);
+        if let Some(parent) = full_path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(full_path, content).unwrap();
+    }
+    dir
+}
+
+#[test]
+fn test_cli_binary_exists() {
+    // Verify the binary can be found and shows help
+    let output = std::process::Command::new("cargo")
+        .args(["run", "-p", "everruns-cli", "--", "--help"])
+        .output()
+        .expect("Failed to run cargo");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Everruns CLI") || stdout.contains("everruns"),
+        "Help output should contain CLI name"
+    );
+}
+
+#[test]
+fn test_cli_files_help() {
+    let output = std::process::Command::new("cargo")
+        .args(["run", "-p", "everruns-cli", "--", "files", "--help"])
+        .output()
+        .expect("Failed to run cargo");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("sync"), "Should list sync subcommand");
+    assert!(stdout.contains("push"), "Should list push subcommand");
+    assert!(stdout.contains("pull"), "Should list pull subcommand");
+    assert!(stdout.contains("ls"), "Should list ls subcommand");
+}
+
+#[test]
+fn test_cli_files_sync_help() {
+    let output = std::process::Command::new("cargo")
+        .args(["run", "-p", "everruns-cli", "--", "files", "sync", "--help"])
+        .output()
+        .expect("Failed to run cargo");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--session"), "Should have --session flag");
+    assert!(stdout.contains("--interval"), "Should have --interval flag");
+    assert!(stdout.contains("--conflict"), "Should have --conflict flag");
+    assert!(stdout.contains("--dry-run"), "Should have --dry-run flag");
+    assert!(stdout.contains("--delete"), "Should have --delete flag");
+    assert!(stdout.contains("--verbose"), "Should have --verbose flag");
+}
+
+#[test]
+fn test_cli_files_push_requires_session() {
+    let output = std::process::Command::new("cargo")
+        .args(["run", "-p", "everruns-cli", "--", "files", "push"])
+        .output()
+        .expect("Failed to run cargo");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--session") || stderr.contains("required"),
+        "Should fail with missing session"
+    );
+    assert!(!output.status.success());
+}
+
+#[test]
+fn test_cli_files_pull_requires_session() {
+    let output = std::process::Command::new("cargo")
+        .args(["run", "-p", "everruns-cli", "--", "files", "pull"])
+        .output()
+        .expect("Failed to run cargo");
+    assert!(!output.status.success());
+}
+
+#[test]
+fn test_cli_files_ls_requires_session() {
+    let output = std::process::Command::new("cargo")
+        .args(["run", "-p", "everruns-cli", "--", "files", "ls"])
+        .output()
+        .expect("Failed to run cargo");
+    assert!(!output.status.success());
+}
+
+#[test]
+fn test_sync_state_roundtrip_with_files() {
+    let dir = create_test_dir(&[
+        ("src/main.rs", "fn main() {}"),
+        ("src/lib.rs", "pub mod foo;"),
+        ("README.md", "# Hello"),
+    ]);
+
+    let state_dir = dir.path().join(".everruns-sync");
+
+    // Create state with file entries
+    let state_json = serde_json::json!({
+        "session_id": "ses_integration_test",
+        "last_sync": "2026-03-20T12:00:00Z",
+        "files": {
+            "src/main.rs": {
+                "local_hash": "sha256:aaa",
+                "remote_hash": "sha256:bbb",
+                "local_mtime": null,
+                "remote_updated_at": "2026-03-20T12:00:00Z"
+            },
+            "README.md": {
+                "local_hash": "sha256:ccc",
+                "remote_hash": "sha256:ccc",
+                "local_mtime": null,
+                "remote_updated_at": null
+            }
+        }
+    });
+
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(
+        state_dir.join("state.json"),
+        serde_json::to_string_pretty(&state_json).unwrap(),
+    )
+    .unwrap();
+
+    // Verify it can be read back
+    let data = fs::read_to_string(state_dir.join("state.json")).unwrap();
+    let loaded: serde_json::Value = serde_json::from_str(&data).unwrap();
+    assert_eq!(loaded["session_id"], "ses_integration_test");
+    assert_eq!(loaded["files"]["src/main.rs"]["local_hash"], "sha256:aaa");
+}
+
+#[test]
+fn test_gitignore_respected() {
+    let dir = create_test_dir(&[
+        ("keep.txt", "keep me"),
+        ("build/output.js", "compiled"),
+        (".gitignore", "build/\n"),
+    ]);
+
+    // WalkBuilder needs a .git dir to recognize .gitignore
+    fs::create_dir_all(dir.path().join(".git")).unwrap();
+
+    // Simulate what scan_local does: walk with gitignore support
+    let mut builder = ignore::WalkBuilder::new(dir.path());
+    builder
+        .hidden(false)
+        .git_ignore(true)
+        .git_global(false)
+        .git_exclude(false);
+
+    let mut found_files: Vec<String> = Vec::new();
+    for entry in builder.build() {
+        let entry = entry.unwrap();
+        if entry.path().is_file() {
+            let rel = entry.path().strip_prefix(dir.path()).unwrap();
+            found_files.push(rel.to_string_lossy().replace('\\', "/"));
+        }
+    }
+
+    assert!(found_files.contains(&"keep.txt".to_string()));
+    assert!(found_files.contains(&".gitignore".to_string()));
+    assert!(
+        !found_files.contains(&"build/output.js".to_string()),
+        "build/ should be gitignored, found: {:?}",
+        found_files
+    );
+}
+
+#[test]
+fn test_binary_detection() {
+    // Binary detection: null bytes in first 8KB → base64
+    let text_content = b"Hello, World!";
+    let binary_content = b"Hello\x00World";
+
+    let is_text_binary = text_content.contains(&0);
+    let is_binary_binary = binary_content.contains(&0);
+
+    assert!(!is_text_binary, "Text should not be detected as binary");
+    assert!(
+        is_binary_binary,
+        "Content with null bytes should be detected as binary"
+    );
+}
+
+#[test]
+fn test_content_hash_consistency() {
+    use sha2::{Digest, Sha256};
+
+    let content = b"fn main() { println!(\"hello\"); }";
+
+    // Hash the same way the CLI does
+    let mut hasher = Sha256::new();
+    hasher.update(content);
+    let result = hasher.finalize();
+    let hash1 = format!(
+        "sha256:{}",
+        result
+            .iter()
+            .map(|b| format!("{:02x}", b))
+            .collect::<String>()
+    );
+
+    // Hash again — should be deterministic
+    let mut hasher2 = Sha256::new();
+    hasher2.update(content);
+    let result2 = hasher2.finalize();
+    let hash2 = format!(
+        "sha256:{}",
+        result2
+            .iter()
+            .map(|b| format!("{:02x}", b))
+            .collect::<String>()
+    );
+
+    assert_eq!(hash1, hash2);
+    assert!(hash1.starts_with("sha256:"));
+    assert_eq!(hash1.len(), 7 + 64); // "sha256:" + 64 hex chars
+}
+
+#[test]
+fn test_sync_state_dir_not_synced() {
+    // .everruns-sync directory should never be synced
+    let dir = create_test_dir(&[("code.rs", "fn main() {}")]);
+
+    // Create a sync state file
+    let state_dir = dir.path().join(".everruns-sync");
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(state_dir.join("state.json"), "{}").unwrap();
+
+    // Walk and verify .everruns-sync is excluded
+    let mut builder = ignore::WalkBuilder::new(dir.path());
+    builder.hidden(false).git_ignore(false);
+
+    let mut overrides = ignore::overrides::OverrideBuilder::new(dir.path());
+    overrides.add("!.everruns-sync").unwrap();
+    builder.overrides(overrides.build().unwrap());
+
+    let mut found: Vec<String> = Vec::new();
+    for entry in builder.build() {
+        let entry = entry.unwrap();
+        if entry.path().is_file() {
+            let rel = entry.path().strip_prefix(dir.path()).unwrap();
+            found.push(rel.to_string_lossy().to_string());
+        }
+    }
+
+    assert!(found.contains(&"code.rs".to_string()));
+    assert!(
+        !found.iter().any(|f| f.contains(".everruns-sync")),
+        ".everruns-sync should be excluded"
+    );
+}

--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,7 @@ allow = [
     "Apache-2.0",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "CC0-1.0",
     "CDLA-Permissive-2.0",
     "ISC",
     "OpenSSL",

--- a/specs/cli.md
+++ b/specs/cli.md
@@ -1,17 +1,67 @@
-# File Sync CLI Specification
+# CLI Specification
 
-## Abstract
+## Overview
 
-Live bidirectional file synchronization between a local directory and a session's virtual filesystem (`/workspace`). Enables developers to edit files locally (in their IDE) while an agent works on them remotely, and vice versa.
+`everruns` — command-line interface for the Everruns platform. Manages agents, sessions, chat, and file sync.
 
-## Design Decisions
+**Crate:** `crates/cli/`
 
-### Decision 1: CLI Subcommand under `files`
+**Global Flags:**
+- `-o, --output` — Output format: `text` (default), `json`, `yaml`
+- `-q, --quiet` — Suppress non-essential output
+
+**Configuration:**
+- `EVERRUNS_API_KEY` — API authentication token
+- `EVERRUNS_API_URL` — Base URL (default: `https://app.everruns.com/api`)
+
+## Commands
+
+### `everruns agents`
+
+Agent CRUD. Create from YAML/JSON/Markdown (YAML front matter + body = system prompt).
+
+- `create --file <path>` | `--name <n> --system-prompt <s>`
+- `list`
+- `get <id>`
+- `delete <id>` (soft archive)
+
+### `everruns sessions`
+
+Session management.
+
+- `create --harness <id> [--agent <id>] [--title <t>] [--model <m>]`
+- `list`
+- `get <id>`
+
+### `everruns chat`
+
+Send message and poll for response.
+
+- `chat --session <id> "<message>" [--timeout <s>] [--no-stream]`
+- Polls `/v1/sessions/{id}/events` every 500ms until `turn.completed` or timeout (default 300s)
+
+### `everruns capabilities`
+
+List platform capabilities.
+
+- `list [--status available|coming_soon|all]`
+
+### `everruns files`
+
+Session filesystem operations — sync, push, pull, list. See [Files](#files) section below.
+
+---
+
+## Files
+
+### Design Decisions
+
+#### Decision 1: CLI Subcommand under `files`
 
 **Chosen:** `everruns files sync --session <id> [local-dir]`
 **Rationale:** Groups all file operations (sync, push, pull, ls) under one noun. `sync` is the long-running watch command; `push`/`pull` are one-shot bulk transfers.
 
-### Decision 2: Polling-based Change Detection
+#### Decision 2: Polling-based Change Detection
 
 **Chosen:** Poll local filesystem with `notify` (inotify/FSEvents/kqueue) + poll remote via periodic `GET /fs/?recursive=true` with `If-Modified-Since` semantics (compare `updated_at`).
 **Alternatives considered:**
@@ -19,7 +69,7 @@ Live bidirectional file synchronization between a local directory and a session'
 - Pure polling both sides: Higher latency, more API calls.
 **Rationale:** `notify` gives near-instant local detection. Remote polling at 2-5s intervals is acceptable for MVP. Server can add file-change SSE events later to eliminate remote polling.
 
-### Decision 3: Conflict Resolution — Last-Write-Wins with Warning
+#### Decision 3: Conflict Resolution — Last-Write-Wins with Warning
 
 **Chosen:** If both sides changed the same file since last sync, apply last-write-wins and print a warning. Optionally `--conflict=ask` to prompt user.
 **Alternatives considered:**
@@ -27,19 +77,19 @@ Live bidirectional file synchronization between a local directory and a session'
 - Always-local-wins / always-remote-wins: Too aggressive.
 **Rationale:** Conflicts are rare in practice (user edits locally, agent edits remotely, typically different files). Warning + configurable strategy covers edge cases without over-engineering.
 
-### Decision 4: `.syncignore` + Sensible Defaults
+#### Decision 4: `.syncignore` + Sensible Defaults
 
 **Chosen:** Respect `.gitignore` patterns by default (via `ignore` crate). Additional `.syncignore` file for sync-specific exclusions. Always exclude: `.git/`, `node_modules/`, `target/`, `__pycache__/`, `.env`.
 **Rationale:** Prevents syncing build artifacts and secrets. Aligns with developer expectations.
 
-### Decision 5: Incremental Sync via Content Hashing
+#### Decision 5: Incremental Sync via Content Hashing
 
 **Chosen:** Track `sha256` content hashes locally in `.sync-state.json` (in sync metadata dir). Only upload/download when hash differs.
 **Rationale:** Avoids redundant transfers. The session filesystem already returns `content_hash` on reads.
 
-## Commands
+### File Commands
 
-### `everruns files sync`
+#### `everruns files sync`
 
 Long-running bidirectional watch.
 
@@ -63,7 +113,7 @@ everruns files sync --session <session_id> [local-dir]
 4. Print summary line on each sync cycle (e.g., `↑2 ↓1 files synced`)
 5. Ctrl+C: graceful shutdown, print final stats
 
-### `everruns files push`
+#### `everruns files push`
 
 One-shot upload local → remote.
 
@@ -74,7 +124,7 @@ everruns files push --session <session_id> [local-dir] [-- paths...]
   --dry-run         Show what would be pushed
 ```
 
-### `everruns files pull`
+#### `everruns files pull`
 
 One-shot download remote → local.
 
@@ -85,7 +135,7 @@ everruns files pull --session <session_id> [local-dir] [-- paths...]
   --dry-run         Show what would be pulled
 ```
 
-### `everruns files ls`
+#### `everruns files ls`
 
 List remote session files.
 
@@ -96,7 +146,7 @@ everruns files ls --session <session_id> [path]
   --long, -l        Show size, dates
 ```
 
-## Sync State
+### Sync State
 
 Stored in `<local-dir>/.everruns-sync/state.json`:
 
@@ -115,7 +165,7 @@ Stored in `<local-dir>/.everruns-sync/state.json`:
 }
 ```
 
-## Sync Algorithm
+### Sync Algorithm
 
 ```
 for each file in (local ∪ remote):
@@ -130,7 +180,7 @@ for each file in (local ∪ remote):
   if file only on remote → download (or delete remote if --delete and was previously synced)
 ```
 
-## Wire Protocol
+### Wire Protocol
 
 Uses existing session filesystem REST API:
 
@@ -143,7 +193,7 @@ Uses existing session filesystem REST API:
 
 Binary detection: same as server — null bytes in first 8KB → base64.
 
-## Future Enhancements
+### Future Enhancements
 
 1. **Server-side file change events** via SSE (`file.created`, `file.updated`, `file.deleted`) to eliminate remote polling
 2. **Delta sync** using content-defined chunking for large files
@@ -151,7 +201,7 @@ Binary detection: same as server — null bytes in first 8KB → base64.
 4. **Selective path sync** (`everruns files sync --session ses_xxx ./src` to sync only `src/`)
 5. **Integration with `everruns chat`** — auto-sync while chatting
 
-## Dependencies (new for CLI crate)
+### Dependencies (new for CLI crate)
 
 - `notify` — cross-platform filesystem watcher
 - `ignore` — gitignore-compatible pattern matching

--- a/specs/cli.md
+++ b/specs/cli.md
@@ -84,7 +84,7 @@ Session filesystem operations — sync, push, pull, list. See [Files](#files) se
 
 #### Decision 5: Incremental Sync via Content Hashing
 
-**Chosen:** Track `sha256` content hashes locally in `.sync-state.json` (in sync metadata dir). Only upload/download when hash differs.
+**Chosen:** Track `sha256` content hashes locally in `<local-dir>/.everruns-sync/state.json`. Only upload/download when hash differs. The `.everruns-sync/` directory is always excluded from syncing.
 **Rationale:** Avoids redundant transfers. The session filesystem already returns `content_hash` on reads.
 
 ### File Commands
@@ -97,9 +97,8 @@ Long-running bidirectional watch.
 everruns files sync --session <session_id> [local-dir]
   --session, -s     Session ID (required)
   --interval        Remote poll interval in seconds (default: 3)
-  --conflict        Conflict strategy: last-write-wins | local-wins | remote-wins | ask (default: last-write-wins)
+  --conflict        Conflict strategy: last-write-wins | local-wins | remote-wins (default: last-write-wins)
   --exclude         Additional exclude patterns (repeatable)
-  --include         Override excludes for specific patterns (repeatable)
   --no-gitignore    Don't read .gitignore
   --dry-run         Show what would sync without making changes
   --delete          Delete files on one side when deleted on the other (default: false)
@@ -118,7 +117,7 @@ everruns files sync --session <session_id> [local-dir]
 One-shot upload local → remote.
 
 ```
-everruns files push --session <session_id> [local-dir] [-- paths...]
+everruns files push --session <session_id> [local-dir]
   --session, -s     Session ID (required)
   --delete          Delete remote files not present locally (default: false)
   --dry-run         Show what would be pushed
@@ -129,7 +128,7 @@ everruns files push --session <session_id> [local-dir] [-- paths...]
 One-shot download remote → local.
 
 ```
-everruns files pull --session <session_id> [local-dir] [-- paths...]
+everruns files pull --session <session_id> [local-dir]
   --session, -s     Session ID (required)
   --delete          Delete local files not present remotely (default: false)
   --dry-run         Show what would be pulled

--- a/specs/file-sync.md
+++ b/specs/file-sync.md
@@ -1,0 +1,161 @@
+# File Sync CLI Specification
+
+## Abstract
+
+Live bidirectional file synchronization between a local directory and a session's virtual filesystem (`/workspace`). Enables developers to edit files locally (in their IDE) while an agent works on them remotely, and vice versa.
+
+## Design Decisions
+
+### Decision 1: CLI Subcommand under `files`
+
+**Chosen:** `everruns files sync --session <id> [local-dir]`
+**Rationale:** Groups all file operations (sync, push, pull, ls) under one noun. `sync` is the long-running watch command; `push`/`pull` are one-shot bulk transfers.
+
+### Decision 2: Polling-based Change Detection
+
+**Chosen:** Poll local filesystem with `notify` (inotify/FSEvents/kqueue) + poll remote via periodic `GET /fs/?recursive=true` with `If-Modified-Since` semantics (compare `updated_at`).
+**Alternatives considered:**
+- WebSocket-based push from server: Requires new server endpoint; SSE is unidirectional and event types don't include file-change events today.
+- Pure polling both sides: Higher latency, more API calls.
+**Rationale:** `notify` gives near-instant local detection. Remote polling at 2-5s intervals is acceptable for MVP. Server can add file-change SSE events later to eliminate remote polling.
+
+### Decision 3: Conflict Resolution — Last-Write-Wins with Warning
+
+**Chosen:** If both sides changed the same file since last sync, apply last-write-wins and print a warning. Optionally `--conflict=ask` to prompt user.
+**Alternatives considered:**
+- Three-way merge: Complex, error-prone for binary files.
+- Always-local-wins / always-remote-wins: Too aggressive.
+**Rationale:** Conflicts are rare in practice (user edits locally, agent edits remotely, typically different files). Warning + configurable strategy covers edge cases without over-engineering.
+
+### Decision 4: `.syncignore` + Sensible Defaults
+
+**Chosen:** Respect `.gitignore` patterns by default (via `ignore` crate). Additional `.syncignore` file for sync-specific exclusions. Always exclude: `.git/`, `node_modules/`, `target/`, `__pycache__/`, `.env`.
+**Rationale:** Prevents syncing build artifacts and secrets. Aligns with developer expectations.
+
+### Decision 5: Incremental Sync via Content Hashing
+
+**Chosen:** Track `sha256` content hashes locally in `.sync-state.json` (in sync metadata dir). Only upload/download when hash differs.
+**Rationale:** Avoids redundant transfers. The session filesystem already returns `content_hash` on reads.
+
+## Commands
+
+### `everruns files sync`
+
+Long-running bidirectional watch.
+
+```
+everruns files sync --session <session_id> [local-dir]
+  --session, -s     Session ID (required)
+  --interval        Remote poll interval in seconds (default: 3)
+  --conflict        Conflict strategy: last-write-wins | local-wins | remote-wins | ask (default: last-write-wins)
+  --exclude         Additional exclude patterns (repeatable)
+  --include         Override excludes for specific patterns (repeatable)
+  --no-gitignore    Don't read .gitignore
+  --dry-run         Show what would sync without making changes
+  --delete          Delete files on one side when deleted on the other (default: false)
+  --verbose, -v     Show every file operation
+```
+
+**Behavior:**
+1. On start: full reconciliation (compare both sides, sync differences)
+2. Watch local via `notify` crate → upload changes to remote
+3. Poll remote every `--interval` seconds → download changes to local
+4. Print summary line on each sync cycle (e.g., `↑2 ↓1 files synced`)
+5. Ctrl+C: graceful shutdown, print final stats
+
+### `everruns files push`
+
+One-shot upload local → remote.
+
+```
+everruns files push --session <session_id> [local-dir] [-- paths...]
+  --session, -s     Session ID (required)
+  --delete          Delete remote files not present locally (default: false)
+  --dry-run         Show what would be pushed
+```
+
+### `everruns files pull`
+
+One-shot download remote → local.
+
+```
+everruns files pull --session <session_id> [local-dir] [-- paths...]
+  --session, -s     Session ID (required)
+  --delete          Delete local files not present remotely (default: false)
+  --dry-run         Show what would be pulled
+```
+
+### `everruns files ls`
+
+List remote session files.
+
+```
+everruns files ls --session <session_id> [path]
+  --session, -s     Session ID (required)
+  --recursive, -r   List recursively
+  --long, -l        Show size, dates
+```
+
+## Sync State
+
+Stored in `<local-dir>/.everruns-sync/state.json`:
+
+```json
+{
+  "session_id": "ses_xxx",
+  "last_sync": "2026-03-20T12:00:00Z",
+  "files": {
+    "src/main.rs": {
+      "local_hash": "sha256:abc...",
+      "remote_hash": "sha256:abc...",
+      "local_mtime": "2026-03-20T12:00:00Z",
+      "remote_updated_at": "2026-03-20T12:00:00Z"
+    }
+  }
+}
+```
+
+## Sync Algorithm
+
+```
+for each file in (local ∪ remote):
+  local_changed  = local_hash  != state.files[path].local_hash
+  remote_changed = remote_hash != state.files[path].remote_hash
+
+  if !local_changed && !remote_changed → skip
+  if local_changed  && !remote_changed → upload to remote
+  if !local_changed && remote_changed  → download to local
+  if local_changed  && remote_changed  → apply conflict strategy
+  if file only on local  → upload (or delete local if --delete and was previously synced)
+  if file only on remote → download (or delete remote if --delete and was previously synced)
+```
+
+## Wire Protocol
+
+Uses existing session filesystem REST API:
+
+- **List remote:** `GET /v1/sessions/{id}/fs/?recursive=true`
+- **Read file:** `GET /v1/sessions/{id}/fs/{path}`
+- **Create file:** `POST /v1/sessions/{id}/fs/{path}` with `{ "content": "...", "encoding": "text"|"base64" }`
+- **Update file:** `PUT /v1/sessions/{id}/fs/{path}` with `{ "content": "...", "encoding": "text"|"base64" }`
+- **Delete file:** `DELETE /v1/sessions/{id}/fs/{path}`
+- **Create dir:** `POST /v1/sessions/{id}/fs/{path}` with `{ "is_directory": true }`
+
+Binary detection: same as server — null bytes in first 8KB → base64.
+
+## Future Enhancements
+
+1. **Server-side file change events** via SSE (`file.created`, `file.updated`, `file.deleted`) to eliminate remote polling
+2. **Delta sync** using content-defined chunking for large files
+3. **Multi-session sync** (fan-out from one local dir to multiple sessions)
+4. **Selective path sync** (`everruns files sync --session ses_xxx ./src` to sync only `src/`)
+5. **Integration with `everruns chat`** — auto-sync while chatting
+
+## Dependencies (new for CLI crate)
+
+- `notify` — cross-platform filesystem watcher
+- `ignore` — gitignore-compatible pattern matching
+- `sha2` — content hashing
+- `base64` — binary encoding (may already be transitive)
+- `chrono` — timestamp handling
+- `indicatif` — progress bars for push/pull (optional)

--- a/test_cases/cli/TC001_files_ls_list_session_files.md
+++ b/test_cases/cli/TC001_files_ls_list_session_files.md
@@ -1,0 +1,81 @@
+# TC001: Files Ls — List Session Files
+
+## Description
+
+Verify that `everruns files ls` lists files in a session's workspace and supports recursive and long output modes.
+
+## Preconditions
+
+- API server running (`just start-dev` or `just start-all`)
+- An agent and session exist with files in the workspace
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Session | (created during test) |
+| Test file 1 | `/hello.txt` with content `Hello, World!` |
+| Test file 2 | `/src/main.rs` with content `fn main() {}` |
+
+## Steps
+
+1. Create an agent:
+   ```bash
+   curl -s -X POST "http://localhost:9300/api/v1/agents" \
+     -H "Content-Type: application/json" \
+     -d '{"name": "Test Agent", "system_prompt": "Test"}' | jq -r '.id'
+   ```
+   Save as `$AGENT_ID`.
+
+2. Create a session:
+   ```bash
+   curl -s -X POST "http://localhost:9300/api/v1/sessions" \
+     -H "Content-Type: application/json" \
+     -d "{\"agent_id\": \"$AGENT_ID\"}" | jq -r '.id'
+   ```
+   Save as `$SESSION_ID`.
+
+3. Create test files:
+   ```bash
+   curl -s -X POST "http://localhost:9300/api/v1/sessions/$SESSION_ID/fs/hello.txt" \
+     -H "Content-Type: application/json" \
+     -d '{"content": "Hello, World!", "encoding": "text"}'
+   curl -s -X POST "http://localhost:9300/api/v1/sessions/$SESSION_ID/fs/src/main.rs" \
+     -H "Content-Type: application/json" \
+     -d '{"content": "fn main() {}", "encoding": "text"}'
+   ```
+
+4. List files (short format):
+   ```bash
+   EVERRUNS_API_URL=http://localhost:9300/api EVERRUNS_API_KEY=dev \
+     everruns files ls --session $SESSION_ID
+   ```
+
+5. List files (long format):
+   ```bash
+   EVERRUNS_API_URL=http://localhost:9300/api EVERRUNS_API_KEY=dev \
+     everruns files ls --session $SESSION_ID -l
+   ```
+
+6. List files (recursive):
+   ```bash
+   EVERRUNS_API_URL=http://localhost:9300/api EVERRUNS_API_KEY=dev \
+     everruns files ls --session $SESSION_ID -r
+   ```
+
+7. List files (JSON output):
+   ```bash
+   EVERRUNS_API_URL=http://localhost:9300/api EVERRUNS_API_KEY=dev \
+     everruns -o json files ls --session $SESSION_ID -r
+   ```
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Step 4 output | Lists files at root level (may show `src/` directory and `hello.txt`) |
+| Step 5 output | Shows SIZE, UPDATED, PATH columns |
+| Step 6 output | Shows both `hello.txt` and `src/main.rs` |
+| Step 7 output | Valid JSON with `entries` array containing file objects |
+| File paths | Start with `/` |
+| Directory entries | Suffixed with `/` in text mode |

--- a/test_cases/cli/TC002_files_push_upload_local_to_remote.md
+++ b/test_cases/cli/TC002_files_push_upload_local_to_remote.md
@@ -1,0 +1,78 @@
+# TC002: Files Push — Upload Local Files to Remote
+
+## Description
+
+Verify that `everruns files push` uploads local files to a session's workspace, supports dry-run, and tracks state for incremental sync.
+
+## Preconditions
+
+- API server running (`just start-dev` or `just start-all`)
+- An agent and session exist
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Local dir | Temp directory with test files |
+| File 1 | `hello.txt` with content `Hello from push!` |
+| File 2 | `src/lib.rs` with content `pub fn greet() {}` |
+
+## Steps
+
+1. Create agent and session (as in TC001). Save `$SESSION_ID`.
+
+2. Create local test directory:
+   ```bash
+   TMPDIR=$(mktemp -d)
+   echo "Hello from push!" > "$TMPDIR/hello.txt"
+   mkdir -p "$TMPDIR/src"
+   echo "pub fn greet() {}" > "$TMPDIR/src/lib.rs"
+   ```
+
+3. Dry-run push:
+   ```bash
+   EVERRUNS_API_URL=http://localhost:9300/api EVERRUNS_API_KEY=dev \
+     everruns files push --session $SESSION_ID --dry-run "$TMPDIR"
+   ```
+
+4. Actual push:
+   ```bash
+   EVERRUNS_API_URL=http://localhost:9300/api EVERRUNS_API_KEY=dev \
+     everruns files push --session $SESSION_ID "$TMPDIR"
+   ```
+
+5. Verify remote files:
+   ```bash
+   curl -s "http://localhost:9300/api/v1/sessions/$SESSION_ID/fs/hello.txt" | jq '.content'
+   ```
+
+6. Push again (no changes — should be incremental):
+   ```bash
+   EVERRUNS_API_URL=http://localhost:9300/api EVERRUNS_API_KEY=dev \
+     everruns files push --session $SESSION_ID "$TMPDIR"
+   ```
+
+7. Modify a file and push again:
+   ```bash
+   echo "Updated content" > "$TMPDIR/hello.txt"
+   EVERRUNS_API_URL=http://localhost:9300/api EVERRUNS_API_KEY=dev \
+     everruns files push --session $SESSION_ID "$TMPDIR"
+   ```
+
+8. JSON output push:
+   ```bash
+   EVERRUNS_API_URL=http://localhost:9300/api EVERRUNS_API_KEY=dev \
+     everruns -o json files push --session $SESSION_ID "$TMPDIR"
+   ```
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Step 3 (dry-run) | Shows files that would be pushed, no actual upload |
+| Step 4 output | `Pushed: 2 files, deleted: 0, errors: 0` |
+| Step 5 | Content matches `Hello from push!` |
+| Step 6 (re-push) | `Pushed: 0 files` (incremental — already synced) |
+| Step 7 (after modify) | `Pushed: 1 files` (only changed file) |
+| Step 8 (JSON) | Valid JSON with `uploaded`, `deleted`, `errors` fields |
+| State file | `.everruns-sync/state.json` created in local dir |

--- a/test_cases/cli/TC003_files_pull_download_remote_to_local.md
+++ b/test_cases/cli/TC003_files_pull_download_remote_to_local.md
@@ -1,0 +1,80 @@
+# TC003: Files Pull — Download Remote Files to Local
+
+## Description
+
+Verify that `everruns files pull` downloads session workspace files to a local directory, supports dry-run, and handles incremental sync.
+
+## Preconditions
+
+- API server running (`just start-dev` or `just start-all`)
+- An agent and session exist with files in the workspace
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Remote file 1 | `/config.yaml` with content `key: value` |
+| Remote file 2 | `/src/app.rs` with content `fn app() {}` |
+| Local dir | Empty temp directory |
+
+## Steps
+
+1. Create agent and session (as in TC001). Save `$SESSION_ID`.
+
+2. Create remote files:
+   ```bash
+   curl -s -X POST "http://localhost:9300/api/v1/sessions/$SESSION_ID/fs/config.yaml" \
+     -H "Content-Type: application/json" \
+     -d '{"content": "key: value", "encoding": "text"}'
+   curl -s -X POST "http://localhost:9300/api/v1/sessions/$SESSION_ID/fs/src/app.rs" \
+     -H "Content-Type: application/json" \
+     -d '{"content": "fn app() {}", "encoding": "text"}'
+   ```
+
+3. Create empty local directory:
+   ```bash
+   TMPDIR=$(mktemp -d)
+   ```
+
+4. Dry-run pull:
+   ```bash
+   EVERRUNS_API_URL=http://localhost:9300/api EVERRUNS_API_KEY=dev \
+     everruns files pull --session $SESSION_ID --dry-run "$TMPDIR"
+   ```
+
+5. Actual pull:
+   ```bash
+   EVERRUNS_API_URL=http://localhost:9300/api EVERRUNS_API_KEY=dev \
+     everruns files pull --session $SESSION_ID "$TMPDIR"
+   ```
+
+6. Verify local files:
+   ```bash
+   cat "$TMPDIR/config.yaml"
+   cat "$TMPDIR/src/app.rs"
+   ```
+
+7. Pull again (incremental — no changes):
+   ```bash
+   EVERRUNS_API_URL=http://localhost:9300/api EVERRUNS_API_KEY=dev \
+     everruns files pull --session $SESSION_ID "$TMPDIR"
+   ```
+
+8. Pull with --delete after removing remote file:
+   ```bash
+   curl -s -X DELETE "http://localhost:9300/api/v1/sessions/$SESSION_ID/fs/config.yaml"
+   EVERRUNS_API_URL=http://localhost:9300/api EVERRUNS_API_KEY=dev \
+     everruns files pull --session $SESSION_ID --delete "$TMPDIR"
+   ```
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Step 4 (dry-run) | Shows files that would be pulled, no actual download |
+| Step 5 output | `Pulled: 2 files, deleted: 0, errors: 0` |
+| Step 6 | `config.yaml` contains `key: value`, `src/app.rs` contains `fn app() {}` |
+| Step 7 (re-pull) | `Pulled: 0 files` (incremental) |
+| Step 8 (--delete) | `config.yaml` deleted from local dir |
+| Parent dirs | `src/` directory auto-created |
+| State file | `.everruns-sync/state.json` updated |

--- a/test_cases/cli/TC004_files_sync_bidirectional.md
+++ b/test_cases/cli/TC004_files_sync_bidirectional.md
@@ -1,0 +1,86 @@
+# TC004: Files Sync — Bidirectional Live Sync
+
+## Description
+
+Verify that `everruns files sync` performs bidirectional sync: initial reconciliation, local→remote on local changes, remote→local on remote changes, and graceful shutdown.
+
+## Preconditions
+
+- API server running (`just start-dev` or `just start-all`)
+- An agent and session exist
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Local file | `local.txt` with content `from local` |
+| Remote file | `/remote.txt` with content `from remote` |
+| Poll interval | 2 seconds (for faster test feedback) |
+
+## Steps
+
+1. Create agent and session. Save `$SESSION_ID`.
+
+2. Create a remote file:
+   ```bash
+   curl -s -X POST "http://localhost:9300/api/v1/sessions/$SESSION_ID/fs/remote.txt" \
+     -H "Content-Type: application/json" \
+     -d '{"content": "from remote", "encoding": "text"}'
+   ```
+
+3. Create local directory with a file:
+   ```bash
+   TMPDIR=$(mktemp -d)
+   echo "from local" > "$TMPDIR/local.txt"
+   ```
+
+4. Start sync in background:
+   ```bash
+   EVERRUNS_API_URL=http://localhost:9300/api EVERRUNS_API_KEY=dev \
+     everruns files sync --session $SESSION_ID --interval 2 --verbose "$TMPDIR" &
+   SYNC_PID=$!
+   sleep 5  # Wait for initial sync
+   ```
+
+5. Verify initial sync pulled remote file:
+   ```bash
+   cat "$TMPDIR/remote.txt"
+   ```
+
+6. Verify initial sync pushed local file:
+   ```bash
+   curl -s "http://localhost:9300/api/v1/sessions/$SESSION_ID/fs/local.txt" | jq '.content'
+   ```
+
+7. Create new local file and wait for sync:
+   ```bash
+   echo "new file" > "$TMPDIR/new_local.txt"
+   sleep 5
+   curl -s "http://localhost:9300/api/v1/sessions/$SESSION_ID/fs/new_local.txt" | jq '.content'
+   ```
+
+8. Create new remote file and wait for sync:
+   ```bash
+   curl -s -X POST "http://localhost:9300/api/v1/sessions/$SESSION_ID/fs/new_remote.txt" \
+     -H "Content-Type: application/json" \
+     -d '{"content": "new from remote", "encoding": "text"}'
+   sleep 5
+   cat "$TMPDIR/new_remote.txt"
+   ```
+
+9. Stop sync:
+   ```bash
+   kill $SYNC_PID
+   ```
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Step 4 | Sync starts, prints `Initial sync...` and `Initial sync done: ↑1 ↓1` |
+| Step 5 | `remote.txt` contains `from remote` |
+| Step 6 | Remote `local.txt` contains `from local` |
+| Step 7 | Remote `new_local.txt` synced |
+| Step 8 | Local `new_remote.txt` contains `new from remote` |
+| Step 9 | Clean shutdown with `Sync stopped. Total: ↑N ↓N` |
+| Verbose output | Shows `↑` and `↓` for each file operation |

--- a/test_cases/cli/TC005_files_push_with_delete.md
+++ b/test_cases/cli/TC005_files_push_with_delete.md
@@ -1,0 +1,52 @@
+# TC005: Files Push — Delete Remote Files Not Present Locally
+
+## Description
+
+Verify that `everruns files push --delete` removes remote files that are no longer present locally, after an initial sync establishes the baseline.
+
+## Preconditions
+
+- API server running (`just start-dev` or `just start-all`)
+- An agent and session exist
+
+## Steps
+
+1. Create agent and session. Save `$SESSION_ID`.
+
+2. Create local directory with files:
+   ```bash
+   TMPDIR=$(mktemp -d)
+   echo "keep me" > "$TMPDIR/keep.txt"
+   echo "delete me" > "$TMPDIR/remove.txt"
+   ```
+
+3. Push both files:
+   ```bash
+   EVERRUNS_API_URL=http://localhost:9300/api EVERRUNS_API_KEY=dev \
+     everruns files push --session $SESSION_ID "$TMPDIR"
+   ```
+
+4. Delete local file:
+   ```bash
+   rm "$TMPDIR/remove.txt"
+   ```
+
+5. Push with --delete:
+   ```bash
+   EVERRUNS_API_URL=http://localhost:9300/api EVERRUNS_API_KEY=dev \
+     everruns files push --session $SESSION_ID --delete "$TMPDIR"
+   ```
+
+6. Verify remote state:
+   ```bash
+   curl -s "http://localhost:9300/api/v1/sessions/$SESSION_ID/fs/keep.txt" | jq '.content'
+   curl -s "http://localhost:9300/api/v1/sessions/$SESSION_ID/fs/remove.txt"
+   ```
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Step 3 | Both files pushed (2 files) |
+| Step 5 | Output includes `deleted: 1` |
+| Step 6 | `keep.txt` still exists, `remove.txt` returns 404 |

--- a/test_cases/cli/TC006_files_sync_conflict_resolution.md
+++ b/test_cases/cli/TC006_files_sync_conflict_resolution.md
@@ -1,0 +1,63 @@
+# TC006: Files Sync — Conflict Resolution
+
+## Description
+
+Verify that `everruns files sync` correctly detects and resolves conflicts when both local and remote versions of a file change between sync cycles.
+
+## Preconditions
+
+- API server running (`just start-dev` or `just start-all`)
+- An agent and session exist
+
+## Steps
+
+1. Create agent and session. Save `$SESSION_ID`.
+
+2. Create initial file locally and push:
+   ```bash
+   TMPDIR=$(mktemp -d)
+   echo "version 1" > "$TMPDIR/conflict.txt"
+   EVERRUNS_API_URL=http://localhost:9300/api EVERRUNS_API_KEY=dev \
+     everruns files push --session $SESSION_ID "$TMPDIR"
+   ```
+
+3. Modify both local and remote:
+   ```bash
+   echo "local version 2" > "$TMPDIR/conflict.txt"
+   curl -s -X PUT "http://localhost:9300/api/v1/sessions/$SESSION_ID/fs/conflict.txt" \
+     -H "Content-Type: application/json" \
+     -d '{"content": "remote version 2", "encoding": "text"}'
+   ```
+
+4. Sync with local-wins strategy:
+   ```bash
+   EVERRUNS_API_URL=http://localhost:9300/api EVERRUNS_API_KEY=dev \
+     everruns files sync --session $SESSION_ID --conflict local-wins --verbose "$TMPDIR" &
+   SYNC_PID=$!
+   sleep 5
+   kill $SYNC_PID
+   ```
+
+5. Check remote file:
+   ```bash
+   curl -s "http://localhost:9300/api/v1/sessions/$SESSION_ID/fs/conflict.txt" | jq '.content'
+   ```
+
+6. Repeat steps 2-4 with `--conflict remote-wins`:
+   ```bash
+   # ... same setup, then sync with remote-wins
+   ```
+
+7. Check local file:
+   ```bash
+   cat "$TMPDIR/conflict.txt"
+   ```
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Step 4 output | Shows `! conflict: conflict.txt (local wins)` |
+| Step 5 (local-wins) | Remote contains `local version 2` |
+| Step 6/7 (remote-wins) | Local contains `remote version 2` |
+| Stats | `conflicts:1` in sync output |

--- a/test_cases/cli/TC007_files_binary_content.md
+++ b/test_cases/cli/TC007_files_binary_content.md
@@ -1,0 +1,55 @@
+# TC007: Files Push/Pull — Binary Content Handling
+
+## Description
+
+Verify that binary files (containing null bytes) are correctly handled with base64 encoding during push and pull operations.
+
+## Preconditions
+
+- API server running (`just start-dev` or `just start-all`)
+- An agent and session exist
+
+## Steps
+
+1. Create agent and session. Save `$SESSION_ID`.
+
+2. Create a binary file locally:
+   ```bash
+   TMPDIR=$(mktemp -d)
+   printf '\x00\x01\x02\x03\x04\x05' > "$TMPDIR/binary.bin"
+   echo "text file" > "$TMPDIR/text.txt"
+   ```
+
+3. Push files:
+   ```bash
+   EVERRUNS_API_URL=http://localhost:9300/api EVERRUNS_API_KEY=dev \
+     everruns files push --session $SESSION_ID "$TMPDIR"
+   ```
+
+4. Verify remote encoding:
+   ```bash
+   curl -s "http://localhost:9300/api/v1/sessions/$SESSION_ID/fs/binary.bin" | jq '.encoding'
+   curl -s "http://localhost:9300/api/v1/sessions/$SESSION_ID/fs/text.txt" | jq '.encoding'
+   ```
+
+5. Pull to fresh directory:
+   ```bash
+   PULLDIR=$(mktemp -d)
+   EVERRUNS_API_URL=http://localhost:9300/api EVERRUNS_API_KEY=dev \
+     everruns files pull --session $SESSION_ID "$PULLDIR"
+   ```
+
+6. Verify binary file integrity:
+   ```bash
+   xxd "$PULLDIR/binary.bin" | head -1
+   diff "$TMPDIR/binary.bin" "$PULLDIR/binary.bin"
+   ```
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Step 3 | Both files pushed successfully |
+| Step 4 | `binary.bin` encoding is `base64`, `text.txt` is `text` |
+| Step 5 | Both files pulled |
+| Step 6 | Binary file identical after roundtrip (diff exits 0) |


### PR DESCRIPTION
## What
Add CLI file sync commands (`everruns files sync/push/pull/ls`) with TODO(sdk) markers for future SDK migration, comprehensive test coverage, and path traversal protection.

## Why
The CLI spec (`specs/cli.md`) defines file sync operations but they needed:
- TODO markers for SDK replacement (tracks everruns/sdk#60)
- Unit and integration tests (went from 24 to 84 tests)
- Manual test cases for QA (`test_cases/cli/`)
- Bug fixes found during smoke testing (API response format, change detection)
- Security hardening (path traversal protection)

## How
- **TODO markers**: Added `TODO(sdk)` comments to all raw reqwest call sites in `remote.rs`, `sessions.rs`, `capabilities.rs`, `mod.rs`
- **Tests**: 49 new unit tests (state, sync_engine, remote, ls), 11 integration tests, 7 manual test cases
- **Bug fix**: API returns `data` not `entries` for directory listings; fall back to `updated_at` when `content_hash` unavailable
- **Security**: `safe_local_path()` validates server-supplied paths cannot escape sync directory via traversal or absolute paths
- **Spec**: Renamed `specs/file-sync.md` → `specs/cli.md`, broadened to full CLI spec with all commands documented

## Risk
- Low — CLI-only changes, no server modifications
- Path traversal fix is additive protection
- API response parsing fix aligns with actual server behavior (verified via smoke tests)

## Checklist
- [x] Tests added or updated (84 total: 73 unit + 11 integration)
- [x] Backward compatibility considered (no breaking changes)