### PR TITLE
refactor(ui): extract generic CRUD APIs and hooks

### DIFF
--- a/apps/ui/src/__tests__/create-crud-hooks.test.tsx
+++ b/apps/ui/src/__tests__/create-crud-hooks.test.tsx
@@ -1,0 +1,88 @@
+import { renderHook, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { createCrudHooks } from "@/hooks/create-crud-hooks";
+
+const mockUseOrg = jest.fn();
+jest.mock("@/providers/org-provider", () => ({
+  useOrg: () => mockUseOrg(),
+}));
+
+describe("createCrudHooks", () => {
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    mockUseOrg.mockReturnValue({
+      currentOrg: { public_id: "org-123" },
+      isLoading: false,
+    });
+  });
+
+  it("adds org scope to list queries and passes includeArchived", async () => {
+    const api = {
+      create: jest.fn(),
+      list: jest.fn().mockResolvedValue([{ id: "widget-1" }]),
+      get: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      destroy: jest.fn(),
+    };
+    const hooks = createCrudHooks({
+      api,
+      queryKeys: {
+        all: ["widgets"] as const,
+        list: (includeArchived = false) => ["widgets", { includeArchived }] as const,
+        detail: (id: string) => ["widget", id] as const,
+      },
+    });
+
+    const { result } = renderHook(() => hooks.useList({ includeArchived: true }), { wrapper });
+
+    expect(result.current.isLoading).toBe(true);
+    await act(async () => {});
+
+    expect(api.list).toHaveBeenCalledWith(true);
+    expect(queryClient.getQueryData(["widgets", { includeArchived: true }, "org-123"])).toEqual([
+      { id: "widget-1" },
+    ]);
+  });
+
+  it("invalidates list and detail queries after update succeeds", async () => {
+    const invalidateSpy = jest.spyOn(queryClient, "invalidateQueries");
+    const hooks = createCrudHooks({
+      api: {
+        create: jest.fn(),
+        list: jest.fn(),
+        get: jest.fn(),
+        update: jest.fn().mockResolvedValue({ id: "widget-1", name: "Updated" }),
+        delete: jest.fn(),
+        destroy: jest.fn(),
+      },
+      queryKeys: {
+        all: ["widgets"] as const,
+        list: (includeArchived = false) => ["widgets", { includeArchived }] as const,
+        detail: (id: string) => ["widget", id] as const,
+      },
+    });
+
+    const { result } = renderHook(() => hooks.useUpdate(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ id: "widget-1", request: { archived: true } });
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["widgets"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["widget", "widget-1"] });
+  });
+});

--- a/apps/ui/src/__tests__/crud-api.test.ts
+++ b/apps/ui/src/__tests__/crud-api.test.ts
@@ -1,0 +1,66 @@
+import { api } from "@/lib/api/client";
+import { createCrudApi } from "@/lib/api/crud";
+
+jest.mock("@/lib/api/client", () => ({
+  api: {
+    post: jest.fn(),
+    get: jest.fn(),
+    patch: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+const mockApi = jest.mocked(api);
+
+describe("createCrudApi", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("uses the base path for create/get/update/delete/destroy", async () => {
+    const crud = createCrudApi<{ id: string; name: string }, { name: string }, { name?: string }>(
+      "/v1/widgets",
+    );
+
+    mockApi.post.mockResolvedValueOnce({ data: { id: "w1", name: "Widget" } } as never);
+    mockApi.get.mockResolvedValueOnce({ data: { id: "w1", name: "Widget" } } as never);
+    mockApi.patch.mockResolvedValueOnce({ data: { id: "w1", name: "Renamed" } } as never);
+    mockApi.delete.mockResolvedValueOnce(undefined as never);
+    mockApi.post.mockResolvedValueOnce(undefined as never);
+
+    await expect(crud.create({ name: "Widget" })).resolves.toEqual({ id: "w1", name: "Widget" });
+    await expect(crud.get("w1")).resolves.toEqual({ id: "w1", name: "Widget" });
+    await expect(crud.update("w1", { name: "Renamed" })).resolves.toEqual({
+      id: "w1",
+      name: "Renamed",
+    });
+    await expect(crud.delete("w1")).resolves.toBeUndefined();
+    await expect(crud.destroy("w1")).resolves.toBeUndefined();
+
+    expect(mockApi.post).toHaveBeenNthCalledWith(1, "/v1/widgets", { name: "Widget" });
+    expect(mockApi.get).toHaveBeenCalledWith("/v1/widgets/w1");
+    expect(mockApi.patch).toHaveBeenCalledWith("/v1/widgets/w1", { name: "Renamed" });
+    expect(mockApi.delete).toHaveBeenCalledWith("/v1/widgets/w1");
+    expect(mockApi.post).toHaveBeenNthCalledWith(2, "/v1/widgets/w1/delete");
+  });
+
+  it("appends include_archived to list requests", async () => {
+    const crud = createCrudApi<{ id: string }, never, never>("/v1/widgets");
+    mockApi.get.mockResolvedValue({ data: { data: [{ id: "w1" }] } } as never);
+
+    await expect(crud.list()).resolves.toEqual([{ id: "w1" }]);
+    await expect(crud.list(true)).resolves.toEqual([{ id: "w1" }]);
+
+    expect(mockApi.get).toHaveBeenNthCalledWith(1, "/v1/widgets");
+    expect(mockApi.get).toHaveBeenNthCalledWith(2, "/v1/widgets?include_archived=true");
+  });
+
+  it("reuses an existing query string when include_archived is enabled", async () => {
+    const crud = createCrudApi<{ id: string }, never, never>("/v1/widgets?limit=20");
+    mockApi.get.mockResolvedValue({ data: { data: [] } } as never);
+
+    await crud.list(true);
+
+    expect(mockApi.get).toHaveBeenCalledWith("/v1/widgets?limit=20&include_archived=true");
+  });
+});

--- a/apps/ui/src/__tests__/use-apps.test.tsx
+++ b/apps/ui/src/__tests__/use-apps.test.tsx
@@ -5,15 +5,28 @@ import { usePublishApp, useUnpublishApp, useUpdateApp } from "@/hooks/use-apps";
 import { queryKeys } from "@/lib/query-keys";
 import type { App, UpdateAppRequest } from "@/lib/api/types";
 
-jest.mock("@/lib/api/apps", () => ({
-  createApp: jest.fn(),
-  deleteApp: jest.fn(),
-  getApp: jest.fn(),
-  getApps: jest.fn(),
-  publishApp: jest.fn(),
-  unpublishApp: jest.fn(),
-  updateApp: jest.fn(),
-}));
+jest.mock("@/lib/api/apps", () => {
+  const api = {
+    create: jest.fn(),
+    list: jest.fn(),
+    get: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    destroy: jest.fn(),
+  };
+
+  return {
+    appsCrudApi: api,
+    createApp: api.create,
+    deleteApp: api.delete,
+    destroyApp: api.destroy,
+    getApp: api.get,
+    getApps: api.list,
+    publishApp: jest.fn(),
+    unpublishApp: jest.fn(),
+    updateApp: api.update,
+  };
+});
 
 const mockUseOrg = jest.fn();
 jest.mock("@/providers/org-provider", () => ({

--- a/apps/ui/src/hooks/create-crud-hooks.ts
+++ b/apps/ui/src/hooks/create-crud-hooks.ts
@@ -1,0 +1,152 @@
+"use client";
+
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type QueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import type { CrudApi } from "@/lib/api/crud";
+import { useOrg } from "@/providers/org-provider";
+
+interface UseCrudListOptions {
+  includeArchived?: boolean;
+}
+
+type QueryKeyValue = readonly unknown[];
+
+interface CrudQueryKeys {
+  all: QueryKeyValue;
+  list(includeArchived?: boolean): QueryKeyValue;
+  detail(id: string): QueryKeyValue;
+}
+
+interface UseOrgScopedQueryOptions<TData> {
+  queryKey: QueryKeyValue;
+  queryFn: () => Promise<TData>;
+  enabled?: boolean;
+  staleTime?: number;
+}
+
+export function useOrgScopedQuery<TData>({
+  queryKey,
+  queryFn,
+  enabled = true,
+  staleTime,
+}: UseOrgScopedQueryOptions<TData>): UseQueryResult<TData> & { isLoading: boolean } {
+  const { currentOrg, isLoading: orgLoading } = useOrg();
+  const org = currentOrg?.public_id;
+
+  const query = useQuery({
+    queryKey: [...queryKey, org],
+    queryFn,
+    enabled: enabled && !!org,
+    staleTime,
+  });
+
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  } as UseQueryResult<TData> & { isLoading: boolean };
+}
+
+function invalidateCrudQueries(queryClient: QueryClient, queryKeys: CrudQueryKeys, id?: string) {
+  queryClient.invalidateQueries({ queryKey: queryKeys.all });
+  if (id) {
+    queryClient.invalidateQueries({ queryKey: queryKeys.detail(id) });
+  }
+}
+
+interface CreateCrudHooksOptions<TItem, TCreate, TUpdate> {
+  api: CrudApi<TItem, TCreate, TUpdate>;
+  queryKeys: CrudQueryKeys;
+  staleTime?: number;
+  syncEntityCache?(queryClient: QueryClient, item: TItem): void;
+}
+
+interface UpdateMutationVariables<TUpdate> {
+  id: string;
+  request: TUpdate;
+}
+
+export function createCrudHooks<TItem, TCreate, TUpdate>({
+  api,
+  queryKeys,
+  staleTime,
+  syncEntityCache,
+}: CreateCrudHooksOptions<TItem, TCreate, TUpdate>) {
+  function useList(options: UseCrudListOptions = {}) {
+    const includeArchived = options.includeArchived ?? false;
+
+    return useOrgScopedQuery({
+      queryKey: queryKeys.list(includeArchived),
+      queryFn: () => api.list(includeArchived),
+      staleTime,
+    });
+  }
+
+  function useDetail(id: string | undefined) {
+    return useOrgScopedQuery({
+      queryKey: queryKeys.detail(id ?? ""),
+      queryFn: () => api.get(id!),
+      enabled: !!id,
+      staleTime,
+    });
+  }
+
+  function useCreate(): UseMutationResult<TItem, Error, TCreate> {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+      mutationFn: api.create,
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: queryKeys.all });
+      },
+    });
+  }
+
+  function useUpdate(): UseMutationResult<TItem, Error, UpdateMutationVariables<TUpdate>> {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+      mutationFn: ({ id, request }) => api.update(id, request),
+      onSuccess: (item, { id }) => {
+        syncEntityCache?.(queryClient, item);
+        invalidateCrudQueries(queryClient, queryKeys, id);
+      },
+    });
+  }
+
+  function useDelete(): UseMutationResult<void, Error, string> {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+      mutationFn: api.delete,
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: queryKeys.all });
+      },
+    });
+  }
+
+  function useDestroy(): UseMutationResult<void, Error, string> {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+      mutationFn: api.destroy,
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: queryKeys.all });
+      },
+    });
+  }
+
+  return {
+    useList,
+    useDetail,
+    useCreate,
+    useUpdate,
+    useDelete,
+    useDestroy,
+  };
+}

--- a/apps/ui/src/hooks/use-agents.ts
+++ b/apps/ui/src/hooks/use-agents.ts
@@ -1,115 +1,48 @@
 // Agent hooks (M2)
 "use client";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  copyAgent,
-  createAgent,
-  deleteAgent,
-  destroyAgent,
-  exportAgent,
-  getAgent,
-  importAgent,
-  listAgents,
-  previewAgent,
-  updateAgent,
-} from "@/lib/api/agents";
-import { queryKeys } from "@/lib/query-keys";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { agentsCrudApi, copyAgent, exportAgent, importAgent, previewAgent } from "@/lib/api/agents";
 import type { CreateAgentRequest, PreviewAgentRequest, UpdateAgentRequest } from "@/lib/api/types";
-import { useOrg } from "@/providers/org-provider";
+import { queryKeys } from "@/lib/query-keys";
+import { createCrudHooks } from "./create-crud-hooks";
 
-interface UseAgentsOptions {
-  includeArchived?: boolean;
-}
+const agentCrudHooks = createCrudHooks<
+  Awaited<ReturnType<typeof agentsCrudApi.get>>,
+  CreateAgentRequest,
+  UpdateAgentRequest
+>({
+  api: agentsCrudApi,
+  queryKeys: queryKeys.agents,
+});
 
-export function useAgents(options: UseAgentsOptions = {}) {
-  const { currentOrg, isLoading: orgLoading } = useOrg();
-  const org = currentOrg?.public_id;
-  const includeArchived = options.includeArchived ?? false;
-
-  const query = useQuery({
-    queryKey: [...queryKeys.agents.list(includeArchived), org],
-    queryFn: () => listAgents(includeArchived),
-    enabled: !!org,
-  });
-
-  // Include org loading state so pages show skeleton while org initializes
-  return {
-    ...query,
-    isLoading: orgLoading || query.isLoading,
-  };
-}
-
-export function useAgent(agentId: string | undefined) {
-  const { currentOrg, isLoading: orgLoading } = useOrg();
-  const org = currentOrg?.public_id;
-
-  const query = useQuery({
-    queryKey: [...queryKeys.agents.detail(agentId!), org],
-    queryFn: () => getAgent(agentId!),
-    enabled: !!org && !!agentId,
-  });
-
-  // Include org loading state so pages show skeleton while org initializes
-  return {
-    ...query,
-    isLoading: orgLoading || query.isLoading,
-  };
-}
-
-export function useCreateAgent() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (request: CreateAgentRequest) => createAgent(request),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
-    },
-  });
-}
+export const useAgents = agentCrudHooks.useList;
+export const useAgent = agentCrudHooks.useDetail;
+export const useCreateAgent = agentCrudHooks.useCreate;
+export const useDeleteAgent = agentCrudHooks.useDelete;
+export const useDestroyAgent = agentCrudHooks.useDestroy;
 
 export function useUpdateAgent() {
-  const queryClient = useQueryClient();
+  const mutation = agentCrudHooks.useUpdate();
 
-  return useMutation({
-    mutationFn: ({ agentId, request }: { agentId: string; request: UpdateAgentRequest }) =>
-      updateAgent(agentId, request),
-    onSuccess: (_, { agentId }) => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.agents.detail(agentId),
-      });
-    },
-  });
-}
-
-export function useDeleteAgent() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (agentId: string) => deleteAgent(agentId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
-    },
-  });
-}
-
-export function useDestroyAgent() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (agentId: string) => destroyAgent(agentId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
-    },
-  });
+  return {
+    ...mutation,
+    mutate: (
+      variables: { agentId: string; request: UpdateAgentRequest },
+      options?: Parameters<typeof mutation.mutate>[1],
+    ) => mutation.mutate({ id: variables.agentId, request: variables.request }, options),
+    mutateAsync: (
+      variables: { agentId: string; request: UpdateAgentRequest },
+      options?: Parameters<typeof mutation.mutateAsync>[1],
+    ) => mutation.mutateAsync({ id: variables.agentId, request: variables.request }, options),
+  };
 }
 
 export function useCopyAgent() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (agentId: string) => copyAgent(agentId),
+    mutationFn: copyAgent,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
     },
@@ -118,7 +51,7 @@ export function useCopyAgent() {
 
 export function useExportAgent() {
   return useMutation({
-    mutationFn: (agentId: string) => exportAgent(agentId),
+    mutationFn: exportAgent,
   });
 }
 
@@ -126,7 +59,7 @@ export function useImportAgent() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (markdown: string) => importAgent(markdown),
+    mutationFn: importAgent,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
     },

--- a/apps/ui/src/hooks/use-apps.ts
+++ b/apps/ui/src/hooks/use-apps.ts
@@ -1,20 +1,11 @@
 // App hooks for Slack bot integration
 "use client";
 
-import { useMutation, useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
-import {
-  createApp,
-  deleteApp,
-  destroyApp,
-  getApp,
-  getApps,
-  publishApp,
-  unpublishApp,
-  updateApp,
-} from "@/lib/api/apps";
-import { queryKeys } from "@/lib/query-keys";
+import { useMutation, useQueryClient, type QueryClient } from "@tanstack/react-query";
+import { appsCrudApi, publishApp, unpublishApp } from "@/lib/api/apps";
 import type { App, CreateAppRequest, UpdateAppRequest } from "@/lib/api/types";
-import { useOrg } from "@/providers/org-provider";
+import { queryKeys } from "@/lib/query-keys";
+import { createCrudHooks } from "./create-crud-hooks";
 
 // Keep list/detail app caches in sync so detail pages do not wait for a background refetch.
 function syncAppCache(queryClient: QueryClient, app: App) {
@@ -29,118 +20,51 @@ function syncAppCache(queryClient: QueryClient, app: App) {
   );
 }
 
-interface UseAppsOptions {
-  includeArchived?: boolean;
-}
+const appCrudHooks = createCrudHooks<App, CreateAppRequest, UpdateAppRequest>({
+  api: appsCrudApi,
+  queryKeys: queryKeys.apps,
+  syncEntityCache: syncAppCache,
+});
 
-export function useApps(options: UseAppsOptions = {}) {
-  const { currentOrg, isLoading: orgLoading } = useOrg();
-  const org = currentOrg?.public_id;
-  const includeArchived = options.includeArchived ?? false;
-
-  const query = useQuery({
-    queryKey: [...queryKeys.apps.list(includeArchived), org],
-    queryFn: () => getApps(includeArchived),
-    enabled: !!org,
-  });
-
-  return {
-    ...query,
-    isLoading: orgLoading || query.isLoading,
-  };
-}
-
-export function useApp(appId: string | undefined) {
-  const { currentOrg, isLoading: orgLoading } = useOrg();
-  const org = currentOrg?.public_id;
-
-  const query = useQuery({
-    queryKey: [...queryKeys.apps.detail(appId!), org],
-    queryFn: () => getApp(appId!),
-    enabled: !!org && !!appId,
-  });
-
-  return {
-    ...query,
-    isLoading: orgLoading || query.isLoading,
-  };
-}
-
-export function useCreateApp() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (request: CreateAppRequest) => createApp(request),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.apps.all });
-    },
-  });
-}
+export const useApps = appCrudHooks.useList;
+export const useApp = appCrudHooks.useDetail;
+export const useCreateApp = appCrudHooks.useCreate;
+export const useDeleteApp = appCrudHooks.useDelete;
+export const useDestroyApp = appCrudHooks.useDestroy;
 
 export function useUpdateApp() {
+  const mutation = appCrudHooks.useUpdate();
+
+  return {
+    ...mutation,
+    mutate: (
+      variables: { appId: string; data: UpdateAppRequest },
+      options?: Parameters<typeof mutation.mutate>[1],
+    ) => mutation.mutate({ id: variables.appId, request: variables.data }, options),
+    mutateAsync: (
+      variables: { appId: string; data: UpdateAppRequest },
+      options?: Parameters<typeof mutation.mutateAsync>[1],
+    ) => mutation.mutateAsync({ id: variables.appId, request: variables.data }, options),
+  };
+}
+
+function useAppStatusMutation(mutationFn: (appId: string) => Promise<App>) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ appId, data }: { appId: string; data: UpdateAppRequest }) =>
-      updateApp(appId, data),
-    onSuccess: async (app) => {
+    mutationFn,
+    onSuccess: (app) => {
       syncAppCache(queryClient, app);
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: queryKeys.apps.all }),
-        queryClient.invalidateQueries({ queryKey: queryKeys.apps.detail(app.id) }),
-      ]);
-    },
-  });
-}
-
-export function useDeleteApp() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (appId: string) => deleteApp(appId),
-    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.apps.all });
-    },
-  });
-}
-
-export function useDestroyApp() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (appId: string) => destroyApp(appId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.apps.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.apps.detail(app.id) });
     },
   });
 }
 
 export function usePublishApp() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (appId: string) => publishApp(appId),
-    onSuccess: async (app) => {
-      syncAppCache(queryClient, app);
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: queryKeys.apps.all }),
-        queryClient.invalidateQueries({ queryKey: queryKeys.apps.detail(app.id) }),
-      ]);
-    },
-  });
+  return useAppStatusMutation(publishApp);
 }
 
 export function useUnpublishApp() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (appId: string) => unpublishApp(appId),
-    onSuccess: async (app) => {
-      syncAppCache(queryClient, app);
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: queryKeys.apps.all }),
-        queryClient.invalidateQueries({ queryKey: queryKeys.apps.detail(app.id) }),
-      ]);
-    },
-  });
+  return useAppStatusMutation(unpublishApp);
 }

--- a/apps/ui/src/hooks/use-harnesses.ts
+++ b/apps/ui/src/hooks/use-harnesses.ts
@@ -1,115 +1,52 @@
 // Harness hooks
 "use client";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  copyHarness,
-  createHarness,
-  deleteHarness,
-  destroyHarness,
-  getHarness,
-  listHarnesses,
-  previewHarness,
-  updateHarness,
-} from "@/lib/api/harnesses";
-import { queryKeys } from "@/lib/query-keys";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { copyHarness, harnessesCrudApi, previewHarness } from "@/lib/api/harnesses";
 import type {
   CreateHarnessRequest,
   PreviewHarnessRequest,
   UpdateHarnessRequest,
 } from "@/lib/api/types";
-import { useOrg } from "@/providers/org-provider";
+import { queryKeys } from "@/lib/query-keys";
+import { createCrudHooks } from "./create-crud-hooks";
 
-interface UseHarnessesOptions {
-  includeArchived?: boolean;
-}
+const harnessCrudHooks = createCrudHooks<
+  Awaited<ReturnType<typeof harnessesCrudApi.get>>,
+  CreateHarnessRequest,
+  UpdateHarnessRequest
+>({
+  api: harnessesCrudApi,
+  queryKeys: queryKeys.harnesses,
+});
 
-export function useHarnesses(options: UseHarnessesOptions = {}) {
-  const { currentOrg, isLoading: orgLoading } = useOrg();
-  const org = currentOrg?.public_id;
-  const includeArchived = options.includeArchived ?? false;
-
-  const query = useQuery({
-    queryKey: [...queryKeys.harnesses.list(includeArchived), org],
-    queryFn: () => listHarnesses(includeArchived),
-    enabled: !!org,
-  });
-
-  return {
-    ...query,
-    isLoading: orgLoading || query.isLoading,
-  };
-}
-
-export function useHarness(harnessId: string | undefined) {
-  const { currentOrg, isLoading: orgLoading } = useOrg();
-  const org = currentOrg?.public_id;
-
-  const query = useQuery({
-    queryKey: [...queryKeys.harnesses.detail(harnessId!), org],
-    queryFn: () => getHarness(harnessId!),
-    enabled: !!org && !!harnessId,
-  });
-
-  return {
-    ...query,
-    isLoading: orgLoading || query.isLoading,
-  };
-}
-
-export function useCreateHarness() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (request: CreateHarnessRequest) => createHarness(request),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.harnesses.all });
-    },
-  });
-}
+export const useHarnesses = harnessCrudHooks.useList;
+export const useHarness = harnessCrudHooks.useDetail;
+export const useCreateHarness = harnessCrudHooks.useCreate;
+export const useDeleteHarness = harnessCrudHooks.useDelete;
+export const useDestroyHarness = harnessCrudHooks.useDestroy;
 
 export function useUpdateHarness() {
-  const queryClient = useQueryClient();
+  const mutation = harnessCrudHooks.useUpdate();
 
-  return useMutation({
-    mutationFn: ({ harnessId, request }: { harnessId: string; request: UpdateHarnessRequest }) =>
-      updateHarness(harnessId, request),
-    onSuccess: (_, { harnessId }) => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.harnesses.all });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.harnesses.detail(harnessId),
-      });
-    },
-  });
+  return {
+    ...mutation,
+    mutate: (
+      variables: { harnessId: string; request: UpdateHarnessRequest },
+      options?: Parameters<typeof mutation.mutate>[1],
+    ) => mutation.mutate({ id: variables.harnessId, request: variables.request }, options),
+    mutateAsync: (
+      variables: { harnessId: string; request: UpdateHarnessRequest },
+      options?: Parameters<typeof mutation.mutateAsync>[1],
+    ) => mutation.mutateAsync({ id: variables.harnessId, request: variables.request }, options),
+  };
 }
 
 export function useCopyHarness() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (harnessId: string) => copyHarness(harnessId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.harnesses.all });
-    },
-  });
-}
-
-export function useDeleteHarness() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (harnessId: string) => deleteHarness(harnessId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.harnesses.all });
-    },
-  });
-}
-
-export function useDestroyHarness() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (harnessId: string) => destroyHarness(harnessId),
+    mutationFn: copyHarness,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.harnesses.all });
     },

--- a/apps/ui/src/hooks/use-mcp-servers.ts
+++ b/apps/ui/src/hooks/use-mcp-servers.ts
@@ -1,103 +1,38 @@
 "use client";
 
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import {
-  getMcpServers,
-  getMcpServer,
-  createMcpServer,
-  updateMcpServer,
-  deleteMcpServer,
-  destroyMcpServer,
-} from "@/lib/api/mcp-servers";
-import { queryKeys } from "@/lib/query-keys";
+import { mcpServersCrudApi } from "@/lib/api/mcp-servers";
 import type { CreateMcpServerRequest, UpdateMcpServerRequest } from "@/lib/api/types";
-import { useOrg } from "@/providers/org-provider";
+import { queryKeys } from "@/lib/query-keys";
+import { createCrudHooks } from "./create-crud-hooks";
 
 // MCP Server hooks
 
-interface UseMcpServersOptions {
-  includeArchived?: boolean;
-}
+const mcpServerCrudHooks = createCrudHooks<
+  Awaited<ReturnType<typeof mcpServersCrudApi.get>>,
+  CreateMcpServerRequest,
+  UpdateMcpServerRequest
+>({
+  api: mcpServersCrudApi,
+  queryKeys: queryKeys.mcpServers,
+  staleTime: 30000,
+});
 
-export function useMcpServers(options: UseMcpServersOptions = {}) {
-  const { currentOrg, isLoading: orgLoading } = useOrg();
-  const org = currentOrg?.public_id;
-  const includeArchived = options.includeArchived ?? false;
-
-  const query = useQuery({
-    queryKey: [...queryKeys.mcpServers.list(includeArchived), org],
-    queryFn: () => getMcpServers(includeArchived),
-    enabled: !!org,
-    staleTime: 30000,
-  });
-
-  // Include org loading state so pages show skeleton while org initializes
-  return {
-    ...query,
-    isLoading: orgLoading || query.isLoading,
-  };
-}
-
-export function useMcpServer(serverId: string) {
-  const { currentOrg, isLoading: orgLoading } = useOrg();
-  const org = currentOrg?.public_id;
-
-  const query = useQuery({
-    queryKey: [...queryKeys.mcpServers.detail(serverId), org],
-    queryFn: () => getMcpServer(serverId),
-    enabled: !!org && !!serverId,
-  });
-
-  // Include org loading state so pages show skeleton while org initializes
-  return {
-    ...query,
-    isLoading: orgLoading || query.isLoading,
-  };
-}
-
-export function useCreateMcpServer() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (data: CreateMcpServerRequest) => createMcpServer(data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.mcpServers.all });
-    },
-  });
-}
+export const useMcpServers = mcpServerCrudHooks.useList;
+export const useMcpServer = mcpServerCrudHooks.useDetail;
+export const useCreateMcpServer = mcpServerCrudHooks.useCreate;
+export const useDeleteMcpServer = mcpServerCrudHooks.useDelete;
+export const useDestroyMcpServer = mcpServerCrudHooks.useDestroy;
 
 export function useUpdateMcpServer(serverId: string) {
-  const queryClient = useQueryClient();
+  const mutation = mcpServerCrudHooks.useUpdate();
 
-  return useMutation({
-    mutationFn: (data: UpdateMcpServerRequest) => updateMcpServer(serverId, data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.mcpServers.all });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.mcpServers.detail(serverId),
-      });
-    },
-  });
-}
-
-export function useDeleteMcpServer() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (serverId: string) => deleteMcpServer(serverId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.mcpServers.all });
-    },
-  });
-}
-
-export function useDestroyMcpServer() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (serverId: string) => destroyMcpServer(serverId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.mcpServers.all });
-    },
-  });
+  return {
+    ...mutation,
+    mutate: (request: UpdateMcpServerRequest, options?: Parameters<typeof mutation.mutate>[1]) =>
+      mutation.mutate({ id: serverId, request }, options),
+    mutateAsync: (
+      request: UpdateMcpServerRequest,
+      options?: Parameters<typeof mutation.mutateAsync>[1],
+    ) => mutation.mutateAsync({ id: serverId, request }, options),
+  };
 }

--- a/apps/ui/src/hooks/use-skills.ts
+++ b/apps/ui/src/hooks/use-skills.ts
@@ -1,84 +1,48 @@
 "use client";
 
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import {
-  getSkills,
-  getSkill,
-  getSkillContent,
-  createSkill,
-  updateSkill,
-  deleteSkill,
-  destroySkill,
-  uploadSkillArchive,
-} from "@/lib/api/skills";
-import { queryKeys } from "@/lib/query-keys";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { getSkillContent, skillsCrudApi, uploadSkillArchive } from "@/lib/api/skills";
 import type { CreateSkillRequest, UpdateSkillRequest } from "@/lib/api/types";
-import { useOrg } from "@/providers/org-provider";
+import { queryKeys } from "@/lib/query-keys";
+import { createCrudHooks, useOrgScopedQuery } from "./create-crud-hooks";
 
 // Skill hooks
 
-interface UseSkillsOptions {
-  includeArchived?: boolean;
-}
+const skillCrudHooks = createCrudHooks<
+  Awaited<ReturnType<typeof skillsCrudApi.get>>,
+  CreateSkillRequest,
+  UpdateSkillRequest
+>({
+  api: skillsCrudApi,
+  queryKeys: queryKeys.skills,
+  staleTime: 30000,
+});
 
-export function useSkills(options: UseSkillsOptions = {}) {
-  const { currentOrg, isLoading: orgLoading } = useOrg();
-  const org = currentOrg?.public_id;
-  const includeArchived = options.includeArchived ?? false;
+export const useSkills = skillCrudHooks.useList;
+export const useSkill = skillCrudHooks.useDetail;
+export const useCreateSkill = skillCrudHooks.useCreate;
+export const useDeleteSkill = skillCrudHooks.useDelete;
+export const useDestroySkill = skillCrudHooks.useDestroy;
 
-  const query = useQuery({
-    queryKey: [...queryKeys.skills.list(includeArchived), org],
-    queryFn: () => getSkills(includeArchived),
-    enabled: !!org,
-    staleTime: 30000,
-  });
-
-  return {
-    ...query,
-    isLoading: orgLoading || query.isLoading,
-  };
-}
-
-export function useSkill(skillId: string) {
-  const { currentOrg, isLoading: orgLoading } = useOrg();
-  const org = currentOrg?.public_id;
-
-  const query = useQuery({
-    queryKey: [...queryKeys.skills.detail(skillId), org],
-    queryFn: () => getSkill(skillId),
-    enabled: !!org && !!skillId,
-  });
+export function useUpdateSkill(skillId: string) {
+  const mutation = skillCrudHooks.useUpdate();
 
   return {
-    ...query,
-    isLoading: orgLoading || query.isLoading,
+    ...mutation,
+    mutate: (request: UpdateSkillRequest, options?: Parameters<typeof mutation.mutate>[1]) =>
+      mutation.mutate({ id: skillId, request }, options),
+    mutateAsync: (
+      request: UpdateSkillRequest,
+      options?: Parameters<typeof mutation.mutateAsync>[1],
+    ) => mutation.mutateAsync({ id: skillId, request }, options),
   };
 }
 
 export function useSkillContent(skillId: string) {
-  const { currentOrg, isLoading: orgLoading } = useOrg();
-  const org = currentOrg?.public_id;
-
-  const query = useQuery({
-    queryKey: [...queryKeys.skills.content(skillId), org],
+  return useOrgScopedQuery({
+    queryKey: queryKeys.skills.content(skillId),
     queryFn: () => getSkillContent(skillId),
-    enabled: !!org && !!skillId,
-  });
-
-  return {
-    ...query,
-    isLoading: orgLoading || query.isLoading,
-  };
-}
-
-export function useCreateSkill() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (data: CreateSkillRequest) => createSkill(data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.skills.all });
-    },
+    enabled: !!skillId,
   });
 }
 
@@ -86,43 +50,7 @@ export function useUploadSkill() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (file: File) => uploadSkillArchive(file),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.skills.all });
-    },
-  });
-}
-
-export function useUpdateSkill(skillId: string) {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (data: UpdateSkillRequest) => updateSkill(skillId, data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.skills.all });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.skills.detail(skillId),
-      });
-    },
-  });
-}
-
-export function useDeleteSkill() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (skillId: string) => deleteSkill(skillId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.skills.all });
-    },
-  });
-}
-
-export function useDestroySkill() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (skillId: string) => destroySkill(skillId),
+    mutationFn: uploadSkillArchive,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.skills.all });
     },

--- a/apps/ui/src/lib/api/agents.ts
+++ b/apps/ui/src/lib/api/agents.ts
@@ -2,43 +2,25 @@
 // Org is sent via everruns_org cookie (set by OrgProvider via /v1/users/me/switch-org)
 
 import { api, throwApiError } from "./client";
+import { createCrudApi } from "./crud";
 import type {
   Agent,
   AgentPreviewResponse,
   CreateAgentRequest,
   PreviewAgentRequest,
   UpdateAgentRequest,
-  ListResponse,
 } from "./types";
 
-export async function createAgent(request: CreateAgentRequest): Promise<Agent> {
-  const response = await api.post<Agent>("/v1/agents", request);
-  return response.data;
-}
+export const agentsCrudApi = createCrudApi<Agent, CreateAgentRequest, UpdateAgentRequest>(
+  "/v1/agents",
+);
 
-export async function listAgents(includeArchived = false): Promise<Agent[]> {
-  const path = includeArchived ? "/v1/agents?include_archived=true" : "/v1/agents";
-  const response = await api.get<ListResponse<Agent>>(path);
-  return response.data.data;
-}
-
-export async function getAgent(agentId: string): Promise<Agent> {
-  const response = await api.get<Agent>(`/v1/agents/${agentId}`);
-  return response.data;
-}
-
-export async function updateAgent(agentId: string, request: UpdateAgentRequest): Promise<Agent> {
-  const response = await api.patch<Agent>(`/v1/agents/${agentId}`, request);
-  return response.data;
-}
-
-export async function deleteAgent(agentId: string): Promise<void> {
-  await api.delete(`/v1/agents/${agentId}`);
-}
-
-export async function destroyAgent(agentId: string): Promise<void> {
-  await api.post(`/v1/agents/${agentId}/delete`);
-}
+export const createAgent = agentsCrudApi.create;
+export const listAgents = agentsCrudApi.list;
+export const getAgent = agentsCrudApi.get;
+export const updateAgent = agentsCrudApi.update;
+export const deleteAgent = agentsCrudApi.delete;
+export const destroyAgent = agentsCrudApi.destroy;
 
 export async function exportAgent(agentId: string): Promise<string> {
   // Raw fetch needed: returns text/markdown, not JSON

--- a/apps/ui/src/lib/api/apps.ts
+++ b/apps/ui/src/lib/api/apps.ts
@@ -2,36 +2,17 @@
 // Org is sent via everruns_org cookie (set by OrgProvider via /v1/users/me/switch-org)
 
 import { api } from "./client";
-import type { App, CreateAppRequest, UpdateAppRequest, ListResponse } from "./types";
+import { createCrudApi } from "./crud";
+import type { App, CreateAppRequest, UpdateAppRequest } from "./types";
 
-export async function getApps(includeArchived = false): Promise<App[]> {
-  const path = includeArchived ? "/v1/apps?include_archived=true" : "/v1/apps";
-  const response = await api.get<ListResponse<App>>(path);
-  return response.data.data;
-}
+export const appsCrudApi = createCrudApi<App, CreateAppRequest, UpdateAppRequest>("/v1/apps");
 
-export async function getApp(appId: string): Promise<App> {
-  const response = await api.get<App>(`/v1/apps/${appId}`);
-  return response.data;
-}
-
-export async function createApp(data: CreateAppRequest): Promise<App> {
-  const response = await api.post<App>("/v1/apps", data);
-  return response.data;
-}
-
-export async function updateApp(appId: string, data: UpdateAppRequest): Promise<App> {
-  const response = await api.patch<App>(`/v1/apps/${appId}`, data);
-  return response.data;
-}
-
-export async function deleteApp(appId: string): Promise<void> {
-  await api.delete(`/v1/apps/${appId}`);
-}
-
-export async function destroyApp(appId: string): Promise<void> {
-  await api.post(`/v1/apps/${appId}/delete`);
-}
+export const getApps = appsCrudApi.list;
+export const getApp = appsCrudApi.get;
+export const createApp = appsCrudApi.create;
+export const updateApp = appsCrudApi.update;
+export const deleteApp = appsCrudApi.delete;
+export const destroyApp = appsCrudApi.destroy;
 
 export async function publishApp(appId: string): Promise<App> {
   const response = await api.post<App>(`/v1/apps/${appId}/publish`);

--- a/apps/ui/src/lib/api/crud.ts
+++ b/apps/ui/src/lib/api/crud.ts
@@ -1,0 +1,56 @@
+import { api } from "./client";
+import type { ListResponse } from "./types";
+
+function withArchivedQuery(basePath: string, includeArchived: boolean): string {
+  if (!includeArchived) {
+    return basePath;
+  }
+
+  const separator = basePath.includes("?") ? "&" : "?";
+  return `${basePath}${separator}include_archived=true`;
+}
+
+export interface CrudApi<TItem, TCreate, TUpdate> {
+  create(request: TCreate): Promise<TItem>;
+  list(includeArchived?: boolean): Promise<TItem[]>;
+  get(id: string): Promise<TItem>;
+  update(id: string, request: TUpdate): Promise<TItem>;
+  delete(id: string): Promise<void>;
+  destroy(id: string): Promise<void>;
+}
+
+export function createCrudApi<TItem, TCreate, TUpdate>(
+  basePath: string,
+): CrudApi<TItem, TCreate, TUpdate> {
+  return {
+    async create(request: TCreate): Promise<TItem> {
+      const response = await api.post<TItem>(basePath, request);
+      return response.data;
+    },
+
+    async list(includeArchived = false): Promise<TItem[]> {
+      const response = await api.get<ListResponse<TItem>>(
+        withArchivedQuery(basePath, includeArchived),
+      );
+      return response.data.data;
+    },
+
+    async get(id: string): Promise<TItem> {
+      const response = await api.get<TItem>(`${basePath}/${id}`);
+      return response.data;
+    },
+
+    async update(id: string, request: TUpdate): Promise<TItem> {
+      const response = await api.patch<TItem>(`${basePath}/${id}`, request);
+      return response.data;
+    },
+
+    async delete(id: string): Promise<void> {
+      await api.delete(`${basePath}/${id}`);
+    },
+
+    async destroy(id: string): Promise<void> {
+      await api.post(`${basePath}/${id}/delete`);
+    },
+  };
+}

--- a/apps/ui/src/lib/api/harnesses.ts
+++ b/apps/ui/src/lib/api/harnesses.ts
@@ -2,46 +2,25 @@
 // Org is sent via everruns_org cookie (set by OrgProvider via /v1/users/me/switch-org)
 
 import { api } from "./client";
+import { createCrudApi } from "./crud";
 import type {
-  Harness,
-  CreateHarnessRequest,
-  UpdateHarnessRequest,
-  ListResponse,
-  PreviewHarnessRequest,
   AgentPreviewResponse,
+  CreateHarnessRequest,
+  Harness,
+  PreviewHarnessRequest,
+  UpdateHarnessRequest,
 } from "./types";
 
-export async function createHarness(request: CreateHarnessRequest): Promise<Harness> {
-  const response = await api.post<Harness>("/v1/harnesses", request);
-  return response.data;
-}
+export const harnessesCrudApi = createCrudApi<Harness, CreateHarnessRequest, UpdateHarnessRequest>(
+  "/v1/harnesses",
+);
 
-export async function listHarnesses(includeArchived = false): Promise<Harness[]> {
-  const path = includeArchived ? "/v1/harnesses?include_archived=true" : "/v1/harnesses";
-  const response = await api.get<ListResponse<Harness>>(path);
-  return response.data.data;
-}
-
-export async function getHarness(harnessId: string): Promise<Harness> {
-  const response = await api.get<Harness>(`/v1/harnesses/${harnessId}`);
-  return response.data;
-}
-
-export async function updateHarness(
-  harnessId: string,
-  request: UpdateHarnessRequest,
-): Promise<Harness> {
-  const response = await api.patch<Harness>(`/v1/harnesses/${harnessId}`, request);
-  return response.data;
-}
-
-export async function deleteHarness(harnessId: string): Promise<void> {
-  await api.delete(`/v1/harnesses/${harnessId}`);
-}
-
-export async function destroyHarness(harnessId: string): Promise<void> {
-  await api.post(`/v1/harnesses/${harnessId}/delete`);
-}
+export const createHarness = harnessesCrudApi.create;
+export const listHarnesses = harnessesCrudApi.list;
+export const getHarness = harnessesCrudApi.get;
+export const updateHarness = harnessesCrudApi.update;
+export const deleteHarness = harnessesCrudApi.delete;
+export const destroyHarness = harnessesCrudApi.destroy;
 
 export async function copyHarness(harnessId: string): Promise<Harness> {
   const response = await api.post<Harness>(`/v1/harnesses/${harnessId}/copy`, {});

--- a/apps/ui/src/lib/api/mcp-servers.ts
+++ b/apps/ui/src/lib/api/mcp-servers.ts
@@ -1,44 +1,18 @@
 // MCP Server API functions
 // Org is sent via everruns_org cookie (set by OrgProvider via /v1/users/me/switch-org)
 
-import { api } from "./client";
-import type {
+import { createCrudApi } from "./crud";
+import type { CreateMcpServerRequest, McpServer, UpdateMcpServerRequest } from "./types";
+
+export const mcpServersCrudApi = createCrudApi<
   McpServer,
   CreateMcpServerRequest,
-  UpdateMcpServerRequest,
-  ListResponse,
-} from "./types";
+  UpdateMcpServerRequest
+>("/v1/mcp-servers");
 
-// MCP Server CRUD
-
-export async function getMcpServers(includeArchived = false): Promise<McpServer[]> {
-  const path = includeArchived ? "/v1/mcp-servers?include_archived=true" : "/v1/mcp-servers";
-  const response = await api.get<ListResponse<McpServer>>(path);
-  return response.data.data;
-}
-
-export async function getMcpServer(serverId: string): Promise<McpServer> {
-  const response = await api.get<McpServer>(`/v1/mcp-servers/${serverId}`);
-  return response.data;
-}
-
-export async function createMcpServer(data: CreateMcpServerRequest): Promise<McpServer> {
-  const response = await api.post<McpServer>("/v1/mcp-servers", data);
-  return response.data;
-}
-
-export async function updateMcpServer(
-  serverId: string,
-  data: UpdateMcpServerRequest,
-): Promise<McpServer> {
-  const response = await api.patch<McpServer>(`/v1/mcp-servers/${serverId}`, data);
-  return response.data;
-}
-
-export async function deleteMcpServer(serverId: string): Promise<void> {
-  await api.delete(`/v1/mcp-servers/${serverId}`);
-}
-
-export async function destroyMcpServer(serverId: string): Promise<void> {
-  await api.post(`/v1/mcp-servers/${serverId}/delete`);
-}
+export const getMcpServers = mcpServersCrudApi.list;
+export const getMcpServer = mcpServersCrudApi.get;
+export const createMcpServer = mcpServersCrudApi.create;
+export const updateMcpServer = mcpServersCrudApi.update;
+export const deleteMcpServer = mcpServersCrudApi.delete;
+export const destroyMcpServer = mcpServersCrudApi.destroy;

--- a/apps/ui/src/lib/api/skills.ts
+++ b/apps/ui/src/lib/api/skills.ts
@@ -2,50 +2,30 @@
 // Org is sent via everruns_org cookie (set by OrgProvider via /v1/users/me/switch-org)
 
 import { api, throwApiError } from "./client";
+import { createCrudApi } from "./crud";
 import type {
+  CreateSkillRequest,
   Skill,
   SkillContent,
   SkillValidationResult,
-  CreateSkillRequest,
   UpdateSkillRequest,
   ValidateSkillRequest,
-  ListResponse,
 } from "./types";
 
-// Skill CRUD
+export const skillsCrudApi = createCrudApi<Skill, CreateSkillRequest, UpdateSkillRequest>(
+  "/v1/skills",
+);
 
-export async function getSkills(includeArchived = false): Promise<Skill[]> {
-  const path = includeArchived ? "/v1/skills?include_archived=true" : "/v1/skills";
-  const response = await api.get<ListResponse<Skill>>(path);
-  return response.data.data;
-}
-
-export async function getSkill(skillId: string): Promise<Skill> {
-  const response = await api.get<Skill>(`/v1/skills/${skillId}`);
-  return response.data;
-}
+export const getSkills = skillsCrudApi.list;
+export const getSkill = skillsCrudApi.get;
+export const createSkill = skillsCrudApi.create;
+export const updateSkill = skillsCrudApi.update;
+export const deleteSkill = skillsCrudApi.delete;
+export const destroySkill = skillsCrudApi.destroy;
 
 export async function getSkillContent(skillId: string): Promise<SkillContent> {
   const response = await api.get<SkillContent>(`/v1/skills/${skillId}/content`);
   return response.data;
-}
-
-export async function createSkill(data: CreateSkillRequest): Promise<Skill> {
-  const response = await api.post<Skill>("/v1/skills", data);
-  return response.data;
-}
-
-export async function updateSkill(skillId: string, data: UpdateSkillRequest): Promise<Skill> {
-  const response = await api.patch<Skill>(`/v1/skills/${skillId}`, data);
-  return response.data;
-}
-
-export async function deleteSkill(skillId: string): Promise<void> {
-  await api.delete(`/v1/skills/${skillId}`);
-}
-
-export async function destroySkill(skillId: string): Promise<void> {
-  await api.post(`/v1/skills/${skillId}/delete`);
 }
 
 export async function validateSkill(data: ValidateSkillRequest): Promise<SkillValidationResult> {


### PR DESCRIPTION
## What
Refactor the duplicated frontend CRUD API and React Query hook layers into shared factories, while keeping the existing page-level hook signatures intact.

## Why
EVE-121 targets the repeated CRUD plumbing across agents, harnesses, skills, apps, and MCP servers. The previous pass reduced some duplication but still leaked a new `{ id, request }` contract into page components, creating avoidable churn outside the hook layer.

## How
- Added `createCrudApi` for the shared REST CRUD implementation, including archived list handling.
- Added `createCrudHooks` and `useOrgScopedQuery` for the shared org-scoped React Query behavior.
- Exported reusable `*CrudApi` objects from the entity API modules and rewired entity hooks to consume those shared API objects.
- Restored the existing exported hook signatures (`useUpdateAgent`, `useUpdateHarness`, `useUpdateApp`, `useUpdateSkill`, `useUpdateMcpServer`) so the abstraction change stays inside the API/hook layer rather than touching page call sites.
- Added/updated focused tests for the generic CRUD API and hook behavior.

## Risk
- Medium
- Shared CRUD behavior now affects multiple entity screens at once. Targeted tests, a production build, and a runtime smoke check were run to reduce regression risk.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
