### PR TITLE
feat(core): add ToolHints to tool definitions

### DIFF
--- a/apps/ui/src/lib/api/types/common-types.ts
+++ b/apps/ui/src/lib/api/types/common-types.ts
@@ -28,6 +28,26 @@ export interface InitialFile {
 
 export type ToolPolicy = "auto" | "requires_approval";
 
+/**
+ * Semantic hints describing a tool's behavioral properties.
+ * All fields are optional — undefined means "unspecified".
+ * Follows MCP tool annotations convention plus everruns-specific hints.
+ */
+export interface ToolHints {
+  /** Tool does not modify any state (read-only queries, lookups) */
+  readonly?: boolean;
+  /** Tool may irreversibly destroy or delete data */
+  destructive?: boolean;
+  /** Same args produce same effect; safe to retry */
+  idempotent?: boolean;
+  /** Interacts with external entities (network, APIs, cloud services) */
+  open_world?: boolean;
+  /** Needs API keys or credentials to function */
+  requires_secrets?: boolean;
+  /** May take significant time to complete (> ~5s typical) */
+  long_running?: boolean;
+}
+
 /** Tool definition - builtin tool configuration */
 export interface BuiltinTool {
   type: "builtin";
@@ -41,6 +61,8 @@ export interface BuiltinTool {
   parameters: Record<string, unknown>;
   /** Tool policy (auto or requires_approval) */
   policy?: ToolPolicy;
+  /** Semantic hints describing the tool's behavioral properties */
+  hints?: ToolHints;
 }
 
 /** Tool definition - client-side tool executed by the caller */
@@ -54,6 +76,8 @@ export interface ClientSideTool {
   description: string;
   /** JSON schema for tool parameters */
   parameters: Record<string, unknown>;
+  /** Semantic hints describing the tool's behavioral properties */
+  hints?: ToolHints;
 }
 
 /** Tool definition - builtin or client-side */

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -983,6 +983,7 @@ mod tests {
             policy: Default::default(),
             category: None,
             deferrable: Default::default(),
+            hints: crate::tool_types::ToolHints::default(),
         })
     }
 

--- a/crates/core/src/capabilities/current_time.rs
+++ b/crates/core/src/capabilities/current_time.rs
@@ -1,6 +1,7 @@
 //! CurrentTime Capability - provides tools to get current date and time
 
 use super::{Capability, CapabilityStatus};
+use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
 use async_trait::async_trait;
 use serde_json::Value;
@@ -75,6 +76,12 @@ impl Tool for GetCurrentTimeTool {
             },
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {

--- a/crates/core/src/capabilities/fake_aws.rs
+++ b/crates/core/src/capabilities/fake_aws.rs
@@ -20,6 +20,7 @@
 
 use super::{Capability, CapabilityStatus};
 use crate::SessionId;
+use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::{SessionFileStore, ToolContext};
 use async_trait::async_trait;
@@ -753,6 +754,12 @@ impl Tool for AwsListEc2InstancesTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error("aws_list_ec2_instances requires context")
     }
@@ -936,6 +943,10 @@ impl Tool for AwsStopEc2InstanceTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default().with_destructive(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error("aws_stop_ec2_instance requires context")
     }
@@ -1007,6 +1018,12 @@ impl Tool for AwsListRdsDatabasesTool {
 
     fn parameters_schema(&self) -> Value {
         json!({"type": "object", "properties": {}, "additionalProperties": false})
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -1170,6 +1187,12 @@ impl Tool for AwsListS3BucketsTool {
         json!({"type": "object", "properties": {}, "additionalProperties": false})
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error("Requires context")
     }
@@ -1305,6 +1328,12 @@ impl Tool for AwsListIamUsersTool {
 
     fn parameters_schema(&self) -> Value {
         json!({"type": "object", "properties": {}, "additionalProperties": false})
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -1447,6 +1476,12 @@ impl Tool for AwsListSecurityGroupsTool {
         json!({"type": "object", "properties": {}, "additionalProperties": false})
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error("Requires context")
     }
@@ -1509,6 +1544,12 @@ impl Tool for AwsGetCloudWatchMetricsTool {
             "required": ["resource_id", "metric_name"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {

--- a/crates/core/src/capabilities/fake_crm.rs
+++ b/crates/core/src/capabilities/fake_crm.rs
@@ -14,6 +14,7 @@
 //! - `crm_search_customers`: Search customers by criteria
 
 use super::{Capability, CapabilityStatus};
+use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
@@ -124,6 +125,12 @@ impl Tool for CrmListCustomersTool {
             },
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -244,6 +251,12 @@ impl Tool for CrmGetCustomerTool {
             "required": ["customer_id"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -448,6 +461,12 @@ impl Tool for CrmListTicketsTool {
             },
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -656,6 +675,10 @@ impl Tool for CrmUpdateTicketTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default().with_idempotent(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error("Requires context")
     }
@@ -793,6 +816,12 @@ impl Tool for CrmSearchCustomersTool {
             "required": ["query"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {

--- a/crates/core/src/capabilities/fake_financial.rs
+++ b/crates/core/src/capabilities/fake_financial.rs
@@ -14,6 +14,7 @@
 //! - `finance_forecast_cash_flow`: Forecast cash flow
 
 use super::{Capability, CapabilityStatus};
+use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
@@ -131,6 +132,12 @@ impl Tool for FinanceListTransactionsTool {
             },
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -396,6 +403,12 @@ impl Tool for FinanceGetBalanceTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error("finance_get_balance requires context")
     }
@@ -467,6 +480,12 @@ impl Tool for FinanceListBudgetsTool {
 
     fn parameters_schema(&self) -> Value {
         json!({"type": "object", "properties": {}, "additionalProperties": false})
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -589,6 +608,12 @@ impl Tool for FinanceGetExpenseReportTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error("Requires context")
     }
@@ -651,6 +676,12 @@ impl Tool for FinanceGetRevenueReportTool {
             },
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -716,6 +747,12 @@ impl Tool for FinanceForecastCashFlowTool {
             },
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {

--- a/crates/core/src/capabilities/fake_warehouse.rs
+++ b/crates/core/src/capabilities/fake_warehouse.rs
@@ -16,6 +16,7 @@
 //! - `warehouse_inventory_report`: Generate inventory report
 
 use super::{Capability, CapabilityStatus};
+use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
@@ -142,6 +143,12 @@ impl Tool for WarehouseGetInventoryTool {
             },
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -302,6 +309,10 @@ impl Tool for WarehouseUpdateInventoryTool {
             "required": ["sku", "quantity_change"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default().with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -554,6 +565,12 @@ impl Tool for WarehouseListShipmentsTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error("warehouse_list_shipments requires context")
     }
@@ -639,6 +656,10 @@ impl Tool for WarehouseUpdateShipmentStatusTool {
             "required": ["shipment_id", "status"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default().with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -844,6 +865,12 @@ impl Tool for WarehouseListOrdersTool {
         json!({"type": "object", "properties": {}, "additionalProperties": false})
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error("Requires context")
     }
@@ -1007,6 +1034,12 @@ impl Tool for WarehouseInventoryReportTool {
 
     fn parameters_schema(&self) -> Value {
         json!({"type": "object", "properties": {}, "additionalProperties": false})
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {

--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -14,6 +14,7 @@
 
 use super::{Capability, CapabilityStatus};
 use crate::session_file::SessionFile;
+use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult, ToolResultImage};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
@@ -417,6 +418,12 @@ impl Tool for ReadFileTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
             "read_file requires context. This tool must be executed with session context.",
@@ -551,6 +558,10 @@ impl Tool for WriteFileTool {
             "required": ["path", "content"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default().with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -690,6 +701,10 @@ impl Tool for EditFileTool {
             "required": ["path", "expected_hash"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -905,6 +920,12 @@ impl Tool for ListDirectoryTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
             "list_directory requires context. This tool must be executed with session context.",
@@ -1013,6 +1034,12 @@ impl Tool for GrepFilesTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
             "grep_files requires context. This tool must be executed with session context.",
@@ -1118,6 +1145,12 @@ impl Tool for DeleteFileTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_destructive(true)
+            .with_idempotent(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
             "delete_file requires context. This tool must be executed with session context.",
@@ -1215,6 +1248,12 @@ impl Tool for StatFileTool {
             "required": ["path"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {

--- a/crates/core/src/capabilities/infinity_context.rs
+++ b/crates/core/src/capabilities/infinity_context.rs
@@ -6,6 +6,7 @@
 use super::{Capability, CapabilityStatus};
 use crate::message::{ContentPart, Message, MessageRole};
 use crate::message_filter::{ExcludedNoticeTransform, MessageFilterProvider, MessageQuery};
+use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
@@ -184,6 +185,12 @@ impl Tool for QueryHistoryTool {
             },
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {

--- a/crates/core/src/capabilities/mcp.rs
+++ b/crates/core/src/capabilities/mcp.rs
@@ -12,7 +12,7 @@
 
 use crate::capability_types::{CapabilityId, CapabilityStatus};
 use crate::mcp_server::{McpToolDefinition, mcp_tool_name};
-use crate::tool_types::{BuiltinTool, DeferrablePolicy, ToolDefinition, ToolPolicy};
+use crate::tool_types::{BuiltinTool, DeferrablePolicy, ToolDefinition, ToolHints, ToolPolicy};
 use crate::tools::Tool;
 
 use super::Capability;
@@ -77,9 +77,27 @@ impl McpCapability {
         mcp_capability_id(self.server_id)
     }
 
-    /// Convert MCP tool definition to our ToolDefinition with prefixed name
+    /// Convert MCP tool definition to our ToolDefinition with prefixed name.
+    /// Maps MCP annotations to ToolHints when available.
     fn mcp_tool_to_definition(&self, mcp_tool: &McpToolDefinition) -> ToolDefinition {
         let prefixed_name = mcp_tool_name(&self.server_name, &mcp_tool.name);
+
+        // Map MCP annotations to ToolHints
+        let hints = match &mcp_tool.annotations {
+            Some(ann) => ToolHints {
+                readonly: ann.read_only_hint,
+                destructive: ann.destructive_hint,
+                idempotent: ann.idempotent_hint,
+                // Default open_world to true for MCP tools unless explicitly set to false
+                open_world: Some(ann.open_world_hint.unwrap_or(true)),
+                // MCP doesn't define requires_secrets or long_running — leave as None
+                ..ToolHints::default()
+            },
+            None => {
+                // MCP tools are external by nature
+                ToolHints::default().with_open_world(true)
+            }
+        };
 
         ToolDefinition::Builtin(BuiltinTool {
             name: prefixed_name,
@@ -92,6 +110,7 @@ impl McpCapability {
             policy: ToolPolicy::Auto,
             category: self.category().map(|s| s.to_string()),
             deferrable: DeferrablePolicy::default(),
+            hints,
         })
     }
 }
@@ -207,6 +226,7 @@ mod tests {
                     "query": { "type": "string" }
                 }
             }),
+            annotations: None,
         }];
 
         let capability = McpCapability::new(

--- a/crates/core/src/capabilities/platform_management.rs
+++ b/crates/core/src/capabilities/platform_management.rs
@@ -7,6 +7,7 @@
 // Decision: get_messages defaults to last 10; session_read_response defaults to 120s timeout
 
 use super::{Capability, CapabilityStatus};
+use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
@@ -121,6 +122,12 @@ impl Tool for ReadHarnessesTool {
             },
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -493,6 +500,12 @@ impl Tool for ReadAgentsTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
             "read_agents requires context. This tool must be executed with session context.",
@@ -786,6 +799,12 @@ impl Tool for ReadSessionsTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
             "read_sessions requires context. This tool must be executed with session context.",
@@ -1076,6 +1095,10 @@ impl Tool for SessionSendMessageTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default().with_long_running(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
             "session_send_message requires context. This tool must be executed with session context.",
@@ -1162,6 +1185,12 @@ impl Tool for SessionReadMessagesTool {
             "required": ["session_id"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -1266,6 +1295,13 @@ impl Tool for SessionReadResponseTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+            .with_long_running(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
             "session_read_response requires context. This tool must be executed with session context.",
@@ -1348,6 +1384,12 @@ impl Tool for ReadCapabilitiesTool {
             },
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {

--- a/crates/core/src/capabilities/session.rs
+++ b/crates/core/src/capabilities/session.rs
@@ -5,6 +5,7 @@
 //! - `get_session_info`: return session id, title, and agent name (if any)
 
 use super::{Capability, CapabilityStatus};
+use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
@@ -77,6 +78,10 @@ impl Tool for WriteSessionTitleTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default().with_idempotent(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
             "write_session_title requires context. This tool must be executed with session context.",
@@ -136,6 +141,12 @@ impl Tool for GetSessionInfoTool {
             "properties": {},
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {

--- a/crates/core/src/capabilities/session_schedule.rs
+++ b/crates/core/src/capabilities/session_schedule.rs
@@ -7,6 +7,7 @@
 
 use super::{Capability, CapabilityStatus};
 use crate::session_schedule::MAX_ACTIVE_SCHEDULES_PER_SESSION;
+use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
@@ -222,6 +223,10 @@ impl Tool for CancelScheduleTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default().with_destructive(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
             "cancel_schedule requires context. This tool must be executed with session context.",
@@ -289,6 +294,12 @@ impl Tool for ListSchedulesTool {
             "properties": {},
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {

--- a/crates/core/src/capabilities/session_sql_database.rs
+++ b/crates/core/src/capabilities/session_sql_database.rs
@@ -7,6 +7,7 @@
 
 use super::{Capability, CapabilityStatus};
 use crate::session_sqldb::SessionSqlDbError;
+use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
@@ -109,6 +110,10 @@ impl Tool for SqlExecuteTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
             "sql_execute requires context. This tool must be executed with session context.",
@@ -194,6 +199,10 @@ impl Tool for SqlQueryTool {
             "required": ["database", "sql"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default().with_readonly(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -288,6 +297,12 @@ impl Tool for SqlSchemaTool {
             "required": ["database"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {

--- a/crates/core/src/capabilities/session_storage.rs
+++ b/crates/core/src/capabilities/session_storage.rs
@@ -8,6 +8,7 @@
 //! - `secret_store`: Encrypted secret storage operations (set, get, delete, list)
 
 use super::{Capability, CapabilityStatus};
+use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
@@ -104,6 +105,10 @@ impl Tool for KvStoreTool {
             "required": ["operation"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default().with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -281,6 +286,12 @@ impl Tool for SecretStoreTool {
             "required": ["operation"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_idempotent(true)
+            .with_requires_secrets(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {

--- a/crates/core/src/capabilities/skills.rs
+++ b/crates/core/src/capabilities/skills.rs
@@ -14,7 +14,7 @@
 // mounts skill files into the VFS so this capability discovers them.
 
 use super::{Capability, CapabilityStatus, SystemPromptContext};
-use crate::tool_types::{BuiltinTool, DeferrablePolicy, ToolDefinition, ToolPolicy};
+use crate::tool_types::{BuiltinTool, DeferrablePolicy, ToolDefinition, ToolHints, ToolPolicy};
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
@@ -206,6 +206,9 @@ Skills are instruction packages (SKILL.md files) that teach the agent new abilit
                 policy: ToolPolicy::Auto,
                 category: None,
                 deferrable: DeferrablePolicy::default(),
+                hints: ToolHints::default()
+                    .with_readonly(true)
+                    .with_idempotent(true),
             }),
             ToolDefinition::Builtin(BuiltinTool {
                 name: "activate_skill".to_string(),
@@ -231,6 +234,9 @@ Skills are instruction packages (SKILL.md files) that teach the agent new abilit
                 policy: ToolPolicy::Auto,
                 category: None,
                 deferrable: DeferrablePolicy::default(),
+                hints: ToolHints::default()
+                    .with_readonly(true)
+                    .with_idempotent(true),
             }),
         ]
     }
@@ -268,6 +274,12 @@ impl Tool for ListSkillsTool {
             "properties": {},
             "required": []
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     fn requires_context(&self) -> bool {
@@ -390,6 +402,12 @@ impl Tool for ActivateSkillFromVfsTool {
             },
             "required": ["name"]
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     fn requires_context(&self) -> bool {

--- a/crates/core/src/capabilities/stateless_todo_list.rs
+++ b/crates/core/src/capabilities/stateless_todo_list.rs
@@ -39,6 +39,7 @@
 //! growth becomes an issue in long-running sessions.
 
 use super::{Capability, CapabilityStatus};
+use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
 use async_trait::async_trait;
 use serde_json::Value;
@@ -187,6 +188,10 @@ impl Tool for WriteTodosTool {
             "required": ["todos"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default().with_idempotent(true)
     }
 
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {

--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -17,6 +17,7 @@
 
 use super::{Capability, CapabilityStatus};
 use crate::platform_store::PlatformStore;
+use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
@@ -180,6 +181,10 @@ impl Tool for SpawnSubagentTool {
             "required": ["name", "task"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default().with_long_running(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -366,6 +371,12 @@ impl Tool for GetSubagentsTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error("get_subagents requires context.")
     }
@@ -503,6 +514,10 @@ impl Tool for MessageSubagentTool {
             "required": ["name_or_id", "message"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default().with_long_running(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {

--- a/crates/core/src/capabilities/test_math.rs
+++ b/crates/core/src/capabilities/test_math.rs
@@ -1,6 +1,7 @@
 //! TestMath Capability - calculator tools for testing tool calling
 
 use super::{Capability, CapabilityStatus};
+use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
 use async_trait::async_trait;
 use serde_json::Value;
@@ -82,6 +83,12 @@ impl Tool for AddTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {
         let a = arguments.get("a").and_then(|v| v.as_f64()).unwrap_or(0.0);
         let b = arguments.get("b").and_then(|v| v.as_f64()).unwrap_or(0.0);
@@ -133,6 +140,12 @@ impl Tool for SubtractTool {
             "required": ["a", "b"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {
@@ -188,6 +201,12 @@ impl Tool for MultiplyTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {
         let a = arguments.get("a").and_then(|v| v.as_f64()).unwrap_or(0.0);
         let b = arguments.get("b").and_then(|v| v.as_f64()).unwrap_or(0.0);
@@ -239,6 +258,12 @@ impl Tool for DivideTool {
             "required": ["a", "b"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {

--- a/crates/core/src/capabilities/test_weather.rs
+++ b/crates/core/src/capabilities/test_weather.rs
@@ -1,6 +1,7 @@
 //! TestWeather Capability - mock weather tools for testing tool calling
 
 use super::{Capability, CapabilityStatus};
+use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
 use async_trait::async_trait;
 use serde_json::Value;
@@ -76,6 +77,13 @@ impl Tool for GetWeatherTool {
             "required": ["location"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+            .with_open_world(true)
     }
 
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {
@@ -165,6 +173,13 @@ impl Tool for GetForecastTool {
             "required": ["location"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+            .with_open_world(true)
     }
 
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {

--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -15,6 +15,7 @@
 
 use super::{Capability, CapabilityStatus};
 use crate::session_file::SessionFile;
+use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::{SessionFileStore, ToolContext};
 use crate::typed_id::SessionId;
@@ -162,6 +163,12 @@ impl Tool for BashTool {
             "required": ["command"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_long_running(true)
+            .with_open_world(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {

--- a/crates/core/src/capabilities/web_fetch.rs
+++ b/crates/core/src/capabilities/web_fetch.rs
@@ -7,6 +7,7 @@
 //! - See specs/fetchkit.md for design details
 
 use super::{Capability, CapabilityStatus, RiskLevel};
+use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::{SessionFileStore, ToolContext};
 use crate::typed_id::SessionId;
@@ -276,6 +277,13 @@ impl Tool for WebFetchTool {
     fn requires_context(&self) -> bool {
         // Needed for save_to_file (SessionFileStore access)
         true
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_open_world(true)
+            .with_long_running(true)
     }
 
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -2952,6 +2952,7 @@ mod contract_tests {
             policy: ToolPolicy::Auto,
             category: None,
             deferrable: DeferrablePolicy::default(),
+            hints: crate::tool_types::ToolHints::default(),
         })];
 
         let data = ActStartedData::with_definitions(&tool_calls, &tool_defs);
@@ -3010,6 +3011,7 @@ mod contract_tests {
             policy: ToolPolicy::Auto,
             category: None,
             deferrable: DeferrablePolicy::default(),
+            hints: crate::tool_types::ToolHints::default(),
         });
 
         let summary = ToolDefinitionSummary::from(&def);

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -202,7 +202,8 @@ pub use atoms::{
 
 // Tool types (runtime types defined in this crate)
 pub use tool_types::{
-    BuiltinTool, ClientSideTool, DeferrablePolicy, ToolCall, ToolDefinition, ToolPolicy, ToolResult,
+    BuiltinTool, ClientSideTool, DeferrablePolicy, ToolCall, ToolDefinition, ToolHints, ToolPolicy,
+    ToolResult,
 };
 
 // Note: CapabilityId and CapabilityStatus are re-exported via capabilities module
@@ -242,10 +243,10 @@ pub use llm_models::{
 };
 pub use mcp_server::{
     McpContent, McpError, McpServer, McpServerAuthMode, McpServerStatus, McpServerTransportType,
-    McpToolCallParams, McpToolCallRequest, McpToolCallResponse, McpToolCallResult,
-    McpToolDefinition, McpToolsListRequest, McpToolsListResponse, McpToolsListResult, is_mcp_tool,
-    mcp_oauth_provider_id_for_uuid, mcp_oauth_session_secret_name, mcp_tool_name,
-    parse_mcp_tool_name,
+    McpToolAnnotations, McpToolCallParams, McpToolCallRequest, McpToolCallResponse,
+    McpToolCallResult, McpToolDefinition, McpToolsListRequest, McpToolsListResponse,
+    McpToolsListResult, is_mcp_tool, mcp_oauth_provider_id_for_uuid, mcp_oauth_session_secret_name,
+    mcp_tool_name, parse_mcp_tool_name,
 };
 pub use organization::{
     ANONYMOUS_USER_EMAIL, ANONYMOUS_USER_ID, ANONYMOUS_USER_NAME, DEFAULT_ORG_ID,

--- a/crates/core/src/mcp_server.rs
+++ b/crates/core/src/mcp_server.rs
@@ -187,6 +187,41 @@ pub struct McpToolDefinition {
     /// JSON Schema describing the tool's input parameters.
     #[serde(rename = "inputSchema")]
     pub input_schema: Value,
+    /// MCP tool annotations (behavioral hints).
+    /// See: https://spec.modelcontextprotocol.io
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<McpToolAnnotations>,
+}
+
+/// MCP tool annotations as defined by the MCP specification.
+/// All fields are optional booleans following the MCP convention.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct McpToolAnnotations {
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "readOnlyHint"
+    )]
+    pub read_only_hint: Option<bool>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "destructiveHint"
+    )]
+    pub destructive_hint: Option<bool>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "idempotentHint"
+    )]
+    pub idempotent_hint: Option<bool>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "openWorldHint"
+    )]
+    pub open_world_hint: Option<bool>,
 }
 
 /// Request for MCP tools/list endpoint.

--- a/crates/core/src/memory.rs
+++ b/crates/core/src/memory.rs
@@ -902,6 +902,7 @@ mod tests {
             policy: crate::tool_types::ToolPolicy::Auto,
             category: None,
             deferrable: crate::tool_types::DeferrablePolicy::default(),
+            hints: crate::tool_types::ToolHints::default(),
         });
 
         let result = executor.execute(&tool_call, &tool_def).await.unwrap();

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -2699,6 +2699,7 @@ mod tests {
             policy: crate::tool_types::ToolPolicy::Auto,
             category: category.map(|s| s.to_string()),
             deferrable,
+            hints: crate::tool_types::ToolHints::default(),
         })
     }
 

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -628,6 +628,7 @@ mod tests {
             }),
             category: None,
             deferrable: DeferrablePolicy::default(),
+            hints: crate::tool_types::ToolHints::default(),
         });
 
         let agent = Agent {
@@ -679,6 +680,7 @@ mod tests {
             parameters: serde_json::json!({"type": "object"}),
             category: None,
             deferrable: DeferrablePolicy::default(),
+            hints: crate::tool_types::ToolHints::default(),
         });
 
         let agent = Agent {
@@ -880,6 +882,7 @@ mod tests {
                 policy: ToolPolicy::Auto,
                 category: None,
                 deferrable: Default::default(),
+                hints: crate::tool_types::ToolHints::default(),
             })
         };
 

--- a/crates/core/src/tool_types.rs
+++ b/crates/core/src/tool_types.rs
@@ -87,6 +87,9 @@ pub struct BuiltinTool {
     /// Whether this tool's schema can be deferred via tool_search
     #[serde(default, skip_serializing_if = "DeferrablePolicy::is_default")]
     pub deferrable: DeferrablePolicy,
+    /// Semantic hints describing the tool's behavioral properties
+    #[serde(default, skip_serializing_if = "ToolHints::is_empty")]
+    pub hints: ToolHints,
 }
 
 /// Client-side tool - executed by the client, not the server
@@ -109,6 +112,9 @@ pub struct ClientSideTool {
     /// Whether this tool's schema can be deferred via tool_search
     #[serde(default, skip_serializing_if = "DeferrablePolicy::is_default")]
     pub deferrable: DeferrablePolicy,
+    /// Semantic hints describing the tool's behavioral properties
+    #[serde(default, skip_serializing_if = "ToolHints::is_empty")]
+    pub hints: ToolHints,
 }
 
 impl ToolDefinition {
@@ -168,12 +174,118 @@ impl ToolDefinition {
         }
     }
 
+    /// Get the tool hints
+    pub fn hints(&self) -> &ToolHints {
+        match self {
+            ToolDefinition::Builtin(b) => &b.hints,
+            ToolDefinition::ClientSide(c) => &c.hints,
+        }
+    }
+
     /// Set the category on this tool definition (builder pattern)
     pub fn with_category(mut self, category: impl Into<String>) -> Self {
         match &mut self {
             ToolDefinition::Builtin(b) => b.category = Some(category.into()),
             ToolDefinition::ClientSide(c) => c.category = Some(category.into()),
         }
+        self
+    }
+
+    /// Set the hints on this tool definition (builder pattern)
+    pub fn with_hints(mut self, hints: ToolHints) -> Self {
+        match &mut self {
+            ToolDefinition::Builtin(b) => b.hints = hints,
+            ToolDefinition::ClientSide(c) => c.hints = hints,
+        }
+        self
+    }
+}
+
+/// Semantic hints describing a tool's behavioral properties.
+///
+/// Follows the MCP tool annotations convention (readOnlyHint, destructiveHint,
+/// idempotentHint, openWorldHint) plus everruns-specific hints. All fields are
+/// optional booleans — `None` means "unknown/unspecified". Consumers should
+/// treat `None` as the conservative default (e.g., assume not readonly, assume
+/// not idempotent).
+///
+/// These hints are informational — they do not enforce policy. Use `ToolPolicy`
+/// for execution gating (auto vs requires_approval).
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct ToolHints {
+    /// Tool does not modify any state (read-only queries, lookups).
+    /// When true: safe to call speculatively, result can be cached.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub readonly: Option<bool>,
+
+    /// Tool may irreversibly destroy or delete data.
+    /// Subset of non-readonly — a tool can be non-readonly (writes) without
+    /// being destructive (e.g., create/update operations).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub destructive: Option<bool>,
+
+    /// Calling the tool repeatedly with the same arguments produces the same
+    /// effect. Safe to retry on transient failures.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idempotent: Option<bool>,
+
+    /// Tool interacts with external entities beyond the local system
+    /// (network calls, third-party APIs, cloud services).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub open_world: Option<bool>,
+
+    /// Tool requires API keys, credentials, or other secrets to function.
+    /// Useful for UI to show connection prompts and for LLMs to anticipate
+    /// authentication failures.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requires_secrets: Option<bool>,
+
+    /// Tool may take significant time to complete (> ~5s typical).
+    /// Useful for clients to show progress indicators and set timeouts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub long_running: Option<bool>,
+}
+
+impl ToolHints {
+    /// Returns true when all fields are None (default/empty state).
+    pub fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+
+    /// Builder: set readonly hint.
+    pub fn with_readonly(mut self, value: bool) -> Self {
+        self.readonly = Some(value);
+        self
+    }
+
+    /// Builder: set destructive hint.
+    pub fn with_destructive(mut self, value: bool) -> Self {
+        self.destructive = Some(value);
+        self
+    }
+
+    /// Builder: set idempotent hint.
+    pub fn with_idempotent(mut self, value: bool) -> Self {
+        self.idempotent = Some(value);
+        self
+    }
+
+    /// Builder: set open_world hint.
+    pub fn with_open_world(mut self, value: bool) -> Self {
+        self.open_world = Some(value);
+        self
+    }
+
+    /// Builder: set requires_secrets hint.
+    pub fn with_requires_secrets(mut self, value: bool) -> Self {
+        self.requires_secrets = Some(value);
+        self
+    }
+
+    /// Builder: set long_running hint.
+    pub fn with_long_running(mut self, value: bool) -> Self {
+        self.long_running = Some(value);
         self
     }
 }
@@ -311,6 +423,7 @@ mod tests {
             policy: ToolPolicy::RequiresApproval,
             category: None,
             deferrable: DeferrablePolicy::default(),
+            hints: ToolHints::default(),
         });
 
         assert_eq!(tool.name(), "test_tool");
@@ -330,6 +443,7 @@ mod tests {
             policy: ToolPolicy::Auto,
             category: None,
             deferrable: DeferrablePolicy::default(),
+            hints: ToolHints::default(),
         });
         assert_eq!(builtin.display_name(), Some("Get Weather"));
 
@@ -340,6 +454,7 @@ mod tests {
             parameters: serde_json::json!({}),
             category: None,
             deferrable: DeferrablePolicy::default(),
+            hints: ToolHints::default(),
         });
         assert_eq!(client.display_name(), Some("Deploy"));
     }
@@ -354,6 +469,7 @@ mod tests {
             policy: ToolPolicy::Auto,
             category: None,
             deferrable: DeferrablePolicy::default(),
+            hints: ToolHints::default(),
         };
         let json = serde_json::to_string(&tool).unwrap();
         assert!(!json.contains("display_name"));
@@ -366,6 +482,7 @@ mod tests {
             policy: ToolPolicy::Auto,
             category: None,
             deferrable: DeferrablePolicy::default(),
+            hints: ToolHints::default(),
         };
         let json = serde_json::to_string(&tool_with).unwrap();
         assert!(json.contains("\"display_name\":\"Test\""));
@@ -437,6 +554,7 @@ mod tests {
             parameters: serde_json::json!({"type": "object"}),
             category: None,
             deferrable: DeferrablePolicy::default(),
+            hints: ToolHints::default(),
         });
 
         let json = serde_json::to_string(&tool).unwrap();
@@ -462,6 +580,7 @@ mod tests {
             }),
             category: None,
             deferrable: DeferrablePolicy::default(),
+            hints: ToolHints::default(),
         });
 
         assert_eq!(tool.name(), "deploy_app");
@@ -480,6 +599,7 @@ mod tests {
             parameters: serde_json::json!({}),
             category: None,
             deferrable: DeferrablePolicy::default(),
+            hints: ToolHints::default(),
         });
         assert_eq!(tool.policy(), &ToolPolicy::ClientSide);
     }
@@ -511,6 +631,7 @@ mod tests {
                 policy: ToolPolicy::Auto,
                 category: None,
                 deferrable: DeferrablePolicy::default(),
+                hints: ToolHints::default(),
             }),
             ToolDefinition::ClientSide(ClientSideTool {
                 name: "client_tool".to_string(),
@@ -519,6 +640,7 @@ mod tests {
                 parameters: serde_json::json!({"type": "object"}),
                 category: None,
                 deferrable: DeferrablePolicy::default(),
+                hints: ToolHints::default(),
             }),
         ];
 
@@ -530,5 +652,123 @@ mod tests {
         assert!(matches!(&parsed[1], ToolDefinition::ClientSide(_)));
         assert_eq!(parsed[0].policy(), &ToolPolicy::Auto);
         assert_eq!(parsed[1].policy(), &ToolPolicy::ClientSide);
+    }
+
+    #[test]
+    fn test_tool_hints_default_is_empty() {
+        let hints = ToolHints::default();
+        assert!(hints.is_empty());
+        assert_eq!(hints.readonly, None);
+        assert_eq!(hints.destructive, None);
+        assert_eq!(hints.idempotent, None);
+        assert_eq!(hints.open_world, None);
+        assert_eq!(hints.requires_secrets, None);
+        assert_eq!(hints.long_running, None);
+    }
+
+    #[test]
+    fn test_tool_hints_builder() {
+        let hints = ToolHints::default()
+            .with_readonly(true)
+            .with_destructive(false)
+            .with_idempotent(true)
+            .with_open_world(true)
+            .with_requires_secrets(true)
+            .with_long_running(false);
+
+        assert!(!hints.is_empty());
+        assert_eq!(hints.readonly, Some(true));
+        assert_eq!(hints.destructive, Some(false));
+        assert_eq!(hints.idempotent, Some(true));
+        assert_eq!(hints.open_world, Some(true));
+        assert_eq!(hints.requires_secrets, Some(true));
+        assert_eq!(hints.long_running, Some(false));
+    }
+
+    #[test]
+    fn test_tool_hints_serialization_skip_empty() {
+        let tool = BuiltinTool {
+            name: "test".to_string(),
+            display_name: None,
+            description: "test".to_string(),
+            parameters: serde_json::json!({}),
+            policy: ToolPolicy::Auto,
+            category: None,
+            deferrable: DeferrablePolicy::default(),
+            hints: ToolHints::default(),
+        };
+        let json = serde_json::to_string(&tool).unwrap();
+        assert!(!json.contains("hints"), "empty hints should be skipped");
+    }
+
+    #[test]
+    fn test_tool_hints_serialization_present() {
+        let tool = BuiltinTool {
+            name: "test".to_string(),
+            display_name: None,
+            description: "test".to_string(),
+            parameters: serde_json::json!({}),
+            policy: ToolPolicy::Auto,
+            category: None,
+            deferrable: DeferrablePolicy::default(),
+            hints: ToolHints::default()
+                .with_readonly(true)
+                .with_idempotent(true),
+        };
+        let json = serde_json::to_string(&tool).unwrap();
+        assert!(json.contains("\"hints\""));
+        assert!(json.contains("\"readonly\":true"));
+        assert!(json.contains("\"idempotent\":true"));
+        // Unset hints should not appear
+        assert!(!json.contains("destructive"));
+        assert!(!json.contains("open_world"));
+    }
+
+    #[test]
+    fn test_tool_hints_deserialization_missing() {
+        let json = r#"{
+            "type": "builtin",
+            "name": "test",
+            "description": "test",
+            "parameters": {}
+        }"#;
+        let tool: ToolDefinition = serde_json::from_str(json).unwrap();
+        assert!(tool.hints().is_empty());
+    }
+
+    #[test]
+    fn test_tool_hints_deserialization_present() {
+        let json = r#"{
+            "type": "builtin",
+            "name": "test",
+            "description": "test",
+            "parameters": {},
+            "hints": {"readonly": true, "open_world": true, "requires_secrets": true}
+        }"#;
+        let tool: ToolDefinition = serde_json::from_str(json).unwrap();
+        let hints = tool.hints();
+        assert_eq!(hints.readonly, Some(true));
+        assert_eq!(hints.open_world, Some(true));
+        assert_eq!(hints.requires_secrets, Some(true));
+        assert_eq!(hints.destructive, None);
+        assert_eq!(hints.idempotent, None);
+        assert_eq!(hints.long_running, None);
+    }
+
+    #[test]
+    fn test_tool_definition_with_hints_builder() {
+        let tool = ToolDefinition::Builtin(BuiltinTool {
+            name: "test".to_string(),
+            display_name: None,
+            description: "test".to_string(),
+            parameters: serde_json::json!({}),
+            policy: ToolPolicy::Auto,
+            category: None,
+            deferrable: DeferrablePolicy::default(),
+            hints: ToolHints::default(),
+        })
+        .with_hints(ToolHints::default().with_readonly(true));
+
+        assert_eq!(tool.hints().readonly, Some(true));
     }
 }

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use tracing::error;
 
 use crate::tool_types::{
-    BuiltinTool, DeferrablePolicy, ToolCall, ToolDefinition, ToolPolicy, ToolResult,
+    BuiltinTool, DeferrablePolicy, ToolCall, ToolDefinition, ToolHints, ToolPolicy, ToolResult,
 };
 use crate::traits::ToolContext;
 
@@ -391,6 +391,14 @@ pub trait Tool: Send + Sync {
         ToolPolicy::Auto
     }
 
+    /// Returns semantic hints describing the tool's behavioral properties.
+    ///
+    /// Override to provide hints like readonly, destructive, idempotent, etc.
+    /// Default is empty (all hints unspecified).
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+    }
+
     /// Convert this tool to a ToolDefinition for the agent config.
     ///
     /// This is used by ToolRegistry to generate tool definitions
@@ -404,6 +412,7 @@ pub trait Tool: Send + Sync {
             policy: self.policy(),
             category: None,
             deferrable: DeferrablePolicy::default(),
+            hints: self.hints(),
         })
     }
 }
@@ -692,6 +701,12 @@ impl Tool for EchoTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {
         let message = arguments
             .get("message")
@@ -755,6 +770,12 @@ impl Tool for FailingTool {
             "properties": {},
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {

--- a/crates/core/tests/tool_calling_test.rs
+++ b/crates/core/tests/tool_calling_test.rs
@@ -5,7 +5,7 @@
 
 use async_trait::async_trait;
 use everruns_core::{
-    BuiltinTool, DeferrablePolicy, ToolCall, ToolDefinition, ToolPolicy, ToolResultImage,
+    BuiltinTool, DeferrablePolicy, ToolCall, ToolDefinition, ToolHints, ToolPolicy, ToolResultImage,
 };
 use everruns_core::{
     GetCurrentTimeTool, Message, MessageRetriever, MessageRole, SessionId,
@@ -45,6 +45,7 @@ async fn test_tool_registry_as_executor() {
         policy: ToolPolicy::Auto,
         category: None,
         deferrable: DeferrablePolicy::default(),
+        hints: ToolHints::default(),
     });
 
     // Execute via ToolExecutor trait
@@ -72,6 +73,7 @@ async fn test_get_current_time_tool() {
         policy: ToolPolicy::Auto,
         category: None,
         deferrable: DeferrablePolicy::default(),
+        hints: ToolHints::default(),
     });
 
     let result = registry.execute(&tool_call, &tool_def).await.unwrap();
@@ -103,6 +105,7 @@ async fn test_tool_error_handling() {
         policy: ToolPolicy::Auto,
         category: None,
         deferrable: DeferrablePolicy::default(),
+        hints: ToolHints::default(),
     });
 
     // Execute and verify error is packaged as {"error": "..."} in result field
@@ -136,6 +139,7 @@ async fn test_internal_error_is_hidden() {
         policy: ToolPolicy::Auto,
         category: None,
         deferrable: DeferrablePolicy::default(),
+        hints: ToolHints::default(),
     });
 
     // Execute and verify internal error is hidden (packaged as {"error": "..."} with generic message)
@@ -167,6 +171,7 @@ async fn test_tool_not_found_error() {
         policy: ToolPolicy::Auto,
         category: None,
         deferrable: DeferrablePolicy::default(),
+        hints: ToolHints::default(),
     });
 
     // Should return error for tool not found
@@ -234,6 +239,7 @@ async fn test_custom_tool_execution() {
         policy: ToolPolicy::Auto,
         category: None,
         deferrable: DeferrablePolicy::default(),
+        hints: ToolHints::default(),
     });
 
     // Execute multiple times
@@ -275,6 +281,7 @@ async fn test_multiple_tools_in_registry() {
         policy: ToolPolicy::Auto,
         category: None,
         deferrable: DeferrablePolicy::default(),
+        hints: ToolHints::default(),
     });
 
     let time_result = registry.execute(&time_call, &time_def).await.unwrap();
@@ -296,6 +303,7 @@ async fn test_multiple_tools_in_registry() {
         policy: ToolPolicy::Auto,
         category: None,
         deferrable: DeferrablePolicy::default(),
+        hints: ToolHints::default(),
     });
 
     let echo_result = registry.execute(&echo_call, &echo_def).await.unwrap();

--- a/crates/gemini/src/driver.rs
+++ b/crates/gemini/src/driver.rs
@@ -1051,6 +1051,7 @@ mod tests {
             policy: ToolPolicy::Auto,
             category: None,
             deferrable: DeferrablePolicy::default(),
+            hints: everruns_core::tool_types::ToolHints::default(),
         })];
 
         let gemini_tools = GeminiLlmDriver::convert_tools(&tools);
@@ -1079,6 +1080,7 @@ mod tests {
             policy: ToolPolicy::Auto,
             category: None,
             deferrable: DeferrablePolicy::default(),
+            hints: everruns_core::tool_types::ToolHints::default(),
         })];
 
         let gemini_tools = GeminiLlmDriver::convert_tools(&tools).unwrap();

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1186,6 +1186,7 @@ impl DirectWorkerAdapters {
                     policy: ToolPolicy::Auto,
                     category: None,
                     deferrable: DeferrablePolicy::default(),
+                    hints: everruns_core::tool_types::ToolHints::default().with_open_world(true),
                 }));
             }
         }

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -192,13 +192,14 @@ use utoipa::OpenApi;
             // Tool types
             ToolCall,
             everruns_core::ToolDefinition, everruns_core::BuiltinTool, everruns_core::ClientSideTool,
-            everruns_core::ToolPolicy,
+            everruns_core::ToolPolicy, everruns_core::ToolHints,
             everruns_core::ToolCallRequestedData,
             api::tool_results::SubmitToolResultsRequest,
             api::tool_results::ClientToolResult,
             api::tool_results::SubmitToolResultsResponse,
             // MCP Server types
             McpServer, McpServerStatus, McpServerTransportType,
+            everruns_core::mcp_server::McpToolAnnotations,
             api::mcp_servers::CreateMcpServerRequest,
             api::mcp_servers::UpdateMcpServerRequest,
             ListResponse<McpServer>,

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -625,6 +625,7 @@ mod tests {
                 policy: ToolPolicy::Auto,
                 category: None,
                 deferrable: DeferrablePolicy::default(),
+                hints: everruns_core::tool_types::ToolHints::default(),
             })],
             locale: None,
             blueprint_id: None,

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -1281,6 +1281,9 @@ fn proto_mcp_tool_def_to_tool_definition(
         policy: ToolPolicy::Auto, // MCP tools are auto-executed
         category: None,
         deferrable: DeferrablePolicy::default(),
+        // MCP tools are remote/networked; default open_world to true.
+        // Full annotation propagation requires extending the internal proto.
+        hints: everruns_core::tool_types::ToolHints::default().with_open_world(true),
     })
 }
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4905,6 +4905,10 @@
             ],
             "description": "Human-readable display name for UI rendering (e.g., \"Get Current Time\" for `get_current_time`)"
           },
+          "hints": {
+            "$ref": "#/components/schemas/ToolHints",
+            "description": "Semantic hints describing the tool's behavioral properties"
+          },
           "name": {
             "type": "string",
             "description": "Tool name (used by LLM and for registry lookup)"
@@ -5057,6 +5061,10 @@
               "null"
             ],
             "description": "Human-readable display name for UI rendering"
+          },
+          "hints": {
+            "$ref": "#/components/schemas/ToolHints",
+            "description": "Semantic hints describing the tool's behavioral properties"
           },
           "name": {
             "type": "string",
@@ -9097,6 +9105,36 @@
           "http"
         ]
       },
+      "McpToolAnnotations": {
+        "type": "object",
+        "description": "MCP tool annotations as defined by the MCP specification.\nAll fields are optional booleans following the MCP convention.",
+        "properties": {
+          "destructiveHint": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "idempotentHint": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "openWorldHint": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "readOnlyHint": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        }
+      },
       "Message": {
         "type": "object",
         "description": "A message in the conversation",
@@ -11427,6 +11465,54 @@
           "name": {
             "type": "string",
             "description": "Tool name"
+          }
+        }
+      },
+      "ToolHints": {
+        "type": "object",
+        "description": "Semantic hints describing a tool's behavioral properties.\n\nFollows the MCP tool annotations convention (readOnlyHint, destructiveHint,\nidempotentHint, openWorldHint) plus everruns-specific hints. All fields are\noptional booleans — `None` means \"unknown/unspecified\". Consumers should\ntreat `None` as the conservative default (e.g., assume not readonly, assume\nnot idempotent).\n\nThese hints are informational — they do not enforce policy. Use `ToolPolicy`\nfor execution gating (auto vs requires_approval).",
+        "properties": {
+          "destructive": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Tool may irreversibly destroy or delete data.\nSubset of non-readonly — a tool can be non-readonly (writes) without\nbeing destructive (e.g., create/update operations)."
+          },
+          "idempotent": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Calling the tool repeatedly with the same arguments produces the same\neffect. Safe to retry on transient failures."
+          },
+          "long_running": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Tool may take significant time to complete (> ~5s typical).\nUseful for clients to show progress indicators and set timeouts."
+          },
+          "open_world": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Tool interacts with external entities beyond the local system\n(network calls, third-party APIs, cloud services)."
+          },
+          "readonly": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Tool does not modify any state (read-only queries, lookups).\nWhen true: safe to call speculatively, result can be cached."
+          },
+          "requires_secrets": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Tool requires API keys, credentials, or other secrets to function.\nUseful for UI to show connection prompts and for LLMs to anticipate\nauthentication failures."
           }
         }
       },

--- a/integrations/brave-search/src/tools.rs
+++ b/integrations/brave-search/src/tools.rs
@@ -1,5 +1,6 @@
 //! Tool implementations for Brave Search operations.
 
+use everruns_core::ToolHints;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
 
@@ -98,6 +99,14 @@ impl Tool for BraveWebSearchTool {
             "required": ["query"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+            .with_open_world(true)
+            .with_requires_secrets(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {

--- a/integrations/browserless/src/session_tools.rs
+++ b/integrations/browserless/src/session_tools.rs
@@ -6,6 +6,7 @@
 //! Decision: Each tool call reconnects → does work → calls reconnect → disconnects.
 //!   No long-lived WebSocket connections. The browser stays alive on Browserless servers.
 
+use everruns_core::ToolHints;
 use everruns_core::UpsertLeasedResource;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
@@ -128,6 +129,13 @@ impl Tool for BrowserlessOpenBrowserTool {
             },
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_requires_secrets(true)
+            .with_long_running(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -320,6 +328,13 @@ impl Tool for BrowserlessCloseBrowserTool {
             "properties": {},
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_requires_secrets(true)
+            .with_destructive(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {

--- a/integrations/browserless/src/tools.rs
+++ b/integrations/browserless/src/tools.rs
@@ -11,6 +11,7 @@
 //! the persistent browser, preserving login state and cookies across tool calls.
 //! When no session exists, each tool call uses a fresh browser via REST API.
 
+use everruns_core::ToolHints;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
 
@@ -101,6 +102,14 @@ impl Tool for BrowserlessScreenshotTool {
             "required": ["url"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_open_world(true)
+            .with_requires_secrets(true)
+            .with_long_running(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -246,6 +255,14 @@ impl Tool for BrowserlessContentTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_open_world(true)
+            .with_requires_secrets(true)
+            .with_long_running(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error("browserless_content requires context.")
     }
@@ -386,6 +403,14 @@ impl Tool for BrowserlessScrapeTool {
             "required": ["url", "elements"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_open_world(true)
+            .with_requires_secrets(true)
+            .with_long_running(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -650,6 +675,13 @@ impl Tool for BrowserlessInteractTool {
             "required": ["url", "steps"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_requires_secrets(true)
+            .with_long_running(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -929,6 +961,13 @@ impl Tool for BrowserlessNavigateTool {
             "required": ["url"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_requires_secrets(true)
+            .with_long_running(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -1,5 +1,6 @@
 //! Tool implementations for Daytona sandbox operations.
 
+use everruns_core::ToolHints;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
 
@@ -103,6 +104,13 @@ impl Tool for DaytonaCreateSandboxTool {
             },
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_requires_secrets(true)
+            .with_long_running(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -334,6 +342,13 @@ impl Tool for DaytonaExecTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_requires_secrets(true)
+            .with_long_running(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
             "daytona_exec requires context. This tool must be executed with session context.",
@@ -424,6 +439,13 @@ impl Tool for DaytonaReadFileTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_open_world(true)
+            .with_requires_secrets(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
             "daytona_read_file requires context. This tool must be executed with session context.",
@@ -511,6 +533,12 @@ impl Tool for DaytonaWriteFileTool {
             "required": ["sandbox_id", "path", "content"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_requires_secrets(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -606,6 +634,14 @@ impl Tool for DaytonaDownloadWorkspaceTool {
             "required": ["sandbox_id"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_open_world(true)
+            .with_requires_secrets(true)
+            .with_long_running(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -768,6 +804,14 @@ impl Tool for DaytonaListSandboxesTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+            .with_open_world(true)
+            .with_requires_secrets(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
             "daytona_list_sandboxes requires context. This tool must be executed with session context.",
@@ -839,6 +883,13 @@ impl Tool for DaytonaManageSandboxTool {
             "required": ["sandbox_id", "action"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_requires_secrets(true)
+            .with_destructive(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -953,6 +1004,13 @@ impl Tool for DaytonaGitCloneTool {
             "required": ["sandbox_id", "repo_url"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_requires_secrets(true)
+            .with_long_running(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -1113,6 +1171,12 @@ impl Tool for DaytonaGitCredentialsTool {
             "required": ["sandbox_id"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_requires_secrets(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {

--- a/integrations/deno/src/tools.rs
+++ b/integrations/deno/src/tools.rs
@@ -4,6 +4,7 @@
 //! write, list, delete.
 
 use async_trait::async_trait;
+use everruns_core::ToolHints;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
 use serde_json::{Value, json};
@@ -82,6 +83,13 @@ impl Tool for DenoCreateSandboxTool {
             },
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_requires_secrets(true)
+            .with_long_running(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -223,6 +231,13 @@ impl Tool for DenoExecTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_requires_secrets(true)
+            .with_long_running(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
             "deno_exec requires context. This tool must be executed with session context.",
@@ -318,6 +333,13 @@ impl Tool for DenoReadFileTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_open_world(true)
+            .with_requires_secrets(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
             "deno_read_file requires context. This tool must be executed with session context.",
@@ -392,6 +414,12 @@ impl Tool for DenoWriteFileTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_requires_secrets(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
             "deno_write_file requires context. This tool must be executed with session context.",
@@ -464,6 +492,14 @@ impl Tool for DenoListSandboxesTool {
         json!({ "type": "object", "properties": {}, "additionalProperties": false })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+            .with_open_world(true)
+            .with_requires_secrets(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
             "deno_list_sandboxes requires context. This tool must be executed with session context.",
@@ -520,6 +556,13 @@ impl Tool for DenoManageSandboxTool {
             "required": ["sandbox_id", "action"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_requires_secrets(true)
+            .with_destructive(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {

--- a/integrations/docker/src/lib.rs
+++ b/integrations/docker/src/lib.rs
@@ -17,6 +17,7 @@
 //! }
 //! ```
 
+use everruns_core::ToolHints;
 use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin, RiskLevel};
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
@@ -331,6 +332,12 @@ impl Tool for DockerExecTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_long_running(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
             "docker_exec requires context. This tool must be executed with session context.",
@@ -447,6 +454,12 @@ impl Tool for DockerReadFileTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_open_world(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
             "docker_read_file requires context. This tool must be executed with session context.",
@@ -554,6 +567,10 @@ impl Tool for DockerWriteFileTool {
             "required": ["path", "content"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default().with_open_world(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -677,6 +694,12 @@ impl Tool for DockerStopTool {
             },
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_destructive(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -814,6 +837,13 @@ impl Tool for DockerLogsTool {
             },
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_open_world(true)
+            .with_idempotent(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {

--- a/integrations/duckduckgo/src/tools.rs
+++ b/integrations/duckduckgo/src/tools.rs
@@ -1,5 +1,6 @@
 //! Tool implementations for DuckDuckGo operations.
 
+use everruns_core::ToolHints;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
 
@@ -43,6 +44,13 @@ impl Tool for DuckDuckGoSearchTool {
             "required": ["query"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+            .with_open_world(true)
     }
 
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {

--- a/integrations/e2b/src/tools.rs
+++ b/integrations/e2b/src/tools.rs
@@ -1,6 +1,7 @@
 //! Tool implementations for E2B sandboxes.
 
 use async_trait::async_trait;
+use everruns_core::ToolHints;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
 use serde_json::{Value, json};
@@ -86,6 +87,13 @@ impl Tool for E2BCreateSandboxTool {
             },
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_requires_secrets(true)
+            .with_long_running(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -239,6 +247,13 @@ impl Tool for E2BExecTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_requires_secrets(true)
+            .with_long_running(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
             "e2b_exec requires context. This tool must be executed with session context.",
@@ -324,6 +339,13 @@ impl Tool for E2BReadFileTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_open_world(true)
+            .with_requires_secrets(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
             "e2b_read_file requires context. This tool must be executed with session context.",
@@ -390,6 +412,12 @@ impl Tool for E2BWriteFileTool {
             "required": ["sandbox_id", "path", "content"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_requires_secrets(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -459,6 +487,14 @@ impl Tool for E2BListSandboxesTool {
         })
     }
 
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+            .with_open_world(true)
+            .with_requires_secrets(true)
+    }
+
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         ToolExecutionResult::tool_error(
             "e2b_list_sandboxes requires context. This tool must be executed with session context.",
@@ -513,6 +549,13 @@ impl Tool for E2BManageSandboxTool {
             "required": ["sandbox_id", "action"],
             "additionalProperties": false
         })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_requires_secrets(true)
+            .with_destructive(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -54,6 +54,28 @@ Tools can also be provided by Capabilities (see [capabilities.md](capabilities.m
 
 **ToolRegistry:** Manages multiple tools and implements `ToolExecutor` trait. See `crates/core/src/tools.rs` for `ToolRegistry` and its builder pattern.
 
+### Tool Hints
+
+`ToolHints` provides semantic metadata about a tool's behavioral properties. See `crates/core/src/tool_types.rs` for the struct definition. All fields are `Option<bool>` — `None` means unspecified.
+
+Follows the [MCP tool annotations](https://spec.modelcontextprotocol.io) convention plus everruns-specific hints:
+
+| Hint | Meaning | Conservative default (when `None`) |
+|------|---------|-------------------------------------|
+| `readonly` | Tool does not modify any state | Assume not readonly |
+| `destructive` | Tool may irreversibly destroy data | Assume not destructive |
+| `idempotent` | Same args → same effect; safe to retry | Assume not idempotent |
+| `open_world` | Interacts with external entities (network, APIs) | Assume closed-world |
+| `requires_secrets` | Needs API keys or credentials | Assume no secrets needed |
+| `long_running` | May take significant time (> ~5s typical) | Assume fast |
+
+**Design rules:**
+- Hints are informational — they do not enforce policy. Use `ToolPolicy` for execution gating.
+- Tools should set hints via the `Tool::hints()` trait method or directly on `BuiltinTool.hints`.
+- MCP server tools inherit hints from MCP `annotations` when available.
+- External toolkit libraries expose hints via the `Tool::hints()` method in the toolkit library contract.
+- `destructive` is a subset of non-readonly — a tool can write without being destructive.
+
 ### Tool Policies
 
 - `auto`: Execute immediately without approval

--- a/specs/toolkit-library-contract.md
+++ b/specs/toolkit-library-contract.md
@@ -162,6 +162,13 @@ impl Tool {
     /// See §2a for schema authoring rules.
     fn input_schema(&self) -> serde_json::Value;
 
+    /// Semantic hints describing the tool's behavioral properties.
+    /// Follows the MCP annotations convention (readonly, destructive,
+    /// idempotent, open_world) plus everruns-specific hints (requires_secrets,
+    /// long_running). See `everruns_core::ToolHints` for field definitions.
+    /// Returns `ToolHints::default()` (all unspecified) if not overridden.
+    fn hints(&self) -> ToolHints;
+
     /// Terse system prompt addition for the LLM.
     /// Must start with tool name (e.g. "web_fetch: ..."). No title/header.
     /// Minimal tokens — only behavior the LLM can't infer from the schema.


### PR DESCRIPTION
## What
Add a `ToolHints` struct to tool definitions (`BuiltinTool` and `ClientSideTool`) that carries semantic metadata about tool behavior: `readonly`, `destructive`, `idempotent`, `open_world`, `requires_secrets`, `long_running`.

## Why
Tool hints enable smarter tool routing, UI affordances (e.g., confirmation for destructive tools), and align with the MCP tool annotations convention. LLM drivers and orchestrators can use hints to make better decisions about tool execution without inspecting tool implementations.

## How
- Added `ToolHints` struct in `crates/core/src/tool_types.rs` with builder methods
- Extended `Tool` trait with a default `hints()` method
- Populated hints on all built-in capabilities and integration tools
- Propagated `hints` field through MCP server registration, OpenAPI schema, and UI types
- Updated `specs/tool-execution.md` and `specs/toolkit-library-contract.md`

## Risk
- Low
- Purely additive change. All hints default to `None`/unset. No behavioral changes to existing tool execution paths.

## Security
- No security-relevant code changes. This is metadata-only — hints are informational annotations on tool definitions. No changes to authentication, authorization, tool execution, input validation, or data flow.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)