### PR TITLE
fix(browserless): declare session_storage as dependency

### DIFF
--- a/integrations/browserless/src/lib.rs
+++ b/integrations/browserless/src/lib.rs
@@ -176,7 +176,7 @@ or leave it false to get the DOM content instead."#,
     }
 
     fn dependencies(&self) -> Vec<&'static str> {
-        vec![]
+        vec!["session_storage"]
     }
 
     fn features(&self) -> Vec<&'static str> {
@@ -248,9 +248,9 @@ mod tests {
     }
 
     #[test]
-    fn test_capability_no_dependencies() {
+    fn test_capability_depends_on_session_storage() {
         let cap = BrowserlessCapability;
-        assert!(cap.dependencies().is_empty());
+        assert_eq!(cap.dependencies(), vec!["session_storage"]);
     }
 
     #[test]

--- a/integrations/browserless/tests/plugin_registration.rs
+++ b/integrations/browserless/tests/plugin_registration.rs
@@ -64,6 +64,6 @@ fn test_browserless_capability_metadata() {
     assert_eq!(cap.name(), "Browserless");
     assert_eq!(cap.icon(), Some("browserless"));
     assert_eq!(cap.category(), Some("Browser"));
-    assert!(cap.dependencies().is_empty());
+    assert_eq!(cap.dependencies(), vec!["session_storage"]);
     assert_eq!(cap.tools().len(), 7);
 }


### PR DESCRIPTION
## What
Browserless capability now declares `session_storage` as a dependency so it is auto-included when browserless is enabled.

## Why
When an agent has `browserless` but not `session_storage`, the LLM tries to call `secret_store` for credential handling during login flows and fails with "Tool not found: secret_store". The `secret_store` tool is provided by the `session_storage` capability.

## How
Added `"session_storage"` to the `dependencies()` return value of `BrowserlessCapability`. The existing dependency resolution system handles the rest — when a user enables `browserless`, `session_storage` is automatically included (and shown as an auto-added dependency in the UI).

## Risk
- Low
- Only changes capability metadata (dependency declaration). No runtime code paths, API surface, or data handling changes.

## Security
- No security-relevant code changes. This is a metadata-only change to capability dependency declarations — no new endpoints, no input handling, no auth changes, no data exposure. The `session_storage` capability already exists and has its own security controls (encrypted secret storage).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- All 14 browserless crate tests pass (unit + integration)
- All 539 core capability tests pass
- Clippy clean on browserless crate
- Rebased on latest main

Closes EVE-180