### PR TITLE
fix(grpc): add GetMessage RPC to replace O(n) message lookup

### DIFF
--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -35,6 +35,7 @@ service WorkerService {
     rpc SetSessionTitle(SetSessionTitleRequest) returns (SetSessionTitleResponse);
 
     // Message operations
+    rpc GetMessage(GetMessageRequest) returns (GetMessageResponse);
     rpc LoadMessages(LoadMessagesRequest) returns (LoadMessagesResponse);
     rpc AddMessage(AddMessageRequest) returns (AddMessageResponse);
 
@@ -414,6 +415,15 @@ message Message {
     optional string thinking_signature = 8;
     // External actor identity (for messages from external channels like Slack)
     optional google.protobuf.Struct external_actor = 9;
+}
+
+message GetMessageRequest {
+    Uuid session_id = 1;
+    Uuid message_id = 2;
+}
+
+message GetMessageResponse {
+    optional Message message = 1;
 }
 
 message LoadMessagesRequest {

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -748,6 +748,43 @@ fn json_value_to_proto(value: serde_json::Value) -> prost_types::Value {
     prost_types::Value { kind }
 }
 
+/// Convert a domain Message to a proto Message.
+fn message_to_proto(message: &everruns_core::Message) -> proto::Message {
+    use everruns_internal_protocol::{datetime_to_proto_timestamp, uuid_to_proto_uuid};
+
+    let content_json_val = serde_json::to_value(&message.content).unwrap_or_default();
+    let content = Some(everruns_internal_protocol::json_to_proto_list(
+        &content_json_val,
+    ));
+
+    let controls = message.controls.as_ref().map(|c| {
+        let json = serde_json::to_value(c).unwrap_or_default();
+        everruns_internal_protocol::json_to_proto_struct(&json)
+    });
+
+    let metadata = message.metadata.as_ref().map(|m| {
+        let json = serde_json::to_value(m).unwrap_or_default();
+        everruns_internal_protocol::json_to_proto_struct(&json)
+    });
+
+    let external_actor = message.external_actor.as_ref().map(|ea| {
+        let json = serde_json::to_value(ea).unwrap_or_default();
+        everruns_internal_protocol::json_to_proto_struct(&json)
+    });
+
+    proto::Message {
+        id: Some(uuid_to_proto_uuid(message.id.uuid())),
+        role: message.role.to_string(),
+        content,
+        controls,
+        metadata,
+        created_at: Some(datetime_to_proto_timestamp(message.created_at)),
+        thinking: message.thinking.clone(),
+        thinking_signature: message.thinking_signature.clone(),
+        external_actor,
+    }
+}
+
 /// Extract a Message from an Event's data field
 ///
 /// Events returned from EventService already have data parsed into EventData.
@@ -898,38 +935,7 @@ impl WorkerService for WorkerServiceImpl {
                 }
             };
 
-            // Convert to proto Message using prost types
-            let content_json_val = serde_json::to_value(&message.content).unwrap_or_default();
-            let content = Some(everruns_internal_protocol::json_to_proto_list(
-                &content_json_val,
-            ));
-
-            let controls = message.controls.as_ref().map(|c| {
-                let json = serde_json::to_value(c).unwrap_or_default();
-                everruns_internal_protocol::json_to_proto_struct(&json)
-            });
-
-            let metadata = message.metadata.as_ref().map(|m| {
-                let json = serde_json::to_value(m).unwrap_or_default();
-                everruns_internal_protocol::json_to_proto_struct(&json)
-            });
-
-            let external_actor = message.external_actor.as_ref().map(|ea| {
-                let json = serde_json::to_value(ea).unwrap_or_default();
-                everruns_internal_protocol::json_to_proto_struct(&json)
-            });
-
-            proto_messages.push(proto::Message {
-                id: Some(uuid_to_proto_uuid(message.id.uuid())),
-                role: message.role.to_string(),
-                content,
-                controls,
-                metadata,
-                created_at: Some(datetime_to_proto_timestamp(message.created_at)),
-                thinking: message.thinking.clone(),
-                thinking_signature: message.thinking_signature.clone(),
-                external_actor,
-            });
+            proto_messages.push(message_to_proto(&message));
         }
 
         // Get model with provider (decrypted API key) via LlmResolverService
@@ -1241,53 +1247,25 @@ impl WorkerService for WorkerServiceImpl {
             .await
             .map_err(|e| Status::internal(format!("Failed to list messages: {}", e)))?;
 
-        use everruns_internal_protocol::{datetime_to_proto_timestamp, uuid_to_proto_uuid};
-
         for event in events {
             let message = match event_to_message(&event) {
                 Some(m) => m,
-                None => continue,
+                None => {
+                    tracing::warn!(
+                        "Failed to extract message from event {}: type={}",
+                        event.id,
+                        event.event_type
+                    );
+                    continue;
+                }
             };
 
             if message.id.uuid() != message_id {
                 continue;
             }
 
-            // Convert to proto Message
-            let content_json_val = serde_json::to_value(&message.content).unwrap_or_default();
-            let content = Some(everruns_internal_protocol::json_to_proto_list(
-                &content_json_val,
-            ));
-
-            let controls = message.controls.as_ref().map(|c| {
-                let json = serde_json::to_value(c).unwrap_or_default();
-                everruns_internal_protocol::json_to_proto_struct(&json)
-            });
-
-            let metadata = message.metadata.as_ref().map(|m| {
-                let json = serde_json::to_value(m).unwrap_or_default();
-                everruns_internal_protocol::json_to_proto_struct(&json)
-            });
-
-            let external_actor = message.external_actor.as_ref().map(|ea| {
-                let json = serde_json::to_value(ea).unwrap_or_default();
-                everruns_internal_protocol::json_to_proto_struct(&json)
-            });
-
-            let proto_msg = proto::Message {
-                id: Some(uuid_to_proto_uuid(message.id.uuid())),
-                role: message.role.to_string(),
-                content,
-                controls,
-                metadata,
-                created_at: Some(datetime_to_proto_timestamp(message.created_at)),
-                thinking: message.thinking.clone(),
-                thinking_signature: message.thinking_signature.clone(),
-                external_actor,
-            };
-
             return Ok(Response::new(GetMessageResponse {
-                message: Some(proto_msg),
+                message: Some(message_to_proto(&message)),
             }));
         }
 
@@ -1309,8 +1287,6 @@ impl WorkerService for WorkerServiceImpl {
             .await
             .map_err(|e| Status::internal(format!("Failed to list messages: {}", e)))?;
 
-        use everruns_internal_protocol::{datetime_to_proto_timestamp, uuid_to_proto_uuid};
-
         let mut proto_messages: Vec<proto::Message> = Vec::with_capacity(events.len());
 
         for event in events {
@@ -1327,38 +1303,7 @@ impl WorkerService for WorkerServiceImpl {
                 }
             };
 
-            // Convert to proto Message using prost types
-            let content_json_val = serde_json::to_value(&message.content).unwrap_or_default();
-            let content = Some(everruns_internal_protocol::json_to_proto_list(
-                &content_json_val,
-            ));
-
-            let controls = message.controls.as_ref().map(|c| {
-                let json = serde_json::to_value(c).unwrap_or_default();
-                everruns_internal_protocol::json_to_proto_struct(&json)
-            });
-
-            let metadata = message.metadata.as_ref().map(|m| {
-                let json = serde_json::to_value(m).unwrap_or_default();
-                everruns_internal_protocol::json_to_proto_struct(&json)
-            });
-
-            let external_actor = message.external_actor.as_ref().map(|ea| {
-                let json = serde_json::to_value(ea).unwrap_or_default();
-                everruns_internal_protocol::json_to_proto_struct(&json)
-            });
-
-            proto_messages.push(proto::Message {
-                id: Some(uuid_to_proto_uuid(message.id.uuid())),
-                role: message.role.to_string(),
-                content,
-                controls,
-                metadata,
-                created_at: Some(datetime_to_proto_timestamp(message.created_at)),
-                thinking: message.thinking.clone(),
-                thinking_signature: message.thinking_signature.clone(),
-                external_actor,
-            });
+            proto_messages.push(message_to_proto(&message));
         }
 
         Ok(Response::new(LoadMessagesResponse {

--- a/crates/server/src/grpc_service.rs
+++ b/crates/server/src/grpc_service.rs
@@ -74,6 +74,8 @@ use everruns_internal_protocol::proto::{
     GetHarnessResponse,
     GetMcpServerByPrefixRequest,
     GetMcpServerByPrefixResponse,
+    GetMessageRequest,
+    GetMessageResponse,
     GetModelWithProviderRequest,
     GetModelWithProviderResponse,
     GetSessionRequest,
@@ -1222,6 +1224,75 @@ impl WorkerService for WorkerServiceImpl {
         Ok(Response::new(SetSessionTitleResponse {
             session: Some(proto_session),
         }))
+    }
+
+    async fn get_message(
+        &self,
+        request: Request<GetMessageRequest>,
+    ) -> Result<Response<GetMessageResponse>, Status> {
+        let req = request.into_inner();
+        let session_id = parse_uuid(req.session_id.as_ref())?;
+        let message_id = parse_uuid(req.message_id.as_ref())?;
+
+        // Load message events and find the one matching message_id
+        let events = self
+            .event_service
+            .list_message_events(session_id)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to list messages: {}", e)))?;
+
+        use everruns_internal_protocol::{datetime_to_proto_timestamp, uuid_to_proto_uuid};
+
+        for event in events {
+            let message = match event_to_message(&event) {
+                Some(m) => m,
+                None => continue,
+            };
+
+            if message.id.uuid() != message_id {
+                continue;
+            }
+
+            // Convert to proto Message
+            let content_json_val = serde_json::to_value(&message.content).unwrap_or_default();
+            let content = Some(everruns_internal_protocol::json_to_proto_list(
+                &content_json_val,
+            ));
+
+            let controls = message.controls.as_ref().map(|c| {
+                let json = serde_json::to_value(c).unwrap_or_default();
+                everruns_internal_protocol::json_to_proto_struct(&json)
+            });
+
+            let metadata = message.metadata.as_ref().map(|m| {
+                let json = serde_json::to_value(m).unwrap_or_default();
+                everruns_internal_protocol::json_to_proto_struct(&json)
+            });
+
+            let external_actor = message.external_actor.as_ref().map(|ea| {
+                let json = serde_json::to_value(ea).unwrap_or_default();
+                everruns_internal_protocol::json_to_proto_struct(&json)
+            });
+
+            let proto_msg = proto::Message {
+                id: Some(uuid_to_proto_uuid(message.id.uuid())),
+                role: message.role.to_string(),
+                content,
+                controls,
+                metadata,
+                created_at: Some(datetime_to_proto_timestamp(message.created_at)),
+                thinking: message.thinking.clone(),
+                thinking_signature: message.thinking_signature.clone(),
+                external_actor,
+            };
+
+            return Ok(Response::new(GetMessageResponse {
+                message: Some(proto_msg),
+            }));
+        }
+
+        // Message not found
+        Ok(Response::new(GetMessageResponse { message: None }))
     }
 
     async fn load_messages(

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -351,10 +351,23 @@ impl GrpcMessageRetriever {
 #[async_trait]
 impl MessageRetriever for GrpcMessageRetriever {
     async fn get(&self, session_id: SessionId, message_id: MessageId) -> Result<Option<Message>> {
-        // Load all messages and find the one we want
-        // TODO: Add a specific get_message RPC
-        let messages = self.load(session_id).await?;
-        Ok(messages.into_iter().find(|m| m.id == message_id))
+        let mut client = self.client.inner.lock().await;
+
+        let request = proto::GetMessageRequest {
+            session_id: Some(uuid_to_proto(session_id.uuid())),
+            message_id: Some(uuid_to_proto(message_id.uuid())),
+        };
+
+        let response = client
+            .get_message(request)
+            .await
+            .map_err(|e| grpc_error(format!("gRPC get_message failed: {}", e)))?;
+
+        response
+            .into_inner()
+            .message
+            .map(proto_message_to_message)
+            .transpose()
     }
 
     async fn load(&self, session_id: SessionId) -> Result<Vec<Message>> {


### PR DESCRIPTION
## What
Add a dedicated `GetMessage` gRPC RPC so the worker can fetch a single message by ID instead of loading all messages and filtering client-side.

## Why
`GrpcMessageRetriever::get()` loaded ALL messages via `LoadMessages` RPC then did `.find()` — O(n) network transfer for a single message lookup. The code had a TODO acknowledging the missing RPC.

## How
- Added `GetMessageRequest`/`GetMessageResponse` to `worker.proto`
- Implemented `get_message` handler in `grpc_service.rs` (server side)
- Updated `GrpcMessageRetriever::get()` in `grpc_adapters.rs` to call the new RPC

The server-side handler still iterates events (a direct DB query can optimize later), but the key win is transferring only 1 message over gRPC instead of all messages.

## Risk
- Low
- Only changes the internal gRPC protocol between server and worker. No external API surface affected.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (internal protocol, worker and server deploy together)

Fixes EVE-107