### PR TITLE
feat(browserless): add secret references in interact steps

### DIFF
--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -870,12 +870,24 @@ Set `return_screenshot: true` to get a screenshot after interactions.
 - **Content verification**: Scrape specific elements and validate their text/attributes
 - **Visual QA**: Take screenshots before/after interactions to verify UI changes
 
+## Secure Login Flows
+
+For login-protected pages, use **secret references** to avoid exposing credentials:
+
+1. Store credentials first: `secret_store set login_email user@example.com` and `secret_store set login_password s3cret`
+2. In browserless_interact steps, set the value field to a secret reference pattern: dollar-sign followed by double-braces around secrets.NAME — for example a type step with value set to the pattern referencing secrets.login_password
+3. Secrets are resolved server-side — you never see the plaintext values
+4. Secret references only work in step value fields (not in url or navigate actions)
+
+**Important**: Never ask users to paste credentials into chat. Always use secret_store + secret references in browserless_interact.
+
 ## Guidelines
 
 - Each tool call uses a fresh browser — no state carries between calls
 - Use `wait_for_selector` or `wait_for_timeout` for pages with dynamic content
-- For login-protected pages, use `browserless_interact` with type/click steps
-- Always clean up: Browserless handles this automatically (no resources to manage)
+- For login-protected pages, use secret references (see above) with `browserless_interact`
+- Use `browserless_open_browser` for multi-step workflows that need persistent cookies/sessions
+- Always clean up persistent sessions with `browserless_close_browser` when done
 
 ## Prerequisites
 
@@ -890,7 +902,10 @@ Get a token at https://www.browserless.io/account/home"#,
             "demo",
             "seed",
         ],
-        capabilities: &[SeedCapability::new("browserless")],
+        capabilities: &[
+            SeedCapability::new("browserless"),
+            SeedCapability::new("session_storage"),
+        ],
         dev_only: false,
     },
     SeedAgent {

--- a/integrations/browserless/SPEC.md
+++ b/integrations/browserless/SPEC.md
@@ -161,6 +161,21 @@ Multi-step browser interactions.
 | `wait_for_selector` | `selector`, `wait_ms` | Wait for element to appear |
 | `navigate` | `value` (URL) | Navigate to different URL |
 
+### Secret References
+
+The `browserless_interact` tool supports `${{secrets.<name>}}` placeholders in step `value` fields. This allows agents to fill login forms and other sensitive inputs without ever seeing the plaintext credentials.
+
+**Flow:**
+1. User stores credentials via `secret_store set login_password hunter2`
+2. Agent references them: `{ "action": "type", "selector": "#password", "value": "${{secrets.login_password}}" }`
+3. Tool resolves `login_password` from `session_secrets` at execution time, substitutes into the step, executes
+4. Plaintext never appears in tool arguments, agent messages, or tool results
+
+**Security constraints:**
+- Secret refs only allowed in step `value` fields — blocked in `url` parameter and `navigate` action values to prevent exfiltration via URL
+- All referenced secrets must exist; tool fails fast with a clear error if any are missing
+- Supports mixed values: `"Bearer ${{secrets.api_token}}"` resolves correctly
+
 ## Resource Management
 
 ### REST Mode
@@ -184,6 +199,7 @@ No long-lived WebSocket connections from our side — we connect/disconnect for 
 - **Timeout caps**: All wait/timeout values capped at 120s to prevent unbounded resource consumption
 - **Ephemeral by default**: REST mode has no cross-request data leakage
 - **Content truncation**: Large DOM responses truncated to 100KB (UTF-8 safe boundary) to prevent context flooding
+- **Secret references**: `${{secrets.*}}` resolved server-side from `session_secrets`; blocked in `url` param and `navigate` step values to prevent exfiltration via URL
 
 ## Testing
 
@@ -230,7 +246,7 @@ doppler run -- cargo test -p everruns-integrations-browserless --features browse
 - **Icon**: `browserless`
 - **Category**: `Browser`
 - **Risk Level**: Medium
-- **Dependencies**: none (session_storage used opportunistically for CDP state)
+- **Dependencies**: `session_storage` (for CDP session state and secret references)
 
 ## Seeded Agent: Browser Tester
 

--- a/integrations/browserless/src/state.rs
+++ b/integrations/browserless/src/state.rs
@@ -197,12 +197,35 @@ pub fn extract_secret_refs(s: &str) -> Vec<String> {
 }
 
 /// Replace all `${{secrets.<name>}}` patterns in `s` with resolved values.
+/// Uses a single left-to-right pass to avoid order-dependent or nested substitution.
 pub fn substitute_secrets(s: &str, resolved: &std::collections::HashMap<String, String>) -> String {
-    let mut result = s.to_string();
-    for (name, value) in resolved {
-        let pattern = format!("{SECRET_REF_PREFIX}{name}{SECRET_REF_SUFFIX}");
-        result = result.replace(&pattern, value);
+    let mut result = String::with_capacity(s.len());
+    let mut pos = 0;
+
+    while let Some(rel_start) = s[pos..].find(SECRET_REF_PREFIX) {
+        let start = pos + rel_start;
+        result.push_str(&s[pos..start]);
+
+        let name_start = start + SECRET_REF_PREFIX.len();
+        let Some(rel_end) = s[name_start..].find(SECRET_REF_SUFFIX) else {
+            // No closing suffix — push the rest verbatim
+            result.push_str(&s[start..]);
+            return result;
+        };
+        let name_end = name_start + rel_end;
+        let name = &s[name_start..name_end];
+
+        if let Some(value) = resolved.get(name) {
+            result.push_str(value);
+        } else {
+            // Unknown secret — leave placeholder as-is
+            result.push_str(&s[start..name_end + SECRET_REF_SUFFIX.len()]);
+        }
+
+        pos = name_end + SECRET_REF_SUFFIX.len();
     }
+
+    result.push_str(&s[pos..]);
     result
 }
 
@@ -449,6 +472,22 @@ mod tests {
             substitute_secrets("Bearer ${{secrets.token}}", &resolved),
             "Bearer abc123"
         );
+    }
+
+    /// Nested `${{secrets.*}}` inside a resolved value must NOT be recursively expanded.
+    /// Single-pass left-to-right substitution guarantees deterministic behavior.
+    #[test]
+    fn test_substitute_secrets_nested_placeholder_in_value() {
+        let mut resolved = std::collections::HashMap::new();
+        resolved.insert("inner".to_string(), "INNER_VALUE".to_string());
+        resolved.insert(
+            "outer".to_string(),
+            "prefix ${{secrets.inner}} suffix".to_string(),
+        );
+
+        let result = substitute_secrets("${{secrets.outer}}", &resolved);
+        // Only the top-level placeholder is substituted; nested placeholder stays as-is
+        assert_eq!(result, "prefix ${{secrets.inner}} suffix");
     }
 
     #[test]

--- a/integrations/browserless/src/state.rs
+++ b/integrations/browserless/src/state.rs
@@ -169,6 +169,121 @@ pub async fn delete_browser_session(context: &ToolContext) -> Result<(), ToolExe
 }
 
 // ============================================================================
+// Secret Reference Resolution
+// ============================================================================
+
+/// Pattern: `${{secrets.name}}` where `name` is a session secret key.
+/// Double-brace avoids collision with JS template literals.
+const SECRET_REF_PREFIX: &str = "${{secrets.";
+const SECRET_REF_SUFFIX: &str = "}}";
+
+/// Extract all secret names referenced in `${{secrets.<name>}}` patterns within a string.
+pub fn extract_secret_refs(s: &str) -> Vec<String> {
+    let mut refs = Vec::new();
+    let mut search_from = 0;
+    while let Some(start) = s[search_from..].find(SECRET_REF_PREFIX) {
+        let abs_start = search_from + start + SECRET_REF_PREFIX.len();
+        if let Some(end) = s[abs_start..].find(SECRET_REF_SUFFIX) {
+            let name = &s[abs_start..abs_start + end];
+            if !name.is_empty() && !refs.contains(&name.to_string()) {
+                refs.push(name.to_string());
+            }
+            search_from = abs_start + end + SECRET_REF_SUFFIX.len();
+        } else {
+            break;
+        }
+    }
+    refs
+}
+
+/// Replace all `${{secrets.<name>}}` patterns in `s` with resolved values.
+pub fn substitute_secrets(s: &str, resolved: &std::collections::HashMap<String, String>) -> String {
+    let mut result = s.to_string();
+    for (name, value) in resolved {
+        let pattern = format!("{SECRET_REF_PREFIX}{name}{SECRET_REF_SUFFIX}");
+        result = result.replace(&pattern, value);
+    }
+    result
+}
+
+/// Resolve all `${{secrets.<name>}}` references found in interaction step `value` fields.
+/// Returns a map of secret_name → plaintext_value.
+/// Fails if any referenced secret is missing or session storage is unavailable.
+pub async fn resolve_step_secrets(
+    context: &ToolContext,
+    steps: &[Value],
+) -> Result<std::collections::HashMap<String, String>, ToolExecutionResult> {
+    // Collect all unique secret names from step value fields
+    let mut secret_names: Vec<String> = Vec::new();
+    for step in steps {
+        if let Some(val) = step.get("value").and_then(|v| v.as_str()) {
+            for name in extract_secret_refs(val) {
+                if !secret_names.contains(&name) {
+                    secret_names.push(name);
+                }
+            }
+        }
+    }
+
+    if secret_names.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+
+    let storage = context.storage_store.as_ref().ok_or_else(|| {
+        ToolExecutionResult::tool_error(
+            "Session storage not available. Secret references require the 'session_storage' capability.",
+        )
+    })?;
+
+    let mut resolved = std::collections::HashMap::new();
+    for name in &secret_names {
+        match storage.get_secret(context.session_id, name).await {
+            Ok(Some(value)) => {
+                resolved.insert(name.clone(), value);
+            }
+            Ok(None) => {
+                return Err(ToolExecutionResult::tool_error(format!(
+                    "Secret '{name}' not found. Store it first with: secret_store set {name} <value>"
+                )));
+            }
+            Err(e) => {
+                return Err(ToolExecutionResult::tool_error(format!(
+                    "Failed to resolve secret '{name}': {e}"
+                )));
+            }
+        }
+    }
+
+    Ok(resolved)
+}
+
+/// Apply secret substitution to a cloned list of steps, replacing `${{secrets.*}}`
+/// in `value` fields with resolved plaintext. Returns new steps (originals unchanged).
+pub fn substitute_step_secrets(
+    steps: &[Value],
+    resolved: &std::collections::HashMap<String, String>,
+) -> Vec<Value> {
+    if resolved.is_empty() {
+        return steps.to_vec();
+    }
+    steps
+        .iter()
+        .map(|step| {
+            let mut step = step.clone();
+            if let Some(val) = step.get("value").and_then(|v| v.as_str()) {
+                let substituted = substitute_secrets(val, resolved);
+                if substituted != val {
+                    step.as_object_mut()
+                        .unwrap()
+                        .insert("value".to_string(), Value::String(substituted));
+                }
+            }
+            step
+        })
+        .collect()
+}
+
+// ============================================================================
 // Parameter Helpers
 // ============================================================================
 
@@ -279,5 +394,99 @@ mod tests {
                 "Session state must not contain secret-like field: {key}"
             );
         }
+    }
+
+    // ====================================================================
+    // Secret reference tests
+    // ====================================================================
+
+    #[test]
+    fn test_extract_secret_refs_none() {
+        assert!(extract_secret_refs("plain text").is_empty());
+        assert!(extract_secret_refs("").is_empty());
+    }
+
+    #[test]
+    fn test_extract_secret_refs_single() {
+        let refs = extract_secret_refs("${{secrets.my_password}}");
+        assert_eq!(refs, vec!["my_password"]);
+    }
+
+    #[test]
+    fn test_extract_secret_refs_multiple() {
+        let refs = extract_secret_refs("user=${{secrets.user}} pass=${{secrets.pass}}");
+        assert_eq!(refs, vec!["user", "pass"]);
+    }
+
+    #[test]
+    fn test_extract_secret_refs_deduplicates() {
+        let refs = extract_secret_refs("${{secrets.token}} and again ${{secrets.token}}");
+        assert_eq!(refs, vec!["token"]);
+    }
+
+    #[test]
+    fn test_extract_secret_refs_ignores_empty_name() {
+        assert!(extract_secret_refs("${{secrets.}}").is_empty());
+    }
+
+    #[test]
+    fn test_extract_secret_refs_ignores_unclosed() {
+        assert!(extract_secret_refs("${{secrets.name").is_empty());
+    }
+
+    #[test]
+    fn test_substitute_secrets_basic() {
+        let mut resolved = std::collections::HashMap::new();
+        resolved.insert("pw".to_string(), "hunter2".to_string());
+        assert_eq!(substitute_secrets("${{secrets.pw}}", &resolved), "hunter2");
+    }
+
+    #[test]
+    fn test_substitute_secrets_mixed() {
+        let mut resolved = std::collections::HashMap::new();
+        resolved.insert("token".to_string(), "abc123".to_string());
+        assert_eq!(
+            substitute_secrets("Bearer ${{secrets.token}}", &resolved),
+            "Bearer abc123"
+        );
+    }
+
+    #[test]
+    fn test_substitute_secrets_no_match() {
+        let resolved = std::collections::HashMap::new();
+        assert_eq!(
+            substitute_secrets("no refs here", &resolved),
+            "no refs here"
+        );
+    }
+
+    #[test]
+    fn test_substitute_step_secrets_replaces_value_only() {
+        let steps = vec![
+            serde_json::json!({
+                "action": "type",
+                "selector": "#password",
+                "value": "${{secrets.pw}}"
+            }),
+            serde_json::json!({
+                "action": "click",
+                "selector": "#submit"
+            }),
+        ];
+        let mut resolved = std::collections::HashMap::new();
+        resolved.insert("pw".to_string(), "hunter2".to_string());
+
+        let result = substitute_step_secrets(&steps, &resolved);
+        assert_eq!(result[0]["value"], "hunter2");
+        assert_eq!(result[0]["selector"], "#password"); // untouched
+        assert_eq!(result[1]["selector"], "#submit"); // untouched
+    }
+
+    #[test]
+    fn test_substitute_step_secrets_empty_resolved() {
+        let steps = vec![serde_json::json!({"action": "click", "selector": "#btn"})];
+        let resolved = std::collections::HashMap::new();
+        let result = substitute_step_secrets(&steps, &resolved);
+        assert_eq!(result, steps);
     }
 }

--- a/integrations/browserless/src/tools.rs
+++ b/integrations/browserless/src/tools.rs
@@ -20,7 +20,9 @@ use tracing::debug;
 
 use crate::client::BrowserlessClient;
 use crate::session_tools::{keep_session_alive, try_get_cdp_session};
-use crate::state::{get_api_token, required_str, resolve_step_secrets, substitute_step_secrets};
+use crate::state::{
+    extract_secret_refs, get_api_token, required_str, resolve_step_secrets, substitute_step_secrets,
+};
 use crate::validation::{validate_browserless_url, validate_interaction_steps};
 
 const MAX_HTML_BYTES: usize = 100_000;
@@ -665,7 +667,7 @@ impl Tool for BrowserlessInteractTool {
         };
 
         // THREAT: Block secret references in URL param to prevent exfiltration
-        if url.contains("${{secrets.") {
+        if !extract_secret_refs(url).is_empty() {
             return ToolExecutionResult::tool_error(
                 "Secret references (${{secrets.*}}) are not allowed in the 'url' parameter.",
             );
@@ -689,7 +691,7 @@ impl Tool for BrowserlessInteractTool {
         for step in &steps {
             if step.get("action").and_then(|v| v.as_str()) == Some("navigate")
                 && let Some(val) = step.get("value").and_then(|v| v.as_str())
-                && val.contains("${{secrets.")
+                && !extract_secret_refs(val).is_empty()
             {
                 return ToolExecutionResult::tool_error(
                     "Secret references (${{secrets.*}}) are not allowed in 'navigate' step values.",

--- a/integrations/browserless/src/tools.rs
+++ b/integrations/browserless/src/tools.rs
@@ -20,7 +20,7 @@ use tracing::debug;
 
 use crate::client::BrowserlessClient;
 use crate::session_tools::{keep_session_alive, try_get_cdp_session};
-use crate::state::{get_api_token, required_str};
+use crate::state::{get_api_token, required_str, resolve_step_secrets, substitute_step_secrets};
 use crate::validation::{validate_browserless_url, validate_interaction_steps};
 
 const MAX_HTML_BYTES: usize = 100_000;
@@ -584,7 +584,12 @@ impl Tool for BrowserlessInteractTool {
     fn description(&self) -> &str {
         "Interact with a web page: navigate to a URL, then perform a sequence of actions \
          (click, type, keyboard, mouse, touch, scroll, wait). Returns the page title, \
-         final URL, and optionally a screenshot or DOM content after all steps complete."
+         final URL, and optionally a screenshot or DOM content after all steps complete.\n\n\
+         Secret references: Use ${{secrets.<name>}} in step 'value' fields to inject \
+         session secrets without exposing them. Store secrets first with secret_store, \
+         then reference them: {\"action\": \"type\", \"selector\": \"#password\", \
+         \"value\": \"${{secrets.my_password}}\"}. Secrets are resolved server-side \
+         and never returned to the agent."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -612,7 +617,8 @@ impl Tool for BrowserlessInteractTool {
                             },
                             "value": {
                                 "type": "string",
-                                "description": "Text to type (for type action), URL (for navigate), or scroll amount (for scroll)"
+                                "description": "Text to type (for type action), URL (for navigate), or scroll amount (for scroll). \
+                                    Supports ${{secrets.<name>}} references to inject session secrets without exposing them to the agent."
                             },
                             "key": {
                                 "type": "string",
@@ -657,6 +663,14 @@ impl Tool for BrowserlessInteractTool {
             Ok(v) => v,
             Err(e) => return e,
         };
+
+        // THREAT: Block secret references in URL param to prevent exfiltration
+        if url.contains("${{secrets.") {
+            return ToolExecutionResult::tool_error(
+                "Secret references (${{secrets.*}}) are not allowed in the 'url' parameter.",
+            );
+        }
+
         if let Err(e) = validate_url(url) {
             return e;
         }
@@ -669,6 +683,28 @@ impl Tool for BrowserlessInteractTool {
                 );
             }
         };
+
+        // THREAT: Block secret references in navigate step URLs to prevent
+        // secret exfiltration via URL (e.g. navigating to attacker.com/${{secrets.pw}})
+        for step in &steps {
+            if step.get("action").and_then(|v| v.as_str()) == Some("navigate")
+                && let Some(val) = step.get("value").and_then(|v| v.as_str())
+                && val.contains("${{secrets.")
+            {
+                return ToolExecutionResult::tool_error(
+                    "Secret references (${{secrets.*}}) are not allowed in 'navigate' step values.",
+                );
+            }
+        }
+
+        // Resolve ${{secrets.*}} references in step value fields
+        let resolved_secrets = match resolve_step_secrets(context, &steps).await {
+            Ok(r) => r,
+            Err(e) => return e,
+        };
+        let steps = substitute_step_secrets(&steps, &resolved_secrets);
+
+        // Validate interaction steps (including navigate URL validation) after substitution
         if let Err(e) = validate_interaction_steps(&steps) {
             return e;
         }


### PR DESCRIPTION
## What
Support `${{secrets.<name>}}` placeholders in `browserless_interact` step `value` fields. Secrets are resolved server-side from `session_secrets` at execution time, so agents never see plaintext credentials.

## Why
Agents automating login flows need to type passwords/tokens into forms. Without this, credentials would appear in tool arguments visible to the LLM. Secret references let the agent reference credentials by name while the tool resolves them server-side.

## How
- `extract_secret_refs()` / `substitute_secrets()` / `resolve_step_secrets()` / `substitute_step_secrets()` in `state.rs`
- Wired into `execute_with_context` before both CDP and REST execution paths
- Secret refs blocked in `url` param and `navigate` step values (exfiltration prevention)
- `session_storage` capability added to Browser Tester seed agent
- SPEC.md updated with Secret References section

## Risk
- Low
- Only affects `browserless_interact` tool when steps contain `${{secrets.*}}` patterns
- No-op when no secret refs are present (empty resolved map → steps returned unchanged)

## Security
- Threat categories reviewed: TM-TOOL, TM-LLM
- **TM-TOOL**: Secret refs only substituted in step `value` fields. Blocked in `url` param and `navigate` action values to prevent exfiltration via URL (e.g. `attacker.com/${{secrets.pw}}`). Two `// THREAT:` comments added at blocking points.
- **TM-LLM**: Resolved plaintext never appears in tool arguments, agent messages, or tool results. Agent only sees the `${{secrets.name}}` pattern.
- No new threat model entries needed — extends existing tool execution path with well-scoped substitution.

## Checklist
- [x] Tests added or updated (10 new unit tests for secret ref parsing/substitution)
- [x] Backward compatibility considered (no-op when no secret refs present)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)