### PR TITLE
feat(daytona): expose cpu, memory, and disk resource options on sandbox creation

### DIFF
--- a/integrations/daytona/SPEC.md
+++ b/integrations/daytona/SPEC.md
@@ -77,7 +77,7 @@ This avoids entering the key in chat (see TM-AGENT-016).
 
 | Method | Path | Purpose | Request Body |
 |--------|------|---------|-------------|
-| POST | `/sandbox` | Create sandbox | `{ name?, image?, autoStopInterval, autoArchiveInterval, autoDeleteInterval, labels? }` |
+| POST | `/sandbox` | Create sandbox | `{ name?, image?, resources?: { cpu?, memory?, disk? }, autoStopInterval, autoArchiveInterval, autoDeleteInterval, labels? }` |
 | GET | `/sandbox/{id}` | Get sandbox info | — |
 | POST | `/sandbox/{id}/start` | Start sandbox | — |
 | POST | `/sandbox/{id}/stop` | Stop sandbox | — |
@@ -104,6 +104,9 @@ Creates a new sandbox. Optionally uploads files from session storage.
 - **Parameters**:
   - `title`: string (optional) — sandbox name
   - `image`: string (optional) — container image
+  - `cpu`: integer (optional) — vCPUs, 1-4 (default: 1)
+  - `memory`: integer (optional) — GiB RAM, 1-8 (default: 1)
+  - `disk`: integer (optional) — GiB disk, 1-10 (default: 3)
   - `upload_files`: array (optional) — `[{session_path, sandbox_path}]`
 - **Returns**: `{ sandbox_id, status, workspace_path }`
 

--- a/integrations/daytona/SPEC.md
+++ b/integrations/daytona/SPEC.md
@@ -109,6 +109,7 @@ Creates a new sandbox. Optionally uploads files from session storage.
   - `disk`: integer (optional) — GiB disk, 1-10 (default: 3)
   - `upload_files`: array (optional) — `[{session_path, sandbox_path}]`
 - **Returns**: `{ sandbox_id, status, workspace_path }`
+- **Resource mapping**: When any of `cpu`/`memory`/`disk` are specified, they are sent as a `resources` object in the Daytona API request body. Only specified fields are included; omitted fields use Daytona defaults. Values are validated client-side (type + range) before the API call.
 
 ### daytona_exec
 

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -45,6 +45,18 @@ impl Tool for DaytonaCreateSandboxTool {
                     "type": "string",
                     "description": "Container image (optional, uses Daytona default if omitted)"
                 },
+                "cpu": {
+                    "type": "integer",
+                    "description": "Number of vCPUs (1-4, default: 1)"
+                },
+                "memory": {
+                    "type": "integer",
+                    "description": "Memory in GiB (1-8, default: 1)"
+                },
+                "disk": {
+                    "type": "integer",
+                    "description": "Disk size in GiB (1-10, default: 3)"
+                },
                 "upload_files": {
                     "type": "array",
                     "description": "Files to upload from session storage (optional)",
@@ -118,6 +130,24 @@ impl Tool for DaytonaCreateSandboxTool {
         });
         if let Some(image) = arguments.get("image").and_then(|v| v.as_str()) {
             create_body["image"] = json!(image);
+        }
+
+        // Add resource constraints if any are specified
+        let cpu = arguments.get("cpu").and_then(|v| v.as_u64());
+        let memory = arguments.get("memory").and_then(|v| v.as_u64());
+        let disk = arguments.get("disk").and_then(|v| v.as_u64());
+        if cpu.is_some() || memory.is_some() || disk.is_some() {
+            let mut resources = serde_json::Map::new();
+            if let Some(cpu) = cpu {
+                resources.insert("cpu".to_string(), json!(cpu));
+            }
+            if let Some(memory) = memory {
+                resources.insert("memory".to_string(), json!(memory));
+            }
+            if let Some(disk) = disk {
+                resources.insert("disk".to_string(), json!(disk));
+            }
+            create_body["resources"] = json!(resources);
         }
 
         // Create sandbox

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -17,6 +17,28 @@ use crate::{
     EXEC_TIMEOUT_MS,
 };
 
+/// Parse an optional integer resource parameter, validating type and range.
+fn parse_resource_param(
+    arguments: &Value,
+    name: &str,
+    min: u64,
+    max: u64,
+) -> Result<Option<u64>, String> {
+    let Some(val) = arguments.get(name) else {
+        return Ok(None);
+    };
+    if val.is_null() {
+        return Ok(None);
+    }
+    let n = val
+        .as_u64()
+        .ok_or_else(|| format!("Invalid '{name}': must be a positive integer"))?;
+    if n < min || n > max {
+        return Err(format!("Invalid '{name}': must be between {min} and {max}"));
+    }
+    Ok(Some(n))
+}
+
 // ============================================================================
 // DaytonaCreateSandboxTool
 // ============================================================================
@@ -47,15 +69,24 @@ impl Tool for DaytonaCreateSandboxTool {
                 },
                 "cpu": {
                     "type": "integer",
-                    "description": "Number of vCPUs (1-4, default: 1)"
+                    "description": "Number of vCPUs (1-4, default: 1)",
+                    "minimum": 1,
+                    "maximum": 4,
+                    "default": 1
                 },
                 "memory": {
                     "type": "integer",
-                    "description": "Memory in GiB (1-8, default: 1)"
+                    "description": "Memory in GiB (1-8, default: 1)",
+                    "minimum": 1,
+                    "maximum": 8,
+                    "default": 1
                 },
                 "disk": {
                     "type": "integer",
-                    "description": "Disk size in GiB (1-10, default: 3)"
+                    "description": "Disk size in GiB (1-10, default: 3)",
+                    "minimum": 1,
+                    "maximum": 10,
+                    "default": 3
                 },
                 "upload_files": {
                     "type": "array",
@@ -132,10 +163,19 @@ impl Tool for DaytonaCreateSandboxTool {
             create_body["image"] = json!(image);
         }
 
-        // Add resource constraints if any are specified
-        let cpu = arguments.get("cpu").and_then(|v| v.as_u64());
-        let memory = arguments.get("memory").and_then(|v| v.as_u64());
-        let disk = arguments.get("disk").and_then(|v| v.as_u64());
+        // Parse and validate resource constraints
+        let cpu = match parse_resource_param(&arguments, "cpu", 1, 4) {
+            Ok(v) => v,
+            Err(e) => return ToolExecutionResult::tool_error(&e),
+        };
+        let memory = match parse_resource_param(&arguments, "memory", 1, 8) {
+            Ok(v) => v,
+            Err(e) => return ToolExecutionResult::tool_error(&e),
+        };
+        let disk = match parse_resource_param(&arguments, "disk", 1, 10) {
+            Ok(v) => v,
+            Err(e) => return ToolExecutionResult::tool_error(&e),
+        };
         if cpu.is_some() || memory.is_some() || disk.is_some() {
             let mut resources = serde_json::Map::new();
             if let Some(cpu) = cpu {

--- a/integrations/daytona/tests/tool_integration.rs
+++ b/integrations/daytona/tests/tool_integration.rs
@@ -714,3 +714,133 @@ async fn test_client_sends_bearer_auth() {
     let info = client.get_sandbox("sb_auth").await.unwrap();
     assert_eq!(info.id, "sb_auth");
 }
+
+// ============================================================================
+// Resource options tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_create_sandbox_with_resources_via_client() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/sandbox"))
+        .and(wiremock::matchers::body_json(json!({
+            "name": "Resource Test",
+            "resources": {"cpu": 2, "memory": 4, "disk": 8}
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "sb_resource",
+            "name": "Resource Test",
+            "state": "started"
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client =
+        DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
+
+    let info = client
+        .create_sandbox(json!({
+            "name": "Resource Test",
+            "resources": {"cpu": 2, "memory": 4, "disk": 8}
+        }))
+        .await
+        .unwrap();
+    assert_eq!(info.id, "sb_resource");
+}
+
+#[tokio::test]
+async fn test_create_sandbox_partial_resources_via_client() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/sandbox"))
+        .and(wiremock::matchers::body_json(json!({
+            "name": "Partial",
+            "resources": {"disk": 5}
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "sb_partial",
+            "state": "started"
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client =
+        DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
+
+    let info = client
+        .create_sandbox(json!({
+            "name": "Partial",
+            "resources": {"disk": 5}
+        }))
+        .await
+        .unwrap();
+    assert_eq!(info.id, "sb_partial");
+}
+
+#[tokio::test]
+async fn test_create_sandbox_tool_rejects_invalid_cpu() {
+    let tool = get_tool("daytona_create_sandbox");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store)
+        .with_connection_resolver(daytona_resolver());
+
+    let result = tool
+        .execute_with_context(json!({"cpu": 10}), &context)
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("cpu"), "Got: {msg}");
+            assert!(msg.contains("between 1 and 4"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_create_sandbox_tool_rejects_zero_memory() {
+    let tool = get_tool("daytona_create_sandbox");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store)
+        .with_connection_resolver(daytona_resolver());
+
+    let result = tool
+        .execute_with_context(json!({"memory": 0}), &context)
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("memory"), "Got: {msg}");
+            assert!(msg.contains("between 1 and 8"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_create_sandbox_tool_rejects_string_disk() {
+    let tool = get_tool("daytona_create_sandbox");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store)
+        .with_connection_resolver(daytona_resolver());
+
+    let result = tool
+        .execute_with_context(json!({"disk": "big"}), &context)
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("disk"), "Got: {msg}");
+            assert!(msg.contains("positive integer"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}


### PR DESCRIPTION
## What
Expose Daytona sandbox resource options (cpu, memory, disk) as optional parameters on `daytona_create_sandbox` tool.

## Why
Daytona API supports resource constraints (`resources: {cpu, memory, disk}`) at sandbox creation time, but the tool only passed name, image, labels, and autoStopInterval. Agents had no way to request more powerful sandboxes (e.g. for Docker-in-Docker or heavy builds).

## How
- Added `cpu` (integer, 1-4 vCPUs), `memory` (integer, 1-8 GiB), `disk` (integer, 1-10 GiB) to the tool parameter schema
- When any resource param is present, builds a `resources` object in the create request body
- Only sends specified fields — omitted fields use Daytona defaults (1 vCPU, 1 GiB RAM, 3 GiB disk)
- Updated SPEC.md with new parameters and request body format

## Risk
- **Low**
- All params are optional; no behavioral change when omitted
- Values are passed directly to Daytona API which enforces its own limits

## Security
- Threat categories reviewed: TM-TOOL, TM-DOS
- **TM-TOOL**: New parameters are integers extracted via `as_u64()` — no injection vector. Values flow into a JSON body sent to the Daytona management API. No new trust boundary crossed.
- **TM-DOS**: Daytona enforces org-level resource limits server-side (max 4 vCPU, 8 GiB RAM, 10 GiB disk). No unbounded allocation possible from our side.
- No secrets, auth, or tenant-scoping changes.

## Checklist
- [x] Tests added or updated (existing 18 tests pass; resource params are optional so no new test needed — Daytona API validates server-side)
- [x] Backward compatibility considered (fully backward compatible — all new params are optional)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)