### PR TITLE
feat(cli): remove default timeout from chat command

### DIFF
--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -12,7 +12,7 @@ pub async fn run(
     quiet: bool,
     message: String,
     session_id: String,
-    timeout_secs: u64,
+    timeout_secs: Option<u64>,
     no_stream: bool,
 ) -> Result<()> {
     // Create the message
@@ -28,13 +28,15 @@ pub async fn run(
 
     // Poll for events until turn.completed or timeout
     let start = Instant::now();
-    let timeout = Duration::from_secs(timeout_secs);
+    let timeout = timeout_secs.map(Duration::from_secs);
     let poll_interval = Duration::from_millis(500);
     let mut last_event_id: Option<String> = None;
     let mut agent_content = String::new();
 
     loop {
-        if start.elapsed() > timeout {
+        if let Some(timeout) = timeout
+            && start.elapsed() > timeout
+        {
             if output.is_text() {
                 eprintln!("\nTimeout waiting for response");
             }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -95,9 +95,9 @@ pub enum Commands {
         #[arg(long, short)]
         session: String,
 
-        /// Max wait time in seconds
-        #[arg(long, default_value = "300")]
-        timeout: u64,
+        /// Max wait time in seconds (default: unlimited)
+        #[arg(long)]
+        timeout: Option<u64>,
 
         /// Send message and exit immediately without waiting for response
         #[arg(long)]
@@ -295,7 +295,7 @@ mod tests {
         {
             assert_eq!(message, "Hello world");
             assert_eq!(session, "ses_xyz");
-            assert_eq!(timeout, 300); // default
+            assert_eq!(timeout, None); // default: no timeout
             assert!(!no_stream);
         } else {
             panic!("Expected Chat command");
@@ -324,7 +324,7 @@ mod tests {
         {
             assert_eq!(message, "Test message");
             assert_eq!(session, "ses_xyz");
-            assert_eq!(timeout, 60);
+            assert_eq!(timeout, Some(60));
             assert!(no_stream);
         } else {
             panic!("Expected Chat command");

--- a/specs/cli.md
+++ b/specs/cli.md
@@ -72,7 +72,8 @@ Session management.
 Send message and poll for response.
 
 - `chat --session <id> "<message>" [--timeout <s>] [--no-stream]`
-- Polls `/v1/sessions/{id}/events` every 500ms until `turn.completed` or timeout (default 300s)
+- Polls `/v1/sessions/{id}/events` every 500ms until `turn.completed` or timeout
+- No timeout by default (waits indefinitely); use `--timeout <s>` to set a limit
 
 ### `everruns capabilities`
 


### PR DESCRIPTION
## What
Change `everruns chat --timeout` from a mandatory 300s default to unlimited by default. `--timeout <s>` is still available for users who want a deadline.

## Why
Sessions can run for hours or days (e.g. multi-step browser automation). The 300s default was too restrictive and there was no "fire and forget" option. The natural default should be unlimited — crash on timeout is the wrong behavior for long-running agent work.

## How
- Changed `timeout` CLI arg from `u64` (default 300) to `Option<u64>` (default None).
- Timeout check in the polling loop only activates when `--timeout` is explicitly provided.
- Updated tests and spec.

## Risk
- Low
- Existing users relying on the 300s default will now wait indefinitely. This is the desired behavior per the issue.

## Security
- No security-relevant code changes. This change only modifies a CLI timeout default for a local polling loop. No auth, API surface, input validation, or trust boundary changes. No threat model categories are touched.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)