### PR TITLE
fix(ci): replace deprecated macos-13 runner with macos-latest

### DIFF
--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -21,9 +21,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-apple-darwin
-            runner: macos-latest
-            archive: everruns-x86_64-apple-darwin.tar.gz
           - target: aarch64-apple-darwin
             runner: macos-latest
             archive: everruns-aarch64-apple-darwin.tar.gz

--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-apple-darwin
-            runner: macos-13
+            runner: macos-latest
             archive: everruns-x86_64-apple-darwin.tar.gz
           - target: aarch64-apple-darwin
             runner: macos-latest


### PR DESCRIPTION
## Summary
- Replace deprecated `macos-13` runner with `macos-latest` for x86_64-apple-darwin CLI binary builds
- `macos-13` is no longer supported by GitHub Actions, causing the build to be cancelled with "configuration not supported" error
- Cross-compilation from ARM to x86_64 works natively with Rust toolchain

## Test plan
- [ ] Merge and re-trigger CLI binaries workflow for v0.8.7
- [ ] Verify x86_64-apple-darwin binary is built and uploaded to release