### PR TITLE
chore(cli): bump everruns-sdk to v0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
 dependencies = [
  "rustversion",
 ]
@@ -302,9 +302,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -313,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",
@@ -331,6 +331,7 @@ checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
  "axum-macros",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -349,8 +350,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite 0.28.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1494,7 +1497,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.26.2",
  "tracing",
  "wiremock",
 ]
@@ -1597,8 +1600,8 @@ version = "0.8.6"
 
 [[package]]
 name = "everruns-sdk"
-version = "0.1.4"
-source = "git+https://github.com/everruns/sdk?tag=v0.1.4#a273c8a3778d4b77f6971e01fdf9655157ace160"
+version = "0.1.5"
+source = "git+https://github.com/everruns/sdk?tag=v0.1.5#d37f9edca297ca1f73f30f9a44b99aebcafa348b"
 dependencies = [
  "async-stream",
  "futures",
@@ -2806,9 +2809,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jaq-core"
@@ -3115,9 +3118,9 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llmsim"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee85a0452328a104883fab9f72c292d0548b842fb3b1fe6bec122383a9dbccf"
+checksum = "c11f7bad1bed2978afdd2670412e1af1503a024367ca6369bb0a7f368ea241a0"
 dependencies = [
  "async-stream",
  "axum",
@@ -3733,9 +3736,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
  "http",
  "opentelemetry",
@@ -4206,9 +4209,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c41efbf8f90ac44de7f3a868f0867851d261b56291732d0cbf7cceaaeb55a6"
+checksum = "14104c5a24d9bcf7eb2c24753e0f49fe14555d8bd565ea3d38e4b4303267259d"
 dependencies = [
  "bitflags 2.11.0",
  "memchr",
@@ -5961,7 +5964,19 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.26.2",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -6243,6 +6258,23 @@ dependencies = [
  "rand 0.9.2",
  "rustls",
  "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -7437,18 +7469,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7558,9 +7590,9 @@ checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec5f41c76397b7da451efd19915684f727d7e1d516384ca6bd0ec43ec94de23c"
+checksum = "0b7a1c0af6e5d8d1363f4994b7a091ccf963d8b694f7da5b0b9cceb82da2c0a6"
 dependencies = [
  "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ tokio-tungstenite = { version = "0.26", features = ["rustls-tls-native-roots"] }
 futures-util = "0.3"
 
 # Everruns SDK
-everruns-sdk = { git = "https://github.com/everruns/sdk", tag = "v0.1.4" }
+everruns-sdk = { git = "https://github.com/everruns/sdk", tag = "v0.1.5" }
 
 # gRPC (tonic)
 tonic = { version = "0.14", features = ["tls-ring"] }

--- a/crates/cli/src/commands/capabilities.rs
+++ b/crates/cli/src/commands/capabilities.rs
@@ -38,8 +38,21 @@ pub async fn run(client: &Everruns, output: OutputFormat, status_filter: &str) -
             ]);
         }
     } else {
-        // For JSON/YAML output, return the filtered list
-        output.print_value(&serde_json::json!({ "data": filtered, "total": filtered.len() }));
+        // For JSON/YAML output, project to a stable field set
+        let items: Vec<_> = filtered
+            .iter()
+            .map(|c| {
+                serde_json::json!({
+                    "id": c.id,
+                    "name": c.name,
+                    "description": c.description,
+                    "status": c.status,
+                    "icon": c.icon,
+                    "category": c.category,
+                })
+            })
+            .collect();
+        output.print_value(&serde_json::json!({ "data": items, "total": items.len() }));
     }
 
     Ok(())

--- a/crates/cli/src/commands/capabilities.rs
+++ b/crates/cli/src/commands/capabilities.rs
@@ -1,50 +1,14 @@
 // Capabilities listing command
-//
-// TODO(sdk): Replace raw reqwest with SDK capabilities() methods once available.
-// Note: Capabilities endpoint is not yet supported by the SDK,
-// so we use reqwest directly here.
 
 use crate::output::{OutputFormat, print_table_header, print_table_row};
 use anyhow::Result;
-use serde::{Deserialize, Serialize};
+use everruns_sdk::Everruns;
 
-/// Capability info from API
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CapabilityInfo {
-    pub id: String,
-    pub name: String,
-    pub description: String,
-    pub status: String,
-    #[serde(default)]
-    pub icon: Option<String>,
-    #[serde(default)]
-    pub category: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct ListResponse<T> {
-    data: Vec<T>,
-}
-
-pub async fn run(
-    api_url: &str,
-    api_key: &str,
-    output: OutputFormat,
-    status_filter: &str,
-) -> Result<()> {
-    let client = reqwest::Client::new();
-    let url = format!("{}/v1/capabilities", api_url.trim_end_matches('/'));
-
-    let response: ListResponse<CapabilityInfo> = client
-        .get(&url)
-        .header("Authorization", api_key)
-        .send()
-        .await?
-        .json()
-        .await?;
+pub async fn run(client: &Everruns, output: OutputFormat, status_filter: &str) -> Result<()> {
+    let response = client.capabilities().list().await?;
 
     // Filter by status
-    let filtered: Vec<&CapabilityInfo> = response
+    let filtered: Vec<_> = response
         .data
         .iter()
         .filter(|c| {

--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -8,8 +8,6 @@ use std::time::{Duration, Instant};
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
     client: &Everruns,
-    _api_url: &str,
-    _api_key: &str,
     output: OutputFormat,
     quiet: bool,
     message: String,

--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -1,39 +1,15 @@
 // Chat command - send message and stream response
-//
-// Design Decision: Use raw reqwest for event polling instead of SDK's events().list()
-// because the server's ListResponse for events only has `data` while the SDK's
-// ListResponse expects `total`, `offset`, `limit` — causing deserialization failures.
-// TODO(sdk): Switch back to client.events().list() once https://github.com/everruns/sdk/issues/63 lands.
 
 use crate::output::OutputFormat;
 use anyhow::Result;
 use everruns_sdk::Everruns;
-use serde::Deserialize;
 use std::time::{Duration, Instant};
-
-/// Minimal event response matching what the server actually returns.
-/// The server's ListResponse only contains `data` (no total/offset/limit),
-/// which differs from the SDK's ListResponse that requires those fields.
-#[derive(Debug, Deserialize)]
-struct EventsResponse {
-    data: Vec<EventEntry>,
-}
-
-#[derive(Debug, Deserialize)]
-struct EventEntry {
-    id: String,
-    #[serde(rename = "type")]
-    event_type: String,
-    ts: String,
-    session_id: String,
-    data: serde_json::Value,
-}
 
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
     client: &Everruns,
-    api_url: &str,
-    api_key: &str,
+    _api_url: &str,
+    _api_key: &str,
     output: OutputFormat,
     quiet: bool,
     message: String,
@@ -59,9 +35,6 @@ pub async fn run(
     let mut last_event_id: Option<String> = None;
     let mut agent_content = String::new();
 
-    // Build a raw HTTP client for event polling to avoid SDK ListResponse mismatch
-    let http = reqwest::Client::new();
-
     loop {
         if start.elapsed() > timeout {
             if output.is_text() {
@@ -70,19 +43,8 @@ pub async fn run(
             anyhow::bail!("Timeout waiting for response");
         }
 
-        // Fetch events via raw HTTP to avoid SDK deserialization issues
-        let url = format!(
-            "{}/v1/sessions/{}/events",
-            api_url.trim_end_matches('/'),
-            session_id
-        );
-        let response: EventsResponse = http
-            .get(&url)
-            .header("Authorization", api_key)
-            .send()
-            .await?
-            .json()
-            .await?;
+        // Fetch events via SDK (ListResponse pagination fields are optional since SDK v0.1.5)
+        let response = client.events().list(&session_id).await?;
 
         // Filter events since last seen
         let events: Vec<_> = if let Some(ref last_id) = last_event_id {

--- a/crates/cli/src/commands/files/mod.rs
+++ b/crates/cli/src/commands/files/mod.rs
@@ -1,10 +1,10 @@
 // File sync CLI commands
 //
-// TODO(sdk): Replace RemoteClient (raw reqwest) with SDK session_files() methods
-// once everruns-sdk ships support (see https://github.com/everruns/sdk/issues/60).
+// TODO(sdk): Replace RemoteClient (raw reqwest) with SDK session_files() methods.
+// SDK v0.1.5 ships session filesystem support (https://github.com/everruns/sdk/issues/60 resolved).
+// Migration is tracked separately — involves adapting to SDK's FileInfo/SessionFile types.
 //
 // Design Decision: All file operations grouped under `everruns files` subcommand.
-// Design Decision: Remote API client uses reqwest directly (session filesystem not in SDK yet).
 
 pub mod ls;
 pub mod pull;

--- a/crates/cli/src/commands/files/remote.rs
+++ b/crates/cli/src/commands/files/remote.rs
@@ -1,10 +1,10 @@
 // Remote session filesystem API client
 //
-// TODO(sdk): Replace all raw reqwest calls with SDK methods once everruns-sdk
-// ships session filesystem support (see https://github.com/everruns/sdk/issues/60).
+// TODO(sdk): Replace all raw reqwest calls with SDK session_files() methods.
+// SDK v0.1.5 ships session filesystem support (https://github.com/everruns/sdk/issues/60 resolved).
+// Migration is tracked separately — involves adapting to SDK's FileInfo/SessionFile types.
 // Affected methods: list, read_file, write_file, create_dir, delete.
 //
-// Design Decision: Direct reqwest calls since session filesystem is not in the SDK yet.
 // Design Decision: Binary detection mirrors server logic (null bytes in first 8KB).
 
 use anyhow::{Context, Result};
@@ -76,7 +76,6 @@ impl RemoteClient {
     }
 
     /// List files at a path. If recursive, lists the entire tree.
-    // TODO(sdk): Replace with sdk.session_files().list(session_id, path, recursive)
     pub async fn list(&self, path: &str, recursive: bool) -> Result<Vec<RemoteFileEntry>> {
         let mut url = self.fs_url(path);
         if recursive {
@@ -118,7 +117,6 @@ impl RemoteClient {
     }
 
     /// Read file content.
-    // TODO(sdk): Replace with sdk.session_files().read(session_id, path)
     pub async fn read_file(&self, path: &str) -> Result<RemoteFileContent> {
         let url = self.fs_url(path);
         let resp = self
@@ -151,7 +149,6 @@ impl RemoteClient {
     }
 
     /// Create or update a file on remote.
-    // TODO(sdk): Replace with sdk.session_files().create() / .update()
     pub async fn write_file(&self, path: &str, content: &[u8], create: bool) -> Result<()> {
         let url = self.fs_url(path);
 
@@ -226,7 +223,6 @@ impl RemoteClient {
     }
 
     /// Delete a file or directory on remote.
-    // TODO(sdk): Replace with sdk.session_files().delete(session_id, path, recursive)
     pub async fn delete(&self, path: &str, recursive: bool) -> Result<()> {
         let mut url = self.fs_url(path);
         if recursive {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -167,7 +167,7 @@ async fn main() -> anyhow::Result<()> {
                 Some(CapabilitiesCommand::List { status }) => status.clone(),
                 None => "available".to_string(),
             };
-            commands::capabilities::run(&api_url, &api_key, output_format, &status).await
+            commands::capabilities::run(&client, output_format, &status).await
         }
         Commands::Sessions { command } => {
             commands::sessions::run(command, &client, output_format, cli.quiet).await

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -183,8 +183,6 @@ async fn main() -> anyhow::Result<()> {
         } => {
             commands::chat::run(
                 &client,
-                &api_url,
-                &api_key,
                 output_format,
                 cli.quiet,
                 message,


### PR DESCRIPTION
## What
Bump everruns-sdk from v0.1.4 to v0.1.5 and resolve two CLI workarounds that the new SDK version enables.

## Why
SDK v0.1.5 ships two fixes the CLI was working around:
- **PR #64**: `ListResponse` pagination fields are now optional, fixing deserialization when the server omits them.
- **PR #62**: Session filesystem client methods added.

## How
- **Cargo.toml**: `everruns-sdk` tag `v0.1.4` to `v0.1.5`
- **chat.rs**: Removed raw `reqwest` event polling, custom types, and unused `api_url`/`api_key` params. Now uses `client.events().list()` directly.
- **capabilities.rs**: Removed raw `reqwest` calls and local types. Now uses `client.capabilities().list()`. JSON output projects to a stable field set matching the previous local type.
- **main.rs**: Updated call sites for new signatures.
- **files/mod.rs, files/remote.rs**: Updated TODO comments to note SDK v0.1.5 ships session filesystem support. Full migration to SDK types deferred.

Net: removes two raw HTTP workarounds in favor of typed SDK calls.

## Risk
- Low
- The SDK client methods hit the same API endpoints as the raw reqwest calls they replace.

## Security
- Threat categories reviewed: TM-LLM -- dependency version change
- No new endpoints, auth changes, or input handling. Removes raw HTTP handling in favor of typed SDK client calls. First-party dependency minor version bump.

## Checklist
- [x] Tests added or updated -- existing 110 CLI tests pass; no new tests needed as this is a dependency bump with equivalent behavior
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed