### PR TITLE
feat(blueprints): implement agent blueprints infrastructure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,7 @@ Always make sure you are working on top of latest main from remote.
 - `specs/localization.md` - Locale/timezone resolution and backend localization rules
 - `specs/client-hints.md` - Generic client hints mechanism (session defaults + per-message overrides)
 - `specs/agent-identities.md` - Agent identities (virtual principals for unattended execution)
+- `specs/agent-blueprints.md` - Pre-built agent definitions (private tools, fixed models, typed config)
 
 ### Test Cases
 

--- a/crates/core/examples/turn_based_execution.rs
+++ b/crates/core/examples/turn_based_execution.rs
@@ -182,6 +182,8 @@ async fn main() -> anyhow::Result<()> {
         subagent_name: None,
         subagent_task: None,
         subagent_status: None,
+        blueprint_id: None,
+        blueprint_config: None,
     };
     session_store.add_session(session).await;
 
@@ -321,6 +323,7 @@ async fn main() -> anyhow::Result<()> {
                 tool_calls: reason_result.tool_calls.clone(),
                 tool_definitions: reason_result.tool_definitions.clone(),
                 locale: reason_result.locale.clone(),
+                blueprint_id: None,
             })
             .await?;
 

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -694,62 +694,9 @@ where
             };
         };
 
-<<<<<<< HEAD
         // Execute the tool (always with context so tools can emit progress events)
         let mut tool_context = if let Some(ref store) = self.file_store {
             ToolContext::with_file_store(context.session_id, store.clone())
-=======
-        // Execute the tool
-        let result = if self.file_store.is_some()
-            || self.sqldb_store.is_some()
-            || self.storage_store.is_some()
-            || self.connection_resolver.is_some()
-            || self.session_store.is_some()
-            || self.session_mutator.is_some()
-            || self.agent_store.is_some()
-            || self.schedule_store.is_some()
-            || self.platform_store.is_some()
-            || self.leased_resource_store.is_some()
-        {
-            let mut tool_context = if let Some(ref store) = self.file_store {
-                ToolContext::with_file_store(context.session_id, store.clone())
-            } else {
-                ToolContext::new(context.session_id)
-            };
-            if let Some(ref store) = self.sqldb_store {
-                tool_context.sqldb_store = Some(store.clone());
-            }
-            if let Some(ref store) = self.storage_store {
-                tool_context.storage_store = Some(store.clone());
-            }
-            if let Some(ref resolver) = self.connection_resolver {
-                tool_context.connection_resolver = Some(resolver.clone());
-            }
-            if let Some(ref store) = self.session_store {
-                tool_context.session_store = Some(store.clone());
-            }
-            if let Some(ref mutator) = self.session_mutator {
-                tool_context.session_mutator = Some(mutator.clone());
-            }
-            if let Some(ref store) = self.agent_store {
-                tool_context.agent_store = Some(store.clone());
-            }
-            if let Some(ref store) = self.schedule_store {
-                tool_context.schedule_store = Some(store.clone());
-            }
-            if let Some(ref store) = self.platform_store {
-                tool_context.platform_store = Some(store.clone());
-            }
-            if let Some(ref store) = self.leased_resource_store {
-                tool_context.leased_resource_store = Some(store.clone());
-            }
-            if let Some(ref registry) = self.capability_registry {
-                tool_context.capability_registry = Some(registry.clone());
-            }
-            self.tool_executor
-                .execute_with_context(&tool_call, tool_def, &tool_context)
-                .await
->>>>>>> ebe0ca9 (feat(blueprints): implement agent blueprints infrastructure)
         } else {
             ToolContext::new(context.session_id)
         };
@@ -779,6 +726,9 @@ where
         }
         if let Some(ref store) = self.leased_resource_store {
             tool_context.leased_resource_store = Some(store.clone());
+        }
+        if let Some(ref registry) = self.capability_registry {
+            tool_context.capability_registry = Some(registry.clone());
         }
         // Provide event emitter + context so tools can emit tool.progress events
         tool_context.event_emitter = Some(self.event_emitter.clone() as Arc<dyn EventEmitter>);

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -71,6 +71,10 @@ pub struct ActInput {
     /// Resolved locale for backend-authored tool narration and labels.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub locale: Option<String>,
+    /// Blueprint ID for blueprint-backed sessions. When set, act_activity
+    /// loads tools from the blueprint instead of from agent/harness capabilities.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blueprint_id: Option<String>,
 }
 
 /// Result of a single tool call execution
@@ -165,6 +169,8 @@ where
     platform_store: Option<Arc<dyn crate::platform_store::PlatformStore>>,
     /// Optional leased resource store for provider lease tracking
     leased_resource_store: Option<Arc<dyn crate::traits::LeasedResourceStore>>,
+    /// Optional capability registry for blueprint lookups in subagent tools
+    capability_registry: Option<crate::capabilities::CapabilityRegistry>,
     /// Post-act hooks that run after tool execution completes.
     /// Hooks inspect the result and may emit events (e.g. tool.call_requested).
     hooks: Vec<Box<dyn PostActHook>>,
@@ -190,6 +196,7 @@ where
             schedule_store: None,
             platform_store: None,
             leased_resource_store: None,
+            capability_registry: None,
             hooks: Self::default_hooks(),
         }
     }
@@ -213,6 +220,7 @@ where
             schedule_store: None,
             platform_store: None,
             leased_resource_store: None,
+            capability_registry: None,
             hooks: Self::default_hooks(),
         }
     }
@@ -298,6 +306,14 @@ where
         store: Arc<dyn crate::traits::LeasedResourceStore>,
     ) -> Self {
         self.leased_resource_store = Some(store);
+        self
+    }
+
+    pub fn with_capability_registry(
+        mut self,
+        registry: crate::capabilities::CapabilityRegistry,
+    ) -> Self {
+        self.capability_registry = Some(registry);
         self
     }
 }
@@ -678,9 +694,62 @@ where
             };
         };
 
+<<<<<<< HEAD
         // Execute the tool (always with context so tools can emit progress events)
         let mut tool_context = if let Some(ref store) = self.file_store {
             ToolContext::with_file_store(context.session_id, store.clone())
+=======
+        // Execute the tool
+        let result = if self.file_store.is_some()
+            || self.sqldb_store.is_some()
+            || self.storage_store.is_some()
+            || self.connection_resolver.is_some()
+            || self.session_store.is_some()
+            || self.session_mutator.is_some()
+            || self.agent_store.is_some()
+            || self.schedule_store.is_some()
+            || self.platform_store.is_some()
+            || self.leased_resource_store.is_some()
+        {
+            let mut tool_context = if let Some(ref store) = self.file_store {
+                ToolContext::with_file_store(context.session_id, store.clone())
+            } else {
+                ToolContext::new(context.session_id)
+            };
+            if let Some(ref store) = self.sqldb_store {
+                tool_context.sqldb_store = Some(store.clone());
+            }
+            if let Some(ref store) = self.storage_store {
+                tool_context.storage_store = Some(store.clone());
+            }
+            if let Some(ref resolver) = self.connection_resolver {
+                tool_context.connection_resolver = Some(resolver.clone());
+            }
+            if let Some(ref store) = self.session_store {
+                tool_context.session_store = Some(store.clone());
+            }
+            if let Some(ref mutator) = self.session_mutator {
+                tool_context.session_mutator = Some(mutator.clone());
+            }
+            if let Some(ref store) = self.agent_store {
+                tool_context.agent_store = Some(store.clone());
+            }
+            if let Some(ref store) = self.schedule_store {
+                tool_context.schedule_store = Some(store.clone());
+            }
+            if let Some(ref store) = self.platform_store {
+                tool_context.platform_store = Some(store.clone());
+            }
+            if let Some(ref store) = self.leased_resource_store {
+                tool_context.leased_resource_store = Some(store.clone());
+            }
+            if let Some(ref registry) = self.capability_registry {
+                tool_context.capability_registry = Some(registry.clone());
+            }
+            self.tool_executor
+                .execute_with_context(&tool_call, tool_def, &tool_context)
+                .await
+>>>>>>> ebe0ca9 (feat(blueprints): implement agent blueprints infrastructure)
         } else {
             ToolContext::new(context.session_id)
         };
@@ -900,6 +969,7 @@ mod tests {
             tool_calls: vec![],
             tool_definitions: vec![],
             locale: None,
+            blueprint_id: None,
         };
 
         let result = atom.execute(input).await.unwrap();
@@ -929,6 +999,7 @@ mod tests {
             }],
             tool_definitions: vec![],
             locale: None,
+            blueprint_id: None,
         };
 
         let result = atom.execute(input).await.unwrap();
@@ -994,6 +1065,7 @@ mod tests {
             }],
             tool_definitions: vec![manage_harnesses_tool_def()],
             locale: None,
+            blueprint_id: None,
         };
 
         let result = atom.execute(input).await.unwrap();
@@ -1038,6 +1110,7 @@ mod tests {
             }],
             tool_definitions: vec![manage_harnesses_tool_def()],
             locale: None,
+            blueprint_id: None,
         };
 
         let result = atom.execute(input).await.unwrap();

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -588,9 +588,7 @@ impl ReasonAtom {
             )
             .await?;
 
-        // 6. Build runtime agent: harness (base) → agent (optional) → session caps
-        //    Uses async builder methods so capabilities can resolve dynamic system
-        //    prompt content (e.g., reading AGENTS.md, discovering skills).
+        // 6. Build runtime agent
         let resolved_locale = extract_locale_override(&messages).or_else(|| session.locale.clone());
         let prompt_ctx = crate::capabilities::SystemPromptContext {
             session_id,
@@ -598,31 +596,71 @@ impl ReasonAtom {
             file_store: self.file_store.clone(),
         };
 
-        let mut builder = RuntimeAgentBuilder::new()
-            .with_harness(&harness, &self.capability_registry, &prompt_ctx)
-            .await;
-        if let Some(ref agent) = agent {
-            builder = builder
-                .with_agent(agent, &self.capability_registry, &prompt_ctx)
+        let mut runtime_agent = if let Some(ref blueprint_id) = session.blueprint_id {
+            // Blueprint path: build RuntimeAgent from blueprint definition
+            let blueprint = self
+                .capability_registry
+                .blueprint(blueprint_id)
+                .ok_or_else(|| {
+                    anyhow::anyhow!("Unknown blueprint: \"{blueprint_id}\". Session has blueprint_id set but blueprint not found in registry.")
+                })?;
+
+            let blueprint_model = match &blueprint.model {
+                crate::capabilities::BlueprintModel::Fixed(m) => m.clone(),
+                crate::capabilities::BlueprintModel::Default(m) => {
+                    // Allow config to override model
+                    session
+                        .blueprint_config
+                        .as_ref()
+                        .and_then(|c| c.get("model"))
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| m.clone())
+                }
+                crate::capabilities::BlueprintModel::Inherit => model_with_provider.model.clone(),
+            };
+
+            let mut prompt = blueprint.system_prompt.to_string();
+            if let Some(ref config) = session.blueprint_config {
+                prompt.push_str(&format!("\n\n<config>\n{}\n</config>", config));
+            }
+
+            RuntimeAgentBuilder::new()
+                .system_prompt(&prompt)
+                .tools(blueprint.tool_definitions())
+                .model(&blueprint_model)
+                .max_iterations(blueprint.max_turns.unwrap_or(20))
+                .with_locale(prompt_ctx.locale.as_deref())
+                .build()
+        } else {
+            // Standard path: harness (base) → agent (optional) → session caps
+            let mut builder = RuntimeAgentBuilder::new()
+                .with_harness(&harness, &self.capability_registry, &prompt_ctx)
                 .await;
-        }
-        builder = builder
-            .with_capability_configs(
-                &session.capabilities,
-                &self.capability_registry,
-                &prompt_ctx,
-            )
-            .await
-            .with_locale(prompt_ctx.locale.as_deref())
-            .tools(mcp_tool_definitions.iter().cloned())
-            .model(&model_with_provider.model);
+            if let Some(ref agent) = agent {
+                builder = builder
+                    .with_agent(agent, &self.capability_registry, &prompt_ctx)
+                    .await;
+            }
+            builder = builder
+                .with_capability_configs(
+                    &session.capabilities,
+                    &self.capability_registry,
+                    &prompt_ctx,
+                )
+                .await
+                .with_locale(prompt_ctx.locale.as_deref())
+                .tools(mcp_tool_definitions.iter().cloned())
+                .model(&model_with_provider.model);
 
-        // Add session-level client-side tools (additive to agent tools)
-        if !session.tools.is_empty() {
-            builder = builder.tools(session.tools.clone());
-        }
+            // Add session-level client-side tools (additive to agent tools)
+            if !session.tools.is_empty() {
+                builder = builder.tools(session.tools.clone());
+            }
 
-        let mut runtime_agent = builder.build();
+            builder.build()
+        };
+
         if crate::progress_reporting::session_uses_report_progress(&session.tags) {
             runtime_agent = crate::progress_reporting::apply_report_progress_mode(runtime_agent);
         }

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -27,6 +27,7 @@ use crate::tools::{Tool, ToolRegistry};
 use crate::traits::SessionFileStore;
 use crate::typed_id::SessionId;
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -176,6 +177,7 @@ pub use session_storage::{KvStoreTool, SecretStoreTool, SessionStorageCapability
 pub use skills::{SKILLS_CAPABILITY_ID, SkillsCapability};
 pub use stateless_todo_list::{StatelessTodoListCapability, WriteTodosTool};
 pub use subagents::SubagentCapability;
+// Blueprint types are exported directly from the trait definitions above
 pub use system_commands::{SYSTEM_COMMANDS_CAPABILITY_ID, SystemCommandsCapability};
 pub use test_math::{AddTool, DivideTool, MultiplyTool, SubtractTool, TestMathCapability};
 pub use test_weather::{GetForecastTool, GetWeatherTool, TestWeatherCapability};
@@ -450,6 +452,17 @@ pub trait Capability: Send + Sync {
     fn commands(&self) -> Vec<CommandDescriptor> {
         vec![]
     }
+
+    /// Returns agent blueprints contributed by this capability.
+    ///
+    /// Blueprints are pre-built agent definitions with private tools, baked-in prompts,
+    /// and fixed/default models. They are spawned via `spawn_subagent(blueprint: "<id>")`.
+    /// Blueprint tools never appear in the host agent's tool list.
+    ///
+    /// By default, returns an empty vector (no blueprints).
+    fn agent_blueprints(&self) -> Vec<AgentBlueprint> {
+        vec![]
+    }
 }
 
 /// Risk classification for capabilities (TM-AGENT-005).
@@ -467,6 +480,65 @@ pub enum RiskLevel {
     Medium,
     /// Requires org admin role to assign
     High,
+}
+
+// ============================================================================
+// Agent Blueprints
+// ============================================================================
+
+/// Model selection strategy for agent blueprints.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BlueprintModel {
+    /// Always use this model. Host cannot override.
+    Fixed(String),
+    /// Use this model unless host provides override via config.
+    Default(String),
+    /// Use whatever model the host agent uses.
+    Inherit,
+}
+
+/// Pre-built agent definition with private tools, baked-in prompt, and model selection.
+///
+/// Contributed by capabilities via `agent_blueprints()`. Spawned via
+/// `spawn_subagent(blueprint: "<id>")`. Blueprint tools never appear in the
+/// host agent's tool list — they exist only inside the spawned child session.
+pub struct AgentBlueprint {
+    /// Unique identifier (e.g. `"github_scout"`)
+    pub id: &'static str,
+    /// Human-readable display name
+    pub name: &'static str,
+    /// When to use this blueprint (LLM reads this for delegation decisions)
+    pub description: &'static str,
+    /// Model selection strategy
+    pub model: BlueprintModel,
+    /// Baked-in system prompt for the child agent
+    pub system_prompt: &'static str,
+    /// Private tools — only available inside the blueprint's session
+    pub tools: Vec<Box<dyn Tool>>,
+    /// Iteration limit (default: 20)
+    pub max_turns: Option<usize>,
+    /// JSON Schema for allowed host-provided config. `None` = no config accepted.
+    pub config_schema: Option<serde_json::Value>,
+}
+
+impl AgentBlueprint {
+    /// Convert blueprint tools to tool definitions (for RuntimeAgent building).
+    pub fn tool_definitions(&self) -> Vec<ToolDefinition> {
+        self.tools.iter().map(|t| t.to_definition()).collect()
+    }
+}
+
+impl std::fmt::Debug for AgentBlueprint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AgentBlueprint")
+            .field("id", &self.id)
+            .field("name", &self.name)
+            .field("model", &self.model)
+            .field("tool_count", &self.tools.len())
+            .field("max_turns", &self.max_turns)
+            .finish()
+    }
 }
 
 // ============================================================================
@@ -627,6 +699,28 @@ impl CapabilityRegistry {
     /// Create a builder for fluent capability registration
     pub fn builder() -> CapabilityRegistryBuilder {
         CapabilityRegistryBuilder::new()
+    }
+
+    /// Find a blueprint by ID across all registered capabilities.
+    ///
+    /// Returns a fresh `AgentBlueprint` (with new tool instances) each time.
+    pub fn blueprint(&self, id: &str) -> Option<AgentBlueprint> {
+        for cap in self.capabilities.values() {
+            for bp in cap.agent_blueprints() {
+                if bp.id == id {
+                    return Some(bp);
+                }
+            }
+        }
+        None
+    }
+
+    /// Collect all blueprints from all registered capabilities.
+    pub fn all_blueprints(&self) -> Vec<AgentBlueprint> {
+        self.capabilities
+            .values()
+            .flat_map(|cap| cap.agent_blueprints())
+            .collect()
     }
 }
 

--- a/crates/core/src/capabilities/platform_management.rs
+++ b/crates/core/src/capabilities/platform_management.rs
@@ -798,7 +798,7 @@ impl Tool for ManageSessionsTool {
                 let title = get_str(&arguments, "title");
                 let locale = get_str(&arguments, "locale");
                 match store
-                    .create_session(harness_id, agent_id, title, locale)
+                    .create_session(harness_id, agent_id, title, locale, None, None)
                     .await
                 {
                     Ok(s) => ToolExecutionResult::success(json!({

--- a/crates/core/src/capabilities/session.rs
+++ b/crates/core/src/capabilities/session.rs
@@ -261,6 +261,8 @@ mod tests {
             subagent_name: None,
             subagent_task: None,
             subagent_status: None,
+            blueprint_id: None,
+            blueprint_config: None,
         }
     }
 

--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -5,6 +5,10 @@
 // - get_subagents lists/details child sessions by querying parent_session_id
 // - message_subagent sends steering messages (by name or id)
 //
+// Blueprint support: spawn_subagent accepts optional `blueprint` and `config`
+// params. When blueprint is set, the child session uses the blueprint's
+// RuntimeAgent (own prompt, tools, model) instead of inheriting parent's.
+//
 // Foreground mode: blocks until subagent completes (send_message + wait_for_idle)
 // Background mode: returns immediately (deferred to Phase 1b)
 //
@@ -67,7 +71,8 @@ const SUBAGENT_SYSTEM_PROMPT: &str = r#"Delegate tasks to subagents running in t
 
 - Move noisy/verbose work off the main conversation (test runs, large searches).
 - Run independent tasks in parallel (multiple spawn_subagent calls in one response).
-- Subagents cannot spawn other subagents (no nesting)."#;
+- Subagents cannot spawn other subagents (no nesting).
+- Use `blueprint` parameter to spawn specialist agents with their own tools and model."#;
 
 // =============================================================================
 // Helper: get platform store from context
@@ -148,7 +153,7 @@ impl Tool for SpawnSubagentTool {
     }
 
     fn description(&self) -> &str {
-        "Spawn a named subagent to handle a specific task in its own context window."
+        "Spawn a named subagent to handle a specific task in its own context window. Use `blueprint` to spawn a specialist agent with its own tools and model."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -162,6 +167,14 @@ impl Tool for SpawnSubagentTool {
                 "task": {
                     "type": "string",
                     "description": "Task description — what the subagent should do."
+                },
+                "blueprint": {
+                    "type": "string",
+                    "description": "Blueprint ID to spawn a specialist agent with its own tools and model. Omit to inherit parent's configuration."
+                },
+                "config": {
+                    "type": "object",
+                    "description": "Blueprint-specific configuration. Only valid when `blueprint` is set. Validated against the blueprint's config schema."
                 }
             },
             "required": ["name", "task"],
@@ -198,6 +211,48 @@ impl Tool for SpawnSubagentTool {
             Err(e) => return e,
         };
 
+        let blueprint_param = arguments
+            .get("blueprint")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.trim().is_empty())
+            .map(|s| s.to_string());
+        let config_param = arguments.get("config").filter(|v| !v.is_null()).cloned();
+
+        // Reject config without blueprint
+        if config_param.is_some() && blueprint_param.is_none() {
+            return ToolExecutionResult::tool_error(
+                "The `config` parameter is only valid when `blueprint` is set.",
+            );
+        }
+
+        // Validate blueprint exists if specified
+        if let Some(ref bp_id) = blueprint_param {
+            if let Some(ref registry) = context.capability_registry {
+                if registry.blueprint(bp_id).is_none() {
+                    return ToolExecutionResult::tool_error(format!(
+                        "Unknown blueprint: \"{bp_id}\". Check available blueprints."
+                    ));
+                }
+                // Validate config against schema if blueprint has one
+                if let Some(blueprint) = registry.blueprint(bp_id)
+                    && let Some(ref schema) = blueprint.config_schema
+                    && config_param.is_none()
+                    && schema
+                        .get("required")
+                        .is_some_and(|r| r.as_array().is_some_and(|arr| !arr.is_empty()))
+                {
+                    return ToolExecutionResult::tool_error(format!(
+                        "Blueprint \"{bp_id}\" requires config. Schema: {}",
+                        serde_json::to_string_pretty(schema).unwrap_or_default()
+                    ));
+                }
+            } else {
+                return ToolExecutionResult::tool_error(
+                    "Blueprint support requires capability_registry context.",
+                );
+            }
+        }
+
         // Nesting check: reject if current session is already a subagent
         let parent_session = match session_store.get_session(context.session_id).await {
             Ok(Some(s)) => s,
@@ -211,13 +266,19 @@ impl Tool for SpawnSubagentTool {
             );
         }
 
-        // Create child session using the same harness as parent
+        // Create child session
         let child_session = match store
             .create_session(
                 parent_session.harness_id,
-                parent_session.agent_id,
+                if blueprint_param.is_some() {
+                    None // Blueprint sessions don't inherit agent
+                } else {
+                    parent_session.agent_id
+                },
                 Some(&name),
                 parent_session.locale.as_deref(),
+                blueprint_param.as_deref(),
+                config_param.as_ref(),
             )
             .await
         {
@@ -239,6 +300,7 @@ impl Tool for SpawnSubagentTool {
                     "name": name,
                     "status": "failed",
                     "error": e.to_string(),
+                    "blueprint": blueprint_param,
                 }));
             }
         };
@@ -257,6 +319,7 @@ impl Tool for SpawnSubagentTool {
             "name": name,
             "status": status,
             "result": result_text,
+            "blueprint": blueprint_param,
         }))
     }
 
@@ -348,6 +411,7 @@ impl Tool for GetSubagentsTool {
                         "session_status": child.status.to_string(),
                         "created_at": child.created_at.to_rfc3339(),
                         "result": last_response,
+                        "blueprint_id": child.blueprint_id,
                     }))
                 }
                 None => ToolExecutionResult::tool_error(format!(
@@ -381,6 +445,7 @@ impl Tool for GetSubagentsTool {
                         "status": s.subagent_status.as_ref().map(|st| st.to_string())
                             .unwrap_or_else(|| s.status.to_string()),
                         "created_at": s.created_at.to_rfc3339(),
+                        "blueprint_id": s.blueprint_id,
                     })
                 })
                 .collect();
@@ -566,6 +631,19 @@ mod tests {
         let required = schema["required"].as_array().unwrap();
         assert!(required.contains(&json!("name")));
         assert!(required.contains(&json!("task")));
+    }
+
+    #[test]
+    fn spawn_subagent_schema_has_blueprint_fields() {
+        let tool = SpawnSubagentTool;
+        let schema = tool.parameters_schema();
+        let props = schema["properties"].as_object().unwrap();
+        assert!(props.contains_key("blueprint"));
+        assert!(props.contains_key("config"));
+        // blueprint and config should NOT be required
+        let required = schema["required"].as_array().unwrap();
+        assert!(!required.contains(&json!("blueprint")));
+        assert!(!required.contains(&json!("config")));
     }
 
     #[tokio::test]

--- a/crates/core/src/in_memory_loop.rs
+++ b/crates/core/src/in_memory_loop.rs
@@ -398,6 +398,8 @@ impl InMemoryAgenticLoopBuilder {
             subagent_name: None,
             subagent_task: None,
             subagent_status: None,
+            blueprint_id: None,
+            blueprint_config: None,
         };
         session_store.add_session(session).await;
 
@@ -671,6 +673,7 @@ impl InMemoryAgenticLoop {
                             tool_calls: reason_result.tool_calls,
                             tool_definitions: reason_result.tool_definitions,
                             locale: reason_result.locale,
+                            blueprint_id: None,
                         })
                         .await?;
                     state_machine.on_act_completed();

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -171,11 +171,11 @@ pub use platform_definition::{
 
 pub use capabilities::SystemPromptContext;
 pub use capabilities::{
-    AddTool, AgentCapabilityConfig, AppliedCapabilities, Capability, CapabilityId,
-    CapabilityRegistry, CapabilityRegistryBuilder, CapabilityStatus, CollectedCapabilities,
-    CurrentTimeCapability, DeleteFileTool, DependencyError, DivideTool, FileSystemCapability,
-    GetCurrentTimeTool, GetForecastTool, GetSessionInfoTool, GetWeatherTool, GrepFilesTool,
-    INFINITY_CONTEXT_CAPABILITY_ID, InfinityContextCapability, IntegrationPlugin,
+    AddTool, AgentBlueprint, AgentCapabilityConfig, AppliedCapabilities, BlueprintModel,
+    Capability, CapabilityId, CapabilityRegistry, CapabilityRegistryBuilder, CapabilityStatus,
+    CollectedCapabilities, CurrentTimeCapability, DeleteFileTool, DependencyError, DivideTool,
+    FileSystemCapability, GetCurrentTimeTool, GetForecastTool, GetSessionInfoTool, GetWeatherTool,
+    GrepFilesTool, INFINITY_CONTEXT_CAPABILITY_ID, InfinityContextCapability, IntegrationPlugin,
     ListDirectoryTool, MAX_RESOLVED_CAPABILITIES, MCP_CAPABILITY_PREFIX, McpCapability,
     MountAccess, MountDirectoryBuilder, MountEntry, MountPoint, MountSource, MultiplyTool,
     NoopCapability, OPENAI_TOOL_SEARCH_CAPABILITY_ID, OpenAiToolSearchCapability,

--- a/crates/core/src/platform_store.rs
+++ b/crates/core/src/platform_store.rs
@@ -109,12 +109,18 @@ pub trait PlatformStore: Send + Sync {
     ) -> Result<Vec<Session>>;
 
     /// Create a new session.
+    ///
+    /// When `blueprint_id` is set, the session runs a blueprint agent instead
+    /// of inheriting from `harness_id`/`agent_id`. `blueprint_config` is
+    /// validated config for the blueprint (JSON, optional).
     async fn create_session(
         &self,
         harness_id: HarnessId,
         agent_id: Option<AgentId>,
         title: Option<&str>,
         locale: Option<&str>,
+        blueprint_id: Option<&str>,
+        blueprint_config: Option<&serde_json::Value>,
     ) -> Result<Session>;
 
     /// Get a session by ID.
@@ -261,6 +267,8 @@ pub mod tests {
                     subagent_name: None,
                     subagent_task: None,
                     subagent_status: None,
+                    blueprint_id: None,
+                    blueprint_config: None,
                 },
             }
         }
@@ -359,10 +367,14 @@ pub mod tests {
             _aid: Option<crate::typed_id::AgentId>,
             title: Option<&str>,
             locale: Option<&str>,
+            blueprint_id: Option<&str>,
+            blueprint_config: Option<&serde_json::Value>,
         ) -> Result<Session> {
             let mut s = self.session.clone();
             s.title = title.map(|t| t.to_string());
             s.locale = locale.map(|value| value.to_string());
+            s.blueprint_id = blueprint_id.map(|b| b.to_string());
+            s.blueprint_config = blueprint_config.cloned();
             Ok(s)
         }
         async fn get_session_by_id(&self, _id: SessionId) -> Result<Option<Session>> {

--- a/crates/core/src/platform_store.rs
+++ b/crates/core/src/platform_store.rs
@@ -113,6 +113,7 @@ pub trait PlatformStore: Send + Sync {
     /// When `blueprint_id` is set, the session runs a blueprint agent instead
     /// of inheriting from `harness_id`/`agent_id`. `blueprint_config` is
     /// validated config for the blueprint (JSON, optional).
+    #[allow(clippy::too_many_arguments)]
     async fn create_session(
         &self,
         harness_id: HarnessId,

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -197,4 +197,13 @@ pub struct Session {
     /// Subagent lifecycle status: spawning, running, completed, failed, cancelled.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subagent_status: Option<SubagentStatus>,
+
+    // -- Blueprint fields (only set when this session runs a blueprint agent) --
+    /// Blueprint ID. When set, reason_activity and act_activity build RuntimeAgent
+    /// from the blueprint definition instead of from harness_id/agent_id.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blueprint_id: Option<String>,
+    /// Validated config passed by host at blueprint spawn time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blueprint_config: Option<serde_json::Value>,
 }

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -520,6 +520,8 @@ pub struct ToolContext {
     /// The tool call ID for the current execution (set by ActAtom).
     /// Used by tools to emit correlated progress events.
     pub tool_call_id: Option<String>,
+    /// Optional capability registry for blueprint lookups.
+    pub capability_registry: Option<crate::capabilities::CapabilityRegistry>,
 }
 
 impl ToolContext {
@@ -541,6 +543,7 @@ impl ToolContext {
             event_emitter: None,
             event_context: None,
             tool_call_id: None,
+            capability_registry: None,
         }
     }
 
@@ -562,6 +565,7 @@ impl ToolContext {
             event_emitter: None,
             event_context: None,
             tool_call_id: None,
+            capability_registry: None,
         }
     }
 
@@ -586,6 +590,7 @@ impl ToolContext {
             event_emitter: None,
             event_context: None,
             tool_call_id: None,
+            capability_registry: None,
         }
     }
 
@@ -611,6 +616,7 @@ impl ToolContext {
             event_emitter: None,
             event_context: None,
             tool_call_id: None,
+            capability_registry: None,
         }
     }
 

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -122,6 +122,8 @@ async fn setup_test_environment() -> (
         subagent_name: None,
         subagent_task: None,
         subagent_status: None,
+        blueprint_id: None,
+        blueprint_config: None,
     };
     session_store.add_session(session).await;
 
@@ -488,6 +490,8 @@ async fn test_reason_atom_with_different_configs() {
         subagent_name: None,
         subagent_task: None,
         subagent_status: None,
+        blueprint_id: None,
+        blueprint_config: None,
     };
     session_store.add_session(session2).await;
     message_retriever

--- a/crates/core/tests/subagent_test.rs
+++ b/crates/core/tests/subagent_test.rs
@@ -47,11 +47,10 @@ fn test_subagent_capability_registration() {
     assert!(cap.system_prompt_addition().is_some());
     assert_eq!(cap.features(), vec!["subagents"]);
 
-    // Verify system prompt mentions the three tools
+    // Verify system prompt mentions delegation and blueprints
     let prompt = cap.system_prompt_addition().unwrap();
     assert!(prompt.contains("spawn_subagent"));
-    assert!(prompt.contains("get_subagents"));
-    assert!(prompt.contains("message_subagent"));
+    assert!(prompt.contains("blueprint"));
 }
 
 // =============================================================================

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -1549,6 +1549,8 @@ message PlatformCreateSessionRequest {
     optional Uuid agent_id = 3;
     optional string title = 4;
     optional string locale = 5;
+    optional string blueprint_id = 6;
+    optional string blueprint_config_json = 7;
 }
 
 message PlatformCreateSessionResponse {

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -1362,6 +1362,8 @@ mod tests {
             subagent_name: None,
             subagent_task: None,
             subagent_status: None,
+            blueprint_id: None,
+            blueprint_config: None,
         };
 
         // Convert to proto

--- a/crates/server/migrations/010_agent_blueprints.sql
+++ b/crates/server/migrations/010_agent_blueprints.sql
@@ -1,0 +1,6 @@
+-- Agent Blueprints: blueprint-backed sessions
+-- When set, reason_activity and act_activity build RuntimeAgent from the
+-- blueprint definition instead of from harness_id/agent_id.
+
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS blueprint_id TEXT;
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS blueprint_config JSONB;

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -2037,6 +2037,8 @@ mod tests {
             capabilities: serde_json::json!([]),
             tools: serde_json::json!([]),
             hints: None,
+            blueprint_id: None,
+            blueprint_config: None,
         };
         let session = db.create_session(row).await.unwrap();
         session.id

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -253,6 +253,8 @@ impl WorkerAdapters for DirectWorkerAdapters {
                 subagent_name: None,
                 subagent_task: None,
                 subagent_status: None,
+                blueprint_id: r.blueprint_id,
+                blueprint_config: r.blueprint_config,
             }
         }))
     }

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1362,6 +1362,8 @@ impl DirectPlatformStore {
             subagent_name: None,
             subagent_task: None,
             subagent_status: None,
+            blueprint_id: row.blueprint_id,
+            blueprint_config: row.blueprint_config,
         }
     }
 }
@@ -1704,6 +1706,8 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
         agent_id: Option<AgentId>,
         title: Option<&str>,
         locale: Option<&str>,
+        blueprint_id: Option<&str>,
+        blueprint_config: Option<&serde_json::Value>,
     ) -> everruns_core::error::Result<Session> {
         use crate::storage::models::CreateSessionRow;
 
@@ -1718,15 +1722,18 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
                 "Archived or deleted harnesses cannot be assigned",
             ));
         }
-        if let Some(agent_id) = agent_id {
-            let agent = self
-                .db
-                .get_agent(self.org_id, agent_id)
-                .await
-                .map_err(|e| store_error(format!("Failed to get agent: {e}")))?
-                .ok_or_else(|| store_error("Agent not found"))?;
-            if agent.status != "active" {
-                return Err(store_error("Archived or deleted agents cannot be assigned"));
+        // Skip agent validation for blueprint sessions (agent_id may be None)
+        if blueprint_id.is_none() {
+            if let Some(agent_id) = agent_id {
+                let agent = self
+                    .db
+                    .get_agent(self.org_id, agent_id)
+                    .await
+                    .map_err(|e| store_error(format!("Failed to get agent: {e}")))?
+                    .ok_or_else(|| store_error("Agent not found"))?;
+                if agent.status != "active" {
+                    return Err(store_error("Archived or deleted agents cannot be assigned"));
+                }
             }
         }
 
@@ -1742,6 +1749,8 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
             capabilities: serde_json::Value::Array(vec![]),
             tools: serde_json::Value::Array(vec![]),
             hints: None,
+            blueprint_id: blueprint_id.map(|s| s.to_string()),
+            blueprint_config: blueprint_config.cloned(),
         };
         let row = self
             .db
@@ -2749,6 +2758,8 @@ mod tests {
                 capabilities: serde_json::Value::Array(vec![]),
                 tools: serde_json::Value::Array(vec![]),
                 hints: None,
+                blueprint_id: None,
+                blueprint_config: None,
             })
             .await
             .expect("create session");

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1725,17 +1725,17 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
             ));
         }
         // Skip agent validation for blueprint sessions (agent_id may be None)
-        if blueprint_id.is_none() {
-            if let Some(agent_id) = agent_id {
-                let agent = self
-                    .db
-                    .get_agent(self.org_id, agent_id)
-                    .await
-                    .map_err(|e| store_error(format!("Failed to get agent: {e}")))?
-                    .ok_or_else(|| store_error("Agent not found"))?;
-                if agent.status != "active" {
-                    return Err(store_error("Archived or deleted agents cannot be assigned"));
-                }
+        if blueprint_id.is_none()
+            && let Some(agent_id) = agent_id
+        {
+            let agent = self
+                .db
+                .get_agent(self.org_id, agent_id)
+                .await
+                .map_err(|e| store_error(format!("Failed to get agent: {e}")))?
+                .ok_or_else(|| store_error("Agent not found"))?;
+            if agent.status != "active" {
+                return Err(store_error("Archived or deleted agents cannot be assigned"));
             }
         }
 

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -3003,6 +3003,12 @@ impl WorkerService for WorkerServiceImpl {
             None
         };
 
+        // Parse blueprint config from JSON string if present
+        let blueprint_config: Option<serde_json::Value> = req
+            .blueprint_config_json
+            .as_ref()
+            .and_then(|s| serde_json::from_str(s).ok());
+
         let create_req = crate::api::sessions::CreateSessionRequest {
             harness_id: Some(everruns_core::HarnessId::from_uuid(harness_id)),
             agent_id: agent_public_id,
@@ -3018,12 +3024,14 @@ impl WorkerService for WorkerServiceImpl {
 
         let session = self
             .session_service
-            .create(
+            .create_with_blueprint(
                 &internal_caller,
                 harness_id,
                 agent_uuid,
                 create_req.agent_id,
                 create_req,
+                req.blueprint_id,
+                blueprint_config,
             )
             .await
             .map_err(|e| Status::internal(format!("Failed to create session: {}", e)))?;

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -3022,19 +3022,29 @@ impl WorkerService for WorkerServiceImpl {
             hints: None,
         };
 
-        let session = self
-            .session_service
-            .create_with_blueprint(
-                &internal_caller,
-                harness_id,
-                agent_uuid,
-                create_req.agent_id,
-                create_req,
-                req.blueprint_id,
-                blueprint_config,
-            )
-            .await
-            .map_err(|e| Status::internal(format!("Failed to create session: {}", e)))?;
+        let session = if let Some(blueprint_id) = req.blueprint_id {
+            self.session_service
+                .create_blueprint_session(
+                    &internal_caller,
+                    harness_id,
+                    blueprint_id,
+                    blueprint_config,
+                    create_req,
+                )
+                .await
+                .map_err(|e| Status::internal(format!("Failed to create session: {}", e)))?
+        } else {
+            self.session_service
+                .create(
+                    &internal_caller,
+                    harness_id,
+                    agent_uuid,
+                    create_req.agent_id,
+                    create_req,
+                )
+                .await
+                .map_err(|e| Status::internal(format!("Failed to create session: {}", e)))?
+        };
 
         Ok(Response::new(PlatformCreateSessionResponse {
             session: Some(schema_session_to_proto(&session)),

--- a/crates/server/src/services/notification.rs
+++ b/crates/server/src/services/notification.rs
@@ -272,6 +272,8 @@ mod tests {
                 capabilities: json!([]),
                 tools: json!([]),
                 hints: None,
+                blueprint_id: None,
+                blueprint_config: None,
             })
             .await
             .unwrap();

--- a/crates/server/src/services/session.rs
+++ b/crates/server/src/services/session.rs
@@ -167,6 +167,8 @@ impl SessionService {
             capabilities: capabilities_json,
             tools: serde_json::to_value(&req.tools).unwrap_or_default(),
             hints: hints_json,
+            blueprint_id: None,
+            blueprint_config: None,
         };
         let row = self.db.create_session(input).await?;
         let mut session = Self::row_to_session(row, org_public_id);
@@ -196,6 +198,50 @@ impl SessionService {
         .await?;
 
         Ok(session)
+    }
+
+    /// Create a session with optional blueprint fields (used by gRPC platform create).
+    pub async fn create_with_blueprint(
+        &self,
+        caller: &Caller,
+        harness_id: Uuid,
+        agent_internal_id: Option<Uuid>,
+        agent_public_id: Option<AgentId>,
+        req: CreateSessionRequest,
+        blueprint_id: Option<String>,
+        blueprint_config: Option<serde_json::Value>,
+    ) -> Result<Session> {
+        // For blueprint sessions, skip agent validation (agent_id may be None)
+        if blueprint_id.is_some() {
+            let org_id = caller.org_id;
+            let org_public_id = &caller.org_public_id;
+            let harness_id = HarnessId::from_uuid(harness_id);
+            let agent_id = agent_internal_id.map(AgentId::from_uuid);
+
+            let input = CreateSessionRow {
+                org_id,
+                harness_id: Some(harness_id),
+                agent_id,
+                agent_identity_id: None,
+                title: req.title,
+                locale: req.locale,
+                tags: req.tags,
+                model_id: None,
+                capabilities: serde_json::Value::Array(vec![]),
+                tools: serde_json::Value::Array(vec![]),
+                hints: None,
+                blueprint_id,
+                blueprint_config,
+            };
+            let row = self.db.create_session(input).await?;
+            let mut session = Self::row_to_session(row, org_public_id);
+            self.populate_features(org_id, &mut session).await?;
+            session.agent_id = agent_public_id;
+            return Ok(session);
+        }
+        // Fall through to standard create
+        self.create(caller, harness_id, agent_internal_id, agent_public_id, req)
+            .await
     }
 
     /// Apply capability mounts to a session's filesystem.
@@ -555,6 +601,8 @@ impl SessionService {
             capabilities: serde_json::json!([]),
             tools: serde_json::json!([]),
             hints: None,
+            blueprint_id: None,
+            blueprint_config: None,
         };
         let row = self.db.create_session(input).await?;
         let session_id = row.id.uuid();
@@ -737,6 +785,8 @@ impl SessionService {
             subagent_status: row
                 .subagent_status
                 .map(|s| SubagentStatus::from(s.as_str())),
+            blueprint_id: row.blueprint_id,
+            blueprint_config: row.blueprint_config,
         }
     }
 
@@ -1275,6 +1325,8 @@ mod tests {
                 .unwrap(),
                 tools: serde_json::json!([]),
                 hints: None,
+                blueprint_id: None,
+                blueprint_config: None,
             })
             .await
             .unwrap();
@@ -1361,6 +1413,8 @@ mod tests {
                 capabilities: serde_json::json!([]),
                 tools: serde_json::json!([]),
                 hints: None,
+                blueprint_id: None,
+                blueprint_config: None,
             })
             .await
             .unwrap();

--- a/crates/server/src/services/session.rs
+++ b/crates/server/src/services/session.rs
@@ -200,48 +200,39 @@ impl SessionService {
         Ok(session)
     }
 
-    /// Create a session with optional blueprint fields (used by gRPC platform create).
-    pub async fn create_with_blueprint(
+    /// Create a blueprint-backed session (used by gRPC platform create).
+    /// Skips agent validation since blueprint sessions don't inherit agent config.
+    pub async fn create_blueprint_session(
         &self,
         caller: &Caller,
         harness_id: Uuid,
-        agent_internal_id: Option<Uuid>,
-        agent_public_id: Option<AgentId>,
-        req: CreateSessionRequest,
-        blueprint_id: Option<String>,
+        blueprint_id: String,
         blueprint_config: Option<serde_json::Value>,
+        req: CreateSessionRequest,
     ) -> Result<Session> {
-        // For blueprint sessions, skip agent validation (agent_id may be None)
-        if blueprint_id.is_some() {
-            let org_id = caller.org_id;
-            let org_public_id = &caller.org_public_id;
-            let harness_id = HarnessId::from_uuid(harness_id);
-            let agent_id = agent_internal_id.map(AgentId::from_uuid);
+        let org_id = caller.org_id;
+        let org_public_id = &caller.org_public_id;
+        let harness_id = HarnessId::from_uuid(harness_id);
 
-            let input = CreateSessionRow {
-                org_id,
-                harness_id: Some(harness_id),
-                agent_id,
-                agent_identity_id: None,
-                title: req.title,
-                locale: req.locale,
-                tags: req.tags,
-                model_id: None,
-                capabilities: serde_json::Value::Array(vec![]),
-                tools: serde_json::Value::Array(vec![]),
-                hints: None,
-                blueprint_id,
-                blueprint_config,
-            };
-            let row = self.db.create_session(input).await?;
-            let mut session = Self::row_to_session(row, org_public_id);
-            self.populate_features(org_id, &mut session).await?;
-            session.agent_id = agent_public_id;
-            return Ok(session);
-        }
-        // Fall through to standard create
-        self.create(caller, harness_id, agent_internal_id, agent_public_id, req)
-            .await
+        let input = CreateSessionRow {
+            org_id,
+            harness_id: Some(harness_id),
+            agent_id: None,
+            agent_identity_id: None,
+            title: req.title,
+            locale: req.locale,
+            tags: req.tags,
+            model_id: None,
+            capabilities: serde_json::Value::Array(vec![]),
+            tools: serde_json::Value::Array(vec![]),
+            hints: None,
+            blueprint_id: Some(blueprint_id),
+            blueprint_config,
+        };
+        let row = self.db.create_session(input).await?;
+        let mut session = Self::row_to_session(row, org_public_id);
+        self.populate_features(org_id, &mut session).await?;
+        Ok(session)
     }
 
     /// Apply capability mounts to a session's filesystem.

--- a/crates/server/src/storage/leased_resource_store.rs
+++ b/crates/server/src/storage/leased_resource_store.rs
@@ -167,6 +167,8 @@ mod tests {
             capabilities: json!([]),
             tools: json!([]),
             hints: None,
+            blueprint_id: None,
+            blueprint_config: None,
         })
         .await
         .expect("test session should be created")

--- a/crates/server/src/storage/memory/sessions.rs
+++ b/crates/server/src/storage/memory/sessions.rs
@@ -42,6 +42,8 @@ impl InMemoryDatabase {
             subagent_name: None,
             subagent_task: None,
             subagent_status: None,
+            blueprint_id: input.blueprint_id,
+            blueprint_config: input.blueprint_config,
         };
         self.sessions.write().insert(id, row.clone());
         Ok(row)

--- a/crates/server/src/storage/memory/tests.rs
+++ b/crates/server/src/storage/memory/tests.rs
@@ -72,6 +72,8 @@ async fn test_create_and_list_sessions() {
             capabilities: serde_json::json!([]),
             tools: serde_json::json!([]),
             hints: None,
+            blueprint_id: None,
+            blueprint_config: None,
         })
         .await
         .unwrap();
@@ -121,6 +123,8 @@ async fn test_session_updated_at() {
             capabilities: serde_json::json!([]),
             tools: serde_json::json!([]),
             hints: None,
+            blueprint_id: None,
+            blueprint_config: None,
         })
         .await
         .unwrap();
@@ -185,6 +189,8 @@ async fn test_events_sequence() {
             capabilities: serde_json::json!([]),
             tools: serde_json::json!([]),
             hints: None,
+            blueprint_id: None,
+            blueprint_config: None,
         })
         .await
         .unwrap();
@@ -246,6 +252,8 @@ async fn create_session_with_events(db: &InMemoryDatabase) -> SessionId {
             capabilities: serde_json::json!([]),
             tools: serde_json::json!([]),
             hints: None,
+            blueprint_id: None,
+            blueprint_config: None,
         })
         .await
         .unwrap();
@@ -722,6 +730,8 @@ async fn test_list_events_empty_session_with_limit() {
             capabilities: serde_json::json!([]),
             tools: serde_json::json!([]),
             hints: None,
+            blueprint_id: None,
+            blueprint_config: None,
         })
         .await
         .unwrap();
@@ -769,6 +779,8 @@ async fn test_sessions_pagination() {
             capabilities: serde_json::json!([]),
             tools: serde_json::json!([]),
             hints: None,
+            blueprint_id: None,
+            blueprint_config: None,
         })
         .await
         .unwrap();
@@ -855,6 +867,8 @@ async fn test_sessions_pagination_ordering() {
             capabilities: serde_json::json!([]),
             tools: serde_json::json!([]),
             hints: None,
+            blueprint_id: None,
+            blueprint_config: None,
         })
         .await
         .unwrap();
@@ -1390,6 +1404,8 @@ async fn test_search_sessions_by_title() {
         capabilities: serde_json::json!([]),
         tools: serde_json::json!([]),
         hints: None,
+        blueprint_id: None,
+        blueprint_config: None,
     })
     .await
     .unwrap();
@@ -1406,6 +1422,8 @@ async fn test_search_sessions_by_title() {
         capabilities: serde_json::json!([]),
         tools: serde_json::json!([]),
         hints: None,
+        blueprint_id: None,
+        blueprint_config: None,
     })
     .await
     .unwrap();
@@ -1438,6 +1456,8 @@ async fn test_search_sessions_with_agent_filter() {
         capabilities: serde_json::json!([]),
         tools: serde_json::json!([]),
         hints: None,
+        blueprint_id: None,
+        blueprint_config: None,
     })
     .await
     .unwrap();
@@ -1454,6 +1474,8 @@ async fn test_search_sessions_with_agent_filter() {
         capabilities: serde_json::json!([]),
         tools: serde_json::json!([]),
         hints: None,
+        blueprint_id: None,
+        blueprint_config: None,
     })
     .await
     .unwrap();
@@ -1659,6 +1681,8 @@ async fn create_session_with_content_events(db: &InMemoryDatabase) -> SessionId 
             capabilities: serde_json::json!([]),
             tools: serde_json::json!([]),
             hints: None,
+            blueprint_id: None,
+            blueprint_config: None,
         })
         .await
         .unwrap();
@@ -1812,6 +1836,8 @@ async fn test_list_sessions_waiting_tool_results_before() {
             capabilities: serde_json::json!({}),
             tools: serde_json::json!([]),
             hints: None,
+            blueprint_id: None,
+            blueprint_config: None,
         })
         .await
         .unwrap();
@@ -1828,6 +1854,8 @@ async fn test_list_sessions_waiting_tool_results_before() {
             capabilities: serde_json::json!({}),
             tools: serde_json::json!([]),
             hints: None,
+            blueprint_id: None,
+            blueprint_config: None,
         })
         .await
         .unwrap();
@@ -1844,6 +1872,8 @@ async fn test_list_sessions_waiting_tool_results_before() {
             capabilities: serde_json::json!({}),
             tools: serde_json::json!([]),
             hints: None,
+            blueprint_id: None,
+            blueprint_config: None,
         })
         .await
         .unwrap();

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -418,6 +418,11 @@ pub struct SessionRow {
     pub subagent_task: Option<String>,
     #[sqlx(default)]
     pub subagent_status: Option<String>,
+    // -- Blueprint fields --
+    #[sqlx(default)]
+    pub blueprint_id: Option<String>,
+    #[sqlx(default)]
+    pub blueprint_config: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone)]
@@ -436,6 +441,10 @@ pub struct CreateSessionRow {
     pub tools: serde_json::Value,
     /// Session-level client hints (JSONB in DB)
     pub hints: Option<serde_json::Value>,
+    /// Blueprint ID for blueprint-backed sessions.
+    pub blueprint_id: Option<String>,
+    /// Validated blueprint config (JSONB in DB).
+    pub blueprint_config: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/crates/server/src/storage/repositories/sessions.rs
+++ b/crates/server/src/storage/repositories/sessions.rs
@@ -17,10 +17,11 @@ impl Database {
     pub async fn create_session(&self, input: CreateSessionRow) -> Result<SessionRow> {
         let row = sqlx::query_as::<_, SessionRow>(
             r#"
-            INSERT INTO sessions (org_id, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, hints, status)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 'started')
+            INSERT INTO sessions (org_id, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, hints, blueprint_id, blueprint_config, status)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, 'started')
             RETURNING id, org_id, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, hints, status, created_at, updated_at, started_at, finished_at,
-                      total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, parent_session_id, subagent_name, subagent_task, subagent_status
+                      total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, parent_session_id, subagent_name, subagent_task, subagent_status,
+                      blueprint_id, blueprint_config
             "#,
         )
         .bind(input.org_id)
@@ -34,6 +35,8 @@ impl Database {
         .bind(&input.capabilities)
         .bind(&input.tools)
         .bind(&input.hints)
+        .bind(&input.blueprint_id)
+        .bind(&input.blueprint_config)
         .fetch_one(&self.pool)
         .await?;
 
@@ -45,7 +48,8 @@ impl Database {
         let row = sqlx::query_as::<_, SessionRow>(
             r#"
             SELECT id, org_id, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, hints, status, created_at, updated_at, started_at, finished_at,
-                   total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, parent_session_id, subagent_name, subagent_task, subagent_status
+                   total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, parent_session_id, subagent_name, subagent_task, subagent_status,
+                   blueprint_id, blueprint_config
             FROM sessions
             WHERE org_id = $1 AND id = $2
             "#,
@@ -63,7 +67,8 @@ impl Database {
         let row = sqlx::query_as::<_, SessionRow>(
             r#"
             SELECT id, org_id, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, hints, status, created_at, updated_at, started_at, finished_at,
-                   total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, parent_session_id, subagent_name, subagent_task, subagent_status
+                   total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, parent_session_id, subagent_name, subagent_task, subagent_status,
+                   blueprint_id, blueprint_config
             FROM sessions
             WHERE id = $1
             "#,
@@ -122,7 +127,8 @@ impl Database {
         let offset_idx = param_idx + 1;
         let select_sql = format!(
             r#"SELECT id, org_id, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, hints, status, created_at, updated_at, started_at, finished_at,
-                   total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, parent_session_id, subagent_name, subagent_task, subagent_status
+                   total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, parent_session_id, subagent_name, subagent_task, subagent_status,
+                   blueprint_id, blueprint_config
             FROM sessions {where_clause}
             ORDER BY created_at DESC
             LIMIT ${limit_idx} OFFSET ${offset_idx}"#,
@@ -164,7 +170,8 @@ impl Database {
         let row = sqlx::query_as::<_, SessionRow>(
             r#"
             SELECT id, org_id, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, hints, status, created_at, updated_at, started_at, finished_at,
-                   total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, parent_session_id, subagent_name, subagent_task, subagent_status
+                   total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, parent_session_id, subagent_name, subagent_task, subagent_status,
+                   blueprint_id, blueprint_config
             FROM sessions
             WHERE org_id = $1 AND tags @> $2
             ORDER BY created_at ASC
@@ -185,7 +192,8 @@ impl Database {
         let rows = sqlx::query_as::<_, SessionRow>(
             r#"
             SELECT id, org_id, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, hints, status, created_at, updated_at, started_at, finished_at,
-                   total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, parent_session_id, subagent_name, subagent_task, subagent_status
+                   total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, parent_session_id, subagent_name, subagent_task, subagent_status,
+                   blueprint_id, blueprint_config
             FROM sessions
             WHERE status = 'active'
               AND EXISTS (
@@ -243,7 +251,8 @@ impl Database {
                 finished_at = COALESCE($11, finished_at)
             WHERE org_id = $1 AND id = $2
             RETURNING id, org_id, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, hints, status, created_at, updated_at, started_at, finished_at,
-                      total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, parent_session_id, subagent_name, subagent_task, subagent_status
+                      total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, parent_session_id, subagent_name, subagent_task, subagent_status,
+                      blueprint_id, blueprint_config
             "#,
         )
         .bind(org_id)

--- a/crates/server/src/storage/session_store.rs
+++ b/crates/server/src/storage/session_store.rs
@@ -107,8 +107,8 @@ impl SessionStore for DbSessionStore {
                     subagent_status: row
                         .subagent_status
                         .map(|s| SubagentStatus::from(s.as_str())),
-                    blueprint_id: None,
-                    blueprint_config: None,
+                    blueprint_id: row.blueprint_id,
+                    blueprint_config: row.blueprint_config,
                 }))
             }
             None => Ok(None),

--- a/crates/server/src/storage/session_store.rs
+++ b/crates/server/src/storage/session_store.rs
@@ -107,6 +107,8 @@ impl SessionStore for DbSessionStore {
                     subagent_status: row
                         .subagent_status
                         .map(|s| SubagentStatus::from(s.as_str())),
+                    blueprint_id: None,
+                    blueprint_config: None,
                 }))
             }
             None => Ok(None),

--- a/crates/server/tests/org_isolation_test.rs
+++ b/crates/server/tests/org_isolation_test.rs
@@ -939,6 +939,8 @@ async fn create_session_in_org(backend: &StorageBackend, org_id: i64) -> everrun
             capabilities: serde_json::json!([]),
             tools: serde_json::json!([]),
             hints: None,
+            blueprint_id: None,
+            blueprint_config: None,
         })
         .await
         .unwrap();

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -196,6 +196,8 @@ async fn test_session_crud() {
             capabilities: serde_json::json!([]),
             tools: serde_json::json!([]),
             hints: None,
+            blueprint_id: None,
+            blueprint_config: None,
         })
         .await
         .expect("Failed to create session");
@@ -291,6 +293,8 @@ async fn test_event_crud() {
             capabilities: serde_json::json!([]),
             tools: serde_json::json!([]),
             hints: None,
+            blueprint_id: None,
+            blueprint_config: None,
         })
         .await
         .expect("Failed to create session");
@@ -367,6 +371,8 @@ async fn test_event_exclude_types() {
             capabilities: serde_json::json!([]),
             tools: serde_json::json!([]),
             hints: None,
+            blueprint_id: None,
+            blueprint_config: None,
         })
         .await
         .expect("Failed to create session");
@@ -451,6 +457,8 @@ async fn test_event_filter_types() {
             capabilities: serde_json::json!([]),
             tools: serde_json::json!([]),
             hints: None,
+            blueprint_id: None,
+            blueprint_config: None,
         })
         .await
         .expect("Failed to create session");
@@ -737,6 +745,8 @@ async fn test_session_file_crud() {
             capabilities: serde_json::json!([]),
             tools: serde_json::json!([]),
             hints: None,
+            blueprint_id: None,
+            blueprint_config: None,
         })
         .await
         .expect("Failed to create session");
@@ -1180,6 +1190,8 @@ async fn test_session_usage_tracking() {
             capabilities: serde_json::json!([]),
             tools: serde_json::json!([]),
             hints: None,
+            blueprint_id: None,
+            blueprint_config: None,
         })
         .await
         .expect("Failed to create session");
@@ -1262,6 +1274,8 @@ async fn test_session_previews() {
             capabilities: serde_json::json!([]),
             tools: serde_json::json!([]),
             hints: None,
+            blueprint_id: None,
+            blueprint_config: None,
         })
         .await
         .expect("Failed to create session");

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -410,50 +410,82 @@ pub async fn act_activity(
     // Create tool registry with default built-in tools
     let mut builtin_executor = ToolRegistry::with_defaults();
 
-    // Load capabilities and register their tools.
-    // When agent_id is present, use agent capabilities.
-    // When agent_id is absent, fall back to harness capabilities so that
-    // harness-provided tools (e.g. bash) are still registered.
-    let cap_ids: Vec<String> = if let Some(agent_id) = input.agent_id {
-        let agent_store = GrpcAgentStore::new(grpc_client.clone(), org_id);
-        if let Ok(Some(agent)) = agent_store.get_agent(agent_id).await {
-            agent
-                .capabilities
-                .iter()
-                .map(|c| c.capability_id().to_string())
-                .filter(|id| !is_mcp_capability(id))
-                .collect()
-        } else {
-            vec![]
-        }
+    // Resolve blueprint_id: prefer ActInput field, fall back to session lookup
+    let blueprint_id = if input.blueprint_id.is_some() {
+        input.blueprint_id.clone()
     } else {
-        let harness_store = GrpcHarnessStore::new(grpc_client.clone(), org_id);
-        if let Ok(Some(harness)) =
-            everruns_core::traits::HarnessStore::get_harness(&harness_store, input.harness_id).await
-        {
-            harness
-                .capabilities
-                .iter()
-                .map(|c| c.capability_id().to_string())
-                .filter(|id| !is_mcp_capability(id))
-                .collect()
-        } else {
-            vec![]
+        let session_store = GrpcSessionStore::new(grpc_client.clone(), org_id);
+        match session_store.get_session(input.context.session_id).await {
+            Ok(Some(session)) => session.blueprint_id.clone(),
+            _ => None,
         }
     };
 
-    if !cap_ids.is_empty() {
+    // Load tools: blueprint tools for blueprint sessions, capability tools otherwise.
+    if let Some(ref blueprint_id) = blueprint_id {
+        // Blueprint path: load tools from the blueprint definition
         let capability_registry = platform_definition.capability_registry().clone();
-        let ctx = SystemPromptContext::without_file_store(input.context.session_id);
-        let collected = collect_capabilities(&cap_ids, &capability_registry, &ctx).await;
-        for tool in collected.tools {
-            builtin_executor.register_boxed(tool);
+        if let Some(blueprint) = capability_registry.blueprint(blueprint_id) {
+            for tool in blueprint.tools {
+                builtin_executor.register_boxed(tool);
+            }
+            tracing::debug!(
+                blueprint_id = blueprint_id,
+                "Registered blueprint tools for act_activity"
+            );
+        } else {
+            tracing::warn!(
+                blueprint_id = blueprint_id,
+                "Blueprint not found in registry for act_activity"
+            );
         }
-        tracing::debug!(
-            capability_count = cap_ids.len(),
-            tool_count = collected.tool_definitions.len(),
-            "Registered capability tools for act_activity"
-        );
+    } else {
+        // Standard path: load capabilities from agent or harness.
+        // When agent_id is present, use agent capabilities.
+        // When agent_id is absent, fall back to harness capabilities so that
+        // harness-provided tools (e.g. bash) are still registered.
+        let cap_ids: Vec<String> = if let Some(agent_id) = input.agent_id {
+            let agent_store = GrpcAgentStore::new(grpc_client.clone(), org_id);
+            if let Ok(Some(agent)) = agent_store.get_agent(agent_id).await {
+                agent
+                    .capabilities
+                    .iter()
+                    .map(|c| c.capability_id().to_string())
+                    .filter(|id| !is_mcp_capability(id))
+                    .collect()
+            } else {
+                vec![]
+            }
+        } else {
+            let harness_store = GrpcHarnessStore::new(grpc_client.clone(), org_id);
+            if let Ok(Some(harness)) =
+                everruns_core::traits::HarnessStore::get_harness(&harness_store, input.harness_id)
+                    .await
+            {
+                harness
+                    .capabilities
+                    .iter()
+                    .map(|c| c.capability_id().to_string())
+                    .filter(|id| !is_mcp_capability(id))
+                    .collect()
+            } else {
+                vec![]
+            }
+        };
+
+        if !cap_ids.is_empty() {
+            let capability_registry = platform_definition.capability_registry().clone();
+            let ctx = SystemPromptContext::without_file_store(input.context.session_id);
+            let collected = collect_capabilities(&cap_ids, &capability_registry, &ctx).await;
+            for tool in collected.tools {
+                builtin_executor.register_boxed(tool);
+            }
+            tracing::debug!(
+                capability_count = cap_ids.len(),
+                tool_count = collected.tool_definitions.len(),
+                "Registered capability tools for act_activity"
+            );
+        }
     }
 
     // Create composite tool executor that handles both built-in and MCP tools
@@ -494,7 +526,8 @@ pub async fn act_activity(
         .with_sqldb_store(sqldb_store)
         .with_leased_resource_store(leased_resource_store)
         .with_schedule_store(schedule_store)
-        .with_platform_store(platform_store);
+        .with_platform_store(platform_store)
+        .with_capability_registry(platform_definition.capability_registry().clone());
 
     atom.execute(input)
         .await
@@ -593,6 +626,7 @@ mod tests {
                 deferrable: DeferrablePolicy::default(),
             })],
             locale: None,
+            blueprint_id: None,
         };
 
         let json = serde_json::to_string(&input).unwrap();

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -425,20 +425,21 @@ pub async fn act_activity(
     if let Some(ref blueprint_id) = blueprint_id {
         // Blueprint path: load tools from the blueprint definition
         let capability_registry = platform_definition.capability_registry().clone();
-        if let Some(blueprint) = capability_registry.blueprint(blueprint_id) {
-            for tool in blueprint.tools {
-                builtin_executor.register_boxed(tool);
-            }
-            tracing::debug!(
-                blueprint_id = blueprint_id,
-                "Registered blueprint tools for act_activity"
-            );
-        } else {
-            tracing::warn!(
-                blueprint_id = blueprint_id,
-                "Blueprint not found in registry for act_activity"
-            );
+        let blueprint = capability_registry
+            .blueprint(blueprint_id)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Blueprint \"{}\" not found in registry. Session has blueprint_id but no matching blueprint.",
+                    blueprint_id
+                )
+            })?;
+        for tool in blueprint.tools {
+            builtin_executor.register_boxed(tool);
         }
+        tracing::debug!(
+            blueprint_id = blueprint_id,
+            "Registered blueprint tools for act_activity"
+        );
     } else {
         // Standard path: load capabilities from agent or harness.
         // When agent_id is present, use agent capabilities.

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -16,7 +16,7 @@ use anyhow::{Context, Result};
 use everruns_core::ToolRegistry;
 use everruns_core::atoms::{ActAtom, Atom, InputAtom, ReasonAtom};
 use everruns_core::capabilities::{SystemPromptContext, collect_capabilities, is_mcp_capability};
-use everruns_core::traits::AgentStore;
+use everruns_core::traits::{AgentStore, SessionStore};
 use everruns_core::{Message, PlatformDefinition};
 use std::sync::Arc;
 

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -1380,6 +1380,7 @@ impl DurableWorker {
                             tool_calls: reason_result.tool_calls,
                             tool_definitions: reason_result.tool_definitions,
                             locale: reason_result.locale,
+                            blueprint_id: None, // Resolved by act_activity from session
                         },
                     };
                     let mut act_input_json = serde_json::to_value(&act_task_input)?;

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -814,6 +814,8 @@ fn proto_session_to_session(proto_session: proto::Session) -> Result<Session> {
         subagent_name: None,
         subagent_task: None,
         subagent_status: None,
+        blueprint_id: None,
+        blueprint_config: None,
     })
 }
 
@@ -2143,6 +2145,8 @@ impl everruns_core::platform_store::PlatformStore for GrpcOrgAdapter {
         agent_id: Option<AgentId>,
         title: Option<&str>,
         locale: Option<&str>,
+        blueprint_id: Option<&str>,
+        blueprint_config: Option<&serde_json::Value>,
     ) -> Result<Session> {
         let mut client = self.client.inner.lock().await;
         let response = client
@@ -2152,6 +2156,9 @@ impl everruns_core::platform_store::PlatformStore for GrpcOrgAdapter {
                 agent_id: agent_id.map(|id| uuid_to_proto(id.uuid())),
                 title: title.map(|s| s.to_string()),
                 locale: locale.map(|value| value.to_string()),
+                blueprint_id: blueprint_id.map(|s| s.to_string()),
+                blueprint_config_json: blueprint_config
+                    .map(|v| serde_json::to_string(v).unwrap_or_default()),
             })
             .await
             .map_err(grpc_status_to_error)?;

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -919,6 +919,7 @@ async fn schedule_next_activity<S: WorkflowEventStore>(
                     tool_calls: reason_result.tool_calls,
                     tool_definitions: reason_result.tool_definitions,
                     locale: reason_result.locale,
+                    blueprint_id: None, // Resolved by act_activity from session
                 };
                 let mut act_input_json = serde_json::to_value(&act_input)?;
                 if let Some(rid) = &response_id {

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -5897,16 +5897,6 @@
             "description": "Optional resident agent identity used for unattended/background execution.",
             "example": "identity_01933b5a00007000800000000000001"
           },
-          "blueprint_config": {
-            "description": "Validated config passed by host at blueprint spawn time."
-          },
-          "blueprint_id": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Blueprint ID. When set, reason_activity and act_activity build RuntimeAgent\nfrom the blueprint definition instead of from harness_id/agent_id."
-          },
           "capabilities": {
             "type": "array",
             "items": {

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -9586,6 +9586,16 @@
                   "description": "Optional resident agent identity for unattended/background execution.",
                   "example": "identity_01933b5a00007000800000000000001"
                 },
+                "blueprint_config": {
+                  "description": "Validated config passed by host at blueprint spawn time."
+                },
+                "blueprint_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Blueprint ID. When set, reason_activity and act_activity build RuntimeAgent\nfrom the blueprint definition instead of from harness_id/agent_id."
+                },
                 "capabilities": {
                   "type": "array",
                   "items": {

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -5897,6 +5897,16 @@
             "description": "Optional resident agent identity used for unattended/background execution.",
             "example": "identity_01933b5a00007000800000000000001"
           },
+          "blueprint_config": {
+            "description": "Validated config passed by host at blueprint spawn time."
+          },
+          "blueprint_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Blueprint ID. When set, reason_activity and act_activity build RuntimeAgent\nfrom the blueprint definition instead of from harness_id/agent_id."
+          },
           "capabilities": {
             "type": "array",
             "items": {
@@ -10416,6 +10426,16 @@
             ],
             "description": "Optional resident agent identity for unattended/background execution.",
             "example": "identity_01933b5a00007000800000000000001"
+          },
+          "blueprint_config": {
+            "description": "Validated config passed by host at blueprint spawn time."
+          },
+          "blueprint_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Blueprint ID. When set, reason_activity and act_activity build RuntimeAgent\nfrom the blueprint definition instead of from harness_id/agent_id."
           },
           "capabilities": {
             "type": "array",

--- a/specs/agent-blueprints.md
+++ b/specs/agent-blueprints.md
@@ -1,5 +1,6 @@
 # Agent Blueprints Specification
 
+
 <!-- Design Decisions:
   - AgentBlueprint: code-defined agent template with private tools, baked-in prompt, fixed/default model
   - Contributed by capabilities via new `agent_blueprints()` trait method

--- a/specs/agent-blueprints.md
+++ b/specs/agent-blueprints.md
@@ -1,0 +1,325 @@
+# Agent Blueprints Specification
+
+<!-- Design Decisions:
+  - AgentBlueprint: code-defined agent template with private tools, baked-in prompt, fixed/default model
+  - Contributed by capabilities via new `agent_blueprints()` trait method
+  - Invoked through existing spawn_subagent tool (new `blueprint` parameter)
+  - Private tools: blueprint tools never leak to host agent's tool list
+  - Fixed model: blueprint can hardcode model (e.g. Haiku 4.6 for cheap scout work)
+  - Config surface is narrow and typed: blueprint declares JSON Schema for allowed overrides
+  - Same invocation contract as subagents (spawn/get/message), different runtime assembly
+  - First implementation: GitHubScout (read-only GitHub search, hardcoded to fast model)
+-->
+
+## Abstract
+
+Agent Blueprints are pre-built agent definitions contributed by capabilities. Unlike subagents (which inherit the parent's agent config and run a parent-controlled prompt), blueprints encapsulate a complete agent — prompt, private tools, model selection — behind a simple invocation interface. The host agent spawns a blueprint the same way it spawns a subagent, but the blueprint controls its own internals.
+
+Inspired by Claude Code's built-in subagents (Explore, Plan, Claude Code Guide) and AmpCode's Librarian pattern.
+
+## Design Principles
+
+| Principle | Rationale |
+|-----------|-----------|
+| Blueprints are capabilities, not a new primitive | Reuses existing Capability trait, RuntimeAgent builder, and subagent infrastructure. No new entity type in DB. |
+| Private tools | Blueprint tools never appear in the host agent's tool list. They exist only inside the spawned child session. |
+| Fixed model is first-class | Cheap/fast work (search, lookup) should not burn host's expensive model. Blueprint author decides. |
+| Narrow config surface | Host can pass structured config (e.g. repos to search). Cannot override prompt or tools. Blueprint declares allowed config via JSON Schema. |
+| Same invocation contract | `spawn_subagent(blueprint: "github_scout", task: "...")` — host doesn't need new tools to use blueprints. |
+| Discovery via system prompt | Available blueprints listed in system prompt so LLM can decide when to use them during reasoning, not during tool execution. |
+
+## Data Model
+
+### AgentBlueprint
+
+Returned by `Capability::agent_blueprints()`. Defined in code, not persisted.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `&'static str` | Unique identifier (e.g. `"github_scout"`) |
+| `name` | `&'static str` | Human-readable display name (e.g. `"GitHub Scout"`) |
+| `description` | `&'static str` | When to use this blueprint (LLM reads this for delegation decisions) |
+| `model` | `BlueprintModel` | Model selection strategy |
+| `system_prompt` | `&'static str` | Baked-in system prompt for the child agent |
+| `tools` | `Vec<Box<dyn Tool>>` | Private tools — only available inside the blueprint's session |
+| `max_turns` | `Option<usize>` | Iteration limit (default: 20) |
+| `config_schema` | `Option<Value>` | JSON Schema for allowed host-provided config. `None` = no config accepted. |
+
+### BlueprintModel
+
+```rust
+pub enum BlueprintModel {
+    /// Always use this model. Host cannot override.
+    Fixed(&'static str),
+    /// Use this model unless host provides override via config.
+    Default(&'static str),
+    /// Use whatever model the host agent uses.
+    Inherit,
+}
+```
+
+**Rationale:** `Fixed` exists because scout/lookup work should use cheap models regardless of host context. A GitHub search agent doesn't need Opus. `Default` allows power users to upgrade when needed. `Inherit` preserves subagent behavior for blueprints that need the same reasoning capability as the host.
+
+## Capability Trait Extension
+
+New method on the `Capability` trait with a default empty implementation:
+
+```rust
+/// Agent blueprints contributed by this capability.
+/// Blueprints are pre-built agents with private tools and baked-in prompts.
+/// They are spawnable via `spawn_subagent(blueprint: "<id>")`.
+fn agent_blueprints(&self) -> Vec<AgentBlueprint> {
+    vec![]
+}
+```
+
+This is additive — existing capabilities are unaffected. Only capabilities that want to contribute blueprints implement it.
+
+### Blueprint Registration
+
+The `CapabilityRegistry` collects blueprints from all registered capabilities:
+
+```rust
+impl CapabilityRegistry {
+    /// All blueprints from all registered capabilities.
+    pub fn blueprints(&self) -> Vec<&AgentBlueprint> { ... }
+
+    /// Find a blueprint by ID across all capabilities.
+    pub fn blueprint(&self, id: &str) -> Option<&AgentBlueprint> { ... }
+}
+```
+
+Blueprints are keyed by `id`. Duplicate IDs across capabilities are rejected at registration time (panic in debug, last-wins in release).
+
+## Invocation: spawn_subagent Extension
+
+The existing `spawn_subagent` tool gains one optional parameter:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Human-readable name (same as today) |
+| `task` | string | Yes | Task description (same as today) |
+| `blueprint` | string | No | Blueprint ID. When set, child uses the blueprint's RuntimeAgent instead of inheriting parent's. |
+| `config` | object | No | Blueprint-specific config. Validated against `config_schema`. Ignored when `blueprint` is absent. |
+
+### Behavior When `blueprint` Is Set
+
+1. Look up `blueprint` ID in `CapabilityRegistry::blueprint()`
+2. Validate `config` against `blueprint.config_schema` (if schema exists). Reject invalid config.
+3. Create child session with `parent_session_id` set (same as today)
+4. Build a **new RuntimeAgent** from the blueprint:
+   - System prompt: `blueprint.system_prompt` (NOT the parent's prompt)
+   - Tools: `blueprint.tools` (NOT the parent's tools) — these are private
+   - Model: resolved from `BlueprintModel` (Fixed/Default/Inherit)
+   - Max iterations: `blueprint.max_turns` or default
+5. Inject `config` values into system prompt or tool context as appropriate
+6. Send `task` as first user message
+7. Block on `wait_for_idle` (foreground mode, same as today)
+8. Return result (same as today)
+
+### Behavior When `blueprint` Is Absent
+
+Identical to current behavior — child inherits parent's harness/agent config.
+
+## Discovery: System Prompt Contribution
+
+When blueprints are registered, the `SubagentCapability` (or a new aggregator) contributes to the system prompt:
+
+```
+<available-blueprints>
+Specialized agents you can delegate to via spawn_subagent(blueprint: "<id>"):
+
+- github_scout: Search GitHub repositories for code, issues, and discussions.
+  Fast read-only agent. Use for codebase exploration, finding patterns,
+  understanding unfamiliar repos. Config: { "repos": ["owner/repo"] }
+</available-blueprints>
+```
+
+This is generated dynamically from `CapabilityRegistry::blueprints()`. Each entry shows `id`, `description`, and a summary of `config_schema` (if any).
+
+**Rationale:** The LLM needs the menu upfront during reasoning. A `list_blueprints` tool would require a tool call before the LLM can decide — wasteful for a small, static list.
+
+## Tool Encapsulation
+
+Blueprint tools are **private** to the spawned session:
+
+- They do NOT appear in `RuntimeAgent.tools` of the host agent
+- They do NOT appear in the host's system prompt
+- They are instantiated only when the blueprint is spawned
+- They are destroyed when the child session completes
+
+This means a capability can contribute both:
+1. Tools for the host agent (via `tools()`) — e.g. `spawn_subagent`
+2. Tools for a blueprint agent (via `agent_blueprints()` → `AgentBlueprint.tools`) — e.g. `search_github_code`
+
+These are separate namespaces. A tool name can exist in both without conflict.
+
+## Security Considerations
+
+| Concern | Mitigation |
+|---------|------------|
+| Capability escalation | Blueprint tools cannot exceed the capability's own permissions. A blueprint contributed by `github_scout` capability can only access what that capability's API keys allow. |
+| Prompt injection via config | Config is validated against typed JSON Schema. No free-form prompt override. |
+| Model cost | `Fixed` model prevents host from accidentally running expensive models for cheap work. `Default` model documents the intended cost profile. |
+| Tool leakage | Blueprint tools never enter host's tool list. Separate RuntimeAgent assembly path. |
+| Nesting | Same constraint as subagents — blueprints cannot spawn subagents or other blueprints. |
+| Resource exhaustion | `max_turns` limit on blueprint. Same 300s timeout as subagents. |
+
+## Concrete Example: GitHubScout
+
+First blueprint implementation. Capability: `github_scout`.
+
+### GitHubScout Capability
+
+```rust
+pub struct GitHubScoutCapability;
+
+impl Capability for GitHubScoutCapability {
+    fn id(&self) -> &str { "github_scout" }
+    fn name(&self) -> &str { "GitHub Scout" }
+    fn description(&self) -> &str {
+        "Pre-built agent that searches GitHub repositories for code, issues, and discussions."
+    }
+    fn status(&self) -> CapabilityStatus { CapabilityStatus::Available }
+    fn icon(&self) -> Option<&str> { Some("github") }
+    fn category(&self) -> Option<&str> { Some("Orchestration") }
+
+    // No tools for host — all tools are private to the blueprint
+    fn tools(&self) -> Vec<Box<dyn Tool>> { vec![] }
+
+    fn agent_blueprints(&self) -> Vec<AgentBlueprint> {
+        vec![AgentBlueprint {
+            id: "github_scout",
+            name: "GitHub Scout",
+            description: "Search GitHub repositories for code, issues, and discussions. \
+                          Fast read-only agent for codebase exploration and pattern discovery.",
+            model: BlueprintModel::Fixed("claude-haiku-4-5-20251001"),
+            system_prompt: GITHUB_SCOUT_PROMPT,
+            tools: vec![
+                Box::new(SearchGitHubCodeTool),
+                Box::new(ReadGitHubFileTool),
+                Box::new(SearchGitHubIssuesTool),
+            ],
+            max_turns: Some(15),
+            config_schema: Some(json!({
+                "type": "object",
+                "properties": {
+                    "repos": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Repository list to scope searches (owner/repo format)"
+                    },
+                    "max_results": {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Maximum results per search query"
+                    }
+                }
+            })),
+        }]
+    }
+}
+```
+
+### Private Tools
+
+| Tool | Description |
+|------|-------------|
+| `search_github_code` | Search code across repos using GitHub code search API |
+| `read_github_file` | Read a specific file from a GitHub repo (by path + ref) |
+| `search_github_issues` | Search issues and discussions with filters |
+
+These tools use the GitHub API token from the capability's configuration (via User Connections or environment). They are never visible to the host agent.
+
+### Usage
+
+Host agent delegates GitHub research:
+
+```json
+{
+  "name": "spawn_subagent",
+  "arguments": {
+    "name": "Scout",
+    "task": "Find how authentication middleware is implemented in the fastify repo. Look for JWT validation patterns and report the key files.",
+    "blueprint": "github_scout",
+    "config": {
+      "repos": ["fastify/fastify", "fastify/fastify-jwt"]
+    }
+  }
+}
+```
+
+Result: A child session runs with Haiku, the 3 GitHub tools, and the scout prompt. Host gets back a summary. Host never sees `search_github_code` in its own tool list.
+
+## RuntimeAgent Assembly
+
+When spawning from a blueprint, the `RuntimeAgentBuilder` takes a different path:
+
+```
+Standard subagent:
+  RuntimeAgentBuilder::new()
+    .with_harness(parent_harness, ...)     // inherit
+    .with_agent(parent_agent, ...)         // inherit
+    .build()
+
+Blueprint subagent:
+  RuntimeAgentBuilder::new()
+    .system_prompt(blueprint.system_prompt)  // blueprint's own prompt
+    .tools(blueprint.tools)                  // blueprint's private tools
+    .model(resolve_model(blueprint.model))   // blueprint's model strategy
+    .max_iterations(blueprint.max_turns)
+    .build()
+```
+
+The blueprint path skips harness/agent inheritance entirely. The blueprint is self-contained.
+
+## Relationship to Subagents
+
+| Aspect | Subagent | Blueprint |
+|--------|----------|-----------|
+| Prompt | Controlled by host (task = prompt) | Baked in by blueprint author |
+| Tools | Inherits parent's tools | Private tools, no inheritance |
+| Model | Inherits parent's model | Fixed/Default/Inherit per blueprint |
+| Config | None (host controls everything via task) | Narrow, typed, validated |
+| Use case | Offload work the host knows how to do | Delegate to specialist the host doesn't need to understand |
+| Invocation | `spawn_subagent(name, task)` | `spawn_subagent(name, task, blueprint, config)` |
+| Tool visibility | Host's tools visible in child | Blueprint's tools invisible to host |
+| Example | "Run these 5 tests" | "Search GitHub for auth patterns" |
+
+Both use the same 3-tool contract (`spawn/get/message`). Both create child sessions with `parent_session_id`. Both respect nesting prevention. The difference is purely in RuntimeAgent assembly.
+
+## Implementation Path
+
+### Phase 1: Core Infrastructure
+
+1. Add `AgentBlueprint` and `BlueprintModel` structs to `crates/core/src/capabilities/mod.rs`
+2. Add `agent_blueprints()` default method to `Capability` trait
+3. Add `blueprints()` and `blueprint(id)` to `CapabilityRegistry`
+4. Extend `spawn_subagent` tool schema with `blueprint` and `config` parameters
+5. Extend `SpawnSubagentTool::execute_with_context` to handle blueprint path
+6. Add blueprint discovery system prompt contribution
+
+### Phase 2: GitHubScout
+
+1. New integration crate: `integrations/github-scout/`
+2. Implement `GitHubScoutCapability` with 3 private tools
+3. Wire GitHub API via User Connections (OAuth token)
+4. Register via `inventory::submit!` plugin system
+5. Add to Generic harness capabilities
+
+### Phase 3: Framework Maturation
+
+| Feature | Description |
+|---------|-------------|
+| Blueprint config injection | Pass validated config into tool context or prompt template |
+| Blueprint-scoped MCP | Blueprint can declare MCP servers that start/stop with the child session |
+| Blueprint isolation modes | `shared_ro` / `isolated` filesystem access |
+| More blueprints | CodeReviewer, TestRunner, DocWriter as built-in blueprints |
+
+## Open Questions
+
+1. **Should blueprints have access to parent's filesystem?** Current lean: no by default. GitHubScout doesn't need it. Future blueprints (CodeReviewer) might want read-only access — add as opt-in field on `AgentBlueprint`.
+
+2. **Should `get_subagents` distinguish blueprint-spawned children?** Probably yes — include `blueprint_id` in the response so the host knows which specialist it's talking to.
+
+3. **Can a capability contribute both host tools AND a blueprint?** Yes. Example: a `github` capability could give the host `create_github_issue` directly AND contribute a GitHubScout blueprint for research. The host tool and the blueprint tools are separate namespaces.

--- a/specs/agent-blueprints.md
+++ b/specs/agent-blueprints.md
@@ -3,30 +3,50 @@
 <!-- Design Decisions:
   - AgentBlueprint: code-defined agent template with private tools, baked-in prompt, fixed/default model
   - Contributed by capabilities via new `agent_blueprints()` trait method
-  - Invoked through existing spawn_subagent tool (new `blueprint` parameter)
+  - Spawned via `spawn_subagent` tool (new `blueprint` + `config` params)
+  - Child session stores `blueprint_id` — reason_activity and act_activity branch on it
   - Private tools: blueprint tools never leak to host agent's tool list
-  - Fixed model: blueprint can hardcode model (e.g. Haiku 4.6 for cheap scout work)
-  - Config surface is narrow and typed: blueprint declares JSON Schema for allowed overrides
-  - Same invocation contract as subagents (spawn/get/message), different runtime assembly
+  - Fixed model: blueprint can hardcode model (e.g. Haiku for cheap scout work)
+  - Config surface is narrow and typed: JSON Schema for allowed overrides
+  - Runs on the same durable execution engine, same agentic loop, same event stream
   - First implementation: GitHubScout (read-only GitHub search, hardcoded to fast model)
 -->
 
 ## Abstract
 
-Agent Blueprints are pre-built agent definitions contributed by capabilities. Unlike subagents (which inherit the parent's agent config and run a parent-controlled prompt), blueprints encapsulate a complete agent — prompt, private tools, model selection — behind a simple invocation interface. The host agent spawns a blueprint the same way it spawns a subagent, but the blueprint controls its own internals.
+Agent Blueprints are pre-built agent definitions contributed by capabilities. Unlike subagents (which inherit the parent's harness + agent config), blueprints encapsulate a complete agent — prompt, private tools, model selection — behind a simple invocation interface. The host agent spawns a blueprint via `spawn_subagent`, but the blueprint controls its own internals.
 
 Inspired by Claude Code's built-in subagents (Explore, Plan, Claude Code Guide) and AmpCode's Librarian pattern.
+
+## Motivation
+
+Current subagents inherit parent's `harness_id` + `agent_id`. In `reason_activity`, the child builds the same RuntimeAgent as the parent:
+
+```
+RuntimeAgentBuilder::new()
+    .with_harness(parent_harness, ...)
+    .with_agent(parent_agent, ...)
+    .build()
+```
+
+This works for "do the same kind of work in parallel" (run tests, process files). It fails for specialist delegation where the child needs:
+- **Different tools** — GitHub search tools the host doesn't have
+- **Different model** — Haiku for cheap lookup work, not the host's Opus
+- **Different prompt** — specialist instructions unrelated to the host's agent prompt
+- **Tool privacy** — host shouldn't see or be tempted to call the specialist's internal tools
+
+Blueprints solve this by providing an alternative RuntimeAgent assembly path.
 
 ## Design Principles
 
 | Principle | Rationale |
 |-----------|-----------|
-| Blueprints are capabilities, not a new primitive | Reuses existing Capability trait, RuntimeAgent builder, and subagent infrastructure. No new entity type in DB. |
-| Private tools | Blueprint tools never appear in the host agent's tool list. They exist only inside the spawned child session. |
-| Fixed model is first-class | Cheap/fast work (search, lookup) should not burn host's expensive model. Blueprint author decides. |
-| Narrow config surface | Host can pass structured config (e.g. repos to search). Cannot override prompt or tools. Blueprint declares allowed config via JSON Schema. |
-| Same invocation contract | `spawn_subagent(blueprint: "github_scout", task: "...")` — host doesn't need new tools to use blueprints. |
-| Discovery via system prompt | Available blueprints listed in system prompt so LLM can decide when to use them during reasoning, not during tool execution. |
+| Blueprints are capabilities, not a new DB entity | Contributed via `Capability` trait. No new table. Session gains `blueprint_id` field to signal alternate assembly. |
+| Same durable execution infrastructure | Same agentic loop (InputAtom → ReasonAtom → ActAtom). Same PostgreSQL workflows. Same event stream. Only RuntimeAgent assembly differs. |
+| Private tools | Blueprint tools never appear in the host's tool list. They exist only in the child session's RuntimeAgent. |
+| Fixed model is first-class | Cheap work should not burn expensive models. Blueprint author decides. |
+| Narrow config surface | Host passes structured config validated against JSON Schema. Cannot override prompt or tools. |
+| Discovery via system prompt | Available blueprints listed upfront so LLM delegates during reasoning, not via a discovery tool call. |
 
 ## Data Model
 
@@ -34,10 +54,12 @@ Inspired by Claude Code's built-in subagents (Explore, Plan, Claude Code Guide) 
 
 Returned by `Capability::agent_blueprints()`. Defined in code, not persisted.
 
+See `crates/core/src/capabilities/mod.rs` for the trait definition.
+
 | Field | Type | Description |
 |-------|------|-------------|
 | `id` | `&'static str` | Unique identifier (e.g. `"github_scout"`) |
-| `name` | `&'static str` | Human-readable display name (e.g. `"GitHub Scout"`) |
+| `name` | `&'static str` | Human-readable display name |
 | `description` | `&'static str` | When to use this blueprint (LLM reads this for delegation decisions) |
 | `model` | `BlueprintModel` | Model selection strategy |
 | `system_prompt` | `&'static str` | Baked-in system prompt for the child agent |
@@ -58,7 +80,18 @@ pub enum BlueprintModel {
 }
 ```
 
-**Rationale:** `Fixed` exists because scout/lookup work should use cheap models regardless of host context. A GitHub search agent doesn't need Opus. `Default` allows power users to upgrade when needed. `Inherit` preserves subagent behavior for blueprints that need the same reasoning capability as the host.
+`Fixed` — scout/lookup work uses cheap models regardless of host context. `Default` — power users can upgrade via config. `Inherit` — blueprints that need the host's reasoning level.
+
+### Session Model Extension
+
+New field on `Session`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `blueprint_id` | `Option<String>` | Blueprint ID. When set, `reason_activity` and `act_activity` build RuntimeAgent from the blueprint instead of from `harness_id`/`agent_id`. |
+| `blueprint_config` | `Option<Value>` | Validated config passed by host at spawn time. |
+
+This is the **key integration point** with the durable execution engine. The blueprint_id travels through the workflow — it's stored on the session row, not passed ephemerally.
 
 ## Capability Trait Extension
 
@@ -67,17 +100,16 @@ New method on the `Capability` trait with a default empty implementation:
 ```rust
 /// Agent blueprints contributed by this capability.
 /// Blueprints are pre-built agents with private tools and baked-in prompts.
-/// They are spawnable via `spawn_subagent(blueprint: "<id>")`.
 fn agent_blueprints(&self) -> Vec<AgentBlueprint> {
     vec![]
 }
 ```
 
-This is additive — existing capabilities are unaffected. Only capabilities that want to contribute blueprints implement it.
+Additive — existing capabilities unaffected.
 
 ### Blueprint Registration
 
-The `CapabilityRegistry` collects blueprints from all registered capabilities:
+`CapabilityRegistry` collects blueprints from all registered capabilities:
 
 ```rust
 impl CapabilityRegistry {
@@ -89,41 +121,125 @@ impl CapabilityRegistry {
 }
 ```
 
-Blueprints are keyed by `id`. Duplicate IDs across capabilities are rejected at registration time (panic in debug, last-wins in release).
+Duplicate IDs across capabilities rejected at registration time.
 
-## Invocation: spawn_subagent Extension
+## Execution: How It Actually Works
 
-The existing `spawn_subagent` tool gains one optional parameter:
+### Spawn (in `spawn_subagent` tool)
+
+`SpawnSubagentTool::execute_with_context` gains a new branch:
+
+```
+if blueprint param present:
+    1. Look up blueprint in CapabilityRegistry
+    2. Validate config against blueprint.config_schema
+    3. Create child session with:
+       - parent_session_id = current session
+       - harness_id = parent's harness_id (for infrastructure, not for RuntimeAgent)
+       - agent_id = None (blueprint replaces the agent)
+       - blueprint_id = blueprint.id
+       - blueprint_config = validated config
+       - subagent_name, subagent_task = as today
+    4. PlatformStore.send_message(child_session_id, task)
+    5. wait_for_idle(300s)
+    6. Return result
+```
+
+Key difference: child session has `blueprint_id` set and `agent_id` cleared. This signals to the worker that RuntimeAgent assembly should use the blueprint path.
+
+### RuntimeAgent Assembly (in `reason_activity`)
+
+Currently `reason_activity` builds RuntimeAgent unconditionally from harness + agent. This changes:
+
+```rust
+// In reason_activity, after loading the session:
+let runtime_agent = if let Some(ref blueprint_id) = session.blueprint_id {
+    // Blueprint path: build from blueprint definition
+    let blueprint = capability_registry.blueprint(blueprint_id)
+        .ok_or_else(|| anyhow!("unknown blueprint: {}", blueprint_id))?;
+
+    let model = match blueprint.model {
+        BlueprintModel::Fixed(m) => m.to_string(),
+        BlueprintModel::Default(m) => {
+            // Check if config overrides model
+            session.blueprint_config
+                .as_ref()
+                .and_then(|c| c.get("model"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| m.to_string())
+        }
+        BlueprintModel::Inherit => parent_model.clone(),
+    };
+
+    let mut prompt = blueprint.system_prompt.to_string();
+    if let Some(ref config) = session.blueprint_config {
+        // Inject config into prompt context
+        prompt.push_str(&format!("\n<config>\n{}\n</config>", config));
+    }
+
+    RuntimeAgentBuilder::new()
+        .system_prompt(&prompt)
+        .tools(blueprint.tool_definitions())
+        .model(&model)
+        .max_iterations(blueprint.max_turns.unwrap_or(20))
+        .build()
+} else {
+    // Standard path: build from harness + agent (unchanged)
+    RuntimeAgentBuilder::new()
+        .with_harness(harness, &registry, &ctx).await
+        .with_agent(agent, &registry, &ctx).await
+        .build()
+};
+```
+
+### Tool Execution (in `act_activity`)
+
+`act_activity` currently loads tools from harness + agent capabilities. For blueprint sessions, it loads tools from the blueprint instead:
+
+```rust
+// In act_activity, after loading the session:
+let tools: Vec<Box<dyn Tool>> = if let Some(ref blueprint_id) = session.blueprint_id {
+    let blueprint = capability_registry.blueprint(blueprint_id)?;
+    blueprint.tools()  // Private tools only
+} else {
+    // Standard: load from harness + agent capabilities (unchanged)
+    load_capability_tools(harness, agent, &registry)
+};
+```
+
+This is where tool privacy is enforced. Blueprint tools are instantiated only inside the child's `act_activity`. The host's `act_activity` never sees them.
+
+### Event Stream
+
+Blueprint sessions emit the same events as any session:
+- `subagent.spawned`, `subagent.completed`, `subagent.failed`, `subagent.cancelled` (lifecycle)
+- `turn.started`, `turn.completed` (agentic loop)
+- `output.message.*` (LLM output)
+- `tool.started`, `tool.completed` (tool execution)
+
+No new event types needed. The `subagent.spawned` event gains an optional `blueprint_id` field so the UI can display the blueprint name/icon.
+
+### Statefulness and Follow-ups
+
+The spawned session is **fully stateful** — real session with messages, events, durable workflow state. The host can:
+- `message_subagent("Scout", "also check the auth middleware tests")` — sends a follow-up
+- `get_subagents("Scout")` — checks status and reads messages
+
+The `AgentBlueprint` definition is stateless (code template). The session instance is stateful.
+
+## Invocation: spawn_subagent Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes | Human-readable name (same as today) |
 | `task` | string | Yes | Task description (same as today) |
-| `blueprint` | string | No | Blueprint ID. When set, child uses the blueprint's RuntimeAgent instead of inheriting parent's. |
-| `config` | object | No | Blueprint-specific config. Validated against `config_schema`. Ignored when `blueprint` is absent. |
-
-### Behavior When `blueprint` Is Set
-
-1. Look up `blueprint` ID in `CapabilityRegistry::blueprint()`
-2. Validate `config` against `blueprint.config_schema` (if schema exists). Reject invalid config.
-3. Create child session with `parent_session_id` set (same as today)
-4. Build a **new RuntimeAgent** from the blueprint:
-   - System prompt: `blueprint.system_prompt` (NOT the parent's prompt)
-   - Tools: `blueprint.tools` (NOT the parent's tools) — these are private
-   - Model: resolved from `BlueprintModel` (Fixed/Default/Inherit)
-   - Max iterations: `blueprint.max_turns` or default
-5. Inject `config` values into system prompt or tool context as appropriate
-6. Send `task` as first user message
-7. Block on `wait_for_idle` (foreground mode, same as today)
-8. Return result (same as today)
-
-### Behavior When `blueprint` Is Absent
-
-Identical to current behavior — child inherits parent's harness/agent config.
+| `blueprint` | string | No | Blueprint ID. When set, child uses blueprint's RuntimeAgent. |
+| `config` | object | No | Blueprint-specific config. Validated against `config_schema`. |
 
 ## Discovery: System Prompt Contribution
 
-When blueprints are registered, the `SubagentCapability` (or a new aggregator) contributes to the system prompt:
+The `SubagentCapability` system prompt contribution expands to include available blueprints:
 
 ```
 <available-blueprints>
@@ -135,41 +251,25 @@ Specialized agents you can delegate to via spawn_subagent(blueprint: "<id>"):
 </available-blueprints>
 ```
 
-This is generated dynamically from `CapabilityRegistry::blueprints()`. Each entry shows `id`, `description`, and a summary of `config_schema` (if any).
-
-**Rationale:** The LLM needs the menu upfront during reasoning. A `list_blueprints` tool would require a tool call before the LLM can decide — wasteful for a small, static list.
-
-## Tool Encapsulation
-
-Blueprint tools are **private** to the spawned session:
-
-- They do NOT appear in `RuntimeAgent.tools` of the host agent
-- They do NOT appear in the host's system prompt
-- They are instantiated only when the blueprint is spawned
-- They are destroyed when the child session completes
-
-This means a capability can contribute both:
-1. Tools for the host agent (via `tools()`) — e.g. `spawn_subagent`
-2. Tools for a blueprint agent (via `agent_blueprints()` → `AgentBlueprint.tools`) — e.g. `search_github_code`
-
-These are separate namespaces. A tool name can exist in both without conflict.
+Generated dynamically from `CapabilityRegistry::blueprints()`. Each entry shows `id`, `description`, and a summary of `config_schema`.
 
 ## Security Considerations
 
 | Concern | Mitigation |
 |---------|------------|
-| Capability escalation | Blueprint tools cannot exceed the capability's own permissions. A blueprint contributed by `github_scout` capability can only access what that capability's API keys allow. |
-| Prompt injection via config | Config is validated against typed JSON Schema. No free-form prompt override. |
-| Model cost | `Fixed` model prevents host from accidentally running expensive models for cheap work. `Default` model documents the intended cost profile. |
-| Tool leakage | Blueprint tools never enter host's tool list. Separate RuntimeAgent assembly path. |
-| Nesting | Same constraint as subagents — blueprints cannot spawn subagents or other blueprints. |
+| Capability escalation | Blueprint tools cannot exceed the contributing capability's permissions. Scoped by API keys/connections. |
+| Prompt injection via config | Config validated against typed JSON Schema. No free-form prompt override. |
+| Model cost | `Fixed` prevents host from running expensive models for cheap work. |
+| Tool leakage | Blueprint tools only instantiated in child's `act_activity`. Host's `act_activity` never loads them. |
+| Nesting | Same constraint as subagents — blueprint children cannot spawn subagents or blueprints. |
 | Resource exhaustion | `max_turns` limit on blueprint. Same 300s timeout as subagents. |
+| Blueprint impersonation | `blueprint_id` validated against registry at spawn time. Invalid IDs rejected. |
 
 ## Concrete Example: GitHubScout
 
-First blueprint implementation. Capability: `github_scout`.
+First blueprint implementation. Integration crate: `integrations/github-scout/`.
 
-### GitHubScout Capability
+### Capability
 
 ```rust
 pub struct GitHubScoutCapability;
@@ -178,13 +278,10 @@ impl Capability for GitHubScoutCapability {
     fn id(&self) -> &str { "github_scout" }
     fn name(&self) -> &str { "GitHub Scout" }
     fn description(&self) -> &str {
-        "Pre-built agent that searches GitHub repositories for code, issues, and discussions."
+        "Pre-built agent for searching GitHub repositories."
     }
-    fn status(&self) -> CapabilityStatus { CapabilityStatus::Available }
-    fn icon(&self) -> Option<&str> { Some("github") }
-    fn category(&self) -> Option<&str> { Some("Orchestration") }
 
-    // No tools for host — all tools are private to the blueprint
+    // No host tools — all tools are private to the blueprint
     fn tools(&self) -> Vec<Box<dyn Tool>> { vec![] }
 
     fn agent_blueprints(&self) -> Vec<AgentBlueprint> {
@@ -208,11 +305,6 @@ impl Capability for GitHubScoutCapability {
                         "type": "array",
                         "items": { "type": "string" },
                         "description": "Repository list to scope searches (owner/repo format)"
-                    },
-                    "max_results": {
-                        "type": "integer",
-                        "default": 20,
-                        "description": "Maximum results per search query"
                     }
                 }
             })),
@@ -229,97 +321,122 @@ impl Capability for GitHubScoutCapability {
 | `read_github_file` | Read a specific file from a GitHub repo (by path + ref) |
 | `search_github_issues` | Search issues and discussions with filters |
 
-These tools use the GitHub API token from the capability's configuration (via User Connections or environment). They are never visible to the host agent.
+These use the GitHub token from User Connections. Never visible to the host agent.
 
-### Usage
-
-Host agent delegates GitHub research:
+### Host Usage
 
 ```json
 {
   "name": "spawn_subagent",
   "arguments": {
     "name": "Scout",
-    "task": "Find how authentication middleware is implemented in the fastify repo. Look for JWT validation patterns and report the key files.",
+    "task": "Find how authentication middleware is implemented in the fastify repo.",
     "blueprint": "github_scout",
-    "config": {
-      "repos": ["fastify/fastify", "fastify/fastify-jwt"]
-    }
+    "config": { "repos": ["fastify/fastify"] }
   }
 }
 ```
 
-Result: A child session runs with Haiku, the 3 GitHub tools, and the scout prompt. Host gets back a summary. Host never sees `search_github_code` in its own tool list.
-
-## RuntimeAgent Assembly
-
-When spawning from a blueprint, the `RuntimeAgentBuilder` takes a different path:
-
-```
-Standard subagent:
-  RuntimeAgentBuilder::new()
-    .with_harness(parent_harness, ...)     // inherit
-    .with_agent(parent_agent, ...)         // inherit
-    .build()
-
-Blueprint subagent:
-  RuntimeAgentBuilder::new()
-    .system_prompt(blueprint.system_prompt)  // blueprint's own prompt
-    .tools(blueprint.tools)                  // blueprint's private tools
-    .model(resolve_model(blueprint.model))   // blueprint's model strategy
-    .max_iterations(blueprint.max_turns)
-    .build()
-```
-
-The blueprint path skips harness/agent inheritance entirely. The blueprint is self-contained.
+Child session runs with Haiku, 3 GitHub tools, scout prompt. Host gets back a summary.
 
 ## Relationship to Subagents
 
 | Aspect | Subagent | Blueprint |
 |--------|----------|-----------|
-| Prompt | Controlled by host (task = prompt) | Baked in by blueprint author |
-| Tools | Inherits parent's tools | Private tools, no inheritance |
-| Model | Inherits parent's model | Fixed/Default/Inherit per blueprint |
-| Config | None (host controls everything via task) | Narrow, typed, validated |
-| Use case | Offload work the host knows how to do | Delegate to specialist the host doesn't need to understand |
-| Invocation | `spawn_subagent(name, task)` | `spawn_subagent(name, task, blueprint, config)` |
-| Tool visibility | Host's tools visible in child | Blueprint's tools invisible to host |
-| Example | "Run these 5 tests" | "Search GitHub for auth patterns" |
+| RuntimeAgent source | Inherited from parent's `harness_id` + `agent_id` | Built from blueprint definition |
+| Session fields | `agent_id` = parent's, `blueprint_id` = None | `agent_id` = None, `blueprint_id` = set |
+| Prompt | Parent's prompt + task as user message | Blueprint's baked-in prompt + task as user message |
+| Tools | Parent's tools (same `act_activity` path) | Blueprint's private tools (alternate `act_activity` path) |
+| Model | Parent's model | Fixed/Default/Inherit per blueprint |
+| Config | None (host controls via task text) | Narrow, typed, validated JSON Schema |
+| Agentic loop | Same (InputAtom → ReasonAtom → ActAtom) | Same |
+| Durable execution | Same (PostgreSQL workflow) | Same |
+| Event stream | Same (SSE events on child session) | Same |
+| Lifecycle | Same (spawn/get/message tools) | Same |
+| Nesting prevention | Same (cannot spawn children) | Same |
+| Use case | Parallel work with same capabilities | Specialist delegation with different capabilities |
 
-Both use the same 3-tool contract (`spawn/get/message`). Both create child sessions with `parent_session_id`. Both respect nesting prevention. The difference is purely in RuntimeAgent assembly.
+## Changes Required
+
+### Session Model (`crates/core/src/session.rs`)
+
+Add two fields:
+
+```rust
+/// Blueprint ID. When set, reason_activity/act_activity use blueprint
+/// for RuntimeAgent assembly instead of harness_id/agent_id.
+pub blueprint_id: Option<String>,
+
+/// Blueprint config passed at spawn time. Validated against blueprint's config_schema.
+pub blueprint_config: Option<serde_json::Value>,
+```
+
+Migration: add nullable columns `blueprint_id TEXT` and `blueprint_config JSONB` to sessions table.
+
+### Capability Trait (`crates/core/src/capabilities/mod.rs`)
+
+Add `agent_blueprints()` default method returning `Vec<AgentBlueprint>`.
+
+Add `AgentBlueprint` and `BlueprintModel` structs.
+
+### CapabilityRegistry (`crates/core/src/capabilities/mod.rs`)
+
+Add `blueprints()` and `blueprint(id)` methods that aggregate across all registered capabilities.
+
+### SpawnSubagentTool (`crates/core/src/capabilities/subagents.rs`)
+
+- Add `blueprint` and `config` params to schema
+- New branch: when blueprint is set, validate config, create session with `blueprint_id`/`blueprint_config`/`agent_id=None`
+- System prompt contribution includes `<available-blueprints>` section
+
+### reason_activity (`crates/worker/src/activities.rs`)
+
+Branch on `session.blueprint_id`:
+- If set: build RuntimeAgent from blueprint (prompt, model, tool definitions)
+- If not: existing path (harness + agent)
+
+### act_activity (`crates/worker/src/activities.rs`)
+
+Branch on `session.blueprint_id`:
+- If set: load tools from blueprint
+- If not: existing path (harness + agent capabilities)
+
+### Subagent Events
+
+`subagent.spawned` event gains optional `blueprint_id` field.
 
 ## Implementation Path
 
 ### Phase 1: Core Infrastructure
 
-1. Add `AgentBlueprint` and `BlueprintModel` structs to `crates/core/src/capabilities/mod.rs`
-2. Add `agent_blueprints()` default method to `Capability` trait
-3. Add `blueprints()` and `blueprint(id)` to `CapabilityRegistry`
-4. Extend `spawn_subagent` tool schema with `blueprint` and `config` parameters
-5. Extend `SpawnSubagentTool::execute_with_context` to handle blueprint path
-6. Add blueprint discovery system prompt contribution
+1. `AgentBlueprint`, `BlueprintModel` structs
+2. `Capability::agent_blueprints()` trait method
+3. `CapabilityRegistry::blueprints()` / `blueprint(id)`
+4. Session model: `blueprint_id`, `blueprint_config` fields + migration
+5. `reason_activity` blueprint branch
+6. `act_activity` blueprint branch
+7. `spawn_subagent` blueprint parameter handling
+8. System prompt blueprint discovery
 
 ### Phase 2: GitHubScout
 
-1. New integration crate: `integrations/github-scout/`
-2. Implement `GitHubScoutCapability` with 3 private tools
-3. Wire GitHub API via User Connections (OAuth token)
-4. Register via `inventory::submit!` plugin system
-5. Add to Generic harness capabilities
+1. `integrations/github-scout/` crate with 3 private tools
+2. Wire GitHub API via User Connections
+3. Register via `inventory::submit!`
+4. Add to Generic harness capabilities
 
-### Phase 3: Framework Maturation
+### Phase 3: Maturation
 
-| Feature | Description |
-|---------|-------------|
-| Blueprint config injection | Pass validated config into tool context or prompt template |
-| Blueprint-scoped MCP | Blueprint can declare MCP servers that start/stop with the child session |
-| Blueprint isolation modes | `shared_ro` / `isolated` filesystem access |
-| More blueprints | CodeReviewer, TestRunner, DocWriter as built-in blueprints |
+- Blueprint-scoped MCP servers
+- Filesystem access modes (none / read-only parent / isolated)
+- More blueprints: CodeReviewer, TestRunner, DocWriter
 
 ## Open Questions
 
-1. **Should blueprints have access to parent's filesystem?** Current lean: no by default. GitHubScout doesn't need it. Future blueprints (CodeReviewer) might want read-only access — add as opt-in field on `AgentBlueprint`.
+1. **Filesystem access** — GitHubScout doesn't need it. CodeReviewer would want read-only access to the parent's session filesystem. Add `filesystem_access: FilesystemAccess` field (None/ReadOnly/ReadWrite) to AgentBlueprint in Phase 3.
 
-2. **Should `get_subagents` distinguish blueprint-spawned children?** Probably yes — include `blueprint_id` in the response so the host knows which specialist it's talking to.
+2. **`get_subagents` response** — include `blueprint_id` in the response so the host knows which specialist it's talking to.
 
-3. **Can a capability contribute both host tools AND a blueprint?** Yes. Example: a `github` capability could give the host `create_github_issue` directly AND contribute a GitHubScout blueprint for research. The host tool and the blueprint tools are separate namespaces.
+3. **Can a capability contribute both host tools AND a blueprint?** Yes. A `github` capability could give the host `create_github_issue` directly AND contribute a GitHubScout blueprint for research. Separate namespaces.
+
+4. **Blueprint model resolution for `Inherit`** — needs the parent session's model. `reason_activity` can load the parent session via `parent_session_id` to resolve this.


### PR DESCRIPTION
## What
Implements Agent Blueprints infrastructure — pre-built agent definitions with private tools, baked-in prompts, and fixed/default models. Spawned via `spawn_subagent(blueprint: "<id>", config: {...})`.

## Why
Current subagents inherit parent config. Blueprints provide an alternative RuntimeAgent assembly path for specialist delegation with different tools, models, and prompts.

## How
- AgentBlueprint/BlueprintModel types, Capability trait extension
- Session blueprint_id + blueprint_config fields, DB migration 010
- ReasonAtom/act_activity branch on blueprint_id for RuntimeAgent assembly
- spawn_subagent extended with blueprint + config parameters
- PlatformStore.create_session extended across all implementations + proto

Infrastructure only — no concrete blueprints registered yet.

## Risk
- Low — new code paths unreachable until a capability provides agent_blueprints()

## Security
- TM-TOOL, TM-API, TM-TENANT, TM-LLM, TM-SQL reviewed
- Blueprint IDs validated against registry, config validated against schema
- No new threats identified

## Checklist
- [x] Tests added or updated (1391 tests pass)
- [x] Security review performed
- [x] All review comments addressed