### PR TITLE
fix(ui): add informative tooltip to chat sidebar warning badge — Fixes EVE-147

### DIFF
--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -68,12 +68,14 @@ jest.mock("@/providers/feature-flags-provider", () => ({
   }),
 }));
 
-// Mock LLM providers hook (default: providers configured, no warning)
+/// Mock LLM providers hook (default: providers configured, no warning)
+const mockUseLlmProviders = jest.fn(() => ({
+  data: [{ id: "provider-1", name: "Test Provider" }],
+  isLoading: false,
+  isError: false,
+}));
 jest.mock("@/hooks/use-llm-providers", () => ({
-  useLlmProviders: () => ({
-    data: [{ id: "provider-1", name: "Test Provider" }],
-    isLoading: false,
-  }),
+  useLlmProviders: () => mockUseLlmProviders(),
 }));
 
 describe("Sidebar", () => {
@@ -411,5 +413,36 @@ describe("Create Organisation dialog", () => {
 
     expect(mockPush).not.toHaveBeenCalled();
     expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("shows chat warning badge when no LLM providers configured", () => {
+    mockUseLlmProviders.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<Sidebar />);
+
+    const warningBtn = screen.getByRole("button", {
+      name: /no llm provider configured/i,
+    });
+    expect(warningBtn).toBeInTheDocument();
+
+    // Restore default mock
+    mockUseLlmProviders.mockReturnValue({
+      data: [{ id: "provider-1", name: "Test Provider" }],
+      isLoading: false,
+      isError: false,
+    });
+  });
+
+  it("hides chat warning badge when LLM providers are configured", () => {
+    render(<Sidebar />);
+
+    const warningBtn = screen.queryByRole("button", {
+      name: /no llm provider configured/i,
+    });
+    expect(warningBtn).not.toBeInTheDocument();
   });
 });

--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -68,6 +68,14 @@ jest.mock("@/providers/feature-flags-provider", () => ({
   }),
 }));
 
+// Mock LLM providers hook (default: providers configured, no warning)
+jest.mock("@/hooks/use-llm-providers", () => ({
+  useLlmProviders: () => ({
+    data: [{ id: "provider-1", name: "Test Provider" }],
+    isLoading: false,
+  }),
+}));
+
 describe("Sidebar", () => {
   beforeEach(() => {
     mockPathname.mockReturnValue("/dashboard");

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -343,8 +343,7 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
     isError: llmProvidersError,
   } = useLlmProviders();
   const llmProvidersReady = !llmProvidersLoading && !llmProvidersError;
-  const shouldShowChatWarning =
-    llmProvidersReady && (!llmProviders || llmProviders.length === 0);
+  const shouldShowChatWarning = llmProvidersReady && (!llmProviders || llmProviders.length === 0);
 
   const baseSections = config?.navigation ?? defaultNavigationSections;
 

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -337,17 +337,23 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
   const [createOrgOpen, setCreateOrgOpen] = useState(false);
 
   // Check LLM provider availability for Chat warning badge
-  const { data: llmProviders } = useLlmProviders();
-  const hasLlmProviders = llmProviders && llmProviders.length > 0;
+  const {
+    data: llmProviders,
+    isLoading: llmProvidersLoading,
+    isError: llmProvidersError,
+  } = useLlmProviders();
+  const llmProvidersReady = !llmProvidersLoading && !llmProvidersError;
+  const shouldShowChatWarning =
+    llmProvidersReady && (!llmProviders || llmProviders.length === 0);
 
   const baseSections = config?.navigation ?? defaultNavigationSections;
 
   // Enrich Chat nav item with warning when no LLM providers configured
-  const sections = !hasLlmProviders
+  const sections = shouldShowChatWarning
     ? baseSections.map((section) => ({
         ...section,
         items: section.items.map((item) =>
-          item.name === "Chat" && item.flag === "global_chat"
+          item.href === "/chat"
             ? {
                 ...item,
                 warningTooltip:

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -74,8 +74,10 @@ import {
 } from "lucide-react";
 import { capabilityIconMap } from "@/lib/capability-icons";
 import { ExperimentalBadge } from "@/components/ui/experimental-badge";
+import { WarningBadge } from "@/components/ui/warning-badge";
 import { useCommandPalette } from "@/hooks/use-command-palette";
 import { NotificationBell } from "@/components/layout/notification-bell";
+import { useLlmProviders } from "@/hooks/use-llm-providers";
 import type { FeatureFlags } from "@/lib/api/types";
 
 const isDev = process.env.NODE_ENV === "development";
@@ -93,6 +95,8 @@ export type NavigationItem = {
   exact?: boolean;
   /** Show experimental badge */
   experimental?: boolean;
+  /** Show warning badge with this tooltip message */
+  warningTooltip?: string;
 };
 
 export type NavigationSection = {
@@ -198,7 +202,8 @@ function NavLink({
     >
       <item.icon className="icon-sharp h-[18px] w-[18px] shrink-0 stroke-[2.15]" />
       {item.name}
-      {item.experimental && <ExperimentalBadge />}
+      {item.warningTooltip && <WarningBadge tooltip={item.warningTooltip} />}
+      {item.experimental && !item.warningTooltip && <ExperimentalBadge />}
     </Link>
   );
 }
@@ -331,7 +336,28 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
   const { currentOrg, organizations, setCurrentOrg } = useOrg();
   const [createOrgOpen, setCreateOrgOpen] = useState(false);
 
-  const sections = config?.navigation ?? defaultNavigationSections;
+  // Check LLM provider availability for Chat warning badge
+  const { data: llmProviders } = useLlmProviders();
+  const hasLlmProviders = llmProviders && llmProviders.length > 0;
+
+  const baseSections = config?.navigation ?? defaultNavigationSections;
+
+  // Enrich Chat nav item with warning when no LLM providers configured
+  const sections = !hasLlmProviders
+    ? baseSections.map((section) => ({
+        ...section,
+        items: section.items.map((item) =>
+          item.name === "Chat" && item.flag === "global_chat"
+            ? {
+                ...item,
+                warningTooltip:
+                  "No LLM provider configured. Set one up in Settings \u2192 Providers to use Chat.",
+              }
+            : item,
+        ),
+      }))
+    : baseSections;
+
   const allSections = config?.extraSections ? [...sections, ...config.extraSections] : sections;
 
   const { setOpen: openCommandPalette } = useCommandPalette();

--- a/apps/ui/src/components/ui/warning-badge.tsx
+++ b/apps/ui/src/components/ui/warning-badge.tsx
@@ -1,0 +1,23 @@
+import { AlertTriangle } from "lucide-react";
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/components/ui/tooltip";
+
+/**
+ * Compact warning badge for sidebar nav items.
+ * Shows an alert triangle icon with a descriptive tooltip on hover.
+ */
+export function WarningBadge({ tooltip }: { tooltip: string }) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="ml-auto text-amber-500 cursor-default">
+            <AlertTriangle className="!size-3.5" />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>{tooltip}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/apps/ui/src/components/ui/warning-badge.tsx
+++ b/apps/ui/src/components/ui/warning-badge.tsx
@@ -10,9 +10,13 @@ export function WarningBadge({ tooltip }: { tooltip: string }) {
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>
-          <span className="ml-auto text-amber-500 cursor-default">
+          <button
+            type="button"
+            className="ml-auto text-amber-500 cursor-default"
+            aria-label={tooltip}
+          >
             <AlertTriangle className="!size-3.5" />
-          </span>
+          </button>
         </TooltipTrigger>
         <TooltipContent>
           <p>{tooltip}</p>


### PR DESCRIPTION
## What
Add a descriptive tooltip to the chat sidebar warning badge explaining why it appears.

## Why
Orange triangle warning badge next to "Chat" confused users who hadn't configured LLM providers. No indication of what the warning means or how to resolve it.

## How
- Created `WarningBadge` component with tooltip (consistent with existing `ExperimentalBadge` pattern)
- Sidebar now fetches LLM providers and shows tooltip: "No LLM provider configured. Set one up in Settings -> Providers to use Chat."
- Added `warningTooltip` field to `NavigationItem` type
- Updated sidebar tests with `useLlmProviders` mock

## Risk
- Low
- UI-only change, no backend impact

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

Fixes EVE-147