### PR TITLE
refactor(ui): combine agents page into single view with links to full lists

### DIFF
--- a/apps/ui/src/app/(main)/agents/all/page.tsx
+++ b/apps/ui/src/app/(main)/agents/all/page.tsx
@@ -19,7 +19,7 @@ export default function AllAgentsPage() {
       <div className="flex items-center justify-between mb-6">
         <div className="flex items-center gap-3">
           <Link href="/agents">
-            <Button variant="ghost" size="icon" className="h-8 w-8">
+            <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Back to agents">
               <ArrowLeft className="w-4 h-4" />
             </Button>
           </Link>

--- a/apps/ui/src/app/(main)/agents/all/page.tsx
+++ b/apps/ui/src/app/(main)/agents/all/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+import { useAgents, useCapabilities } from "@/hooks";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Plus, ArrowLeft } from "lucide-react";
+import { QueryStateWrapper } from "@/components/query-state-wrapper";
+import { AgentCard } from "@/components/agents";
+import { ArchiveFilter } from "@/components/archive-filter";
+
+export default function AllAgentsPage() {
+  const [showArchived, setShowArchived] = useState(false);
+  const { data: agents, isLoading, error } = useAgents({ includeArchived: showArchived });
+  const { data: allCapabilities } = useCapabilities();
+
+  return (
+    <div className="container mx-auto p-6">
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <Link href="/agents">
+            <Button variant="ghost" size="icon" className="h-8 w-8">
+              <ArrowLeft className="w-4 h-4" />
+            </Button>
+          </Link>
+          <h1 className="text-2xl font-bold">All Agents</h1>
+        </div>
+        <div className="flex items-center gap-2">
+          <ArchiveFilter showArchived={showArchived} onShowArchivedChange={setShowArchived} />
+          <Link href="/agents/new">
+            <Button variant="accent">
+              <Plus className="w-4 h-4 mr-2" />
+              New Agent
+            </Button>
+          </Link>
+        </div>
+      </div>
+
+      <QueryStateWrapper
+        isLoading={isLoading}
+        error={error}
+        data={agents}
+        errorMessagePrefix="Failed to load agents"
+        emptyState={
+          <div className="text-center py-12">
+            <p className="text-muted-foreground mb-4">No agents yet</p>
+            <Link href="/agents/new">
+              <Button>
+                <Plus className="w-4 h-4 mr-2" />
+                Create your first agent
+              </Button>
+            </Link>
+          </div>
+        }
+      >
+        {(items) => (
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {items.map((agent) => (
+              <AgentCard
+                key={agent.id}
+                agent={agent}
+                allCapabilities={allCapabilities}
+                showEditButton
+              />
+            ))}
+          </div>
+        )}
+      </QueryStateWrapper>
+    </div>
+  );
+}

--- a/apps/ui/src/app/(main)/agents/examples/page.tsx
+++ b/apps/ui/src/app/(main)/agents/examples/page.tsx
@@ -49,11 +49,11 @@ export default function AllExamplesPage() {
       <div className="flex items-center justify-between mb-6">
         <div className="flex items-center gap-3">
           <Link href="/agents">
-            <Button variant="ghost" size="icon" className="h-8 w-8">
+            <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Back to agents">
               <ArrowLeft className="w-4 h-4" />
             </Button>
           </Link>
-          <h2 className="text-2xl font-bold">Example Agents</h2>
+          <h1 className="text-2xl font-bold">Example Agents</h1>
         </div>
         <div className="relative">
           <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />

--- a/apps/ui/src/app/(main)/agents/examples/page.tsx
+++ b/apps/ui/src/app/(main)/agents/examples/page.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useState, useCallback, useMemo } from "react";
+import { useAgentExamples, useAdoptAgentExample, useCapabilities } from "@/hooks";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ArrowLeft, Search } from "lucide-react";
+import { QueryStateWrapper } from "@/components/query-state-wrapper";
+import { ExampleCard } from "@/components/agents";
+
+export default function AllExamplesPage() {
+  const router = useRouter();
+  const [exampleSearch, setExampleSearch] = useState("");
+  const { data: allCapabilities } = useCapabilities();
+  const { data: examples, isLoading, error } = useAgentExamples();
+  const adoptExample = useAdoptAgentExample();
+  const [adoptingSlug, setAdoptingSlug] = useState<string | null>(null);
+
+  const handleUse = useCallback(
+    async (slug: string) => {
+      setAdoptingSlug(slug);
+      try {
+        const agent = await adoptExample.mutateAsync(slug);
+        router.push(`/agents/${agent.id}`);
+      } catch (err) {
+        console.error("Failed to use example:", err);
+      } finally {
+        setAdoptingSlug(null);
+      }
+    },
+    [adoptExample, router],
+  );
+
+  const filteredExamples = useMemo(() => {
+    if (!examples || !exampleSearch.trim()) return examples;
+    const query = exampleSearch.toLowerCase();
+    return examples.filter(
+      (ex) =>
+        ex.name.toLowerCase().includes(query) ||
+        ex.description.toLowerCase().includes(query) ||
+        ex.tags.some((tag) => tag.toLowerCase().includes(query)),
+    );
+  }, [examples, exampleSearch]);
+
+  return (
+    <div className="container mx-auto p-6">
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <Link href="/agents">
+            <Button variant="ghost" size="icon" className="h-8 w-8">
+              <ArrowLeft className="w-4 h-4" />
+            </Button>
+          </Link>
+          <h2 className="text-2xl font-bold">Example Agents</h2>
+        </div>
+        <div className="relative">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search examples..."
+            value={exampleSearch}
+            onChange={(e) => setExampleSearch(e.target.value)}
+            className="pl-8 w-64"
+          />
+        </div>
+      </div>
+
+      <QueryStateWrapper
+        isLoading={isLoading}
+        error={error}
+        data={filteredExamples}
+        errorMessagePrefix="Failed to load examples"
+        emptyState={
+          <div className="text-center py-12">
+            <p className="text-muted-foreground">
+              {exampleSearch.trim() ? "No examples match your search" : "No examples available"}
+            </p>
+          </div>
+        }
+      >
+        {(items) => (
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {items.map((example) => (
+              <ExampleCard
+                key={example.slug}
+                example={example}
+                allCapabilities={allCapabilities}
+                onUse={handleUse}
+                adopting={adoptingSlug === example.slug}
+              />
+            ))}
+          </div>
+        )}
+      </QueryStateWrapper>
+    </div>
+  );
+}

--- a/apps/ui/src/app/(main)/agents/page.tsx
+++ b/apps/ui/src/app/(main)/agents/page.tsx
@@ -88,11 +88,7 @@ export default function AgentsPage() {
             accept=".md,.yaml,.yml,.json"
             className="hidden"
           />
-          <Button
-            variant="outline"
-            onClick={handleImportClick}
-            disabled={importAgent.isPending}
-          >
+          <Button variant="outline" onClick={handleImportClick} disabled={importAgent.isPending}>
             <Upload className="w-4 h-4 mr-2" />
             {importAgent.isPending ? "Importing..." : "Import"}
           </Button>

--- a/apps/ui/src/app/(main)/agents/page.tsx
+++ b/apps/ui/src/app/(main)/agents/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, useCallback, useMemo } from "react";
+import { useRef, useState, useCallback } from "react";
 import {
   useAgents,
   useAgentExamples,
@@ -11,19 +11,15 @@ import {
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Plus, Upload, Search } from "lucide-react";
+import { Plus, Upload, ArrowRight } from "lucide-react";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { AgentCard, ExampleCard } from "@/components/agents";
-import { ArchiveFilter } from "@/components/archive-filter";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+
+const PREVIEW_LIMIT = 6;
 
 export default function AgentsPage() {
   const router = useRouter();
-  const [tab, setTab] = useState("agents");
-  const [showArchived, setShowArchived] = useState(false);
-  const [exampleSearch, setExampleSearch] = useState("");
-  const { data: agents, isLoading, error } = useAgents({ includeArchived: showArchived });
+  const { data: agents, isLoading, error } = useAgents({ includeArchived: false });
   const { data: allCapabilities } = useCapabilities();
   const { data: examples, isLoading: examplesLoading, error: examplesError } = useAgentExamples();
   const importAgent = useImportAgent();
@@ -52,7 +48,6 @@ export default function AgentsPage() {
         setImportError(err instanceof Error ? err.message : "Failed to import agent");
       }
 
-      // Reset file input
       if (fileInputRef.current) {
         fileInputRef.current.value = "";
       }
@@ -75,142 +70,137 @@ export default function AgentsPage() {
     [adoptExample, router],
   );
 
-  const filteredExamples = useMemo(() => {
-    if (!examples || !exampleSearch.trim()) return examples;
-    const query = exampleSearch.toLowerCase();
-    return examples.filter(
-      (ex) =>
-        ex.name.toLowerCase().includes(query) ||
-        ex.description.toLowerCase().includes(query) ||
-        ex.tags.some((tag) => tag.toLowerCase().includes(query)),
-    );
-  }, [examples, exampleSearch]);
+  const previewAgents = agents?.slice(0, PREVIEW_LIMIT);
+  const previewExamples = examples?.slice(0, PREVIEW_LIMIT);
+  const hasMoreAgents = (agents?.length ?? 0) > PREVIEW_LIMIT;
+  const hasMoreExamples = (examples?.length ?? 0) > PREVIEW_LIMIT;
 
   return (
-    <div className="container mx-auto p-6">
-      <div className="flex items-center justify-between mb-6">
+    <div className="container mx-auto p-6 space-y-10">
+      {/* Header */}
+      <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">Agents</h1>
         <div className="flex items-center gap-2">
-          {tab === "agents" && (
-            <>
-              <ArchiveFilter showArchived={showArchived} onShowArchivedChange={setShowArchived} />
-              <input
-                type="file"
-                ref={fileInputRef}
-                onChange={handleFileChange}
-                accept=".md,.yaml,.yml,.json"
-                className="hidden"
-              />
-              <Button
-                variant="outline"
-                onClick={handleImportClick}
-                disabled={importAgent.isPending}
-              >
-                <Upload className="w-4 h-4 mr-2" />
-                {importAgent.isPending ? "Importing..." : "Import"}
-              </Button>
-              <Link href="/agents/new">
-                <Button variant="accent">
-                  <Plus className="w-4 h-4 mr-2" />
-                  New Agent
-                </Button>
-              </Link>
-            </>
-          )}
-          {tab === "examples" && (
-            <div className="relative">
-              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-              <Input
-                placeholder="Search examples..."
-                value={exampleSearch}
-                onChange={(e) => setExampleSearch(e.target.value)}
-                className="pl-8 w-64"
-              />
-            </div>
-          )}
+          <input
+            type="file"
+            ref={fileInputRef}
+            onChange={handleFileChange}
+            accept=".md,.yaml,.yml,.json"
+            className="hidden"
+          />
+          <Button
+            variant="outline"
+            onClick={handleImportClick}
+            disabled={importAgent.isPending}
+          >
+            <Upload className="w-4 h-4 mr-2" />
+            {importAgent.isPending ? "Importing..." : "Import"}
+          </Button>
+          <Link href="/agents/new">
+            <Button variant="accent">
+              <Plus className="w-4 h-4 mr-2" />
+              New Agent
+            </Button>
+          </Link>
         </div>
       </div>
 
       {importError && (
-        <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-md text-red-600 text-sm">
+        <div className="p-4 bg-red-50 border border-red-200 rounded-md text-red-600 text-sm">
           {importError}
         </div>
       )}
 
-      <Tabs value={tab} onValueChange={setTab}>
-        <TabsList>
-          <TabsTrigger value="agents">Agents</TabsTrigger>
-          <TabsTrigger value="examples">Examples</TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="agents">
-          <QueryStateWrapper
-            isLoading={isLoading}
-            error={error}
-            data={agents}
-            errorMessagePrefix="Failed to load agents"
-            emptyState={
-              <div className="text-center py-12">
-                <p className="text-muted-foreground mb-4">No agents yet</p>
-                <div className="flex items-center justify-center gap-2">
-                  <Link href="/agents/new">
-                    <Button>
-                      <Plus className="w-4 h-4 mr-2" />
-                      Create your first agent
-                    </Button>
-                  </Link>
-                  <Button variant="outline" onClick={() => setTab("examples")}>
-                    Browse examples
+      {/* My Agents Section */}
+      <section>
+        <QueryStateWrapper
+          isLoading={isLoading}
+          error={error}
+          data={previewAgents}
+          errorMessagePrefix="Failed to load agents"
+          emptyState={
+            <div className="text-center py-12">
+              <p className="text-muted-foreground mb-4">No agents yet</p>
+              <div className="flex items-center justify-center gap-2">
+                <Link href="/agents/new">
+                  <Button>
+                    <Plus className="w-4 h-4 mr-2" />
+                    Create your first agent
                   </Button>
-                </div>
+                </Link>
               </div>
-            }
-          >
-            {(items) => (
-              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-                {items.map((agent) => (
-                  <AgentCard
-                    key={agent.id}
-                    agent={agent}
-                    allCapabilities={allCapabilities}
-                    showEditButton
-                  />
-                ))}
-              </div>
-            )}
-          </QueryStateWrapper>
-        </TabsContent>
+            </div>
+          }
+        >
+          {(items) => (
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {items.map((agent) => (
+                <AgentCard
+                  key={agent.id}
+                  agent={agent}
+                  allCapabilities={allCapabilities}
+                  showEditButton
+                />
+              ))}
+            </div>
+          )}
+        </QueryStateWrapper>
+        {hasMoreAgents && (
+          <div className="flex justify-end mt-4">
+            <Link href="/agents/all">
+              <Button variant="outline">
+                All agents
+                <ArrowRight className="w-4 h-4 ml-2" />
+              </Button>
+            </Link>
+          </div>
+        )}
+      </section>
 
-        <TabsContent value="examples">
-          <QueryStateWrapper
-            isLoading={examplesLoading}
-            error={examplesError}
-            data={filteredExamples}
-            errorMessagePrefix="Failed to load examples"
-            emptyState={
-              <div className="text-center py-12">
-                <p className="text-muted-foreground">
-                  {exampleSearch.trim() ? "No examples match your search" : "No examples available"}
-                </p>
-              </div>
-            }
-          >
-            {(items) => (
-              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-                {items.map((example) => (
-                  <ExampleCard
-                    key={example.slug}
-                    example={example}
-                    allCapabilities={allCapabilities}
-                    onUse={handleUse}
-                    adopting={adoptingSlug === example.slug}
-                  />
-                ))}
-              </div>
-            )}
-          </QueryStateWrapper>
-        </TabsContent>
-      </Tabs>
+      {/* Divider */}
+      <hr className="border-border" />
+
+      {/* Example Agents Section */}
+      <section>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-xl font-semibold">Example agents</h2>
+        </div>
+        <QueryStateWrapper
+          isLoading={examplesLoading}
+          error={examplesError}
+          data={previewExamples}
+          errorMessagePrefix="Failed to load examples"
+          emptyState={
+            <div className="text-center py-12">
+              <p className="text-muted-foreground">No examples available</p>
+            </div>
+          }
+        >
+          {(items) => (
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {items.map((example) => (
+                <ExampleCard
+                  key={example.slug}
+                  example={example}
+                  allCapabilities={allCapabilities}
+                  onUse={handleUse}
+                  adopting={adoptingSlug === example.slug}
+                />
+              ))}
+            </div>
+          )}
+        </QueryStateWrapper>
+        {hasMoreExamples && (
+          <div className="flex justify-end mt-4">
+            <Link href="/agents/examples">
+              <Button variant="outline">
+                All examples
+                <ArrowRight className="w-4 h-4 ml-2" />
+              </Button>
+            </Link>
+          </div>
+        )}
+      </section>
     </div>
   );
 }

--- a/apps/ui/src/app/(main)/agents/page.tsx
+++ b/apps/ui/src/app/(main)/agents/page.tsx
@@ -124,6 +124,12 @@ export default function AgentsPage() {
                     Create your first agent
                   </Button>
                 </Link>
+                <Link href="/agents/all">
+                  <Button variant="outline">
+                    View all agents
+                    <ArrowRight className="w-4 h-4 ml-2" />
+                  </Button>
+                </Link>
               </div>
             </div>
           }


### PR DESCRIPTION
## What
Replace the tab-based agents/examples layout with a unified single page showing preview grids of both sections, with dedicated "All agents" and "All examples" links to full-list pages.

## Why
The agents page should be one single view showing both user agents and example agents at a glance, rather than hiding one behind a tab. Full lists are accessible via dedicated pages for users who need to browse everything.

## How
- Refactored `/agents` page to show both sections on one page with a 6-item preview limit per section
- Created `/agents/all` page with full agent list, archive filter, and back navigation
- Created `/agents/examples` page with full examples list, search, and back navigation
- "All agents >" and "All examples >" buttons appear when there are more than 6 items
- Removed tab/search state from the main page; search lives on the examples full-list page

## Risk
- Low
- UI-only change, no API or backend changes
- Existing agent card and example card components are reused unchanged

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered