### PR TITLE
feat(agent-identities): add identity-scoped connections

### DIFF
--- a/apps/ui/src/app/(main)/agent-identities/[identityId]/page.tsx
+++ b/apps/ui/src/app/(main)/agent-identities/[identityId]/page.tsx
@@ -18,6 +18,7 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { CopyButton } from "@/components/ui/copy-button";
 import { getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
+import { IdentityConnections } from "@/components/agent-identity/identity-connections";
 
 export default function AgentIdentityDetailPage({
   params,
@@ -88,6 +89,7 @@ export default function AgentIdentityDetailPage({
               }
             />
           </div>
+          <IdentityConnections identityId={identityId} />
           <div className="flex gap-3">
             {identity.status === "active" ? (
               <Button

--- a/apps/ui/src/components/agent-identity/identity-api-key-dialog.tsx
+++ b/apps/ui/src/components/agent-identity/identity-api-key-dialog.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useCreateIdentityApiKeyConnection } from "@/hooks/use-identity-connections";
+import { AlertCircle } from "lucide-react";
+import type { ConnectionProvider } from "@/lib/api/types";
+import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
+import { ProviderIcon } from "@/components/connections/provider-icon";
+
+interface IdentityApiKeyDialogProps {
+  identityId: string;
+  provider: ConnectionProvider | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function IdentityApiKeyDialog({
+  identityId,
+  provider,
+  open,
+  onOpenChange,
+}: IdentityApiKeyDialogProps) {
+  const [formValues, setFormValues] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string | null>(null);
+  const createConnection = useCreateIdentityApiKeyConnection(identityId);
+
+  useEffect(() => {
+    if (open) {
+      setFormValues({});
+      setError(null);
+    }
+  }, [open]);
+
+  if (!provider?.form_schema) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    const apiKey = formValues["api_key"] ?? "";
+    if (!apiKey.trim()) {
+      setError("API key is required");
+      return;
+    }
+
+    try {
+      await createConnection.mutateAsync({
+        provider: provider.provider_id,
+        apiKey,
+      });
+      onOpenChange(false);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to save connection";
+      const apiError = (err as { response?: { data?: string } })?.response?.data;
+      setError(typeof apiError === "string" ? apiError : message);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ProviderIcon iconName={provider.icon} className="h-5 w-5" />
+            Connect {provider.display_name}
+          </DialogTitle>
+          <DialogDescription>{provider.description}</DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit}>
+          <InlineStreamdownMessage className="text-sm text-muted-foreground mb-4 leading-relaxed">
+            {provider.form_schema.instructions_markdown}
+          </InlineStreamdownMessage>
+
+          <div className="space-y-4 mb-4">
+            {provider.form_schema.fields.map((field) => (
+              <div key={field.name} className="space-y-2">
+                <Label htmlFor={field.name}>{field.label}</Label>
+                <Input
+                  id={field.name}
+                  type={field.field_type}
+                  required={field.required}
+                  placeholder={field.placeholder}
+                  value={formValues[field.name] ?? ""}
+                  onChange={(e) =>
+                    setFormValues((prev) => ({
+                      ...prev,
+                      [field.name]: e.target.value,
+                    }))
+                  }
+                  autoComplete="off"
+                />
+                {field.help_text && (
+                  <p className="text-xs text-muted-foreground">{field.help_text}</p>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {error && (
+            <div className="flex items-center gap-2 text-destructive text-sm mb-4">
+              <AlertCircle className="h-4 w-4 flex-shrink-0" />
+              {error}
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={createConnection.isPending}>
+              {createConnection.isPending ? "Validating..." : "Connect"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/ui/src/components/agent-identity/identity-connections.tsx
+++ b/apps/ui/src/components/agent-identity/identity-connections.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  useIdentityConnections,
+  useDeleteIdentityConnection,
+  useVerifyIdentityConnection,
+} from "@/hooks/use-identity-connections";
+import { useConnectionProviders } from "@/hooks/use-user-connections";
+import {
+  LinkIcon,
+  Trash2,
+  CheckCircle,
+  ShieldCheck,
+  XCircle,
+  Loader2,
+} from "lucide-react";
+import type { UserConnection, ConnectionProvider } from "@/lib/api/types";
+import { ProviderIcon } from "@/components/connections/provider-icon";
+import { IdentityApiKeyDialog } from "./identity-api-key-dialog";
+
+function ConnectionRow({
+  identityId,
+  connection,
+  provider,
+  onDisconnect,
+  isDisconnecting,
+}: {
+  identityId: string;
+  connection: UserConnection;
+  provider?: ConnectionProvider;
+  onDisconnect: (provider: string) => void;
+  isDisconnecting: boolean;
+}) {
+  const displayName = provider?.display_name ?? connection.provider;
+  const icon = provider?.icon ?? "link";
+  const isApiKey = connection.connection_type === "api_key";
+  const verify = useVerifyIdentityConnection(identityId);
+  const [verifyStatus, setVerifyStatus] = useState<"idle" | "valid" | "invalid">("idle");
+  const [verifyError, setVerifyError] = useState<string | null>(null);
+
+  const handleVerify = async () => {
+    setVerifyStatus("idle");
+    setVerifyError(null);
+    try {
+      const result = await verify.mutateAsync(connection.provider);
+      if (result.valid) {
+        setVerifyStatus("valid");
+      } else {
+        setVerifyStatus("invalid");
+        setVerifyError(result.error ?? "Verification failed");
+      }
+    } catch {
+      setVerifyStatus("invalid");
+      setVerifyError("Failed to verify connection");
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-between p-4 border rounded-lg">
+      <div className="flex items-center gap-3">
+        <ProviderIcon iconName={icon} className="h-5 w-5" />
+        <div>
+          <div className="font-medium flex items-center gap-2">
+            {displayName}
+            {connection.provider_username && (
+              <Badge variant="outline" className="text-xs font-normal">
+                {connection.provider_username}
+              </Badge>
+            )}
+          </div>
+          <div className="text-sm text-muted-foreground">
+            Connected {new Date(connection.connected_at).toLocaleDateString()}
+            {connection.scopes && <span className="ml-2">({connection.scopes})</span>}
+          </div>
+          {verifyStatus === "valid" && (
+            <div className="flex items-center gap-1 text-green-600 dark:text-green-400 text-xs mt-1">
+              <CheckCircle className="h-3 w-3" />
+              API key is valid
+            </div>
+          )}
+          {verifyStatus === "invalid" && (
+            <div className="flex items-center gap-1 text-destructive text-xs mt-1">
+              <XCircle className="h-3 w-3" />
+              {verifyError}
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        {isApiKey && (
+          <Button variant="outline" size="sm" onClick={handleVerify} disabled={verify.isPending}>
+            {verify.isPending ? (
+              <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+            ) : (
+              <ShieldCheck className="h-4 w-4 mr-1" />
+            )}
+            {verify.isPending ? "Verifying..." : "Verify"}
+          </Button>
+        )}
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-destructive"
+          onClick={() => onDisconnect(connection.provider)}
+          disabled={isDisconnecting}
+        >
+          <Trash2 className="h-4 w-4 mr-1" />
+          Disconnect
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function AvailableProviderRow({
+  provider,
+  onConnectApiKey,
+}: {
+  provider: ConnectionProvider;
+  onConnectApiKey: (provider: ConnectionProvider) => void;
+}) {
+  // Only API-key providers are supported for identity connections
+  if (provider.connection_type !== "api_key") return null;
+
+  return (
+    <div className="flex items-center justify-between p-4 border rounded-lg">
+      <div className="flex items-center gap-3">
+        <ProviderIcon iconName={provider.icon} className="h-5 w-5" />
+        <div>
+          <div className="font-medium">{provider.display_name}</div>
+          <div className="text-sm text-muted-foreground">{provider.description}</div>
+        </div>
+      </div>
+      <Button variant="outline" size="sm" onClick={() => onConnectApiKey(provider)}>
+        <LinkIcon className="h-4 w-4 mr-1" />
+        Connect
+      </Button>
+    </div>
+  );
+}
+
+export function IdentityConnections({ identityId }: { identityId: string }) {
+  const { data: connections = [], isLoading, error } = useIdentityConnections(identityId);
+  const { data: providers = [] } = useConnectionProviders();
+  const deleteConnection = useDeleteIdentityConnection(identityId);
+  const [apiKeyProvider, setApiKeyProvider] = useState<ConnectionProvider | null>(null);
+
+  const handleDisconnect = async (provider: string) => {
+    const meta = providers.find((p) => p.provider_id === provider);
+    const name = meta?.display_name ?? provider;
+    if (confirm(`Disconnect ${name} from this identity?`)) {
+      await deleteConnection.mutateAsync(provider);
+    }
+  };
+
+  // Only show API-key providers as available (OAuth not yet supported for identities)
+  const connectedProviders = new Set(connections.map((c) => c.provider));
+  const availableProviders = providers.filter(
+    (p) => p.connection_type === "api_key" && !connectedProviders.has(p.provider_id),
+  );
+
+  const providerMap = new Map(providers.map((p) => [p.provider_id, p]));
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-lg font-semibold">Connections</h3>
+        <p className="text-sm text-muted-foreground">
+          Connections assigned to this identity are used in sessions running as this identity.
+        </p>
+      </div>
+
+      {error && (
+        <div className="bg-destructive/10 text-destructive p-4 rounded-lg">
+          Failed to load connections: {error.message}
+        </div>
+      )}
+
+      {isLoading ? (
+        <Skeleton className="h-[72px] w-full" />
+      ) : connections.length === 0 && availableProviders.length === 0 ? (
+        <div className="p-6 text-center border rounded-lg">
+          <LinkIcon className="h-8 w-8 mx-auto text-muted-foreground mb-2" />
+          <p className="text-muted-foreground text-sm">No connection providers available.</p>
+        </div>
+      ) : (
+        <>
+          {connections.length > 0 && (
+            <div className="space-y-2">
+              {connections.map((conn) => (
+                <ConnectionRow
+                  key={conn.provider}
+                  identityId={identityId}
+                  connection={conn}
+                  provider={providerMap.get(conn.provider)}
+                  onDisconnect={handleDisconnect}
+                  isDisconnecting={deleteConnection.isPending}
+                />
+              ))}
+            </div>
+          )}
+
+          {availableProviders.length > 0 && (
+            <div className="space-y-2">
+              {connections.length > 0 && (
+                <h4 className="text-sm font-medium text-muted-foreground pt-2">Available</h4>
+              )}
+              {availableProviders.map((provider) => (
+                <AvailableProviderRow
+                  key={provider.provider_id}
+                  provider={provider}
+                  onConnectApiKey={setApiKeyProvider}
+                />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      <IdentityApiKeyDialog
+        identityId={identityId}
+        provider={apiKeyProvider}
+        open={apiKeyProvider !== null}
+        onOpenChange={(open) => {
+          if (!open) setApiKeyProvider(null);
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/ui/src/components/agent-identity/identity-connections.tsx
+++ b/apps/ui/src/components/agent-identity/identity-connections.tsx
@@ -10,14 +10,7 @@ import {
   useVerifyIdentityConnection,
 } from "@/hooks/use-identity-connections";
 import { useConnectionProviders } from "@/hooks/use-user-connections";
-import {
-  LinkIcon,
-  Trash2,
-  CheckCircle,
-  ShieldCheck,
-  XCircle,
-  Loader2,
-} from "lucide-react";
+import { LinkIcon, Trash2, CheckCircle, ShieldCheck, XCircle, Loader2 } from "lucide-react";
 import type { UserConnection, ConnectionProvider } from "@/lib/api/types";
 import { ProviderIcon } from "@/components/connections/provider-icon";
 import { IdentityApiKeyDialog } from "./identity-api-key-dialog";

--- a/apps/ui/src/hooks/use-identity-connections.ts
+++ b/apps/ui/src/hooks/use-identity-connections.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  listIdentityConnections,
+  createIdentityApiKeyConnection,
+  deleteIdentityConnection,
+  verifyIdentityConnection,
+} from "@/lib/api/agent-identity-connections";
+import { queryKeys } from "@/lib/query-keys";
+
+export function useIdentityConnections(identityId: string) {
+  return useQuery({
+    queryKey: queryKeys.identityConnections.list(identityId),
+    queryFn: () => listIdentityConnections(identityId),
+    staleTime: 30000,
+  });
+}
+
+export function useCreateIdentityApiKeyConnection(identityId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ provider, apiKey }: { provider: string; apiKey: string }) =>
+      createIdentityApiKeyConnection(identityId, provider, apiKey),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.identityConnections.list(identityId),
+      });
+    },
+  });
+}
+
+export function useDeleteIdentityConnection(identityId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (provider: string) => deleteIdentityConnection(identityId, provider),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.identityConnections.list(identityId),
+      });
+    },
+  });
+}
+
+export function useVerifyIdentityConnection(identityId: string) {
+  return useMutation({
+    mutationFn: (provider: string) => verifyIdentityConnection(identityId, provider),
+  });
+}

--- a/apps/ui/src/lib/api/agent-identity-connections.ts
+++ b/apps/ui/src/lib/api/agent-identity-connections.ts
@@ -1,0 +1,41 @@
+// Agent Identity Connections API functions
+// Identity-scoped (not user-scoped) — connections belong to an agent identity
+
+import { api } from "./client";
+import type { UserConnection, VerifyConnectionResponse } from "./types";
+
+export async function listIdentityConnections(identityId: string): Promise<UserConnection[]> {
+  const response = await api.get<UserConnection[]>(
+    `/v1/agent-identities/${identityId}/connections`,
+  );
+  return response.data;
+}
+
+export async function createIdentityApiKeyConnection(
+  identityId: string,
+  provider: string,
+  apiKey: string,
+): Promise<UserConnection> {
+  const response = await api.post<UserConnection>(
+    `/v1/agent-identities/${identityId}/connections/${provider}`,
+    { api_key: apiKey },
+  );
+  return response.data;
+}
+
+export async function deleteIdentityConnection(
+  identityId: string,
+  provider: string,
+): Promise<void> {
+  await api.delete(`/v1/agent-identities/${identityId}/connections/${provider}`);
+}
+
+export async function verifyIdentityConnection(
+  identityId: string,
+  provider: string,
+): Promise<VerifyConnectionResponse> {
+  const response = await api.post<VerifyConnectionResponse>(
+    `/v1/agent-identities/${identityId}/connections/${provider}/verify`,
+  );
+  return response.data;
+}

--- a/apps/ui/src/lib/query-keys.ts
+++ b/apps/ui/src/lib/query-keys.ts
@@ -128,6 +128,12 @@ export const queryKeys = {
     members: (orgId: string) => ["organization", orgId, "members"] as const,
   },
 
+  // Agent Identity Connection queries
+  identityConnections: {
+    all: ["identity-connections"] as const,
+    list: (identityId: string) => ["identity-connections", identityId] as const,
+  },
+
   // User Connection queries
   userConnections: {
     all: ["user-connections"] as const,

--- a/crates/server/migrations/009_v0.8.8.sql
+++ b/crates/server/migrations/009_v0.8.8.sql
@@ -1,0 +1,40 @@
+-- Migration 009: Agent identity connections
+-- Mirrors user_connections but scoped to agent_identity_id instead of user_id.
+-- Allows agent identities to have their own connection credentials for
+-- unattended execution without borrowing from the session creator.
+
+----------------------------------------------------------------------
+-- 001: Agent identity connections
+----------------------------------------------------------------------
+
+CREATE TABLE agent_identity_connections (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    agent_identity_id UUID NOT NULL REFERENCES agent_identities(id) ON DELETE CASCADE,
+    -- Provider identifier: 'github', 'daytona', etc.
+    provider VARCHAR(50) NOT NULL,
+    -- Connection type: 'oauth' or 'api_key'
+    connection_type VARCHAR(20) NOT NULL DEFAULT 'api_key',
+    -- Provider-side user identity
+    provider_user_id TEXT,
+    provider_username TEXT,
+    -- Encrypted credentials (AES-256-GCM envelope encryption)
+    access_token_encrypted BYTEA,
+    refresh_token_encrypted BYTEA,
+    -- GitHub App: installation_id for minting short-lived tokens
+    installation_id BIGINT,
+    -- What scopes were granted
+    scopes TEXT,
+    -- NULL = no expiry
+    expires_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- One connection per identity per provider
+    UNIQUE (agent_identity_id, provider)
+);
+
+CREATE INDEX idx_agent_identity_connections_identity
+    ON agent_identity_connections(agent_identity_id);
+
+CREATE TRIGGER update_agent_identity_connections_updated_at
+    BEFORE UPDATE ON agent_identity_connections
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/crates/server/src/api/agent_identity_connections.rs
+++ b/crates/server/src/api/agent_identity_connections.rs
@@ -9,7 +9,6 @@ use crate::auth::{AuthState, ResolvedOrg};
 use crate::services::agent_identity::AGENT_IDENTITY_MANAGE;
 use crate::storage::models::CreateAgentIdentityConnectionRow;
 use crate::storage::{EncryptionService, StorageBackend};
-use axum::extract::FromRef;
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -22,7 +21,7 @@ use everruns_core::{AgentIdentityId, Caller};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-use super::common::ErrorResponse;
+use super::common::{ErrorResponse, impl_auth_state};
 
 /// App state for identity connection routes
 #[derive(Clone)]
@@ -49,11 +48,7 @@ impl AppState {
     }
 }
 
-impl FromRef<AppState> for AuthState {
-    fn from_ref(input: &AppState) -> Self {
-        input.auth.clone()
-    }
-}
+impl_auth_state!(AppState);
 
 // ============================================================================
 // Response / Request Types

--- a/crates/server/src/api/agent_identity_connections.rs
+++ b/crates/server/src/api/agent_identity_connections.rs
@@ -1,6 +1,9 @@
 // Agent identity connection HTTP routes.
 // Sub-resource of agent identities: /v1/agent-identities/{identity_id}/connections/...
 // Mirrors user_connections but scoped to an agent identity instead of a user.
+//
+// THREAT[TM-AUTHZ-020]: All handlers enforce AGENT_IDENTITY_MANAGE policy before
+// any data access. Identity org-scoping prevents cross-tenant access.
 
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::services::agent_identity::AGENT_IDENTITY_MANAGE;
@@ -15,7 +18,7 @@ use axum::{
 };
 use chrono::{DateTime, Utc};
 use everruns_core::connection_provider::{ConnectionProviderRegistry, ConnectionType};
-use everruns_core::{AgentIdentityId, Caller, evaluate_policies_with};
+use everruns_core::{AgentIdentityId, Caller};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -72,6 +75,13 @@ pub struct CreateApiKeyConnectionRequest {
     pub api_key: String,
 }
 
+#[derive(Debug, Serialize)]
+pub struct VerifyConnectionResponse {
+    pub valid: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
 // ============================================================================
 // Routes
 // ============================================================================
@@ -94,28 +104,35 @@ pub fn routes(state: AppState) -> Router {
 }
 
 // ============================================================================
-// Handlers
+// Helpers
 // ============================================================================
 
-/// GET /v1/agent-identities/:identity_id/connections
-pub async fn list_connections(
-    org: ResolvedOrg,
-    State(state): State<AppState>,
-    Path(identity_id): Path<String>,
-) -> Result<Json<Vec<ConnectionResponse>>, (StatusCode, Json<ErrorResponse>)> {
-    let identity_id: AgentIdentityId = identity_id.parse().map_err(|e| {
+/// Enforce AGENT_IDENTITY_MANAGE policy. Returns 403 on failure.
+fn enforce_manage_policy(
+    state: &AppState,
+    caller: &Caller,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    AGENT_IDENTITY_MANAGE
+        .evaluate_with(state.auth.permission_resolver.as_ref(), caller)
+        .map_err(|_| {
+            ErrorResponse::new("Permission denied".to_string()).into_response(StatusCode::FORBIDDEN)
+        })
+}
+
+/// Parse identity ID, enforce policy, and verify the identity exists in the caller's org.
+async fn resolve_identity(
+    state: &AppState,
+    org: &ResolvedOrg,
+    raw_id: &str,
+) -> Result<(Caller, AgentIdentityId), (StatusCode, Json<ErrorResponse>)> {
+    let identity_id: AgentIdentityId = raw_id.parse().map_err(|e| {
         ErrorResponse::new(format!("Invalid identity ID: {}", e))
             .into_response(StatusCode::BAD_REQUEST)
     })?;
 
-    let caller = Caller::from(&org);
-    evaluate_policies_with(
-        state.auth.permission_resolver.as_ref(),
-        &caller,
-        &[&AGENT_IDENTITY_MANAGE],
-    );
+    let caller = Caller::from(org);
+    enforce_manage_policy(state, &caller)?;
 
-    // Verify identity exists in this org
     state
         .db
         .get_agent_identity(caller.org_id, identity_id)
@@ -129,6 +146,21 @@ pub async fn list_connections(
             ErrorResponse::new("Agent identity not found".to_string())
                 .into_response(StatusCode::NOT_FOUND)
         })?;
+
+    Ok((caller, identity_id))
+}
+
+// ============================================================================
+// Handlers
+// ============================================================================
+
+/// GET /v1/agent-identities/:identity_id/connections
+pub async fn list_connections(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(identity_id): Path<String>,
+) -> Result<Json<Vec<ConnectionResponse>>, (StatusCode, Json<ErrorResponse>)> {
+    let (_, identity_id) = resolve_identity(&state, &org, &identity_id).await?;
 
     let rows = state
         .db
@@ -161,32 +193,7 @@ pub async fn create_api_key_connection(
     Path((identity_id, provider_id)): Path<(String, String)>,
     Json(body): Json<CreateApiKeyConnectionRequest>,
 ) -> Result<(StatusCode, Json<ConnectionResponse>), (StatusCode, Json<ErrorResponse>)> {
-    let identity_id: AgentIdentityId = identity_id.parse().map_err(|e| {
-        ErrorResponse::new(format!("Invalid identity ID: {}", e))
-            .into_response(StatusCode::BAD_REQUEST)
-    })?;
-
-    let caller = Caller::from(&org);
-    evaluate_policies_with(
-        state.auth.permission_resolver.as_ref(),
-        &caller,
-        &[&AGENT_IDENTITY_MANAGE],
-    );
-
-    // Verify identity exists
-    state
-        .db
-        .get_agent_identity(caller.org_id, identity_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to get agent identity: {}", e);
-            ErrorResponse::new("Internal error".to_string())
-                .into_response(StatusCode::INTERNAL_SERVER_ERROR)
-        })?
-        .ok_or_else(|| {
-            ErrorResponse::new("Agent identity not found".to_string())
-                .into_response(StatusCode::NOT_FOUND)
-        })?;
+    let (_, identity_id) = resolve_identity(&state, &org, &identity_id).await?;
 
     let provider = state
         .connection_providers
@@ -260,32 +267,7 @@ pub async fn delete_connection(
     State(state): State<AppState>,
     Path((identity_id, provider)): Path<(String, String)>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    let identity_id: AgentIdentityId = identity_id.parse().map_err(|e| {
-        ErrorResponse::new(format!("Invalid identity ID: {}", e))
-            .into_response(StatusCode::BAD_REQUEST)
-    })?;
-
-    let caller = Caller::from(&org);
-    evaluate_policies_with(
-        state.auth.permission_resolver.as_ref(),
-        &caller,
-        &[&AGENT_IDENTITY_MANAGE],
-    );
-
-    // Verify identity exists
-    state
-        .db
-        .get_agent_identity(caller.org_id, identity_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to get agent identity: {}", e);
-            ErrorResponse::new("Internal error".to_string())
-                .into_response(StatusCode::INTERNAL_SERVER_ERROR)
-        })?
-        .ok_or_else(|| {
-            ErrorResponse::new("Agent identity not found".to_string())
-                .into_response(StatusCode::NOT_FOUND)
-        })?;
+    let (_, identity_id) = resolve_identity(&state, &org, &identity_id).await?;
 
     let deleted = state
         .db
@@ -311,32 +293,7 @@ pub async fn verify_connection(
     State(state): State<AppState>,
     Path((identity_id, provider_id)): Path<(String, String)>,
 ) -> Result<Json<VerifyConnectionResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let identity_id: AgentIdentityId = identity_id.parse().map_err(|e| {
-        ErrorResponse::new(format!("Invalid identity ID: {}", e))
-            .into_response(StatusCode::BAD_REQUEST)
-    })?;
-
-    let caller = Caller::from(&org);
-    evaluate_policies_with(
-        state.auth.permission_resolver.as_ref(),
-        &caller,
-        &[&AGENT_IDENTITY_MANAGE],
-    );
-
-    // Verify identity exists
-    state
-        .db
-        .get_agent_identity(caller.org_id, identity_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to get agent identity: {}", e);
-            ErrorResponse::new("Internal error".to_string())
-                .into_response(StatusCode::INTERNAL_SERVER_ERROR)
-        })?
-        .ok_or_else(|| {
-            ErrorResponse::new("Agent identity not found".to_string())
-                .into_response(StatusCode::NOT_FOUND)
-        })?;
+    let (_, identity_id) = resolve_identity(&state, &org, &identity_id).await?;
 
     let row = state
         .db
@@ -393,11 +350,4 @@ pub async fn verify_connection(
             error: Some(e.to_string()),
         })),
     }
-}
-
-#[derive(Debug, Serialize)]
-pub struct VerifyConnectionResponse {
-    pub valid: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
 }

--- a/crates/server/src/api/agent_identity_connections.rs
+++ b/crates/server/src/api/agent_identity_connections.rs
@@ -1,0 +1,403 @@
+// Agent identity connection HTTP routes.
+// Sub-resource of agent identities: /v1/agent-identities/{identity_id}/connections/...
+// Mirrors user_connections but scoped to an agent identity instead of a user.
+
+use crate::auth::{AuthState, ResolvedOrg};
+use crate::services::agent_identity::AGENT_IDENTITY_MANAGE;
+use crate::storage::models::CreateAgentIdentityConnectionRow;
+use crate::storage::{EncryptionService, StorageBackend};
+use axum::extract::FromRef;
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    http::StatusCode,
+    routing::{get, post},
+};
+use chrono::{DateTime, Utc};
+use everruns_core::connection_provider::{ConnectionProviderRegistry, ConnectionType};
+use everruns_core::{AgentIdentityId, Caller, evaluate_policies_with};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use super::common::ErrorResponse;
+
+/// App state for identity connection routes
+#[derive(Clone)]
+pub struct AppState {
+    pub db: Arc<StorageBackend>,
+    pub encryption: Option<Arc<EncryptionService>>,
+    pub auth: AuthState,
+    pub connection_providers: ConnectionProviderRegistry,
+}
+
+impl AppState {
+    pub fn new(
+        db: Arc<StorageBackend>,
+        encryption: Option<Arc<EncryptionService>>,
+        auth: AuthState,
+        connection_providers: ConnectionProviderRegistry,
+    ) -> Self {
+        Self {
+            db,
+            encryption,
+            auth,
+            connection_providers,
+        }
+    }
+}
+
+impl FromRef<AppState> for AuthState {
+    fn from_ref(input: &AppState) -> Self {
+        input.auth.clone()
+    }
+}
+
+// ============================================================================
+// Response / Request Types
+// ============================================================================
+
+#[derive(Debug, Serialize)]
+pub struct ConnectionResponse {
+    pub provider: String,
+    pub connection_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider_username: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scopes: Option<String>,
+    pub connected_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateApiKeyConnectionRequest {
+    pub api_key: String,
+}
+
+// ============================================================================
+// Routes
+// ============================================================================
+
+pub fn routes(state: AppState) -> Router {
+    Router::new()
+        .route(
+            "/v1/agent-identities/{identity_id}/connections",
+            get(list_connections),
+        )
+        .route(
+            "/v1/agent-identities/{identity_id}/connections/{provider}",
+            post(create_api_key_connection).delete(delete_connection),
+        )
+        .route(
+            "/v1/agent-identities/{identity_id}/connections/{provider}/verify",
+            post(verify_connection),
+        )
+        .with_state(state)
+}
+
+// ============================================================================
+// Handlers
+// ============================================================================
+
+/// GET /v1/agent-identities/:identity_id/connections
+pub async fn list_connections(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(identity_id): Path<String>,
+) -> Result<Json<Vec<ConnectionResponse>>, (StatusCode, Json<ErrorResponse>)> {
+    let identity_id: AgentIdentityId = identity_id.parse().map_err(|e| {
+        ErrorResponse::new(format!("Invalid identity ID: {}", e))
+            .into_response(StatusCode::BAD_REQUEST)
+    })?;
+
+    let caller = Caller::from(&org);
+    evaluate_policies_with(
+        state.auth.permission_resolver.as_ref(),
+        &caller,
+        &[&AGENT_IDENTITY_MANAGE],
+    );
+
+    // Verify identity exists in this org
+    state
+        .db
+        .get_agent_identity(caller.org_id, identity_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get agent identity: {}", e);
+            ErrorResponse::new("Internal error".to_string())
+                .into_response(StatusCode::INTERNAL_SERVER_ERROR)
+        })?
+        .ok_or_else(|| {
+            ErrorResponse::new("Agent identity not found".to_string())
+                .into_response(StatusCode::NOT_FOUND)
+        })?;
+
+    let rows = state
+        .db
+        .list_agent_identity_connections(identity_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to list identity connections: {}", e);
+            ErrorResponse::new("Internal error".to_string())
+                .into_response(StatusCode::INTERNAL_SERVER_ERROR)
+        })?;
+
+    let connections = rows
+        .into_iter()
+        .map(|r| ConnectionResponse {
+            provider: r.provider,
+            connection_type: r.connection_type,
+            provider_username: r.provider_username,
+            scopes: r.scopes,
+            connected_at: r.created_at,
+        })
+        .collect();
+
+    Ok(Json(connections))
+}
+
+/// POST /v1/agent-identities/:identity_id/connections/:provider
+pub async fn create_api_key_connection(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path((identity_id, provider_id)): Path<(String, String)>,
+    Json(body): Json<CreateApiKeyConnectionRequest>,
+) -> Result<(StatusCode, Json<ConnectionResponse>), (StatusCode, Json<ErrorResponse>)> {
+    let identity_id: AgentIdentityId = identity_id.parse().map_err(|e| {
+        ErrorResponse::new(format!("Invalid identity ID: {}", e))
+            .into_response(StatusCode::BAD_REQUEST)
+    })?;
+
+    let caller = Caller::from(&org);
+    evaluate_policies_with(
+        state.auth.permission_resolver.as_ref(),
+        &caller,
+        &[&AGENT_IDENTITY_MANAGE],
+    );
+
+    // Verify identity exists
+    state
+        .db
+        .get_agent_identity(caller.org_id, identity_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get agent identity: {}", e);
+            ErrorResponse::new("Internal error".to_string())
+                .into_response(StatusCode::INTERNAL_SERVER_ERROR)
+        })?
+        .ok_or_else(|| {
+            ErrorResponse::new("Agent identity not found".to_string())
+                .into_response(StatusCode::NOT_FOUND)
+        })?;
+
+    let provider = state
+        .connection_providers
+        .get(&provider_id)
+        .ok_or_else(|| {
+            ErrorResponse::new(format!("Unknown connection provider: {provider_id}"))
+                .into_response(StatusCode::NOT_FOUND)
+        })?;
+
+    if provider.connection_type() != ConnectionType::ApiKey {
+        return Err(ErrorResponse::new(format!(
+            "Provider '{provider_id}' uses OAuth, not API key"
+        ))
+        .into_response(StatusCode::BAD_REQUEST));
+    }
+
+    let encryption = state.encryption.as_ref().ok_or_else(|| {
+        ErrorResponse::new("Encryption not configured".to_string())
+            .into_response(StatusCode::INTERNAL_SERVER_ERROR)
+    })?;
+
+    // Validate the API key
+    let validation = provider.validate(&body.api_key).await.map_err(|e| {
+        ErrorResponse::new(format!("API key validation failed: {e}"))
+            .into_response(StatusCode::BAD_REQUEST)
+    })?;
+
+    // Encrypt and store
+    let access_token_encrypted = encryption.encrypt_string(&body.api_key).map_err(|e| {
+        tracing::error!("Failed to encrypt API key: {}", e);
+        ErrorResponse::new("Failed to store connection".to_string())
+            .into_response(StatusCode::INTERNAL_SERVER_ERROR)
+    })?;
+
+    let row = state
+        .db
+        .upsert_agent_identity_connection(CreateAgentIdentityConnectionRow {
+            agent_identity_id: identity_id,
+            provider: provider_id,
+            connection_type: "api_key".to_string(),
+            provider_user_id: None,
+            provider_username: validation.provider_username.clone(),
+            access_token_encrypted: Some(access_token_encrypted),
+            refresh_token_encrypted: None,
+            scopes: None,
+            expires_at: None,
+            installation_id: None,
+        })
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to store identity connection: {}", e);
+            ErrorResponse::new("Failed to store connection".to_string())
+                .into_response(StatusCode::INTERNAL_SERVER_ERROR)
+        })?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(ConnectionResponse {
+            provider: row.provider,
+            connection_type: row.connection_type,
+            provider_username: row.provider_username,
+            scopes: row.scopes,
+            connected_at: row.created_at,
+        }),
+    ))
+}
+
+/// DELETE /v1/agent-identities/:identity_id/connections/:provider
+pub async fn delete_connection(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path((identity_id, provider)): Path<(String, String)>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let identity_id: AgentIdentityId = identity_id.parse().map_err(|e| {
+        ErrorResponse::new(format!("Invalid identity ID: {}", e))
+            .into_response(StatusCode::BAD_REQUEST)
+    })?;
+
+    let caller = Caller::from(&org);
+    evaluate_policies_with(
+        state.auth.permission_resolver.as_ref(),
+        &caller,
+        &[&AGENT_IDENTITY_MANAGE],
+    );
+
+    // Verify identity exists
+    state
+        .db
+        .get_agent_identity(caller.org_id, identity_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get agent identity: {}", e);
+            ErrorResponse::new("Internal error".to_string())
+                .into_response(StatusCode::INTERNAL_SERVER_ERROR)
+        })?
+        .ok_or_else(|| {
+            ErrorResponse::new("Agent identity not found".to_string())
+                .into_response(StatusCode::NOT_FOUND)
+        })?;
+
+    let deleted = state
+        .db
+        .delete_agent_identity_connection(identity_id, &provider)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete identity connection: {}", e);
+            ErrorResponse::new("Internal error".to_string())
+                .into_response(StatusCode::INTERNAL_SERVER_ERROR)
+        })?;
+
+    if deleted {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(ErrorResponse::new("Connection not found".to_string())
+            .into_response(StatusCode::NOT_FOUND))
+    }
+}
+
+/// POST /v1/agent-identities/:identity_id/connections/:provider/verify
+pub async fn verify_connection(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path((identity_id, provider_id)): Path<(String, String)>,
+) -> Result<Json<VerifyConnectionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let identity_id: AgentIdentityId = identity_id.parse().map_err(|e| {
+        ErrorResponse::new(format!("Invalid identity ID: {}", e))
+            .into_response(StatusCode::BAD_REQUEST)
+    })?;
+
+    let caller = Caller::from(&org);
+    evaluate_policies_with(
+        state.auth.permission_resolver.as_ref(),
+        &caller,
+        &[&AGENT_IDENTITY_MANAGE],
+    );
+
+    // Verify identity exists
+    state
+        .db
+        .get_agent_identity(caller.org_id, identity_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get agent identity: {}", e);
+            ErrorResponse::new("Internal error".to_string())
+                .into_response(StatusCode::INTERNAL_SERVER_ERROR)
+        })?
+        .ok_or_else(|| {
+            ErrorResponse::new("Agent identity not found".to_string())
+                .into_response(StatusCode::NOT_FOUND)
+        })?;
+
+    let row = state
+        .db
+        .get_agent_identity_connection(identity_id, &provider_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to look up connection for verify: {}", e);
+            ErrorResponse::new("Internal error".to_string())
+                .into_response(StatusCode::INTERNAL_SERVER_ERROR)
+        })?
+        .ok_or_else(|| {
+            ErrorResponse::new(format!("No connection found for provider: {provider_id}"))
+                .into_response(StatusCode::NOT_FOUND)
+        })?;
+
+    if row.connection_type != "api_key" {
+        return Err(ErrorResponse::new(format!(
+            "Provider '{provider_id}' does not support API key verification"
+        ))
+        .into_response(StatusCode::BAD_REQUEST));
+    }
+
+    let encrypted = row.access_token_encrypted.ok_or_else(|| {
+        ErrorResponse::new("No stored credential found".to_string())
+            .into_response(StatusCode::INTERNAL_SERVER_ERROR)
+    })?;
+
+    let encryption = state.encryption.as_ref().ok_or_else(|| {
+        ErrorResponse::new("Encryption not configured".to_string())
+            .into_response(StatusCode::INTERNAL_SERVER_ERROR)
+    })?;
+
+    let api_key = encryption.decrypt_to_string(&encrypted).map_err(|e| {
+        tracing::error!("Failed to decrypt stored credential: {}", e);
+        ErrorResponse::new("Failed to verify connection".to_string())
+            .into_response(StatusCode::INTERNAL_SERVER_ERROR)
+    })?;
+
+    let provider = state
+        .connection_providers
+        .get(&provider_id)
+        .ok_or_else(|| {
+            ErrorResponse::new(format!("Unknown connection provider: {provider_id}"))
+                .into_response(StatusCode::NOT_FOUND)
+        })?;
+
+    match provider.validate(&api_key).await {
+        Ok(_) => Ok(Json(VerifyConnectionResponse {
+            valid: true,
+            error: None,
+        })),
+        Err(e) => Ok(Json(VerifyConnectionResponse {
+            valid: false,
+            error: Some(e.to_string()),
+        })),
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct VerifyConnectionResponse {
+    pub valid: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod agent_examples;
 pub mod agent_identities;
+pub mod agent_identity_connections;
 pub mod agents;
 pub mod apps;
 pub mod audit_logs;

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -522,6 +522,12 @@ impl ServerAppBuilder {
             api::agents::AppState::new(db.clone(), capability_service, auth_state.clone());
         let agent_identities_state =
             api::agent_identities::AppState::new(db.clone(), auth_state.clone());
+        let agent_identity_connections_state = api::agent_identity_connections::AppState::new(
+            db.clone(),
+            encryption.clone(),
+            auth_state.clone(),
+            platform_definition.connection_providers().clone(),
+        );
         let apps_state =
             api::apps::AppState::new(db.clone(), encryption.clone(), auth_state.clone());
         let slack_state = api::slack_events::SlackState::new(
@@ -622,6 +628,9 @@ impl ServerAppBuilder {
             .merge(api::agent_examples::routes(agent_examples_state))
             .merge(api::agents::routes(agents_state))
             .merge(api::agent_identities::routes(agent_identities_state))
+            .merge(api::agent_identity_connections::routes(
+                agent_identity_connections_state,
+            ))
             .merge(api::apps::routes(apps_state))
             .merge(api::harnesses::routes(harnesses_state))
             .merge(api::sessions::routes(sessions_state))

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -1613,6 +1613,45 @@ impl StorageBackend {
     }
 
     // ============================================
+    // Agent Identity Connections
+    // ============================================
+
+    pub async fn upsert_agent_identity_connection(
+        &self,
+        input: CreateAgentIdentityConnectionRow,
+    ) -> Result<AgentIdentityConnectionRow> {
+        dispatch!(self, upsert_agent_identity_connection, input)
+    }
+
+    pub async fn get_agent_identity_connection(
+        &self,
+        identity_id: AgentIdentityId,
+        provider: &str,
+    ) -> Result<Option<AgentIdentityConnectionRow>> {
+        dispatch!(self, get_agent_identity_connection, identity_id, provider)
+    }
+
+    pub async fn list_agent_identity_connections(
+        &self,
+        identity_id: AgentIdentityId,
+    ) -> Result<Vec<AgentIdentityConnectionRow>> {
+        dispatch!(self, list_agent_identity_connections, identity_id)
+    }
+
+    pub async fn delete_agent_identity_connection(
+        &self,
+        identity_id: AgentIdentityId,
+        provider: &str,
+    ) -> Result<bool> {
+        dispatch!(
+            self,
+            delete_agent_identity_connection,
+            identity_id,
+            provider
+        )
+    }
+
+    // ============================================
     // Session Schedules
     // ============================================
 

--- a/crates/server/src/storage/encryption.rs
+++ b/crates/server/src/storage/encryption.rs
@@ -401,6 +401,18 @@ pub const ENCRYPTED_COLUMNS: &[EncryptedColumn] = &[
         column: "channel_config_encrypted",
         id_column: "id",
     },
+    // Agent identity connection access tokens are encrypted at rest
+    EncryptedColumn {
+        table: "agent_identity_connections",
+        column: "access_token_encrypted",
+        id_column: "id",
+    },
+    // Agent identity connection refresh tokens are encrypted at rest
+    EncryptedColumn {
+        table: "agent_identity_connections",
+        column: "refresh_token_encrypted",
+        id_column: "id",
+    },
 ];
 
 #[cfg(test)]

--- a/crates/server/src/storage/memory/agent_identity_connections.rs
+++ b/crates/server/src/storage/memory/agent_identity_connections.rs
@@ -1,0 +1,83 @@
+// In-memory storage: Agent Identity Connections
+
+use super::super::models::*;
+use super::InMemoryDatabase;
+use anyhow::Result;
+use everruns_core::AgentIdentityId;
+use uuid::Uuid;
+
+impl InMemoryDatabase {
+    // ============================================
+    // Agent Identity Connections
+    // ============================================
+
+    pub async fn upsert_agent_identity_connection(
+        &self,
+        input: CreateAgentIdentityConnectionRow,
+    ) -> Result<AgentIdentityConnectionRow> {
+        let now = Self::now();
+        let id = Uuid::now_v7();
+
+        let mut connections = self.agent_identity_connections.write();
+        connections.retain(|_, c| {
+            !(c.agent_identity_id == input.agent_identity_id && c.provider == input.provider)
+        });
+
+        let row = AgentIdentityConnectionRow {
+            id,
+            agent_identity_id: input.agent_identity_id,
+            provider: input.provider,
+            connection_type: input.connection_type,
+            provider_user_id: input.provider_user_id,
+            provider_username: input.provider_username,
+            access_token_encrypted: input.access_token_encrypted,
+            refresh_token_encrypted: input.refresh_token_encrypted,
+            scopes: input.scopes,
+            expires_at: input.expires_at,
+            installation_id: input.installation_id,
+            created_at: now,
+            updated_at: now,
+        };
+        connections.insert(id, row.clone());
+        Ok(row)
+    }
+
+    pub async fn get_agent_identity_connection(
+        &self,
+        identity_id: AgentIdentityId,
+        provider: &str,
+    ) -> Result<Option<AgentIdentityConnectionRow>> {
+        Ok(self
+            .agent_identity_connections
+            .read()
+            .values()
+            .find(|c| c.agent_identity_id == identity_id && c.provider == provider)
+            .cloned())
+    }
+
+    pub async fn list_agent_identity_connections(
+        &self,
+        identity_id: AgentIdentityId,
+    ) -> Result<Vec<AgentIdentityConnectionRow>> {
+        let mut connections: Vec<_> = self
+            .agent_identity_connections
+            .read()
+            .values()
+            .filter(|c| c.agent_identity_id == identity_id)
+            .cloned()
+            .collect();
+        connections.sort_by(|a, b| a.provider.cmp(&b.provider));
+        Ok(connections)
+    }
+
+    pub async fn delete_agent_identity_connection(
+        &self,
+        identity_id: AgentIdentityId,
+        provider: &str,
+    ) -> Result<bool> {
+        let mut connections = self.agent_identity_connections.write();
+        let before = connections.len();
+        connections.retain(|_, c| !(c.agent_identity_id == identity_id && c.provider == provider));
+        Ok(connections.len() < before)
+    }
+}

--- a/crates/server/src/storage/memory/mod.rs
+++ b/crates/server/src/storage/memory/mod.rs
@@ -8,6 +8,7 @@
 // Split into per-entity modules for maintainability (EVE-99).
 
 mod agent_identities;
+mod agent_identity_connections;
 mod agents;
 mod apps;
 mod audit_logs;
@@ -117,6 +118,8 @@ pub struct InMemoryDatabase {
     apps: RwLock<HashMap<Uuid, AppRow>>,
     // Agent identities (virtual principals)
     agent_identities: RwLock<HashMap<AgentIdentityId, AgentIdentityRow>>,
+    // Agent identity connections (identity-scoped external accounts)
+    agent_identity_connections: RwLock<HashMap<Uuid, AgentIdentityConnectionRow>>,
     // Organization settings (default model, etc.)
     org_settings: RwLock<HashMap<i64, OrganizationSettingsRow>>,
 }
@@ -174,6 +177,7 @@ impl Default for InMemoryDatabase {
             audit_logs: RwLock::new(Vec::new()),
             apps: RwLock::new(HashMap::new()),
             agent_identities: RwLock::new(HashMap::new()),
+            agent_identity_connections: RwLock::new(HashMap::new()),
             org_settings: RwLock::new(HashMap::new()),
         }
     }

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -1096,6 +1096,43 @@ pub struct CreateUserConnectionRow {
 }
 
 // ============================================
+// Agent Identity Connection models
+// ============================================
+
+/// Agent identity connection row from database
+#[derive(Debug, Clone, FromRow)]
+pub struct AgentIdentityConnectionRow {
+    pub id: Uuid,
+    pub agent_identity_id: AgentIdentityId,
+    pub provider: String,
+    pub connection_type: String,
+    pub provider_user_id: Option<String>,
+    pub provider_username: Option<String>,
+    pub access_token_encrypted: Option<Vec<u8>>,
+    pub refresh_token_encrypted: Option<Vec<u8>>,
+    pub scopes: Option<String>,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub installation_id: Option<i64>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Input for creating an agent identity connection
+#[derive(Debug, Clone)]
+pub struct CreateAgentIdentityConnectionRow {
+    pub agent_identity_id: AgentIdentityId,
+    pub provider: String,
+    pub connection_type: String,
+    pub provider_user_id: Option<String>,
+    pub provider_username: Option<String>,
+    pub access_token_encrypted: Option<Vec<u8>>,
+    pub refresh_token_encrypted: Option<Vec<u8>>,
+    pub scopes: Option<String>,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub installation_id: Option<i64>,
+}
+
+// ============================================
 // Session Schedule models
 // ============================================
 

--- a/crates/server/src/storage/repositories/agent_identity_connections.rs
+++ b/crates/server/src/storage/repositories/agent_identity_connections.rs
@@ -1,0 +1,107 @@
+// PostgreSQL repository: Agent Identity Connections
+
+use super::super::models::*;
+use super::Database;
+use anyhow::Result;
+use everruns_core::AgentIdentityId;
+
+impl Database {
+    // ============================================
+    // Agent Identity Connections
+    // ============================================
+
+    /// Create or replace an identity connection for a provider.
+    pub async fn upsert_agent_identity_connection(
+        &self,
+        input: CreateAgentIdentityConnectionRow,
+    ) -> Result<AgentIdentityConnectionRow> {
+        sqlx::query(
+            "DELETE FROM agent_identity_connections WHERE agent_identity_id = $1 AND provider = $2",
+        )
+        .bind(input.agent_identity_id)
+        .bind(&input.provider)
+        .execute(&self.pool)
+        .await?;
+
+        let row = sqlx::query_as::<_, AgentIdentityConnectionRow>(
+            r#"
+            INSERT INTO agent_identity_connections (agent_identity_id, provider, connection_type, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            RETURNING id, agent_identity_id, provider, connection_type, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id, created_at, updated_at
+            "#,
+        )
+        .bind(input.agent_identity_id)
+        .bind(&input.provider)
+        .bind(&input.connection_type)
+        .bind(&input.provider_user_id)
+        .bind(&input.provider_username)
+        .bind(&input.access_token_encrypted)
+        .bind(&input.refresh_token_encrypted)
+        .bind(&input.scopes)
+        .bind(input.expires_at)
+        .bind(input.installation_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    /// Get an identity's connection for a specific provider
+    pub async fn get_agent_identity_connection(
+        &self,
+        identity_id: AgentIdentityId,
+        provider: &str,
+    ) -> Result<Option<AgentIdentityConnectionRow>> {
+        let row = sqlx::query_as::<_, AgentIdentityConnectionRow>(
+            r#"
+            SELECT id, agent_identity_id, provider, connection_type, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id, created_at, updated_at
+            FROM agent_identity_connections
+            WHERE agent_identity_id = $1 AND provider = $2
+            LIMIT 1
+            "#,
+        )
+        .bind(identity_id)
+        .bind(provider)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    /// List all connections for an agent identity
+    pub async fn list_agent_identity_connections(
+        &self,
+        identity_id: AgentIdentityId,
+    ) -> Result<Vec<AgentIdentityConnectionRow>> {
+        let rows = sqlx::query_as::<_, AgentIdentityConnectionRow>(
+            r#"
+            SELECT id, agent_identity_id, provider, connection_type, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id, created_at, updated_at
+            FROM agent_identity_connections
+            WHERE agent_identity_id = $1
+            ORDER BY provider ASC
+            "#,
+        )
+        .bind(identity_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
+    /// Delete an identity's connection for a specific provider
+    pub async fn delete_agent_identity_connection(
+        &self,
+        identity_id: AgentIdentityId,
+        provider: &str,
+    ) -> Result<bool> {
+        let result = sqlx::query(
+            "DELETE FROM agent_identity_connections WHERE agent_identity_id = $1 AND provider = $2",
+        )
+        .bind(identity_id)
+        .bind(provider)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+}

--- a/crates/server/src/storage/repositories/agent_identity_connections.rs
+++ b/crates/server/src/storage/repositories/agent_identity_connections.rs
@@ -11,23 +11,31 @@ impl Database {
     // ============================================
 
     /// Create or replace an identity connection for a provider.
+    /// Uses ON CONFLICT to atomically upsert, avoiding data loss from a
+    /// DELETE+INSERT race if the INSERT were to fail after the DELETE.
     pub async fn upsert_agent_identity_connection(
         &self,
         input: CreateAgentIdentityConnectionRow,
     ) -> Result<AgentIdentityConnectionRow> {
-        sqlx::query(
-            "DELETE FROM agent_identity_connections WHERE agent_identity_id = $1 AND provider = $2",
-        )
-        .bind(input.agent_identity_id)
-        .bind(&input.provider)
-        .execute(&self.pool)
-        .await?;
-
         let row = sqlx::query_as::<_, AgentIdentityConnectionRow>(
             r#"
-            INSERT INTO agent_identity_connections (agent_identity_id, provider, connection_type, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id)
+            INSERT INTO agent_identity_connections
+                (agent_identity_id, provider, connection_type, provider_user_id, provider_username,
+                 access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-            RETURNING id, agent_identity_id, provider, connection_type, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id, created_at, updated_at
+            ON CONFLICT (agent_identity_id, provider) DO UPDATE SET
+                connection_type = EXCLUDED.connection_type,
+                provider_user_id = EXCLUDED.provider_user_id,
+                provider_username = EXCLUDED.provider_username,
+                access_token_encrypted = EXCLUDED.access_token_encrypted,
+                refresh_token_encrypted = EXCLUDED.refresh_token_encrypted,
+                scopes = EXCLUDED.scopes,
+                expires_at = EXCLUDED.expires_at,
+                installation_id = EXCLUDED.installation_id,
+                updated_at = NOW()
+            RETURNING id, agent_identity_id, provider, connection_type, provider_user_id,
+                      provider_username, access_token_encrypted, refresh_token_encrypted,
+                      scopes, expires_at, installation_id, created_at, updated_at
             "#,
         )
         .bind(input.agent_identity_id)

--- a/crates/server/src/storage/repositories/mod.rs
+++ b/crates/server/src/storage/repositories/mod.rs
@@ -2,6 +2,7 @@
 // Decision: PostgreSQL-backed, split into per-entity modules (EVE-100).
 
 mod agent_identities;
+mod agent_identity_connections;
 mod agents;
 mod apps;
 mod audit_logs;

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -2746,3 +2746,77 @@ async fn test_list_connections_initially_empty() {
 
     assert!(resp.is_empty());
 }
+
+// ============================================================================
+// Agent Identity Connection tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_identity_connections_list_empty() {
+    let server = TestServer::in_memory().await;
+
+    // Create an identity first
+    let identity: Value = server
+        .post("/v1/agent-identities", json!({"name": "ConnTest"}))
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    let id = identity["id"].as_str().unwrap();
+
+    // List connections — should be empty
+    let connections: Vec<Value> = server
+        .get(&format!("/v1/agent-identities/{id}/connections"))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    assert!(connections.is_empty());
+}
+
+#[tokio::test]
+async fn test_identity_connections_not_found_for_missing_identity() {
+    let server = TestServer::in_memory().await;
+
+    server
+        .get("/v1/agent-identities/identity_019d166cd0147e638c72892ecb30ffff/connections")
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_identity_connections_delete_not_found() {
+    let server = TestServer::in_memory().await;
+
+    let identity: Value = server
+        .post("/v1/agent-identities", json!({"name": "ConnDel"}))
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    let id = identity["id"].as_str().unwrap();
+
+    server
+        .delete(&format!(
+            "/v1/agent-identities/{id}/connections/nonexistent"
+        ))
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_identity_connections_create_unknown_provider() {
+    let server = TestServer::in_memory().await;
+
+    let identity: Value = server
+        .post("/v1/agent-identities", json!({"name": "ConnProv"}))
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    let id = identity["id"].as_str().unwrap();
+
+    server
+        .post(
+            &format!("/v1/agent-identities/{id}/connections/nonexistent"),
+            json!({"api_key": "test"}),
+        )
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -245,6 +245,14 @@ impl TestServer {
             mcp_service,
         );
 
+        let agent_identities_state =
+            api::agent_identities::AppState::new(db.clone(), auth_state.clone());
+        let agent_identity_connections_state = api::agent_identity_connections::AppState::new(
+            db.clone(),
+            encryption.clone(),
+            auth_state.clone(),
+            platform_definition.connection_providers().clone(),
+        );
         let apps_state = api::apps::AppState::new(db.clone(), None, auth_state.clone());
         let slack_state = api::slack_events::SlackState::new(
             db.clone(),
@@ -257,6 +265,10 @@ impl TestServer {
         // Build API routes
         let mut api_routes = Router::new()
             .merge(api::agents::routes(agents_state))
+            .merge(api::agent_identities::routes(agent_identities_state))
+            .merge(api::agent_identity_connections::routes(
+                agent_identity_connections_state,
+            ))
             .merge(api::apps::routes(apps_state))
             .merge(api::harnesses::routes(harnesses_state))
             .merge(api::sessions::routes(sessions_state))


### PR DESCRIPTION
## What
Add connection management (list, create, delete, verify) scoped to agent identities, mirroring the existing user connections system.

## Why
Agent identities need their own connection credentials for unattended execution. Previously, connections were only user-scoped, meaning identities could not hold their own API keys for services like Daytona, Brave Search, etc.

## How
**Backend:**
- Migration 009: `agent_identity_connections` table with unique constraint per `(identity_id, provider)`
- Storage models + Postgres & InMemory repository implementations
- API routes at `/v1/agent-identities/{identity_id}/connections/`:
  - `GET /` — list connections
  - `POST /{provider}` — create API key connection (validates + encrypts)
  - `DELETE /{provider}` — disconnect
  - `POST /{provider}/verify` — verify stored API key
- Authorization enforced via `AGENT_IDENTITY_MANAGE` policy on all endpoints
- Identity org-scoping prevents cross-tenant access

**Frontend:**
- API client (`agent-identity-connections.ts`), React Query hooks, query keys
- `IdentityConnections` component on identity detail page showing connected + available providers
- `IdentityApiKeyDialog` for API key entry (mirrors user `ApiKeyDialog`)
- Only API-key providers shown (OAuth requires user interaction, not applicable to identity-owned connections)

## Risk
- Low
- New isolated feature. No changes to existing user connection flows or session resolution. Uses same encryption and provider validation as user connections.

## Security
- Threat categories reviewed: **TM-AUTHZ**, **TM-API**, **TM-TENANT**, **TM-AUTH**
- Findings and resolutions:
  - **TM-AUTHZ**: Initial implementation had `evaluate_policies_with` result discarded (not enforced). Fixed in second commit: all handlers now enforce `AGENT_IDENTITY_MANAGE` policy via `Policy::evaluate_with()`, returning 403 on failure.
  - **TM-TENANT**: Identity org-scoping enforced by `get_agent_identity(caller.org_id, identity_id)` check before any connection data access. DB table uses FK to `agent_identities` with CASCADE delete.
  - **TM-API**: Input validation via typed ID parsing. API key validated by provider before storage. No raw credentials in responses or logs. Keys encrypted via existing `EncryptionService`.
  - **TM-AUTH**: Routes require `ResolvedOrg` extractor (authenticated org context).

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)