### PR TITLE
refactor(skills): remove redundant bundled_files from activate_skill result

### DIFF
--- a/crates/core/src/capabilities/attach_skill.rs
+++ b/crates/core/src/capabilities/attach_skill.rs
@@ -451,7 +451,7 @@ mod tests {
     }
 
     #[test]
-    fn test_attach_skill_mounts_with_bundled_files() {
+    fn test_attach_skill_mounts_with_files() {
         let skill_id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
         let cap = AttachSkillCapability::from_registry(
             skill_id,

--- a/crates/core/src/capabilities/skills.rs
+++ b/crates/core/src/capabilities/skills.rs
@@ -478,18 +478,27 @@ impl Tool for ActivateSkillFromVfsTool {
                     parsed.name, preprocessed
                 );
 
-                // List bundled files in the skill directory
+                // Recursively list bundled files in the skill directory
                 let skill_dir = format!("{}/{}", SKILLS_PATH, name);
-                let bundled_files = match file_store
-                    .list_directory(context.session_id, &skill_dir)
-                    .await
-                {
-                    Ok(entries) => entries
-                        .iter()
-                        .filter(|e| !e.is_directory && e.name != "SKILL.md")
-                        .map(|e| workspace_path(&e.path))
-                        .collect::<Vec<_>>(),
-                    Err(_) => vec![],
+                let bundled_files = {
+                    let mut files = Vec::new();
+                    let mut dirs_to_visit = vec![skill_dir.clone()];
+                    while let Some(dir) = dirs_to_visit.pop() {
+                        if let Ok(entries) =
+                            file_store.list_directory(context.session_id, &dir).await
+                        {
+                            for entry in entries {
+                                if entry.is_directory {
+                                    dirs_to_visit.push(entry.path);
+                                } else if entry.name != "SKILL.md"
+                                    || entry.path != format!("{}/SKILL.md", skill_dir)
+                                {
+                                    files.push(workspace_path(&entry.path));
+                                }
+                            }
+                        }
+                    }
+                    files
                 };
 
                 let mut result = serde_json::json!({
@@ -1142,7 +1151,57 @@ mod tests {
                 assert!(!bundled.is_empty());
                 let paths: Vec<&str> = bundled.iter().map(|f| f.as_str().unwrap()).collect();
                 assert!(paths.contains(&"/workspace/.agents/skills/data-tool/README.md"));
-                // scripts/run.py is nested so won't be a direct child
+                // Nested files in subdirectories should also be included
+                assert!(paths.contains(&"/workspace/.agents/skills/data-tool/scripts/run.py"));
+            }
+            other => panic!("Expected Success, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_activate_skill_bundled_files_includes_nested_subdirs() {
+        let fs = Arc::new(MockFileStore::new());
+        let session_id = SessionId::new();
+        fs.add_file(
+            session_id,
+            "/.agents/skills/auditor/SKILL.md",
+            &valid_skill_md("auditor", "Audit tool"),
+        );
+        fs.add_file(
+            session_id,
+            "/.agents/skills/auditor/references/page-checks.md",
+            "# Page checks",
+        );
+        fs.add_file(
+            session_id,
+            "/.agents/skills/auditor/references/report-format.md",
+            "# Report format",
+        );
+        fs.add_file(
+            session_id,
+            "/.agents/skills/auditor/scripts/run.sh",
+            "#!/bin/bash",
+        );
+
+        let context = ToolContext::with_file_store(session_id, fs);
+        let tool = ActivateSkillFromVfsTool;
+
+        let result = tool
+            .execute_with_context(serde_json::json!({"name": "auditor"}), &context)
+            .await;
+        match result {
+            ToolExecutionResult::Success(val) => {
+                let bundled = val["bundled_files"].as_array().unwrap();
+                let paths: Vec<&str> = bundled.iter().map(|f| f.as_str().unwrap()).collect();
+                assert_eq!(paths.len(), 3, "Expected 3 bundled files, got: {:?}", paths);
+                assert!(
+                    paths.contains(&"/workspace/.agents/skills/auditor/references/page-checks.md")
+                );
+                assert!(
+                    paths
+                        .contains(&"/workspace/.agents/skills/auditor/references/report-format.md")
+                );
+                assert!(paths.contains(&"/workspace/.agents/skills/auditor/scripts/run.sh"));
             }
             other => panic!("Expected Success, got: {:?}", other),
         }

--- a/crates/core/src/capabilities/skills.rs
+++ b/crates/core/src/capabilities/skills.rs
@@ -478,29 +478,6 @@ impl Tool for ActivateSkillFromVfsTool {
                     parsed.name, preprocessed
                 );
 
-                // Recursively list bundled files in the skill directory
-                let skill_dir = format!("{}/{}", SKILLS_PATH, name);
-                let bundled_files = {
-                    let mut files = Vec::new();
-                    let mut dirs_to_visit = vec![skill_dir.clone()];
-                    while let Some(dir) = dirs_to_visit.pop() {
-                        if let Ok(entries) =
-                            file_store.list_directory(context.session_id, &dir).await
-                        {
-                            for entry in entries {
-                                if entry.is_directory {
-                                    dirs_to_visit.push(entry.path);
-                                } else if entry.name != "SKILL.md"
-                                    || entry.path != format!("{}/SKILL.md", skill_dir)
-                                {
-                                    files.push(workspace_path(&entry.path));
-                                }
-                            }
-                        }
-                    }
-                    files
-                };
-
                 let mut result = serde_json::json!({
                     "skill": parsed.name,
                     "instructions": instructions,
@@ -515,10 +492,6 @@ impl Tool for ActivateSkillFromVfsTool {
                     if let Some(ref model) = parsed.model {
                         result["model"] = serde_json::json!(model);
                     }
-                }
-
-                if !bundled_files.is_empty() {
-                    result["bundled_files"] = serde_json::json!(bundled_files);
                 }
 
                 ToolExecutionResult::success(result)
@@ -1065,8 +1038,6 @@ mod tests {
                 assert!(instructions.contains("<skill name=\"pdf-tool\">"));
                 assert!(instructions.contains("# Instructions"));
                 assert!(instructions.contains("</skill>"));
-                // No bundled_files key when no extra files
-                assert!(val.get("bundled_files").is_none());
             }
             other => panic!("Expected Success, got: {:?}", other),
         }
@@ -1114,96 +1085,6 @@ mod tests {
                 assert!(msg.contains("Invalid SKILL.md"));
             }
             other => panic!("Expected ToolError, got: {:?}", other),
-        }
-    }
-
-    #[tokio::test]
-    async fn test_activate_skill_with_bundled_files() {
-        let fs = Arc::new(MockFileStore::new());
-        let session_id = SessionId::new();
-        fs.add_file(
-            session_id,
-            "/.agents/skills/data-tool/SKILL.md",
-            &valid_skill_md("data-tool", "Analyze data"),
-        );
-        fs.add_file(
-            session_id,
-            "/.agents/skills/data-tool/scripts/run.py",
-            "print('hello')",
-        );
-        fs.add_file(
-            session_id,
-            "/.agents/skills/data-tool/README.md",
-            "# Reference",
-        );
-
-        let context = ToolContext::with_file_store(session_id, fs);
-        let tool = ActivateSkillFromVfsTool;
-
-        let result = tool
-            .execute_with_context(serde_json::json!({"name": "data-tool"}), &context)
-            .await;
-        match result {
-            ToolExecutionResult::Success(val) => {
-                assert_eq!(val["skill"], "data-tool");
-                let bundled = val["bundled_files"].as_array().unwrap();
-                // Should have the extra files (not SKILL.md)
-                assert!(!bundled.is_empty());
-                let paths: Vec<&str> = bundled.iter().map(|f| f.as_str().unwrap()).collect();
-                assert!(paths.contains(&"/workspace/.agents/skills/data-tool/README.md"));
-                // Nested files in subdirectories should also be included
-                assert!(paths.contains(&"/workspace/.agents/skills/data-tool/scripts/run.py"));
-            }
-            other => panic!("Expected Success, got: {:?}", other),
-        }
-    }
-
-    #[tokio::test]
-    async fn test_activate_skill_bundled_files_includes_nested_subdirs() {
-        let fs = Arc::new(MockFileStore::new());
-        let session_id = SessionId::new();
-        fs.add_file(
-            session_id,
-            "/.agents/skills/auditor/SKILL.md",
-            &valid_skill_md("auditor", "Audit tool"),
-        );
-        fs.add_file(
-            session_id,
-            "/.agents/skills/auditor/references/page-checks.md",
-            "# Page checks",
-        );
-        fs.add_file(
-            session_id,
-            "/.agents/skills/auditor/references/report-format.md",
-            "# Report format",
-        );
-        fs.add_file(
-            session_id,
-            "/.agents/skills/auditor/scripts/run.sh",
-            "#!/bin/bash",
-        );
-
-        let context = ToolContext::with_file_store(session_id, fs);
-        let tool = ActivateSkillFromVfsTool;
-
-        let result = tool
-            .execute_with_context(serde_json::json!({"name": "auditor"}), &context)
-            .await;
-        match result {
-            ToolExecutionResult::Success(val) => {
-                let bundled = val["bundled_files"].as_array().unwrap();
-                let paths: Vec<&str> = bundled.iter().map(|f| f.as_str().unwrap()).collect();
-                assert_eq!(paths.len(), 3, "Expected 3 bundled files, got: {:?}", paths);
-                assert!(
-                    paths.contains(&"/workspace/.agents/skills/auditor/references/page-checks.md")
-                );
-                assert!(
-                    paths
-                        .contains(&"/workspace/.agents/skills/auditor/references/report-format.md")
-                );
-                assert!(paths.contains(&"/workspace/.agents/skills/auditor/scripts/run.sh"));
-            }
-            other => panic!("Expected Success, got: {:?}", other),
         }
     }
 
@@ -1714,7 +1595,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_attach_skill_with_bundled_files_discovered() {
+    async fn test_attach_skill_with_files_discovered() {
         use crate::capabilities::attach_skill::AttachSkillCapability;
 
         let skill_id = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
@@ -1744,21 +1625,6 @@ mod tests {
         match result {
             ToolExecutionResult::Success(val) => {
                 assert_eq!(val["skills"][0]["name"], "data-pipeline");
-            }
-            other => panic!("Expected Success, got: {:?}", other),
-        }
-
-        // activate_skill returns bundled files
-        let tool = ActivateSkillFromVfsTool;
-        let result = tool
-            .execute_with_context(serde_json::json!({"name": "data-pipeline"}), &context)
-            .await;
-        match result {
-            ToolExecutionResult::Success(val) => {
-                assert_eq!(val["skill"], "data-pipeline");
-                let bundled = val["bundled_files"].as_array().unwrap();
-                // Should list non-SKILL.md files as bundled
-                assert!(!bundled.is_empty());
             }
             other => panic!("Expected Success, got: {:?}", other),
         }

--- a/specs/skills-registry.md
+++ b/specs/skills-registry.md
@@ -341,7 +341,7 @@ The agent can then read these files using existing session filesystem tools (`re
 **Mounting strategy**:
 1. On `activate_skill` call, the worker fetches skill files from the `skill_files` table via gRPC
 2. Files are mounted into the session VFS at `/skills/{skill-name}/`
-3. The `activate_skill` tool result includes the SKILL.md body AND a note about mounted file paths
+3. The `activate_skill` tool result includes the SKILL.md body only — no separate file listing
 4. Text files become `MountSource::InlineFile` with `encoding: "text"`
 5. Binary files become `MountSource::InlineFile` with `encoding: "base64"`
 
@@ -349,6 +349,8 @@ This approach:
 - Reuses existing VFS infrastructure (no new tool needed)
 - Files are accessible via the same `read_file` / `list_files` tools the agent already has
 - Consistent with how other capabilities mount content (e.g., `sample_data`)
+
+**No `bundled_files` in tool result**: The `activate_skill` tool result does not include a separate list of companion file paths. The agent discovers referenced files from relative paths in the SKILL.md instructions (per the [agentskills.io progressive disclosure model](https://agentskills.io/specification)), or via `list_files` on the skill directory. A well-written SKILL.md already references every file the agent needs.
 
 ## Database Schema
 
@@ -589,5 +591,6 @@ Example skills are provided in `examples/skills/`:
 | Why per-org uniqueness? | Multitenancy | Different orgs can have skills with same name. |
 | Why 10 MB archive limit? | Practical bound | Skills are instructions, not large binary packages. |
 | Why keep original ZIP + extracted files? | Both needed | ZIP for reference/re-download. Extracted rows for fast reads and VFS mounting (no runtime extraction). |
+| Why no `bundled_files` in activate result? | Redundant | SKILL.md already references companion files via relative paths (agentskills.io spec). Agent can also use `list_files`. Listing paths wastes tokens. |
 | Why `skill_files` table? | VFS mounting | Session VFS needs individual file content. Extracting from ZIP on every activation is wasteful. |
 | Why VFS mounting instead of `read_skill_file` tool? | Reuse existing infra | Session filesystem tools (`read_file`, `list_files`) already exist. No new tool needed. Consistent with how `sample_data` capability mounts files. |

--- a/specs/skills-registry.md
+++ b/specs/skills-registry.md
@@ -326,11 +326,11 @@ When the agent calls `activate_skill`:
 
 For archive-based skills, extracted files are mounted into the session's virtual filesystem when the skill is activated. This reuses the existing `MountPoint` / `MountSource` system that capabilities already use.
 
-**Mount path**: `/skills/{skill-name}/`
+**Mount path**: `/.agents/skills/{skill-name}/`
 
 Example: A skill named `pdf-processing` with files `scripts/extract.py` and `references/REFERENCE.md` would be mounted as:
 ```
-/skills/pdf-processing/
+/.agents/skills/pdf-processing/
 ├── SKILL.md
 ├── scripts/extract.py
 └── references/REFERENCE.md
@@ -340,8 +340,8 @@ The agent can then read these files using existing session filesystem tools (`re
 
 **Mounting strategy**:
 1. On `activate_skill` call, the worker fetches skill files from the `skill_files` table via gRPC
-2. Files are mounted into the session VFS at `/skills/{skill-name}/`
-3. The `activate_skill` tool result includes the SKILL.md body only — no separate file listing
+2. Files are mounted into the session VFS at `/.agents/skills/{skill-name}/`
+3. The `activate_skill` tool result includes instructions and metadata (`skill`, `description`, and fork-mode fields when applicable), but does not include a separate companion-file listing
 4. Text files become `MountSource::InlineFile` with `encoding: "text"`
 5. Binary files become `MountSource::InlineFile` with `encoding: "base64"`
 


### PR DESCRIPTION
## What
Remove the `bundled_files` field from the `activate_skill` tool result. This field listed companion file paths alongside the SKILL.md instructions.

## Why
The `bundled_files` list is redundant. SKILL.md already references companion files via relative paths per the [agentskills.io progressive disclosure model](https://agentskills.io/specification). The agent can also use `list_files` on the skill directory. Returning file paths separately wastes tokens without adding value.

## How
- Removed the VFS directory walk that collected bundled file paths in `ActivateSkillFromVfsTool`
- Removed the `bundled_files` JSON field from the tool result
- Removed 3 dedicated tests, updated 2 test names
- Updated `specs/skills-registry.md` with design decision and corrected mounting strategy docs

## Risk
- Low
- Agents that previously relied on `bundled_files` to discover companion files will now need to read relative paths from SKILL.md or use `list_files`. Well-written skills already reference their files in the markdown body.

## Security
- No security-relevant code changes. Pure removal of redundant output from a tool result — no trust boundaries, auth, or input parsing affected.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)