### PR TITLE
refactor(api): add ApiResult type alias and impl_auth_state! macro

### DIFF
--- a/crates/server/src/api/agent_examples.rs
+++ b/crates/server/src/api/agent_examples.rs
@@ -7,7 +7,6 @@
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::seed::{SEED_AGENTS, SeedAgent};
 use crate::services::CapabilityService;
-use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -20,7 +19,7 @@ use std::sync::Arc;
 use utoipa::ToSchema;
 
 use super::agents::CreateAgentRequest;
-use super::common::{ApiPolicyResultExt, ErrorResponse};
+use super::common::{ApiPolicyResultExt, ErrorResponse, impl_auth_state};
 
 use crate::services::AgentService;
 
@@ -89,11 +88,7 @@ pub struct AppState {
     pub platform_definition: Arc<PlatformDefinition>,
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(input: &AppState) -> Self {
-        input.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 /// Create agent example routes
 pub fn routes(state: AppState) -> Router {

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -4,7 +4,6 @@
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::errors::ResourceNotFoundError;
 use crate::storage::StorageBackend;
-use axum::extract::FromRef;
 use axum::{
     Json, Router,
     body::Body,
@@ -21,7 +20,8 @@ use everruns_core::{
 };
 
 use super::common::{
-    ApiOptionExt, ApiPolicyResultExt, ErrorResponse, PaginatedResponse, Pagination,
+    ApiOptionExt, ApiPolicyResultExt, ApiResult, ErrorResponse, PaginatedResponse, Pagination,
+    impl_auth_state,
 };
 use super::validation::{
     validate_create_agent_input, validate_import_file_size, validate_update_agent_input,
@@ -231,11 +231,7 @@ impl AppState {
     }
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(input: &AppState) -> Self {
-        input.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 /// GET /v1/agents/config
 #[utoipa::path(
@@ -369,7 +365,7 @@ pub async fn list_agents(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListAgentsQuery>,
-) -> Result<Json<PaginatedResponse<Agent>>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<PaginatedResponse<Agent>> {
     let offset = query.offset.unwrap_or(0);
     let limit = query.limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT);
     let pagination = Pagination::new(offset, limit);
@@ -408,7 +404,7 @@ pub async fn get_agent(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(agent_id): Path<String>,
-) -> Result<Json<Agent>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<Agent> {
     let agent_id: AgentId = agent_id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -450,7 +446,7 @@ pub async fn update_agent(
     State(state): State<AppState>,
     Path(agent_id): Path<String>,
     Json(req): Json<UpdateAgentRequest>,
-) -> Result<Json<Agent>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<Agent> {
     let agent_id: AgentId = agent_id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -961,7 +957,7 @@ pub async fn preview_agent(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Json(req): Json<PreviewAgentRequest>,
-) -> Result<Json<AgentPreviewResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<AgentPreviewResponse> {
     let (system_prompt, mut tools) = state
         .capability_service
         .preview(org.org_id, &req.system_prompt, &req.capabilities)

--- a/crates/server/src/api/apps.rs
+++ b/crates/server/src/api/apps.rs
@@ -5,7 +5,6 @@
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::services::app::{APP_DANGEROUS, APP_MANAGE, APP_VIEW};
 use crate::storage::StorageBackend;
-use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, Query, State},
@@ -17,7 +16,9 @@ use everruns_core::{
     App, AppStatus, Caller, ChannelType, ResourceConfigResponse, evaluate_policies_with,
 };
 
-use super::common::{ApiOptionExt, ApiPolicyResultExt, ErrorResponse, ListResponse};
+use super::common::{
+    ApiOptionExt, ApiPolicyResultExt, ApiResult, ErrorResponse, ListResponse, impl_auth_state,
+};
 use serde::Deserialize;
 use std::sync::Arc;
 use utoipa::{IntoParams, ToSchema};
@@ -104,11 +105,7 @@ impl AppState {
     }
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(input: &AppState) -> Self {
-        input.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 /// Create app routes
 pub fn routes(state: AppState) -> Router {
@@ -189,7 +186,7 @@ pub async fn list_apps(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListAppsQuery>,
-) -> Result<Json<ListResponse<App>>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<ListResponse<App>> {
     let caller = Caller::from(&org);
     let apps = state
         .service
@@ -221,7 +218,7 @@ pub async fn get_app(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(app_id): Path<String>,
-) -> Result<Json<App>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<App> {
     let app_id: AppId = app_id.parse().map_err(|e| {
         ErrorResponse::new(format!("Invalid app ID: {}", e)).into_response(StatusCode::BAD_REQUEST)
     })?;
@@ -256,7 +253,7 @@ pub async fn update_app(
     State(state): State<AppState>,
     Path(app_id): Path<String>,
     Json(req): Json<UpdateAppRequest>,
-) -> Result<Json<App>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<App> {
     let app_id: AppId = app_id.parse().map_err(|e| {
         ErrorResponse::new(format!("Invalid app ID: {}", e)).into_response(StatusCode::BAD_REQUEST)
     })?;
@@ -348,7 +345,7 @@ pub async fn publish_app(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(app_id): Path<String>,
-) -> Result<Json<App>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<App> {
     let app_id: AppId = app_id.parse().map_err(|e| {
         ErrorResponse::new(format!("Invalid app ID: {}", e)).into_response(StatusCode::BAD_REQUEST)
     })?;
@@ -381,7 +378,7 @@ pub async fn unpublish_app(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(app_id): Path<String>,
-) -> Result<Json<App>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<App> {
     let app_id: AppId = app_id.parse().map_err(|e| {
         ErrorResponse::new(format!("Invalid app ID: {}", e)).into_response(StatusCode::BAD_REQUEST)
     })?;

--- a/crates/server/src/api/audit_logs.rs
+++ b/crates/server/src/api/audit_logs.rs
@@ -4,7 +4,6 @@
 
 use crate::auth::middleware::{AuthState, OrgAdmin};
 use crate::storage::StorageBackend;
-use axum::extract::FromRef;
 use axum::{Json, Router, extract::State, routing::get};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -12,7 +11,7 @@ use std::sync::Arc;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-use super::common::ListResponse;
+use super::common::{ApiResult, ErrorResponse, ListResponse, impl_auth_state};
 
 #[derive(Clone)]
 pub struct AppState {
@@ -26,11 +25,7 @@ impl AppState {
     }
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(input: &AppState) -> Self {
-        input.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 /// Audit log entry response
 #[derive(Debug, Serialize, ToSchema)]
@@ -67,10 +62,7 @@ async fn list_audit_logs(
     State(state): State<AppState>,
     org: OrgAdmin,
     axum::extract::Query(query): axum::extract::Query<ListAuditLogsQuery>,
-) -> Result<
-    Json<ListResponse<AuditLogResponse>>,
-    (axum::http::StatusCode, Json<super::common::ErrorResponse>),
-> {
+) -> ApiResult<ListResponse<AuditLogResponse>> {
     let limit = query.limit.unwrap_or(50).clamp(1, 200);
 
     let rows = state
@@ -87,7 +79,7 @@ async fn list_audit_logs(
             tracing::error!("Failed to list audit logs: {}", e);
             (
                 axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                Json(super::common::ErrorResponse {
+                Json(ErrorResponse {
                     error: "Failed to list audit logs".to_string(),
                 }),
             )

--- a/crates/server/src/api/capabilities.rs
+++ b/crates/server/src/api/capabilities.rs
@@ -8,7 +8,6 @@
 // Agent capabilities are managed through the agents API (POST/PATCH /v1/agents).
 
 use crate::auth::{AuthState, ResolvedOrg};
-use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -17,7 +16,7 @@ use axum::{
 };
 use everruns_core::{CapabilityId, CapabilityInfo};
 
-use super::common::ListResponse;
+use super::common::{ListResponse, impl_auth_state};
 use std::sync::Arc;
 
 use crate::services::CapabilityService;
@@ -35,11 +34,7 @@ impl AppState {
     }
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(input: &AppState) -> Self {
-        input.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 /// Create capability routes
 pub fn routes(state: AppState) -> Router {

--- a/crates/server/src/api/commands.rs
+++ b/crates/server/src/api/commands.rs
@@ -7,13 +7,14 @@
 
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::services::CapabilityService;
-use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, State},
     http::StatusCode,
     routing::get,
 };
+
+use super::common::{ApiResult, ErrorResponse, impl_auth_state};
 use everruns_core::command::CommandDescriptor;
 use everruns_core::typed_id::SessionId;
 use serde::Serialize;
@@ -36,11 +37,7 @@ impl AppState {
     }
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(input: &AppState) -> Self {
-        input.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 /// Response for listing available commands
 #[derive(Debug, Clone, Serialize, ToSchema)]
@@ -67,7 +64,7 @@ async fn list_session_commands(
     State(state): State<AppState>,
     org: ResolvedOrg,
     Path(session_id): Path<SessionId>,
-) -> Result<Json<CommandsResponse>, (StatusCode, Json<super::ErrorResponse>)> {
+) -> ApiResult<CommandsResponse> {
     let _ = session_id; // Reserved for session-scoped command filtering
 
     // Collect system commands from all capabilities
@@ -83,7 +80,7 @@ async fn list_session_commands(
         .map_err(|e| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(super::ErrorResponse {
+                Json(ErrorResponse {
                     error: format!("Failed to list skill commands: {e}"),
                 }),
             )

--- a/crates/server/src/api/common.rs
+++ b/crates/server/src/api/common.rs
@@ -1,6 +1,8 @@
 // Common DTOs for public API
 //
 // These types are shared across multiple API endpoints.
+// ApiResult: standard return type for API handlers
+// impl_auth_state!: macro to eliminate repeated FromRef<AppState> for AuthState impls
 
 use axum::Json;
 use axum::http::StatusCode;
@@ -10,6 +12,35 @@ use std::sync::Arc;
 use utoipa::ToSchema;
 
 use crate::storage::StorageBackend;
+
+/// Standard return type for API handlers that return JSON with error responses.
+///
+/// Replaces the repeated pattern:
+/// ```ignore
+/// Result<Json<T>, (StatusCode, Json<ErrorResponse>)>
+/// ```
+pub type ApiResult<T> = Result<Json<T>, (StatusCode, Json<ErrorResponse>)>;
+
+/// Implement `FromRef<$state> for AuthState` for an API module's state struct.
+///
+/// Every API module with auth repeats the same 5-line impl. This macro eliminates
+/// that boilerplate. The state struct must have a field `auth: AuthState`.
+///
+/// Usage:
+/// ```ignore
+/// impl_auth_state!(AppState);
+/// impl_auth_state!(UsersState);
+/// ```
+macro_rules! impl_auth_state {
+    ($state:ty) => {
+        impl ::axum::extract::FromRef<$state> for crate::auth::AuthState {
+            fn from_ref(input: &$state) -> Self {
+                input.auth.clone()
+            }
+        }
+    };
+}
+pub(crate) use impl_auth_state;
 
 /// Standard error response for API endpoints.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/crates/server/src/api/durable.rs
+++ b/crates/server/src/api/durable.rs
@@ -33,10 +33,9 @@ use tokio::time::Instant;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-use super::common::ErrorResponse;
+use super::common::{ApiResult, ErrorResponse, impl_auth_state};
 use super::sse::{DisconnectReason, SseStreamConfig};
 use crate::auth::middleware::{AdminUser, AuthState};
-use axum::extract::FromRef;
 
 /// App state for durable routes
 /// TM-DURABLE-010: All durable endpoints require admin role (not just authentication).
@@ -47,11 +46,7 @@ pub struct AppState {
     auth: AuthState,
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(state: &AppState) -> Self {
-        state.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 impl AppState {
     /// Create new state with an optional workflow event store
@@ -702,7 +697,7 @@ pub struct SendSignalRequest {
 pub async fn get_health(
     _auth: AdminUser,
     State(state): State<AppState>,
-) -> Result<Json<HealthResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<HealthResponse> {
     let store = state.get_store()?;
     let health = store.get_system_health().await.map_err(|e| {
         tracing::error!("Failed to get system health: {}", e);
@@ -729,7 +724,7 @@ pub async fn get_health(
 pub async fn get_metrics_timeseries(
     _auth: AdminUser,
     State(state): State<AppState>,
-) -> Result<Json<MetricsTimeSeriesResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<MetricsTimeSeriesResponse> {
     let points = state.metrics.get_points().await;
     let instance_count: u32 = std::env::var("EXPECTED_INSTANCES")
         .ok()
@@ -761,7 +756,7 @@ pub async fn list_workers(
     _auth: AdminUser,
     State(state): State<AppState>,
     Query(query): Query<ListWorkersQuery>,
-) -> Result<Json<WorkersListResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<WorkersListResponse> {
     let store = state.get_store()?;
     let filter = WorkerFilter {
         status: query.status,
@@ -888,7 +883,7 @@ pub async fn list_workflows(
     _auth: AdminUser,
     State(state): State<AppState>,
     Query(query): Query<ListWorkflowsQuery>,
-) -> Result<Json<WorkflowsListResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<WorkflowsListResponse> {
     let store = state.get_store()?;
     let status = query.status.and_then(|s| match s.as_str() {
         "pending" => Some(WorkflowStatus::Pending),
@@ -947,7 +942,7 @@ pub async fn get_workflow(
     _auth: AdminUser,
     State(state): State<AppState>,
     Path(workflow_id): Path<Uuid>,
-) -> Result<Json<WorkflowResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<WorkflowResponse> {
     let store = state.get_store()?;
     // Use list_workflows with a filter to get the extended info
     let filter = WorkflowFilter::default();
@@ -997,7 +992,7 @@ pub async fn get_workflow_events(
     _auth: AdminUser,
     State(state): State<AppState>,
     Path(workflow_id): Path<Uuid>,
-) -> Result<Json<WorkflowEventsListResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<WorkflowEventsListResponse> {
     let store = state.get_store()?;
     let events = store.get_workflow_events(workflow_id).await.map_err(|e| {
         tracing::error!("Failed to get workflow events: {}", e);
@@ -1124,7 +1119,7 @@ pub async fn list_tasks(
     _auth: AdminUser,
     State(state): State<AppState>,
     Query(query): Query<ListTasksQuery>,
-) -> Result<Json<TasksListResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<TasksListResponse> {
     let store = state.get_store()?;
     let status = query.status.and_then(|s| match s.as_str() {
         "pending" => Some(TaskStatus::Pending),
@@ -1260,7 +1255,7 @@ pub async fn list_dlq(
     _auth: AdminUser,
     State(state): State<AppState>,
     Query(query): Query<ListDlqQuery>,
-) -> Result<Json<DlqListResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<DlqListResponse> {
     let store = state.get_store()?;
     let filter = DlqFilter {
         workflow_id: query.workflow_id,
@@ -1306,7 +1301,7 @@ pub async fn retry_dlq(
     _auth: AdminUser,
     State(state): State<AppState>,
     Path(dlq_id): Path<Uuid>,
-) -> Result<Json<Uuid>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<Uuid> {
     let store = state.get_store()?;
     let task_id = store.requeue_from_dlq(dlq_id).await.map_err(|e| match e {
         everruns_durable::StoreError::TaskNotFound(_) => (
@@ -1342,7 +1337,7 @@ pub async fn retry_dlq(
 pub async fn list_circuit_breakers(
     _auth: AdminUser,
     State(state): State<AppState>,
-) -> Result<Json<CircuitBreakersListResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<CircuitBreakersListResponse> {
     let store = state.get_store()?;
     let circuit_breakers = store.list_circuit_breakers().await.map_err(|e| {
         tracing::error!("Failed to list circuit breakers: {}", e);
@@ -1381,7 +1376,7 @@ pub async fn get_circuit_breaker(
     _auth: AdminUser,
     State(state): State<AppState>,
     Path(key): Path<String>,
-) -> Result<Json<CircuitBreakerResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<CircuitBreakerResponse> {
     let store = state.get_store()?;
     let circuit_breakers = store.list_circuit_breakers().await.map_err(|e| {
         tracing::error!("Failed to list circuit breakers: {}", e);

--- a/crates/server/src/api/events.rs
+++ b/crates/server/src/api/events.rs
@@ -4,7 +4,6 @@
 
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::storage::StorageBackend;
-use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -23,7 +22,7 @@ use everruns_core::typed_id::{EventId, SessionId};
 use everruns_core::{Caller, Event, EventListener, VALID_EVENT_TYPES};
 use serde::Deserialize;
 
-use super::common::{ErrorResponse, ListResponse};
+use super::common::{ErrorResponse, ListResponse, impl_auth_state};
 use super::sse::{DisconnectReason, SseConnectionTracker, SseStreamConfig};
 use crate::event_notifications::EventNotificationBroadcaster;
 use crate::services::EventService;
@@ -139,11 +138,7 @@ impl AppState {
     }
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(input: &AppState) -> Self {
-        input.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 /// Create event routes (nested under sessions)
 pub fn routes(state: AppState) -> Router {

--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -7,7 +7,6 @@ use crate::services::harness::{
     HARNESS_DANGEROUS, HARNESS_MANAGE, HARNESS_VIEW, merge_preview_layer, resolve_effective_harness,
 };
 use crate::storage::StorageBackend;
-use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, Query, State},
@@ -20,7 +19,9 @@ use everruns_core::{
     ToolDefinition, evaluate_policies_with,
 };
 
-use super::common::{ApiOptionExt, ApiPolicyResultExt, ErrorResponse, ListResponse};
+use super::common::{
+    ApiOptionExt, ApiPolicyResultExt, ApiResult, ErrorResponse, ListResponse, impl_auth_state,
+};
 use super::validation::{validate_create_agent_input, validate_update_agent_input};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -139,11 +140,7 @@ impl AppState {
     }
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(input: &AppState) -> Self {
-        input.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 /// Create harness routes (no import/export)
 pub fn routes(state: AppState) -> Router {
@@ -240,7 +237,7 @@ pub async fn list_harnesses(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListHarnessesQuery>,
-) -> Result<Json<ListResponse<Harness>>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<ListResponse<Harness>> {
     let caller = Caller::from(&org);
     let harnesses = state
         .service
@@ -275,7 +272,7 @@ pub async fn get_harness(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(harness_id): Path<String>,
-) -> Result<Json<Harness>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<Harness> {
     let harness_id: HarnessId = harness_id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -318,7 +315,7 @@ pub async fn update_harness(
     State(state): State<AppState>,
     Path(harness_id): Path<String>,
     Json(req): Json<UpdateHarnessRequest>,
-) -> Result<Json<Harness>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<Harness> {
     let harness_id: HarnessId = harness_id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -489,7 +486,7 @@ pub async fn preview_harness(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Json(req): Json<PreviewHarnessRequest>,
-) -> Result<Json<HarnessPreviewResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<HarnessPreviewResponse> {
     let parent = match req.parent_harness_id {
         Some(parent_harness_id) => Some(
             resolve_effective_harness(state.service.db().as_ref(), org.org_id, parent_harness_id)

--- a/crates/server/src/api/images.rs
+++ b/crates/server/src/api/images.rs
@@ -5,9 +5,9 @@
 // Supports PNG, JPEG, GIF, WebP (OpenAI Vision compatible formats).
 // Generates thumbnails on upload for efficient display.
 
+use super::common::impl_auth_state;
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::storage::{StorageBackend, models::CreateImageRow};
-use axum::extract::FromRef;
 use axum::{
     Json, Router,
     body::Body,
@@ -101,11 +101,7 @@ impl AppState {
     }
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(input: &AppState) -> Self {
-        input.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 /// Create images routes
 pub fn routes(state: AppState) -> Router {

--- a/crates/server/src/api/llm_models.rs
+++ b/crates/server/src/api/llm_models.rs
@@ -1,11 +1,12 @@
 // LLM Model API endpoints
 // Routes: /v1/llm-providers/:provider_id/models/... and /v1/llm-models/...
 
-use crate::api::common::{ApiOptionExt, ApiPolicyResultExt, ErrorResponse, ListResponse};
+use crate::api::common::{
+    ApiOptionExt, ApiPolicyResultExt, ApiResult, ErrorResponse, ListResponse, impl_auth_state,
+};
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::services::llm_model::{LLM_MODEL_MANAGE, LLM_MODEL_VIEW};
 use crate::storage::StorageBackend;
-use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, Query, State},
@@ -47,11 +48,7 @@ impl AppState {
     }
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(input: &AppState) -> Self {
-        input.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 /// Request to create a new LLM model for a provider
 #[derive(Debug, Deserialize, ToSchema)]
@@ -179,7 +176,7 @@ pub async fn list_provider_models(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(provider_id): Path<String>,
-) -> Result<Json<ListResponse<LlmModel>>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<ListResponse<LlmModel>> {
     let provider_id: ProviderId = provider_id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -215,7 +212,7 @@ pub async fn list_all_models(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListModelsQuery>,
-) -> Result<Json<ListResponse<LlmModelWithProvider>>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<ListResponse<LlmModelWithProvider>> {
     let caller = Caller::from(&org);
     let models = state
         .service
@@ -249,7 +246,7 @@ pub async fn get_model(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(id): Path<String>,
-) -> Result<Json<LlmModelWithProvider>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<LlmModelWithProvider> {
     let model_id: ModelId = id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -290,7 +287,7 @@ pub async fn update_model(
     State(state): State<AppState>,
     Path(id): Path<String>,
     Json(req): Json<UpdateLlmModelRequest>,
-) -> Result<Json<LlmModel>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<LlmModel> {
     let model_id: ModelId = id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,

--- a/crates/server/src/api/llm_providers.rs
+++ b/crates/server/src/api/llm_providers.rs
@@ -5,7 +5,6 @@ use crate::auth::{AuthState, ResolvedOrg};
 use crate::services::llm_provider::{LLM_PROVIDER_MANAGE, LLM_PROVIDER_VIEW};
 use crate::services::{LlmProviderService, LlmResolverService, ModelSyncService, SyncResult};
 use crate::storage::{EncryptionService, StorageBackend};
-use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -22,7 +21,9 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
 
-use super::common::{ApiOptionExt, ApiPolicyResultExt, ErrorResponse, ListResponse};
+use super::common::{
+    ApiOptionExt, ApiPolicyResultExt, ApiResult, ErrorResponse, ListResponse, impl_auth_state,
+};
 
 #[derive(Clone)]
 pub struct AppState {
@@ -52,11 +53,7 @@ impl AppState {
     }
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(input: &AppState) -> Self {
-        input.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 /// Request to create a new LLM provider
 #[derive(Debug, Deserialize, ToSchema)]
@@ -156,7 +153,7 @@ pub async fn create_provider(
 pub async fn list_providers(
     org: ResolvedOrg,
     State(state): State<AppState>,
-) -> Result<Json<ListResponse<LlmProvider>>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<ListResponse<LlmProvider>> {
     let caller = Caller::from(&org);
     let providers = state
         .service
@@ -185,7 +182,7 @@ pub async fn get_provider(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(id): Path<String>,
-) -> Result<Json<LlmProvider>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<LlmProvider> {
     let provider_id: ProviderId = id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -226,7 +223,7 @@ pub async fn update_provider(
     State(state): State<AppState>,
     Path(id): Path<String>,
     Json(req): Json<UpdateLlmProviderRequest>,
-) -> Result<Json<LlmProvider>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<LlmProvider> {
     let provider_id: ProviderId = id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -311,7 +308,7 @@ pub async fn sync_models(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(id): Path<String>,
-) -> Result<Json<SyncModelsResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<SyncModelsResponse> {
     let provider_id: ProviderId = id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,

--- a/crates/server/src/api/mcp_servers.rs
+++ b/crates/server/src/api/mcp_servers.rs
@@ -5,7 +5,6 @@ use crate::auth::{AuthState, ResolvedOrg};
 use crate::services::McpServerService;
 use crate::services::mcp_server::{MCP_SERVER_DANGEROUS, MCP_SERVER_MANAGE, MCP_SERVER_VIEW};
 use crate::storage::{EncryptionService, StorageBackend};
-use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, Query, State},
@@ -18,7 +17,9 @@ use everruns_core::{
     evaluate_policies_with, validate_safe_url,
 };
 
-use super::common::{ApiOptionExt, ApiPolicyResultExt, ErrorResponse, ListResponse};
+use super::common::{
+    ApiOptionExt, ApiPolicyResultExt, ApiResult, ErrorResponse, ListResponse, impl_auth_state,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -120,11 +121,7 @@ impl AppState {
     }
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(input: &AppState) -> Self {
-        input.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 /// Create MCP server routes
 pub fn routes(state: AppState) -> Router {
@@ -231,7 +228,7 @@ pub async fn list_mcp_servers(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListMcpServersQuery>,
-) -> Result<Json<ListResponse<McpServer>>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<ListResponse<McpServer>> {
     let caller = Caller::from(&org);
     let servers = state
         .service
@@ -265,7 +262,7 @@ pub async fn get_mcp_server(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(server_id): Path<String>,
-) -> Result<Json<McpServer>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<McpServer> {
     let server_id: McpServerId = server_id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -307,7 +304,7 @@ pub async fn update_mcp_server(
     State(state): State<AppState>,
     Path(server_id): Path<String>,
     Json(req): Json<UpdateMcpServerRequest>,
-) -> Result<Json<McpServer>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<McpServer> {
     let server_id: McpServerId = server_id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,

--- a/crates/server/src/api/messages.rs
+++ b/crates/server/src/api/messages.rs
@@ -10,7 +10,6 @@
 
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::storage::StorageBackend;
-use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -20,7 +19,7 @@ use axum::{
 use chrono::{DateTime, Utc};
 use everruns_core::typed_id::{MessageId, SessionId};
 
-use super::common::{ErrorResponse, ListResponse};
+use super::common::{ApiResult, ErrorResponse, ListResponse, impl_auth_state};
 use everruns_worker::AgentRunner;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, sync::Arc};
@@ -179,11 +178,7 @@ impl AppState {
     }
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(input: &AppState) -> Self {
-        input.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 /// Create message routes (nested under sessions)
 pub fn routes(state: AppState) -> Router {
@@ -313,7 +308,7 @@ pub async fn list_messages(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(session_id): Path<String>,
-) -> Result<Json<ListResponse<Message>>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<ListResponse<Message>> {
     let session_id: SessionId = session_id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,

--- a/crates/server/src/api/notifications.rs
+++ b/crates/server/src/api/notifications.rs
@@ -4,7 +4,6 @@
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::notification_notifications::NotificationNotificationBroadcaster;
 use crate::services::NotificationService;
-use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -21,7 +20,7 @@ use tokio::sync::broadcast;
 use tokio::time::Instant;
 use utoipa::{IntoParams, ToSchema};
 
-use super::common::ErrorResponse;
+use super::common::{ApiResult, ErrorResponse, impl_auth_state};
 use super::sse::{DisconnectReason, SseConnectionTracker, SseStreamConfig};
 use futures::{
     StreamExt,
@@ -69,11 +68,7 @@ pub struct AppState {
     pub auth: AuthState,
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(input: &AppState) -> Self {
-        input.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 pub fn routes(state: AppState) -> Router {
     Router::new()
@@ -118,7 +113,7 @@ pub async fn list_notifications(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListNotificationsQuery>,
-) -> Result<Json<ListNotificationsResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<ListNotificationsResponse> {
     let user_id = require_user_id(&org)?;
     let limit = query.limit.unwrap_or(50).clamp(1, 100);
 
@@ -159,7 +154,7 @@ pub async fn mark_notification_viewed(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(notification_id): Path<String>,
-) -> Result<Json<Notification>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<Notification> {
     let user_id = require_user_id(&org)?;
     let notification_id: NotificationId = notification_id.parse().map_err(|e| {
         (

--- a/crates/server/src/api/organizations.rs
+++ b/crates/server/src/api/organizations.rs
@@ -5,7 +5,6 @@
 
 use crate::auth::middleware::{AuthState, AuthUser, OrgAdmin, OrgContext};
 use crate::storage::{StorageBackend, models::UpdateOrganizationSettings};
-use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -18,7 +17,9 @@ use everruns_core::{
 };
 use everruns_durable::UpdateField;
 
-use super::common::{ApiOptionExt, ApiResultExt, ErrorResponse, ListResponse};
+use super::common::{
+    ApiOptionExt, ApiResult, ApiResultExt, ErrorResponse, ListResponse, impl_auth_state,
+};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
@@ -64,11 +65,7 @@ impl AppState {
     }
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(input: &AppState) -> Self {
-        input.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 /// Request to create a new organization
 #[derive(Debug, Clone, Deserialize, ToSchema)]
@@ -157,7 +154,7 @@ pub fn routes(state: AppState) -> Router {
 pub async fn list_organizations(
     State(state): State<AppState>,
     user: AuthUser,
-) -> Result<Json<ListResponse<OrganizationResponse>>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<ListResponse<OrganizationResponse>> {
     // Query the database for fresh membership data.
     // Previously this read from user.organizations (populated at auth time),
     // which meant newly created orgs were invisible until re-login.
@@ -299,7 +296,7 @@ pub async fn get_organization(
     State(state): State<AppState>,
     user: AuthUser,
     Path(org_public_id): Path<String>,
-) -> Result<Json<OrganizationResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<OrganizationResponse> {
     // Validate format
     if !validate_org_public_id(&org_public_id) {
         return Err(ErrorResponse::not_found("Organization"));
@@ -346,7 +343,7 @@ pub async fn update_organization(
     user: AuthUser,
     Path(org_public_id): Path<String>,
     Json(req): Json<UpdateOrganizationRequest>,
-) -> Result<Json<OrganizationResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<OrganizationResponse> {
     use crate::storage::models::UpdateOrganization;
 
     // Validate format
@@ -551,7 +548,7 @@ pub struct UpdateMemberRoleRequest {
 pub async fn list_members(
     State(state): State<AppState>,
     org: OrgContext,
-) -> Result<Json<ListResponse<MemberResponse>>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<ListResponse<MemberResponse>> {
     let members = state
         .db
         .list_organization_members_with_users(org.org_id)
@@ -660,7 +657,7 @@ pub async fn update_member_role(
     OrgAdmin(org): OrgAdmin,
     Path((_org_public_id, user_id_str)): Path<(String, String)>,
     Json(req): Json<UpdateMemberRoleRequest>,
-) -> Result<Json<MemberResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<MemberResponse> {
     let new_role: OrgRole = req.role.parse().map_err(|_| {
         (
             StatusCode::BAD_REQUEST,

--- a/crates/server/src/api/schedules.rs
+++ b/crates/server/src/api/schedules.rs
@@ -11,7 +11,7 @@
 
 use axum::{
     Json, Router,
-    extract::{FromRef, Path, Query, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     routing::{delete, get, patch, post},
 };
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-use super::common::ErrorResponse;
+use super::common::{ApiResult, ErrorResponse, impl_auth_state};
 use crate::auth::middleware::{AuthState, AuthUser};
 
 /// App state for schedule routes
@@ -37,11 +37,7 @@ pub struct ScheduleAppState {
     auth: AuthState,
 }
 
-impl FromRef<ScheduleAppState> for AuthState {
-    fn from_ref(state: &ScheduleAppState) -> Self {
-        state.auth.clone()
-    }
-}
+impl_auth_state!(ScheduleAppState);
 
 impl ScheduleAppState {
     /// Create new state with an optional workflow event store and auth state
@@ -514,7 +510,7 @@ pub async fn list_schedules(
     _auth: AuthUser,
     State(state): State<ScheduleAppState>,
     Query(query): Query<ListSchedulesQuery>,
-) -> Result<Json<SchedulesListResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<SchedulesListResponse> {
     let store = state.get_store()?;
 
     let target_type = query.target_type.and_then(|t| match t.as_str() {
@@ -580,7 +576,7 @@ pub async fn get_schedule(
     _auth: AuthUser,
     State(state): State<ScheduleAppState>,
     Path(schedule_id): Path<Uuid>,
-) -> Result<Json<ScheduleResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<ScheduleResponse> {
     let store = state.get_store()?;
 
     let schedule = store.get_schedule(schedule_id).await.map_err(|e| match e {
@@ -626,7 +622,7 @@ pub async fn update_schedule(
     State(state): State<ScheduleAppState>,
     Path(schedule_id): Path<Uuid>,
     Json(req): Json<UpdateScheduleRequest>,
-) -> Result<Json<ScheduleResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<ScheduleResponse> {
     let store = state.get_store()?;
 
     // Parse target type if provided
@@ -777,7 +773,7 @@ pub async fn pause_schedule(
     _auth: AuthUser,
     State(state): State<ScheduleAppState>,
     Path(schedule_id): Path<Uuid>,
-) -> Result<Json<ScheduleResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<ScheduleResponse> {
     let store = state.get_store()?;
 
     let update = UpdateSchedule {
@@ -844,7 +840,7 @@ pub async fn resume_schedule(
     _auth: AuthUser,
     State(state): State<ScheduleAppState>,
     Path(schedule_id): Path<Uuid>,
-) -> Result<Json<ScheduleResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<ScheduleResponse> {
     let store = state.get_store()?;
 
     // Get current schedule to get cron expression
@@ -931,7 +927,7 @@ pub async fn trigger_schedule(
     _auth: AuthUser,
     State(state): State<ScheduleAppState>,
     Path(schedule_id): Path<Uuid>,
-) -> Result<Json<TriggerResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<TriggerResponse> {
     let store = state.get_store()?;
 
     // Get schedule to verify it exists
@@ -996,7 +992,7 @@ pub async fn list_schedule_executions(
     State(state): State<ScheduleAppState>,
     Path(schedule_id): Path<Uuid>,
     Query(query): Query<ListExecutionsQuery>,
-) -> Result<Json<ScheduleExecutionsListResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<ScheduleExecutionsListResponse> {
     let store = state.get_store()?;
 
     // Verify schedule exists
@@ -1077,7 +1073,7 @@ pub async fn get_execution(
     _auth: AuthUser,
     State(state): State<ScheduleAppState>,
     Path(execution_id): Path<Uuid>,
-) -> Result<Json<ScheduleExecutionResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<ScheduleExecutionResponse> {
     let store = state.get_store()?;
 
     let execution = store
@@ -1123,7 +1119,7 @@ pub async fn get_schedule_stats(
     _auth: AuthUser,
     State(state): State<ScheduleAppState>,
     Path(schedule_id): Path<Uuid>,
-) -> Result<Json<ScheduleStatsResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<ScheduleStatsResponse> {
     let store = state.get_store()?;
 
     // Verify schedule exists

--- a/crates/server/src/api/session_databases.rs
+++ b/crates/server/src/api/session_databases.rs
@@ -4,7 +4,6 @@
 // Routes under /v1/sessions/{session_id}/databases.
 
 use crate::auth::{AuthState, ResolvedOrg};
-use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -19,7 +18,7 @@ use utoipa::ToSchema;
 
 use crate::storage::StorageBackend;
 
-use super::common::{ListResponse, verify_session_ownership};
+use super::common::{ListResponse, impl_auth_state, verify_session_ownership};
 
 /// Request body for creating a database.
 #[derive(Debug, Deserialize, ToSchema)]
@@ -79,11 +78,7 @@ impl AppState {
     }
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(input: &AppState) -> Self {
-        input.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 /// Create session database routes.
 pub fn routes(state: AppState) -> Router {

--- a/crates/server/src/api/session_files.rs
+++ b/crates/server/src/api/session_files.rs
@@ -15,7 +15,6 @@
 
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::storage::StorageBackend;
-use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{DefaultBodyLimit, Path, Query, State},
@@ -25,7 +24,7 @@ use axum::{
 use everruns_core::typed_id::SessionId;
 use everruns_core::{FileInfo, FileStat, GrepResult, SessionFile};
 
-use super::common::{ListResponse, verify_session_ownership};
+use super::common::{ListResponse, impl_auth_state, verify_session_ownership};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
@@ -150,11 +149,7 @@ impl AppState {
     }
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(input: &AppState) -> Self {
-        input.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 /// Create session files routes
 pub fn routes(state: AppState) -> Router {

--- a/crates/server/src/api/session_git.rs
+++ b/crates/server/src/api/session_git.rs
@@ -13,7 +13,6 @@ use crate::services::session_git::{
     CommitResult, GitCommitInfo, GitDiff, GitRefInfo, SessionGitService,
 };
 use crate::storage::StorageBackend;
-use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, Query, State},
@@ -25,7 +24,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
 
-use super::common::verify_session_ownership;
+use super::common::{impl_auth_state, verify_session_ownership};
 
 /// Request to create a commit
 #[derive(Debug, Clone, Deserialize, ToSchema)]
@@ -97,11 +96,7 @@ impl AppState {
     }
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(input: &AppState) -> Self {
-        input.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 /// Create session git routes
 pub fn routes(state: AppState) -> Router {

--- a/crates/server/src/api/session_resources.rs
+++ b/crates/server/src/api/session_resources.rs
@@ -5,17 +5,15 @@
 
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::services::LeasedResourceService;
-use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, State},
-    http::StatusCode,
     routing::get,
 };
 use everruns_core::{LeasedResource, SessionId};
 use std::sync::Arc;
 
-use super::common::{ApiOptionExt, ApiResultExt, ErrorResponse};
+use super::common::{ApiOptionExt, ApiResult, ApiResultExt, impl_auth_state};
 
 /// App state for session leased-resource routes.
 #[derive(Clone)]
@@ -33,11 +31,7 @@ impl AppState {
     }
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(state: &AppState) -> Self {
-        state.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 pub fn routes(state: AppState) -> Router {
     Router::new()
@@ -59,7 +53,7 @@ pub async fn list_resources(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(session_id): Path<SessionId>,
-) -> Result<Json<Vec<LeasedResource>>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<Vec<LeasedResource>> {
     let resources = state
         .leased_resource_service
         .list_for_session(org.org_id, session_id)

--- a/crates/server/src/api/session_schedules.rs
+++ b/crates/server/src/api/session_schedules.rs
@@ -3,7 +3,6 @@
 
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::services::SessionScheduleService;
-use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -13,7 +12,7 @@ use axum::{
 use everruns_core::session_schedule::SessionSchedule;
 use everruns_core::typed_id::{ScheduleId, SessionId};
 
-use super::common::{ApiOptionExt, ApiResultExt, ErrorResponse};
+use super::common::{ApiOptionExt, ApiResult, ApiResultExt, ErrorResponse, impl_auth_state};
 use serde::Deserialize;
 use std::sync::Arc;
 use utoipa::ToSchema;
@@ -37,11 +36,7 @@ impl AppState {
     }
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(state: &AppState) -> Self {
-        state.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 // ============================================
 // Request/Response types
@@ -90,7 +85,7 @@ pub async fn list_schedules(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(session_id): Path<SessionId>,
-) -> Result<Json<Vec<SessionSchedule>>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<Vec<SessionSchedule>> {
     let schedules = state
         .schedule_service
         .list(org.org_id, session_id)
@@ -114,7 +109,7 @@ pub async fn get_schedule(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path((session_id, schedule_id)): Path<(SessionId, ScheduleId)>,
-) -> Result<Json<SessionSchedule>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<SessionSchedule> {
     let schedule =
         get_schedule_in_session(&state, org.org_id, session_id, schedule_id, "get schedule")
             .await?;
@@ -138,7 +133,7 @@ pub async fn update_schedule(
     State(state): State<AppState>,
     Path((session_id, schedule_id)): Path<(SessionId, ScheduleId)>,
     Json(req): Json<UpdateScheduleRequest>,
-) -> Result<Json<SessionSchedule>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<SessionSchedule> {
     let enabled = req.enabled.unwrap_or(true);
     get_schedule_in_session(
         &state,
@@ -215,7 +210,7 @@ pub async fn trigger_schedule(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path((session_id, schedule_id)): Path<(SessionId, ScheduleId)>,
-) -> Result<Json<SessionSchedule>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<SessionSchedule> {
     get_schedule_in_session(
         &state,
         org.org_id,

--- a/crates/server/src/api/session_storage.rs
+++ b/crates/server/src/api/session_storage.rs
@@ -4,7 +4,6 @@
 
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::storage::StorageBackend;
-use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -16,7 +15,7 @@ use serde::Serialize;
 use std::sync::Arc;
 use utoipa::ToSchema;
 
-use super::common::{ApiResultExt, ListResponse, verify_session_ownership};
+use super::common::{ApiResultExt, ListResponse, impl_auth_state, verify_session_ownership};
 
 /// Key-value entry info (key and timestamps, no value)
 #[derive(Debug, Clone, Serialize, ToSchema)]
@@ -55,11 +54,7 @@ impl AppState {
     }
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(input: &AppState) -> Self {
-        input.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 /// Create session storage routes (nested under sessions)
 pub fn routes(state: AppState) -> Router {

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -7,7 +7,6 @@ use crate::services::session::{SESSION_MANAGE, SESSION_VIEW};
 use crate::services::{EventService, SessionService};
 use crate::storage::StorageBackend;
 use anyhow::Context;
-use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, Query, State},
@@ -24,7 +23,8 @@ use everruns_core::{
 use everruns_worker::AgentRunner;
 
 use super::common::{
-    ApiOptionExt, ApiPolicyResultExt, ApiResultExt, ErrorResponse, PaginatedResponse, Pagination,
+    ApiOptionExt, ApiPolicyResultExt, ApiResult, ApiResultExt, ErrorResponse, PaginatedResponse,
+    Pagination, impl_auth_state,
 };
 use super::validation::normalize_locale;
 use serde::{Deserialize, Serialize};
@@ -188,11 +188,7 @@ impl AppState {
     }
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(input: &AppState) -> Self {
-        input.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 /// Response for session statistics endpoint
 #[derive(Debug, Clone, Serialize, ToSchema)]
@@ -380,7 +376,7 @@ async fn resolve_session_harness_id(
 pub async fn get_or_create_chat_session(
     org: ResolvedOrg,
     State(state): State<AppState>,
-) -> Result<Json<Session>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<Session> {
     // Use authenticated user_id, or fall back to anonymous user (auth=none mode)
     let user_id = org.user_id.unwrap_or(everruns_core::ANONYMOUS_USER_ID);
     let chat_harness_name = state.chat_harness_name.clone().ok_or((
@@ -442,7 +438,7 @@ pub async fn list_sessions(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListSessionsQuery>,
-) -> Result<Json<PaginatedResponse<Session>>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<PaginatedResponse<Session>> {
     let offset = query.offset.unwrap_or(0);
     let limit = query.limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT);
     let pagination = Pagination::new(offset, limit);
@@ -495,7 +491,7 @@ pub async fn list_sessions(
 pub async fn get_session_stats(
     org: ResolvedOrg,
     State(state): State<AppState>,
-) -> Result<Json<SessionStatsResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<SessionStatsResponse> {
     let caller = Caller::from(&org);
     let stats = state
         .session_service
@@ -531,7 +527,7 @@ pub async fn get_session(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(session_id): Path<String>,
-) -> Result<Json<Session>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<Session> {
     let session_id: SessionId = session_id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -580,7 +576,7 @@ pub async fn update_session(
     State(state): State<AppState>,
     Path(session_id): Path<String>,
     Json(mut req): Json<UpdateSessionRequest>,
-) -> Result<Json<Session>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<Session> {
     req.locale = normalize_locale(req.locale)
         .map_err(|err| -> (StatusCode, Json<ErrorResponse>) { err.into() })?;
 
@@ -772,7 +768,7 @@ pub async fn cancel_turn(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(session_id): Path<String>,
-) -> Result<Json<CancelTurnResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<CancelTurnResponse> {
     let session_id: SessionId = session_id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,

--- a/crates/server/src/api/skills.rs
+++ b/crates/server/src/api/skills.rs
@@ -4,12 +4,13 @@
 // CRUD for Agent Skills (agentskills.io format).
 // Supports both SKILL.md text upload and ZIP archive upload.
 
-use crate::api::common::{ApiOptionExt, ApiPolicyResultExt, ErrorResponse, ListResponse};
+use crate::api::common::{
+    ApiOptionExt, ApiPolicyResultExt, ApiResult, ErrorResponse, ListResponse, impl_auth_state,
+};
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::services::SkillService;
 use crate::services::skill::{SKILL_DANGEROUS, SKILL_MANAGE, SKILL_VIEW};
 use crate::storage::StorageBackend;
-use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{DefaultBodyLimit, Path, Query, State},
@@ -92,11 +93,7 @@ impl AppState {
     }
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(input: &AppState) -> Self {
-        input.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 // ============================================
 // Helpers
@@ -260,7 +257,7 @@ pub async fn list_skills(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListSkillsQuery>,
-) -> Result<Json<ListResponse<Skill>>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<ListResponse<Skill>> {
     let caller = Caller::from(&org);
     let skills = state
         .service
@@ -292,7 +289,7 @@ pub async fn get_skill(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(skill_id): Path<String>,
-) -> Result<Json<Skill>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<Skill> {
     let skill_id: SkillId = skill_id.parse().map_err(|e| {
         ErrorResponse::new(format!("Invalid skill ID: {e}")).into_response(StatusCode::BAD_REQUEST)
     })?;
@@ -325,7 +322,7 @@ pub async fn get_skill_content(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(skill_id): Path<String>,
-) -> Result<Json<SkillContent>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<SkillContent> {
     let skill_id: SkillId = skill_id.parse().map_err(|e| {
         ErrorResponse::new(format!("Invalid skill ID: {e}")).into_response(StatusCode::BAD_REQUEST)
     })?;
@@ -359,7 +356,7 @@ pub async fn update_skill(
     State(state): State<AppState>,
     Path(skill_id): Path<String>,
     Json(req): Json<UpdateSkillRequest>,
-) -> Result<Json<Skill>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<Skill> {
     let skill_id: SkillId = skill_id.parse().map_err(|e| {
         ErrorResponse::new(format!("Invalid skill ID: {e}")).into_response(StatusCode::BAD_REQUEST)
     })?;

--- a/crates/server/src/api/tool_results.rs
+++ b/crates/server/src/api/tool_results.rs
@@ -11,7 +11,6 @@
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::services::{EventService, SessionService};
 use crate::storage::StorageBackend;
-use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -24,7 +23,7 @@ use everruns_core::message::ContentPart;
 use everruns_core::typed_id::{MessageId, SessionId, TurnId};
 use everruns_worker::AgentRunner;
 
-use super::common::{ApiOptionExt, ApiResultExt, ErrorResponse};
+use super::common::{ApiOptionExt, ApiResult, ApiResultExt, ErrorResponse, impl_auth_state};
 use everruns_core::Caller;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -81,11 +80,7 @@ impl AppState {
     }
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(input: &AppState) -> Self {
-        input.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 /// Create tool results routes
 pub fn routes(state: AppState) -> Router {
@@ -122,7 +117,7 @@ pub async fn submit_tool_results(
     State(state): State<AppState>,
     Path(session_id): Path<String>,
     Json(req): Json<SubmitToolResultsRequest>,
-) -> Result<Json<SubmitToolResultsResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> ApiResult<SubmitToolResultsResponse> {
     let session_id: SessionId = session_id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,

--- a/crates/server/src/api/user_connections.rs
+++ b/crates/server/src/api/user_connections.rs
@@ -10,7 +10,7 @@ use crate::auth::oauth::GitHubAppService;
 use crate::storage::{EncryptionService, StorageBackend};
 use axum::{
     Json, Router,
-    extract::{FromRef, Path, Query, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     response::Redirect,
     routing::{delete, get, post, put},
@@ -25,6 +25,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
 
+use super::common::impl_auth_state;
 use crate::storage::models::CreateUserConnectionRow;
 
 /// App state for user connections routes
@@ -55,11 +56,7 @@ impl AppState {
     }
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(input: &AppState) -> Self {
-        input.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 // ============================================================================
 // Response / Request Types

--- a/crates/server/src/api/users.rs
+++ b/crates/server/src/api/users.rs
@@ -13,14 +13,13 @@ use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use chrono::{DateTime, Utc};
 use everruns_core::validate_org_public_id;
 
-use super::common::ListResponse;
+use super::common::{ListResponse, impl_auth_state};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
 
 use crate::auth::middleware::{AuthState, AuthUser, ResolvedOrg};
 use crate::storage::models::UpdateUser;
-use axum::extract::FromRef;
 
 /// Cookie name for storing selected organization
 pub const ORG_COOKIE_NAME: &str = "everruns_org";
@@ -32,11 +31,7 @@ pub struct UsersState {
     pub auth: AuthState,
 }
 
-impl FromRef<UsersState> for AuthState {
-    fn from_ref(input: &UsersState) -> Self {
-        input.auth.clone()
-    }
-}
+impl_auth_state!(UsersState);
 
 /// User response for listing
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]


### PR DESCRIPTION
## What
Add shared utilities to `common.rs` to reduce API route boilerplate, applied to all 28 API modules with auth.

- `ApiResult<T>` type alias — replaces `Result<Json<T>, (StatusCode, Json<ErrorResponse>)>`
- `impl_auth_state!` macro — replaces 28 identical `FromRef<AppState> for AuthState` impls (5 lines each → 1 line)

## Why
EVE-110: 53 API modules repeat identical boilerplate. The `FromRef` impl alone accounts for 140 lines of pure duplication. The Result type is repeated in nearly every handler signature.

## How
- Defined macro and type alias in `common.rs`
- Applied `impl_auth_state!` to all 28 modules that have auth state
- Applied `ApiResult<T>` where handler signatures used the full type
- Removed now-unused `FromRef` imports

## Risk
- **Low**
- Pure refactoring — macro expands to identical code
- No behavioral changes, no API surface changes
- 29 files changed, net -91 lines

## Checklist
- [x] Tests added or updated (existing tests cover handler behavior unchanged)
- [x] Backward compatibility considered (internal refactor only)