### PR TITLE
fix(browserless): use correct env var name BROWSERLESS_TOKEN

### DIFF
--- a/integrations/browserless/SPEC.md
+++ b/integrations/browserless/SPEC.md
@@ -216,7 +216,7 @@ No long-lived WebSocket connections from our side — we connect/disconnect for 
 - `tool_integration.rs`: full tool execution flow via wiremock, parameter validation, auth, error handling, resource cleanup
 
 ### Live API Tests
-Tests against the real Browserless API require `BROWSERLESS_KEY` in Doppler. Gated behind `browserless-live-tests` feature flag:
+Tests against the real Browserless API require `BROWSERLESS_TOKEN` in Doppler. Gated behind `browserless-live-tests` feature flag:
 
 ```bash
 doppler run -- cargo test -p everruns-integrations-browserless --features browserless-live-tests

--- a/integrations/browserless/tests/live_api.rs
+++ b/integrations/browserless/tests/live_api.rs
@@ -1,6 +1,6 @@
 //! Live API tests against the real Browserless service.
 //!
-//! These tests require a valid `BROWSERLESS_KEY` environment variable (set via Doppler).
+//! These tests require a valid `BROWSERLESS_TOKEN` environment variable (set via Doppler).
 //! Run via: doppler run -- cargo test -p everruns-integrations-browserless --features browserless-live-tests
 //!
 //! All tests are gated behind the `browserless-live-tests` feature flag.
@@ -12,8 +12,8 @@ use everruns_integrations_browserless::cdp::CdpSession;
 use everruns_integrations_browserless::client::BrowserlessClient;
 
 fn api_token() -> String {
-    std::env::var("BROWSERLESS_KEY")
-        .expect("BROWSERLESS_KEY must be set for live API tests (available via Doppler)")
+    std::env::var("BROWSERLESS_TOKEN")
+        .expect("BROWSERLESS_TOKEN must be set for live API tests (available via Doppler)")
 }
 
 // ============================================================================


### PR DESCRIPTION
## What
Rename `BROWSERLESS_KEY` → `BROWSERLESS_TOKEN` in live API test code and SPEC.md.

## Why
Doppler provides the secret as `BROWSERLESS_TOKEN`, but tests looked for `BROWSERLESS_KEY`, causing CI live tests to silently skip or fail.

## How
- Renamed the env var in `integrations/browserless/tests/live_api.rs` (3 occurrences)
- Updated `integrations/browserless/SPEC.md` to match

## Risk
- Low
- Nothing can break — only test infrastructure affected, no runtime code changed

## Security
- No security-relevant code changes. Only env var name in test code and spec doc.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)