### PR TITLE
refactor(store): add StoreResultExt trait and JSON helpers

### DIFF
--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -1,7 +1,7 @@
 // Error types for the agent loop
 //
-// StoreResultExt: extension trait to replace 912+ .map_err(|e| AgentLoopError::store(...))? sites
-// json_val / from_json: helpers to replace 137 serde_json::to_value/from_value boilerplate
+// StoreResultExt: extension trait to replace repeated .map_err(|e| AgentLoopError::store(...))? patterns
+// json_val / from_json: helpers to replace repeated serde_json::to_value/from_value boilerplate
 
 use crate::typed_id::{AgentId, HarnessId, SessionId};
 use serde::{Serialize, de::DeserializeOwned};

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -1,6 +1,10 @@
 // Error types for the agent loop
+//
+// StoreResultExt: extension trait to replace 912+ .map_err(|e| AgentLoopError::store(...))? sites
+// json_val / from_json: helpers to replace 137 serde_json::to_value/from_value boilerplate
 
 use crate::typed_id::{AgentId, HarnessId, SessionId};
+use serde::{Serialize, de::DeserializeOwned};
 use thiserror::Error;
 
 /// Result type alias for agent loop operations
@@ -238,6 +242,55 @@ impl AgentLoopError {
     }
 }
 
+// ============================================================================
+// Store Result Extension Trait
+// ============================================================================
+
+/// Extension trait that converts any `Result<T, E: Display>` into `Result<T, AgentLoopError>`
+/// via `AgentLoopError::store(e.to_string())`.
+///
+/// Replaces the boilerplate pattern:
+/// ```ignore
+/// .map_err(|e| AgentLoopError::store(e.to_string()))?
+/// ```
+/// with:
+/// ```ignore
+/// .store_err()?
+/// ```
+pub trait StoreResultExt<T> {
+    fn store_err(self) -> Result<T>;
+}
+
+impl<T, E: std::fmt::Display> StoreResultExt<T> for std::result::Result<T, E> {
+    fn store_err(self) -> Result<T> {
+        self.map_err(|e| AgentLoopError::store(e.to_string()))
+    }
+}
+
+// ============================================================================
+// JSON Helpers
+// ============================================================================
+
+/// Convert a serializable value to `serde_json::Value`, falling back to `Value::Null` on error.
+///
+/// Replaces the boilerplate pattern:
+/// ```ignore
+/// serde_json::to_value(&x).unwrap_or_default()
+/// ```
+pub fn json_val<T: Serialize>(value: &T) -> serde_json::Value {
+    serde_json::to_value(value).unwrap_or_default()
+}
+
+/// Deserialize a `serde_json::Value` into `T`, falling back to `T::default()` on error.
+///
+/// Replaces the boilerplate pattern:
+/// ```ignore
+/// serde_json::from_value(v).unwrap_or_default()
+/// ```
+pub fn from_json<T: DeserializeOwned + Default>(value: serde_json::Value) -> T {
+    serde_json::from_value(value).unwrap_or_default()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -386,5 +439,39 @@ mod tests {
     fn test_user_facing_message_request_too_large() {
         let err = AgentLoopError::request_too_large("context length exceeded");
         assert!(err.user_facing_message().contains("too long"));
+    }
+
+    #[test]
+    fn test_store_result_ext_ok() {
+        let result: std::result::Result<i32, String> = Ok(42);
+        assert_eq!(result.store_err().unwrap(), 42);
+    }
+
+    #[test]
+    fn test_store_result_ext_err() {
+        let result: std::result::Result<i32, String> = Err("db error".to_string());
+        let err = result.store_err().unwrap_err();
+        assert!(matches!(err, AgentLoopError::MessageStore(_)));
+        assert!(err.to_string().contains("db error"));
+    }
+
+    #[test]
+    fn test_json_val() {
+        let v = json_val(&vec![1, 2, 3]);
+        assert_eq!(v, serde_json::json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn test_from_json() {
+        let v = serde_json::json!(["a", "b"]);
+        let result: Vec<String> = from_json(v);
+        assert_eq!(result, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn test_from_json_default_on_mismatch() {
+        let v = serde_json::json!("not a number");
+        let result: i32 = from_json(v);
+        assert_eq!(result, 0);
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -103,7 +103,7 @@ pub mod turn;
 // This enables dependency inversion - provider crates register their drivers at startup.
 
 // Re-exports for convenience
-pub use error::{AgentLoopError, Result};
+pub use error::{AgentLoopError, Result, StoreResultExt, from_json, json_val};
 pub use message::{
     ContentPart, ContentType, Controls, ExternalActor, ImageContentPart, ImageFileContentPart,
     InputContentPart, Message, MessageRole, ReasoningConfig, TextContentPart, ToolCallContentPart,

--- a/crates/server/src/storage/agent_store.rs
+++ b/crates/server/src/storage/agent_store.rs
@@ -9,8 +9,9 @@
 
 use async_trait::async_trait;
 use everruns_core::{
-    AgentCapabilityConfig, AgentId, AgentLoopError, Result,
+    AgentCapabilityConfig, AgentId, Result, StoreResultExt,
     agent::{Agent, AgentStatus},
+    from_json,
     traits::AgentStore,
 };
 
@@ -39,11 +40,7 @@ impl DbAgentStore {
 #[async_trait]
 impl AgentStore for DbAgentStore {
     async fn get_agent(&self, agent_id: AgentId) -> Result<Option<Agent>> {
-        let agent_row = self
-            .db
-            .get_agent(self.org_id, agent_id)
-            .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+        let agent_row = self.db.get_agent(self.org_id, agent_id).await.store_err()?;
 
         match agent_row {
             Some(row) => {
@@ -52,7 +49,7 @@ impl AgentStore for DbAgentStore {
                     .db
                     .get_agent_capabilities(agent_id.uuid())
                     .await
-                    .map_err(|e| AgentLoopError::store(e.to_string()))?;
+                    .store_err()?;
 
                 let capabilities: Vec<AgentCapabilityConfig> = capability_rows
                     .into_iter()
@@ -71,8 +68,8 @@ impl AgentStore for DbAgentStore {
                     default_model_id: row.default_model_id,
                     tags: row.tags,
                     capabilities,
-                    initial_files: serde_json::from_value(row.initial_files).unwrap_or_default(),
-                    tools: serde_json::from_value(row.tools).unwrap_or_default(),
+                    initial_files: from_json(row.initial_files),
+                    tools: from_json(row.tools),
                     status: AgentStatus::from(row.status.as_str()),
                     created_at: row.created_at,
                     updated_at: row.updated_at,

--- a/crates/server/src/storage/harness_store.rs
+++ b/crates/server/src/storage/harness_store.rs
@@ -8,7 +8,7 @@
 
 use async_trait::async_trait;
 use everruns_core::{
-    AgentCapabilityConfig, AgentLoopError, HarnessId, Result,
+    AgentCapabilityConfig, AgentLoopError, HarnessId, Result, StoreResultExt, from_json,
     harness::{Harness, HarnessStatus},
     merge_harness,
     traits::HarnessStore,
@@ -55,7 +55,7 @@ impl HarnessStore for DbHarnessStore {
                 .db
                 .get_harness(self.org_id, current_harness_id)
                 .await
-                .map_err(|e| AgentLoopError::store(e.to_string()))?
+                .store_err()?
             else {
                 if chain.is_empty() {
                     return Ok(None);
@@ -69,7 +69,7 @@ impl HarnessStore for DbHarnessStore {
                 .db
                 .get_harness_capabilities(current_harness_id.uuid())
                 .await
-                .map_err(|e| AgentLoopError::store(e.to_string()))?;
+                .store_err()?;
 
             let capabilities: Vec<AgentCapabilityConfig> = capability_rows
                 .into_iter()
@@ -86,7 +86,7 @@ impl HarnessStore for DbHarnessStore {
                 default_model_id: row.default_model_id,
                 tags: row.tags,
                 capabilities,
-                initial_files: serde_json::from_value(row.initial_files).unwrap_or_default(),
+                initial_files: from_json(row.initial_files),
                 is_built_in: row.is_built_in,
                 status: HarnessStatus::from(row.status.as_str()),
                 created_at: row.created_at,

--- a/crates/server/src/storage/llm_provider_store.rs
+++ b/crates/server/src/storage/llm_provider_store.rs
@@ -8,7 +8,7 @@
 
 use async_trait::async_trait;
 use everruns_core::{
-    AgentLoopError, ModelId, Result,
+    AgentLoopError, ModelId, Result, StoreResultExt,
     llm_models::LlmProviderType,
     traits::{LlmProviderStore, ModelWithProvider},
 };
@@ -53,7 +53,7 @@ impl LlmProviderStore for DbLlmProviderStore {
             .db
             .get_llm_model(self.org_id, model_id.uuid())
             .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+            .store_err()?;
 
         let model_row = match model_row {
             Some(row) => row,
@@ -65,7 +65,7 @@ impl LlmProviderStore for DbLlmProviderStore {
             .db
             .get_llm_provider(self.org_id, model_row.provider_id.uuid())
             .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+            .store_err()?;
 
         let provider_row = match provider_row {
             Some(row) => row,
@@ -76,7 +76,7 @@ impl LlmProviderStore for DbLlmProviderStore {
         let provider_with_key = self
             .db
             .get_provider_with_api_key(&provider_row, &self.encryption)
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+            .store_err()?;
 
         // Parse provider type
         let provider_type = parse_provider_type(&provider_with_key.provider_type)?;
@@ -95,7 +95,7 @@ impl LlmProviderStore for DbLlmProviderStore {
             .db
             .get_default_llm_model(self.org_id)
             .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+            .store_err()?;
 
         let model_row = match model_row {
             Some(row) => row,
@@ -107,7 +107,7 @@ impl LlmProviderStore for DbLlmProviderStore {
             .db
             .get_llm_provider(self.org_id, model_row.provider_id.uuid())
             .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+            .store_err()?;
 
         let provider_row = match provider_row {
             Some(row) => row,
@@ -118,7 +118,7 @@ impl LlmProviderStore for DbLlmProviderStore {
         let provider_with_key = self
             .db
             .get_provider_with_api_key(&provider_row, &self.encryption)
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+            .store_err()?;
 
         // Parse provider type
         let provider_type = parse_provider_type(&provider_with_key.provider_type)?;

--- a/crates/server/src/storage/message_store.rs
+++ b/crates/server/src/storage/message_store.rs
@@ -12,8 +12,8 @@
 use async_trait::async_trait;
 use chrono::Utc;
 use everruns_core::{
-    AgentLoopError, ContentPart, Event, EventData, InputMessage, Message, MessageFilter, MessageId,
-    MessageQuery, MessageRetriever, MessageRole, Result, SessionId,
+    ContentPart, Event, EventData, InputMessage, Message, MessageFilter, MessageId, MessageQuery,
+    MessageRetriever, MessageRole, Result, SessionId, StoreResultExt,
     events::{
         EventContext, EventRequest, InputMessageData, OutputMessageCompletedData, ToolCompletedData,
     },
@@ -85,10 +85,7 @@ impl DbMessageRetriever {
             }
         };
 
-        self.event_service
-            .emit(event_request)
-            .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+        self.event_service.emit(event_request).await.store_err()?;
 
         Ok(message)
     }
@@ -102,11 +99,7 @@ impl MessageRetriever for DbMessageRetriever {
     }
 
     async fn load(&self, session_id: SessionId) -> Result<Vec<Message>> {
-        let events = self
-            .db
-            .list_message_events(session_id)
-            .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+        let events = self.db.list_message_events(session_id).await.store_err()?;
 
         let mut messages = Vec::with_capacity(events.len());
 
@@ -131,7 +124,7 @@ impl MessageRetriever for DbMessageRetriever {
             .db
             .list_message_events_filtered(&query)
             .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+            .store_err()?;
 
         // Convert events to messages
         let mut messages = Vec::with_capacity(events.len());
@@ -163,11 +156,7 @@ impl MessageRetriever for DbMessageRetriever {
     }
 
     async fn count(&self, session_id: SessionId) -> Result<usize> {
-        let count = self
-            .db
-            .count_message_events(session_id)
-            .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+        let count = self.db.count_message_events(session_id).await.store_err()?;
         Ok(count as usize)
     }
 }

--- a/crates/server/src/storage/session_file_store.rs
+++ b/crates/server/src/storage/session_file_store.rs
@@ -5,7 +5,7 @@
 
 use async_trait::async_trait;
 use everruns_core::{
-    AgentLoopError, FileInfo, FileStat, GrepMatch, Result, SessionFile, SessionId,
+    AgentLoopError, FileInfo, FileStat, GrepMatch, Result, SessionFile, SessionId, StoreResultExt,
     traits::SessionFileStore,
 };
 use regex::Regex;
@@ -120,7 +120,7 @@ impl SessionFileStore for DbSessionFileStore {
             .db
             .get_session_file(session_id.uuid(), &path)
             .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+            .store_err()?;
 
         Ok(row.map(|r| {
             let (content, encoding) = if let Some(bytes) = r.content {
@@ -169,7 +169,7 @@ impl SessionFileStore for DbSessionFileStore {
             .db
             .get_session_file(session_id.uuid(), &path)
             .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+            .store_err()?;
 
         let row = if let Some(existing) = existing {
             // Update existing file
@@ -196,7 +196,7 @@ impl SessionFileStore for DbSessionFileStore {
                     },
                 )
                 .await
-                .map_err(|e| AgentLoopError::store(e.to_string()))?
+                .store_err()?
                 .ok_or_else(|| AgentLoopError::store("File not found after update"))?
         } else {
             // Create new file
@@ -227,7 +227,7 @@ impl SessionFileStore for DbSessionFileStore {
                                 },
                             )
                             .await
-                            .map_err(|e| AgentLoopError::store(e.to_string()))?
+                            .store_err()?
                             .ok_or_else(|| {
                                 AgentLoopError::store("File not found after race recovery")
                             })?
@@ -291,7 +291,7 @@ impl SessionFileStore for DbSessionFileStore {
                 },
             )
             .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+            .store_err()?;
 
         Ok(row.map(|row| {
             let (content, encoding) = if let Some(bytes) = row.content {
@@ -332,7 +332,7 @@ impl SessionFileStore for DbSessionFileStore {
                     .db
                     .has_readonly_session_files(session_id.uuid(), "/")
                     .await
-                    .map_err(|e| AgentLoopError::store(e.to_string()))?;
+                    .store_err()?;
                 if has_readonly {
                     return Err(AgentLoopError::store(
                         "Cannot delete: directory contains readonly files",
@@ -341,7 +341,7 @@ impl SessionFileStore for DbSessionFileStore {
                 self.db
                     .delete_session_file_recursive(session_id.uuid(), "/")
                     .await
-                    .map_err(|e| AgentLoopError::store(e.to_string()))?;
+                    .store_err()?;
                 return Ok(true);
             } else {
                 return Err(AgentLoopError::store(
@@ -355,7 +355,7 @@ impl SessionFileStore for DbSessionFileStore {
             .db
             .get_session_file(session_id.uuid(), &path)
             .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+            .store_err()?;
 
         // Check readonly on the target itself
         if let Some(ref f) = file
@@ -375,7 +375,7 @@ impl SessionFileStore for DbSessionFileStore {
                 .db
                 .session_directory_has_children(session_id.uuid(), &path)
                 .await
-                .map_err(|e| AgentLoopError::store(e.to_string()))?;
+                .store_err()?;
             if has_children {
                 return Err(AgentLoopError::store(
                     "Directory is not empty. Use recursive=true to delete",
@@ -389,7 +389,7 @@ impl SessionFileStore for DbSessionFileStore {
                 .db
                 .has_readonly_session_files(session_id.uuid(), &path)
                 .await
-                .map_err(|e| AgentLoopError::store(e.to_string()))?;
+                .store_err()?;
             if has_readonly {
                 return Err(AgentLoopError::store(
                     "Cannot delete: directory contains readonly files",
@@ -399,7 +399,7 @@ impl SessionFileStore for DbSessionFileStore {
                 .db
                 .delete_session_file_recursive(session_id.uuid(), &path)
                 .await
-                .map_err(|e| AgentLoopError::store(e.to_string()))?;
+                .store_err()?;
             Ok(deleted > 0)
         } else {
             self.db
@@ -418,7 +418,7 @@ impl SessionFileStore for DbSessionFileStore {
                 .db
                 .get_session_file(session_id.uuid(), &path)
                 .await
-                .map_err(|e| AgentLoopError::store(e.to_string()))?;
+                .store_err()?;
             match dir {
                 Some(d) if !d.is_directory => {
                     return Err(AgentLoopError::store(format!(
@@ -440,7 +440,7 @@ impl SessionFileStore for DbSessionFileStore {
             .db
             .list_session_files(session_id.uuid(), &path)
             .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+            .store_err()?;
 
         Ok(rows
             .into_iter()
@@ -478,7 +478,7 @@ impl SessionFileStore for DbSessionFileStore {
             .db
             .get_session_file(session_id.uuid(), &path)
             .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+            .store_err()?;
 
         Ok(row.map(|r| FileStat {
             path: r.path.clone(),
@@ -506,7 +506,7 @@ impl SessionFileStore for DbSessionFileStore {
             .db
             .grep_session_files(session_id.uuid(), pattern, path_pattern)
             .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+            .store_err()?;
 
         let mut results = Vec::new();
 
@@ -517,7 +517,7 @@ impl SessionFileStore for DbSessionFileStore {
                 .db
                 .get_session_file(session_id.uuid(), &file_info.path)
                 .await
-                .map_err(|e| AgentLoopError::store(e.to_string()))?;
+                .store_err()?;
 
             if let Some(f) = file
                 && let Some(content) = f.content
@@ -548,7 +548,7 @@ impl SessionFileStore for DbSessionFileStore {
             .db
             .get_session_file(session_id.uuid(), &path)
             .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?
+            .store_err()?
         {
             if existing.is_directory {
                 return Ok(FileInfo {
@@ -596,7 +596,7 @@ impl SessionFileStore for DbSessionFileStore {
                         .db
                         .get_session_file(session_id.uuid(), &path)
                         .await
-                        .map_err(|e| AgentLoopError::store(e.to_string()))?
+                        .store_err()?
                         && existing.is_directory
                     {
                         return Ok(FileInfo {

--- a/crates/server/src/storage/session_schedule_store.rs
+++ b/crates/server/src/storage/session_schedule_store.rs
@@ -6,8 +6,8 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use everruns_core::{
-    AgentLoopError, Result, ScheduleId, SessionId, session_schedule::SessionSchedule,
-    traits::SessionScheduleStore,
+    AgentLoopError, Result, ScheduleId, SessionId, StoreResultExt,
+    session_schedule::SessionSchedule, traits::SessionScheduleStore,
 };
 
 use super::backend::StorageBackend;
@@ -77,7 +77,7 @@ impl SessionScheduleStore for DbSessionScheduleStore {
                 next_trigger_at: next_trigger,
             })
             .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+            .store_err()?;
 
         Ok(row_to_domain(&row))
     }
@@ -98,7 +98,7 @@ impl SessionScheduleStore for DbSessionScheduleStore {
                 },
             )
             .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?
+            .store_err()?
             .ok_or_else(|| AgentLoopError::tool("Schedule not found".to_string()))?;
 
         Ok(row_to_domain(&row))
@@ -109,7 +109,7 @@ impl SessionScheduleStore for DbSessionScheduleStore {
             .db
             .list_session_schedules(self.org_id, session_id)
             .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+            .store_err()?;
 
         Ok(rows.iter().map(row_to_domain).collect())
     }

--- a/crates/server/src/storage/session_storage_store.rs
+++ b/crates/server/src/storage/session_storage_store.rs
@@ -5,7 +5,8 @@
 
 use async_trait::async_trait;
 use everruns_core::{
-    AgentLoopError, KeyInfo, Result, SecretInfo, SessionId, traits::SessionStorageStore,
+    AgentLoopError, KeyInfo, Result, SecretInfo, SessionId, StoreResultExt,
+    traits::SessionStorageStore,
 };
 
 use super::encryption::EncryptionService;
@@ -67,10 +68,7 @@ impl SessionStorageStore for DbSessionStorageStore {
             value: value.to_string(),
         };
 
-        self.db
-            .upsert_session_key_value(input)
-            .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+        self.db.upsert_session_key_value(input).await.store_err()?;
 
         Ok(())
     }
@@ -80,7 +78,7 @@ impl SessionStorageStore for DbSessionStorageStore {
             .db
             .get_session_key_value(session_id.uuid(), key)
             .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+            .store_err()?;
 
         Ok(row.map(|r| r.value))
     }
@@ -97,7 +95,7 @@ impl SessionStorageStore for DbSessionStorageStore {
             .db
             .list_session_keys(session_id.uuid())
             .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+            .store_err()?;
 
         Ok(rows
             .into_iter()
@@ -127,10 +125,7 @@ impl SessionStorageStore for DbSessionStorageStore {
             value_encrypted: encrypted,
         };
 
-        self.db
-            .upsert_session_secret(input)
-            .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+        self.db.upsert_session_secret(input).await.store_err()?;
 
         Ok(())
     }
@@ -142,7 +137,7 @@ impl SessionStorageStore for DbSessionStorageStore {
             .db
             .get_session_secret(session_id.uuid(), name)
             .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+            .store_err()?;
 
         match row {
             Some(r) => {
@@ -168,7 +163,7 @@ impl SessionStorageStore for DbSessionStorageStore {
             .db
             .list_session_secrets(session_id.uuid())
             .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+            .store_err()?;
 
         Ok(rows
             .into_iter()

--- a/crates/server/src/storage/session_store.rs
+++ b/crates/server/src/storage/session_store.rs
@@ -9,7 +9,7 @@
 use crate::org_init::BASE_HARNESS_ID;
 use async_trait::async_trait;
 use everruns_core::{
-    AgentLoopError, HarnessId, Result, SessionId, TokenUsage,
+    HarnessId, Result, SessionId, StoreResultExt, TokenUsage,
     session::{Session, SessionStatus, SubagentStatus},
     traits::SessionStore,
 };
@@ -48,7 +48,7 @@ impl SessionStore for DbSessionStore {
             .db
             .get_session(self.org_id, session_id)
             .await
-            .map_err(|e| AgentLoopError::store(e.to_string()))?;
+            .store_err()?;
 
         match session_row {
             Some(row) => {


### PR DESCRIPTION
## What
Add `StoreResultExt` trait and `json_val()`/`from_json()` helpers to `everruns-core` to reduce store layer boilerplate. Apply to all 8 storage store files in `crates/server/src/storage/`.

## Why
EVE-106: 912+ `.map_err(|e| AgentLoopError::store(e.to_string()))?` sites and 137 `serde_json::from_value().unwrap_or_default()` patterns across 54+ files. This PR establishes the shared helpers and applies them to the storage layer (46 map_err + 3 from_json replacements), demonstrating the pattern for gradual adoption.

## How
- `StoreResultExt` trait: `.store_err()` replaces `.map_err(|e| AgentLoopError::store(e.to_string()))?`
- `from_json(v)`: replaces `serde_json::from_value(v).unwrap_or_default()`
- `json_val(&v)`: replaces `serde_json::to_value(&v).unwrap_or_default()`
- Applied to: agent_store, harness_store, llm_provider_store, message_store, session_file_store, session_schedule_store, session_storage_store, session_store

## Risk
- **Low**
- Pure refactoring — no behavioral changes
- Extension trait is additive, unused `AgentLoopError` imports cleaned up
- 5 new unit tests for the helpers

## Checklist
- [x] Tests added or updated (5 new tests for StoreResultExt, json_val, from_json)
- [x] Backward compatibility considered (additive trait, no API changes)