### PR TITLE
fix(docs): fix mermaid diagram rendering in docs site

### DIFF
--- a/apps/docs/src/components/Head.astro
+++ b/apps/docs/src/components/Head.astro
@@ -29,6 +29,20 @@ import DefaultHead from "@astrojs/starlight/components/Head.astro";
   const isPreElement = (value: Element | null): value is HTMLPreElement =>
     value instanceof HTMLPreElement;
 
+  // Expressive Code wraps each line in a <div class="ec-line"> element.
+  // textContent concatenates text nodes without newlines between block
+  // elements, producing a single-line string that mermaid cannot parse.
+  // Join each line's text with newlines to reconstruct valid source.
+  const extractSource = (el: Element): string => {
+    const lines = el.querySelectorAll(".ec-line");
+    if (lines.length > 0) {
+      return Array.from(lines)
+        .map((line) => line.textContent ?? "")
+        .join("\n");
+    }
+    return el.textContent ?? "";
+  };
+
   const prepareBlock = (
     block: HTMLPreElement,
     source: string | null | undefined
@@ -49,7 +63,7 @@ import DefaultHead from "@astrojs/starlight/components/Head.astro";
       document.querySelectorAll('pre[data-language="mermaid"]')
     )
       .map((block) =>
-        block instanceof HTMLPreElement ? prepareBlock(block, block.textContent) : null
+        block instanceof HTMLPreElement ? prepareBlock(block, extractSource(block)) : null
       )
       .filter((block): block is HTMLPreElement => block !== null);
 
@@ -59,7 +73,7 @@ import DefaultHead from "@astrojs/starlight/components/Head.astro";
       .map((code): HTMLPreElement | null => {
         const container = code.parentElement;
         if (!isPreElement(container)) return null;
-        return prepareBlock(container, code.textContent);
+        return prepareBlock(container, extractSource(code));
       })
       .filter((block): block is HTMLPreElement => block !== null);
 


### PR DESCRIPTION
## What

Fix mermaid diagrams rendering as raw code blocks on the documentation site.

## Why

Expressive Code (Starlight's code block renderer) wraps each line in `<div class="ec-line">` elements. The mermaid client-side script used `block.textContent` to extract source, but `textContent` concatenates text nodes **without inserting newlines** between block elements. This produced a single-line string that mermaid could not parse, so diagrams stayed as raw code blocks.

## How

- Add `extractSource()` helper that finds `.ec-line` elements and joins their text with `\n`
- Falls back to `textContent` when no `.ec-line` elements exist (plain code blocks)
- Replace both `block.textContent` / `code.textContent` calls with `extractSource()`

## Risk
- Low
- Only affects mermaid block source extraction in the docs site; no other rendering paths changed

## Security
- No security-relevant code changes — client-side text extraction only, no new inputs or trust boundaries

## Checklist
- [x] Tests added or updated — docs build verified, CSS/JS only
- [x] Backward compatibility considered — falls back to textContent for non-Expressive-Code blocks
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)