### PR TITLE
fix(core): make session_interact schema OpenAI-compatible

### DIFF
--- a/crates/core/src/capabilities/platform_management.rs
+++ b/crates/core/src/capabilities/platform_management.rs
@@ -922,19 +922,19 @@ impl Tool for SessionInteractTool {
                     "description": "Session ID (required for all operations)"
                 },
                 "content": {
-                    "type": "string",
-                    "description": "Message content (required for send_message)"
+                    "type": ["string", "null"],
+                    "description": "Message content (required for send_message, null for other operations)"
                 },
                 "limit": {
-                    "type": "integer",
+                    "type": ["integer", "null"],
                     "description": "Max messages to return (default 10, for get_messages)"
                 },
                 "timeout_secs": {
-                    "type": "integer",
+                    "type": ["integer", "null"],
                     "description": "Timeout in seconds (default 120, for wait_for_idle)"
                 }
             },
-            "required": ["operation", "session_id"],
+            "required": ["operation", "session_id", "content", "limit", "timeout_secs"],
             "additionalProperties": false
         })
     }
@@ -1863,5 +1863,45 @@ mod tests {
         let prompt = cap.system_prompt_addition().expect("should have prompt");
         assert!(prompt.contains("list_capabilities"));
         assert!(prompt.contains("Capabilities"));
+    }
+
+    #[test]
+    fn session_interact_schema_all_properties_required_and_nullable() {
+        // OpenAI models with additionalProperties:false need all properties in
+        // the required array. Operation-specific params use nullable types so
+        // models can pass null when the param doesn't apply.
+        let tool = SessionInteractTool;
+        let schema = tool.parameters_schema();
+        let required = schema["required"].as_array().unwrap();
+        let props = schema["properties"].as_object().unwrap();
+
+        // Every property must be listed in required
+        for key in props.keys() {
+            assert!(
+                required.iter().any(|v| v.as_str() == Some(key)),
+                "property {key} must be in required array for OpenAI compatibility"
+            );
+        }
+
+        // Operation-specific params must accept null
+        for nullable_key in ["content", "limit", "timeout_secs"] {
+            let ty = &props[nullable_key]["type"];
+            let types: Vec<&str> = ty
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|v| v.as_str().unwrap())
+                .collect();
+            assert!(types.contains(&"null"), "{nullable_key} must be nullable");
+        }
+
+        // Core params must NOT be nullable
+        for non_null_key in ["operation", "session_id"] {
+            let ty = &props[non_null_key]["type"];
+            assert!(
+                ty.is_string(),
+                "{non_null_key} must have a simple string type"
+            );
+        }
     }
 }

--- a/crates/core/src/capabilities/platform_management.rs
+++ b/crates/core/src/capabilities/platform_management.rs
@@ -927,11 +927,11 @@ impl Tool for SessionInteractTool {
                 },
                 "limit": {
                     "type": ["integer", "null"],
-                    "description": "Max messages to return (default 10, for get_messages)"
+                    "description": "Max messages to return (null to use default 10, for get_messages)"
                 },
                 "timeout_secs": {
                     "type": ["integer", "null"],
-                    "description": "Timeout in seconds (default 120, for wait_for_idle)"
+                    "description": "Timeout in seconds (null to use default 120, for wait_for_idle)"
                 }
             },
             "required": ["operation", "session_id", "content", "limit", "timeout_secs"],
@@ -1875,16 +1875,25 @@ mod tests {
         let required = schema["required"].as_array().unwrap();
         let props = schema["properties"].as_object().unwrap();
 
-        // Every property must be listed in required
+        // Every property must be listed in required (no extras/duplicates)
         for key in props.keys() {
             assert!(
                 required.iter().any(|v| v.as_str() == Some(key)),
                 "property {key} must be in required array for OpenAI compatibility"
             );
         }
+        assert_eq!(
+            required.len(),
+            props.len(),
+            "required array must contain all and only the schema properties"
+        );
 
-        // Operation-specific params must accept null
-        for nullable_key in ["content", "limit", "timeout_secs"] {
+        // Operation-specific params must accept null AND their concrete type
+        for (nullable_key, concrete_type) in [
+            ("content", "string"),
+            ("limit", "integer"),
+            ("timeout_secs", "integer"),
+        ] {
             let ty = &props[nullable_key]["type"];
             let types: Vec<&str> = ty
                 .as_array()
@@ -1893,6 +1902,10 @@ mod tests {
                 .map(|v| v.as_str().unwrap())
                 .collect();
             assert!(types.contains(&"null"), "{nullable_key} must be nullable");
+            assert!(
+                types.contains(&concrete_type),
+                "{nullable_key} must accept {concrete_type}"
+            );
         }
 
         // Core params must NOT be nullable


### PR DESCRIPTION
## What
Make `session_interact` tool schema compatible with OpenAI models that enforce `additionalProperties: false` by listing all properties in the `required` array with nullable types for operation-specific params.

## Why
OpenAI models with `additionalProperties: false` need all properties in the `required` array. Previously only `operation` and `session_id` were required, causing models to either omit needed params (like `content` for `send_message`) or fail schema validation.

## How
- Changed `content`, `limit`, and `timeout_secs` types from simple types to nullable (`["string", "null"]`, `["integer", "null"]`)
- Added all five properties to the `required` array
- Existing execute logic already handles null correctly via `as_str()`/`as_u64()` returning `None` for null values
- Added a test verifying all properties are required and operation-specific params are nullable

## Risk
- Low
- Only affects `session_interact` tool schema sent to LLMs. Execute logic unchanged for non-null values.

## Checklist
- [x] Tests added or updated
- [ ] Backward compatibility considered — N/A, internal tool schema