### PR TITLE
test(agent-identities): cover identity connections UI

### DIFF
--- a/apps/ui/src/__tests__/identity-connections.test.tsx
+++ b/apps/ui/src/__tests__/identity-connections.test.tsx
@@ -1,0 +1,164 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { IdentityConnections } from "@/components/agent-identity/identity-connections";
+import type { ConnectionProvider, UserConnection } from "@/lib/api/types";
+
+const mockUseIdentityConnections = jest.fn();
+const mockUseDeleteIdentityConnection = jest.fn();
+const mockUseVerifyIdentityConnection = jest.fn();
+const mockUseConnectionProviders = jest.fn();
+
+jest.mock("@/hooks/use-identity-connections", () => ({
+  useIdentityConnections: (identityId: string) => mockUseIdentityConnections(identityId),
+  useDeleteIdentityConnection: (identityId: string) => mockUseDeleteIdentityConnection(identityId),
+  useVerifyIdentityConnection: (identityId: string) => mockUseVerifyIdentityConnection(identityId),
+}));
+
+jest.mock("@/hooks/use-user-connections", () => ({
+  useConnectionProviders: () => mockUseConnectionProviders(),
+}));
+
+jest.mock("@/components/connections/provider-icon", () => ({
+  ProviderIcon: ({ iconName }: { iconName: string }) => <div data-testid={`icon-${iconName}`} />,
+}));
+
+jest.mock("@/components/agent-identity/identity-api-key-dialog", () => ({
+  IdentityApiKeyDialog: ({
+    open,
+    provider,
+  }: {
+    open: boolean;
+    provider: ConnectionProvider | null;
+  }) => (open ? <div data-testid="identity-api-key-dialog">{provider?.display_name}</div> : null),
+}));
+
+const githubProvider: ConnectionProvider = {
+  provider_id: "github",
+  display_name: "GitHub",
+  description: "GitHub API access",
+  icon: "github",
+  connection_type: "api_key",
+  form_schema: {
+    fields: [
+      {
+        name: "api_key",
+        label: "API Key",
+        field_type: "password",
+        required: true,
+        placeholder: "Enter API key",
+        help_text: null,
+      },
+    ],
+    instructions_markdown: "Paste a GitHub token",
+  },
+};
+
+const daytonaProvider: ConnectionProvider = {
+  provider_id: "daytona",
+  display_name: "Daytona",
+  description: "Cloud sandbox access",
+  icon: "cloud",
+  connection_type: "api_key",
+  form_schema: {
+    fields: [
+      {
+        name: "api_key",
+        label: "API Key",
+        field_type: "password",
+        required: true,
+        placeholder: "Enter API key",
+        help_text: null,
+      },
+    ],
+    instructions_markdown: "Paste a Daytona API key",
+  },
+};
+
+const githubConnection = {
+  provider: "github",
+  connection_type: "api_key",
+  provider_username: "octocat",
+  connected_at: "2026-03-01T00:00:00Z",
+  scopes: "repo",
+} as UserConnection;
+
+describe("IdentityConnections", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(window, "confirm").mockReturnValue(true);
+
+    mockUseIdentityConnections.mockReturnValue({
+      data: [githubConnection],
+      isLoading: false,
+      error: null,
+    });
+    mockUseDeleteIdentityConnection.mockReturnValue({
+      mutateAsync: jest.fn().mockResolvedValue(undefined),
+      isPending: false,
+    });
+    mockUseVerifyIdentityConnection.mockReturnValue({
+      mutateAsync: jest.fn().mockResolvedValue({ valid: true }),
+      isPending: false,
+    });
+    mockUseConnectionProviders.mockReturnValue({
+      data: [githubProvider, daytonaProvider],
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("renders connected and available identity providers", () => {
+    render(<IdentityConnections identityId="identity_123" />);
+
+    expect(screen.getByText("GitHub")).toBeInTheDocument();
+    expect(screen.getByText("octocat")).toBeInTheDocument();
+    expect(screen.getByText("Daytona")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Verify" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Connect" })).toBeInTheDocument();
+  });
+
+  it("opens the API key dialog for an available provider", async () => {
+    render(<IdentityConnections identityId="identity_123" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("identity-api-key-dialog")).toHaveTextContent("Daytona");
+    });
+  });
+
+  it("verifies API-key connections and shows success feedback", async () => {
+    const verifyMutateAsync = jest.fn().mockResolvedValue({ valid: true });
+    mockUseVerifyIdentityConnection.mockReturnValue({
+      mutateAsync: verifyMutateAsync,
+      isPending: false,
+    });
+
+    render(<IdentityConnections identityId="identity_123" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Verify" }));
+
+    await waitFor(() => {
+      expect(verifyMutateAsync).toHaveBeenCalledWith("github");
+      expect(screen.getByText("API key is valid")).toBeInTheDocument();
+    });
+  });
+
+  it("disconnects a provider after confirmation", async () => {
+    const deleteMutateAsync = jest.fn().mockResolvedValue(undefined);
+    mockUseDeleteIdentityConnection.mockReturnValue({
+      mutateAsync: deleteMutateAsync,
+      isPending: false,
+    });
+
+    render(<IdentityConnections identityId="identity_123" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Disconnect" }));
+
+    await waitFor(() => {
+      expect(window.confirm).toHaveBeenCalledWith("Disconnect GitHub from this identity?");
+      expect(deleteMutateAsync).toHaveBeenCalledWith("github");
+    });
+  });
+});

--- a/specs/skills-registry.md
+++ b/specs/skills-registry.md
@@ -318,7 +318,7 @@ Skills provide a virtual tool for activation:
 
 When the agent calls `activate_skill`:
 1. Worker resolves skill by name from the registry (via gRPC)
-2. Full SKILL.md body returned as tool result
+2. The tool result returns the SKILL.md instructions alongside skill metadata
 3. Agent uses the loaded instructions to perform the task
 4. For archive-based skills, file paths in instructions can be resolved via additional tool calls
 
@@ -425,7 +425,7 @@ CREATE INDEX idx_skill_files_skill_id ON skill_files(skill_id);
 |-------|----------------|
 | `everruns-core` | Skill types, SKILL.md parser, name validation, `AttachSkillCapability` + `SkillsCapability` |
 | `everruns-server` | API routes, gRPC services, database operations, ZIP handling |
-| `everruns-worker` | `SkillToolExecutor` for `activate_skill` and `read_skill_file` tool execution |
+| `everruns-worker` | `SkillToolExecutor` for `activate_skill` tool execution and skill-file VFS mounting |
 
 ### Key Components
 


### PR DESCRIPTION
## What
- add RTL coverage for the `IdentityConnections` surface so list/connect/verify/disconnect flows are exercised
- clarify `activate_skill` spec wording so it reflects the current tool result and VFS-mount behavior

## Why
Inline review feedback on the original identity-connections / skills changes called out missing UI coverage and stale skills-registry wording. Those gaps are still present on `main` and should be closed with a small follow-up.

## How
- add `apps/ui/src/__tests__/identity-connections.test.tsx` with mocked hook coverage for connected providers, available providers, verify, and disconnect flows
- update `specs/skills-registry.md` to describe `activate_skill` results as instructions plus metadata and to remove the stale `read_skill_file` worker-responsibility wording

## Risk
- Low
- Test-only UI change plus doc/spec clarification

## Security
- Threat categories reviewed: No security-relevant code changes
- Findings and resolutions:
  - No runtime auth/authz, secret handling, storage, or execution-path code changed
  - Added regression coverage only; spec edits align docs with existing behavior

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
