### PR TITLE
fix(cli): fix four CLI bugs — streaming, upsert, capabilities list, optional harness

### DIFF
--- a/crates/cli/src/commands/agents.rs
+++ b/crates/cli/src/commands/agents.rs
@@ -54,6 +54,8 @@ pub enum AgentsCommand {
 /// Agent definition from YAML/JSON file
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AgentFile {
+    /// Agent ID for upsert. When present, uses apply (create-or-update).
+    pub id: Option<String>,
     pub name: Option<String>,
     pub description: Option<String>,
     pub system_prompt: Option<String>,
@@ -211,13 +213,23 @@ async fn create(
         req = req.tags(final_tags);
     }
 
-    let agent = client.agents().create_with_options(req).await?;
+    let agent = if let Some(id) = &file_config.id {
+        client.agents().apply_with_options(id, req).await?
+    } else {
+        client.agents().create_with_options(req).await?
+    };
+
+    let verb = if file_config.id.is_some() {
+        "Applied"
+    } else {
+        "Created"
+    };
 
     if output.is_text() {
         if quiet {
             println!("{}", agent.id);
         } else {
-            println!("Created agent: {}", agent.id);
+            println!("{} agent: {}", verb, agent.id);
             print_field("Name", &agent.name);
         }
     } else {
@@ -412,9 +424,39 @@ tags:
         let yaml = "name: minimal";
         let result: AgentFile = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(result.name, Some("minimal".to_string()));
+        assert_eq!(result.id, None);
         assert_eq!(result.description, None);
         assert_eq!(result.system_prompt, None);
         assert_eq!(result.default_model_id, None);
         assert!(result.tags.is_empty());
+    }
+
+    #[test]
+    fn test_agent_file_with_id() {
+        let yaml = r#"
+id: "agent_abc123"
+name: "upsert-agent"
+system_prompt: "You help."
+"#;
+        let result: AgentFile = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(result.id, Some("agent_abc123".to_string()));
+        assert_eq!(result.name, Some("upsert-agent".to_string()));
+    }
+
+    #[test]
+    fn test_parse_markdown_frontmatter_with_id() {
+        let content = r#"---
+id: "agent_abc123"
+name: "test-agent"
+---
+You are a helpful assistant."#;
+
+        let result = parse_markdown_frontmatter(content).unwrap();
+        assert_eq!(result.id, Some("agent_abc123".to_string()));
+        assert_eq!(result.name, Some("test-agent".to_string()));
+        assert_eq!(
+            result.system_prompt,
+            Some("You are a helpful assistant.".to_string())
+        );
     }
 }

--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -3,6 +3,7 @@
 // Design Decision: Use raw reqwest for event polling instead of SDK's events().list()
 // because the server's ListResponse for events only has `data` while the SDK's
 // ListResponse expects `total`, `offset`, `limit` — causing deserialization failures.
+// TODO(sdk): Switch back to client.events().list() once https://github.com/everruns/sdk/issues/63 lands.
 
 use crate::output::OutputFormat;
 use anyhow::Result;

--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -1,12 +1,38 @@
 // Chat command - send message and stream response
+//
+// Design Decision: Use raw reqwest for event polling instead of SDK's events().list()
+// because the server's ListResponse for events only has `data` while the SDK's
+// ListResponse expects `total`, `offset`, `limit` — causing deserialization failures.
 
 use crate::output::OutputFormat;
 use anyhow::Result;
 use everruns_sdk::Everruns;
+use serde::Deserialize;
 use std::time::{Duration, Instant};
 
+/// Minimal event response matching what the server actually returns.
+/// The server's ListResponse only contains `data` (no total/offset/limit),
+/// which differs from the SDK's ListResponse that requires those fields.
+#[derive(Debug, Deserialize)]
+struct EventsResponse {
+    data: Vec<EventEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EventEntry {
+    id: String,
+    #[serde(rename = "type")]
+    event_type: String,
+    ts: String,
+    session_id: String,
+    data: serde_json::Value,
+}
+
+#[allow(clippy::too_many_arguments)]
 pub async fn run(
     client: &Everruns,
+    api_url: &str,
+    api_key: &str,
     output: OutputFormat,
     quiet: bool,
     message: String,
@@ -32,6 +58,9 @@ pub async fn run(
     let mut last_event_id: Option<String> = None;
     let mut agent_content = String::new();
 
+    // Build a raw HTTP client for event polling to avoid SDK ListResponse mismatch
+    let http = reqwest::Client::new();
+
     loop {
         if start.elapsed() > timeout {
             if output.is_text() {
@@ -40,8 +69,19 @@ pub async fn run(
             anyhow::bail!("Timeout waiting for response");
         }
 
-        // Fetch events
-        let response = client.events().list(&session_id).await?;
+        // Fetch events via raw HTTP to avoid SDK deserialization issues
+        let url = format!(
+            "{}/v1/sessions/{}/events",
+            api_url.trim_end_matches('/'),
+            session_id
+        );
+        let response: EventsResponse = http
+            .get(&url)
+            .header("Authorization", api_key)
+            .send()
+            .await?
+            .json()
+            .await?;
 
         // Filter events since last seen
         let events: Vec<_> = if let Some(ref last_id) = last_event_id {

--- a/crates/cli/src/commands/sessions.rs
+++ b/crates/cli/src/commands/sessions.rs
@@ -1,19 +1,17 @@
 // Session management commands
-//
-// TODO(sdk): Replace raw reqwest in create() with SDK once it supports harness_id parameter.
 
 use crate::output::{OutputFormat, print_field, print_table_header, print_table_row};
 use anyhow::Result;
 use clap::Subcommand;
-use everruns_sdk::Everruns;
+use everruns_sdk::{CreateSessionRequest, Everruns};
 
 #[derive(Subcommand)]
 pub enum SessionsCommand {
     /// Create a new session
     Create {
-        /// Harness ID (e.g. harness_xxx)
+        /// Harness ID (e.g. harness_xxx). Omit to use org default.
         #[arg(long, short = 'H')]
-        harness: String,
+        harness: Option<String>,
 
         /// Agent ID (optional, e.g. agent_xxx)
         #[arg(long, short)]
@@ -41,8 +39,6 @@ pub enum SessionsCommand {
 pub async fn run(
     command: SessionsCommand,
     client: &Everruns,
-    api_url: &str,
-    api_key: &str,
     output: OutputFormat,
     quiet: bool,
 ) -> Result<()> {
@@ -52,71 +48,47 @@ pub async fn run(
             agent,
             title,
             model,
-        } => {
-            create(
-                api_url, api_key, output, quiet, harness, agent, title, model,
-            )
-            .await
-        }
+        } => create(client, output, quiet, harness, agent, title, model).await,
         SessionsCommand::List => list(client, output).await,
         SessionsCommand::Get { session } => get(client, output, session).await,
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 async fn create(
-    api_url: &str,
-    api_key: &str,
+    client: &Everruns,
     output: OutputFormat,
     quiet: bool,
-    harness_id: String,
+    harness_id: Option<String>,
     agent_id: Option<String>,
     title: Option<String>,
     model_id: Option<String>,
 ) -> Result<()> {
-    // SDK doesn't support harness_id yet, use reqwest directly
-    let mut body = serde_json::json!({
-        "harness_id": harness_id,
-    });
+    let mut req = CreateSessionRequest::new();
+    if let Some(h) = harness_id {
+        req = req.harness_id(h);
+    }
     if let Some(a) = agent_id {
-        body["agent_id"] = serde_json::Value::String(a);
+        req = req.agent_id(a);
     }
     if let Some(t) = title {
-        body["title"] = serde_json::Value::String(t);
+        req = req.title(t);
     }
     if let Some(m) = model_id {
-        body["model_id"] = serde_json::Value::String(m);
+        req = req.model_id(m);
     }
 
-    let http = reqwest::Client::new();
-    let url = format!("{}/v1/sessions", api_url.trim_end_matches('/'));
-    let resp = http
-        .post(&url)
-        .header("Authorization", api_key)
-        .header("Content-Type", "application/json")
-        .json(&body)
-        .send()
-        .await?;
-
-    if !resp.status().is_success() {
-        let status = resp.status();
-        let text = resp.text().await.unwrap_or_default();
-        anyhow::bail!("Failed to create session: {} {}", status, text);
-    }
-
-    let session: serde_json::Value = resp.json().await?;
+    let session = client.sessions().create_with_options(req).await?;
 
     if output.is_text() {
-        let id = session["id"].as_str().unwrap_or("unknown");
         if quiet {
-            println!("{}", id);
+            println!("{}", session.id);
         } else {
-            println!("Created session: {}", id);
-            if let Some(agent) = session["agent_id"].as_str() {
+            println!("Created session: {}", session.id);
+            if let Some(agent) = &session.agent_id {
                 print_field("Agent", agent);
             }
-            let status = session["status"].as_str().unwrap_or("unknown");
-            print_field("Status", status);
+            let status = format!("{:?}", session.status).to_lowercase();
+            print_field("Status", &status);
         }
     } else {
         output.print_value(&session);

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -68,11 +68,10 @@ pub enum Commands {
         command: commands::agents::AgentsCommand,
     },
 
-    /// List available capabilities
+    /// Manage capabilities
     Capabilities {
-        /// Filter by status
-        #[arg(long, default_value = "available", value_parser = ["available", "coming_soon", "all"])]
-        status: String,
+        #[command(subcommand)]
+        command: Option<CapabilitiesCommand>,
     },
 
     /// Manage sessions
@@ -110,6 +109,16 @@ pub enum Commands {
 pub enum OrgsCommand {
     /// Interactive organization picker
     Select,
+}
+
+#[derive(Subcommand)]
+pub enum CapabilitiesCommand {
+    /// List available capabilities
+    List {
+        /// Filter by status
+        #[arg(long, default_value = "available", value_parser = ["available", "coming_soon", "all"])]
+        status: String,
+    },
 }
 
 #[tokio::main]
@@ -153,19 +162,15 @@ async fn main() -> anyhow::Result<()> {
         Commands::Agents { command } => {
             commands::agents::run(command, &client, output_format, cli.quiet).await
         }
-        Commands::Capabilities { status } => {
+        Commands::Capabilities { command } => {
+            let status = match &command {
+                Some(CapabilitiesCommand::List { status }) => status.clone(),
+                None => "available".to_string(),
+            };
             commands::capabilities::run(&api_url, &api_key, output_format, &status).await
         }
         Commands::Sessions { command } => {
-            commands::sessions::run(
-                command,
-                &client,
-                &api_url,
-                &api_key,
-                output_format,
-                cli.quiet,
-            )
-            .await
+            commands::sessions::run(command, &client, output_format, cli.quiet).await
         }
         Commands::Files { command } => {
             commands::files::run(command, &api_url, &api_key, output_format, cli.quiet).await
@@ -178,6 +183,8 @@ async fn main() -> anyhow::Result<()> {
         } => {
             commands::chat::run(
                 &client,
+                &api_url,
+                &api_key,
                 output_format,
                 cli.quiet,
                 message,
@@ -243,10 +250,24 @@ mod tests {
                 model,
             } = command
             {
-                assert_eq!(harness, "harness_abc");
+                assert_eq!(harness, Some("harness_abc".to_string()));
                 assert_eq!(agent, Some("agt_abc".to_string()));
                 assert_eq!(title, Some("Test Session".to_string()));
                 assert_eq!(model, None);
+            } else {
+                panic!("Expected Create command");
+            }
+        } else {
+            panic!("Expected Sessions command");
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_sessions_create_no_harness() {
+        let cli = Cli::try_parse_from(["everruns", "sessions", "create"]).unwrap();
+        if let Commands::Sessions { command } = cli.command {
+            if let commands::sessions::SessionsCommand::Create { harness, .. } = command {
+                assert_eq!(harness, None); // org default
             } else {
                 panic!("Expected Create command");
             }
@@ -323,19 +344,39 @@ mod tests {
     }
 
     #[test]
-    fn test_cli_parse_capabilities() {
+    fn test_cli_parse_capabilities_bare() {
         let cli = Cli::try_parse_from(["everruns", "capabilities"]).unwrap();
-        if let Commands::Capabilities { status } = cli.command {
-            assert_eq!(status, "available"); // default
+        if let Commands::Capabilities { command } = cli.command {
+            assert!(command.is_none()); // bare defaults to list with available
         } else {
             panic!("Expected Capabilities command");
         }
+    }
 
-        let cli = Cli::try_parse_from(["everruns", "capabilities", "--status", "all"]).unwrap();
-        if let Commands::Capabilities { status } = cli.command {
+    #[test]
+    fn test_cli_parse_capabilities_list() {
+        let cli = Cli::try_parse_from(["everruns", "capabilities", "list"]).unwrap();
+        if let Commands::Capabilities {
+            command: Some(CapabilitiesCommand::List { status }),
+        } = cli.command
+        {
+            assert_eq!(status, "available"); // default
+        } else {
+            panic!("Expected Capabilities List command");
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_capabilities_list_status() {
+        let cli =
+            Cli::try_parse_from(["everruns", "capabilities", "list", "--status", "all"]).unwrap();
+        if let Commands::Capabilities {
+            command: Some(CapabilitiesCommand::List { status }),
+        } = cli.command
+        {
             assert_eq!(status, "all");
         } else {
-            panic!("Expected Capabilities command");
+            panic!("Expected Capabilities List command");
         }
     }
 

--- a/scripts/cli-e2e-test.sh
+++ b/scripts/cli-e2e-test.sh
@@ -99,7 +99,7 @@ echo ""
 # Test: Capabilities
 # ========================================
 log_test "capabilities list"
-CAPS_OUTPUT=$($CLI --api-url "$API_URL" capabilities --status all --output json 2>&1) || {
+CAPS_OUTPUT=$($CLI --api-url "$API_URL" capabilities list --status all --output json 2>&1) || {
   log_fail "capabilities list failed"
   echo "$CAPS_OUTPUT"
   exit 1


### PR DESCRIPTION
## Summary

Fixes four CLI bugs reported by users:

- **`everruns chat` streaming crash**: Server event list response lacks `total`/`offset`/`limit` fields that the SDK `ListResponse` requires, causing `missing field total` deserialization error. Fixed by using raw reqwest for event polling (matching the pattern already used by capabilities and files commands).

- **`everruns agents create --file` ignores `id` in frontmatter**: `AgentFile` struct had no `id` field, so the command always created new agents. Added `id` field and when present, calls `apply_with_options()` (upsert) instead of `create_with_options()`.

- **`everruns capabilities` rejects `list` subcommand**: Was a flat command with `--status` flag only. Converted to subcommand-based with `list` subcommand. Bare `everruns capabilities` still works (defaults to listing available).

- **`everruns sessions create` requires `--harness`**: Was `harness: String` (required). Changed to `Option<String>` so users can omit it to use org default. Also migrated from raw reqwest to SDK `CreateSessionRequest` (which already supports optional `harness_id`).

## Test plan

- [x] All 90 unit tests + 20 integration tests pass (`cargo test -p everruns-cli`)
- [x] `just pre-push` passes (fmt, clippy, lockfile)
- [ ] Verify `everruns chat --session <id> "hello"` no longer crashes with missing field error
- [ ] Verify `everruns agents create --file agent.md` upserts when frontmatter contains `id:`
- [ ] Verify `everruns capabilities list` and `everruns capabilities list --status all` work
- [ ] Verify `everruns sessions create` works without `--harness`