### PR TITLE
feat(ci): publish pre-built CLI binaries to GitHub releases

### DIFF
--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -1,0 +1,65 @@
+name: Publish CLI Binaries
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build CLI (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-apple-darwin
+            runner: macos-13
+            archive: everruns-x86_64-apple-darwin.tar.gz
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+            archive: everruns-aarch64-apple-darwin.tar.gz
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            archive: everruns-x86_64-unknown-linux-gnu.tar.gz
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install protobuf compiler (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Install protobuf compiler (macOS)
+        if: runner.os == 'macOS'
+        run: brew install protobuf
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "cli-${{ matrix.target }}"
+
+      - name: Build CLI binary
+        run: cargo build --release --target ${{ matrix.target }} -p everruns-cli
+
+      - name: Package binary
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf "$GITHUB_WORKSPACE/${{ matrix.archive }}" everruns
+          cd "$GITHUB_WORKSPACE"
+          shasum -a 256 "${{ matrix.archive }}" > "${{ matrix.archive }}.sha256"
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            "${{ matrix.archive }}" \
+            "${{ matrix.archive }}.sha256"

--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -70,4 +70,5 @@ jobs:
         run: |
           gh release upload "${{ inputs.tag }}" \
             "${{ matrix.archive }}" \
-            "${{ matrix.archive }}.sha256"
+            "${{ matrix.archive }}.sha256" \
+            --clobber

--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -1,8 +1,14 @@
 name: Publish CLI Binaries
 
+# GITHUB_TOKEN-created releases don't trigger `release: published` (anti-recursion).
+# The Release workflow dispatches this workflow explicitly, same pattern as Docker Publish.
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., v0.8.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -27,6 +33,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -60,6 +68,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${{ github.event.release.tag_name }}" \
+          gh release upload "${{ inputs.tag }}" \
             "${{ matrix.archive }}" \
             "${{ matrix.archive }}.sha256"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,3 +129,12 @@ jobs:
           echo "Triggering Docker Publish for tag $TAG..."
           gh workflow run docker-publish.yml --ref "$TAG" -f "tag=$TAG"
           echo "Docker Publish triggered for $TAG"
+
+      - name: Trigger CLI binary builds for release tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ steps.version.outputs.version }}"
+          echo "Triggering CLI binary builds for tag $TAG..."
+          gh workflow run cli-binaries.yml --ref "$TAG" -f "tag=$TAG"
+          echo "CLI binary builds triggered for $TAG"

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -62,10 +62,10 @@ The workflow will extract release notes from CHANGELOG.md and create the GitHub 
 2. Release title: `vX.Y.Z`
 3. Release body: Extracted from CHANGELOG.md section for that version
 4. Docker images tagged with version (triggered via `workflow_dispatch` from Release workflow)
-5. Pre-built CLI binaries attached as release assets (triggered by `release: published` event)
+5. Pre-built CLI binaries attached as release assets (triggered via `workflow_dispatch` from Release workflow)
 
 > **Note:** Tags created by `GITHUB_TOKEN` don't trigger other workflows (GitHub anti-recursion).
-> The Release workflow explicitly dispatches Docker Publish after creating the release.
+> The Release workflow explicitly dispatches Docker Publish and CLI Binaries after creating the release.
 
 ### CLI Binary Assets
 

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -62,9 +62,22 @@ The workflow will extract release notes from CHANGELOG.md and create the GitHub 
 2. Release title: `vX.Y.Z`
 3. Release body: Extracted from CHANGELOG.md section for that version
 4. Docker images tagged with version (triggered via `workflow_dispatch` from Release workflow)
+5. Pre-built CLI binaries attached as release assets (triggered by `release: published` event)
 
 > **Note:** Tags created by `GITHUB_TOKEN` don't trigger other workflows (GitHub anti-recursion).
 > The Release workflow explicitly dispatches Docker Publish after creating the release.
+
+### CLI Binary Assets
+
+The `Publish CLI Binaries` workflow builds and attaches pre-built CLI binaries to each GitHub Release:
+
+| Asset | Target |
+|-------|--------|
+| `everruns-x86_64-apple-darwin.tar.gz` | macOS Intel |
+| `everruns-aarch64-apple-darwin.tar.gz` | macOS Apple Silicon |
+| `everruns-x86_64-unknown-linux-gnu.tar.gz` | Linux x86_64 |
+
+Each archive contains the `everruns` binary. SHA-256 checksums (`.sha256` files) are included for verification. These assets are used by the Homebrew formula for installation.
 
 ### Docker Image Tagging
 


### PR DESCRIPTION
## What
Adds a GitHub Actions workflow that builds pre-built CLI binaries and attaches them to GitHub Releases. Produces:
- `everruns-x86_64-apple-darwin.tar.gz` (macOS Intel)
- `everruns-aarch64-apple-darwin.tar.gz` (macOS Apple Silicon)
- `everruns-x86_64-unknown-linux-gnu.tar.gz` (Linux x86_64)

Each archive includes a `.sha256` checksum file.

## Why
Homebrew formula needs downloadable pre-built binaries from GitHub Releases.

## How
- New `cli-binaries.yml` workflow triggered via `workflow_dispatch` from the Release workflow (same pattern as Docker Publish, required because GITHUB_TOKEN anti-recursion prevents `release: published` from firing).
- Matrix strategy: native compilation on macOS 13 (x86_64), macOS latest (aarch64), and Ubuntu (x86_64-linux-gnu).
- Release workflow updated to dispatch CLI binary builds after creating the release.
- Spec updated to document the new assets.

## Risk
- Low
- Only affects release pipeline; no runtime code changed. If the workflow fails, the release still publishes — binaries just won't be attached.

## Checklist
- [x] Tests added or updated (CI-only, validated by workflow syntax)
- [x] Backward compatibility considered (additive change)