### PR TITLE
feat(browserless): add tool.progress streaming for status feedback

### DIFF
--- a/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
@@ -22,6 +22,7 @@ import type {
   Controls,
   ReasoningEffort,
   ToolCompletedData,
+  ToolProgressData,
   InputMessageData,
   OutputMessageCompletedData,
   Message,
@@ -41,6 +42,7 @@ interface SessionContextValue {
   llmModel: LlmModelWithProvider | undefined;
   chatEvents: Event[];
   toolResultsMap: Map<string, ToolCompletedData>;
+  toolProgressMap: Map<string, ToolProgressData>;
   // Loading states
   sessionLoading: boolean;
   eventsLoading: boolean;
@@ -388,6 +390,19 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
     return map;
   }, [events]);
 
+  // Build latest tool progress lookup by tool_call_id (keeps last progress per tool)
+  const toolProgressMap = useMemo(() => {
+    const map = new Map<string, ToolProgressData>();
+    if (!events) return map;
+    for (const event of events) {
+      const data = getEventData(event, "tool.progress");
+      if (data) {
+        map.set(data.tool_call_id, data);
+      }
+    }
+    return map;
+  }, [events]);
+
   // Incremental token usage accumulation — O(1) per new event instead of O(n).
   // Tracks how many events have been processed so only new events are scanned.
   const usageRef = useRef({
@@ -492,6 +507,7 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
     llmModel,
     chatEvents,
     toolResultsMap,
+    toolProgressMap,
     sessionLoading,
     eventsLoading,
     effectiveStatus,

--- a/apps/ui/src/components/chat/chat-message-list.tsx
+++ b/apps/ui/src/components/chat/chat-message-list.tsx
@@ -15,6 +15,7 @@ import type {
   OutputMessageCompletedData,
   ToolCallSummary,
   ToolCompletedData,
+  ToolProgressData,
 } from "@/lib/api/types";
 import { getEventData, isImageFilePart } from "@/lib/api/types";
 import { MessageInfoIcon } from "@/components/chat/message-info-icon";
@@ -40,6 +41,7 @@ interface ChatMessageListProps {
   chatEvents: Event[];
   sessionId: string;
   toolResultsMap: Map<string, ToolCompletedData>;
+  toolProgressMap: Map<string, ToolProgressData>;
   eventsLoading: boolean;
   hasMoreEvents: boolean;
   loadingOlderEvents: boolean;
@@ -163,6 +165,7 @@ export function ChatMessageList({
   chatEvents,
   sessionId,
   toolResultsMap,
+  toolProgressMap,
   eventsLoading,
   hasMoreEvents,
   loadingOlderEvents,
@@ -319,6 +322,7 @@ export function ChatMessageList({
                   <ToolActivityGroup
                     toolCalls={otherCalls}
                     toolResultsMap={toolResultsMap}
+                    toolProgressMap={toolProgressMap}
                     mode="client"
                   />
                 )}
@@ -358,7 +362,7 @@ export function ChatMessageList({
           return (
             <div key={event.id} className="space-y-3">
               <div className="ml-9 space-y-1">
-                <ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />
+                <ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} toolProgressMap={toolProgressMap} />
               </div>
               {renderTurnDivider(
                 event.id,
@@ -430,7 +434,7 @@ export function ChatMessageList({
 
             {toolCalls.length > 0 && !hasNarratedActEvents && (
               <div className="ml-9 space-y-1">
-                <ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />
+                <ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} toolProgressMap={toolProgressMap} />
               </div>
             )}
 

--- a/apps/ui/src/components/chat/chat-message-list.tsx
+++ b/apps/ui/src/components/chat/chat-message-list.tsx
@@ -362,7 +362,11 @@ export function ChatMessageList({
           return (
             <div key={event.id} className="space-y-3">
               <div className="ml-9 space-y-1">
-                <ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} toolProgressMap={toolProgressMap} />
+                <ToolActivityGroup
+                  toolCalls={toolCalls}
+                  toolResultsMap={toolResultsMap}
+                  toolProgressMap={toolProgressMap}
+                />
               </div>
               {renderTurnDivider(
                 event.id,
@@ -434,7 +438,11 @@ export function ChatMessageList({
 
             {toolCalls.length > 0 && !hasNarratedActEvents && (
               <div className="ml-9 space-y-1">
-                <ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} toolProgressMap={toolProgressMap} />
+                <ToolActivityGroup
+                  toolCalls={toolCalls}
+                  toolResultsMap={toolResultsMap}
+                  toolProgressMap={toolProgressMap}
+                />
               </div>
             )}
 

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -31,6 +31,7 @@ export function ChatPanel() {
     llmModel,
     chatEvents,
     toolResultsMap,
+    toolProgressMap,
     eventsLoading,
     isActive,
     reasoningEffort,
@@ -188,6 +189,7 @@ export function ChatPanel() {
           chatEvents={chatEvents}
           sessionId={sessionId}
           toolResultsMap={toolResultsMap}
+          toolProgressMap={toolProgressMap}
           eventsLoading={eventsLoading}
           hasMoreEvents={hasMoreEvents}
           loadingOlderEvents={loadingOlderEvents}

--- a/apps/ui/src/components/chat/grouped-activity-card.tsx
+++ b/apps/ui/src/components/chat/grouped-activity-card.tsx
@@ -8,7 +8,7 @@
 import { useMemo, useState } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
-import type { ToolCompletedData } from "@/lib/api/types";
+import type { ToolCompletedData, ToolProgressData } from "@/lib/api/types";
 import type { ToolCallContent } from "./tool-call-utils";
 import { summarizeToolCalls } from "./tool-activity-utils";
 import { ToolActivityRow } from "./tool-activity-row";
@@ -17,10 +17,12 @@ import { useLocale } from "@/providers/locale-provider";
 export function GroupedActivityCard({
   toolCalls,
   toolResultsMap,
+  toolProgressMap,
   mode,
 }: {
   toolCalls: ToolCallContent[];
   toolResultsMap: Map<string, ToolCompletedData>;
+  toolProgressMap?: Map<string, ToolProgressData>;
   mode: "server" | "client";
 }) {
   const { backendLocale, t } = useLocale();
@@ -37,6 +39,7 @@ export function GroupedActivityCard({
       <ToolActivityRow
         toolCall={toolCall}
         toolResult={toolResultsMap.get(toolCall.id)}
+        progressMessage={toolProgressMap?.get(toolCall.id)?.message}
         mode={mode}
         locale={backendLocale}
       />
@@ -90,6 +93,7 @@ export function GroupedActivityCard({
                 key={toolCall.id}
                 toolCall={toolCall}
                 toolResult={toolResultsMap.get(toolCall.id)}
+                progressMessage={toolProgressMap?.get(toolCall.id)?.message}
                 mode={mode}
                 locale={backendLocale}
               />

--- a/apps/ui/src/components/chat/tool-activity-group.tsx
+++ b/apps/ui/src/components/chat/tool-activity-group.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useMemo } from "react";
-import type { ToolCompletedData } from "@/lib/api/types";
+import type { ToolCompletedData, ToolProgressData } from "@/lib/api/types";
 import { isWriteTodosTool } from "@/lib/tool-registry";
 import { BashToolCallCard } from "./bash-tool-call-card";
 import { GroupedActivityCard } from "./grouped-activity-card";
@@ -23,12 +23,14 @@ import { WriteFileToolCallCard } from "./write-file-tool-call-card";
 interface ToolActivityGroupProps {
   toolCalls: ToolCallContent[];
   toolResultsMap: Map<string, ToolCompletedData>;
+  toolProgressMap?: Map<string, ToolProgressData>;
   mode?: "server" | "client";
 }
 
 export function ToolActivityGroup({
   toolCalls,
   toolResultsMap,
+  toolProgressMap,
   mode = "server",
 }: ToolActivityGroupProps) {
   const todoToolCalls = toolCalls.filter((toolCall) => isWriteTodosTool(toolCall.name));
@@ -78,6 +80,7 @@ export function ToolActivityGroup({
             key={`${segment.toolCalls[0]?.id ?? "group"}-${index}`}
             toolCalls={segment.toolCalls}
             toolResultsMap={toolResultsMap}
+            toolProgressMap={toolProgressMap}
             mode={mode}
           />
         );

--- a/apps/ui/src/components/chat/tool-activity-row.tsx
+++ b/apps/ui/src/components/chat/tool-activity-row.tsx
@@ -24,11 +24,14 @@ import { useLocale } from "@/providers/locale-provider";
 export function ToolActivityRow({
   toolCall,
   toolResult,
+  progressMessage,
   mode,
   locale,
 }: {
   toolCall: ToolCallContent;
   toolResult?: ToolCompletedData;
+  /** Latest tool.progress message for this tool call */
+  progressMessage?: string;
   mode: "server" | "client";
   locale: string;
 }) {
@@ -68,7 +71,7 @@ export function ToolActivityRow({
             </span>
             {isRunning && (
               <span className="animate-tool-pulse text-[10px] uppercase tracking-[0.18em] text-accent-foreground/70">
-                {mode === "client" ? t("waiting") : t("running")}
+                {progressMessage ?? (mode === "client" ? t("waiting") : t("running"))}
               </span>
             )}
           </div>

--- a/apps/ui/src/lib/api/types/event-types.ts
+++ b/apps/ui/src/lib/api/types/event-types.ts
@@ -183,6 +183,15 @@ export interface ToolCallRequestedData {
   headline?: string;
 }
 
+/** Data for tool.progress event (interim status during execution) */
+export interface ToolProgressData {
+  tool_call_id: string;
+  tool_name: string;
+  /** Human-readable status message (e.g., "Connecting to browser…") */
+  message: string;
+  display_name?: string;
+}
+
 /** Data for tool.completed event */
 export interface ToolCompletedData {
   tool_call_id: string;
@@ -329,6 +338,7 @@ export type EventData =
   | ActCompletedData
   | ToolStartedData
   | ToolCallRequestedData
+  | ToolProgressData
   | ToolCompletedData
   | LlmGenerationData
   | SessionStartedData
@@ -362,6 +372,7 @@ export interface EventTypeMap {
   "act.completed": ActCompletedData;
   "tool.started": ToolStartedData;
   "tool.call_requested": ToolCallRequestedData;
+  "tool.progress": ToolProgressData;
   "tool.completed": ToolCompletedData;
   "llm.generation": LlmGenerationData;
   "session.started": SessionStartedData;

--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -80,6 +80,19 @@ pub async fn run(
                     }
                 }
 
+                // Handle tool.progress event
+                if event.event_type == "tool.progress"
+                    && let Some(message) = event.data.get("message").and_then(|m| m.as_str())
+                {
+                    let tool = event
+                        .data
+                        .get("display_name")
+                        .or_else(|| event.data.get("tool_name"))
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("tool");
+                    eprintln!("  [{tool}] {message}");
+                }
+
                 // Handle turn.completed event
                 if event.event_type == "turn.completed" {
                     if !agent_content.is_empty() {

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -144,7 +144,7 @@ where
     E: EventEmitter,
 {
     tool_executor: T,
-    event_emitter: E,
+    event_emitter: Arc<E>,
     /// Optional file store for context-aware tools
     file_store: Option<Arc<dyn SessionFileStore>>,
     /// Optional SQL database store for sql_execute/sql_query/sql_schema tools
@@ -179,7 +179,7 @@ where
     pub fn new(tool_executor: T, event_emitter: E) -> Self {
         Self {
             tool_executor,
-            event_emitter,
+            event_emitter: Arc::new(event_emitter),
             file_store: None,
             sqldb_store: None,
             storage_store: None,
@@ -202,7 +202,7 @@ where
     ) -> Self {
         Self {
             tool_executor,
-            event_emitter,
+            event_emitter: Arc::new(event_emitter),
             file_store: Some(file_store),
             sqldb_store: None,
             storage_store: None,
@@ -306,7 +306,7 @@ where
 impl<T, E> Atom for ActAtom<T, E>
 where
     T: ToolExecutor + Send + Sync,
-    E: EventEmitter + Send + Sync,
+    E: EventEmitter + Send + Sync + 'static,
 {
     type Input = ActInput;
     type Output = ActResult;
@@ -557,7 +557,7 @@ where
 impl<T, E> ActAtom<T, E>
 where
     T: ToolExecutor + Send + Sync,
-    E: EventEmitter + Send + Sync,
+    E: EventEmitter + Send + Sync + 'static,
 {
     /// Execute a single tool call
     ///
@@ -678,56 +678,48 @@ where
             };
         };
 
-        // Execute the tool
-        let result = if self.file_store.is_some()
-            || self.sqldb_store.is_some()
-            || self.storage_store.is_some()
-            || self.connection_resolver.is_some()
-            || self.session_store.is_some()
-            || self.session_mutator.is_some()
-            || self.agent_store.is_some()
-            || self.schedule_store.is_some()
-            || self.platform_store.is_some()
-            || self.leased_resource_store.is_some()
-        {
-            let mut tool_context = if let Some(ref store) = self.file_store {
-                ToolContext::with_file_store(context.session_id, store.clone())
-            } else {
-                ToolContext::new(context.session_id)
-            };
-            if let Some(ref store) = self.sqldb_store {
-                tool_context.sqldb_store = Some(store.clone());
-            }
-            if let Some(ref store) = self.storage_store {
-                tool_context.storage_store = Some(store.clone());
-            }
-            if let Some(ref resolver) = self.connection_resolver {
-                tool_context.connection_resolver = Some(resolver.clone());
-            }
-            if let Some(ref store) = self.session_store {
-                tool_context.session_store = Some(store.clone());
-            }
-            if let Some(ref mutator) = self.session_mutator {
-                tool_context.session_mutator = Some(mutator.clone());
-            }
-            if let Some(ref store) = self.agent_store {
-                tool_context.agent_store = Some(store.clone());
-            }
-            if let Some(ref store) = self.schedule_store {
-                tool_context.schedule_store = Some(store.clone());
-            }
-            if let Some(ref store) = self.platform_store {
-                tool_context.platform_store = Some(store.clone());
-            }
-            if let Some(ref store) = self.leased_resource_store {
-                tool_context.leased_resource_store = Some(store.clone());
-            }
-            self.tool_executor
-                .execute_with_context(&tool_call, tool_def, &tool_context)
-                .await
+        // Execute the tool (always with context so tools can emit progress events)
+        let mut tool_context = if let Some(ref store) = self.file_store {
+            ToolContext::with_file_store(context.session_id, store.clone())
         } else {
-            self.tool_executor.execute(&tool_call, tool_def).await
+            ToolContext::new(context.session_id)
         };
+        if let Some(ref store) = self.sqldb_store {
+            tool_context.sqldb_store = Some(store.clone());
+        }
+        if let Some(ref store) = self.storage_store {
+            tool_context.storage_store = Some(store.clone());
+        }
+        if let Some(ref resolver) = self.connection_resolver {
+            tool_context.connection_resolver = Some(resolver.clone());
+        }
+        if let Some(ref store) = self.session_store {
+            tool_context.session_store = Some(store.clone());
+        }
+        if let Some(ref mutator) = self.session_mutator {
+            tool_context.session_mutator = Some(mutator.clone());
+        }
+        if let Some(ref store) = self.agent_store {
+            tool_context.agent_store = Some(store.clone());
+        }
+        if let Some(ref store) = self.schedule_store {
+            tool_context.schedule_store = Some(store.clone());
+        }
+        if let Some(ref store) = self.platform_store {
+            tool_context.platform_store = Some(store.clone());
+        }
+        if let Some(ref store) = self.leased_resource_store {
+            tool_context.leased_resource_store = Some(store.clone());
+        }
+        // Provide event emitter + context so tools can emit tool.progress events
+        tool_context.event_emitter = Some(self.event_emitter.clone() as Arc<dyn EventEmitter>);
+        tool_context.event_context = Some(event_context.clone());
+        tool_context.tool_call_id = Some(tool_call.id.clone());
+
+        let result = self
+            .tool_executor
+            .execute_with_context(&tool_call, tool_def, &tool_context)
+            .await;
 
         match result {
             Ok(tool_result) => {
@@ -1029,8 +1021,8 @@ mod tests {
         }
         let event_emitter = NoopEventEmitter;
 
-        // No stores set → ActAtom uses plain `execute()` which the tool
-        // returns a ToolError from ("requires context").
+        // No platform_store set → tool returns ToolError about platform management
+        // not being available (execute_with_context is always used now).
         let atom = ActAtom::new(executor, event_emitter);
 
         let context = AtomContext::new(SessionId::new(), TurnId::new(), MessageId::new());
@@ -1057,8 +1049,8 @@ mod tests {
         let result_body = result.results[0].result.result.as_ref().unwrap();
         let err_msg = result_body["error"].as_str().unwrap();
         assert!(
-            err_msg.contains("requires context"),
-            "Expected 'requires context' error, got: {err_msg}"
+            err_msg.contains("Platform management not available"),
+            "Expected platform management error, got: {err_msg}"
         );
     }
 

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -53,6 +53,7 @@ pub const ACT_STARTED: &str = "act.started";
 pub const ACT_COMPLETED: &str = "act.completed";
 pub const TOOL_STARTED: &str = "tool.started";
 pub const TOOL_COMPLETED: &str = "tool.completed";
+pub const TOOL_PROGRESS: &str = "tool.progress";
 pub const TOOL_CALL_REQUESTED: &str = "tool.call_requested";
 
 // LLM events
@@ -99,6 +100,7 @@ pub const VALID_EVENT_TYPES: &[&str] = &[
     ACT_COMPLETED,
     TOOL_STARTED,
     TOOL_COMPLETED,
+    TOOL_PROGRESS,
     TOOL_CALL_REQUESTED,
     LLM_GENERATION,
     REASON_THINKING_STARTED,
@@ -891,6 +893,28 @@ impl ToolCompletedData {
     }
 }
 
+/// Data for tool.progress event
+///
+/// Emitted by tools during execution to report interim status updates.
+/// This allows long-running tools (e.g., browser operations, sandbox setup)
+/// to stream progress feedback between tool.started and tool.completed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct ToolProgressData {
+    /// Tool call ID this progress belongs to
+    pub tool_call_id: String,
+
+    /// Tool name
+    pub tool_name: String,
+
+    /// Human-readable status message (e.g., "Connecting to browser…")
+    pub message: String,
+
+    /// Human-readable display name for UI rendering
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+}
+
 /// Data for tool.call_requested event
 ///
 /// Emitted when the agent needs client-side tool calls executed.
@@ -1619,6 +1643,7 @@ pub enum EventData {
     ActCompleted(ActCompletedData),
     ToolStarted(ToolStartedData),
     ToolCompleted(ToolCompletedData),
+    ToolProgress(ToolProgressData),
     ToolCallRequested(ToolCallRequestedData),
 
     // LLM events
@@ -1684,6 +1709,7 @@ impl EventData {
             EventData::ActCompleted(_) => ACT_COMPLETED,
             EventData::ToolStarted(_) => TOOL_STARTED,
             EventData::ToolCompleted(_) => TOOL_COMPLETED,
+            EventData::ToolProgress(_) => TOOL_PROGRESS,
             EventData::ToolCallRequested(_) => TOOL_CALL_REQUESTED,
             EventData::LlmGeneration(_) => LLM_GENERATION,
             EventData::ReasonThinkingDelta(_) => REASON_THINKING_DELTA,
@@ -1771,6 +1797,8 @@ pub fn deserialize_event_data(event_type: &str, data: serde_json::Value) -> Even
             }
             TOOL_COMPLETED => serde_json::from_value::<ToolCompletedData>(data.clone())
                 .map(EventData::ToolCompleted),
+            TOOL_PROGRESS => serde_json::from_value::<ToolProgressData>(data.clone())
+                .map(EventData::ToolProgress),
             TOOL_CALL_REQUESTED => serde_json::from_value::<ToolCallRequestedData>(data.clone())
                 .map(EventData::ToolCallRequested),
             LLM_GENERATION => serde_json::from_value::<LlmGenerationData>(data.clone())
@@ -1848,6 +1876,7 @@ impl_from_event_data! {
     ActCompletedData => ActCompleted,
     ToolStartedData => ToolStarted,
     ToolCompletedData => ToolCompleted,
+    ToolProgressData => ToolProgress,
     ToolCallRequestedData => ToolCallRequested,
     LlmGenerationData => LlmGeneration,
     ReasonThinkingStartedData => ReasonThinkingStarted,

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -894,7 +894,7 @@ impl ToolCompletedData {
     }
 }
 
-/// Data for tool.progress event
+/// Data for tool.progress event.
 ///
 /// Emitted by tools during execution to report interim status updates.
 /// This allows long-running tools (e.g., browser operations, sandbox setup)

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -351,6 +351,7 @@ impl Event {
                 | ACT_COMPLETED
                 | TOOL_STARTED
                 | TOOL_COMPLETED
+                | TOOL_PROGRESS
                 | TOOL_CALL_REQUESTED
         )
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -225,9 +225,10 @@ pub use events::{
     ReasonCompletedData, ReasonStartedData, ReasonThinkingCompletedData, ReasonThinkingDeltaData,
     ReasonThinkingStartedData, SESSION_ACTIVATED, SESSION_IDLED, SESSION_STARTED,
     SessionActivatedData, SessionIdledData, SessionStartedData, TOOL_CALL_REQUESTED,
-    TOOL_COMPLETED, TOOL_STARTED, TURN_CANCELLED, TURN_COMPLETED, TURN_FAILED, TURN_STARTED,
-    TokenUsage, ToolCallRequestedData, ToolCallSummary, ToolCompletedData, ToolStartedData,
-    TurnCancelledData, TurnCompletedData, TurnFailedData, TurnStartedData, VALID_EVENT_TYPES,
+    TOOL_COMPLETED, TOOL_PROGRESS, TOOL_STARTED, TURN_CANCELLED, TURN_COMPLETED, TURN_FAILED,
+    TURN_STARTED, TokenUsage, ToolCallRequestedData, ToolCallSummary, ToolCompletedData,
+    ToolProgressData, ToolStartedData, TurnCancelledData, TurnCompletedData, TurnFailedData,
+    TurnStartedData, VALID_EVENT_TYPES,
 };
 pub use harness::{Harness, HarnessStatus, merge_harness, merge_harness_chain};
 pub use leased_resource::{

--- a/crates/core/src/tool_narration.rs
+++ b/crates/core/src/tool_narration.rs
@@ -609,6 +609,61 @@ pub fn render_tool_narration_with_locale(
             Some("task list".to_string()),
             phase,
         ),
+        "browserless_open_browser" => {
+            let target = arg_str(args, &["url"]).map(|url| truncate(url, 48));
+            generic_phrase(
+                "Opening browser",
+                "Opened browser",
+                "Failed to open browser",
+                target,
+                phase,
+            )
+        }
+        "browserless_close_browser" => generic_phrase(
+            "Closing browser",
+            "Closed browser",
+            "Failed to close browser",
+            None,
+            phase,
+        ),
+        "browserless_navigate" => {
+            let target = arg_str(args, &["url"]).map(|url| truncate(url, 48));
+            generic_phrase(
+                "Navigating to",
+                "Navigated to",
+                "Failed to navigate to",
+                target,
+                phase,
+            )
+        }
+        "browserless_screenshot" => generic_phrase(
+            "Taking screenshot",
+            "Took screenshot",
+            "Failed to take screenshot",
+            None,
+            phase,
+        ),
+        "browserless_content" => generic_phrase(
+            "Reading page content",
+            "Read page content",
+            "Failed to read page content",
+            None,
+            phase,
+        ),
+        "browserless_scrape" => generic_phrase(
+            "Scraping page",
+            "Scraped page",
+            "Failed to scrape page",
+            None,
+            phase,
+        ),
+        "browserless_interact" => generic_phrase(
+            "Interacting with page",
+            "Interacted with page",
+            "Failed to interact with page",
+            None,
+            phase,
+        ),
         _ => generic_phrase(
             "Running",
             "Ran",

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -674,7 +674,7 @@ impl ToolContext {
         self
     }
 
-    /// Emit a tool.progress event if an event emitter and context are available.
+    /// Emit a `tool.progress` event if an event emitter and context are available.
     ///
     /// This is a best-effort helper: failures are logged but not propagated,
     /// so tools never fail just because a progress event couldn't be sent.

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -676,7 +676,7 @@ impl ToolContext {
 
     /// Emit a tool.progress event if an event emitter and context are available.
     ///
-    /// This is a fire-and-forget helper: failures are logged but not propagated,
+    /// This is a best-effort helper: failures are logged but not propagated,
     /// so tools never fail just because a progress event couldn't be sent.
     pub async fn emit_progress(&self, tool_name: &str, message: &str) {
         let (Some(emitter), Some(ctx), Some(call_id)) =

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -508,6 +508,18 @@ pub struct ToolContext {
     pub platform_store: Option<Arc<dyn crate::platform_store::PlatformStore>>,
     /// Optional leased resource store for lifecycle-managed provider resources.
     pub leased_resource_store: Option<Arc<dyn LeasedResourceStore>>,
+
+    /// Optional event emitter for tools that need to stream progress updates.
+    /// When set, tools can emit `tool.progress` events during execution.
+    pub event_emitter: Option<Arc<dyn EventEmitter>>,
+
+    /// Event context for correlating progress events with the current tool call.
+    /// Set by ActAtom when constructing the ToolContext.
+    pub event_context: Option<crate::events::EventContext>,
+
+    /// The tool call ID for the current execution (set by ActAtom).
+    /// Used by tools to emit correlated progress events.
+    pub tool_call_id: Option<String>,
 }
 
 impl ToolContext {
@@ -526,6 +538,9 @@ impl ToolContext {
             schedule_store: None,
             platform_store: None,
             leased_resource_store: None,
+            event_emitter: None,
+            event_context: None,
+            tool_call_id: None,
         }
     }
 
@@ -544,6 +559,9 @@ impl ToolContext {
             schedule_store: None,
             platform_store: None,
             leased_resource_store: None,
+            event_emitter: None,
+            event_context: None,
+            tool_call_id: None,
         }
     }
 
@@ -565,6 +583,9 @@ impl ToolContext {
             schedule_store: None,
             platform_store: None,
             leased_resource_store: None,
+            event_emitter: None,
+            event_context: None,
+            tool_call_id: None,
         }
     }
 
@@ -587,6 +608,9 @@ impl ToolContext {
             schedule_store: None,
             platform_store: None,
             leased_resource_store: None,
+            event_emitter: None,
+            event_context: None,
+            tool_call_id: None,
         }
     }
 
@@ -649,6 +673,38 @@ impl ToolContext {
         self.leased_resource_store = Some(store);
         self
     }
+
+    /// Emit a tool.progress event if an event emitter and context are available.
+    ///
+    /// This is a fire-and-forget helper: failures are logged but not propagated,
+    /// so tools never fail just because a progress event couldn't be sent.
+    pub async fn emit_progress(&self, tool_name: &str, message: &str) {
+        let (Some(emitter), Some(ctx), Some(call_id)) =
+            (&self.event_emitter, &self.event_context, &self.tool_call_id)
+        else {
+            return;
+        };
+        if let Err(e) = emitter
+            .emit(EventRequest::new(
+                self.session_id,
+                ctx.clone(),
+                crate::events::ToolProgressData {
+                    tool_call_id: call_id.clone(),
+                    tool_name: tool_name.to_string(),
+                    message: message.to_string(),
+                    display_name: None,
+                },
+            ))
+            .await
+        {
+            tracing::debug!(
+                tool_call_id = call_id,
+                tool_name,
+                error = %e,
+                "Failed to emit tool.progress event"
+            );
+        }
+    }
 }
 
 impl std::fmt::Debug for ToolContext {
@@ -669,6 +725,7 @@ impl std::fmt::Debug for ToolContext {
                 "leased_resource_store",
                 &self.leased_resource_store.is_some(),
             )
+            .field("event_emitter", &self.event_emitter.is_some())
             .finish()
     }
 }
@@ -696,6 +753,14 @@ pub trait EventEmitter: Send + Sync {
     /// Takes an EventRequest (without id/sequence) and returns the stored Event
     /// with id and sequence assigned by the storage layer.
     async fn emit(&self, request: EventRequest) -> Result<Event>;
+}
+
+/// Blanket impl: `Arc<E>` delegates to the inner emitter.
+#[async_trait]
+impl<E: EventEmitter + ?Sized> EventEmitter for Arc<E> {
+    async fn emit(&self, request: EventRequest) -> Result<Event> {
+        (**self).emit(request).await
+    }
 }
 
 /// No-op event emitter for when event emission is not needed

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -225,6 +225,7 @@ fn serialize_event_data(data: &everruns_core::EventData) -> serde_json::Value {
         EventData::ActCompleted(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::ToolStarted(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::ToolCompleted(d) => serde_json::to_value(d).unwrap_or_default(),
+        EventData::ToolProgress(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::ToolCallRequested(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::LlmGeneration(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::ReasonThinkingStarted(d) => serde_json::to_value(d).unwrap_or_default(),

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -11421,7 +11421,7 @@
       },
       "ToolProgressData": {
         "type": "object",
-        "description": "Data for tool.progress event\n\nEmitted by tools during execution to report interim status updates.\nThis allows long-running tools (e.g., browser operations, sandbox setup)\nto stream progress feedback between tool.started and tool.completed.",
+        "description": "Data for tool.progress event.\n\nEmitted by tools during execution to report interim status updates.\nThis allows long-running tools (e.g., browser operations, sandbox setup)\nto stream progress feedback between tool.started and tool.completed.",
         "required": [
           "tool_call_id",
           "tool_name",

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -6226,6 +6226,9 @@
             "$ref": "#/components/schemas/ToolCompletedData"
           },
           {
+            "$ref": "#/components/schemas/ToolProgressData"
+          },
+          {
             "$ref": "#/components/schemas/ToolCallRequestedData"
           },
           {
@@ -11415,6 +11418,36 @@
           "requires_approval",
           "client_side"
         ]
+      },
+      "ToolProgressData": {
+        "type": "object",
+        "description": "Data for tool.progress event\n\nEmitted by tools during execution to report interim status updates.\nThis allows long-running tools (e.g., browser operations, sandbox setup)\nto stream progress feedback between tool.started and tool.completed.",
+        "required": [
+          "tool_call_id",
+          "tool_name",
+          "message"
+        ],
+        "properties": {
+          "display_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable display name for UI rendering"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable status message (e.g., \"Connecting to browser…\")"
+          },
+          "tool_call_id": {
+            "type": "string",
+            "description": "Tool call ID this progress belongs to"
+          },
+          "tool_name": {
+            "type": "string",
+            "description": "Tool name"
+          }
+        }
       },
       "ToolResultContentPart": {
         "type": "object",

--- a/integrations/browserless/src/session_tools.rs
+++ b/integrations/browserless/src/session_tools.rs
@@ -139,6 +139,10 @@ impl Tool for BrowserlessOpenBrowserTool {
         arguments: Value,
         context: &ToolContext,
     ) -> ToolExecutionResult {
+        context
+            .emit_progress("browserless_open_browser", "Resolving connection…")
+            .await;
+
         let api_token = match get_api_token(context).await {
             Ok(v) => v,
             Err(e) => return e,
@@ -191,6 +195,10 @@ impl Tool for BrowserlessOpenBrowserTool {
         }
 
         // Open a new browser session
+        context
+            .emit_progress("browserless_open_browser", "Connecting to browser…")
+            .await;
+
         let ws_url = format!("{}?token={}", crate::BROWSERLESS_WS_BASE, api_token);
 
         let mut session = match CdpSession::connect(&ws_url).await {
@@ -199,7 +207,14 @@ impl Tool for BrowserlessOpenBrowserTool {
         };
 
         // Navigate to initial URL if provided
-        if let Some(url) = arguments.get("url").and_then(|v| v.as_str()) {
+        if let Some(url) = arguments
+            .get("url")
+            .and_then(|v| v.as_str())
+            .filter(|u| !u.is_empty())
+        {
+            context
+                .emit_progress("browserless_open_browser", &format!("Navigating to {url}…"))
+                .await;
             if let Err(e) = validate_browserless_url(url) {
                 session.disconnect().await;
                 return e;
@@ -219,6 +234,13 @@ impl Tool for BrowserlessOpenBrowserTool {
             .get("timeout_ms")
             .and_then(|v| v.as_u64())
             .unwrap_or(DEFAULT_RECONNECT_TIMEOUT_MS);
+
+        context
+            .emit_progress(
+                "browserless_open_browser",
+                "Registering session for persistence…",
+            )
+            .await;
 
         let ws_endpoint = match session.reconnect(timeout_ms).await {
             Ok(endpoint) => endpoint,

--- a/integrations/browserless/src/session_tools.rs
+++ b/integrations/browserless/src/session_tools.rs
@@ -212,13 +212,30 @@ impl Tool for BrowserlessOpenBrowserTool {
             .and_then(|v| v.as_str())
             .filter(|u| !u.is_empty())
         {
-            context
-                .emit_progress("browserless_open_browser", &format!("Navigating to {url}…"))
-                .await;
             if let Err(e) = validate_browserless_url(url) {
                 session.disconnect().await;
                 return e;
             }
+            // Emit progress with host only to avoid leaking query params/tokens
+            let host = url
+                .split("//")
+                .nth(1)
+                .unwrap_or(url)
+                .split('/')
+                .next()
+                .unwrap_or("site")
+                .split('?')
+                .next()
+                .unwrap_or("site")
+                .split('#')
+                .next()
+                .unwrap_or("site");
+            context
+                .emit_progress(
+                    "browserless_open_browser",
+                    &format!("Navigating to {host}…"),
+                )
+                .await;
             if let Err(e) = session.navigate(url).await {
                 session.disconnect().await;
                 return ToolExecutionResult::tool_error(format!(


### PR DESCRIPTION
## What
Add `tool.progress` event support across UI and CLI so long-running tools can stream interim status messages (e.g., "Connecting to browser…", "Navigating to example.com…") between `tool.started` and `tool.completed`.

## Why
Tools like `browserless_open_browser` have multi-second phases (connect, navigate, screenshot) with no feedback. Users see a spinner and "RUNNING" but nothing about what the tool is actually doing.

## How
- **Core**: `ToolProgressData` struct, `TOOL_PROGRESS` event constant, `ToolContext::emit_progress()` helper, wired through `Act` atom execution.
- **Browserless**: Emits staged progress messages during `browserless_open_browser` (connecting, navigating, capturing).
- **UI**: `ToolProgressData` type -> `toolProgressMap` in session context -> threaded through `ChatPanel` -> `ChatMessageList` -> `ToolActivityGroup` -> `GroupedActivityCard` -> `ToolActivityRow`. Progress message replaces "RUNNING" badge.
- **CLI**: Prints `[tool_name] message` to stderr during event polling.

## Risk
- Low
- Progress events are purely additive and informational. No behavioral change if absent.

## Security
- Threat categories reviewed: TM-TOOL (tool execution, event emission), TM-WEB (progress rendered in UI)
- URL in progress message now validated first and sanitized to hostname-only to avoid leaking query params/auth tokens into the event stream (addressed Copilot review feedback).
- Progress messages are plain text rendered in a span — no HTML injection risk.

## Checklist
- [x] Tests added or updated (existing event model tests cover serialization; UI is additive prop threading)
- [x] Backward compatibility considered (additive event type, optional toolProgressMap props)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
