### PR TITLE
feat(core): add link-following hint to agent_instructions prompt

### DIFF
--- a/crates/core/src/capabilities/agent_instructions.rs
+++ b/crates/core/src/capabilities/agent_instructions.rs
@@ -289,6 +289,14 @@ mod tests {
         assert!(result.ends_with("</agent-instructions>"));
         assert!(result.contains("truncated"));
         assert!(result.contains("Read referenced files before concluding"));
+
+        // Verify the AGENTS.md content portion is truncated to MAX_AGENTS_MD_SIZE.
+        // Extract the body between the header newline and the truncation notice.
+        let header = "<agent-instructions source=\"AGENTS.md\">\n";
+        let body_start = result.find(header).unwrap() + header.len();
+        let truncation_marker = "\n\n[AGENTS.md was truncated";
+        let body_end = result.find(truncation_marker).unwrap();
+        assert_eq!(body_end - body_start, MAX_AGENTS_MD_SIZE);
     }
 
     #[test]

--- a/crates/core/src/capabilities/agent_instructions.rs
+++ b/crates/core/src/capabilities/agent_instructions.rs
@@ -119,6 +119,13 @@ pub fn format_agents_md_content(content: &str) -> Option<String> {
     if was_truncated {
         result.push_str("\n\n[AGENTS.md was truncated — content exceeds 32 KiB limit]");
     }
+    result.push_str(concat!(
+        "\n\n",
+        "AGENTS.md may reference specs, skills, and other files in the workspace. ",
+        "Read referenced files before concluding you cannot perform a task. ",
+        "Follow links progressively — don't load everything upfront, ",
+        "but do read a file when its topic is relevant to the current request.",
+    ));
     result.push_str("\n</agent-instructions>");
     Some(result)
 }
@@ -263,6 +270,7 @@ mod tests {
         assert!(result.starts_with("<agent-instructions source=\"AGENTS.md\">"));
         assert!(result.ends_with("</agent-instructions>"));
         assert!(result.contains("Use snake_case"));
+        assert!(result.contains("Read referenced files before concluding"));
     }
 
     #[test]
@@ -277,15 +285,10 @@ mod tests {
         let content = "x".repeat(MAX_AGENTS_MD_SIZE + 1000);
         let result = format_agents_md_content(&content).unwrap();
 
-        let header = "<agent-instructions source=\"AGENTS.md\">\n";
-        let truncation_notice = "\n\n[AGENTS.md was truncated — content exceeds 32 KiB limit]";
-        let closing = "\n</agent-instructions>";
-        let expected_len =
-            header.len() + MAX_AGENTS_MD_SIZE + truncation_notice.len() + closing.len();
-        assert_eq!(result.len(), expected_len);
         assert!(result.starts_with("<agent-instructions"));
         assert!(result.ends_with("</agent-instructions>"));
         assert!(result.contains("truncated"));
+        assert!(result.contains("Read referenced files before concluding"));
     }
 
     #[test]

--- a/specs/agent-instructions.md
+++ b/specs/agent-instructions.md
@@ -18,7 +18,7 @@ Everruns implements AGENTS.md as a built-in capability that reads from the sessi
 | Discovery | Single file at workspace root (`/AGENTS.md`) — no upward walk (session filesystem is flat) |
 | Injection point | Prepended to system prompt, before capability additions |
 | Dynamic reading | Re-read on every LLM turn (picks up changes immediately) |
-| Size limit | 32 KiB max (truncated with warning if exceeded, matching Codex convention) |
+| Size limit | 32 KiB max of AGENTS.md content; truncated with warning if exceeded, excluding wrapper/hint text (matching Codex convention) |
 | Missing file | Silently ignored (no error) |
 | Format | Plain markdown, no special syntax, no `@` imports |
 | Link-following hint | Appended after content; nudges LLM to read referenced files progressively |

--- a/specs/agent-instructions.md
+++ b/specs/agent-instructions.md
@@ -21,6 +21,7 @@ Everruns implements AGENTS.md as a built-in capability that reads from the sessi
 | Size limit | 32 KiB max (truncated with warning if exceeded, matching Codex convention) |
 | Missing file | Silently ignored (no error) |
 | Format | Plain markdown, no special syntax, no `@` imports |
+| Link-following hint | Appended after content; nudges LLM to read referenced files progressively |
 | Architecture | Self-contained capability with `system_prompt_contribution()` override |
 | Dependencies | None required; `session_file_system` recommended for authoring |
 


### PR DESCRIPTION
## Summary

- Appends a progressive link-following hint after AGENTS.md content in the system prompt, nudging the LLM to read referenced specs/skills/files before concluding it cannot perform a task
- Updates spec with new design decision row

## Test plan

- [x] All 16 `agent_instructions` unit tests pass (including updated assertions for the hint text)
- [x] `cargo fmt` and `cargo clippy` clean
- [ ] Manual: verify agent reads linked specs when asked about a topic covered by a referenced file

Closes EVE-181