### PR TITLE
feat(e2b): add cloud sandbox integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,6 +545,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "buffa"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fb26cf6d5fa531c242d47df5d6bad0e379c26dcfa0270680a028d09030f7f1a"
+dependencies = [
+ "base64",
+ "bytes",
+ "hashbrown 0.15.5",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "buffa-codegen"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b8f1742cc45062edd1df41e7cbf56dd87388638472ddcff39ab5828214e67dc"
+dependencies = [
+ "buffa",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,6 +602,9 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytes-utils"
@@ -742,6 +774,8 @@ dependencies = [
  "compression-core",
  "flate2",
  "memchr",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -757,6 +791,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "connectrpc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348832a19a9d7e3854438c0f5693996c660d696bdf9ba49954b7c0a7bd28822b"
+dependencies = [
+ "async-compression",
+ "base64",
+ "buffa",
+ "bytes",
+ "flate2",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tracing",
+ "zstd",
+]
+
+[[package]]
+name = "connectrpc-build"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f62358d843d4d9f945eece93673bec2fef96a2d6e33ecfd585c21bee4592386"
+dependencies = [
+ "anyhow",
+ "buffa",
+ "buffa-codegen",
+ "connectrpc-codegen",
+ "tempfile",
+]
+
+[[package]]
+name = "connectrpc-codegen"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f604d1f5a75de6fbf25795d50c62748204c3f9f53474f97287916380f6e1afc7"
+dependencies = [
+ "anyhow",
+ "buffa",
+ "buffa-codegen",
+ "heck",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1546,6 +1642,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-integrations-e2b"
+version = "0.8.7"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "buffa",
+ "chrono",
+ "connectrpc",
+ "connectrpc-build",
+ "everruns-core",
+ "futures",
+ "http",
+ "http-body",
+ "inventory",
+ "reqwest 0.13.1",
+ "rustls",
+ "rustls-native-certs",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "urlencoding",
+ "wiremock",
+]
+
+[[package]]
 name = "everruns-internal-protocol"
 version = "0.8.7"
 dependencies = [
@@ -1638,6 +1761,7 @@ dependencies = [
  "everruns-integrations-daytona",
  "everruns-integrations-docker",
  "everruns-integrations-duckduckgo",
+ "everruns-integrations-e2b",
  "everruns-internal-protocol",
  "everruns-macros",
  "everruns-sdk",
@@ -1722,6 +1846,7 @@ dependencies = [
  "everruns-integrations-daytona",
  "everruns-integrations-docker",
  "everruns-integrations-duckduckgo",
+ "everruns-integrations-e2b",
  "everruns-internal-protocol",
  "everruns-openai",
  "futures",
@@ -2252,6 +2377,7 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
+ "serde",
 ]
 
 [[package]]
@@ -7578,6 +7704,34 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "integrations/brave-search",
     "integrations/duckduckgo",
     "integrations/browserless",
+    "integrations/e2b",
 ]
 
 exclude = [

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -70,6 +70,7 @@ everruns-integrations-brave-search = { path = "../../integrations/brave-search" 
 everruns-integrations-duckduckgo = { path = "../../integrations/duckduckgo" }
 everruns-integrations-daytona = { path = "../../integrations/daytona" }
 everruns-integrations-browserless = { path = "../../integrations/browserless" }
+everruns-integrations-e2b = { path = "../../integrations/e2b" }
 everruns-session-sqldb = { path = "../session-sqldb" }
 everruns-worker = { path = "../worker" }  # For AgentRunner trait
 everruns-internal-protocol = { path = "../internal-protocol" }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -9,6 +9,7 @@ extern crate everruns_integrations_browserless;
 extern crate everruns_integrations_daytona;
 extern crate everruns_integrations_docker;
 extern crate everruns_integrations_duckduckgo;
+extern crate everruns_integrations_e2b;
 
 // API routes and types (shared for OpenAPI generation)
 pub mod api;

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -56,6 +56,7 @@ mod seed_ids {
     pub const SHELL_ASSISTANT_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000105);
     pub const DATA_ANALYST_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000106);
     pub const DAYTONA_CODER_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000108);
+    pub const E2B_CODER_AGENT: Uuid = Uuid::from_u128(0x0195bb5a_0000_7000_8000_00000000010f);
     pub const CLOUD_INFRA_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000109);
     pub const PLATFORM_MANAGER_AGENT: Uuid =
         Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000010a);
@@ -634,6 +635,31 @@ Always delete sandboxes when done."#,
         tags: &["coding", "cloud", "sandbox", "daytona", "demo", "seed"],
         capabilities: &[
             SeedCapability::new("daytona"),
+            SeedCapability::new("session_storage"),
+            SeedCapability::new("session_file_system"),
+        ],
+        dev_only: false,
+    },
+    SeedAgent {
+        id: seed_ids::E2B_CODER_AGENT,
+        name: "E2B Coder",
+        description: "A coding agent that runs code in cloud sandboxes powered by E2B",
+        system_prompt: r#"You are an E2B Coder Agent. You run code in cloud sandboxes powered by E2B.
+
+The E2B API key is resolved automatically from the platform environment or session secrets.
+
+Workflow:
+1. Create sandbox: `e2b_create_sandbox` (workspace: /home/user)
+2. Write files / install deps: `e2b_write_file`, `e2b_exec`
+3. Read results: `e2b_read_file`
+4. Inspect active sandboxes: `e2b_list_sandboxes`
+5. Clean up: `e2b_manage_sandbox` action="pause" or action="delete"
+
+You can run multiple sandboxes in parallel for separate tasks.
+Delete sandboxes when work is complete; pause only when the user explicitly wants to keep state around."#,
+        tags: &["coding", "cloud", "sandbox", "e2b", "demo", "seed"],
+        capabilities: &[
+            SeedCapability::new("e2b"),
             SeedCapability::new("session_storage"),
             SeedCapability::new("session_file_system"),
         ],

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -21,6 +21,7 @@ everruns-integrations-brave-search = { path = "../../integrations/brave-search" 
 everruns-integrations-duckduckgo = { path = "../../integrations/duckduckgo" }
 everruns-integrations-daytona = { path = "../../integrations/daytona" }
 everruns-integrations-browserless = { path = "../../integrations/browserless" }
+everruns-integrations-e2b = { path = "../../integrations/e2b" }
 everruns-openai = { path = "../openai" }
 everruns-anthropic = { path = "../anthropic" }
 everruns-gemini = { path = "../gemini" }

--- a/crates/worker/src/leased_resource_cleanup.rs
+++ b/crates/worker/src/leased_resource_cleanup.rs
@@ -18,6 +18,7 @@ use tracing::{info, warn};
 use crate::worker_adapters::WorkerAdapters;
 
 const DAYTONA_SNAPSHOT_SECRET_PREFIX: &str = "daytona_sandbox:";
+const E2B_SANDBOX_SECRET_PREFIX: &str = "e2b_sandbox:";
 const BROWSERLESS_SESSION_KEY: &str = "browserless_browser_session";
 
 /// Durable activity input for leased-resource cleanup.
@@ -191,10 +192,11 @@ async fn cleanup_resource(
     resolver: &dyn UserConnectionResolver,
     storage_store: &dyn SessionStorageStore,
 ) -> Result<String> {
-    let token = resolve_provider_token(resource, resolver).await?;
+    let token = resolve_provider_token(resource, resolver, storage_store).await?;
 
     match (resource.provider.as_str(), resource.resource_type.as_str()) {
         ("daytona", "sandbox") => cleanup_daytona(resource, storage_store, &token).await,
+        ("e2b", "sandbox") => cleanup_e2b(resource, storage_store, &token).await,
         ("browserless", "browser_session") => {
             cleanup_browserless(resource, storage_store, &token).await
         }
@@ -209,7 +211,11 @@ async fn cleanup_resource(
 async fn resolve_provider_token(
     resource: &LeasedResource,
     resolver: &dyn UserConnectionResolver,
+    storage_store: &dyn SessionStorageStore,
 ) -> Result<String> {
+    if resource.provider == "e2b" {
+        return resolve_e2b_api_key(resource, storage_store).await;
+    }
     if let Some(owner_user_id) = resource.owner_user_id
         && let Some(token) = resolver
             .get_connection_token_for_user(owner_user_id, &resource.provider)
@@ -232,6 +238,29 @@ async fn resolve_provider_token(
         resource.provider,
         resource.resource_type
     ))
+}
+
+async fn resolve_e2b_api_key(
+    resource: &LeasedResource,
+    storage_store: &dyn SessionStorageStore,
+) -> Result<String> {
+    if let Some(session_id) = resource.session_id
+        && let Some(token) = storage_store.get_secret(session_id, "E2B_API_KEY").await?
+        && !token.trim().is_empty()
+    {
+        return Ok(token);
+    }
+
+    let env_token = std::env::var("E2B_API_KEY")
+        .map_err(|_| anyhow!("E2B_API_KEY not configured for leased resource cleanup"))?;
+
+    if env_token.trim().is_empty() {
+        return Err(anyhow!(
+            "E2B_API_KEY is set but empty/whitespace for leased resource cleanup"
+        ));
+    }
+
+    Ok(env_token)
 }
 
 async fn cleanup_daytona(
@@ -263,6 +292,37 @@ async fn cleanup_daytona(
     }
 
     Ok(format!("Deleted Daytona sandbox {}", resource.external_id))
+}
+
+async fn cleanup_e2b(
+    resource: &LeasedResource,
+    storage_store: &dyn SessionStorageStore,
+    token: &str,
+) -> Result<String> {
+    let client = everruns_integrations_e2b::client::E2BClient::new(token.to_string());
+
+    match client.delete_sandbox(&resource.external_id).await {
+        Ok(()) => {}
+        Err(error) if is_e2b_not_found(&error) => {
+            warn!(
+                sandbox_id = %resource.external_id,
+                error = %error,
+                "E2B sandbox already gone during cleanup"
+            );
+        }
+        Err(error) => return Err(anyhow!("E2B cleanup failed: {error}")),
+    }
+
+    if let Some(session_id) = resource.session_id {
+        let _ = storage_store
+            .delete_secret(
+                session_id,
+                &format!("{E2B_SANDBOX_SECRET_PREFIX}{}", resource.external_id),
+            )
+            .await;
+    }
+
+    Ok(format!("Deleted E2B sandbox {}", resource.external_id))
 }
 
 async fn cleanup_browserless(
@@ -342,6 +402,10 @@ fn is_daytona_not_found(error: &str) -> bool {
     error.contains("404") || error.to_ascii_lowercase().contains("not found")
 }
 
+fn is_e2b_not_found(error: &str) -> bool {
+    error.contains("404") || error.to_ascii_lowercase().contains("not found")
+}
+
 fn is_browserless_already_gone(error: &str) -> bool {
     let error = error.to_ascii_lowercase();
     error.contains("404")
@@ -353,6 +417,104 @@ fn is_browserless_already_gone(error: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    use async_trait::async_trait;
+    use everruns_core::{KeyInfo, LeasedResourceStatus, SecretInfo};
+    use uuid::Uuid;
+
+    struct TestSessionStorageStore {
+        secrets: Mutex<HashMap<(String, String), String>>,
+    }
+
+    impl TestSessionStorageStore {
+        fn with_secret(session_id: SessionId, name: &str, value: &str) -> Self {
+            let mut secrets = HashMap::new();
+            secrets.insert(
+                (session_id.to_string(), name.to_string()),
+                value.to_string(),
+            );
+            Self {
+                secrets: Mutex::new(secrets),
+            }
+        }
+
+        fn empty() -> Self {
+            Self {
+                secrets: Mutex::new(HashMap::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl SessionStorageStore for TestSessionStorageStore {
+        async fn set_value(
+            &self,
+            _session_id: SessionId,
+            _key: &str,
+            _value: &str,
+        ) -> everruns_core::Result<()> {
+            unimplemented!()
+        }
+
+        async fn get_value(
+            &self,
+            _session_id: SessionId,
+            _key: &str,
+        ) -> everruns_core::Result<Option<String>> {
+            unimplemented!()
+        }
+
+        async fn delete_value(
+            &self,
+            _session_id: SessionId,
+            _key: &str,
+        ) -> everruns_core::Result<bool> {
+            unimplemented!()
+        }
+
+        async fn list_keys(&self, _session_id: SessionId) -> everruns_core::Result<Vec<KeyInfo>> {
+            unimplemented!()
+        }
+
+        async fn set_secret(
+            &self,
+            _session_id: SessionId,
+            _name: &str,
+            _value: &str,
+        ) -> everruns_core::Result<()> {
+            unimplemented!()
+        }
+
+        async fn get_secret(
+            &self,
+            session_id: SessionId,
+            name: &str,
+        ) -> everruns_core::Result<Option<String>> {
+            Ok(self
+                .secrets
+                .lock()
+                .expect("test secrets lock poisoned")
+                .get(&(session_id.to_string(), name.to_string()))
+                .cloned())
+        }
+
+        async fn delete_secret(
+            &self,
+            _session_id: SessionId,
+            _name: &str,
+        ) -> everruns_core::Result<bool> {
+            unimplemented!()
+        }
+
+        async fn list_secrets(
+            &self,
+            _session_id: SessionId,
+        ) -> everruns_core::Result<Vec<SecretInfo>> {
+            unimplemented!()
+        }
+    }
 
     #[test]
     fn browserless_external_id_drops_query_string() {
@@ -373,11 +535,127 @@ mod tests {
     #[test]
     fn error_classifiers_match_expected_patterns() {
         assert!(is_daytona_not_found("Daytona API error (404): not found"));
+        assert!(is_e2b_not_found("E2B API error (404): sandbox not found"));
         assert!(is_browserless_already_gone(
             "CDP WebSocket connection failed: HTTP error: 404 Not Found"
         ));
         assert!(!is_browserless_already_gone(
             "CDP WebSocket connection failed: dns error"
         ));
+    }
+
+    #[tokio::test]
+    async fn e2b_cleanup_prefers_session_secret_override() {
+        let session_id = SessionId::from_uuid(Uuid::nil());
+        let storage =
+            TestSessionStorageStore::with_secret(session_id, "E2B_API_KEY", "session-key");
+        let resource = LeasedResource {
+            id: Uuid::new_v4().into(),
+            session_id: Some(session_id),
+            provider: "e2b".to_string(),
+            resource_type: "sandbox".to_string(),
+            external_id: "sb_test".to_string(),
+            display_name: None,
+            status: LeasedResourceStatus::Active,
+            owner_user_id: None,
+            lease_duration_seconds: 60,
+            last_touched_at: chrono::Utc::now(),
+            metadata: serde_json::json!({}),
+            lease_expires_at: chrono::Utc::now(),
+            cleanup_started_at: None,
+            cleanup_completed_at: None,
+            cleanup_attempts: 0,
+            last_cleanup_error: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+
+        unsafe {
+            std::env::set_var("E2B_API_KEY", "env-key");
+        }
+        let token = resolve_e2b_api_key(&resource, &storage)
+            .await
+            .expect("session override should resolve");
+        unsafe {
+            std::env::remove_var("E2B_API_KEY");
+        }
+
+        assert_eq!(token, "session-key");
+    }
+
+    #[tokio::test]
+    async fn e2b_cleanup_falls_back_to_env_key() {
+        let session_id = SessionId::from_uuid(Uuid::nil());
+        let storage = TestSessionStorageStore::empty();
+        let resource = LeasedResource {
+            id: Uuid::new_v4().into(),
+            session_id: Some(session_id),
+            provider: "e2b".to_string(),
+            resource_type: "sandbox".to_string(),
+            external_id: "sb_test".to_string(),
+            display_name: None,
+            status: LeasedResourceStatus::Active,
+            owner_user_id: None,
+            lease_duration_seconds: 60,
+            last_touched_at: chrono::Utc::now(),
+            metadata: serde_json::json!({}),
+            lease_expires_at: chrono::Utc::now(),
+            cleanup_started_at: None,
+            cleanup_completed_at: None,
+            cleanup_attempts: 0,
+            last_cleanup_error: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+
+        unsafe {
+            std::env::set_var("E2B_API_KEY", "env-key");
+        }
+        let token = resolve_e2b_api_key(&resource, &storage)
+            .await
+            .expect("env fallback should resolve");
+        unsafe {
+            std::env::remove_var("E2B_API_KEY");
+        }
+
+        assert_eq!(token, "env-key");
+    }
+
+    #[tokio::test]
+    async fn e2b_cleanup_rejects_blank_env_key() {
+        let session_id = SessionId::from_uuid(Uuid::nil());
+        let storage = TestSessionStorageStore::empty();
+        let resource = LeasedResource {
+            id: Uuid::new_v4().into(),
+            session_id: Some(session_id),
+            provider: "e2b".to_string(),
+            resource_type: "sandbox".to_string(),
+            external_id: "sb_test".to_string(),
+            display_name: None,
+            status: LeasedResourceStatus::Active,
+            owner_user_id: None,
+            lease_duration_seconds: 60,
+            last_touched_at: chrono::Utc::now(),
+            metadata: serde_json::json!({}),
+            lease_expires_at: chrono::Utc::now(),
+            cleanup_started_at: None,
+            cleanup_completed_at: None,
+            cleanup_attempts: 0,
+            last_cleanup_error: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+
+        unsafe {
+            std::env::set_var("E2B_API_KEY", "   ");
+        }
+        let error = resolve_e2b_api_key(&resource, &storage)
+            .await
+            .expect_err("blank env token should fail");
+        unsafe {
+            std::env::remove_var("E2B_API_KEY");
+        }
+
+        assert!(error.to_string().contains("empty/whitespace"));
     }
 }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -4,6 +4,7 @@ extern crate everruns_integrations_browserless;
 extern crate everruns_integrations_daytona;
 extern crate everruns_integrations_docker;
 extern crate everruns_integrations_duckduckgo;
+extern crate everruns_integrations_e2b;
 
 pub mod activities;
 pub mod adapters;

--- a/integrations/e2b/Cargo.toml
+++ b/integrations/e2b/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "everruns-integrations-e2b"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "E2B cloud sandbox integration for Everruns"
+build = "build.rs"
+
+[dependencies]
+async-trait.workspace = true
+chrono.workspace = true
+inventory.workspace = true
+reqwest = { workspace = true, features = ["multipart"] }
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+urlencoding = "2"
+http = "1"
+http-body = "1"
+futures.workspace = true
+connectrpc = { version = "0.2.1", features = ["client", "client-tls"] }
+buffa = "0.2.0"
+rustls = "0.23"
+rustls-native-certs = "0.8"
+anyhow.workspace = true
+
+everruns-core = { path = "../../crates/core" }
+
+[build-dependencies]
+connectrpc-build = "0.2.0"
+
+[dev-dependencies]
+wiremock = "0.6"
+tokio.workspace = true
+
+[features]
+e2b-live-tests = []

--- a/integrations/e2b/SPEC.md
+++ b/integrations/e2b/SPEC.md
@@ -1,0 +1,148 @@
+# E2B Capability Specification
+
+## Abstract
+
+The E2B capability integrates [E2B](https://e2b.dev/docs) cloud sandboxes as an agent execution environment. Agents can create, pause, resume, delete, and interact with isolated Linux environments per session. The implementation intentionally uses a **platform-owned** `E2B_API_KEY` from the server/worker environment instead of per-user connections.
+
+**Status**: Available (All environments)
+
+## Architecture
+
+### Split Control/Data Plane
+
+E2B uses two surfaces:
+
+1. **Management API** (`https://api.e2b.app`) — sandbox lifecycle, metadata, timeout, and detail fetches. Auth: `X-API-KEY: <key>`.
+2. **envd sandbox endpoint** (`https://49983-<sandboxId>.<domain>`) — in-sandbox file access and command execution. Auth: `X-Access-Token`, `E2b-Sandbox-Id`, and `E2b-Sandbox-Port` headers.
+
+The Everruns integration mirrors Daytona's session-scoped state model, but uses E2B's native split between the management API and envd runtime endpoints.
+
+## Authentication Model
+
+### Why global env-backed auth
+
+E2B sandboxes are treated as **platform infrastructure** rather than user-owned external accounts:
+
+1. The control plane and workers read `E2B_API_KEY` from environment (Doppler in cloud agents).
+2. A per-session secret named `E2B_API_KEY` may override the env var for testing or custom deployments.
+3. Agents never ask end users to paste E2B credentials in chat.
+
+This keeps credentials out of message history and avoids adding user-connections UI for a platform-managed service.
+
+## State Management
+
+Per-sandbox state is stored in session secrets under `e2b_sandbox:{sandbox_id}`. Stored fields:
+
+- `sandbox_id`
+- `sandbox_domain`
+- `envd_version`
+- `envd_access_token`
+- `workspace_path`
+- `started_at`
+- `timeout_seconds`
+
+Leased resources register provider `e2b`, type `sandbox`, enabling generic cleanup on the worker side.
+
+## Tools
+
+### e2b_create_sandbox
+
+Creates a new sandbox from an E2B template.
+
+- **Parameters**:
+  - `title` (optional)
+  - `template` (optional, default `base`)
+  - `timeout_seconds` (optional, default `3600`)
+  - `env_vars` (optional object)
+  - `upload_files` (optional array of `{session_path, sandbox_path}`)
+- **Returns**: `{ sandbox_id, status, template, workspace_path, timeout_seconds, files_uploaded }`
+
+### e2b_exec
+
+Executes a shell command in a sandbox using E2B's process service.
+
+- **Parameters**:
+  - `sandbox_id` (required)
+  - `command` (required)
+  - `cwd` (optional)
+  - `timeout_ms` (optional)
+- **Returns**: `{ sandbox_id, cwd, stdout, stderr, exit_code, error }`
+
+### e2b_read_file
+
+Reads a file from the sandbox filesystem.
+
+- **Parameters**: `sandbox_id`, `path`
+- **Returns**: `{ sandbox_id, path, content }`
+
+### e2b_write_file
+
+Writes a file into the sandbox filesystem.
+
+- **Parameters**: `sandbox_id`, `path`, `content`
+- **Returns**: `{ sandbox_id, path, success }`
+
+### e2b_list_sandboxes
+
+Lists all E2B sandboxes created in the current session.
+
+- **Parameters**: none
+- **Returns**: `{ sandboxes: [...], count }`
+
+### e2b_manage_sandbox
+
+Lifecycle management.
+
+- **Parameters**:
+  - `sandbox_id` (required)
+  - `action` (`pause | resume | delete`)
+  - `timeout_seconds` (optional; used for `resume`)
+- **Returns**: `{ sandbox_id, action, success, timeout_seconds? }`
+
+## Metadata
+
+All created sandboxes include Everruns ownership metadata:
+
+- `everruns=true`
+- `everruns.title`
+- `everruns.session_id`
+- `everruns.harness_id`
+- `everruns.org_id`
+- `everruns.agent_id` (when available)
+
+This supports dashboard traceability, orphan cleanup, and audit review.
+
+## Security
+
+- **Global API key** stays in environment/session secrets and never appears in tool output.
+- **envd access tokens** are session-scoped and stored only in encrypted session secrets.
+- **Sandbox isolation** depends on E2B runtime boundaries plus Everruns session-scoped secret lookups.
+- **Resource leak mitigation** uses E2B timeout + auto-pause plus Everruns leased-resource cleanup.
+
+## Error Handling
+
+| Scenario | Result Type | Message |
+|---|---|---|
+| Missing required param | `ToolError` | `Missing required parameter: {name}` |
+| Missing API key | `ToolError` | `E2B API key not configured...` |
+| Missing sandbox state | `ToolError` | `Sandbox '{id}' not found...` |
+| E2B lifecycle/file/process error | `ToolError` | `E2B API error (...)` or sandbox-specific error |
+| Missing storage context | `ToolError` | `Storage not available in this context` |
+
+## Testing
+
+### Unit tests
+
+```bash
+cargo test -p everruns-integrations-e2b
+```
+
+Covers capability metadata, plugin registration, state serialization, and HTTP request shaping for management/file APIs.
+
+### Live API smoke tests
+
+```bash
+E2B_API_KEY=<key> cargo test -p everruns-integrations-e2b --features e2b-live-tests --test live_api_test
+```
+
+Exercises sandbox create → file write/read → command exec → cleanup against the real E2B service.

--- a/integrations/e2b/build.rs
+++ b/integrations/e2b/build.rs
@@ -1,0 +1,10 @@
+fn main() {
+    println!("cargo:rerun-if-changed=proto/process.proto");
+
+    connectrpc_build::Config::new()
+        .files(&["proto/process.proto"])
+        .includes(&["proto"])
+        .include_file("_e2b.rs")
+        .compile()
+        .expect("failed to compile E2B process proto");
+}

--- a/integrations/e2b/proto/process.proto
+++ b/integrations/e2b/proto/process.proto
@@ -1,0 +1,169 @@
+syntax = "proto3";
+
+package process;
+
+service Process {
+    rpc List(ListRequest) returns (ListResponse);
+
+    rpc Connect(ConnectRequest) returns (stream ConnectResponse);
+    rpc Start(StartRequest) returns (stream StartResponse);
+
+    rpc Update(UpdateRequest) returns (UpdateResponse);
+
+    // Client input stream ensures ordering of messages
+    rpc StreamInput(stream StreamInputRequest) returns (StreamInputResponse);
+    rpc SendInput(SendInputRequest) returns (SendInputResponse);
+    rpc SendSignal(SendSignalRequest) returns (SendSignalResponse);
+
+    // Close stdin to signal EOF to the process.
+    // Only works for non-PTY processes. For PTY, send Ctrl+D (0x04) instead.
+    rpc CloseStdin(CloseStdinRequest) returns (CloseStdinResponse);
+}
+
+message PTY {
+    Size size = 1;
+
+    message Size {
+        uint32 cols = 1;
+        uint32 rows = 2;
+    }
+}
+
+message ProcessConfig {
+    string cmd = 1;
+    repeated string args = 2;
+
+    map<string, string> envs = 3;
+    optional string cwd = 4;
+}
+
+message ListRequest {}
+
+message ProcessInfo {
+    ProcessConfig config = 1;
+    uint32 pid = 2;
+    optional string tag = 3;
+}
+
+message ListResponse {
+    repeated ProcessInfo processes = 1;
+}
+
+message StartRequest {
+    ProcessConfig process = 1;
+    optional PTY pty = 2;
+    optional string tag = 3;
+    optional bool stdin = 4;
+}
+
+message UpdateRequest {
+    ProcessSelector process = 1;
+
+    optional PTY pty = 2;
+}
+
+message UpdateResponse {}
+
+message ProcessEvent {
+    oneof event {
+        StartEvent start = 1;
+        DataEvent data = 2;
+        EndEvent end = 3;
+        KeepAlive keepalive = 4;
+    }
+
+    message StartEvent {
+        uint32 pid = 1;
+    }
+
+    message DataEvent {
+        oneof output {
+            bytes stdout = 1;
+            bytes stderr = 2;
+            bytes pty = 3;
+        }
+    }
+
+    message EndEvent {
+        sint32 exit_code = 1;
+        bool exited = 2;
+        string status = 3;
+        optional string error = 4;
+    }
+
+    message KeepAlive {}
+}
+
+message StartResponse {
+    ProcessEvent event = 1;
+}
+
+message ConnectResponse {
+    ProcessEvent event = 1;
+}
+
+message SendInputRequest {
+    ProcessSelector process = 1;
+
+    ProcessInput input = 2;
+}
+
+message SendInputResponse {}
+
+message ProcessInput {
+    oneof input {
+        bytes stdin = 1;
+        bytes pty = 2;
+    }
+}
+
+message StreamInputRequest {
+    oneof event {
+        StartEvent start = 1;
+        DataEvent data = 2;
+        KeepAlive keepalive = 3;
+    }
+
+    message StartEvent {
+        ProcessSelector process = 1;
+    }
+
+    message DataEvent {
+        ProcessInput input = 2;
+    }
+
+    message KeepAlive {}
+}
+
+message StreamInputResponse {}
+
+enum Signal {
+    SIGNAL_UNSPECIFIED = 0;
+    SIGNAL_SIGTERM = 15;
+    SIGNAL_SIGKILL = 9;
+}
+
+message SendSignalRequest {
+    ProcessSelector process = 1;
+
+    Signal signal = 2;
+}
+
+message SendSignalResponse {}
+
+message CloseStdinRequest {
+    ProcessSelector process = 1;
+}
+
+message CloseStdinResponse {}
+
+message ConnectRequest {
+    ProcessSelector process = 1;
+}
+
+message ProcessSelector {
+    oneof selector {
+        uint32 pid = 1;
+        string tag = 2;
+    }
+}

--- a/integrations/e2b/src/client.rs
+++ b/integrations/e2b/src/client.rs
@@ -1,0 +1,438 @@
+//! E2B API client.
+
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use connectrpc::Protocol;
+use connectrpc::client::{ClientConfig, HttpClient};
+use rustls::RootCertStore;
+use serde_json::{Value, json};
+
+use crate::state::{E2BSandboxCreateResponse, E2BSandboxDetail, SandboxState};
+use crate::{E2B_API_BASE, E2B_DEFAULT_TIMEOUT_SECS, E2B_ENVD_PORT};
+
+mod proto {
+    #![allow(clippy::upper_case_acronyms)]
+    include!(concat!(env!("OUT_DIR"), "/_e2b.rs"));
+}
+
+pub struct E2BClient {
+    http: reqwest::Client,
+    api_key: String,
+    api_base: String,
+    process_tls_config: OnceLock<Result<Arc<rustls::ClientConfig>, String>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExecResult {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+    pub error: Option<String>,
+}
+
+impl E2BClient {
+    pub fn new(api_key: String) -> Self {
+        Self::with_base_url(api_key, E2B_API_BASE.to_string())
+    }
+
+    pub fn with_base_url(api_key: String, api_base: String) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            api_key,
+            api_base,
+            process_tls_config: OnceLock::new(),
+        }
+    }
+
+    async fn management_request(
+        &self,
+        method: reqwest::Method,
+        path: &str,
+        body: Option<Value>,
+    ) -> Result<Value, String> {
+        let url = format!("{}{}", self.api_base, path);
+        let mut req = self
+            .http
+            .request(method, &url)
+            .header("X-API-KEY", &self.api_key)
+            .header("Content-Type", "application/json");
+
+        if let Some(body) = body {
+            req = req.json(&body);
+        }
+
+        let response = req
+            .send()
+            .await
+            .map_err(|e| format!("Failed to reach E2B API: {e}"))?;
+        let status = response.status();
+        let body_text = response
+            .text()
+            .await
+            .map_err(|e| format!("Failed to read E2B API response: {e}"))?;
+
+        if !status.is_success() {
+            return Err(format!("E2B API error ({status}): {body_text}"));
+        }
+
+        if body_text.is_empty() {
+            return Ok(json!({}));
+        }
+
+        serde_json::from_str(&body_text).map_err(|e| format!("Invalid E2B JSON: {e}"))
+    }
+
+    fn create_sandbox_body(
+        template_id: &str,
+        timeout_seconds: u64,
+        metadata: Value,
+        env_vars: Value,
+    ) -> Value {
+        json!({
+            "templateID": template_id,
+            "timeout": timeout_seconds,
+            "autoPause": true,
+            "allowInternetAccess": true,
+            "metadata": metadata,
+            "envVars": env_vars,
+        })
+    }
+
+    pub async fn create_sandbox(
+        &self,
+        template_id: &str,
+        timeout_seconds: u64,
+        metadata: Value,
+        env_vars: Value,
+    ) -> Result<E2BSandboxCreateResponse, String> {
+        let value = self
+            .management_request(
+                reqwest::Method::POST,
+                "/sandboxes",
+                Some(Self::create_sandbox_body(
+                    template_id,
+                    timeout_seconds,
+                    metadata,
+                    env_vars,
+                )),
+            )
+            .await?;
+        serde_json::from_value(value).map_err(|e| format!("Failed to parse sandbox response: {e}"))
+    }
+
+    pub async fn get_sandbox(&self, sandbox_id: &str) -> Result<E2BSandboxDetail, String> {
+        let value = self
+            .management_request(
+                reqwest::Method::GET,
+                &format!("/sandboxes/{sandbox_id}"),
+                None,
+            )
+            .await?;
+        serde_json::from_value(value).map_err(|e| format!("Failed to parse sandbox detail: {e}"))
+    }
+
+    pub async fn pause_sandbox(&self, sandbox_id: &str) -> Result<(), String> {
+        self.management_request(
+            reqwest::Method::POST,
+            &format!("/sandboxes/{sandbox_id}/pause"),
+            None,
+        )
+        .await?;
+        Ok(())
+    }
+
+    pub async fn resume_sandbox(
+        &self,
+        sandbox_id: &str,
+        timeout_seconds: u64,
+    ) -> Result<E2BSandboxCreateResponse, String> {
+        let value = self
+            .management_request(
+                reqwest::Method::POST,
+                &format!("/sandboxes/{sandbox_id}/resume"),
+                Some(json!({
+                    "autoPause": true,
+                    "timeout": timeout_seconds,
+                })),
+            )
+            .await?;
+        serde_json::from_value(value)
+            .map_err(|e| format!("Failed to parse sandbox resume response: {e}"))
+    }
+
+    pub async fn delete_sandbox(&self, sandbox_id: &str) -> Result<(), String> {
+        self.management_request(
+            reqwest::Method::DELETE,
+            &format!("/sandboxes/{sandbox_id}"),
+            None,
+        )
+        .await?;
+        Ok(())
+    }
+
+    pub async fn set_timeout(&self, sandbox_id: &str, timeout_seconds: u64) -> Result<(), String> {
+        self.management_request(
+            reqwest::Method::POST,
+            &format!("/sandboxes/{sandbox_id}/timeout"),
+            Some(json!({ "timeout": timeout_seconds })),
+        )
+        .await?;
+        Ok(())
+    }
+
+    pub async fn read_file(&self, state: &SandboxState, path: &str) -> Result<String, String> {
+        let url = format!(
+            "{}/files?path={}",
+            self.envd_base_url(state),
+            urlencoding::encode(path)
+        );
+        let response = self
+            .http
+            .get(&url)
+            .headers(self.envd_headers(state)?)
+            .send()
+            .await
+            .map_err(|e| format!("Failed to read sandbox file: {e}"))?;
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .map_err(|e| format!("Failed to read sandbox file body: {e}"))?;
+        if !status.is_success() {
+            return Err(format!("E2B sandbox file API error ({status}): {body}"));
+        }
+        Ok(body)
+    }
+
+    pub async fn write_file(
+        &self,
+        state: &SandboxState,
+        path: &str,
+        content: &str,
+    ) -> Result<(), String> {
+        let url = format!(
+            "{}/files?path={}",
+            self.envd_base_url(state),
+            urlencoding::encode(path)
+        );
+        let part = reqwest::multipart::Part::text(content.to_string())
+            .file_name(path.rsplit('/').next().unwrap_or("file").to_string());
+        let form = reqwest::multipart::Form::new().part("file", part);
+        let response = self
+            .http
+            .post(&url)
+            .headers(self.envd_headers(state)?)
+            .multipart(form)
+            .send()
+            .await
+            .map_err(|e| format!("Failed to write sandbox file: {e}"))?;
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .map_err(|e| format!("Failed to read sandbox write response: {e}"))?;
+        if !status.is_success() {
+            return Err(format!("E2B sandbox file API error ({status}): {body}"));
+        }
+        Ok(())
+    }
+
+    pub async fn exec(
+        &self,
+        state: &SandboxState,
+        command: &str,
+        cwd: Option<&str>,
+        timeout_ms: Option<u64>,
+    ) -> Result<ExecResult, String> {
+        let client = self.process_client(state)?;
+        let request = proto::process::StartRequest {
+            process: buffa::MessageField::some(proto::process::ProcessConfig {
+                cmd: "/bin/bash".to_string(),
+                args: vec!["-l".to_string(), "-c".to_string(), command.to_string()],
+                envs: std::collections::HashMap::new(),
+                cwd: cwd.map(|v| v.to_string()),
+                ..Default::default()
+            }),
+            stdin: Some(false),
+            ..Default::default()
+        };
+
+        let options = connectrpc::client::CallOptions::default()
+            .with_timeout(Duration::from_millis(timeout_ms.unwrap_or(60_000)));
+        let mut stream = client
+            .start_with_options(request, options)
+            .await
+            .map_err(|e| format!("Failed to start sandbox command: {e}"))?;
+
+        let mut stdout = String::new();
+        let mut stderr = String::new();
+        let mut exit_code = -1;
+        let mut error = None;
+
+        while let Some(message) = stream
+            .message()
+            .await
+            .map_err(|e| format!("Failed reading sandbox command stream: {e}"))?
+        {
+            let Some(event) = message.event.as_option() else {
+                continue;
+            };
+            match &event.event {
+                Some(proto::process::process_event::EventView::Data(data)) => match &data.output {
+                    Some(proto::process::process_event::data_event::OutputView::Stdout(bytes)) => {
+                        stdout.push_str(&String::from_utf8_lossy(bytes));
+                    }
+                    Some(proto::process::process_event::data_event::OutputView::Stderr(bytes)) => {
+                        stderr.push_str(&String::from_utf8_lossy(bytes));
+                    }
+                    Some(proto::process::process_event::data_event::OutputView::Pty(bytes)) => {
+                        stdout.push_str(&String::from_utf8_lossy(bytes));
+                    }
+                    None => {}
+                },
+                Some(proto::process::process_event::EventView::End(end)) => {
+                    exit_code = end.exit_code;
+                    error = end.error.map(|value| value.to_string());
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        Ok(ExecResult {
+            stdout,
+            stderr,
+            exit_code,
+            error,
+        })
+    }
+
+    fn envd_base_url(&self, state: &SandboxState) -> String {
+        format!(
+            "https://{}-{}.{}",
+            E2B_ENVD_PORT, state.sandbox_id, state.sandbox_domain
+        )
+    }
+
+    fn envd_headers(&self, state: &SandboxState) -> Result<reqwest::header::HeaderMap, String> {
+        use reqwest::header::{HeaderMap, HeaderValue};
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "E2b-Sandbox-Id",
+            HeaderValue::from_str(&state.sandbox_id)
+                .map_err(|e| format!("Invalid sandbox id header: {e}"))?,
+        );
+        headers.insert(
+            "E2b-Sandbox-Port",
+            HeaderValue::from_str(&E2B_ENVD_PORT.to_string())
+                .map_err(|e| format!("Invalid sandbox port header: {e}"))?,
+        );
+        let token = state.envd_access_token.as_ref().ok_or_else(|| {
+            "Missing envd access token; cannot authenticate envd request".to_string()
+        })?;
+        headers.insert(
+            "X-Access-Token",
+            HeaderValue::from_str(token)
+                .map_err(|e| format!("Invalid envd access token header: {e}"))?,
+        );
+        Ok(headers)
+    }
+
+    fn process_client(
+        &self,
+        state: &SandboxState,
+    ) -> Result<proto::process::ProcessClient<HttpClient>, String> {
+        let tls_config = self.process_tls_config.get_or_init(|| {
+            let mut roots = RootCertStore::empty();
+            let certs = rustls_native_certs::load_native_certs();
+            for cert in certs.certs {
+                roots
+                    .add(cert)
+                    .map_err(|e| format!("Failed to load native CA roots: {e}"))?;
+            }
+
+            Ok::<Arc<rustls::ClientConfig>, String>(Arc::new(
+                rustls::ClientConfig::builder()
+                    .with_root_certificates(roots)
+                    .with_no_client_auth(),
+            ))
+        });
+        let http = HttpClient::with_tls(tls_config.clone()?);
+        let uri: http::Uri = self
+            .envd_base_url(state)
+            .parse()
+            .map_err(|e| format!("Invalid envd URI: {e}"))?;
+        let mut config = ClientConfig::new(uri)
+            .protocol(Protocol::Connect)
+            .default_timeout(Duration::from_secs(E2B_DEFAULT_TIMEOUT_SECS));
+        for (name, value) in self.envd_headers(state)?.iter() {
+            config = config.default_header(name, value.clone());
+        }
+        Ok(proto::process::ProcessClient::new(http, config))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_sandbox_body_matches_expected_shape() {
+        let body = E2BClient::create_sandbox_body(
+            "base",
+            3600,
+            json!({"everruns": "true"}),
+            json!({"HELLO": "world"}),
+        );
+        assert_eq!(
+            body,
+            json!({
+                "templateID": "base",
+                "timeout": 3600,
+                "autoPause": true,
+                "allowInternetAccess": true,
+                "metadata": {"everruns": "true"},
+                "envVars": {"HELLO": "world"},
+            })
+        );
+    }
+
+    #[test]
+    fn envd_headers_include_expected_auth_headers() {
+        let client = E2BClient::new("key".to_string());
+        let state = SandboxState {
+            sandbox_id: "sb_test".to_string(),
+            sandbox_domain: "example.e2b.app".to_string(),
+            envd_version: "0.1.0".to_string(),
+            envd_access_token: Some("envd_token".to_string()),
+            workspace_path: "/home/user".to_string(),
+            started_at: "2026-03-22T00:00:00Z".to_string(),
+            timeout_seconds: 3600,
+        };
+
+        let headers = client.envd_headers(&state).unwrap();
+        assert_eq!(headers.get("e2b-sandbox-id").unwrap(), "sb_test");
+        assert_eq!(headers.get("e2b-sandbox-port").unwrap(), "49983");
+        assert_eq!(headers.get("x-access-token").unwrap(), "envd_token");
+    }
+
+    #[test]
+    fn envd_headers_require_access_token() {
+        let client = E2BClient::new("key".to_string());
+        let state = SandboxState {
+            sandbox_id: "sb_test".to_string(),
+            sandbox_domain: "example.e2b.app".to_string(),
+            envd_version: "0.1.0".to_string(),
+            envd_access_token: None,
+            workspace_path: "/home/user".to_string(),
+            started_at: "2026-03-22T00:00:00Z".to_string(),
+            timeout_seconds: 3600,
+        };
+
+        let error = client
+            .envd_headers(&state)
+            .expect_err("missing token should fail");
+        assert!(error.contains("Missing envd access token"));
+    }
+}

--- a/integrations/e2b/src/lib.rs
+++ b/integrations/e2b/src/lib.rs
@@ -1,0 +1,131 @@
+//! E2B Integration
+//!
+//! Cloud sandboxes backed by E2B. This integration intentionally uses a
+//! platform-owned API key (`E2B_API_KEY`) from the server/worker environment
+//! instead of user connections because E2B sandboxes are provisioned as shared
+//! platform infrastructure, not per-user third-party accounts.
+//! Decision: external integration crate, auto-registered via inventory.
+//! Decision: global env-backed API key with optional per-session secret override.
+//! Decision: session-scoped sandbox state + leased-resource cleanup, similar to Daytona.
+
+pub mod client;
+pub mod state;
+mod tools;
+
+use everruns_core::LEASED_RESOURCES_FEATURE;
+use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin, RiskLevel};
+use everruns_core::tools::Tool;
+
+use tools::{
+    E2BCreateSandboxTool, E2BExecTool, E2BListSandboxesTool, E2BManageSandboxTool, E2BReadFileTool,
+    E2BWriteFileTool,
+};
+
+inventory::submit! {
+    IntegrationPlugin {
+        experimental_only: false,
+        factory: || Box::new(E2BCapability),
+    }
+}
+
+pub const E2B_API_BASE: &str = "https://api.e2b.app";
+pub const E2B_API_KEY_SECRET: &str = "E2B_API_KEY";
+pub const E2B_SANDBOX_SECRET_PREFIX: &str = "e2b_sandbox:";
+pub const E2B_DEFAULT_TEMPLATE: &str = "base";
+pub const E2B_DEFAULT_TIMEOUT_SECS: u64 = 60 * 60;
+pub const E2B_DEFAULT_WORKSPACE_PATH: &str = "/home/user";
+pub const E2B_ENVD_PORT: u16 = 49_983;
+
+pub struct E2BCapability;
+
+impl Capability for E2BCapability {
+    fn id(&self) -> &str {
+        "e2b"
+    }
+
+    fn name(&self) -> &str {
+        "E2B"
+    }
+
+    fn description(&self) -> &str {
+        "Run code in cloud sandboxes powered by E2B. Create isolated Linux environments, execute commands, and manage sandbox files."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn risk_level(&self) -> RiskLevel {
+        RiskLevel::High
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("cloud")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Execution")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(
+            r#"## E2B
+
+Cloud sandboxes via E2B. Each sandbox is an isolated Linux environment with network access.
+
+Use `e2b_create_sandbox` first, then `e2b_exec`, `e2b_read_file`, and `e2b_write_file` against the returned `sandbox_id`.
+Prefer `/home/user` as the workspace root.
+Always pause or delete sandboxes when done. Deleted sandboxes are cleaned up immediately; paused sandboxes may still consume platform quota until resumed or deleted."#,
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(E2BCreateSandboxTool),
+            Box::new(E2BExecTool),
+            Box::new(E2BReadFileTool),
+            Box::new(E2BWriteFileTool),
+            Box::new(E2BListSandboxesTool),
+            Box::new(E2BManageSandboxTool),
+        ]
+    }
+
+    fn dependencies(&self) -> Vec<&'static str> {
+        vec!["session_storage"]
+    }
+
+    fn features(&self) -> Vec<&'static str> {
+        vec![LEASED_RESOURCES_FEATURE]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capability_metadata() {
+        let cap = E2BCapability;
+        assert_eq!(cap.id(), "e2b");
+        assert_eq!(cap.name(), "E2B");
+        assert_eq!(cap.icon(), Some("cloud"));
+        assert_eq!(cap.category(), Some("Execution"));
+        assert_eq!(cap.dependencies(), vec!["session_storage"]);
+    }
+
+    #[test]
+    fn capability_tools() {
+        let cap = E2BCapability;
+        let names: Vec<_> = cap
+            .tools()
+            .into_iter()
+            .map(|tool| tool.name().to_string())
+            .collect();
+        assert!(names.contains(&"e2b_create_sandbox".to_string()));
+        assert!(names.contains(&"e2b_exec".to_string()));
+        assert!(names.contains(&"e2b_read_file".to_string()));
+        assert!(names.contains(&"e2b_write_file".to_string()));
+        assert!(names.contains(&"e2b_list_sandboxes".to_string()));
+        assert!(names.contains(&"e2b_manage_sandbox".to_string()));
+    }
+}

--- a/integrations/e2b/src/state.rs
+++ b/integrations/e2b/src/state.rs
@@ -1,0 +1,288 @@
+//! E2B API types and session state helpers.
+
+use std::env;
+
+use everruns_core::UpsertLeasedResource;
+use everruns_core::tools::ToolExecutionResult;
+use everruns_core::traits::ToolContext;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tracing::{error, warn};
+
+use crate::{E2B_API_KEY_SECRET, E2B_DEFAULT_WORKSPACE_PATH, E2B_SANDBOX_SECRET_PREFIX};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct E2BSandboxCreateResponse {
+    pub client_id: String,
+    pub envd_version: String,
+    pub sandbox_id: String,
+    pub template_id: String,
+    #[serde(default)]
+    pub alias: Option<String>,
+    #[serde(default)]
+    pub domain: Option<String>,
+    #[serde(default)]
+    pub envd_access_token: Option<String>,
+    #[serde(default)]
+    pub traffic_access_token: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct E2BSandboxDetail {
+    pub client_id: String,
+    pub cpu_count: i64,
+    pub disk_size_mb: i64,
+    pub end_at: String,
+    pub envd_version: String,
+    pub memory_mb: i64,
+    pub sandbox_id: String,
+    pub started_at: String,
+    pub state: String,
+    pub template_id: String,
+    #[serde(default)]
+    pub alias: Option<String>,
+    #[serde(default)]
+    pub domain: Option<String>,
+    #[serde(default)]
+    pub envd_access_token: Option<String>,
+    #[serde(default)]
+    pub metadata: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SandboxState {
+    pub sandbox_id: String,
+    pub sandbox_domain: String,
+    pub envd_version: String,
+    pub envd_access_token: Option<String>,
+    pub workspace_path: String,
+    pub started_at: String,
+    pub timeout_seconds: u64,
+}
+
+pub const E2B_SANDBOX_LEASE_DURATION_SECONDS: u32 = 20 * 60;
+
+pub async fn get_api_key(context: &ToolContext) -> Result<String, ToolExecutionResult> {
+    if let Some(storage) = context.storage_store.as_ref() {
+        match storage
+            .get_secret(context.session_id, E2B_API_KEY_SECRET)
+            .await
+        {
+            Ok(Some(key)) if !key.trim().is_empty() => return Ok(key),
+            Ok(_) => {}
+            Err(e) => {
+                error!("Failed to resolve E2B session secret: {e}");
+            }
+        }
+    }
+
+    match env::var(E2B_API_KEY_SECRET) {
+        Ok(key) if !key.trim().is_empty() => Ok(key),
+        _ => Err(ToolExecutionResult::tool_error(
+            "E2B API key not configured. Set E2B_API_KEY in the server/worker environment or as a session secret.",
+        )),
+    }
+}
+
+pub async fn get_sandbox_state(
+    context: &ToolContext,
+    sandbox_id: &str,
+) -> Result<SandboxState, ToolExecutionResult> {
+    let storage = context
+        .storage_store
+        .as_ref()
+        .ok_or_else(|| ToolExecutionResult::tool_error("Storage not available in this context"))?;
+
+    let secret_name = format!("{E2B_SANDBOX_SECRET_PREFIX}{sandbox_id}");
+    let json_str = storage
+        .get_secret(context.session_id, &secret_name)
+        .await
+        .map_err(|e| {
+            error!("Failed to read E2B sandbox state: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to read sandbox state: {e}"))
+        })?
+        .ok_or_else(|| {
+            ToolExecutionResult::tool_error(format!(
+                "Sandbox '{sandbox_id}' not found. Create one first with e2b_create_sandbox."
+            ))
+        })?;
+
+    serde_json::from_str(&json_str).map_err(|e| {
+        error!("Corrupt E2B sandbox state for {sandbox_id}: {e}");
+        ToolExecutionResult::internal_error_msg(format!("Corrupt sandbox state: {e}"))
+    })
+}
+
+pub async fn save_sandbox_state(
+    context: &ToolContext,
+    state: &SandboxState,
+) -> Result<(), ToolExecutionResult> {
+    let storage = context
+        .storage_store
+        .as_ref()
+        .ok_or_else(|| ToolExecutionResult::tool_error("Storage not available in this context"))?;
+
+    let secret_name = format!("{E2B_SANDBOX_SECRET_PREFIX}{}", state.sandbox_id);
+    let json_str = serde_json::to_string(state).map_err(|e| {
+        ToolExecutionResult::internal_error_msg(format!("Failed to serialize sandbox state: {e}"))
+    })?;
+
+    storage
+        .set_secret(context.session_id, &secret_name, &json_str)
+        .await
+        .map_err(|e| {
+            error!("Failed to save E2B sandbox state: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to save sandbox state: {e}"))
+        })
+}
+
+pub async fn delete_sandbox_state(
+    context: &ToolContext,
+    sandbox_id: &str,
+) -> Result<(), ToolExecutionResult> {
+    let storage = context
+        .storage_store
+        .as_ref()
+        .ok_or_else(|| ToolExecutionResult::tool_error("Storage not available in this context"))?;
+
+    let secret_name = format!("{E2B_SANDBOX_SECRET_PREFIX}{sandbox_id}");
+    storage
+        .delete_secret(context.session_id, &secret_name)
+        .await
+        .map(|_| ())
+        .map_err(|e| {
+            error!("Failed to delete E2B sandbox state: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to delete sandbox state: {e}"))
+        })
+}
+
+pub async fn list_sandbox_states(
+    context: &ToolContext,
+) -> Result<Vec<SandboxState>, ToolExecutionResult> {
+    let storage = context
+        .storage_store
+        .as_ref()
+        .ok_or_else(|| ToolExecutionResult::tool_error("Storage not available in this context"))?;
+
+    let secrets = storage
+        .list_secrets(context.session_id)
+        .await
+        .map_err(|e| {
+            error!("Failed to list E2B secrets: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to list secrets: {e}"))
+        })?;
+
+    let mut states = Vec::new();
+    for secret_info in secrets {
+        if let Some(sandbox_id) = secret_info.name.strip_prefix(E2B_SANDBOX_SECRET_PREFIX) {
+            match get_sandbox_state(context, sandbox_id).await {
+                Ok(state) => states.push(state),
+                Err(_) => warn!("Skipping corrupt E2B sandbox state: {sandbox_id}"),
+            }
+        }
+    }
+
+    Ok(states)
+}
+
+pub async fn touch_sandbox_lease(
+    context: &ToolContext,
+    state: &SandboxState,
+    display_name: Option<String>,
+) -> Result<(), ToolExecutionResult> {
+    let Some(store) = context.leased_resource_store.as_ref() else {
+        return Ok(());
+    };
+
+    store
+        .upsert_resource(UpsertLeasedResource {
+            session_id: context.session_id,
+            provider: "e2b".to_string(),
+            resource_type: "sandbox".to_string(),
+            external_id: state.sandbox_id.clone(),
+            display_name,
+            owner_user_id: None,
+            lease_duration_seconds: E2B_SANDBOX_LEASE_DURATION_SECONDS,
+            metadata: json!({
+                "workspace_path": state.workspace_path,
+                "sandbox_domain": state.sandbox_domain,
+                "started_at": state.started_at,
+            }),
+        })
+        .await
+        .map_err(|e| {
+            error!("Failed to upsert E2B sandbox lease: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to update sandbox lease: {e}"))
+        })?;
+
+    Ok(())
+}
+
+pub async fn release_sandbox_lease(
+    context: &ToolContext,
+    sandbox_id: &str,
+) -> Result<(), ToolExecutionResult> {
+    let Some(store) = context.leased_resource_store.as_ref() else {
+        return Ok(());
+    };
+
+    store
+        .release_resource(context.session_id, "e2b", "sandbox", sandbox_id)
+        .await
+        .map_err(|e| {
+            error!("Failed to release E2B sandbox lease: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to release sandbox lease: {e}"))
+        })?;
+
+    Ok(())
+}
+
+pub fn required_str<'a>(
+    args: &'a serde_json::Value,
+    name: &str,
+) -> Result<&'a str, ToolExecutionResult> {
+    args.get(name).and_then(|v| v.as_str()).ok_or_else(|| {
+        ToolExecutionResult::tool_error(format!("Missing required parameter: {name}"))
+    })
+}
+
+pub fn build_state(detail: &E2BSandboxDetail, timeout_seconds: u64) -> SandboxState {
+    SandboxState {
+        sandbox_id: detail.sandbox_id.clone(),
+        sandbox_domain: detail
+            .domain
+            .clone()
+            .unwrap_or_else(|| "e2b.app".to_string()),
+        envd_version: detail.envd_version.clone(),
+        envd_access_token: detail.envd_access_token.clone(),
+        workspace_path: E2B_DEFAULT_WORKSPACE_PATH.to_string(),
+        started_at: detail.started_at.clone(),
+        timeout_seconds,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sandbox_state_roundtrip() {
+        let state = SandboxState {
+            sandbox_id: "sb_test".to_string(),
+            sandbox_domain: "example.e2b.app".to_string(),
+            envd_version: "0.1.0".to_string(),
+            envd_access_token: Some("token".to_string()),
+            workspace_path: E2B_DEFAULT_WORKSPACE_PATH.to_string(),
+            started_at: "2026-03-22T00:00:00Z".to_string(),
+            timeout_seconds: 3600,
+        };
+
+        let json = serde_json::to_string(&state).unwrap();
+        let decoded: SandboxState = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.sandbox_id, "sb_test");
+        assert_eq!(decoded.sandbox_domain, "example.e2b.app");
+        assert_eq!(decoded.timeout_seconds, 3600);
+    }
+}

--- a/integrations/e2b/src/tools.rs
+++ b/integrations/e2b/src/tools.rs
@@ -1,0 +1,641 @@
+//! Tool implementations for E2B sandboxes.
+
+use async_trait::async_trait;
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::ToolContext;
+use serde_json::{Value, json};
+use tracing::warn;
+
+use crate::client::E2BClient;
+use crate::state::{
+    E2BSandboxDetail, build_state, delete_sandbox_state, get_api_key, get_sandbox_state,
+    list_sandbox_states, release_sandbox_lease, required_str, save_sandbox_state,
+    touch_sandbox_lease,
+};
+use crate::{E2B_DEFAULT_TEMPLATE, E2B_DEFAULT_TIMEOUT_SECS, E2B_DEFAULT_WORKSPACE_PATH};
+
+fn parse_timeout_seconds(arguments: &Value) -> Result<u64, ToolExecutionResult> {
+    match arguments.get("timeout_seconds") {
+        None => Ok(E2B_DEFAULT_TIMEOUT_SECS),
+        Some(value) => value
+            .as_u64()
+            .filter(|timeout| *timeout > 0)
+            .ok_or_else(|| {
+                ToolExecutionResult::tool_error(
+                    "Invalid 'timeout_seconds': must be a positive integer",
+                )
+            }),
+    }
+}
+
+fn detail_from_create(create: crate::state::E2BSandboxCreateResponse) -> E2BSandboxDetail {
+    E2BSandboxDetail {
+        client_id: create.client_id,
+        cpu_count: 0,
+        disk_size_mb: 0,
+        end_at: String::new(),
+        envd_version: create.envd_version,
+        memory_mb: 0,
+        sandbox_id: create.sandbox_id,
+        started_at: chrono::Utc::now().to_rfc3339(),
+        state: "running".to_string(),
+        template_id: create.template_id,
+        alias: create.alias,
+        domain: create.domain,
+        envd_access_token: create.envd_access_token,
+        metadata: json!({}),
+    }
+}
+
+pub struct E2BCreateSandboxTool;
+
+#[async_trait]
+impl Tool for E2BCreateSandboxTool {
+    fn name(&self) -> &str {
+        "e2b_create_sandbox"
+    }
+
+    fn description(&self) -> &str {
+        "Create a new E2B cloud sandbox. Optionally upload files from session storage."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "title": {"type": "string", "description": "Human-readable sandbox name"},
+                "template": {"type": "string", "description": "E2B template ID (defaults to base)"},
+                "timeout_seconds": {"type": "integer", "description": "Sandbox TTL in seconds", "minimum": 1, "default": E2B_DEFAULT_TIMEOUT_SECS},
+                "env_vars": {
+                    "type": "object",
+                    "description": "Environment variables injected into the sandbox",
+                    "additionalProperties": {"type": "string"}
+                },
+                "upload_files": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "session_path": {"type": "string"},
+                            "sandbox_path": {"type": "string"}
+                        },
+                        "required": ["session_path", "sandbox_path"],
+                        "additionalProperties": false
+                    }
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "e2b_create_sandbox requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let api_key = match get_api_key(context).await {
+            Ok(key) => key,
+            Err(err) => return err,
+        };
+        let timeout_seconds = match parse_timeout_seconds(&arguments) {
+            Ok(timeout) => timeout,
+            Err(err) => return err,
+        };
+        let template = arguments
+            .get("template")
+            .and_then(|v| v.as_str())
+            .unwrap_or(E2B_DEFAULT_TEMPLATE);
+        let title = arguments
+            .get("title")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Everruns E2B Sandbox");
+
+        let mut metadata = serde_json::Map::new();
+        metadata.insert("everruns".to_string(), json!("true"));
+        metadata.insert("everruns.title".to_string(), json!(title));
+        metadata.insert(
+            "everruns.session_id".to_string(),
+            json!(context.session_id.to_string()),
+        );
+        if let Some(session_store) = &context.session_store
+            && let Ok(Some(session)) = session_store.get_session(context.session_id).await
+        {
+            metadata.insert(
+                "everruns.harness_id".to_string(),
+                json!(session.harness_id.to_string()),
+            );
+            metadata.insert(
+                "everruns.org_id".to_string(),
+                json!(session.organization_id),
+            );
+            if let Some(agent_id) = session.agent_id {
+                metadata.insert("everruns.agent_id".to_string(), json!(agent_id.to_string()));
+            }
+        }
+
+        let env_vars = arguments
+            .get("env_vars")
+            .cloned()
+            .unwrap_or_else(|| json!({}));
+
+        let client = E2BClient::new(api_key);
+        let create = match client
+            .create_sandbox(template, timeout_seconds, json!(metadata), env_vars)
+            .await
+        {
+            Ok(create) => create,
+            Err(err) => return ToolExecutionResult::tool_error(err),
+        };
+
+        let detail = detail_from_create(create);
+        let state = build_state(&detail, timeout_seconds);
+        if let Err(err) = save_sandbox_state(context, &state).await {
+            return err;
+        }
+        if let Err(err) = touch_sandbox_lease(context, &state, Some(title.to_string())).await {
+            return err;
+        }
+
+        let mut uploaded_count = 0;
+        if let Some(file_specs) = arguments.get("upload_files").and_then(|v| v.as_array()) {
+            let Some(file_store) = context.file_store.as_ref() else {
+                return ToolExecutionResult::tool_error("File store not available for file upload");
+            };
+            for (index, file_spec) in file_specs.iter().enumerate() {
+                let Some(session_path) = file_spec.get("session_path").and_then(|v| v.as_str())
+                else {
+                    return ToolExecutionResult::tool_error(format!(
+                        "Invalid upload_files[{index}]: missing required 'session_path'"
+                    ));
+                };
+                let Some(sandbox_path) = file_spec.get("sandbox_path").and_then(|v| v.as_str())
+                else {
+                    return ToolExecutionResult::tool_error(format!(
+                        "Invalid upload_files[{index}]: missing required 'sandbox_path'"
+                    ));
+                };
+                match file_store.read_file(context.session_id, session_path).await {
+                    Ok(Some(file)) => {
+                        if let Some(content) = file.content {
+                            if let Err(err) =
+                                client.write_file(&state, sandbox_path, &content).await
+                            {
+                                warn!("Failed to upload {session_path} to E2B sandbox: {err}");
+                            } else {
+                                uploaded_count += 1;
+                            }
+                        }
+                    }
+                    Ok(None) => warn!("Session file not found during E2B upload: {session_path}"),
+                    Err(err) => warn!("Failed to read {session_path} for E2B upload: {err}"),
+                }
+            }
+        }
+
+        ToolExecutionResult::success(json!({
+            "sandbox_id": state.sandbox_id,
+            "status": "running",
+            "template": template,
+            "workspace_path": state.workspace_path,
+            "timeout_seconds": timeout_seconds,
+            "files_uploaded": uploaded_count,
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct E2BExecTool;
+
+#[async_trait]
+impl Tool for E2BExecTool {
+    fn name(&self) -> &str {
+        "e2b_exec"
+    }
+
+    fn description(&self) -> &str {
+        "Execute a shell command in an E2B sandbox. Returns output synchronously."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sandbox_id": {"type": "string"},
+                "command": {"type": "string"},
+                "cwd": {"type": "string", "description": "Working directory inside the sandbox"},
+                "timeout_ms": {"type": "integer", "minimum": 1, "description": "Command timeout in milliseconds"}
+            },
+            "required": ["sandbox_id", "command"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "e2b_exec requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let api_key = match get_api_key(context).await {
+            Ok(key) => key,
+            Err(err) => return err,
+        };
+        let sandbox_id = match required_str(&arguments, "sandbox_id") {
+            Ok(value) => value,
+            Err(err) => return err,
+        };
+        let command = match required_str(&arguments, "command") {
+            Ok(value) => value,
+            Err(err) => return err,
+        };
+        let cwd = arguments.get("cwd").and_then(|v| v.as_str());
+        let timeout_ms = arguments.get("timeout_ms").and_then(|v| v.as_u64());
+        let state = match get_sandbox_state(context, sandbox_id).await {
+            Ok(state) => state,
+            Err(err) => return err,
+        };
+
+        let client = E2BClient::new(api_key);
+        let result = match client.exec(&state, command, cwd, timeout_ms).await {
+            Ok(result) => result,
+            Err(err) => return ToolExecutionResult::tool_error(err),
+        };
+
+        if let Err(err) = client
+            .set_timeout(&state.sandbox_id, state.timeout_seconds)
+            .await
+        {
+            warn!("Failed to refresh E2B sandbox timeout after exec: {err}");
+        }
+        if let Err(err) = touch_sandbox_lease(context, &state, None).await {
+            return err;
+        }
+
+        ToolExecutionResult::success(json!({
+            "sandbox_id": sandbox_id,
+            "cwd": cwd.unwrap_or(E2B_DEFAULT_WORKSPACE_PATH),
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "exit_code": result.exit_code,
+            "error": result.error,
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct E2BReadFileTool;
+
+#[async_trait]
+impl Tool for E2BReadFileTool {
+    fn name(&self) -> &str {
+        "e2b_read_file"
+    }
+
+    fn description(&self) -> &str {
+        "Read a file from an E2B sandbox."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sandbox_id": {"type": "string"},
+                "path": {"type": "string"}
+            },
+            "required": ["sandbox_id", "path"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "e2b_read_file requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let api_key = match get_api_key(context).await {
+            Ok(key) => key,
+            Err(err) => return err,
+        };
+        let sandbox_id = match required_str(&arguments, "sandbox_id") {
+            Ok(value) => value,
+            Err(err) => return err,
+        };
+        let path = match required_str(&arguments, "path") {
+            Ok(value) => value,
+            Err(err) => return err,
+        };
+        let state = match get_sandbox_state(context, sandbox_id).await {
+            Ok(state) => state,
+            Err(err) => return err,
+        };
+        let client = E2BClient::new(api_key);
+        match client.read_file(&state, path).await {
+            Ok(content) => ToolExecutionResult::success(json!({
+                "sandbox_id": sandbox_id,
+                "path": path,
+                "content": content,
+            })),
+            Err(err) => ToolExecutionResult::tool_error(err),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct E2BWriteFileTool;
+
+#[async_trait]
+impl Tool for E2BWriteFileTool {
+    fn name(&self) -> &str {
+        "e2b_write_file"
+    }
+
+    fn description(&self) -> &str {
+        "Write a file into an E2B sandbox. Creates parent directories when supported by the sandbox runtime."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sandbox_id": {"type": "string"},
+                "path": {"type": "string"},
+                "content": {"type": "string"}
+            },
+            "required": ["sandbox_id", "path", "content"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "e2b_write_file requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let api_key = match get_api_key(context).await {
+            Ok(key) => key,
+            Err(err) => return err,
+        };
+        let sandbox_id = match required_str(&arguments, "sandbox_id") {
+            Ok(value) => value,
+            Err(err) => return err,
+        };
+        let path = match required_str(&arguments, "path") {
+            Ok(value) => value,
+            Err(err) => return err,
+        };
+        let content = match required_str(&arguments, "content") {
+            Ok(value) => value,
+            Err(err) => return err,
+        };
+        let state = match get_sandbox_state(context, sandbox_id).await {
+            Ok(state) => state,
+            Err(err) => return err,
+        };
+        let client = E2BClient::new(api_key);
+        match client.write_file(&state, path, content).await {
+            Ok(()) => ToolExecutionResult::success(json!({
+                "sandbox_id": sandbox_id,
+                "path": path,
+                "success": true,
+            })),
+            Err(err) => ToolExecutionResult::tool_error(err),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct E2BListSandboxesTool;
+
+#[async_trait]
+impl Tool for E2BListSandboxesTool {
+    fn name(&self) -> &str {
+        "e2b_list_sandboxes"
+    }
+
+    fn description(&self) -> &str {
+        "List E2B sandboxes created in the current session."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "e2b_list_sandboxes requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        _arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        match list_sandbox_states(context).await {
+            Ok(states) => ToolExecutionResult::success(json!({
+                "sandboxes": states.iter().map(|state| json!({
+                    "sandbox_id": state.sandbox_id,
+                    "sandbox_domain": state.sandbox_domain,
+                    "workspace_path": state.workspace_path,
+                    "started_at": state.started_at,
+                    "timeout_seconds": state.timeout_seconds,
+                })).collect::<Vec<_>>(),
+                "count": states.len(),
+            })),
+            Err(err) => err,
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct E2BManageSandboxTool;
+
+#[async_trait]
+impl Tool for E2BManageSandboxTool {
+    fn name(&self) -> &str {
+        "e2b_manage_sandbox"
+    }
+
+    fn description(&self) -> &str {
+        "Manage an E2B sandbox lifecycle. Supported actions: pause, resume, delete."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sandbox_id": {"type": "string"},
+                "action": {"type": "string", "enum": ["pause", "resume", "delete"]},
+                "timeout_seconds": {"type": "integer", "minimum": 1, "description": "Timeout to apply when resuming a sandbox"}
+            },
+            "required": ["sandbox_id", "action"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "e2b_manage_sandbox requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let api_key = match get_api_key(context).await {
+            Ok(key) => key,
+            Err(err) => return err,
+        };
+        let sandbox_id = match required_str(&arguments, "sandbox_id") {
+            Ok(value) => value,
+            Err(err) => return err,
+        };
+        let action = match required_str(&arguments, "action") {
+            Ok(value) => value,
+            Err(err) => return err,
+        };
+        let state = match get_sandbox_state(context, sandbox_id).await {
+            Ok(state) => state,
+            Err(err) => return err,
+        };
+        let client = E2BClient::new(api_key);
+
+        match action {
+            "pause" => {
+                if let Err(err) = client.pause_sandbox(sandbox_id).await {
+                    return ToolExecutionResult::tool_error(err);
+                }
+                if let Err(err) = touch_sandbox_lease(context, &state, None).await {
+                    return err;
+                }
+                ToolExecutionResult::success(json!({
+                    "sandbox_id": sandbox_id,
+                    "action": action,
+                    "success": true,
+                }))
+            }
+            "resume" => {
+                let timeout_seconds = arguments
+                    .get("timeout_seconds")
+                    .and_then(|value| value.as_u64())
+                    .unwrap_or(state.timeout_seconds);
+                let resumed = match client.resume_sandbox(sandbox_id, timeout_seconds).await {
+                    Ok(resumed) => resumed,
+                    Err(err) => return ToolExecutionResult::tool_error(err),
+                };
+                let detail = detail_from_create(resumed);
+                let refreshed = build_state(&detail, timeout_seconds);
+                if let Err(err) = save_sandbox_state(context, &refreshed).await {
+                    return err;
+                }
+                if let Err(err) = touch_sandbox_lease(context, &refreshed, None).await {
+                    return err;
+                }
+                ToolExecutionResult::success(json!({
+                    "sandbox_id": sandbox_id,
+                    "action": action,
+                    "success": true,
+                    "timeout_seconds": timeout_seconds,
+                }))
+            }
+            "delete" => {
+                if let Err(err) = client.delete_sandbox(sandbox_id).await {
+                    return ToolExecutionResult::tool_error(err);
+                }
+                if let Err(err) = delete_sandbox_state(context, sandbox_id).await {
+                    return err;
+                }
+                if let Err(err) = release_sandbox_lease(context, sandbox_id).await {
+                    return err;
+                }
+                ToolExecutionResult::success(json!({
+                    "sandbox_id": sandbox_id,
+                    "action": action,
+                    "success": true,
+                }))
+            }
+            _ => ToolExecutionResult::tool_error(
+                "Invalid action. Expected one of: pause, resume, delete.",
+            ),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_sandbox_tool_schema_requires_expected_fields() {
+        let schema = E2BCreateSandboxTool.parameters_schema();
+        let upload_files = schema
+            .get("properties")
+            .and_then(|value| value.get("upload_files"))
+            .and_then(|value| value.get("items"))
+            .and_then(|value| value.get("required"))
+            .and_then(Value::as_array)
+            .expect("upload_files required array");
+
+        let required: Vec<_> = upload_files.iter().filter_map(Value::as_str).collect();
+        assert_eq!(required, vec!["session_path", "sandbox_path"]);
+    }
+
+    #[tokio::test]
+    async fn no_context_tools_return_context_error() {
+        let result = E2BExecTool.execute(json!({})).await;
+        match result {
+            ToolExecutionResult::ToolError(message) => {
+                assert!(message.contains("requires context"));
+            }
+            other => panic!("expected ToolError, got {other:?}"),
+        }
+    }
+}

--- a/integrations/e2b/tests/live_api_test.rs
+++ b/integrations/e2b/tests/live_api_test.rs
@@ -1,0 +1,92 @@
+#![cfg(feature = "e2b-live-tests")]
+
+use everruns_integrations_e2b::client::E2BClient;
+use everruns_integrations_e2b::state::SandboxState;
+use everruns_integrations_e2b::{E2B_DEFAULT_TIMEOUT_SECS, E2B_DEFAULT_WORKSPACE_PATH};
+use serde_json::json;
+
+fn require_api_key() -> String {
+    std::env::var("E2B_API_KEY")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .expect("E2B_API_KEY must be set for e2b-live-tests")
+}
+
+struct SandboxGuard {
+    sandbox_id: String,
+}
+
+impl Drop for SandboxGuard {
+    fn drop(&mut self) {
+        let client = E2BClient::new(require_api_key());
+        let sandbox_id = self.sandbox_id.clone();
+        let handle =
+            tokio::runtime::Handle::try_current().expect("tokio runtime required for cleanup");
+        handle.block_on(async move {
+            let _ = client.delete_sandbox(&sandbox_id).await;
+        });
+    }
+}
+
+#[tokio::test]
+async fn smoke_live_sandbox_exec_and_files() {
+    let client = E2BClient::new(require_api_key());
+    let created = client
+        .create_sandbox(
+            "base",
+            E2B_DEFAULT_TIMEOUT_SECS,
+            json!({"everruns": "true", "test": "smoke_live_sandbox_exec_and_files"}),
+            json!({"HELLO": "world"}),
+        )
+        .await
+        .expect("create sandbox");
+    let _guard = SandboxGuard {
+        sandbox_id: created.sandbox_id.clone(),
+    };
+
+    let detail = client
+        .get_sandbox(&created.sandbox_id)
+        .await
+        .expect("get sandbox detail");
+    let state = SandboxState {
+        sandbox_id: detail.sandbox_id.clone(),
+        sandbox_domain: detail.domain.clone().expect("sandbox domain"),
+        envd_version: detail.envd_version.clone(),
+        envd_access_token: detail.envd_access_token.clone(),
+        workspace_path: E2B_DEFAULT_WORKSPACE_PATH.to_string(),
+        started_at: detail.started_at.clone(),
+        timeout_seconds: E2B_DEFAULT_TIMEOUT_SECS,
+    };
+
+    client
+        .write_file(&state, "/home/user/hello.txt", "hello from everruns\n")
+        .await
+        .expect("write file");
+    let content = client
+        .read_file(&state, "/home/user/hello.txt")
+        .await
+        .expect("read file");
+    assert_eq!(content, "hello from everruns\n");
+
+    let result = client
+        .exec(
+            &state,
+            "pwd && cat /home/user/hello.txt && echo $HELLO",
+            Some("/home/user"),
+            Some(60_000),
+        )
+        .await
+        .expect("exec command");
+    assert_eq!(result.exit_code, 0);
+    assert!(
+        result.stdout.contains("/home/user"),
+        "stdout: {}",
+        result.stdout
+    );
+    assert!(
+        result.stdout.contains("hello from everruns"),
+        "stdout: {}",
+        result.stdout
+    );
+    assert!(result.stdout.contains("world"), "stdout: {}", result.stdout);
+}

--- a/integrations/e2b/tests/plugin_registration.rs
+++ b/integrations/e2b/tests/plugin_registration.rs
@@ -1,0 +1,22 @@
+use everruns_core::capabilities::{Capability, IntegrationPlugin};
+use everruns_integrations_e2b::E2BCapability;
+
+#[test]
+fn capability_metadata() {
+    let capability = E2BCapability;
+    assert_eq!(capability.id(), "e2b");
+    assert_eq!(capability.name(), "E2B");
+    assert_eq!(capability.icon(), Some("cloud"));
+    assert_eq!(capability.category(), Some("Execution"));
+}
+
+#[test]
+fn plugin_registered() {
+    let plugins: Vec<&IntegrationPlugin> =
+        inventory::iter::<IntegrationPlugin>.into_iter().collect();
+    assert!(
+        plugins
+            .iter()
+            .any(|plugin| (plugin.factory)().id() == "e2b")
+    );
+}

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -58,6 +58,7 @@ graph TB
    - `anthropic/` → `everruns-anthropic` - Anthropic LLM provider implementation
    - `integrations/docker/` → `everruns-integrations-docker` - Docker container integration (auto-registered via `inventory` plugin system)
    - `integrations/daytona/` → `everruns-integrations-daytona` - Daytona cloud sandbox integration (auto-registered via `inventory` plugin system)
+   - `integrations/e2b/` → `everruns-integrations-e2b` - E2B cloud sandbox integration (auto-registered via `inventory` plugin system)
 3. **Frontend**: Next.js application in `apps/ui/` for management and chat interfaces
    - Exports providers, components, hooks, and lib modules via `package.json` `exports` field for SaaS wrapper consumption
 4. **Documentation Site**: Astro Starlight in `apps/docs/` deployed to https://docs.everruns.com/
@@ -80,7 +81,8 @@ everruns/
 │   └── anthropic/        # Anthropic provider
 ├── integrations/
 │   ├── docker/           # Docker container (inventory plugin)
-│   └── daytona/          # Daytona cloud sandbox (inventory plugin)
+│   ├── daytona/          # Daytona cloud sandbox (inventory plugin)
+│   └── e2b/              # E2B cloud sandbox (inventory plugin)
 ├── docs/                 # Documentation content (symlinked to apps/docs)
 ├── specs/                # Feature specifications
 ├── test_cases/           # Manual test cases
@@ -129,7 +131,7 @@ This keeps the existing OSS runtime as the default while allowing embedders to r
 
 ### Integration Plugin Force-Linking
 
-Integration crates (`docker`, `daytona`) register capabilities at startup via `inventory::submit!`. The `inventory` crate uses linker sections — if the crate is not explicitly referenced, Rust's linker will optimize it out and the `submit!` registrations silently disappear.
+Integration crates (`docker`, `daytona`, `e2b`) register capabilities at startup via `inventory::submit!`. The `inventory` crate uses linker sections — if the crate is not explicitly referenced, Rust's linker will optimize it out and the `submit!` registrations silently disappear.
 
 **Both `crates/server/src/lib.rs` and `crates/worker/src/lib.rs` must have `extern crate` statements for every integration crate** (see those files for the current list).
 

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -248,7 +248,7 @@ Each capability declares a `RiskLevel` via the `Capability` trait. The API enfor
 | `medium` | Logged but allowed for org members. | Any org member |
 | `high` | Can access external compute or resources. | Requires Admin role |
 
-High-risk built-in capabilities: `docker_container`, `daytona`.
+High-risk built-in capabilities: `docker_container`, `daytona`, `e2b`.
 
 See `crates/core/src/capabilities/mod.rs` for the `RiskLevel` enum and `crates/server/src/api/agents.rs` for `require_admin_for_high_risk()`.
 

--- a/specs/integrations.md
+++ b/specs/integrations.md
@@ -11,6 +11,7 @@ Auto-registered via `inventory` plugin system. Each crate has a `SPEC.md`.
 | Brave Search | [`integrations/brave-search/SPEC.md`](../integrations/brave-search/SPEC.md) | Web search via Brave Search API. Experimental (Dev only). |
 | DuckDuckGo | [`integrations/duckduckgo/SPEC.md`](../integrations/duckduckgo/SPEC.md) | Instant answers via DuckDuckGo API. Experimental (Dev only). |
 | Browserless | [`integrations/browserless/SPEC.md`](../integrations/browserless/SPEC.md) | Cloud browser automation — screenshots, DOM, scraping, multi-step interactions. REST and CDP modes. |
+| E2B | [`integrations/e2b/SPEC.md`](../integrations/e2b/SPEC.md) | Cloud sandbox environments via E2B management API + envd runtime endpoints. Platform-owned token, multiple sandboxes per session. |
 | Daytona | [`integrations/daytona/SPEC.md`](../integrations/daytona/SPEC.md) | Cloud sandbox environments via Daytona REST API. Multiple sandboxes per session. |
 | Docker | `integrations/docker/` | Container-based agent execution. Experimental (Dev only). No spec yet. |
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -603,7 +603,7 @@ The agent loop is a core trust boundary: an LLM decides which tools to call with
 | TM-AGENT-002 | Indirect prompt injection via tool results | High | Tool results use `tool_result` role, not `system`; LLM may still follow adversarial instructions in results | **ACCEPTED** |
 | TM-AGENT-003 | Indirect prompt injection via MCP tool descriptions | Medium | MCP tool names/descriptions fed to LLM as tool schema; adversarial descriptions could influence behavior | **ACCEPTED** |
 | TM-AGENT-004 | Agent jailbreak via system prompt | Medium | System prompt set by org member at agent creation; no sanitization of prompt content | **BY DESIGN** |
-| TM-AGENT-005 | Capability escalation via agent creation | High | RiskLevel enum on Capability trait; high-risk capabilities (docker, daytona) require Admin role to assign via API | MITIGATED |
+| TM-AGENT-005 | Capability escalation via agent creation | High | RiskLevel enum on Capability trait; high-risk capabilities (docker, daytona, e2b) require Admin role to assign via API | MITIGATED |
 | TM-AGENT-006 | Cost runaway — unbounded LLM calls | High | Max iterations per turn (default 100); configurable per agent | MITIGATED |
 | TM-AGENT-007 | Cost runaway — many tools per iteration | Medium | No per-iteration tool call limit; agent can invoke many tools in a single LLM response | **OPEN** |
 | TM-AGENT-008 | Context window poisoning | Medium | Auto-compaction via `llm_driver.compact()` on `RequestTooLarge`; older messages compressed | MITIGATED |
@@ -617,7 +617,7 @@ The agent loop is a core trust boundary: an LLM decides which tools to call with
 | TM-AGENT-016 | Plaintext secrets in chat history | Medium | When agent asks user for API key in chat, plaintext value stored in events table as message content; session secrets encrypt separately but chat retains plaintext | **OPEN** |
 | TM-AGENT-017 | Agent-initiated entity management | High | Agents with `platform_management` can create/update/delete harnesses, agents, sessions org-wide; no fine-grained RBAC within org; capability must be explicitly assigned | **OPEN** |
 | TM-AGENT-018 | No outbound URL filtering on web_fetch | Medium | Agent with `web_fetch` can POST session data to any URL; no allowlist/blocklist for outbound destinations; prompt injection could chain file read + web_fetch for exfiltration | **OPEN** |
-| TM-AGENT-019 | Internal network probing via high-risk execution capabilities | High | `daytona` provides full network access by design; `docker_container` uses host networking in dev mode; both rely on Admin-only assignment plus infrastructure egress isolation | **ACCEPTED** |
+| TM-AGENT-019 | Internal network probing via high-risk execution capabilities | High | `daytona` and `e2b` provide full network access by design; `docker_container` uses host networking in dev mode; all rely on Admin-only assignment plus infrastructure egress isolation | **ACCEPTED** |
 
 ### Mitigation Details
 
@@ -645,7 +645,7 @@ Combined prompt sent to LLM as system message
 The agent creator is trusted within their org. A malicious system prompt can instruct the agent to misuse its capabilities, but only within the sandbox (session files, SQLite, bash sandbox). The blast radius is limited to the session.
 
 **TM-AGENT-005 — Capability Escalation (MITIGATED):**
-Each capability declares a `RiskLevel` (Low, Medium, High) via the `Capability` trait. High-risk capabilities (`docker_container`, `daytona`) require `OrgRole::Admin` to assign. The check runs in create/update/upsert/import agent API handlers, returning 403 if a non-admin user attempts to assign a high-risk capability. The `risk_level` field is exposed in the capabilities list API for UI display.
+Each capability declares a `RiskLevel` (Low, Medium, High) via the `Capability` trait. High-risk capabilities (`docker_container`, `daytona`, `e2b`) require `OrgRole::Admin` to assign. The check runs in create/update/upsert/import agent API handlers, returning 403 if a non-admin user attempts to assign a high-risk capability. The `risk_level` field is exposed in the capabilities list API for UI display.
 
 **TM-AGENT-006 — Iteration Limit:**
 ```rust
@@ -702,6 +702,7 @@ An agent influenced by prompt injection (via tool results or user messages) coul
 **TM-AGENT-019 — Internal Network Probing via High-Risk Execution Capabilities (ACCEPTED):**
 Some execution capabilities intentionally originate network traffic outside the worker process:
 - `daytona` sandboxes have full Linux and network access by design
+- `e2b` sandboxes have full Linux and network access by design
 - `docker_container` uses host networking and is experimental/dev-only
 
 This means an agent with one of these capabilities can probe whatever network the sandbox/container can reach. Current mitigations are:
@@ -848,7 +849,30 @@ Session B stores: daytona_sandbox:sb_xyz → {sandbox_id, workspace_path, starte
 Session A cannot access sb_xyz (different session_id in storage query)
 ```
 
-## 17. Client-Side Tools (TM-CLIENT)
+
+## 17. E2B Cloud Sandbox (TM-E2B)
+
+E2B sandboxes are remote Linux environments managed through the E2B Management API plus per-sandbox envd runtime endpoints. Everruns uses a platform-owned `E2B_API_KEY` from environment or session secret override, and stores per-sandbox envd access tokens in session-scoped secrets.
+
+| ID | Threat | Severity | Mitigation | Status |
+|----|--------|----------|------------|--------|
+| TM-E2B-001 | Platform-owned E2B API key compromise | High | `E2B_API_KEY` stays in server/worker environment or encrypted session secret override; never emitted in tool output | MITIGATED |
+| TM-E2B-002 | envd access token disclosure | Medium | envd access token stored only in encrypted session secrets and sent only to E2B runtime headers | MITIGATED |
+| TM-E2B-003 | Cross-session sandbox access | Critical | Sandbox IDs + envd tokens stored under `e2b_sandbox:{id}` in session-scoped secrets; storage queries enforce session isolation | MITIGATED |
+| TM-E2B-004 | Sandbox not deleted or paused — resource leak | Low | E2B timeout + auto-pause on create/resume, plus Everruns leased-resource cleanup | MITIGATED |
+| TM-E2B-005 | Full-network sandbox misuse | High | Capability is high-risk/Admin-gated via capability assignment policy; residual network exposure depends on deployment egress isolation | **CALLER RISK** |
+
+### Mitigation Details
+
+**TM-E2B-003 — Cross-Session Isolation:**
+```
+Session A stores: e2b_sandbox:sb_abc → {sandbox_id, sandbox_domain, envd_access_token, ...}
+Session B stores: e2b_sandbox:sb_xyz → {sandbox_id, sandbox_domain, envd_access_token, ...}
+
+Session A cannot access sb_xyz because storage lookups are scoped by session_id.
+```
+
+## 18. Client-Side Tools (TM-CLIENT)
 
 Client-side tools pause server execution and wait for client to submit results via API. Attack surface includes tool call ID spoofing and timeout abuse.
 
@@ -858,7 +882,7 @@ Client-side tools pause server execution and wait for client to submit results v
 | TM-CLIENT-002 | Tool result size explosion | Medium | Per-result size capped at 100 KB | MITIGATED |
 | TM-CLIENT-003 | Client timeout abuse | Low | Default 5 min timeout; session transitions to failed state on expiry | MITIGATED |
 
-## 18. Brave Search (TM-LLM)
+## 19. Brave Search (TM-LLM)
 
 Search results from Brave Search are returned as tool results. Adversarial content in search results could influence LLM behavior.
 
@@ -912,6 +936,7 @@ Search results from Brave Search are returned as tool results. Adversarial conte
 | TM-AGENT-019 | Internal network probing via high-risk execution capabilities | High-risk capabilities are Admin-gated; residual exposure depends on deployment network isolation |
 | TM-DURABLE-006 | DLQ growth | Tasks preserved for debugging; manual cleanup |
 | TM-DAYTONA-001 | Git token on sandbox disk | Same trust boundary as exec; `/tmp` cleared on stop; short-lived token |
+| TM-E2B-005 | Full-network sandbox misuse | Same residual risk class as other cloud sandboxes; require deployment egress isolation where needed |
 
 ### Caller Responsibilities
 
@@ -929,7 +954,7 @@ Search results from Brave Search are returned as tool results. Adversarial conte
 | System prompt review | TM-AGENT-004 | Review agent system prompts for jailbreak patterns before deployment |
 | Block cloud metadata | TM-API-009 | Defense-in-depth: enable IMDSv2 (AWS), metadata concealment (GCP), or equivalent; fetchkit v0.1.2 blocks 169.254.0.0/16 at application level |
 | Worker network isolation | TM-API-008, TM-API-010, TM-API-011 | Defense-in-depth: restrict worker container egress; fetchkit v0.1.2 blocks private IPs at application level |
-| Sandbox/container egress isolation | TM-AGENT-019 | Restrict Daytona sandbox and any Docker-backed execution environment from reaching internal networks unless explicitly intended |
+| Sandbox/container egress isolation | TM-AGENT-019, TM-E2B-005 | Restrict Daytona, E2B, and any Docker-backed execution environment from reaching internal networks unless explicitly intended |
 | Review GitHub App permissions | TM-DAYTONA-003 | Audit which repositories the GitHub App installation can access; Everruns does not enforce per-repo restrictions |
 
 ## Security Controls Matrix
@@ -952,6 +977,7 @@ Search results from Brave Search are returned as tool results. Adversarial conte
 | Resource limits | TM-DOS, TM-BASH | Input sizes, iteration limits, query timeouts, bash limits |
 | Task ownership | TM-DURABLE | Verified on completion, heartbeat-based reclaim |
 | Daytona sandbox isolation | TM-DAYTONA | Session-scoped secrets, encrypted API key, auto-stop, short-lived git tokens |
+| E2B sandbox isolation | TM-E2B | Session-scoped secrets, envd access tokens, timeout refresh, leased-resource cleanup |
 | Slack webhook forgery | TM-SLACK-001 | HMAC-SHA256 signing secret verification, 5-min replay window |
 | Slack bot loop | TM-SLACK-002 | Skip events with `bot_id` or `subtype` to prevent infinite loops |
 | Slack signing secret exposure | TM-SLACK-003 | Stored in `channel_config` (org-scoped access), not logged |
@@ -974,6 +1000,7 @@ Search results from Brave Search are returned as tool results. Adversarial conte
 - `specs/capabilities.md` — Agent capabilities system
 - `specs/bashkit-requirements.md` — Bashkit integration requirements
 - `integrations/daytona/SPEC.md` — Daytona cloud sandbox integration
+- `integrations/e2b/SPEC.md` — E2B cloud sandbox integration
 - `specs/client-side-tools.md` — Client-side tools for API/SDK consumers
 - `specs/apps.md` — Apps system (agent deployment to channels)
 - `crates/server/specs/slack-integration.md` — Slack bot integration


### PR DESCRIPTION
## What
Add a new `integrations/e2b` capability for cloud sandbox execution, wire it into server/worker startup, seed an `E2B Coder` example agent, and extend leased-resource cleanup plus specs/threat-model coverage for E2B sandboxes.

## Why
We need a platform-managed cloud execution backend alongside Daytona. E2B fits the same remote-sandbox use case, but it should behave like shared execution infrastructure rather than a user-linked third-party account.

## How
- add a new inventory-registered `e2b` integration crate with lifecycle, file, and exec tools
- resolve `E2B_API_KEY` from env with optional session-secret override
- store sandbox state in session secrets and leased resources for cleanup
- wire the integration into workspace/server/worker force-linking
- add an `E2B Coder` seed agent
- extend worker leased-resource cleanup for E2B sandboxes
- fix cleanup token resolution so worker cleanup honors the documented session-secret override before falling back to env
- update integration/capability/architecture/threat-model specs

## Risk
- Medium
- New high-risk execution capability with external networked sandboxes
- Cleanup path must not leak or orphan sandboxes when session override credentials are used

## Security
- Threat categories reviewed: TM-AGENT, TM-E2B, TM-TOOL
- Findings and resolutions:
  - Treated E2B as Admin-gated high-risk execution capability, same class as other cloud sandboxes
  - Kept the platform API key in env or encrypted session secret override only; never in chat/tool output
  - Stored per-sandbox envd access tokens in session-scoped secrets
  - Fixed leased-resource cleanup to read the session override first, preventing sandbox leaks when `E2B_API_KEY` is not present in process env
  - Documented E2B-specific threat surface and caller egress-isolation responsibility

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
