### PR TITLE
feat(core): implement SearchCapable for bashkit indexed search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,8 +429,8 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.1.11"
-source = "git+https://github.com/everruns/bashkit?tag=v0.1.11#3eeedbdfd3a40878252ffb9c1c490013b780adea"
+version = "0.1.12"
+source = "git+https://github.com/everruns/bashkit?tag=v0.1.12#c7765259590a6a7cc3876e2b1bdd224a52c4b73d"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -62,7 +62,7 @@ url = "2"
 fetchkit = "0.1.3"
 
 # Virtual bash interpreter
-bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.1.11" }
+bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.1.12" }
 
 # OpenAPI schema generation (optional, enabled by everruns-server)
 utoipa = { workspace = true, optional = true }

--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -606,7 +606,9 @@ impl FileSystem for SessionFileSystemAdapter {
 // ============================================================================
 
 impl SearchCapable for SessionFileSystemAdapter {
-    fn search_provider(&self, _path: &Path) -> Option<Box<dyn SearchProvider>> {
+    fn search_provider(&self, path: &Path) -> Option<Box<dyn SearchProvider>> {
+        // Only provide indexed search for paths inside /workspace
+        Self::to_session_path(path)?;
         Some(Box::new(SessionSearchProvider {
             session_id: self.session_id,
             store: self.store.clone(),
@@ -616,9 +618,8 @@ impl SearchCapable for SessionFileSystemAdapter {
 
 /// Bridges bashkit's synchronous `SearchProvider` to `SessionFileStore::grep_files`.
 ///
-/// Uses `tokio::task::block_in_place` + `Handle::block_on` to call the async
-/// store method from the sync trait. This is safe because bashkit's builtins
-/// already run inside a tokio runtime context.
+/// Uses a scoped thread with a dedicated tokio runtime to call the async
+/// store method from the sync trait, avoiding nested `block_on` calls.
 struct SessionSearchProvider {
     session_id: SessionId,
     store: Arc<dyn SessionFileStore>,
@@ -628,14 +629,31 @@ impl SearchProvider for SessionSearchProvider {
     fn search(&self, query: &SearchQuery) -> bashkit::Result<SearchResults> {
         let session_id = self.session_id;
         let store = self.store.clone();
-        let pattern = query.pattern.clone();
         let root = query.root.to_string_lossy().into_owned();
         let max_results = query.max_results;
 
-        // Convert root path from bash VFS path to session store path
-        let path_pattern = SessionFileSystemAdapter::to_session_path(Path::new(&root))
-            .map(|p| if p == "/" { None } else { Some(p) })
-            .unwrap_or(None);
+        // Honor case_insensitive flag via inline regex flag
+        let pattern = if query.case_insensitive {
+            format!("(?i){}", query.pattern)
+        } else {
+            query.pattern.clone()
+        };
+
+        // Convert root path from bash VFS path to session store path.
+        // search_provider already guards against paths outside /workspace,
+        // so to_session_path should always succeed here.
+        let session_root =
+            SessionFileSystemAdapter::to_session_path(Path::new(&root)).ok_or_else(|| {
+                bashkit::Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("Path not in workspace: {}", root),
+                ))
+            })?;
+        let path_pattern = if session_root == "/" {
+            None
+        } else {
+            Some(session_root)
+        };
 
         // Bridge async grep_files to sync SearchProvider::search.
         // Run on a dedicated thread with its own runtime to avoid nesting

--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -10,6 +10,8 @@
 //! - Live visibility: files written by other tools are immediately visible
 //! - Resource limits prevent runaway scripts (max commands, loop iterations)
 //! - Context-aware tool that requires session filesystem access
+//! - SearchCapable impl delegates grep to SessionFileStore::grep_files for
+//!   single-query indexed search instead of per-file linear scan
 
 use super::{Capability, CapabilityStatus};
 use crate::session_file::SessionFile;
@@ -19,7 +21,8 @@ use crate::typed_id::SessionId;
 use async_trait::async_trait;
 use bashkit::{
     Bash, BashTool as BashkitTool, DirEntry, ExecutionLimits, FileSystem, FileSystemExt, FileType,
-    Metadata, Tool as BashkitToolTrait,
+    Metadata, SearchCapabilities, SearchCapable, SearchMatch as BashkitSearchMatch, SearchProvider,
+    SearchQuery, SearchResults, Tool as BashkitToolTrait,
 };
 use serde_json::{Value, json};
 use std::path::{Path, PathBuf};
@@ -592,6 +595,98 @@ impl FileSystem for SessionFileSystemAdapter {
         // chmod is a no-op - session filesystem doesn't track permissions
         Ok(())
     }
+
+    fn as_search_capable(&self) -> Option<&dyn SearchCapable> {
+        Some(self)
+    }
+}
+
+// ============================================================================
+// SearchCapable / SearchProvider — indexed search via SessionFileStore
+// ============================================================================
+
+impl SearchCapable for SessionFileSystemAdapter {
+    fn search_provider(&self, _path: &Path) -> Option<Box<dyn SearchProvider>> {
+        Some(Box::new(SessionSearchProvider {
+            session_id: self.session_id,
+            store: self.store.clone(),
+        }))
+    }
+}
+
+/// Bridges bashkit's synchronous `SearchProvider` to `SessionFileStore::grep_files`.
+///
+/// Uses `tokio::task::block_in_place` + `Handle::block_on` to call the async
+/// store method from the sync trait. This is safe because bashkit's builtins
+/// already run inside a tokio runtime context.
+struct SessionSearchProvider {
+    session_id: SessionId,
+    store: Arc<dyn SessionFileStore>,
+}
+
+impl SearchProvider for SessionSearchProvider {
+    fn search(&self, query: &SearchQuery) -> bashkit::Result<SearchResults> {
+        let session_id = self.session_id;
+        let store = self.store.clone();
+        let pattern = query.pattern.clone();
+        let root = query.root.to_string_lossy().into_owned();
+        let max_results = query.max_results;
+
+        // Convert root path from bash VFS path to session store path
+        let path_pattern = SessionFileSystemAdapter::to_session_path(Path::new(&root))
+            .map(|p| if p == "/" { None } else { Some(p) })
+            .unwrap_or(None);
+
+        // Bridge async grep_files to sync SearchProvider::search.
+        // Run on a dedicated thread with its own runtime to avoid nesting
+        // block_on calls within the caller's tokio runtime.
+        let matches = std::thread::scope(|s| {
+            s.spawn(|| {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|e| bashkit::Error::Io(std::io::Error::other(e.to_string())))?;
+                rt.block_on(async {
+                    store
+                        .grep_files(session_id, &pattern, path_pattern.as_deref())
+                        .await
+                })
+                .map_err(|e| bashkit::Error::Io(std::io::Error::other(e.to_string())))
+            })
+            .join()
+            .unwrap_or_else(|_| {
+                Err(bashkit::Error::Io(std::io::Error::other(
+                    "search thread panicked",
+                )))
+            })
+        })?;
+
+        let truncated = max_results.is_some_and(|max| matches.len() > max);
+        let matches: Vec<BashkitSearchMatch> = matches
+            .into_iter()
+            .take(max_results.unwrap_or(usize::MAX))
+            .map(|m| {
+                // Convert session store path back to bash VFS path
+                let vfs_path = format!("{}{}", SessionFileSystemAdapter::WORKSPACE_PREFIX, m.path);
+                BashkitSearchMatch {
+                    path: PathBuf::from(vfs_path),
+                    line_number: m.line_number,
+                    line_content: m.line,
+                }
+            })
+            .collect();
+
+        Ok(SearchResults { matches, truncated })
+    }
+
+    fn capabilities(&self) -> SearchCapabilities {
+        SearchCapabilities {
+            regex: true,
+            glob_filter: false,
+            content_search: true,
+            filename_search: false,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -776,11 +871,38 @@ mod tests {
 
         async fn grep_files(
             &self,
-            _session_id: SessionId,
-            _pattern: &str,
-            _path_pattern: Option<&str>,
+            session_id: SessionId,
+            pattern: &str,
+            path_pattern: Option<&str>,
         ) -> Result<Vec<GrepMatch>> {
-            Ok(vec![])
+            let regex = regex::Regex::new(pattern)
+                .map_err(|e| anyhow::anyhow!("invalid pattern: {}", e))?;
+            let files = self.files.lock().unwrap();
+            let mut matches = Vec::new();
+            for ((sid, file_path), (content, _)) in files.iter() {
+                if *sid != session_id {
+                    continue;
+                }
+                if let Some(pp) = path_pattern
+                    && !file_path.starts_with(pp)
+                {
+                    continue;
+                }
+                let decoded = SessionFile::decode_content(content, "utf-8")
+                    .unwrap_or_else(|_| content.as_bytes().to_vec());
+                let text = String::from_utf8_lossy(&decoded);
+                for (i, line) in text.lines().enumerate() {
+                    if regex.is_match(line) {
+                        matches.push(GrepMatch {
+                            path: file_path.clone(),
+                            line_number: i + 1,
+                            line: line.to_string(),
+                        });
+                    }
+                }
+            }
+            matches.sort_by(|a, b| a.path.cmp(&b.path).then(a.line_number.cmp(&b.line_number)));
+            Ok(matches)
         }
 
         async fn create_directory(&self, session_id: SessionId, path: &str) -> Result<FileInfo> {
@@ -2062,7 +2184,7 @@ mod tests {
     }
 
     // ========================================================================
-    // bashkit API smoke tests (v0.1.10 surface)
+    // bashkit API smoke tests
     // ========================================================================
 
     #[test]
@@ -2146,5 +2268,133 @@ mod tests {
         // Just verify it doesn't panic and returns a valid object
         // The limits are used by both BASHKIT_TOOL and per-execution Bash instances
         let _ = limits;
+    }
+
+    // ========================================================================
+    // SearchCapable / indexed search tests
+    // ========================================================================
+
+    #[test]
+    fn test_adapter_is_search_capable() {
+        let session_id = SessionId::new();
+        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::new());
+        let adapter = SessionFileSystemAdapter::new(session_id, store);
+
+        let sc = adapter.as_search_capable();
+        assert!(
+            sc.is_some(),
+            "SessionFileSystemAdapter should be SearchCapable"
+        );
+
+        let provider = sc.unwrap().search_provider(Path::new("/workspace"));
+        assert!(provider.is_some(), "Should return a SearchProvider");
+
+        let caps = provider.unwrap().capabilities();
+        assert!(caps.content_search, "Should support content search");
+        assert!(caps.regex, "Should support regex patterns");
+    }
+
+    #[tokio::test]
+    async fn test_search_provider_returns_grep_results() {
+        let session_id = SessionId::new();
+        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::new());
+        let adapter = SessionFileSystemAdapter::new(session_id, store.clone());
+
+        // Write files via the adapter
+        adapter
+            .write_file(
+                Path::new("/workspace/hello.txt"),
+                b"hello world\ngoodbye world",
+            )
+            .await
+            .unwrap();
+        adapter
+            .write_file(Path::new("/workspace/other.txt"), b"no match here")
+            .await
+            .unwrap();
+
+        let sc = adapter.as_search_capable().unwrap();
+        let provider = sc.search_provider(Path::new("/workspace")).unwrap();
+
+        let results = provider
+            .search(&SearchQuery {
+                pattern: "hello".into(),
+                is_regex: false,
+                case_insensitive: false,
+                root: PathBuf::from("/workspace"),
+                glob_filter: None,
+                max_results: None,
+            })
+            .unwrap();
+
+        assert_eq!(results.matches.len(), 1);
+        assert_eq!(
+            results.matches[0].path,
+            PathBuf::from("/workspace/hello.txt")
+        );
+        assert_eq!(results.matches[0].line_number, 1);
+        assert_eq!(results.matches[0].line_content, "hello world");
+    }
+
+    #[tokio::test]
+    async fn test_search_provider_truncates_at_max_results() {
+        let session_id = SessionId::new();
+        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::new());
+        let adapter = SessionFileSystemAdapter::new(session_id, store.clone());
+
+        adapter
+            .write_file(
+                Path::new("/workspace/many.txt"),
+                b"match line 1\nmatch line 2\nmatch line 3\nmatch line 4",
+            )
+            .await
+            .unwrap();
+
+        let sc = adapter.as_search_capable().unwrap();
+        let provider = sc.search_provider(Path::new("/workspace")).unwrap();
+
+        let results = provider
+            .search(&SearchQuery {
+                pattern: "match".into(),
+                is_regex: false,
+                case_insensitive: false,
+                root: PathBuf::from("/workspace"),
+                glob_filter: None,
+                max_results: Some(2),
+            })
+            .unwrap();
+
+        assert_eq!(results.matches.len(), 2);
+        assert!(results.truncated);
+    }
+
+    #[tokio::test]
+    async fn test_bash_grep_uses_indexed_search() {
+        let (context, _) = create_context_with_mock_store();
+        let tool = BashTool;
+
+        // Create files
+        tool.execute_with_context(
+            json!({"command": "mkdir -p /workspace/src && echo 'fn main() { println!(\"hello\"); }' > /workspace/src/main.rs && echo 'fn test() {}' > /workspace/src/test.rs"}),
+            &context,
+        )
+        .await;
+
+        // Run grep -r which should use indexed search via SearchCapable
+        let result = tool
+            .execute_with_context(json!({"command": "grep -r 'fn' /workspace/src"}), &context)
+            .await;
+
+        if let ToolExecutionResult::Success(output) = result {
+            assert_eq!(output["exit_code"], 0);
+            let stdout = output["stdout"].as_str().unwrap_or("");
+            assert!(
+                stdout.contains("fn main") || stdout.contains("fn test"),
+                "grep -r should find matches via indexed search, got: {}",
+                stdout
+            );
+        } else {
+            panic!("Expected success result, got: {:?}", result);
+        }
     }
 }

--- a/specs/bashkit-requirements.md
+++ b/specs/bashkit-requirements.md
@@ -1,11 +1,15 @@
 # Bashkit Requirements for Custom FileSystem Adapters
 
-> **Status: IMPLEMENTED** - bashkit now exports the required types and
-> `SessionFileSystemAdapter` has been implemented in `crates/core/src/capabilities/virtual_bash.rs`.
+> **Status: IMPLEMENTED** - bashkit v0.1.12 exports all required types and
+> `SessionFileSystemAdapter` is implemented in `crates/core/src/capabilities/virtual_bash.rs`.
 >
 > **Workspace Mount**: Session files are mounted at `/workspace` in the bash environment.
 > Both `virtual_bash` and `session_file_system` capabilities normalize paths, enabling
 > seamless file sharing between bash commands and file system tools.
+>
+> **Indexed Search**: `SessionFileSystemAdapter` implements bashkit's `SearchCapable` trait,
+> delegating `grep -r` to `SessionFileStore::grep_files` for single-query database search
+> instead of per-file linear scanning.
 
 ## Context
 
@@ -13,135 +17,15 @@ Everruns implements a custom `FileSystem` adapter that bridges bashkit to the se
 
 The implementation is in `crates/core/src/capabilities/virtual_bash.rs` with `SessionFileSystemAdapter`.
 
-## Required Exports
+## Indexed Search
 
-Add to `bashkit/src/lib.rs`:
+Bashkit v0.1.12 restored `SearchCapable`/`SearchProvider` traits. When a `FileSystem` implements `SearchCapable`, builtins like `grep -r` use indexed search instead of reading every file individually.
 
-```rust
-pub use fs::{DirEntry, FileType, Metadata};  // ADD these
-```
+`SessionFileSystemAdapter` implements `SearchCapable` by delegating to `SessionFileStore::grep_files()`, which executes a single SQL query with server-side regex matching. This eliminates N+1 database calls for recursive grep.
 
-### Types Needed
+The sync-to-async bridge uses `std::thread::scope` with a dedicated thread and its own tokio runtime to avoid nesting `block_on` calls.
 
-**1. `FileType`** (from `fs/traits.rs:82-90`)
-```rust
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum FileType {
-    File,
-    Directory,
-    Symlink,
-}
-```
-
-Required for:
-- Implementing `stat()` return value
-- Checking entry types in `read_dir()` results
-
-**2. `Metadata`** (from `fs/traits.rs:54-67`)
-```rust
-#[derive(Debug, Clone)]
-pub struct Metadata {
-    pub file_type: FileType,
-    pub size: u64,
-    pub mode: u32,
-    pub modified: SystemTime,
-    pub created: SystemTime,
-}
-```
-
-Required for:
-- `stat(&self, path: &Path) -> Result<Metadata>`
-- Building `DirEntry` instances
-
-**3. `DirEntry`** (from `fs/traits.rs:109-116`)
-```rust
-#[derive(Debug, Clone)]
-pub struct DirEntry {
-    pub name: String,
-    pub metadata: Metadata,
-}
-```
-
-Required for:
-- `read_dir(&self, path: &Path) -> Result<Vec<DirEntry>>`
-
-## FileSystem Trait Methods
-
-For reference, the full trait that users need to implement:
-
-```rust
-#[async_trait]
-pub trait FileSystem: Send + Sync {
-    async fn read_file(&self, path: &Path) -> Result<Vec<u8>>;
-    async fn write_file(&self, path: &Path, content: &[u8]) -> Result<()>;
-    async fn append_file(&self, path: &Path, content: &[u8]) -> Result<()>;
-    async fn mkdir(&self, path: &Path, recursive: bool) -> Result<()>;
-    async fn remove(&self, path: &Path, recursive: bool) -> Result<()>;
-    async fn stat(&self, path: &Path) -> Result<Metadata>;           // needs Metadata
-    async fn read_dir(&self, path: &Path) -> Result<Vec<DirEntry>>;  // needs DirEntry
-    async fn exists(&self, path: &Path) -> Result<bool>;
-    async fn rename(&self, from: &Path, to: &Path) -> Result<()>;
-    async fn copy(&self, from: &Path, to: &Path) -> Result<()>;
-    async fn symlink(&self, target: &Path, link: &Path) -> Result<()>;
-    async fn read_link(&self, path: &Path) -> Result<PathBuf>;
-    async fn chmod(&self, path: &Path, mode: u32) -> Result<()>;
-}
-```
-
-## Implementation Change
-
-**File:** `crates/bashkit/src/lib.rs`
-
-**Current (line 29):**
-```rust
-pub use fs::{FileSystem, InMemoryFs, MountableFs, OverlayFs};
-```
-
-**Required:**
-```rust
-pub use fs::{DirEntry, FileSystem, FileType, InMemoryFs, Metadata, MountableFs, OverlayFs};
-```
-
-## Use Case: Session FileSystem Adapter
-
-Once exported, Everruns can implement:
-
-```rust
-use bashkit::{DirEntry, FileSystem, FileType, Metadata, Result};
-
-pub struct SessionFileSystemAdapter {
-    session_id: SessionId,
-    store: Arc<dyn SessionFileStore>,
-}
-
-#[async_trait]
-impl FileSystem for SessionFileSystemAdapter {
-    async fn read_file(&self, path: &Path) -> Result<Vec<u8>> {
-        // Delegate to SessionFileStore::read_file
-    }
-
-    async fn write_file(&self, path: &Path, content: &[u8]) -> Result<()> {
-        // Delegate to SessionFileStore::write_file
-    }
-
-    async fn stat(&self, path: &Path) -> Result<Metadata> {
-        // Build Metadata from SessionFile info
-        Ok(Metadata {
-            file_type: FileType::File,
-            size: content.len() as u64,
-            mode: 0o644,
-            modified: SystemTime::now(),
-            created: SystemTime::now(),
-        })
-    }
-
-    async fn read_dir(&self, path: &Path) -> Result<Vec<DirEntry>> {
-        // Map SessionFileStore::list_directory to Vec<DirEntry>
-    }
-
-    // ... other methods
-}
-```
+See `crates/core/src/capabilities/virtual_bash.rs` for the full implementation.
 
 ## Benefits
 
@@ -149,14 +33,4 @@ impl FileSystem for SessionFileSystemAdapter {
 2. **No sync overhead** - Eliminates pre/post execution sync of entire filesystem
 3. **Memory efficiency** - Files read on-demand instead of loading all into memory
 4. **Consistency** - Single source of truth for file state
-
-## Backward Compatibility
-
-This is a purely additive change - only adds new exports. No breaking changes.
-
-## Priority
-
-Medium - Current sync-based approach works for most use cases. This optimization matters for:
-- Long-running bash scripts
-- Concurrent tool execution
-- Large session filesystems
+5. **Indexed search** - `grep -r` uses single-query database search instead of per-file reads


### PR DESCRIPTION
## What
Bump bashkit from v0.1.11 to v0.1.12 and implement `SearchCapable` on `SessionFileSystemAdapter` so that bashkit's `grep -r` uses single-query database search instead of per-file linear scanning.

## Why
When an agent runs `grep -r pattern /workspace`, bashkit's grep builtin was walking the directory tree via `read_dir` and reading every file individually — each call hitting the database. With `SearchCapable`, grep delegates to `SessionFileStore::grep_files()` which executes a single SQL query with server-side regex matching.

## How
- Bump bashkit to v0.1.12 which restores `SearchCapable`/`SearchProvider` traits (removed in v0.1.11 as dead code, re-added in v0.1.12 for this use case)
- `SessionFileSystemAdapter` now implements `SearchCapable`, returning a `SessionSearchProvider`
- `SessionSearchProvider` bridges the sync `SearchProvider::search` to the async `SessionFileStore::grep_files` via a scoped thread with its own tokio runtime
- Path translation between bash VFS (`/workspace/...`) and session store paths (`/...`) handled automatically
- Updated `specs/bashkit-requirements.md` to reflect indexed search integration

## Risk
- Low
- The `as_search_capable()` override is opt-in — bashkit falls back to linear scan if the provider returns an error or `None`
- Sync-to-async bridge spawns a scoped thread per search call; acceptable since grep -r is already an expensive operation

## Checklist
- [x] Tests added or updated (3 new search tests + enriched mock grep_files)
- [x] Backward compatibility considered (purely additive — no API/schema changes)
