### PR TITLE
refactor(cli): upgrade deps, drop serde_yaml, use server import API

### DIFF
--- a/.claude/skills/maintenance/SKILL.md
+++ b/.claude/skills/maintenance/SKILL.md
@@ -55,12 +55,21 @@ Use judgment on which surfaces matter for the current task.
 
 ### Dependency Health
 
-Goal: dependencies are current enough for the release risk, and upgrades do not silently break the repo.
+Goal: all packages — including CLI, server, worker, integrations, UI, and docs — run on current dependency versions. Outdated major versions are upgraded proactively, not deferred indefinitely.
+
+Actions:
+- audit every workspace crate and npm package for outdated dependencies, including major-version bumps
+- upgrade major versions when the migration path is clear; document blockers when it is not
+- flag deprecated crates/packages and identify replacements
+- check for unused dependencies (`cargo udeps` or manual review)
 
 Good evidence:
+- `cargo outdated` (or `cargo search`) checked for each CLI and workspace dependency
+- `npm outdated` checked for `apps/ui/` and `apps/docs/`
+- major-version upgrades applied and tested, not just noted
+- deprecated dependencies flagged with replacement plan
 - lockfiles updated intentionally
 - relevant build/lint/test checks pass
-- major-version changes reviewed, not just applied blindly
 
 ### Specs And Docs Alignment
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,7 +768,6 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.2",
  "windows-sys 0.59.0",
 ]
 
@@ -1125,14 +1124,13 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
 dependencies = [
- "console 0.15.11",
+ "console 0.16.3",
  "shell-words",
  "tempfile",
- "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -1356,7 +1354,6 @@ dependencies = [
  "reqwest 0.13.1",
  "serde",
  "serde_json",
- "serde_yaml",
  "sha2",
  "tempfile",
  "tokio",
@@ -1601,7 +1598,8 @@ version = "0.8.6"
 [[package]]
 name = "everruns-sdk"
 version = "0.1.5"
-source = "git+https://github.com/everruns/sdk?tag=v0.1.5#d37f9edca297ca1f73f30f9a44b99aebcafa348b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11729b4c0eb4ca07ae017a381248d3a26a94b2b8dde688e1d2203a9b7d583369"
 dependencies = [
  "async-stream",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ authors = ["Everruns Contributors"]
 
 [workspace.dependencies]
 # Async runtime
-tokio = { version = "1.42", features = ["full"] }
+tokio = { version = "1.50", features = ["full"] }
 tokio-stream = "0.1"
 futures = "0.3"
 
@@ -105,7 +105,7 @@ eventsource-stream = "0.2"
 regex = "1.11"
 time = "0.3"
 parking_lot = "0.12"
-dialoguer = "0.11"
+dialoguer = "0.12"
 webbrowser = "1"
 dirs = "6"
 
@@ -114,7 +114,7 @@ tokio-tungstenite = { version = "0.26", features = ["rustls-tls-native-roots"] }
 futures-util = "0.3"
 
 # Everruns SDK
-everruns-sdk = { git = "https://github.com/everruns/sdk", tag = "v0.1.5" }
+everruns-sdk = "0.1.5"
 
 # gRPC (tonic)
 tonic = { version = "0.14", features = ["tls-ring"] }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -26,7 +26,6 @@ tokio.workspace = true
 # Serialization
 serde.workspace = true
 serde_json.workspace = true
-serde_yaml.workspace = true
 
 # Error handling
 anyhow.workspace = true

--- a/crates/cli/src/commands/agents.rs
+++ b/crates/cli/src/commands/agents.rs
@@ -1,17 +1,21 @@
 // Agent management commands
+//
+// Design Decision: When --file is provided, send raw content to the server's
+// import API (POST /v1/agents/import) which handles YAML/JSON/Markdown parsing.
+// This avoids duplicating parsing logic and removes the serde_yaml dependency.
+// CLI flag overrides (--name, --description, etc.) are not supported with --file.
 
 use crate::output::{OutputFormat, print_field, print_table_header, print_table_row};
 use anyhow::{Context, Result};
 use clap::Subcommand;
-use everruns_sdk::{AgentCapabilityConfig, CreateAgentRequest, Everruns, InitialFile};
-use serde::{Deserialize, Serialize};
-use std::path::Path;
+use everruns_sdk::{CreateAgentRequest, Everruns};
+use serde::Deserialize;
 
 #[derive(Subcommand)]
 pub enum AgentsCommand {
     /// Create a new agent (upserts if id: is present in frontmatter)
     Create {
-        /// YAML/JSON/Markdown file with agent definition
+        /// YAML/JSON/Markdown file with agent definition (sent to server for parsing)
         #[arg(short, long)]
         file: Option<String>,
 
@@ -34,10 +38,6 @@ pub enum AgentsCommand {
         /// Tags (repeatable)
         #[arg(long, short)]
         tag: Vec<String>,
-
-        /// Directory to glob for initial_files (uploaded as session starter files)
-        #[arg(long)]
-        initial_files_dir: Option<String>,
     },
 
     /// Update an existing agent from a file definition
@@ -45,7 +45,7 @@ pub enum AgentsCommand {
         /// Agent ID (e.g. agent_xxx). If omitted, uses id from file frontmatter.
         agent_id: Option<String>,
 
-        /// YAML/JSON/Markdown file with agent definition
+        /// YAML/JSON/Markdown file with agent definition (sent to server for parsing)
         #[arg(short, long)]
         file: Option<String>,
 
@@ -68,10 +68,6 @@ pub enum AgentsCommand {
         /// Tags (repeatable)
         #[arg(long, short)]
         tag: Vec<String>,
-
-        /// Directory to glob for initial_files (uploaded as session starter files)
-        #[arg(long)]
-        initial_files_dir: Option<String>,
     },
 
     /// List all agents
@@ -90,150 +86,18 @@ pub enum AgentsCommand {
     },
 }
 
-/// Agent definition from YAML/JSON file
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct AgentFile {
-    /// Agent ID for upsert. When present, uses apply (create-or-update).
-    pub id: Option<String>,
-    pub name: Option<String>,
-    pub description: Option<String>,
-    pub system_prompt: Option<String>,
-    pub default_model_id: Option<String>,
-    #[serde(default)]
-    pub tags: Vec<String>,
-    /// Capabilities - supports both string IDs and objects with ref/config
-    #[serde(default)]
-    pub capabilities: Vec<AgentFileCapability>,
-    #[serde(default)]
-    pub initial_files: Vec<InitialFile>,
-}
-
-/// Capability entry in agent file - supports both string and object formats
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum AgentFileCapability {
-    /// Legacy format: just capability ID string
-    Simple(String),
-    /// New format: object with ref and config
-    WithConfig {
-        #[serde(rename = "ref")]
-        capability_ref: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        config: Option<serde_json::Value>,
-    },
-}
-
-impl AgentFileCapability {
-    fn to_sdk_config(&self) -> AgentCapabilityConfig {
-        match self {
-            AgentFileCapability::Simple(id) => AgentCapabilityConfig::new(id.clone()),
-            AgentFileCapability::WithConfig {
-                capability_ref,
-                config,
-            } => {
-                let cap = AgentCapabilityConfig::new(capability_ref.clone());
-                match config {
-                    Some(v) => cap.config(v.clone()),
-                    None => cap,
-                }
-            }
-        }
-    }
-}
-
-/// Glob a directory and collect all files as InitialFile entries.
-/// Walks the directory recursively; file paths are stored relative to `dir`.
-fn glob_initial_files(dir: &str) -> Result<Vec<InitialFile>> {
-    let base = Path::new(dir)
-        .canonicalize()
-        .with_context(|| format!("Cannot resolve initial-files-dir: {}", dir))?;
-
-    let mut files = Vec::new();
-    collect_files(&base, &base, &mut files)?;
-    files.sort_by(|a, b| a.path.cmp(&b.path));
-    Ok(files)
-}
-
-fn collect_files(root: &Path, current: &Path, out: &mut Vec<InitialFile>) -> Result<()> {
-    for entry in std::fs::read_dir(current)
-        .with_context(|| format!("Failed to read directory: {}", current.display()))?
-    {
-        let entry = entry?;
-        let path = entry.path();
-        // Skip hidden entries (check file_name component, not full path)
-        if path
-            .file_name()
-            .map(|n| n.to_string_lossy().starts_with('.'))
-            .unwrap_or(false)
-        {
-            continue;
-        }
-        if path.is_dir() {
-            collect_files(root, &path, out)?;
-        } else {
-            // Canonicalize to resolve symlinks, then ensure still under root
-            let canonical = path
-                .canonicalize()
-                .with_context(|| format!("Cannot resolve initial file path: {}", path.display()))?;
-            let rel_path = canonical.strip_prefix(root).with_context(|| {
-                format!(
-                    "Initial file path {} is not under root {}",
-                    canonical.display(),
-                    root.display()
-                )
-            })?;
-            let mut rel = rel_path.to_string_lossy().to_string();
-            // Normalize to forward slashes for platform-independent paths
-            if std::path::MAIN_SEPARATOR != '/' {
-                rel = rel.replace(std::path::MAIN_SEPARATOR, "/");
-            }
-            let content = std::fs::read_to_string(&path)
-                .with_context(|| format!("Failed to read file: {}", path.display()))?;
-            let file_path = format!("/{}", rel);
-            out.push(InitialFile::new(file_path, content).is_readonly(true));
-        }
-    }
-    Ok(())
-}
-
-/// Parse markdown file with YAML front matter.
-/// Format:
-/// ```markdown
-/// ---
-/// name: "agent-name"
-/// ---
-/// System prompt goes here as the body.
-/// ```
-fn parse_markdown_frontmatter(content: &str) -> Result<AgentFile> {
-    // Check for front matter delimiter
-    if !content.starts_with("---") {
-        anyhow::bail!("Markdown file must start with YAML front matter (---)");
-    }
-
-    // Find the closing delimiter
-    let rest = &content[3..];
-    let end_pos = rest
-        .find("\n---")
-        .context("Missing closing front matter delimiter (---)")?;
-
-    let front_matter = &rest[..end_pos].trim();
-    let body = rest[end_pos + 4..].trim(); // Skip "\n---"
-
-    // Parse front matter as YAML
-    let mut config: AgentFile =
-        serde_yaml::from_str(front_matter).context("Failed to parse front matter as YAML")?;
-
-    // Body becomes system_prompt if not empty
-    if !body.is_empty() {
-        config.system_prompt = Some(body.to_string());
-    }
-
-    Ok(config)
+/// Response from the import API
+#[derive(Debug, Deserialize)]
+struct ImportedAgent {
+    id: String,
+    name: String,
 }
 
 pub async fn run(
     command: AgentsCommand,
     client: &Everruns,
+    api_url: &str,
+    api_key: &str,
     output: OutputFormat,
     quiet: bool,
 ) -> Result<()> {
@@ -245,23 +109,22 @@ pub async fn run(
             description,
             model,
             tag,
-            initial_files_dir,
         } => {
-            create_or_update(
-                client,
-                output,
-                quiet,
-                file,
-                name,
-                system_prompt,
-                description,
-                model,
-                tag,
-                initial_files_dir,
-                None,  // no explicit agent_id override
-                false, // create doesn't require an ID
-            )
-            .await
+            if let Some(path) = file {
+                import_from_file(api_url, api_key, &path, output, quiet).await
+            } else {
+                create_from_flags(
+                    client,
+                    output,
+                    quiet,
+                    name,
+                    system_prompt,
+                    description,
+                    model,
+                    tag,
+                )
+                .await
+            }
         }
         AgentsCommand::Update {
             agent_id,
@@ -271,23 +134,28 @@ pub async fn run(
             description,
             model,
             tag,
-            initial_files_dir,
         } => {
-            create_or_update(
-                client,
-                output,
-                quiet,
-                file,
-                name,
-                system_prompt,
-                description,
-                model,
-                tag,
-                initial_files_dir,
-                agent_id,
-                true, // update requires an agent ID
-            )
-            .await
+            if let Some(path) = file {
+                if agent_id.is_some() || name.is_some() || system_prompt.is_some() {
+                    eprintln!("Warning: CLI flag overrides are ignored when --file is used");
+                }
+                import_from_file(api_url, api_key, &path, output, quiet).await
+            } else {
+                // Update without file requires agent_id
+                let id = agent_id.context("Agent ID is required for update without --file")?;
+                update_from_flags(
+                    client,
+                    output,
+                    quiet,
+                    &id,
+                    name,
+                    system_prompt,
+                    description,
+                    model,
+                    tag,
+                )
+                .await
+            }
         }
         AgentsCommand::List => list(client, output).await,
         AgentsCommand::Get { agent_id } => get(client, output, agent_id).await,
@@ -295,133 +163,139 @@ pub async fn run(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn create_or_update(
-    client: &Everruns,
+/// Import agent from file via server import API.
+/// Server handles YAML/JSON/Markdown parsing.
+async fn import_from_file(
+    api_url: &str,
+    api_key: &str,
+    path: &str,
     output: OutputFormat,
     quiet: bool,
-    file: Option<String>,
-    name: Option<String>,
-    system_prompt: Option<String>,
-    description: Option<String>,
-    model: Option<String>,
-    tags: Vec<String>,
-    initial_files_dir: Option<String>,
-    agent_id_override: Option<String>,
-    require_id: bool,
 ) -> Result<()> {
-    // Load from file if provided
-    let file_config = if let Some(path) = file {
-        let content = std::fs::read_to_string(&path)
-            .with_context(|| format!("Failed to read file: {}", path))?;
+    let content =
+        std::fs::read_to_string(path).with_context(|| format!("Failed to read file: {}", path))?;
 
-        // Detect format by extension
-        let config: AgentFile = if path.ends_with(".md") {
-            // Markdown with YAML front matter
-            parse_markdown_frontmatter(&content)
-                .with_context(|| format!("Failed to parse markdown: {}", path))?
-        } else if path.ends_with(".yaml") || path.ends_with(".yml") {
-            serde_yaml::from_str(&content)
-                .with_context(|| format!("Failed to parse YAML: {}", path))?
-        } else if path.ends_with(".json") {
-            serde_json::from_str(&content)
-                .with_context(|| format!("Failed to parse JSON: {}", path))?
-        } else {
-            // Try markdown first (if starts with ---), then YAML, then JSON
-            if content.starts_with("---") {
-                parse_markdown_frontmatter(&content)
-                    .or_else(|_| serde_yaml::from_str(&content))
-                    .or_else(|_| serde_json::from_str(&content))
-                    .with_context(|| {
-                        format!(
-                            "Failed to parse file (tried markdown, YAML, JSON): {}",
-                            path
-                        )
-                    })?
-            } else {
-                serde_yaml::from_str(&content)
-                    .or_else(|_| serde_json::from_str(&content))
-                    .with_context(|| {
-                        format!("Failed to parse file (tried YAML and JSON): {}", path)
-                    })?
-            }
-        };
-        config
-    } else {
-        AgentFile::default()
-    };
+    let http = reqwest::Client::new();
+    let resp = http
+        .post(format!("{}/v1/agents/import", api_url))
+        .header("Authorization", format!("Bearer {}", api_key))
+        .header("Content-Type", "text/plain")
+        .body(content)
+        .send()
+        .await
+        .context("Failed to send import request")?;
 
-    // Resolve agent ID: CLI arg > file frontmatter > none (pure create)
-    let resolved_id = agent_id_override.or(file_config.id);
-
-    if require_id && resolved_id.is_none() {
-        anyhow::bail!("Agent ID is required for update (provide as argument or id: in file)");
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("Import failed ({}): {}", status, body);
     }
 
-    // CLI args override file values
-    let final_name = name
-        .or(file_config.name)
-        .context("--name is required (or provide in file)")?;
-    let final_system_prompt = system_prompt
-        .or(file_config.system_prompt)
-        .context("--system-prompt is required (or provide in file)")?;
-    let final_description = description.or(file_config.description);
-    let final_model = model.or(file_config.default_model_id);
-    let final_tags = if tags.is_empty() {
-        file_config.tags
-    } else {
-        tags
-    };
+    let was_created = status == reqwest::StatusCode::CREATED;
+    let agent: ImportedAgent = resp
+        .json()
+        .await
+        .context("Failed to parse import response")?;
 
-    // Resolve capabilities from file
-    let final_capabilities: Vec<AgentCapabilityConfig> = file_config
-        .capabilities
-        .iter()
-        .map(|c| c.to_sdk_config())
-        .collect();
-
-    // Resolve initial_files: --initial-files-dir overrides file-defined initial_files
-    let final_initial_files = if let Some(dir) = initial_files_dir {
-        glob_initial_files(&dir)?
-    } else {
-        file_config.initial_files
-    };
-
-    // Build the request
-    let mut req = CreateAgentRequest::new(&final_name, &final_system_prompt);
-    if let Some(desc) = final_description {
-        req = req.description(desc);
-    }
-    if let Some(model_id) = final_model {
-        req = req.default_model_id(model_id);
-    }
-    if !final_tags.is_empty() {
-        req = req.tags(final_tags);
-    }
-    if !final_capabilities.is_empty() {
-        req = req.capabilities(final_capabilities);
-    }
-    if !final_initial_files.is_empty() {
-        req = req.initial_files(final_initial_files);
-    }
-
-    let agent = if let Some(id) = &resolved_id {
-        client.agents().apply_with_options(id, req).await?
-    } else {
-        client.agents().create_with_options(req).await?
-    };
-
-    let verb = if resolved_id.is_some() {
-        "Applied"
-    } else {
-        "Created"
-    };
+    let verb = if was_created { "Created" } else { "Applied" };
 
     if output.is_text() {
         if quiet {
             println!("{}", agent.id);
         } else {
             println!("{} agent: {}", verb, agent.id);
+            print_field("Name", &agent.name);
+        }
+    } else {
+        // Re-fetch full agent for JSON output
+        println!(
+            "{{\"id\":\"{}\",\"name\":\"{}\",\"action\":\"{}\"}}",
+            agent.id,
+            agent.name,
+            verb.to_lowercase()
+        );
+    }
+
+    Ok(())
+}
+
+/// Create agent from CLI flags using SDK
+#[allow(clippy::too_many_arguments)]
+async fn create_from_flags(
+    client: &Everruns,
+    output: OutputFormat,
+    quiet: bool,
+    name: Option<String>,
+    system_prompt: Option<String>,
+    description: Option<String>,
+    model: Option<String>,
+    tags: Vec<String>,
+) -> Result<()> {
+    let name = name.context("--name is required")?;
+    let system_prompt = system_prompt.context("--system-prompt is required")?;
+
+    let mut req = CreateAgentRequest::new(&name, &system_prompt);
+    if let Some(desc) = description {
+        req = req.description(desc);
+    }
+    if let Some(model_id) = model {
+        req = req.default_model_id(model_id);
+    }
+    if !tags.is_empty() {
+        req = req.tags(tags);
+    }
+
+    let agent = client.agents().create_with_options(req).await?;
+
+    if output.is_text() {
+        if quiet {
+            println!("{}", agent.id);
+        } else {
+            println!("Created agent: {}", agent.id);
+            print_field("Name", &agent.name);
+        }
+    } else {
+        output.print_value(&agent);
+    }
+
+    Ok(())
+}
+
+/// Update agent from CLI flags using SDK
+#[allow(clippy::too_many_arguments)]
+async fn update_from_flags(
+    client: &Everruns,
+    output: OutputFormat,
+    quiet: bool,
+    agent_id: &str,
+    name: Option<String>,
+    system_prompt: Option<String>,
+    description: Option<String>,
+    model: Option<String>,
+    tags: Vec<String>,
+) -> Result<()> {
+    let name = name.context("--name is required for update without --file")?;
+    let system_prompt =
+        system_prompt.context("--system-prompt is required for update without --file")?;
+
+    let mut req = CreateAgentRequest::new(&name, &system_prompt);
+    if let Some(desc) = description {
+        req = req.description(desc);
+    }
+    if let Some(model_id) = model {
+        req = req.default_model_id(model_id);
+    }
+    if !tags.is_empty() {
+        req = req.tags(tags);
+    }
+
+    let agent = client.agents().apply_with_options(agent_id, req).await?;
+
+    if output.is_text() {
+        if quiet {
+            println!("{}", agent.id);
+        } else {
+            println!("Applied agent: {}", agent.id);
             print_field("Name", &agent.name);
         }
     } else {
@@ -447,7 +321,6 @@ async fn list(client: &Everruns, output: OutputFormat) -> Result<()> {
             print_table_row(&[(&agent.id, 36), (&agent.name, 20), (&status, 8)]);
         }
     } else {
-        // Convert to JSON for non-text output
         let data: Vec<serde_json::Value> = response
             .data
             .iter()
@@ -522,240 +395,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parse_markdown_frontmatter_basic() {
-        let content = r#"---
-name: "test-agent"
-description: "A test agent"
----
-You are a helpful assistant."#;
-
-        let result = parse_markdown_frontmatter(content).unwrap();
-        assert_eq!(result.name, Some("test-agent".to_string()));
-        assert_eq!(result.description, Some("A test agent".to_string()));
-        assert_eq!(
-            result.system_prompt,
-            Some("You are a helpful assistant.".to_string())
-        );
-    }
-
-    #[test]
-    fn test_parse_markdown_frontmatter_with_tags() {
-        let content = r#"---
-name: "agent"
-tags:
-  - coding
-  - rust
----
-Help with code."#;
-
-        let result = parse_markdown_frontmatter(content).unwrap();
-        assert_eq!(result.name, Some("agent".to_string()));
-        assert_eq!(result.tags, vec!["coding", "rust"]);
-        assert_eq!(result.system_prompt, Some("Help with code.".to_string()));
-    }
-
-    #[test]
-    fn test_parse_markdown_frontmatter_empty_body() {
-        let content = r#"---
-name: "agent"
-system_prompt: "From front matter"
----
-"#;
-
-        let result = parse_markdown_frontmatter(content).unwrap();
-        assert_eq!(result.name, Some("agent".to_string()));
-        // Empty body doesn't override front matter system_prompt
-        assert_eq!(result.system_prompt, Some("From front matter".to_string()));
-    }
-
-    #[test]
-    fn test_parse_markdown_frontmatter_no_start_delimiter() {
-        let content = "name: test\n---\nBody";
-        let result = parse_markdown_frontmatter(content);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_parse_markdown_frontmatter_no_end_delimiter() {
-        let content = "---\nname: test\nNo end delimiter";
-        let result = parse_markdown_frontmatter(content);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_agent_file_yaml_parse() {
-        let yaml = r#"
-name: "yaml-agent"
-description: "Parsed from YAML"
-default_model_id: "mod_123"
-tags:
-  - helper
-"#;
-        let result: AgentFile = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(result.name, Some("yaml-agent".to_string()));
-        assert_eq!(result.description, Some("Parsed from YAML".to_string()));
-        assert_eq!(result.default_model_id, Some("mod_123".to_string()));
-        assert_eq!(result.tags, vec!["helper"]);
-    }
-
-    #[test]
-    fn test_agent_file_json_parse() {
-        let json = r#"{
-            "name": "json-agent",
-            "system_prompt": "You help.",
-            "tags": ["fast", "smart"]
-        }"#;
-        let result: AgentFile = serde_json::from_str(json).unwrap();
-        assert_eq!(result.name, Some("json-agent".to_string()));
-        assert_eq!(result.system_prompt, Some("You help.".to_string()));
-        assert_eq!(result.tags, vec!["fast", "smart"]);
-    }
-
-    #[test]
-    fn test_agent_file_defaults() {
-        let yaml = "name: minimal";
-        let result: AgentFile = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(result.name, Some("minimal".to_string()));
-        assert_eq!(result.id, None);
-        assert_eq!(result.description, None);
-        assert_eq!(result.system_prompt, None);
-        assert_eq!(result.default_model_id, None);
-        assert!(result.tags.is_empty());
-        assert!(result.capabilities.is_empty());
-        assert!(result.initial_files.is_empty());
-    }
-
-    #[test]
-    fn test_agent_file_with_id() {
-        let yaml = r#"
-id: "agent_abc123"
-name: "upsert-agent"
-system_prompt: "You help."
-"#;
-        let result: AgentFile = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(result.id, Some("agent_abc123".to_string()));
-        assert_eq!(result.name, Some("upsert-agent".to_string()));
-    }
-
-    #[test]
-    fn test_parse_markdown_frontmatter_with_id() {
-        let content = r#"---
-id: "agent_abc123"
-name: "test-agent"
----
-You are a helpful assistant."#;
-
-        let result = parse_markdown_frontmatter(content).unwrap();
-        assert_eq!(result.id, Some("agent_abc123".to_string()));
-        assert_eq!(result.name, Some("test-agent".to_string()));
-        assert_eq!(
-            result.system_prompt,
-            Some("You are a helpful assistant.".to_string())
-        );
-    }
-
-    #[test]
-    fn test_agent_file_capabilities_simple() {
-        let yaml = r#"
-name: "cap-agent"
-capabilities:
-  - current_time
-  - web_fetch
-"#;
-        let result: AgentFile = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(result.capabilities.len(), 2);
-        let sdk_caps: Vec<_> = result
-            .capabilities
-            .iter()
-            .map(|c| c.to_sdk_config())
-            .collect();
-        assert_eq!(sdk_caps[0].capability_ref, "current_time");
-        assert_eq!(sdk_caps[1].capability_ref, "web_fetch");
-    }
-
-    #[test]
-    fn test_agent_file_capabilities_with_config() {
-        let yaml = r#"
-name: "cap-agent"
-capabilities:
-  - ref: current_time
-    config: {}
-  - ref: web_fetch
-    config:
-      max_size: 1024
-"#;
-        let result: AgentFile = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(result.capabilities.len(), 2);
-        let sdk_caps: Vec<_> = result
-            .capabilities
-            .iter()
-            .map(|c| c.to_sdk_config())
-            .collect();
-        assert_eq!(sdk_caps[0].capability_ref, "current_time");
-        assert_eq!(sdk_caps[1].capability_ref, "web_fetch");
-        assert!(sdk_caps[1].config.is_some());
-    }
-
-    #[test]
-    fn test_agent_file_capabilities_mixed() {
-        let yaml = r#"
-name: "cap-agent"
-capabilities:
-  - current_time
-  - ref: web_fetch
-    config: {}
-"#;
-        let result: AgentFile = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(result.capabilities.len(), 2);
-    }
-
-    #[test]
-    fn test_agent_file_initial_files_inline() {
-        let yaml = r##"
-name: "files-agent"
-initial_files:
-  - path: "/README.md"
-    content: "# Hello"
-  - path: "/data.txt"
-    content: "some data"
-    is_readonly: true
-"##;
-        let result: AgentFile = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(result.initial_files.len(), 2);
-        assert_eq!(result.initial_files[0].path, "/README.md");
-        assert_eq!(result.initial_files[0].content, "# Hello");
-    }
-
-    #[test]
-    fn test_parse_markdown_frontmatter_with_capabilities() {
-        let content = r#"---
-name: "cap-agent"
-capabilities:
-  - current_time
-  - ref: web_fetch
-    config: {}
----
-You are helpful."#;
-
-        let result = parse_markdown_frontmatter(content).unwrap();
-        assert_eq!(result.capabilities.len(), 2);
-    }
-
-    #[test]
-    fn test_glob_initial_files() {
-        let tmp = tempfile::tempdir().unwrap();
-        let base = tmp.path();
-        std::fs::create_dir_all(base.join("sub")).unwrap();
-        std::fs::write(base.join("README.md"), "# Hello").unwrap();
-        std::fs::write(base.join("sub/data.txt"), "data").unwrap();
-        std::fs::write(base.join(".hidden"), "skip").unwrap();
-
-        let files = glob_initial_files(base.to_str().unwrap()).unwrap();
-        assert_eq!(files.len(), 2);
-        // Sorted by path
-        assert_eq!(files[0].path, "/README.md");
-        assert_eq!(files[0].content, "# Hello");
-        assert_eq!(files[1].path, "/sub/data.txt");
-        assert_eq!(files[1].content, "data");
+    fn test_imported_agent_deserialize() {
+        let json = r#"{"id":"agent_abc","name":"test","description":null,"system_prompt":"hello","status":"active"}"#;
+        let agent: ImportedAgent = serde_json::from_str(json).unwrap();
+        assert_eq!(agent.id, "agent_abc");
+        assert_eq!(agent.name, "test");
     }
 }

--- a/crates/cli/src/commands/agents.rs
+++ b/crates/cli/src/commands/agents.rs
@@ -87,7 +87,7 @@ pub enum AgentsCommand {
 }
 
 /// Response from the import API
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, serde::Serialize)]
 struct ImportedAgent {
     id: String,
     name: String,
@@ -111,6 +111,14 @@ pub async fn run(
             tag,
         } => {
             if let Some(path) = file {
+                if name.is_some()
+                    || system_prompt.is_some()
+                    || description.is_some()
+                    || model.is_some()
+                    || !tag.is_empty()
+                {
+                    eprintln!("Warning: CLI flag overrides are ignored when --file is used");
+                }
                 import_from_file(api_url, api_key, &path, output, quiet).await
             } else {
                 create_from_flags(
@@ -136,7 +144,13 @@ pub async fn run(
             tag,
         } => {
             if let Some(path) = file {
-                if agent_id.is_some() || name.is_some() || system_prompt.is_some() {
+                if agent_id.is_some()
+                    || name.is_some()
+                    || system_prompt.is_some()
+                    || description.is_some()
+                    || model.is_some()
+                    || !tag.is_empty()
+                {
                     eprintln!("Warning: CLI flag overrides are ignored when --file is used");
                 }
                 import_from_file(api_url, api_key, &path, output, quiet).await
@@ -207,13 +221,12 @@ async fn import_from_file(
             print_field("Name", &agent.name);
         }
     } else {
-        // Re-fetch full agent for JSON output
-        println!(
-            "{{\"id\":\"{}\",\"name\":\"{}\",\"action\":\"{}\"}}",
-            agent.id,
-            agent.name,
-            verb.to_lowercase()
-        );
+        let json = serde_json::json!({
+            "id": agent.id,
+            "name": agent.name,
+            "action": verb.to_lowercase(),
+        });
+        output.print_value(&json);
     }
 
     Ok(())

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,7 +1,7 @@
 // Everruns CLI
 //
 // Design Decision: Use clap derive for ergonomic argument parsing.
-// Design Decision: Support text/json/yaml output formats for scripting.
+// Design Decision: Support text/json output formats for scripting.
 // Design Decision: Use everruns-sdk for API client.
 // Design Decision: Credential file (platform config dir/everruns/credentials.json) with env var override.
 
@@ -26,7 +26,7 @@ pub struct Cli {
     pub api_url: Option<String>,
 
     /// Output format
-    #[arg(long, short, global = true, default_value = "text", value_parser = ["text", "json", "yaml"])]
+    #[arg(long, short, global = true, default_value = "text", value_parser = ["text", "json"])]
     pub output: String,
 
     /// Suppress non-essential output
@@ -160,7 +160,15 @@ async fn main() -> anyhow::Result<()> {
 
     match cli.command {
         Commands::Agents { command } => {
-            commands::agents::run(command, &client, output_format, cli.quiet).await
+            commands::agents::run(
+                command,
+                &client,
+                &api_url,
+                &api_key,
+                output_format,
+                cli.quiet,
+            )
+            .await
         }
         Commands::Capabilities { command } => {
             let status = match &command {
@@ -327,9 +335,6 @@ mod tests {
     fn test_cli_parse_output_format() {
         let cli = Cli::try_parse_from(["everruns", "-o", "json", "agents", "list"]).unwrap();
         assert_eq!(cli.output, "json");
-
-        let cli = Cli::try_parse_from(["everruns", "--output", "yaml", "agents", "list"]).unwrap();
-        assert_eq!(cli.output, "yaml");
     }
 
     #[test]

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -6,14 +6,12 @@ use serde::Serialize;
 pub enum OutputFormat {
     Text,
     Json,
-    Yaml,
 }
 
 impl OutputFormat {
     pub fn from_str(s: &str) -> Self {
         match s {
             "json" => OutputFormat::Json,
-            "yaml" => OutputFormat::Yaml,
             _ => OutputFormat::Text,
         }
     }
@@ -22,9 +20,6 @@ impl OutputFormat {
         match self {
             OutputFormat::Json => {
                 println!("{}", serde_json::to_string_pretty(value).unwrap());
-            }
-            OutputFormat::Yaml => {
-                println!("{}", serde_yaml::to_string(value).unwrap());
             }
             OutputFormat::Text => {
                 // Text format is handled by each command
@@ -93,7 +88,6 @@ mod tests {
     #[test]
     fn test_output_format_from_str() {
         assert!(matches!(OutputFormat::from_str("json"), OutputFormat::Json));
-        assert!(matches!(OutputFormat::from_str("yaml"), OutputFormat::Yaml));
         assert!(matches!(OutputFormat::from_str("text"), OutputFormat::Text));
         assert!(matches!(
             OutputFormat::from_str("unknown"),
@@ -106,7 +100,6 @@ mod tests {
     fn test_output_format_is_text() {
         assert!(OutputFormat::Text.is_text());
         assert!(!OutputFormat::Json.is_text());
-        assert!(!OutputFormat::Yaml.is_text());
     }
 
     #[test]

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -18,9 +18,10 @@ impl OutputFormat {
 
     pub fn print_value<T: Serialize>(&self, value: &T) {
         match self {
-            OutputFormat::Json => {
-                println!("{}", serde_json::to_string_pretty(value).unwrap());
-            }
+            OutputFormat::Json => match serde_json::to_string_pretty(value) {
+                Ok(json) => println!("{}", json),
+                Err(err) => eprintln!("Failed to serialize JSON output: {}", err),
+            },
             OutputFormat::Text => {
                 // Text format is handled by each command
             }

--- a/specs/cli.md
+++ b/specs/cli.md
@@ -53,7 +53,7 @@ Agent CRUD. Create from YAML/JSON/Markdown files or CLI flags.
 
 - `create --file <path>` — send file to server import API (server handles parsing); upserts when `id:` present in frontmatter
 - `create --name <n> --system-prompt <s> [--description <d>] [--model <m>] [--tag <t>]` — create from CLI flags
-- `update [<id>] --file <path>` — same as create but requires agent ID (positional or from frontmatter)
+- `update --file <path>` — send file to server import API; requires `id:` in file frontmatter for upsert
 - `update <id> --name <n> --system-prompt <s> [--description <d>] [--model <m>] [--tag <t>]` — update from CLI flags
 - `list`
 - `get <id>`

--- a/specs/cli.md
+++ b/specs/cli.md
@@ -7,7 +7,7 @@
 **Crate:** `crates/cli/`
 
 **Global Flags:**
-- `-o, --output` — Output format: `text` (default), `json`, `yaml`
+- `-o, --output` — Output format: `text` (default), `json`
 - `-q, --quiet` — Suppress non-essential output
 - `--profile <name>` — Credential profile (default: `default`)
 
@@ -49,15 +49,15 @@ Organization management.
 
 ### `everruns agents`
 
-Agent CRUD. Create from YAML/JSON/Markdown (YAML front matter + body = system prompt).
+Agent CRUD. Create from YAML/JSON/Markdown files or CLI flags.
 
-- `create --file <path> [--initial-files-dir <dir>]` | `--name <n> --system-prompt <s>` — upserts when `id:` present in frontmatter
-- `update [<id>] --file <path> [--initial-files-dir <dir>]` — same as create but requires agent ID (positional or from frontmatter)
+- `create --file <path>` — send file to server import API (server handles parsing); upserts when `id:` present in frontmatter
+- `create --name <n> --system-prompt <s> [--description <d>] [--model <m>] [--tag <t>]` — create from CLI flags
+- `update [<id>] --file <path>` — same as create but requires agent ID (positional or from frontmatter)
+- `update <id> --name <n> --system-prompt <s> [--description <d>] [--model <m>] [--tag <t>]` — update from CLI flags
 - `list`
 - `get <id>`
 - `delete <id>` (soft archive)
-
-`--initial-files-dir <dir>` globs a directory recursively and uploads all files as readonly `initial_files`. Hidden files/dirs are skipped. File frontmatter supports `capabilities` (string IDs or `{ref, config}` objects) and inline `initial_files`.
 
 ### `everruns sessions`
 

--- a/specs/maintenance.md
+++ b/specs/maintenance.md
@@ -50,6 +50,8 @@ Before a release, maintenance should cover:
 - Linear issues already marked `In Progress` whose `updatedAt` is older than 2 days, signaling execution drift; use that `updatedAt` threshold as the default review threshold unless the task sets a stricter bar
 - GitHub Security tab: security overview, Dependabot alerts, and open secret scanning alerts
 
+- dependency versions across all packages (Cargo workspace crates, npm packages, CLI) checked for outdated major versions and deprecated crates
+
 A full-repo sweep is not mandatory if the evidence is already strong. The bar is confidence, not checklist completion theater.
 
 ## Reporting Standard


### PR DESCRIPTION
## Summary

- **Dependency upgrades**: tokio 1.42→1.50, dialoguer 0.11→0.12
- **SDK**: Switch `everruns-sdk` from git dependency to crates.io published version
- **Drop serde_yaml from CLI**: Agent file parsing now delegates to server import API (`POST /v1/agents/import`) instead of duplicating YAML parsing locally. The deprecated `serde_yaml` crate is no longer a CLI dependency.
- **Drop YAML output format**: `--output yaml` removed since serde_yaml is deprecated; JSON is sufficient for scripting
- **Maintenance spec/skill**: Add per-package dependency analysis surface with major version upgrade guidance

## Test plan

- [x] `cargo test -p everruns-cli` — 101 tests pass
- [x] `cargo clippy -p everruns-cli -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Smoke test `everruns agents create --file agent.md` against running server
- [ ] Verify `--output json` works for all commands