### PR TITLE
feat(skills): add ${SESSION_ID} and ${SKILL_DIR} variable substitution — Fixes EVE-141

### DIFF
--- a/crates/core/src/capabilities/skills.rs
+++ b/crates/core/src/capabilities/skills.rs
@@ -466,7 +466,7 @@ impl Tool for ActivateSkillFromVfsTool {
                 let skill_dir = format!("{}/{}", SKILLS_PATH, name);
                 let session_id_str = context.session_id.to_string();
                 let substituted =
-                    crate::skill::substitute_env_vars(&expanded, &session_id_str, &skill_dir);
+                    crate::skill::substitute_activation_vars(&expanded, &session_id_str, &skill_dir);
                 let executor = crate::skill::ProcessCommandExecutor::default();
                 let preprocessed =
                     crate::skill::preprocess_command_injections(&substituted, &executor).await;

--- a/crates/core/src/capabilities/skills.rs
+++ b/crates/core/src/capabilities/skills.rs
@@ -465,8 +465,11 @@ impl Tool for ActivateSkillFromVfsTool {
                     crate::skill::expand_skill_arguments(&parsed.instructions, skill_args);
                 let skill_dir = format!("{}/{}", SKILLS_PATH, name);
                 let session_id_str = context.session_id.to_string();
-                let substituted =
-                    crate::skill::substitute_activation_vars(&expanded, &session_id_str, &skill_dir);
+                let substituted = crate::skill::substitute_activation_vars(
+                    &expanded,
+                    &session_id_str,
+                    &skill_dir,
+                );
                 let executor = crate::skill::ProcessCommandExecutor::default();
                 let preprocessed =
                     crate::skill::preprocess_command_injections(&substituted, &executor).await;

--- a/crates/core/src/capabilities/skills.rs
+++ b/crates/core/src/capabilities/skills.rs
@@ -460,12 +460,16 @@ impl Tool for ActivateSkillFromVfsTool {
         let content = file.content.as_deref().unwrap_or("");
         match crate::skill::parse_skill_md(content) {
             Ok(parsed) => {
-                // Apply argument substitution, then command injection preprocessing
+                // Apply substitution pipeline: arguments → env vars → command injection
                 let expanded =
                     crate::skill::expand_skill_arguments(&parsed.instructions, skill_args);
+                let skill_dir = format!("{}/{}", SKILLS_PATH, name);
+                let session_id_str = context.session_id.to_string();
+                let substituted =
+                    crate::skill::substitute_env_vars(&expanded, &session_id_str, &skill_dir);
                 let executor = crate::skill::ProcessCommandExecutor::default();
                 let preprocessed =
-                    crate::skill::preprocess_command_injections(&expanded, &executor).await;
+                    crate::skill::preprocess_command_injections(&substituted, &executor).await;
                 let instructions = format!(
                     "<skill name=\"{}\">\n{}\n</skill>",
                     parsed.name, preprocessed
@@ -1816,6 +1820,100 @@ mod tests {
                     skills[0]["description"],
                     "Description with: colons, #hashtags, and \"quotes\""
                 );
+            }
+            other => panic!("Expected Success, got: {:?}", other),
+        }
+    }
+
+    // ========================================================================
+    // activate_skill env var substitution tests
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_activate_skill_substitutes_session_id() {
+        let fs = Arc::new(MockFileStore::new());
+        let session_id = SessionId::new();
+        let skill_md =
+            "---\nname: test-env\ndescription: Test env vars.\n---\n\nSession: ${SESSION_ID}";
+        fs.add_file(session_id, "/.agents/skills/test-env/SKILL.md", skill_md);
+
+        let context = ToolContext::with_file_store(session_id, fs);
+        let tool = ActivateSkillFromVfsTool;
+
+        let result = tool
+            .execute_with_context(serde_json::json!({"name": "test-env"}), &context)
+            .await;
+        match result {
+            ToolExecutionResult::Success(val) => {
+                let instructions = val["instructions"].as_str().unwrap();
+                let expected_id = session_id.to_string();
+                assert!(
+                    instructions.contains(&expected_id),
+                    "Instructions should contain session ID '{}', got: {}",
+                    expected_id,
+                    instructions
+                );
+                assert!(
+                    !instructions.contains("${SESSION_ID}"),
+                    "Raw placeholder should be replaced"
+                );
+            }
+            other => panic!("Expected Success, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_activate_skill_substitutes_skill_dir() {
+        let fs = Arc::new(MockFileStore::new());
+        let session_id = SessionId::new();
+        let skill_md =
+            "---\nname: test-dir\ndescription: Test skill dir.\n---\n\nDir: ${SKILL_DIR}";
+        fs.add_file(session_id, "/.agents/skills/test-dir/SKILL.md", skill_md);
+
+        let context = ToolContext::with_file_store(session_id, fs);
+        let tool = ActivateSkillFromVfsTool;
+
+        let result = tool
+            .execute_with_context(serde_json::json!({"name": "test-dir"}), &context)
+            .await;
+        match result {
+            ToolExecutionResult::Success(val) => {
+                let instructions = val["instructions"].as_str().unwrap();
+                assert!(
+                    instructions.contains("/.agents/skills/test-dir"),
+                    "Instructions should contain skill dir path, got: {}",
+                    instructions
+                );
+                assert!(
+                    !instructions.contains("${SKILL_DIR}"),
+                    "Raw placeholder should be replaced"
+                );
+            }
+            other => panic!("Expected Success, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_activate_skill_substitutes_both_env_vars() {
+        let fs = Arc::new(MockFileStore::new());
+        let session_id = SessionId::new();
+        let skill_md = "---\nname: test-both\ndescription: Both vars.\n---\n\n${SKILL_DIR}/run.sh --session ${SESSION_ID}";
+        fs.add_file(session_id, "/.agents/skills/test-both/SKILL.md", skill_md);
+
+        let context = ToolContext::with_file_store(session_id, fs);
+        let tool = ActivateSkillFromVfsTool;
+
+        let result = tool
+            .execute_with_context(serde_json::json!({"name": "test-both"}), &context)
+            .await;
+        match result {
+            ToolExecutionResult::Success(val) => {
+                let instructions = val["instructions"].as_str().unwrap();
+                let expected_id = session_id.to_string();
+                assert!(instructions.contains("/.agents/skills/test-both/run.sh"));
+                assert!(instructions.contains(&format!("--session {}", expected_id)));
+                assert!(!instructions.contains("${SESSION_ID}"));
+                assert!(!instructions.contains("${SKILL_DIR}"));
             }
             other => panic!("Expected Success, got: {:?}", other),
         }

--- a/crates/core/src/skill.rs
+++ b/crates/core/src/skill.rs
@@ -559,6 +559,23 @@ pub fn expand_skill_arguments(content: &str, raw_args: &str) -> String {
 }
 
 // ============================================================================
+// Environment Variable Substitution
+// ============================================================================
+
+/// Substitute environment variables in skill content.
+///
+/// Replaces:
+/// - `${SESSION_ID}` → current session's prefixed ID (e.g. `session_01abc...`)
+/// - `${SKILL_DIR}` → absolute path to the skill's directory
+///
+/// Called after `$ARGUMENTS`/`$N` substitution, before `!command` preprocessing.
+pub fn substitute_env_vars(content: &str, session_id: &str, skill_dir: &str) -> String {
+    content
+        .replace("${SESSION_ID}", session_id)
+        .replace("${SKILL_DIR}", skill_dir)
+}
+
+// ============================================================================
 // Dynamic Context Injection: !`command` preprocessing
 // ============================================================================
 
@@ -1255,6 +1272,55 @@ Body.
     fn test_split_skill_args_extra_whitespace() {
         let args = split_skill_args("  a   b  ");
         assert_eq!(args, vec!["a", "b"]);
+    }
+
+    // ========================================================================
+    // substitute_env_vars tests
+    // ========================================================================
+
+    #[test]
+    fn test_substitute_session_id() {
+        let content = "Session: ${SESSION_ID}";
+        let result = substitute_env_vars(content, "session_01abc123", "/some/dir");
+        assert_eq!(result, "Session: session_01abc123");
+    }
+
+    #[test]
+    fn test_substitute_skill_dir_filesystem() {
+        let content = "Dir: ${SKILL_DIR}";
+        let result = substitute_env_vars(content, "session_x", "/home/user/skills/my-skill");
+        assert_eq!(result, "Dir: /home/user/skills/my-skill");
+    }
+
+    #[test]
+    fn test_substitute_skill_dir_db_backed() {
+        let content = "Dir: ${SKILL_DIR}";
+        let result = substitute_env_vars(content, "session_x", "/.agents/skills/my-skill");
+        assert_eq!(result, "Dir: /.agents/skills/my-skill");
+    }
+
+    #[test]
+    fn test_substitute_both_vars() {
+        let content = "Run: ${SKILL_DIR}/run.sh --session ${SESSION_ID}";
+        let result = substitute_env_vars(content, "session_01abc", "/.agents/skills/data-tool");
+        assert_eq!(
+            result,
+            "Run: /.agents/skills/data-tool/run.sh --session session_01abc"
+        );
+    }
+
+    #[test]
+    fn test_substitute_no_vars() {
+        let content = "No variables here.";
+        let result = substitute_env_vars(content, "session_x", "/dir");
+        assert_eq!(result, "No variables here.");
+    }
+
+    #[test]
+    fn test_substitute_multiple_occurrences() {
+        let content = "${SESSION_ID} and ${SESSION_ID} again";
+        let result = substitute_env_vars(content, "session_abc", "/dir");
+        assert_eq!(result, "session_abc and session_abc again");
     }
 
     // ========================================================================

--- a/crates/core/src/skill.rs
+++ b/crates/core/src/skill.rs
@@ -562,14 +562,14 @@ pub fn expand_skill_arguments(content: &str, raw_args: &str) -> String {
 // Environment Variable Substitution
 // ============================================================================
 
-/// Substitute environment variables in skill content.
+/// Substitute activation-time placeholders in skill content.
 ///
 /// Replaces:
 /// - `${SESSION_ID}` → current session's prefixed ID (e.g. `session_01abc...`)
 /// - `${SKILL_DIR}` → absolute path to the skill's directory
 ///
 /// Called after `$ARGUMENTS`/`$N` substitution, before `!command` preprocessing.
-pub fn substitute_env_vars(content: &str, session_id: &str, skill_dir: &str) -> String {
+pub fn substitute_activation_vars(content: &str, session_id: &str, skill_dir: &str) -> String {
     content
         .replace("${SESSION_ID}", session_id)
         .replace("${SKILL_DIR}", skill_dir)
@@ -1275,34 +1275,34 @@ Body.
     }
 
     // ========================================================================
-    // substitute_env_vars tests
+    // substitute_activation_vars tests
     // ========================================================================
 
     #[test]
     fn test_substitute_session_id() {
         let content = "Session: ${SESSION_ID}";
-        let result = substitute_env_vars(content, "session_01abc123", "/some/dir");
+        let result = substitute_activation_vars(content, "session_01abc123", "/some/dir");
         assert_eq!(result, "Session: session_01abc123");
     }
 
     #[test]
     fn test_substitute_skill_dir_filesystem() {
         let content = "Dir: ${SKILL_DIR}";
-        let result = substitute_env_vars(content, "session_x", "/home/user/skills/my-skill");
+        let result = substitute_activation_vars(content, "session_x", "/home/user/skills/my-skill");
         assert_eq!(result, "Dir: /home/user/skills/my-skill");
     }
 
     #[test]
     fn test_substitute_skill_dir_db_backed() {
         let content = "Dir: ${SKILL_DIR}";
-        let result = substitute_env_vars(content, "session_x", "/.agents/skills/my-skill");
+        let result = substitute_activation_vars(content, "session_x", "/.agents/skills/my-skill");
         assert_eq!(result, "Dir: /.agents/skills/my-skill");
     }
 
     #[test]
     fn test_substitute_both_vars() {
         let content = "Run: ${SKILL_DIR}/run.sh --session ${SESSION_ID}";
-        let result = substitute_env_vars(content, "session_01abc", "/.agents/skills/data-tool");
+        let result = substitute_activation_vars(content, "session_01abc", "/.agents/skills/data-tool");
         assert_eq!(
             result,
             "Run: /.agents/skills/data-tool/run.sh --session session_01abc"
@@ -1312,14 +1312,14 @@ Body.
     #[test]
     fn test_substitute_no_vars() {
         let content = "No variables here.";
-        let result = substitute_env_vars(content, "session_x", "/dir");
+        let result = substitute_activation_vars(content, "session_x", "/dir");
         assert_eq!(result, "No variables here.");
     }
 
     #[test]
     fn test_substitute_multiple_occurrences() {
         let content = "${SESSION_ID} and ${SESSION_ID} again";
-        let result = substitute_env_vars(content, "session_abc", "/dir");
+        let result = substitute_activation_vars(content, "session_abc", "/dir");
         assert_eq!(result, "session_abc and session_abc again");
     }
 

--- a/crates/core/src/skill.rs
+++ b/crates/core/src/skill.rs
@@ -1302,7 +1302,8 @@ Body.
     #[test]
     fn test_substitute_both_vars() {
         let content = "Run: ${SKILL_DIR}/run.sh --session ${SESSION_ID}";
-        let result = substitute_activation_vars(content, "session_01abc", "/.agents/skills/data-tool");
+        let result =
+            substitute_activation_vars(content, "session_01abc", "/.agents/skills/data-tool");
         assert_eq!(
             result,
             "Run: /.agents/skills/data-tool/run.sh --session session_01abc"


### PR DESCRIPTION
## What
Support `${SESSION_ID}` and `${SKILL_DIR}` variable substitution in skill content at activation time.

## Why
Skill authors must hardcode paths or discover session info at runtime. These variables let skills reference bundled scripts (`${SKILL_DIR}/scripts/analyze.py`) and create session-specific output (`logs/${SESSION_ID}.log`).

## How
- Added `substitute_env_vars()` in `crates/core/src/skill.rs` with 6 unit tests
- Integrated into `ActivateSkillFromVfsTool` pipeline in `capabilities/skills.rs` (after `$ARGUMENTS`, before `!command`)
- For VFS-based skills, `${SKILL_DIR}` resolves to `/.agents/skills/{name}`
- Added 3 integration tests through the full tool execution path

## Risk
- Low
- Additive feature. Only affects skills that use `${SESSION_ID}` or `${SKILL_DIR}` — existing skills unaffected.

## Checklist
- [x] Tests added or updated (6 unit + 3 integration)
- [x] Backward compatibility considered (additive, no breaking changes)

Fixes EVE-141