### PR TITLE
chore(config): add shared config crate, unify env-loading pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,6 +1361,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-config"
+version = "0.8.6"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "everruns-core"
 version = "0.8.6"
 dependencies = [
@@ -1371,6 +1378,7 @@ dependencies = [
  "chrono",
  "eventsource-stream",
  "everruns-anthropic",
+ "everruns-config",
  "everruns-gemini",
  "everruns-openai",
  "everruns-openui",
@@ -1621,6 +1629,7 @@ dependencies = [
  "clap",
  "cron",
  "dotenvy",
+ "everruns-config",
  "everruns-core",
  "everruns-durable",
  "everruns-integrations-brave-search",
@@ -1703,6 +1712,7 @@ dependencies = [
  "base64",
  "chrono",
  "everruns-anthropic",
+ "everruns-config",
  "everruns-core",
  "everruns-durable",
  "everruns-gemini",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/internal-protocol",
     "crates/cli",
     "crates/durable",
+    "crates/config",
     "crates/openui",
     "crates/session-sqldb",
     "integrations/docker",

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,0 +1,16 @@
+# Shared configuration helpers
+#
+# Zero internal dependencies — a leaf crate that any workspace member can use.
+# Provides env-var loading helpers and a common ConfigError type so every
+# subsystem config struct doesn't reinvent the same parsing boilerplate.
+
+[package]
+name = "everruns-config"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Shared configuration loading helpers for Everruns"
+
+[dependencies]
+thiserror.workspace = true

--- a/crates/config/src/env.rs
+++ b/crates/config/src/env.rs
@@ -1,0 +1,267 @@
+// Environment variable loading helpers
+//
+// Each function encapsulates the read → parse → fallback pattern that is
+// repeated dozens of times across config structs.
+
+use std::str::FromStr;
+use std::time::Duration;
+
+use crate::ConfigError;
+
+/// Read an env var, parse it to `T`, or return `default`.
+///
+/// Silently falls back on missing or unparseable values — use [`env_required`]
+/// when the caller needs to distinguish those cases.
+pub fn env_or<T: FromStr>(var: &str, default: T) -> T {
+    std::env::var(var)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+/// Read an env var as a `String`, or return `default`.
+pub fn env_string(var: &str, default: &str) -> String {
+    std::env::var(var).unwrap_or_else(|_| default.to_string())
+}
+
+/// Read an env var as a `bool` (`"true"` or `"1"`), or return `default`.
+pub fn env_bool(var: &str, default: bool) -> bool {
+    std::env::var(var)
+        .ok()
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(default)
+}
+
+/// Read an env var as a `Duration` in whole seconds, or return `default`.
+pub fn env_duration_secs(var: &str, default: Duration) -> Duration {
+    std::env::var(var)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or(default)
+}
+
+/// Read an env var as a `Duration` in milliseconds, or return `default`.
+pub fn env_duration_ms(var: &str, default: Duration) -> Duration {
+    std::env::var(var)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(default)
+}
+
+/// Read an optional env var, parsing it to `T`. Returns `None` if the var is
+/// unset or empty.
+pub fn env_opt<T: FromStr>(var: &str) -> Option<T> {
+    std::env::var(var)
+        .ok()
+        .filter(|s| !s.is_empty())
+        .and_then(|v| v.parse().ok())
+}
+
+/// Read a required env var, parsing it to `T`. Returns `Err` if unset or
+/// unparseable.
+pub fn env_required<T: FromStr>(var: &str) -> Result<T, ConfigError> {
+    let value = std::env::var(var).map_err(|_| ConfigError::Missing {
+        var: var.to_string(),
+    })?;
+    value.parse().map_err(|_| ConfigError::Invalid {
+        var: var.to_string(),
+        value: value.clone(),
+        reason: format!("could not parse as {}", std::any::type_name::<T>()),
+    })
+}
+
+/// Read an env var as a comma-separated list of `T`. Returns an empty vec if
+/// the var is unset or empty. Items that fail to parse are silently skipped.
+pub fn env_list<T: FromStr>(var: &str) -> Vec<T> {
+    std::env::var(var)
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            s.split(',')
+                .filter_map(|item| item.trim().parse().ok())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Read an env var as a `String`, or return `None` if unset/empty.
+pub fn env_opt_string(var: &str) -> Option<String> {
+    std::env::var(var).ok().filter(|s| !s.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+
+    // Use a prefix to avoid collisions with real env vars in test runners
+    const PREFIX: &str = "EVERRUNS_CONFIG_TEST_";
+
+    fn set(suffix: &str, val: &str) -> String {
+        let key = format!("{PREFIX}{suffix}");
+        // SAFETY: Tests run single-threaded (cargo test -- --test-threads=1) or
+        // use unique key prefixes so concurrent mutation is safe.
+        unsafe { env::set_var(&key, val) };
+        key
+    }
+
+    fn unset(suffix: &str) -> String {
+        let key = format!("{PREFIX}{suffix}");
+        // SAFETY: see `set` above.
+        unsafe { env::remove_var(&key) };
+        key
+    }
+
+    #[test]
+    fn env_or_present() {
+        let key = set("OR_PRESENT", "42");
+        assert_eq!(env_or::<u32>(&key, 0), 42);
+    }
+
+    #[test]
+    fn env_or_missing() {
+        let key = unset("OR_MISSING");
+        assert_eq!(env_or::<u32>(&key, 7), 7);
+    }
+
+    #[test]
+    fn env_or_unparseable() {
+        let key = set("OR_BAD", "not_a_number");
+        assert_eq!(env_or::<u32>(&key, 99), 99);
+    }
+
+    #[test]
+    fn env_string_present() {
+        let key = set("STR_P", "hello");
+        assert_eq!(env_string(&key, "default"), "hello");
+    }
+
+    #[test]
+    fn env_string_missing() {
+        let key = unset("STR_M");
+        assert_eq!(env_string(&key, "fallback"), "fallback");
+    }
+
+    #[test]
+    fn env_bool_true_variants() {
+        let key = set("BOOL_T", "true");
+        assert!(env_bool(&key, false));
+        let key = set("BOOL_1", "1");
+        assert!(env_bool(&key, false));
+    }
+
+    #[test]
+    fn env_bool_false() {
+        let key = set("BOOL_F", "false");
+        assert!(!env_bool(&key, true));
+    }
+
+    #[test]
+    fn env_bool_missing() {
+        let key = unset("BOOL_M");
+        assert!(env_bool(&key, true));
+    }
+
+    #[test]
+    fn env_duration_secs_present() {
+        let key = set("DUR_S", "10");
+        assert_eq!(
+            env_duration_secs(&key, Duration::from_secs(1)),
+            Duration::from_secs(10)
+        );
+    }
+
+    #[test]
+    fn env_duration_secs_missing() {
+        let key = unset("DUR_S_M");
+        assert_eq!(
+            env_duration_secs(&key, Duration::from_secs(5)),
+            Duration::from_secs(5)
+        );
+    }
+
+    #[test]
+    fn env_duration_ms_present() {
+        let key = set("DUR_MS", "250");
+        assert_eq!(
+            env_duration_ms(&key, Duration::from_millis(100)),
+            Duration::from_millis(250)
+        );
+    }
+
+    #[test]
+    fn env_opt_present() {
+        let key = set("OPT_P", "42");
+        assert_eq!(env_opt::<u32>(&key), Some(42));
+    }
+
+    #[test]
+    fn env_opt_missing() {
+        let key = unset("OPT_M");
+        assert_eq!(env_opt::<u32>(&key), None::<u32>);
+    }
+
+    #[test]
+    fn env_opt_empty() {
+        let key = set("OPT_E", "");
+        assert_eq!(env_opt::<u32>(&key), None::<u32>);
+    }
+
+    #[test]
+    fn env_required_ok() {
+        let key = set("REQ_OK", "100");
+        assert_eq!(env_required::<u32>(&key).unwrap(), 100);
+    }
+
+    #[test]
+    fn env_required_missing() {
+        let key = unset("REQ_M");
+        let err = env_required::<u32>(&key).unwrap_err();
+        assert!(matches!(err, ConfigError::Missing { .. }));
+    }
+
+    #[test]
+    fn env_required_invalid() {
+        let key = set("REQ_BAD", "xyz");
+        let err = env_required::<u32>(&key).unwrap_err();
+        assert!(matches!(err, ConfigError::Invalid { .. }));
+    }
+
+    #[test]
+    fn env_list_present() {
+        let key = set("LIST_P", "1, 2, 3");
+        assert_eq!(env_list::<u32>(&key), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn env_list_missing() {
+        let key = unset("LIST_M");
+        assert_eq!(env_list::<u32>(&key), Vec::<u32>::new());
+    }
+
+    #[test]
+    fn env_list_with_bad_items() {
+        let key = set("LIST_B", "1,bad,3");
+        assert_eq!(env_list::<u32>(&key), vec![1, 3]);
+    }
+
+    #[test]
+    fn env_opt_string_present() {
+        let key = set("OSTR_P", "value");
+        assert_eq!(env_opt_string(&key), Some("value".to_string()));
+    }
+
+    #[test]
+    fn env_opt_string_empty() {
+        let key = set("OSTR_E", "");
+        assert_eq!(env_opt_string(&key), None);
+    }
+
+    #[test]
+    fn env_opt_string_missing() {
+        let key = unset("OSTR_M");
+        assert_eq!(env_opt_string(&key), None);
+    }
+}

--- a/crates/config/src/error.rs
+++ b/crates/config/src/error.rs
@@ -1,0 +1,15 @@
+/// Errors that can occur when loading configuration from environment variables.
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    /// A required environment variable was not set.
+    #[error("required env var {var} is not set")]
+    Missing { var: String },
+
+    /// An environment variable had a value that could not be parsed.
+    #[error("env var {var} has invalid value \"{value}\": {reason}")]
+    Invalid {
+        var: String,
+        value: String,
+        reason: String,
+    },
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,0 +1,15 @@
+// Shared configuration helpers
+//
+// Decision: Helper functions over traits — configs are too heterogeneous for a
+// single trait to add value. Composable functions give the same deduplication
+// with zero abstraction overhead.
+//
+// Decision: No derive macro — the complexity of a proc macro isn't justified
+// for ~49 structs with varying patterns. Plain functions are transparent and
+// easy to audit.
+
+mod env;
+mod error;
+
+pub use env::*;
+pub use error::ConfigError;

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,6 +15,7 @@ description = "Core agent abstractions for Everruns - agent loop, events, tools,
 
 [dependencies]
 # Core dependencies
+everruns-config = { path = "../config" }
 anyhow.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true

--- a/crates/core/src/telemetry.rs
+++ b/crates/core/src/telemetry.rs
@@ -214,26 +214,21 @@ impl TelemetryConfig {
     /// - `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`: Record input/output content (standard OTel)
     /// - `OTEL_RECORD_CONTENT`: Legacy alias for content recording
     pub fn from_env() -> Self {
-        // Check if SDK is disabled via environment variable
-        let sdk_disabled = std::env::var("OTEL_SDK_DISABLED")
-            .map(|v| v.to_lowercase() == "true")
-            .unwrap_or(false);
+        use everruns_config::{env_bool, env_opt_string, env_string};
+
+        let sdk_disabled = env_bool("OTEL_SDK_DISABLED", false);
 
         Self {
-            service_name: std::env::var("OTEL_SERVICE_NAME")
-                .unwrap_or_else(|_| "everruns".to_string()),
-            service_version: std::env::var("OTEL_SERVICE_VERSION").ok(),
-            // Don't configure OTLP endpoint if SDK is disabled
+            service_name: env_string("OTEL_SERVICE_NAME", "everruns"),
+            service_version: env_opt_string("OTEL_SERVICE_VERSION"),
             otlp_endpoint: if sdk_disabled {
                 None
             } else {
-                std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok()
+                env_opt_string("OTEL_EXPORTER_OTLP_ENDPOINT")
             },
-            environment: std::env::var("OTEL_ENVIRONMENT").ok(),
+            environment: env_opt_string("OTEL_ENVIRONMENT"),
             enable_console: true,
-            log_filter: std::env::var("RUST_LOG")
-                .ok()
-                .or_else(|| std::env::var("LOG_LEVEL").ok()),
+            log_filter: env_opt_string("RUST_LOG").or_else(|| env_opt_string("LOG_LEVEL")),
             // Standard OTel env var, with legacy alias fallback
             record_content: std::env::var("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT")
                 .or_else(|_| std::env::var("OTEL_RECORD_CONTENT"))

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -62,6 +62,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 urlencoding = "2"
 git2.workspace = true
 
+everruns-config = { path = "../config" }
 everruns-core = { path = "../core", features = ["openapi", "sqlx"] }
 everruns-macros = { path = "../macros" }
 everruns-integrations-docker = { path = "../../integrations/docker" }

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -4,6 +4,7 @@
 
 use axum::Router;
 use axum::http::HeaderValue;
+use everruns_config::{env_bool, env_list, env_string};
 
 /// Server configuration loaded from environment
 pub struct ServerConfig {
@@ -18,29 +19,16 @@ pub struct ServerConfig {
 impl ServerConfig {
     /// Load server configuration from environment variables
     pub fn from_env() -> Self {
-        let dev_mode = std::env::var("DEV_MODE")
-            .map(|v| v == "true" || v == "1")
-            .unwrap_or(false);
-
-        let api_prefix = std::env::var("API_PREFIX").unwrap_or_default();
-
-        let cors_origins: Vec<HeaderValue> = std::env::var("CORS_ALLOWED_ORIGINS")
-            .ok()
-            .filter(|s| !s.is_empty())
-            .map(|s| s.split(',').filter_map(|s| s.trim().parse().ok()).collect())
-            .unwrap_or_default();
-
-        let addr = std::env::var("ADDR").unwrap_or_else(|_| "0.0.0.0:9000".to_string());
-        let grpc_addr =
-            std::env::var("WORKER_GRPC_ADDR").unwrap_or_else(|_| "0.0.0.0:9001".to_string());
-
         Self {
-            dev_mode,
+            dev_mode: env_bool("DEV_MODE", false),
             no_migrations: false,
-            api_prefix,
-            cors_origins,
-            addr,
-            grpc_addr,
+            api_prefix: std::env::var("API_PREFIX").unwrap_or_default(),
+            cors_origins: env_list::<String>("CORS_ALLOWED_ORIGINS")
+                .into_iter()
+                .filter_map(|s| s.parse::<HeaderValue>().ok())
+                .collect(),
+            addr: env_string("ADDR", "0.0.0.0:9000"),
+            grpc_addr: env_string("WORKER_GRPC_ADDR", "0.0.0.0:9001"),
         }
     }
 }

--- a/crates/server/src/storage/repositories/mod.rs
+++ b/crates/server/src/storage/repositories/mod.rs
@@ -24,6 +24,7 @@ mod users;
 mod tests;
 
 use anyhow::Result;
+use everruns_config::{env_duration_secs, env_or};
 use sqlx::PgPool;
 use sqlx::postgres::PgPoolOptions;
 
@@ -51,24 +52,13 @@ impl DatabasePoolConfig {
     pub fn from_env() -> Self {
         let defaults = Self::default();
         Self {
-            max_connections: std::env::var("DATABASE_POOL_MAX")
-                .ok()
-                .and_then(|v| v.parse().ok())
-                .unwrap_or(defaults.max_connections),
-            min_connections: std::env::var("DATABASE_POOL_MIN")
-                .ok()
-                .and_then(|v| v.parse().ok())
-                .unwrap_or(defaults.min_connections),
-            acquire_timeout: std::env::var("DATABASE_ACQUIRE_TIMEOUT_SECS")
-                .ok()
-                .and_then(|v| v.parse().ok())
-                .map(std::time::Duration::from_secs)
-                .unwrap_or(defaults.acquire_timeout),
-            idle_timeout: std::env::var("DATABASE_IDLE_TIMEOUT_SECS")
-                .ok()
-                .and_then(|v| v.parse().ok())
-                .map(std::time::Duration::from_secs)
-                .unwrap_or(defaults.idle_timeout),
+            max_connections: env_or("DATABASE_POOL_MAX", defaults.max_connections),
+            min_connections: env_or("DATABASE_POOL_MIN", defaults.min_connections),
+            acquire_timeout: env_duration_secs(
+                "DATABASE_ACQUIRE_TIMEOUT_SECS",
+                defaults.acquire_timeout,
+            ),
+            idle_timeout: env_duration_secs("DATABASE_IDLE_TIMEOUT_SECS", defaults.idle_timeout),
         }
     }
 }

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -14,6 +14,7 @@ thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 
+everruns-config = { path = "../config" }
 everruns-core = { path = "../core" }
 everruns-integrations-docker = { path = "../../integrations/docker" }
 everruns-integrations-brave-search = { path = "../../integrations/brave-search" }

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -146,28 +146,19 @@ impl Default for DurableWorkerConfig {
 impl DurableWorkerConfig {
     /// Create configuration from environment variables
     pub fn from_env() -> Self {
-        let worker_id =
-            std::env::var("WORKER_ID").unwrap_or_else(|_| format!("worker-{}", Uuid::now_v7()));
+        use everruns_config::{env_duration_secs, env_or, env_string};
 
-        let grpc_address =
-            std::env::var("WORKER_GRPC_ADDRESS").unwrap_or_else(|_| "127.0.0.1:9001".to_string());
-
-        let max_concurrent = std::env::var("MAX_CONCURRENT_TASKS")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(10);
-
-        let connect_timeout_secs: u64 = std::env::var("WORKER_GRPC_CONNECT_TIMEOUT")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(30);
-
+        let defaults = Self::default();
         Self {
-            worker_id,
-            grpc_address,
-            max_concurrent_tasks: max_concurrent,
-            connect_timeout: Duration::from_secs(connect_timeout_secs),
-            ..Default::default()
+            worker_id: std::env::var("WORKER_ID")
+                .unwrap_or_else(|_| format!("worker-{}", Uuid::now_v7())),
+            grpc_address: env_string("WORKER_GRPC_ADDRESS", "127.0.0.1:9001"),
+            max_concurrent_tasks: env_or("MAX_CONCURRENT_TASKS", 10),
+            connect_timeout: env_duration_secs(
+                "WORKER_GRPC_CONNECT_TIMEOUT",
+                defaults.connect_timeout,
+            ),
+            ..defaults
         }
     }
 }


### PR DESCRIPTION
## Summary

- Introduces `crates/config` (`everruns-config`), a zero-internal-dependency leaf crate providing shared env-var loading helpers (`env_or`, `env_bool`, `env_string`, `env_duration_secs`, `env_opt`, `env_required`, `env_list`, `env_opt_string`) and a common `ConfigError` type
- Migrates 4 representative config structs as proof of concept: `ServerConfig`, `DatabasePoolConfig`, `DurableWorkerConfig`, `TelemetryConfig` — reducing ~4 lines of boilerplate per field to 1
- Establishes the shared pattern for the remaining ~45 config structs to adopt incrementally
- 23 unit tests covering all helpers (edge cases: missing vars, empty strings, parse failures, comma-separated lists)

Closes EVE-119

## Test plan

- [x] `cargo test -p everruns-config` — 23/23 pass
- [x] `cargo build` for all affected crates (server, worker, core)
- [x] `just pre-push` — all checks green (fmt, clippy, lockfile, author)
- [x] No behavior change — identical output for same environment variables