### PR TITLE
feat(agents): upsert on import when agent ID exists

### DIFF
--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -725,11 +725,15 @@ pub async fn export_agent(
 /// - Pure YAML
 /// - Pure JSON
 /// - Plain text (treated as system prompt, name auto-generated)
+///
+/// If the file contains an `id` field and an agent with that ID already exists,
+/// the agent is updated (upsert). Returns 201 on create, 200 on update.
 #[utoipa::path(
     post,
     path = "/v1/agents/import",
     request_body(content = String, content_type = "text/plain"),
     responses(
+        (status = 200, description = "Agent updated via import", body = Agent),
         (status = 201, description = "Agent imported successfully", body = Agent),
         (status = 400, description = "Invalid format or input exceeds limits", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
@@ -792,20 +796,34 @@ pub async fn import_agent(
     require_admin_for_high_risk(&org, &request.capabilities, &state.capability_service)?;
 
     let caller = Caller::from(&org);
-    let agent = state
-        .service
-        .create(&caller, client_id, request)
-        .await
-        .map_err(|e| {
-            let msg = e.to_string();
-            if msg.contains("duplicate key") || msg.contains("already exists") {
-                return ErrorResponse::conflict("Agent with this ID already exists");
-            }
-            tracing::error!("Failed to import agent: {}", msg);
-            ErrorResponse::internal_error()
-        })?;
 
-    Ok((StatusCode::CREATED, Json(agent)))
+    // If the file has an ID, upsert (create or update). Otherwise, always create.
+    if let Some(ref id) = client_id {
+        let (agent, was_created) = state
+            .service
+            .upsert(&caller, &id.to_string(), request)
+            .await
+            .map_policy_or_internal("import agent")?;
+
+        let status = if was_created {
+            StatusCode::CREATED
+        } else {
+            StatusCode::OK
+        };
+
+        Ok((status, Json(agent)))
+    } else {
+        let agent = state
+            .service
+            .create(&caller, None, request)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to import agent: {}", e);
+                ErrorResponse::internal_error()
+            })?;
+
+        Ok((StatusCode::CREATED, Json(agent)))
+    }
 }
 
 /// Convert agent to Markdown format with YAML front matter

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -152,7 +152,7 @@
           "agents"
         ],
         "summary": "POST /v1/agents/import - Import agent from Markdown, YAML, or JSON",
-        "description": "Accepts agent definition in multiple formats:\n- Markdown with YAML front matter (if starts with ---)\n- Pure YAML\n- Pure JSON\n- Plain text (treated as system prompt, name auto-generated)",
+        "description": "Accepts agent definition in multiple formats:\n- Markdown with YAML front matter (if starts with ---)\n- Pure YAML\n- Pure JSON\n- Plain text (treated as system prompt, name auto-generated)\n\nIf the file contains an `id` field and an agent with that ID already exists,\nthe agent is updated (upsert). Returns 201 on create, 200 on update.",
         "operationId": "import_agent",
         "requestBody": {
           "content": {
@@ -165,6 +165,16 @@
           "required": true
         },
         "responses": {
+          "200": {
+            "description": "Agent updated via import",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Agent"
+                }
+              }
+            }
+          },
           "201": {
             "description": "Agent imported successfully",
             "content": {


### PR DESCRIPTION
## Summary

- `POST /v1/agents/import` now upserts when the imported file contains an agent `id` that already exists, instead of returning 409 Conflict
- Returns `201 Created` for new agents, `200 OK` for updates
- Files without an `id` field always create a new agent (unchanged behavior)

## Test plan

- [ ] Import agent file with no `id` → 201, new agent created
- [ ] Import agent file with new `id` → 201, agent created with that ID
- [ ] Import agent file with existing `id` → 200, agent updated
- [ ] Import with invalid format → 400
- [ ] Re-export updated agent, verify fields match