### PR TITLE
fix(grpc): replace 150MB gRPC message limit with presigned URLs for images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,6 +1700,7 @@ version = "0.8.6"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64",
  "chrono",
  "everruns-anthropic",
  "everruns-core",

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -894,16 +894,20 @@ message ResolveImageRequest {
 }
 
 // Response with resolved image data
-// Returns base64-encoded image data and media type for LLM consumption
+// Returns either a presigned URL or base64-encoded image data for LLM consumption.
+// When `url` is present, workers should fetch image data via HTTP instead of using `base64`.
 message ResolveImageResponse {
     // True if image was found
     bool found = 1;
     // Base64-encoded image data (without data URL prefix)
-    // Empty string when found=false
+    // Empty when url is provided or when found=false
     string base64 = 2;
     // MIME type (e.g., "image/png", "image/jpeg")
     // Empty string when found=false
     string media_type = 3;
+    // Presigned URL to fetch the image binary via HTTP GET
+    // When present, workers should use this instead of the base64 field
+    string url = 4;
 }
 
 // Batch request to resolve multiple images
@@ -923,9 +927,13 @@ message ResolveImagesResponse {
 // Resolved image data for batch response
 message ResolvedImageData {
     // Base64-encoded image data (without data URL prefix)
+    // Empty when url is provided
     string base64 = 1;
     // MIME type (e.g., "image/png", "image/jpeg")
     string media_type = 2;
+    // Presigned URL to fetch the image binary via HTTP GET
+    // When present, workers should use this instead of the base64 field
+    string url = 3;
 }
 
 // === Record success ===

--- a/crates/server/src/api/internal_images.rs
+++ b/crates/server/src/api/internal_images.rs
@@ -1,0 +1,218 @@
+// Internal presigned image endpoint for worker image resolution
+//
+// Decision: Workers fetch images via presigned HTTP URLs instead of base64 over gRPC.
+// This removes the 150MB gRPC message limit workaround and keeps gRPC messages small.
+// Presigned URLs are HMAC-signed with WORKER_GRPC_AUTH_TOKEN so no org auth is needed.
+
+use crate::storage::StorageBackend;
+use axum::{
+    Router,
+    body::Body,
+    extract::{Path, Query, State},
+    http::{StatusCode, header},
+    response::Response,
+    routing::get,
+};
+use hmac::{Hmac, Mac};
+use serde::Deserialize;
+use sha2::Sha256;
+use std::sync::Arc;
+use uuid::Uuid;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Presigned URL expiry duration (5 minutes)
+const PRESIGN_EXPIRY_SECS: i64 = 300;
+
+/// App state for internal image routes
+#[derive(Clone)]
+pub struct AppState {
+    pub db: Arc<StorageBackend>,
+    /// Shared secret for HMAC signature validation (WORKER_GRPC_AUTH_TOKEN)
+    pub signing_secret: String,
+}
+
+/// Query parameters for presigned image fetch
+#[derive(Debug, Deserialize)]
+pub struct PresignedQuery {
+    pub org_id: i64,
+    pub expires: i64,
+    pub sig: String,
+}
+
+/// Create internal image routes (no org auth — presigned URL validates access)
+pub fn routes(state: AppState) -> Router {
+    Router::new()
+        .route("/internal/images/{image_id}", get(get_presigned_image))
+        .with_state(state)
+}
+
+/// Generate a presigned URL for an image
+pub fn generate_presigned_url(
+    base_url: &str,
+    image_id: Uuid,
+    org_id: i64,
+    signing_secret: &str,
+) -> String {
+    let expires = chrono::Utc::now().timestamp() + PRESIGN_EXPIRY_SECS;
+    let sig = compute_signature(signing_secret, image_id, org_id, expires);
+    format!(
+        "{}/internal/images/{}?org_id={}&expires={}&sig={}",
+        base_url.trim_end_matches('/'),
+        image_id,
+        org_id,
+        expires,
+        sig
+    )
+}
+
+/// Compute HMAC-SHA256 signature for presigned URL parameters
+fn compute_signature(secret: &str, image_id: Uuid, org_id: i64, expires: i64) -> String {
+    let message = format!("{}:{}:{}", image_id, org_id, expires);
+    let mut mac =
+        HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC accepts any key length");
+    mac.update(message.as_bytes());
+    hex::encode(mac.finalize().into_bytes())
+}
+
+/// Validate presigned URL signature and expiry
+fn validate_presigned(
+    signing_secret: &str,
+    image_id: Uuid,
+    query: &PresignedQuery,
+) -> Result<(), (StatusCode, String)> {
+    // Check expiry
+    let now = chrono::Utc::now().timestamp();
+    if now > query.expires {
+        return Err((StatusCode::FORBIDDEN, "Presigned URL expired".to_string()));
+    }
+
+    // Validate signature
+    let expected = compute_signature(signing_secret, image_id, query.org_id, query.expires);
+    if !constant_time_eq(expected.as_bytes(), query.sig.as_bytes()) {
+        return Err((
+            StatusCode::FORBIDDEN,
+            "Invalid presigned URL signature".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Constant-time comparison to prevent timing attacks on signature validation
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter()
+        .zip(b.iter())
+        .fold(0u8, |acc, (x, y)| acc | (x ^ y))
+        == 0
+}
+
+/// GET /internal/images/{image_id}?org_id=...&expires=...&sig=...
+///
+/// Returns image binary data. Validates presigned URL signature against WORKER_GRPC_AUTH_TOKEN.
+async fn get_presigned_image(
+    State(state): State<AppState>,
+    Path(image_id): Path<Uuid>,
+    Query(query): Query<PresignedQuery>,
+) -> Result<Response, (StatusCode, String)> {
+    validate_presigned(&state.signing_secret, image_id, &query)?;
+
+    let row = state
+        .db
+        .get_image(query.org_id, image_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(%image_id, error = %e, "Failed to get presigned image");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal server error".to_string(),
+            )
+        })?
+        .ok_or((StatusCode::NOT_FOUND, "Image not found".to_string()))?;
+
+    let response = Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, row.content_type)
+        .header(header::CACHE_CONTROL, "private, max-age=60")
+        .body(Body::from(row.data))
+        .unwrap();
+
+    Ok(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn presigned_url_roundtrip() {
+        let secret = "test-secret-token";
+        let image_id = Uuid::new_v4();
+        let org_id = 42;
+
+        let url = generate_presigned_url("http://localhost:9000", image_id, org_id, secret);
+
+        // Parse the URL to extract query params
+        assert!(url.contains(&format!("/internal/images/{}", image_id)));
+        assert!(url.contains(&format!("org_id={}", org_id)));
+        assert!(url.contains("expires="));
+        assert!(url.contains("sig="));
+    }
+
+    #[test]
+    fn signature_validation_succeeds_for_valid_params() {
+        let secret = "test-secret";
+        let image_id = Uuid::new_v4();
+        let org_id = 1;
+        let expires = chrono::Utc::now().timestamp() + 300;
+        let sig = compute_signature(secret, image_id, org_id, expires);
+
+        let query = PresignedQuery {
+            org_id,
+            expires,
+            sig,
+        };
+        assert!(validate_presigned(secret, image_id, &query).is_ok());
+    }
+
+    #[test]
+    fn signature_validation_rejects_expired() {
+        let secret = "test-secret";
+        let image_id = Uuid::new_v4();
+        let org_id = 1;
+        let expires = chrono::Utc::now().timestamp() - 10; // expired
+        let sig = compute_signature(secret, image_id, org_id, expires);
+
+        let query = PresignedQuery {
+            org_id,
+            expires,
+            sig,
+        };
+        assert!(validate_presigned(secret, image_id, &query).is_err());
+    }
+
+    #[test]
+    fn signature_validation_rejects_wrong_sig() {
+        let secret = "test-secret";
+        let image_id = Uuid::new_v4();
+        let org_id = 1;
+        let expires = chrono::Utc::now().timestamp() + 300;
+
+        let query = PresignedQuery {
+            org_id,
+            expires,
+            sig: "bad-signature".to_string(),
+        };
+        assert!(validate_presigned(secret, image_id, &query).is_err());
+    }
+
+    #[test]
+    fn constant_time_eq_works() {
+        assert!(constant_time_eq(b"hello", b"hello"));
+        assert!(!constant_time_eq(b"hello", b"world"));
+        assert!(!constant_time_eq(b"hello", b"hell"));
+    }
+}

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -15,6 +15,7 @@ pub mod events;
 pub mod feature_flags;
 pub mod harnesses;
 pub mod images;
+pub mod internal_images;
 pub mod llm_models;
 pub mod llm_providers;
 pub mod mcp_servers;

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -637,11 +637,20 @@ impl ServerAppBuilder {
             .merge(schedules_state)
             .merge(api::images::routes(images_state))
             .merge({
-                let signing_secret = std::env::var("WORKER_GRPC_AUTH_TOKEN").unwrap_or_default();
-                api::internal_images::routes(api::internal_images::AppState {
-                    db: db.clone(),
-                    signing_secret,
-                })
+                // Only mount presigned image routes when WORKER_GRPC_AUTH_TOKEN is set.
+                // Without a signing secret, presigned URLs would be trivially forgeable.
+                match std::env::var("WORKER_GRPC_AUTH_TOKEN")
+                    .ok()
+                    .filter(|s| !s.is_empty())
+                {
+                    Some(signing_secret) => {
+                        api::internal_images::routes(api::internal_images::AppState {
+                            db: db.clone(),
+                            signing_secret,
+                        })
+                    }
+                    None => Router::new(),
+                }
             })
             .merge(api::skills::routes(skills_state))
             .merge(api::organizations::routes(organizations_state))

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -636,6 +636,13 @@ impl ServerAppBuilder {
             .merge(api::durable::routes(durable_state))
             .merge(schedules_state)
             .merge(api::images::routes(images_state))
+            .merge({
+                let signing_secret = std::env::var("WORKER_GRPC_AUTH_TOKEN").unwrap_or_default();
+                api::internal_images::routes(api::internal_images::AppState {
+                    db: db.clone(),
+                    signing_secret,
+                })
+            })
             .merge(api::skills::routes(skills_state))
             .merge(api::organizations::routes(organizations_state))
             .merge(api::user_connections::routes(user_connections_state))

--- a/crates/server/src/grpc_service/mod.rs
+++ b/crates/server/src/grpc_service/mod.rs
@@ -341,6 +341,11 @@ pub struct WorkerServiceImpl {
     runner: Option<Arc<dyn everruns_worker::AgentRunner>>,
     /// Lazy connection token resolver (decrypts stored tokens / mints GitHub App tokens)
     connection_resolver: Option<Arc<dyn everruns_core::traits::UserConnectionResolver>>,
+    /// Base URL for generating presigned image URLs (e.g., "http://127.0.0.1:9000")
+    /// When set, image resolution returns presigned URLs instead of base64 data.
+    api_base_url: Option<String>,
+    /// Signing secret for presigned URLs (WORKER_GRPC_AUTH_TOKEN)
+    presign_secret: Option<String>,
 }
 
 impl WorkerServiceImpl {
@@ -405,6 +410,13 @@ impl WorkerServiceImpl {
                 sqldb_backend,
             )));
 
+        // Presigned URL support: when API_BASE_URL is set, image resolution
+        // returns presigned HTTP URLs instead of base64 data over gRPC.
+        let api_base_url = std::env::var("API_BASE_URL").ok().filter(|s| !s.is_empty());
+        let presign_secret = std::env::var("WORKER_GRPC_AUTH_TOKEN")
+            .ok()
+            .filter(|s| !s.is_empty());
+
         Self {
             event_service,
             agent_service,
@@ -421,12 +433,26 @@ impl WorkerServiceImpl {
             sqldb_store,
             runner,
             connection_resolver,
+            api_base_url,
+            presign_secret,
         }
     }
 
     /// Set the task notification broadcaster (must be called after async initialization)
     pub fn set_task_broadcaster(&mut self, broadcaster: Arc<TaskNotificationBroadcaster>) {
         self.task_broadcaster = Some(broadcaster);
+    }
+
+    /// Generate a presigned URL for an image, or None if presigned URLs are not configured.
+    fn presigned_image_url(&self, image_id: uuid::Uuid, org_id: i64) -> Option<String> {
+        match (&self.api_base_url, &self.presign_secret) {
+            (Some(base_url), Some(secret)) => {
+                Some(crate::api::internal_images::generate_presigned_url(
+                    base_url, image_id, org_id, secret,
+                ))
+            }
+            _ => None,
+        }
     }
 
     /// Get durable store or return unavailable error
@@ -504,13 +530,12 @@ impl WorkerServiceImpl {
             .ok_or_else(|| Status::unavailable("Session SQL database not available"))
     }
 
-    /// Max gRPC message size (150MB for base64-encoded images + overhead)
+    /// Max gRPC message size (16MB)
     ///
-    /// TODO: Sending large images over gRPC is inefficient. Future improvements:
-    /// - Use presigned URLs for workers to fetch images directly from storage
-    /// - Stream images in chunks instead of single large messages
-    /// - Move to S3/blob storage with direct worker access
-    const MAX_GRPC_MESSAGE_SIZE: usize = 150 * 1024 * 1024;
+    /// Image data no longer flows through gRPC — workers fetch images via presigned
+    /// HTTP URLs returned by resolve_image/resolve_images RPCs. The limit only needs
+    /// to accommodate metadata, proto messages, and session file content.
+    const MAX_GRPC_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
 
     /// Create a tonic server for this service
     pub fn into_server(self) -> WorkerServiceServer<Self> {

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -1776,7 +1776,34 @@ impl WorkerService for WorkerServiceImpl {
         let req = request.into_inner();
         let image_id = parse_uuid(req.image_id.as_ref())?;
 
-        // Get image from storage (org-scoped)
+        // Prefer presigned URL to avoid sending image data over gRPC
+        if let Some(url) = self.presigned_image_url(image_id, req.org_id) {
+            // Still need media_type for LLM provider formatting — look up metadata only
+            let media_type = match self.db.get_image(req.org_id, image_id).await {
+                Ok(Some(row)) => row.content_type,
+                Ok(None) => {
+                    return Ok(Response::new(ResolveImageResponse {
+                        found: false,
+                        base64: String::new(),
+                        media_type: String::new(),
+                        url: String::new(),
+                    }));
+                }
+                Err(e) => {
+                    tracing::error!(%image_id, error = %e, "Failed to get image");
+                    return Err(Status::internal("Failed to get image"));
+                }
+            };
+
+            return Ok(Response::new(ResolveImageResponse {
+                found: true,
+                base64: String::new(),
+                media_type,
+                url,
+            }));
+        }
+
+        // Fallback: send base64 over gRPC (when API_BASE_URL is not configured)
         let image_row = match self.db.get_image(req.org_id, image_id).await {
             Ok(Some(row)) => row,
             Ok(None) => {
@@ -1784,6 +1811,7 @@ impl WorkerService for WorkerServiceImpl {
                     found: false,
                     base64: String::new(),
                     media_type: String::new(),
+                    url: String::new(),
                 }));
             }
             Err(e) => {
@@ -1792,13 +1820,13 @@ impl WorkerService for WorkerServiceImpl {
             }
         };
 
-        // Encode to base64
         let base64_data = base64::engine::general_purpose::STANDARD.encode(&image_row.data);
 
         Ok(Response::new(ResolveImageResponse {
             found: true,
             base64: base64_data,
             media_type: image_row.content_type,
+            url: String::new(),
         }))
     }
 
@@ -1813,24 +1841,41 @@ impl WorkerService for WorkerServiceImpl {
         let req = request.into_inner();
 
         let mut images = std::collections::HashMap::new();
+        let use_presigned = self.api_base_url.is_some() && self.presign_secret.is_some();
 
         for proto_id in req.image_ids {
             let image_id = parse_uuid(Some(&proto_id))?;
 
-            // Get image from storage (org-scoped)
             match self.db.get_image(req.org_id, image_id).await {
                 Ok(Some(row)) => {
-                    let base64_data = base64::engine::general_purpose::STANDARD.encode(&row.data);
-                    images.insert(
-                        image_id.to_string(),
-                        ResolvedImageData {
-                            base64: base64_data,
-                            media_type: row.content_type,
-                        },
-                    );
+                    if use_presigned {
+                        // Return presigned URL — no image data over gRPC
+                        let url = self
+                            .presigned_image_url(image_id, req.org_id)
+                            .unwrap_or_default();
+                        images.insert(
+                            image_id.to_string(),
+                            ResolvedImageData {
+                                base64: String::new(),
+                                media_type: row.content_type,
+                                url,
+                            },
+                        );
+                    } else {
+                        // Fallback: base64 over gRPC
+                        let base64_data =
+                            base64::engine::general_purpose::STANDARD.encode(&row.data);
+                        images.insert(
+                            image_id.to_string(),
+                            ResolvedImageData {
+                                base64: base64_data,
+                                media_type: row.content_type,
+                                url: String::new(),
+                            },
+                        );
+                    }
                 }
                 Ok(None) => {
-                    // Image not found - skip it
                     tracing::debug!(%image_id, "Image not found during batch resolution");
                 }
                 Err(e) => {

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -1778,9 +1778,9 @@ impl WorkerService for WorkerServiceImpl {
 
         // Prefer presigned URL to avoid sending image data over gRPC
         if let Some(url) = self.presigned_image_url(image_id, req.org_id) {
-            // Still need media_type for LLM provider formatting — look up metadata only
-            let media_type = match self.db.get_image(req.org_id, image_id).await {
-                Ok(Some(row)) => row.content_type,
+            // Metadata-only lookup — avoids loading the full image blob
+            let media_type = match self.db.get_image_info(req.org_id, image_id).await {
+                Ok(Some(info)) => info.content_type,
                 Ok(None) => {
                     return Ok(Response::new(ResolveImageResponse {
                         found: false,
@@ -1846,10 +1846,10 @@ impl WorkerService for WorkerServiceImpl {
         for proto_id in req.image_ids {
             let image_id = parse_uuid(Some(&proto_id))?;
 
-            match self.db.get_image(req.org_id, image_id).await {
-                Ok(Some(row)) => {
-                    if use_presigned {
-                        // Return presigned URL — no image data over gRPC
+            if use_presigned {
+                // Metadata-only lookup — avoids loading the full image blob
+                match self.db.get_image_info(req.org_id, image_id).await {
+                    Ok(Some(info)) => {
                         let url = self
                             .presigned_image_url(image_id, req.org_id)
                             .unwrap_or_default();
@@ -1857,12 +1857,22 @@ impl WorkerService for WorkerServiceImpl {
                             image_id.to_string(),
                             ResolvedImageData {
                                 base64: String::new(),
-                                media_type: row.content_type,
+                                media_type: info.content_type,
                                 url,
                             },
                         );
-                    } else {
-                        // Fallback: base64 over gRPC
+                    }
+                    Ok(None) => {
+                        tracing::debug!(%image_id, "Image not found during batch resolution");
+                    }
+                    Err(e) => {
+                        tracing::warn!(%image_id, error = %e, "Failed to get image during batch resolution");
+                    }
+                }
+            } else {
+                // Fallback: base64 over gRPC
+                match self.db.get_image(req.org_id, image_id).await {
+                    Ok(Some(row)) => {
                         let base64_data =
                             base64::engine::general_purpose::STANDARD.encode(&row.data);
                         images.insert(
@@ -1874,12 +1884,12 @@ impl WorkerService for WorkerServiceImpl {
                             },
                         );
                     }
-                }
-                Ok(None) => {
-                    tracing::debug!(%image_id, "Image not found during batch resolution");
-                }
-                Err(e) => {
-                    tracing::warn!(%image_id, error = %e, "Failed to get image during batch resolution");
+                    Ok(None) => {
+                        tracing::debug!(%image_id, "Image not found during batch resolution");
+                    }
+                    Err(e) => {
+                        tracing::warn!(%image_id, error = %e, "Failed to get image during batch resolution");
+                    }
                 }
             }
         }

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -33,6 +33,7 @@ chrono.workspace = true
 async-trait.workspace = true
 futures.workspace = true
 reqwest.workspace = true
+base64.workspace = true
 sha2.workspace = true
 hex.workspace = true
 url = "2.5"

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -17,7 +17,7 @@ use everruns_core::message_retriever::{InputMessage, MessageRetriever};
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
 use everruns_core::traits::{
     AgentStore, EventEmitter, HarnessStore, LeasedResourceStore, LlmProviderStore,
-    ModelWithProvider, SessionFileStore, SessionStore,
+    ModelWithProvider, ResolvedImage, SessionFileStore, SessionStore,
 };
 use everruns_core::typed_id::{AgentId, LeasedResourceId, MessageId, ModelId, SessionId};
 use everruns_core::{Agent, Harness, HarnessStatus, Message, Session};
@@ -81,19 +81,44 @@ fn grpc_missing_field(field: &str) -> AgentLoopError {
     AgentLoopError::store(format!("gRPC response error: {field}"))
 }
 
+/// Fetch image binary from a presigned URL and return as base64-encoded ResolvedImage.
+///
+/// Used when the control plane returns presigned URLs instead of inline base64 data,
+/// keeping gRPC messages small while still providing base64 data to LLM providers.
+async fn fetch_image_from_url(url: &str, media_type: &str) -> Result<ResolvedImage> {
+    let response = reqwest::get(url).await.map_err(|e| {
+        AgentLoopError::store(format!("Failed to fetch image from presigned URL: {e}"))
+    })?;
+
+    if !response.status().is_success() {
+        return Err(AgentLoopError::store(format!(
+            "Presigned image fetch returned status {}",
+            response.status()
+        )));
+    }
+
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| AgentLoopError::store(format!("Failed to read image response body: {e}")))?;
+
+    use base64::Engine;
+    let base64_data = base64::engine::general_purpose::STANDARD.encode(&bytes);
+    Ok(ResolvedImage::new(base64_data, media_type))
+}
+
 /// gRPC client wrapper for worker operations
 #[derive(Clone)]
 pub struct GrpcClient {
     inner: Arc<Mutex<WorkerServiceClient<InterceptedService<Channel, GrpcClientAuth>>>>,
 }
 
-/// Max gRPC message size (150MB for base64-encoded images + overhead)
+/// Max gRPC message size (16MB)
 ///
-/// TODO: Sending large images over gRPC is inefficient. Future improvements:
-/// - Use presigned URLs to fetch images directly from storage
-/// - Stream images in chunks instead of single large messages
-/// - Move to S3/blob storage with direct worker access
-const MAX_GRPC_MESSAGE_SIZE: usize = 150 * 1024 * 1024;
+/// Image data no longer flows through gRPC — workers fetch images via presigned
+/// HTTP URLs returned by resolve_image/resolve_images RPCs. The limit only needs
+/// to accommodate metadata, proto messages, and session file content.
+const MAX_GRPC_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
 
 impl GrpcClient {
     /// Connect to the control plane gRPC server
@@ -1246,9 +1271,7 @@ fn proto_mcp_tool_def_to_tool_definition(
 // ImageResolver implementation
 // ============================================================================
 
-use everruns_core::traits::{
-    ImageResolver, KeyInfo, ResolvedImage, SecretInfo, SessionStorageStore,
-};
+use everruns_core::traits::{ImageResolver, KeyInfo, SecretInfo, SessionStorageStore};
 use std::collections::HashMap;
 
 impl GrpcOrgAdapter {
@@ -1256,6 +1279,7 @@ impl GrpcOrgAdapter {
     ///
     /// Returns a HashMap mapping image_id to ResolvedImage for all found images.
     /// Missing images are silently skipped.
+    /// When the server returns presigned URLs, images are fetched via HTTP.
     pub async fn resolve_images_batch(
         &self,
         image_ids: &[Uuid],
@@ -1279,7 +1303,12 @@ impl GrpcOrgAdapter {
         let mut result = HashMap::new();
         for (id_str, data) in response.into_inner().images {
             if let Ok(id) = Uuid::parse_str(&id_str) {
-                result.insert(id, ResolvedImage::new(data.base64, data.media_type));
+                let resolved = if !data.url.is_empty() {
+                    fetch_image_from_url(&data.url, &data.media_type).await?
+                } else {
+                    ResolvedImage::new(data.base64, data.media_type)
+                };
+                result.insert(id, resolved);
             }
         }
 
@@ -1292,6 +1321,7 @@ impl ImageResolver for GrpcOrgAdapter {
     /// Resolve a single image by ID
     ///
     /// Returns the base64-encoded image data and media type, or None if not found.
+    /// When the server returns a presigned URL, the image is fetched via HTTP.
     async fn resolve_image(&self, image_id: Uuid) -> Result<Option<ResolvedImage>> {
         let mut client = self.client.inner.lock().await;
 
@@ -1307,10 +1337,15 @@ impl ImageResolver for GrpcOrgAdapter {
 
         let inner = response.into_inner();
 
-        if inner.found {
-            Ok(Some(ResolvedImage::new(inner.base64, inner.media_type)))
+        if !inner.found {
+            return Ok(None);
+        }
+
+        if !inner.url.is_empty() {
+            let resolved = fetch_image_from_url(&inner.url, &inner.media_type).await?;
+            Ok(Some(resolved))
         } else {
-            Ok(None)
+            Ok(Some(ResolvedImage::new(inner.base64, inner.media_type)))
         }
     }
 }

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -86,7 +86,13 @@ fn grpc_missing_field(field: &str) -> AgentLoopError {
 /// Used when the control plane returns presigned URLs instead of inline base64 data,
 /// keeping gRPC messages small while still providing base64 data to LLM providers.
 async fn fetch_image_from_url(url: &str, media_type: &str) -> Result<ResolvedImage> {
-    let response = reqwest::get(url).await.map_err(|e| {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(60))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|e| AgentLoopError::store(format!("Failed to build HTTP client: {e}")))?;
+
+    let response = client.get(url).send().await.map_err(|e| {
         AgentLoopError::store(format!("Failed to fetch image from presigned URL: {e}"))
     })?;
 

--- a/scripts/lib/services.sh
+++ b/scripts/lib/services.sh
@@ -184,6 +184,7 @@ case "$cmd" in
     export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-$PROXY_URL_DEFAULT}
     export PUBLIC_APP_URL=${PUBLIC_APP_URL:-$PROXY_URL_DEFAULT}
     export APP_URL=${APP_URL:-$PUBLIC_APP_URL}
+    export API_BASE_URL=${API_BASE_URL:-"http://127.0.0.1:${API_PORT}"}
     cargo run -p everruns-server
     ;;
 
@@ -201,6 +202,7 @@ case "$cmd" in
     export CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-$PROXY_URL_DEFAULT}
     export PUBLIC_APP_URL=${PUBLIC_APP_URL:-$PROXY_URL_DEFAULT}
     export APP_URL=${APP_URL:-$PUBLIC_APP_URL}
+    export API_BASE_URL=${API_BASE_URL:-"http://127.0.0.1:${API_PORT}"}
     cargo watch -w crates -x 'run -p everruns-server'
     ;;
 
@@ -282,6 +284,7 @@ case "$cmd" in
     export APP_URL=${APP_URL:-$PUBLIC_APP_URL}
     export AUTH_BASE_URL=${AUTH_BASE_URL:-${PROXY_URL_DEFAULT}/api}
     export FRONTEND_URL=${FRONTEND_URL:-$PROXY_URL_DEFAULT}
+    export API_BASE_URL=${API_BASE_URL:-"http://127.0.0.1:${API_PORT}"}
     export RUST_LOG=${RUST_LOG:-info}
 
     # Set encryption key if not provided (standard dev key from .env.example)
@@ -522,6 +525,7 @@ case "$cmd" in
     export APP_URL=${APP_URL:-$PUBLIC_APP_URL}
     export AUTH_BASE_URL=${AUTH_BASE_URL:-${PROXY_URL_DEFAULT}/api}
     export FRONTEND_URL=${FRONTEND_URL:-$PROXY_URL_DEFAULT}
+    export API_BASE_URL=${API_BASE_URL:-"http://127.0.0.1:${API_PORT}"}
     export DEPLOYMENT_GRADE=dev
     export RUST_LOG=${RUST_LOG:-info}
     if [ "$NO_WATCH" = true ]; then

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -502,6 +502,7 @@ Indirect prompt injection via tool results or user messages is an inherent LLM l
 | TM-DURABLE-008 | Worker impersonation | High | Bearer token auth + optional mTLS prevents unauthorized access (see TM-DURABLE-002) | MITIGATED |
 | TM-DURABLE-009 | Replay attack on workflow events | Low | Event store is append-only; events processed in sequence order | MITIGATED |
 | TM-DURABLE-010 | Durable API endpoints unauthenticated | High | All `/v1/durable/*` endpoints require `AuthUser` extractor | MITIGATED |
+| TM-DURABLE-011 | Presigned image URL forgery | Medium | HMAC-SHA256 signed with `WORKER_GRPC_AUTH_TOKEN`; 5-min expiry; signature covers image_id + org_id + expires; constant-time comparison | MITIGATED |
 
 ### Mitigation Details
 


### PR DESCRIPTION
## What
Replace the 150MB gRPC message limit workaround with presigned HTTP URLs for image resolution. Workers now fetch images via HTTP instead of receiving base64-encoded data through gRPC.

## Why
Both `grpc_service.rs` and `grpc_adapters.rs` set a 150MB gRPC message limit as a temporary workaround for transferring images between the control plane and workers. This inflated all gRPC communication limits and was flagged as technical debt (EVE-109).

## How
- **Proto**: Added `url` field to `ResolveImageResponse` and `ResolvedImageData`
- **Server**: When `API_BASE_URL` is configured, generates HMAC-SHA256 presigned URLs (5-min expiry) instead of base64-encoding images
- **New endpoint**: `/internal/images/{image_id}?org_id=...&expires=...&sig=...` validates presigned signature and returns binary image data
- **Worker**: When `url` field is present in gRPC response, fetches image via HTTP and base64-encodes locally for LLM providers
- **Fallback**: When `API_BASE_URL` is not set, the old base64-over-gRPC path still works
- **gRPC limit**: Reduced from 150MB to 16MB (sufficient for metadata, proto messages, session files)
- **Start scripts**: `API_BASE_URL` set automatically in `start-dev`, `start-all`, `server`, `watch-server`

## Risk
- **Medium**
- Presigned URL path is new — if `API_BASE_URL` or `WORKER_GRPC_AUTH_TOKEN` is missing, falls back to base64 (safe degradation)
- gRPC limit reduced from 150MB to 16MB — could affect large non-image messages (session files). 16MB should be sufficient for all current use cases
- Threat model updated: TM-DURABLE-011 covers presigned URL forgery mitigation

## Checklist
- [x] Tests added or updated (5 unit tests for presigned URL generation/validation)
- [x] Backward compatibility considered (graceful fallback when API_BASE_URL not set)

Fixes EVE-109