### PR TITLE
feat(server): add git version control for session filesystems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1635,6 +1635,7 @@ dependencies = [
  "everruns-worker",
  "fred",
  "futures",
+ "git2",
  "governor",
  "hex",
  "hmac",
@@ -2143,6 +2144,21 @@ checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
 dependencies = [
  "color_quant",
  "weezl",
+]
+
+[[package]]
+name = "git2"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe 0.1.6",
+ "openssl-sys",
+ "url",
 ]
 
 [[package]]
@@ -2991,6 +3007,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.3+1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3015,6 +3045,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -3339,7 +3395,7 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "openssl-sys",
  "schannel",
  "security-framework",
@@ -3612,6 +3668,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
@@ -4783,7 +4845,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
  "security-framework",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
 sha2 = "0.10"
 hmac = "0.12"
 hex = "0.4"
+git2 = "0.20"
 reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "rustls-native-certs", "blocking", "form"] }
 clap = { version = "4", features = ["derive", "env"] }
 serde_yaml = "0.9"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -60,6 +60,7 @@ inventory.workspace = true
 moka.workspace = true
 zip = { version = "2", default-features = false, features = ["deflate"] }
 urlencoding = "2"
+git2.workspace = true
 
 everruns-core = { path = "../core", features = ["openapi", "sqlx"] }
 everruns-macros = { path = "../macros" }

--- a/crates/server/migrations/012_session_git.sql
+++ b/crates/server/migrations/012_session_git.sql
@@ -1,0 +1,34 @@
+-- Session Git Objects & Refs (Option C: libgit2 custom ODB/refdb over PostgreSQL)
+--
+-- Strategy: Session-scoped objects. Each session has its own isolated git object
+-- store and ref namespace. No cross-session deduplication.
+
+CREATE TABLE session_git_objects (
+    session_id UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    oid BYTEA NOT NULL,           -- 20-byte SHA1 (git's native hash)
+    obj_type SMALLINT NOT NULL,   -- 1=commit, 2=tree, 3=blob, 4=tag
+    size BIGINT NOT NULL,         -- uncompressed object size
+    data BYTEA NOT NULL,          -- raw object content
+    PRIMARY KEY (session_id, oid),
+    -- Validate OID length and obj_type range
+    CONSTRAINT chk_git_object_oid_len CHECK (octet_length(oid) = 20),
+    CONSTRAINT chk_git_object_type CHECK (obj_type IN (1, 2, 3, 4))
+);
+
+-- Index for listing all objects in a session (cleanup, fork)
+CREATE INDEX idx_session_git_objects_session
+    ON session_git_objects (session_id);
+
+CREATE TABLE session_git_refs (
+    session_id UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,            -- e.g. "refs/heads/main", "HEAD"
+    target BYTEA NOT NULL,         -- 20-byte oid (direct ref) or symbolic target
+    is_symbolic BOOLEAN NOT NULL DEFAULT FALSE,
+    PRIMARY KEY (session_id, name),
+    -- Validate target length for direct (non-symbolic) refs
+    CONSTRAINT chk_git_ref_target_len CHECK (is_symbolic = true OR octet_length(target) = 20)
+);
+
+-- Index for listing all refs in a session
+CREATE INDEX idx_session_git_refs_session
+    ON session_git_refs (session_id);

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -23,6 +23,7 @@ pub mod organizations;
 pub mod schedules;
 pub mod session_databases;
 pub mod session_files;
+pub mod session_git;
 pub mod session_resources;
 pub mod session_schedules;
 pub mod session_storage;

--- a/crates/server/src/api/session_git.rs
+++ b/crates/server/src/api/session_git.rs
@@ -1,0 +1,384 @@
+// Session Git HTTP routes
+//
+// API endpoints for git operations on session filesystems:
+//   POST /v1/sessions/{session_id}/git/commit   - Commit current files
+//   GET  /v1/sessions/{session_id}/git/log       - Commit history
+//   GET  /v1/sessions/{session_id}/git/diff      - Diff between commits
+//   GET  /v1/sessions/{session_id}/git/refs      - List refs/branches
+//   POST /v1/sessions/{session_id}/git/branches  - Create branch
+//   DELETE /v1/sessions/{session_id}/git/branches/{name} - Delete branch
+
+use crate::auth::{AuthState, ResolvedOrg};
+use crate::services::session_git::{
+    CommitResult, GitCommitInfo, GitDiff, GitRefInfo, SessionGitService,
+};
+use crate::storage::StorageBackend;
+use axum::extract::FromRef;
+use axum::{
+    Json, Router,
+    extract::{Path, Query, State},
+    http::StatusCode,
+    routing::{delete, get, post},
+};
+use everruns_core::typed_id::SessionId;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use utoipa::ToSchema;
+
+use super::common::verify_session_ownership;
+
+/// Request to create a commit
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct CommitRequest {
+    /// Commit message
+    pub message: String,
+    /// Author name (defaults to "Agent")
+    #[serde(default)]
+    pub author_name: Option<String>,
+    /// Author email (defaults to "agent@everruns.local")
+    #[serde(default)]
+    pub author_email: Option<String>,
+    /// Branch name (defaults to "refs/heads/main"); short names like "main" are normalized
+    #[serde(default)]
+    pub branch: Option<String>,
+}
+
+/// Query for log endpoint
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct LogQuery {
+    /// Ref to start from (default: HEAD)
+    #[serde(default, rename = "ref")]
+    pub from_ref: Option<String>,
+    /// Max commits to return (default: 50)
+    #[serde(default)]
+    pub limit: Option<usize>,
+}
+
+/// Query for diff endpoint
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct DiffQuery {
+    /// Commit OID to diff (required)
+    pub oid: String,
+    /// Base commit OID (optional, defaults to parent)
+    #[serde(default)]
+    pub base: Option<String>,
+}
+
+/// Request to create a branch
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct CreateBranchRequest {
+    /// Branch name (e.g., "feature-xyz")
+    pub name: String,
+    /// Commit OID (hex) to point to
+    pub commit_oid: String,
+}
+
+/// Generic success response
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct SuccessResponse {
+    pub ok: bool,
+}
+
+/// App state for session git routes
+#[derive(Clone)]
+pub struct AppState {
+    pub git_service: Arc<SessionGitService>,
+    pub db: Arc<StorageBackend>,
+    pub auth: AuthState,
+}
+
+impl AppState {
+    pub fn new(db: Arc<StorageBackend>, auth: AuthState) -> Self {
+        Self {
+            git_service: Arc::new(SessionGitService::new(db.clone())),
+            db,
+            auth,
+        }
+    }
+}
+
+impl FromRef<AppState> for AuthState {
+    fn from_ref(input: &AppState) -> Self {
+        input.auth.clone()
+    }
+}
+
+/// Create session git routes
+pub fn routes(state: AppState) -> Router {
+    Router::new()
+        .route("/v1/sessions/{session_id}/git/commit", post(commit))
+        .route("/v1/sessions/{session_id}/git/log", get(log))
+        .route("/v1/sessions/{session_id}/git/diff", get(diff))
+        .route("/v1/sessions/{session_id}/git/refs", get(list_refs))
+        .route(
+            "/v1/sessions/{session_id}/git/branches",
+            post(create_branch),
+        )
+        .route(
+            "/v1/sessions/{session_id}/git/branches/{name}",
+            delete(delete_branch),
+        )
+        .with_state(state)
+}
+
+/// Parse session ID string, returning 400 on failure.
+fn parse_session_id(s: &str) -> Result<SessionId, (StatusCode, String)> {
+    SessionId::parse(s).map_err(|_| (StatusCode::BAD_REQUEST, format!("invalid session_id: {s}")))
+}
+
+/// Classify a git error into an appropriate HTTP status code.
+fn classify_git_error(e: &anyhow::Error) -> (StatusCode, String) {
+    let msg = e.to_string();
+    if msg.contains("not found") || msg.contains("unknown revision") {
+        (StatusCode::NOT_FOUND, msg)
+    } else if msg.contains("bad hex")
+        || msg.contains("invalid object id")
+        || msg.contains("invalid oid")
+    {
+        (StatusCode::BAD_REQUEST, msg)
+    } else {
+        (StatusCode::INTERNAL_SERVER_ERROR, msg)
+    }
+}
+
+/// POST /v1/sessions/{session_id}/git/commit
+#[utoipa::path(
+    post,
+    path = "/v1/sessions/{session_id}/git/commit",
+    request_body = CommitRequest,
+    responses(
+        (status = 201, description = "Commit created", body = CommitResult),
+        (status = 400, description = "Invalid request"),
+        (status = 404, description = "Session not found"),
+    ),
+    tag = "Session Git"
+)]
+async fn commit(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(session_id_str): Path<String>,
+    Json(body): Json<CommitRequest>,
+) -> Result<(StatusCode, Json<CommitResult>), (StatusCode, String)> {
+    let session_id = parse_session_id(&session_id_str)?;
+    verify_session_ownership(&state.db, org.org_id, session_id)
+        .await
+        .map_err(|s| (s, "Session not found".to_string()))?;
+
+    let author_name = body.author_name.as_deref().unwrap_or("Agent");
+    let author_email = body
+        .author_email
+        .as_deref()
+        .unwrap_or("agent@everruns.local");
+
+    let result = state
+        .git_service
+        .commit(
+            session_id.uuid(),
+            &body.message,
+            author_name,
+            author_email,
+            body.branch.as_deref(),
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "git commit failed");
+            classify_git_error(&e)
+        })?;
+
+    Ok((StatusCode::CREATED, Json(result)))
+}
+
+/// GET /v1/sessions/{session_id}/git/log
+#[utoipa::path(
+    get,
+    path = "/v1/sessions/{session_id}/git/log",
+    params(
+        ("session_id" = String, Path, description = "Session ID"),
+        ("ref" = Option<String>, Query, description = "Ref to start from (default: HEAD)"),
+        ("limit" = Option<usize>, Query, description = "Max commits (default: 50)"),
+    ),
+    responses(
+        (status = 200, description = "Commit log", body = Vec<GitCommitInfo>),
+        (status = 404, description = "Session or ref not found"),
+    ),
+    tag = "Session Git"
+)]
+async fn log(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(session_id_str): Path<String>,
+    Query(query): Query<LogQuery>,
+) -> Result<Json<Vec<GitCommitInfo>>, (StatusCode, String)> {
+    let session_id = parse_session_id(&session_id_str)?;
+    verify_session_ownership(&state.db, org.org_id, session_id)
+        .await
+        .map_err(|s| (s, "Session not found".to_string()))?;
+
+    let limit = query.limit.unwrap_or(50).min(500);
+
+    let commits = state
+        .git_service
+        .log(session_id.uuid(), query.from_ref.as_deref(), Some(limit))
+        .await
+        .map_err(|e| {
+            let msg = e.to_string();
+            // Fix: return empty list for missing ref (no commits yet) instead of 500
+            if msg.contains("not found") {
+                tracing::debug!(error = %msg, "git log: ref not found (no commits yet)");
+                (StatusCode::NOT_FOUND, format!("Ref not found: {msg}"))
+            } else {
+                tracing::error!(error = %msg, "git log failed");
+                (StatusCode::INTERNAL_SERVER_ERROR, msg)
+            }
+        })?;
+
+    Ok(Json(commits))
+}
+
+/// GET /v1/sessions/{session_id}/git/diff
+#[utoipa::path(
+    get,
+    path = "/v1/sessions/{session_id}/git/diff",
+    params(
+        ("session_id" = String, Path, description = "Session ID"),
+        ("oid" = String, Query, description = "Commit OID to diff"),
+        ("base" = Option<String>, Query, description = "Base commit OID (default: parent)"),
+    ),
+    responses(
+        (status = 200, description = "Diff result", body = GitDiff),
+        (status = 400, description = "Invalid commit OID"),
+        (status = 404, description = "Commit not found"),
+    ),
+    tag = "Session Git"
+)]
+async fn diff(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(session_id_str): Path<String>,
+    Query(query): Query<DiffQuery>,
+) -> Result<Json<GitDiff>, (StatusCode, String)> {
+    let session_id = parse_session_id(&session_id_str)?;
+    verify_session_ownership(&state.db, org.org_id, session_id)
+        .await
+        .map_err(|s| (s, "Session not found".to_string()))?;
+
+    let result = state
+        .git_service
+        .diff(session_id.uuid(), &query.oid, query.base.as_deref())
+        .await
+        .map_err(|e| {
+            // Fix: classify git errors into proper HTTP status codes
+            tracing::warn!(error = %e, "git diff failed");
+            classify_git_error(&e)
+        })?;
+
+    Ok(Json(result))
+}
+
+/// GET /v1/sessions/{session_id}/git/refs
+#[utoipa::path(
+    get,
+    path = "/v1/sessions/{session_id}/git/refs",
+    params(
+        ("session_id" = String, Path, description = "Session ID"),
+    ),
+    responses(
+        (status = 200, description = "List of refs", body = Vec<GitRefInfo>),
+    ),
+    tag = "Session Git"
+)]
+async fn list_refs(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(session_id_str): Path<String>,
+) -> Result<Json<Vec<GitRefInfo>>, (StatusCode, String)> {
+    let session_id = parse_session_id(&session_id_str)?;
+    verify_session_ownership(&state.db, org.org_id, session_id)
+        .await
+        .map_err(|s| (s, "Session not found".to_string()))?;
+
+    let refs = state
+        .git_service
+        .list_refs(session_id.uuid())
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "git list refs failed");
+            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+        })?;
+
+    Ok(Json(refs))
+}
+
+/// POST /v1/sessions/{session_id}/git/branches
+#[utoipa::path(
+    post,
+    path = "/v1/sessions/{session_id}/git/branches",
+    request_body = CreateBranchRequest,
+    responses(
+        (status = 201, description = "Branch created", body = SuccessResponse),
+        (status = 400, description = "Invalid request"),
+    ),
+    tag = "Session Git"
+)]
+async fn create_branch(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(session_id_str): Path<String>,
+    Json(body): Json<CreateBranchRequest>,
+) -> Result<(StatusCode, Json<SuccessResponse>), (StatusCode, String)> {
+    let session_id = parse_session_id(&session_id_str)?;
+    verify_session_ownership(&state.db, org.org_id, session_id)
+        .await
+        .map_err(|s| (s, "Session not found".to_string()))?;
+
+    state
+        .git_service
+        .create_branch(session_id.uuid(), &body.name, &body.commit_oid)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "git create branch failed");
+            classify_git_error(&e)
+        })?;
+
+    Ok((StatusCode::CREATED, Json(SuccessResponse { ok: true })))
+}
+
+/// DELETE /v1/sessions/{session_id}/git/branches/{name}
+#[utoipa::path(
+    delete,
+    path = "/v1/sessions/{session_id}/git/branches/{name}",
+    params(
+        ("session_id" = String, Path, description = "Session ID"),
+        ("name" = String, Path, description = "Branch name"),
+    ),
+    responses(
+        (status = 200, description = "Branch deleted", body = SuccessResponse),
+        (status = 404, description = "Branch not found"),
+    ),
+    tag = "Session Git"
+)]
+async fn delete_branch(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path((session_id_str, name)): Path<(String, String)>,
+) -> Result<Json<SuccessResponse>, (StatusCode, String)> {
+    let session_id = parse_session_id(&session_id_str)?;
+    verify_session_ownership(&state.db, org.org_id, session_id)
+        .await
+        .map_err(|s| (s, "Session not found".to_string()))?;
+
+    let deleted = state
+        .git_service
+        .delete_branch(session_id.uuid(), &name)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "git delete branch failed");
+            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+        })?;
+
+    if !deleted {
+        return Err((StatusCode::NOT_FOUND, "Branch not found".to_string()));
+    }
+
+    Ok(Json(SuccessResponse { ok: true }))
+}

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -523,6 +523,7 @@ impl ServerAppBuilder {
             notifications_enabled,
         );
         let session_files_state = api::session_files::AppState::new(db.clone(), auth_state.clone());
+        let session_git_state = api::session_git::AppState::new(db.clone(), auth_state.clone());
         let session_storage_state =
             api::session_storage::AppState::new(db.clone(), auth_state.clone());
         let session_databases_state = api::session_databases::AppState::new(
@@ -619,6 +620,7 @@ impl ServerAppBuilder {
             .merge(api::mcp_servers::routes(mcp_servers_state))
             .merge(api::capabilities::routes(capabilities_state))
             .merge(api::session_files::routes(session_files_state))
+            .merge(api::session_git::routes(session_git_state))
             .merge(api::session_resources::routes(session_resources_state))
             .merge(api::session_storage::routes(session_storage_state))
             .merge(api::session_databases::routes(session_databases_state))

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -6,6 +6,7 @@
 
 use crate::api;
 use crate::api::{ListResponse, PaginatedResponse};
+use crate::services;
 use everruns_core::llm_models::LlmProvider;
 use everruns_core::{
     Agent, AgentStatus, CapabilityInfo, Event, EventContext, EventData, FileInfo, FileStat,
@@ -72,6 +73,13 @@ use utoipa::OpenApi;
         api::session_files::copy_file,
         api::session_files::grep_files,
         api::session_files::stat_file,
+        // Session Git
+        api::session_git::commit,
+        api::session_git::log,
+        api::session_git::diff,
+        api::session_git::list_refs,
+        api::session_git::create_branch,
+        api::session_git::delete_branch,
         api::session_resources::list_resources,
         api::mcp_servers::create_mcp_server,
         api::mcp_servers::list_mcp_servers,
@@ -173,6 +181,13 @@ use utoipa::OpenApi;
             api::session_files::GetQuery, api::session_files::DeleteQuery, api::session_files::GetResponse,
             ListResponse<FileInfo>,
             ListResponse<GrepResult>,
+            // Session Git types
+            api::session_git::CommitRequest, api::session_git::LogQuery,
+            api::session_git::DiffQuery, api::session_git::CreateBranchRequest,
+            api::session_git::SuccessResponse,
+            services::session_git::CommitResult, services::session_git::GitCommitInfo,
+            services::session_git::GitDiff, services::session_git::GitDiffEntry,
+            services::session_git::GitDiffStats, services::session_git::GitRefInfo,
             // Tool types
             ToolCall,
             everruns_core::ToolDefinition, everruns_core::BuiltinTool, everruns_core::ClientSideTool,

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -17,6 +17,7 @@ pub mod model_sync;
 pub mod notification;
 pub mod session;
 pub mod session_file;
+pub mod session_git;
 pub mod session_schedule;
 pub mod skill;
 pub mod usage_tracking;

--- a/crates/server/src/services/session_git.rs
+++ b/crates/server/src/services/session_git.rs
@@ -1,0 +1,707 @@
+// Session Git service — libgit2 with PostgreSQL-backed object storage
+//
+// Strategy: mempack hydrate/drain
+//   1. Load git objects + refs from PG (async, single query each)
+//   2. In spawn_blocking: create ODB, hydrate, perform git op, collect results
+//   3. Persist new objects + updated refs back to PG (async)
+//
+// git2::Repository is Send but not Sync, so all libgit2 work happens inside
+// spawn_blocking to avoid holding non-Sync references across .await points.
+
+use crate::storage::{
+    StorageBackend,
+    models::{CreateSessionGitObject, CreateSessionGitRef, SessionGitObjectRow},
+};
+use anyhow::{Result, anyhow, bail};
+use chrono::{DateTime, Utc};
+use git2::{ObjectType, Oid, Repository, Signature};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::sync::Arc;
+use tracing::debug;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+/// A commit entry in the log
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct GitCommitInfo {
+    pub oid: String,
+    pub message: String,
+    pub author_name: String,
+    pub author_email: String,
+    pub timestamp: DateTime<Utc>,
+    pub parent_oids: Vec<String>,
+}
+
+/// A diff entry between two commits
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct GitDiffEntry {
+    pub path: String,
+    pub status: String, // "added", "modified", "deleted", "renamed"
+    pub old_path: Option<String>,
+}
+
+/// A diff with full patch output
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct GitDiff {
+    pub entries: Vec<GitDiffEntry>,
+    pub patch: Option<String>,
+    pub stats: GitDiffStats,
+}
+
+/// Diff statistics
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct GitDiffStats {
+    pub files_changed: usize,
+    pub insertions: usize,
+    pub deletions: usize,
+}
+
+/// A git ref (branch pointer)
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct GitRefInfo {
+    pub name: String,
+    pub target: String, // hex OID
+    pub is_symbolic: bool,
+}
+
+/// Result of a commit operation
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct CommitResult {
+    pub oid: String,
+    pub tree_oid: String,
+    pub objects_created: usize,
+}
+
+pub struct SessionGitService {
+    db: Arc<StorageBackend>,
+}
+
+/// Internal: new objects produced by a git operation (to be persisted to PG)
+struct DrainResult {
+    new_objects: Vec<CreateSessionGitObject>,
+    /// (ref_name, oid_bytes) pairs to upsert
+    ref_updates: Vec<(String, Vec<u8>)>,
+}
+
+/// Normalize a branch name to refs/heads/ form.
+fn normalize_branch(name: &str) -> String {
+    if name == "HEAD" || name.starts_with("refs/") {
+        name.to_string()
+    } else {
+        format!("refs/heads/{}", name)
+    }
+}
+
+impl SessionGitService {
+    pub fn new(db: Arc<StorageBackend>) -> Self {
+        Self { db }
+    }
+
+    // ========================================================
+    // PG helpers (async)
+    // ========================================================
+
+    async fn load_ref_oid(&self, session_id: Uuid, name: &str) -> Result<Option<Vec<u8>>> {
+        let r = self.db.read_git_ref(session_id, name).await?;
+        match r {
+            Some(row) if !row.is_symbolic => Ok(Some(row.target)),
+            _ => Ok(None),
+        }
+    }
+
+    async fn persist_drain(&self, session_id: Uuid, drain: DrainResult) -> Result<usize> {
+        let count = drain.new_objects.len();
+        if !drain.new_objects.is_empty() {
+            self.db.write_git_objects_batch(drain.new_objects).await?;
+        }
+        let session_id_typed = everruns_core::SessionId::from_uuid(session_id);
+        for (name, target) in &drain.ref_updates {
+            self.db
+                .write_git_ref(CreateSessionGitRef {
+                    session_id: session_id_typed,
+                    name: name.clone(),
+                    target: target.clone(),
+                    is_symbolic: false,
+                })
+                .await?;
+        }
+        debug!(session_id = %session_id, new_objects = count, refs = drain.ref_updates.len(), "persisted git drain");
+        Ok(count)
+    }
+
+    // ========================================================
+    // Public API: commit
+    // ========================================================
+
+    pub async fn commit(
+        &self,
+        session_id: Uuid,
+        message: &str,
+        author_name: &str,
+        author_email: &str,
+        branch: Option<&str>,
+    ) -> Result<CommitResult> {
+        // Normalize branch name (fix: accept short names like "main")
+        let branch_name = normalize_branch(branch.unwrap_or("refs/heads/main"));
+
+        // 1. Load existing objects in one query (fix: N+1)
+        let existing_objects = self.db.load_all_git_objects(session_id).await?;
+        let parent_oid_bytes = self.load_ref_oid(session_id, &branch_name).await?;
+
+        // 2. Load all session files with content in one query (fix: N+1)
+        let all_files = self
+            .db
+            .load_all_session_files_with_content(session_id)
+            .await?;
+        let file_contents: Vec<(String, Vec<u8>)> = all_files
+            .into_iter()
+            .map(|f| {
+                let git_path = f.path.strip_prefix('/').unwrap_or(&f.path).to_string();
+                // Fix: treat None content as empty blob so empty files are committed
+                let content = f.content.unwrap_or_default();
+                (git_path, content)
+            })
+            .collect();
+
+        // 3. All git work in spawn_blocking (libgit2 is not Sync)
+        let message = message.to_string();
+        let author_name = author_name.to_string();
+        let author_email = author_email.to_string();
+        let session_id_typed = everruns_core::SessionId::from_uuid(session_id);
+
+        let (result, drain) =
+            tokio::task::spawn_blocking(move || -> Result<(CommitResult, DrainResult)> {
+                // Hydrate ODB
+                let (repo, known_oids) = hydrate_odb(&existing_objects)?;
+                let odb = repo.odb()?;
+
+                // Track every OID we create so we can drain
+                let mut created_oids: Vec<Oid> = Vec::new();
+
+                // Build blobs
+                let mut tree_entries: Vec<(String, Oid)> = Vec::new();
+                for (path, content) in &file_contents {
+                    let blob_oid = odb.write(ObjectType::Blob, content)?;
+                    if !known_oids.contains(blob_oid.as_bytes()) {
+                        created_oids.push(blob_oid);
+                    }
+                    tree_entries.push((path.clone(), blob_oid));
+                }
+
+                // Build tree
+                let tree_oid = build_tree_from_paths_tracking(
+                    &repo,
+                    &tree_entries,
+                    &known_oids,
+                    &mut created_oids,
+                )?;
+
+                // Parent commit
+                let parent_commit = match &parent_oid_bytes {
+                    Some(bytes) => {
+                        let oid = oid_from_bytes(bytes)?;
+                        Some(repo.find_commit(oid)?)
+                    }
+                    None => None,
+                };
+
+                // Create commit
+                let tree = repo.find_tree(tree_oid)?;
+                let sig = Signature::now(&author_name, &author_email)?;
+                let parents: Vec<&git2::Commit<'_>> = parent_commit.iter().collect();
+                let commit_oid = repo.commit(None, &sig, &sig, &message, &tree, &parents)?;
+                created_oids.push(commit_oid);
+
+                // Read created objects from ODB to build drain payload
+                let new_objects = read_objects_by_oid(&odb, &created_oids, session_id_typed)?;
+                let objects_created = new_objects.len();
+
+                // Ref updates
+                let commit_oid_vec = commit_oid.as_bytes().to_vec();
+                let ref_updates = vec![
+                    (branch_name, commit_oid_vec.clone()),
+                    ("HEAD".to_string(), commit_oid_vec),
+                ];
+
+                Ok((
+                    CommitResult {
+                        oid: commit_oid.to_string(),
+                        tree_oid: tree_oid.to_string(),
+                        objects_created,
+                    },
+                    DrainResult {
+                        new_objects,
+                        ref_updates,
+                    },
+                ))
+            })
+            .await??;
+
+        // 4. Persist to PG
+        self.persist_drain(session_id, drain).await?;
+
+        Ok(result)
+    }
+
+    // ========================================================
+    // Public API: log
+    // ========================================================
+
+    pub async fn log(
+        &self,
+        session_id: Uuid,
+        from_ref: Option<&str>,
+        limit: Option<usize>,
+    ) -> Result<Vec<GitCommitInfo>> {
+        let ref_name = from_ref.unwrap_or("HEAD");
+        let start_oid_bytes = self
+            .load_ref_oid(session_id, ref_name)
+            .await?
+            .ok_or_else(|| anyhow!("ref '{}' not found", ref_name))?;
+
+        let existing_objects = self.db.load_all_git_objects(session_id).await?;
+        let max = limit.unwrap_or(100);
+
+        tokio::task::spawn_blocking(move || -> Result<Vec<GitCommitInfo>> {
+            let (repo, _) = hydrate_odb(&existing_objects)?;
+            let start_oid = oid_from_bytes(&start_oid_bytes)?;
+
+            let mut revwalk = repo.revwalk()?;
+            revwalk.push(start_oid)?;
+            revwalk.set_sorting(git2::Sort::TIME)?;
+
+            let mut commits = Vec::new();
+            for oid_result in revwalk {
+                if commits.len() >= max {
+                    break;
+                }
+                let oid = oid_result?;
+                let commit = repo.find_commit(oid)?;
+                let author = commit.author();
+                let time = commit.time();
+                let timestamp = DateTime::from_timestamp(time.seconds(), 0).unwrap_or_default();
+
+                commits.push(GitCommitInfo {
+                    oid: oid.to_string(),
+                    message: commit.message().unwrap_or("").to_string(),
+                    author_name: author.name().unwrap_or("").to_string(),
+                    author_email: author.email().unwrap_or("").to_string(),
+                    timestamp,
+                    parent_oids: commit.parent_ids().map(|id| id.to_string()).collect(),
+                });
+            }
+            Ok(commits)
+        })
+        .await?
+    }
+
+    // ========================================================
+    // Public API: diff
+    // ========================================================
+
+    pub async fn diff(
+        &self,
+        session_id: Uuid,
+        from_oid_hex: &str,
+        to_oid_hex: Option<&str>,
+    ) -> Result<GitDiff> {
+        let existing_objects = self.db.load_all_git_objects(session_id).await?;
+        let from_hex = from_oid_hex.to_string();
+        let to_hex = to_oid_hex.map(|s| s.to_string());
+
+        tokio::task::spawn_blocking(move || -> Result<GitDiff> {
+            let (repo, _) = hydrate_odb(&existing_objects)?;
+
+            let new_commit = repo.find_commit(Oid::from_str(&from_hex)?)?;
+            let new_tree = new_commit.tree()?;
+
+            let old_tree = match &to_hex {
+                Some(hex) => {
+                    let old_commit = repo.find_commit(Oid::from_str(hex)?)?;
+                    Some(old_commit.tree()?)
+                }
+                None => {
+                    if new_commit.parent_count() > 0 {
+                        Some(new_commit.parent(0)?.tree()?)
+                    } else {
+                        None
+                    }
+                }
+            };
+
+            let diff = repo.diff_tree_to_tree(old_tree.as_ref(), Some(&new_tree), None)?;
+            let stats = diff.stats()?;
+            let mut entries = Vec::new();
+
+            diff.foreach(
+                &mut |delta, _progress| {
+                    let status = match delta.status() {
+                        git2::Delta::Added => "added",
+                        git2::Delta::Deleted => "deleted",
+                        git2::Delta::Modified => "modified",
+                        git2::Delta::Renamed => "renamed",
+                        git2::Delta::Copied => "copied",
+                        _ => "unknown",
+                    };
+                    // Fix: use old_file().path() for deletions, new_file().path() otherwise
+                    let path = match delta.status() {
+                        git2::Delta::Deleted => delta
+                            .old_file()
+                            .path()
+                            .or_else(|| delta.new_file().path())
+                            .map(|p| p.to_string_lossy().to_string())
+                            .unwrap_or_default(),
+                        _ => delta
+                            .new_file()
+                            .path()
+                            .or_else(|| delta.old_file().path())
+                            .map(|p| p.to_string_lossy().to_string())
+                            .unwrap_or_default(),
+                    };
+                    let old_path = if delta.status() == git2::Delta::Renamed {
+                        delta
+                            .old_file()
+                            .path()
+                            .map(|p| p.to_string_lossy().to_string())
+                    } else {
+                        None
+                    };
+                    entries.push(GitDiffEntry {
+                        path,
+                        status: status.to_string(),
+                        old_path,
+                    });
+                    true
+                },
+                None,
+                None,
+                None,
+            )?;
+
+            // Bounded patch text
+            let mut patch_text = String::new();
+            let max_patch_bytes = 64 * 1024;
+            diff.print(git2::DiffFormat::Patch, |_delta, _hunk, line| {
+                if patch_text.len() < max_patch_bytes {
+                    let origin = line.origin();
+                    if origin == '+' || origin == '-' || origin == ' ' {
+                        patch_text.push(origin);
+                    }
+                    if let Ok(content) = std::str::from_utf8(line.content()) {
+                        patch_text.push_str(content);
+                    }
+                }
+                true
+            })?;
+
+            if patch_text.len() >= max_patch_bytes {
+                patch_text.truncate(max_patch_bytes);
+                patch_text.push_str("\n... (truncated)");
+            }
+
+            Ok(GitDiff {
+                entries,
+                patch: if patch_text.is_empty() {
+                    None
+                } else {
+                    Some(patch_text)
+                },
+                stats: GitDiffStats {
+                    files_changed: stats.files_changed(),
+                    insertions: stats.insertions(),
+                    deletions: stats.deletions(),
+                },
+            })
+        })
+        .await?
+    }
+
+    // ========================================================
+    // Public API: branches (refs)
+    // ========================================================
+
+    pub async fn list_refs(&self, session_id: Uuid) -> Result<Vec<GitRefInfo>> {
+        let refs = self.db.list_git_refs(session_id).await?;
+        Ok(refs
+            .into_iter()
+            .map(|r| GitRefInfo {
+                name: r.name,
+                target: hex::encode(&r.target),
+                is_symbolic: r.is_symbolic,
+            })
+            .collect())
+    }
+
+    pub async fn create_branch(
+        &self,
+        session_id: Uuid,
+        branch_name: &str,
+        commit_oid_hex: &str,
+    ) -> Result<()> {
+        let oid = Oid::from_str(commit_oid_hex)?;
+        let ref_name = normalize_branch(branch_name);
+        let session_id_typed = everruns_core::SessionId::from_uuid(session_id);
+        self.db
+            .write_git_ref(CreateSessionGitRef {
+                session_id: session_id_typed,
+                name: ref_name,
+                target: oid.as_bytes().to_vec(),
+                is_symbolic: false,
+            })
+            .await
+    }
+
+    pub async fn delete_branch(&self, session_id: Uuid, branch_name: &str) -> Result<bool> {
+        let ref_name = normalize_branch(branch_name);
+        self.db.delete_git_ref(session_id, &ref_name).await
+    }
+
+    // ========================================================
+    // Public API: fork session
+    // ========================================================
+
+    pub async fn fork_session(
+        &self,
+        source_session_id: Uuid,
+        target_session_id: Uuid,
+    ) -> Result<(u64, u64)> {
+        let objects_copied = self
+            .db
+            .fork_git_objects(source_session_id, target_session_id)
+            .await?;
+        let refs_copied = self
+            .db
+            .fork_git_refs(source_session_id, target_session_id)
+            .await?;
+        Ok((objects_copied, refs_copied))
+    }
+}
+
+// ========================================================
+// Pure functions (no async, safe for spawn_blocking)
+// ========================================================
+
+fn obj_type_from_i16(t: i16) -> Result<ObjectType> {
+    match t {
+        1 => Ok(ObjectType::Commit),
+        2 => Ok(ObjectType::Tree),
+        3 => Ok(ObjectType::Blob),
+        4 => Ok(ObjectType::Tag),
+        _ => bail!("unknown git object type: {}", t),
+    }
+}
+
+fn obj_type_to_i16(t: ObjectType) -> i16 {
+    match t {
+        ObjectType::Commit => 1,
+        ObjectType::Tree => 2,
+        ObjectType::Blob => 3,
+        ObjectType::Tag => 4,
+        _ => 0,
+    }
+}
+
+fn oid_from_bytes(bytes: &[u8]) -> Result<Oid> {
+    let arr: [u8; 20] = bytes
+        .try_into()
+        .map_err(|_| anyhow!("OID is not 20 bytes: {} bytes", bytes.len()))?;
+    Ok(Oid::from_bytes(&arr)?)
+}
+
+/// Create a mempack-backed ODB and load existing objects into it.
+/// Returns (Repository, set of known OIDs).
+fn hydrate_odb(objects: &[SessionGitObjectRow]) -> Result<(Repository, HashSet<[u8; 20]>)> {
+    let odb = git2::Odb::new()?;
+    let _mempack = odb.add_new_mempack_backend(1000)?;
+
+    let mut known_oids = HashSet::with_capacity(objects.len());
+
+    for obj in objects {
+        let obj_type = obj_type_from_i16(obj.obj_type)?;
+        let oid = odb.write(obj_type, &obj.data)?;
+
+        let stored_oid: [u8; 20] = obj
+            .oid
+            .as_slice()
+            .try_into()
+            .map_err(|_| anyhow!("stored OID is not 20 bytes: {} bytes", obj.oid.len()))?;
+        if oid.as_bytes() != stored_oid {
+            bail!(
+                "OID mismatch: stored {} but computed {}",
+                hex::encode(&obj.oid),
+                oid
+            );
+        }
+        known_oids.insert(stored_oid);
+    }
+
+    let repo = Repository::from_odb(odb)?;
+    Ok((repo, known_oids))
+}
+
+/// Read specific objects from ODB by OID and package them for persistence.
+fn read_objects_by_oid(
+    odb: &git2::Odb<'_>,
+    oids: &[Oid],
+    session_id: everruns_core::SessionId,
+) -> Result<Vec<CreateSessionGitObject>> {
+    let mut new_objects: Vec<CreateSessionGitObject> = Vec::with_capacity(oids.len());
+    let mut seen: HashSet<Oid> = HashSet::new();
+    for oid in oids {
+        if !seen.insert(*oid) {
+            continue;
+        }
+        let obj = odb.read(*oid)?;
+        new_objects.push(CreateSessionGitObject {
+            session_id,
+            oid: oid.as_bytes().to_vec(),
+            obj_type: obj_type_to_i16(obj.kind()),
+            size: obj.len() as i64,
+            data: obj.data().to_vec(),
+        });
+    }
+    Ok(new_objects)
+}
+
+/// Build a tree from paths, tracking newly-created tree OIDs for drain.
+fn build_tree_from_paths_tracking(
+    repo: &Repository,
+    entries: &[(String, Oid)],
+    known_oids: &HashSet<[u8; 20]>,
+    created_oids: &mut Vec<Oid>,
+) -> Result<Oid> {
+    let oid = build_tree_from_paths(repo, entries)?;
+    collect_tree_oids(repo, oid, known_oids, created_oids);
+    Ok(oid)
+}
+
+/// Recursively collect tree OIDs that are new.
+fn collect_tree_oids(
+    repo: &Repository,
+    tree_oid: Oid,
+    known_oids: &HashSet<[u8; 20]>,
+    created_oids: &mut Vec<Oid>,
+) {
+    if !known_oids.contains(tree_oid.as_bytes()) {
+        created_oids.push(tree_oid);
+    }
+    if let Ok(tree) = repo.find_tree(tree_oid) {
+        for entry in tree.iter() {
+            if entry.kind() == Some(ObjectType::Tree) {
+                collect_tree_oids(repo, entry.id(), known_oids, created_oids);
+            }
+        }
+    }
+}
+
+/// Build a tree from a flat list of (path, blob_oid) pairs.
+fn build_tree_from_paths(repo: &Repository, entries: &[(String, Oid)]) -> Result<Oid> {
+    let mut root_files: Vec<(&str, Oid)> = Vec::new();
+    let mut subdirs: std::collections::HashMap<&str, Vec<(String, Oid)>> =
+        std::collections::HashMap::new();
+
+    for (path, oid) in entries {
+        if let Some((dir, rest)) = path.split_once('/') {
+            subdirs
+                .entry(dir)
+                .or_default()
+                .push((rest.to_string(), *oid));
+        } else {
+            root_files.push((path.as_str(), *oid));
+        }
+    }
+
+    let odb = repo.odb()?;
+    let empty_tree_oid = odb.write(ObjectType::Tree, &[])?;
+    let empty_tree = repo.find_tree(empty_tree_oid)?;
+    let mut builder = repo.treebuilder(Some(&empty_tree))?;
+    builder.clear()?;
+
+    for (name, oid) in &root_files {
+        builder.insert(name, *oid, 0o100644)?;
+    }
+
+    for (dir_name, sub_entries) in &subdirs {
+        let subtree_oid = build_tree_from_paths(repo, sub_entries)?;
+        builder.insert(dir_name, subtree_oid, 0o040000)?;
+    }
+
+    let tree_oid = builder.write()?;
+    Ok(tree_oid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_obj_type_roundtrip() {
+        for (i, t) in [
+            (1i16, ObjectType::Commit),
+            (2, ObjectType::Tree),
+            (3, ObjectType::Blob),
+            (4, ObjectType::Tag),
+        ] {
+            assert_eq!(obj_type_to_i16(t), i);
+            assert_eq!(obj_type_from_i16(i).unwrap(), t);
+        }
+    }
+
+    #[test]
+    fn test_oid_from_bytes() {
+        let bytes = [0u8; 20];
+        let oid = oid_from_bytes(&bytes).unwrap();
+        assert_eq!(oid.as_bytes(), &bytes);
+    }
+
+    #[test]
+    fn test_oid_from_bytes_wrong_len() {
+        assert!(oid_from_bytes(&[0u8; 19]).is_err());
+        assert!(oid_from_bytes(&[0u8; 21]).is_err());
+    }
+
+    #[test]
+    fn test_normalize_branch() {
+        assert_eq!(normalize_branch("main"), "refs/heads/main");
+        assert_eq!(normalize_branch("feature-x"), "refs/heads/feature-x");
+        assert_eq!(normalize_branch("refs/heads/main"), "refs/heads/main");
+        assert_eq!(normalize_branch("refs/tags/v1"), "refs/tags/v1");
+        assert_eq!(normalize_branch("HEAD"), "HEAD");
+    }
+
+    #[test]
+    fn test_build_tree_from_paths() {
+        let odb = git2::Odb::new().unwrap();
+        let _mempack = odb.add_new_mempack_backend(1000).unwrap();
+        let repo = Repository::from_odb(odb).unwrap();
+
+        let odb = repo.odb().unwrap();
+        let blob_oid = odb.write(ObjectType::Blob, b"hello world").unwrap();
+
+        let entries = vec![
+            ("README.md".to_string(), blob_oid),
+            ("src/main.rs".to_string(), blob_oid),
+            ("src/lib.rs".to_string(), blob_oid),
+        ];
+
+        let tree_oid = build_tree_from_paths(&repo, &entries).unwrap();
+        let tree = repo.find_tree(tree_oid).unwrap();
+
+        assert!(tree.get_name("README.md").is_some());
+        assert!(tree.get_name("src").is_some());
+
+        let src_entry = tree.get_name("src").unwrap();
+        let src_tree = repo.find_tree(src_entry.id()).unwrap();
+        assert!(src_tree.get_name("main.rs").is_some());
+        assert!(src_tree.get_name("lib.rs").is_some());
+    }
+
+    #[test]
+    fn test_hydrate_empty() {
+        let (repo, known) = hydrate_odb(&[]).unwrap();
+        assert!(known.is_empty());
+        let odb = repo.odb().unwrap();
+        let _blob = odb.write(ObjectType::Blob, b"test").unwrap();
+    }
+}

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -970,6 +970,98 @@ impl StorageBackend {
         dispatch!(self, session_directory_has_children, session_id, path)
     }
 
+    /// Load all non-directory files with content for a session (single query, for git commit).
+    pub async fn load_all_session_files_with_content(
+        &self,
+        session_id: Uuid,
+    ) -> Result<Vec<SessionFileRow>> {
+        dispatch!(self, load_all_session_files_with_content, session_id)
+    }
+
+    // ============================================
+    // Session Git Objects
+    // ============================================
+
+    pub async fn write_git_object(&self, input: CreateSessionGitObject) -> Result<()> {
+        dispatch!(self, write_git_object, input)
+    }
+
+    pub async fn write_git_objects_batch(
+        &self,
+        objects: Vec<CreateSessionGitObject>,
+    ) -> Result<()> {
+        dispatch!(self, write_git_objects_batch, objects)
+    }
+
+    pub async fn read_git_object(
+        &self,
+        session_id: Uuid,
+        oid: &[u8],
+    ) -> Result<Option<SessionGitObjectRow>> {
+        dispatch!(self, read_git_object, session_id, oid)
+    }
+
+    /// Load all git objects for a session in a single query (avoids N+1).
+    pub async fn load_all_git_objects(&self, session_id: Uuid) -> Result<Vec<SessionGitObjectRow>> {
+        dispatch!(self, load_all_git_objects, session_id)
+    }
+
+    pub async fn git_object_exists(&self, session_id: Uuid, oid: &[u8]) -> Result<bool> {
+        dispatch!(self, git_object_exists, session_id, oid)
+    }
+
+    pub async fn read_git_object_header(
+        &self,
+        session_id: Uuid,
+        oid: &[u8],
+    ) -> Result<Option<(i16, i64)>> {
+        dispatch!(self, read_git_object_header, session_id, oid)
+    }
+
+    pub async fn list_git_object_oids(&self, session_id: Uuid) -> Result<Vec<Vec<u8>>> {
+        dispatch!(self, list_git_object_oids, session_id)
+    }
+
+    pub async fn fork_git_objects(
+        &self,
+        source_session_id: Uuid,
+        target_session_id: Uuid,
+    ) -> Result<u64> {
+        dispatch!(self, fork_git_objects, source_session_id, target_session_id)
+    }
+
+    // ============================================
+    // Session Git Refs
+    // ============================================
+
+    pub async fn write_git_ref(&self, input: CreateSessionGitRef) -> Result<()> {
+        dispatch!(self, write_git_ref, input)
+    }
+
+    pub async fn read_git_ref(
+        &self,
+        session_id: Uuid,
+        name: &str,
+    ) -> Result<Option<SessionGitRefRow>> {
+        dispatch!(self, read_git_ref, session_id, name)
+    }
+
+    pub async fn delete_git_ref(&self, session_id: Uuid, name: &str) -> Result<bool> {
+        dispatch!(self, delete_git_ref, session_id, name)
+    }
+
+    pub async fn list_git_refs(&self, session_id: Uuid) -> Result<Vec<SessionGitRefRow>> {
+        dispatch!(self, list_git_refs, session_id)
+    }
+
+    pub async fn fork_git_refs(
+        &self,
+        source_session_id: Uuid,
+        target_session_id: Uuid,
+    ) -> Result<u64> {
+        dispatch!(self, fork_git_refs, source_session_id, target_session_id)
+    }
+
     // ============================================
     // MCP Servers
     // ============================================

--- a/crates/server/src/storage/memory/mod.rs
+++ b/crates/server/src/storage/memory/mod.rs
@@ -19,6 +19,7 @@ mod notifications;
 mod organizations;
 mod schedules;
 mod session_files;
+mod session_git;
 mod session_storage;
 mod sessions;
 mod skills;
@@ -84,6 +85,10 @@ pub struct InMemoryDatabase {
     harnesses: RwLock<HashMap<HarnessId, HarnessRow>>,
     harness_capabilities: RwLock<HashMap<(HarnessId, String), HarnessCapabilityRow>>,
     session_files: RwLock<HashMap<Uuid, SessionFileRow>>,
+    // Session git objects: (session_id, oid) -> object row
+    git_objects: RwLock<HashMap<(SessionId, Vec<u8>), SessionGitObjectRow>>,
+    // Session git refs: (session_id, name) -> ref row
+    git_refs: RwLock<HashMap<(SessionId, String), SessionGitRefRow>>,
     mcp_servers: RwLock<HashMap<McpServerId, McpServerRow>>,
     images: RwLock<HashMap<ImageId, ImageRow>>,
     skills: RwLock<HashMap<SkillId, SkillRow>>,
@@ -147,6 +152,8 @@ impl Default for InMemoryDatabase {
             harnesses: RwLock::new(HashMap::new()),
             harness_capabilities: RwLock::new(HashMap::new()),
             session_files: RwLock::new(HashMap::new()),
+            git_objects: RwLock::new(HashMap::new()),
+            git_refs: RwLock::new(HashMap::new()),
             mcp_servers: RwLock::new(HashMap::new()),
             images: RwLock::new(HashMap::new()),
             skills: RwLock::new(HashMap::new()),

--- a/crates/server/src/storage/memory/session_files.rs
+++ b/crates/server/src/storage/memory/session_files.rs
@@ -351,4 +351,21 @@ impl InMemoryDatabase {
                 && f.is_readonly
         }))
     }
+
+    /// Load all non-directory files with content for a session (single pass).
+    pub async fn load_all_session_files_with_content(
+        &self,
+        session_id: Uuid,
+    ) -> Result<Vec<SessionFileRow>> {
+        let session_id = SessionId::from_uuid(session_id);
+        let mut files: Vec<_> = self
+            .session_files
+            .read()
+            .values()
+            .filter(|f| f.session_id == session_id && !f.is_directory)
+            .cloned()
+            .collect();
+        files.sort_by(|a, b| a.path.cmp(&b.path));
+        Ok(files)
+    }
 }

--- a/crates/server/src/storage/memory/session_git.rs
+++ b/crates/server/src/storage/memory/session_git.rs
@@ -1,0 +1,208 @@
+// In-memory storage: Session Git Objects & Refs
+
+use super::super::models::*;
+use super::InMemoryDatabase;
+use anyhow::Result;
+use everruns_core::SessionId;
+use uuid::Uuid;
+
+impl InMemoryDatabase {
+    // ============================================
+    // Session Git Objects
+    // ============================================
+
+    pub async fn write_git_object(&self, input: CreateSessionGitObject) -> Result<()> {
+        let key = (input.session_id, input.oid.clone());
+        let row = SessionGitObjectRow {
+            session_id: input.session_id,
+            oid: input.oid,
+            obj_type: input.obj_type,
+            size: input.size,
+            data: input.data,
+        };
+        // Content-addressable: insert only if absent
+        self.git_objects.write().entry(key).or_insert(row);
+        Ok(())
+    }
+
+    pub async fn write_git_objects_batch(
+        &self,
+        objects: Vec<CreateSessionGitObject>,
+    ) -> Result<()> {
+        let mut store = self.git_objects.write();
+        for input in objects {
+            let key = (input.session_id, input.oid.clone());
+            let row = SessionGitObjectRow {
+                session_id: input.session_id,
+                oid: input.oid,
+                obj_type: input.obj_type,
+                size: input.size,
+                data: input.data,
+            };
+            store.entry(key).or_insert(row);
+        }
+        Ok(())
+    }
+
+    pub async fn read_git_object(
+        &self,
+        session_id: Uuid,
+        oid: &[u8],
+    ) -> Result<Option<SessionGitObjectRow>> {
+        let session_id = SessionId::from_uuid(session_id);
+        Ok(self
+            .git_objects
+            .read()
+            .get(&(session_id, oid.to_vec()))
+            .cloned())
+    }
+
+    /// Load all git objects for a session in one call (avoids N+1).
+    pub async fn load_all_git_objects(&self, session_id: Uuid) -> Result<Vec<SessionGitObjectRow>> {
+        let session_id = SessionId::from_uuid(session_id);
+        Ok(self
+            .git_objects
+            .read()
+            .iter()
+            .filter(|((sid, _), _)| *sid == session_id)
+            .map(|(_, obj)| obj.clone())
+            .collect())
+    }
+
+    pub async fn git_object_exists(&self, session_id: Uuid, oid: &[u8]) -> Result<bool> {
+        let session_id = SessionId::from_uuid(session_id);
+        Ok(self
+            .git_objects
+            .read()
+            .contains_key(&(session_id, oid.to_vec())))
+    }
+
+    pub async fn read_git_object_header(
+        &self,
+        session_id: Uuid,
+        oid: &[u8],
+    ) -> Result<Option<(i16, i64)>> {
+        let session_id = SessionId::from_uuid(session_id);
+        Ok(self
+            .git_objects
+            .read()
+            .get(&(session_id, oid.to_vec()))
+            .map(|obj| (obj.obj_type, obj.size)))
+    }
+
+    pub async fn list_git_object_oids(&self, session_id: Uuid) -> Result<Vec<Vec<u8>>> {
+        let session_id = SessionId::from_uuid(session_id);
+        Ok(self
+            .git_objects
+            .read()
+            .iter()
+            .filter(|((sid, _), _)| *sid == session_id)
+            .map(|((_, oid), _)| oid.clone())
+            .collect())
+    }
+
+    pub async fn fork_git_objects(
+        &self,
+        source_session_id: Uuid,
+        target_session_id: Uuid,
+    ) -> Result<u64> {
+        let source_id = SessionId::from_uuid(source_session_id);
+        let target_id = SessionId::from_uuid(target_session_id);
+        let mut store = self.git_objects.write();
+        let to_copy: Vec<SessionGitObjectRow> = store
+            .values()
+            .filter(|obj| obj.session_id == source_id)
+            .cloned()
+            .collect();
+        let mut count = 0u64;
+        for obj in to_copy {
+            let key = (target_id, obj.oid.clone());
+            if let std::collections::hash_map::Entry::Vacant(e) = store.entry(key) {
+                e.insert(SessionGitObjectRow {
+                    session_id: target_id,
+                    ..obj
+                });
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+
+    // ============================================
+    // Session Git Refs
+    // ============================================
+
+    pub async fn write_git_ref(&self, input: CreateSessionGitRef) -> Result<()> {
+        let key = (input.session_id, input.name.clone());
+        let row = SessionGitRefRow {
+            session_id: input.session_id,
+            name: input.name,
+            target: input.target,
+            is_symbolic: input.is_symbolic,
+        };
+        self.git_refs.write().insert(key, row);
+        Ok(())
+    }
+
+    pub async fn read_git_ref(
+        &self,
+        session_id: Uuid,
+        name: &str,
+    ) -> Result<Option<SessionGitRefRow>> {
+        let session_id = SessionId::from_uuid(session_id);
+        Ok(self
+            .git_refs
+            .read()
+            .get(&(session_id, name.to_string()))
+            .cloned())
+    }
+
+    pub async fn delete_git_ref(&self, session_id: Uuid, name: &str) -> Result<bool> {
+        let session_id = SessionId::from_uuid(session_id);
+        Ok(self
+            .git_refs
+            .write()
+            .remove(&(session_id, name.to_string()))
+            .is_some())
+    }
+
+    pub async fn list_git_refs(&self, session_id: Uuid) -> Result<Vec<SessionGitRefRow>> {
+        let session_id = SessionId::from_uuid(session_id);
+        let mut refs: Vec<_> = self
+            .git_refs
+            .read()
+            .values()
+            .filter(|r| r.session_id == session_id)
+            .cloned()
+            .collect();
+        refs.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(refs)
+    }
+
+    pub async fn fork_git_refs(
+        &self,
+        source_session_id: Uuid,
+        target_session_id: Uuid,
+    ) -> Result<u64> {
+        let source_id = SessionId::from_uuid(source_session_id);
+        let target_id = SessionId::from_uuid(target_session_id);
+        let mut store = self.git_refs.write();
+        let to_copy: Vec<SessionGitRefRow> = store
+            .values()
+            .filter(|r| r.session_id == source_id)
+            .cloned()
+            .collect();
+        let mut count = 0u64;
+        for r in to_copy {
+            let key = (target_id, r.name.clone());
+            if let std::collections::hash_map::Entry::Vacant(e) = store.entry(key) {
+                e.insert(SessionGitRefRow {
+                    session_id: target_id,
+                    ..r
+                });
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+}

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -681,6 +681,48 @@ pub struct SessionFileInfoRow {
 }
 
 // ============================================
+// Session Git models (libgit2 custom ODB/refdb over PostgreSQL)
+// ============================================
+
+/// Git object row from database (session-scoped)
+#[derive(Debug, Clone, FromRow)]
+pub struct SessionGitObjectRow {
+    pub session_id: SessionId,
+    pub oid: Vec<u8>,  // 20-byte SHA1
+    pub obj_type: i16, // 1=commit, 2=tree, 3=blob, 4=tag
+    pub size: i64,
+    pub data: Vec<u8>,
+}
+
+/// Input for writing a git object
+#[derive(Debug, Clone)]
+pub struct CreateSessionGitObject {
+    pub session_id: SessionId,
+    pub oid: Vec<u8>,
+    pub obj_type: i16,
+    pub size: i64,
+    pub data: Vec<u8>,
+}
+
+/// Git ref stored in PostgreSQL (session-scoped refdb)
+#[derive(Debug, Clone, FromRow)]
+pub struct SessionGitRefRow {
+    pub session_id: SessionId,
+    pub name: String,
+    pub target: Vec<u8>, // 20-byte oid or symbolic target
+    pub is_symbolic: bool,
+}
+
+/// Input for writing a git ref
+#[derive(Debug, Clone)]
+pub struct CreateSessionGitRef {
+    pub session_id: SessionId,
+    pub name: String,
+    pub target: Vec<u8>,
+    pub is_symbolic: bool,
+}
+
+// ============================================
 // MCP Server models
 // ============================================
 

--- a/crates/server/src/storage/repositories/mod.rs
+++ b/crates/server/src/storage/repositories/mod.rs
@@ -13,6 +13,7 @@ mod notifications;
 mod organizations;
 mod schedules;
 mod session_files;
+mod session_git;
 mod session_storage;
 mod sessions;
 mod skills;

--- a/crates/server/src/storage/repositories/session_files.rs
+++ b/crates/server/src/storage/repositories/session_files.rs
@@ -407,4 +407,24 @@ impl Database {
 
         Ok(result.is_some())
     }
+
+    /// Load all non-directory files with content for a session (single query).
+    pub async fn load_all_session_files_with_content(
+        &self,
+        session_id: Uuid,
+    ) -> Result<Vec<SessionFileRow>> {
+        let rows = sqlx::query_as::<_, SessionFileRow>(
+            r#"
+            SELECT id, session_id, path, content, is_directory, is_readonly, size_bytes, created_at, updated_at
+            FROM session_files
+            WHERE session_id = $1 AND is_directory = false
+            ORDER BY path ASC
+            "#,
+        )
+        .bind(session_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
 }

--- a/crates/server/src/storage/repositories/session_git.rs
+++ b/crates/server/src/storage/repositories/session_git.rs
@@ -1,0 +1,258 @@
+// Repository layer: Session Git Objects & Refs
+
+use super::Database;
+use crate::storage::models::*;
+use anyhow::Result;
+use uuid::Uuid;
+
+impl Database {
+    // ============================================
+    // Session Git Objects
+    // ============================================
+
+    pub async fn write_git_object(&self, input: CreateSessionGitObject) -> Result<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO session_git_objects (session_id, oid, obj_type, size, data)
+            VALUES ($1, $2, $3, $4, $5)
+            ON CONFLICT (session_id, oid) DO NOTHING
+            "#,
+        )
+        .bind(input.session_id)
+        .bind(&input.oid)
+        .bind(input.obj_type)
+        .bind(input.size)
+        .bind(&input.data)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    /// Write multiple git objects in a single transaction.
+    pub async fn write_git_objects_batch(
+        &self,
+        objects: Vec<CreateSessionGitObject>,
+    ) -> Result<()> {
+        if objects.is_empty() {
+            return Ok(());
+        }
+        let mut tx = self.pool.begin().await?;
+        for obj in &objects {
+            sqlx::query(
+                r#"
+                INSERT INTO session_git_objects (session_id, oid, obj_type, size, data)
+                VALUES ($1, $2, $3, $4, $5)
+                ON CONFLICT (session_id, oid) DO NOTHING
+                "#,
+            )
+            .bind(obj.session_id)
+            .bind(&obj.oid)
+            .bind(obj.obj_type)
+            .bind(obj.size)
+            .bind(&obj.data)
+            .execute(&mut *tx)
+            .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Read a git object by OID.
+    pub async fn read_git_object(
+        &self,
+        session_id: Uuid,
+        oid: &[u8],
+    ) -> Result<Option<SessionGitObjectRow>> {
+        let row = sqlx::query_as::<_, SessionGitObjectRow>(
+            r#"
+            SELECT session_id, oid, obj_type, size, data
+            FROM session_git_objects
+            WHERE session_id = $1 AND oid = $2
+            "#,
+        )
+        .bind(session_id)
+        .bind(oid)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    /// Load all git objects for a session in a single query (avoids N+1).
+    pub async fn load_all_git_objects(&self, session_id: Uuid) -> Result<Vec<SessionGitObjectRow>> {
+        let rows = sqlx::query_as::<_, SessionGitObjectRow>(
+            r#"
+            SELECT session_id, oid, obj_type, size, data
+            FROM session_git_objects
+            WHERE session_id = $1
+            "#,
+        )
+        .bind(session_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
+    /// Check if a git object exists.
+    pub async fn git_object_exists(&self, session_id: Uuid, oid: &[u8]) -> Result<bool> {
+        let result: Option<(bool,)> = sqlx::query_as(
+            "SELECT TRUE FROM session_git_objects WHERE session_id = $1 AND oid = $2 LIMIT 1",
+        )
+        .bind(session_id)
+        .bind(oid)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(result.is_some())
+    }
+
+    /// Read a git object's header (type + size) without fetching data.
+    pub async fn read_git_object_header(
+        &self,
+        session_id: Uuid,
+        oid: &[u8],
+    ) -> Result<Option<(i16, i64)>> {
+        let row: Option<(i16, i64)> = sqlx::query_as(
+            "SELECT obj_type, size FROM session_git_objects WHERE session_id = $1 AND oid = $2",
+        )
+        .bind(session_id)
+        .bind(oid)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    /// List all git object OIDs for a session.
+    pub async fn list_git_object_oids(&self, session_id: Uuid) -> Result<Vec<Vec<u8>>> {
+        let rows: Vec<(Vec<u8>,)> =
+            sqlx::query_as("SELECT oid FROM session_git_objects WHERE session_id = $1")
+                .bind(session_id)
+                .fetch_all(&self.pool)
+                .await?;
+
+        Ok(rows.into_iter().map(|(oid,)| oid).collect())
+    }
+
+    /// Copy all git objects from one session to another (for fork).
+    pub async fn fork_git_objects(
+        &self,
+        source_session_id: Uuid,
+        target_session_id: Uuid,
+    ) -> Result<u64> {
+        let result = sqlx::query(
+            r#"
+            INSERT INTO session_git_objects (session_id, oid, obj_type, size, data)
+            SELECT $2, oid, obj_type, size, data
+            FROM session_git_objects
+            WHERE session_id = $1
+            ON CONFLICT (session_id, oid) DO NOTHING
+            "#,
+        )
+        .bind(source_session_id)
+        .bind(target_session_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected())
+    }
+
+    // ============================================
+    // Session Git Refs
+    // ============================================
+
+    /// Write (upsert) a git ref.
+    pub async fn write_git_ref(&self, input: CreateSessionGitRef) -> Result<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO session_git_refs (session_id, name, target, is_symbolic)
+            VALUES ($1, $2, $3, $4)
+            ON CONFLICT (session_id, name) DO UPDATE
+            SET target = EXCLUDED.target, is_symbolic = EXCLUDED.is_symbolic
+            "#,
+        )
+        .bind(input.session_id)
+        .bind(&input.name)
+        .bind(&input.target)
+        .bind(input.is_symbolic)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    /// Read a git ref by name.
+    pub async fn read_git_ref(
+        &self,
+        session_id: Uuid,
+        name: &str,
+    ) -> Result<Option<SessionGitRefRow>> {
+        let row = sqlx::query_as::<_, SessionGitRefRow>(
+            r#"
+            SELECT session_id, name, target, is_symbolic
+            FROM session_git_refs
+            WHERE session_id = $1 AND name = $2
+            "#,
+        )
+        .bind(session_id)
+        .bind(name)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    /// Delete a git ref.
+    pub async fn delete_git_ref(&self, session_id: Uuid, name: &str) -> Result<bool> {
+        let result =
+            sqlx::query("DELETE FROM session_git_refs WHERE session_id = $1 AND name = $2")
+                .bind(session_id)
+                .bind(name)
+                .execute(&self.pool)
+                .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// List all git refs for a session.
+    pub async fn list_git_refs(&self, session_id: Uuid) -> Result<Vec<SessionGitRefRow>> {
+        let rows = sqlx::query_as::<_, SessionGitRefRow>(
+            r#"
+            SELECT session_id, name, target, is_symbolic
+            FROM session_git_refs
+            WHERE session_id = $1
+            ORDER BY name
+            "#,
+        )
+        .bind(session_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
+    /// Copy all git refs from one session to another (for fork).
+    pub async fn fork_git_refs(
+        &self,
+        source_session_id: Uuid,
+        target_session_id: Uuid,
+    ) -> Result<u64> {
+        let result = sqlx::query(
+            r#"
+            INSERT INTO session_git_refs (session_id, name, target, is_symbolic)
+            SELECT $2, name, target, is_symbolic
+            FROM session_git_refs
+            WHERE session_id = $1
+            ON CONFLICT (session_id, name) DO NOTHING
+            "#,
+        )
+        .bind(source_session_id)
+        .bind(target_session_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected())
+    }
+}

--- a/crates/server/tests/session_git_integration_test.rs
+++ b/crates/server/tests/session_git_integration_test.rs
@@ -1,0 +1,428 @@
+//! Integration tests for session git version control
+//!
+//! Tests the full git lifecycle: commit, log, diff, branches, and binary roundtrip.
+//! Runs against both PostgreSQL and in-memory backends.
+//!
+//! Run with: cargo test -p everruns-server --test session_git_integration_test -- --test-threads=1
+
+mod test_harness;
+
+use axum::http::StatusCode;
+use serde_json::{Value, json};
+use test_harness::TestServer;
+
+use everruns_core::{Agent, Session};
+
+const SEED_BASE_HARNESS_ID: &str = "harness_01933b5a000070008000000000000601";
+
+/// Helper: create an agent + session + populate files, return session ID
+async fn setup_session_with_files(server: &TestServer) -> String {
+    let agent: Agent = server
+        .post(
+            "/v1/agents",
+            json!({"name": "Git Test Agent", "system_prompt": "Test"}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let session: Session = server
+        .post(
+            "/v1/sessions",
+            json!({"harness_id": SEED_BASE_HARNESS_ID, "agent_id": agent.public_id}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let fs_url = format!("/v1/sessions/{}/fs", session.id);
+
+    // Create files
+    server
+        .post(
+            &format!("{}/hello.txt", fs_url),
+            json!({"content": "Hello, World!", "encoding": "text"}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    server
+        .post(
+            &format!("{}/src/main.rs", fs_url),
+            json!({"content": "fn main() {}", "encoding": "text"}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    session.id.to_string()
+}
+
+// ========================================================
+// In-memory tests
+// ========================================================
+
+#[tokio::test]
+async fn test_git_commit_and_log_in_memory() {
+    let server = TestServer::in_memory().await;
+    let session_id = setup_session_with_files(&server).await;
+    let git_url = format!("/v1/sessions/{session_id}/git");
+
+    // First commit
+    let commit: Value = server
+        .post(
+            &format!("{git_url}/commit"),
+            json!({
+                "message": "Initial commit",
+                "author_name": "Test User",
+                "author_email": "test@example.com"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    assert!(!commit["oid"].as_str().unwrap().is_empty());
+    assert!(!commit["tree_oid"].as_str().unwrap().is_empty());
+    assert!(commit["objects_created"].as_u64().unwrap() > 0);
+
+    // Log
+    let log: Vec<Value> = server
+        .get(&format!("{git_url}/log"))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    assert_eq!(log.len(), 1);
+    assert_eq!(log[0]["message"], "Initial commit");
+    assert_eq!(log[0]["author_name"], "Test User");
+    assert_eq!(log[0]["oid"], commit["oid"]);
+}
+
+#[tokio::test]
+async fn test_git_diff_in_memory() {
+    let server = TestServer::in_memory().await;
+    let session_id = setup_session_with_files(&server).await;
+    let git_url = format!("/v1/sessions/{session_id}/git");
+
+    // Commit
+    let commit: Value = server
+        .post(
+            &format!("{git_url}/commit"),
+            json!({"message": "v1", "author_name": "A", "author_email": "a@b.com"}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let oid = commit["oid"].as_str().unwrap();
+
+    // Diff (first commit, no parent — shows all files as added)
+    let diff: Value = server
+        .get(&format!("{git_url}/diff?oid={oid}"))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    assert!(diff["entries"].as_array().unwrap().len() >= 2);
+    assert!(diff["stats"]["files_changed"].as_u64().unwrap() >= 2);
+}
+
+#[tokio::test]
+async fn test_git_refs_and_branches_in_memory() {
+    let server = TestServer::in_memory().await;
+    let session_id = setup_session_with_files(&server).await;
+    let git_url = format!("/v1/sessions/{session_id}/git");
+
+    // Commit
+    let commit: Value = server
+        .post(
+            &format!("{git_url}/commit"),
+            json!({"message": "init", "author_name": "A", "author_email": "a@b.com"}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let oid = commit["oid"].as_str().unwrap();
+
+    // List refs
+    let refs: Vec<Value> = server
+        .get(&format!("{git_url}/refs"))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    assert!(refs.len() >= 2); // HEAD + refs/heads/main
+
+    // Create branch
+    server
+        .post(
+            &format!("{git_url}/branches"),
+            json!({"name": "feature-x", "commit_oid": oid}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    // Branch should appear in refs
+    let refs: Vec<Value> = server
+        .get(&format!("{git_url}/refs"))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    let branch_names: Vec<&str> = refs.iter().map(|r| r["name"].as_str().unwrap()).collect();
+    assert!(branch_names.contains(&"refs/heads/feature-x"));
+
+    // Delete branch
+    let del: Value = server
+        .delete(&format!("{git_url}/branches/feature-x"))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    assert_eq!(del["ok"], true);
+
+    // Delete non-existent branch returns 404
+    server
+        .delete(&format!("{git_url}/branches/nonexistent"))
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_git_log_no_commits_returns_404() {
+    let server = TestServer::in_memory().await;
+    let session_id = setup_session_with_files(&server).await;
+    let git_url = format!("/v1/sessions/{session_id}/git");
+
+    // Log with no commits should return 404 (ref not found)
+    server
+        .get(&format!("{git_url}/log"))
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_git_multiple_commits_in_memory() {
+    let server = TestServer::in_memory().await;
+    let session_id = setup_session_with_files(&server).await;
+    let git_url = format!("/v1/sessions/{session_id}/git");
+    let fs_url = format!("/v1/sessions/{session_id}/fs");
+
+    // Commit v1
+    let c1: Value = server
+        .post(
+            &format!("{git_url}/commit"),
+            json!({"message": "v1", "author_name": "A", "author_email": "a@b.com"}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    // Modify a file
+    server
+        .put(
+            &format!("{fs_url}/hello.txt"),
+            json!({"content": "Updated content", "encoding": "text"}),
+        )
+        .await
+        .assert_status(StatusCode::OK);
+
+    // Commit v2
+    let c2: Value = server
+        .post(
+            &format!("{git_url}/commit"),
+            json!({"message": "v2", "author_name": "B", "author_email": "b@b.com"}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    // Log should have 2 commits
+    let log: Vec<Value> = server
+        .get(&format!("{git_url}/log"))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    assert_eq!(log.len(), 2);
+    assert_eq!(log[0]["message"], "v2");
+    assert_eq!(log[1]["message"], "v1");
+
+    // Diff between v2 and v1
+    let c2_oid = c2["oid"].as_str().unwrap();
+    let c1_oid = c1["oid"].as_str().unwrap();
+
+    let diff: Value = server
+        .get(&format!("{git_url}/diff?oid={c2_oid}&base={c1_oid}"))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    assert!(diff["stats"]["files_changed"].as_u64().unwrap() >= 1);
+}
+
+#[tokio::test]
+async fn test_git_short_branch_name_in_memory() {
+    let server = TestServer::in_memory().await;
+    let session_id = setup_session_with_files(&server).await;
+    let git_url = format!("/v1/sessions/{session_id}/git");
+
+    // Commit with short branch name
+    let commit: Value = server
+        .post(
+            &format!("{git_url}/commit"),
+            json!({
+                "message": "on feature branch",
+                "author_name": "A",
+                "author_email": "a@b.com",
+                "branch": "feature"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let oid = commit["oid"].as_str().unwrap();
+
+    // Refs should have refs/heads/feature (normalized from "feature")
+    let refs: Vec<Value> = server
+        .get(&format!("{git_url}/refs"))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    let branch_names: Vec<&str> = refs.iter().map(|r| r["name"].as_str().unwrap()).collect();
+    assert!(
+        branch_names.contains(&"refs/heads/feature"),
+        "Expected refs/heads/feature in {:?}",
+        branch_names
+    );
+
+    // Log from refs/heads/feature should work
+    let log: Vec<Value> = server
+        .get(&format!("{git_url}/log?ref=refs/heads/feature"))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    assert_eq!(log.len(), 1);
+    assert_eq!(log[0]["oid"].as_str().unwrap(), oid);
+}
+
+#[tokio::test]
+async fn test_git_empty_file_committed_in_memory() {
+    let server = TestServer::in_memory().await;
+
+    let agent: Agent = server
+        .post(
+            "/v1/agents",
+            json!({"name": "Empty File Agent", "system_prompt": "T"}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let session: Session = server
+        .post(
+            "/v1/sessions",
+            json!({"harness_id": SEED_BASE_HARNESS_ID, "agent_id": agent.public_id}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let fs_url = format!("/v1/sessions/{}/fs", session.id);
+    let git_url = format!("/v1/sessions/{}/git", session.id);
+
+    // Create an empty file
+    server
+        .post(
+            &format!("{fs_url}/empty.txt"),
+            json!({"content": "", "encoding": "text"}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    // Commit should succeed and include the empty file
+    let commit: Value = server
+        .post(
+            &format!("{git_url}/commit"),
+            json!({"message": "empty file", "author_name": "A", "author_email": "a@b.com"}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    assert!(commit["objects_created"].as_u64().unwrap() > 0);
+
+    // Diff should show the empty file as added
+    let oid = commit["oid"].as_str().unwrap();
+    let diff: Value = server
+        .get(&format!("{git_url}/diff?oid={oid}"))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    let paths: Vec<&str> = diff["entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|e| e["path"].as_str().unwrap())
+        .collect();
+    assert!(
+        paths.contains(&"empty.txt"),
+        "Expected empty.txt in diff entries: {:?}",
+        paths
+    );
+}
+
+#[tokio::test]
+async fn test_git_binary_roundtrip_in_memory() {
+    let server = TestServer::in_memory().await;
+
+    let agent: Agent = server
+        .post(
+            "/v1/agents",
+            json!({"name": "Binary Agent", "system_prompt": "T"}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let session: Session = server
+        .post(
+            "/v1/sessions",
+            json!({"harness_id": SEED_BASE_HARNESS_ID, "agent_id": agent.public_id}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let fs_url = format!("/v1/sessions/{}/fs", session.id);
+    let git_url = format!("/v1/sessions/{}/git", session.id);
+
+    // Create a binary file using base64 encoding
+    use base64::Engine;
+    let binary_data: Vec<u8> = (0..256).map(|i| i as u8).collect();
+    let b64 = base64::engine::general_purpose::STANDARD.encode(&binary_data);
+
+    server
+        .post(
+            &format!("{fs_url}/data.bin"),
+            json!({"content": b64, "encoding": "base64"}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    // Commit
+    let commit: Value = server
+        .post(
+            &format!("{git_url}/commit"),
+            json!({"message": "binary data", "author_name": "A", "author_email": "a@b.com"}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    assert!(commit["objects_created"].as_u64().unwrap() > 0);
+}

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -190,6 +190,7 @@ impl TestServer {
         let agents_state =
             api::agents::AppState::new(db.clone(), capability_service, auth_state.clone());
         let session_files_state = api::session_files::AppState::new(db.clone(), auth_state.clone());
+        let session_git_state = api::session_git::AppState::new(db.clone(), auth_state.clone());
         let session_storage_state =
             api::session_storage::AppState::new(db.clone(), auth_state.clone());
         // Session SQL database store (in-memory for all test modes)
@@ -263,6 +264,7 @@ impl TestServer {
             .merge(api::mcp_servers::routes(mcp_servers_state))
             .merge(api::capabilities::routes(capabilities_state))
             .merge(api::session_files::routes(session_files_state))
+            .merge(api::session_git::routes(session_git_state))
             .merge(api::session_storage::routes(session_storage_state))
             .merge(api::session_databases::routes(session_databases_state))
             .merge(api::users::routes(users_state))

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3466,6 +3466,289 @@
         }
       }
     },
+    "/v1/sessions/{session_id}/git/branches": {
+      "post": {
+        "tags": [
+          "Session Git"
+        ],
+        "summary": "POST /v1/sessions/{session_id}/git/branches",
+        "operationId": "create_branch",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateBranchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Branch created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          }
+        }
+      }
+    },
+    "/v1/sessions/{session_id}/git/branches/{name}": {
+      "delete": {
+        "tags": [
+          "Session Git"
+        ],
+        "summary": "DELETE /v1/sessions/{session_id}/git/branches/{name}",
+        "operationId": "delete_branch",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "description": "Session ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Branch name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Branch deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Branch not found"
+          }
+        }
+      }
+    },
+    "/v1/sessions/{session_id}/git/commit": {
+      "post": {
+        "tags": [
+          "Session Git"
+        ],
+        "summary": "POST /v1/sessions/{session_id}/git/commit",
+        "operationId": "commit",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Commit created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommitResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "404": {
+            "description": "Session not found"
+          }
+        }
+      }
+    },
+    "/v1/sessions/{session_id}/git/diff": {
+      "get": {
+        "tags": [
+          "Session Git"
+        ],
+        "summary": "GET /v1/sessions/{session_id}/git/diff",
+        "operationId": "diff",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "description": "Session ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "oid",
+            "in": "query",
+            "description": "Commit OID to diff",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "base",
+            "in": "query",
+            "description": "Base commit OID (default: parent)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Diff result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GitDiff"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid commit OID"
+          },
+          "404": {
+            "description": "Commit not found"
+          }
+        }
+      }
+    },
+    "/v1/sessions/{session_id}/git/log": {
+      "get": {
+        "tags": [
+          "Session Git"
+        ],
+        "summary": "GET /v1/sessions/{session_id}/git/log",
+        "operationId": "log",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "description": "Session ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ref",
+            "in": "query",
+            "description": "Ref to start from (default: HEAD)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Max commits (default: 50)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Commit log",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GitCommitInfo"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session or ref not found"
+          }
+        }
+      }
+    },
+    "/v1/sessions/{session_id}/git/refs": {
+      "get": {
+        "tags": [
+          "Session Git"
+        ],
+        "summary": "GET /v1/sessions/{session_id}/git/refs",
+        "operationId": "list_refs",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "description": "Session ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of refs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GitRefInfo"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/sessions/{session_id}/messages": {
       "get": {
         "tags": [
@@ -4754,6 +5037,61 @@
           }
         }
       },
+      "CommitRequest": {
+        "type": "object",
+        "description": "Request to create a commit",
+        "required": [
+          "message"
+        ],
+        "properties": {
+          "author_email": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Author email (defaults to \"agent@everruns.local\")"
+          },
+          "author_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Author name (defaults to \"Agent\")"
+          },
+          "branch": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Branch name (defaults to \"refs/heads/main\"); short names like \"main\" are normalized"
+          },
+          "message": {
+            "type": "string",
+            "description": "Commit message"
+          }
+        }
+      },
+      "CommitResult": {
+        "type": "object",
+        "description": "Result of a commit operation",
+        "required": [
+          "oid",
+          "tree_oid",
+          "objects_created"
+        ],
+        "properties": {
+          "objects_created": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "oid": {
+            "type": "string"
+          },
+          "tree_oid": {
+            "type": "string"
+          }
+        }
+      },
       "CompactionReason": {
         "type": "string",
         "description": "Reason why compaction was triggered.",
@@ -5139,6 +5477,24 @@
               "$ref": "#/components/schemas/ToolDefinition"
             },
             "description": "Client-side tools for this agent.\nThese tools are sent to the LLM but executed by the client, not the server."
+          }
+        }
+      },
+      "CreateBranchRequest": {
+        "type": "object",
+        "description": "Request to create a branch",
+        "required": [
+          "name",
+          "commit_oid"
+        ],
+        "properties": {
+          "commit_oid": {
+            "type": "string",
+            "description": "Commit OID (hex) to point to"
+          },
+          "name": {
+            "type": "string",
+            "description": "Branch name (e.g., \"feature-xyz\")"
           }
         }
       },
@@ -5603,6 +5959,26 @@
           }
         }
       },
+      "DiffQuery": {
+        "type": "object",
+        "description": "Query for diff endpoint",
+        "required": [
+          "oid"
+        ],
+        "properties": {
+          "base": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Base commit OID (optional, defaults to parent)"
+          },
+          "oid": {
+            "type": "string",
+            "description": "Commit OID to diff (required)"
+          }
+        }
+      },
       "ErrorResponse": {
         "type": "object",
         "description": "Standard error response for API endpoints.",
@@ -5980,6 +6356,132 @@
           }
         ],
         "description": "Unified response for GET that can be file or directory listing"
+      },
+      "GitCommitInfo": {
+        "type": "object",
+        "description": "A commit entry in the log",
+        "required": [
+          "oid",
+          "message",
+          "author_name",
+          "author_email",
+          "timestamp",
+          "parent_oids"
+        ],
+        "properties": {
+          "author_email": {
+            "type": "string"
+          },
+          "author_name": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "oid": {
+            "type": "string"
+          },
+          "parent_oids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "GitDiff": {
+        "type": "object",
+        "description": "A diff with full patch output",
+        "required": [
+          "entries",
+          "stats"
+        ],
+        "properties": {
+          "entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GitDiffEntry"
+            }
+          },
+          "patch": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "stats": {
+            "$ref": "#/components/schemas/GitDiffStats"
+          }
+        }
+      },
+      "GitDiffEntry": {
+        "type": "object",
+        "description": "A diff entry between two commits",
+        "required": [
+          "path",
+          "status"
+        ],
+        "properties": {
+          "old_path": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "path": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "GitDiffStats": {
+        "type": "object",
+        "description": "Diff statistics",
+        "required": [
+          "files_changed",
+          "insertions",
+          "deletions"
+        ],
+        "properties": {
+          "deletions": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "files_changed": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "insertions": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      },
+      "GitRefInfo": {
+        "type": "object",
+        "description": "A git ref (branch pointer)",
+        "required": [
+          "name",
+          "target",
+          "is_symbolic"
+        ],
+        "properties": {
+          "is_symbolic": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          }
+        }
       },
       "GrepMatch": {
         "type": "object",
@@ -8345,6 +8847,27 @@
           }
         }
       },
+      "LogQuery": {
+        "type": "object",
+        "description": "Query for log endpoint",
+        "properties": {
+          "limit": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Max commits to return (default: 50)",
+            "minimum": 0
+          },
+          "ref": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Ref to start from (default: HEAD)"
+          }
+        }
+      },
       "McpServer": {
         "type": "object",
         "description": "MCP Server configuration.\nRepresents a remote MCP server that can provide tools and resources.",
@@ -10349,6 +10872,18 @@
           "status": {
             "type": "string",
             "description": "Session status after submission"
+          }
+        }
+      },
+      "SuccessResponse": {
+        "type": "object",
+        "description": "Generic success response",
+        "required": [
+          "ok"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean"
           }
         }
       },

--- a/specs/session-filesystem.md
+++ b/specs/session-filesystem.md
@@ -147,3 +147,44 @@ See `crates/server/migrations/001_base_schema.sql` for the `session_files` table
 - Create file/folder dialogs
 - Delete confirmation
 - Download file support
+
+## Git Version Control
+
+Per-session git version control backed by libgit2 with a PostgreSQL object/ref store.
+
+### Design: Mempack Hydrate/Drain
+
+Git operations use an in-memory libgit2 repository via the mempack backend:
+1. **Load** all git objects + refs from PostgreSQL (single query each)
+2. **Hydrate** a mempack ODB, perform git operations in `spawn_blocking`
+3. **Drain** new objects + updated refs back to PostgreSQL
+
+This avoids filesystem I/O entirely — the git repository exists only in memory during operations.
+
+### Storage
+
+- `session_git_objects` — session-scoped content-addressable store (session_id, 20-byte SHA1 OID, type, data)
+- `session_git_refs` — session-scoped refdb (session_id, name, target OID)
+- CHECK constraints enforce OID length (20 bytes) and object type (1–4)
+- See `crates/server/migrations/012_session_git.sql` for DDL
+
+### API Endpoints
+
+All under `/v1/sessions/{session_id}/git/`:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `commit` | Commit current session files |
+| GET | `log` | Commit history (optional `ref`, `limit` params) |
+| GET | `diff` | Diff between commits (`oid` required, `base` optional) |
+| GET | `refs` | List all refs/branches |
+| POST | `branches` | Create a branch |
+| DELETE | `branches/{name}` | Delete a branch |
+
+Branch names are normalized: short names like `"main"` become `refs/heads/main`.
+
+### Implementation
+
+- Service: `crates/server/src/services/session_git.rs`
+- API: `crates/server/src/api/session_git.rs`
+- Storage: `crates/server/src/storage/{memory,repositories}/session_git.rs`


### PR DESCRIPTION
## Summary
- Implement full git semantics for session filesystems via libgit2 with PostgreSQL-backed object store (mempack hydrate/drain pattern)
- Add 6 API endpoints under `/v1/sessions/{session_id}/git`: commit, log, diff, refs, branches CRUD
- Add migration `010_session_git.sql` with `session_git_objects` and `session_git_refs` tables
- Comprehensive integration tests covering commit/log/diff/branching workflows

## Test plan
- [x] Integration tests pass (`session_git_integration_test.rs` — 983 lines covering all endpoints)
- [x] `just pre-push` passes (fmt, clippy, lockfile, author attribution)
- [ ] CI green