### PR TITLE
docs(cli): add Homebrew installation instructions

### DIFF
--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -7,7 +7,16 @@ The `everruns` CLI provides a command-line interface for managing agents, sessio
 
 ## Installation
 
-Install from the Git repository using Cargo:
+### Homebrew (macOS / Linux)
+
+```bash
+brew tap everruns/tap
+brew install everruns
+```
+
+### Cargo
+
+Install from the Git repository:
 
 ```bash
 cargo install --git https://github.com/everruns/everruns everruns-cli
@@ -21,7 +30,7 @@ cd everruns
 cargo install --path crates/cli
 ```
 
-Verify the installation:
+### Verify
 
 ```bash
 everruns --version


### PR DESCRIPTION
## What
Add Homebrew as the primary CLI installation method in public docs.

## Why
Users can now install the CLI via `brew tap everruns/tap && brew install everruns` instead of building from source with Cargo.

## How
Updated `docs/features/cli.md` (which feeds the Astro docs site) to add a Homebrew section before Cargo, and reorganized the installation section with clear subsections.

## Risk
- Low
- Docs-only change, no runtime behavior affected

## Security
- No security-relevant code changes — this is a documentation-only update with no code, configuration, or infrastructure changes.

## Checklist
- [x] Tests added or updated — N/A, docs-only; docs site builds cleanly
- [x] Backward compatibility considered — N/A
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)