### PR TITLE
feat(server): resolve connections from agent identity on session

### DIFF
--- a/crates/server/src/storage/connection_resolver.rs
+++ b/crates/server/src/storage/connection_resolver.rs
@@ -19,10 +19,12 @@ use super::backend::StorageBackend;
 use super::encryption::EncryptionService;
 use crate::auth::oauth::GitHubAppService;
 
-/// Resolves user connection tokens from stored user connections.
+/// Resolves connection tokens for tool execution.
 ///
-/// Tool execution still supports the existing session-based lookup
-/// (`session_id -> org_members -> user_connections`) for convenience.
+/// Session-based lookup priority:
+/// 1. If the session has an `agent_identity_id`, resolves from `agent_identity_connections`.
+/// 2. Falls back to `user_connections` via org membership.
+///
 /// Leased-resource cleanup additionally uses explicit owner-user lookups so
 /// the same provider identity that created a resource can delete it later.
 #[derive(Clone)]

--- a/crates/server/src/storage/memory/user_connections.rs
+++ b/crates/server/src/storage/memory/user_connections.rs
@@ -84,18 +84,24 @@ impl InMemoryDatabase {
         let agent_identity_id = session.agent_identity_id;
         drop(sessions);
 
-        // Try agent identity connection first
+        // Check identity connections first — if any exist for this provider,
+        // they take full precedence (even if the specific credential field is absent).
         if let Some(identity_id) = agent_identity_id {
             let id_connections = self.agent_identity_connections.read();
-            for conn in id_connections.values() {
-                if conn.agent_identity_id == identity_id
-                    && conn.provider == provider
-                    && conn.access_token_encrypted.is_some()
-                {
-                    return Ok(conn.access_token_encrypted.clone());
-                }
+            let has_any = id_connections
+                .values()
+                .any(|c| c.agent_identity_id == identity_id && c.provider == provider);
+            if has_any {
+                // Return the token if present, None otherwise (caller uses installation_id path)
+                return Ok(id_connections
+                    .values()
+                    .find(|c| {
+                        c.agent_identity_id == identity_id
+                            && c.provider == provider
+                            && c.access_token_encrypted.is_some()
+                    })
+                    .and_then(|c| c.access_token_encrypted.clone()));
             }
-            drop(id_connections);
         }
 
         // Fall back to user connections via org membership
@@ -201,18 +207,23 @@ impl InMemoryDatabase {
         let agent_identity_id = session.agent_identity_id;
         drop(sessions);
 
-        // Try agent identity connection first
+        // Check identity connections first — if any exist for this provider,
+        // they take full precedence (even if the specific credential field is absent).
         if let Some(identity_id) = agent_identity_id {
             let id_connections = self.agent_identity_connections.read();
-            for conn in id_connections.values() {
-                if conn.agent_identity_id == identity_id
-                    && conn.provider == provider
-                    && conn.installation_id.is_some()
-                {
-                    return Ok(conn.installation_id);
-                }
+            let has_any = id_connections
+                .values()
+                .any(|c| c.agent_identity_id == identity_id && c.provider == provider);
+            if has_any {
+                return Ok(id_connections
+                    .values()
+                    .find(|c| {
+                        c.agent_identity_id == identity_id
+                            && c.provider == provider
+                            && c.installation_id.is_some()
+                    })
+                    .and_then(|c| c.installation_id));
             }
-            drop(id_connections);
         }
 
         // Fall back to user connections via org membership

--- a/crates/server/src/storage/memory/user_connections.rs
+++ b/crates/server/src/storage/memory/user_connections.rs
@@ -66,22 +66,39 @@ impl InMemoryDatabase {
         Ok(connections)
     }
 
-    /// Get encrypted connection token for a session's org member (in-memory equivalent).
+    /// Get encrypted connection token for a session.
+    ///
+    /// If the session has an `agent_identity_id`, checks `agent_identity_connections`
+    /// first; falls back to `user_connections` via org membership.
     pub async fn get_connection_token_for_session(
         &self,
         session_id: SessionId,
         provider: &str,
     ) -> Result<Option<Vec<u8>>> {
-        // Find the session to get org_id
         let sessions = self.sessions.read();
         let session = match sessions.get(&session_id) {
             Some(s) => s,
             None => return Ok(None),
         };
         let org_id = session.org_id;
+        let agent_identity_id = session.agent_identity_id;
         drop(sessions);
 
-        // Find org members
+        // Try agent identity connection first
+        if let Some(identity_id) = agent_identity_id {
+            let id_connections = self.agent_identity_connections.read();
+            for conn in id_connections.values() {
+                if conn.agent_identity_id == identity_id
+                    && conn.provider == provider
+                    && conn.access_token_encrypted.is_some()
+                {
+                    return Ok(conn.access_token_encrypted.clone());
+                }
+            }
+            drop(id_connections);
+        }
+
+        // Fall back to user connections via org membership
         let members = self.organization_members.read();
         let user_ids: Vec<Uuid> = members
             .iter()
@@ -90,9 +107,8 @@ impl InMemoryDatabase {
             .collect();
         drop(members);
 
-        // Find first matching connection with an encrypted token
         let connections = self.user_connections.read();
-        for uid in user_ids.clone() {
+        for uid in user_ids {
             for conn in connections.values() {
                 if conn.user_id == uid
                     && conn.provider == provider
@@ -106,6 +122,8 @@ impl InMemoryDatabase {
         Ok(None)
     }
 
+    /// Resolve the user whose connection would be used for a session/provider pair.
+    /// Returns None when the session uses an agent identity connection.
     pub async fn get_connection_user_for_session(
         &self,
         session_id: SessionId,
@@ -117,7 +135,19 @@ impl InMemoryDatabase {
             None => return Ok(None),
         };
         let org_id = session.org_id;
+        let agent_identity_id = session.agent_identity_id;
         drop(sessions);
+
+        // If session has an identity connection, return None (no owning user)
+        if let Some(identity_id) = agent_identity_id {
+            let id_connections = self.agent_identity_connections.read();
+            if id_connections
+                .values()
+                .any(|c| c.agent_identity_id == identity_id && c.provider == provider)
+            {
+                return Ok(None);
+            }
+        }
 
         let members = self.organization_members.read();
         let user_ids: Vec<Uuid> = members
@@ -155,20 +185,37 @@ impl InMemoryDatabase {
             .and_then(|c| c.access_token_encrypted.clone()))
     }
 
+    /// Get the GitHub App installation ID for a session.
+    /// Checks agent identity connections first, falls back to user connections.
     pub async fn get_installation_id_for_session(
         &self,
         session_id: SessionId,
         provider: &str,
     ) -> Result<Option<i64>> {
-        // Look up session → org → members → connections (same join as token lookup)
         let sessions = self.sessions.read();
         let session = match sessions.get(&session_id) {
             Some(s) => s,
             None => return Ok(None),
         };
         let org_id = session.org_id;
+        let agent_identity_id = session.agent_identity_id;
         drop(sessions);
 
+        // Try agent identity connection first
+        if let Some(identity_id) = agent_identity_id {
+            let id_connections = self.agent_identity_connections.read();
+            for conn in id_connections.values() {
+                if conn.agent_identity_id == identity_id
+                    && conn.provider == provider
+                    && conn.installation_id.is_some()
+                {
+                    return Ok(conn.installation_id);
+                }
+            }
+            drop(id_connections);
+        }
+
+        // Fall back to user connections via org membership
         let members = self.organization_members.read();
         let user_ids: Vec<Uuid> = members
             .iter()

--- a/crates/server/src/storage/repositories/user_connections.rs
+++ b/crates/server/src/storage/repositories/user_connections.rs
@@ -101,7 +101,16 @@ impl Database {
     ) -> Result<Option<Vec<u8>>> {
         let row: Option<(Option<Vec<u8>>,)> = sqlx::query_as(
             r#"
-            WITH identity_conn AS (
+            WITH has_identity_conn AS (
+                SELECT 1 AS v
+                FROM sessions s
+                JOIN agent_identity_connections aic
+                    ON aic.agent_identity_id = s.agent_identity_id AND aic.provider = $2
+                WHERE s.id = $1
+                  AND s.agent_identity_id IS NOT NULL
+                LIMIT 1
+            ),
+            identity_conn AS (
                 SELECT aic.access_token_encrypted
                 FROM sessions s
                 JOIN agent_identity_connections aic
@@ -118,7 +127,8 @@ impl Database {
                 JOIN user_connections uc ON uc.user_id = om.user_id AND uc.provider = $2
                 WHERE s.id = $1
                   AND uc.access_token_encrypted IS NOT NULL
-                  AND NOT EXISTS (SELECT 1 FROM identity_conn)
+                  AND NOT EXISTS (SELECT 1 FROM has_identity_conn)
+                ORDER BY uc.created_at ASC
                 LIMIT 1
             )
             SELECT access_token_encrypted FROM identity_conn
@@ -221,7 +231,16 @@ impl Database {
     ) -> Result<Option<i64>> {
         let row: Option<(i64,)> = sqlx::query_as(
             r#"
-            WITH identity_conn AS (
+            WITH has_identity_conn AS (
+                SELECT 1 AS v
+                FROM sessions s
+                JOIN agent_identity_connections aic
+                    ON aic.agent_identity_id = s.agent_identity_id AND aic.provider = $2
+                WHERE s.id = $1
+                  AND s.agent_identity_id IS NOT NULL
+                LIMIT 1
+            ),
+            identity_conn AS (
                 SELECT aic.installation_id
                 FROM sessions s
                 JOIN agent_identity_connections aic
@@ -238,7 +257,8 @@ impl Database {
                 JOIN user_connections uc ON uc.user_id = om.user_id AND uc.provider = $2
                 WHERE s.id = $1
                   AND uc.installation_id IS NOT NULL
-                  AND NOT EXISTS (SELECT 1 FROM identity_conn)
+                  AND NOT EXISTS (SELECT 1 FROM has_identity_conn)
+                ORDER BY uc.created_at ASC
                 LIMIT 1
             )
             SELECT installation_id FROM identity_conn

--- a/crates/server/src/storage/repositories/user_connections.rs
+++ b/crates/server/src/storage/repositories/user_connections.rs
@@ -87,8 +87,12 @@ impl Database {
         Ok(rows)
     }
 
-    /// Get the encrypted connection token for a session's org member.
-    /// Joins session → org_members → user_connections to resolve lazily.
+    /// Get the encrypted connection token for a session.
+    ///
+    /// Resolution order:
+    /// 1. If the session has an `agent_identity_id`, use `agent_identity_connections`.
+    /// 2. Otherwise fall back to `user_connections` via org membership.
+    ///
     /// Returns None for GitHub App connections (use get_installation_id_for_session instead).
     pub async fn get_connection_token_for_session(
         &self,
@@ -97,12 +101,29 @@ impl Database {
     ) -> Result<Option<Vec<u8>>> {
         let row: Option<(Option<Vec<u8>>,)> = sqlx::query_as(
             r#"
-            SELECT uc.access_token_encrypted
-            FROM sessions s
-            JOIN organization_members om ON om.org_id = s.org_id
-            JOIN user_connections uc ON uc.user_id = om.user_id AND uc.provider = $2
-            WHERE s.id = $1
-              AND uc.access_token_encrypted IS NOT NULL
+            WITH identity_conn AS (
+                SELECT aic.access_token_encrypted
+                FROM sessions s
+                JOIN agent_identity_connections aic
+                    ON aic.agent_identity_id = s.agent_identity_id AND aic.provider = $2
+                WHERE s.id = $1
+                  AND s.agent_identity_id IS NOT NULL
+                  AND aic.access_token_encrypted IS NOT NULL
+                LIMIT 1
+            ),
+            user_conn AS (
+                SELECT uc.access_token_encrypted
+                FROM sessions s
+                JOIN organization_members om ON om.org_id = s.org_id
+                JOIN user_connections uc ON uc.user_id = om.user_id AND uc.provider = $2
+                WHERE s.id = $1
+                  AND uc.access_token_encrypted IS NOT NULL
+                  AND NOT EXISTS (SELECT 1 FROM identity_conn)
+                LIMIT 1
+            )
+            SELECT access_token_encrypted FROM identity_conn
+            UNION ALL
+            SELECT access_token_encrypted FROM user_conn
             LIMIT 1
             "#,
         )
@@ -115,11 +136,36 @@ impl Database {
     }
 
     /// Resolve the user whose connection would be used for a session/provider pair.
+    ///
+    /// Returns None when the session uses an agent identity connection (identity
+    /// connections are not owned by a user).
     pub async fn get_connection_user_for_session(
         &self,
         session_id: SessionId,
         provider: &str,
     ) -> Result<Option<Uuid>> {
+        // If session uses an agent identity with a matching connection, there is
+        // no owning user — return None so callers know the credential is identity-owned.
+        let has_identity_conn: Option<(i32,)> = sqlx::query_as(
+            r#"
+            SELECT 1 as v
+            FROM sessions s
+            JOIN agent_identity_connections aic
+                ON aic.agent_identity_id = s.agent_identity_id AND aic.provider = $2
+            WHERE s.id = $1
+              AND s.agent_identity_id IS NOT NULL
+            LIMIT 1
+            "#,
+        )
+        .bind(session_id)
+        .bind(provider)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        if has_identity_conn.is_some() {
+            return Ok(None);
+        }
+
         let row: Option<(Uuid,)> = sqlx::query_as(
             r#"
             SELECT uc.user_id
@@ -163,8 +209,11 @@ impl Database {
         Ok(row.and_then(|(blob,)| blob))
     }
 
-    /// Get the GitHub App installation ID for a session's org member.
-    /// Used by the connection resolver to mint fresh installation tokens.
+    /// Get the GitHub App installation ID for a session.
+    ///
+    /// Resolution order:
+    /// 1. If the session has an `agent_identity_id`, use `agent_identity_connections`.
+    /// 2. Otherwise fall back to `user_connections` via org membership.
     pub async fn get_installation_id_for_session(
         &self,
         session_id: SessionId,
@@ -172,12 +221,29 @@ impl Database {
     ) -> Result<Option<i64>> {
         let row: Option<(i64,)> = sqlx::query_as(
             r#"
-            SELECT uc.installation_id
-            FROM sessions s
-            JOIN organization_members om ON om.org_id = s.org_id
-            JOIN user_connections uc ON uc.user_id = om.user_id AND uc.provider = $2
-            WHERE s.id = $1
-              AND uc.installation_id IS NOT NULL
+            WITH identity_conn AS (
+                SELECT aic.installation_id
+                FROM sessions s
+                JOIN agent_identity_connections aic
+                    ON aic.agent_identity_id = s.agent_identity_id AND aic.provider = $2
+                WHERE s.id = $1
+                  AND s.agent_identity_id IS NOT NULL
+                  AND aic.installation_id IS NOT NULL
+                LIMIT 1
+            ),
+            user_conn AS (
+                SELECT uc.installation_id
+                FROM sessions s
+                JOIN organization_members om ON om.org_id = s.org_id
+                JOIN user_connections uc ON uc.user_id = om.user_id AND uc.provider = $2
+                WHERE s.id = $1
+                  AND uc.installation_id IS NOT NULL
+                  AND NOT EXISTS (SELECT 1 FROM identity_conn)
+                LIMIT 1
+            )
+            SELECT installation_id FROM identity_conn
+            UNION ALL
+            SELECT installation_id FROM user_conn
             LIMIT 1
             "#,
         )

--- a/specs/agent-identities.md
+++ b/specs/agent-identities.md
@@ -46,5 +46,6 @@ This implementation introduces:
 - Frontend management pages.
 - Session/App assignment UI.
 - Event provenance metadata for interactive, scheduled, and app-driven input messages.
+- Identity-owned connections: when a session has `agent_identity_id`, connection resolution prefers `agent_identity_connections` over `user_connections`, falling back to user connections only if no identity connection exists for the requested provider.
 
-It does **not** yet introduce identity-owned inboxes or identity-owned connection management UI. That remains follow-up work on top of the principal model.
+It does **not** yet introduce identity-owned inboxes. That remains follow-up work on top of the principal model.


### PR DESCRIPTION
## Summary
- When a session has `agent_identity_id`, connection resolution (tokens, installation IDs) now prefers `agent_identity_connections` over `user_connections`
- Falls back to user connections only when no identity connection exists for the requested provider
- `get_connection_user_for_session` returns `None` for identity-owned connections (no owning user)

## Changes
- **PostgreSQL queries** (`repositories/user_connections.rs`): Modified `get_connection_token_for_session`, `get_connection_user_for_session`, and `get_installation_id_for_session` with CTE-based priority resolution
- **In-memory implementation** (`memory/user_connections.rs`): Same identity-first logic for dev mode
- **Spec update** (`specs/agent-identities.md`): Documented identity-owned connection resolution

## Test plan
- [ ] Create agent identity with connection (e.g., GitHub API key)
- [ ] Create session with `agent_identity_id` set
- [ ] Verify tool execution uses identity connection instead of user connection
- [ ] Verify fallback: session without identity still uses user connections
- [ ] Verify fallback: session with identity but no matching provider falls back to user connections