### PR TITLE
fix(cli): show credentials path in status and fix macOS path docs

### DIFF
--- a/crates/cli/src/auth.rs
+++ b/crates/cli/src/auth.rs
@@ -259,16 +259,19 @@ mod tests {
     #[cfg(target_os = "macos")]
     fn test_credentials_path_macos_uses_application_support() {
         let path = credentials_path().unwrap();
-        let path_str = path.to_str().unwrap();
+        let expected_prefix =
+            dirs::config_dir().expect("dirs::config_dir() should succeed on macOS");
         assert!(
-            path_str.contains("Library/Application Support"),
-            "macOS credentials path should use ~/Library/Application Support, got: {}",
-            path_str
+            path.starts_with(&expected_prefix),
+            "macOS credentials path should start with {}, got: {}",
+            expected_prefix.display(),
+            path.display()
         );
         assert!(
-            !path_str.contains(".config"),
-            "macOS credentials path must not use ~/.config, got: {}",
-            path_str
+            path.to_string_lossy()
+                .contains("Library/Application Support"),
+            "macOS credentials path should use ~/Library/Application Support, got: {}",
+            path.display()
         );
     }
 }

--- a/crates/cli/src/auth.rs
+++ b/crates/cli/src/auth.rs
@@ -1,6 +1,7 @@
 // CLI credential management
 //
-// Decision: Credentials stored in ~/.config/everruns/credentials.json
+// Decision: Credentials stored via dirs::config_dir()/everruns/credentials.json
+// (Linux: ~/.config/everruns/, macOS: ~/Library/Application Support/everruns/)
 // Decision: Multi-profile support from day one
 // Decision: EVERRUNS_API_KEY env var always takes precedence
 // Decision: File permissions 0600 on Unix
@@ -252,5 +253,22 @@ mod tests {
         let path = credentials_path().unwrap();
         assert!(path.to_str().unwrap().contains("everruns"));
         assert!(path.to_str().unwrap().ends_with("credentials.json"));
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_credentials_path_macos_uses_application_support() {
+        let path = credentials_path().unwrap();
+        let path_str = path.to_str().unwrap();
+        assert!(
+            path_str.contains("Library/Application Support"),
+            "macOS credentials path should use ~/Library/Application Support, got: {}",
+            path_str
+        );
+        assert!(
+            !path_str.contains(".config"),
+            "macOS credentials path must not use ~/.config, got: {}",
+            path_str
+        );
     }
 }

--- a/crates/cli/src/commands/status.rs
+++ b/crates/cli/src/commands/status.rs
@@ -41,7 +41,18 @@ pub fn run(profile: &str) -> Result<()> {
         }
     } else {
         let path_hint = credentials_path()
-            .map(|p| format!(" (looked in {})", p.display()))
+            .map(|p| {
+                let display = if let Some(home) = dirs::home_dir() {
+                    if let Ok(rel) = p.strip_prefix(&home) {
+                        format!("~/{}", rel.display())
+                    } else {
+                        p.display().to_string()
+                    }
+                } else {
+                    p.display().to_string()
+                };
+                format!(" (looked in {})", display)
+            })
             .unwrap_or_default();
         eprintln!(
             "Not logged in. Run `everruns login` to authenticate.{}",

--- a/crates/cli/src/commands/status.rs
+++ b/crates/cli/src/commands/status.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 
-use crate::auth::CredentialStore;
+use crate::auth::{CredentialStore, credentials_path};
 
 pub fn run(profile: &str) -> Result<()> {
     let store = CredentialStore::load().unwrap_or_default();
@@ -40,7 +40,13 @@ pub fn run(profile: &str) -> Result<()> {
             println!("Org:     {}", org_id);
         }
     } else {
-        eprintln!("Not logged in. Run `everruns login` to authenticate.");
+        let path_hint = credentials_path()
+            .map(|p| format!(" (looked in {})", p.display()))
+            .unwrap_or_default();
+        eprintln!(
+            "Not logged in. Run `everruns login` to authenticate.{}",
+            path_hint
+        );
         std::process::exit(1);
     }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3,7 +3,7 @@
 // Design Decision: Use clap derive for ergonomic argument parsing.
 // Design Decision: Support text/json/yaml output formats for scripting.
 // Design Decision: Use everruns-sdk for API client.
-// Design Decision: Credential file (~/.config/everruns/credentials.json) with env var override.
+// Design Decision: Credential file (platform config dir/everruns/credentials.json) with env var override.
 
 mod auth;
 mod commands;

--- a/specs/authentication.md
+++ b/specs/authentication.md
@@ -57,7 +57,7 @@ Interactive CLI authentication via `everruns login`. Flow:
 6. CLI receives code, redirects browser to `/cli/login-success` (branded success page)
 7. CLI calls `POST /v1/auth/cli/exchange` with code + hostname + os
 8. Server creates API key with metadata, returns key + user + orgs
-9. CLI prompts for org selection (if multiple), stores credentials in `~/.config/everruns/credentials.json`
+9. CLI prompts for org selection (if multiple), stores credentials in platform config dir (`~/.config/everruns/` on Linux, `~/Library/Application Support/everruns/` on macOS)
 
 Endpoints: `POST /v1/auth/cli/start`, `GET /v1/auth/cli/callback`, `POST /v1/auth/cli/exchange`, `GET /cli/login-success`
 

--- a/specs/authentication.md
+++ b/specs/authentication.md
@@ -57,7 +57,7 @@ Interactive CLI authentication via `everruns login`. Flow:
 6. CLI receives code, redirects browser to `/cli/login-success` (branded success page)
 7. CLI calls `POST /v1/auth/cli/exchange` with code + hostname + os
 8. Server creates API key with metadata, returns key + user + orgs
-9. CLI prompts for org selection (if multiple), stores credentials in platform config dir (`~/.config/everruns/` on Linux, `~/Library/Application Support/everruns/` on macOS)
+9. CLI prompts for org selection (if multiple), stores credentials in the platform config file (`~/.config/everruns/credentials.json` on Linux, `~/Library/Application Support/everruns/credentials.json` on macOS)
 
 Endpoints: `POST /v1/auth/cli/start`, `GET /v1/auth/cli/callback`, `POST /v1/auth/cli/exchange`, `GET /cli/login-success`
 

--- a/specs/cli.md
+++ b/specs/cli.md
@@ -14,7 +14,7 @@
 **Configuration (precedence order):**
 1. CLI flags (`--api-key`, `--api-url`)
 2. Environment variables (`EVERRUNS_API_KEY`, `EVERRUNS_API_URL`)
-3. Credential file (`~/.config/everruns/credentials.json`)
+3. Credential file (`<config_dir>/everruns/credentials.json` — Linux: `~/.config/everruns/`, macOS: `~/Library/Application Support/everruns/`)
 
 **Credential File:**
 - Multi-profile support: `{ "profiles": { "default": { "api_url", "api_key", "org_id" } }, "current_profile": "default" }`


### PR DESCRIPTION
## Summary

- `everruns status` now prints the credentials file path when not logged in, so macOS users can see it looked in `~/Library/Application Support/everruns/` (not `~/.config/everruns/`)
- Fixed misleading comments and specs that hardcoded `~/.config/everruns/` — the Linux-only path — causing macOS users to write credentials to the wrong location
- Added a `cfg(target_os = "macos")` test asserting the path uses `Library/Application Support`

**Root cause:** The code correctly uses `dirs::config_dir()` (platform-aware), but all documentation referenced `~/.config/everruns/`. macOS users who manually placed credentials at `~/.config/everruns/` got a silent "Not logged in" from `everruns status` with no hint about where it actually looked.

## Test plan

- [x] `cargo test -p everruns-cli` passes
- [x] `cargo clippy -p everruns-cli` clean
- [x] `just pre-push` passes
- [ ] On macOS: `everruns status` (not logged in) prints `~/Library/Application Support/everruns/credentials.json` in the error message
- [ ] On Linux: `everruns status` (not logged in) prints `~/.config/everruns/credentials.json` in the error message