### PR TITLE
fix: remove automatic agent seeding to prevent duplicates with examples

### DIFF
--- a/crates/server/src/api/organizations.rs
+++ b/crates/server/src/api/organizations.rs
@@ -12,8 +12,8 @@ use axum::{
     routing::get,
 };
 use everruns_core::{
-    BuiltInHarnessDefinition, DEFAULT_ORG_ID, DeploymentGrade, OrgRole, Organization,
-    PlatformDefinition, generate_org_public_id, validate_org_public_id,
+    BuiltInHarnessDefinition, DEFAULT_ORG_ID, OrgRole, Organization, generate_org_public_id,
+    validate_org_public_id,
 };
 use everruns_durable::UpdateField;
 
@@ -30,21 +30,14 @@ pub struct AppState {
     pub db: Arc<StorageBackend>,
     pub auth: AuthState,
     pub built_in_harnesses: Vec<BuiltInHarnessDefinition>,
-    pub platform_definition: Arc<PlatformDefinition>,
-    pub deployment_grade: DeploymentGrade,
 }
 
 impl AppState {
     pub fn new(db: Arc<StorageBackend>, auth: AuthState) -> Self {
-        let grade = DeploymentGrade::from_env();
-        let platform_definition =
-            Arc::new(crate::platform::oss_platform_definition_for_grade(grade));
         Self {
             db,
             auth,
             built_in_harnesses: crate::platform::oss_built_in_harnesses(),
-            platform_definition,
-            deployment_grade: grade,
         }
     }
 
@@ -52,15 +45,11 @@ impl AppState {
         db: Arc<StorageBackend>,
         auth: AuthState,
         built_in_harnesses: Vec<BuiltInHarnessDefinition>,
-        platform_definition: Arc<PlatformDefinition>,
-        deployment_grade: DeploymentGrade,
     ) -> Self {
         Self {
             db,
             auth,
             built_in_harnesses,
-            platform_definition,
-            deployment_grade,
         }
     }
 }
@@ -255,21 +244,9 @@ pub async fn create_organization(
         );
     }
 
-    // Seed example agents for the new organization
-    if let Err(e) = crate::org_init::initialize_org_agents(
-        &state.db,
-        row.org_id,
-        state.deployment_grade,
-        &state.platform_definition,
-    )
-    .await
-    {
-        tracing::warn!(
-            org_id = row.org_id,
-            error = %e,
-            "Failed to seed example agents for new org (non-fatal)"
-        );
-    }
+    // Seed agents are available as examples (GET /v1/agent-examples) and adopted
+    // on demand via POST /v1/agent-examples/{slug}/use. No automatic seeding —
+    // this prevents duplicate agents when users adopt from the examples gallery.
 
     let response = build_organization_response(&state.db, row.org_id, row).await?;
     Ok((StatusCode::CREATED, Json(response)))

--- a/crates/server/src/api/organizations.rs
+++ b/crates/server/src/api/organizations.rs
@@ -41,7 +41,7 @@ impl AppState {
         }
     }
 
-    pub fn with_platform(
+    pub fn with_harnesses(
         db: Arc<StorageBackend>,
         auth: AuthState,
         built_in_harnesses: Vec<BuiltInHarnessDefinition>,

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -566,8 +566,6 @@ impl ServerAppBuilder {
             db.clone(),
             auth_state.clone(),
             platform_definition.built_in_harnesses().to_vec(),
-            platform_definition.clone(),
-            everruns_core::DeploymentGrade::from_env(),
         );
         let audit_logs_state = api::audit_logs::AppState::new(db.clone(), auth_state.clone());
         let user_connections_state = api::user_connections::AppState::new(

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -562,7 +562,7 @@ impl ServerAppBuilder {
         ));
         let skills_state = api::skills::AppState::new(db.clone(), auth_state.clone());
         let images_state = api::images::AppState::new(db.clone(), auth_state.clone());
-        let organizations_state = api::organizations::AppState::with_platform(
+        let organizations_state = api::organizations::AppState::with_harnesses(
             db.clone(),
             auth_state.clone(),
             platform_definition.built_in_harnesses().to_vec(),

--- a/crates/server/src/org_init.rs
+++ b/crates/server/src/org_init.rs
@@ -1,23 +1,18 @@
-// Organization initialization: built-in harnesses and seed agents
+// Organization initialization: built-in harnesses
 //
 // Decision: Built-in harnesses are readonly, system-managed, provisioned per-org
-// Decision: Seed agents are provisioned per-org during org creation (same as harnesses)
-// Decision: New orgs get built-in harnesses and seed agents during creation
-// Decision: Reconciliation ensures all orgs stay up-to-date with built-in definitions
+// Decision: Seed agents are NOT auto-seeded; they live as examples (GET /v1/agent-examples)
+//   and are adopted on demand (POST /v1/agent-examples/{slug}/use). This prevents duplicates.
+// Decision: Reconciliation ensures all orgs stay up-to-date with built-in harness definitions
 // Decision: Default org uses fixed seed UUIDs for backward compat; other orgs get fresh UUIDs
 // Decision: Org settings keep separate default and base harness pointers
 
-use crate::api::common::Pagination;
-use crate::seed::{SEED_AGENTS, sync_agent_capabilities};
 use crate::storage::{
     StorageBackend,
-    models::{CreateAgentRow, CreateHarnessRow, UpdateOrganizationSettings},
+    models::{CreateHarnessRow, UpdateOrganizationSettings},
 };
 use anyhow::{Context, Result};
-use everruns_core::{
-    BuiltInCapabilityDefinition, BuiltInHarnessDefinition, BuiltInHarnessRole, DeploymentGrade,
-    PlatformDefinition,
-};
+use everruns_core::{BuiltInCapabilityDefinition, BuiltInHarnessDefinition, BuiltInHarnessRole};
 use everruns_durable::UpdateField;
 use uuid::Uuid;
 /// Well-known seed IDs for default org harnesses (backward compat)
@@ -339,156 +334,6 @@ async fn sync_harness_capabilities(
         .collect();
     db.set_harness_capabilities(harness_id, cap_tuples).await?;
     Ok(true)
-}
-
-// ============================================
-// Seed Agent Initialization (per-org)
-// ============================================
-
-/// Initialize seed agents for a specific organization.
-///
-/// For `DEFAULT_ORG_ID`, uses fixed seed UUIDs for backward compatibility.
-/// For other orgs, creates agents with fresh UUIDs (skips if already exists by name).
-///
-/// Filters out dev-only agents when deployment grade disallows experimental features,
-/// and skips agents whose capabilities are not registered in the platform definition.
-pub async fn initialize_org_agents(
-    db: &StorageBackend,
-    org_id: i64,
-    grade: DeploymentGrade,
-    platform_definition: &PlatformDefinition,
-) -> Result<InitResult> {
-    use everruns_core::DEFAULT_ORG_ID;
-
-    let mut result = InitResult::default();
-    let is_default_org = org_id == DEFAULT_ORG_ID;
-    let include_dev_only = grade.experimental_features_enabled();
-
-    for seed in SEED_AGENTS {
-        if seed.dev_only && !include_dev_only {
-            tracing::debug!(
-                name = seed.name,
-                org_id,
-                "Skipping dev-only agent (deployment_grade={})",
-                grade
-            );
-            continue;
-        }
-
-        let missing_capabilities: Vec<&str> = seed
-            .capabilities
-            .iter()
-            .map(|cap| cap.id)
-            .filter(|cap_id| !platform_definition.capability_registry().has(cap_id))
-            .collect();
-        if !missing_capabilities.is_empty() {
-            tracing::debug!(
-                name = seed.name,
-                org_id,
-                missing = ?missing_capabilities,
-                "Skipping seed agent — missing capabilities in platform definition"
-            );
-            continue;
-        }
-
-        let input = CreateAgentRow {
-            public_id: everruns_core::AgentId::from_uuid(seed.id).to_string(),
-            name: seed.name.to_string(),
-            description: Some(seed.description.to_string()),
-            system_prompt: seed.system_prompt.to_string(),
-            default_model_id: None,
-            tags: seed.tags.iter().map(|s| s.to_string()).collect(),
-            initial_files: serde_json::json!([]),
-            tools: serde_json::json!([]),
-        };
-
-        if is_default_org {
-            // Default org: use fixed seed UUIDs for backward compat
-            match db
-                .create_agent_with_id(org_id, seed.id.into(), input)
-                .await?
-            {
-                Some(row) => {
-                    sync_agent_capabilities(db, row.id.uuid(), seed.capabilities).await?;
-                    if row.created_at == row.updated_at {
-                        tracing::info!(name = seed.name, org_id, "Created seed agent");
-                        result.created += 1;
-                    } else {
-                        tracing::info!(name = seed.name, org_id, "Updated seed agent");
-                        result.updated += 1;
-                    }
-                }
-                None => {
-                    let caps_changed =
-                        sync_agent_capabilities(db, seed.id, seed.capabilities).await?;
-                    if caps_changed {
-                        tracing::info!(name = seed.name, org_id, "Updated seed agent capabilities");
-                        result.updated += 1;
-                    } else {
-                        tracing::debug!(name = seed.name, org_id, "Seed agent up to date");
-                        result.unchanged += 1;
-                    }
-                }
-            }
-        } else {
-            // Non-default org: check if agent already exists by name
-            let (existing, _) = db
-                .list_agents(org_id, Some(seed.name), false, Pagination::new(0, 1))
-                .await?;
-            let already_exists = existing.iter().any(|a| a.name == seed.name);
-
-            if already_exists {
-                result.unchanged += 1;
-            } else {
-                let row = db.create_agent(org_id, input).await?;
-                sync_agent_capabilities(db, row.id.uuid(), seed.capabilities).await?;
-                tracing::info!(
-                    name = seed.name,
-                    org_id,
-                    id = %row.id,
-                    "Created seed agent for org"
-                );
-                result.created += 1;
-            }
-        }
-    }
-
-    Ok(result)
-}
-
-/// Reconcile seed agents across all organizations.
-///
-/// Ensures every org has up-to-date seed agents. Called during seeding
-/// and can be triggered for upgrades when seed definitions change.
-pub async fn reconcile_built_in_agents(
-    db: &StorageBackend,
-    grade: DeploymentGrade,
-    platform_definition: &PlatformDefinition,
-) -> Result<InitResult> {
-    let orgs = db.list_organizations().await?;
-    let mut total = InitResult::default();
-
-    for org in &orgs {
-        let org_result = initialize_org_agents(db, org.org_id, grade, platform_definition).await?;
-        tracing::debug!(
-            org_id = org.org_id,
-            created = org_result.created,
-            updated = org_result.updated,
-            unchanged = org_result.unchanged,
-            "Reconciled seed agents for org"
-        );
-        total.merge(org_result);
-    }
-
-    tracing::info!(
-        org_count = orgs.len(),
-        created = total.created,
-        updated = total.updated,
-        unchanged = total.unchanged,
-        "Seed agent reconciliation complete"
-    );
-
-    Ok(total)
 }
 
 /// Result of org initialization
@@ -860,96 +705,6 @@ mod tests {
             unchanged: 3,
         };
         assert!(!result3.has_changes());
-    }
-
-    // --- Agent initialization tests ---
-
-    fn platform() -> PlatformDefinition {
-        crate::platform::oss_platform_definition()
-    }
-
-    #[tokio::test]
-    async fn test_initialize_default_org_creates_agents() {
-        let db = make_db();
-        seed_default_org(&db).await;
-        // Harnesses must exist first (agents may reference them indirectly)
-        initialize_org_harnesses(&db, DEFAULT_ORG_ID).await.unwrap();
-
-        let pd = platform();
-        let result = initialize_org_agents(&db, DEFAULT_ORG_ID, DeploymentGrade::Dev, &pd)
-            .await
-            .unwrap();
-        assert!(result.created > 0, "Should create at least one agent");
-
-        let (agents, _) = db
-            .list_agents(DEFAULT_ORG_ID, None, false, Pagination::new(0, 100))
-            .await
-            .unwrap();
-        assert!(!agents.is_empty(), "Agents should exist after init");
-    }
-
-    #[tokio::test]
-    async fn test_initialize_agents_idempotent() {
-        let db = make_db();
-        seed_default_org(&db).await;
-        initialize_org_harnesses(&db, DEFAULT_ORG_ID).await.unwrap();
-
-        let pd = platform();
-        let r1 = initialize_org_agents(&db, DEFAULT_ORG_ID, DeploymentGrade::Dev, &pd)
-            .await
-            .unwrap();
-        assert!(r1.created > 0);
-
-        let r2 = initialize_org_agents(&db, DEFAULT_ORG_ID, DeploymentGrade::Dev, &pd)
-            .await
-            .unwrap();
-        assert_eq!(r2.created, 0, "Second run should create nothing");
-        assert!(r2.unchanged > 0);
-    }
-
-    #[tokio::test]
-    async fn test_initialize_agents_new_org() {
-        let db = make_db();
-        seed_default_org(&db).await;
-
-        let org2 = db
-            .create_organization(crate::storage::models::CreateOrganizationRow {
-                public_id: "org_00000000000000000000000000000099".to_string(),
-                name: "Agent Test Org".to_string(),
-                created_by: None,
-            })
-            .await
-            .unwrap();
-        initialize_org_harnesses(&db, org2.org_id).await.unwrap();
-
-        let pd = platform();
-        let result = initialize_org_agents(&db, org2.org_id, DeploymentGrade::Dev, &pd)
-            .await
-            .unwrap();
-        assert!(result.created > 0, "New org should get seed agents");
-
-        // Second call should be idempotent
-        let r2 = initialize_org_agents(&db, org2.org_id, DeploymentGrade::Dev, &pd)
-            .await
-            .unwrap();
-        assert_eq!(r2.created, 0);
-    }
-
-    #[tokio::test]
-    async fn test_seed_agents_respect_deployment_grade() {
-        // Verify the filtering logic itself: dev-only agents exist in SEED_AGENTS
-        let dev_only_count = SEED_AGENTS.iter().filter(|a| a.dev_only).count();
-        assert!(
-            dev_only_count > 0,
-            "SEED_AGENTS should contain at least one dev-only agent"
-        );
-
-        // Non-dev-only agents count
-        let non_dev_count = SEED_AGENTS.iter().filter(|a| !a.dev_only).count();
-        assert!(
-            non_dev_count > 0,
-            "SEED_AGENTS should contain at least one non-dev-only agent"
-        );
     }
 
     async fn seed_default_org(db: &StorageBackend) {

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -154,33 +154,6 @@ impl SeedResult {
     }
 }
 
-/// Sync capabilities for an agent, only writing if the set actually changed.
-/// Returns true if capabilities were updated.
-pub(crate) async fn sync_agent_capabilities(
-    db: &StorageBackend,
-    agent_id: Uuid,
-    desired: &[SeedCapability],
-) -> anyhow::Result<bool> {
-    let current = db.get_agent_capabilities(agent_id).await?;
-    let current_ids: Vec<&str> = current.iter().map(|c| c.capability_id.as_str()).collect();
-    let desired_ids: Vec<&str> = desired.iter().map(|c| c.id).collect();
-
-    if current_ids == desired_ids {
-        return Ok(false);
-    }
-
-    let cap_tuples: Vec<(String, i32, serde_json::Value)> = desired
-        .iter()
-        .enumerate()
-        .map(|(idx, cap)| {
-            let config = cap.config.map_or_else(|| serde_json::json!({}), |f| f());
-            (cap.id.to_string(), idx as i32, config)
-        })
-        .collect();
-    db.set_agent_capabilities(agent_id, cap_tuples).await?;
-    Ok(true)
-}
-
 // ============================================
 // Default Organization Seeder
 // ============================================
@@ -348,8 +321,10 @@ impl std::fmt::Display for SeedCapability {
         f.write_str(self.id)
     }
 }
-/// Seed agent definition
+/// Seed agent definition (used by agent examples API, not auto-seeded into DB)
 pub(crate) struct SeedAgent {
+    /// Retained for stable identification; not auto-seeded into DB.
+    #[allow(dead_code)]
     pub(crate) id: Uuid,
     pub(crate) name: &'static str,
     pub(crate) description: &'static str,
@@ -1019,7 +994,8 @@ User: "Analyze my codebase and suggest improvements"
     },
 ];
 
-// Agent seeding has moved to org_init::initialize_org_agents (per-org, mirrors harness pattern).
+// Agents are NOT auto-seeded. They live as examples (agent_examples.rs) and are adopted on
+// demand via POST /v1/agent-examples/{slug}/use. This prevents duplicate agents.
 
 // ============================================
 // LLM Provider Seeder
@@ -1836,7 +1812,7 @@ pub async fn seed_all(
 /// Run all seeders in order using an explicit platform definition.
 pub async fn seed_all_with_platform_definition(
     db: &StorageBackend,
-    grade: DeploymentGrade,
+    _grade: DeploymentGrade,
     auth_ctx: &SeedAuthContext,
     platform_definition: &PlatformDefinition,
 ) -> anyhow::Result<SeedResult> {
@@ -1932,17 +1908,9 @@ pub async fn seed_all_with_platform_definition(
     result.updated += harness_result.updated;
     result.unchanged += harness_result.unchanged;
 
-    // Reconcile built-in agents across all orgs (mirrors harness reconciliation)
-    let agent_result = org_init::reconcile_built_in_agents(db, grade, platform_definition).await?;
-    tracing::debug!(
-        created = agent_result.created,
-        updated = agent_result.updated,
-        unchanged = agent_result.unchanged,
-        "Built-in agents reconciled"
-    );
-    result.created += agent_result.created;
-    result.updated += agent_result.updated;
-    result.unchanged += agent_result.unchanged;
+    // Seed agents are available as examples (GET /v1/agent-examples) and adopted
+    // on demand via POST /v1/agent-examples/{slug}/use. No automatic seeding —
+    // this prevents duplicate agents when users adopt from the examples gallery.
 
     Ok(result)
 }
@@ -1952,7 +1920,7 @@ mod tests {
     use super::*;
     use crate::storage::StorageBackend;
     use crate::storage::models::{
-        UpdateAgent, UpdateHarness, UpdateLlmModel, UpdateLlmProvider, UpdateMcpServer,
+        UpdateHarness, UpdateLlmModel, UpdateLlmProvider, UpdateMcpServer,
     };
 
     fn make_db() -> StorageBackend {
@@ -2246,52 +2214,6 @@ mod tests {
         assert!(!second.has_changes());
     }
 
-    // --- Agent upsert ---
-
-    #[tokio::test]
-    async fn test_agent_seed_detects_name_change() {
-        let db = make_db();
-        let _ = seed_all(&db, DeploymentGrade::Dev, &SeedAuthContext::default())
-            .await
-            .unwrap();
-
-        // Mutate agent name via public API to simulate DB drift
-        let agent_id = everruns_core::AgentId::from_uuid(seed_ids::DAD_JOKES_AGENT);
-        db.update_agent(
-            DEFAULT_ORG_ID,
-            agent_id,
-            UpdateAgent {
-                name: Some("STALE NAME".to_string()),
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-
-        let result = seed_all(&db, DeploymentGrade::Dev, &SeedAuthContext::default())
-            .await
-            .unwrap();
-        assert!(result.updated >= 1, "should detect agent name change");
-    }
-
-    #[tokio::test]
-    async fn test_agent_seed_detects_capability_change() {
-        let db = make_db();
-        let _ = seed_all(&db, DeploymentGrade::Dev, &SeedAuthContext::default())
-            .await
-            .unwrap();
-
-        // Remove capabilities to simulate drift
-        db.set_agent_capabilities(seed_ids::DAD_JOKES_AGENT, vec![])
-            .await
-            .unwrap();
-
-        let result = seed_all(&db, DeploymentGrade::Dev, &SeedAuthContext::default())
-            .await
-            .unwrap();
-        assert!(result.updated >= 1, "should detect capability change");
-    }
-
     // --- Model upsert ---
 
     #[tokio::test]
@@ -2417,40 +2339,6 @@ mod tests {
             result.updated >= 1,
             "should detect harness description change"
         );
-    }
-
-    // --- Dev-only filtering ---
-
-    #[tokio::test]
-    async fn test_seed_prod_skips_dev_only_agents() {
-        let db = make_db();
-        let result = seed_all(&db, DeploymentGrade::Prod, &SeedAuthContext::default())
-            .await
-            .unwrap();
-
-        // Python Coder is dev_only — should not be created in prod
-        let python_coder_id = everruns_core::AgentId::from_uuid(seed_ids::PYTHON_CODER_AGENT);
-        let agent = db.get_agent(DEFAULT_ORG_ID, python_coder_id).await.unwrap();
-        assert!(agent.is_none(), "dev-only agent should not exist in prod");
-
-        // But non-dev agents should exist
-        let dad_jokes_id = everruns_core::AgentId::from_uuid(seed_ids::DAD_JOKES_AGENT);
-        let agent = db.get_agent(DEFAULT_ORG_ID, dad_jokes_id).await.unwrap();
-        assert!(agent.is_some(), "non-dev agent should exist");
-
-        assert!(result.created > 0);
-    }
-
-    #[tokio::test]
-    async fn test_seed_dev_includes_dev_only_agents() {
-        let db = make_db();
-        seed_all(&db, DeploymentGrade::Dev, &SeedAuthContext::default())
-            .await
-            .unwrap();
-
-        let python_coder_id = everruns_core::AgentId::from_uuid(seed_ids::PYTHON_CODER_AGENT);
-        let agent = db.get_agent(DEFAULT_ORG_ID, python_coder_id).await.unwrap();
-        assert!(agent.is_some(), "dev-only agent should exist in dev mode");
     }
 
     // --- SeedResult ---

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -1798,8 +1798,9 @@ async fn run_seed_with_retry(
 }
 
 /// Run all seeders in order
-/// Order: organization → users → providers → models → mcp_servers → agents
+/// Order: organization → users → providers → models → mcp_servers → harnesses
 /// Organization must be seeded first (all resources have org_id FK)
+/// Note: Agents are NOT seeded; they live as examples and are adopted on demand.
 pub async fn seed_all(
     db: &StorageBackend,
     grade: DeploymentGrade,
@@ -2212,6 +2213,31 @@ mod tests {
             .await
             .unwrap();
         assert!(!second.has_changes());
+    }
+
+    // --- Agent seeding regression ---
+
+    #[tokio::test]
+    async fn test_seed_all_does_not_create_agents() {
+        // Agents should NOT be auto-seeded; they live as examples and are adopted on demand.
+        let db = make_db();
+        seed_all(&db, DeploymentGrade::Dev, &SeedAuthContext::default())
+            .await
+            .unwrap();
+
+        let (agents, _) = db
+            .list_agents(
+                DEFAULT_ORG_ID,
+                None,
+                false,
+                crate::api::common::Pagination::new(0, 100),
+            )
+            .await
+            .unwrap();
+        assert!(
+            agents.is_empty(),
+            "seed_all should not create agents; they are adopted from examples"
+        );
     }
 
     // --- Model upsert ---

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -214,8 +214,6 @@ impl TestServer {
             db.clone(),
             auth_state.clone(),
             platform_definition.built_in_harnesses().to_vec(),
-            Arc::new(platform_definition.clone()),
-            grade,
         );
         let session_schedules_state = api::session_schedules::AppState::new(
             Arc::new(services::SessionScheduleService::new(db.clone())),

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -210,7 +210,7 @@ impl TestServer {
             api::schedules::ScheduleAppState::new(Some(durable_store), auth_state.clone());
         let skills_state = api::skills::AppState::new(db.clone(), auth_state.clone());
         let images_state = api::images::AppState::new(db.clone(), auth_state.clone());
-        let organizations_state = api::organizations::AppState::with_platform(
+        let organizations_state = api::organizations::AppState::with_harnesses(
             db.clone(),
             auth_state.clone(),
             platform_definition.built_in_harnesses().to_vec(),


### PR DESCRIPTION
## What
Remove automatic agent seeding from server startup and org creation. Agents are now only available via the examples API.

## Why
Seed agents were auto-created in every org during init AND shown in the examples gallery. When users adopted an example via `POST /v1/agent-examples/{slug}/use`, they got a duplicate agent.

## How
- Removed `initialize_org_agents` and `reconcile_built_in_agents` from `org_init.rs`
- Removed agent reconciliation from `seed_all_with_platform_definition`
- Removed agent seeding call from org creation in `organizations.rs`
- Cleaned up `organizations::AppState` (removed unused `platform_definition` and `deployment_grade` fields)
- Removed dead `sync_agent_capabilities` function
- `SEED_AGENTS` array and examples API (`agent_examples.rs`) remain unchanged

## Risk
- Low
- Existing orgs that already have seeded agents keep them; they just won't get new seeds on restart
- New orgs start with no agents and discover them through the examples gallery

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered