### PR TITLE
feat(server): seed example agents during org init

### DIFF
--- a/apps/ui/src/app/(main)/orgs/[orgId]/setup/page.tsx
+++ b/apps/ui/src/app/(main)/orgs/[orgId]/setup/page.tsx
@@ -12,6 +12,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { getOrganization } from "@/lib/api/organizations";
 import { listHarnesses } from "@/lib/api/harnesses";
+import { listAgents } from "@/lib/api/agents";
 import { queryKeys } from "@/lib/query-keys";
 import { useOrg } from "@/providers/org-provider";
 import { Building2, Check, CircleDot, Loader2, ArrowRight } from "lucide-react";
@@ -34,6 +35,11 @@ const SETUP_STEPS: SetupStep[] = [
     id: "harnesses_init",
     label: "Harnesses initialised",
     description: "Built-in harnesses (Base, Generic, Platform Chat) are ready",
+  },
+  {
+    id: "agents_seeded",
+    label: "Example agents seeded",
+    description: "Starter agents are ready to use out of the box",
   },
   {
     id: "defaults_configured",
@@ -71,11 +77,20 @@ export default function OrgSetupPage() {
     staleTime: 30000,
   });
 
+  // Fetch agents for this org
+  const { data: agents = [] } = useQuery({
+    queryKey: [...queryKeys.agents.all, orgId],
+    queryFn: () => listAgents(),
+    enabled: !!org,
+    staleTime: 30000,
+  });
+
   // Derive step statuses from real data
   const orgReady = !!org;
   const harnessesReady = harnesses.length > 0;
+  const agentsReady = agents.length > 0;
   const defaultsReady = !!org?.default_harness_id && !!org?.base_harness_id;
-  const allDone = orgReady && harnessesReady && defaultsReady;
+  const allDone = orgReady && harnessesReady && agentsReady && defaultsReady;
 
   // Ensure this org is set as current so harness queries work
   useEffect(() => {

--- a/crates/server/src/api/organizations.rs
+++ b/crates/server/src/api/organizations.rs
@@ -13,8 +13,8 @@ use axum::{
     routing::get,
 };
 use everruns_core::{
-    BuiltInHarnessDefinition, DEFAULT_ORG_ID, OrgRole, Organization, generate_org_public_id,
-    validate_org_public_id,
+    BuiltInHarnessDefinition, DEFAULT_ORG_ID, DeploymentGrade, OrgRole, Organization,
+    PlatformDefinition, generate_org_public_id, validate_org_public_id,
 };
 use everruns_durable::UpdateField;
 
@@ -29,22 +29,37 @@ pub struct AppState {
     pub db: Arc<StorageBackend>,
     pub auth: AuthState,
     pub built_in_harnesses: Vec<BuiltInHarnessDefinition>,
+    pub platform_definition: Arc<PlatformDefinition>,
+    pub deployment_grade: DeploymentGrade,
 }
 
 impl AppState {
     pub fn new(db: Arc<StorageBackend>, auth: AuthState) -> Self {
-        Self::with_built_in_harnesses(db, auth, crate::platform::oss_built_in_harnesses())
+        let grade = DeploymentGrade::from_env();
+        let platform_definition =
+            Arc::new(crate::platform::oss_platform_definition_for_grade(grade));
+        Self {
+            db,
+            auth,
+            built_in_harnesses: crate::platform::oss_built_in_harnesses(),
+            platform_definition,
+            deployment_grade: grade,
+        }
     }
 
-    pub fn with_built_in_harnesses(
+    pub fn with_platform(
         db: Arc<StorageBackend>,
         auth: AuthState,
         built_in_harnesses: Vec<BuiltInHarnessDefinition>,
+        platform_definition: Arc<PlatformDefinition>,
+        deployment_grade: DeploymentGrade,
     ) -> Self {
         Self {
             db,
             auth,
             built_in_harnesses,
+            platform_definition,
+            deployment_grade,
         }
     }
 }
@@ -240,6 +255,22 @@ pub async fn create_organization(
             org_id = row.org_id,
             error = %e,
             "Failed to initialize built-in harnesses for new org (non-fatal)"
+        );
+    }
+
+    // Seed example agents for the new organization
+    if let Err(e) = crate::org_init::initialize_org_agents(
+        &state.db,
+        row.org_id,
+        state.deployment_grade,
+        &state.platform_definition,
+    )
+    .await
+    {
+        tracing::warn!(
+            org_id = row.org_id,
+            error = %e,
+            "Failed to seed example agents for new org (non-fatal)"
         );
     }
 

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -554,10 +554,12 @@ impl ServerAppBuilder {
         ));
         let skills_state = api::skills::AppState::new(db.clone(), auth_state.clone());
         let images_state = api::images::AppState::new(db.clone(), auth_state.clone());
-        let organizations_state = api::organizations::AppState::with_built_in_harnesses(
+        let organizations_state = api::organizations::AppState::with_platform(
             db.clone(),
             auth_state.clone(),
             platform_definition.built_in_harnesses().to_vec(),
+            platform_definition.clone(),
+            everruns_core::DeploymentGrade::from_env(),
         );
         let audit_logs_state = api::audit_logs::AppState::new(db.clone(), auth_state.clone());
         let user_connections_state = api::user_connections::AppState::new(

--- a/crates/server/src/org_init.rs
+++ b/crates/server/src/org_init.rs
@@ -1,17 +1,23 @@
-// Organization initialization and built-in harness management
+// Organization initialization: built-in harnesses and seed agents
 //
 // Decision: Built-in harnesses are readonly, system-managed, provisioned per-org
-// Decision: New orgs get built-in harnesses during creation
+// Decision: Seed agents are provisioned per-org during org creation (same as harnesses)
+// Decision: New orgs get built-in harnesses and seed agents during creation
 // Decision: Reconciliation ensures all orgs stay up-to-date with built-in definitions
 // Decision: Default org uses fixed seed UUIDs for backward compat; other orgs get fresh UUIDs
 // Decision: Org settings keep separate default and base harness pointers
 
+use crate::api::common::Pagination;
+use crate::seed::{SEED_AGENTS, sync_agent_capabilities};
 use crate::storage::{
     StorageBackend,
-    models::{CreateHarnessRow, UpdateOrganizationSettings},
+    models::{CreateAgentRow, CreateHarnessRow, UpdateOrganizationSettings},
 };
 use anyhow::{Context, Result};
-use everruns_core::{BuiltInCapabilityDefinition, BuiltInHarnessDefinition, BuiltInHarnessRole};
+use everruns_core::{
+    BuiltInCapabilityDefinition, BuiltInHarnessDefinition, BuiltInHarnessRole, DeploymentGrade,
+    PlatformDefinition,
+};
 use everruns_durable::UpdateField;
 use uuid::Uuid;
 /// Well-known seed IDs for default org harnesses (backward compat)
@@ -333,6 +339,156 @@ async fn sync_harness_capabilities(
         .collect();
     db.set_harness_capabilities(harness_id, cap_tuples).await?;
     Ok(true)
+}
+
+// ============================================
+// Seed Agent Initialization (per-org)
+// ============================================
+
+/// Initialize seed agents for a specific organization.
+///
+/// For `DEFAULT_ORG_ID`, uses fixed seed UUIDs for backward compatibility.
+/// For other orgs, creates agents with fresh UUIDs (skips if already exists by name).
+///
+/// Filters out dev-only agents when deployment grade disallows experimental features,
+/// and skips agents whose capabilities are not registered in the platform definition.
+pub async fn initialize_org_agents(
+    db: &StorageBackend,
+    org_id: i64,
+    grade: DeploymentGrade,
+    platform_definition: &PlatformDefinition,
+) -> Result<InitResult> {
+    use everruns_core::DEFAULT_ORG_ID;
+
+    let mut result = InitResult::default();
+    let is_default_org = org_id == DEFAULT_ORG_ID;
+    let include_dev_only = grade.experimental_features_enabled();
+
+    for seed in SEED_AGENTS {
+        if seed.dev_only && !include_dev_only {
+            tracing::debug!(
+                name = seed.name,
+                org_id,
+                "Skipping dev-only agent (deployment_grade={})",
+                grade
+            );
+            continue;
+        }
+
+        let missing_capabilities: Vec<&str> = seed
+            .capabilities
+            .iter()
+            .map(|cap| cap.id)
+            .filter(|cap_id| !platform_definition.capability_registry().has(cap_id))
+            .collect();
+        if !missing_capabilities.is_empty() {
+            tracing::debug!(
+                name = seed.name,
+                org_id,
+                missing = ?missing_capabilities,
+                "Skipping seed agent — missing capabilities in platform definition"
+            );
+            continue;
+        }
+
+        let input = CreateAgentRow {
+            public_id: everruns_core::AgentId::from_uuid(seed.id).to_string(),
+            name: seed.name.to_string(),
+            description: Some(seed.description.to_string()),
+            system_prompt: seed.system_prompt.to_string(),
+            default_model_id: None,
+            tags: seed.tags.iter().map(|s| s.to_string()).collect(),
+            initial_files: serde_json::json!([]),
+            tools: serde_json::json!([]),
+        };
+
+        if is_default_org {
+            // Default org: use fixed seed UUIDs for backward compat
+            match db
+                .create_agent_with_id(org_id, seed.id.into(), input)
+                .await?
+            {
+                Some(row) => {
+                    sync_agent_capabilities(db, row.id.uuid(), seed.capabilities).await?;
+                    if row.created_at == row.updated_at {
+                        tracing::info!(name = seed.name, org_id, "Created seed agent");
+                        result.created += 1;
+                    } else {
+                        tracing::info!(name = seed.name, org_id, "Updated seed agent");
+                        result.updated += 1;
+                    }
+                }
+                None => {
+                    let caps_changed =
+                        sync_agent_capabilities(db, seed.id, seed.capabilities).await?;
+                    if caps_changed {
+                        tracing::info!(name = seed.name, org_id, "Updated seed agent capabilities");
+                        result.updated += 1;
+                    } else {
+                        tracing::debug!(name = seed.name, org_id, "Seed agent up to date");
+                        result.unchanged += 1;
+                    }
+                }
+            }
+        } else {
+            // Non-default org: check if agent already exists by name
+            let (existing, _) = db
+                .list_agents(org_id, Some(seed.name), false, Pagination::new(0, 1))
+                .await?;
+            let already_exists = existing.iter().any(|a| a.name == seed.name);
+
+            if already_exists {
+                result.unchanged += 1;
+            } else {
+                let row = db.create_agent(org_id, input).await?;
+                sync_agent_capabilities(db, row.id.uuid(), seed.capabilities).await?;
+                tracing::info!(
+                    name = seed.name,
+                    org_id,
+                    id = %row.id,
+                    "Created seed agent for org"
+                );
+                result.created += 1;
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+/// Reconcile seed agents across all organizations.
+///
+/// Ensures every org has up-to-date seed agents. Called during seeding
+/// and can be triggered for upgrades when seed definitions change.
+pub async fn reconcile_built_in_agents(
+    db: &StorageBackend,
+    grade: DeploymentGrade,
+    platform_definition: &PlatformDefinition,
+) -> Result<InitResult> {
+    let orgs = db.list_organizations().await?;
+    let mut total = InitResult::default();
+
+    for org in &orgs {
+        let org_result = initialize_org_agents(db, org.org_id, grade, platform_definition).await?;
+        tracing::debug!(
+            org_id = org.org_id,
+            created = org_result.created,
+            updated = org_result.updated,
+            unchanged = org_result.unchanged,
+            "Reconciled seed agents for org"
+        );
+        total.merge(org_result);
+    }
+
+    tracing::info!(
+        org_count = orgs.len(),
+        created = total.created,
+        updated = total.updated,
+        unchanged = total.unchanged,
+        "Seed agent reconciliation complete"
+    );
+
+    Ok(total)
 }
 
 /// Result of org initialization
@@ -704,6 +860,96 @@ mod tests {
             unchanged: 3,
         };
         assert!(!result3.has_changes());
+    }
+
+    // --- Agent initialization tests ---
+
+    fn platform() -> PlatformDefinition {
+        crate::platform::oss_platform_definition()
+    }
+
+    #[tokio::test]
+    async fn test_initialize_default_org_creates_agents() {
+        let db = make_db();
+        seed_default_org(&db).await;
+        // Harnesses must exist first (agents may reference them indirectly)
+        initialize_org_harnesses(&db, DEFAULT_ORG_ID).await.unwrap();
+
+        let pd = platform();
+        let result = initialize_org_agents(&db, DEFAULT_ORG_ID, DeploymentGrade::Dev, &pd)
+            .await
+            .unwrap();
+        assert!(result.created > 0, "Should create at least one agent");
+
+        let (agents, _) = db
+            .list_agents(DEFAULT_ORG_ID, None, false, Pagination::new(0, 100))
+            .await
+            .unwrap();
+        assert!(!agents.is_empty(), "Agents should exist after init");
+    }
+
+    #[tokio::test]
+    async fn test_initialize_agents_idempotent() {
+        let db = make_db();
+        seed_default_org(&db).await;
+        initialize_org_harnesses(&db, DEFAULT_ORG_ID).await.unwrap();
+
+        let pd = platform();
+        let r1 = initialize_org_agents(&db, DEFAULT_ORG_ID, DeploymentGrade::Dev, &pd)
+            .await
+            .unwrap();
+        assert!(r1.created > 0);
+
+        let r2 = initialize_org_agents(&db, DEFAULT_ORG_ID, DeploymentGrade::Dev, &pd)
+            .await
+            .unwrap();
+        assert_eq!(r2.created, 0, "Second run should create nothing");
+        assert!(r2.unchanged > 0);
+    }
+
+    #[tokio::test]
+    async fn test_initialize_agents_new_org() {
+        let db = make_db();
+        seed_default_org(&db).await;
+
+        let org2 = db
+            .create_organization(crate::storage::models::CreateOrganizationRow {
+                public_id: "org_00000000000000000000000000000099".to_string(),
+                name: "Agent Test Org".to_string(),
+                created_by: None,
+            })
+            .await
+            .unwrap();
+        initialize_org_harnesses(&db, org2.org_id).await.unwrap();
+
+        let pd = platform();
+        let result = initialize_org_agents(&db, org2.org_id, DeploymentGrade::Dev, &pd)
+            .await
+            .unwrap();
+        assert!(result.created > 0, "New org should get seed agents");
+
+        // Second call should be idempotent
+        let r2 = initialize_org_agents(&db, org2.org_id, DeploymentGrade::Dev, &pd)
+            .await
+            .unwrap();
+        assert_eq!(r2.created, 0);
+    }
+
+    #[tokio::test]
+    async fn test_seed_agents_respect_deployment_grade() {
+        // Verify the filtering logic itself: dev-only agents exist in SEED_AGENTS
+        let dev_only_count = SEED_AGENTS.iter().filter(|a| a.dev_only).count();
+        assert!(
+            dev_only_count > 0,
+            "SEED_AGENTS should contain at least one dev-only agent"
+        );
+
+        // Non-dev-only agents count
+        let non_dev_count = SEED_AGENTS.iter().filter(|a| !a.dev_only).count();
+        assert!(
+            non_dev_count > 0,
+            "SEED_AGENTS should contain at least one non-dev-only agent"
+        );
     }
 
     async fn seed_default_org(db: &StorageBackend) {

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -11,8 +11,8 @@ use crate::org_init;
 use crate::storage::{
     StorageBackend,
     models::{
-        CreateAgentRow, CreateLlmModelRow, CreateLlmProviderRow, CreateMcpServerRow,
-        CreateOrganizationRow, CreateUserRow,
+        CreateLlmModelRow, CreateLlmProviderRow, CreateMcpServerRow, CreateOrganizationRow,
+        CreateUserRow,
     },
     password::hash_password,
 };
@@ -156,7 +156,7 @@ impl SeedResult {
 
 /// Sync capabilities for an agent, only writing if the set actually changed.
 /// Returns true if capabilities were updated.
-async fn sync_agent_capabilities(
+pub(crate) async fn sync_agent_capabilities(
     db: &StorageBackend,
     agent_id: Uuid,
     desired: &[SeedCapability],
@@ -325,17 +325,17 @@ async fn seed_admin_user(
 // ============================================
 
 /// Capability entry with optional per-capability config.
-struct SeedCapability {
-    id: &'static str,
-    config: Option<fn() -> serde_json::Value>,
+pub(crate) struct SeedCapability {
+    pub(crate) id: &'static str,
+    pub(crate) config: Option<fn() -> serde_json::Value>,
 }
 
 impl SeedCapability {
-    const fn new(id: &'static str) -> Self {
+    pub(crate) const fn new(id: &'static str) -> Self {
         Self { id, config: None }
     }
 
-    const fn with_config(id: &'static str, config: fn() -> serde_json::Value) -> Self {
+    pub(crate) const fn with_config(id: &'static str, config: fn() -> serde_json::Value) -> Self {
         Self {
             id,
             config: Some(config),
@@ -349,19 +349,19 @@ impl std::fmt::Display for SeedCapability {
     }
 }
 /// Seed agent definition
-struct SeedAgent {
-    id: Uuid,
-    name: &'static str,
-    description: &'static str,
-    system_prompt: &'static str,
-    tags: &'static [&'static str],
-    capabilities: &'static [SeedCapability],
+pub(crate) struct SeedAgent {
+    pub(crate) id: Uuid,
+    pub(crate) name: &'static str,
+    pub(crate) description: &'static str,
+    pub(crate) system_prompt: &'static str,
+    pub(crate) tags: &'static [&'static str],
+    pub(crate) capabilities: &'static [SeedCapability],
     /// If true, only seed in dev environments (experimental features)
-    dev_only: bool,
+    pub(crate) dev_only: bool,
 }
 
 /// Built-in seed agents
-const SEED_AGENTS: &[SeedAgent] = &[
+pub(crate) const SEED_AGENTS: &[SeedAgent] = &[
     SeedAgent {
         id: seed_ids::DAD_JOKES_AGENT,
         name: "Dad Jokes Agent",
@@ -1019,85 +1019,7 @@ User: "Analyze my codebase and suggest improvements"
     },
 ];
 
-/// Seed agents into the database (upserts, only when changed).
-///
-/// Filters out dev-only agents when not in dev environment.
-async fn seed_agents_with_platform_definition(
-    db: &StorageBackend,
-    grade: DeploymentGrade,
-    platform_definition: &PlatformDefinition,
-) -> anyhow::Result<SeedResult> {
-    let mut result = SeedResult::default();
-    let include_dev_only = grade.experimental_features_enabled();
-
-    for seed in SEED_AGENTS {
-        // Skip dev-only agents in non-dev environments
-        if seed.dev_only && !include_dev_only {
-            tracing::debug!(
-                name = seed.name,
-                id = %seed.id,
-                "Skipping dev-only agent (deployment_grade={})",
-                grade
-            );
-            continue;
-        }
-        let missing_capabilities: Vec<&str> = seed
-            .capabilities
-            .iter()
-            .map(|capability| capability.id)
-            .filter(|capability_id| !platform_definition.capability_registry().has(capability_id))
-            .collect();
-        if !missing_capabilities.is_empty() {
-            tracing::debug!(
-                name = seed.name,
-                id = %seed.id,
-                missing_capabilities = ?missing_capabilities,
-                "Skipping seed agent because platform definition does not register all required capabilities"
-            );
-            continue;
-        }
-        let input = CreateAgentRow {
-            public_id: everruns_core::AgentId::from_uuid(seed.id).to_string(),
-            name: seed.name.to_string(),
-            description: Some(seed.description.to_string()),
-            system_prompt: seed.system_prompt.to_string(),
-            default_model_id: None,
-            tags: seed.tags.iter().map(|s| s.to_string()).collect(),
-            initial_files: serde_json::json!([]),
-            tools: serde_json::json!([]),
-        };
-
-        match db
-            .create_agent_with_id(DEFAULT_ORG_ID, seed.id.into(), input)
-            .await?
-        {
-            Some(row) => {
-                // Row was created or updated — sync capabilities
-                sync_agent_capabilities(db, row.id.uuid(), seed.capabilities).await?;
-                if row.created_at == row.updated_at {
-                    tracing::info!(name = seed.name, id = %seed.id, "Created seed agent");
-                    result.created += 1;
-                } else {
-                    tracing::info!(name = seed.name, id = %seed.id, "Updated seed agent");
-                    result.updated += 1;
-                }
-            }
-            None => {
-                // Row unchanged — check if capabilities need syncing
-                let caps_changed = sync_agent_capabilities(db, seed.id, seed.capabilities).await?;
-                if caps_changed {
-                    tracing::info!(name = seed.name, id = %seed.id, "Updated seed agent capabilities");
-                    result.updated += 1;
-                } else {
-                    tracing::debug!(name = seed.name, id = %seed.id, "Agent up to date");
-                    result.unchanged += 1;
-                }
-            }
-        }
-    }
-
-    Ok(result)
-}
+// Agent seeding has moved to org_init::initialize_org_agents (per-org, mirrors harness pattern).
 
 // ============================================
 // LLM Provider Seeder
@@ -2010,15 +1932,17 @@ pub async fn seed_all_with_platform_definition(
     result.updated += harness_result.updated;
     result.unchanged += harness_result.unchanged;
 
-    // Seed agents (respects deployment grade for dev-only agents)
-    let agent_result = seed_agents_with_platform_definition(db, grade, platform_definition).await?;
+    // Reconcile built-in agents across all orgs (mirrors harness reconciliation)
+    let agent_result = org_init::reconcile_built_in_agents(db, grade, platform_definition).await?;
     tracing::debug!(
         created = agent_result.created,
         updated = agent_result.updated,
         unchanged = agent_result.unchanged,
-        "Agents seeded"
+        "Built-in agents reconciled"
     );
-    result.merge(agent_result);
+    result.created += agent_result.created;
+    result.updated += agent_result.updated;
+    result.unchanged += agent_result.unchanged;
 
     Ok(result)
 }

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -209,10 +209,12 @@ impl TestServer {
             api::schedules::ScheduleAppState::new(Some(durable_store), auth_state.clone());
         let skills_state = api::skills::AppState::new(db.clone(), auth_state.clone());
         let images_state = api::images::AppState::new(db.clone(), auth_state.clone());
-        let organizations_state = api::organizations::AppState::with_built_in_harnesses(
+        let organizations_state = api::organizations::AppState::with_platform(
             db.clone(),
             auth_state.clone(),
             platform_definition.built_in_harnesses().to_vec(),
+            Arc::new(platform_definition.clone()),
+            grade,
         );
         let session_schedules_state = api::session_schedules::AppState::new(
             Arc::new(services::SessionScheduleService::new(db.clone())),


### PR DESCRIPTION
## What
Move seeding of example agents to the same `init_org` process that handles harnesses, so every new organization gets starter agents out of the box.

## Why
Previously, seed agents were only created for the default org during server startup. New organizations created via the API got harnesses but no agents, leaving them empty.

## How
- Added `initialize_org_agents` and `reconcile_built_in_agents` to `org_init.rs`, mirroring the existing harness initialization pattern
- Default org: fixed seed UUIDs for backward compat. New orgs: fresh UUIDs, skip-if-exists by name
- Org creation endpoint (`POST /v1/orgs`) now calls `initialize_org_agents` after harness init
- Startup `seed_all` now reconciles agents across all orgs (not just default)
- Exposed `SeedAgent`, `SeedCapability`, `SEED_AGENTS`, `sync_agent_capabilities` as `pub(crate)` from `seed.rs`
- Added `PlatformDefinition` + `DeploymentGrade` to org `AppState`
- Setup UI shows new "Example agents seeded" step

## Risk
- Low
- Agent seeding failure is non-fatal (logged as warning, does not block org creation)
- Default org path unchanged (same seed IDs, same upsert logic)
- No migration needed — reconciliation seeds agents for existing orgs on next startup

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered