### PR TITLE
fix(images): use SessionId instead of Uuid for upload query parameter

### DIFF
--- a/crates/server/src/api/images.rs
+++ b/crates/server/src/api/images.rs
@@ -18,7 +18,7 @@ use axum::{
 };
 use axum_extra::extract::Multipart;
 use chrono::{DateTime, Utc};
-use everruns_core::typed_id::ImageId;
+use everruns_core::typed_id::{ImageId, SessionId};
 use image::ImageFormat;
 use serde::{Deserialize, Serialize};
 use std::io::Cursor;
@@ -81,7 +81,7 @@ fn default_limit() -> i64 {
 #[derive(Debug, Deserialize)]
 pub struct UploadImageQuery {
     /// Optional session ID stored as metadata for tracking (not required for upload)
-    pub session_id: Option<Uuid>,
+    pub session_id: Option<SessionId>,
 }
 
 // ============================================
@@ -164,7 +164,7 @@ fn generate_thumbnail(data: &[u8], content_type: &str) -> Option<(Vec<u8>, Strin
     post,
     path = "/v1/images",
     params(
-        ("session_id" = Option<Uuid>, Query, description = "Optional: session ID stored as metadata for tracking (not required for upload)")
+        ("session_id" = Option<String>, Query, description = "Optional: session ID stored as metadata for tracking (not required for upload)")
     ),
     request_body(content = String, description = "Multipart form data with 'file' field", content_type = "multipart/form-data"),
     responses(

--- a/crates/server/src/api/images.rs
+++ b/crates/server/src/api/images.rs
@@ -511,10 +511,12 @@ mod tests {
         assert!(query.session_id.is_none());
 
         // Raw UUID without prefix is rejected
-        let result: Result<UploadImageQuery, _> = serde_html_form::from_str(
-            "session_id=01933b5a-0000-7000-8000-00000000001a",
+        let result: Result<UploadImageQuery, _> =
+            serde_html_form::from_str("session_id=01933b5a-0000-7000-8000-00000000001a");
+        assert!(
+            result.is_err(),
+            "raw UUID without prefix should be rejected"
         );
-        assert!(result.is_err(), "raw UUID without prefix should be rejected");
     }
 
     #[test]

--- a/crates/server/src/api/images.rs
+++ b/crates/server/src/api/images.rs
@@ -498,6 +498,26 @@ mod tests {
     }
 
     #[test]
+    fn test_upload_query_session_id_parsing() {
+        // Typed SessionId with prefix parses correctly
+        let query: UploadImageQuery =
+            serde_html_form::from_str("session_id=session_01933b5a00007000800000000000001a")
+                .expect("typed session ID should parse");
+        assert!(query.session_id.is_some());
+
+        // Omitted session_id is fine (it's optional)
+        let query: UploadImageQuery =
+            serde_html_form::from_str("").expect("empty query should parse");
+        assert!(query.session_id.is_none());
+
+        // Raw UUID without prefix is rejected
+        let result: Result<UploadImageQuery, _> = serde_html_form::from_str(
+            "session_id=01933b5a-0000-7000-8000-00000000001a",
+        );
+        assert!(result.is_err(), "raw UUID without prefix should be rejected");
+    }
+
+    #[test]
     fn test_format_from_content_type() {
         assert!(matches!(
             format_from_content_type("image/png"),

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1363,8 +1363,7 @@
             "description": "Optional: session ID stored as metadata for tracking (not required for upload)",
             "required": false,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           }
         ],

--- a/test_cases/ui/images/TC001_paste_image.md
+++ b/test_cases/ui/images/TC001_paste_image.md
@@ -1,0 +1,35 @@
+# TC001: Paste Image via Ctrl+V
+
+## Description
+
+Verify that pasting an image from clipboard into the chat input uploads it successfully.
+
+## Preconditions
+
+- Server running (`just start-all`)
+- User logged in
+- An active session open in the chat view
+- An image copied to the clipboard (e.g. screenshot or copied from another app)
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Image source | Screenshot or copied PNG/JPEG from clipboard |
+
+## Steps
+
+1. Navigate to a session chat view
+2. Click into the message input textarea
+3. Press Ctrl+V (or Cmd+V on macOS) with an image on the clipboard
+4. Observe the image attachment area above the input
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Image thumbnail | Appears in attachment area with loading spinner |
+| Upload completes | Spinner replaced by image preview (no error icon) |
+| Filename shown | Shows generated filename (e.g. "image.png") below thumbnail |
+| No error | No "Failed to deserialize" or "API Error" message |
+| Remove button | Hover over thumbnail shows X button to remove |

--- a/test_cases/ui/images/TC002_drag_drop_image.md
+++ b/test_cases/ui/images/TC002_drag_drop_image.md
@@ -1,0 +1,34 @@
+# TC002: Drag and Drop Image
+
+## Description
+
+Verify that dragging and dropping an image file onto the chat input uploads it successfully.
+
+## Preconditions
+
+- Server running (`just start-all`)
+- User logged in
+- An active session open in the chat view
+- An image file accessible in the file system
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Image file | Any PNG, JPEG, GIF, or WebP file under 100 MB |
+
+## Steps
+
+1. Navigate to a session chat view
+2. Open a file manager window alongside the browser
+3. Drag an image file from the file manager onto the message input area
+4. Observe the drop zone highlight and image attachment
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Drop zone highlight | Input area shows visual highlight during drag-over |
+| Image thumbnail | Appears in attachment area after drop |
+| Upload completes | Spinner replaced by image preview |
+| Filename shown | Shows original filename below thumbnail |

--- a/test_cases/ui/images/TC003_file_picker_image.md
+++ b/test_cases/ui/images/TC003_file_picker_image.md
@@ -1,0 +1,33 @@
+# TC003: Upload Image via File Picker
+
+## Description
+
+Verify that clicking the image attach button opens a file picker and uploads selected images.
+
+## Preconditions
+
+- Server running (`just start-all`)
+- User logged in
+- An active session open in the chat view
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Image file | Any PNG, JPEG, GIF, or WebP file |
+
+## Steps
+
+1. Navigate to a session chat view
+2. Click the image attach button (ImagePlus icon) below the message input
+3. Select one or more image files from the file picker dialog
+4. Observe the image attachment area
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| File picker | Opens with image type filter |
+| Image thumbnails | Appear in attachment area |
+| Upload completes | All images show preview (no error) |
+| Multiple images | Up to 10 images can be attached |

--- a/test_cases/ui/images/TC004_send_message_with_image.md
+++ b/test_cases/ui/images/TC004_send_message_with_image.md
@@ -1,0 +1,37 @@
+# TC004: Send Message with Image Attachment
+
+## Description
+
+Verify that a message with attached images is sent successfully and displayed in the chat.
+
+## Preconditions
+
+- Server running (`just start-all`)
+- User logged in
+- An active session open in the chat view
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Message text | "Describe this image" |
+| Image | Any PNG or JPEG file |
+
+## Steps
+
+1. Navigate to a session chat view
+2. Attach an image via paste, drag-drop, or file picker
+3. Wait for the upload to complete (spinner disappears)
+4. Type "Describe this image" in the message input
+5. Press Enter or click the Send button
+6. Observe the sent message in the chat
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Send button | Enabled only after image upload completes |
+| Sent message | Shows text and image thumbnail in chat history |
+| Image clickable | Clicking thumbnail opens full-size preview dialog |
+| Download button | Preview dialog has a download button |
+| Agent response | Agent processes the image (no deserialization error) |

--- a/test_cases/ui/images/TC005_invalid_image_type.md
+++ b/test_cases/ui/images/TC005_invalid_image_type.md
@@ -1,0 +1,32 @@
+# TC005: Invalid Image Type Rejected
+
+## Description
+
+Verify that non-image files and unsupported image formats are rejected with clear error messages.
+
+## Preconditions
+
+- Server running (`just start-all`)
+- User logged in
+- An active session open in the chat view
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Invalid file | A .txt, .pdf, or .svg file |
+
+## Steps
+
+1. Navigate to a session chat view
+2. Click the image attach button
+3. Attempt to select a non-image file (change file picker filter to "All Files" if needed)
+4. Observe behavior
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| File picker filter | Only shows PNG, JPEG, GIF, WebP by default |
+| Invalid file | Rejected with validation error in console |
+| No upload | No upload request sent for invalid files |

--- a/test_cases/ui/images/TC006_remove_image_before_send.md
+++ b/test_cases/ui/images/TC006_remove_image_before_send.md
@@ -1,0 +1,35 @@
+# TC006: Remove Image Before Sending
+
+## Description
+
+Verify that attached images can be removed before sending the message.
+
+## Preconditions
+
+- Server running (`just start-all`)
+- User logged in
+- An active session open in the chat view
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Images | Two image files |
+
+## Steps
+
+1. Navigate to a session chat view
+2. Attach two images via any method
+3. Wait for both uploads to complete
+4. Hover over the first image thumbnail
+5. Click the X button to remove it
+6. Observe the attachment area
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Remove button | Appears on hover over thumbnail |
+| After removal | Only the second image remains |
+| Send readiness | Can still send with remaining image |
+| Remove all | Removing all images disables send (if no text) |


### PR DESCRIPTION
## What
Change the `session_id` query parameter on the image upload endpoint from `Option<Uuid>` to `Option<SessionId>`.

## Why
The UI sends session IDs with the `ses_` prefix (typed ID format), but the endpoint expected a raw UUID. This caused paste-image and other image attachment flows to fail with a deserialization error because `ses_abc123` cannot parse as a UUID.

## How
- Changed `UploadImageQuery.session_id` from `Option<Uuid>` to `Option<SessionId>` in `crates/server/src/api/images.rs`
- Updated the utoipa schema annotation to use `Option<String>` for OpenAPI compatibility

## Risk
- Low
- Only affects parsing of an optional metadata field; image upload itself is unaffected even if the parameter is omitted

## Security
- Threat categories reviewed: TM-API
- The change narrows the accepted type from raw UUID to a typed SessionId, which is strictly more restrictive. No new attack surface.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)