### PR TITLE
fix(browserless): accept HTTP 204 from v2 /active endpoint

### DIFF
--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -880,7 +880,7 @@ Set `return_screenshot: true` to get a screenshot after interactions.
 ## Prerequisites
 
 Browserless API token must be configured in Settings > Connections.
-Get a token at https://cloud.browserless.io/"#,
+Get a token at https://www.browserless.io/account/home"#,
         tags: &[
             "browser",
             "testing",

--- a/docs/integrations/browserless.md
+++ b/docs/integrations/browserless.md
@@ -17,7 +17,7 @@ Everruns integrates with [Browserless](https://www.browserless.io/) to provide c
 
 ### 1. Get Your API Token
 
-1. Go to the [Browserless Dashboard](https://cloud.browserless.io)
+1. Go to the [Browserless Dashboard](https://www.browserless.io/account/home)
 2. Navigate to **API Keys** in your account settings
 3. Copy your API token
 
@@ -83,5 +83,5 @@ Use `browserless_open_browser` to create a persistent browser via Chrome DevTool
 ## Links
 
 - [Browserless Website](https://www.browserless.io/)
-- [Browserless Dashboard](https://cloud.browserless.io)
+- [Browserless Dashboard](https://www.browserless.io/account/home)
 - [Browserless Documentation](https://docs.browserless.io/)

--- a/integrations/browserless/SPEC.md
+++ b/integrations/browserless/SPEC.md
@@ -55,7 +55,7 @@ The Browserless API token is resolved via **user connection** for the `browserle
 
 Browserless registers as a `ConnectionProviderPlugin` (API-key type). Users configure their token in **Settings > Connections > Browserless**:
 
-1. User enters API token (from [Browserless Dashboard](https://cloud.browserless.io))
+1. User enters API token (from [Browserless Dashboard](https://www.browserless.io/account/home))
 2. Token validated via `GET /active` endpoint
 3. Token encrypted and stored in `user_connections` table
 

--- a/integrations/browserless/src/connection.rs
+++ b/integrations/browserless/src/connection.rs
@@ -1,7 +1,7 @@
 // Browserless Connection Provider
 //
 // Decision: API-token-based connection (not OAuth). User enters token from Browserless dashboard.
-// Decision: Validate token by calling GET /active — 200 means valid, 401 means invalid.
+// Decision: Validate token by calling GET /active — 200/204 means valid, 401 means invalid.
 
 use async_trait::async_trait;
 use everruns_core::connection_provider::{
@@ -46,7 +46,7 @@ impl ConnectionProvider for BrowserlessConnectionProvider {
                 help_text: None,
             }],
             instructions_markdown: "\
-1. Go to [Browserless Dashboard](https://cloud.browserless.io)\n\
+1. Go to [Browserless Dashboard](https://www.browserless.io/account/home)\n\
 2. Navigate to **API Keys** in your account settings\n\
 3. Copy your API token and paste it below"
                 .to_string(),
@@ -62,7 +62,8 @@ impl ConnectionProvider for BrowserlessConnectionProvider {
             .map_err(|e| format!("Failed to reach Browserless API: {e}"))?;
 
         match response.status().as_u16() {
-            200 => Ok(ConnectionValidation {
+            // Browserless v2 /active returns 204 No Content; v1 returned 200.
+            200 | 204 => Ok(ConnectionValidation {
                 provider_username: None,
             }),
             401 | 403 => {
@@ -95,10 +96,6 @@ mod tests {
         assert_eq!(schema.fields.len(), 1);
         assert_eq!(schema.fields[0].name, "api_key");
         assert!(schema.fields[0].required);
-        assert!(
-            schema
-                .instructions_markdown
-                .contains("cloud.browserless.io")
-        );
+        assert!(schema.instructions_markdown.contains("browserless.io"));
     }
 }

--- a/integrations/browserless/src/connection.rs
+++ b/integrations/browserless/src/connection.rs
@@ -1,7 +1,7 @@
 // Browserless Connection Provider
 //
 // Decision: API-token-based connection (not OAuth). User enters token from Browserless dashboard.
-// Decision: Validate token by calling GET /active — 200/204 means valid, 401 means invalid.
+// Decision: Validate token by calling GET /active — 200/204 means valid, 401/403 means invalid.
 
 use async_trait::async_trait;
 use everruns_core::connection_provider::{
@@ -96,6 +96,10 @@ mod tests {
         assert_eq!(schema.fields.len(), 1);
         assert_eq!(schema.fields[0].name, "api_key");
         assert!(schema.fields[0].required);
-        assert!(schema.instructions_markdown.contains("browserless.io"));
+        assert!(
+            schema
+                .instructions_markdown
+                .contains("https://www.browserless.io/account/home")
+        );
     }
 }

--- a/integrations/browserless/src/state.rs
+++ b/integrations/browserless/src/state.rs
@@ -39,7 +39,7 @@ pub async fn get_api_token(context: &ToolContext) -> Result<String, ToolExecutio
     Err(ToolExecutionResult::tool_error(
         "Browserless API token not configured.\n\n\
          Set up your API token in **Settings > Connections > Browserless**.\n\n\
-         Get your token at https://cloud.browserless.io/ under API Keys.",
+         Get your token at https://www.browserless.io/account/home under API Keys.",
     ))
 }
 


### PR DESCRIPTION
## What
Accept HTTP 204 (in addition to 200) from the Browserless `/active` validation endpoint, and update all dashboard links from deprecated `cloud.browserless.io` to `www.browserless.io/account/home`.

## Why
Browserless v2 changed the `/active` health-check endpoint to return 204 No Content instead of 200. Our validation only accepted 200, so valid v2 API tokens were rejected with "Unexpected response from Browserless API (HTTP 204)". The old `cloud.browserless.io` dashboard URL is also deprecated.

## How
- Added `204` to the accepted status codes in `connection.rs` validation
- Updated all `cloud.browserless.io` references to `www.browserless.io/account/home` across code, docs, specs, and seed data

## Risk
- Low
- Accepting 204 alongside 200 is strictly additive; no existing valid-token flows change

## Security
- Threat categories reviewed: TM-LLM (API key handling)
- No new attack surface. Token validation still uses the same `/active` endpoint with `?token=` query param. The only change is accepting the correct v2 success code (204). No credential exposure or injection risk.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)