### PR TITLE
feat(cli): add install script and just recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -17,6 +17,10 @@ default:
 init:
     ./scripts/lib/setup.sh init
 
+# Install the everruns CLI (pre-built binary or --source)
+install-cli *args:
+    ./scripts/install-cli.sh {{args}}
+
 # Upload example agents from examples/agents/
 upload-agents:
     ./scripts/lib/setup.sh upload-agents

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Install the everruns CLI binary.
+#
+# Modes:
+#   1. Pre-built binary from GitHub Release (default, no Rust needed)
+#   2. Build from source via `cargo install` (fallback, or --source flag)
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/everruns/everruns/main/scripts/install-cli.sh | bash
+#   ./scripts/install-cli.sh                  # latest release binary
+#   ./scripts/install-cli.sh --version v0.9.0 # specific version
+#   ./scripts/install-cli.sh --source         # build from source
+#   INSTALL_DIR=~/.local/bin ./scripts/install-cli.sh
+
+set -euo pipefail
+
+REPO="everruns/everruns"
+BINARY_NAME="everruns"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+VERSION=""
+FROM_SOURCE=false
+
+# --- Parse args ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version) VERSION="$2"; shift 2 ;;
+    --source)  FROM_SOURCE=true; shift ;;
+    --install-dir) INSTALL_DIR="$2"; shift 2 ;;
+    -h|--help)
+      echo "Usage: install-cli.sh [OPTIONS]"
+      echo ""
+      echo "Options:"
+      echo "  --version TAG    Install a specific release (e.g. v0.9.0)"
+      echo "  --source         Build from source via cargo install"
+      echo "  --install-dir DIR  Installation directory (default: /usr/local/bin)"
+      echo "  -h, --help       Show this help"
+      echo ""
+      echo "Environment:"
+      echo "  INSTALL_DIR      Same as --install-dir"
+      exit 0
+      ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+info()  { echo "  → $*"; }
+error() { echo "ERROR: $*" >&2; exit 1; }
+
+# --- Source install ---
+if $FROM_SOURCE; then
+  command -v cargo >/dev/null 2>&1 || error "cargo not found. Install Rust: https://rustup.rs"
+  info "Building from source via cargo install..."
+
+  # If we're inside the repo, use local path
+  if [[ -f "crates/cli/Cargo.toml" ]]; then
+    cargo install --path crates/cli --force
+  else
+    cargo install --git "https://github.com/${REPO}" everruns-cli --force
+  fi
+  info "Installed $(everruns --version)"
+  exit 0
+fi
+
+# --- Detect platform ---
+detect_target() {
+  local os arch
+  os="$(uname -s)"
+  arch="$(uname -m)"
+
+  case "$os" in
+    Darwin)
+      case "$arch" in
+        x86_64)  echo "x86_64-apple-darwin" ;;
+        arm64)   echo "aarch64-apple-darwin" ;;
+        *)       error "Unsupported macOS architecture: $arch" ;;
+      esac
+      ;;
+    Linux)
+      case "$arch" in
+        x86_64)  echo "x86_64-unknown-linux-gnu" ;;
+        *)       error "Unsupported Linux architecture: $arch. Use --source to build from source." ;;
+      esac
+      ;;
+    *)
+      error "Unsupported OS: $os. Use --source to build from source."
+      ;;
+  esac
+}
+
+TARGET="$(detect_target)"
+ARCHIVE="${BINARY_NAME}-${TARGET}.tar.gz"
+
+# --- Resolve version ---
+if [[ -z "$VERSION" ]]; then
+  info "Fetching latest release..."
+  VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"tag_name":\s*"([^"]+)".*/\1/')"
+  [[ -n "$VERSION" ]] || error "Could not determine latest release version"
+fi
+info "Version: $VERSION"
+
+# --- Download ---
+DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARCHIVE}"
+CHECKSUM_URL="${DOWNLOAD_URL}.sha256"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+info "Downloading ${ARCHIVE}..."
+curl -fSL -o "$TMPDIR/$ARCHIVE" "$DOWNLOAD_URL" || error "Download failed. Check that release $VERSION has pre-built binaries for $TARGET."
+
+info "Downloading checksum..."
+if curl -fSL -o "$TMPDIR/${ARCHIVE}.sha256" "$CHECKSUM_URL" 2>/dev/null; then
+  info "Verifying checksum..."
+  cd "$TMPDIR"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c "${ARCHIVE}.sha256"
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -c "${ARCHIVE}.sha256"
+  else
+    info "Warning: no sha256sum/shasum available, skipping verification"
+  fi
+  cd - >/dev/null
+else
+  info "Warning: checksum file not found, skipping verification"
+fi
+
+# --- Extract and install ---
+info "Extracting..."
+tar xzf "$TMPDIR/$ARCHIVE" -C "$TMPDIR"
+
+info "Installing to $INSTALL_DIR..."
+mkdir -p "$INSTALL_DIR"
+if [[ -w "$INSTALL_DIR" ]]; then
+  mv "$TMPDIR/$BINARY_NAME" "$INSTALL_DIR/$BINARY_NAME"
+else
+  sudo mv "$TMPDIR/$BINARY_NAME" "$INSTALL_DIR/$BINARY_NAME"
+fi
+chmod +x "$INSTALL_DIR/$BINARY_NAME"
+
+info "Installed $($INSTALL_DIR/$BINARY_NAME --version) to $INSTALL_DIR/$BINARY_NAME"
+
+# --- PATH check ---
+if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
+  echo ""
+  echo "  Note: $INSTALL_DIR is not in your PATH."
+  echo "  Add it with:  export PATH=\"$INSTALL_DIR:\$PATH\""
+fi

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -19,13 +19,24 @@ BINARY_NAME="everruns"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 VERSION=""
 FROM_SOURCE=false
+CURL_OPTS=(--connect-timeout 10 --max-time 120 --retry 3 --retry-delay 2)
 
 # --- Parse args ---
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --version) VERSION="$2"; shift 2 ;;
+    --version)
+      if [[ $# -lt 2 ]]; then
+        echo "ERROR: --version requires a value (e.g. v0.9.0)" >&2; exit 1
+      fi
+      VERSION="$2"; shift 2
+      ;;
     --source)  FROM_SOURCE=true; shift ;;
-    --install-dir) INSTALL_DIR="$2"; shift 2 ;;
+    --install-dir)
+      if [[ $# -lt 2 ]]; then
+        echo "ERROR: --install-dir requires a directory path" >&2; exit 1
+      fi
+      INSTALL_DIR="$2"; shift 2
+      ;;
     -h|--help)
       echo "Usage: install-cli.sh [OPTIONS]"
       echo ""
@@ -51,13 +62,23 @@ if $FROM_SOURCE; then
   command -v cargo >/dev/null 2>&1 || error "cargo not found. Install Rust: https://rustup.rs"
   info "Building from source via cargo install..."
 
-  # If we're inside the repo, use local path
+  CARGO_ROOT="$(mktemp -d)"
+  trap 'rm -rf "$CARGO_ROOT"' EXIT
+
   if [[ -f "crates/cli/Cargo.toml" ]]; then
-    cargo install --path crates/cli --force
+    cargo install --path crates/cli --root "$CARGO_ROOT" --force
   else
-    cargo install --git "https://github.com/${REPO}" everruns-cli --force
+    cargo install --git "https://github.com/${REPO}" everruns-cli --root "$CARGO_ROOT" --force
   fi
-  info "Installed $(everruns --version)"
+
+  mkdir -p "$INSTALL_DIR"
+  if [[ -w "$INSTALL_DIR" ]]; then
+    mv "$CARGO_ROOT/bin/$BINARY_NAME" "$INSTALL_DIR/$BINARY_NAME"
+  else
+    sudo mv "$CARGO_ROOT/bin/$BINARY_NAME" "$INSTALL_DIR/$BINARY_NAME"
+  fi
+
+  info "Installed $("$INSTALL_DIR/$BINARY_NAME" --version) to $INSTALL_DIR/$BINARY_NAME"
   exit 0
 fi
 
@@ -93,7 +114,7 @@ ARCHIVE="${BINARY_NAME}-${TARGET}.tar.gz"
 # --- Resolve version ---
 if [[ -z "$VERSION" ]]; then
   info "Fetching latest release..."
-  VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"tag_name":\s*"([^"]+)".*/\1/')"
+  VERSION="$(curl -fsSL "${CURL_OPTS[@]}" "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"tag_name":\s*"([^"]+)".*/\1/')"
   [[ -n "$VERSION" ]] || error "Could not determine latest release version"
 fi
 info "Version: $VERSION"
@@ -106,10 +127,10 @@ TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 
 info "Downloading ${ARCHIVE}..."
-curl -fSL -o "$TMPDIR/$ARCHIVE" "$DOWNLOAD_URL" || error "Download failed. Check that release $VERSION has pre-built binaries for $TARGET."
+curl -fSL "${CURL_OPTS[@]}" -o "$TMPDIR/$ARCHIVE" "$DOWNLOAD_URL" || error "Download failed. Check that release $VERSION has pre-built binaries for $TARGET."
 
 info "Downloading checksum..."
-if curl -fSL -o "$TMPDIR/${ARCHIVE}.sha256" "$CHECKSUM_URL" 2>/dev/null; then
+if curl -fSL "${CURL_OPTS[@]}" -o "$TMPDIR/${ARCHIVE}.sha256" "$CHECKSUM_URL" 2>/dev/null; then
   info "Verifying checksum..."
   cd "$TMPDIR"
   if command -v sha256sum >/dev/null 2>&1; then
@@ -129,15 +150,17 @@ info "Extracting..."
 tar xzf "$TMPDIR/$ARCHIVE" -C "$TMPDIR"
 
 info "Installing to $INSTALL_DIR..."
-mkdir -p "$INSTALL_DIR"
-if [[ -w "$INSTALL_DIR" ]]; then
+if [[ -w "$INSTALL_DIR" ]] || [[ -w "$(dirname "$INSTALL_DIR")" ]]; then
+  mkdir -p "$INSTALL_DIR"
   mv "$TMPDIR/$BINARY_NAME" "$INSTALL_DIR/$BINARY_NAME"
+  chmod +x "$INSTALL_DIR/$BINARY_NAME"
 else
+  sudo mkdir -p "$INSTALL_DIR"
   sudo mv "$TMPDIR/$BINARY_NAME" "$INSTALL_DIR/$BINARY_NAME"
+  sudo chmod +x "$INSTALL_DIR/$BINARY_NAME"
 fi
-chmod +x "$INSTALL_DIR/$BINARY_NAME"
 
-info "Installed $($INSTALL_DIR/$BINARY_NAME --version) to $INSTALL_DIR/$BINARY_NAME"
+info "Installed $("$INSTALL_DIR/$BINARY_NAME" --version) to $INSTALL_DIR/$BINARY_NAME"
 
 # --- PATH check ---
 if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then


### PR DESCRIPTION
## Summary

- Adds `scripts/install-cli.sh` — a standalone installer that downloads pre-built CLI binaries from GitHub Releases, verifies SHA-256 checksums, and installs to `/usr/local/bin` (or custom dir). Supports `--source` for cargo-based builds, `--version` for pinned versions, and auto-detects platform (macOS x86/ARM, Linux x86_64).
- Adds `just install-cli` recipe as a convenient wrapper.

Designed to work as a curl-pipe-bash one-liner:
```bash
curl -fsSL https://raw.githubusercontent.com/everruns/everruns/main/scripts/install-cli.sh | bash
```

## Test plan

- [ ] Run `just install-cli --help` — prints usage
- [ ] Run `just install-cli --source` — builds and installs via cargo
- [ ] Verify platform detection on macOS ARM, macOS x86, Linux x86_64
- [ ] Verify checksum validation with a published release