### PR TITLE
fix(ui): improve code block styling in light theme

### DIFF
--- a/apps/ui/src/app/globals.css
+++ b/apps/ui/src/app/globals.css
@@ -40,8 +40,8 @@
     --border: 0 0% 88%;
     --input: 0 0% 85%;
     --ring: 43 60% 53%;
-    /* Sidebar: used by Streamdown code blocks */
-    --sidebar: 0 0% 96%;
+    /* Sidebar: used by Streamdown code blocks — slightly darker than muted for contrast */
+    --sidebar: 0 0% 93%;
     --sidebar-foreground: 0 0% 10%;
     /* Sharp corners */
     --radius: 0px;

--- a/apps/ui/src/components/chat/streamdown-message.css
+++ b/apps/ui/src/components/chat/streamdown-message.css
@@ -89,6 +89,7 @@
 .streamdown [data-streamdown="code-block"] {
   border-radius: 0;
   position: relative;
+  border: 1px solid var(--color-border);
 }
 .streamdown [data-streamdown="code-block-body"] {
   border-radius: 0;
@@ -105,6 +106,11 @@
 }
 .streamdown [data-streamdown="code-block-header"] {
   display: inline-flex;
+  border-bottom: 1px solid var(--color-border);
+}
+/* Hide the header bar when it has no language label (empty gray bar) */
+.streamdown [data-streamdown="code-block-header"]:empty {
+  display: none;
 }
 .streamdown [data-streamdown="code-block-actions"] {
   position: absolute;


### PR DESCRIPTION
## What

Fix the empty gray bar above code blocks and improve code block styling in light theme.

## Why

Streamdown's `code-block-header` renders even when no language label is present, producing a pointless gray stripe. Additionally, the sidebar and muted colors were identical in light mode (`hsl(0 0% 96%)`), making the header indistinguishable from the code body.

## How

- Hide `code-block-header` via `:empty` CSS selector when no language label is present
- Add `border-bottom` on the header to visually separate it from code body when a label exists
- Add a `border` on the code-block container for better definition against the page background
- Darken light-mode `--sidebar` from 96% to 93% lightness so the header contrasts with the code body

## Risk
- Low
- Purely visual CSS changes; only affects code block rendering in markdown messages

## Security
- No security-relevant code changes — CSS-only styling, no JS logic, no input handling, no API changes.

## Checklist
- [x] Tests added or updated — CSS-only, validated via UI build + lint
- [x] Backward compatibility considered — N/A, internal styling
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)