### PR TITLE
fix(cli): robust event filtering in chat polling

### DIFF
--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -50,10 +50,11 @@ pub async fn run(
         // Use position-based lookup instead of skip_while: if last_event_id
         // is no longer in the response (server-side truncation/retention),
         // treat all returned events as new rather than silently dropping them.
-        let events: Vec<_> = if let Some(ref last_id) = last_event_id {
-            match response.data.iter().position(|e| &e.id == last_id) {
-                Some(idx) => response.data.into_iter().skip(idx + 1).collect(),
-                None => response.data, // last seen event was evicted; all events are new
+        let events = if let Some(ref last_id) = last_event_id {
+            let mut data = response.data;
+            match data.iter().position(|e| &e.id == last_id) {
+                Some(idx) => data.split_off(idx + 1),
+                None => data, // last seen event was evicted; all events are new
             }
         } else {
             response.data

--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -46,14 +46,15 @@ pub async fn run(
         // Fetch events via SDK (ListResponse pagination fields are optional since SDK v0.1.5)
         let response = client.events().list(&session_id).await?;
 
-        // Filter events since last seen
+        // Filter events since last seen.
+        // Use position-based lookup instead of skip_while: if last_event_id
+        // is no longer in the response (server-side truncation/retention),
+        // treat all returned events as new rather than silently dropping them.
         let events: Vec<_> = if let Some(ref last_id) = last_event_id {
-            response
-                .data
-                .into_iter()
-                .skip_while(|e| &e.id != last_id)
-                .skip(1) // skip the last seen event itself
-                .collect()
+            match response.data.iter().position(|e| &e.id == last_id) {
+                Some(idx) => response.data.into_iter().skip(idx + 1).collect(),
+                None => response.data, // last seen event was evicted; all events are new
+            }
         } else {
             response.data
         };


### PR DESCRIPTION
## What

Replace `skip_while`-based event filtering with `position()`-based lookup in the CLI `chat` command polling loop.

## Why

If `last_event_id` is no longer present in the server response (server-side truncation, retention, or forward safety limit), `skip_while` consumes the entire iterator and returns zero events — causing the polling loop to stall until timeout (EVE-165).

## How

Use `position()` to find the anchor event. If found, skip up to and including it (identical to previous behavior). If not found, treat all returned events as new — correct because events are returned oldest→newest, so a missing anchor means it was evicted and all remaining events are newer.

The SDK (`everruns-sdk@0.1.5`) does not expose `since_id` in `ListEventsOptions`, so server-side filtering is not currently possible without an SDK update. The client-side fix is correct and sufficient.

## Risk

- Low
- Only the CLI `chat` polling path is affected. The change is a strict behavioral superset: identical when the anchor is found, graceful fallback when not.

## Security

- No security-relevant code changes. The diff is a pure algorithm swap in a local iterator over already-authenticated API response data. No trust boundaries, inputs, or auth paths are affected.

## Checklist

- [x] Tests added or updated (no testable surface change; existing CLI tests pass)
- [x] Backward compatibility considered (N/A, internal CLI code)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Closes EVE-165