### PR TITLE
refactor(auth): decouple CLI auth routes from BuiltinAuthBackend (EVE-176)

### DIFF
--- a/crates/server/src/auth/builtin.rs
+++ b/crates/server/src/auth/builtin.rs
@@ -229,11 +229,12 @@ impl AuthBackend for BuiltinAuthBackend {
         let auth_routes = routes::routes(self.clone());
         let auth_state =
             super::middleware::AuthState::new(self.config.clone(), Arc::new(self.clone()));
+        let api_prefix = std::env::var("API_PREFIX").unwrap_or_default();
         let cli_state = super::cli_auth::CliAuthState {
             db: self.db.clone(),
             auth: auth_state,
             frontend_url: self.config.frontend_url.clone(),
-            base_url: self.config.base_url.clone(),
+            base_url: format!("{}{}", self.config.base_url, api_prefix),
         };
         let cli_routes = super::cli_auth::cli_auth_routes(cli_state);
         Some(auth_routes.merge(cli_routes))

--- a/crates/server/src/auth/builtin.rs
+++ b/crates/server/src/auth/builtin.rs
@@ -227,7 +227,15 @@ impl AuthBackend for BuiltinAuthBackend {
 
     fn auth_routes(&self) -> Option<Router> {
         let auth_routes = routes::routes(self.clone());
-        let cli_routes = super::cli_auth::cli_auth_routes(self.clone());
+        let auth_state =
+            super::middleware::AuthState::new(self.config.clone(), Arc::new(self.clone()));
+        let cli_state = super::cli_auth::CliAuthState {
+            db: self.db.clone(),
+            auth: auth_state,
+            frontend_url: self.config.frontend_url.clone(),
+            base_url: self.config.base_url.clone(),
+        };
+        let cli_routes = super::cli_auth::cli_auth_routes(cli_state);
         Some(auth_routes.merge(cli_routes))
     }
 

--- a/crates/server/src/auth/cli_auth.rs
+++ b/crates/server/src/auth/cli_auth.rs
@@ -8,14 +8,14 @@
 use super::{
     api_key::generate_api_key,
     audit,
-    builtin::BuiltinAuthBackend,
-    middleware::{AuthError, AuthUser},
+    middleware::{AuthError, AuthState, AuthUser},
     routes::OrgMembershipResponse,
 };
+use crate::storage::StorageBackend;
 use crate::storage::models::{CreateApiKeyRow, CreateCliAuthSessionRow};
 use axum::{
     Json, Router,
-    extract::{Query, State},
+    extract::{FromRef, Query, State},
     http::{HeaderMap, StatusCode},
     response::{Html, IntoResponse, Redirect, Response},
     routing::{get, post},
@@ -23,6 +23,7 @@ use axum::{
 use chrono::{Duration, Utc};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use utoipa::ToSchema;
 
 /// CLI auth session TTL (5 minutes)
@@ -94,11 +95,34 @@ pub struct CliUserInfo {
 }
 
 // ============================================
+// State
+// ============================================
+
+/// State for CLI auth routes — decoupled from any specific AuthBackend.
+///
+/// Embedders construct this with their own URLs and mount via `cli_auth_routes()`.
+#[derive(Clone)]
+pub struct CliAuthState {
+    pub db: Arc<StorageBackend>,
+    pub auth: AuthState,
+    /// Frontend URL for login redirects (e.g. https://app.example.com)
+    pub frontend_url: String,
+    /// Backend base URL for callback construction (e.g. https://app.example.com/api)
+    pub base_url: String,
+}
+
+impl FromRef<CliAuthState> for AuthState {
+    fn from_ref(state: &CliAuthState) -> Self {
+        state.auth.clone()
+    }
+}
+
+// ============================================
 // Routes
 // ============================================
 
 /// Create CLI auth routes
-pub fn cli_auth_routes(state: BuiltinAuthBackend) -> Router {
+pub fn cli_auth_routes(state: CliAuthState) -> Router {
     Router::new()
         .route("/v1/auth/cli/start", post(cli_auth_start))
         .route("/v1/auth/cli/callback", get(cli_auth_callback))
@@ -112,7 +136,7 @@ pub fn cli_auth_routes(state: BuiltinAuthBackend) -> Router {
 /// Creates a pending CLI auth session and returns the login URL.
 /// The CLI should open this URL in the user's browser.
 async fn cli_auth_start(
-    State(state): State<BuiltinAuthBackend>,
+    State(state): State<CliAuthState>,
     headers: HeaderMap,
     Json(req): Json<CliAuthStartRequest>,
 ) -> Result<Json<CliAuthStartResponse>, AuthError> {
@@ -144,14 +168,15 @@ async fn cli_auth_start(
     let api_prefix = std::env::var("API_PREFIX").unwrap_or_default();
     let callback_url = format!(
         "{}{}/v1/auth/cli/callback?state={}",
-        state.config.base_url, api_prefix, auth_state
+        state.base_url, api_prefix, auth_state
     );
 
-    // For OSS (built-in auth), redirect to the frontend login page with a
-    // redirect_to parameter pointing back to our CLI callback.
+    // Redirect to the frontend login page with a redirect_to parameter
+    // pointing back to our CLI callback. Works for both OSS (built-in login)
+    // and external auth providers (login page handles redirect_to).
     let auth_url = format!(
         "{}/login?redirect_to={}",
-        state.config.frontend_url.trim_end_matches('/'),
+        state.frontend_url.trim_end_matches('/'),
         urlencoding::encode(&callback_url)
     );
 
@@ -175,7 +200,7 @@ async fn cli_auth_start(
 /// Called after the user completes login. Associates the authenticated user
 /// with the pending CLI session and redirects to the CLI's localhost server.
 async fn cli_auth_callback(
-    State(state): State<BuiltinAuthBackend>,
+    State(state): State<CliAuthState>,
     headers: HeaderMap,
     user: AuthUser,
     Query(query): Query<CliCallbackQuery>,
@@ -230,7 +255,7 @@ async fn cli_auth_callback(
 /// CLI sends the exchange code received via localhost callback.
 /// Server creates an API key and returns it with user/org info.
 async fn cli_auth_exchange(
-    State(state): State<BuiltinAuthBackend>,
+    State(state): State<CliAuthState>,
     headers: HeaderMap,
     Json(req): Json<CliExchangeRequest>,
 ) -> Result<(StatusCode, Json<CliExchangeResponse>), AuthError> {

--- a/crates/server/src/auth/cli_auth.rs
+++ b/crates/server/src/auth/cli_auth.rs
@@ -105,9 +105,10 @@ pub struct CliUserInfo {
 pub struct CliAuthState {
     pub db: Arc<StorageBackend>,
     pub auth: AuthState,
-    /// Frontend URL for login redirects (e.g. https://app.example.com)
+    /// Frontend URL for login redirects (e.g. `https://app.example.com`)
     pub frontend_url: String,
-    /// Backend base URL for callback construction (e.g. https://app.example.com/api)
+    /// Full backend base URL including any path prefix (e.g. `https://app.example.com/api`).
+    /// Used directly to construct callback URLs — no env-var lookup is performed.
     pub base_url: String,
 }
 
@@ -164,11 +165,12 @@ async fn cli_auth_start(
         })?;
 
     // Build auth URL — points to the server's login page with a redirect back to
-    // the CLI callback endpoint on the server
-    let api_prefix = std::env::var("API_PREFIX").unwrap_or_default();
+    // the CLI callback endpoint on the server.
+    // base_url already includes any API prefix (e.g. "/api"), so no env lookup needed.
     let callback_url = format!(
-        "{}{}/v1/auth/cli/callback?state={}",
-        state.base_url, api_prefix, auth_state
+        "{}/v1/auth/cli/callback?state={}",
+        state.base_url.trim_end_matches('/'),
+        auth_state
     );
 
     // Redirect to the frontend login page with a redirect_to parameter

--- a/crates/server/src/auth/mod.rs
+++ b/crates/server/src/auth/mod.rs
@@ -17,6 +17,7 @@ pub mod routes;
 
 pub use backend::AuthBackend;
 pub use builtin::BuiltinAuthBackend;
+pub use cli_auth::CliAuthState;
 pub use config::AuthConfig;
 pub use middleware::{
     AuthError, AuthMethod, AuthState, AuthUser, OrgAdmin, OrgContext, OrgOwner, ResolvedOrg,

--- a/specs/embedding.md
+++ b/specs/embedding.md
@@ -130,6 +130,27 @@ Embedders may extend execution by:
 - Replacing the `PlatformDefinition`
 - Reusing Everruns worker runtime and lifecycle handling
 
+## CLI Auth Extension Point
+
+CLI authentication routes (`/v1/auth/cli/*`) are decoupled from any specific auth backend via `CliAuthState`. Embedders with external auth providers can mount CLI login without duplicating handler code.
+
+Construct `CliAuthState` with your storage backend, `AuthState`, and URLs, then mount via `cli_auth_routes()`:
+
+```rust
+use everruns_server::auth::cli_auth::{CliAuthState, cli_auth_routes};
+
+let cli_state = CliAuthState {
+    db: db.clone(),
+    auth: auth_state.clone(),
+    frontend_url: "https://my-saas.example.com".into(),
+    base_url: "https://my-saas.example.com/api".into(),
+};
+// In AuthBackend::auth_routes():
+Some(my_auth_routes.merge(cli_auth_routes(cli_state)))
+```
+
+See `crates/server/src/auth/cli_auth.rs` for the full implementation.
+
 ## Non-goals
 
 This spec does not require:
@@ -144,6 +165,7 @@ Those may be added later, but they are outside the current embedding contract.
 
 - `crates/core/src/platform_definition.rs`
 - `crates/core/src/connection_provider.rs`
+- `crates/server/src/auth/cli_auth.rs`
 - `crates/server/src/app_builder.rs`
 - `crates/server/src/platform.rs`
 - `crates/server/src/seed.rs`

--- a/specs/embedding.md
+++ b/specs/embedding.md
@@ -134,7 +134,7 @@ Embedders may extend execution by:
 
 CLI authentication routes (`/v1/auth/cli/*`) are decoupled from any specific auth backend via `CliAuthState`. Embedders with external auth providers can mount CLI login without duplicating handler code.
 
-Construct `CliAuthState` with your storage backend, `AuthState`, and URLs, then mount via `cli_auth_routes()`:
+Construct `CliAuthState` with your storage backend, `AuthState`, and URLs, then mount via `cli_auth_routes()`. `base_url` must include any API path prefix (e.g. `/api`) — no env-var lookup is performed at runtime:
 
 ```rust
 use everruns_server::auth::cli_auth::{CliAuthState, cli_auth_routes};
@@ -142,7 +142,9 @@ use everruns_server::auth::cli_auth::{CliAuthState, cli_auth_routes};
 let cli_state = CliAuthState {
     db: db.clone(),
     auth: auth_state.clone(),
+    // Frontend origin for login page redirects
     frontend_url: "https://my-saas.example.com".into(),
+    // Full backend URL including API prefix — used directly in callback URLs
     base_url: "https://my-saas.example.com/api".into(),
 };
 // In AuthBackend::auth_routes():


### PR DESCRIPTION
## What

Extract `CliAuthState` as a generic state type for CLI auth routes, removing the tight coupling to `BuiltinAuthBackend`.

## Why

`cli_auth_routes(state: BuiltinAuthBackend)` was tightly coupled to the OSS auth backend. The handlers only need `Arc<StorageBackend>` (for session CRUD + API key creation) and `AuthState` (for the `AuthUser` extractor). SaaS was forced to duplicate the entire ~250-line module just to swap the state type.

## How

- Add `CliAuthState` struct with `db`, `auth`, `frontend_url`, `base_url` fields
- Implement `FromRef<CliAuthState> for AuthState` (enables `AuthUser` extractor)
- Update `BuiltinAuthBackend::auth_routes()` to construct `CliAuthState` (folds `API_PREFIX` into `base_url`)
- Export `CliAuthState` from `everruns_server::auth`
- Document CLI auth extension point in `specs/embedding.md`

## Risk

- **Low** — Pure refactor. No new endpoints, no auth logic changes. `AuthBackend` trait unchanged.
- Existing CLI auth integration tests pass unchanged (same handlers, same DB queries).

## Security

- Threat categories reviewed: **TM-AUTH**, **TM-API**, **TM-TENANT**
- TM-AUTH: CLI auth session creation/exchange/callback flow unchanged. `AuthUser` extractor still operates through `AuthState`/`AuthBackend` trait.
- TM-API: Same routes, same handlers, same validation. Removing hidden `API_PREFIX` env-var lookup reduces misconfiguration risk.
- TM-TENANT: `StorageBackend` access unchanged — same DB queries, same org scoping.
- No injection, data exposure, or resource exhaustion risks introduced.

## Checklist

- [x] Tests added or updated (existing CLI auth tests cover the change — no new behavior)
- [x] Backward compatibility considered (no breaking changes to `AuthBackend` trait)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Closes EVE-176