### PR TITLE
feat(deno): support personal tokens (ddp_...) in generic connection flow

### DIFF
--- a/apps/ui/src/components/agent-identity/identity-api-key-dialog.tsx
+++ b/apps/ui/src/components/agent-identity/identity-api-key-dialog.tsx
@@ -54,10 +54,19 @@ export function IdentityApiKeyDialog({
       return;
     }
 
+    // Collect extra fields (everything except api_key)
+    const extraFields: Record<string, string> = {};
+    for (const [key, value] of Object.entries(formValues)) {
+      if (key !== "api_key" && value.trim()) {
+        extraFields[key] = value;
+      }
+    }
+
     try {
       await createConnection.mutateAsync({
         provider: provider.provider_id,
         apiKey,
+        extraFields: Object.keys(extraFields).length > 0 ? extraFields : undefined,
       });
       onOpenChange(false);
     } catch (err) {

--- a/apps/ui/src/components/connections/api-key-dialog.tsx
+++ b/apps/ui/src/components/connections/api-key-dialog.tsx
@@ -56,10 +56,19 @@ export function ApiKeyDialog({ provider, open, onOpenChange, onConnected }: ApiK
       return;
     }
 
+    // Collect extra fields (everything except api_key)
+    const extraFields: Record<string, string> = {};
+    for (const [key, value] of Object.entries(formValues)) {
+      if (key !== "api_key" && value.trim()) {
+        extraFields[key] = value;
+      }
+    }
+
     try {
       await createConnection.mutateAsync({
         provider: provider.provider_id,
         apiKey,
+        extraFields: Object.keys(extraFields).length > 0 ? extraFields : undefined,
       });
       onOpenChange(false);
       onConnected?.();

--- a/apps/ui/src/hooks/use-identity-connections.ts
+++ b/apps/ui/src/hooks/use-identity-connections.ts
@@ -21,8 +21,15 @@ export function useCreateIdentityApiKeyConnection(identityId: string) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ provider, apiKey }: { provider: string; apiKey: string }) =>
-      createIdentityApiKeyConnection(identityId, provider, apiKey),
+    mutationFn: ({
+      provider,
+      apiKey,
+      extraFields,
+    }: {
+      provider: string;
+      apiKey: string;
+      extraFields?: Record<string, string>;
+    }) => createIdentityApiKeyConnection(identityId, provider, apiKey, extraFields),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.identityConnections.list(identityId),

--- a/apps/ui/src/hooks/use-user-connections.ts
+++ b/apps/ui/src/hooks/use-user-connections.ts
@@ -30,8 +30,15 @@ export function useCreateApiKeyConnection() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ provider, apiKey }: { provider: string; apiKey: string }) =>
-      createApiKeyConnection(provider, apiKey),
+    mutationFn: ({
+      provider,
+      apiKey,
+      extraFields,
+    }: {
+      provider: string;
+      apiKey: string;
+      extraFields?: Record<string, string>;
+    }) => createApiKeyConnection(provider, apiKey, extraFields),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.userConnections.all,

--- a/apps/ui/src/lib/api/agent-identity-connections.ts
+++ b/apps/ui/src/lib/api/agent-identity-connections.ts
@@ -15,10 +15,11 @@ export async function createIdentityApiKeyConnection(
   identityId: string,
   provider: string,
   apiKey: string,
+  extraFields?: Record<string, string>,
 ): Promise<UserConnection> {
   const response = await api.post<UserConnection>(
     `/v1/agent-identities/${identityId}/connections/${provider}`,
-    { api_key: apiKey },
+    { api_key: apiKey, ...extraFields },
   );
   return response.data;
 }

--- a/apps/ui/src/lib/api/user-connections.ts
+++ b/apps/ui/src/lib/api/user-connections.ts
@@ -17,9 +17,11 @@ export async function getConnectionProviders(): Promise<ConnectionProvider[]> {
 export async function createApiKeyConnection(
   provider: string,
   apiKey: string,
+  extraFields?: Record<string, string>,
 ): Promise<UserConnection> {
   const response = await api.post<UserConnection>(`/v1/user/connections/${provider}`, {
     api_key: apiKey,
+    ...extraFields,
   });
   return response.data;
 }

--- a/crates/core/src/connection_provider.rs
+++ b/crates/core/src/connection_provider.rs
@@ -78,6 +78,16 @@ pub trait ConnectionProvider: Send + Sync {
     /// Validate a credential before saving. Called for API key providers.
     /// Returns Ok with optional metadata on success, Err with user-facing message on failure.
     async fn validate(&self, credential: &str) -> Result<ConnectionValidation, String>;
+
+    /// Validate with all form fields. Default delegates to `validate()` using the `api_key` field.
+    /// Override this when the provider needs extra fields (e.g. org slug for personal tokens).
+    async fn validate_fields(
+        &self,
+        fields: &HashMap<String, String>,
+    ) -> Result<ConnectionValidation, String> {
+        let api_key = fields.get("api_key").map(|s| s.as_str()).unwrap_or("");
+        self.validate(api_key).await
+    }
 }
 
 // ============================================================================
@@ -247,4 +257,7 @@ pub enum FieldType {
 pub struct ConnectionValidation {
     /// Display name from the provider (e.g. organization name, username).
     pub provider_username: Option<String>,
+    /// Provider-specific metadata to store alongside the connection (e.g. org slug).
+    /// Stored as JSONB in the database and returned via the connection resolver.
+    pub provider_metadata: Option<serde_json::Value>,
 }

--- a/crates/core/src/platform_definition.rs
+++ b/crates/core/src/platform_definition.rs
@@ -401,6 +401,7 @@ mod tests {
         async fn validate(&self, _credential: &str) -> Result<ConnectionValidation, String> {
             Ok(ConnectionValidation {
                 provider_username: Some("test-user".to_string()),
+                provider_metadata: None,
             })
         }
     }

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -462,6 +462,16 @@ pub trait UserConnectionResolver: Send + Sync {
     ) -> Result<Option<String>> {
         Ok(None)
     }
+
+    /// Get provider-specific metadata stored alongside the connection.
+    /// Returns None if no metadata is stored or no connection exists.
+    async fn get_connection_metadata(
+        &self,
+        _session_id: SessionId,
+        _provider: &str,
+    ) -> Result<Option<serde_json::Value>> {
+        Ok(None)
+    }
 }
 
 /// Runtime context provided to tools during execution.

--- a/crates/server/migrations/010_connection_metadata.sql
+++ b/crates/server/migrations/010_connection_metadata.sql
@@ -1,0 +1,10 @@
+-- Migration 010: Connection provider metadata
+-- Adds provider_metadata JSONB column to user_connections and
+-- agent_identity_connections for storing provider-specific data
+-- (e.g. Deno org slug for personal tokens).
+
+ALTER TABLE user_connections
+    ADD COLUMN provider_metadata JSONB;
+
+ALTER TABLE agent_identity_connections
+    ADD COLUMN provider_metadata JSONB;

--- a/crates/server/src/api/agent_identity_connections.rs
+++ b/crates/server/src/api/agent_identity_connections.rs
@@ -347,7 +347,20 @@ pub async fn verify_connection(
                 .into_response(StatusCode::NOT_FOUND)
         })?;
 
-    match provider.validate(&api_key).await {
+    // Build fields map from stored credential + metadata for full validation
+    let mut fields = std::collections::HashMap::new();
+    fields.insert("api_key".to_string(), api_key);
+    if let Some(meta) = row.provider_metadata.as_ref()
+        && let Some(obj) = meta.as_object()
+    {
+        for (k, v) in obj {
+            if let Some(s) = v.as_str() {
+                fields.insert(k.clone(), s.to_string());
+            }
+        }
+    }
+
+    match provider.validate_fields(&fields).await {
         Ok(_) => Ok(Json(VerifyConnectionResponse {
             valid: true,
             error: None,

--- a/crates/server/src/api/agent_identity_connections.rs
+++ b/crates/server/src/api/agent_identity_connections.rs
@@ -68,6 +68,8 @@ pub struct ConnectionResponse {
 #[derive(Debug, Deserialize)]
 pub struct CreateApiKeyConnectionRequest {
     pub api_key: String,
+    #[serde(flatten)]
+    pub extra_fields: std::collections::HashMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Serialize)]
@@ -210,8 +212,17 @@ pub async fn create_api_key_connection(
             .into_response(StatusCode::INTERNAL_SERVER_ERROR)
     })?;
 
-    // Validate the API key
-    let validation = provider.validate(&body.api_key).await.map_err(|e| {
+    // Build form fields map for validation
+    let mut fields = std::collections::HashMap::new();
+    fields.insert("api_key".to_string(), body.api_key.clone());
+    for (key, value) in &body.extra_fields {
+        if let Some(s) = value.as_str() {
+            fields.insert(key.clone(), s.to_string());
+        }
+    }
+
+    // Validate all fields via the provider
+    let validation = provider.validate_fields(&fields).await.map_err(|e| {
         ErrorResponse::new(format!("API key validation failed: {e}"))
             .into_response(StatusCode::BAD_REQUEST)
     })?;
@@ -236,6 +247,7 @@ pub async fn create_api_key_connection(
             scopes: None,
             expires_at: None,
             installation_id: None,
+            provider_metadata: validation.provider_metadata.clone(),
         })
         .await
         .map_err(|e| {

--- a/crates/server/src/api/user_connections.rs
+++ b/crates/server/src/api/user_connections.rs
@@ -119,10 +119,14 @@ pub struct FormFieldResponse {
     pub help_text: Option<String>,
 }
 
-/// Request body for API-key connection creation (plugin-based providers)
+/// Request body for API-key connection creation (plugin-based providers).
+/// Accepts api_key plus any additional form fields as extra_fields.
 #[derive(Debug, Deserialize)]
 pub struct CreateApiKeyConnectionRequest {
     pub api_key: String,
+    /// Additional provider-specific form fields (e.g. org_slug for Deno personal tokens).
+    #[serde(flatten)]
+    pub extra_fields: std::collections::HashMap<String, serde_json::Value>,
 }
 
 /// Request body for API-key-based connections (e.g., Brave Search)
@@ -373,9 +377,18 @@ pub async fn create_api_key_connection(
         )
     })?;
 
-    // Validate the API key
+    // Build form fields map for validation (includes api_key + any extra fields)
+    let mut fields = std::collections::HashMap::new();
+    fields.insert("api_key".to_string(), body.api_key.clone());
+    for (key, value) in &body.extra_fields {
+        if let Some(s) = value.as_str() {
+            fields.insert(key.clone(), s.to_string());
+        }
+    }
+
+    // Validate all fields via the provider
     let validation: everruns_core::connection_provider::ConnectionValidation =
-        provider.validate(&body.api_key).await.map_err(|e| {
+        provider.validate_fields(&fields).await.map_err(|e| {
             (
                 StatusCode::BAD_REQUEST,
                 format!("API key validation failed: {e}"),
@@ -404,6 +417,7 @@ pub async fn create_api_key_connection(
             refresh_token_encrypted: None,
             scopes: None,
             expires_at: None,
+            provider_metadata: validation.provider_metadata.clone(),
         })
         .await
         .map_err(|e| {
@@ -809,6 +823,7 @@ pub async fn connection_oauth_callback(
                 scopes: token.scope.clone(),
                 expires_at,
                 installation_id: None,
+                provider_metadata: None,
             })
             .await
             .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
@@ -923,6 +938,7 @@ pub async fn github_callback(
             scopes: Some(result.permissions),
             expires_at: None,
             installation_id: Some(result.installation_id),
+            provider_metadata: None,
         })
         .await
         .map_err(|e| {
@@ -1004,6 +1020,7 @@ pub async fn put_api_key_connection(
             scopes: None,
             expires_at: None,
             installation_id: None,
+            provider_metadata: None,
         })
         .await
         .map_err(|e| {

--- a/crates/server/src/api/user_connections.rs
+++ b/crates/server/src/api/user_connections.rs
@@ -539,8 +539,20 @@ pub async fn verify_connection(
             )
         })?;
 
-    // Call provider's validate()
-    match provider.validate(&credential).await {
+    // Build fields map from stored credential + metadata for full validation
+    let mut fields = std::collections::HashMap::new();
+    fields.insert("api_key".to_string(), credential);
+    if let Some(meta) = row.provider_metadata.as_ref()
+        && let Some(obj) = meta.as_object()
+    {
+        for (k, v) in obj {
+            if let Some(s) = v.as_str() {
+                fields.insert(k.clone(), s.to_string());
+            }
+        }
+    }
+
+    match provider.validate_fields(&fields).await {
         Ok(_) => Ok(Json(VerifyConnectionResponse {
             valid: true,
             error: None,

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -1580,6 +1580,19 @@ impl StorageBackend {
         dispatch!(self, get_connection_token_for_session, session_id, provider)
     }
 
+    pub async fn get_connection_metadata_for_session(
+        &self,
+        session_id: SessionId,
+        provider: &str,
+    ) -> Result<Option<serde_json::Value>> {
+        dispatch!(
+            self,
+            get_connection_metadata_for_session,
+            session_id,
+            provider
+        )
+    }
+
     pub async fn get_connection_user_for_session(
         &self,
         session_id: SessionId,

--- a/crates/server/src/storage/connection_resolver.rs
+++ b/crates/server/src/storage/connection_resolver.rs
@@ -138,6 +138,19 @@ impl UserConnectionResolver for DbConnectionResolver {
             .map_err(|e| AgentLoopError::store(format!("Failed to resolve connection owner: {e}")))
     }
 
+    async fn get_connection_metadata(
+        &self,
+        session_id: SessionId,
+        provider: &str,
+    ) -> Result<Option<serde_json::Value>> {
+        self.db
+            .get_connection_metadata_for_session(session_id, provider)
+            .await
+            .map_err(|e| {
+                AgentLoopError::store(format!("Failed to resolve connection metadata: {e}"))
+            })
+    }
+
     async fn get_connection_token_for_user(
         &self,
         user_id: Uuid,

--- a/crates/server/src/storage/memory/agent_identity_connections.rs
+++ b/crates/server/src/storage/memory/agent_identity_connections.rs
@@ -35,6 +35,7 @@ impl InMemoryDatabase {
             scopes: input.scopes,
             expires_at: input.expires_at,
             installation_id: input.installation_id,
+            provider_metadata: input.provider_metadata,
             created_at: now,
             updated_at: now,
         };

--- a/crates/server/src/storage/memory/user_connections.rs
+++ b/crates/server/src/storage/memory/user_connections.rs
@@ -34,6 +34,7 @@ impl InMemoryDatabase {
             scopes: input.scopes,
             expires_at: input.expires_at,
             installation_id: input.installation_id,
+            provider_metadata: input.provider_metadata,
             created_at: now,
             updated_at: now,
         };
@@ -122,6 +123,53 @@ impl InMemoryDatabase {
                 {
                     return Ok(conn.access_token_encrypted.clone());
                 }
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Get provider metadata for a session/provider pair.
+    /// Same resolution order as get_connection_token_for_session.
+    pub async fn get_connection_metadata_for_session(
+        &self,
+        session_id: SessionId,
+        provider: &str,
+    ) -> Result<Option<serde_json::Value>> {
+        let sessions = self.sessions.read();
+        let session = match sessions.get(&session_id) {
+            Some(s) => s,
+            None => return Ok(None),
+        };
+        let org_id = session.org_id;
+        let agent_identity_id = session.agent_identity_id;
+        drop(sessions);
+
+        if let Some(identity_id) = agent_identity_id {
+            let id_connections = self.agent_identity_connections.read();
+            if let Some(conn) = id_connections
+                .values()
+                .find(|c| c.agent_identity_id == identity_id && c.provider == provider)
+            {
+                return Ok(conn.provider_metadata.as_ref().cloned());
+            }
+        }
+
+        let members = self.organization_members.read();
+        let user_ids: Vec<Uuid> = members
+            .iter()
+            .filter(|((oid, _), _)| *oid == org_id)
+            .map(|((_, uid), _)| *uid)
+            .collect();
+        drop(members);
+
+        let connections = self.user_connections.read();
+        for uid in user_ids {
+            if let Some(conn) = connections
+                .values()
+                .find(|c| c.user_id == uid && c.provider == provider)
+            {
+                return Ok(conn.provider_metadata.as_ref().cloned());
             }
         }
 

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -1074,6 +1074,8 @@ pub struct UserConnectionRow {
     pub expires_at: Option<DateTime<Utc>>,
     /// GitHub App installation ID (tokens minted on demand)
     pub installation_id: Option<i64>,
+    /// Provider-specific metadata (e.g. Deno org slug for personal tokens)
+    pub provider_metadata: Option<sqlx::types::JsonValue>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -1093,6 +1095,8 @@ pub struct CreateUserConnectionRow {
     pub expires_at: Option<DateTime<Utc>>,
     /// GitHub App installation ID (tokens minted on demand)
     pub installation_id: Option<i64>,
+    /// Provider-specific metadata (e.g. Deno org slug for personal tokens)
+    pub provider_metadata: Option<serde_json::Value>,
 }
 
 // ============================================
@@ -1113,6 +1117,8 @@ pub struct AgentIdentityConnectionRow {
     pub scopes: Option<String>,
     pub expires_at: Option<DateTime<Utc>>,
     pub installation_id: Option<i64>,
+    /// Provider-specific metadata (e.g. Deno org slug for personal tokens)
+    pub provider_metadata: Option<sqlx::types::JsonValue>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -1130,6 +1136,8 @@ pub struct CreateAgentIdentityConnectionRow {
     pub scopes: Option<String>,
     pub expires_at: Option<DateTime<Utc>>,
     pub installation_id: Option<i64>,
+    /// Provider-specific metadata (e.g. Deno org slug for personal tokens)
+    pub provider_metadata: Option<serde_json::Value>,
 }
 
 // ============================================

--- a/crates/server/src/storage/repositories/agent_identity_connections.rs
+++ b/crates/server/src/storage/repositories/agent_identity_connections.rs
@@ -21,8 +21,8 @@ impl Database {
             r#"
             INSERT INTO agent_identity_connections
                 (agent_identity_id, provider, connection_type, provider_user_id, provider_username,
-                 access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+                 access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id, provider_metadata)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
             ON CONFLICT (agent_identity_id, provider) DO UPDATE SET
                 connection_type = EXCLUDED.connection_type,
                 provider_user_id = EXCLUDED.provider_user_id,
@@ -32,10 +32,11 @@ impl Database {
                 scopes = EXCLUDED.scopes,
                 expires_at = EXCLUDED.expires_at,
                 installation_id = EXCLUDED.installation_id,
+                provider_metadata = EXCLUDED.provider_metadata,
                 updated_at = NOW()
             RETURNING id, agent_identity_id, provider, connection_type, provider_user_id,
                       provider_username, access_token_encrypted, refresh_token_encrypted,
-                      scopes, expires_at, installation_id, created_at, updated_at
+                      scopes, expires_at, installation_id, provider_metadata, created_at, updated_at
             "#,
         )
         .bind(input.agent_identity_id)
@@ -48,6 +49,7 @@ impl Database {
         .bind(&input.scopes)
         .bind(input.expires_at)
         .bind(input.installation_id)
+        .bind(&input.provider_metadata)
         .fetch_one(&self.pool)
         .await?;
 
@@ -62,7 +64,7 @@ impl Database {
     ) -> Result<Option<AgentIdentityConnectionRow>> {
         let row = sqlx::query_as::<_, AgentIdentityConnectionRow>(
             r#"
-            SELECT id, agent_identity_id, provider, connection_type, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id, created_at, updated_at
+            SELECT id, agent_identity_id, provider, connection_type, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id, provider_metadata, created_at, updated_at
             FROM agent_identity_connections
             WHERE agent_identity_id = $1 AND provider = $2
             LIMIT 1
@@ -83,7 +85,7 @@ impl Database {
     ) -> Result<Vec<AgentIdentityConnectionRow>> {
         let rows = sqlx::query_as::<_, AgentIdentityConnectionRow>(
             r#"
-            SELECT id, agent_identity_id, provider, connection_type, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id, created_at, updated_at
+            SELECT id, agent_identity_id, provider, connection_type, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id, provider_metadata, created_at, updated_at
             FROM agent_identity_connections
             WHERE agent_identity_id = $1
             ORDER BY provider ASC

--- a/crates/server/src/storage/repositories/user_connections.rs
+++ b/crates/server/src/storage/repositories/user_connections.rs
@@ -26,9 +26,9 @@ impl Database {
 
         let row = sqlx::query_as::<_, UserConnectionRow>(
             r#"
-            INSERT INTO user_connections (user_id, provider, connection_type, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-            RETURNING id, user_id, provider, connection_type, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id, created_at, updated_at
+            INSERT INTO user_connections (user_id, provider, connection_type, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id, provider_metadata)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            RETURNING id, user_id, provider, connection_type, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id, provider_metadata, created_at, updated_at
             "#,
         )
         .bind(input.user_id)
@@ -41,6 +41,7 @@ impl Database {
         .bind(&input.scopes)
         .bind(input.expires_at)
         .bind(input.installation_id)
+        .bind(&input.provider_metadata)
         .fetch_one(&self.pool)
         .await?;
 
@@ -55,7 +56,7 @@ impl Database {
     ) -> Result<Option<UserConnectionRow>> {
         let row = sqlx::query_as::<_, UserConnectionRow>(
             r#"
-            SELECT id, user_id, provider, connection_type, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id, created_at, updated_at
+            SELECT id, user_id, provider, connection_type, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id, provider_metadata, created_at, updated_at
             FROM user_connections
             WHERE user_id = $1 AND provider = $2
             ORDER BY created_at DESC
@@ -74,7 +75,7 @@ impl Database {
     pub async fn list_user_connections(&self, user_id: Uuid) -> Result<Vec<UserConnectionRow>> {
         let rows = sqlx::query_as::<_, UserConnectionRow>(
             r#"
-            SELECT id, user_id, provider, connection_type, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id, created_at, updated_at
+            SELECT id, user_id, provider, connection_type, provider_user_id, provider_username, access_token_encrypted, refresh_token_encrypted, scopes, expires_at, installation_id, provider_metadata, created_at, updated_at
             FROM user_connections
             WHERE user_id = $1
             ORDER BY provider ASC
@@ -143,6 +144,58 @@ impl Database {
         .await?;
 
         Ok(row.and_then(|(blob,)| blob))
+    }
+
+    /// Get provider metadata for a session/provider pair.
+    ///
+    /// Same resolution order as get_connection_token_for_session.
+    pub async fn get_connection_metadata_for_session(
+        &self,
+        session_id: SessionId,
+        provider: &str,
+    ) -> Result<Option<serde_json::Value>> {
+        let row: Option<(Option<serde_json::Value>,)> = sqlx::query_as(
+            r#"
+            WITH has_identity_conn AS (
+                SELECT 1 AS v
+                FROM sessions s
+                JOIN agent_identity_connections aic
+                    ON aic.agent_identity_id = s.agent_identity_id AND aic.provider = $2
+                WHERE s.id = $1
+                  AND s.agent_identity_id IS NOT NULL
+                LIMIT 1
+            ),
+            identity_conn AS (
+                SELECT aic.provider_metadata
+                FROM sessions s
+                JOIN agent_identity_connections aic
+                    ON aic.agent_identity_id = s.agent_identity_id AND aic.provider = $2
+                WHERE s.id = $1
+                  AND s.agent_identity_id IS NOT NULL
+                LIMIT 1
+            ),
+            user_conn AS (
+                SELECT uc.provider_metadata
+                FROM sessions s
+                JOIN organization_members om ON om.org_id = s.org_id
+                JOIN user_connections uc ON uc.user_id = om.user_id AND uc.provider = $2
+                WHERE s.id = $1
+                  AND NOT EXISTS (SELECT 1 FROM has_identity_conn)
+                ORDER BY uc.created_at ASC
+                LIMIT 1
+            )
+            SELECT provider_metadata FROM identity_conn
+            UNION ALL
+            SELECT provider_metadata FROM user_conn
+            LIMIT 1
+            "#,
+        )
+        .bind(session_id)
+        .bind(provider)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.and_then(|(meta,)| meta))
     }
 
     /// Resolve the user whose connection would be used for a session/provider pair.

--- a/integrations/brave-search/src/connection.rs
+++ b/integrations/brave-search/src/connection.rs
@@ -69,6 +69,7 @@ impl ConnectionProvider for BraveSearchConnectionProvider {
         match response.status().as_u16() {
             200 => Ok(ConnectionValidation {
                 provider_username: None,
+                provider_metadata: None,
             }),
             401 | 403 => Err("Invalid API key. Check that the key is correct and active.".into()),
             429 => Err("API key is valid but rate-limited. Try again in a moment.".into()),

--- a/integrations/browserless/src/connection.rs
+++ b/integrations/browserless/src/connection.rs
@@ -65,6 +65,7 @@ impl ConnectionProvider for BrowserlessConnectionProvider {
             // Browserless v2 /active returns 204 No Content; v1 returned 200.
             200 | 204 => Ok(ConnectionValidation {
                 provider_username: None,
+                provider_metadata: None,
             }),
             401 | 403 => {
                 Err("Invalid API token. Check that the token is correct and active.".into())

--- a/integrations/daytona/src/connection.rs
+++ b/integrations/daytona/src/connection.rs
@@ -68,6 +68,7 @@ impl ConnectionProvider for DaytonaConnectionProvider {
         match response.status().as_u16() {
             200 => Ok(ConnectionValidation {
                 provider_username: None,
+                provider_metadata: None,
             }),
             401 | 403 => Err("Invalid API key. Check that the key is correct and active.".into()),
             status => Err(format!(

--- a/integrations/deno/src/connection.rs
+++ b/integrations/deno/src/connection.rs
@@ -1,8 +1,7 @@
 // Deno Deploy connection provider.
 //
-// Decision: this generic connection uses a single organization access token
-// (`ddo_...`). Personal tokens (`ddp_...`) that require org metadata are not
-// supported here yet.
+// Supports both organization tokens (`ddo_...`) and personal tokens (`ddp_...`).
+// Personal tokens require an org slug, stored as provider_metadata.
 
 use crate::client::DenoClient;
 use async_trait::async_trait;
@@ -10,6 +9,7 @@ use everruns_core::connection_provider::{
     ConnectionFormSchema, ConnectionProvider, ConnectionType, ConnectionValidation, FieldType,
     FormField,
 };
+use std::collections::HashMap;
 
 pub struct DenoConnectionProvider;
 
@@ -37,23 +37,41 @@ impl ConnectionProvider for DenoConnectionProvider {
 
     fn form_schema(&self) -> Option<ConnectionFormSchema> {
         Some(ConnectionFormSchema {
-            fields: vec![FormField {
-                name: "api_key".to_string(),
-                label: "Access Token".to_string(),
-                field_type: FieldType::Password,
-                required: true,
-                placeholder: Some("ddo_...".to_string()),
-                help_text: Some("Use an organization token. Personal tokens require org metadata that the generic API-key flow does not store yet.".to_string()),
-            }],
-            instructions_markdown: "1. Go to [Deno Deploy Sandbox](https://console.deno.com)\n2. Create an organization access token (`ddo_...`)\n3. Paste the token below"
-                .to_string(),
+            fields: vec![
+                FormField {
+                    name: "api_key".to_string(),
+                    label: "Access Token".to_string(),
+                    field_type: FieldType::Password,
+                    required: true,
+                    placeholder: Some("ddo_... or ddp_...".to_string()),
+                    help_text: Some(
+                        "Organization token (ddo_...) or personal token (ddp_...). Personal tokens require the organization slug below."
+                            .to_string(),
+                    ),
+                },
+                FormField {
+                    name: "org_slug".to_string(),
+                    label: "Organization Slug".to_string(),
+                    field_type: FieldType::Text,
+                    required: false,
+                    placeholder: Some("my-org".to_string()),
+                    help_text: Some(
+                        "Required for personal tokens (ddp_...). Find it in your Deno Deploy dashboard URL."
+                            .to_string(),
+                    ),
+                },
+            ],
+            instructions_markdown:
+                "1. Go to [Deno Deploy Sandbox](https://console.deno.com)\n2. Create an access token (`ddo_...` or `ddp_...`)\n3. Paste the token below"
+                    .to_string(),
         })
     }
 
     async fn validate(&self, credential: &str) -> Result<ConnectionValidation, String> {
+        // Single-field validation: only org tokens work without extra fields.
         if credential.starts_with("ddp_") {
             return Err(
-                "Personal Deno tokens are not supported in the generic connection flow yet. Use an organization token (ddo_...).".to_string(),
+                "Personal Deno tokens require an organization slug. Use the full form with the org slug field, or use an organization token (ddo_...).".to_string(),
             );
         }
 
@@ -63,6 +81,44 @@ impl ConnectionProvider for DenoConnectionProvider {
             .await?;
         Ok(ConnectionValidation {
             provider_username: None,
+            provider_metadata: None,
+        })
+    }
+
+    async fn validate_fields(
+        &self,
+        fields: &HashMap<String, String>,
+    ) -> Result<ConnectionValidation, String> {
+        let api_key = fields.get("api_key").map(|s| s.as_str()).unwrap_or("");
+        if api_key.is_empty() {
+            return Err("Access token is required.".to_string());
+        }
+
+        let org_slug = fields
+            .get("org_slug")
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
+        if api_key.starts_with("ddp_") && org_slug.is_none() {
+            return Err("Personal Deno tokens (ddp_...) require an organization slug.".to_string());
+        }
+
+        let org_for_client = if api_key.starts_with("ddp_") {
+            org_slug.clone()
+        } else {
+            None
+        };
+
+        let client = DenoClient::new(api_key.to_string(), org_for_client);
+        client
+            .list_sandboxes(&std::collections::BTreeMap::new())
+            .await?;
+
+        let provider_metadata = org_slug.map(|slug| serde_json::json!({ "org": slug }));
+
+        Ok(ConnectionValidation {
+            provider_username: None,
+            provider_metadata,
         })
     }
 }
@@ -84,8 +140,25 @@ mod tests {
     fn test_form_schema() {
         let provider = DenoConnectionProvider;
         let schema = provider.form_schema().expect("schema");
-        assert_eq!(schema.fields.len(), 1);
+        assert_eq!(schema.fields.len(), 2);
         assert_eq!(schema.fields[0].name, "api_key");
+        assert_eq!(schema.fields[1].name, "org_slug");
         assert!(schema.instructions_markdown.contains("console.deno.com"));
+    }
+
+    #[tokio::test]
+    async fn test_validate_rejects_personal_token_without_org() {
+        let provider = DenoConnectionProvider;
+        let err = provider.validate("ddp_test_token").await.unwrap_err();
+        assert!(err.contains("organization slug"));
+    }
+
+    #[tokio::test]
+    async fn test_validate_fields_rejects_personal_token_without_org() {
+        let provider = DenoConnectionProvider;
+        let mut fields = HashMap::new();
+        fields.insert("api_key".to_string(), "ddp_test_token".to_string());
+        let err = provider.validate_fields(&fields).await.unwrap_err();
+        assert!(err.contains("organization slug"));
     }
 }

--- a/integrations/deno/src/connection.rs
+++ b/integrations/deno/src/connection.rs
@@ -114,7 +114,12 @@ impl ConnectionProvider for DenoConnectionProvider {
             .list_sandboxes(&std::collections::BTreeMap::new())
             .await?;
 
-        let provider_metadata = org_slug.map(|slug| serde_json::json!({ "org": slug }));
+        // Only store metadata for personal tokens; org tokens don't need it.
+        let provider_metadata = if api_key.starts_with("ddp_") {
+            org_slug.map(|slug| serde_json::json!({ "org": slug }))
+        } else {
+            None
+        };
 
         Ok(ConnectionValidation {
             provider_username: None,

--- a/integrations/deno/src/state.rs
+++ b/integrations/deno/src/state.rs
@@ -38,7 +38,22 @@ pub async fn get_credentials(
             .await
         {
             Ok(Some(token)) => {
-                return Ok(DenoCredentials { token, org: None });
+                // Resolve org from provider_metadata if stored (personal tokens)
+                let org = match resolver
+                    .get_connection_metadata(context.session_id, "deno")
+                    .await
+                {
+                    Ok(Some(meta)) => meta
+                        .get("org")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string()),
+                    Ok(None) => None,
+                    Err(e) => {
+                        warn!("Failed to resolve Deno connection metadata: {e}");
+                        None
+                    }
+                };
+                return Ok(DenoCredentials { token, org });
             }
             Ok(None) => {}
             Err(e) => error!("Failed to resolve Deno user connection: {e}"),

--- a/integrations/deno/src/state.rs
+++ b/integrations/deno/src/state.rs
@@ -53,6 +53,10 @@ pub async fn get_credentials(
                         None
                     }
                 };
+                // Personal tokens require an org slug; fail early if missing.
+                if token.starts_with("ddp_") && org.is_none() {
+                    return Err(ToolExecutionResult::connection_required("deno"));
+                }
                 return Ok(DenoCredentials { token, org });
             }
             Ok(None) => {}


### PR DESCRIPTION
## What
Support Deno Deploy personal access tokens (`ddp_...`) in the generic API-key connection flow, alongside existing organization tokens (`ddo_...`).

## Why
Users with personal Deno tokens were blocked — the connection form rejected them outright. Personal tokens require an org slug to scope API calls, which the generic flow had no way to capture or store.

## How
- Added `validate_fields()` to `ConnectionProvider` trait — receives all form fields, default delegates to `validate()` for backward compat
- Added `provider_metadata` (JSONB) column to `user_connections` and `agent_identity_connections` via migration 010
- Deno connection provider now exposes an `org_slug` form field and validates personal tokens with it
- Stored org slug as `provider_metadata` on the connection row
- `get_credentials()` in the Deno integration resolves org from metadata at runtime
- UI dialogs forward extra form fields through the API

## Risk
- Low
- Existing org token (`ddo_...`) flow unchanged — `validate_fields()` defaults to `validate()`. New column is nullable, so no migration risk.

## Security
- Threat categories reviewed: TM-API, TM-AUTH, TM-SQL
- `extra_fields` uses `serde(flatten)` with `HashMap<String, serde_json::Value>` — values are only used as strings (`.as_str()`), non-string values silently dropped. No injection vector.
- `provider_metadata` is JSONB written via parameterized queries (sqlx bind). No SQL injection.
- API key validation unchanged — personal tokens still validated against Deno API before storage.
- No new endpoints, no auth bypass, no data exposure.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)