### PR TITLE
feat(worker): increase default max concurrent tasks from 10 to 1000

### DIFF
--- a/crates/durable/benches/concurrent_workers.rs
+++ b/crates/durable/benches/concurrent_workers.rs
@@ -42,14 +42,6 @@ struct TestScenario {
 
 impl TestScenario {
     fn new(task_count: u64, worker_count: usize, simulate_execution: bool) -> Self {
-        // Raise per-workflow queue limit to accommodate large task counts
-        // SAFETY: bench is single-threaded at construction time; no other thread reads this var yet.
-        unsafe {
-            env::set_var(
-                "DURABLE_MAX_PENDING_TASKS_PER_WORKFLOW",
-                task_count.max(10_000).to_string(),
-            );
-        }
         Self {
             store: Arc::new(InMemoryWorkflowEventStore::new()),
             workflow_id: Uuid::now_v7(),
@@ -316,6 +308,15 @@ fn parse_args() -> CliOptions {
 
 fn main() {
     let opts = parse_args();
+
+    // Raise per-workflow queue limit before creating the runtime (set_var is
+    // unsafe in Rust 2024 because other threads may read env concurrently).
+    // 60_000 covers the largest scenario (burst_50k_tasks) with headroom.
+    // SAFETY: no other threads exist yet — runtime is created below.
+    unsafe {
+        env::set_var("DURABLE_MAX_PENDING_TASKS_PER_WORKFLOW", "60000");
+    }
+
     let rt = Runtime::new().unwrap();
 
     println!("═══════════════════════════════════════════════════════════");

--- a/crates/durable/benches/concurrent_workers.rs
+++ b/crates/durable/benches/concurrent_workers.rs
@@ -42,6 +42,14 @@ struct TestScenario {
 
 impl TestScenario {
     fn new(task_count: u64, worker_count: usize, simulate_execution: bool) -> Self {
+        // Raise per-workflow queue limit to accommodate large task counts
+        // SAFETY: bench is single-threaded at construction time; no other thread reads this var yet.
+        unsafe {
+            env::set_var(
+                "DURABLE_MAX_PENDING_TASKS_PER_WORKFLOW",
+                task_count.max(10_000).to_string(),
+            );
+        }
         Self {
             store: Arc::new(InMemoryWorkflowEventStore::new()),
             workflow_id: Uuid::now_v7(),

--- a/crates/durable/src/worker/pool.rs
+++ b/crates/durable/src/worker/pool.rs
@@ -65,7 +65,7 @@ impl Default for WorkerPoolConfig {
             worker_id: format!("worker-{}", Uuid::now_v7()),
             worker_group: "default".to_string(),
             activity_types: vec![],
-            max_concurrency: 10,
+            max_concurrency: 1000,
             backpressure: BackpressureConfig::default(),
             poller: PollerConfig::default(),
             heartbeat_interval: Duration::from_secs(5),
@@ -687,7 +687,7 @@ mod tests {
         let config = WorkerPoolConfig::default();
         assert!(!config.worker_id.is_empty());
         assert_eq!(config.worker_group, "default");
-        assert_eq!(config.max_concurrency, 10);
+        assert_eq!(config.max_concurrency, 1000);
         assert_eq!(config.heartbeat_interval, Duration::from_secs(5));
     }
 

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -153,7 +153,7 @@ impl DurableWorkerConfig {
             worker_id: std::env::var("WORKER_ID")
                 .unwrap_or_else(|_| format!("worker-{}", Uuid::now_v7())),
             grpc_address: env_string("WORKER_GRPC_ADDRESS", "127.0.0.1:9001"),
-            max_concurrent_tasks: env_or("MAX_CONCURRENT_TASKS", 10),
+            max_concurrent_tasks: env_or("MAX_CONCURRENT_TASKS", 1000),
             connect_timeout: env_duration_secs(
                 "WORKER_GRPC_CONNECT_TIMEOUT",
                 defaults.connect_timeout,

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -103,7 +103,7 @@ impl TaskWorkerConfig {
         let max_concurrent = std::env::var("MAX_CONCURRENT_TASKS")
             .ok()
             .and_then(|s| s.parse().ok())
-            .unwrap_or(10);
+            .unwrap_or(1000);
 
         let worker_group = std::env::var("WORKER_GROUP").ok();
 

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -66,7 +66,7 @@ impl Default for TaskWorkerConfig {
                 "act".to_string(),
                 "leased_resource_cleanup".to_string(),
             ],
-            max_concurrent_tasks: 10,
+            max_concurrent_tasks: 1000,
             poll_interval: Duration::from_millis(100),
             heartbeat_interval: Duration::from_secs(10),
             worker_group: None,
@@ -1042,7 +1042,7 @@ mod tests {
     fn test_config_default() {
         let config = TaskWorkerConfig::default();
         assert!(config.worker_id.starts_with("worker-"));
-        assert_eq!(config.max_concurrent_tasks, 10);
+        assert_eq!(config.max_concurrent_tasks, 1000);
     }
 
     #[test]

--- a/docs/sre/runbooks/durable-mode-setup.md
+++ b/docs/sre/runbooks/durable-mode-setup.md
@@ -75,7 +75,7 @@ async fn main() -> anyhow::Result<()> {
 | `WORKER_GRPC_ADDRESS` | Control-plane gRPC address | `127.0.0.1:9001` |
 | `WORKER_GRPC_AUTH_TOKEN` | Bearer token for gRPC auth | Unset (disabled) |
 | `WORKER_ID` | Unique worker identifier | Auto-generated |
-| `MAX_CONCURRENT_TASKS` | Max tasks per worker | `10` |
+| `MAX_CONCURRENT_TASKS` | Max tasks per worker | `1000` |
 
 ### Database Tables
 


### PR DESCRIPTION
## What
Increase the default `MAX_CONCURRENT_TASKS` from 10 to 1000 across the worker pool, durable worker, and unified worker. Fix the `concurrent_workers` bench which was failing due to per-workflow task queue limit.

## Why
The default of 10 was too conservative for production workloads. Workers can handle far more concurrent tasks, especially for I/O-bound LLM activities. The bench was broken because it enqueued 10k+ tasks into a single workflow but the per-workflow queue limit is 100.

## How
- Changed default `max_concurrency` / `max_concurrent_tasks` from 10 → 1000 in `WorkerPoolConfig`, `DurableWorkerConfig`, and `TaskWorkerConfig`
- Updated the corresponding test assertion and SRE runbook docs
- In the bench, set `DURABLE_MAX_PENDING_TASKS_PER_WORKFLOW` env var before store creation to match the task count

## Risk
- Low
- Workers accept more concurrent tasks by default. The limit is still configurable via `MAX_CONCURRENT_TASKS` env var. Real concurrency is bounded by available system resources (CPU, memory, network).

## Security
- Threat categories reviewed: TM-DOS
- The change raises a concurrency default but preserves the configurable limit mechanism. No new attack surface. No auth, injection, or data exposure changes.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
