### PR TITLE
feat(deno): bring Deno integration to parity with Daytona

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
       daytona: ${{ steps.filter.outputs.daytona }}
+      deno: ${{ steps.filter.outputs.deno }}
       e2b: ${{ steps.filter.outputs.e2b }}
       sdk_compat: ${{ steps.filter.outputs.sdk_compat }}
       ui: ${{ steps.filter.outputs.ui }}
@@ -50,6 +51,8 @@ jobs:
               - '.github/workflows/ci.yml'
             daytona:
               - 'integrations/daytona/**'
+            deno:
+              - 'integrations/deno/**'
             e2b:
               - 'integrations/e2b/**'
             sdk_compat:
@@ -167,6 +170,7 @@ jobs:
         run: |
           cargo test -p everruns-anthropic -p everruns-openai -p everruns-gemini -p everruns-internal-protocol -p everruns-core --lib --all-features
           cargo test -p everruns-integrations-daytona --all-features
+          cargo test -p everruns-integrations-deno
           cargo test -p everruns-integrations-e2b
 
   # Live Daytona API tests — only when integrations/daytona/** changes and secret exists
@@ -270,6 +274,57 @@ jobs:
       - name: Run E2B live integration tests
         if: steps.check-key.outputs.skip != 'true'
         run: doppler run -- cargo test -p everruns-integrations-e2b --features e2b-live-tests --test live_api_test -- --test-threads=1
+
+  # Live Deno API tests — only when integrations/deno/** changes and secret exists
+  deno-live-test:
+    name: Deno Live API Tests
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.deno == 'true' && github.event_name == 'push'
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for Doppler token
+        id: check-key
+        run: |
+          if [ -z "$DOPPLER_TOKEN" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "⏭️ DOPPLER_TOKEN not configured, skipping live tests"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Doppler CLI
+        if: steps.check-key.outputs.skip != 'true'
+        uses: dopplerhq/cli-action@v3
+
+      - name: Install Rust toolchain
+        if: steps.check-key.outputs.skip != 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install protobuf compiler
+        if: steps.check-key.outputs.skip != 'true'
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Setup sccache
+        if: steps.check-key.outputs.skip != 'true'
+        uses: mozilla-actions/sccache-action@v0.0.7
+
+      - name: Configure sccache S3 backend
+        if: steps.check-key.outputs.skip != 'true' && env.DOPPLER_TOKEN != ''
+        run: ./.github/scripts/ci-sccache-env.sh >> "$GITHUB_ENV"
+
+      - name: Cache Rust
+        if: steps.check-key.outputs.skip != 'true'
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "test"
+
+      - name: Run Deno live integration tests
+        if: steps.check-key.outputs.skip != 'true'
+        run: doppler run -- cargo test -p everruns-integrations-deno --features deno-live-tests --test live_api_test -- --test-threads=1
 
   # Integration tests requiring PostgreSQL
   # Tests API endpoints, repositories, and durable execution against real database

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -57,6 +57,7 @@ mod seed_ids {
     pub const DATA_ANALYST_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000106);
     pub const DAYTONA_CODER_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000108);
     pub const E2B_CODER_AGENT: Uuid = Uuid::from_u128(0x0195bb5a_0000_7000_8000_00000000010f);
+    pub const DENO_CODER_AGENT: Uuid = Uuid::from_u128(0x0195bb5a_0000_7000_8000_000000000110);
     pub const CLOUD_INFRA_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000109);
     pub const PLATFORM_MANAGER_AGENT: Uuid =
         Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000010a);
@@ -660,6 +661,31 @@ Delete sandboxes when work is complete; pause only when the user explicitly want
         tags: &["coding", "cloud", "sandbox", "e2b", "demo", "seed"],
         capabilities: &[
             SeedCapability::new("e2b"),
+            SeedCapability::new("session_storage"),
+            SeedCapability::new("session_file_system"),
+        ],
+        dev_only: false,
+    },
+    SeedAgent {
+        id: seed_ids::DENO_CODER_AGENT,
+        name: "Deno Coder",
+        description: "A coding agent that runs code in cloud sandboxes powered by Deno",
+        system_prompt: r#"You are a Deno Coder Agent. You run code in cloud sandboxes powered by Deno.
+
+Just call sandbox tools directly — the access token is resolved automatically from Settings > Connections or environment variables.
+
+Workflow:
+1. Create sandbox: `deno_create_sandbox` (working directory: /home/sandbox)
+2. Write code / install deps: `deno_write_file`, `deno_exec`
+3. Read results: `deno_read_file`
+4. Inspect active sandboxes: `deno_list_sandboxes`
+5. Clean up: `deno_manage_sandbox` action="delete"
+
+You can run multiple sandboxes in parallel for different tasks.
+Always delete sandboxes when done."#,
+        tags: &["coding", "cloud", "sandbox", "deno", "demo", "seed"],
+        capabilities: &[
+            SeedCapability::new("deno"),
             SeedCapability::new("session_storage"),
             SeedCapability::new("session_file_system"),
         ],

--- a/docs/integrations/deno.md
+++ b/docs/integrations/deno.md
@@ -1,0 +1,64 @@
+---
+title: Deno
+description: Integrate Deno cloud sandbox environments for secure, isolated code execution. Configure access tokens, sandbox lifecycle, and session-scoped state.
+---
+
+Everruns integrates with [Deno Sandboxes](https://docs.deno.com/sandbox/) to provide cloud-based sandbox environments for secure, isolated code execution. Agents can create, manage, and interact with multiple sandboxes per session — each an isolated Linux microVM with network access.
+
+## What You Get
+
+- **Isolated Sandboxes**: Each sandbox is a secure, isolated Linux microVM
+- **Multi-Sandbox Sessions**: Create and manage multiple sandboxes within a single session
+- **File Operations**: Read and write text files in sandbox filesystems
+- **Shell Execution**: Run arbitrary commands via `bash -lc` with stdout/stderr capture
+- **Fixed Timeout Lifecycle**: Sandboxes are created with a concrete timeout (e.g. 20 minutes) since Everruns uses per-tool websocket connections
+
+## Quick Start
+
+### 1. Get Your Access Token
+
+1. Go to the [Deno Deploy Console](https://console.deno.com)
+2. Create an **organization access token** (`ddo_...`)
+3. Copy the token
+
+> **Note**: Personal tokens (`ddp_...`) are not supported in the generic connection flow yet. Use an organization token.
+
+### 2. Connect in Everruns
+
+1. Go to **Settings** > **Connections**
+2. Find **Deno Deploy** in the available providers
+3. Click **Connect** and paste your access token
+
+Once connected, the Deno capability is automatically available in agent sessions.
+
+### 3. Use in Sessions
+
+Agents with the Deno capability can use these tools:
+
+| Tool | Description |
+|------|-------------|
+| `deno_create_sandbox` | Create and start a new sandbox |
+| `deno_exec` | Execute shell commands |
+| `deno_read_file` | Read text files from sandbox |
+| `deno_write_file` | Write text files to sandbox |
+| `deno_list_sandboxes` | List active sandboxes in this session |
+| `deno_manage_sandbox` | Delete sandboxes |
+
+## Sandbox Lifecycle
+
+Deno sandboxes are created with a fixed timeout (default: 20 minutes) because Everruns closes the creator websocket after each tool call. The `timeout="session"` mode is not supported.
+
+Best practice is to explicitly delete sandboxes when done using `deno_manage_sandbox` with `action="delete"`.
+
+## Security
+
+- Access tokens are encrypted at rest (AES-256-GCM envelope encryption)
+- Each sandbox is a fully isolated Linux microVM
+- Tokens are resolved fresh from user connections on each tool call — never stored in sandbox state
+- Sandbox state is stored in encrypted session secrets
+- Capability is high-risk and requires admin configuration
+
+## Links
+
+- [Deno Sandboxes Documentation](https://docs.deno.com/sandbox/)
+- [Deno Deploy Console](https://console.deno.com)

--- a/integrations/deno/tests/tool_integration.rs
+++ b/integrations/deno/tests/tool_integration.rs
@@ -1,0 +1,500 @@
+//! Integration tests: tool execute_with_context for Deno sandbox tools.
+//!
+//! These tests exercise the full tool execution flow through the tool layer:
+//! MockStorageStore → tool.execute_with_context() → parameter/state/credential validation.
+//!
+//! Unlike the unit tests in src/tools.rs (which test schemas and parsing), these tests
+//! verify the orchestration between credential resolution, sandbox state persistence,
+//! and tool parameter validation through execute_with_context.
+//!
+//! NOTE: Deno uses websocket-based sandbox communication, so we cannot mock the
+//! sandbox API with wiremock (HTTP). These tests cover everything up to the actual
+//! websocket connection: credential resolution, state management, and parameter
+//! validation — the same surface Daytona's tool_integration.rs covers.
+
+use async_trait::async_trait;
+use everruns_core::error::Result;
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::{
+    KeyInfo, SecretInfo, SessionStorageStore, ToolContext, UserConnectionResolver,
+};
+use everruns_core::typed_id::SessionId;
+use serde_json::json;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+// Force linker to include the integration crate.
+use everruns_integrations_deno as _;
+
+use everruns_integrations_deno::state::SandboxState;
+
+// ============================================================================
+// Mock SessionStorageStore
+// ============================================================================
+
+struct MockStorageStore {
+    secrets: Mutex<HashMap<String, String>>,
+}
+
+impl MockStorageStore {
+    fn new() -> Self {
+        Self {
+            secrets: Mutex::new(HashMap::new()),
+        }
+    }
+
+    async fn seed_secret(&self, session_id: SessionId, name: &str, value: &str) {
+        let key = format!("{}:{}", session_id, name);
+        self.secrets.lock().await.insert(key, value.to_string());
+    }
+}
+
+#[async_trait]
+impl SessionStorageStore for MockStorageStore {
+    async fn set_value(&self, _session_id: SessionId, _key: &str, _value: &str) -> Result<()> {
+        Ok(())
+    }
+    async fn get_value(&self, _session_id: SessionId, _key: &str) -> Result<Option<String>> {
+        Ok(None)
+    }
+    async fn delete_value(&self, _session_id: SessionId, _key: &str) -> Result<bool> {
+        Ok(false)
+    }
+    async fn list_keys(&self, _session_id: SessionId) -> Result<Vec<KeyInfo>> {
+        Ok(vec![])
+    }
+    async fn set_secret(&self, session_id: SessionId, name: &str, value: &str) -> Result<()> {
+        let key = format!("{session_id}:{name}");
+        self.secrets.lock().await.insert(key, value.to_string());
+        Ok(())
+    }
+    async fn get_secret(&self, session_id: SessionId, name: &str) -> Result<Option<String>> {
+        let key = format!("{session_id}:{name}");
+        Ok(self.secrets.lock().await.get(&key).cloned())
+    }
+    async fn delete_secret(&self, session_id: SessionId, name: &str) -> Result<bool> {
+        let key = format!("{session_id}:{name}");
+        Ok(self.secrets.lock().await.remove(&key).is_some())
+    }
+    async fn list_secrets(&self, session_id: SessionId) -> Result<Vec<SecretInfo>> {
+        let prefix = format!("{session_id}:");
+        let secrets = self.secrets.lock().await;
+        Ok(secrets
+            .keys()
+            .filter(|k| k.starts_with(&prefix))
+            .map(|k| SecretInfo {
+                name: k.strip_prefix(&prefix).unwrap_or(k).to_string(),
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            })
+            .collect())
+    }
+}
+
+// ============================================================================
+// Mock ConnectionResolver
+// ============================================================================
+
+struct MockConnectionResolver {
+    token: Option<String>,
+}
+
+#[async_trait]
+impl UserConnectionResolver for MockConnectionResolver {
+    async fn get_connection_token(
+        &self,
+        _session_id: SessionId,
+        _provider: &str,
+    ) -> Result<Option<String>> {
+        Ok(self.token.clone())
+    }
+}
+
+/// Create a mock connection resolver that returns a fixed Deno access token.
+fn deno_resolver() -> Arc<dyn UserConnectionResolver> {
+    Arc::new(MockConnectionResolver {
+        token: Some("ddo_test_token".to_string()),
+    })
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Seed sandbox state into the store.
+async fn setup_context_with_sandbox(
+    session_id: SessionId,
+    store: &Arc<MockStorageStore>,
+    sandbox_id: &str,
+) {
+    let state = SandboxState {
+        sandbox_id: sandbox_id.to_string(),
+        region: "ord".to_string(),
+        org: None,
+        workspace_path: "/home/sandbox".to_string(),
+        started_at: "2026-03-22T10:00:00Z".to_string(),
+    };
+    store
+        .seed_secret(
+            session_id,
+            &format!("deno_sandbox:{sandbox_id}"),
+            &serde_json::to_string(&state).unwrap(),
+        )
+        .await;
+}
+
+fn get_tool(name: &str) -> Box<dyn Tool> {
+    let cap = everruns_integrations_deno::DenoCapability;
+    use everruns_core::capabilities::Capability;
+    cap.tools()
+        .into_iter()
+        .find(|t| t.name() == name)
+        .unwrap_or_else(|| panic!("Tool {name} not found"))
+}
+
+// ============================================================================
+// Credential resolution tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_exec_tool_missing_api_key() {
+    let tool = get_tool("deno_exec");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store);
+
+    let result = tool
+        .execute_with_context(json!({"sandbox_id": "sb_test", "command": "ls"}), &context)
+        .await;
+
+    match result {
+        ToolExecutionResult::ConnectionRequired { provider } => {
+            assert_eq!(provider, "deno");
+        }
+        other => panic!("Expected ConnectionRequired, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_create_tool_missing_api_key() {
+    let tool = get_tool("deno_create_sandbox");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store);
+
+    let result = tool.execute_with_context(json!({}), &context).await;
+
+    match result {
+        ToolExecutionResult::ConnectionRequired { provider } => {
+            assert_eq!(provider, "deno");
+        }
+        other => panic!("Expected ConnectionRequired, got: {other:?}"),
+    }
+}
+
+// ============================================================================
+// Sandbox state tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_exec_tool_missing_sandbox_state() {
+    let tool = get_tool("deno_exec");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store)
+        .with_connection_resolver(deno_resolver());
+
+    let result = tool
+        .execute_with_context(
+            json!({"sandbox_id": "sb_missing", "command": "ls"}),
+            &context,
+        )
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("not found"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_read_file_tool_missing_sandbox_state() {
+    let tool = get_tool("deno_read_file");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store)
+        .with_connection_resolver(deno_resolver());
+
+    let result = tool
+        .execute_with_context(
+            json!({"sandbox_id": "sb_missing", "path": "/test.txt"}),
+            &context,
+        )
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("not found"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+// ============================================================================
+// Parameter validation tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_exec_tool_missing_command_param() {
+    let tool = get_tool("deno_exec");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store);
+
+    let result = tool
+        .execute_with_context(json!({"sandbox_id": "sb_test"}), &context)
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("Missing required parameter"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_exec_tool_missing_sandbox_id_param() {
+    let tool = get_tool("deno_exec");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store);
+
+    let result = tool
+        .execute_with_context(json!({"command": "ls"}), &context)
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("Missing required parameter"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_read_file_tool_missing_path() {
+    let tool = get_tool("deno_read_file");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store);
+
+    let result = tool
+        .execute_with_context(json!({"sandbox_id": "sb_test"}), &context)
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("Missing required parameter"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_write_file_tool_missing_content() {
+    let tool = get_tool("deno_write_file");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store);
+
+    let result = tool
+        .execute_with_context(
+            json!({"sandbox_id": "sb_test", "path": "/test.txt"}),
+            &context,
+        )
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("Missing required parameter"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_manage_sandbox_unsupported_action() {
+    let tool = get_tool("deno_manage_sandbox");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    setup_context_with_sandbox(session_id, &store, "sb_test").await;
+    let context = ToolContext::with_storage_store(session_id, store)
+        .with_connection_resolver(deno_resolver());
+
+    let result = tool
+        .execute_with_context(json!({"sandbox_id": "sb_test", "action": "stop"}), &context)
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("Unsupported action"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_create_sandbox_rejects_session_timeout() {
+    let tool = get_tool("deno_create_sandbox");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store)
+        .with_connection_resolver(deno_resolver());
+
+    let result = tool
+        .execute_with_context(json!({"timeout": "session"}), &context)
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("session"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_create_sandbox_rejects_invalid_memory() {
+    let tool = get_tool("deno_create_sandbox");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store)
+        .with_connection_resolver(deno_resolver());
+
+    let result = tool
+        .execute_with_context(json!({"memory_mb": 0}), &context)
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("memory_mb"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_create_sandbox_rejects_string_memory() {
+    let tool = get_tool("deno_create_sandbox");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store)
+        .with_connection_resolver(deno_resolver());
+
+    let result = tool
+        .execute_with_context(json!({"memory_mb": "big"}), &context)
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("memory_mb"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+// ============================================================================
+// List sandboxes state tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_list_sandboxes_empty() {
+    let tool = get_tool("deno_list_sandboxes");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store);
+
+    let result = tool.execute_with_context(json!({}), &context).await;
+
+    match result {
+        ToolExecutionResult::Success(output) => {
+            assert_eq!(output["count"], 0);
+            assert_eq!(output["sandboxes"].as_array().unwrap().len(), 0);
+        }
+        other => panic!("Expected Success, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_list_sandboxes_with_entries() {
+    let tool = get_tool("deno_list_sandboxes");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+
+    // Seed two sandbox states
+    setup_context_with_sandbox(session_id, &store, "sb_one").await;
+    let state2 = SandboxState {
+        sandbox_id: "sb_two".to_string(),
+        region: "ams".to_string(),
+        org: Some("test-org".to_string()),
+        workspace_path: "/home/sandbox".to_string(),
+        started_at: "2026-03-22T11:00:00Z".to_string(),
+    };
+    store
+        .seed_secret(
+            session_id,
+            "deno_sandbox:sb_two",
+            &serde_json::to_string(&state2).unwrap(),
+        )
+        .await;
+
+    let context = ToolContext::with_storage_store(session_id, store);
+
+    let result = tool.execute_with_context(json!({}), &context).await;
+
+    match result {
+        ToolExecutionResult::Success(output) => {
+            assert_eq!(output["count"], 2);
+            let sandboxes = output["sandboxes"].as_array().unwrap();
+            let ids: Vec<&str> = sandboxes
+                .iter()
+                .map(|s| s["sandbox_id"].as_str().unwrap())
+                .collect();
+            assert!(ids.contains(&"sb_one"));
+            assert!(ids.contains(&"sb_two"));
+        }
+        other => panic!("Expected Success, got: {other:?}"),
+    }
+}
+
+// ============================================================================
+// State persistence roundtrip test
+// ============================================================================
+
+#[tokio::test]
+async fn test_sandbox_state_persistence_roundtrip() {
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+
+    setup_context_with_sandbox(session_id, &store, "sb_persist").await;
+
+    let context = ToolContext::with_storage_store(session_id, store.clone());
+
+    let tool = get_tool("deno_list_sandboxes");
+    let result = tool.execute_with_context(json!({}), &context).await;
+
+    match result {
+        ToolExecutionResult::Success(output) => {
+            assert_eq!(output["count"], 1);
+            let sandbox = &output["sandboxes"][0];
+            assert_eq!(sandbox["sandbox_id"], "sb_persist");
+            assert_eq!(sandbox["region"], "ord");
+            assert_eq!(sandbox["workspace_path"], "/home/sandbox");
+        }
+        other => panic!("Expected Success, got: {other:?}"),
+    }
+}

--- a/specs/integrations.md
+++ b/specs/integrations.md
@@ -2,6 +2,27 @@
 
 Index of external service integrations. Each spec lives alongside the code that implements it.
 
+## Integration Parity Requirements
+
+Every sandbox/execution integration crate must ship with the following artifacts to be considered production-ready. Use Daytona as the reference implementation.
+
+| Requirement | Description |
+|---|---|
+| **SPEC.md** | Co-located specification: architecture, tool surface, state management, security review. |
+| **Connection provider** | User connection (OAuth or API-key form) with validation and fallback env vars for operator/test use. |
+| **Unit tests** | Plugin registration, parameter validation, state serialization, tool schemas. |
+| **Integration tests** | `tests/tool_integration.rs` — tool `execute_with_context` flows against mocked storage/connections (wiremock for HTTP APIs, mock storage for websocket APIs). |
+| **Live API tests** | `tests/live_api_test.rs` — feature-gated (`<name>-live-tests`), optional Doppler credentials. |
+| **CI: unit tests** | Crate listed in the `unit-test` job: `cargo test -p everruns-integrations-<name>`. |
+| **CI: change detection** | Path filter in `changes` job: `<name>: integrations/<name>/**`. |
+| **CI: live-test job** | Dedicated `<name>-live-test` job, conditional on change detection + `push` event. |
+| **User docs** | `docs/integrations/<name>.md` — quick start, tool table, lifecycle, security. |
+| **UI test case** | `test_cases/ui/<name>_connection/TC001_*.md` — manual test for connection + sandbox lifecycle. |
+| **Seed agent** | Entry in `crates/server/src/seed.rs` with capabilities wired. |
+| **Threat model** | Section in `specs/threat-model.md` covering integration-specific threats. |
+
+New integrations should check off every row before merging. Existing integrations that are missing items should be brought up to parity incrementally.
+
 ## Integration Crates (`integrations/`)
 
 Auto-registered via `inventory` plugin system. Each crate has a `SPEC.md`.

--- a/test_cases/ui/deno_connection/TC001_deno_openui_connection_sandbox.md
+++ b/test_cases/ui/deno_connection/TC001_deno_openui_connection_sandbox.md
@@ -1,0 +1,64 @@
+# TC001: Deno OpenUI Connection - Sandbox Lifecycle
+
+## Description
+
+Verify that an agent with Deno capability prompts for a Deno access token via the inline OpenUI connection dialog when no connection exists, creates a sandbox after connecting, executes a command, and deletes the sandbox on request.
+
+## Preconditions
+
+- Server running (`just start-all` — full mode with PostgreSQL required for leased resources)
+- User logged in
+- LLM API keys configured (Anthropic or OpenAI)
+- **No** existing Deno connection in Settings > Connections (disconnect first if present)
+- Valid Deno organization access token (`ddo_...`) available for test
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Agent | Deno Coder (seed agent) |
+| First Message | Create a sandbox and calculate the result of 123 * 456. Do NOT delete the sandbox after - I want to keep it running. |
+| Deno Access Token | *(use a valid Deno organization token, `ddo_...`)* |
+| Cleanup Message | Delete the sandbox |
+
+## Steps
+
+1. Navigate to the Agents page and locate **Deno Coder**
+2. Click **Run** to start a new session
+3. Send the message: `Create a sandbox and calculate the result of 123 * 456. Do NOT delete the sandbox after - I want to keep it running.`
+4. Wait for the inline **Setup Connection** card to appear in the chat (OpenUI connection prompt for Deno)
+5. Click the **Connect** button on the inline card
+6. In the Access Token dialog:
+   - Verify the dialog shows Deno Deploy provider name and instructions
+   - Enter the Deno organization access token
+   - Click **Submit**
+7. Wait for the connection to be validated and the dialog to close
+8. Wait for the agent to resume and create a sandbox (tool call: `deno_create_sandbox`)
+9. Wait for the agent to execute the calculation (tool call: `deno_exec`)
+10. Verify the agent responds with the correct result (123 * 456 = 56088)
+11. Send the message: `Delete the sandbox`
+12. Wait for the agent to delete the sandbox (tool call: `deno_manage_sandbox` with action "delete")
+13. Verify the agent confirms the sandbox has been **deleted**
+
+## Notes
+
+- The Deno Coder agent's system prompt says "Always delete sandboxes when done." To test explicit deletion as a separate step, the first message must instruct the agent **not** to delete the sandbox.
+- Deno sandboxes use websocket connections, so sandbox creation may take a few seconds longer than REST-based integrations.
+- **DEV_MODE limitation**: The connection resume flow (steps 7–8) may fail in DEV_MODE due to a race condition in the in-memory message store. Use `just start-all` (PostgreSQL) for reliable testing of the full connection flow.
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Connection prompt | Inline "Setup Connection" card appears for Deno provider |
+| Access Token dialog | Shows Deno Deploy icon, provider name, and instructions |
+| Connection saved | After submit, dialog closes and connection is stored |
+| Sandbox created | Agent creates sandbox successfully (sandbox_id returned) |
+| Command executed | Agent runs calculation, result includes 56088 |
+| Sandbox deleted | Agent confirms sandbox is deleted |
+| Resources cleaned | Session resources page (`/sessions/{id}/resources`) shows the sandbox as "Released" |
+
+## Cleanup
+
+- After the test, navigate to **Settings > Connections** and verify or disconnect the Deno connection if it should not persist
+- If the sandbox deletion step failed, manually delete any remaining sandboxes via the Deno Deploy Console to avoid resource leaks


### PR DESCRIPTION
## What

Bring the Deno sandbox integration (#1047) to feature parity with Daytona by adding the missing CI, test, documentation, and seed artifacts.

## Why

The Deno integration shipped without CI wiring, integration tests, user docs, UI test case, or seed agent — all of which Daytona and E2B have. This PR closes those gaps and documents parity requirements for future integrations.

## How

- **CI**: Add `deno` path filter in change detection, add `everruns-integrations-deno` to unit-test job, add dedicated `deno-live-test` CI job (mirrors `daytona-live-test`).
- **Integration tests**: Add `tests/tool_integration.rs` with 15 tests covering credential resolution (`ConnectionRequired`), sandbox state management, parameter validation, and list sandbox flows.
- **User docs**: Add `docs/integrations/deno.md` with quick start, tool table, lifecycle, and security info.
- **UI test case**: Add `test_cases/ui/deno_connection/TC001` for manual connection + sandbox lifecycle testing.
- **Seed agent**: Add "Deno Coder" seed agent in `seed.rs` with `deno` capability wired.
- **Spec**: Document integration parity requirements checklist in `specs/integrations.md`.

## Risk

- Low
- No runtime code changes. All changes are CI config, tests, docs, seed data, and spec documentation. The Deno integration code itself was already merged in #1047.

## Security

- Threat categories reviewed: None applicable — this change adds CI/docs/tests/seed data around an already-reviewed integration. No new code paths, no auth changes, no API changes, no tool execution changes.
- No security-relevant code changes. The Deno integration runtime code was security-reviewed in #1047.

## Checklist

- [x] Tests added or updated (15 new integration tests, all passing)
- [x] Backward compatibility considered (additive only — new CI job, new tests, new docs, new seed agent)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (Copilot reviewed 6/6 files, no comments generated)