### PR TITLE
fix(ui): widen API key dialog and inline copy button

### DIFF
--- a/apps/ui/src/app/(main)/settings/api-keys/page.tsx
+++ b/apps/ui/src/app/(main)/settings/api-keys/page.tsx
@@ -160,7 +160,7 @@ function ShowApiKeyDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent className="sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>API Key Created</DialogTitle>
           <DialogDescription>
@@ -168,8 +168,17 @@ function ShowApiKeyDialog({
           </DialogDescription>
         </DialogHeader>
         <div className="flex items-center gap-2">
-          <div className="bg-muted p-3 rounded-md font-mono text-sm flex-1 min-w-0">{apiKey}</div>
-          <Button onClick={handleCopy} variant="outline" size="icon" className="shrink-0">
+          <div className="bg-muted p-3 rounded-md font-mono text-sm flex-1 min-w-0 max-w-full whitespace-nowrap overflow-x-auto">
+            {apiKey}
+          </div>
+          <Button
+            onClick={handleCopy}
+            variant="outline"
+            size="icon"
+            className="shrink-0"
+            aria-label={copied ? "API key copied" : "Copy API key"}
+            title={copied ? "API key copied" : "Copy API key"}
+          >
             {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
           </Button>
         </div>

--- a/apps/ui/src/app/(main)/settings/api-keys/page.tsx
+++ b/apps/ui/src/app/(main)/settings/api-keys/page.tsx
@@ -160,27 +160,17 @@ function ShowApiKeyDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent className="max-w-2xl">
         <DialogHeader>
           <DialogTitle>API Key Created</DialogTitle>
           <DialogDescription>
             Copy your API key now. You won&apos;t be able to see it again!
           </DialogDescription>
         </DialogHeader>
-        <div className="space-y-4">
-          <div className="bg-muted p-3 rounded-md font-mono text-sm break-all">{apiKey}</div>
-          <Button onClick={handleCopy} className="w-full" variant="outline">
-            {copied ? (
-              <>
-                <Check className="mr-2 h-4 w-4" />
-                Copied!
-              </>
-            ) : (
-              <>
-                <Copy className="mr-2 h-4 w-4" />
-                Copy to clipboard
-              </>
-            )}
+        <div className="flex items-center gap-2">
+          <div className="bg-muted p-3 rounded-md font-mono text-sm flex-1 min-w-0">{apiKey}</div>
+          <Button onClick={handleCopy} variant="outline" size="icon" className="shrink-0">
+            {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
           </Button>
         </div>
         <DialogFooter>


### PR DESCRIPTION
## What
Widen the "API Key Created" dialog and place the copy button inline next to the key.

## Why
The default dialog width causes long API keys to wrap to two lines, making them harder to read and copy.

## How
- Set `max-w-2xl` on `DialogContent` so the key fits on one line
- Changed layout from vertical (`space-y-4`) to horizontal (`flex items-center gap-2`)
- Copy button is now a compact icon button beside the key instead of a full-width button below

## Risk
- Low
- Purely cosmetic — only Tailwind classes changed on a single dialog

## Security
- No security-relevant code changes — cosmetic layout change only (CSS classes on an existing dialog component)

## Checklist
- [x] Tests added or updated — N/A, cosmetic change
- [x] Backward compatibility considered — N/A, internal UI
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)