### PR TITLE
chore(ship): add structured security review and enforce review comment resolution

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -34,7 +34,7 @@ Use this skill when the user asks to:
    - Validation must match risk. For bugs, prefer a failing test first when practical.
 3. The changed code is fit to merge.
    - Simplify obvious duplication or accidental complexity.
-   - Review touched areas for auth, input validation, data exposure, injection, dependency, and performance risk.
+   - Perform a structured security review (see **Security Review** section below).
    - Fix issues you find and refresh the evidence.
 4. Relevant artifacts stay in sync.
    - Update only the artifacts affected by the change: `specs/`, `specs/threat-model.md`, `AGENTS.md`, `test_cases/`, `apps/docs/`, and OpenAPI exports when applicable.
@@ -49,11 +49,10 @@ Use this skill when the user asks to:
    - Create or update the PR with `.github/pull_request_template.md`.
    - Check the PR conversation, review threads, and review state from all reviewers, including bots.
    - After each push and again after CI turns green, wait at least 2 minutes for async reviewer bots to finish, then re-check for new comments before merge.
-   - Address actionable review comments with code or doc changes, or reply with the resolution when no code change is needed.
-   - Analyze **all** review comments, including non-blocking ones (COMMENTED state, bot suggestions). Non-blocking comments often contain valid improvements (UX, robustness, doc clarity). Evaluate each on merit and fix worthwhile ones before merge — do not dismiss comments solely because they are non-blocking.
-   - Do not merge while substantive review feedback is still outstanding.
+   - **Address every review comment** — including low-confidence suggestions, nits, non-blocking ones (COMMENTED state), and bot suggestions. Non-blocking comments often contain valid improvements (UX, robustness, doc clarity). For each comment: analyze the concern, reason about whether a code change is warranted, and either apply the fix or reply with a clear explanation of why the current code is correct. Do not dismiss comments without reasoning.
+   - Do not merge while any review comment is unresolved. Every thread must be explicitly addressed (code change or written resolution) before merge.
    - Wait for CI to go green.
-   - Merge with squash only after CI is green and the final review/comment sweep above is clean.
+   - Merge with squash only after CI is green, all review threads are resolved, and the final review/comment sweep above is clean.
 
 ## Operating Model
 
@@ -64,6 +63,43 @@ Use this skill when the user asks to:
 - Do not use auto-merge or `gh pr merge --auto`; merge manually only after the final review sweep is clean because async review bots can post after the last push or after CI turns green.
 - If `just fmt` can auto-fix a failing formatting check, use it once and retry.
 - Stop only for blockers you cannot safely resolve alone: merge conflicts, missing credentials, ambiguous product intent, or CI failures you cannot reproduce or fix.
+
+## Security Review
+
+**This is a mandatory step for every change that touches code, configuration, or infrastructure. It is not optional and must not be skipped based on perceived low risk.**
+
+For every shipped change, explicitly perform these steps:
+
+1. **Identify the threat surface.** Read `git diff origin/main...HEAD` and determine which threat model categories from [`specs/threat-model.md`](../../../specs/threat-model.md) the change touches. Common categories:
+   - `TM-AUTH` — authentication changes, session handling, token generation
+   - `TM-AUTHZ` — permission checks, policy enforcement, role changes
+   - `TM-API` — new/changed endpoints, input parsing, query parameters
+   - `TM-TOOL` — tool registration, MCP servers, tool execution paths
+   - `TM-LLM` — prompt construction, API key handling, model parameters
+   - `TM-TENANT` — data queries, org scoping, cross-tenant boundaries
+   - `TM-FS` / `TM-SQL` — file paths, database queries, sandbox boundaries
+   - `TM-BASH` — sandbox configuration, command execution
+   - `TM-WEB` — frontend rendering, CORS, CSP, cookie handling
+   - `TM-DOS` — unbounded inputs, missing pagination, resource limits
+
+2. **Review each touched category.** For every relevant category, check the diff for:
+   - **Injection** — SQL, command, prompt, XSS, path traversal
+   - **Authentication/Authorization bypass** — missing auth checks, broken access control
+   - **Data exposure** — sensitive data in logs, responses, errors, or traces
+   - **Input validation** — missing or insufficient validation at trust boundaries
+   - **Dependency risk** — new dependencies, version changes, supply chain
+   - **Resource exhaustion** — unbounded loops, missing limits, large allocations
+
+3. **Check for THREAT comments.** If the change modifies code near existing `// THREAT[TM-XXX-NNN]` comments, verify the mitigation is preserved. If the change introduces new threat surface, add appropriate `THREAT` comments.
+
+4. **Update the threat model.** If the change introduces a genuinely new threat or materially changes an existing mitigation, update `specs/threat-model.md` with new entries or revised mitigations. Do not skip this for "small" changes — small changes at trust boundaries can have outsized impact.
+
+5. **Document the review.** Include a **Security** section in the PR body listing:
+   - Which threat categories were reviewed
+   - Any findings and how they were addressed
+   - Explicit statement if no security-relevant surface was touched (with reasoning)
+
+Changes that are purely docs, comments, specs, or test-only may state "No security-relevant code changes" with a one-line justification instead of the full review.
 
 ## Common Evidence Commands
 

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -77,7 +77,8 @@ For every shipped change, explicitly perform these steps:
    - `TM-TOOL` — tool registration, MCP servers, tool execution paths
    - `TM-LLM` — prompt construction, API key handling, model parameters
    - `TM-TENANT` — data queries, org scoping, cross-tenant boundaries
-   - `TM-FS` / `TM-SQL` — file paths, database queries, sandbox boundaries
+   - `TM-FS` — file paths, sandbox boundaries
+   - `TM-SQL` — database queries, sandbox boundaries
    - `TM-BASH` — sandbox configuration, command execution
    - `TM-WEB` — frontend rendering, CORS, CSP, cookie handling
    - `TM-DOS` — unbounded inputs, missing pagination, resource limits

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,12 @@ High-level approach.
 - Low / Medium / High
 - What can break
 
+## Security
+- Threat categories reviewed: (e.g. TM-AUTH, TM-API, or "No security-relevant code changes" with justification)
+- Findings and resolutions:
+
 ## Checklist
 - [ ] Tests added or updated
 - [ ] Backward compatibility considered
+- [ ] Security review performed against relevant threat model categories
+- [ ] All review comments addressed (code change or written reasoning)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,9 +207,9 @@ If checks fail, auto-fix with `just fmt`, then re-run `just pre-push`.
 
 ### Shipping
 
-"Ship" means: achieve the requested goal, produce enough evidence that it works, create a mergeable PR, and merge only after CI is green.
+"Ship" means: achieve the requested goal, produce enough evidence that it works, perform a structured security review, create a mergeable PR, address every review comment, and merge only after CI is green.
 
-Use [`/ship`](.claude/skills/ship/SKILL.md) for the canonical shipping workflow. It is an invokable skill and intentionally goal-oriented: start from the goal and changed risk surface, choose the smallest evidence that proves the change, and expand only when risk demands it.
+Use [`/ship`](.claude/skills/ship/SKILL.md) for the canonical shipping workflow. It is an invokable skill and intentionally goal-oriented: start from the goal and changed risk surface, choose the smallest evidence that proves the change, and expand only when risk demands it. Security review against `specs/threat-model.md` categories is mandatory for all code changes.
 
 See [`specs/shipping.md`](specs/shipping.md) for the shipping success bar and constraints. When asked to "fix and ship", implement the fix first, then run `/ship`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,7 +209,7 @@ If checks fail, auto-fix with `just fmt`, then re-run `just pre-push`.
 
 "Ship" means: achieve the requested goal, produce enough evidence that it works, perform a structured security review, create a mergeable PR, address every review comment, and merge only after CI is green.
 
-Use [`/ship`](.claude/skills/ship/SKILL.md) for the canonical shipping workflow. It is an invokable skill and intentionally goal-oriented: start from the goal and changed risk surface, choose the smallest evidence that proves the change, and expand only when risk demands it. Security review against `specs/threat-model.md` categories is mandatory for all code changes.
+Use [`/ship`](.claude/skills/ship/SKILL.md) for the canonical shipping workflow. It is an invokable skill and intentionally goal-oriented: start from the goal and changed risk surface, choose the smallest evidence that proves the change, and expand only when risk demands it. Security review against `specs/threat-model.md` categories is mandatory for all code, configuration, and infrastructure changes.
 
 See [`specs/shipping.md`](specs/shipping.md) for the shipping success bar and constraints. When asked to "fix and ship", implement the fix first, then run `/ship`.
 

--- a/specs/shipping.md
+++ b/specs/shipping.md
@@ -34,10 +34,10 @@ Relevant references:
 
 1. Safe branch state: no shipping from `main` or `master`; working tree clean before final push; rebased onto the latest `origin/main` before merge.
 2. Goal achieved with evidence: the requested behavior is implemented and validated with proof that matches the risk.
-3. Merge-ready code: touched code is reviewed for avoidable complexity plus security and performance risk, and issues found during that review are addressed or explicitly blocked.
+3. Merge-ready code: touched code is reviewed for avoidable complexity and performance risk. A structured security review is performed against the relevant threat model categories from `specs/threat-model.md` (see the Security Review section in the ship skill). Issues found during review are addressed or explicitly blocked.
 4. Synced artifacts: only the affected artifacts are updated, including specs, threat model, docs, OpenAPI, test cases, and agent instructions when relevant.
 5. Smoke test impacted functionality: always smoke test the flows affected by the change end-to-end. This is mandatory, not conditional on risk assessment. Docs-only or config-only changes that do not affect runtime behavior may skip smoke testing with explicit justification.
-6. Safe merge: the PR uses the repo template, CI is green, review comments from all reviewers, including async bot reviewers, are addressed after a final post-green sweep, and merge happens with squash only.
+6. Safe merge: the PR uses the repo template, CI is green, **every** review comment from all reviewers (including async bot reviewers and low-confidence suggestions) is explicitly analyzed, reasoned about, and resolved — either with a code change or a written explanation — after a final post-green sweep, and merge happens with squash only.
 
 ## Constraints
 
@@ -45,6 +45,8 @@ Relevant references:
 - Validation should start with the smallest high-signal proof and deepen only when risk or weak signals require it.
 - Bug fixes should prefer a failing test before the fix when practical, but the validation strategy may vary when a smaller or stronger proof exists.
 - Docs-only or config-only changes may skip code tests if that choice is justified and the relevant docs or build checks were run.
+- Security review is mandatory for all code, configuration, and infrastructure changes. The review must identify relevant threat model categories, check the diff against them, and document findings. Perceived low risk does not justify skipping the review.
+- Every review comment must be explicitly addressed before merge — including low-confidence suggestions, nits, and bot comments. For each comment, the agent must analyze the concern, reason about whether a change is warranted, and either apply a fix or reply with a clear explanation. Dismissing or ignoring comments without reasoning is not permitted.
 - Auto-merge must not bypass the final review pass; shipping should give async reviewer bots time to comment after the last push and after CI turns green, then re-check before merge.
 - If a blocker cannot be resolved safely by the agent alone, shipping must stop and report the blocker rather than guess.
 
@@ -54,5 +56,7 @@ Shipping output should make it easy to evaluate readiness:
 
 - what changed
 - what evidence was gathered
+- security review: which threat categories were checked, any findings, and how they were resolved
 - what was skipped and why
+- review comments: how each comment was addressed (code change or written reasoning)
 - what blockers or residual risks remain


### PR DESCRIPTION
## What
Strengthen the `/ship` skill with a mandatory structured security review step and enforce that every PR review comment is explicitly addressed before merge.

## Why
The previous security review was a single bullet point ("review touched areas for auth, input validation...") that was easy to gloss over. Review comment handling allowed dismissing "non-substantive" feedback without reasoning.

## How
- Added a dedicated **Security Review** section to the ship skill with 5 mandatory steps: identify threat surface, review each category, check THREAT comments, update threat model, document findings
- Strengthened review comment resolution: every comment (including low-confidence, nits, bot comments) must be analyzed, reasoned about, and resolved before merge
- Updated `specs/shipping.md` required outcomes and constraints to match
- Added Security section and checklist items to PR template
- Updated AGENTS.md shipping definition

## Risk
- Low
- No runtime code changes. Worst case: agents spend slightly more time on security review (which is the goal)

## Security
- No security-relevant code changes — this is a docs/specs-only change that strengthens the security review process itself

## Checklist
- [x] Tests added or updated (N/A — no runtime code)
- [x] Backward compatibility considered (N/A — agent instructions only)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)