### PR TITLE
feat(deno): add Deno Deploy sandbox integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,6 +1612,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-integrations-deno"
+version = "0.8.7"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "everruns-core",
+ "futures-util",
+ "http",
+ "inventory",
+ "reqwest 0.13.1",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite 0.26.2",
+ "tracing",
+ "urlencoding",
+ "wiremock",
+]
+
+[[package]]
 name = "everruns-integrations-docker"
 version = "0.8.7"
 dependencies = [
@@ -1759,6 +1780,7 @@ dependencies = [
  "everruns-integrations-brave-search",
  "everruns-integrations-browserless",
  "everruns-integrations-daytona",
+ "everruns-integrations-deno",
  "everruns-integrations-docker",
  "everruns-integrations-duckduckgo",
  "everruns-integrations-e2b",
@@ -1844,6 +1866,7 @@ dependencies = [
  "everruns-integrations-brave-search",
  "everruns-integrations-browserless",
  "everruns-integrations-daytona",
+ "everruns-integrations-deno",
  "everruns-integrations-docker",
  "everruns-integrations-duckduckgo",
  "everruns-integrations-e2b",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/session-sqldb",
     "integrations/docker",
     "integrations/daytona",
+    "integrations/deno",
     "integrations/brave-search",
     "integrations/duckduckgo",
     "integrations/browserless",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -69,6 +69,7 @@ everruns-integrations-docker = { path = "../../integrations/docker" }
 everruns-integrations-brave-search = { path = "../../integrations/brave-search" }
 everruns-integrations-duckduckgo = { path = "../../integrations/duckduckgo" }
 everruns-integrations-daytona = { path = "../../integrations/daytona" }
+everruns-integrations-deno = { path = "../../integrations/deno" }
 everruns-integrations-browserless = { path = "../../integrations/browserless" }
 everruns-integrations-e2b = { path = "../../integrations/e2b" }
 everruns-session-sqldb = { path = "../session-sqldb" }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -7,6 +7,7 @@
 extern crate everruns_integrations_brave_search;
 extern crate everruns_integrations_browserless;
 extern crate everruns_integrations_daytona;
+extern crate everruns_integrations_deno;
 extern crate everruns_integrations_docker;
 extern crate everruns_integrations_duckduckgo;
 extern crate everruns_integrations_e2b;

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -20,6 +20,7 @@ everruns-integrations-docker = { path = "../../integrations/docker" }
 everruns-integrations-brave-search = { path = "../../integrations/brave-search" }
 everruns-integrations-duckduckgo = { path = "../../integrations/duckduckgo" }
 everruns-integrations-daytona = { path = "../../integrations/daytona" }
+everruns-integrations-deno = { path = "../../integrations/deno" }
 everruns-integrations-browserless = { path = "../../integrations/browserless" }
 everruns-integrations-e2b = { path = "../../integrations/e2b" }
 everruns-openai = { path = "../openai" }

--- a/crates/worker/src/leased_resource_cleanup.rs
+++ b/crates/worker/src/leased_resource_cleanup.rs
@@ -19,6 +19,7 @@ use crate::worker_adapters::WorkerAdapters;
 
 const DAYTONA_SNAPSHOT_SECRET_PREFIX: &str = "daytona_sandbox:";
 const E2B_SANDBOX_SECRET_PREFIX: &str = "e2b_sandbox:";
+const DENO_SNAPSHOT_SECRET_PREFIX: &str = "deno_sandbox:";
 const BROWSERLESS_SESSION_KEY: &str = "browserless_browser_session";
 
 /// Durable activity input for leased-resource cleanup.
@@ -197,6 +198,7 @@ async fn cleanup_resource(
     match (resource.provider.as_str(), resource.resource_type.as_str()) {
         ("daytona", "sandbox") => cleanup_daytona(resource, storage_store, &token).await,
         ("e2b", "sandbox") => cleanup_e2b(resource, storage_store, &token).await,
+        ("deno", "sandbox") => cleanup_deno(resource, storage_store, &token).await,
         ("browserless", "browser_session") => {
             cleanup_browserless(resource, storage_store, &token).await
         }
@@ -228,6 +230,13 @@ async fn resolve_provider_token(
         && let Some(token) = resolver
             .get_connection_token(session_id, &resource.provider)
             .await?
+    {
+        return Ok(token);
+    }
+
+    if resource.provider == "deno"
+        && let Ok(token) = std::env::var("DENO_DEPLOY_TOKEN")
+        && !token.is_empty()
     {
         return Ok(token);
     }
@@ -325,6 +334,43 @@ async fn cleanup_e2b(
     Ok(format!("Deleted E2B sandbox {}", resource.external_id))
 }
 
+async fn cleanup_deno(
+    resource: &LeasedResource,
+    storage_store: &dyn SessionStorageStore,
+    token: &str,
+) -> Result<String> {
+    let region = resource
+        .metadata
+        .get("region")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| anyhow!("Deno leased resource missing metadata.region"))?;
+    let org = deno_cleanup_org(resource);
+
+    let client = everruns_integrations_deno::client::DenoClient::new(token.to_string(), org);
+    match client.delete_sandbox(&resource.external_id, region).await {
+        Ok(()) => {}
+        Err(error) if is_deno_not_found(&error) => {
+            warn!(
+                sandbox_id = %resource.external_id,
+                error = %error,
+                "Deno sandbox already gone during cleanup"
+            );
+        }
+        Err(error) => return Err(anyhow!("Deno cleanup failed: {error}")),
+    }
+
+    if let Some(session_id) = resource.session_id {
+        let _ = storage_store
+            .delete_secret(
+                session_id,
+                &format!("{DENO_SNAPSHOT_SECRET_PREFIX}{}", resource.external_id),
+            )
+            .await;
+    }
+
+    Ok(format!("Deleted Deno sandbox {}", resource.external_id))
+}
+
 async fn cleanup_browserless(
     resource: &LeasedResource,
     storage_store: &dyn SessionStorageStore,
@@ -403,6 +449,24 @@ fn is_daytona_not_found(error: &str) -> bool {
 }
 
 fn is_e2b_not_found(error: &str) -> bool {
+    error.contains("404") || error.to_ascii_lowercase().contains("not found")
+}
+
+fn deno_cleanup_org(resource: &LeasedResource) -> Option<String> {
+    resource
+        .metadata
+        .get("org")
+        .and_then(serde_json::Value::as_str)
+        .filter(|org| !org.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            std::env::var("DENO_DEPLOY_ORG")
+                .ok()
+                .filter(|org| !org.is_empty())
+        })
+}
+
+fn is_deno_not_found(error: &str) -> bool {
     error.contains("404") || error.to_ascii_lowercase().contains("not found")
 }
 
@@ -536,6 +600,9 @@ mod tests {
     fn error_classifiers_match_expected_patterns() {
         assert!(is_daytona_not_found("Daytona API error (404): not found"));
         assert!(is_e2b_not_found("E2B API error (404): sandbox not found"));
+        assert!(is_deno_not_found(
+            "Deno sandbox delete error (404): not found"
+        ));
         assert!(is_browserless_already_gone(
             "CDP WebSocket connection failed: HTTP error: 404 Not Found"
         ));
@@ -657,5 +724,34 @@ mod tests {
         }
 
         assert!(error.to_string().contains("empty/whitespace"));
+    }
+
+    #[test]
+    fn deno_cleanup_org_prefers_metadata() {
+        let resource = LeasedResource {
+            id: uuid::Uuid::nil().into(),
+            session_id: None,
+            provider: "deno".to_string(),
+            resource_type: "sandbox".to_string(),
+            external_id: "sb_123".to_string(),
+            display_name: None,
+            status: everruns_core::LeasedResourceStatus::Active,
+            owner_user_id: None,
+            lease_duration_seconds: 60,
+            last_touched_at: chrono::Utc::now(),
+            lease_expires_at: chrono::Utc::now(),
+            cleanup_started_at: None,
+            cleanup_completed_at: None,
+            cleanup_attempts: 0,
+            last_cleanup_error: None,
+            metadata: serde_json::json!({
+                "region": "ord",
+                "org": "everruns",
+            }),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+
+        assert_eq!(deno_cleanup_org(&resource).as_deref(), Some("everruns"));
     }
 }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate everruns_integrations_brave_search;
 extern crate everruns_integrations_browserless;
 extern crate everruns_integrations_daytona;
+extern crate everruns_integrations_deno;
 extern crate everruns_integrations_docker;
 extern crate everruns_integrations_duckduckgo;
 extern crate everruns_integrations_e2b;

--- a/integrations/deno/Cargo.toml
+++ b/integrations/deno/Cargo.toml
@@ -1,0 +1,33 @@
+# Deno Sandbox Integration
+# Decision: External integration crate, auto-registered via inventory plugin system.
+
+[package]
+name = "everruns-integrations-deno"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Deno Sandbox integration for Everruns"
+
+[dependencies]
+everruns-core = { path = "../../crates/core" }
+inventory.workspace = true
+reqwest = { workspace = true, features = ["multipart"] }
+serde.workspace = true
+serde_json.workspace = true
+async-trait.workspace = true
+tokio.workspace = true
+chrono.workspace = true
+tracing.workspace = true
+futures-util.workspace = true
+tokio-tungstenite.workspace = true
+base64.workspace = true
+http = "1"
+urlencoding = "2.1"
+
+[features]
+deno-live-tests = []
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full", "test-util"] }
+wiremock = "0.6"

--- a/integrations/deno/SPEC.md
+++ b/integrations/deno/SPEC.md
@@ -1,0 +1,120 @@
+# Deno Sandbox Capability Specification
+
+## Abstract
+
+The Deno capability integrates [Deno Sandboxes](https://docs.deno.com/sandbox/) as a cloud execution environment for agents. Agents can create, execute commands in, read from, write to, list, and delete multiple isolated sandboxes per session.
+
+**Status**: Available (all environments)
+
+## Architecture
+
+### Transport model
+
+Deno sandboxes use two APIs:
+
+1. **Console API** (`https://console.deno.com/api/v2`) — list sandboxes and validate tokens.
+2. **Sandbox API** (`wss://<region>.sandbox-api.deno.net/api/v3/...`) — create/connect sandboxes and run JSON-RPC filesystem/process operations over websocket.
+
+Everruns opens a fresh websocket per tool call. This keeps tool execution stateless between calls while preserving sandbox state remotely.
+
+### State management
+
+Per-sandbox state is stored in session secrets (encrypted at rest):
+
+- secret name: `deno_sandbox:{sandbox_id}`
+- secret value: JSON-serialized `SandboxState`
+
+`SandboxState` stores only non-secret metadata: sandbox ID, region, optional org slug, workspace path, and start time.
+
+### Credential resolution
+
+Credential resolution order:
+
+1. User connection for provider `deno`
+2. Environment fallback: `DENO_DEPLOY_TOKEN` and optional `DENO_DEPLOY_ORG`
+
+The env fallback exists for operator-managed deployments and live smoke tests.
+
+## Tool surface
+
+### `deno_create_sandbox`
+
+Create a new sandbox.
+
+Parameters:
+- `title?` — label shown in Deno metadata
+- `region?` — region like `ord` or `ams`
+- `timeout?` — concrete lifetime like `20m` or `600s`
+- `memory_mb?` — memory in MiB
+- `allow_net?` — outbound allowlist entries
+
+Returns: `{ sandbox_id, region, workspace_path, status, timeout }`
+
+### `deno_exec`
+
+Run a shell command with `bash -lc` inside a sandbox.
+
+Parameters:
+- `sandbox_id`
+- `command`
+- `cwd?`
+
+Returns: `{ exit_code, stdout, stderr, output }`
+
+### `deno_read_file`
+
+Read a text file from the sandbox.
+
+Parameters: `sandbox_id`, `path`
+
+Returns: `{ path, content }`
+
+### `deno_write_file`
+
+Write a text file into the sandbox.
+
+Parameters: `sandbox_id`, `path`, `content`
+
+Returns: `{ path, success }`
+
+### `deno_list_sandboxes`
+
+List session-owned sandboxes from persisted session state.
+
+Returns: `{ sandboxes, count }`
+
+### `deno_manage_sandbox`
+
+Delete a sandbox.
+
+Parameters: `sandbox_id`, `action="delete"`
+
+Returns: `{ sandbox_id, action, success }`
+
+## Design decisions
+
+### Concrete timeout required
+
+Deno's default sandbox lifetime is `session`, meaning the sandbox dies when the creator websocket disconnects. Everruns closes the creator websocket after each tool call, so sandboxes must be created with a concrete timeout (for example `20m`). `deno_create_sandbox` rejects `timeout="session"`.
+
+### Session-owned listing
+
+Like Daytona, Everruns lists only sandboxes created in the current session by reading session secret state. This avoids cross-session leakage and does not depend on remote label filtering for correctness.
+
+### Leased-resource cleanup
+
+Each created Deno sandbox registers a leased resource with provider `deno` and type `sandbox`. Cleanup deletes the sandbox remotely, then removes the session secret. The lease metadata stores the non-secret region and optional org slug so cleanup can reconnect to the correct Deno control plane without depending on unrelated process env state.
+
+## Security
+
+Reviewed categories:
+- `TM-TOOL` — new tool registration and websocket RPC execution path
+- `TM-AGENT-019` / high-risk execution — remote compute with network access
+- `TM-DOS` — fixed timeout prevents unbounded sandbox lifetime from idle sessions
+
+Threat summary:
+- Sandboxes have network access by design; capability is high-risk and Admin-gated.
+- Tokens are resolved from user connections or operator env vars and never stored in sandbox state.
+- Session isolation relies on per-session secret names and leased-resource ownership.
+
+See `specs/threat-model.md` for the Deno-specific threat section.

--- a/integrations/deno/src/client.rs
+++ b/integrations/deno/src/client.rs
@@ -615,10 +615,18 @@ impl DenoSandboxSession {
         while !collectors.is_complete() {
             let next = match timeout(self.stream_idle_timeout, self.ws.next()).await {
                 Ok(message) => message,
-                Err(_) => break,
+                Err(_) => {
+                    return Err(format!(
+                        "Timed out waiting for Deno sandbox streams to finish: {}",
+                        collectors.pending_streams().join(", ")
+                    ));
+                }
             };
             let Some(message) = next else {
-                break;
+                return Err(format!(
+                    "Deno sandbox websocket closed before streams completed: {}",
+                    collectors.pending_streams().join(", ")
+                ));
             };
             let message = message.map_err(|e| format!("Deno sandbox websocket error: {e}"))?;
             if let Some(value) = decode_message(message)?
@@ -627,7 +635,6 @@ impl DenoSandboxSession {
                 collectors.handle_notification(notification_method, value.get("params"));
             }
         }
-        collectors.finish_missing();
         Ok(())
     }
 }
@@ -727,15 +734,6 @@ impl StreamCollectors {
                 .is_none_or(StreamCollector::is_complete)
     }
 
-    fn finish_missing(&mut self) {
-        if let Some(stdout) = &mut self.stdout {
-            stdout.ended = true;
-        }
-        if let Some(stderr) = &mut self.stderr {
-            stderr.ended = true;
-        }
-    }
-
     fn stdout_string(&self) -> String {
         self.stdout
             .as_ref()
@@ -766,6 +764,25 @@ impl StreamCollectors {
             return self.stderr.as_mut();
         }
         None
+    }
+
+    fn pending_streams(&self) -> Vec<&'static str> {
+        let mut pending = Vec::new();
+        if self
+            .stdout
+            .as_ref()
+            .is_some_and(|stream| !stream.is_complete())
+        {
+            pending.push("stdout");
+        }
+        if self
+            .stderr
+            .as_ref()
+            .is_some_and(|stream| !stream.is_complete())
+        {
+            pending.push("stderr");
+        }
+        pending
     }
 }
 
@@ -826,6 +843,15 @@ mod tests {
 
         assert!(collectors.is_complete());
         assert_eq!(collectors.stdout_string(), "hello");
+    }
+
+    #[test]
+    fn stream_collectors_report_pending_stream_names() {
+        let mut collectors = StreamCollectors::new(Some(7), Some(8));
+        collectors.handle_notification("$sandbox.stream.start", Some(&json!({"streamId": 7})));
+        collectors.handle_notification("$sandbox.stream.end", Some(&json!({"streamId": 7})));
+
+        assert_eq!(collectors.pending_streams(), vec!["stderr"]);
     }
 
     #[test]

--- a/integrations/deno/src/client.rs
+++ b/integrations/deno/src/client.rs
@@ -371,10 +371,15 @@ impl DenoClient {
             json!(request.memory_mb.unwrap_or(DENO_DEFAULT_MEMORY_MB)),
         );
         if let Some(timeout_seconds) = request.timeout_seconds {
-            config.insert(
-                "stop_at_ms".to_string(),
-                json!(chrono::Utc::now().timestamp_millis() + (timeout_seconds as i64 * 1000)),
-            );
+            let timeout_ms = i64::try_from(timeout_seconds)
+                .ok()
+                .and_then(|s| s.checked_mul(1000))
+                .ok_or_else(|| "Requested timeout is too large".to_string())?;
+            let stop_at_ms = chrono::Utc::now()
+                .timestamp_millis()
+                .checked_add(timeout_ms)
+                .ok_or_else(|| "Requested timeout is too large".to_string())?;
+            config.insert("stop_at_ms".to_string(), json!(stop_at_ms));
         }
         if !request.labels.is_empty() {
             config.insert("labels".to_string(), Value::Object(request.labels.clone()));

--- a/integrations/deno/src/client.rs
+++ b/integrations/deno/src/client.rs
@@ -1,0 +1,842 @@
+//! Deno Sandbox API client.
+//!
+//! Decision: use the public websocket sandbox API directly so the worker only
+//! needs Rust dependencies at runtime.
+//! Decision: open a fresh websocket per tool call; operations are short-lived
+//! and this keeps session state small and deterministic.
+
+use base64::Engine;
+use futures_util::{SinkExt, StreamExt};
+use http::Request;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use tokio::net::TcpStream;
+use tokio::time::{Duration, timeout};
+use tokio_tungstenite::{
+    MaybeTlsStream, WebSocketStream, client_async_tls,
+    tungstenite::{self, Message, client::IntoClientRequest},
+};
+
+use crate::{
+    DENO_CONSOLE_API_BASE, DENO_DEFAULT_MEMORY_MB, DENO_RPC_TIMEOUT, DENO_SANDBOX_BASE_DOMAIN,
+    DENO_STREAM_IDLE_TIMEOUT, DENO_WORKSPACE_PATH,
+};
+
+const DEFAULT_REGION: &str = "ord";
+
+type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+async fn connect_async_all_addrs(
+    request: Request<()>,
+) -> Result<(WsStream, http::Response<Option<Vec<u8>>>), String> {
+    let uri = request.uri().clone();
+    let host = uri
+        .host()
+        .ok_or_else(|| "Missing websocket host".to_string())?
+        .to_string();
+    let port = uri
+        .port_u16()
+        .unwrap_or(if uri.scheme_str() == Some("wss") {
+            443
+        } else {
+            80
+        });
+
+    if let Some(proxy) = proxy_url_for_scheme(uri.scheme_str())? {
+        let stream = connect_via_http_proxy(&proxy, &host, port).await?;
+        return client_async_tls(request, stream)
+            .await
+            .map_err(map_ws_error);
+    }
+
+    let mut last_error = None;
+    let addrs = tokio::net::lookup_host((host.as_str(), port))
+        .await
+        .map_err(|e| format!("Failed to resolve Deno sandbox host {host}:{port}: {e}"))?;
+
+    for addr in addrs {
+        match TcpStream::connect(addr).await {
+            Ok(stream) => match client_async_tls(request.clone(), stream).await {
+                Ok((ws, response)) => return Ok((ws, response)),
+                Err(error) => last_error = Some(map_ws_error(error)),
+            },
+            Err(error) => {
+                last_error = Some(format!(
+                    "Failed to connect to Deno sandbox websocket address {addr}: {error}"
+                ))
+            }
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| "Failed to connect to any Deno sandbox address".to_string()))
+}
+
+fn proxy_url_for_scheme(scheme: Option<&str>) -> Result<Option<reqwest::Url>, String> {
+    let candidates = match scheme {
+        Some("wss") | Some("https") => ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"],
+        _ => ["HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"],
+    };
+
+    for key in candidates {
+        if let Ok(value) = std::env::var(key)
+            && !value.is_empty()
+        {
+            let url = reqwest::Url::parse(&value)
+                .map_err(|e| format!("Invalid proxy URL in {key}: {e}"))?;
+            return Ok(Some(url));
+        }
+    }
+
+    Ok(None)
+}
+
+async fn connect_via_http_proxy(
+    proxy: &reqwest::Url,
+    target_host: &str,
+    target_port: u16,
+) -> Result<TcpStream, String> {
+    let proxy_host = proxy
+        .host_str()
+        .ok_or_else(|| "Proxy URL missing host".to_string())?;
+    let proxy_port = proxy.port_or_known_default().unwrap_or(8080);
+    let mut stream = TcpStream::connect((proxy_host, proxy_port))
+        .await
+        .map_err(|e| format!("Failed to connect to proxy {proxy_host}:{proxy_port}: {e}"))?;
+
+    let connect_request = format!(
+        "CONNECT {target_host}:{target_port} HTTP/1.1\r\nHost: {target_host}:{target_port}\r\n\r\n"
+    );
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    stream
+        .write_all(connect_request.as_bytes())
+        .await
+        .map_err(|e| format!("Failed to write proxy CONNECT request: {e}"))?;
+
+    let mut response = Vec::new();
+    let mut buf = [0u8; 1024];
+    loop {
+        let read = stream
+            .read(&mut buf)
+            .await
+            .map_err(|e| format!("Failed to read proxy CONNECT response: {e}"))?;
+        if read == 0 {
+            break;
+        }
+        response.extend_from_slice(&buf[..read]);
+        if response.windows(4).any(|window| window == b"\r\n\r\n") {
+            break;
+        }
+        if response.len() > 16 * 1024 {
+            return Err("Proxy CONNECT response too large".to_string());
+        }
+    }
+
+    let response_text = String::from_utf8_lossy(&response);
+    let status_line = response_text.lines().next().unwrap_or_default();
+    if !status_line.contains(" 200 ") {
+        return Err(format!("Proxy CONNECT failed: {status_line}"));
+    }
+
+    Ok(stream)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DenoSandboxMetadata {
+    pub id: String,
+    pub region: String,
+    pub status: String,
+    #[serde(default)]
+    pub labels: serde_json::Map<String, Value>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateSandboxRequest {
+    pub region: Option<String>,
+    pub timeout_seconds: Option<u64>,
+    pub memory_mb: Option<u64>,
+    pub labels: serde_json::Map<String, Value>,
+    pub allow_net: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreatedSandbox {
+    pub sandbox_id: String,
+    pub region: String,
+    pub workspace_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecOutput {
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+pub struct DenoClient {
+    http: reqwest::Client,
+    token: String,
+    org: Option<String>,
+    console_api_base: String,
+    sandbox_base_domain: String,
+    rpc_timeout: Duration,
+    stream_idle_timeout: Duration,
+}
+
+impl DenoClient {
+    pub fn new(token: String, org: Option<String>) -> Self {
+        Self::with_endpoints(
+            token,
+            org,
+            DENO_CONSOLE_API_BASE.to_string(),
+            DENO_SANDBOX_BASE_DOMAIN.to_string(),
+        )
+    }
+
+    pub fn with_endpoints(
+        token: String,
+        org: Option<String>,
+        console_api_base: String,
+        sandbox_base_domain: String,
+    ) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            token,
+            org,
+            console_api_base,
+            sandbox_base_domain,
+            rpc_timeout: DENO_RPC_TIMEOUT,
+            stream_idle_timeout: DENO_STREAM_IDLE_TIMEOUT,
+        }
+    }
+
+    pub fn org(&self) -> Option<&str> {
+        self.org.as_deref()
+    }
+
+    pub async fn create_sandbox(
+        &self,
+        request: CreateSandboxRequest,
+    ) -> Result<CreatedSandbox, String> {
+        let region = request
+            .region
+            .clone()
+            .unwrap_or_else(|| DEFAULT_REGION.to_string());
+        let mut session = self.open_create_session(&region, &request).await?;
+        session.close().await?;
+        Ok(CreatedSandbox {
+            sandbox_id: session.sandbox_id,
+            region,
+            workspace_path: DENO_WORKSPACE_PATH.to_string(),
+        })
+    }
+
+    pub async fn exec(
+        &self,
+        sandbox_id: &str,
+        region: &str,
+        command: &str,
+        cwd: Option<&str>,
+    ) -> Result<ExecOutput, String> {
+        let mut session = self.connect_sandbox(sandbox_id, region).await?;
+        let output = session.exec(command, cwd).await;
+        session.close().await?;
+        output
+    }
+
+    pub async fn read_text_file(
+        &self,
+        sandbox_id: &str,
+        region: &str,
+        path: &str,
+    ) -> Result<String, String> {
+        let mut session = self.connect_sandbox(sandbox_id, region).await?;
+        let result = session.read_text_file(path).await;
+        session.close().await?;
+        result
+    }
+
+    pub async fn write_text_file(
+        &self,
+        sandbox_id: &str,
+        region: &str,
+        path: &str,
+        content: &str,
+    ) -> Result<(), String> {
+        let mut session = self.connect_sandbox(sandbox_id, region).await?;
+        let result = session.write_text_file(path, content).await;
+        session.close().await?;
+        result
+    }
+
+    pub async fn delete_sandbox(&self, sandbox_id: &str, region: &str) -> Result<(), String> {
+        let url = format!(
+            "https://{}.{}/api/v3/sandbox/{}",
+            region, self.sandbox_base_domain, sandbox_id
+        );
+        let mut req = self.http.delete(url).bearer_auth(&self.token);
+        if let Some(org) = &self.org {
+            req = req.header("X-Deno-Org", org);
+        }
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| format!("Failed to connect to Deno sandbox API: {e}"))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!("Deno sandbox delete error ({status}): {body}"));
+        }
+        Ok(())
+    }
+
+    pub async fn list_sandboxes(
+        &self,
+        labels: &std::collections::BTreeMap<String, String>,
+    ) -> Result<Vec<DenoSandboxMetadata>, String> {
+        let mut url = format!("{}/api/v2/sandboxes", self.console_api_base);
+        if !labels.is_empty() {
+            let query = labels
+                .iter()
+                .map(|(key, value)| {
+                    format!(
+                        "labels[{}]={}",
+                        urlencoding::encode(key),
+                        urlencoding::encode(value)
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("&");
+            url.push('?');
+            url.push_str(&query);
+        }
+
+        let mut req = self.http.get(url).bearer_auth(&self.token);
+        if let Some(org) = &self.org {
+            req = req.header("X-Deno-Org", org);
+        }
+
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| format!("Failed to connect to Deno Deploy API: {e}"))?;
+        let status = resp.status();
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| format!("Failed to read response: {e}"))?;
+        if !status.is_success() {
+            return Err(format!("Deno Deploy API error ({status}): {body}"));
+        }
+
+        let values: Vec<Value> = serde_json::from_str(&body)
+            .map_err(|e| format!("Invalid JSON from Deno Deploy API: {e}"))?;
+        values
+            .into_iter()
+            .map(|value| {
+                let labels = value
+                    .get("labels")
+                    .and_then(Value::as_object)
+                    .cloned()
+                    .unwrap_or_default();
+                Ok(DenoSandboxMetadata {
+                    id: value
+                        .get("id")
+                        .and_then(Value::as_str)
+                        .ok_or_else(|| "Missing sandbox id".to_string())?
+                        .to_string(),
+                    region: value
+                        .get("region")
+                        .and_then(Value::as_str)
+                        .unwrap_or(DEFAULT_REGION)
+                        .to_string(),
+                    status: value
+                        .get("status")
+                        .and_then(Value::as_str)
+                        .unwrap_or("unknown")
+                        .to_string(),
+                    labels,
+                })
+            })
+            .collect()
+    }
+
+    async fn open_create_session(
+        &self,
+        region: &str,
+        request: &CreateSandboxRequest,
+    ) -> Result<DenoSandboxSession, String> {
+        let mut config = serde_json::Map::new();
+        config.insert(
+            "memory_mb".to_string(),
+            json!(request.memory_mb.unwrap_or(DENO_DEFAULT_MEMORY_MB)),
+        );
+        if let Some(timeout_seconds) = request.timeout_seconds {
+            config.insert(
+                "stop_at_ms".to_string(),
+                json!(chrono::Utc::now().timestamp_millis() + (timeout_seconds as i64 * 1000)),
+            );
+        }
+        if !request.labels.is_empty() {
+            config.insert("labels".to_string(), Value::Object(request.labels.clone()));
+        }
+        if !request.allow_net.is_empty() {
+            config.insert("allow_net".to_string(), json!(request.allow_net));
+        }
+
+        let url = format!(
+            "wss://{}.{}/api/v3/sandboxes/create",
+            region, self.sandbox_base_domain
+        );
+        self.connect_websocket(url, Some(Value::Object(config)))
+            .await
+    }
+
+    async fn connect_sandbox(
+        &self,
+        sandbox_id: &str,
+        region: &str,
+    ) -> Result<DenoSandboxSession, String> {
+        let url = format!(
+            "wss://{}.{}/api/v3/sandbox/{}/connect",
+            region, self.sandbox_base_domain, sandbox_id
+        );
+        self.connect_websocket(url, None).await
+    }
+
+    async fn connect_websocket(
+        &self,
+        url: String,
+        config: Option<Value>,
+    ) -> Result<DenoSandboxSession, String> {
+        let mut request = url
+            .as_str()
+            .into_client_request()
+            .map_err(|e| format!("Invalid websocket request: {e}"))?;
+        request.headers_mut().insert(
+            "Authorization",
+            format!("Bearer {}", self.token)
+                .parse()
+                .map_err(|e| format!("Invalid Authorization header: {e}"))?,
+        );
+        if let Some(org) = &self.org {
+            request.headers_mut().insert(
+                "X-Deno-Org",
+                org.parse()
+                    .map_err(|e| format!("Invalid X-Deno-Org header: {e}"))?,
+            );
+        }
+        if let Some(config) = config {
+            let encoded = base64::engine::general_purpose::STANDARD.encode(config.to_string());
+            request.headers_mut().insert(
+                "x-deno-sandbox-config",
+                encoded
+                    .parse()
+                    .map_err(|e| format!("Invalid x-deno-sandbox-config header: {e}"))?,
+            );
+        }
+        let (ws, response) = connect_async_all_addrs(request).await?;
+        let sandbox_id = response
+            .headers()
+            .get("x-deno-sandbox-id")
+            .and_then(|v| v.to_str().ok())
+            .ok_or_else(|| "Deno sandbox connect response missing x-deno-sandbox-id".to_string())?
+            .to_string();
+        Ok(DenoSandboxSession::new(
+            ws,
+            sandbox_id,
+            self.rpc_timeout,
+            self.stream_idle_timeout,
+        ))
+    }
+}
+
+struct DenoSandboxSession {
+    ws: WsStream,
+    sandbox_id: String,
+    next_request_id: u64,
+    rpc_timeout: Duration,
+    stream_idle_timeout: Duration,
+}
+
+impl DenoSandboxSession {
+    fn new(
+        ws: WsStream,
+        sandbox_id: String,
+        rpc_timeout: Duration,
+        stream_idle_timeout: Duration,
+    ) -> Self {
+        Self {
+            ws,
+            sandbox_id,
+            next_request_id: 1,
+            rpc_timeout,
+            stream_idle_timeout,
+        }
+    }
+
+    async fn close(&mut self) -> Result<(), String> {
+        self.ws
+            .close(None)
+            .await
+            .map_err(|e| format!("Failed to close Deno sandbox websocket: {e}"))
+    }
+
+    async fn exec(&mut self, command: &str, cwd: Option<&str>) -> Result<ExecOutput, String> {
+        let mut spawn = serde_json::Map::new();
+        spawn.insert("command".to_string(), json!("bash"));
+        spawn.insert("args".to_string(), json!(["-lc", command]));
+        spawn.insert("stdout".to_string(), json!("piped"));
+        spawn.insert("stderr".to_string(), json!("piped"));
+        if let Some(cwd) = cwd {
+            spawn.insert("cwd".to_string(), json!(cwd));
+        }
+
+        let result = self.call("spawn", Value::Object(spawn), None).await?;
+        let ok = extract_ok(result)?;
+        let pid = ok
+            .get("pid")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| "Deno sandbox spawn response missing pid".to_string())?;
+        let stdout_id = ok.get("stdoutStreamId").and_then(Value::as_u64);
+        let stderr_id = ok.get("stderrStreamId").and_then(Value::as_u64);
+
+        let mut collectors = StreamCollectors::new(stdout_id, stderr_id);
+        let wait_result = self
+            .call("processWait", json!({ "pid": pid }), Some(&mut collectors))
+            .await?;
+        self.drain_streams(&mut collectors).await?;
+
+        let wait_ok = extract_ok(wait_result)?;
+        let exit_code = wait_ok
+            .get("code")
+            .and_then(Value::as_i64)
+            .ok_or_else(|| "Deno sandbox processWait response missing code".to_string())?
+            as i32;
+
+        Ok(ExecOutput {
+            exit_code,
+            stdout: collectors.stdout_string(),
+            stderr: collectors.stderr_string(),
+        })
+    }
+
+    async fn read_text_file(&mut self, path: &str) -> Result<String, String> {
+        let result = self
+            .call("readFile", json!({ "path": path, "abortId": null }), None)
+            .await?;
+        let ok = extract_ok(result)?;
+        let encoded = ok
+            .as_str()
+            .ok_or_else(|| "Deno sandbox readFile response must be a base64 string".to_string())?;
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .map_err(|e| format!("Failed to decode Deno sandbox file bytes: {e}"))?;
+        Ok(String::from_utf8_lossy(&bytes).to_string())
+    }
+
+    async fn write_text_file(&mut self, path: &str, content: &str) -> Result<(), String> {
+        let result = self
+            .call(
+                "writeTextFile",
+                json!({
+                    "path": path,
+                    "abortId": null,
+                    "options": null,
+                    "content": content,
+                }),
+                None,
+            )
+            .await?;
+        let _ = extract_ok(result)?;
+        Ok(())
+    }
+
+    async fn call(
+        &mut self,
+        method: &str,
+        params: Value,
+        mut collectors: Option<&mut StreamCollectors>,
+    ) -> Result<Value, String> {
+        let request_id = self.next_request_id;
+        self.next_request_id += 1;
+
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params,
+        });
+        self.ws
+            .send(Message::Text(request.to_string().into()))
+            .await
+            .map_err(|e| format!("Failed to send Deno sandbox RPC '{method}': {e}"))?;
+
+        loop {
+            let next = timeout(self.rpc_timeout, self.ws.next())
+                .await
+                .map_err(|_| format!("Timed out waiting for Deno sandbox RPC '{method}'"))?;
+            let Some(message) = next else {
+                return Err("Deno sandbox websocket closed unexpectedly".to_string());
+            };
+            let message = message.map_err(|e| format!("Deno sandbox websocket error: {e}"))?;
+
+            if let Some(value) = decode_message(message)? {
+                if let Some(notification_method) = value.get("method").and_then(Value::as_str) {
+                    if let Some(active) = collectors.as_deref_mut() {
+                        active.handle_notification(notification_method, value.get("params"));
+                    }
+                    continue;
+                }
+
+                let Some(id) = value.get("id").and_then(Value::as_u64) else {
+                    continue;
+                };
+                if id != request_id {
+                    continue;
+                }
+                if let Some(error) = value.get("error") {
+                    return Err(format!(
+                        "Deno sandbox JSON-RPC error: {}",
+                        error
+                            .get("message")
+                            .and_then(Value::as_str)
+                            .unwrap_or("unknown error")
+                    ));
+                }
+                return value
+                    .get("result")
+                    .cloned()
+                    .ok_or_else(|| format!("Deno sandbox RPC '{method}' missing result"));
+            }
+        }
+    }
+
+    async fn drain_streams(&mut self, collectors: &mut StreamCollectors) -> Result<(), String> {
+        while !collectors.is_complete() {
+            let next = match timeout(self.stream_idle_timeout, self.ws.next()).await {
+                Ok(message) => message,
+                Err(_) => break,
+            };
+            let Some(message) = next else {
+                break;
+            };
+            let message = message.map_err(|e| format!("Deno sandbox websocket error: {e}"))?;
+            if let Some(value) = decode_message(message)?
+                && let Some(notification_method) = value.get("method").and_then(Value::as_str)
+            {
+                collectors.handle_notification(notification_method, value.get("params"));
+            }
+        }
+        collectors.finish_missing();
+        Ok(())
+    }
+}
+
+fn extract_ok(result: Value) -> Result<Value, String> {
+    if let Some(ok) = result.get("ok") {
+        return Ok(ok.clone());
+    }
+    if let Some(error) = result.get("error") {
+        let message = error
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown Deno sandbox error");
+        return Err(message.to_string());
+    }
+    Err("Malformed Deno sandbox result".to_string())
+}
+
+fn decode_message(message: Message) -> Result<Option<Value>, String> {
+    match message {
+        Message::Text(text) => serde_json::from_str(&text)
+            .map(Some)
+            .map_err(|e| format!("Invalid JSON from Deno sandbox websocket: {e}")),
+        Message::Binary(bytes) => serde_json::from_slice(&bytes)
+            .map(Some)
+            .map_err(|e| format!("Invalid binary JSON from Deno sandbox websocket: {e}")),
+        Message::Ping(_) | Message::Pong(_) => Ok(None),
+        Message::Close(_) => Ok(None),
+        Message::Frame(_) => Ok(None),
+    }
+}
+
+fn map_ws_error(error: tungstenite::Error) -> String {
+    match error {
+        tungstenite::Error::Http(response) => {
+            format!("Deno sandbox websocket HTTP error: {}", response.status())
+        }
+        other => format!("Failed to connect to Deno sandbox websocket: {other}"),
+    }
+}
+
+#[derive(Default)]
+struct StreamCollectors {
+    stdout: Option<StreamCollector>,
+    stderr: Option<StreamCollector>,
+}
+
+impl StreamCollectors {
+    fn new(stdout_id: Option<u64>, stderr_id: Option<u64>) -> Self {
+        Self {
+            stdout: stdout_id.map(StreamCollector::new),
+            stderr: stderr_id.map(StreamCollector::new),
+        }
+    }
+
+    fn handle_notification(&mut self, method: &str, params: Option<&Value>) {
+        let Some(params) = params else {
+            return;
+        };
+        let stream_id = params.get("streamId").and_then(Value::as_u64);
+        let Some(stream_id) = stream_id else {
+            return;
+        };
+        let Some(target) = self.stream_mut(stream_id) else {
+            return;
+        };
+
+        match method {
+            "$sandbox.stream.start" => target.started = true,
+            "$sandbox.stream.enqueue" => {
+                if let Some(encoded) = params.get("data").and_then(Value::as_str)
+                    && let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(encoded)
+                {
+                    target.buffer.extend_from_slice(&bytes);
+                }
+            }
+            "$sandbox.stream.end" => target.ended = true,
+            "$sandbox.stream.error" => {
+                target.ended = true;
+                target.error = params
+                    .get("error")
+                    .and_then(|v| v.get("message"))
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned);
+            }
+            _ => {}
+        }
+    }
+
+    fn is_complete(&self) -> bool {
+        self.stdout
+            .as_ref()
+            .is_none_or(StreamCollector::is_complete)
+            && self
+                .stderr
+                .as_ref()
+                .is_none_or(StreamCollector::is_complete)
+    }
+
+    fn finish_missing(&mut self) {
+        if let Some(stdout) = &mut self.stdout {
+            stdout.ended = true;
+        }
+        if let Some(stderr) = &mut self.stderr {
+            stderr.ended = true;
+        }
+    }
+
+    fn stdout_string(&self) -> String {
+        self.stdout
+            .as_ref()
+            .map(StreamCollector::as_string)
+            .unwrap_or_default()
+    }
+
+    fn stderr_string(&self) -> String {
+        self.stderr
+            .as_ref()
+            .map(StreamCollector::as_string)
+            .unwrap_or_default()
+    }
+
+    fn stream_mut(&mut self, stream_id: u64) -> Option<&mut StreamCollector> {
+        if self
+            .stdout
+            .as_ref()
+            .is_some_and(|stream| stream.id == stream_id)
+        {
+            return self.stdout.as_mut();
+        }
+        if self
+            .stderr
+            .as_ref()
+            .is_some_and(|stream| stream.id == stream_id)
+        {
+            return self.stderr.as_mut();
+        }
+        None
+    }
+}
+
+struct StreamCollector {
+    id: u64,
+    started: bool,
+    ended: bool,
+    buffer: Vec<u8>,
+    error: Option<String>,
+}
+
+impl StreamCollector {
+    fn new(id: u64) -> Self {
+        Self {
+            id,
+            started: false,
+            ended: false,
+            buffer: Vec::new(),
+            error: None,
+        }
+    }
+
+    fn is_complete(&self) -> bool {
+        self.ended
+    }
+
+    fn as_string(&self) -> String {
+        let mut text = String::from_utf8_lossy(&self.buffer).to_string();
+        if let Some(error) = &self.error {
+            if !text.is_empty() && !text.ends_with('\n') {
+                text.push('\n');
+            }
+            text.push_str(error);
+        }
+        text
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_ok_handles_error_wrapper() {
+        let err = extract_ok(json!({"error": {"message": "boom"}})).unwrap_err();
+        assert_eq!(err, "boom");
+    }
+
+    #[test]
+    fn stream_collectors_decode_base64_notifications() {
+        let mut collectors = StreamCollectors::new(Some(7), None);
+        collectors.handle_notification("$sandbox.stream.start", Some(&json!({"streamId": 7})));
+        collectors.handle_notification(
+            "$sandbox.stream.enqueue",
+            Some(&json!({"streamId": 7, "data": "aGVsbG8="})),
+        );
+        collectors.handle_notification("$sandbox.stream.end", Some(&json!({"streamId": 7})));
+
+        assert!(collectors.is_complete());
+        assert_eq!(collectors.stdout_string(), "hello");
+    }
+
+    #[test]
+    fn create_request_defaults_are_reasonable() {
+        let request = CreateSandboxRequest {
+            region: None,
+            timeout_seconds: Some(1200),
+            memory_mb: None,
+            labels: serde_json::Map::new(),
+            allow_net: vec![],
+        };
+        assert_eq!(request.memory_mb.unwrap_or(DENO_DEFAULT_MEMORY_MB), 1_280);
+    }
+}

--- a/integrations/deno/src/connection.rs
+++ b/integrations/deno/src/connection.rs
@@ -1,0 +1,90 @@
+// Deno Deploy connection provider.
+//
+// Decision: expose token + optional org slug because Deno personal tokens need
+// an org, while org tokens do not.
+
+use crate::client::DenoClient;
+use async_trait::async_trait;
+use everruns_core::connection_provider::{
+    ConnectionFormSchema, ConnectionProvider, ConnectionType, ConnectionValidation, FieldType,
+    FormField,
+};
+
+pub struct DenoConnectionProvider;
+
+#[async_trait]
+impl ConnectionProvider for DenoConnectionProvider {
+    fn provider_id(&self) -> &str {
+        "deno"
+    }
+
+    fn display_name(&self) -> &str {
+        "Deno Deploy"
+    }
+
+    fn description(&self) -> &str {
+        "Deno Sandboxes for code execution"
+    }
+
+    fn icon(&self) -> &str {
+        "server"
+    }
+
+    fn connection_type(&self) -> ConnectionType {
+        ConnectionType::ApiKey
+    }
+
+    fn form_schema(&self) -> Option<ConnectionFormSchema> {
+        Some(ConnectionFormSchema {
+            fields: vec![FormField {
+                name: "api_key".to_string(),
+                label: "Access Token".to_string(),
+                field_type: FieldType::Password,
+                required: true,
+                placeholder: Some("ddo_...".to_string()),
+                help_text: Some("Use an organization token. Personal tokens require org metadata that the generic API-key flow does not store yet.".to_string()),
+            }],
+            instructions_markdown: "1. Go to [Deno Deploy Sandbox](https://console.deno.com)\n2. Create an organization access token (`ddo_...`)\n3. Paste the token below"
+                .to_string(),
+        })
+    }
+
+    async fn validate(&self, credential: &str) -> Result<ConnectionValidation, String> {
+        if credential.starts_with("ddp_") {
+            return Err(
+                "Personal Deno tokens are not supported in the generic connection flow yet. Use an organization token (ddo_...).".to_string(),
+            );
+        }
+
+        let client = DenoClient::new(credential.to_string(), None);
+        client
+            .list_sandboxes(&std::collections::BTreeMap::new())
+            .await?;
+        Ok(ConnectionValidation {
+            provider_username: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_provider_metadata() {
+        let provider = DenoConnectionProvider;
+        assert_eq!(provider.provider_id(), "deno");
+        assert_eq!(provider.display_name(), "Deno Deploy");
+        assert_eq!(provider.connection_type(), ConnectionType::ApiKey);
+        assert_eq!(provider.icon(), "server");
+    }
+
+    #[test]
+    fn test_form_schema() {
+        let provider = DenoConnectionProvider;
+        let schema = provider.form_schema().expect("schema");
+        assert_eq!(schema.fields.len(), 1);
+        assert_eq!(schema.fields[0].name, "api_key");
+        assert!(schema.instructions_markdown.contains("console.deno.com"));
+    }
+}

--- a/integrations/deno/src/connection.rs
+++ b/integrations/deno/src/connection.rs
@@ -1,7 +1,8 @@
 // Deno Deploy connection provider.
 //
-// Decision: expose token + optional org slug because Deno personal tokens need
-// an org, while org tokens do not.
+// Decision: this generic connection uses a single organization access token
+// (`ddo_...`). Personal tokens (`ddp_...`) that require org metadata are not
+// supported here yet.
 
 use crate::client::DenoClient;
 use async_trait::async_trait;

--- a/integrations/deno/src/lib.rs
+++ b/integrations/deno/src/lib.rs
@@ -1,0 +1,151 @@
+//! Deno Sandbox Integration.
+//!
+//! Cloud-based sandboxed code execution via Deno Sandboxes.
+//! Supports multiple sandboxes per session, each identified by `sandbox_id`.
+//!
+//! Decision: model the public tool surface after Daytona so agents can switch
+//! between cloud sandboxes with minimal prompt changes.
+//! Decision: prefer user connections, but allow `DENO_DEPLOY_TOKEN` /
+//! `DENO_DEPLOY_ORG` env fallbacks for operator-managed deployments and live tests.
+//! Decision: create sandboxes with a fixed timeout instead of Deno's default
+//! `session` lifetime because Everruns closes the creator websocket after each tool.
+
+pub mod client;
+pub mod connection;
+pub mod state;
+mod tools;
+
+use everruns_core::LEASED_RESOURCES_FEATURE;
+use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin, RiskLevel};
+use everruns_core::connection_provider::ConnectionProviderPlugin;
+use everruns_core::tools::Tool;
+use std::time::Duration;
+
+use connection::DenoConnectionProvider;
+use tools::{
+    DenoCreateSandboxTool, DenoExecTool, DenoListSandboxesTool, DenoManageSandboxTool,
+    DenoReadFileTool, DenoWriteFileTool,
+};
+
+inventory::submit! {
+    IntegrationPlugin {
+        experimental_only: false,
+        factory: || Box::new(DenoCapability),
+    }
+}
+
+inventory::submit! {
+    ConnectionProviderPlugin {
+        experimental_only: true,
+        factory: || Box::new(DenoConnectionProvider),
+    }
+}
+
+const DENO_CONSOLE_API_BASE: &str = "https://console.deno.com";
+const DENO_SANDBOX_BASE_DOMAIN: &str = "sandbox-api.deno.net";
+const DENO_SANDBOX_SECRET_PREFIX: &str = "deno_sandbox:";
+const DENO_SANDBOX_TIMEOUT: &str = "20m";
+const DENO_DEFAULT_MEMORY_MB: u64 = 1_280;
+const DENO_MAX_MEMORY_MB: u64 = 16 * 1_024;
+const DENO_RPC_TIMEOUT: Duration = Duration::from_secs(30);
+const DENO_STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(2);
+const DENO_WORKSPACE_PATH: &str = "/home/sandbox";
+
+pub struct DenoCapability;
+
+impl Capability for DenoCapability {
+    fn id(&self) -> &str {
+        "deno"
+    }
+
+    fn name(&self) -> &str {
+        "Deno Sandboxes"
+    }
+
+    fn description(&self) -> &str {
+        "Run code in cloud-based Deno sandboxes. Create isolated Linux microVMs, execute commands, and manage files. EXPERIMENTAL: This capability may change."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn risk_level(&self) -> RiskLevel {
+        RiskLevel::High
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("server")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Execution")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(
+            r#"## Deno Sandboxes
+
+Cloud-based sandboxes via Deno. Each sandbox is an isolated Linux microVM with network access.
+
+Authentication: Deno access token is resolved automatically from Settings > Connections > Deno Deploy.
+If not configured, guide the user to set it up in Settings > Connections.
+
+All tools except `deno_create_sandbox` and `deno_list_sandboxes` require a `sandbox_id`.
+Sandboxes are created with a fixed timeout because Everruns closes the create connection after each tool.
+Always DELETE sandboxes when done to avoid resource leaks.
+
+Use `deno_exec` for shell commands, `deno_write_file` / `deno_read_file` for files, and `deno_manage_sandbox` with action=`delete` for cleanup."#,
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(DenoCreateSandboxTool),
+            Box::new(DenoExecTool),
+            Box::new(DenoReadFileTool),
+            Box::new(DenoWriteFileTool),
+            Box::new(DenoListSandboxesTool),
+            Box::new(DenoManageSandboxTool),
+        ]
+    }
+
+    fn dependencies(&self) -> Vec<&'static str> {
+        vec!["session_storage"]
+    }
+
+    fn features(&self) -> Vec<&'static str> {
+        vec![LEASED_RESOURCES_FEATURE]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::capabilities::CapabilityStatus;
+
+    #[test]
+    fn test_capability_metadata() {
+        let cap = DenoCapability;
+        assert_eq!(cap.id(), "deno");
+        assert_eq!(cap.name(), "Deno Sandboxes");
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+        assert_eq!(cap.icon(), Some("server"));
+        assert_eq!(cap.category(), Some("Execution"));
+    }
+
+    #[test]
+    fn test_capability_has_all_tools() {
+        let cap = DenoCapability;
+        let tools = cap.tools();
+        assert_eq!(tools.len(), 6);
+
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(names.contains(&"deno_create_sandbox"));
+        assert!(names.contains(&"deno_exec"));
+        assert!(names.contains(&"deno_read_file"));
+        assert!(names.contains(&"deno_write_file"));
+        assert!(names.contains(&"deno_list_sandboxes"));
+        assert!(names.contains(&"deno_manage_sandbox"));
+    }
+}

--- a/integrations/deno/src/state.rs
+++ b/integrations/deno/src/state.rs
@@ -1,0 +1,275 @@
+//! Deno sandbox session state management.
+//!
+//! Decision: persist only non-secret sandbox metadata in session secrets; always
+//! resolve credentials fresh from user connections or operator env vars.
+
+use everruns_core::UpsertLeasedResource;
+use everruns_core::tools::ToolExecutionResult;
+use everruns_core::traits::ToolContext;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use tracing::{error, warn};
+
+use crate::DENO_SANDBOX_SECRET_PREFIX;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SandboxState {
+    pub sandbox_id: String,
+    pub region: String,
+    pub org: Option<String>,
+    pub workspace_path: String,
+    pub started_at: String,
+}
+
+pub const DENO_SANDBOX_LEASE_DURATION_SECONDS: u32 = 20 * 60;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DenoCredentials {
+    pub token: String,
+    pub org: Option<String>,
+}
+
+pub async fn get_credentials(
+    context: &ToolContext,
+) -> Result<DenoCredentials, ToolExecutionResult> {
+    if let Some(resolver) = context.connection_resolver.as_ref() {
+        match resolver
+            .get_connection_token(context.session_id, "deno")
+            .await
+        {
+            Ok(Some(token)) => {
+                return Ok(DenoCredentials { token, org: None });
+            }
+            Ok(None) => {}
+            Err(e) => error!("Failed to resolve Deno user connection: {e}"),
+        }
+    }
+
+    if let Ok(token) = std::env::var("DENO_DEPLOY_TOKEN")
+        && !token.is_empty()
+    {
+        let org = std::env::var("DENO_DEPLOY_ORG")
+            .ok()
+            .filter(|s| !s.is_empty());
+        if token.starts_with("ddp_") && org.is_none() {
+            return Err(ToolExecutionResult::tool_error(
+                "DENO_DEPLOY_TOKEN is a personal token (ddp_...) but DENO_DEPLOY_ORG is not set. Set DENO_DEPLOY_ORG or use an organization token (ddo_...).",
+            ));
+        }
+        return Ok(DenoCredentials { token, org });
+    }
+
+    // THREAT[TM-AGENT-016]: Asking for sandbox credentials in chat would store
+    // them plaintext in events. Return ConnectionRequired so the UI can render
+    // the inline connection flow instead of asking the user to paste secrets.
+    Err(ToolExecutionResult::connection_required("deno"))
+}
+
+pub async fn get_sandbox_state(
+    context: &ToolContext,
+    sandbox_id: &str,
+) -> Result<SandboxState, ToolExecutionResult> {
+    let storage = context
+        .storage_store
+        .as_ref()
+        .ok_or_else(|| ToolExecutionResult::tool_error("Storage not available in this context"))?;
+
+    let secret_name = format!("{DENO_SANDBOX_SECRET_PREFIX}{sandbox_id}");
+    let json_str = storage
+        .get_secret(context.session_id, &secret_name)
+        .await
+        .map_err(|e| {
+            error!("Failed to read Deno sandbox state: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to read sandbox state: {e}"))
+        })?
+        .ok_or_else(|| {
+            ToolExecutionResult::tool_error(format!(
+                "Sandbox '{sandbox_id}' not found. Create one first with deno_create_sandbox."
+            ))
+        })?;
+
+    serde_json::from_str(&json_str).map_err(|e| {
+        error!("Corrupt Deno sandbox state for {sandbox_id}: {e}");
+        ToolExecutionResult::internal_error_msg(format!("Corrupt sandbox state: {e}"))
+    })
+}
+
+pub async fn save_sandbox_state(
+    context: &ToolContext,
+    state: &SandboxState,
+) -> Result<(), ToolExecutionResult> {
+    let storage = context
+        .storage_store
+        .as_ref()
+        .ok_or_else(|| ToolExecutionResult::tool_error("Storage not available in this context"))?;
+
+    let secret_name = format!("{DENO_SANDBOX_SECRET_PREFIX}{}", state.sandbox_id);
+    let json_str = serde_json::to_string(state).map_err(|e| {
+        ToolExecutionResult::internal_error_msg(format!("Failed to serialize sandbox state: {e}"))
+    })?;
+
+    storage
+        .set_secret(context.session_id, &secret_name, &json_str)
+        .await
+        .map_err(|e| {
+            error!("Failed to save Deno sandbox state: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to save sandbox state: {e}"))
+        })
+}
+
+pub async fn delete_sandbox_state(
+    context: &ToolContext,
+    sandbox_id: &str,
+) -> Result<(), ToolExecutionResult> {
+    let storage = context
+        .storage_store
+        .as_ref()
+        .ok_or_else(|| ToolExecutionResult::tool_error("Storage not available in this context"))?;
+
+    storage
+        .delete_secret(
+            context.session_id,
+            &format!("{DENO_SANDBOX_SECRET_PREFIX}{sandbox_id}"),
+        )
+        .await
+        .map_err(|e| {
+            error!("Failed to delete Deno sandbox state: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to delete sandbox state: {e}"))
+        })?;
+    Ok(())
+}
+
+pub async fn list_sandbox_states(
+    context: &ToolContext,
+) -> Result<Vec<SandboxState>, ToolExecutionResult> {
+    let storage = context
+        .storage_store
+        .as_ref()
+        .ok_or_else(|| ToolExecutionResult::tool_error("Storage not available in this context"))?;
+
+    let secrets = storage
+        .list_secrets(context.session_id)
+        .await
+        .map_err(|e| {
+            error!("Failed to list secrets: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to list secrets: {e}"))
+        })?;
+
+    let mut states = Vec::new();
+    for secret_info in secrets {
+        if let Some(sandbox_id) = secret_info.name.strip_prefix(DENO_SANDBOX_SECRET_PREFIX) {
+            match get_sandbox_state(context, sandbox_id).await {
+                Ok(state) => states.push(state),
+                Err(_) => warn!("Skipping corrupt Deno sandbox state: {sandbox_id}"),
+            }
+        }
+    }
+
+    Ok(states)
+}
+
+pub async fn touch_sandbox_lease(
+    context: &ToolContext,
+    state: &SandboxState,
+    display_name: Option<String>,
+) -> Result<(), ToolExecutionResult> {
+    let Some(store) = context.leased_resource_store.as_ref() else {
+        return Ok(());
+    };
+
+    let owner_user_id = if let Some(resolver) = context.connection_resolver.as_ref() {
+        resolver
+            .get_connection_user(context.session_id, "deno")
+            .await
+            .ok()
+            .flatten()
+    } else {
+        None
+    };
+
+    store
+        .upsert_resource(UpsertLeasedResource {
+            session_id: context.session_id,
+            provider: "deno".to_string(),
+            resource_type: "sandbox".to_string(),
+            external_id: state.sandbox_id.clone(),
+            display_name,
+            owner_user_id,
+            lease_duration_seconds: DENO_SANDBOX_LEASE_DURATION_SECONDS,
+            // THREAT[TM-API-015]: leased-resource metadata is API-visible.
+            // Keep only non-secret routing/debug fields here. The access token
+            // still resolves from the user connection or operator env fallback.
+            metadata: json!({
+                "region": state.region,
+                "org": state.org,
+                "workspace_path": state.workspace_path,
+                "started_at": state.started_at,
+            }),
+        })
+        .await
+        .map_err(|e| {
+            error!("Failed to upsert Deno sandbox lease: {e}");
+            ToolExecutionResult::internal_error_msg(format!(
+                "Failed to update Deno sandbox lease: {e}"
+            ))
+        })?;
+
+    Ok(())
+}
+
+pub async fn release_sandbox_lease(
+    context: &ToolContext,
+    sandbox_id: &str,
+) -> Result<(), ToolExecutionResult> {
+    let Some(store) = context.leased_resource_store.as_ref() else {
+        return Ok(());
+    };
+
+    store
+        .release_resource(context.session_id, "deno", "sandbox", sandbox_id)
+        .await
+        .map_err(|e| {
+            error!("Failed to release Deno sandbox lease: {e}");
+            ToolExecutionResult::internal_error_msg(format!(
+                "Failed to release Deno sandbox lease: {e}"
+            ))
+        })?;
+
+    Ok(())
+}
+
+pub fn required_str<'a>(args: &'a Value, name: &str) -> Result<&'a str, ToolExecutionResult> {
+    args.get(name).and_then(|v| v.as_str()).ok_or_else(|| {
+        ToolExecutionResult::tool_error(format!("Missing required parameter: {name}"))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sandbox_state_roundtrip() {
+        let state = SandboxState {
+            sandbox_id: "sb_123".to_string(),
+            region: "ord".to_string(),
+            org: Some("everruns".to_string()),
+            workspace_path: "/home/sandbox".to_string(),
+            started_at: "2026-03-22T00:00:00Z".to_string(),
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        let deserialized: SandboxState = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.sandbox_id, "sb_123");
+        assert_eq!(deserialized.region, "ord");
+        assert_eq!(deserialized.org.as_deref(), Some("everruns"));
+    }
+
+    #[test]
+    fn required_str_reports_missing_param() {
+        let err = required_str(&json!({}), "sandbox_id").unwrap_err();
+        match err {
+            ToolExecutionResult::ToolError(message) => assert!(message.contains("sandbox_id")),
+            other => panic!("unexpected result: {other:?}"),
+        }
+    }
+}

--- a/integrations/deno/src/tools.rs
+++ b/integrations/deno/src/tools.rs
@@ -14,7 +14,7 @@ use crate::state::{
     SandboxState, delete_sandbox_state, get_credentials, get_sandbox_state, list_sandbox_states,
     release_sandbox_lease, required_str, save_sandbox_state, touch_sandbox_lease,
 };
-use crate::{DENO_MAX_MEMORY_MB, DENO_SANDBOX_TIMEOUT};
+use crate::{DENO_DEFAULT_MEMORY_MB, DENO_MAX_MEMORY_MB, DENO_SANDBOX_TIMEOUT};
 
 fn parse_memory_mb(arguments: &Value) -> Result<Option<u64>, String> {
     let Some(value) = arguments.get("memory_mb") else {
@@ -36,13 +36,15 @@ fn parse_memory_mb(arguments: &Value) -> Result<Option<u64>, String> {
 
 fn parse_timeout_seconds(timeout: &str) -> Result<u64, String> {
     if timeout == "session" {
-        return Err("Deno sandboxes can not use timeout='session' because Everruns closes the creator websocket after each tool. Use a concrete duration like '20m'.".to_string());
+        return Err("Deno sandboxes cannot use timeout='session' because Everruns closes the creator websocket after each tool. Use a concrete duration like '20m'.".to_string());
     }
     if let Some(minutes) = timeout.strip_suffix('m') {
         let minutes = minutes
             .parse::<u64>()
             .map_err(|_| "Invalid timeout: expected e.g. '20m' or '600s'".to_string())?;
-        return Ok(minutes * 60);
+        return minutes
+            .checked_mul(60)
+            .ok_or_else(|| "Timeout too large".to_string());
     }
     if let Some(seconds) = timeout.strip_suffix('s') {
         return seconds
@@ -71,7 +73,7 @@ impl Tool for DenoCreateSandboxTool {
                 "title": { "type": "string", "description": "Sandbox label shown in Deno" },
                 "region": { "type": "string", "description": "Region (for example 'ord' or 'ams')" },
                 "timeout": { "type": "string", "description": "Sandbox lifetime, e.g. '20m' or '600s'", "default": DENO_SANDBOX_TIMEOUT },
-                "memory_mb": { "type": "integer", "description": "Sandbox memory in MiB (1-16384)", "minimum": 1, "maximum": DENO_MAX_MEMORY_MB, "default": 1280 },
+                "memory_mb": { "type": "integer", "description": "Sandbox memory in MiB (1-16384)", "minimum": 1, "maximum": DENO_MAX_MEMORY_MB, "default": DENO_DEFAULT_MEMORY_MB },
                 "allow_net": {
                     "type": "array",
                     "items": { "type": "string" },

--- a/integrations/deno/src/tools.rs
+++ b/integrations/deno/src/tools.rs
@@ -1,0 +1,610 @@
+//! Tool implementations for Deno sandbox operations.
+//!
+//! Decision: keep the surface small for the first version: create, exec, read,
+//! write, list, delete.
+
+use async_trait::async_trait;
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::ToolContext;
+use serde_json::{Value, json};
+use tracing::debug;
+
+use crate::client::{CreateSandboxRequest, DenoClient};
+use crate::state::{
+    SandboxState, delete_sandbox_state, get_credentials, get_sandbox_state, list_sandbox_states,
+    release_sandbox_lease, required_str, save_sandbox_state, touch_sandbox_lease,
+};
+use crate::{DENO_MAX_MEMORY_MB, DENO_SANDBOX_TIMEOUT};
+
+fn parse_memory_mb(arguments: &Value) -> Result<Option<u64>, String> {
+    let Some(value) = arguments.get("memory_mb") else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let memory_mb = value
+        .as_u64()
+        .ok_or_else(|| "Invalid 'memory_mb': must be a positive integer".to_string())?;
+    if memory_mb == 0 || memory_mb > DENO_MAX_MEMORY_MB {
+        return Err(format!(
+            "Invalid 'memory_mb': must be between 1 and {DENO_MAX_MEMORY_MB}"
+        ));
+    }
+    Ok(Some(memory_mb))
+}
+
+fn parse_timeout_seconds(timeout: &str) -> Result<u64, String> {
+    if timeout == "session" {
+        return Err("Deno sandboxes can not use timeout='session' because Everruns closes the creator websocket after each tool. Use a concrete duration like '20m'.".to_string());
+    }
+    if let Some(minutes) = timeout.strip_suffix('m') {
+        let minutes = minutes
+            .parse::<u64>()
+            .map_err(|_| "Invalid timeout: expected e.g. '20m' or '600s'".to_string())?;
+        return Ok(minutes * 60);
+    }
+    if let Some(seconds) = timeout.strip_suffix('s') {
+        return seconds
+            .parse::<u64>()
+            .map_err(|_| "Invalid timeout: expected e.g. '20m' or '600s'".to_string());
+    }
+    Err("Invalid timeout: expected e.g. '20m' or '600s'".to_string())
+}
+
+pub struct DenoCreateSandboxTool;
+
+#[async_trait]
+impl Tool for DenoCreateSandboxTool {
+    fn name(&self) -> &str {
+        "deno_create_sandbox"
+    }
+
+    fn description(&self) -> &str {
+        "Create a new Deno sandbox. Returns the sandbox id and workspace path."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "title": { "type": "string", "description": "Sandbox label shown in Deno" },
+                "region": { "type": "string", "description": "Region (for example 'ord' or 'ams')" },
+                "timeout": { "type": "string", "description": "Sandbox lifetime, e.g. '20m' or '600s'", "default": DENO_SANDBOX_TIMEOUT },
+                "memory_mb": { "type": "integer", "description": "Sandbox memory in MiB (1-16384)", "minimum": 1, "maximum": DENO_MAX_MEMORY_MB, "default": 1280 },
+                "allow_net": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Optional outbound network allowlist hosts/IPs"
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "deno_create_sandbox requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let credentials = match get_credentials(context).await {
+            Ok(credentials) => credentials,
+            Err(error) => return error,
+        };
+
+        let timeout = arguments
+            .get("timeout")
+            .and_then(Value::as_str)
+            .unwrap_or(DENO_SANDBOX_TIMEOUT);
+        let timeout_seconds = match parse_timeout_seconds(timeout) {
+            Ok(timeout) => timeout,
+            Err(error) => return ToolExecutionResult::tool_error(error),
+        };
+        let memory_mb = match parse_memory_mb(&arguments) {
+            Ok(memory_mb) => memory_mb,
+            Err(error) => return ToolExecutionResult::tool_error(error),
+        };
+        let region = arguments
+            .get("region")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let title = arguments
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or("Everruns Deno Sandbox");
+        let allow_net = arguments
+            .get("allow_net")
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_string)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        let mut labels = serde_json::Map::new();
+        labels.insert("everruns".to_string(), json!("true"));
+        labels.insert(
+            "everruns.session_id".to_string(),
+            json!(context.session_id.to_string()),
+        );
+        labels.insert("everruns.title".to_string(), json!(title));
+        if let Some(session_store) = &context.session_store
+            && let Ok(Some(session)) = session_store.get_session(context.session_id).await
+        {
+            labels.insert(
+                "everruns.harness_id".to_string(),
+                json!(session.harness_id.to_string()),
+            );
+            labels.insert(
+                "everruns.org_id".to_string(),
+                json!(session.organization_id.to_string()),
+            );
+            if let Some(agent_id) = &session.agent_id {
+                labels.insert("everruns.agent_id".to_string(), json!(agent_id.to_string()));
+            }
+        }
+
+        let client = DenoClient::new(credentials.token, credentials.org);
+        let created = match client
+            .create_sandbox(CreateSandboxRequest {
+                region,
+                timeout_seconds: Some(timeout_seconds),
+                memory_mb,
+                labels,
+                allow_net,
+            })
+            .await
+        {
+            Ok(created) => created,
+            Err(error) => return ToolExecutionResult::tool_error(error),
+        };
+
+        let state = SandboxState {
+            sandbox_id: created.sandbox_id.clone(),
+            region: created.region.clone(),
+            org: client.org().map(str::to_string),
+            workspace_path: created.workspace_path.clone(),
+            started_at: chrono::Utc::now().to_rfc3339(),
+        };
+        if let Err(error) = save_sandbox_state(context, &state).await {
+            return error;
+        }
+        if let Err(error) = touch_sandbox_lease(context, &state, Some(title.to_string())).await {
+            return error;
+        }
+
+        ToolExecutionResult::success(json!({
+            "sandbox_id": created.sandbox_id,
+            "region": created.region,
+            "workspace_path": created.workspace_path,
+            "status": "running",
+            "timeout": timeout,
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct DenoExecTool;
+
+#[async_trait]
+impl Tool for DenoExecTool {
+    fn name(&self) -> &str {
+        "deno_exec"
+    }
+
+    fn description(&self) -> &str {
+        "Execute a shell command in a Deno sandbox. Returns stdout, stderr, and exit code."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sandbox_id": { "type": "string", "description": "Sandbox ID" },
+                "command": { "type": "string", "description": "Shell command to run" },
+                "cwd": { "type": "string", "description": "Optional working directory" }
+            },
+            "required": ["sandbox_id", "command"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "deno_exec requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let sandbox_id = match required_str(&arguments, "sandbox_id") {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+        let command = match required_str(&arguments, "command") {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+        let cwd = arguments.get("cwd").and_then(Value::as_str);
+
+        let credentials = match get_credentials(context).await {
+            Ok(credentials) => credentials,
+            Err(error) => return error,
+        };
+        let state = match get_sandbox_state(context, sandbox_id).await {
+            Ok(state) => state,
+            Err(error) => return error,
+        };
+
+        let client = DenoClient::new(credentials.token, credentials.org);
+        debug!(sandbox_id, command, "Executing command in Deno sandbox");
+        let exec = match client.exec(sandbox_id, &state.region, command, cwd).await {
+            Ok(exec) => exec,
+            Err(error) => return ToolExecutionResult::tool_error(error),
+        };
+
+        if let Err(error) = touch_sandbox_lease(context, &state, None).await {
+            return error;
+        }
+
+        let output = if exec.stderr.is_empty() {
+            exec.stdout.clone()
+        } else if exec.stdout.is_empty() {
+            exec.stderr.clone()
+        } else {
+            format!(
+                "{}{}{}",
+                exec.stdout,
+                if exec.stdout.ends_with('\n') {
+                    ""
+                } else {
+                    "\n"
+                },
+                exec.stderr
+            )
+        };
+
+        ToolExecutionResult::success(json!({
+            "exit_code": exec.exit_code,
+            "stdout": exec.stdout,
+            "stderr": exec.stderr,
+            "output": output,
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct DenoReadFileTool;
+
+#[async_trait]
+impl Tool for DenoReadFileTool {
+    fn name(&self) -> &str {
+        "deno_read_file"
+    }
+
+    fn description(&self) -> &str {
+        "Read a text file from a Deno sandbox filesystem."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sandbox_id": { "type": "string", "description": "Sandbox ID" },
+                "path": { "type": "string", "description": "Path to read" }
+            },
+            "required": ["sandbox_id", "path"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "deno_read_file requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let sandbox_id = match required_str(&arguments, "sandbox_id") {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+        let path = match required_str(&arguments, "path") {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+
+        let credentials = match get_credentials(context).await {
+            Ok(credentials) => credentials,
+            Err(error) => return error,
+        };
+        let state = match get_sandbox_state(context, sandbox_id).await {
+            Ok(state) => state,
+            Err(error) => return error,
+        };
+
+        let client = DenoClient::new(credentials.token, credentials.org);
+        let content = match client.read_text_file(sandbox_id, &state.region, path).await {
+            Ok(content) => content,
+            Err(error) => return ToolExecutionResult::tool_error(error),
+        };
+        if let Err(error) = touch_sandbox_lease(context, &state, None).await {
+            return error;
+        }
+
+        ToolExecutionResult::success(json!({
+            "path": path,
+            "content": content,
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct DenoWriteFileTool;
+
+#[async_trait]
+impl Tool for DenoWriteFileTool {
+    fn name(&self) -> &str {
+        "deno_write_file"
+    }
+
+    fn description(&self) -> &str {
+        "Write a text file into a Deno sandbox filesystem."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sandbox_id": { "type": "string", "description": "Sandbox ID" },
+                "path": { "type": "string", "description": "Path to write" },
+                "content": { "type": "string", "description": "File content" }
+            },
+            "required": ["sandbox_id", "path", "content"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "deno_write_file requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let sandbox_id = match required_str(&arguments, "sandbox_id") {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+        let path = match required_str(&arguments, "path") {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+        let content = match required_str(&arguments, "content") {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+
+        let credentials = match get_credentials(context).await {
+            Ok(credentials) => credentials,
+            Err(error) => return error,
+        };
+        let state = match get_sandbox_state(context, sandbox_id).await {
+            Ok(state) => state,
+            Err(error) => return error,
+        };
+
+        let client = DenoClient::new(credentials.token, credentials.org);
+        match client
+            .write_text_file(sandbox_id, &state.region, path, content)
+            .await
+        {
+            Ok(()) => {}
+            Err(error) => return ToolExecutionResult::tool_error(error),
+        }
+        if let Err(error) = touch_sandbox_lease(context, &state, None).await {
+            return error;
+        }
+
+        ToolExecutionResult::success(json!({
+            "path": path,
+            "success": true,
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct DenoListSandboxesTool;
+
+#[async_trait]
+impl Tool for DenoListSandboxesTool {
+    fn name(&self) -> &str {
+        "deno_list_sandboxes"
+    }
+
+    fn description(&self) -> &str {
+        "List all Deno sandboxes created in this session."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({ "type": "object", "properties": {}, "additionalProperties": false })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "deno_list_sandboxes requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        _arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let sandboxes = match list_sandbox_states(context).await {
+            Ok(sandboxes) => sandboxes,
+            Err(error) => return error,
+        };
+
+        ToolExecutionResult::success(json!({
+            "sandboxes": sandboxes.iter().map(|state| {
+                json!({
+                    "sandbox_id": state.sandbox_id,
+                    "region": state.region,
+                    "workspace_path": state.workspace_path,
+                    "started_at": state.started_at,
+                })
+            }).collect::<Vec<_>>(),
+            "count": sandboxes.len(),
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct DenoManageSandboxTool;
+
+#[async_trait]
+impl Tool for DenoManageSandboxTool {
+    fn name(&self) -> &str {
+        "deno_manage_sandbox"
+    }
+
+    fn description(&self) -> &str {
+        "Delete a Deno sandbox."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sandbox_id": { "type": "string", "description": "Sandbox ID" },
+                "action": { "type": "string", "enum": ["delete"], "description": "Lifecycle action" }
+            },
+            "required": ["sandbox_id", "action"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "deno_manage_sandbox requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let sandbox_id = match required_str(&arguments, "sandbox_id") {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+        let action = match required_str(&arguments, "action") {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+        if action != "delete" {
+            return ToolExecutionResult::tool_error(
+                "Unsupported action. Deno sandboxes currently support only action='delete'.",
+            );
+        }
+
+        let credentials = match get_credentials(context).await {
+            Ok(credentials) => credentials,
+            Err(error) => return error,
+        };
+        let state = match get_sandbox_state(context, sandbox_id).await {
+            Ok(state) => state,
+            Err(error) => return error,
+        };
+
+        let client = DenoClient::new(credentials.token, credentials.org);
+        if let Err(error) = client.delete_sandbox(sandbox_id, &state.region).await {
+            return ToolExecutionResult::tool_error(error);
+        }
+        if let Err(error) = delete_sandbox_state(context, sandbox_id).await {
+            return error;
+        }
+        if let Err(error) = release_sandbox_lease(context, sandbox_id).await {
+            return error;
+        }
+
+        ToolExecutionResult::success(json!({
+            "sandbox_id": sandbox_id,
+            "action": action,
+            "success": true,
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_timeout_rejects_session() {
+        let err = parse_timeout_seconds("session").unwrap_err();
+        assert!(err.contains("session"));
+    }
+
+    #[test]
+    fn parse_memory_validates_bounds() {
+        assert!(parse_memory_mb(&json!({"memory_mb": 0})).is_err());
+        assert!(
+            parse_memory_mb(&json!({"memory_mb": 1280}))
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn create_tool_mentions_fixed_timeout() {
+        let tool = DenoCreateSandboxTool;
+        let schema = tool.parameters_schema();
+        assert_eq!(
+            schema["properties"]["timeout"]["default"],
+            DENO_SANDBOX_TIMEOUT
+        );
+        assert_eq!(crate::DENO_WORKSPACE_PATH, "/home/sandbox");
+    }
+}

--- a/integrations/deno/tests/live_api_test.rs
+++ b/integrations/deno/tests/live_api_test.rs
@@ -1,0 +1,138 @@
+//! Live Deno sandbox integration tests.
+//!
+//! Run with:
+//!   doppler run -- cargo test -p everruns-integrations-deno \
+//!     --features deno-live-tests --test live_api_test -- --test-threads=1 --nocapture
+
+#![cfg(feature = "deno-live-tests")]
+
+use everruns_integrations_deno::client::{CreateSandboxRequest, DenoClient};
+use serde_json::Value;
+
+struct SandboxGuard {
+    sandbox_id: String,
+    region: String,
+}
+
+impl Drop for SandboxGuard {
+    fn drop(&mut self) {
+        let sandbox_id = self.sandbox_id.clone();
+        let region = self.region.clone();
+        let Some(token) = std::env::var("DENO_DEPLOY_TOKEN")
+            .ok()
+            .filter(|t| !t.is_empty())
+        else {
+            eprintln!("[cleanup] No DENO_DEPLOY_TOKEN, cannot delete sandbox {sandbox_id}");
+            return;
+        };
+        let org = std::env::var("DENO_DEPLOY_ORG")
+            .ok()
+            .filter(|v| !v.is_empty());
+        let handle = std::thread::spawn(move || {
+            let rt = tokio::runtime::Runtime::new().expect("cleanup runtime");
+            rt.block_on(async move {
+                let client = DenoClient::new(token, org);
+                match client.delete_sandbox(&sandbox_id, &region).await {
+                    Ok(()) => eprintln!("[cleanup] Deleted sandbox {sandbox_id}"),
+                    Err(error) => {
+                        eprintln!("[cleanup] Failed to delete sandbox {sandbox_id}: {error}")
+                    }
+                }
+            });
+        });
+        let _ = handle.join();
+    }
+}
+
+fn token() -> Option<String> {
+    std::env::var("DENO_DEPLOY_TOKEN")
+        .ok()
+        .filter(|t| !t.is_empty())
+}
+
+fn org() -> Option<String> {
+    std::env::var("DENO_DEPLOY_ORG")
+        .ok()
+        .filter(|v| !v.is_empty())
+}
+
+macro_rules! require_token {
+    () => {{
+        match token() {
+            Some(token) => {
+                if token.starts_with("ddp_") && org().is_none() {
+                    eprintln!("[skip] DENO_DEPLOY_TOKEN is personal (ddp_...) but DENO_DEPLOY_ORG is unset; skipping live test");
+                    return;
+                }
+                token
+            }
+            None => {
+                eprintln!("[skip] DENO_DEPLOY_TOKEN not set, skipping live test");
+                return;
+            }
+        }
+    }};
+}
+
+#[tokio::test]
+async fn test_live_sandbox_lifecycle() {
+    let token = require_token!();
+    let client = DenoClient::new(token, org());
+    let created = client
+        .create_sandbox(CreateSandboxRequest {
+            region: None,
+            timeout_seconds: Some(10 * 60),
+            memory_mb: Some(1_280),
+            labels: serde_json::Map::from_iter([(
+                String::from("everruns-test"),
+                Value::String(String::from("live")),
+            )]),
+            allow_net: vec![],
+        })
+        .await
+        .expect("create sandbox");
+    let _guard = SandboxGuard {
+        sandbox_id: created.sandbox_id.clone(),
+        region: created.region.clone(),
+    };
+
+    let exec = client
+        .exec(
+            &created.sandbox_id,
+            &created.region,
+            "echo hello-deno && pwd",
+            None,
+        )
+        .await
+        .expect("exec");
+    assert_eq!(exec.exit_code, 0);
+    assert!(
+        exec.stdout.contains("hello-deno"),
+        "stdout: {}",
+        exec.stdout
+    );
+    assert!(
+        exec.stdout.contains("/home/sandbox"),
+        "stdout: {}",
+        exec.stdout
+    );
+
+    client
+        .write_text_file(
+            &created.sandbox_id,
+            &created.region,
+            "/home/sandbox/live.txt",
+            "hello from everruns\n",
+        )
+        .await
+        .expect("write file");
+    let content = client
+        .read_text_file(
+            &created.sandbox_id,
+            &created.region,
+            "/home/sandbox/live.txt",
+        )
+        .await
+        .expect("read file");
+    assert_eq!(content, "hello from everruns\n");
+}

--- a/integrations/deno/tests/plugin_registration.rs
+++ b/integrations/deno/tests/plugin_registration.rs
@@ -1,0 +1,37 @@
+//! Integration tests for Deno plugin registration and capability.
+
+use everruns_core::capabilities::{CapabilityRegistry, IntegrationPlugin};
+use everruns_core::connection_provider::ConnectionProviderPlugin;
+use everruns_core::deployment::DeploymentGrade;
+use everruns_integrations_deno as _;
+
+#[test]
+fn test_deno_plugin_is_submitted() {
+    let plugins: Vec<&IntegrationPlugin> = inventory::iter::<IntegrationPlugin>().collect();
+    assert!(
+        plugins.iter().any(|plugin| {
+            let capability = (plugin.factory)();
+            capability.id() == "deno"
+        }),
+        "Deno IntegrationPlugin should be submitted via inventory"
+    );
+}
+
+#[test]
+fn test_deno_registered_in_prod_registry() {
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Prod);
+    assert!(registry.has("deno"), "Deno should be in prod registry");
+}
+
+#[test]
+fn test_deno_connection_provider_is_submitted() {
+    let plugins: Vec<&ConnectionProviderPlugin> =
+        inventory::iter::<ConnectionProviderPlugin>().collect();
+    assert!(
+        plugins.iter().any(|plugin| {
+            let provider = (plugin.factory)();
+            provider.provider_id() == "deno"
+        }),
+        "Deno ConnectionProviderPlugin should be submitted via inventory"
+    );
+}

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -59,6 +59,7 @@ graph TB
    - `integrations/docker/` → `everruns-integrations-docker` - Docker container integration (auto-registered via `inventory` plugin system)
    - `integrations/daytona/` → `everruns-integrations-daytona` - Daytona cloud sandbox integration (auto-registered via `inventory` plugin system)
    - `integrations/e2b/` → `everruns-integrations-e2b` - E2B cloud sandbox integration (auto-registered via `inventory` plugin system)
+   - `integrations/deno/` → `everruns-integrations-deno` - Deno sandbox integration (auto-registered via `inventory` plugin system)
 3. **Frontend**: Next.js application in `apps/ui/` for management and chat interfaces
    - Exports providers, components, hooks, and lib modules via `package.json` `exports` field for SaaS wrapper consumption
 4. **Documentation Site**: Astro Starlight in `apps/docs/` deployed to https://docs.everruns.com/
@@ -82,7 +83,8 @@ everruns/
 ├── integrations/
 │   ├── docker/           # Docker container (inventory plugin)
 │   ├── daytona/          # Daytona cloud sandbox (inventory plugin)
-│   └── e2b/              # E2B cloud sandbox (inventory plugin)
+│   ├── e2b/              # E2B cloud sandbox (inventory plugin)
+│   └── deno/             # Deno sandbox (inventory plugin)
 ├── docs/                 # Documentation content (symlinked to apps/docs)
 ├── specs/                # Feature specifications
 ├── test_cases/           # Manual test cases

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -248,7 +248,7 @@ Each capability declares a `RiskLevel` via the `Capability` trait. The API enfor
 | `medium` | Logged but allowed for org members. | Any org member |
 | `high` | Can access external compute or resources. | Requires Admin role |
 
-High-risk built-in capabilities: `docker_container`, `daytona`, `e2b`.
+High-risk built-in capabilities: `docker_container`, `daytona`, `e2b`, `deno`.
 
 See `crates/core/src/capabilities/mod.rs` for the `RiskLevel` enum and `crates/server/src/api/agents.rs` for `require_admin_for_high_risk()`.
 

--- a/specs/integrations.md
+++ b/specs/integrations.md
@@ -13,6 +13,7 @@ Auto-registered via `inventory` plugin system. Each crate has a `SPEC.md`.
 | Browserless | [`integrations/browserless/SPEC.md`](../integrations/browserless/SPEC.md) | Cloud browser automation — screenshots, DOM, scraping, multi-step interactions. REST and CDP modes. |
 | E2B | [`integrations/e2b/SPEC.md`](../integrations/e2b/SPEC.md) | Cloud sandbox environments via E2B management API + envd runtime endpoints. Platform-owned token, multiple sandboxes per session. |
 | Daytona | [`integrations/daytona/SPEC.md`](../integrations/daytona/SPEC.md) | Cloud sandbox environments via Daytona REST API. Multiple sandboxes per session. |
+| Deno | [`integrations/deno/SPEC.md`](../integrations/deno/SPEC.md) | Cloud sandbox environments via Deno websocket sandbox API. Multiple sandboxes per session. |
 | Docker | `integrations/docker/` | Container-based agent execution. Experimental (Dev only). No spec yet. |
 
 ## Server Integrations (`crates/server/specs/`)

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -850,6 +850,18 @@ Session A cannot access sb_xyz (different session_id in storage query)
 ```
 
 
+## 16A. Deno Sandbox (TM-DENO)
+
+Deno sandboxes are remote Linux microVMs managed over a websocket + REST control plane. Everruns creates sandboxes with a fixed timeout, reconnects for each tool call, and deletes them via leased-resource cleanup.
+
+| ID | Threat | Severity | Mitigation | Status |
+|----|--------|----------|------------|--------|
+| TM-DENO-001 | Service-wide token misuse via env fallback | High | Prefer user connections; env fallback is operator-controlled and intended for managed deployments/tests | **CALLER RISK** |
+| TM-DENO-002 | Cross-session sandbox access | Critical | Sandbox IDs stored in session-scoped secrets (`deno_sandbox:{id}`); tool access requires matching session state | MITIGATED |
+| TM-DENO-003 | Sandbox leak from default `session` timeout | Medium | `deno_create_sandbox` forbids `timeout="session"`; Everruns always uses explicit TTLs plus leased-resource cleanup | MITIGATED |
+| TM-API-015 | Lease metadata exposure | Medium | Deno lease metadata stores only non-secret routing/debug fields (`region`, optional `org`, workspace path, timestamps); tokens still resolve from connections/env at cleanup time | MITIGATED |
+| TM-DENO-004 | Network probing from remote sandbox | High | Capability is Admin-gated; residual exposure depends on operator egress controls | **ACCEPTED** |
+
 ## 17. E2B Cloud Sandbox (TM-E2B)
 
 E2B sandboxes are remote Linux environments managed through the E2B Management API plus per-sandbox envd runtime endpoints. Everruns uses a platform-owned `E2B_API_KEY` from environment or session secret override, and stores per-sandbox envd access tokens in session-scoped secrets.
@@ -936,6 +948,7 @@ Search results from Brave Search are returned as tool results. Adversarial conte
 | TM-AGENT-019 | Internal network probing via high-risk execution capabilities | High-risk capabilities are Admin-gated; residual exposure depends on deployment network isolation |
 | TM-DURABLE-006 | DLQ growth | Tasks preserved for debugging; manual cleanup |
 | TM-DAYTONA-001 | Git token on sandbox disk | Same trust boundary as exec; `/tmp` cleared on stop; short-lived token |
+| TM-DENO-004 | Network probing from Deno sandbox | Same residual risk as other remote execution capabilities; requires Admin + operator egress controls |
 | TM-E2B-005 | Full-network sandbox misuse | Same residual risk class as other cloud sandboxes; require deployment egress isolation where needed |
 
 ### Caller Responsibilities
@@ -1000,6 +1013,7 @@ Search results from Brave Search are returned as tool results. Adversarial conte
 - `specs/capabilities.md` — Agent capabilities system
 - `specs/bashkit-requirements.md` — Bashkit integration requirements
 - `integrations/daytona/SPEC.md` — Daytona cloud sandbox integration
+- `integrations/deno/SPEC.md` — Deno sandbox integration
 - `integrations/e2b/SPEC.md` — E2B cloud sandbox integration
 - `specs/client-side-tools.md` — Client-side tools for API/SDK consumers
 - `specs/apps.md` — Apps system (agent deployment to channels)


### PR DESCRIPTION
## What
Add the Deno Deploy sandbox integration as a new execution capability with websocket-based sandbox management, leased-resource cleanup, and connection provider.

Supersedes #1041 (rebased onto latest main to resolve conflicts).

## Why
Everruns needs a Deno-backed cloud sandbox option alongside Daytona and E2B for remote code execution.

## How
- New `integrations/deno` crate: client (REST + websocket JSON-RPC), connection provider, state management, tools (create/exec/read/write/list/delete), and tests.
- Register capability + connection provider in workspace; wire into server/worker builds.
- Leased-resource cleanup handler for Deno sandboxes in worker.
- Specs and threat model updated (TM-DENO section).

## Risk
- Medium
- New remote execution provider touches tool execution, credential resolution, leased-resource cleanup, and worker cleanup paths.
- Live Deno API validation depends on operator credentials.

## Security
- Threat categories reviewed: TM-TOOL, TM-API, TM-DOS, TM-DENO, TM-API-015, TM-AGENT-016
- Findings and resolutions:
  - Tokens never stored in lease metadata or sandbox state — only non-secret routing/debug fields persisted (TM-API-015).
  - Credential resolution prefers user connections, falls back to env, returns `connection_required` instead of requesting plaintext secrets in chat (TM-AGENT-016).
  - Session-scoped sandbox isolation via `deno_sandbox:{id}` keys (TM-DENO-002).
  - `session` timeout explicitly rejected; explicit TTLs + cleanup enforced (TM-DENO-003).
  - Stream drain returns errors on timeout instead of silently truncating output.
  - Unbounded stream buffer is a known low-priority follow-up (mitigated by sandbox TTL and memory limits).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)