### PR TITLE
fix(durable): notify workflow when reclaimed tasks are marked dead

### DIFF
--- a/crates/durable/src/persistence/memory.rs
+++ b/crates/durable/src/persistence/memory.rs
@@ -715,9 +715,9 @@ impl WorkflowEventStore for InMemoryWorkflowEventStore {
     async fn reclaim_stale_tasks(
         &self,
         _stale_threshold: Duration,
-    ) -> Result<Vec<Uuid>, StoreError> {
+    ) -> Result<ReclaimResult, StoreError> {
         // In-memory implementation doesn't track timestamps
-        Ok(vec![])
+        Ok(ReclaimResult::default())
     }
 
     async fn send_signal(

--- a/crates/durable/src/persistence/mod.rs
+++ b/crates/durable/src/persistence/mod.rs
@@ -13,12 +13,12 @@ pub use memory::InMemoryWorkflowEventStore;
 pub use postgres::PostgresWorkflowEventStore;
 pub use store::{
     CapacitySnapshot, CircuitBreakerState, ClaimedTask, CreateScheduleRow,
-    DEFAULT_MAX_PENDING_TASKS_PER_WORKFLOW, DEFAULT_SNAPSHOT_INTERVAL, DlqEntry, DlqFilter,
-    HeartbeatResponse, Pagination, ScheduleExecutionFilter, ScheduleExecutionRow,
-    ScheduleExecutionStatus, ScheduleFilter, ScheduleRow, ScheduleStats, ScheduleTargetType,
-    SchedulerInstanceInfo, StoreError, SystemHealth, TaskDefinition, TaskFailureOutcome,
-    TaskFilter, TaskInfo, TaskStatus, TraceContext, UpdateSchedule, WORKER_HEARTBEAT_TIMEOUT_SECS,
-    WorkerFilter, WorkerInfo, WorkflowEventInfo, WorkflowEventStore, WorkflowFilter, WorkflowInfo,
-    WorkflowInfoExtended, WorkflowSnapshot, WorkflowStatus, event_type_name,
-    snapshot_interval_from_env,
+    DEFAULT_MAX_PENDING_TASKS_PER_WORKFLOW, DEFAULT_SNAPSHOT_INTERVAL, DeadTaskInfo, DlqEntry,
+    DlqFilter, HeartbeatResponse, Pagination, ReclaimResult, ScheduleExecutionFilter,
+    ScheduleExecutionRow, ScheduleExecutionStatus, ScheduleFilter, ScheduleRow, ScheduleStats,
+    ScheduleTargetType, SchedulerInstanceInfo, StoreError, SystemHealth, TaskDefinition,
+    TaskFailureOutcome, TaskFilter, TaskInfo, TaskStatus, TraceContext, UpdateSchedule,
+    WORKER_HEARTBEAT_TIMEOUT_SECS, WorkerFilter, WorkerInfo, WorkflowEventInfo, WorkflowEventStore,
+    WorkflowFilter, WorkflowInfo, WorkflowInfoExtended, WorkflowSnapshot, WorkflowStatus,
+    event_type_name, snapshot_interval_from_env,
 };

--- a/crates/durable/src/persistence/postgres.rs
+++ b/crates/durable/src/persistence/postgres.rs
@@ -14,13 +14,13 @@ use tracing::{debug, error, info, instrument};
 use uuid::Uuid;
 
 use super::store::{
-    CapacitySnapshot, CircuitBreakerState, ClaimedTask, CreateScheduleRow, DlqEntry, DlqFilter,
-    HeartbeatResponse, Pagination, ScheduleExecutionFilter, ScheduleExecutionRow,
-    ScheduleExecutionStatus, ScheduleFilter, ScheduleRow, ScheduleStats, ScheduleTargetType,
-    SchedulerInstanceInfo, StoreError, SystemHealth, TaskDefinition, TaskFailureOutcome,
-    TaskFilter, TaskInfo, TaskStatus, TraceContext, UpdateSchedule, WORKER_HEARTBEAT_TIMEOUT_SECS,
-    WorkerFilter, WorkerInfo, WorkflowEventInfo, WorkflowEventStore, WorkflowFilter, WorkflowInfo,
-    WorkflowInfoExtended, WorkflowStatus,
+    CapacitySnapshot, CircuitBreakerState, ClaimedTask, CreateScheduleRow, DeadTaskInfo, DlqEntry,
+    DlqFilter, HeartbeatResponse, Pagination, ReclaimResult, ScheduleExecutionFilter,
+    ScheduleExecutionRow, ScheduleExecutionStatus, ScheduleFilter, ScheduleRow, ScheduleStats,
+    ScheduleTargetType, SchedulerInstanceInfo, StoreError, SystemHealth, TaskDefinition,
+    TaskFailureOutcome, TaskFilter, TaskInfo, TaskStatus, TraceContext, UpdateSchedule,
+    WORKER_HEARTBEAT_TIMEOUT_SECS, WorkerFilter, WorkerInfo, WorkflowEventInfo, WorkflowEventStore,
+    WorkflowFilter, WorkflowInfo, WorkflowInfoExtended, WorkflowStatus,
 };
 use crate::reliability::{CircuitBreakerConfig, CircuitState};
 use crate::workflow::{ActivityOptions, WorkflowError, WorkflowEvent, WorkflowSignal};
@@ -1059,7 +1059,7 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
     async fn reclaim_stale_tasks(
         &self,
         stale_threshold: Duration,
-    ) -> Result<Vec<Uuid>, StoreError> {
+    ) -> Result<ReclaimResult, StoreError> {
         let threshold =
             Utc::now() - chrono::Duration::from_std(stale_threshold).unwrap_or_default();
 
@@ -1073,7 +1073,7 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
             WHERE status = 'claimed'
               AND heartbeat_at < $1
               AND attempt >= max_attempts
-            RETURNING id
+            RETURNING id, workflow_id, activity_id, last_error
             "#,
         )
         .bind(threshold)
@@ -1084,9 +1084,21 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
             StoreError::Database(e.to_string())
         })?;
 
-        let dead_count = dead_rows.len();
-        if dead_count > 0 {
-            info!(count = dead_count, "marked exhausted stale tasks as dead");
+        let dead_tasks: Vec<DeadTaskInfo> = dead_rows
+            .iter()
+            .map(|r| DeadTaskInfo {
+                task_id: r.get("id"),
+                workflow_id: r.get("workflow_id"),
+                activity_id: r.get("activity_id"),
+                last_error: r.get("last_error"),
+            })
+            .collect();
+
+        if !dead_tasks.is_empty() {
+            info!(
+                count = dead_tasks.len(),
+                "marked exhausted stale tasks as dead"
+            );
         }
 
         // Then, reclaim stale tasks that still have attempts remaining
@@ -1110,14 +1122,12 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
             StoreError::Database(e.to_string())
         })?;
 
-        // Return all affected tasks (both dead and reclaimed)
-        let mut reclaimed: Vec<Uuid> = dead_rows.iter().map(|r| r.get("id")).collect();
-        reclaimed.extend(rows.iter().map(|r| r.get::<Uuid, _>("id")));
+        let reclaimed_ids: Vec<Uuid> = rows.iter().map(|r| r.get("id")).collect();
 
-        if !reclaimed.is_empty() {
+        if !reclaimed_ids.is_empty() || !dead_tasks.is_empty() {
             debug!(
-                count = reclaimed.len(),
-                dead = dead_count,
+                reclaimed = reclaimed_ids.len(),
+                dead = dead_tasks.len(),
                 "processed stale tasks"
             );
         }
@@ -1148,7 +1158,10 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
             info!(count = stale_workers.len(), worker_ids = ?ids, "marked stale workers as stopped");
         }
 
-        Ok(reclaimed)
+        Ok(ReclaimResult {
+            reclaimed_ids,
+            dead_tasks,
+        })
     }
 
     #[instrument(skip(self, signal))]

--- a/crates/durable/src/persistence/store.rs
+++ b/crates/durable/src/persistence/store.rs
@@ -214,6 +214,24 @@ pub enum TaskFailureOutcome {
     ExhaustedRetries,
 }
 
+/// Information about a task that was marked as dead during stale reclamation.
+#[derive(Debug, Clone)]
+pub struct DeadTaskInfo {
+    pub task_id: Uuid,
+    pub workflow_id: Option<Uuid>,
+    pub activity_id: String,
+    pub last_error: Option<String>,
+}
+
+/// Result of stale task reclamation.
+#[derive(Debug, Clone, Default)]
+pub struct ReclaimResult {
+    /// Tasks that were reclaimed (returned to pending for retry).
+    pub reclaimed_ids: Vec<Uuid>,
+    /// Tasks that were marked as dead (exhausted all retries).
+    pub dead_tasks: Vec<DeadTaskInfo>,
+}
+
 /// Filter for listing workers
 #[derive(Debug, Clone, Default)]
 pub struct WorkerFilter {
@@ -633,8 +651,10 @@ pub trait WorkflowEventStore: Send + Sync + 'static {
     async fn get_task(&self, task_id: Uuid) -> Result<TaskInfo, StoreError>;
 
     /// Find and reclaim stale tasks (no heartbeat)
-    async fn reclaim_stale_tasks(&self, stale_threshold: Duration)
-    -> Result<Vec<Uuid>, StoreError>;
+    async fn reclaim_stale_tasks(
+        &self,
+        stale_threshold: Duration,
+    ) -> Result<ReclaimResult, StoreError>;
 
     // =========================================================================
     // Signal Operations

--- a/crates/durable/src/task_events.rs
+++ b/crates/durable/src/task_events.rs
@@ -22,7 +22,7 @@ const MAX_RETRY_ATTEMPTS: u32 = 5;
 /// 3. Retry on concurrency conflict
 ///
 /// Returns Ok(()) on success, or the last error after all retries exhausted.
-pub async fn append_event<S: WorkflowEventStore>(
+pub async fn append_event<S: WorkflowEventStore + ?Sized>(
     store: &S,
     workflow_id: Uuid,
     event: WorkflowEvent,
@@ -151,7 +151,7 @@ pub async fn record_activity_completed<S: WorkflowEventStore>(
 ///
 /// This should be called when a worker fails a task.
 /// For standalone tasks (workflow_id is None), this is a no-op.
-pub async fn record_activity_failed<S: WorkflowEventStore>(
+pub async fn record_activity_failed<S: WorkflowEventStore + ?Sized>(
     store: &S,
     workflow_id: Option<Uuid>,
     activity_id: String,

--- a/crates/durable/src/worker/pool.rs
+++ b/crates/durable/src/worker/pool.rs
@@ -615,9 +615,31 @@ impl WorkerPool {
                 tokio::select! {
                     _ = ticker.tick() => {
                         match store.reclaim_stale_tasks(threshold).await {
-                            Ok(reclaimed) => {
-                                if !reclaimed.is_empty() {
-                                    info!(count = reclaimed.len(), "Reclaimed stale tasks");
+                            Ok(result) => {
+                                if !result.reclaimed_ids.is_empty() {
+                                    info!(count = result.reclaimed_ids.len(), "Reclaimed stale tasks");
+                                }
+
+                                // Notify workflows about dead tasks so they can transition
+                                // to failed instead of staying stuck in running forever.
+                                for dead in &result.dead_tasks {
+                                    let error_msg = dead.last_error.clone().unwrap_or_else(|| {
+                                        "Worker became unresponsive after exhausting all retry attempts".to_string()
+                                    });
+                                    info!(
+                                        task_id = %dead.task_id,
+                                        workflow_id = ?dead.workflow_id,
+                                        activity_id = %dead.activity_id,
+                                        "Notifying workflow of dead task"
+                                    );
+                                    crate::task_events::record_activity_failed(
+                                        store.as_ref(),
+                                        dead.workflow_id,
+                                        dead.activity_id.clone(),
+                                        error_msg,
+                                        false, // will_retry = false, all attempts exhausted
+                                    )
+                                    .await;
                                 }
                             }
                             Err(e) => {

--- a/crates/durable/tests/postgres_integration_test.rs
+++ b/crates/durable/tests/postgres_integration_test.rs
@@ -1633,6 +1633,16 @@ async fn test_stale_reclaim_respects_max_attempts() {
     assert_eq!(result.dead_tasks.len(), 1);
     assert_eq!(result.reclaimed_ids.len(), 0);
 
+    // Verify DeadTaskInfo fields are populated correctly
+    let dead = &result.dead_tasks[0];
+    assert_eq!(dead.task_id, task_id);
+    assert_eq!(dead.workflow_id, Some(workflow_id));
+    assert_eq!(dead.activity_id, "panic_task");
+    assert!(
+        dead.last_error.is_some(),
+        "Dead task should have last_error populated"
+    );
+
     // BUG: Without fix, this would claim the task for attempt 3 (exceeding max_attempts=2)
     // FIXED: Task should NOT be claimable because attempt (2) >= max_attempts (2)
     let claimed = store

--- a/crates/durable/tests/postgres_integration_test.rs
+++ b/crates/durable/tests/postgres_integration_test.rs
@@ -715,11 +715,11 @@ async fn test_reclaim_stale_tasks() {
     .unwrap();
 
     // Reclaim stale tasks (threshold: 30 seconds)
-    let reclaimed = store
+    let result = store
         .reclaim_stale_tasks(Duration::from_secs(30))
         .await
         .unwrap();
-    assert_eq!(reclaimed.len(), 1);
+    assert_eq!(result.reclaimed_ids.len(), 1);
 
     // Task should be claimable again
     let claimed = store
@@ -1294,11 +1294,11 @@ async fn test_task_completion_rejected_when_reclaimed() {
     .unwrap();
 
     // Reclaim stale tasks
-    let reclaimed = store
+    let result = store
         .reclaim_stale_tasks(Duration::from_secs(30))
         .await
         .unwrap();
-    assert_eq!(reclaimed.len(), 1);
+    assert_eq!(result.reclaimed_ids.len(), 1);
 
     // Worker 2 claims the reclaimed task
     let claimed = store
@@ -1598,11 +1598,11 @@ async fn test_stale_reclaim_respects_max_attempts() {
     .unwrap();
 
     // Reclaim stale task
-    let reclaimed = store
+    let result = store
         .reclaim_stale_tasks(Duration::from_secs(30))
         .await
         .unwrap();
-    assert_eq!(reclaimed.len(), 1);
+    assert_eq!(result.reclaimed_ids.len(), 1);
 
     // Attempt 2: Another worker claims the reclaimed task
     let claimed = store
@@ -1625,12 +1625,13 @@ async fn test_stale_reclaim_respects_max_attempts() {
     .await
     .unwrap();
 
-    // Reclaim stale task again
-    let reclaimed = store
+    // Reclaim stale task again — this time task is dead (attempt >= max_attempts)
+    let result = store
         .reclaim_stale_tasks(Duration::from_secs(30))
         .await
         .unwrap();
-    assert_eq!(reclaimed.len(), 1);
+    assert_eq!(result.dead_tasks.len(), 1);
+    assert_eq!(result.reclaimed_ids.len(), 0);
 
     // BUG: Without fix, this would claim the task for attempt 3 (exceeding max_attempts=2)
     // FIXED: Task should NOT be claimable because attempt (2) >= max_attempts (2)

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -847,13 +847,35 @@ impl ServerAppBuilder {
                         loop {
                             interval.tick().await;
                             match store.reclaim_stale_tasks(stale_threshold).await {
-                                Ok(reclaimed) => {
-                                    if !reclaimed.is_empty() {
+                                Ok(result) => {
+                                    if !result.reclaimed_ids.is_empty() {
                                         tracing::info!(
-                                            count = reclaimed.len(),
-                                            task_ids = ?reclaimed,
+                                            count = result.reclaimed_ids.len(),
+                                            task_ids = ?result.reclaimed_ids,
                                             "Reclaimed stale tasks"
                                         );
+                                    }
+
+                                    // Notify workflows about dead tasks so they can
+                                    // transition to failed instead of staying stuck.
+                                    for dead in &result.dead_tasks {
+                                        let error_msg = dead.last_error.clone().unwrap_or_else(|| {
+                                            "Worker became unresponsive after exhausting all retry attempts".to_string()
+                                        });
+                                        tracing::info!(
+                                            task_id = %dead.task_id,
+                                            workflow_id = ?dead.workflow_id,
+                                            activity_id = %dead.activity_id,
+                                            "Notifying workflow of dead task"
+                                        );
+                                        everruns_durable::record_activity_failed(
+                                            store.as_ref(),
+                                            dead.workflow_id,
+                                            dead.activity_id.clone(),
+                                            error_msg,
+                                            false,
+                                        )
+                                        .await;
                                     }
                                 }
                                 Err(e) => {

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -869,7 +869,7 @@ impl ServerAppBuilder {
                                             "Notifying workflow of dead task"
                                         );
                                         everruns_durable::record_activity_failed(
-                                            store.as_ref(),
+                                            &store,
                                             dead.workflow_id,
                                             dead.activity_id.clone(),
                                             error_msg,


### PR DESCRIPTION
## What

When `reclaim_stale_tasks` marks a task as `dead` (exhausted all retry attempts), the reclaim loop now notifies the workflow by appending an `ActivityFailed` event. Previously, dead tasks were silently marked in the DB but the workflow was never informed, leaving it stuck in `running` status forever.

## Why

Sessions with dead tasks remained permanently stuck in `active` status because the workflow never transitioned to `failed`. This affected any activity type, not just specific integrations.

Fixes EVE-178

## How

1. Introduced `DeadTaskInfo` and `ReclaimResult` types so `reclaim_stale_tasks` returns structured info about dead tasks (workflow_id, activity_id, error) alongside reclaimed task IDs.
2. Updated the SQL `RETURNING` clause to include `workflow_id`, `activity_id`, `last_error`.
3. The reclaim loop in `pool.rs` now calls `record_activity_failed()` with `will_retry=false` for each dead task, which appends the `ActivityFailed` event.
4. The workflow handler processes this event and transitions the workflow to `failed`.
5. Added `?Sized` bounds to `append_event` and `record_activity_failed` so they work with `dyn WorkflowEventStore`.

## Risk

- Low
- Only affects the stale task reclamation path. Existing retry and completion flows are unchanged.

## Security

- Threat categories reviewed: TM-SQL, TM-DOS
- TM-SQL: Query change only adds columns to RETURNING clause; no new user input binding, no injection risk.
- TM-DOS: Dead task notification loop is bounded by actual dead task count (already bounded by DB result set).
- No auth, authz, API, tenant, or web surface touched.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)