### PR TITLE
fix(server): include initial_files in agent upsert SQL query

### DIFF
--- a/crates/server/src/services/agent.rs
+++ b/crates/server/src/services/agent.rs
@@ -735,4 +735,40 @@ mod tests {
 
         assert_eq!(err.to_string(), "Capability not found");
     }
+
+    #[tokio::test]
+    async fn upsert_updates_initial_files() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let service = AgentService::new(db.clone());
+        let caller = Caller::internal(DEFAULT_ORG_ID);
+
+        // Create agent with initial_files via upsert
+        let public_id = "agent_00000000000000000000000000000050";
+        let mut req = build_create_request(None);
+        req.initial_files = vec![InitialFile {
+            path: "/AGENTS.md".to_string(),
+            content: "old content".to_string(),
+            encoding: "utf-8".to_string(),
+            is_readonly: false,
+        }];
+
+        let (agent, was_created) = service.upsert(&caller, public_id, req).await.unwrap();
+        assert!(was_created);
+        assert_eq!(agent.initial_files.len(), 1);
+        assert_eq!(agent.initial_files[0].content, "old content");
+
+        // Upsert again with updated initial_files
+        let mut req2 = build_create_request(None);
+        req2.initial_files = vec![InitialFile {
+            path: "/AGENTS.md".to_string(),
+            content: "new content".to_string(),
+            encoding: "utf-8".to_string(),
+            is_readonly: false,
+        }];
+
+        let (agent2, was_created2) = service.upsert(&caller, public_id, req2).await.unwrap();
+        assert!(!was_created2);
+        assert_eq!(agent2.initial_files.len(), 1);
+        assert_eq!(agent2.initial_files[0].content, "new content");
+    }
 }

--- a/crates/server/src/storage/repositories/agents.rs
+++ b/crates/server/src/storage/repositories/agents.rs
@@ -273,18 +273,19 @@ impl Database {
             WITH existing AS (
                 SELECT id FROM agents WHERE org_id = $1 AND public_id = $2
             )
-            INSERT INTO agents (org_id, public_id, name, description, system_prompt, default_model_id, tags, tools, status)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'active')
+            INSERT INTO agents (org_id, public_id, name, description, system_prompt, default_model_id, tags, initial_files, tools, status)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'active')
             ON CONFLICT (org_id, public_id) DO UPDATE SET
                 name = EXCLUDED.name,
                 description = EXCLUDED.description,
                 system_prompt = EXCLUDED.system_prompt,
                 default_model_id = EXCLUDED.default_model_id,
                 tags = EXCLUDED.tags,
+                initial_files = EXCLUDED.initial_files,
                 tools = EXCLUDED.tools,
                 status = 'active',
                 updated_at = NOW()
-            RETURNING id, public_id, org_id, name, description, system_prompt, default_model_id, tags, status, created_at, updated_at, archived_at, deleted_at, tools,
+            RETURNING id, public_id, org_id, name, description, system_prompt, default_model_id, tags, status, created_at, updated_at, archived_at, deleted_at, initial_files, tools,
                       total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens
             "#,
         )
@@ -295,6 +296,7 @@ impl Database {
         .bind(&input.system_prompt)
         .bind(input.default_model_id)
         .bind(&input.tags)
+        .bind(&input.initial_files)
         .bind(&input.tools)
         .fetch_one(&self.pool)
         .await?;

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -122,6 +122,66 @@ async fn test_agent_crud() {
 }
 
 #[tokio::test]
+async fn test_agent_upsert_initial_files() {
+    let backend = create_test_backend().await;
+    let public_id = everruns_core::AgentId::new().to_string();
+
+    // First upsert — creates agent with initial_files
+    let (agent, was_created) = backend
+        .upsert_agent(
+            TEST_ORG_ID,
+            CreateAgentRow {
+                public_id: public_id.clone(),
+                name: "Upsert Files Agent".to_string(),
+                description: None,
+                system_prompt: "prompt".to_string(),
+                default_model_id: None,
+                tags: vec![],
+                initial_files: serde_json::json!([
+                    {"path": "/AGENTS.md", "content": "old", "encoding": "utf-8", "is_readonly": false}
+                ]),
+                tools: serde_json::json!([]),
+            },
+        )
+        .await
+        .expect("First upsert failed");
+    assert!(was_created);
+    assert_eq!(agent.initial_files.as_array().unwrap().len(), 1);
+    assert_eq!(agent.initial_files[0]["content"], "old");
+
+    // Second upsert — updates initial_files
+    let (agent2, was_created2) = backend
+        .upsert_agent(
+            TEST_ORG_ID,
+            CreateAgentRow {
+                public_id: public_id.clone(),
+                name: "Upsert Files Agent".to_string(),
+                description: None,
+                system_prompt: "prompt".to_string(),
+                default_model_id: None,
+                tags: vec![],
+                initial_files: serde_json::json!([
+                    {"path": "/AGENTS.md", "content": "new", "encoding": "utf-8", "is_readonly": false}
+                ]),
+                tools: serde_json::json!([]),
+            },
+        )
+        .await
+        .expect("Second upsert failed");
+    assert!(!was_created2);
+    assert_eq!(agent2.initial_files.as_array().unwrap().len(), 1);
+    assert_eq!(agent2.initial_files[0]["content"], "new");
+
+    // Verify via get
+    let fetched = backend
+        .get_agent(TEST_ORG_ID, agent2.id)
+        .await
+        .expect("Failed to get agent")
+        .expect("Agent not found");
+    assert_eq!(fetched.initial_files[0]["content"], "new");
+}
+
+#[tokio::test]
 async fn test_agent_get_by_name() {
     let backend = create_test_backend().await;
 


### PR DESCRIPTION
## What
Fix PostgreSQL upsert_agent SQL query to include initial_files in INSERT, ON CONFLICT UPDATE SET, and RETURNING clauses.

## Why
The initial_files column was silently dropped during agent upsert (agents create --file or PUT /v1/agents/{id}), causing agent workspace files (AGENTS.md, specs, skills) to drift out of sync after an upsert. The in-memory backend handled this correctly, masking the bug in unit tests.

## How
Added initial_files to the three missing positions in the SQL query and the corresponding .bind() call. Added both a unit test (in-memory) and a PostgreSQL integration test proving the fix.

## Risk
- Low
- Only changes the upsert SQL query for agents. No schema change. The column already existed and was used by create/update paths.

## Security
- Threat categories reviewed: TM-SQL (database query change), TM-API (PUT endpoint behavior)
- The change adds a column that was already present in other queries (create, update). No new input surface. The initial_files value is bound via parameterized query (no injection risk). No auth/authz changes.

## Checklist
- [x] Tests added or updated (unit test + PostgreSQL integration test)
- [x] Backward compatibility considered (additive fix, no breaking change)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (added PostgreSQL integration test per Copilot feedback)

Fixes EVE-179