### PR TITLE
Add i18n/localization support (UI + backend) and propagate per-turn locale

### DIFF
--- a/apps/ui/src/app/layout.tsx
+++ b/apps/ui/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { QueryProvider } from "@/providers/query-provider";
 import { FeatureFlagsProvider } from "@/providers/feature-flags-provider";
 import { AuthProvider } from "@/providers/auth-provider";
 import { OrgProvider } from "@/providers/org-provider";
+import { LocaleProvider } from "@/providers/locale-provider";
 
 // Self-hosted via next/font/local to avoid any runtime or build-time dependency
 // on fonts.googleapis.com. Downstream apps with strict CSP (font-src 'self')
@@ -29,13 +30,15 @@ export default function RootLayout({
   return (
     <html lang="en" className={caveat.variable}>
       <body className="font-sans antialiased bg-brand-dots">
-        <QueryProvider>
-          <FeatureFlagsProvider>
-            <AuthProvider>
-              <OrgProvider>{children}</OrgProvider>
-            </AuthProvider>
-          </FeatureFlagsProvider>
-        </QueryProvider>
+        <LocaleProvider>
+          <QueryProvider>
+            <FeatureFlagsProvider>
+              <AuthProvider>
+                <OrgProvider>{children}</OrgProvider>
+              </AuthProvider>
+            </FeatureFlagsProvider>
+          </QueryProvider>
+        </LocaleProvider>
       </body>
     </html>
   );

--- a/apps/ui/src/components/chat/chat-composer.tsx
+++ b/apps/ui/src/components/chat/chat-composer.tsx
@@ -27,6 +27,7 @@ import { ALLOWED_IMAGE_TYPES } from "@/lib/api/types";
 import type { CommandDescriptor, Controls, LlmModel, ReasoningEffortConfig } from "@/lib/api/types";
 import type { PendingImage } from "@/lib/api/images";
 import { useEffect, useRef, useState } from "react";
+import { useLocale } from "@/providers/locale-provider";
 
 export function ChatComposer({
   commands,
@@ -89,12 +90,11 @@ export function ChatComposer({
   sendPending: boolean;
   textareaRef: React.RefObject<HTMLTextAreaElement | null>;
 }) {
+  const { backendLocale, t } = useLocale();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [showCommands, setShowCommands] = useState(false);
   const hasCommands = commands.length > 0;
-  const inputPlaceholder = hasCommands
-    ? "Type a message or / for commands... (Enter to send)"
-    : "Type a message... (Enter to send)";
+  const inputPlaceholder = hasCommands ? t("type_message_or_commands") : t("type_message");
 
   useEffect(() => {
     if (!hasCommands && showCommands) {
@@ -106,9 +106,10 @@ export function ChatComposer({
     selectedModelId || reasoningEffort
       ? {
           ...(selectedModelId && { model_id: selectedModelId }),
+          locale: backendLocale,
           ...(reasoningEffort && supportsReasoning && { reasoning: { effort: reasoningEffort } }),
         }
-      : undefined;
+      : { locale: backendLocale };
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -188,14 +189,14 @@ export function ChatComposer({
               size="icon-lg"
               className={chatSurfaceStyles.composerIconButton}
               onClick={() => fileInputRef.current?.click()}
-              title="Attach images (PNG, JPEG, GIF, WebP)"
+              title={t("attach_images")}
             >
               <ImagePlus className="icon-sharp h-4 w-4" />
             </Button>
 
             <div className={chatSurfaceStyles.composerControlChip}>
               <span className="shrink-0 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
-                Model
+                {t("model")}
               </span>
               <Select value={selectedModelId} onValueChange={onModelChange}>
                 <SelectTrigger
@@ -221,7 +222,7 @@ export function ChatComposer({
               <div className={chatSurfaceStyles.composerControlChip}>
                 <Brain className="icon-sharp h-3.5 w-3.5 text-muted-foreground" />
                 <span className="shrink-0 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
-                  Reasoning
+                  {t("reasoning")}
                 </span>
                 <Select
                   value={reasoningEffort}
@@ -234,11 +235,13 @@ export function ChatComposer({
                     className="h-7 w-[116px] min-w-0 cursor-pointer border-0 bg-transparent px-0 py-0 text-sm shadow-none focus-visible:ring-0 data-[size=sm]:h-7 [&_svg]:icon-sharp"
                   >
                     <SelectValue>
-                      {reasoningEffort ? getReasoningEffortName(reasoningEffort) : "Default"}
+                      {reasoningEffort ? getReasoningEffortName(reasoningEffort) : t("default")}
                     </SelectValue>
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="">{`Default (${defaultEffortName})`}</SelectItem>
+                    <SelectItem value="">
+                      {t("default_with_value", { value: defaultEffortName })}
+                    </SelectItem>
                     {reasoningEffortConfig.values.map((effort) => (
                       <SelectItem key={effort.value} value={effort.value}>
                         {effort.name}
@@ -259,7 +262,7 @@ export function ChatComposer({
                 className={chatSurfaceStyles.composerDangerButton}
                 disabled={cancelCurrentTurn.isPending}
                 onClick={() => cancelCurrentTurn.mutate()}
-                title="Cancel current turn"
+                title={t("cancel_current_turn")}
               >
                 {cancelCurrentTurn.isPending ? (
                   <Loader2 className="h-4 w-4 animate-spin" />
@@ -274,7 +277,7 @@ export function ChatComposer({
               size="icon-lg"
               className={chatSurfaceStyles.composerSubmitButton}
               disabled={!canSubmit}
-              title={isUploading ? "Uploading images..." : undefined}
+              title={isUploading ? t("uploading_images") : undefined}
             >
               {sendPending || isUploading ? (
                 <Loader2 className="h-4 w-4 animate-spin" />

--- a/apps/ui/src/components/chat/chat-message-list.tsx
+++ b/apps/ui/src/components/chat/chat-message-list.tsx
@@ -33,6 +33,7 @@ import {
 import { chatSurfaceStyles } from "@/components/chat/chat-surface";
 import { CompactionDivider } from "@/components/chat/compaction-divider";
 import type { ToolCallContent } from "@/components/chat/tool-call-utils";
+import { useLocale } from "@/providers/locale-provider";
 
 interface ChatMessageListProps {
   events: Event[] | undefined;
@@ -60,7 +61,7 @@ function getMessageImages(content: ContentPart[]): Array<{ image_id: string; fil
   }));
 }
 
-function buildActGroups(chatEvents: Event[]) {
+function buildActGroups(chatEvents: Event[], workingLabel: string) {
   const groupsByExecId = new Map<string, ActGroup>();
 
   const ensureRow = (
@@ -89,7 +90,7 @@ function buildActGroups(chatEvents: Event[]) {
     if (actStarted) {
       groupsByExecId.set(execId, {
         startEventId: event.id,
-        headline: actStarted.headline ?? "Working",
+        headline: actStarted.headline ?? workingLabel,
         rows: (actStarted.tool_calls ?? []).map((toolCall: ToolCallSummary) => ({
           id: toolCall.id,
           label: toolCall.narration ?? toolCall.display_name ?? toolCall.name,
@@ -140,14 +141,20 @@ function buildActGroups(chatEvents: Event[]) {
   return new Map(Array.from(groupsByExecId.values()).map((group) => [group.startEventId, group]));
 }
 
-function renderTurnDivider(eventId: string, turnDurationByEventId: Map<string, number>) {
+function renderTurnDivider(
+  eventId: string,
+  turnDurationByEventId: Map<string, number>,
+  workedForLabel: string,
+) {
   const durationMs = turnDurationByEventId.get(eventId);
   if (durationMs == null) return null;
 
   return (
     <div className="flex items-center gap-4 pt-3 text-xs font-medium text-muted-foreground sm:text-sm">
       <div className="h-px flex-1 bg-border" />
-      <span className="whitespace-nowrap">{`Worked for ${formatWorkedDuration(durationMs)}`}</span>
+      <span className="whitespace-nowrap">
+        {workedForLabel.replace("{duration}", formatWorkedDuration(durationMs))}
+      </span>
       <div className="h-px flex-1 bg-border" />
     </div>
   );
@@ -164,6 +171,7 @@ export function ChatMessageList({
   getMessageText,
   getToolCalls,
 }: ChatMessageListProps) {
+  const { t } = useLocale();
   const clientRequestedToolCallIds = useMemo(() => {
     const ids = new Set<string>();
     for (const event of chatEvents) {
@@ -184,7 +192,10 @@ export function ChatMessageList({
     () => chatEvents.some((event) => event.type === "act.started"),
     [chatEvents],
   );
-  const actGroupsByStartEventId = useMemo(() => buildActGroups(chatEvents), [chatEvents]);
+  const actGroupsByStartEventId = useMemo(
+    () => buildActGroups(chatEvents, t("working")),
+    [chatEvents, t],
+  );
 
   if (eventsLoading) {
     return (
@@ -203,8 +214,8 @@ export function ChatMessageList({
           <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center border border-border/70 bg-background text-muted-foreground">
             <Bot className="h-5 w-5 opacity-65" />
           </div>
-          <p className="text-lg font-medium text-foreground">No messages yet</p>
-          <p className="mt-1 text-sm">Start with a prompt, screenshot, or slash command.</p>
+          <p className="text-lg font-medium text-foreground">{t("no_messages_yet")}</p>
+          <p className="mt-1 text-sm">{t("start_with_prompt")}</p>
         </div>
       </div>
     );
@@ -215,7 +226,7 @@ export function ChatMessageList({
       {loadingOlderEvents && hasMoreEvents && (
         <div className="flex items-center justify-center py-3">
           <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-          <span className="ml-2 text-xs text-muted-foreground">Loading older messages...</span>
+          <span className="ml-2 text-xs text-muted-foreground">{t("loading_older_messages")}</span>
         </div>
       )}
       {chatEvents.map((event) => {
@@ -244,7 +255,7 @@ export function ChatMessageList({
                   rows={group.rows}
                 />
               </div>
-              {renderTurnDivider(event.id, turnDurationByEventId)}
+              {renderTurnDivider(event.id, turnDurationByEventId, t("worked_for"))}
             </div>
           );
         }
@@ -265,11 +276,11 @@ export function ChatMessageList({
                 <div key={event.id} className="space-y-3">
                   <div className="ml-9 space-y-1">
                     <ToolActivityTimelineGroup
-                      headline={reqData.headline ?? "Waiting on tools"}
+                      headline={reqData.headline ?? t("waiting_on_tools")}
                       rows={rows}
                     />
                   </div>
-                  {renderTurnDivider(event.id, turnDurationByEventId)}
+                  {renderTurnDivider(event.id, turnDurationByEventId, t("worked_for"))}
                 </div>
               );
             }
@@ -302,7 +313,7 @@ export function ChatMessageList({
                   />
                 )}
               </div>
-              {renderTurnDivider(event.id, turnDurationByEventId)}
+              {renderTurnDivider(event.id, turnDurationByEventId, t("worked_for"))}
             </div>
           );
         }
@@ -333,7 +344,7 @@ export function ChatMessageList({
               <div className="ml-9 space-y-1">
                 <ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />
               </div>
-              {renderTurnDivider(event.id, turnDurationByEventId)}
+              {renderTurnDivider(event.id, turnDurationByEventId, t("worked_for"))}
             </div>
           );
         }
@@ -347,7 +358,7 @@ export function ChatMessageList({
                     {isScheduleTriggered && (
                       <div className="mb-1 flex items-center gap-1 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
                         <CalendarClock className="h-3 w-3" />
-                        <span>Scheduled</span>
+                        <span>{t("scheduled")}</span>
                       </div>
                     )}
                     <div className="flex items-start gap-2">
@@ -401,7 +412,7 @@ export function ChatMessageList({
               </div>
             )}
 
-            {renderTurnDivider(event.id, turnDurationByEventId)}
+            {renderTurnDivider(event.id, turnDurationByEventId, t("worked_for"))}
           </div>
         );
       })}

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -20,8 +20,10 @@ import { ChatMessageList } from "@/components/chat/chat-message-list";
 import { ChatComposer } from "@/components/chat/chat-composer";
 import { StreamingMessage } from "@/components/streaming-message";
 import { ThinkingIndicator } from "@/components/thinking-indicator";
+import { useLocale } from "@/providers/locale-provider";
 
 export function ChatPanel() {
+  const { t } = useLocale();
   const {
     agentId,
     events,
@@ -202,7 +204,7 @@ export function ChatPanel() {
               <div className={chatSurfaceStyles.agentMessage}>
                 {streamingIteration && streamingIteration > 1 && (
                   <div className="mb-1 text-xs text-muted-foreground">
-                    Iteration {streamingIteration}
+                    {t("iteration", { value: streamingIteration })}
                   </div>
                 )}
                 {isThinking && !streamingText ? (
@@ -224,7 +226,7 @@ export function ChatPanel() {
             className={chatSurfaceStyles.floatingNotice}
           >
             <ArrowDown className="h-3 w-3" />
-            New messages
+            {t("new_messages")}
           </button>
         )}
       </div>

--- a/apps/ui/src/components/chat/grouped-activity-card.tsx
+++ b/apps/ui/src/components/chat/grouped-activity-card.tsx
@@ -12,6 +12,7 @@ import type { ToolCompletedData } from "@/lib/api/types";
 import type { ToolCallContent } from "./tool-call-utils";
 import { summarizeToolCalls } from "./tool-activity-utils";
 import { ToolActivityRow } from "./tool-activity-row";
+import { useLocale } from "@/providers/locale-provider";
 
 export function GroupedActivityCard({
   toolCalls,
@@ -22,6 +23,7 @@ export function GroupedActivityCard({
   toolResultsMap: Map<string, ToolCompletedData>;
   mode: "server" | "client";
 }) {
+  const { backendLocale, t } = useLocale();
   const [isExpanded, setIsExpanded] = useState(true);
   const activityCompletedCount = useMemo(
     () => toolCalls.filter((toolCall) => toolResultsMap.has(toolCall.id)).length,
@@ -36,6 +38,7 @@ export function GroupedActivityCard({
         toolCall={toolCall}
         toolResult={toolResultsMap.get(toolCall.id)}
         mode={mode}
+        locale={backendLocale}
       />
     );
   }
@@ -46,7 +49,7 @@ export function GroupedActivityCard({
         <div className="min-w-0">
           <div className="flex items-center gap-2">
             <div className="text-[11px] uppercase tracking-[0.22em] text-muted-foreground/70">
-              {summarizeToolCalls(toolCalls)}
+              {summarizeToolCalls(toolCalls, backendLocale)}
             </div>
             <div className="text-[10px] text-muted-foreground/50">
               {activityCompletedCount}/{toolCalls.length}
@@ -63,7 +66,7 @@ export function GroupedActivityCard({
             type="button"
             onClick={() => setIsExpanded((current) => !current)}
             className="rounded p-1 text-muted-foreground/60 transition-colors hover:bg-muted hover:text-foreground"
-            aria-label={isExpanded ? "Collapse tool activity" : "Expand tool activity"}
+            aria-label={isExpanded ? t("collapse_tool_activity") : t("expand_tool_activity")}
           >
             {isExpanded ? (
               <ChevronDown className="h-4 w-4" />
@@ -88,6 +91,7 @@ export function GroupedActivityCard({
                 toolCall={toolCall}
                 toolResult={toolResultsMap.get(toolCall.id)}
                 mode={mode}
+                locale={backendLocale}
               />
             ))}
           </div>

--- a/apps/ui/src/components/chat/read-file-tool-call-card.tsx
+++ b/apps/ui/src/components/chat/read-file-tool-call-card.tsx
@@ -14,6 +14,7 @@ import { cn } from "@/lib/utils";
 import { basename } from "@/lib/path-utils";
 import { formatFileSize } from "@/lib/formatting";
 import { getFullText, type ToolCallContent } from "./tool-call-utils";
+import { useLocale } from "@/providers/locale-provider";
 
 // Re-export from centralized registry for backward-compatible imports.
 export { isReadFileTool } from "@/lib/tool-registry";
@@ -133,6 +134,7 @@ function getContentPreview(content: string | null): string | null {
 // isReadFileTool is re-exported from @/lib/tool-registry at the top of this file.
 
 export function ReadFileToolCallCard({ toolCall, toolResult }: ReadFileToolCallCardProps) {
+  const { locale, t } = useLocale();
   const [isExpanded, setIsExpanded] = useState(false);
   const parsed = useMemo(
     () => parseReadFileResult(toolCall, toolResult?.result),
@@ -152,11 +154,20 @@ export function ReadFileToolCallCard({ toolCall, toolResult }: ReadFileToolCallC
     : null;
   const preview =
     getContentPreview(parsed.content) ??
-    (hasImages ? `${parsed.images.length} image${parsed.images.length === 1 ? "" : "s"}` : null) ??
+    (hasImages
+      ? t("image_count", {
+          count: parsed.images.length,
+          suffix: parsed.images.length === 1 ? "" : locale === "uk" ? "я" : "s",
+        })
+      : null) ??
     (isBinaryWithoutPreview
-      ? `binary file${formatFileSize(parsed.sizeBytes) ? ` (${formatFileSize(parsed.sizeBytes)})` : ""}`
+      ? t("binary_file", {
+          value: formatFileSize(parsed.sizeBytes) ? ` (${formatFileSize(parsed.sizeBytes)})` : "",
+        })
       : null);
-  const title = parsed.path ? `Read ${basename(parsed.path)}` : "Read file";
+  const title = parsed.path
+    ? t("read_tool_title", { value: basename(parsed.path) })
+    : t("read_file");
   const showDetails = hasImages || isExpanded;
 
   const statusIcon = isComplete ? (
@@ -192,7 +203,7 @@ export function ReadFileToolCallCard({ toolCall, toolResult }: ReadFileToolCallC
             type="button"
             onClick={() => setIsExpanded((current) => !current)}
             className="flex-shrink-0 opacity-40 transition-opacity hover:opacity-70"
-            aria-label={isExpanded ? "Collapse file output" : "Expand file output"}
+            aria-label={isExpanded ? t("collapse_file_output") : t("expand_file_output")}
           >
             {isExpanded ? (
               <ChevronDown className="h-3 w-3" />
@@ -204,7 +215,9 @@ export function ReadFileToolCallCard({ toolCall, toolResult }: ReadFileToolCallC
       </div>
 
       {hasError && (
-        <div className="ml-[22px] mt-0.5 text-[10px] text-red-600">Error: {toolResult?.error}</div>
+        <div className="ml-[22px] mt-0.5 text-[10px] text-red-600">
+          {t("error_prefix", { value: toolResult?.error ?? "" })}
+        </div>
       )}
 
       {!hasError && preview && !showDetails && (

--- a/apps/ui/src/components/chat/tool-activity-row.tsx
+++ b/apps/ui/src/components/chat/tool-activity-row.tsx
@@ -19,16 +19,20 @@ import type { ToolCompletedData } from "@/lib/api/types";
 import type { ToolCallContent } from "./tool-call-utils";
 import { formatResultDetails, getResultPreview, getToolLabel } from "./tool-activity-utils";
 import { getFullText } from "./tool-call-utils";
+import { useLocale } from "@/providers/locale-provider";
 
 export function ToolActivityRow({
   toolCall,
   toolResult,
   mode,
+  locale,
 }: {
   toolCall: ToolCallContent;
   toolResult?: ToolCompletedData;
   mode: "server" | "client";
+  locale: string;
 }) {
+  const { t } = useLocale();
   const [isExpanded, setIsExpanded] = useState(false);
   const fullText = getFullText(toolResult?.result);
   const detailsId = `tool-activity-details-${toolCall.id}`;
@@ -59,10 +63,12 @@ export function ToolActivityRow({
             {mode === "client" && (
               <MonitorSmartphone className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-primary/75" />
             )}
-            <span className="truncate text-sm text-foreground">{getToolLabel(toolCall)}</span>
+            <span className="truncate text-sm text-foreground">
+              {getToolLabel(toolCall, locale)}
+            </span>
             {isRunning && (
               <span className="animate-tool-pulse text-[10px] uppercase tracking-[0.18em] text-accent-foreground/70">
-                {mode === "client" ? "waiting" : "running"}
+                {mode === "client" ? t("waiting") : t("running")}
               </span>
             )}
           </div>
@@ -90,7 +96,7 @@ export function ToolActivityRow({
               ) : (
                 <ChevronRight className="h-3 w-3" />
               )}
-              {isExpanded ? "hide details" : "details"}
+              {isExpanded ? t("hide_details") : t("details")}
             </button>
           )}
 

--- a/apps/ui/src/components/chat/tool-activity-timeline-group.tsx
+++ b/apps/ui/src/components/chat/tool-activity-timeline-group.tsx
@@ -5,6 +5,7 @@ import { AlertCircle, Check, ChevronDown, ChevronRight, Loader2 } from "lucide-r
 import type { ToolCompletedData } from "@/lib/api/types";
 import { cn } from "@/lib/utils";
 import { getFullText } from "./tool-call-utils";
+import { useLocale } from "@/providers/locale-provider";
 
 export interface TimelineToolRow {
   id: string;
@@ -35,6 +36,7 @@ function resultPreview(result?: ToolCompletedData): string | null {
 }
 
 function TimelineRow({ row }: { row: TimelineToolRow }) {
+  const { t } = useLocale();
   const [expanded, setExpanded] = useState(false);
   const fullText = getFullText(row.result?.result);
   const preview = resultPreview(row.result);
@@ -75,7 +77,7 @@ function TimelineRow({ row }: { row: TimelineToolRow }) {
               ) : (
                 <ChevronRight className="h-3 w-3" />
               )}
-              {expanded ? "hide details" : "details"}
+              {expanded ? t("hide_details") : t("details")}
             </button>
           )}
 
@@ -104,6 +106,7 @@ export function ToolActivityTimelineGroup({
   completedHeadline,
   rows,
 }: ToolActivityTimelineGroupProps) {
+  const { t } = useLocale();
   const completedCount = useMemo(
     () => rows.filter((row) => row.state === "completed" || row.state === "error").length,
     [rows],
@@ -124,7 +127,7 @@ export function ToolActivityTimelineGroup({
         type="button"
         onClick={() => setExpanded((current) => !current)}
         className="inline-flex items-start gap-2 text-left text-muted-foreground transition-colors hover:text-foreground"
-        aria-label={expanded ? "Collapse activity group" : "Expand activity group"}
+        aria-label={expanded ? t("collapse_activity_group") : t("expand_activity_group")}
       >
         {expanded ? (
           <ChevronDown className="mt-[2px] h-4 w-4 flex-shrink-0" />

--- a/apps/ui/src/components/chat/tool-activity-utils.ts
+++ b/apps/ui/src/components/chat/tool-activity-utils.ts
@@ -15,6 +15,7 @@ import {
   isWriteLikeTool,
   type ToolCategory,
 } from "@/lib/tool-registry";
+import { formatMessage, getSupportedLocale, type SupportedLocale } from "@/lib/i18n";
 import { parseBashOutput } from "./bash-tool-call-card";
 import { getFullText, type ToolCallContent } from "./tool-call-utils";
 
@@ -24,10 +25,6 @@ export type ActivitySegment =
   | { type: "read_file"; toolCall: ToolCallContent }
   | { type: "write_file"; toolCall: ToolCallContent };
 
-function pluralize(count: number, singular: string, plural: string) {
-  return `${count} ${count === 1 ? singular : plural}`;
-}
-
 function toTitleCase(value: string): string {
   return value
     .split(/[_\s]+/)
@@ -36,61 +33,73 @@ function toTitleCase(value: string): string {
     .join(" ");
 }
 
-function formatLocation(value: unknown): string {
-  if (typeof value !== "string" || value.trim().length === 0) return "current directory";
-  if (value === "." || value === "/workspace") return "current directory";
+function uiLocale(locale: string): SupportedLocale {
+  return getSupportedLocale(locale);
+}
+
+function formatLocation(value: unknown, locale: string): string {
+  if (typeof value !== "string" || value.trim().length === 0)
+    return formatMessage(uiLocale(locale), "current_directory");
+  if (value === "." || value === "/workspace")
+    return formatMessage(uiLocale(locale), "current_directory");
   return value;
 }
 
-export function getToolLabel(toolCall: ToolCallContent): string {
+export function getToolLabel(toolCall: ToolCallContent, locale: string): string {
+  const currentLocale = uiLocale(locale);
   const { arguments: args, name } = toolCall;
 
   if (isBashTool(name)) {
     const command = args.command;
-    return typeof command === "string" && command.trim().length > 0 ? `$ ${command}` : "Shell";
+    return typeof command === "string" && command.trim().length > 0
+      ? `$ ${command}`
+      : formatMessage(currentLocale, "shell");
   }
 
-  if (name === "list_files") return `List files in ${formatLocation(args.path)}`;
+  if (name === "list_files")
+    return formatMessage(currentLocale, "list_files_in", {
+      value: formatLocation(args.path, locale),
+    });
 
   if (isReadFileTool(name)) {
     const path = args.path;
     return typeof path === "string" && path.trim().length > 0
-      ? `Read ${basename(path)}`
-      : "Read file";
+      ? formatMessage(currentLocale, "read_named_file", { value: basename(path) })
+      : formatMessage(currentLocale, "read_file");
   }
 
   if (name === "grep_files") {
     const pattern = args.pattern;
     return typeof pattern === "string" && pattern.trim().length > 0
-      ? `Find ${pattern}`
-      : "Search files";
+      ? formatMessage(currentLocale, "find_value", { value: pattern })
+      : formatMessage(currentLocale, "search_files");
   }
 
   if (name === "search_web" || name === "search" || name.endsWith("__search")) {
     const query = args.query ?? args.search ?? args.q;
     return typeof query === "string" && query.trim().length > 0
-      ? `Search web for ${query}`
-      : "Search web";
+      ? formatMessage(currentLocale, "search_web_for", { value: query })
+      : formatMessage(currentLocale, "search_web");
   }
 
   if (name === "write_file") {
     const path = args.path;
     return typeof path === "string" && path.trim().length > 0
-      ? `Write ${basename(path)}`
-      : "Write file";
+      ? formatMessage(currentLocale, "write_named_file", { value: basename(path) })
+      : formatMessage(currentLocale, "write_file");
   }
 
   if (name === "replace_in_file" || name === "edit_file") {
     const path = args.path;
     return typeof path === "string" && path.trim().length > 0
-      ? `Edit ${basename(path)}`
-      : "Edit file";
+      ? formatMessage(currentLocale, "edit_named_file", { value: basename(path) })
+      : formatMessage(currentLocale, "edit_file");
   }
 
   if (name === "secret_store") {
     const operation = args.operation;
     const secretName = args.name;
-    if (operation === "list") return "List secrets";
+    if (operation === "list") return formatMessage(currentLocale, "list_secrets");
     if (
       typeof operation === "string" &&
       typeof secretName === "string" &&
@@ -98,25 +107,26 @@ export function getToolLabel(toolCall: ToolCallContent): string {
     ) {
       return `${toTitleCase(operation)} ${secretName}`;
     }
-    return "Secret Store";
+    return formatMessage(currentLocale, "secret_store");
   }
 
   if (name === "kv_store") {
     const operation = args.operation;
     const key = args.key;
-    if (operation === "list") return "List stored values";
+    if (operation === "list") return formatMessage(currentLocale, "list_stored_values");
     if (typeof operation === "string" && typeof key === "string" && key.trim().length > 0) {
       return `${toTitleCase(operation)} ${key}`;
     }
-    return "Key Value Store";
+    return formatMessage(currentLocale, "key_value_store");
   }
 
   return toolCall.display_name ?? toTitleCase(name);
 }
 
-export function summarizeToolCalls(toolCalls: ToolCallContent[]): string {
-  if (toolCalls.length === 0) return "Working";
-  if (toolCalls.length === 1) return getToolLabel(toolCalls[0]);
+export function summarizeToolCalls(toolCalls: ToolCallContent[], locale: string): string {
+  const currentLocale = uiLocale(locale);
+  if (toolCalls.length === 0) return formatMessage(currentLocale, "working");
+  if (toolCalls.length === 1) return getToolLabel(toolCalls[0], locale);
 
   const counts: Record<ToolCategory, number> = {
     read: 0,
@@ -132,13 +142,58 @@ export function summarizeToolCalls(toolCalls: ToolCallContent[]): string {
   }
 
   const parts: string[] = [];
-  if (counts.read > 0) parts.push(pluralize(counts.read, "read", "reads"));
-  if (counts.search > 0) parts.push(pluralize(counts.search, "search", "searches"));
-  if (counts.write > 0) parts.push(pluralize(counts.write, "write", "writes"));
-  if (counts.shell > 0) parts.push(pluralize(counts.shell, "shell", "shells"));
-  if (counts.tool > 0) parts.push(pluralize(counts.tool, "tool", "tools"));
+  if (counts.read > 0)
+    parts.push(
+      formatMessage(currentLocale, "read_count", {
+        count: counts.read,
+        label:
+          counts.read === 1
+            ? formatMessage(currentLocale, "read_label_one")
+            : formatMessage(currentLocale, "read_label_many"),
+      }),
+    );
+  if (counts.search > 0)
+    parts.push(
+      formatMessage(currentLocale, "read_count", {
+        count: counts.search,
+        label:
+          counts.search === 1
+            ? formatMessage(currentLocale, "search_label_one")
+            : formatMessage(currentLocale, "search_label_many"),
+      }),
+    );
+  if (counts.write > 0)
+    parts.push(
+      formatMessage(currentLocale, "read_count", {
+        count: counts.write,
+        label:
+          counts.write === 1
+            ? formatMessage(currentLocale, "write_label_one")
+            : formatMessage(currentLocale, "write_label_many"),
+      }),
+    );
+  if (counts.shell > 0)
+    parts.push(
+      formatMessage(currentLocale, "read_count", {
+        count: counts.shell,
+        label:
+          counts.shell === 1
+            ? formatMessage(currentLocale, "shell_label_one")
+            : formatMessage(currentLocale, "shell_label_many"),
+      }),
+    );
+  if (counts.tool > 0)
+    parts.push(
+      formatMessage(currentLocale, "read_count", {
+        count: counts.tool,
+        label:
+          counts.tool === 1
+            ? formatMessage(currentLocale, "tool_label_one")
+            : formatMessage(currentLocale, "tool_label_many"),
+      }),
+    );
 
-  return `Exploring ${parts.join(", ")}`;
+  return formatMessage(currentLocale, "exploring", { value: parts.join(", ") });
 }
 
 function parseStructuredText(text: string): unknown | null {

--- a/apps/ui/src/components/chat/write-file-tool-call-card.tsx
+++ b/apps/ui/src/components/chat/write-file-tool-call-card.tsx
@@ -14,6 +14,7 @@ import { cn } from "@/lib/utils";
 import { basename } from "@/lib/path-utils";
 import { formatFileSize } from "@/lib/formatting";
 import { getFullText, type ToolCallContent } from "./tool-call-utils";
+import { useLocale } from "@/providers/locale-provider";
 
 // Re-export from centralized registry for backward-compatible imports.
 export { isWriteLikeTool } from "@/lib/tool-registry";
@@ -84,16 +85,16 @@ function parseWriteFilePayload(
   };
 }
 
-function getToolVerb(toolName: string): string {
+function getToolVerb(toolName: string, t: ReturnType<typeof useLocale>["t"]): string {
   switch (toolName) {
     case "edit_file":
-      return "Edit";
+      return t("write_tool_edit");
     case "replace_in_file":
-      return "Replace in";
+      return t("write_tool_replace");
     case "append_file":
-      return "Append to";
+      return t("write_tool_append");
     default:
-      return "Write";
+      return t("write_tool_default");
   }
 }
 
@@ -110,18 +111,25 @@ function getTextPreview(text: string | null): string | null {
 function formatEditPreview(
   appliedEdits: number | undefined,
   firstChangedLine: number | undefined,
+  locale: ReturnType<typeof useLocale>,
 ): string | null {
   const parts = [];
   if (typeof appliedEdits === "number") {
-    parts.push(`${appliedEdits} ${appliedEdits === 1 ? "edit" : "edits"}`);
+    parts.push(
+      locale.t("edit_count", {
+        count: appliedEdits,
+        suffix: appliedEdits === 1 ? "" : locale.locale === "uk" ? "" : "s",
+      }),
+    );
   }
   if (typeof firstChangedLine === "number") {
-    parts.push(`line ${firstChangedLine}`);
+    parts.push(locale.t("line_number", { value: firstChangedLine }));
   }
   return parts.length > 0 ? parts.join(" · ") : null;
 }
 
 export function WriteFileToolCallCard({ toolCall, toolResult }: WriteFileToolCallCardProps) {
+  const locale = useLocale();
   const [isExpanded, setIsExpanded] = useState(false);
   const parsed = useMemo(
     () => parseWriteFilePayload(toolCall, toolResult?.result),
@@ -132,22 +140,25 @@ export function WriteFileToolCallCard({ toolCall, toolResult }: WriteFileToolCal
   const hasError = toolResult?.error !== undefined && toolResult?.error !== null;
   const resolvedPath = parsed.path ?? getPathFromArguments(toolCall);
   const title = resolvedPath
-    ? `${getToolVerb(toolCall.name)} ${basename(resolvedPath)}`
-    : `${getToolVerb(toolCall.name)} file`;
+    ? `${getToolVerb(toolCall.name, locale.t)} ${basename(resolvedPath)}`
+    : `${getToolVerb(toolCall.name, locale.t)} ${locale.t("write_tool_file_suffix")}`;
   const durationLabel = toolResult?.duration_ms
     ? toolResult.duration_ms < 1000
       ? `${toolResult.duration_ms}ms`
       : `${(toolResult.duration_ms / 1000).toFixed(1)}s`
     : null;
-  const metadataPreview = [parsed.created ? "created" : "updated", formatFileSize(parsed.sizeBytes)]
+  const metadataPreview = [
+    parsed.created ? locale.t("created") : locale.t("updated"),
+    formatFileSize(parsed.sizeBytes),
+  ]
     .filter(Boolean)
     .join(" · ");
   const preview =
-    formatEditPreview(parsed.appliedEdits, parsed.firstChangedLine) ||
+    formatEditPreview(parsed.appliedEdits, parsed.firstChangedLine, locale) ||
     metadataPreview ||
     getTextPreview(parsed.textContent);
   const detailLabel =
-    parsed.diffTruncated && toolCall.name === "edit_file" ? "Diff truncated" : null;
+    parsed.diffTruncated && toolCall.name === "edit_file" ? locale.t("diff_truncated") : null;
   const hasTextDetails = !!parsed.textContent;
 
   const statusIcon = isComplete ? (
@@ -183,7 +194,9 @@ export function WriteFileToolCallCard({ toolCall, toolResult }: WriteFileToolCal
             type="button"
             onClick={() => setIsExpanded((current) => !current)}
             className="flex-shrink-0 opacity-40 transition-opacity hover:opacity-70"
-            aria-label={isExpanded ? "Collapse write output" : "Expand write output"}
+            aria-label={
+              isExpanded ? locale.t("collapse_write_output") : locale.t("expand_write_output")
+            }
           >
             {isExpanded ? (
               <ChevronDown className="h-3 w-3" />
@@ -195,7 +208,9 @@ export function WriteFileToolCallCard({ toolCall, toolResult }: WriteFileToolCal
       </div>
 
       {hasError && (
-        <div className="ml-[22px] mt-0.5 text-[10px] text-red-600">Error: {toolResult?.error}</div>
+        <div className="ml-[22px] mt-0.5 text-[10px] text-red-600">
+          {locale.t("error_prefix", { value: toolResult?.error ?? "" })}
+        </div>
       )}
 
       {!hasError && preview && !isExpanded && (

--- a/apps/ui/src/components/thinking-indicator.tsx
+++ b/apps/ui/src/components/thinking-indicator.tsx
@@ -8,6 +8,7 @@
  */
 
 import { cn } from "@/lib/utils";
+import { useLocale } from "@/providers/locale-provider";
 
 interface ThinkingIndicatorProps {
   className?: string;
@@ -16,9 +17,10 @@ interface ThinkingIndicatorProps {
 }
 
 export function ThinkingIndicator({ className, model }: ThinkingIndicatorProps) {
+  const { t } = useLocale();
   return (
     <div className={cn("flex items-center gap-1", className)}>
-      <span className="text-xs text-muted-foreground/60">thinking</span>
+      <span className="text-xs text-muted-foreground/60">{t("thinking")}</span>
       {model && <span className="text-xs text-muted-foreground/40">{model}</span>}
       <span className="flex gap-0.5 ml-0.5">
         <span

--- a/apps/ui/src/hooks/use-global-chat.ts
+++ b/apps/ui/src/hooks/use-global-chat.ts
@@ -7,6 +7,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useOrg } from "@/providers/org-provider";
 import { getOrCreateChatSession } from "@/lib/api/sessions";
+import { useLocale } from "@/providers/locale-provider";
 
 interface UseGlobalChatResult {
   sessionId: string | null;
@@ -16,6 +17,7 @@ interface UseGlobalChatResult {
 
 export function useGlobalChat(): UseGlobalChatResult {
   const { currentOrg } = useOrg();
+  const { backendLocale } = useLocale();
   const orgId = currentOrg?.public_id;
 
   const [sessionId, setSessionId] = useState<string | null>(null);
@@ -29,14 +31,14 @@ export function useGlobalChat(): UseGlobalChatResult {
     setError(null);
 
     try {
-      const session = await getOrCreateChatSession();
+      const session = await getOrCreateChatSession(backendLocale);
       setSessionId(session.id);
     } catch (e) {
       setError(e instanceof Error ? e : new Error("Failed to initialize global chat"));
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [backendLocale]);
 
   useEffect(() => {
     if (!orgId) return;

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -24,6 +24,7 @@ import type {
   PaginationParams,
 } from "@/lib/api/types";
 import { useOrg } from "@/providers/org-provider";
+import { useLocale } from "@/providers/locale-provider";
 import { createReconnectTracker } from "@/lib/sse-reconnect";
 
 /**
@@ -88,11 +89,13 @@ export function useSession(
 
 export function useCreateSession() {
   const queryClient = useQueryClient();
+  const { backendLocale } = useLocale();
 
   return useMutation({
     mutationFn: ({ request }: { request: CreateSessionRequest }) =>
       createSession({
         ...request,
+        locale: request.locale ?? backendLocale,
         // Auto-declare setup_connection hint so the worker emits synthetic
         // setup_connection tool calls that the Chat UI can render inline.
         hints: { setup_connection: true, ...request.hints },

--- a/apps/ui/src/lib/__tests__/i18n.test.ts
+++ b/apps/ui/src/lib/__tests__/i18n.test.ts
@@ -1,0 +1,17 @@
+import { detectBrowserLocale, formatMessage, getSupportedLocale } from "@/lib/i18n";
+
+describe("i18n locale helpers", () => {
+  it("detects Ukrainian browser locale from navigator.languages", () => {
+    expect(detectBrowserLocale({ languages: ["uk-UA", "en-US"], language: "en-US" })).toBe("uk-UA");
+    expect(getSupportedLocale("uk-UA")).toBe("uk");
+  });
+
+  it("falls back to English UI copy for unsupported locales", () => {
+    expect(getSupportedLocale("fr-FR")).toBe("en");
+    expect(formatMessage("en", "no_messages_yet")).toBe("No messages yet");
+  });
+
+  it("formats Ukrainian strings with interpolation", () => {
+    expect(formatMessage("uk", "iteration", { value: 3 })).toBe("Ітерація 3");
+  });
+});

--- a/apps/ui/src/lib/api/sessions.ts
+++ b/apps/ui/src/lib/api/sessions.ts
@@ -130,7 +130,7 @@ export async function submitToolResults(
  * Get or create the global chat session for the current user.
  * Returns a singleton session per user per org.
  */
-export async function getOrCreateChatSession(): Promise<Session> {
-  const response = await api.post<Session>("/v1/sessions/chat");
+export async function getOrCreateChatSession(locale?: string): Promise<Session> {
+  const response = await api.post<Session>("/v1/sessions/chat", locale ? { locale } : {});
   return response.data;
 }

--- a/apps/ui/src/lib/api/types.ts
+++ b/apps/ui/src/lib/api/types.ts
@@ -370,6 +370,8 @@ export interface ReasoningConfig {
 export interface Controls {
   /** UUID of the model to use for this message (overrides session/agent settings) */
   model_id?: string;
+  /** Locale override for this message turn (BCP 47, e.g. `uk-UA`) */
+  locale?: string;
   reasoning?: ReasoningConfig;
   max_tokens?: number;
   temperature?: number;

--- a/apps/ui/src/lib/i18n.ts
+++ b/apps/ui/src/lib/i18n.ts
@@ -1,0 +1,197 @@
+/**
+ * Decisions:
+ * - Keep catalogs in code for now so adding new locales is a small, typed change.
+ * - Separate UI locale (`en`/`uk`) from backend locale (`en-US`, `uk-UA`, etc.).
+ * - Fall back to English for unsupported browser languages until more locales land.
+ */
+
+export type SupportedLocale = "en" | "uk";
+
+const messages = {
+  en: {
+    thinking: "thinking",
+    iteration: "Iteration {value}",
+    new_messages: "New messages",
+    no_messages_yet: "No messages yet",
+    start_with_prompt: "Start with a prompt, screenshot, or slash command.",
+    loading_older_messages: "Loading older messages...",
+    waiting_on_tools: "Waiting on tools",
+    scheduled: "Scheduled",
+    worked_for: "Worked for {duration}",
+    type_message_or_commands: "Type a message or / for commands... (Enter to send)",
+    type_message: "Type a message... (Enter to send)",
+    attach_images: "Attach images (PNG, JPEG, GIF, WebP)",
+    model: "Model",
+    reasoning: "Reasoning",
+    default: "Default",
+    default_with_value: "Default ({value})",
+    cancel_current_turn: "Cancel current turn",
+    uploading_images: "Uploading images...",
+    running: "running",
+    waiting: "waiting",
+    details: "details",
+    hide_details: "hide details",
+    current_directory: "current directory",
+    shell: "Shell",
+    list_files_in: "List files in {value}",
+    read_file: "Read file",
+    read_named_file: "Read {value}",
+    find_value: "Find {value}",
+    search_files: "Search files",
+    search_web: "Search web",
+    search_web_for: "Search web for {value}",
+    write_file: "Write file",
+    write_named_file: "Write {value}",
+    edit_file: "Edit file",
+    edit_named_file: "Edit {value}",
+    list_secrets: "List secrets",
+    secret_store: "Secret Store",
+    list_stored_values: "List stored values",
+    key_value_store: "Key Value Store",
+    working: "Working",
+    exploring: "Exploring {value}",
+    read_count: "{count} {label}",
+    read_label_one: "read",
+    read_label_many: "reads",
+    search_label_one: "search",
+    search_label_many: "searches",
+    write_label_one: "write",
+    write_label_many: "writes",
+    shell_label_one: "shell",
+    shell_label_many: "shells",
+    tool_label_one: "tool",
+    tool_label_many: "tools",
+    collapse_tool_activity: "Collapse tool activity",
+    expand_tool_activity: "Expand tool activity",
+    collapse_activity_group: "Collapse activity group",
+    expand_activity_group: "Expand activity group",
+    error_prefix: "Error: {value}",
+    binary_file: "binary file{value}",
+    image_count: "{count} image{suffix}",
+    read_tool_title: "Read {value}",
+    collapse_file_output: "Collapse file output",
+    expand_file_output: "Expand file output",
+    write_tool_default: "Write",
+    write_tool_edit: "Edit",
+    write_tool_replace: "Replace in",
+    write_tool_append: "Append to",
+    write_tool_file_suffix: "file",
+    created: "created",
+    updated: "updated",
+    diff_truncated: "Diff truncated",
+    collapse_write_output: "Collapse write output",
+    expand_write_output: "Expand write output",
+    edit_count: "{count} edit{suffix}",
+    line_number: "line {value}",
+  },
+  uk: {
+    thinking: "думаю",
+    iteration: "Ітерація {value}",
+    new_messages: "Нові повідомлення",
+    no_messages_yet: "Повідомлень ще немає",
+    start_with_prompt: "Почніть із запиту, скриншота або slash-команди.",
+    loading_older_messages: "Завантажую старіші повідомлення...",
+    waiting_on_tools: "Очікування інструментів",
+    scheduled: "За розкладом",
+    worked_for: "Працював {duration}",
+    type_message_or_commands: "Введіть повідомлення або / для команд... (Enter, щоб надіслати)",
+    type_message: "Введіть повідомлення... (Enter, щоб надіслати)",
+    attach_images: "Додати зображення (PNG, JPEG, GIF, WebP)",
+    model: "Модель",
+    reasoning: "Міркування",
+    default: "За замовчуванням",
+    default_with_value: "За замовчуванням ({value})",
+    cancel_current_turn: "Скасувати поточний хід",
+    uploading_images: "Завантажую зображення...",
+    running: "виконується",
+    waiting: "очікування",
+    details: "деталі",
+    hide_details: "сховати деталі",
+    current_directory: "поточній директорії",
+    shell: "Командний рядок",
+    list_files_in: "Показати файли у {value}",
+    read_file: "Прочитати файл",
+    read_named_file: "Прочитати {value}",
+    find_value: "Знайти {value}",
+    search_files: "Пошук у файлах",
+    search_web: "Пошук у вебі",
+    search_web_for: "Шукати у вебі: {value}",
+    write_file: "Записати файл",
+    write_named_file: "Записати {value}",
+    edit_file: "Редагувати файл",
+    edit_named_file: "Редагувати {value}",
+    list_secrets: "Показати секрети",
+    secret_store: "Сховище секретів",
+    list_stored_values: "Показати збережені значення",
+    key_value_store: "Сховище ключів і значень",
+    working: "Працюю",
+    exploring: "Досліджую: {value}",
+    read_count: "{count} {label}",
+    read_label_one: "читання",
+    read_label_many: "читань",
+    search_label_one: "пошук",
+    search_label_many: "пошуків",
+    write_label_one: "запис",
+    write_label_many: "записів",
+    shell_label_one: "команда",
+    shell_label_many: "команд",
+    tool_label_one: "інструмент",
+    tool_label_many: "інструментів",
+    collapse_tool_activity: "Згорнути активність інструментів",
+    expand_tool_activity: "Розгорнути активність інструментів",
+    collapse_activity_group: "Згорнути групу активності",
+    expand_activity_group: "Розгорнути групу активності",
+    error_prefix: "Помилка: {value}",
+    binary_file: "бінарний файл{value}",
+    image_count: "{count} зображенн{suffix}",
+    read_tool_title: "Прочитати {value}",
+    collapse_file_output: "Згорнути вивід файла",
+    expand_file_output: "Розгорнути вивід файла",
+    write_tool_default: "Записати",
+    write_tool_edit: "Редагувати",
+    write_tool_replace: "Замінити у",
+    write_tool_append: "Дописати у",
+    write_tool_file_suffix: "файл",
+    created: "створено",
+    updated: "оновлено",
+    diff_truncated: "Diff обрізано",
+    collapse_write_output: "Згорнути вивід запису",
+    expand_write_output: "Розгорнути вивід запису",
+    edit_count: "{count} змін{suffix}",
+    line_number: "рядок {value}",
+  },
+} as const;
+
+export type MessageKey = keyof typeof messages.en;
+
+export function normalizeBackendLocale(input?: string | null): string {
+  const normalized = input?.trim().replace(/_/g, "-");
+  return normalized && normalized.length > 0 ? normalized : "en-US";
+}
+
+export function detectBrowserLocale(
+  navigatorLike?: Pick<Navigator, "language" | "languages">,
+): string {
+  const candidate =
+    navigatorLike?.languages?.find((value) => value && value.trim().length > 0) ??
+    navigatorLike?.language;
+  return normalizeBackendLocale(candidate);
+}
+
+export function getSupportedLocale(locale: string): SupportedLocale {
+  return locale.toLowerCase().startsWith("uk") ? "uk" : "en";
+}
+
+export function formatMessage(
+  locale: SupportedLocale,
+  key: MessageKey,
+  values?: Record<string, string | number>,
+): string {
+  const template = messages[locale][key] ?? messages.en[key];
+  if (!values) return template;
+  return template.replace(/\{(\w+)\}/g, (_, name: string) => String(values[name] ?? `{${name}}`));
+}
+
+export function pluralSuffix(locale: SupportedLocale, count: number, one: string, many: string) {
+  return locale === "uk" ? (count === 1 ? one : many) : count === 1 ? one : many;
+}

--- a/apps/ui/src/providers/locale-provider.tsx
+++ b/apps/ui/src/providers/locale-provider.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+/**
+ * Decisions:
+ * - Detect browser locale once on mount and reuse it across the app.
+ * - Expose both UI locale and backend locale so browser-driven overrides stay explicit.
+ */
+
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  detectBrowserLocale,
+  formatMessage,
+  getSupportedLocale,
+  type MessageKey,
+  type SupportedLocale,
+} from "@/lib/i18n";
+
+interface LocaleContextValue {
+  locale: SupportedLocale;
+  backendLocale: string;
+  t: (key: MessageKey, values?: Record<string, string | number>) => string;
+}
+
+const LocaleContext = createContext<LocaleContextValue | null>(null);
+
+function getInitialBrowserLocale(): string {
+  if (typeof window === "undefined") {
+    return "en-US";
+  }
+
+  return detectBrowserLocale(window.navigator);
+}
+
+export function LocaleProvider({ children }: { children: ReactNode }) {
+  const [backendLocale, setBackendLocale] = useState(getInitialBrowserLocale);
+  const [locale, setLocale] = useState<SupportedLocale>(() =>
+    getSupportedLocale(getInitialBrowserLocale()),
+  );
+
+  useEffect(() => {
+    const browserLocale = detectBrowserLocale(window.navigator);
+    setBackendLocale(browserLocale);
+    setLocale(getSupportedLocale(browserLocale));
+    document.documentElement.lang = browserLocale;
+  }, []);
+
+  const value = useMemo<LocaleContextValue>(
+    () => ({
+      locale,
+      backendLocale,
+      t: (key, values) => formatMessage(locale, key, values),
+    }),
+    [backendLocale, locale],
+  );
+
+  return <LocaleContext.Provider value={value}>{children}</LocaleContext.Provider>;
+}
+
+export function useLocale() {
+  const context = useContext(LocaleContext);
+  if (!context) {
+    throw new Error("useLocale must be used within a LocaleProvider");
+  }
+  return context;
+}

--- a/crates/core/examples/turn_based_execution.rs
+++ b/crates/core/examples/turn_based_execution.rs
@@ -319,6 +319,7 @@ async fn main() -> anyhow::Result<()> {
                 agent_id: Some(AgentId::from_uuid(agent_id)),
                 tool_calls: reason_result.tool_calls.clone(),
                 tool_definitions: reason_result.tool_definitions.clone(),
+                locale: reason_result.locale.clone(),
             })
             .await?;
 

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -36,7 +36,9 @@ use crate::events::{
     ToolStartedData,
 };
 use crate::message::ContentPart;
-use crate::tool_narration::{ToolNarrationPhase, render_group_headline, render_tool_narration};
+use crate::tool_narration::{
+    ToolNarrationPhase, render_group_headline_with_locale, render_tool_narration_with_locale,
+};
 use crate::tool_types::{ToolCall, ToolDefinition, ToolResult};
 use crate::traits::{
     AgentStore, EventEmitter, SessionFileStore, SessionMutator, SessionStore, ToolContext,
@@ -66,6 +68,9 @@ pub struct ActInput {
     pub tool_calls: Vec<ToolCall>,
     /// Available tool definitions for resolution
     pub tool_definitions: Vec<ToolDefinition>,
+    /// Resolved locale for backend-authored tool narration and labels.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub locale: Option<String>,
 }
 
 /// Result of a single tool call execution
@@ -315,6 +320,7 @@ where
             context,
             tool_calls,
             tool_definitions,
+            locale,
             .. // agent_id/org_id not needed here, just passed through workflow
         } = input;
 
@@ -377,6 +383,7 @@ where
                 &mut result,
                 &tool_definitions,
                 &self.event_emitter,
+                locale.as_deref(),
             )
             .await;
             return Ok(result);
@@ -429,7 +436,11 @@ where
             .emit(EventRequest::new(
                 context.session_id,
                 event_context.clone(),
-                ActStartedData::with_definitions(&tool_calls, &tool_definitions),
+                ActStartedData::with_definitions_and_locale(
+                    &tool_calls,
+                    &tool_definitions,
+                    locale.as_deref(),
+                ),
             ))
             .await
         {
@@ -451,6 +462,7 @@ where
                     tool_def,
                     &trace_id,
                     &act_span_id,
+                    locale.as_deref(),
                 )
             })
             .collect();
@@ -470,20 +482,19 @@ where
             act_span_id.clone(), // Same span_id as started
             Some(parent_span_id.clone()),
         );
-        let mut completed_headline = render_group_headline(
+        let mut completed_headline = render_group_headline_with_locale(
             &tool_calls,
             &tool_definitions,
             ToolNarrationPhase::Completed,
+            locale.as_deref(),
         );
         if error_count > 0 {
-            let suffix = format!(
-                " with {} error{}",
-                error_count,
-                if error_count == 1 { "" } else { "s" }
-            );
+            let suffix = crate::localization::format_error_suffix(locale.as_deref(), error_count);
             completed_headline = Some(match completed_headline {
                 Some(text) => format!("{text}{suffix}"),
-                None => format!("Completed tool batch{suffix}"),
+                None => {
+                    crate::localization::format_completed_tool_batch(locale.as_deref(), error_count)
+                }
             });
         }
 
@@ -535,6 +546,7 @@ where
             &mut act_result,
             &tool_definitions,
             &self.event_emitter,
+            locale.as_deref(),
         )
         .await;
 
@@ -559,6 +571,7 @@ where
         tool_def: Option<&ToolDefinition>,
         trace_id: &str,
         act_span_id: &str,
+        locale: Option<&str>,
     ) -> ToolCallResult {
         tracing::debug!(
             session_id = %context.session_id,
@@ -582,7 +595,11 @@ where
         let tool_start = Instant::now();
 
         // Resolve display name from tool definition
-        let display_name = tool_def.and_then(|d| d.display_name().map(|s| s.to_string()));
+        let display_name = crate::localization::localized_tool_display_name(
+            &tool_call.name,
+            tool_def.and_then(|d| d.display_name()),
+            locale,
+        );
 
         // Emit tool.started event (child of act.started)
         if let Err(e) = self
@@ -593,10 +610,11 @@ where
                 ToolStartedData {
                     tool_call: tool_call.clone(),
                     display_name: display_name.clone(),
-                    narration: Some(render_tool_narration(
+                    narration: Some(render_tool_narration_with_locale(
                         tool_def,
                         &tool_call,
                         ToolNarrationPhase::Started,
+                        locale,
                     )),
                 },
             ))
@@ -628,10 +646,11 @@ where
                         error_msg.clone(),
                         Some(tool_duration_ms),
                     )
-                    .with_narration(Some(render_tool_narration(
+                    .with_narration(Some(render_tool_narration_with_locale(
                         None,
                         &tool_call,
                         ToolNarrationPhase::Failed,
+                        locale,
                     ))),
                 ))
                 .await
@@ -742,10 +761,11 @@ where
                         Some(tool_duration_ms),
                     )
                     .with_display_name(display_name.clone())
-                    .with_narration(Some(render_tool_narration(
+                    .with_narration(Some(render_tool_narration_with_locale(
                         Some(tool_def),
                         &tool_call,
                         ToolNarrationPhase::Completed,
+                        locale,
                     )))
                 } else {
                     ToolCompletedData::failure(
@@ -756,10 +776,11 @@ where
                         Some(tool_duration_ms),
                     )
                     .with_display_name(display_name.clone())
-                    .with_narration(Some(render_tool_narration(
+                    .with_narration(Some(render_tool_narration_with_locale(
                         Some(tool_def),
                         &tool_call,
                         ToolNarrationPhase::Failed,
+                        locale,
                     )))
                 };
 
@@ -815,11 +836,14 @@ where
                             Some(tool_duration_ms),
                         )
                         .with_display_name(display_name.clone())
-                        .with_narration(Some(render_tool_narration(
-                            Some(tool_def),
-                            &tool_call,
-                            ToolNarrationPhase::Failed,
-                        ))),
+                        .with_narration(Some(
+                            render_tool_narration_with_locale(
+                                Some(tool_def),
+                                &tool_call,
+                                ToolNarrationPhase::Failed,
+                                locale,
+                            ),
+                        )),
                     ))
                     .await
                 {
@@ -883,6 +907,7 @@ mod tests {
             agent_id: Some(AgentId::new()),
             tool_calls: vec![],
             tool_definitions: vec![],
+            locale: None,
         };
 
         let result = atom.execute(input).await.unwrap();
@@ -911,6 +936,7 @@ mod tests {
                 arguments: json!({}),
             }],
             tool_definitions: vec![],
+            locale: None,
         };
 
         let result = atom.execute(input).await.unwrap();
@@ -975,6 +1001,7 @@ mod tests {
                 arguments: json!({"operation": "list"}),
             }],
             tool_definitions: vec![manage_harnesses_tool_def()],
+            locale: None,
         };
 
         let result = atom.execute(input).await.unwrap();
@@ -1018,6 +1045,7 @@ mod tests {
                 arguments: json!({"operation": "list"}),
             }],
             tool_definitions: vec![manage_harnesses_tool_def()],
+            locale: None,
         };
 
         let result = atom.execute(input).await.unwrap();

--- a/crates/core/src/atoms/act_hooks.rs
+++ b/crates/core/src/atoms/act_hooks.rs
@@ -142,6 +142,7 @@ pub(super) async fn run_post_act_hooks<E: EventEmitter>(
     result: &mut ActResult,
     tool_definitions: &[ToolDefinition],
     event_emitter: &E,
+    locale: Option<&str>,
 ) {
     for hook in hooks {
         let actions = hook.on_completed(result, tool_definitions);
@@ -154,7 +155,11 @@ pub(super) async fn run_post_act_hooks<E: EventEmitter>(
                     let event = EventRequest::new(
                         context.session_id,
                         EventContext::turn(context.turn_id, context.input_message_id),
-                        ToolCallRequestedData::with_definitions(&tool_calls, &action_defs),
+                        ToolCallRequestedData::with_definitions_and_locale(
+                            &tool_calls,
+                            &action_defs,
+                            locale,
+                        ),
                     );
                     if let Err(e) = event_emitter.emit(event).await {
                         tracing::warn!(

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -119,9 +119,19 @@ fn extract_locale_override(messages: &[Message]) -> Option<String> {
         .iter()
         .rev()
         .find(|message| message.role == MessageRole::User)
-        .and_then(|message| message.metadata.as_ref())
-        .and_then(|metadata| metadata.get("locale"))
-        .and_then(|value| value.as_str())
+        .and_then(|message| {
+            message
+                .controls
+                .as_ref()
+                .and_then(|controls| controls.locale.as_deref())
+                .or_else(|| {
+                    message
+                        .metadata
+                        .as_ref()
+                        .and_then(|metadata| metadata.get("locale"))
+                        .and_then(|value| value.as_str())
+                })
+        })
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned)
@@ -190,6 +200,9 @@ pub struct ReasonResult {
     /// LLM provider's response ID for chaining with `previous_response_id`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response_id: Option<String>,
+    /// Resolved locale used for this turn's prompt and backend-authored strings.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub locale: Option<String>,
 }
 
 fn default_max_iterations() -> usize {
@@ -498,6 +511,7 @@ impl Atom for ReasonAtom {
                     error: Some(error_msg),
                     usage: None,
                     response_id: None,
+                    locale: None,
                 }
             }
         };
@@ -577,9 +591,10 @@ impl ReasonAtom {
         // 6. Build runtime agent: harness (base) → agent (optional) → session caps
         //    Uses async builder methods so capabilities can resolve dynamic system
         //    prompt content (e.g., reading AGENTS.md, discovering skills).
+        let resolved_locale = extract_locale_override(&messages).or_else(|| session.locale.clone());
         let prompt_ctx = crate::capabilities::SystemPromptContext {
             session_id,
-            locale: extract_locale_override(&messages).or_else(|| session.locale.clone()),
+            locale: resolved_locale.clone(),
             file_store: self.file_store.clone(),
         };
 
@@ -1744,6 +1759,7 @@ impl ReasonAtom {
             error: None,
             usage,
             response_id,
+            locale: resolved_locale,
         })
     }
 
@@ -1951,5 +1967,26 @@ mod tests {
         assert_eq!(patched.len(), 4);
         assert_eq!(patched[2].role, MessageRole::ToolResult);
         assert_eq!(patched[2].tool_call_id(), Some("call_456"));
+    }
+
+    #[test]
+    fn test_extract_locale_override_prefers_controls_locale() {
+        let mut message = Message::user("Привіт");
+        message.controls = Some(crate::Controls {
+            model_id: None,
+            locale: Some("uk-UA".to_string()),
+            reasoning: None,
+            hints: None,
+        });
+        message.metadata = Some(
+            [("locale".to_string(), serde_json::json!("en-US"))]
+                .into_iter()
+                .collect(),
+        );
+
+        assert_eq!(
+            extract_locale_override(&[message]),
+            Some("uk-UA".to_string())
+        );
     }
 }

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -25,6 +25,7 @@ use uuid::Uuid;
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 
+use crate::localization::localized_tool_display_name;
 use crate::typed_id::{AgentId, EventId, ExecId, HarnessId, MessageId, ModelId, SessionId, TurnId};
 
 // ============================================================================
@@ -374,7 +375,9 @@ impl Event {
 // ============================================================================
 
 use crate::message::{ContentPart, Message};
-use crate::tool_narration::{ToolNarrationPhase, render_group_headline, render_tool_narration};
+use crate::tool_narration::{
+    ToolNarrationPhase, render_group_headline_with_locale, render_tool_narration_with_locale,
+};
 use crate::tool_types::ToolCall;
 
 /// Metadata about the model used for generation
@@ -701,9 +704,18 @@ pub struct ActStartedData {
 
 impl ActStartedData {
     pub fn new(tool_calls: &[ToolCall]) -> Self {
+        Self::new_with_locale(tool_calls, None)
+    }
+
+    pub fn new_with_locale(tool_calls: &[ToolCall], locale: Option<&str>) -> Self {
         Self {
             tool_calls: tool_calls.iter().map(ToolCallSummary::from).collect(),
-            headline: render_group_headline(tool_calls, &[], ToolNarrationPhase::Started),
+            headline: render_group_headline_with_locale(
+                tool_calls,
+                &[],
+                ToolNarrationPhase::Started,
+                locale,
+            ),
         }
     }
 
@@ -712,6 +724,14 @@ impl ActStartedData {
         tool_calls: &[ToolCall],
         tool_defs: &[crate::tool_types::ToolDefinition],
     ) -> Self {
+        Self::with_definitions_and_locale(tool_calls, tool_defs, None)
+    }
+
+    pub fn with_definitions_and_locale(
+        tool_calls: &[ToolCall],
+        tool_defs: &[crate::tool_types::ToolDefinition],
+        locale: Option<&str>,
+    ) -> Self {
         let def_map: std::collections::HashMap<&str, &crate::tool_types::ToolDefinition> =
             tool_defs.iter().map(|d| (d.name(), d)).collect();
         Self {
@@ -719,21 +739,30 @@ impl ActStartedData {
                 .iter()
                 .map(|tc| {
                     let tool_def = def_map.get(tc.name.as_str()).copied();
-                    let display_name =
-                        tool_def.and_then(|d| d.display_name().map(|s| s.to_string()));
+                    let display_name = localized_tool_display_name(
+                        &tc.name,
+                        tool_def.and_then(|d| d.display_name()),
+                        locale,
+                    );
                     ToolCallSummary {
                         id: tc.id.clone(),
                         name: tc.name.clone(),
                         display_name,
-                        narration: Some(render_tool_narration(
+                        narration: Some(render_tool_narration_with_locale(
                             tool_def,
                             tc,
                             ToolNarrationPhase::Started,
+                            locale,
                         )),
                     }
                 })
                 .collect(),
-            headline: render_group_headline(tool_calls, tool_defs, ToolNarrationPhase::Started),
+            headline: render_group_headline_with_locale(
+                tool_calls,
+                tool_defs,
+                ToolNarrationPhase::Started,
+                locale,
+            ),
         }
     }
 }
@@ -884,6 +913,14 @@ impl ToolCallRequestedData {
         tool_calls: &[ToolCall],
         tool_defs: &[crate::tool_types::ToolDefinition],
     ) -> Self {
+        Self::with_definitions_and_locale(tool_calls, tool_defs, None)
+    }
+
+    pub fn with_definitions_and_locale(
+        tool_calls: &[ToolCall],
+        tool_defs: &[crate::tool_types::ToolDefinition],
+        locale: Option<&str>,
+    ) -> Self {
         let def_map: std::collections::HashMap<&str, &crate::tool_types::ToolDefinition> =
             tool_defs.iter().map(|d| (d.name(), d)).collect();
 
@@ -894,12 +931,16 @@ impl ToolCallRequestedData {
                 ToolCallSummary {
                     id: tool_call.id.clone(),
                     name: tool_call.name.clone(),
-                    display_name: tool_def
-                        .and_then(|def| def.display_name().map(|value| value.to_string())),
-                    narration: Some(render_tool_narration(
+                    display_name: localized_tool_display_name(
+                        &tool_call.name,
+                        tool_def.and_then(|def| def.display_name()),
+                        locale,
+                    ),
+                    narration: Some(render_tool_narration_with_locale(
                         tool_def,
                         tool_call,
                         ToolNarrationPhase::Waiting,
+                        locale,
                     )),
                 }
             })
@@ -908,7 +949,12 @@ impl ToolCallRequestedData {
         Self {
             tool_calls: tool_calls.to_vec(),
             tool_summaries,
-            headline: render_group_headline(tool_calls, tool_defs, ToolNarrationPhase::Waiting),
+            headline: render_group_headline_with_locale(
+                tool_calls,
+                tool_defs,
+                ToolNarrationPhase::Waiting,
+                locale,
+            ),
         }
     }
 }

--- a/crates/core/src/in_memory_loop.rs
+++ b/crates/core/src/in_memory_loop.rs
@@ -669,6 +669,7 @@ impl InMemoryAgenticLoop {
                             agent_id: Some(self.agent_id),
                             tool_calls: reason_result.tool_calls,
                             tool_definitions: reason_result.tool_definitions,
+                            locale: reason_result.locale,
                         })
                         .await?;
                     state_machine.on_act_completed();

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -25,6 +25,7 @@ pub mod deployment;
 
 // Feature flags
 pub mod feature_flags;
+pub mod localization;
 
 // Telemetry (OpenTelemetry with gen-ai semantic conventions)
 pub mod telemetry;

--- a/crates/core/src/localization.rs
+++ b/crates/core/src/localization.rs
@@ -1,0 +1,137 @@
+//! Backend localization helpers for deterministic platform-authored strings.
+//!
+//! Decisions:
+//! - Keep locale fallback simple: Ukrainian (`uk*`) or default English.
+//! - Centralize string catalogs here so backend-authored copy stays externalized
+//!   as we add more locales.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendLocale {
+    En,
+    Uk,
+}
+
+pub fn resolve_backend_locale(locale: Option<&str>) -> BackendLocale {
+    match locale
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.to_ascii_lowercase())
+    {
+        Some(value) if value == "uk" || value.starts_with("uk-") => BackendLocale::Uk,
+        _ => BackendLocale::En,
+    }
+}
+
+pub struct BackendStrings {
+    pub working: &'static str,
+    pub current_directory: &'static str,
+    pub and_more_actions: &'static str,
+    pub with_errors_one: &'static str,
+    pub with_errors_many: &'static str,
+    pub completed_tool_batch_one: &'static str,
+    pub completed_tool_batch_many: &'static str,
+}
+
+const EN_STRINGS: BackendStrings = BackendStrings {
+    working: "Working",
+    current_directory: "current directory",
+    and_more_actions: "and {count} more actions",
+    with_errors_one: " with 1 error",
+    with_errors_many: " with {count} errors",
+    completed_tool_batch_one: "Completed tool batch with 1 error",
+    completed_tool_batch_many: "Completed tool batch with {count} errors",
+};
+
+const UK_STRINGS: BackendStrings = BackendStrings {
+    working: "Працюю",
+    current_directory: "поточній директорії",
+    and_more_actions: "і ще {count} дій",
+    with_errors_one: " з 1 помилкою",
+    with_errors_many: " з {count} помилками",
+    completed_tool_batch_one: "Пакет інструментів завершено з 1 помилкою",
+    completed_tool_batch_many: "Пакет інструментів завершено з {count} помилками",
+};
+
+pub fn backend_strings(locale: Option<&str>) -> &'static BackendStrings {
+    match resolve_backend_locale(locale) {
+        BackendLocale::En => &EN_STRINGS,
+        BackendLocale::Uk => &UK_STRINGS,
+    }
+}
+
+pub fn format_error_suffix(locale: Option<&str>, error_count: u32) -> String {
+    let strings = backend_strings(locale);
+    if error_count == 1 {
+        strings.with_errors_one.to_string()
+    } else {
+        strings
+            .with_errors_many
+            .replace("{count}", &error_count.to_string())
+    }
+}
+
+pub fn format_completed_tool_batch(locale: Option<&str>, error_count: u32) -> String {
+    let strings = backend_strings(locale);
+    if error_count == 1 {
+        strings.completed_tool_batch_one.to_string()
+    } else {
+        strings
+            .completed_tool_batch_many
+            .replace("{count}", &error_count.to_string())
+    }
+}
+
+pub fn format_more_actions(locale: Option<&str>, count: usize) -> String {
+    match resolve_backend_locale(locale) {
+        BackendLocale::En => backend_strings(locale)
+            .and_more_actions
+            .replace("{count}", &count.to_string()),
+        BackendLocale::Uk => {
+            let template = match count {
+                1 => "і ще 1 дію",
+                2..=4 => "і ще {count} дії",
+                _ => "і ще {count} дій",
+            };
+            template.replace("{count}", &count.to_string())
+        }
+    }
+}
+
+pub fn localized_tool_display_name(
+    tool_name: &str,
+    fallback_display_name: Option<&str>,
+    locale: Option<&str>,
+) -> Option<String> {
+    if resolve_backend_locale(locale) != BackendLocale::Uk {
+        return fallback_display_name.map(ToOwned::to_owned);
+    }
+
+    let localized = match tool_name {
+        "bash" => Some("Командний рядок"),
+        "read_file" | "session_read_file" => Some("Читання файла"),
+        "read_many_files" => Some("Читання файлів"),
+        "list_directory" | "list_files" => Some("Список файлів"),
+        "grep_files" => Some("Пошук у файлах"),
+        "search" | "search_web" => Some("Пошук у вебі"),
+        name if name.ends_with("__search") => Some("Пошук"),
+        "write_file" => Some("Запис файла"),
+        "edit_file" | "replace_in_file" => Some("Редагування файла"),
+        "append_file" => Some("Дописування у файл"),
+        "move_file" => Some("Переміщення файла"),
+        "delete_file" => Some("Видалення файла"),
+        "mkdir" => Some("Створення директорії"),
+        "stat_file" => Some("Інформація про файл"),
+        "secret_store" => Some("Сховище секретів"),
+        "kv_store" => Some("Сховище значень"),
+        "spawn_subagent" => Some("Запуск субагента"),
+        "get_subagents" => Some("Субагенти"),
+        "message_subagent" => Some("Повідомлення субагенту"),
+        "write_todos" => Some("Список задач"),
+        "setup_connection" => Some("Налаштування підключення"),
+        _ => None,
+    };
+
+    localized
+        .map(str::to_string)
+        .or_else(|| fallback_display_name.map(ToOwned::to_owned))
+}

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -194,6 +194,11 @@ pub struct Controls {
     #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "model_01933b5a00007000800000000000001"))]
     pub model_id: Option<ModelId>,
 
+    /// Locale override for this message turn (BCP 47, e.g. `uk-UA`).
+    /// Overrides the session locale for backend-authored strings and prompts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub locale: Option<String>,
+
     /// Reasoning configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<ReasoningConfig>,

--- a/crates/core/src/tool_narration.rs
+++ b/crates/core/src/tool_narration.rs
@@ -1,5 +1,9 @@
 use serde_json::Value;
 
+use crate::localization::{
+    BackendLocale, backend_strings, format_more_actions, localized_tool_display_name,
+    resolve_backend_locale,
+};
 use crate::tool_types::{ToolCall, ToolDefinition};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -29,11 +33,17 @@ fn title_case(name: &str) -> String {
         .join(" ")
 }
 
-fn display_name(tool_def: Option<&ToolDefinition>, tool_call: &ToolCall) -> String {
-    tool_def
-        .and_then(|def| def.display_name())
-        .map(ToOwned::to_owned)
-        .unwrap_or_else(|| title_case(&tool_call.name))
+fn display_name(
+    tool_def: Option<&ToolDefinition>,
+    tool_call: &ToolCall,
+    locale: Option<&str>,
+) -> String {
+    localized_tool_display_name(
+        &tool_call.name,
+        tool_def.and_then(|def| def.display_name()),
+        locale,
+    )
+    .unwrap_or_else(|| title_case(&tool_call.name))
 }
 
 fn arg_str<'a>(arguments: &'a Value, keys: &[&str]) -> Option<&'a str> {
@@ -67,16 +77,16 @@ fn truncate(value: &str, max_len: usize) -> String {
     format!("{truncated}...")
 }
 
-fn location_phrase(arguments: &Value) -> String {
+fn location_phrase(arguments: &Value, locale: Option<&str>) -> String {
     arg_str(arguments, &["path", "directory", "working_dir"])
         .map(|value| {
             if value == "." || value == "/workspace" {
-                "current directory".to_string()
+                backend_strings(locale).current_directory.to_string()
             } else {
                 value.to_string()
             }
         })
-        .unwrap_or_else(|| "current directory".to_string())
+        .unwrap_or_else(|| backend_strings(locale).current_directory.to_string())
 }
 
 fn generic_phrase(
@@ -99,13 +109,328 @@ fn generic_phrase(
     }
 }
 
-pub fn render_tool_narration(
-    tool_def: Option<&ToolDefinition>,
+fn ukrainian_phrase(
     tool_call: &ToolCall,
+    fallback_name: &str,
     phase: ToolNarrationPhase,
 ) -> String {
     let args = &tool_call.arguments;
-    let fallback_name = display_name(tool_def, tool_call);
+    match tool_call.name.as_str() {
+        "bash" => {
+            let command = arg_str(args, &["command"])
+                .map(|value| format!("`{}`", truncate(value, 48)))
+                .unwrap_or_else(|| fallback_name.to_string());
+            match phase {
+                ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => {
+                    format!("Запускаю {command}")
+                }
+                ToolNarrationPhase::Completed => format!("Запустив {command}"),
+                ToolNarrationPhase::Failed => format!("Не вдалося запустити {command}"),
+            }
+        }
+        "read_file" | "session_read_file" => {
+            let target = arg_str(args, &["path"]).map(|path| basename(path).to_string());
+            match phase {
+                ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => match target {
+                    Some(target) => format!("Читаю {target}"),
+                    None => "Читаю файл".to_string(),
+                },
+                ToolNarrationPhase::Completed => match target {
+                    Some(target) => format!("Прочитав {target}"),
+                    None => "Прочитав файл".to_string(),
+                },
+                ToolNarrationPhase::Failed => match target {
+                    Some(target) => format!("Не вдалося прочитати {target}"),
+                    None => "Не вдалося прочитати файл".to_string(),
+                },
+            }
+        }
+        "read_many_files" => match phase {
+            ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => {
+                "Читаю кілька файлів".to_string()
+            }
+            ToolNarrationPhase::Completed => "Прочитав кілька файлів".to_string(),
+            ToolNarrationPhase::Failed => "Не вдалося прочитати кілька файлів".to_string(),
+        },
+        "list_directory" | "list_files" => {
+            let target = location_phrase(args, Some("uk"));
+            match phase {
+                ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => {
+                    format!("Переглядаю файли у {target}")
+                }
+                ToolNarrationPhase::Completed => format!("Переглянув файли у {target}"),
+                ToolNarrationPhase::Failed => format!("Не вдалося переглянути файли у {target}"),
+            }
+        }
+        "grep_files" => {
+            let pattern = arg_str(args, &["pattern"]).map(|pattern| truncate(pattern, 36));
+            match phase {
+                ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => match pattern {
+                    Some(pattern) => format!("Шукаю `{pattern}` у файлах"),
+                    None => "Шукаю у файлах".to_string(),
+                },
+                ToolNarrationPhase::Completed => match pattern {
+                    Some(pattern) => format!("Знайшов `{pattern}` у файлах"),
+                    None => "Завершив пошук у файлах".to_string(),
+                },
+                ToolNarrationPhase::Failed => match pattern {
+                    Some(pattern) => format!("Не вдалося знайти `{pattern}` у файлах"),
+                    None => "Не вдалося виконати пошук у файлах".to_string(),
+                },
+            }
+        }
+        "search" | "search_web" => {
+            let query = arg_str(args, &["query", "q", "search"]).map(|query| truncate(query, 48));
+            match phase {
+                ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => match query {
+                    Some(query) => format!("Шукаю у вебі: {query}"),
+                    None => "Шукаю у вебі".to_string(),
+                },
+                ToolNarrationPhase::Completed => match query {
+                    Some(query) => format!("Завершив пошук у вебі: {query}"),
+                    None => "Завершив пошук у вебі".to_string(),
+                },
+                ToolNarrationPhase::Failed => match query {
+                    Some(query) => format!("Не вдалося знайти у вебі: {query}"),
+                    None => "Не вдалося виконати пошук у вебі".to_string(),
+                },
+            }
+        }
+        name if name.ends_with("__search") => {
+            let query = arg_str(args, &["query", "q", "search"]).map(|query| truncate(query, 48));
+            match phase {
+                ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => match query {
+                    Some(query) => format!("Шукаю: {query}"),
+                    None => "Шукаю".to_string(),
+                },
+                ToolNarrationPhase::Completed => match query {
+                    Some(query) => format!("Завершив пошук: {query}"),
+                    None => "Завершив пошук".to_string(),
+                },
+                ToolNarrationPhase::Failed => match query {
+                    Some(query) => format!("Не вдалося знайти: {query}"),
+                    None => "Не вдалося виконати пошук".to_string(),
+                },
+            }
+        }
+        "write_file" => {
+            let target = arg_str(args, &["path"]).map(|path| basename(path).to_string());
+            match phase {
+                ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => match target {
+                    Some(target) => format!("Записую {target}"),
+                    None => "Записую файл".to_string(),
+                },
+                ToolNarrationPhase::Completed => match target {
+                    Some(target) => format!("Записав {target}"),
+                    None => "Записав файл".to_string(),
+                },
+                ToolNarrationPhase::Failed => match target {
+                    Some(target) => format!("Не вдалося записати {target}"),
+                    None => "Не вдалося записати файл".to_string(),
+                },
+            }
+        }
+        "edit_file" | "replace_in_file" => {
+            let target = arg_str(args, &["path"]).map(|path| basename(path).to_string());
+            match phase {
+                ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => match target {
+                    Some(target) => format!("Редагую {target}"),
+                    None => "Редагую файл".to_string(),
+                },
+                ToolNarrationPhase::Completed => match target {
+                    Some(target) => format!("Відредагував {target}"),
+                    None => "Відредагував файл".to_string(),
+                },
+                ToolNarrationPhase::Failed => match target {
+                    Some(target) => format!("Не вдалося відредагувати {target}"),
+                    None => "Не вдалося відредагувати файл".to_string(),
+                },
+            }
+        }
+        "append_file" => {
+            let target = arg_str(args, &["path"]).map(|path| basename(path).to_string());
+            match phase {
+                ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => match target {
+                    Some(target) => format!("Дописую у {target}"),
+                    None => "Дописую у файл".to_string(),
+                },
+                ToolNarrationPhase::Completed => match target {
+                    Some(target) => format!("Дописав у {target}"),
+                    None => "Дописав у файл".to_string(),
+                },
+                ToolNarrationPhase::Failed => match target {
+                    Some(target) => format!("Не вдалося дописати у {target}"),
+                    None => "Не вдалося дописати у файл".to_string(),
+                },
+            }
+        }
+        "move_file" => {
+            let target = arg_str(args, &["to", "destination", "new_path"])
+                .or_else(|| arg_str(args, &["path"]))
+                .map(|path| basename(path).to_string());
+            match phase {
+                ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => match target {
+                    Some(target) => format!("Переміщую {target}"),
+                    None => "Переміщую файл".to_string(),
+                },
+                ToolNarrationPhase::Completed => match target {
+                    Some(target) => format!("Перемістив {target}"),
+                    None => "Перемістив файл".to_string(),
+                },
+                ToolNarrationPhase::Failed => match target {
+                    Some(target) => format!("Не вдалося перемістити {target}"),
+                    None => "Не вдалося перемістити файл".to_string(),
+                },
+            }
+        }
+        "delete_file" => {
+            let target = arg_str(args, &["path"]).map(|path| basename(path).to_string());
+            match phase {
+                ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => match target {
+                    Some(target) => format!("Видаляю {target}"),
+                    None => "Видаляю файл".to_string(),
+                },
+                ToolNarrationPhase::Completed => match target {
+                    Some(target) => format!("Видалив {target}"),
+                    None => "Видалив файл".to_string(),
+                },
+                ToolNarrationPhase::Failed => match target {
+                    Some(target) => format!("Не вдалося видалити {target}"),
+                    None => "Не вдалося видалити файл".to_string(),
+                },
+            }
+        }
+        "mkdir" => {
+            let target = arg_str(args, &["path"]).map(|path| basename(path).to_string());
+            match phase {
+                ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => match target {
+                    Some(target) => format!("Створюю директорію {target}"),
+                    None => "Створюю директорію".to_string(),
+                },
+                ToolNarrationPhase::Completed => match target {
+                    Some(target) => format!("Створив директорію {target}"),
+                    None => "Створив директорію".to_string(),
+                },
+                ToolNarrationPhase::Failed => match target {
+                    Some(target) => format!("Не вдалося створити директорію {target}"),
+                    None => "Не вдалося створити директорію".to_string(),
+                },
+            }
+        }
+        "stat_file" => {
+            let target = arg_str(args, &["path"]).map(|path| basename(path).to_string());
+            match phase {
+                ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => match target {
+                    Some(target) => format!("Перевіряю {target}"),
+                    None => "Перевіряю файл".to_string(),
+                },
+                ToolNarrationPhase::Completed => match target {
+                    Some(target) => format!("Перевірив {target}"),
+                    None => "Перевірив файл".to_string(),
+                },
+                ToolNarrationPhase::Failed => match target {
+                    Some(target) => format!("Не вдалося перевірити {target}"),
+                    None => "Не вдалося перевірити файл".to_string(),
+                },
+            }
+        }
+        "secret_store" | "kv_store" => {
+            let operation = arg_str(args, &["operation"]).unwrap_or("використати");
+            let target = arg_str(args, &["name", "key"])
+                .map(str::to_string)
+                .unwrap_or_else(|| fallback_name.to_string());
+            match phase {
+                ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => {
+                    format!("Виконую {} {}", title_case(operation), target)
+                        .trim()
+                        .to_string()
+                }
+                ToolNarrationPhase::Completed => {
+                    format!("Виконав {} {}", title_case(operation), target)
+                        .trim()
+                        .to_string()
+                }
+                ToolNarrationPhase::Failed => {
+                    format!("Не вдалося виконати {} {}", operation, target)
+                        .trim()
+                        .to_string()
+                }
+            }
+        }
+        "spawn_subagent" => {
+            let target = arg_str(args, &["name"])
+                .map(|name| format!("субагента {name}"))
+                .unwrap_or_else(|| "субагента".to_string());
+            match phase {
+                ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => {
+                    format!("Запускаю {target}")
+                }
+                ToolNarrationPhase::Completed => format!("Запустив {target}"),
+                ToolNarrationPhase::Failed => format!("Не вдалося запустити {target}"),
+            }
+        }
+        "get_subagents" => {
+            let target = arg_str(args, &["name_or_id"])
+                .map(|value| format!("субагента {value}"))
+                .unwrap_or_else(|| "субагентів".to_string());
+            match phase {
+                ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => {
+                    format!("Перевіряю {target}")
+                }
+                ToolNarrationPhase::Completed => format!("Перевірив {target}"),
+                ToolNarrationPhase::Failed => format!("Не вдалося перевірити {target}"),
+            }
+        }
+        "message_subagent" => {
+            let target = arg_str(args, &["name_or_id"])
+                .map(|value| format!("повідомлення для {value}"))
+                .unwrap_or_else(|| "повідомлення субагенту".to_string());
+            if matches!(phase, ToolNarrationPhase::Completed)
+                && arg_bool(args, "cancel").unwrap_or(false)
+            {
+                format!(
+                    "Поставив у чергу запит на зупинку {}",
+                    target.trim_start_matches("повідомлення для ")
+                )
+            } else {
+                match phase {
+                    ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => {
+                        format!("Ставлю у чергу {target}")
+                    }
+                    ToolNarrationPhase::Completed => format!("Поставив у чергу {target}"),
+                    ToolNarrationPhase::Failed => format!("Не вдалося поставити у чергу {target}"),
+                }
+            }
+        }
+        "write_todos" => match phase {
+            ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => {
+                "Оновлюю список задач".to_string()
+            }
+            ToolNarrationPhase::Completed => "Оновив список задач".to_string(),
+            ToolNarrationPhase::Failed => "Не вдалося оновити список задач".to_string(),
+        },
+        _ => match phase {
+            ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => {
+                format!("Запускаю {fallback_name}")
+            }
+            ToolNarrationPhase::Completed => format!("Запустив {fallback_name}"),
+            ToolNarrationPhase::Failed => format!("Не вдалося запустити {fallback_name}"),
+        },
+    }
+}
+
+pub fn render_tool_narration_with_locale(
+    tool_def: Option<&ToolDefinition>,
+    tool_call: &ToolCall,
+    phase: ToolNarrationPhase,
+    locale: Option<&str>,
+) -> String {
+    let args = &tool_call.arguments;
+    let fallback_name = display_name(tool_def, tool_call, locale);
+
+    if resolve_backend_locale(locale) == BackendLocale::Uk {
+        return ukrainian_phrase(tool_call, &fallback_name, phase);
+    }
 
     match tool_call.name.as_str() {
         "bash" => {
@@ -129,7 +454,7 @@ pub fn render_tool_narration(
             "Listing files in",
             "Listed files in",
             "Failed to list files in",
-            Some(location_phrase(args)),
+            Some(location_phrase(args, locale)),
             phase,
         ),
         "grep_files" => {
@@ -294,24 +619,27 @@ pub fn render_tool_narration(
     }
 }
 
-fn join_phrases(phrases: &[String], total_count: usize) -> String {
-    match phrases {
-        [] => "Working".to_string(),
-        [only] => only.clone(),
-        [first, second] => format!("{first} and {second}"),
-        [first, second, ..] => {
-            format!(
-                "{first}, {second}, and {} more actions",
-                total_count.saturating_sub(2)
-            )
-        }
-    }
-}
-
 pub fn render_group_headline(
     tool_calls: &[ToolCall],
     tool_defs: &[ToolDefinition],
     phase: ToolNarrationPhase,
+) -> Option<String> {
+    render_group_headline_with_locale(tool_calls, tool_defs, phase, None)
+}
+
+pub fn render_tool_narration(
+    tool_def: Option<&ToolDefinition>,
+    tool_call: &ToolCall,
+    phase: ToolNarrationPhase,
+) -> String {
+    render_tool_narration_with_locale(tool_def, tool_call, phase, None)
+}
+
+pub fn render_group_headline_with_locale(
+    tool_calls: &[ToolCall],
+    tool_defs: &[ToolDefinition],
+    phase: ToolNarrationPhase,
+    locale: Option<&str>,
 ) -> Option<String> {
     if tool_calls.is_empty() {
         return None;
@@ -323,23 +651,43 @@ pub fn render_group_headline(
     let phrases = tool_calls
         .iter()
         .map(|tool_call| {
-            render_tool_narration(
+            render_tool_narration_with_locale(
                 tool_map.get(tool_call.name.as_str()).copied(),
                 tool_call,
                 phase,
+                locale,
             )
         })
         .take(3)
         .collect::<Vec<_>>();
 
-    Some(join_phrases(&phrases, tool_calls.len()))
+    Some(join_phrases(&phrases, tool_calls.len(), locale))
+}
+
+fn join_phrases(phrases: &[String], total_count: usize, locale: Option<&str>) -> String {
+    let strings = backend_strings(locale);
+    match phrases {
+        [] => strings.working.to_string(),
+        [only] => only.clone(),
+        [first, second] => match resolve_backend_locale(locale) {
+            BackendLocale::Uk => format!("{first} і {second}"),
+            BackendLocale::En => format!("{first} and {second}"),
+        },
+        [first, second, ..] => {
+            let more = format_more_actions(locale, total_count.saturating_sub(2));
+            format!("{first}, {second}, {more}")
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use serde_json::json;
 
-    use super::{ToolNarrationPhase, render_group_headline, render_tool_narration};
+    use super::{
+        ToolNarrationPhase, render_group_headline, render_group_headline_with_locale,
+        render_tool_narration, render_tool_narration_with_locale,
+    };
     use crate::tool_types::ToolCall;
 
     #[test]
@@ -404,6 +752,68 @@ mod tests {
         assert_eq!(
             headline,
             "Listed files in current directory, Read AGENTS.md, and 1 more actions"
+        );
+    }
+
+    #[test]
+    fn renders_ukrainian_read_file_narration() {
+        let tool_call = ToolCall {
+            id: "call_1".to_string(),
+            name: "read_file".to_string(),
+            arguments: json!({ "path": "/workspace/AGENTS.md" }),
+        };
+
+        assert_eq!(
+            render_tool_narration_with_locale(
+                None,
+                &tool_call,
+                ToolNarrationPhase::Started,
+                Some("uk-UA"),
+            ),
+            "Читаю AGENTS.md"
+        );
+        assert_eq!(
+            render_tool_narration_with_locale(
+                None,
+                &tool_call,
+                ToolNarrationPhase::Completed,
+                Some("uk-UA"),
+            ),
+            "Прочитав AGENTS.md"
+        );
+    }
+
+    #[test]
+    fn renders_ukrainian_group_headline() {
+        let tool_calls = vec![
+            ToolCall {
+                id: "call_1".to_string(),
+                name: "list_directory".to_string(),
+                arguments: json!({ "path": "/workspace" }),
+            },
+            ToolCall {
+                id: "call_2".to_string(),
+                name: "read_file".to_string(),
+                arguments: json!({ "path": "/workspace/AGENTS.md" }),
+            },
+            ToolCall {
+                id: "call_3".to_string(),
+                name: "grep_files".to_string(),
+                arguments: json!({ "pattern": "Doppler" }),
+            },
+        ];
+
+        let headline = render_group_headline_with_locale(
+            &tool_calls,
+            &[],
+            ToolNarrationPhase::Completed,
+            Some("uk"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            headline,
+            "Переглянув файли у поточній директорії, Прочитав AGENTS.md, і ще 1 дію"
         );
     }
 }

--- a/crates/core/tests/agent_run_with_thinking.rs
+++ b/crates/core/tests/agent_run_with_thinking.rs
@@ -54,6 +54,7 @@ async fn test_extended_thinking(#[case] config: ProviderModelConfig) {
         )],
         controls: Some(Controls {
             model_id: None,
+            locale: None,
             reasoning: Some(ReasoningConfig {
                 effort: Some("high".into()),
             }),
@@ -131,6 +132,7 @@ async fn test_thinking_with_tool_call(#[case] config: ProviderModelConfig) {
         content: vec![ContentPart::text("What's the current time in UTC?")],
         controls: Some(Controls {
             model_id: None,
+            locale: None,
             reasoning: Some(ReasoningConfig {
                 effort: Some("low".into()),
             }),

--- a/crates/core/tests/gpt_comparison_bench.rs
+++ b/crates/core/tests/gpt_comparison_bench.rs
@@ -224,6 +224,7 @@ async fn test_gpt52_vs_gpt54_reasoning() {
             )],
             controls: Some(Controls {
                 model_id: None,
+                locale: None,
                 reasoning: Some(ReasoningConfig {
                     effort: Some("high".into()),
                 }),

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -1346,6 +1346,7 @@ async fn test_previous_response_id_round_trips_through_serde() {
         max_iterations: 10,
         error: None,
         usage: None,
+        locale: None,
         response_id: Some("resp_out_456".to_string()),
     };
     let result_json = serde_json::to_value(&result).unwrap();

--- a/crates/server/src/api/messages.rs
+++ b/crates/server/src/api/messages.rs
@@ -28,6 +28,7 @@ use utoipa::ToSchema;
 
 use everruns_core::Caller;
 
+use super::validation::{VALIDATION_ERROR_MESSAGE, normalize_controls_locale};
 use crate::services::{MessageService, SessionService};
 
 // Re-export core types with ToSchema for OpenAPI
@@ -219,8 +220,17 @@ pub async fn create_message(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(session_id): Path<String>,
-    Json(req): Json<CreateMessageRequest>,
+    Json(mut req): Json<CreateMessageRequest>,
 ) -> Result<(StatusCode, Json<Message>), (StatusCode, Json<ErrorResponse>)> {
+    req.controls = normalize_controls_locale(req.controls).map_err(|_| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: VALIDATION_ERROR_MESSAGE.to_string(),
+            }),
+        )
+    })?;
+
     let session_id: SessionId = session_id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -26,7 +26,7 @@ use everruns_worker::AgentRunner;
 use super::common::{
     ApiOptionExt, ApiPolicyResultExt, ApiResultExt, ErrorResponse, PaginatedResponse, Pagination,
 };
-use super::validation::normalize_locale;
+use super::validation::{VALIDATION_ERROR_MESSAGE, normalize_locale};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::{IntoParams, ToSchema};
@@ -114,6 +114,13 @@ pub struct UpdateSessionRequest {
     #[serde(default)]
     #[schema(example = json!(["resolved"]))]
     pub tags: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct GetOrCreateChatSessionRequest {
+    /// Browser locale for seeding the global chat session (BCP 47, e.g. `uk-UA`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub locale: Option<String>,
 }
 
 /// Query parameters for listing sessions with pagination.
@@ -380,7 +387,17 @@ async fn resolve_session_harness_id(
 pub async fn get_or_create_chat_session(
     org: ResolvedOrg,
     State(state): State<AppState>,
+    payload: Option<Json<GetOrCreateChatSessionRequest>>,
 ) -> Result<Json<Session>, (StatusCode, Json<ErrorResponse>)> {
+    let locale = normalize_locale(payload.and_then(|Json(body)| body.locale)).map_err(|_| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: VALIDATION_ERROR_MESSAGE.to_string(),
+            }),
+        )
+    })?;
+
     // Use authenticated user_id, or fall back to anonymous user (auth=none mode)
     let user_id = org.user_id.unwrap_or(everruns_core::ANONYMOUS_USER_ID);
     let chat_harness_name = state.chat_harness_name.clone().ok_or((
@@ -405,6 +422,7 @@ pub async fn get_or_create_chat_session(
                 .chat_session_title
                 .as_deref()
                 .unwrap_or(chat_harness_name.as_str()),
+            locale,
         )
         .await
         .map_policy_or_internal("get or create chat session")?;

--- a/crates/server/src/api/validation.rs
+++ b/crates/server/src/api/validation.rs
@@ -173,6 +173,17 @@ pub fn normalize_locale(locale: Option<String>) -> Result<Option<String>, Valida
     Ok(Some(normalized))
 }
 
+/// Validate and normalize a locale override inside message controls.
+pub fn normalize_controls_locale(
+    controls: Option<everruns_core::Controls>,
+) -> Result<Option<everruns_core::Controls>, ValidationError> {
+    let Some(mut controls) = controls else {
+        return Ok(None);
+    };
+    controls.locale = normalize_locale(controls.locale)?;
+    Ok(Some(controls))
+}
+
 /// Validate starter files collection and per-file shape.
 pub fn validate_initial_files(initial_files: &[InitialFile]) -> Result<(), ValidationError> {
     if initial_files.len() > MAX_INITIAL_FILES {
@@ -348,6 +359,19 @@ mod tests {
         assert!(normalize_locale(Some("".to_string())).is_err());
         assert!(normalize_locale(Some("uk UA".to_string())).is_err());
         assert!(normalize_locale(Some("-uk".to_string())).is_err());
+    }
+
+    #[test]
+    fn test_normalize_controls_locale_updates_message_controls() {
+        let controls = everruns_core::Controls {
+            model_id: None,
+            locale: Some("uk_UA".to_string()),
+            reasoning: None,
+            hints: None,
+        };
+
+        let normalized = normalize_controls_locale(Some(controls)).unwrap().unwrap();
+        assert_eq!(normalized.locale.as_deref(), Some("uk-UA"));
     }
 
     #[test]

--- a/crates/server/src/services/session.rs
+++ b/crates/server/src/services/session.rs
@@ -494,6 +494,7 @@ impl SessionService {
         user_id: Uuid,
         harness_id: Uuid,
         title: &str,
+        locale: Option<String>,
     ) -> Result<Session> {
         let org_id = caller.org_id;
         let org_public_id = &caller.org_public_id;
@@ -515,7 +516,7 @@ impl SessionService {
             harness_id: Some(harness_id_typed),
             agent_id: None,
             title: Some(title.to_string()),
-            locale: None,
+            locale,
             tags: vec!["global-chat".to_string(), user_tag],
             model_id: None,
             capabilities: serde_json::json!([]),

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -251,6 +251,7 @@ pub async fn reason_activity(
             error: Some("dependency_unavailable".to_string()),
             usage: None,
             response_id: None,
+            locale: None,
         });
     }
 
@@ -591,6 +592,7 @@ mod tests {
                 category: None,
                 deferrable: DeferrablePolicy::default(),
             })],
+            locale: None,
         };
 
         let json = serde_json::to_string(&input).unwrap();
@@ -611,6 +613,7 @@ mod tests {
             error: None,
             usage: None,
             response_id: None,
+            locale: None,
         };
 
         let json = serde_json::to_string(&result).unwrap();

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -1388,6 +1388,7 @@ impl DurableWorker {
                             agent_id: input.agent_id,
                             tool_calls: reason_result.tool_calls,
                             tool_definitions: reason_result.tool_definitions,
+                            locale: reason_result.locale,
                         },
                     };
                     let mut act_input_json = serde_json::to_value(&act_task_input)?;

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -686,6 +686,7 @@ async fn execute_reason_activity<A: WorkerAdapters>(
             error: Some("dependency_unavailable".to_string()),
             usage: None,
             response_id: None,
+            locale: None,
         })?);
     }
 
@@ -917,6 +918,7 @@ async fn schedule_next_activity<S: WorkflowEventStore>(
                     agent_id: input.agent_id,
                     tool_calls: reason_result.tool_calls,
                     tool_definitions: reason_result.tool_definitions,
+                    locale: reason_result.locale,
                 };
                 let mut act_input_json = serde_json::to_value(&act_input)?;
                 if let Some(rid) = &response_id {

--- a/specs/localization.md
+++ b/specs/localization.md
@@ -10,7 +10,9 @@ This spec covers:
 - execution-context resolution precedence
 - backend localization of system-generated strings
 
-This spec does not define UI localization.
+This spec also defines the first iteration of UI localization plumbing and
+shared string-catalog rules so new locales do not require hard-coded strings
+throughout the product.
 
 ## Goals
 
@@ -66,17 +68,23 @@ Design rule:
 
 ## Per-Turn Overrides
 
-Message metadata may carry one-turn overrides:
-- `message.metadata.locale`
+Message controls may carry one-turn overrides:
+- `message.controls.locale`
+- `message.metadata.locale` (legacy/reserved compatibility path)
 - `message.metadata.timezone`
 
 These values affect only the triggered turn. They do not mutate durable user or session preferences by themselves.
 
 For browser clients, the expected source of truth is:
-- locale: explicit client locale if provided, otherwise `Accept-Language` only for default seeding
+- locale: explicit client locale in controls if provided, otherwise `Accept-Language` only for default seeding
 - timezone: explicit browser timezone sent by the client
 
 Recommended browser contract:
+- send current browser locale explicitly in `controls.locale` on interactive requests
+- seed `session.locale` from the browser locale when creating browser-originated sessions
+- allow per-message `controls.locale` to override session locale without mutating the session
+- message controls win over session defaults for a single turn
+- message metadata locale remains reserved for compatibility and internal callers
 - send current browser timezone explicitly on interactive requests
 - do not infer timezone from locale
 
@@ -110,12 +118,13 @@ The resolved values should be attached to turn-scoped tracing metadata and may b
 
 #### Locale precedence
 
-1. `message.metadata.locale`
-2. explicit request locale
-3. `session.locale`
-4. `user.locale`
-5. locale seeded from `Accept-Language`
-6. system default `en`
+1. `message.controls.locale`
+2. `message.metadata.locale`
+3. explicit request locale
+4. `session.locale`
+5. `user.locale`
+6. locale seeded from `Accept-Language`
+7. system default `en`
 
 #### Timezone precedence
 
@@ -192,6 +201,7 @@ Backend localization applies only to deterministic backend-authored strings:
 - schedule-triggered inbox text
 - tool/system messages authored by the platform
 - generic validation and policy error messages exposed to users
+- tool display names, narration, and activity headlines emitted in events
 
 It does not apply to:
 - LLM-generated content
@@ -205,6 +215,15 @@ Use stable message keys with parameter interpolation, for example:
 - `session.cancel.agent_response`
 - `validation.input_limits_exceeded`
 - `schedule.trigger.message`
+- `tool.label.read_file`
+- `tool.narration.read.started`
+- `chat.empty_state.title`
+
+Implementation rule:
+- UI strings and backend-authored strings must live in locale catalogs rather than
+  inline string literals inside rendering/business-logic code
+- catalogs may stay code-native in the first iteration; Fluent/ICU are not required yet
+- adding a new locale should primarily mean adding catalog entries, not rewriting logic
 
 Recommended API:
 
@@ -243,8 +262,29 @@ This preserves the rendered message while keeping enough context for future anal
 ### Messages
 
 `POST /v1/sessions/{session_id}/messages`
+- `controls.locale` is the preferred per-turn locale override
 - `metadata.locale` is reserved for per-turn locale override
 - `metadata.timezone` is reserved for per-turn timezone override
+
+`POST /v1/sessions/chat`
+- may accept optional `locale` for seeding the singleton global chat session on first creation
+
+## UI Localization
+
+### Browser locale detection
+
+- The browser client should detect locale from `navigator.languages` / `navigator.language`
+- UI copy should switch by supported language family (`uk*` → Ukrainian, otherwise English in the first iteration)
+- The raw normalized browser locale (for example `uk-UA`) should still be forwarded to the backend so later locales can be enabled without changing the transport
+
+### Catalog structure
+
+- Keep a typed UI string catalog keyed by stable message IDs
+- Keep a backend string catalog keyed by stable message IDs or semantic helpers
+- Use the same fallback rule everywhere:
+  1. exact locale if present
+  2. language family if supported
+  3. default English
 
 ### Users
 


### PR DESCRIPTION
### Motivation

- Introduce first-class localization support so UI copy and deterministic backend-authored strings can be rendered in multiple languages (initially English and Ukrainian). 
- Surface a per-turn locale override from the client (`controls.locale`) and propagate it through the reasoning/act workflow so tool labels, narration, and activity headlines can be localized consistently.
- Seed the global chat session with browser locale and expose plumbing to normalize/validate locales from API inputs.

### Description

- Frontend: add a `LocaleProvider` and `useLocale` hook, create a typed UI catalog in `lib/i18n.ts`, and update many chat components (`chat-composer`, `chat-panel`, `chat-message-list`, `grouped-activity-card`, `read-file-tool-call-card`, `write-file-tool-call-card`, `tool-activity-row`, `tool-activity-timeline-group`, `thinking-indicator`, hooks) to use `t()` and the resolved UI locale; add `apps/ui/src/lib/__tests__/i18n.test.ts` for locale helpers.
- Frontend: pass `backendLocale` into message `Controls` when building per-message controls so the backend can receive a normalized BCP47 locale for the turn; include `LocaleProvider` at app root.
- Backend/core: add localization module `crates/core/src/localization.rs` and wire locale-aware rendering across events and tool narration; extend tool narration and group-headline rendering to support Ukrainian strings and locale-aware joining/pluralization.
- Backend/core/worker: thread `locale` field through `ReasonResult` → Act tasks → `ActInput`, and use locale when emitting act/tool events and rendering display names/narration.
- API/server: accept and normalize locale for session creation and `POST /v1/sessions/chat` payload, add controls locale normalization for `POST /v1/sessions/{session_id}/messages`, and validate/normalize locale tags; persist session-level locale when creating global chat sessions.
- Types and contracts: add `Controls.locale` optional field and update related serializations and tests across crates and worker code to include `locale` where applicable.

### Testing

- Ran frontend unit tests for `apps/ui` that exercise the new `i18n` helpers (`__tests__/i18n.test.ts`), and they passed.
- Ran backend Rust unit tests (`cargo test`) for `crates/core` and worker code that include updated tool narration, act/reason logic, and locale extraction tests, and they passed.
- Executed API route validation tests that cover locale normalization (`crates/server` validation unit tests), and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be2563ec30832b8152b04577ac0321)