### PR TITLE
fix(api): validate virtual capability references on write

### DIFF
--- a/crates/server/src/api/common.rs
+++ b/crates/server/src/api/common.rs
@@ -63,6 +63,8 @@ fn classify_anyhow_error(message: &str) -> Option<(StatusCode, Json<ErrorRespons
         "cannot unpublish archived",
         "cannot update archived",
         "cannot archive built-in",
+        "invalid mcp capability reference",
+        "invalid skill capability reference",
     ]
     .iter()
     .any(|pattern| lowered.contains(pattern));

--- a/crates/server/src/services/agent.rs
+++ b/crates/server/src/services/agent.rs
@@ -72,6 +72,12 @@ impl AgentService {
     ) -> Result<Agent> {
         let capabilities_to_store =
             ensure_file_system_capability(req.capabilities.clone(), !req.initial_files.is_empty());
+        crate::services::capability_validation::validate_capability_refs(
+            &self.db,
+            caller.org_id,
+            &capabilities_to_store,
+        )
+        .await?;
         let default_model_id = self
             .validate_default_model_id(caller.org_id, req.default_model_id)
             .await?;
@@ -233,6 +239,14 @@ impl AgentService {
             )),
             None => None,
         };
+        if let Some(ref caps) = capabilities_override {
+            crate::services::capability_validation::validate_capability_refs(
+                &self.db,
+                caller.org_id,
+                caps,
+            )
+            .await?;
+        }
         let default_model_id = self
             .validate_default_model_id(caller.org_id, req.default_model_id)
             .await?;
@@ -348,6 +362,12 @@ impl AgentService {
     ) -> Result<(Agent, bool)> {
         let capabilities_to_store =
             ensure_file_system_capability(req.capabilities.clone(), !req.initial_files.is_empty());
+        crate::services::capability_validation::validate_capability_refs(
+            &self.db,
+            caller.org_id,
+            &capabilities_to_store,
+        )
+        .await?;
         let default_model_id = self
             .validate_default_model_id(caller.org_id, req.default_model_id)
             .await?;
@@ -634,5 +654,85 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(err.to_string(), "Model not found");
+    }
+
+    #[tokio::test]
+    async fn create_rejects_unknown_builtin_capability() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let service = AgentService::new(db.clone());
+        let caller = Caller::internal(DEFAULT_ORG_ID);
+
+        let mut req = build_create_request(None);
+        req.capabilities = vec![AgentCapabilityConfig::new("nonexistent_cap")];
+
+        let err = service.create(&caller, None, req).await.unwrap_err();
+        assert_eq!(err.to_string(), "Capability not found");
+    }
+
+    #[tokio::test]
+    async fn create_rejects_nonexistent_mcp_ref() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let service = AgentService::new(db.clone());
+        let caller = Caller::internal(DEFAULT_ORG_ID);
+
+        let mut req = build_create_request(None);
+        req.capabilities = vec![AgentCapabilityConfig::new(format!(
+            "mcp:{}",
+            uuid::Uuid::new_v4()
+        ))];
+
+        let err = service.create(&caller, None, req).await.unwrap_err();
+        assert_eq!(err.to_string(), "MCP server not found");
+    }
+
+    #[tokio::test]
+    async fn create_rejects_nonexistent_skill_ref() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let service = AgentService::new(db.clone());
+        let caller = Caller::internal(DEFAULT_ORG_ID);
+
+        let mut req = build_create_request(None);
+        req.capabilities = vec![AgentCapabilityConfig::new(format!(
+            "skill:{}",
+            uuid::Uuid::new_v4()
+        ))];
+
+        let err = service.create(&caller, None, req).await.unwrap_err();
+        assert_eq!(err.to_string(), "Skill not found");
+    }
+
+    #[tokio::test]
+    async fn create_accepts_valid_builtin_capability() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let service = AgentService::new(db.clone());
+        let caller = Caller::internal(DEFAULT_ORG_ID);
+
+        let mut req = build_create_request(None);
+        req.capabilities = vec![AgentCapabilityConfig::new("current_time")];
+
+        let agent = service.create(&caller, None, req).await.unwrap();
+        assert_eq!(agent.capabilities[0].capability_id(), "current_time");
+    }
+
+    #[tokio::test]
+    async fn update_rejects_unknown_capability() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let service = AgentService::new(db.clone());
+        let caller = Caller::internal(DEFAULT_ORG_ID);
+
+        let agent = service
+            .create(&caller, None, build_create_request(None))
+            .await
+            .unwrap();
+
+        let mut req = build_update_request(None);
+        req.capabilities = Some(vec![AgentCapabilityConfig::new("bogus_cap")]);
+
+        let err = service
+            .update(&caller, &agent.public_id.to_string(), req)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), "Capability not found");
     }
 }

--- a/crates/server/src/services/capability_validation.rs
+++ b/crates/server/src/services/capability_validation.rs
@@ -1,0 +1,254 @@
+// Validate capability references on write paths.
+//
+// Ensures that capability refs persisted on agents, harnesses, and sessions
+// actually resolve: built-in IDs must exist in the registry, `mcp:{uuid}`
+// refs must point to an MCP server in the caller's org, and `skill:{uuid}`
+// refs must point to a skill in the caller's org.
+//
+// See EVE-154 for context.
+
+use crate::errors::ResourceNotFoundError;
+use crate::storage::StorageBackend;
+use anyhow::Result;
+use everruns_core::capabilities::{
+    AgentCapabilityConfig, CapabilityRegistry, is_mcp_capability, is_skill_capability,
+    parse_mcp_capability_id, parse_skill_capability_id,
+};
+
+/// Validate that all capability references in `capabilities` resolve.
+///
+/// - Built-in IDs are checked against a static `CapabilityRegistry::with_builtins()`.
+/// - `mcp:{uuid}` refs are resolved against the org's MCP servers.
+/// - `skill:{uuid}` refs are resolved against the org's skills.
+///
+/// Returns `Ok(())` on success, or a typed error identifying the first invalid ref.
+pub async fn validate_capability_refs(
+    db: &StorageBackend,
+    org_id: i64,
+    capabilities: &[AgentCapabilityConfig],
+) -> Result<()> {
+    // Lazily build registry only when needed (when there are non-virtual refs)
+    let mut registry: Option<CapabilityRegistry> = None;
+
+    for cap in capabilities {
+        let cap_id = cap.capability_id();
+
+        if is_mcp_capability(cap_id) {
+            let uuid = parse_mcp_capability_id(cap_id)
+                .ok_or_else(|| anyhow::anyhow!("Invalid MCP capability reference: {cap_id}"))?;
+            db.get_mcp_server(org_id, uuid)
+                .await?
+                .ok_or_else(|| ResourceNotFoundError::new("MCP server"))?;
+        } else if is_skill_capability(cap_id) {
+            let uuid = parse_skill_capability_id(cap_id)
+                .ok_or_else(|| anyhow::anyhow!("Invalid skill capability reference: {cap_id}"))?;
+            db.get_skill(org_id, uuid)
+                .await?
+                .ok_or_else(|| ResourceNotFoundError::new("Skill"))?;
+        } else {
+            // Built-in capability — check registry
+            let reg = registry.get_or_insert_with(CapabilityRegistry::with_builtins);
+            if !reg.has(cap_id) {
+                return Err(ResourceNotFoundError::new("Capability").into());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::models::{CreateMcpServerRow, CreateSkillRow};
+    use everruns_core::DEFAULT_ORG_ID;
+    use std::sync::Arc;
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn valid_builtin_capability_passes() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let caps = vec![AgentCapabilityConfig::new("current_time")];
+
+        validate_capability_refs(&db, DEFAULT_ORG_ID, &caps)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn unknown_builtin_capability_rejected() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let caps = vec![AgentCapabilityConfig::new("nonexistent_capability")];
+
+        let err = validate_capability_refs(&db, DEFAULT_ORG_ID, &caps)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), "Capability not found");
+    }
+
+    #[tokio::test]
+    async fn valid_mcp_ref_passes() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let server = db
+            .create_mcp_server(
+                DEFAULT_ORG_ID,
+                CreateMcpServerRow {
+                    name: "test-server".to_string(),
+                    description: None,
+                    url: "http://localhost:3000".to_string(),
+                    transport_type: "sse".to_string(),
+                    api_key_encrypted: None,
+                    headers: None,
+                    settings: None,
+                },
+            )
+            .await
+            .unwrap();
+        let cap_id = format!("mcp:{}", server.id.uuid());
+        let caps = vec![AgentCapabilityConfig::new(cap_id)];
+
+        validate_capability_refs(&db, DEFAULT_ORG_ID, &caps)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn nonexistent_mcp_ref_rejected() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let cap_id = format!("mcp:{}", Uuid::new_v4());
+        let caps = vec![AgentCapabilityConfig::new(cap_id)];
+
+        let err = validate_capability_refs(&db, DEFAULT_ORG_ID, &caps)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), "MCP server not found");
+    }
+
+    #[tokio::test]
+    async fn invalid_mcp_uuid_rejected() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let caps = vec![AgentCapabilityConfig::new("mcp:not-a-uuid")];
+
+        let err = validate_capability_refs(&db, DEFAULT_ORG_ID, &caps)
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("Invalid MCP capability reference"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn valid_skill_ref_passes() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let skill = db
+            .create_skill(
+                DEFAULT_ORG_ID,
+                CreateSkillRow {
+                    public_id: format!("skill_{}", Uuid::new_v4().simple()),
+                    name: "test-skill".to_string(),
+                    description: "A test skill".to_string(),
+                    license: None,
+                    compatibility: None,
+                    metadata: serde_json::json!({}),
+                    allowed_tools: None,
+                    instructions: "Test instructions".to_string(),
+                    source_type: "registry".to_string(),
+                    archive_data: None,
+                    version: "1.0.0".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        let cap_id = format!("skill:{}", skill.id.uuid());
+        let caps = vec![AgentCapabilityConfig::new(cap_id)];
+
+        validate_capability_refs(&db, DEFAULT_ORG_ID, &caps)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn nonexistent_skill_ref_rejected() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let cap_id = format!("skill:{}", Uuid::new_v4());
+        let caps = vec![AgentCapabilityConfig::new(cap_id)];
+
+        let err = validate_capability_refs(&db, DEFAULT_ORG_ID, &caps)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), "Skill not found");
+    }
+
+    #[tokio::test]
+    async fn invalid_skill_uuid_rejected() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let caps = vec![AgentCapabilityConfig::new("skill:not-a-uuid")];
+
+        let err = validate_capability_refs(&db, DEFAULT_ORG_ID, &caps)
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("Invalid skill capability reference"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_capabilities_passes() {
+        let db = Arc::new(StorageBackend::in_memory());
+
+        validate_capability_refs(&db, DEFAULT_ORG_ID, &[])
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn mcp_ref_from_other_org_rejected() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let other_org_id = db
+            .create_organization_with_id(
+                2,
+                crate::storage::CreateOrganizationRow {
+                    public_id: "org_2".to_string(),
+                    name: "Org 2".to_string(),
+                    created_by: None,
+                },
+            )
+            .await
+            .unwrap()
+            .unwrap()
+            .org_id;
+
+        let server = db
+            .create_mcp_server(
+                other_org_id,
+                CreateMcpServerRow {
+                    name: "other-server".to_string(),
+                    description: None,
+                    url: "http://localhost:3000".to_string(),
+                    transport_type: "sse".to_string(),
+                    api_key_encrypted: None,
+                    headers: None,
+                    settings: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let cap_id = format!("mcp:{}", server.id.uuid());
+        let caps = vec![AgentCapabilityConfig::new(cap_id)];
+
+        let err = validate_capability_refs(&db, DEFAULT_ORG_ID, &caps)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), "MCP server not found");
+    }
+}

--- a/crates/server/src/services/harness.rs
+++ b/crates/server/src/services/harness.rs
@@ -71,6 +71,12 @@ impl HarnessService {
     pub async fn create(&self, caller: &Caller, req: CreateHarnessRequest) -> Result<Harness> {
         let capabilities_to_store =
             ensure_file_system_capability(req.capabilities.clone(), !req.initial_files.is_empty());
+        crate::services::capability_validation::validate_capability_refs(
+            &self.db,
+            caller.org_id,
+            &capabilities_to_store,
+        )
+        .await?;
         let parent_harness_id = self
             .validate_parent_harness(caller.org_id, None, req.parent_harness_id)
             .await?;
@@ -189,6 +195,14 @@ impl HarnessService {
             )),
             None => None,
         };
+        if let Some(ref caps) = capabilities_override {
+            crate::services::capability_validation::validate_capability_refs(
+                &self.db,
+                caller.org_id,
+                caps,
+            )
+            .await?;
+        }
         let default_model_id = self
             .validate_default_model_id(caller.org_id, req.default_model_id)
             .await?;
@@ -784,5 +798,56 @@ mod tests {
 
         assert!(err.downcast_ref::<ResourceNotFoundError>().is_some());
         assert_eq!(err.to_string(), "Harness not found");
+    }
+
+    #[tokio::test]
+    async fn create_rejects_unknown_builtin_capability() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let service = HarnessService::new(db.clone());
+        let caller = Caller::internal(DEFAULT_ORG_ID);
+
+        let mut req = build_create_request(None);
+        req.capabilities = vec![AgentCapabilityConfig::new("nonexistent_cap")];
+
+        let err = service.create(&caller, req).await.unwrap_err();
+        assert_eq!(err.to_string(), "Capability not found");
+    }
+
+    #[tokio::test]
+    async fn create_rejects_nonexistent_mcp_ref() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let service = HarnessService::new(db.clone());
+        let caller = Caller::internal(DEFAULT_ORG_ID);
+
+        let mut req = build_create_request(None);
+        req.capabilities = vec![AgentCapabilityConfig::new(format!(
+            "mcp:{}",
+            Uuid::new_v4()
+        ))];
+
+        let err = service.create(&caller, req).await.unwrap_err();
+        assert_eq!(err.to_string(), "MCP server not found");
+    }
+
+    #[tokio::test]
+    async fn update_rejects_unknown_capability() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let service = HarnessService::new(db.clone());
+        let caller = Caller::internal(DEFAULT_ORG_ID);
+
+        let harness = service
+            .create(&caller, build_create_request(None))
+            .await
+            .unwrap();
+
+        let mut req = build_update_request(None);
+        req.capabilities = Some(vec![AgentCapabilityConfig::new("bogus_cap")]);
+
+        let err = service
+            .update(&caller, harness.id.uuid(), req)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), "Capability not found");
     }
 }

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -4,6 +4,7 @@
 pub mod agent;
 pub mod app;
 pub mod capability;
+pub(crate) mod capability_validation;
 pub mod event;
 pub mod harness;
 pub mod leased_resource;

--- a/crates/server/src/services/session.rs
+++ b/crates/server/src/services/session.rs
@@ -124,6 +124,14 @@ impl SessionService {
                     .or(effective_harness.default_model_id)
             });
 
+        // Validate session-level capability refs before persisting
+        crate::services::capability_validation::validate_capability_refs(
+            &self.db,
+            org_id,
+            &req.capabilities,
+        )
+        .await?;
+
         // Serialize capabilities to JSON for storage
         let capabilities_json = serde_json::to_value(&req.capabilities)?;
 


### PR DESCRIPTION
## What
Validate capability references (`mcp:{uuid}`, `skill:{uuid}`, built-in IDs) on agent, harness, and session write paths before persisting them.

## Why
Previously, write paths accepted nonexistent MCP server refs, nonexistent skill refs, and unknown built-in capability IDs. These would be silently ignored at runtime (fail-closed), but invalid config should be rejected at write time. Fixes EVE-154.

## How
- Added `capability_validation::validate_capability_refs()` shared function
- Built-in IDs checked against `CapabilityRegistry::with_builtins()`
- `mcp:{uuid}` resolved via `db.get_mcp_server(org_id, uuid)`
- `skill:{uuid}` resolved via `db.get_skill(org_id, uuid)`
- Wired into agent create/update/upsert, harness create/update, session create
- Cross-org isolation enforced (MCP/skill lookups are org-scoped)

## Risk
- Low
- Existing valid configurations are unaffected. Only invalid refs (which were already silently ignored at runtime) will now be rejected at write time.

## Checklist
- [x] Tests added or updated (28 unit tests covering all ref types, invalid UUIDs, cross-org isolation)
- [x] Backward compatibility considered (no breaking change — only rejects previously-invalid inputs)