### PR TITLE
refactor(ui): extract magic values to named constants

### DIFF
--- a/apps/ui/src/components/dashboard/agent-list-widget.tsx
+++ b/apps/ui/src/components/dashboard/agent-list-widget.tsx
@@ -16,7 +16,8 @@ interface AgentListWidgetProps {
 }
 
 export function AgentListWidget({ agents, allCapabilities }: AgentListWidgetProps) {
-  const activeAgents = agents.filter((a) => a.status === "active").slice(0, 5);
+  const MAX_DISPLAYED = 5;
+  const activeAgents = agents.filter((a) => a.status === "active").slice(0, MAX_DISPLAYED);
 
   const getCapabilityInfo = (capabilityId: CapabilityId): Capability | undefined =>
     allCapabilities?.find((c) => c.id === capabilityId);

--- a/apps/ui/src/components/dashboard/agent-list-widget.tsx
+++ b/apps/ui/src/components/dashboard/agent-list-widget.tsx
@@ -15,8 +15,9 @@ interface AgentListWidgetProps {
   allCapabilities?: Capability[];
 }
 
+const MAX_DISPLAYED = 5;
+
 export function AgentListWidget({ agents, allCapabilities }: AgentListWidgetProps) {
-  const MAX_DISPLAYED = 5;
   const activeAgents = agents.filter((a) => a.status === "active").slice(0, MAX_DISPLAYED);
 
   const getCapabilityInfo = (capabilityId: CapabilityId): Capability | undefined =>

--- a/apps/ui/src/components/dashboard/recent-sessions.tsx
+++ b/apps/ui/src/components/dashboard/recent-sessions.tsx
@@ -26,7 +26,8 @@ function formatTotalTokens(usage: TokenUsage): string {
 }
 
 export function RecentSessions({ sessions, agents, models = [] }: RecentSessionsProps) {
-  const recentSessions = sessions.slice(0, 10);
+  const MAX_RECENT = 10;
+  const recentSessions = sessions.slice(0, MAX_RECENT);
   const agentMap = new Map(agents.map((a) => [a.id, a]));
   const modelMap = new Map(models.map((m) => [m.id, m]));
 

--- a/apps/ui/src/components/dashboard/recent-sessions.tsx
+++ b/apps/ui/src/components/dashboard/recent-sessions.tsx
@@ -25,8 +25,9 @@ function formatTotalTokens(usage: TokenUsage): string {
   return formatTokens(total);
 }
 
+const MAX_RECENT = 10;
+
 export function RecentSessions({ sessions, agents, models = [] }: RecentSessionsProps) {
-  const MAX_RECENT = 10;
   const recentSessions = sessions.slice(0, MAX_RECENT);
   const agentMap = new Map(agents.map((a) => [a.id, a]));
   const modelMap = new Map(models.map((m) => [m.id, m]));

--- a/apps/ui/src/providers/notifications-provider.tsx
+++ b/apps/ui/src/providers/notifications-provider.tsx
@@ -58,13 +58,16 @@ function sortNotifications(notifications: Notification[]): Notification[] {
   });
 }
 
+/** Maximum notifications kept in memory to limit memory growth. */
+const MAX_NOTIFICATIONS = 50;
+
 function upsertNotification(state: NotificationState, incoming: Notification): NotificationState {
   const previous = state.rawNotifications.find((item) => item.id === incoming.id);
   const notifications = sortNotifications(
     previous
       ? state.rawNotifications.map((item) => (item.id === incoming.id ? incoming : item))
       : [incoming, ...state.rawNotifications],
-  ).slice(0, 50);
+  ).slice(0, MAX_NOTIFICATIONS);
 
   let rawUnviewedCount = state.rawUnviewedCount;
   if (!previous && !incoming.viewed_at) {
@@ -134,7 +137,7 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (!notificationsQuery.data || !isEnabled) return;
     setState({
-      rawNotifications: sortNotifications(notificationsQuery.data.data).slice(0, 50),
+      rawNotifications: sortNotifications(notificationsQuery.data.data).slice(0, MAX_NOTIFICATIONS),
       rawUnviewedCount: notificationsQuery.data.unviewed_count,
       initialized: true,
     });


### PR DESCRIPTION
## What
Replace inline magic numbers with named constants in dashboard and notification components.

## Why
EVE-130: Hardcoded magic values scattered across UI components. Most values were already named (scroll thresholds, chart dimensions, pagination limits), but a few remained as bare literals.

## How
- `recent-sessions.tsx`: `MAX_RECENT = 10`
- `agent-list-widget.tsx`: `MAX_DISPLAYED = 5`
- `notifications-provider.tsx`: `MAX_NOTIFICATIONS = 50`

Note: Chart colors in `metrics-charts.tsx` already use a named `COLORS` constant with Tailwind color comments. Creating CSS design tokens for charts is a separate design decision.

## Risk
- **Low** — renaming literals to constants, no behavioral change

## Checklist
- [x] Tests added or updated (no behavior change, existing tests cover)
- [x] Backward compatibility considered (internal refactor)