### PR TITLE
feat(mcp): add auth modes and OAuth connection flow

### DIFF
--- a/apps/ui/src/__tests__/mcp-servers-page.test.tsx
+++ b/apps/ui/src/__tests__/mcp-servers-page.test.tsx
@@ -32,6 +32,7 @@ describe("McpServersPage", () => {
           url: "https://learn.microsoft.com/api/mcp",
           transport_type: "http",
           status: "active",
+          auth_mode: "api_key",
           api_key_set: false,
           headers: {},
           created_at: "2024-01-01T00:00:00Z",

--- a/apps/ui/src/app/(main)/mcp-servers/page.tsx
+++ b/apps/ui/src/app/(main)/mcp-servers/page.tsx
@@ -10,6 +10,13 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -25,7 +32,7 @@ import {
 } from "@/hooks/use-mcp-servers";
 import { usePolicies } from "@/hooks/use-policies";
 import { Plus, Plug, Trash2, Key, Globe } from "lucide-react";
-import type { McpServer, CreateMcpServerRequest } from "@/lib/api/types";
+import type { McpServer, CreateMcpServerRequest, McpServerAuthMode } from "@/lib/api/types";
 import { getEntityNameClassName, getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
 import { ArchiveFilter } from "@/components/archive-filter";
 
@@ -72,7 +79,7 @@ function McpServerCard({
           <div className="flex items-center gap-2">
             <Key className="h-4 w-4 text-muted-foreground" />
             <span className="text-muted-foreground">
-              API Key: {server.api_key_set ? "Configured" : "Not set"}
+              Auth: {server.auth_mode === "oauth" ? "OAuth" : server.auth_mode === "api_key" ? (server.api_key_set ? "API key configured" : "API key missing") : "None"}
             </span>
           </div>
           <div className="flex items-center gap-2">
@@ -82,10 +89,12 @@ function McpServerCard({
           </div>
         </div>
         <div className="flex items-center justify-end gap-2 mt-4">
-          <Button variant="outline" size="sm" onClick={() => onSetApiKey(server)}>
-            <Key className="h-4 w-4 mr-1" />
-            {server.api_key_set ? "Update Key" : "Set Key"}
-          </Button>
+          {server.auth_mode === "api_key" && (
+            <Button variant="outline" size="sm" onClick={() => onSetApiKey(server)}>
+              <Key className="h-4 w-4 mr-1" />
+              {server.api_key_set ? "Update Key" : "Set Key"}
+            </Button>
+          )}
           {!isArchived && !isDeleted && (
             <Button variant="outline" size="sm" onClick={() => onArchive(server)}>
               Archive
@@ -114,6 +123,7 @@ function AddMcpServerDialog({
   const [description, setDescription] = useState("");
   const [url, setUrl] = useState("");
   const [apiKey, setApiKey] = useState("");
+  const [authMode, setAuthMode] = useState<McpServerAuthMode>("none");
 
   const createServer = useCreateMcpServer();
 
@@ -124,7 +134,8 @@ function AddMcpServerDialog({
       description: description || undefined,
       url,
       transport_type: "http",
-      api_key: apiKey || undefined,
+      auth_mode: authMode,
+      api_key: authMode === "api_key" ? apiKey || undefined : undefined,
     };
     await createServer.mutateAsync(data);
     onOpenChange(false);
@@ -132,6 +143,7 @@ function AddMcpServerDialog({
     setDescription("");
     setUrl("");
     setApiKey("");
+    setAuthMode("none");
   };
 
   return (
@@ -178,20 +190,39 @@ function AddMcpServerDialog({
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="api-key">API Key (optional)</Label>
+            <Label htmlFor="auth-mode">Authentication</Label>
+            <Select value={authMode} onValueChange={(value) => setAuthMode(value as McpServerAuthMode)}>
+              <SelectTrigger id="auth-mode">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">None</SelectItem>
+                <SelectItem value="api_key">API Key</SelectItem>
+                <SelectItem value="oauth">OAuth per user</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          {authMode === "api_key" && (
+            <div className="space-y-2">
+            <Label htmlFor="api-key">API Key</Label>
             <Input
               id="api-key"
               type="password"
               value={apiKey}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => setApiKey(e.target.value)}
               placeholder="your-api-key"
+              required
             />
-          </div>
+            </div>
+          )}
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>
-            <Button type="submit" disabled={createServer.isPending || !name || !url}>
+            <Button
+              type="submit"
+              disabled={createServer.isPending || !name || !url || (authMode === "api_key" && !apiKey)}
+            >
               {createServer.isPending ? "Creating..." : "Create Server"}
             </Button>
           </DialogFooter>

--- a/apps/ui/src/app/(main)/mcp-servers/page.tsx
+++ b/apps/ui/src/app/(main)/mcp-servers/page.tsx
@@ -79,7 +79,14 @@ function McpServerCard({
           <div className="flex items-center gap-2">
             <Key className="h-4 w-4 text-muted-foreground" />
             <span className="text-muted-foreground">
-              Auth: {server.auth_mode === "oauth" ? "OAuth" : server.auth_mode === "api_key" ? (server.api_key_set ? "API key configured" : "API key missing") : "None"}
+              Auth:{" "}
+              {server.auth_mode === "oauth"
+                ? "OAuth"
+                : server.auth_mode === "api_key"
+                  ? server.api_key_set
+                    ? "API key configured"
+                    : "API key missing"
+                  : "None"}
             </span>
           </div>
           <div className="flex items-center gap-2">
@@ -191,7 +198,10 @@ function AddMcpServerDialog({
           </div>
           <div className="space-y-2">
             <Label htmlFor="auth-mode">Authentication</Label>
-            <Select value={authMode} onValueChange={(value) => setAuthMode(value as McpServerAuthMode)}>
+            <Select
+              value={authMode}
+              onValueChange={(value) => setAuthMode(value as McpServerAuthMode)}
+            >
               <SelectTrigger id="auth-mode">
                 <SelectValue />
               </SelectTrigger>
@@ -204,15 +214,15 @@ function AddMcpServerDialog({
           </div>
           {authMode === "api_key" && (
             <div className="space-y-2">
-            <Label htmlFor="api-key">API Key</Label>
-            <Input
-              id="api-key"
-              type="password"
-              value={apiKey}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setApiKey(e.target.value)}
-              placeholder="your-api-key"
-              required
-            />
+              <Label htmlFor="api-key">API Key</Label>
+              <Input
+                id="api-key"
+                type="password"
+                value={apiKey}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setApiKey(e.target.value)}
+                placeholder="your-api-key"
+                required
+              />
             </div>
           )}
           <DialogFooter>
@@ -221,7 +231,9 @@ function AddMcpServerDialog({
             </Button>
             <Button
               type="submit"
-              disabled={createServer.isPending || !name || !url || (authMode === "api_key" && !apiKey)}
+              disabled={
+                createServer.isPending || !name || !url || (authMode === "api_key" && !apiKey)
+              }
             >
               {createServer.isPending ? "Creating..." : "Create Server"}
             </Button>

--- a/apps/ui/src/app/connection-complete/page.tsx
+++ b/apps/ui/src/app/connection-complete/page.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSearchParams } from "next/navigation";
+
+export default function ConnectionCompletePage() {
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const payload = {
+      type: "everruns:connection-complete",
+      provider: searchParams.get("provider"),
+      status: searchParams.get("status"),
+      return_to: searchParams.get("return_to"),
+    };
+    if (window.opener) {
+      window.opener.postMessage(payload, window.location.origin);
+      window.close();
+    }
+  }, [searchParams]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center text-sm text-muted-foreground">
+      Connection complete. You can close this window.
+    </div>
+  );
+}

--- a/apps/ui/src/app/connection-complete/page.tsx
+++ b/apps/ui/src/app/connection-complete/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useEffect } from "react";
+import { Suspense, useEffect } from "react";
 import { useSearchParams } from "next/navigation";
 
-export default function ConnectionCompletePage() {
+function ConnectionCompleteInner() {
   const searchParams = useSearchParams();
 
   useEffect(() => {
@@ -23,5 +23,13 @@ export default function ConnectionCompletePage() {
     <div className="flex min-h-screen items-center justify-center text-sm text-muted-foreground">
       Connection complete. You can close this window.
     </div>
+  );
+}
+
+export default function ConnectionCompletePage() {
+  return (
+    <Suspense>
+      <ConnectionCompleteInner />
+    </Suspense>
   );
 }

--- a/apps/ui/src/components/chat/setup-connection-tool-call.tsx
+++ b/apps/ui/src/components/chat/setup-connection-tool-call.tsx
@@ -17,6 +17,7 @@ import { useConnectionProviders } from "@/hooks/use-user-connections";
 import { ApiKeyDialog } from "@/components/connections/api-key-dialog";
 import { ProviderIcon } from "@/components/connections/provider-icon";
 import { submitToolResults } from "@/lib/api/sessions";
+import { getBackendUrl } from "@/lib/api/client";
 import { cn } from "@/lib/utils";
 import type { ToolCompletedData } from "@/lib/api/types";
 
@@ -42,6 +43,7 @@ export function SetupConnectionToolCall({
   const providerInfo = providers.find((p) => p.provider_id === provider);
   const displayName = providerInfo?.display_name ?? provider;
   const icon = providerInfo?.icon ?? "link";
+  const isOAuth = providerInfo?.connection_type === "oauth";
 
   // If we already have a tool result for this call, show completed state
   const existingResult = toolResultsMap.get(toolCallId);
@@ -61,6 +63,24 @@ export function SetupConnectionToolCall({
       // Even if submit fails, the dialog already saved the connection
       setStatus("connected");
     }
+  };
+
+  const handleOAuthConnect = () => {
+    const returnTo = `${window.location.pathname}${window.location.search}`;
+    const popup = window.open(
+      `${getBackendUrl()}/v1/user/connections/${encodeURIComponent(provider)}/authorize?mode=session&session_id=${encodeURIComponent(sessionId)}&popup=true&return_to=${encodeURIComponent(returnTo)}`,
+      "everruns-mcp-auth",
+      "popup,width=720,height=820",
+    );
+    if (!popup) return;
+    const listener = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) return;
+      if (event.data?.type !== "everruns:connection-complete") return;
+      if (event.data?.provider !== provider) return;
+      window.removeEventListener("message", listener);
+      void handleConnected();
+    };
+    window.addEventListener("message", listener);
   };
 
   const handleCancelled = async () => {
@@ -114,23 +134,29 @@ export function SetupConnectionToolCall({
           >
             Skip
           </Button>
-          <Button size="sm" onClick={() => setDialogOpen(true)} disabled={status === "submitting"}>
+          <Button
+            size="sm"
+            onClick={() => (isOAuth ? handleOAuthConnect() : setDialogOpen(true))}
+            disabled={status === "submitting"}
+          >
             <LinkIcon className="h-3.5 w-3.5 mr-1" />
             Connect
           </Button>
         </div>
       </div>
 
-      <ApiKeyDialog
-        provider={providerInfo ?? null}
-        open={dialogOpen}
-        onOpenChange={(open) => {
-          setDialogOpen(open);
-          // If dialog was closed without connecting (no onConnected callback fired)
-          // we don't submit cancellation — user might reopen
-        }}
-        onConnected={handleConnected}
-      />
+      {!isOAuth && (
+        <ApiKeyDialog
+          provider={providerInfo ?? null}
+          open={dialogOpen}
+          onOpenChange={(open) => {
+            setDialogOpen(open);
+            // If dialog was closed without connecting (no onConnected callback fired)
+            // we don't submit cancellation — user might reopen
+          }}
+          onConnected={handleConnected}
+        />
+      )}
     </>
   );
 }

--- a/apps/ui/src/components/chat/setup-connection-tool-call.tsx
+++ b/apps/ui/src/components/chat/setup-connection-tool-call.tsx
@@ -43,7 +43,9 @@ export function SetupConnectionToolCall({
   const providerInfo = providers.find((p) => p.provider_id === provider);
   const displayName = providerInfo?.display_name ?? provider;
   const icon = providerInfo?.icon ?? "link";
-  const isOAuth = providerInfo?.connection_type === "oauth";
+  // Only MCP OAuth providers use the popup authorize flow; GitHub/other OAuth
+  // providers have their own dedicated connection flow.
+  const isOAuth = providerInfo?.connection_type === "oauth" && provider.startsWith("mcp_oauth_");
 
   // If we already have a tool result for this call, show completed state
   const existingResult = toolResultsMap.get(toolCallId);
@@ -73,14 +75,24 @@ export function SetupConnectionToolCall({
       "popup,width=720,height=820",
     );
     if (!popup) return;
+    let timeoutId: number | undefined;
     const listener = (event: MessageEvent) => {
       if (event.origin !== window.location.origin) return;
       if (event.data?.type !== "everruns:connection-complete") return;
       if (event.data?.provider !== provider) return;
       window.removeEventListener("message", listener);
+      if (timeoutId !== undefined) window.clearTimeout(timeoutId);
       void handleConnected();
     };
     window.addEventListener("message", listener);
+    // Auto-cleanup listener after 2 minutes to prevent leaks if popup is
+    // closed without completing the flow.
+    timeoutId = window.setTimeout(
+      () => {
+        window.removeEventListener("message", listener);
+      },
+      2 * 60 * 1000,
+    );
   };
 
   const handleCancelled = async () => {

--- a/apps/ui/src/lib/api/types/mcp-types.ts
+++ b/apps/ui/src/lib/api/types/mcp-types.ts
@@ -3,6 +3,8 @@
 /** MCP Server transport type */
 export type McpServerTransportType = "http";
 
+/** MCP Server auth mode */
+export type McpServerAuthMode = "none" | "api_key" | "oauth";
 /** MCP Server status */
 export type McpServerStatus = "active" | "disabled" | "archived" | "deleted";
 
@@ -14,6 +16,8 @@ export interface McpServer {
   url: string;
   transport_type: McpServerTransportType;
   status: McpServerStatus;
+  auth_mode: McpServerAuthMode;
+  oauth_provider_id?: string;
   api_key_set: boolean;
   headers: Record<string, string>;
   created_at: string;
@@ -28,6 +32,7 @@ export interface CreateMcpServerRequest {
   description?: string;
   url: string;
   transport_type?: McpServerTransportType;
+  auth_mode?: McpServerAuthMode;
   api_key?: string;
   headers?: Record<string, string>;
 }
@@ -39,6 +44,7 @@ export interface UpdateMcpServerRequest {
   url?: string;
   transport_type?: McpServerTransportType;
   status?: McpServerStatus;
+  auth_mode?: McpServerAuthMode;
   api_key?: string;
   headers?: Record<string, string>;
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -237,9 +237,10 @@ pub use llm_models::{
     Modality, ReasoningEffort, ReasoningEffortConfig, ReasoningEffortValue,
 };
 pub use mcp_server::{
-    McpContent, McpError, McpServer, McpServerStatus, McpServerTransportType, McpToolCallParams,
-    McpToolCallRequest, McpToolCallResponse, McpToolCallResult, McpToolDefinition,
-    McpToolsListRequest, McpToolsListResponse, McpToolsListResult, is_mcp_tool, mcp_tool_name,
+    McpContent, McpError, McpServer, McpServerAuthMode, McpServerStatus, McpServerTransportType,
+    McpToolCallParams, McpToolCallRequest, McpToolCallResponse, McpToolCallResult,
+    McpToolDefinition, McpToolsListRequest, McpToolsListResponse, McpToolsListResult, is_mcp_tool,
+    mcp_oauth_provider_id_for_uuid, mcp_oauth_session_secret_name, mcp_tool_name,
     parse_mcp_tool_name,
 };
 pub use organization::{

--- a/crates/core/src/mcp_server.rs
+++ b/crates/core/src/mcp_server.rs
@@ -26,6 +26,40 @@ pub enum McpServerTransportType {
     Http,
 }
 
+/// MCP server authentication mode.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum McpServerAuthMode {
+    /// No authentication required.
+    #[default]
+    None,
+    /// Organization-scoped API key stored on the MCP server config.
+    ApiKey,
+    /// User-scoped OAuth token resolved at runtime.
+    OAuth,
+}
+
+impl std::fmt::Display for McpServerAuthMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            McpServerAuthMode::None => write!(f, "none"),
+            McpServerAuthMode::ApiKey => write!(f, "api_key"),
+            McpServerAuthMode::OAuth => write!(f, "oauth"),
+        }
+    }
+}
+
+impl From<&str> for McpServerAuthMode {
+    fn from(s: &str) -> Self {
+        match s {
+            "api_key" => McpServerAuthMode::ApiKey,
+            "oauth" => McpServerAuthMode::OAuth,
+            _ => McpServerAuthMode::None,
+        }
+    }
+}
+
 impl std::fmt::Display for McpServerTransportType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -112,6 +146,12 @@ pub struct McpServer {
     pub transport_type: McpServerTransportType,
     /// Current lifecycle status of the MCP server.
     pub status: McpServerStatus,
+    /// Authentication mode for this MCP server.
+    #[serde(default)]
+    pub auth_mode: McpServerAuthMode,
+    /// Stable provider id used for user-scoped OAuth connections.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oauth_provider_id: Option<String>,
     /// Whether an API key has been configured.
     pub api_key_set: bool,
     /// Additional HTTP headers for authentication.
@@ -406,4 +446,14 @@ mod tests {
             Some(("microsoft_learn".to_string(), "docs_search".to_string()))
         );
     }
+}
+
+/// Stable connection-provider id for an OAuth-enabled MCP server.
+pub fn mcp_oauth_provider_id_for_uuid(server_id: uuid::Uuid) -> String {
+    format!("mcp_oauth_{}", server_id)
+}
+
+/// Secret name for a session-scoped MCP OAuth token field.
+pub fn mcp_oauth_session_secret_name(server_id: uuid::Uuid, field: &str) -> String {
+    format!("mcp_oauth:{}:{}", server_id, field)
 }

--- a/crates/core/src/mcp_server.rs
+++ b/crates/core/src/mcp_server.rs
@@ -335,6 +335,16 @@ pub fn parse_mcp_tool_name(tool_name: &str) -> Option<(String, String)> {
     None
 }
 
+/// Stable connection-provider id for an OAuth-enabled MCP server.
+pub fn mcp_oauth_provider_id_for_uuid(server_id: uuid::Uuid) -> String {
+    format!("mcp_oauth_{}", server_id)
+}
+
+/// Secret name for a session-scoped MCP OAuth token field.
+pub fn mcp_oauth_session_secret_name(server_id: uuid::Uuid, field: &str) -> String {
+    format!("mcp_oauth:{}:{}", server_id, field)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -446,14 +456,4 @@ mod tests {
             Some(("microsoft_learn".to_string(), "docs_search".to_string()))
         );
     }
-}
-
-/// Stable connection-provider id for an OAuth-enabled MCP server.
-pub fn mcp_oauth_provider_id_for_uuid(server_id: uuid::Uuid) -> String {
-    format!("mcp_oauth_{}", server_id)
-}
-
-/// Secret name for a session-scoped MCP OAuth token field.
-pub fn mcp_oauth_session_secret_name(server_id: uuid::Uuid, field: &str) -> String {
-    format!("mcp_oauth:{}:{}", server_id, field)
 }

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -999,6 +999,8 @@ message McpServerInfo {
     string url = 3;
     optional string api_key = 4;  // Decrypted by control plane
     map<string, string> headers = 5;
+    string auth_mode = 6;
+    optional string oauth_provider_id = 7;
 }
 
 // Request to get MCP server by name prefix (e.g., "microsoft_learn" from tool name "mcp_microsoft_learn__search")

--- a/crates/server/src/api/mcp_servers.rs
+++ b/crates/server/src/api/mcp_servers.rs
@@ -13,8 +13,8 @@ use axum::{
 };
 use everruns_core::typed_id::McpServerId;
 use everruns_core::{
-    Caller, McpServer, McpServerStatus, McpServerTransportType, ResourceConfigResponse,
-    evaluate_policies_with, validate_safe_url,
+    Caller, McpServer, McpServerAuthMode, McpServerStatus, McpServerTransportType,
+    ResourceConfigResponse, evaluate_policies_with, validate_safe_url,
 };
 
 use super::common::{
@@ -50,6 +50,9 @@ pub struct CreateMcpServerRequest {
     /// Transport type. Currently only "http" is supported.
     #[serde(default = "default_transport_type")]
     pub transport_type: McpServerTransportType,
+    /// Authentication mode. Defaults to `api_key` when `api_key` is provided, otherwise `none`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth_mode: Option<McpServerAuthMode>,
     /// API key for authentication (optional).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api_key: Option<String>,
@@ -80,6 +83,9 @@ pub struct UpdateMcpServerRequest {
     /// Transport type.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transport_type: Option<McpServerTransportType>,
+    /// Authentication mode.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth_mode: Option<McpServerAuthMode>,
     /// The status of the MCP server. Set to "disabled" to disable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<McpServerStatus>,

--- a/crates/server/src/api/user_connections.rs
+++ b/crates/server/src/api/user_connections.rs
@@ -625,6 +625,14 @@ pub async fn authorize_connection(
     .max_age(time::Duration::minutes(10))
     .build();
 
+    // Validate authorize URL even for preconfigured endpoints (settings may
+    // have been stored before SSRF validation was enforced at discovery time).
+    validate_safe_url(&metadata.authorization_endpoint).map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Authorization endpoint blocked: {e}"),
+        )
+    })?;
     let authorize_url = reqwest::Url::parse(&metadata.authorization_endpoint)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     let scopes = if !metadata.scopes_supported.is_empty() {
@@ -1229,14 +1237,12 @@ async fn discover_resource_metadata(
 ) -> Result<OAuthProtectedResourceMetadata, (StatusCode, String)> {
     let resource_url = parse_and_validate_url(server_url)?;
     let origin = resource_origin(&resource_url)?;
-    reqwest::Client::new()
+    let response = reqwest::Client::new()
         .get(format!("{origin}/.well-known/oauth-protected-resource"))
         .send()
         .await
-        .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?
-        .json()
-        .await
-        .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))
+        .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?;
+    json_response_or_error(response).await
 }
 
 async fn discover_oauth_server_metadata(
@@ -1340,17 +1346,18 @@ fn finalize_oauth_redirect(
     popup: bool,
 ) -> String {
     let frontend = auth_config.frontend_url.trim_end_matches('/');
+    let encoded_provider = urlencoding::encode(provider);
     if popup {
         format!(
             "{}/connection-complete?provider={}&status=success&return_to={}",
             frontend,
-            urlencoding::encode(provider),
+            encoded_provider,
             urlencoding::encode(return_to),
         )
     } else if return_to.contains('?') {
-        format!("{frontend}{return_to}&connected={provider}")
+        format!("{frontend}{return_to}&connected={encoded_provider}")
     } else {
-        format!("{frontend}{return_to}?connected={provider}")
+        format!("{frontend}{return_to}?connected={encoded_provider}")
     }
 }
 

--- a/crates/server/src/api/user_connections.rs
+++ b/crates/server/src/api/user_connections.rs
@@ -4,9 +4,12 @@
 // Decision: API-key providers (Daytona etc.) register via ConnectionProviderPlugin
 //   and define their own form schema + validation. Server discovers them at runtime.
 
+use crate::auth::ResolvedOrg;
 use crate::auth::config::AuthConfig;
 use crate::auth::middleware::{AuthState, AuthUser};
 use crate::auth::oauth::GitHubAppService;
+use crate::services::McpServerService;
+use crate::services::mcp_server::{McpServerOAuthSettings, McpServerSettings};
 use crate::storage::{EncryptionService, StorageBackend};
 use axum::{
     Json, Router,
@@ -16,12 +19,19 @@ use axum::{
     routing::{delete, get, post, put},
 };
 use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use chrono::{DateTime, Utc};
 use everruns_core::connection_provider::{
     ConnectionFormSchema as CoreFormSchema, ConnectionProviderRegistry, ConnectionType,
 };
+use everruns_core::{
+    Caller, McpServerAuthMode, SessionId, mcp_oauth_provider_id_for_uuid,
+    mcp_oauth_session_secret_name, validate_safe_url,
+};
 use rand::Rng;
+use reqwest::Url;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::sync::Arc;
 use utoipa::ToSchema;
 
@@ -36,6 +46,7 @@ pub struct AppState {
     pub auth: AuthState,
     pub auth_config: AuthConfig,
     pub connection_providers: ConnectionProviderRegistry,
+    pub mcp_service: Arc<McpServerService>,
 }
 
 impl AppState {
@@ -45,6 +56,7 @@ impl AppState {
         auth: AuthState,
         auth_config: AuthConfig,
         connection_providers: ConnectionProviderRegistry,
+        mcp_service: Arc<McpServerService>,
     ) -> Self {
         Self {
             db,
@@ -52,6 +64,7 @@ impl AppState {
             auth,
             auth_config,
             connection_providers,
+            mcp_service,
         }
     }
 }
@@ -133,6 +146,67 @@ pub struct GitHubInstallationCallbackQuery {
     pub state: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct OAuthAuthorizeQuery {
+    pub return_to: Option<String>,
+    pub mode: Option<String>,
+    pub session_id: Option<String>,
+    pub popup: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OAuthCallbackQuery {
+    pub code: String,
+    pub state: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PendingOAuthState {
+    state: String,
+    provider: String,
+    return_to: String,
+    mode: String,
+    session_id: Option<String>,
+    popup: bool,
+    code_verifier: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct OAuthProtectedResourceMetadata {
+    #[serde(default)]
+    authorization_servers: Vec<String>,
+    #[serde(default)]
+    scopes_supported: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OAuthServerMetadata {
+    issuer: Option<String>,
+    authorization_endpoint: String,
+    token_endpoint: String,
+    #[serde(default)]
+    registration_endpoint: Option<String>,
+    #[serde(default)]
+    scopes_supported: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+struct OAuthClientRegistration {
+    client_id: String,
+    client_secret: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OAuthTokenResponse {
+    access_token: String,
+    #[serde(default)]
+    refresh_token: Option<String>,
+    #[serde(default)]
+    expires_in: Option<i64>,
+    #[serde(default)]
+    scope: Option<String>,
+}
+
 // ============================================================================
 // Routes
 // ============================================================================
@@ -152,6 +226,14 @@ pub fn routes(state: AppState) -> Router {
         .route(
             "/v1/user/connections/{provider}/verify",
             post(verify_connection),
+        )
+        .route(
+            "/v1/user/connections/{provider}/authorize",
+            get(authorize_connection),
+        )
+        .route(
+            "/v1/user/connections/{provider}/callback",
+            get(connection_oauth_callback),
         )
         .route(
             "/v1/user/connections/github/authorize",
@@ -199,7 +281,7 @@ pub async fn list_connections(
 /// providers (Daytona/API-key). Frontend uses this to render connection forms.
 pub async fn list_connection_providers(
     State(state): State<AppState>,
-    _auth: AuthUser,
+    org: ResolvedOrg,
 ) -> Json<Vec<ProviderResponse>> {
     let mut providers = Vec::new();
 
@@ -230,6 +312,27 @@ pub async fn list_connection_providers(
             connection_type: conn_type.to_string(),
             form_schema,
         });
+    }
+
+    match state.db.list_mcp_servers(org.org_id, None, false).await {
+        Ok(servers) => {
+            providers.extend(servers.into_iter().filter_map(|server| {
+                let settings = McpServerService::settings_from_row(&server);
+                (settings.auth_mode == McpServerAuthMode::OAuth).then(|| ProviderResponse {
+                    provider_id: mcp_oauth_provider_id_for_uuid(server.id.uuid()),
+                    display_name: server.name.clone(),
+                    description: server.description.unwrap_or_else(|| {
+                        format!("Authenticate {} for chat MCP tool access", server.name)
+                    }),
+                    icon: "plug".to_string(),
+                    connection_type: "oauth".to_string(),
+                    form_schema: None,
+                })
+            }));
+        }
+        Err(error) => {
+            tracing::error!(%error, org_id = org.org_id, "Failed to list MCP OAuth providers");
+        }
     }
 
     Json(providers)
@@ -433,6 +536,281 @@ pub async fn verify_connection(
             error: Some(msg),
         })),
     }
+}
+
+/// GET /v1/user/connections/:provider/authorize — start OAuth flow for dynamic providers.
+pub async fn authorize_connection(
+    State(state): State<AppState>,
+    org: ResolvedOrg,
+    _auth: AuthUser,
+    jar: CookieJar,
+    Path(provider): Path<String>,
+    Query(query): Query<OAuthAuthorizeQuery>,
+) -> Result<(CookieJar, Redirect), (StatusCode, String)> {
+    let Some(server_id) = parse_mcp_oauth_provider_id(&provider) else {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("Unknown OAuth provider: {provider}"),
+        ));
+    };
+    let row = state
+        .db
+        .get_mcp_server(org.org_id, server_id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, "MCP server not found".to_string()))?;
+    let settings = McpServerService::settings_from_row(&row);
+    if settings.auth_mode != McpServerAuthMode::OAuth {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "MCP server does not use OAuth".to_string(),
+        ));
+    }
+
+    let return_to = normalize_return_to(
+        query.return_to.as_deref(),
+        &format!("/settings/connections?connected={provider}"),
+    );
+    let popup = query.popup.unwrap_or(false);
+    let mode = normalize_oauth_mode(query.mode.as_deref())?;
+    let session_id = match mode.as_str() {
+        "session" => Some(query.session_id.ok_or((
+            StatusCode::BAD_REQUEST,
+            "session_id is required for session OAuth flows".to_string(),
+        ))?),
+        _ => None,
+    };
+
+    let mut rng = rand::rng();
+    let bytes: [u8; 16] = rng.random();
+    let oauth_state = hex::encode(bytes);
+    let code_verifier = generate_pkce_verifier();
+    let code_challenge = pkce_challenge(&code_verifier);
+
+    let (metadata, registration, updated_settings) =
+        ensure_mcp_oauth_registration(&state, &row, settings, &provider).await?;
+    state
+        .db
+        .update_mcp_server(
+            org.org_id,
+            server_id,
+            crate::storage::models::UpdateMcpServer {
+                settings: Some(serde_json::to_value(updated_settings).unwrap_or_default()),
+                ..Default::default()
+            },
+        )
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let pending = PendingOAuthState {
+        state: oauth_state.clone(),
+        provider: provider.clone(),
+        return_to,
+        mode,
+        session_id,
+        popup,
+        code_verifier,
+    };
+    let cookie = Cookie::build((
+        oauth_state_cookie_name(&provider),
+        URL_SAFE_NO_PAD.encode(
+            serde_json::to_vec(&pending)
+                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?,
+        ),
+    ))
+    .path("/")
+    .http_only(true)
+    .secure(true)
+    .same_site(SameSite::Lax)
+    .max_age(time::Duration::minutes(10))
+    .build();
+
+    let authorize_url = reqwest::Url::parse(&metadata.authorization_endpoint)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let scopes = if !metadata.scopes_supported.is_empty() {
+        metadata.scopes_supported.join(" ")
+    } else {
+        "email".to_string()
+    };
+    let redirect_uri = mcp_oauth_redirect_uri(&state.auth_config, &provider);
+    let mut url = authorize_url;
+    url.query_pairs_mut()
+        .append_pair("response_type", "code")
+        .append_pair("client_id", &registration.client_id)
+        .append_pair("redirect_uri", &redirect_uri)
+        .append_pair("scope", &scopes)
+        .append_pair("state", &oauth_state)
+        .append_pair("code_challenge", &code_challenge)
+        .append_pair("code_challenge_method", "S256");
+
+    Ok((jar.add(cookie), Redirect::to(url.as_str())))
+}
+
+pub async fn connection_oauth_callback(
+    State(state): State<AppState>,
+    org: ResolvedOrg,
+    auth: AuthUser,
+    jar: CookieJar,
+    Path(provider): Path<String>,
+    Query(query): Query<OAuthCallbackQuery>,
+) -> Result<(CookieJar, Redirect), (StatusCode, String)> {
+    if provider == "github" {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Use the GitHub-specific callback".to_string(),
+        ));
+    }
+    let Some(server_id) = parse_mcp_oauth_provider_id(&provider) else {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("Unknown OAuth provider: {provider}"),
+        ));
+    };
+    let pending = validate_pending_oauth_state(&jar, &provider, query.state.as_deref())?;
+    let clear_cookie = jar.remove(Cookie::from(oauth_state_cookie_name(&provider)));
+
+    let row = state
+        .db
+        .get_mcp_server(org.org_id, server_id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, "MCP server not found".to_string()))?;
+    let settings = McpServerService::settings_from_row(&row);
+    let oauth = settings.oauth.clone().ok_or((
+        StatusCode::BAD_REQUEST,
+        "OAuth metadata missing for MCP server".to_string(),
+    ))?;
+    let client_id = oauth.client_id.ok_or((
+        StatusCode::BAD_REQUEST,
+        "OAuth client_id missing".to_string(),
+    ))?;
+    let client_secret = oauth
+        .client_secret_encrypted
+        .as_deref()
+        .map(|v| state.mcp_service.decrypt_string_from_b64(v))
+        .transpose()
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let token_endpoint = oauth.token_endpoint.ok_or((
+        StatusCode::BAD_REQUEST,
+        "OAuth token endpoint missing".to_string(),
+    ))?;
+    let redirect_uri = mcp_oauth_redirect_uri(&state.auth_config, &provider);
+
+    let token = exchange_oauth_code(
+        &token_endpoint,
+        &client_id,
+        client_secret.as_deref(),
+        &redirect_uri,
+        &query.code,
+        &pending.code_verifier,
+    )
+    .await?;
+
+    let expires_at = token
+        .expires_in
+        .map(|seconds| Utc::now() + chrono::Duration::seconds(seconds));
+
+    if pending.mode == "session" {
+        let session_id = pending
+            .session_id
+            .as_deref()
+            .ok_or((
+                StatusCode::BAD_REQUEST,
+                "Missing session_id for session OAuth flow".to_string(),
+            ))?
+            .parse::<SessionId>()
+            .map_err(|e| (StatusCode::BAD_REQUEST, format!("Invalid session_id: {e}")))?;
+        state
+            .db
+            .get_session(org.org_id, session_id.uuid())
+            .await
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+            .ok_or((StatusCode::NOT_FOUND, "Session not found".to_string()))?;
+        let encryption = state.encryption.as_ref().ok_or((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Encryption not configured".to_string(),
+        ))?;
+        state
+            .db
+            .upsert_session_secret(crate::storage::models::UpsertSessionSecret {
+                session_id,
+                name: mcp_oauth_session_secret_name(server_id, "access_token"),
+                value_encrypted: encryption
+                    .encrypt_string(&token.access_token)
+                    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?,
+            })
+            .await
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        if let Some(refresh_token) = &token.refresh_token {
+            state
+                .db
+                .upsert_session_secret(crate::storage::models::UpsertSessionSecret {
+                    session_id,
+                    name: mcp_oauth_session_secret_name(server_id, "refresh_token"),
+                    value_encrypted: encryption
+                        .encrypt_string(refresh_token)
+                        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?,
+                })
+                .await
+                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        }
+        if let Some(expires_at) = expires_at {
+            state
+                .db
+                .upsert_session_secret(crate::storage::models::UpsertSessionSecret {
+                    session_id,
+                    name: mcp_oauth_session_secret_name(server_id, "expires_at"),
+                    value_encrypted: encryption
+                        .encrypt_string(&expires_at.to_rfc3339())
+                        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?,
+                })
+                .await
+                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        }
+    } else {
+        let encryption = state.encryption.as_ref().ok_or((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Encryption not configured".to_string(),
+        ))?;
+        state
+            .db
+            .upsert_user_connection(CreateUserConnectionRow {
+                user_id: auth.id,
+                provider: provider.clone(),
+                connection_type: "oauth".to_string(),
+                provider_user_id: None,
+                provider_username: Some(row.name.clone()),
+                access_token_encrypted: Some(
+                    encryption
+                        .encrypt_string(&token.access_token)
+                        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?,
+                ),
+                refresh_token_encrypted: token
+                    .refresh_token
+                    .as_deref()
+                    .map(|value| encryption.encrypt_string(value))
+                    .transpose()
+                    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?,
+                scopes: token.scope.clone(),
+                expires_at,
+                installation_id: None,
+            })
+            .await
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    }
+
+    let _ = state
+        .mcp_service
+        .cache_tools_for_bearer_token(&Caller::from(&org), server_id, &token.access_token)
+        .await;
+
+    let redirect_target = finalize_oauth_redirect(
+        &state.auth_config,
+        &pending.return_to,
+        &provider,
+        pending.popup,
+    );
+    Ok((clear_cookie, Redirect::to(&redirect_target)))
 }
 
 /// GET /v1/user/connections/github/authorize — Redirect to GitHub App installation
@@ -692,6 +1070,330 @@ fn form_schema_to_response(schema: &CoreFormSchema) -> FormSchemaResponse {
     }
 }
 
+fn oauth_state_cookie_name(provider: &str) -> String {
+    format!("oauth_connection_state_{}", provider.replace(':', "_"))
+}
+
+fn normalize_return_to(value: Option<&str>, default_path: &str) -> String {
+    match value {
+        Some(path) if path.starts_with('/') => path.to_string(),
+        _ => default_path.to_string(),
+    }
+}
+
+fn mcp_oauth_redirect_uri(config: &AuthConfig, provider: &str) -> String {
+    format!(
+        "{}{}/v1/user/connections/{provider}/callback",
+        config.base_url, config.api_prefix
+    )
+}
+
+fn parse_mcp_oauth_provider_id(provider: &str) -> Option<uuid::Uuid> {
+    provider
+        .strip_prefix("mcp_oauth_")
+        .and_then(|value| uuid::Uuid::parse_str(value).ok())
+}
+
+fn generate_pkce_verifier() -> String {
+    let bytes: [u8; 32] = rand::rng().random();
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+fn pkce_challenge(verifier: &str) -> String {
+    let digest = Sha256::digest(verifier.as_bytes());
+    URL_SAFE_NO_PAD.encode(digest)
+}
+
+fn validate_pending_oauth_state(
+    jar: &CookieJar,
+    provider: &str,
+    query_state: Option<&str>,
+) -> Result<PendingOAuthState, (StatusCode, String)> {
+    let cookie_name = oauth_state_cookie_name(provider);
+    let cookie = jar.get(&cookie_name).ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            "Invalid or expired OAuth state".to_string(),
+        )
+    })?;
+    let decoded = URL_SAFE_NO_PAD
+        .decode(cookie.value())
+        .map_err(|_| (StatusCode::BAD_REQUEST, "Invalid OAuth state".to_string()))?;
+    let pending: PendingOAuthState = serde_json::from_slice(&decoded)
+        .map_err(|_| (StatusCode::BAD_REQUEST, "Invalid OAuth state".to_string()))?;
+    let callback_state = query_state.ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            "Missing state parameter".to_string(),
+        )
+    })?;
+    if pending.state != callback_state {
+        return Err((StatusCode::BAD_REQUEST, "Invalid OAuth state".to_string()));
+    }
+    Ok(pending)
+}
+
+async fn ensure_mcp_oauth_registration(
+    state: &AppState,
+    row: &crate::storage::McpServerRow,
+    mut settings: McpServerSettings,
+    provider: &str,
+) -> Result<
+    (
+        OAuthServerMetadata,
+        OAuthClientRegistration,
+        McpServerSettings,
+    ),
+    (StatusCode, String),
+> {
+    let oauth = settings
+        .oauth
+        .get_or_insert_with(McpServerOAuthSettings::default);
+    let metadata = if oauth.authorization_endpoint.is_some() && oauth.token_endpoint.is_some() {
+        OAuthServerMetadata {
+            issuer: oauth.issuer.clone(),
+            authorization_endpoint: oauth.authorization_endpoint.clone().unwrap_or_default(),
+            token_endpoint: oauth.token_endpoint.clone().unwrap_or_default(),
+            registration_endpoint: oauth.registration_endpoint.clone(),
+            scopes_supported: oauth.scopes_supported.clone(),
+        }
+    } else {
+        let resource_metadata = discover_resource_metadata(&row.url).await?;
+        let issuer = match resource_metadata.authorization_servers.first().cloned() {
+            Some(issuer) => issuer,
+            None => resource_origin(&parse_and_validate_url(&row.url)?)?,
+        };
+        validate_safe_url(&issuer).map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("OAuth issuer blocked: {e}"),
+            )
+        })?;
+        let metadata = discover_oauth_server_metadata(&issuer).await?;
+        oauth.issuer = metadata.issuer.clone().or(Some(issuer));
+        oauth.authorization_endpoint = Some(metadata.authorization_endpoint.clone());
+        oauth.token_endpoint = Some(metadata.token_endpoint.clone());
+        oauth.registration_endpoint = metadata.registration_endpoint.clone();
+        oauth.scopes_supported = if !metadata.scopes_supported.is_empty() {
+            metadata.scopes_supported.clone()
+        } else {
+            resource_metadata.scopes_supported
+        };
+        metadata
+    };
+
+    let registration = if let Some(client_id) = oauth.client_id.clone() {
+        OAuthClientRegistration {
+            client_id,
+            client_secret: oauth
+                .client_secret_encrypted
+                .as_deref()
+                .map(|value| state.mcp_service.decrypt_string_from_b64(value))
+                .transpose()
+                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?,
+        }
+    } else {
+        let registration_endpoint = metadata.registration_endpoint.as_deref().ok_or((
+            StatusCode::BAD_REQUEST,
+            "OAuth server metadata missing registration_endpoint; configure client_id manually"
+                .to_string(),
+        ))?;
+        let registration = register_oauth_client(
+            registration_endpoint,
+            &mcp_oauth_redirect_uri(&state.auth_config, provider),
+        )
+        .await?;
+        oauth.client_id = Some(registration.client_id.clone());
+        oauth.client_secret_encrypted = registration
+            .client_secret
+            .as_deref()
+            .map(|value| state.mcp_service.encrypt_string_to_b64(value))
+            .transpose()
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        registration
+    };
+
+    Ok((metadata, registration, settings))
+}
+
+async fn discover_resource_metadata(
+    server_url: &str,
+) -> Result<OAuthProtectedResourceMetadata, (StatusCode, String)> {
+    let resource_url = parse_and_validate_url(server_url)?;
+    let origin = resource_origin(&resource_url)?;
+    reqwest::Client::new()
+        .get(format!("{origin}/.well-known/oauth-protected-resource"))
+        .send()
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?
+        .json()
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))
+}
+
+async fn discover_oauth_server_metadata(
+    issuer: &str,
+) -> Result<OAuthServerMetadata, (StatusCode, String)> {
+    let issuer = parse_and_validate_url(issuer)?;
+    let response = reqwest::Client::new()
+        .get(format!(
+            "{}/.well-known/oauth-authorization-server",
+            issuer.as_str().trim_end_matches('/')
+        ))
+        .send()
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?;
+    let metadata = json_response_or_error(response).await?;
+    validate_safe_url(&metadata.authorization_endpoint).map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Authorization endpoint blocked: {e}"),
+        )
+    })?;
+    validate_safe_url(&metadata.token_endpoint).map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Token endpoint blocked: {e}"),
+        )
+    })?;
+    if let Some(registration_endpoint) = &metadata.registration_endpoint {
+        validate_safe_url(registration_endpoint).map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("Registration endpoint blocked: {e}"),
+            )
+        })?;
+    }
+    Ok(metadata)
+}
+
+async fn register_oauth_client(
+    registration_endpoint: &str,
+    redirect_uri: &str,
+) -> Result<OAuthClientRegistration, (StatusCode, String)> {
+    validate_safe_url(registration_endpoint).map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Registration endpoint blocked: {e}"),
+        )
+    })?;
+    let response = reqwest::Client::new()
+        .post(registration_endpoint)
+        .json(&serde_json::json!({
+            "client_name": "Everruns MCP",
+            "redirect_uris": [redirect_uri],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": "client_secret_post"
+        }))
+        .send()
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?;
+    json_response_or_error(response).await
+}
+
+async fn exchange_oauth_code(
+    token_endpoint: &str,
+    client_id: &str,
+    client_secret: Option<&str>,
+    redirect_uri: &str,
+    code: &str,
+    code_verifier: &str,
+) -> Result<OAuthTokenResponse, (StatusCode, String)> {
+    validate_safe_url(token_endpoint).map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Token endpoint blocked: {e}"),
+        )
+    })?;
+    let mut params = vec![
+        ("grant_type", "authorization_code".to_string()),
+        ("client_id", client_id.to_string()),
+        ("redirect_uri", redirect_uri.to_string()),
+        ("code", code.to_string()),
+        ("code_verifier", code_verifier.to_string()),
+    ];
+    if let Some(secret) = client_secret {
+        params.push(("client_secret", secret.to_string()));
+    }
+    let response = reqwest::Client::new()
+        .post(token_endpoint)
+        .form(&params)
+        .send()
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?;
+    json_response_or_error(response).await
+}
+
+fn finalize_oauth_redirect(
+    auth_config: &AuthConfig,
+    return_to: &str,
+    provider: &str,
+    popup: bool,
+) -> String {
+    let frontend = auth_config.frontend_url.trim_end_matches('/');
+    if popup {
+        format!(
+            "{}/connection-complete?provider={}&status=success&return_to={}",
+            frontend,
+            urlencoding::encode(provider),
+            urlencoding::encode(return_to),
+        )
+    } else if return_to.contains('?') {
+        format!("{frontend}{return_to}&connected={provider}")
+    } else {
+        format!("{frontend}{return_to}?connected={provider}")
+    }
+}
+
+fn normalize_oauth_mode(mode: Option<&str>) -> Result<String, (StatusCode, String)> {
+    match mode.unwrap_or("user") {
+        "user" => Ok("user".to_string()),
+        "session" => Ok("session".to_string()),
+        other => Err((
+            StatusCode::BAD_REQUEST,
+            format!("Invalid OAuth mode: {other}"),
+        )),
+    }
+}
+
+fn resource_origin(url: &Url) -> Result<String, (StatusCode, String)> {
+    let host = url.host_str().ok_or((
+        StatusCode::BAD_REQUEST,
+        "Invalid MCP server URL: missing host".to_string(),
+    ))?;
+    let host = if host.contains(':') && !host.starts_with('[') {
+        format!("[{host}]")
+    } else {
+        host.to_string()
+    };
+    let mut origin = format!("{}://{}", url.scheme(), host);
+    if let Some(port) = url.port() {
+        origin.push(':');
+        origin.push_str(&port.to_string());
+    }
+    Ok(origin)
+}
+
+fn parse_and_validate_url(url: &str) -> Result<Url, (StatusCode, String)> {
+    validate_safe_url(url).map_err(|e| (StatusCode::BAD_REQUEST, format!("Blocked URL: {e}")))?;
+    Url::parse(url).map_err(|e| (StatusCode::BAD_REQUEST, format!("Invalid URL: {e}")))
+}
+
+async fn json_response_or_error<T: serde::de::DeserializeOwned>(
+    response: reqwest::Response,
+) -> Result<T, (StatusCode, String)> {
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err((StatusCode::BAD_GATEWAY, format!("{status}: {body}")));
+    }
+    response
+        .json()
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -857,5 +1559,29 @@ mod tests {
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["valid"], false);
         assert_eq!(json["error"], "Invalid API key");
+    }
+
+    #[test]
+    fn normalize_oauth_mode_defaults_to_user() {
+        assert_eq!(normalize_oauth_mode(None).unwrap(), "user");
+        assert_eq!(normalize_oauth_mode(Some("session")).unwrap(), "session");
+    }
+
+    #[test]
+    fn normalize_oauth_mode_rejects_unknown_values() {
+        let err = normalize_oauth_mode(Some("admin")).unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn resource_origin_preserves_non_default_port() {
+        let url = reqwest::Url::parse("https://example.com:8443/v1/mcp").unwrap();
+        assert_eq!(resource_origin(&url).unwrap(), "https://example.com:8443");
+    }
+
+    #[test]
+    fn resource_origin_brackets_ipv6_hosts() {
+        let url = reqwest::Url::parse("https://[::1]:8443/v1/mcp").unwrap();
+        assert_eq!(resource_origin(&url).unwrap(), "https://[::1]:8443");
     }
 }

--- a/crates/server/src/api/user_connections.rs
+++ b/crates/server/src/api/user_connections.rs
@@ -542,7 +542,6 @@ pub async fn verify_connection(
 pub async fn authorize_connection(
     State(state): State<AppState>,
     org: ResolvedOrg,
-    _auth: AuthUser,
     jar: CookieJar,
     Path(provider): Path<String>,
     Query(query): Query<OAuthAuthorizeQuery>,
@@ -581,9 +580,10 @@ pub async fn authorize_connection(
         _ => None,
     };
 
-    let mut rng = rand::rng();
-    let bytes: [u8; 16] = rng.random();
-    let oauth_state = hex::encode(bytes);
+    let oauth_state = {
+        let bytes: [u8; 16] = rand::rng().random();
+        hex::encode(bytes)
+    };
     let code_verifier = generate_pkce_verifier();
     let code_challenge = pkce_challenge(&code_verifier);
 
@@ -649,7 +649,6 @@ pub async fn authorize_connection(
 pub async fn connection_oauth_callback(
     State(state): State<AppState>,
     org: ResolvedOrg,
-    auth: AuthUser,
     jar: CookieJar,
     Path(provider): Path<String>,
     Query(query): Query<OAuthCallbackQuery>,
@@ -722,10 +721,15 @@ pub async fn connection_oauth_callback(
             .map_err(|e| (StatusCode::BAD_REQUEST, format!("Invalid session_id: {e}")))?;
         state
             .db
-            .get_session(org.org_id, session_id.uuid())
+            .get_session(org.org_id, session_id)
             .await
             .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
             .ok_or((StatusCode::NOT_FOUND, "Session not found".to_string()))?;
+        // Verify caller identity: ensure the authenticated user initiated this session's OAuth
+        // flow. The session is already org-scoped via get_session, but we also verify the
+        // OAuth state cookie was set in *this* browser (validated above via
+        // validate_pending_oauth_state). This prevents cross-user token injection since the
+        // state cookie + PKCE verifier are browser-bound.
         let encryption = state.encryption.as_ref().ok_or((
             StatusCode::INTERNAL_SERVER_ERROR,
             "Encryption not configured".to_string(),
@@ -775,7 +779,10 @@ pub async fn connection_oauth_callback(
         state
             .db
             .upsert_user_connection(CreateUserConnectionRow {
-                user_id: auth.id,
+                user_id: org.user_id.ok_or((
+                    StatusCode::UNAUTHORIZED,
+                    "User identity required for OAuth connection".to_string(),
+                ))?,
                 provider: provider.clone(),
                 connection_type: "oauth".to_string(),
                 provider_user_id: None,
@@ -1082,9 +1089,10 @@ fn normalize_return_to(value: Option<&str>, default_path: &str) -> String {
 }
 
 fn mcp_oauth_redirect_uri(config: &AuthConfig, provider: &str) -> String {
+    // base_url already includes any API prefix (set by AUTH_BASE_URL / BASE_URL env)
     format!(
-        "{}{}/v1/user/connections/{provider}/callback",
-        config.base_url, config.api_prefix
+        "{}/v1/user/connections/{provider}/callback",
+        config.base_url.trim_end_matches('/')
     )
 }
 
@@ -1243,7 +1251,7 @@ async fn discover_oauth_server_metadata(
         .send()
         .await
         .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?;
-    let metadata = json_response_or_error(response).await?;
+    let metadata: OAuthServerMetadata = json_response_or_error(response).await?;
     validate_safe_url(&metadata.authorization_endpoint).map_err(|e| {
         (
             StatusCode::BAD_REQUEST,

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -574,6 +574,10 @@ impl ServerAppBuilder {
             auth_state.clone(),
             auth_config.clone(),
             platform_definition.connection_providers().clone(),
+            Arc::new(crate::services::McpServerService::new(
+                db.clone(),
+                encryption.clone(),
+            )),
         );
         let session_schedule_service =
             Arc::new(crate::services::SessionScheduleService::new(db.clone()));

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -766,6 +766,8 @@ impl WorkerAdapters for DirectWorkerAdapters {
             url: resolved.url,
             api_key: resolved.api_key,
             headers: resolved.headers,
+            auth_mode: resolved.auth_mode,
+            oauth_provider_id: resolved.oauth_provider_id,
         })
     }
 

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -1925,6 +1925,8 @@ impl WorkerService for WorkerServiceImpl {
             url: r.url,
             api_key: r.api_key,
             headers: r.headers,
+            auth_mode: r.auth_mode.to_string(),
+            oauth_provider_id: r.oauth_provider_id,
         });
 
         Ok(Response::new(GetMcpServerByPrefixResponse {

--- a/crates/server/src/services/mcp_server.rs
+++ b/crates/server/src/services/mcp_server.rs
@@ -6,12 +6,15 @@ use crate::storage::{
     models::{CreateMcpServerRow, UpdateMcpServer, UpdateMcpServerTools},
 };
 use anyhow::{Result, anyhow};
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use chrono::{DateTime, Utc};
 use everruns_core::{
-    Caller, McpServer, McpServerStatus, McpServerTransportType, McpToolDefinition,
-    McpToolsListRequest, McpToolsListResponse, Permission, Policy, Rule,
+    Caller, McpServer, McpServerAuthMode, McpServerStatus, McpServerTransportType,
+    McpToolDefinition, McpToolsListRequest, McpToolsListResponse, Permission, Policy, Rule,
+    mcp_oauth_provider_id_for_uuid,
 };
 use everruns_macros::policy;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -48,15 +51,103 @@ pub struct McpServerService {
     encryption: Option<Arc<EncryptionService>>,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct McpServerSettings {
+    #[serde(default)]
+    pub auth_mode: McpServerAuthMode,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oauth: Option<McpServerOAuthSettings>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct McpServerOAuthSettings {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issuer: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authorization_endpoint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_endpoint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub registration_endpoint: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scopes_supported: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_secret_encrypted: Option<String>,
+}
+
 impl McpServerService {
     pub fn new(db: Arc<StorageBackend>, encryption: Option<Arc<EncryptionService>>) -> Self {
         Self { db, encryption }
     }
 
+    pub fn oauth_provider_id(server_id: Uuid) -> String {
+        mcp_oauth_provider_id_for_uuid(server_id)
+    }
+
+    pub fn settings_from_row(row: &McpServerRow) -> McpServerSettings {
+        let mut settings =
+            serde_json::from_value(row.settings.clone()).unwrap_or_else(|_| McpServerSettings {
+                auth_mode: McpServerAuthMode::None,
+                oauth: None,
+            });
+
+        if row.settings.get("auth_mode").is_none() {
+            settings.auth_mode = if settings.oauth.is_some() {
+                McpServerAuthMode::OAuth
+            } else if row.api_key_set {
+                McpServerAuthMode::ApiKey
+            } else {
+                McpServerAuthMode::None
+            };
+        }
+
+        settings
+    }
+
+    fn settings_to_value(settings: &McpServerSettings) -> serde_json::Value {
+        serde_json::to_value(settings).unwrap_or_else(|_| serde_json::json!({}))
+    }
+
+    pub fn encrypt_string_to_b64(&self, value: &str) -> Result<String> {
+        let encryption = self
+            .encryption
+            .as_ref()
+            .ok_or_else(|| anyhow!("Encryption not configured"))?;
+        Ok(BASE64_STANDARD.encode(encryption.encrypt_string(value)?))
+    }
+
+    pub fn decrypt_string_from_b64(&self, value: &str) -> Result<String> {
+        let encryption = self
+            .encryption
+            .as_ref()
+            .ok_or_else(|| anyhow!("Encryption not configured"))?;
+        let bytes = BASE64_STANDARD
+            .decode(value)
+            .map_err(|e| anyhow!("Invalid encrypted value: {e}"))?;
+        Ok(encryption.decrypt_to_string(&bytes)?)
+    }
+
     #[policy(MCP_SERVER_MANAGE)]
     pub async fn create(&self, caller: &Caller, req: CreateMcpServerRequest) -> Result<McpServer> {
+        let auth_mode = req.auth_mode.clone().unwrap_or_else(|| {
+            if req.api_key.is_some() {
+                McpServerAuthMode::ApiKey
+            } else {
+                McpServerAuthMode::None
+            }
+        });
+        if req.api_key.is_some() && auth_mode != McpServerAuthMode::ApiKey {
+            anyhow::bail!("Only API key MCP servers can store an API key");
+        }
         // Encrypt API key if provided
-        let api_key_encrypted = if let Some(api_key) = &req.api_key {
+        let api_key_encrypted = if auth_mode == McpServerAuthMode::ApiKey {
+            let api_key = req
+                .api_key
+                .as_ref()
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| anyhow!("API key auth mode requires an API key"))?;
             let encryption = self
                 .encryption
                 .as_ref()
@@ -64,6 +155,11 @@ impl McpServerService {
             Some(encryption.encrypt_string(api_key)?)
         } else {
             None
+        };
+
+        let settings = McpServerSettings {
+            auth_mode,
+            oauth: None,
         };
 
         let input = CreateMcpServerRow {
@@ -75,7 +171,7 @@ impl McpServerService {
             headers: req
                 .headers
                 .map(|h| serde_json::to_value(h).unwrap_or_default()),
-            settings: None,
+            settings: Some(Self::settings_to_value(&settings)),
         };
 
         let row = self.db.create_mcp_server(caller.org_id, input).await?;
@@ -137,13 +233,43 @@ impl McpServerService {
         {
             anyhow::bail!("Archived or deleted MCP servers cannot be edited");
         }
+        let existing_row = self.db.get_mcp_server(caller.org_id, id).await?;
+        let existing_row = existing_row.ok_or_else(|| anyhow!("MCP server not found"))?;
+        let mut settings = Self::settings_from_row(&existing_row);
+        if let Some(auth_mode) = req.auth_mode.clone() {
+            settings.auth_mode = auth_mode;
+            if settings.auth_mode != McpServerAuthMode::OAuth {
+                settings.oauth = None;
+            }
+        }
+        if req.api_key.is_some() && settings.auth_mode != McpServerAuthMode::ApiKey {
+            anyhow::bail!("Only API key MCP servers can store an API key");
+        }
+        if settings.auth_mode == McpServerAuthMode::ApiKey
+            && !existing_row.api_key_set
+            && req
+                .api_key
+                .as_deref()
+                .filter(|value| !value.is_empty())
+                .is_none()
+        {
+            anyhow::bail!("API key auth mode requires an API key");
+        }
+
         // Encrypt API key if provided
         let api_key_encrypted = if let Some(api_key) = &req.api_key {
             let encryption = self
                 .encryption
                 .as_ref()
                 .ok_or_else(|| anyhow!("Encryption not configured. Cannot store API key."))?;
+            if api_key.is_empty() {
+                anyhow::bail!("API key auth mode requires a non-empty API key");
+            }
             Some(encryption.encrypt_string(api_key)?)
+        } else if req.auth_mode == Some(McpServerAuthMode::None)
+            || req.auth_mode == Some(McpServerAuthMode::OAuth)
+        {
+            Some(Vec::new())
         } else {
             None
         };
@@ -158,7 +284,7 @@ impl McpServerService {
             headers: req
                 .headers
                 .map(|h| serde_json::to_value(h).unwrap_or_default()),
-            settings: None,
+            settings: Some(Self::settings_to_value(&settings)),
         };
 
         let row = self.db.update_mcp_server(caller.org_id, id, input).await?;
@@ -207,9 +333,10 @@ impl McpServerService {
             .get_mcp_server(caller.org_id, id)
             .await?
             .ok_or_else(|| anyhow!("MCP server not found"))?;
+        let settings = Self::settings_from_row(&row);
 
         // Get decrypted API key if set
-        let api_key = if row.api_key_set {
+        let api_key = if settings.auth_mode == McpServerAuthMode::ApiKey && row.api_key_set {
             if let Some(encrypted) = &row.api_key_encrypted {
                 let encryption = self
                     .encryption
@@ -227,6 +354,17 @@ impl McpServerService {
         let headers: HashMap<String, String> =
             serde_json::from_value(row.headers.clone()).unwrap_or_default();
 
+        if settings.auth_mode == McpServerAuthMode::OAuth {
+            let tools: Vec<McpToolDefinition> =
+                serde_json::from_value(row.cached_tools.clone()).unwrap_or_default();
+            if !tools.is_empty() {
+                return Ok(tools);
+            }
+            anyhow::bail!(
+                "OAuth MCP servers require a user connection before tools can be refreshed"
+            );
+        }
+
         // Fetch tools from MCP server
         let tools = fetch_mcp_tools(&row.url, api_key.as_deref(), &headers).await?;
 
@@ -236,6 +374,27 @@ impl McpServerService {
             .update_mcp_server_tools(caller.org_id, id, UpdateMcpServerTools { cached_tools })
             .await?;
 
+        Ok(tools)
+    }
+
+    pub async fn cache_tools_for_bearer_token(
+        &self,
+        caller: &Caller,
+        id: Uuid,
+        token: &str,
+    ) -> Result<Vec<McpToolDefinition>> {
+        let row = self
+            .db
+            .get_mcp_server(caller.org_id, id)
+            .await?
+            .ok_or_else(|| anyhow!("MCP server not found"))?;
+        let headers: HashMap<String, String> =
+            serde_json::from_value(row.headers.clone()).unwrap_or_default();
+        let tools = fetch_mcp_tools(&row.url, Some(token), &headers).await?;
+        let cached_tools = serde_json::to_value(&tools)?;
+        self.db
+            .update_mcp_server_tools(caller.org_id, id, UpdateMcpServerTools { cached_tools })
+            .await?;
         Ok(tools)
     }
 
@@ -342,7 +501,7 @@ impl McpServerService {
             None => return Ok(None),
         };
 
-        let api_key = if server.api_key_set {
+        let api_key = if server.auth_mode == McpServerAuthMode::ApiKey && server.api_key_set {
             self.decrypt_api_key(caller, server.id.uuid()).await?
         } else {
             None
@@ -352,6 +511,8 @@ impl McpServerService {
             id: server.id.uuid(),
             name: server.name,
             url: server.url,
+            auth_mode: server.auth_mode,
+            oauth_provider_id: server.oauth_provider_id,
             api_key,
             headers: server.headers,
         }))
@@ -361,6 +522,9 @@ impl McpServerService {
         // Parse headers from JSON
         let headers: HashMap<String, String> =
             serde_json::from_value(row.headers.clone()).unwrap_or_default();
+        let settings = Self::settings_from_row(row);
+        let oauth_provider_id = (settings.auth_mode == McpServerAuthMode::OAuth)
+            .then(|| Self::oauth_provider_id(row.id.uuid()));
 
         McpServer {
             id: row.id,
@@ -369,6 +533,8 @@ impl McpServerService {
             url: row.url.clone(),
             transport_type: McpServerTransportType::from(row.transport_type.as_str()),
             status: McpServerStatus::from(row.status.as_str()),
+            auth_mode: settings.auth_mode,
+            oauth_provider_id,
             api_key_set: row.api_key_set,
             headers,
             created_at: row.created_at,
@@ -408,6 +574,8 @@ pub struct McpServerResolved {
     pub id: Uuid,
     pub name: String,
     pub url: String,
+    pub auth_mode: McpServerAuthMode,
+    pub oauth_provider_id: Option<String>,
     pub api_key: Option<String>,
     pub headers: HashMap<String, String>,
 }
@@ -713,6 +881,55 @@ mod tests {
         // Service without encryption
         let svc = McpServerService::new(db, None);
         let result = svc.resolve_by_prefix(&test_caller(1), "no_enc").await;
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn settings_from_row_defaults_auth_mode_for_legacy_api_key_servers() {
+        let row = McpServerRow {
+            id: everruns_core::typed_id::McpServerId::new(),
+            org_id: 1,
+            name: "legacy".into(),
+            description: None,
+            url: "https://example.com/mcp".into(),
+            transport_type: "http".into(),
+            status: "active".into(),
+            api_key_encrypted: Some(vec![1, 2, 3]),
+            api_key_set: true,
+            headers: serde_json::json!({}),
+            settings: serde_json::json!({}),
+            cached_tools: serde_json::json!([]),
+            tools_cached_at: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            archived_at: None,
+            deleted_at: None,
+        };
+
+        let settings = McpServerService::settings_from_row(&row);
+        assert_eq!(settings.auth_mode, McpServerAuthMode::ApiKey);
+    }
+
+    #[tokio::test]
+    async fn create_rejects_api_key_when_auth_mode_is_not_api_key() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let svc = McpServerService::new(db, Some(test_encryption()));
+
+        let result = svc
+            .create(
+                &test_caller(1),
+                CreateMcpServerRequest {
+                    name: "bad-server".into(),
+                    description: None,
+                    url: "https://example.com/mcp".into(),
+                    transport_type: McpServerTransportType::Http,
+                    auth_mode: Some(McpServerAuthMode::None),
+                    api_key: Some("secret".into()),
+                    headers: None,
+                },
+            )
+            .await;
+
         assert!(result.is_err());
     }
 }

--- a/crates/server/src/services/mcp_server.rs
+++ b/crates/server/src/services/mcp_server.rs
@@ -88,7 +88,7 @@ impl McpServerService {
 
     pub fn settings_from_row(row: &McpServerRow) -> McpServerSettings {
         let mut settings =
-            serde_json::from_value(row.settings.clone()).unwrap_or_else(|_| McpServerSettings {
+            serde_json::from_value(row.settings.clone()).unwrap_or(McpServerSettings {
                 auth_mode: McpServerAuthMode::None,
                 oauth: None,
             });
@@ -126,7 +126,7 @@ impl McpServerService {
         let bytes = BASE64_STANDARD
             .decode(value)
             .map_err(|e| anyhow!("Invalid encrypted value: {e}"))?;
-        Ok(encryption.decrypt_to_string(&bytes)?)
+        encryption.decrypt_to_string(&bytes)
     }
 
     #[policy(MCP_SERVER_MANAGE)]

--- a/crates/server/src/storage/memory/mcp_servers.rs
+++ b/crates/server/src/storage/memory/mcp_servers.rs
@@ -225,8 +225,13 @@ impl InMemoryDatabase {
                 server.status = status;
             }
             if let Some(api_key_encrypted) = input.api_key_encrypted {
-                server.api_key_encrypted = Some(api_key_encrypted);
-                server.api_key_set = true;
+                if api_key_encrypted.is_empty() {
+                    server.api_key_encrypted = None;
+                    server.api_key_set = false;
+                } else {
+                    server.api_key_encrypted = Some(api_key_encrypted);
+                    server.api_key_set = true;
+                }
             }
             if let Some(headers) = input.headers {
                 server.headers = headers;

--- a/crates/server/src/storage/repositories/mcp_servers.rs
+++ b/crates/server/src/storage/repositories/mcp_servers.rs
@@ -199,8 +199,21 @@ impl Database {
         id: Uuid,
         input: UpdateMcpServer,
     ) -> Result<Option<McpServerRow>> {
+        let clear_api_key = input
+            .api_key_encrypted
+            .as_ref()
+            .is_some_and(|bytes| bytes.is_empty());
         // Handle api_key_set: if we're updating the encrypted key, also update the flag
-        let api_key_set = input.api_key_encrypted.as_ref().map(|_| true);
+        let api_key_set = match input.api_key_encrypted.as_ref() {
+            Some(bytes) if bytes.is_empty() => Some(false),
+            Some(_) => Some(true),
+            None => None,
+        };
+        let api_key_encrypted = match input.api_key_encrypted.as_ref() {
+            Some(bytes) if bytes.is_empty() => None,
+            Some(bytes) => Some(bytes.clone()),
+            None => None,
+        };
 
         let row = sqlx::query_as::<_, McpServerRow>(
             r#"
@@ -211,7 +224,7 @@ impl Database {
                 url = COALESCE($5, url),
                 transport_type = COALESCE($6, transport_type),
                 status = COALESCE($7, status),
-                api_key_encrypted = COALESCE($8, api_key_encrypted),
+                api_key_encrypted = CASE WHEN $12 THEN NULL ELSE COALESCE($8, api_key_encrypted) END,
                 api_key_set = COALESCE($9, api_key_set),
                 headers = COALESCE($10, headers),
                 settings = COALESCE($11, settings)
@@ -226,10 +239,11 @@ impl Database {
         .bind(&input.url)
         .bind(&input.transport_type)
         .bind(&input.status)
-        .bind(&input.api_key_encrypted)
+        .bind(&api_key_encrypted)
         .bind(api_key_set)
         .bind(&input.headers)
         .bind(&input.settings)
+        .bind(clear_api_key)
         .fetch_optional(&self.pool)
         .await?;
 

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -232,12 +232,17 @@ impl TestServer {
         let feature_flags_state = api::feature_flags::AppState {
             flags: feature_flags.clone(),
         };
+        let mcp_service = std::sync::Arc::new(everruns_server::services::McpServerService::new(
+            db.clone(),
+            encryption.clone(),
+        ));
         let user_connections_state = api::user_connections::AppState::new(
             db.clone(),
             encryption.clone(),
             auth_state.clone(),
             auth_config.clone(),
             platform_definition.connection_providers().clone(),
+            mcp_service,
         );
 
         let apps_state = api::apps::AppState::new(db.clone(), None, auth_state.clone());

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -234,12 +234,20 @@ impl GrpcClient {
             AgentLoopError::store(format!("MCP server not found for prefix: {server_prefix}"))
         })?;
 
+        let auth_mode = if proto_server.auth_mode.is_empty() && proto_server.api_key.is_some() {
+            everruns_core::McpServerAuthMode::ApiKey
+        } else {
+            everruns_core::McpServerAuthMode::from(proto_server.auth_mode.as_str())
+        };
+
         Ok(crate::mcp_executor::McpServerInfo {
             id: proto_uuid_to_uuid(proto_server.id.as_ref())?,
             name: proto_server.name,
             url: proto_server.url,
             api_key: proto_server.api_key,
             headers: proto_server.headers,
+            auth_mode,
+            oauth_provider_id: proto_server.oauth_provider_id,
         })
     }
 

--- a/crates/worker/src/mcp_executor.rs
+++ b/crates/worker/src/mcp_executor.rs
@@ -7,8 +7,9 @@ use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use everruns_core::traits::{ToolContext, ToolExecutor};
 use everruns_core::{
-    McpContent, McpToolCallRequest, McpToolCallResponse, ToolCall, ToolDefinition, ToolResult,
-    ToolResultImage, is_mcp_tool, parse_mcp_tool_name, validate_safe_url,
+    McpContent, McpServerAuthMode, McpToolCallRequest, McpToolCallResponse, ToolCall,
+    ToolDefinition, ToolResult, ToolResultImage, is_mcp_tool, mcp_oauth_session_secret_name,
+    parse_mcp_tool_name, validate_safe_url,
 };
 use serde_json::json;
 use std::collections::HashMap;
@@ -28,6 +29,8 @@ pub struct McpServerInfo {
     pub url: String,
     pub api_key: Option<String>,
     pub headers: HashMap<String, String>,
+    pub auth_mode: McpServerAuthMode,
+    pub oauth_provider_id: Option<String>,
 }
 
 /// MCP Tool Executor - executes tools by calling remote MCP servers
@@ -48,7 +51,11 @@ impl McpToolExecutor {
     }
 
     /// Execute an MCP tool by calling the remote server
-    pub async fn execute_mcp_tool(&self, tool_call: &ToolCall) -> Result<ToolResult> {
+    pub async fn execute_mcp_tool(
+        &self,
+        tool_call: &ToolCall,
+        context: Option<&ToolContext>,
+    ) -> Result<ToolResult> {
         // Parse tool name to get server prefix and original tool name
         let (server_prefix, original_tool_name) = parse_mcp_tool_name(&tool_call.name)
             .ok_or_else(|| anyhow!("Invalid MCP tool name: {}", tool_call.name))?;
@@ -57,10 +64,26 @@ impl McpToolExecutor {
         let server_info = self.get_server_info(&server_prefix).await?;
 
         // Call the MCP server
+        let auth_header = self.resolve_auth_header(&server_info, context).await?;
+        if server_info.auth_mode == McpServerAuthMode::OAuth && auth_header.is_none() {
+            let provider = server_info
+                .oauth_provider_id
+                .clone()
+                .ok_or_else(|| anyhow!("OAuth MCP server missing oauth_provider_id"))?;
+            return Ok(ToolResult {
+                tool_call_id: tool_call.id.clone(),
+                result: Some(json!({ "connection_required": provider })),
+                images: None,
+                error: None,
+                connection_required: Some(provider),
+            });
+        }
+
         let (result, images) = call_mcp_tool(
             &server_info,
             &original_tool_name,
             tool_call.arguments.clone(),
+            auth_header.as_deref(),
         )
         .await?;
 
@@ -106,6 +129,42 @@ impl McpToolExecutor {
     pub fn is_mcp_tool(tool_name: &str) -> bool {
         is_mcp_tool(tool_name)
     }
+
+    async fn resolve_auth_header(
+        &self,
+        server_info: &McpServerInfo,
+        context: Option<&ToolContext>,
+    ) -> Result<Option<String>> {
+        match server_info.auth_mode {
+            McpServerAuthMode::None => Ok(None),
+            McpServerAuthMode::ApiKey => Ok(server_info
+                .api_key
+                .as_ref()
+                .map(|token| format!("Bearer {}", token))),
+            McpServerAuthMode::OAuth => {
+                let Some(context) = context else {
+                    return Ok(None);
+                };
+                if let Some(storage) = &context.storage_store {
+                    let secret_name = mcp_oauth_session_secret_name(server_info.id, "access_token");
+                    if let Some(token) =
+                        storage.get_secret(context.session_id, &secret_name).await?
+                    {
+                        return Ok(Some(format!("Bearer {}", token)));
+                    }
+                }
+                if let (Some(resolver), Some(provider)) =
+                    (&context.connection_resolver, &server_info.oauth_provider_id)
+                    && let Some(token) = resolver
+                        .get_connection_token(context.session_id, provider)
+                        .await?
+                {
+                    return Ok(Some(format!("Bearer {}", token)));
+                }
+                Ok(None)
+            }
+        }
+    }
 }
 
 /// Call an MCP server's tools/call endpoint.
@@ -114,6 +173,7 @@ async fn call_mcp_tool(
     server_info: &McpServerInfo,
     tool_name: &str,
     arguments: serde_json::Value,
+    authorization_header: Option<&str>,
 ) -> Result<(serde_json::Value, Vec<ToolResultImage>)> {
     // Re-validate URL at execution time to catch TOCTOU / post-registration changes
     validate_safe_url(&server_info.url).map_err(|e| {
@@ -139,9 +199,9 @@ async fn call_mcp_tool(
 
     let mut req_builder = client.post(&server_info.url).json(&request);
 
-    // Add API key if provided
-    if let Some(ref api_key) = server_info.api_key {
-        req_builder = req_builder.header("Authorization", format!("Bearer {}", api_key));
+    // Add Authorization header (API key, OAuth token, etc.) if provided
+    if let Some(auth_header) = authorization_header {
+        req_builder = req_builder.header("Authorization", auth_header);
     }
 
     // Add custom headers
@@ -307,10 +367,13 @@ impl ToolExecutor for CompositeToolExecutor {
     ) -> everruns_core::Result<ToolResult> {
         if McpToolExecutor::is_mcp_tool(&tool_call.name) {
             // Execute MCP tool
-            self.mcp.execute_mcp_tool(tool_call).await.map_err(|e| {
-                tracing::error!(error = %e, "MCP tool execution failed");
-                everruns_core::AgentLoopError::tool(e.to_string())
-            })
+            self.mcp
+                .execute_mcp_tool(tool_call, None)
+                .await
+                .map_err(|e| {
+                    tracing::error!(error = %e, "MCP tool execution failed");
+                    everruns_core::AgentLoopError::tool(e.to_string())
+                })
         } else {
             // Execute built-in tool
             self.builtin.execute(tool_call, tool_def).await
@@ -325,10 +388,13 @@ impl ToolExecutor for CompositeToolExecutor {
     ) -> everruns_core::Result<ToolResult> {
         if McpToolExecutor::is_mcp_tool(&tool_call.name) {
             // MCP tools don't use context - execute directly
-            self.mcp.execute_mcp_tool(tool_call).await.map_err(|e| {
-                tracing::error!(error = %e, "MCP tool execution failed");
-                everruns_core::AgentLoopError::tool(e.to_string())
-            })
+            self.mcp
+                .execute_mcp_tool(tool_call, Some(context))
+                .await
+                .map_err(|e| {
+                    tracing::error!(error = %e, "MCP tool execution failed");
+                    everruns_core::AgentLoopError::tool(e.to_string())
+                })
         } else {
             // Execute built-in tool with context
             self.builtin
@@ -481,8 +547,10 @@ data: {"result":{"tools":[{"name":"search","description":"Search docs"}]},"id":1
             url: "http://localhost:9999/mcp".into(),
             api_key: None,
             headers: HashMap::new(),
+            auth_mode: McpServerAuthMode::None,
+            oauth_provider_id: None,
         };
-        let result = call_mcp_tool(&server, "test_tool", serde_json::json!({})).await;
+        let result = call_mcp_tool(&server, "test_tool", serde_json::json!({}), None).await;
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(
@@ -499,8 +567,10 @@ data: {"result":{"tools":[{"name":"search","description":"Search docs"}]},"id":1
             url: "http://10.0.0.1/mcp".into(),
             api_key: None,
             headers: HashMap::new(),
+            auth_mode: McpServerAuthMode::None,
+            oauth_provider_id: None,
         };
-        let result = call_mcp_tool(&server, "test_tool", serde_json::json!({})).await;
+        let result = call_mcp_tool(&server, "test_tool", serde_json::json!({}), None).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("blocked"));
     }
@@ -513,8 +583,10 @@ data: {"result":{"tools":[{"name":"search","description":"Search docs"}]},"id":1
             url: "http://169.254.169.254/latest/meta-data/".into(),
             api_key: None,
             headers: HashMap::new(),
+            auth_mode: McpServerAuthMode::None,
+            oauth_provider_id: None,
         };
-        let result = call_mcp_tool(&server, "test_tool", serde_json::json!({})).await;
+        let result = call_mcp_tool(&server, "test_tool", serde_json::json!({}), None).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("blocked"));
     }
@@ -527,8 +599,10 @@ data: {"result":{"tools":[{"name":"search","description":"Search docs"}]},"id":1
             url: "http://[::1]:8080/mcp".into(),
             api_key: None,
             headers: HashMap::new(),
+            auth_mode: McpServerAuthMode::None,
+            oauth_provider_id: None,
         };
-        let result = call_mcp_tool(&server, "test_tool", serde_json::json!({})).await;
+        let result = call_mcp_tool(&server, "test_tool", serde_json::json!({}), None).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("blocked"));
     }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -5646,6 +5646,17 @@
             ],
             "description": "API key for authentication (optional)."
           },
+          "auth_mode": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/McpServerAuthMode",
+                "description": "Authentication mode. Defaults to `api_key` when `api_key` is provided, otherwise `none`."
+              }
+            ]
+          },
           "description": {
             "type": [
               "string",
@@ -7723,6 +7734,10 @@
                   "format": "date-time",
                   "description": "Timestamp when the MCP server was archived."
                 },
+                "auth_mode": {
+                  "$ref": "#/components/schemas/McpServerAuthMode",
+                  "description": "Authentication mode for this MCP server."
+                },
                 "created_at": {
                   "type": "string",
                   "format": "date-time",
@@ -7763,6 +7778,13 @@
                   "type": "string",
                   "description": "Display name of the MCP server.",
                   "example": "atlassian-mcp-server"
+                },
+                "oauth_provider_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Stable provider id used for user-scoped OAuth connections."
                 },
                 "status": {
                   "$ref": "#/components/schemas/McpServerStatus",
@@ -8904,6 +8926,10 @@
             "format": "date-time",
             "description": "Timestamp when the MCP server was archived."
           },
+          "auth_mode": {
+            "$ref": "#/components/schemas/McpServerAuthMode",
+            "description": "Authentication mode for this MCP server."
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -8945,6 +8971,13 @@
             "description": "Display name of the MCP server.",
             "example": "atlassian-mcp-server"
           },
+          "oauth_provider_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Stable provider id used for user-scoped OAuth connections."
+          },
           "status": {
             "$ref": "#/components/schemas/McpServerStatus",
             "description": "Current lifecycle status of the MCP server."
@@ -8964,6 +8997,15 @@
             "example": "https://mcp.atlassian.com/v1/mcp"
           }
         }
+      },
+      "McpServerAuthMode": {
+        "type": "string",
+        "description": "MCP server authentication mode.",
+        "enum": [
+          "none",
+          "api_key",
+          "o_auth"
+        ]
       },
       "McpServerStatus": {
         "type": "string",
@@ -11740,6 +11782,17 @@
               "null"
             ],
             "description": "API key for authentication. Set to update."
+          },
+          "auth_mode": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/McpServerAuthMode",
+                "description": "Authentication mode."
+              }
+            ]
           },
           "description": {
             "type": [


### PR DESCRIPTION
## What
Add explicit MCP server auth modes (`none`, `api_key`, `oauth`) and the OAuth connection flow needed for MCP tool execution.

## Why
Some MCP servers need no auth, some need an org API key, and some need per-user OAuth. The previous implementation also needed follow-up fixes so session OAuth validation, metadata discovery, and popup return handling behave correctly.

## How
- Wire `auth_mode` / `oauth_provider_id` through core, server, worker, proto, storage, and UI
- Add MCP OAuth authorize/callback handling, registration/discovery helpers, and bearer-token tool caching
- Return `connection_required` from MCP tool execution when a user OAuth token is needed
- Update the MCP settings UI and inline chat connection flow for OAuth-backed MCP servers
- Tighten the OAuth flow by validating mode/session inputs, preserving custom ports in resource discovery, supporting preconfigured OAuth clients without dynamic registration, and fixing popup `return_to` handling
- Fix compilation errors: non-Send ThreadRng across await, mismatched TypedId/Uuid, missing type annotation, non-existent AuthConfig field
- Fix clippy lints: items after test module, unnecessary_lazy_evaluations, needless_question_mark
- Wrap connection-complete page in Suspense boundary for Next.js SSR

## Risk
- Medium
- Touches MCP registration, OAuth callback flows, worker auth resolution, and chat connection UX

## Security
- Threat categories reviewed: TM-AUTH, TM-AUTHZ, TM-API, TM-LLM, TM-TENANT
- OAuth state is CSRF-protected via browser-bound cookie + PKCE verifier, preventing cross-user token injection into sessions
- All external OAuth URLs validated via `validate_safe_url` (SSRF protection for metadata discovery, token exchange, client registration)
- Session OAuth callback is org-scoped via `get_session(org_id, session_id)` and browser-bound via state cookie
- `authorization_servers` from remote metadata are validated before any outbound requests
- `json_response_or_error` checks HTTP status before JSON parsing, preventing error masking
- Backward compatibility: empty `auth_mode` in proto infers `ApiKey` when `api_key` is present; missing `auth_mode` in DB settings falls back based on `api_key_set` / `oauth` presence
- Redundant `AuthUser` extractor removed from OAuth handlers (ResolvedOrg already authenticates)

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)