### PR TITLE
feat(daytona): add auto-archive and auto-delete lifecycle settings

### DIFF
--- a/integrations/daytona/SPEC.md
+++ b/integrations/daytona/SPEC.md
@@ -77,7 +77,7 @@ This avoids entering the key in chat (see TM-AGENT-016).
 
 | Method | Path | Purpose | Request Body |
 |--------|------|---------|-------------|
-| POST | `/sandbox` | Create sandbox | `{ name?, image?, autoStopInterval, labels? }` |
+| POST | `/sandbox` | Create sandbox | `{ name?, image?, autoStopInterval, autoArchiveInterval, autoDeleteInterval, labels? }` |
 | GET | `/sandbox/{id}` | Get sandbox info | — |
 | POST | `/sandbox/{id}/start` | Start sandbox | — |
 | POST | `/sandbox/{id}/stop` | Stop sandbox | — |

--- a/integrations/daytona/src/client.rs
+++ b/integrations/daytona/src/client.rs
@@ -962,6 +962,8 @@ mod tests {
             .and(wiremock::matchers::body_json(json!({
                 "name": "Labeled Sandbox",
                 "autoStopInterval": 5,
+                "autoArchiveInterval": 30,
+                "autoDeleteInterval": 60,
                 "labels": {
                     "everruns": "true",
                     "everruns.session_id": "session_abc",
@@ -986,6 +988,8 @@ mod tests {
             .create_sandbox(json!({
                 "name": "Labeled Sandbox",
                 "autoStopInterval": 5,
+                "autoArchiveInterval": 30,
+                "autoDeleteInterval": 60,
                 "labels": {
                     "everruns": "true",
                     "everruns.session_id": "session_abc",

--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -58,6 +58,10 @@ const SANDBOX_READY_POLL_INTERVAL: Duration = Duration::from_secs(2);
 const SANDBOX_READY_MAX_WAIT: Duration = Duration::from_secs(60);
 /// Auto-stop after 5 minutes of inactivity (safety net)
 const AUTO_STOP_INTERVAL_MINUTES: u64 = 5;
+/// Auto-archive after 30 minutes — archived sandboxes consume fewer Daytona resources
+const AUTO_ARCHIVE_INTERVAL_MINUTES: u64 = 30;
+/// Auto-delete after 60 minutes — Daytona-native safety net beyond our leased-resource cleanup
+const AUTO_DELETE_INTERVAL_MINUTES: u64 = 60;
 /// Default workspace path inside Daytona sandboxes
 const DAYTONA_WORKSPACE_PATH: &str = "/home/daytona";
 
@@ -112,7 +116,7 @@ Authentication: Daytona API key is resolved automatically from Settings > Connec
 If not configured, guide the user to set up their key in Settings > Connections.
 
 All tools except `daytona_create_sandbox` and `daytona_list_sandboxes` require a `sandbox_id`.
-Sandboxes auto-stop after 5 minutes of inactivity.
+Sandboxes auto-stop after 5 min, auto-archive after 30 min, and auto-delete after 60 min.
 Always DELETE sandboxes when done (stop leaves them on the dashboard).
 Active sandboxes also appear in the session Resources tab so users can see what
 may be cleaned automatically later.

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -12,7 +12,10 @@ use crate::state::{
     SandboxState, delete_sandbox_state, get_api_key, get_sandbox_state, list_sandbox_states,
     release_sandbox_lease, required_str, save_sandbox_state, touch_sandbox_lease,
 };
-use crate::{AUTO_STOP_INTERVAL_MINUTES, EXEC_TIMEOUT_MS};
+use crate::{
+    AUTO_ARCHIVE_INTERVAL_MINUTES, AUTO_DELETE_INTERVAL_MINUTES, AUTO_STOP_INTERVAL_MINUTES,
+    EXEC_TIMEOUT_MS,
+};
 
 // ============================================================================
 // DaytonaCreateSandboxTool
@@ -109,6 +112,8 @@ impl Tool for DaytonaCreateSandboxTool {
         let mut create_body = json!({
             "name": title,
             "autoStopInterval": AUTO_STOP_INTERVAL_MINUTES,
+            "autoArchiveInterval": AUTO_ARCHIVE_INTERVAL_MINUTES,
+            "autoDeleteInterval": AUTO_DELETE_INTERVAL_MINUTES,
             "labels": labels,
         });
         if let Some(image) = arguments.get("image").and_then(|v| v.as_str()) {

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -822,7 +822,7 @@ Daytona sandboxes are remote Linux environments managed via REST API. The agent 
 | TM-DAYTONA-003 | Git token scope — over-privileged access | Medium | Token scoped by GitHub App installation permissions; user controls repo access via GitHub App settings | **CALLER RISK** |
 | TM-DAYTONA-004 | Daytona API key compromise | High | Stored in user connections (Settings > Connections); encrypted at rest via envelope encryption (AES-256-GCM) | MITIGATED |
 | TM-DAYTONA-005 | Cross-session sandbox access | Critical | Sandbox IDs stored in session-scoped secrets (`daytona_sandbox:{id}`); session isolation enforced by storage store | MITIGATED |
-| TM-DAYTONA-006 | Sandbox not deleted — resource leak | Low | Auto-stop after 5 min inactivity; system prompt instructs agent to delete when done | MITIGATED |
+| TM-DAYTONA-006 | Sandbox not deleted — resource leak | Low | Auto-stop 5 min, auto-archive 30 min, auto-delete 60 min (Daytona-native); leased-resource cleanup 20 min (control plane); system prompt instructs agent to delete when done | MITIGATED |
 | TM-DAYTONA-007 | Git credential helper persists after sandbox reuse | Low | Credential file in `/tmp` cleared on stop; sandbox stop resets environment | MITIGATED |
 
 ### Mitigation Details


### PR DESCRIPTION
## What
Add Daytona-native `autoArchiveInterval` (30 min) and `autoDeleteInterval` (60 min) to sandbox creation, alongside the existing `autoStopInterval` (5 min).

## Why
Daytona supports auto-archive and auto-delete as native lifecycle features. Using them provides defense-in-depth on top of our 20-min leased-resource cleanup. If our control-plane cleanup fails, Daytona will auto-delete the sandbox at 60 min.

## How
- Add two new constants (`AUTO_ARCHIVE_INTERVAL_MINUTES`, `AUTO_DELETE_INTERVAL_MINUTES`) in `lib.rs`
- Pass them in the sandbox creation JSON body in `tools.rs`
- Update system prompt, SPEC, threat model (TM-DAYTONA-006), and test assertions

## Risk
- Low
- Daytona API may ignore unknown fields if not yet supported on their side; no negative effect

## Security
- Threat categories reviewed: TM-DAYTONA-006 (resource leak)
- TM-DAYTONA-006 mitigation strengthened: now documents all three Daytona-native lifecycle settings plus leased-resource cleanup
- No new auth, input parsing, tenant scoping, or injection surface

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)