### PR TITLE
feat(sprites): add Sprites sandbox integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1694,6 +1694,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-integrations-sprites"
+version = "0.8.7"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "everruns-core",
+ "inventory",
+ "reqwest 0.13.2",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "wiremock",
+]
+
+[[package]]
 name = "everruns-internal-protocol"
 version = "0.8.7"
 dependencies = [
@@ -1788,6 +1804,7 @@ dependencies = [
  "everruns-integrations-docker",
  "everruns-integrations-duckduckgo",
  "everruns-integrations-e2b",
+ "everruns-integrations-sprites",
  "everruns-internal-protocol",
  "everruns-macros",
  "everruns-sdk",
@@ -1874,6 +1891,7 @@ dependencies = [
  "everruns-integrations-docker",
  "everruns-integrations-duckduckgo",
  "everruns-integrations-e2b",
+ "everruns-integrations-sprites",
  "everruns-internal-protocol",
  "everruns-openai",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "integrations/duckduckgo",
     "integrations/browserless",
     "integrations/e2b",
+    "integrations/sprites",
 ]
 
 exclude = [

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -72,6 +72,7 @@ everruns-integrations-daytona = { path = "../../integrations/daytona" }
 everruns-integrations-deno = { path = "../../integrations/deno" }
 everruns-integrations-browserless = { path = "../../integrations/browserless" }
 everruns-integrations-e2b = { path = "../../integrations/e2b" }
+everruns-integrations-sprites = { path = "../../integrations/sprites" }
 everruns-session-sqldb = { path = "../session-sqldb" }
 everruns-worker = { path = "../worker" }  # For AgentRunner trait
 everruns-internal-protocol = { path = "../internal-protocol" }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -11,6 +11,7 @@ extern crate everruns_integrations_deno;
 extern crate everruns_integrations_docker;
 extern crate everruns_integrations_duckduckgo;
 extern crate everruns_integrations_e2b;
+extern crate everruns_integrations_sprites;
 
 // API routes and types (shared for OpenAPI generation)
 pub mod api;

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -58,6 +58,7 @@ mod seed_ids {
     pub const DAYTONA_CODER_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000108);
     pub const E2B_CODER_AGENT: Uuid = Uuid::from_u128(0x0195bb5a_0000_7000_8000_00000000010f);
     pub const DENO_CODER_AGENT: Uuid = Uuid::from_u128(0x0195bb5a_0000_7000_8000_000000000110);
+    pub const SPRITES_CODER_AGENT: Uuid = Uuid::from_u128(0x0195bb5a_0000_7000_8000_000000000111);
     pub const CLOUD_INFRA_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000109);
     pub const PLATFORM_MANAGER_AGENT: Uuid =
         Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000010a);
@@ -686,6 +687,46 @@ Always delete sandboxes when done."#,
         tags: &["coding", "cloud", "sandbox", "deno", "demo", "seed"],
         capabilities: &[
             SeedCapability::new("deno"),
+            SeedCapability::new("session_storage"),
+            SeedCapability::new("session_file_system"),
+        ],
+        dev_only: false,
+    },
+    SeedAgent {
+        id: seed_ids::SPRITES_CODER_AGENT,
+        name: "Sprites Coder",
+        description: "A coding agent that runs code in persistent Firecracker microVMs powered by Sprites",
+        system_prompt: r#"You are a Sprites Coder Agent. You run code in persistent, hardware-isolated Linux microVMs powered by Sprites.
+
+Just call tools directly — the API token is resolved automatically from Settings > Connections.
+
+Workflow:
+1. Create sprite: `sprites_create_sprite` (working directory: /home/user)
+2. Write code / install deps: `sprites_write_file`, `sprites_exec`
+3. Read results: `sprites_read_file`
+4. Checkpoint before risky operations: `sprites_checkpoint`
+5. Roll back if needed: `sprites_restore_checkpoint`
+6. Expose HTTP services: listen on port 8080, get URL with `sprites_service_url`
+7. Clean up: `sprites_manage_sprite` action="delete"
+
+Key features:
+- Persistent filesystem survives idle/hibernation
+- Checkpoints snapshot state in ~300ms for safe rollback
+- Each sprite has a public HTTP URL for serving web apps
+- Instant wake from hibernation (<1s)
+
+Always delete sprites when done to avoid storage charges."#,
+        tags: &[
+            "coding",
+            "cloud",
+            "sandbox",
+            "sprites",
+            "persistent",
+            "demo",
+            "seed",
+        ],
+        capabilities: &[
+            SeedCapability::new("sprites"),
             SeedCapability::new("session_storage"),
             SeedCapability::new("session_file_system"),
         ],

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -23,6 +23,7 @@ everruns-integrations-daytona = { path = "../../integrations/daytona" }
 everruns-integrations-deno = { path = "../../integrations/deno" }
 everruns-integrations-browserless = { path = "../../integrations/browserless" }
 everruns-integrations-e2b = { path = "../../integrations/e2b" }
+everruns-integrations-sprites = { path = "../../integrations/sprites" }
 everruns-openai = { path = "../openai" }
 everruns-anthropic = { path = "../anthropic" }
 everruns-gemini = { path = "../gemini" }

--- a/crates/worker/src/leased_resource_cleanup.rs
+++ b/crates/worker/src/leased_resource_cleanup.rs
@@ -18,6 +18,7 @@ use tracing::{info, warn};
 use crate::worker_adapters::WorkerAdapters;
 
 const DAYTONA_SNAPSHOT_SECRET_PREFIX: &str = "daytona_sandbox:";
+const SPRITES_SECRET_PREFIX: &str = "sprites_sprite:";
 const E2B_SANDBOX_SECRET_PREFIX: &str = "e2b_sandbox:";
 const DENO_SNAPSHOT_SECRET_PREFIX: &str = "deno_sandbox:";
 const BROWSERLESS_SESSION_KEY: &str = "browserless_browser_session";
@@ -199,6 +200,7 @@ async fn cleanup_resource(
         ("daytona", "sandbox") => cleanup_daytona(resource, storage_store, &token).await,
         ("e2b", "sandbox") => cleanup_e2b(resource, storage_store, &token).await,
         ("deno", "sandbox") => cleanup_deno(resource, storage_store, &token).await,
+        ("sprites", "sprite") => cleanup_sprites(resource, storage_store, &token).await,
         ("browserless", "browser_session") => {
             cleanup_browserless(resource, storage_store, &token).await
         }
@@ -369,6 +371,37 @@ async fn cleanup_deno(
     }
 
     Ok(format!("Deleted Deno sandbox {}", resource.external_id))
+}
+
+async fn cleanup_sprites(
+    resource: &LeasedResource,
+    storage_store: &dyn SessionStorageStore,
+    token: &str,
+) -> Result<String> {
+    let client = everruns_integrations_sprites::client::SpritesClient::new(token.to_string());
+
+    match client.delete_sprite(&resource.external_id).await {
+        Ok(()) => {}
+        Err(error) if error.contains("404") || error.contains("not found") => {
+            warn!(
+                sprite_name = %resource.external_id,
+                error = %error,
+                "Sprites sprite already gone during cleanup"
+            );
+        }
+        Err(error) => return Err(anyhow!("Sprites cleanup failed: {error}")),
+    }
+
+    if let Some(session_id) = resource.session_id {
+        let _ = storage_store
+            .delete_secret(
+                session_id,
+                &format!("{SPRITES_SECRET_PREFIX}{}", resource.external_id),
+            )
+            .await;
+    }
+
+    Ok(format!("Deleted Sprites sprite {}", resource.external_id))
 }
 
 async fn cleanup_browserless(

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -6,6 +6,7 @@ extern crate everruns_integrations_deno;
 extern crate everruns_integrations_docker;
 extern crate everruns_integrations_duckduckgo;
 extern crate everruns_integrations_e2b;
+extern crate everruns_integrations_sprites;
 
 pub mod activities;
 pub mod adapters;

--- a/docs/integrations/sprites.md
+++ b/docs/integrations/sprites.md
@@ -1,0 +1,96 @@
+---
+title: Sprites
+description: Integrate Sprites persistent Firecracker microVMs for isolated code execution with filesystem persistence, checkpoints, and HTTP services.
+---
+
+Everruns integrates with [Sprites](https://sprites.dev/) to provide persistent, hardware-isolated Linux microVMs powered by Firecracker. Unlike ephemeral sandboxes, Sprites maintain their filesystem across idle periods, support instant checkpoint/restore, and expose public HTTP endpoints.
+
+## What You Get
+
+- **Persistent Filesystem**: Full ext4 filesystem survives between sessions, backed to durable object storage
+- **Hardware Isolation**: Firecracker VM-level isolation (stronger than containers)
+- **Checkpoints**: Snapshot filesystem state in ~300ms for safe rollback before risky operations
+- **HTTP Services**: Each sprite gets a unique public URL for exposing web services
+- **Instant Wake**: Sprites wake from hibernation in <1 second
+- **Multi-Sprite Sessions**: Create and manage multiple sprites per session
+
+## Quick Start
+
+### 1. Get Your API Token
+
+1. Install the Sprites CLI: `curl https://sprites.dev/install.sh | bash`
+2. Run `sprite login` to authenticate
+3. Copy your token from the CLI output or dashboard
+
+### 2. Connect in Everruns
+
+1. Go to **Settings** > **Connections**
+2. Find **Sprites** in the available providers
+3. Click **Connect** and paste your API token
+
+Once connected, the Sprites capability is automatically available in agent sessions.
+
+### 3. Use in Sessions
+
+Agents with the Sprites capability can use these tools:
+
+| Tool | Description |
+|------|-------------|
+| `sprites_create_sprite` | Create a new Firecracker microVM |
+| `sprites_exec` | Execute shell commands (wakes sprite if hibernating) |
+| `sprites_read_file` | Read files from sprite filesystem |
+| `sprites_write_file` | Write files to sprite filesystem |
+| `sprites_list_sprites` | List sprites in this session |
+| `sprites_manage_sprite` | Delete sprites |
+| `sprites_checkpoint` | Create a filesystem checkpoint |
+| `sprites_restore_checkpoint` | Restore to a previous checkpoint |
+| `sprites_service_url` | Get the public HTTP URL for a sprite |
+
+## Checkpoints
+
+Sprites support instant filesystem checkpointing — a unique capability not found in other sandbox providers:
+
+1. **Before risky operations**: Call `sprites_checkpoint` to snapshot the current state
+2. **If something goes wrong**: Call `sprites_restore_checkpoint` to roll back
+3. **Checkpoints are fast**: ~300ms without interrupting the running sprite
+
+This makes Sprites ideal for iterative development where agents need to experiment safely.
+
+## HTTP Services
+
+Each sprite gets a unique public URL. To expose a web service:
+
+1. Start a web server inside the sprite listening on **port 8080**
+2. Call `sprites_service_url` to get the public URL
+3. Share the URL for testing or preview
+
+## Sprite Lifecycle
+
+```
+Created → Running → Hibernating (idle) → Running (on next command)
+                 ↘ Deleted (explicit)
+```
+
+- **Running**: Active, consuming compute resources
+- **Hibernating**: Idle, no compute charges, filesystem preserved on durable storage
+- **Deleted**: Permanently removed, all data lost
+
+Sprites persist indefinitely until explicitly deleted. They hibernate automatically when idle (no compute charges while idle). Always delete sprites when done to avoid storage charges.
+
+## Pricing
+
+Sprites bill per-second for compute and per-GB-hour for storage:
+
+- **CPU**: $0.07/CPU-hour
+- **Memory**: $0.04375/GB-hour
+- **Storage**: $0.000027/GB-hour (persistent), $0.000683/GB-hour (hot NVMe cache)
+- **Idle**: No compute charges (filesystem still persisted)
+
+New users receive $30 trial credits (~500 sprite sessions).
+
+## Security
+
+- **Firecracker VMs**: Hardware-level isolation between sprites
+- **L3 Network Policies**: Domain whitelisting for outbound connections
+- **Encrypted Credentials**: API token stored in user connections (encrypted at rest)
+- **Leased Resources**: Sprites registered for automatic cleanup on session end

--- a/integrations/sprites/Cargo.toml
+++ b/integrations/sprites/Cargo.toml
@@ -1,0 +1,35 @@
+# Sprites Integration
+# Decision: External integration crate, auto-registered via inventory plugin system
+# Decision: Embrace persistent VMs — sprites survive across sessions, expose HTTP endpoints
+
+[package]
+name = "everruns-integrations-sprites"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Sprites cloud sandbox integration for Everruns"
+
+[dependencies]
+everruns-core = { path = "../../crates/core" }
+inventory.workspace = true
+
+# HTTP client for Sprites API
+reqwest.workspace = true
+
+# Serialization
+serde.workspace = true
+serde_json.workspace = true
+
+# Async
+async-trait.workspace = true
+tokio.workspace = true
+chrono.workspace = true
+tracing.workspace = true
+
+[features]
+sprites-live-tests = []
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full", "test-util"] }
+wiremock = "0.6"

--- a/integrations/sprites/SPEC.md
+++ b/integrations/sprites/SPEC.md
@@ -1,0 +1,86 @@
+# Sprites Capability Specification
+
+## Abstract
+
+The Sprites capability integrates [Sprites](https://sprites.dev/) (Fly.io) persistent, hardware-isolated Linux microVMs as an agent execution environment. Agents can create, manage, and interact with multiple Firecracker VMs per session via the Sprites REST API. Sprites differ from ephemeral sandboxes — they persist filesystems across idle periods, support instant checkpoint/restore, and expose public HTTP endpoints.
+
+**Status**: Available (All environments)
+
+## Architecture
+
+### Single-Tier API
+
+Sprites exposes a single unified REST API:
+
+- **API Base**: `https://api.sprites.dev/v1`
+- **Auth**: `Bearer <api_token>`
+- **Operations**: Sprite lifecycle, exec, filesystem, checkpoints, services
+
+```
+┌────────────────────────────────────────────┐
+│              Agent Session                  │
+│                                             │
+│  Tool Call (sprites_exec, etc.)             │
+│         ↓                                   │
+│  Load SpriteState from session KV store    │
+│         ↓                                   │
+│  ┌─────────────────────────────────────┐   │
+│  │ SpritesClient                       │   │
+│  │  - REST API (all operations)        │   │
+│  └─────────────────────────────────────┘   │
+│         ↓                                   │
+│  Return result to agent                    │
+└────────────────────────────────────────────┘
+```
+
+### State Management
+
+Per-sprite state is stored in session **secrets** (encrypted at rest via AES-256-GCM envelope encryption):
+
+- **Per-sprite state**: secret name `sprites_sprite:{sprite_name}`, value is JSON-serialized `SpriteState`
+
+### API Token Resolution
+
+The Sprites API token is resolved via **user connection** for the `sprites` provider (Settings > Connections).
+If not configured, a `ConnectionRequired` result triggers the UI's inline connection dialog.
+
+### User Connection
+
+Sprites registers as a `ConnectionProviderPlugin` (API-key type). Users configure their token in **Settings > Connections > Sprites**.
+
+See `src/connection.rs` for the full form schema and validation logic.
+
+## Persistence Model
+
+Unlike ephemeral sandbox providers (E2B, Deno), Sprites embraces persistence:
+
+1. **Filesystem persists**: Full ext4 filesystem survives idle/hibernation, backed to durable object storage.
+2. **No auto-delete**: Sprites hibernate when idle (no compute charges), but exist until explicitly deleted.
+3. **Checkpoints**: Snapshot filesystem state in ~300ms for rollback capability.
+4. **HTTP services**: Each sprite has a unique public URL for exposing web services on port 8080.
+
+This means sprite names must be unique per user account (not per session). The integration tracks which sprites belong to this session via session secrets, but the sprites themselves outlive the session.
+
+## Tool Surface
+
+| Tool | API | Description |
+|---|---|---|
+| `sprites_create_sprite` | `PUT /v1/sprites/{name}` | Create a new Firecracker microVM |
+| `sprites_exec` | `POST /v1/sprites/{name}/exec` | Execute shell command (wakes from hibernation) |
+| `sprites_read_file` | `GET /v1/sprites/{name}/files/{path}` | Read file from sprite filesystem |
+| `sprites_write_file` | `PUT /v1/sprites/{name}/files/{path}` | Write file to sprite filesystem |
+| `sprites_list_sprites` | (session state) | List sprites created in this session |
+| `sprites_manage_sprite` | `DELETE /v1/sprites/{name}` | Delete sprite |
+| `sprites_checkpoint` | `POST /v1/sprites/{name}/checkpoints` | Create filesystem checkpoint |
+| `sprites_restore_checkpoint` | `POST /v1/sprites/{name}/checkpoints/{id}/restore` | Restore to checkpoint |
+| `sprites_service_url` | `GET /v1/sprites/{name}` + `GET /v1/sprites/{name}/services` | Get public HTTP URL |
+
+## Security Review
+
+| Category | Assessment |
+|---|---|
+| **Credential storage** | API token stored in user_connections (encrypted). Never in session events. |
+| **Network isolation** | Firecracker VM-level isolation (stronger than containers). L3 network policies. |
+| **Data persistence** | Filesystem persists — users should be aware data outlives sessions. |
+| **Leased resources** | Registered for cleanup; 30-min lease duration. |
+| **Metadata labels** | Sprites tagged with `everruns.*` metadata for audit and orphan cleanup. |

--- a/integrations/sprites/src/client.rs
+++ b/integrations/sprites/src/client.rs
@@ -1,0 +1,602 @@
+//! Sprites API client.
+//!
+//! Decision: Single API tier — all operations go through api.sprites.dev/v1
+//! Decision: Bearer token auth via Authorization header
+
+use serde_json::{Value, json};
+use tracing::debug;
+
+use crate::state::{CheckpointInfo, ExecResult, SpriteInfo};
+
+// ============================================================================
+// SpritesClient - HTTP client for Sprites API
+// ============================================================================
+
+pub struct SpritesClient {
+    http: reqwest::Client,
+    api_token: String,
+    api_base: String,
+}
+
+impl SpritesClient {
+    pub fn new(api_token: String) -> Self {
+        Self::with_base_url(api_token, crate::SPRITES_API_BASE.to_string())
+    }
+
+    pub fn with_base_url(api_token: String, api_base: String) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            api_token,
+            api_base,
+        }
+    }
+
+    // --- Generic request helpers ---
+
+    async fn request(
+        &self,
+        method: reqwest::Method,
+        path: &str,
+        body: Option<Value>,
+    ) -> Result<Value, String> {
+        let url = format!("{}{}", self.api_base, path);
+        let mut req = self
+            .http
+            .request(method, &url)
+            .bearer_auth(&self.api_token)
+            .header("Content-Type", "application/json");
+
+        if let Some(b) = body {
+            req = req.json(&b);
+        }
+
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| format!("Failed to connect to Sprites API: {e}"))?;
+
+        let status = resp.status();
+        let body_text = resp
+            .text()
+            .await
+            .map_err(|e| format!("Failed to read response: {e}"))?;
+
+        if !status.is_success() {
+            return Err(format!("Sprites API error ({status}): {body_text}"));
+        }
+
+        if body_text.is_empty() {
+            return Ok(json!({}));
+        }
+
+        serde_json::from_str(&body_text).map_err(|e| format!("Invalid JSON from Sprites: {e}"))
+    }
+
+    /// Raw GET that returns bytes (for file download).
+    async fn download(&self, path: &str) -> Result<Vec<u8>, String> {
+        let url = format!("{}{}", self.api_base, path);
+        let resp = self
+            .http
+            .get(&url)
+            .bearer_auth(&self.api_token)
+            .send()
+            .await
+            .map_err(|e| format!("Failed to connect to Sprites API: {e}"))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body_text = resp
+                .text()
+                .await
+                .map_err(|e| format!("Failed to read response: {e}"))?;
+            return Err(format!("Sprites API error ({status}): {body_text}"));
+        }
+
+        resp.bytes()
+            .await
+            .map(|b| b.to_vec())
+            .map_err(|e| format!("Failed to read file bytes: {e}"))
+    }
+
+    // --- Sprite Lifecycle ---
+
+    pub async fn create_sprite(&self, name: &str, body: Value) -> Result<SpriteInfo, String> {
+        let resp = self
+            .request(
+                reqwest::Method::PUT,
+                &format!("/sprites/{name}"),
+                Some(body),
+            )
+            .await?;
+        serde_json::from_value(resp).map_err(|e| format!("Failed to parse sprite info: {e}"))
+    }
+
+    pub async fn get_sprite(&self, name: &str) -> Result<SpriteInfo, String> {
+        let resp = self
+            .request(reqwest::Method::GET, &format!("/sprites/{name}"), None)
+            .await?;
+        serde_json::from_value(resp).map_err(|e| format!("Failed to parse sprite info: {e}"))
+    }
+
+    pub async fn list_sprites(&self) -> Result<Vec<SpriteInfo>, String> {
+        let resp = self.request(reqwest::Method::GET, "/sprites", None).await?;
+        // Response may be an array or an object with a "sprites" key
+        if let Some(arr) = resp.as_array() {
+            let mut sprites = Vec::new();
+            for item in arr {
+                match serde_json::from_value::<SpriteInfo>(item.clone()) {
+                    Ok(s) => sprites.push(s),
+                    Err(e) => debug!("Skipping unparseable sprite: {e}"),
+                }
+            }
+            Ok(sprites)
+        } else if let Some(arr) = resp.get("sprites").and_then(|v| v.as_array()) {
+            let mut sprites = Vec::new();
+            for item in arr {
+                match serde_json::from_value::<SpriteInfo>(item.clone()) {
+                    Ok(s) => sprites.push(s),
+                    Err(e) => debug!("Skipping unparseable sprite: {e}"),
+                }
+            }
+            Ok(sprites)
+        } else {
+            Ok(vec![])
+        }
+    }
+
+    pub async fn delete_sprite(&self, name: &str) -> Result<(), String> {
+        self.request(reqwest::Method::DELETE, &format!("/sprites/{name}"), None)
+            .await?;
+        Ok(())
+    }
+
+    // --- Exec ---
+
+    pub async fn exec(
+        &self,
+        name: &str,
+        command: &str,
+        timeout_ms: Option<u64>,
+    ) -> Result<ExecResult, String> {
+        let mut body = json!({ "command": command });
+        if let Some(t) = timeout_ms {
+            body["timeout"] = json!(t);
+        }
+        let resp = self
+            .request(
+                reqwest::Method::POST,
+                &format!("/sprites/{name}/exec"),
+                Some(body),
+            )
+            .await?;
+        serde_json::from_value(resp).map_err(|e| format!("Failed to parse exec result: {e}"))
+    }
+
+    // --- Filesystem ---
+
+    pub async fn read_file(&self, name: &str, path: &str) -> Result<Vec<u8>, String> {
+        let encoded = urlencoding::encode(path);
+        self.download(&format!("/sprites/{name}/files/{encoded}"))
+            .await
+    }
+
+    pub async fn write_file(&self, name: &str, path: &str, content: &[u8]) -> Result<(), String> {
+        let encoded = urlencoding::encode(path);
+        let url = format!("{}/sprites/{name}/files/{encoded}", self.api_base);
+
+        let resp = self
+            .http
+            .put(&url)
+            .bearer_auth(&self.api_token)
+            .header("Content-Type", "application/octet-stream")
+            .body(content.to_vec())
+            .send()
+            .await
+            .map_err(|e| format!("Failed to write file: {e}"))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body_text = resp
+                .text()
+                .await
+                .map_err(|e| format!("Failed to read response: {e}"))?;
+            return Err(format!("Sprites API error ({status}): {body_text}"));
+        }
+
+        Ok(())
+    }
+
+    // --- Checkpoints ---
+
+    pub async fn create_checkpoint(&self, name: &str) -> Result<CheckpointInfo, String> {
+        let resp = self
+            .request(
+                reqwest::Method::POST,
+                &format!("/sprites/{name}/checkpoints"),
+                None,
+            )
+            .await?;
+        serde_json::from_value(resp).map_err(|e| format!("Failed to parse checkpoint info: {e}"))
+    }
+
+    pub async fn list_checkpoints(&self, name: &str) -> Result<Vec<CheckpointInfo>, String> {
+        let resp = self
+            .request(
+                reqwest::Method::GET,
+                &format!("/sprites/{name}/checkpoints"),
+                None,
+            )
+            .await?;
+        if let Some(arr) = resp.as_array() {
+            let mut checkpoints = Vec::new();
+            for item in arr {
+                match serde_json::from_value::<CheckpointInfo>(item.clone()) {
+                    Ok(c) => checkpoints.push(c),
+                    Err(e) => debug!("Skipping unparseable checkpoint: {e}"),
+                }
+            }
+            Ok(checkpoints)
+        } else {
+            Ok(vec![])
+        }
+    }
+
+    pub async fn restore_checkpoint(&self, name: &str, checkpoint_id: &str) -> Result<(), String> {
+        self.request(
+            reqwest::Method::POST,
+            &format!("/sprites/{name}/checkpoints/{checkpoint_id}/restore"),
+            None,
+        )
+        .await?;
+        Ok(())
+    }
+
+    // --- Services ---
+
+    pub async fn list_services(&self, name: &str) -> Result<Vec<Value>, String> {
+        let resp = self
+            .request(
+                reqwest::Method::GET,
+                &format!("/sprites/{name}/services"),
+                None,
+            )
+            .await?;
+        match resp.as_array() {
+            Some(arr) => Ok(arr.clone()),
+            None => Ok(vec![resp]),
+        }
+    }
+}
+
+pub(crate) mod urlencoding {
+    /// Percent-encode a string for use in URL path segments.
+    pub fn encode(input: &str) -> String {
+        let mut result = String::with_capacity(input.len() * 2);
+        for byte in input.bytes() {
+            match byte {
+                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                    result.push(byte as char);
+                }
+                _ => {
+                    result.push('%');
+                    result.push_str(&format!("{byte:02X}"));
+                }
+            }
+        }
+        result
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn test_client_create_sprite() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/sprites/test-sprite"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "name": "test-sprite",
+                "status": "running"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = SpritesClient::with_base_url("test_token".to_string(), mock_server.uri());
+        let result = client.create_sprite("test-sprite", json!({})).await;
+        assert!(result.is_ok());
+        let info = result.unwrap();
+        assert_eq!(info.name, "test-sprite");
+    }
+
+    #[tokio::test]
+    async fn test_client_get_sprite() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/sprites/my-sprite"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "name": "my-sprite",
+                "status": "running"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = SpritesClient::with_base_url("test_token".to_string(), mock_server.uri());
+        let result = client.get_sprite("my-sprite").await;
+        assert!(result.is_ok());
+        let info = result.unwrap();
+        assert_eq!(info.status, "running");
+    }
+
+    #[tokio::test]
+    async fn test_client_delete_sprite() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/sprites/old-sprite"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .mount(&mock_server)
+            .await;
+
+        let client = SpritesClient::with_base_url("test_token".to_string(), mock_server.uri());
+        let result = client.delete_sprite("old-sprite").await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_client_exec() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/sprites/my-sprite/exec"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "stdout": "hello world\n",
+                "stderr": "",
+                "exit_code": 0
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = SpritesClient::with_base_url("test_token".to_string(), mock_server.uri());
+        let result = client.exec("my-sprite", "echo hello world", None).await;
+        assert!(result.is_ok());
+        let exec_result = result.unwrap();
+        assert_eq!(exec_result.exit_code, 0);
+        assert_eq!(exec_result.stdout, "hello world\n");
+    }
+
+    #[tokio::test]
+    async fn test_client_create_checkpoint() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/sprites/my-sprite/checkpoints"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "cp_abc123"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = SpritesClient::with_base_url("test_token".to_string(), mock_server.uri());
+        let result = client.create_checkpoint("my-sprite").await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().id, "cp_abc123");
+    }
+
+    #[tokio::test]
+    async fn test_client_restore_checkpoint() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/sprites/my-sprite/checkpoints/cp_abc123/restore"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(""))
+            .mount(&mock_server)
+            .await;
+
+        let client = SpritesClient::with_base_url("test_token".to_string(), mock_server.uri());
+        let result = client.restore_checkpoint("my-sprite", "cp_abc123").await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_client_list_sprites() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/sprites"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                {"name": "sprite-1", "status": "running"},
+                {"name": "sprite-2", "status": "stopped"}
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        let client = SpritesClient::with_base_url("test_token".to_string(), mock_server.uri());
+        let result = client.list_sprites().await;
+        assert!(result.is_ok());
+        let sprites = result.unwrap();
+        assert_eq!(sprites.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_client_404_error() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/sprites/nonexistent"))
+            .respond_with(
+                ResponseTemplate::new(404).set_body_string("{\"error\":\"Sprite not found\"}"),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let client = SpritesClient::with_base_url("test_token".to_string(), mock_server.uri());
+        let result = client.get_sprite("nonexistent").await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("404"));
+    }
+
+    #[tokio::test]
+    async fn test_client_401_error() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/sprites/test"))
+            .respond_with(
+                ResponseTemplate::new(401).set_body_string("{\"error\":\"Unauthorized\"}"),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let client = SpritesClient::with_base_url("bad_token".to_string(), mock_server.uri());
+        let result = client.create_sprite("test", json!({})).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("401"));
+    }
+
+    #[tokio::test]
+    async fn test_client_read_file() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/sprites/my-sprite/files/%2Fhome%2Fuser%2Fmain.py"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"print('hello')\n".to_vec()))
+            .mount(&mock_server)
+            .await;
+
+        let client = SpritesClient::with_base_url("test_token".to_string(), mock_server.uri());
+        let result = client.read_file("my-sprite", "/home/user/main.py").await;
+        assert!(result.is_ok());
+        assert_eq!(
+            String::from_utf8_lossy(&result.unwrap()),
+            "print('hello')\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_client_write_file() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/sprites/my-sprite/files/%2Fhome%2Fuser%2Ftest.py"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(""))
+            .mount(&mock_server)
+            .await;
+
+        let client = SpritesClient::with_base_url("test_token".to_string(), mock_server.uri());
+        let result = client
+            .write_file("my-sprite", "/home/user/test.py", b"print('test')")
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_client_list_services() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/sprites/my-sprite/services"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                {"name": "web", "port": 8080, "url": "https://my-sprite.fly.dev"}
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        let client = SpritesClient::with_base_url("test_token".to_string(), mock_server.uri());
+        let result = client.list_services("my-sprite").await;
+        assert!(result.is_ok());
+        let services = result.unwrap();
+        assert_eq!(services.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_client_list_checkpoints() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/sprites/my-sprite/checkpoints"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                {"id": "cp_1"},
+                {"id": "cp_2"}
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        let client = SpritesClient::with_base_url("test_token".to_string(), mock_server.uri());
+        let result = client.list_checkpoints("my-sprite").await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_client_empty_response() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/sprites/my-sprite"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(""))
+            .mount(&mock_server)
+            .await;
+
+        let client = SpritesClient::with_base_url("test_token".to_string(), mock_server.uri());
+        let result = client.delete_sprite("my-sprite").await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_client_malformed_response() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/sprites/bad"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not valid json"))
+            .mount(&mock_server)
+            .await;
+
+        let client = SpritesClient::with_base_url("test_token".to_string(), mock_server.uri());
+        let result = client.get_sprite("bad").await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid JSON"));
+    }
+
+    #[tokio::test]
+    async fn test_client_sends_bearer_auth() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/sprites/auth-test"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer secret_token_123",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "name": "auth-test",
+                "status": "running"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client =
+            SpritesClient::with_base_url("secret_token_123".to_string(), mock_server.uri());
+        let info = client.get_sprite("auth-test").await.unwrap();
+        assert_eq!(info.name, "auth-test");
+    }
+
+    #[test]
+    fn test_encode_simple() {
+        assert_eq!(urlencoding::encode("hello"), "hello");
+    }
+
+    #[test]
+    fn test_encode_path_with_slashes() {
+        assert_eq!(
+            urlencoding::encode("/home/user/main.py"),
+            "%2Fhome%2Fuser%2Fmain.py"
+        );
+    }
+
+    #[test]
+    fn test_encode_preserves_unreserved() {
+        assert_eq!(urlencoding::encode("abc-_.~123"), "abc-_.~123");
+    }
+
+    #[test]
+    fn test_encode_empty_string() {
+        assert_eq!(urlencoding::encode(""), "");
+    }
+}

--- a/integrations/sprites/src/connection.rs
+++ b/integrations/sprites/src/connection.rs
@@ -1,0 +1,103 @@
+// Sprites Connection Provider
+//
+// Decision: Bearer-token-based connection (not OAuth). User gets token from Sprites CLI or dashboard.
+// Decision: Validate token by calling GET /v1/sprites — 200 means valid, 401 means invalid.
+
+use async_trait::async_trait;
+use everruns_core::connection_provider::{
+    ConnectionFormSchema, ConnectionProvider, ConnectionType, ConnectionValidation, FieldType,
+    FormField,
+};
+
+use crate::SPRITES_API_BASE;
+
+pub struct SpritesConnectionProvider;
+
+#[async_trait]
+impl ConnectionProvider for SpritesConnectionProvider {
+    fn provider_id(&self) -> &str {
+        "sprites"
+    }
+
+    fn display_name(&self) -> &str {
+        "Sprites"
+    }
+
+    fn description(&self) -> &str {
+        "Persistent, hardware-isolated Linux microVMs for code execution"
+    }
+
+    fn icon(&self) -> &str {
+        "sprites"
+    }
+
+    fn connection_type(&self) -> ConnectionType {
+        ConnectionType::ApiKey
+    }
+
+    fn form_schema(&self) -> Option<ConnectionFormSchema> {
+        Some(ConnectionFormSchema {
+            fields: vec![FormField {
+                name: "api_key".to_string(),
+                label: "API Token".to_string(),
+                field_type: FieldType::Password,
+                required: true,
+                placeholder: Some("your-sprites-api-token".to_string()),
+                help_text: None,
+            }],
+            instructions_markdown: "\
+1. Install the Sprites CLI: `curl https://sprites.dev/install.sh | bash`\n\
+2. Run `sprite login` to authenticate\n\
+3. Copy your token from the CLI output or dashboard\n\
+4. Paste it below"
+                .to_string(),
+        })
+    }
+
+    async fn validate(&self, credential: &str) -> Result<ConnectionValidation, String> {
+        let client = reqwest::Client::new();
+        let response = client
+            .get(format!("{SPRITES_API_BASE}/sprites"))
+            .bearer_auth(credential)
+            .send()
+            .await
+            .map_err(|e| format!("Failed to reach Sprites API: {e}"))?;
+
+        match response.status().as_u16() {
+            200 => Ok(ConnectionValidation {
+                provider_username: None,
+                provider_metadata: None,
+            }),
+            401 | 403 => {
+                Err("Invalid API token. Check that the token is correct and active.".into())
+            }
+            status => Err(format!(
+                "Unexpected response from Sprites API (HTTP {status})"
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_provider_metadata() {
+        let p = SpritesConnectionProvider;
+        assert_eq!(p.provider_id(), "sprites");
+        assert_eq!(p.display_name(), "Sprites");
+        assert_eq!(p.connection_type(), ConnectionType::ApiKey);
+        assert_eq!(p.icon(), "sprites");
+    }
+
+    #[test]
+    fn test_form_schema() {
+        let p = SpritesConnectionProvider;
+        let schema = p.form_schema().expect("should have form schema");
+        assert_eq!(schema.fields.len(), 1);
+        assert_eq!(schema.fields[0].name, "api_key");
+        assert!(schema.fields[0].required);
+        assert!(schema.instructions_markdown.contains("sprites.dev"));
+    }
+}

--- a/integrations/sprites/src/lib.rs
+++ b/integrations/sprites/src/lib.rs
@@ -4,10 +4,10 @@
 //! Sprites are Firecracker VMs with full ext4 filesystems that persist across sessions.
 //!
 //! Decision: External integration crate, auto-registered via inventory plugin system
-//! Decision: Use secrets store for all state (API token + per-sprite connection info)
+//! Decision: API token resolved via user connections (Settings > Connections), not secrets store
+//! Decision: Per-sprite state stored in session secrets (encrypted at rest)
 //! Decision: Single API tier — all operations go through api.sprites.dev/v1
 //! Decision: Embrace persistence — sprites survive idle, expose HTTP endpoints, support checkpoints
-//! Decision: session_storage dependency for API token and state persistence
 
 pub mod client;
 pub mod connection;

--- a/integrations/sprites/src/lib.rs
+++ b/integrations/sprites/src/lib.rs
@@ -1,0 +1,210 @@
+//! Sprites Integration
+//!
+//! Persistent, hardware-isolated Linux microVMs via Sprites (Fly.io) REST API.
+//! Sprites are Firecracker VMs with full ext4 filesystems that persist across sessions.
+//!
+//! Decision: External integration crate, auto-registered via inventory plugin system
+//! Decision: Use secrets store for all state (API token + per-sprite connection info)
+//! Decision: Single API tier — all operations go through api.sprites.dev/v1
+//! Decision: Embrace persistence — sprites survive idle, expose HTTP endpoints, support checkpoints
+//! Decision: session_storage dependency for API token and state persistence
+
+pub mod client;
+pub mod connection;
+pub mod state;
+mod tools;
+
+use everruns_core::LEASED_RESOURCES_FEATURE;
+use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin, RiskLevel};
+use everruns_core::connection_provider::ConnectionProviderPlugin;
+use everruns_core::tools::Tool;
+
+use connection::SpritesConnectionProvider;
+
+use tools::{
+    SpritesCheckpointTool, SpritesCreateSpriteTool, SpritesExecTool, SpritesListSpritesTool,
+    SpritesManageSpriteTool, SpritesReadFileTool, SpritesRestoreCheckpointTool,
+    SpritesServiceUrlTool, SpritesWriteFileTool,
+};
+
+// ============================================================================
+// Plugin Registration
+// ============================================================================
+
+inventory::submit! {
+    IntegrationPlugin {
+        experimental_only: false,
+        factory: || Box::new(SpritesCapability),
+    }
+}
+
+inventory::submit! {
+    ConnectionProviderPlugin {
+        experimental_only: true,
+        factory: || Box::new(SpritesConnectionProvider),
+    }
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const SPRITES_API_BASE: &str = "https://api.sprites.dev/v1";
+const SPRITES_SECRET_PREFIX: &str = "sprites_sprite:";
+const EXEC_TIMEOUT_MS: u64 = 120_000;
+/// Default workspace path inside sprites
+const SPRITES_WORKSPACE_PATH: &str = "/home/user";
+
+// ============================================================================
+// SpritesCapability
+// ============================================================================
+
+pub struct SpritesCapability;
+
+impl Capability for SpritesCapability {
+    fn id(&self) -> &str {
+        "sprites"
+    }
+
+    fn name(&self) -> &str {
+        "Sprites"
+    }
+
+    fn description(&self) -> &str {
+        "Run code in persistent, hardware-isolated Linux microVMs powered by Sprites. \
+         Create multiple Firecracker VMs per session with full ext4 filesystems, \
+         execute commands, manage files, checkpoint/restore state, and expose HTTP services."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn risk_level(&self) -> RiskLevel {
+        RiskLevel::High
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("sprites")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Execution")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(
+            r#"## Sprites
+
+Persistent, hardware-isolated Linux microVMs (Firecracker) via Sprites. Each sprite is
+a full Linux computer with a persistent ext4 filesystem that survives between sessions.
+
+Authentication: Sprites API token is resolved automatically from Settings > Connections > Sprites.
+If not configured, guide the user to set up their token in Settings > Connections.
+
+All tools except `sprites_create_sprite` and `sprites_list_sprites` require a `sprite_name`.
+Sprites persist indefinitely — they hibernate when idle (no compute charges) and wake instantly.
+Always DELETE sprites when done to avoid storage charges.
+
+Key differences from ephemeral sandboxes:
+- **Persistent filesystem**: Data survives idle/sleep, backed to durable object storage.
+- **Checkpoints**: Use `sprites_checkpoint` to snapshot state before risky operations,
+  `sprites_restore_checkpoint` to roll back. Checkpoints complete in ~300ms.
+- **HTTP services**: Each sprite has a unique public URL. Listen on port 8080 inside
+  the sprite and it's accessible at the sprite's URL. Use `sprites_service_url` to get
+  the URL for sharing or testing.
+- **Instant wake**: Sprites wake from hibernation in <1s when you execute a command.
+
+Working directory is `/home/user`."#,
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(SpritesCreateSpriteTool),
+            Box::new(SpritesExecTool),
+            Box::new(SpritesReadFileTool),
+            Box::new(SpritesWriteFileTool),
+            Box::new(SpritesListSpritesTool),
+            Box::new(SpritesManageSpriteTool),
+            Box::new(SpritesCheckpointTool),
+            Box::new(SpritesRestoreCheckpointTool),
+            Box::new(SpritesServiceUrlTool),
+        ]
+    }
+
+    fn dependencies(&self) -> Vec<&'static str> {
+        vec!["session_storage"]
+    }
+
+    fn features(&self) -> Vec<&'static str> {
+        vec![LEASED_RESOURCES_FEATURE]
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::capabilities::CapabilityStatus;
+
+    #[test]
+    fn test_capability_metadata() {
+        let cap = SpritesCapability;
+        assert_eq!(cap.id(), "sprites");
+        assert_eq!(cap.name(), "Sprites");
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+        assert_eq!(cap.icon(), Some("sprites"));
+        assert_eq!(cap.category(), Some("Execution"));
+    }
+
+    #[test]
+    fn test_capability_has_all_tools() {
+        let cap = SpritesCapability;
+        let tools = cap.tools();
+        assert_eq!(tools.len(), 9);
+
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(names.contains(&"sprites_create_sprite"));
+        assert!(names.contains(&"sprites_exec"));
+        assert!(names.contains(&"sprites_read_file"));
+        assert!(names.contains(&"sprites_write_file"));
+        assert!(names.contains(&"sprites_list_sprites"));
+        assert!(names.contains(&"sprites_manage_sprite"));
+        assert!(names.contains(&"sprites_checkpoint"));
+        assert!(names.contains(&"sprites_restore_checkpoint"));
+        assert!(names.contains(&"sprites_service_url"));
+    }
+
+    #[test]
+    fn test_capability_has_system_prompt() {
+        let cap = SpritesCapability;
+        let prompt = cap.system_prompt_addition().unwrap();
+        assert!(prompt.contains("Sprites"));
+        assert!(prompt.contains("Settings > Connections"));
+        assert!(prompt.contains("sprites_create_sprite"));
+        assert!(prompt.contains("sprites_checkpoint"));
+        assert!(prompt.contains("HTTP services"));
+    }
+
+    #[test]
+    fn test_all_tools_require_context() {
+        let cap = SpritesCapability;
+        for tool in cap.tools() {
+            assert!(
+                tool.requires_context(),
+                "Tool {} should require context",
+                tool.name()
+            );
+        }
+    }
+
+    #[test]
+    fn test_capability_dependencies() {
+        let cap = SpritesCapability;
+        assert_eq!(cap.dependencies(), vec!["session_storage"]);
+    }
+}

--- a/integrations/sprites/src/state.rs
+++ b/integrations/sprites/src/state.rs
@@ -218,6 +218,9 @@ pub async fn touch_sprite_lease(
             display_name,
             owner_user_id,
             lease_duration_seconds: SPRITES_LEASE_DURATION_SECONDS,
+            // THREAT[TM-API-015]: leased-resource metadata is API-visible.
+            // Keep only non-secret fields here. service_url is the sprite's
+            // public URL (not a credential) so it's safe to include for UI display.
             metadata: json!({
                 "workspace_path": state.workspace_path,
                 "started_at": state.started_at,
@@ -258,6 +261,32 @@ pub fn required_str<'a>(args: &'a Value, name: &str) -> Result<&'a str, ToolExec
     args.get(name).and_then(|v| v.as_str()).ok_or_else(|| {
         ToolExecutionResult::tool_error(format!("Missing required parameter: {name}"))
     })
+}
+
+/// Validate that a sprite name is safe for URL interpolation.
+///
+/// Sprite names are user-supplied (unlike Daytona sandbox IDs which come from the API).
+/// Must be lowercase alphanumeric with hyphens, 1-63 chars, no leading/trailing hyphens.
+pub fn validate_sprite_name(name: &str) -> Result<(), ToolExecutionResult> {
+    if name.is_empty() || name.len() > 63 {
+        return Err(ToolExecutionResult::tool_error(
+            "Sprite name must be 1-63 characters",
+        ));
+    }
+    if !name
+        .bytes()
+        .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+    {
+        return Err(ToolExecutionResult::tool_error(
+            "Sprite name must contain only lowercase letters, digits, and hyphens",
+        ));
+    }
+    if name.starts_with('-') || name.ends_with('-') {
+        return Err(ToolExecutionResult::tool_error(
+            "Sprite name must not start or end with a hyphen",
+        ));
+    }
+    Ok(())
 }
 
 // ============================================================================
@@ -391,5 +420,39 @@ mod tests {
         assert!(val.get("sprite_name").is_some());
         assert!(val.get("workspace_path").is_some());
         assert!(val.get("started_at").is_some());
+    }
+
+    #[test]
+    fn test_validate_sprite_name_valid() {
+        assert!(validate_sprite_name("my-sprite").is_ok());
+        assert!(validate_sprite_name("test123").is_ok());
+        assert!(validate_sprite_name("a").is_ok());
+        assert!(validate_sprite_name("a-b-c").is_ok());
+    }
+
+    #[test]
+    fn test_validate_sprite_name_empty() {
+        assert!(validate_sprite_name("").is_err());
+    }
+
+    #[test]
+    fn test_validate_sprite_name_too_long() {
+        let long_name = "a".repeat(64);
+        assert!(validate_sprite_name(&long_name).is_err());
+    }
+
+    #[test]
+    fn test_validate_sprite_name_invalid_chars() {
+        assert!(validate_sprite_name("my sprite").is_err());
+        assert!(validate_sprite_name("my/sprite").is_err());
+        assert!(validate_sprite_name("MY-SPRITE").is_err());
+        assert!(validate_sprite_name("../../admin").is_err());
+        assert!(validate_sprite_name("name?extra=1").is_err());
+    }
+
+    #[test]
+    fn test_validate_sprite_name_leading_trailing_hyphen() {
+        assert!(validate_sprite_name("-bad").is_err());
+        assert!(validate_sprite_name("bad-").is_err());
     }
 }

--- a/integrations/sprites/src/state.rs
+++ b/integrations/sprites/src/state.rs
@@ -1,0 +1,395 @@
+//! Sprites API types and session state management.
+//!
+//! Decision: Embrace persistence — SpriteState includes the public HTTP URL
+
+use everruns_core::UpsertLeasedResource;
+use everruns_core::tools::ToolExecutionResult;
+use everruns_core::traits::ToolContext;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use tracing::{error, warn};
+
+use crate::SPRITES_SECRET_PREFIX;
+
+// ============================================================================
+// API Response Types
+// ============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpriteInfo {
+    pub name: String,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecResult {
+    #[serde(default)]
+    pub stdout: String,
+    #[serde(default)]
+    pub stderr: String,
+    #[serde(default)]
+    pub exit_code: i32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckpointInfo {
+    pub id: String,
+    #[serde(default)]
+    pub created_at: Option<String>,
+}
+
+// ============================================================================
+// Persisted Sprite State (stored in session secrets as JSON)
+// ============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpriteState {
+    pub sprite_name: String,
+    pub workspace_path: String,
+    pub started_at: String,
+    /// Public HTTP URL for this sprite (if it exposes a service on port 8080)
+    #[serde(default)]
+    pub service_url: Option<String>,
+}
+
+/// Everruns lease duration for Sprites.
+///
+/// Sprites hibernate when idle (no compute charges), but we still register
+/// a lease so the control plane can clean up forgotten sprites.
+pub const SPRITES_LEASE_DURATION_SECONDS: u32 = 30 * 60;
+
+// ============================================================================
+// State Management Helpers
+// ============================================================================
+
+/// Resolve Sprites API token via user connection (Settings > Connections > Sprites).
+pub async fn get_api_token(context: &ToolContext) -> Result<String, ToolExecutionResult> {
+    if let Some(resolver) = context.connection_resolver.as_ref() {
+        match resolver
+            .get_connection_token(context.session_id, "sprites")
+            .await
+        {
+            Ok(Some(token)) => return Ok(token),
+            Ok(None) => {} // fall through to error
+            Err(e) => {
+                error!("Failed to resolve Sprites user connection: {e}");
+            }
+        }
+    }
+
+    // THREAT[TM-AGENT-016]: Asking secrets in chat stores them plaintext in events.
+    // Return ConnectionRequired so the UI renders an inline connection dialog.
+    Err(ToolExecutionResult::connection_required("sprites"))
+}
+
+pub async fn get_sprite_state(
+    context: &ToolContext,
+    sprite_name: &str,
+) -> Result<SpriteState, ToolExecutionResult> {
+    let storage = context
+        .storage_store
+        .as_ref()
+        .ok_or_else(|| ToolExecutionResult::tool_error("Storage not available in this context"))?;
+
+    let secret_name = format!("{SPRITES_SECRET_PREFIX}{sprite_name}");
+    let json_str = storage
+        .get_secret(context.session_id, &secret_name)
+        .await
+        .map_err(|e| {
+            error!("Failed to read sprite state: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to read sprite state: {e}"))
+        })?
+        .ok_or_else(|| {
+            ToolExecutionResult::tool_error(format!(
+                "Sprite '{sprite_name}' not found. Create one first with sprites_create_sprite."
+            ))
+        })?;
+
+    serde_json::from_str(&json_str).map_err(|e| {
+        error!("Corrupt sprite state for {sprite_name}: {e}");
+        ToolExecutionResult::internal_error_msg(format!("Corrupt sprite state: {e}"))
+    })
+}
+
+pub async fn save_sprite_state(
+    context: &ToolContext,
+    state: &SpriteState,
+) -> Result<(), ToolExecutionResult> {
+    let storage = context
+        .storage_store
+        .as_ref()
+        .ok_or_else(|| ToolExecutionResult::tool_error("Storage not available in this context"))?;
+
+    let secret_name = format!("{SPRITES_SECRET_PREFIX}{}", state.sprite_name);
+    let json_str = serde_json::to_string(state).map_err(|e| {
+        ToolExecutionResult::internal_error_msg(format!("Failed to serialize sprite state: {e}"))
+    })?;
+
+    storage
+        .set_secret(context.session_id, &secret_name, &json_str)
+        .await
+        .map_err(|e| {
+            error!("Failed to save sprite state: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to save sprite state: {e}"))
+        })
+}
+
+pub async fn delete_sprite_state(
+    context: &ToolContext,
+    sprite_name: &str,
+) -> Result<(), ToolExecutionResult> {
+    let storage = context
+        .storage_store
+        .as_ref()
+        .ok_or_else(|| ToolExecutionResult::tool_error("Storage not available in this context"))?;
+
+    let secret_name = format!("{SPRITES_SECRET_PREFIX}{sprite_name}");
+    storage
+        .delete_secret(context.session_id, &secret_name)
+        .await
+        .map_err(|e| {
+            error!("Failed to delete sprite state: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to delete sprite state: {e}"))
+        })?;
+    Ok(())
+}
+
+pub async fn list_sprite_states(
+    context: &ToolContext,
+) -> Result<Vec<SpriteState>, ToolExecutionResult> {
+    let storage = context
+        .storage_store
+        .as_ref()
+        .ok_or_else(|| ToolExecutionResult::tool_error("Storage not available in this context"))?;
+
+    let secrets = storage
+        .list_secrets(context.session_id)
+        .await
+        .map_err(|e| {
+            error!("Failed to list secrets: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to list secrets: {e}"))
+        })?;
+
+    let mut states = Vec::new();
+    for secret_info in secrets {
+        if let Some(sprite_name) = secret_info.name.strip_prefix(SPRITES_SECRET_PREFIX) {
+            match get_sprite_state(context, sprite_name).await {
+                Ok(state) => states.push(state),
+                Err(_) => {
+                    warn!("Skipping corrupt sprite state: {}", sprite_name);
+                }
+            }
+        }
+    }
+
+    Ok(states)
+}
+
+/// Register or refresh the Sprites lease for generic cleanup.
+pub async fn touch_sprite_lease(
+    context: &ToolContext,
+    state: &SpriteState,
+    display_name: Option<String>,
+) -> Result<(), ToolExecutionResult> {
+    let Some(store) = context.leased_resource_store.as_ref() else {
+        return Ok(());
+    };
+
+    let owner_user_id = if let Some(resolver) = context.connection_resolver.as_ref() {
+        resolver
+            .get_connection_user(context.session_id, "sprites")
+            .await
+            .ok()
+            .flatten()
+    } else {
+        None
+    };
+
+    store
+        .upsert_resource(UpsertLeasedResource {
+            session_id: context.session_id,
+            provider: "sprites".to_string(),
+            resource_type: "sprite".to_string(),
+            external_id: state.sprite_name.clone(),
+            display_name,
+            owner_user_id,
+            lease_duration_seconds: SPRITES_LEASE_DURATION_SECONDS,
+            metadata: json!({
+                "workspace_path": state.workspace_path,
+                "started_at": state.started_at,
+                "service_url": state.service_url,
+            }),
+        })
+        .await
+        .map_err(|e| {
+            error!("Failed to upsert Sprites lease: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to update Sprites lease: {e}"))
+        })?;
+
+    Ok(())
+}
+
+/// Release the Sprites lease after explicit deletion.
+pub async fn release_sprite_lease(
+    context: &ToolContext,
+    sprite_name: &str,
+) -> Result<(), ToolExecutionResult> {
+    let Some(store) = context.leased_resource_store.as_ref() else {
+        return Ok(());
+    };
+
+    store
+        .release_resource(context.session_id, "sprites", "sprite", sprite_name)
+        .await
+        .map_err(|e| {
+            error!("Failed to release Sprites lease: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to release Sprites lease: {e}"))
+        })?;
+
+    Ok(())
+}
+
+/// Extract a required string parameter from tool arguments.
+pub fn required_str<'a>(args: &'a Value, name: &str) -> Result<&'a str, ToolExecutionResult> {
+    args.get(name).and_then(|v| v.as_str()).ok_or_else(|| {
+        ToolExecutionResult::tool_error(format!("Missing required parameter: {name}"))
+    })
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sprite_state_roundtrip() {
+        let state = SpriteState {
+            sprite_name: "my-sprite".to_string(),
+            workspace_path: "/home/user".to_string(),
+            started_at: "2026-03-23T10:00:00Z".to_string(),
+            service_url: Some("https://my-sprite.fly.dev".to_string()),
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        let deserialized: SpriteState = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.sprite_name, "my-sprite");
+        assert_eq!(deserialized.workspace_path, "/home/user");
+        assert_eq!(
+            deserialized.service_url,
+            Some("https://my-sprite.fly.dev".to_string())
+        );
+    }
+
+    #[test]
+    fn test_sprite_state_without_url() {
+        let state = SpriteState {
+            sprite_name: "headless".to_string(),
+            workspace_path: "/home/user".to_string(),
+            started_at: "2026-03-23T10:00:00Z".to_string(),
+            service_url: None,
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        let deserialized: SpriteState = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.service_url, None);
+    }
+
+    #[test]
+    fn test_required_str_present() {
+        let args = serde_json::json!({"name": "test_value"});
+        let result = required_str(&args, "name");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "test_value");
+    }
+
+    #[test]
+    fn test_required_str_missing() {
+        let args = serde_json::json!({"other": "value"});
+        let result = required_str(&args, "name");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_required_str_null_value() {
+        let args = serde_json::json!({"name": null});
+        let result = required_str(&args, "name");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_required_str_non_string_value() {
+        let args = serde_json::json!({"name": 42});
+        let result = required_str(&args, "name");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_sprite_info_deserialization() {
+        let json =
+            r#"{"name": "my-sprite", "status": "running", "url": "https://my-sprite.fly.dev"}"#;
+        let info: SpriteInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.name, "my-sprite");
+        assert_eq!(info.status, "running");
+        assert_eq!(info.url, Some("https://my-sprite.fly.dev".to_string()));
+    }
+
+    #[test]
+    fn test_sprite_info_without_url() {
+        let json = r#"{"name": "headless", "status": "stopped"}"#;
+        let info: SpriteInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.url, None);
+    }
+
+    #[test]
+    fn test_exec_result_deserialization() {
+        let json = r#"{"stdout": "hello\n", "stderr": "", "exit_code": 0}"#;
+        let result: ExecResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.stdout, "hello\n");
+        assert_eq!(result.stderr, "");
+        assert_eq!(result.exit_code, 0);
+    }
+
+    #[test]
+    fn test_exec_result_defaults() {
+        let json = r#"{}"#;
+        let result: ExecResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.stdout, "");
+        assert_eq!(result.stderr, "");
+        assert_eq!(result.exit_code, 0);
+    }
+
+    #[test]
+    fn test_checkpoint_info_deserialization() {
+        let json = r#"{"id": "cp_abc", "created_at": "2026-03-23T10:00:00Z"}"#;
+        let info: CheckpointInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.id, "cp_abc");
+        assert_eq!(info.created_at, Some("2026-03-23T10:00:00Z".to_string()));
+    }
+
+    #[test]
+    fn test_checkpoint_info_without_timestamp() {
+        let json = r#"{"id": "cp_xyz"}"#;
+        let info: CheckpointInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.id, "cp_xyz");
+        assert_eq!(info.created_at, None);
+    }
+
+    #[test]
+    fn test_sprite_state_json_has_all_fields() {
+        let state = SpriteState {
+            sprite_name: "sp_x".to_string(),
+            workspace_path: "/home/user".to_string(),
+            started_at: "2026-01-01T00:00:00Z".to_string(),
+            service_url: None,
+        };
+        let val: serde_json::Value = serde_json::to_value(&state).unwrap();
+        assert!(val.get("sprite_name").is_some());
+        assert!(val.get("workspace_path").is_some());
+        assert!(val.get("started_at").is_some());
+    }
+}

--- a/integrations/sprites/src/tools.rs
+++ b/integrations/sprites/src/tools.rs
@@ -12,6 +12,7 @@ use crate::client::SpritesClient;
 use crate::state::{
     SpriteState, delete_sprite_state, get_api_token, get_sprite_state, list_sprite_states,
     release_sprite_lease, required_str, save_sprite_state, touch_sprite_lease,
+    validate_sprite_name,
 };
 
 /// Parse an optional integer resource parameter, validating type and range.
@@ -100,6 +101,9 @@ impl Tool for SpritesCreateSpriteTool {
             Ok(s) => s,
             Err(e) => return e,
         };
+        if let Err(e) = validate_sprite_name(sprite_name) {
+            return e;
+        }
 
         let client = SpritesClient::new(api_token);
 
@@ -240,7 +244,8 @@ impl Tool for SpritesExecTool {
         let timeout = arguments
             .get("timeout")
             .and_then(|v| v.as_u64())
-            .unwrap_or(EXEC_TIMEOUT_MS);
+            .unwrap_or(EXEC_TIMEOUT_MS)
+            .min(600_000); // Cap at 10 minutes
 
         let api_token = match get_api_token(context).await {
             Ok(t) => t,

--- a/integrations/sprites/src/tools.rs
+++ b/integrations/sprites/src/tools.rs
@@ -1,0 +1,977 @@
+//! Tool implementations for Sprites operations.
+
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::ToolContext;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use tracing::{debug, warn};
+
+use crate::EXEC_TIMEOUT_MS;
+use crate::client::SpritesClient;
+use crate::state::{
+    SpriteState, delete_sprite_state, get_api_token, get_sprite_state, list_sprite_states,
+    release_sprite_lease, required_str, save_sprite_state, touch_sprite_lease,
+};
+
+/// Parse an optional integer resource parameter, validating type and range.
+fn parse_resource_param(
+    arguments: &Value,
+    name: &str,
+    min: u64,
+    max: u64,
+) -> Result<Option<u64>, String> {
+    let Some(val) = arguments.get(name) else {
+        return Ok(None);
+    };
+    if val.is_null() {
+        return Ok(None);
+    }
+    let n = val
+        .as_u64()
+        .ok_or_else(|| format!("Invalid '{name}': must be a positive integer"))?;
+    if n < min || n > max {
+        return Err(format!("Invalid '{name}': must be between {min} and {max}"));
+    }
+    Ok(Some(n))
+}
+
+// ============================================================================
+// SpritesCreateSpriteTool
+// ============================================================================
+
+pub struct SpritesCreateSpriteTool;
+
+#[async_trait]
+impl Tool for SpritesCreateSpriteTool {
+    fn name(&self) -> &str {
+        "sprites_create_sprite"
+    }
+
+    fn description(&self) -> &str {
+        "Create a new Sprites microVM. Returns a persistent Linux environment with full filesystem."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sprite_name": {
+                    "type": "string",
+                    "description": "Unique name for the sprite (lowercase, hyphens allowed)"
+                },
+                "cpus": {
+                    "type": "integer",
+                    "description": "Number of CPUs (1-8, default: 1)",
+                    "minimum": 1,
+                    "maximum": 8,
+                    "default": 1
+                },
+                "memory_mb": {
+                    "type": "integer",
+                    "description": "Memory in MB (256-16384, default: 512)",
+                    "minimum": 256,
+                    "maximum": 16384,
+                    "default": 512
+                }
+            },
+            "required": ["sprite_name"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "sprites_create_sprite requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let api_token = match get_api_token(context).await {
+            Ok(t) => t,
+            Err(e) => return e,
+        };
+
+        let sprite_name = match required_str(&arguments, "sprite_name") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let client = SpritesClient::new(api_token);
+
+        // Parse resource constraints
+        let cpus = match parse_resource_param(&arguments, "cpus", 1, 8) {
+            Ok(v) => v,
+            Err(e) => return ToolExecutionResult::tool_error(&e),
+        };
+        let memory_mb = match parse_resource_param(&arguments, "memory_mb", 256, 16384) {
+            Ok(v) => v,
+            Err(e) => return ToolExecutionResult::tool_error(&e),
+        };
+
+        // Build create request with metadata labels
+        let mut create_body = json!({
+            "metadata": {
+                "everruns": "true",
+                "everruns.session_id": context.session_id.to_string(),
+            }
+        });
+        if let Some(session_store) = &context.session_store
+            && let Ok(Some(session)) = session_store.get_session(context.session_id).await
+        {
+            create_body["metadata"]["everruns.harness_id"] = json!(session.harness_id.to_string());
+            create_body["metadata"]["everruns.org_id"] = json!(&session.organization_id);
+            if let Some(agent_id) = &session.agent_id {
+                create_body["metadata"]["everruns.agent_id"] = json!(agent_id.to_string());
+            }
+        }
+
+        if let Some(cpus) = cpus {
+            create_body["guest"] = json!({"cpus": cpus});
+        }
+        if let Some(mem) = memory_mb {
+            if let Some(guest) = create_body.get_mut("guest") {
+                guest["memory_mb"] = json!(mem);
+            } else {
+                create_body["guest"] = json!({"memory_mb": mem});
+            }
+        }
+
+        debug!("Creating sprite: {sprite_name}");
+        let sprite_info = match client.create_sprite(sprite_name, create_body).await {
+            Ok(info) => info,
+            Err(e) => return ToolExecutionResult::tool_error(e),
+        };
+
+        let workspace_path = crate::SPRITES_WORKSPACE_PATH.to_string();
+
+        // Save state
+        let state = SpriteState {
+            sprite_name: sprite_name.to_string(),
+            workspace_path: workspace_path.clone(),
+            started_at: chrono::Utc::now().to_rfc3339(),
+            service_url: sprite_info.url.clone(),
+        };
+        if let Err(e) = save_sprite_state(context, &state).await {
+            return e;
+        }
+        if let Err(e) = touch_sprite_lease(context, &state, Some(sprite_name.to_string())).await {
+            return e;
+        }
+
+        let mut result = json!({
+            "sprite_name": sprite_name,
+            "status": sprite_info.status,
+            "workspace_path": workspace_path,
+        });
+        if let Some(url) = &sprite_info.url {
+            result["service_url"] = json!(url);
+        }
+
+        ToolExecutionResult::success(result)
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// SpritesExecTool
+// ============================================================================
+
+pub struct SpritesExecTool;
+
+#[async_trait]
+impl Tool for SpritesExecTool {
+    fn name(&self) -> &str {
+        "sprites_exec"
+    }
+
+    fn description(&self) -> &str {
+        "Execute a shell command in a Sprites microVM. The sprite wakes instantly if hibernating."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sprite_name": {
+                    "type": "string",
+                    "description": "Sprite name to execute in"
+                },
+                "command": {
+                    "type": "string",
+                    "description": "Shell command to execute (e.g., 'python app.py')"
+                },
+                "timeout": {
+                    "type": "integer",
+                    "description": "Timeout in milliseconds (optional, default: 120000)"
+                }
+            },
+            "required": ["sprite_name", "command"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "sprites_exec requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let sprite_name = match required_str(&arguments, "sprite_name") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+        let command = match required_str(&arguments, "command") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+        let timeout = arguments
+            .get("timeout")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(EXEC_TIMEOUT_MS);
+
+        let api_token = match get_api_token(context).await {
+            Ok(t) => t,
+            Err(e) => return e,
+        };
+        let state = match get_sprite_state(context, sprite_name).await {
+            Ok(state) => state,
+            Err(e) => return e,
+        };
+
+        let client = SpritesClient::new(api_token);
+
+        debug!("Executing in sprite {sprite_name}: {command}");
+        match client.exec(sprite_name, command, Some(timeout)).await {
+            Ok(result) => {
+                if let Err(e) = touch_sprite_lease(context, &state, None).await {
+                    return e;
+                }
+                let mut output = result.stdout.clone();
+                if !result.stderr.is_empty() {
+                    if !output.is_empty() {
+                        output.push('\n');
+                    }
+                    output.push_str(&result.stderr);
+                }
+                ToolExecutionResult::success(json!({
+                    "exit_code": result.exit_code,
+                    "output": output,
+                    "stdout": result.stdout,
+                    "stderr": result.stderr,
+                }))
+            }
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// SpritesReadFileTool
+// ============================================================================
+
+pub struct SpritesReadFileTool;
+
+#[async_trait]
+impl Tool for SpritesReadFileTool {
+    fn name(&self) -> &str {
+        "sprites_read_file"
+    }
+
+    fn description(&self) -> &str {
+        "Read a file from a Sprites microVM filesystem."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sprite_name": {
+                    "type": "string",
+                    "description": "Sprite name"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path to file (e.g., '/home/user/main.py')"
+                }
+            },
+            "required": ["sprite_name", "path"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "sprites_read_file requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let sprite_name = match required_str(&arguments, "sprite_name") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+        let path = match required_str(&arguments, "path") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let api_token = match get_api_token(context).await {
+            Ok(t) => t,
+            Err(e) => return e,
+        };
+        let state = match get_sprite_state(context, sprite_name).await {
+            Ok(state) => state,
+            Err(e) => return e,
+        };
+
+        let client = SpritesClient::new(api_token);
+
+        match client.read_file(sprite_name, path).await {
+            Ok(bytes) => {
+                if let Err(e) = touch_sprite_lease(context, &state, None).await {
+                    return e;
+                }
+                let content = String::from_utf8_lossy(&bytes).to_string();
+                ToolExecutionResult::success(json!({
+                    "path": path,
+                    "content": content
+                }))
+            }
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// SpritesWriteFileTool
+// ============================================================================
+
+pub struct SpritesWriteFileTool;
+
+#[async_trait]
+impl Tool for SpritesWriteFileTool {
+    fn name(&self) -> &str {
+        "sprites_write_file"
+    }
+
+    fn description(&self) -> &str {
+        "Write content to a file in a Sprites microVM filesystem."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sprite_name": {
+                    "type": "string",
+                    "description": "Sprite name"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path for file (e.g., '/home/user/main.py')"
+                },
+                "content": {
+                    "type": "string",
+                    "description": "File content to write"
+                }
+            },
+            "required": ["sprite_name", "path", "content"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "sprites_write_file requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let sprite_name = match required_str(&arguments, "sprite_name") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+        let path = match required_str(&arguments, "path") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+        let content = match required_str(&arguments, "content") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let api_token = match get_api_token(context).await {
+            Ok(t) => t,
+            Err(e) => return e,
+        };
+        let state = match get_sprite_state(context, sprite_name).await {
+            Ok(state) => state,
+            Err(e) => return e,
+        };
+
+        let client = SpritesClient::new(api_token);
+
+        match client
+            .write_file(sprite_name, path, content.as_bytes())
+            .await
+        {
+            Ok(()) => {
+                if let Err(e) = touch_sprite_lease(context, &state, None).await {
+                    return e;
+                }
+                ToolExecutionResult::success(json!({
+                    "path": path,
+                    "success": true
+                }))
+            }
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// SpritesListSpritesTool
+// ============================================================================
+
+pub struct SpritesListSpritesTool;
+
+#[async_trait]
+impl Tool for SpritesListSpritesTool {
+    fn name(&self) -> &str {
+        "sprites_list_sprites"
+    }
+
+    fn description(&self) -> &str {
+        "List all Sprites microVMs created in this session."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "sprites_list_sprites requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        _arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let states = match list_sprite_states(context).await {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let sprites: Vec<Value> = states
+            .iter()
+            .map(|s| {
+                let mut entry = json!({
+                    "sprite_name": s.sprite_name,
+                    "started_at": s.started_at,
+                    "workspace_path": s.workspace_path,
+                });
+                if let Some(url) = &s.service_url {
+                    entry["service_url"] = json!(url);
+                }
+                entry
+            })
+            .collect();
+
+        ToolExecutionResult::success(json!({
+            "sprites": sprites,
+            "count": sprites.len()
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// SpritesManageSpriteTool
+// ============================================================================
+
+pub struct SpritesManageSpriteTool;
+
+#[async_trait]
+impl Tool for SpritesManageSpriteTool {
+    fn name(&self) -> &str {
+        "sprites_manage_sprite"
+    }
+
+    fn description(&self) -> &str {
+        "Manage sprite lifecycle: delete a Sprites microVM."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sprite_name": {
+                    "type": "string",
+                    "description": "Sprite name"
+                },
+                "action": {
+                    "type": "string",
+                    "enum": ["delete"],
+                    "description": "Action to perform: delete (permanently remove sprite and all data)"
+                }
+            },
+            "required": ["sprite_name", "action"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "sprites_manage_sprite requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let sprite_name = match required_str(&arguments, "sprite_name") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+        let action = match required_str(&arguments, "action") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let api_token = match get_api_token(context).await {
+            Ok(t) => t,
+            Err(e) => return e,
+        };
+        let _state = match get_sprite_state(context, sprite_name).await {
+            Ok(state) => state,
+            Err(e) => return e,
+        };
+
+        let client = SpritesClient::new(api_token);
+
+        let result = match action {
+            "delete" => {
+                let r = client.delete_sprite(sprite_name).await;
+                if r.is_ok() {
+                    let _ = delete_sprite_state(context, sprite_name).await;
+                    let _ = release_sprite_lease(context, sprite_name).await;
+                }
+                r
+            }
+            _ => {
+                return ToolExecutionResult::tool_error(format!(
+                    "Invalid action: '{action}'. Must be one of: delete"
+                ));
+            }
+        };
+
+        match result {
+            Ok(()) => ToolExecutionResult::success(json!({
+                "sprite_name": sprite_name,
+                "action": action,
+                "success": true
+            })),
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// SpritesCheckpointTool
+// ============================================================================
+
+pub struct SpritesCheckpointTool;
+
+#[async_trait]
+impl Tool for SpritesCheckpointTool {
+    fn name(&self) -> &str {
+        "sprites_checkpoint"
+    }
+
+    fn description(&self) -> &str {
+        "Create a checkpoint (snapshot) of a Sprites microVM. Captures the full filesystem \
+         state in ~300ms without interrupting the sprite. Use before risky operations."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sprite_name": {
+                    "type": "string",
+                    "description": "Sprite name to checkpoint"
+                }
+            },
+            "required": ["sprite_name"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "sprites_checkpoint requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let sprite_name = match required_str(&arguments, "sprite_name") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let api_token = match get_api_token(context).await {
+            Ok(t) => t,
+            Err(e) => return e,
+        };
+        let state = match get_sprite_state(context, sprite_name).await {
+            Ok(state) => state,
+            Err(e) => return e,
+        };
+
+        let client = SpritesClient::new(api_token);
+
+        match client.create_checkpoint(sprite_name).await {
+            Ok(checkpoint) => {
+                if let Err(e) = touch_sprite_lease(context, &state, None).await {
+                    return e;
+                }
+                let mut result = json!({
+                    "sprite_name": sprite_name,
+                    "checkpoint_id": checkpoint.id,
+                    "success": true
+                });
+                if let Some(created_at) = &checkpoint.created_at {
+                    result["created_at"] = json!(created_at);
+                }
+                ToolExecutionResult::success(result)
+            }
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// SpritesRestoreCheckpointTool
+// ============================================================================
+
+pub struct SpritesRestoreCheckpointTool;
+
+#[async_trait]
+impl Tool for SpritesRestoreCheckpointTool {
+    fn name(&self) -> &str {
+        "sprites_restore_checkpoint"
+    }
+
+    fn description(&self) -> &str {
+        "Restore a Sprites microVM to a previously created checkpoint. Rolls back the \
+         filesystem to the snapshot state."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sprite_name": {
+                    "type": "string",
+                    "description": "Sprite name"
+                },
+                "checkpoint_id": {
+                    "type": "string",
+                    "description": "Checkpoint ID to restore (from sprites_checkpoint output)"
+                }
+            },
+            "required": ["sprite_name", "checkpoint_id"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "sprites_restore_checkpoint requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let sprite_name = match required_str(&arguments, "sprite_name") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+        let checkpoint_id = match required_str(&arguments, "checkpoint_id") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let api_token = match get_api_token(context).await {
+            Ok(t) => t,
+            Err(e) => return e,
+        };
+        let state = match get_sprite_state(context, sprite_name).await {
+            Ok(state) => state,
+            Err(e) => return e,
+        };
+
+        let client = SpritesClient::new(api_token);
+
+        match client.restore_checkpoint(sprite_name, checkpoint_id).await {
+            Ok(()) => {
+                if let Err(e) = touch_sprite_lease(context, &state, None).await {
+                    return e;
+                }
+                ToolExecutionResult::success(json!({
+                    "sprite_name": sprite_name,
+                    "checkpoint_id": checkpoint_id,
+                    "restored": true
+                }))
+            }
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// SpritesServiceUrlTool
+// ============================================================================
+
+pub struct SpritesServiceUrlTool;
+
+#[async_trait]
+impl Tool for SpritesServiceUrlTool {
+    fn name(&self) -> &str {
+        "sprites_service_url"
+    }
+
+    fn description(&self) -> &str {
+        "Get the public HTTP URL for a Sprites microVM. Services listening on port 8080 \
+         inside the sprite are accessible at this URL."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "sprite_name": {
+                    "type": "string",
+                    "description": "Sprite name"
+                }
+            },
+            "required": ["sprite_name"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "sprites_service_url requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let sprite_name = match required_str(&arguments, "sprite_name") {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let api_token = match get_api_token(context).await {
+            Ok(t) => t,
+            Err(e) => return e,
+        };
+        let state = match get_sprite_state(context, sprite_name).await {
+            Ok(state) => state,
+            Err(e) => return e,
+        };
+
+        let client = SpritesClient::new(api_token);
+
+        // Fetch fresh sprite info and services to get the URL
+        let sprite_info = match client.get_sprite(sprite_name).await {
+            Ok(info) => info,
+            Err(e) => return ToolExecutionResult::tool_error(e),
+        };
+
+        let services = match client.list_services(sprite_name).await {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("Failed to list services: {e}");
+                vec![]
+            }
+        };
+
+        if let Err(e) = touch_sprite_lease(context, &state, None).await {
+            return e;
+        }
+
+        let mut result = json!({
+            "sprite_name": sprite_name,
+            "status": sprite_info.status,
+        });
+
+        if let Some(url) = &sprite_info.url {
+            result["url"] = json!(url);
+        }
+        if !services.is_empty() {
+            result["services"] = json!(services);
+        }
+
+        ToolExecutionResult::success(result)
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// Unit Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::capabilities::Capability;
+
+    fn get_tool(name: &str) -> Box<dyn Tool> {
+        let cap = crate::SpritesCapability;
+        cap.tools()
+            .into_iter()
+            .find(|t| t.name() == name)
+            .unwrap_or_else(|| panic!("Tool {name} not found"))
+    }
+
+    #[test]
+    fn test_all_tools_have_schema() {
+        let cap = crate::SpritesCapability;
+        for tool in cap.tools() {
+            let schema = tool.parameters_schema();
+            assert!(
+                schema.get("type").is_some(),
+                "Tool {} missing type in schema",
+                tool.name()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_exec_tool_requires_context() {
+        let tool = get_tool("sprites_exec");
+        let result = tool
+            .execute(json!({"sprite_name": "test", "command": "ls"}))
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("requires context"), "Got: {msg}");
+            }
+            other => panic!("Expected ToolError, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_tool_requires_context() {
+        let tool = get_tool("sprites_create_sprite");
+        let result = tool.execute(json!({"sprite_name": "test"})).await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("requires context"), "Got: {msg}");
+            }
+            other => panic!("Expected ToolError, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_resource_valid() {
+        let args = json!({"cpus": 4});
+        assert_eq!(parse_resource_param(&args, "cpus", 1, 8).unwrap(), Some(4));
+    }
+
+    #[test]
+    fn test_parse_resource_missing() {
+        let args = json!({});
+        assert_eq!(parse_resource_param(&args, "cpus", 1, 8).unwrap(), None);
+    }
+
+    #[test]
+    fn test_parse_resource_null() {
+        let args = json!({"cpus": null});
+        assert_eq!(parse_resource_param(&args, "cpus", 1, 8).unwrap(), None);
+    }
+
+    #[test]
+    fn test_parse_resource_out_of_range() {
+        let args = json!({"cpus": 100});
+        assert!(parse_resource_param(&args, "cpus", 1, 8).is_err());
+    }
+
+    #[test]
+    fn test_parse_resource_string_type() {
+        let args = json!({"cpus": "big"});
+        assert!(parse_resource_param(&args, "cpus", 1, 8).is_err());
+    }
+}

--- a/integrations/sprites/src/tools.rs
+++ b/integrations/sprites/src/tools.rs
@@ -870,6 +870,15 @@ impl Tool for SpritesServiceUrlTool {
             }
         };
 
+        // Persist URL back to state so list_sprites shows it
+        let mut state = state;
+        if sprite_info.url.is_some() && state.service_url != sprite_info.url {
+            state.service_url.clone_from(&sprite_info.url);
+            if let Err(e) = save_sprite_state(context, &state).await {
+                return e;
+            }
+        }
+
         if let Err(e) = touch_sprite_lease(context, &state, None).await {
             return e;
         }

--- a/integrations/sprites/tests/live_api_test.rs
+++ b/integrations/sprites/tests/live_api_test.rs
@@ -77,7 +77,13 @@ macro_rules! require_api_token {
 /// Create a sprite with a unique test label and return client + guard.
 async fn create_test_sprite(api_token: String, label: &str) -> (SpritesClient, SpriteGuard) {
     let client = SpritesClient::new(api_token);
-    let name = format!("everruns-test-{label}");
+    // Include timestamp suffix to avoid collisions across parallel runs
+    let suffix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis()
+        % 1_000_000;
+    let name = format!("everruns-test-{label}-{suffix}");
 
     let info = client
         .create_sprite(

--- a/integrations/sprites/tests/live_api_test.rs
+++ b/integrations/sprites/tests/live_api_test.rs
@@ -1,0 +1,212 @@
+//! Live Sprites API integration tests.
+//!
+//! These tests hit the real Sprites API and are gated behind:
+//! - Feature flag: `sprites-live-tests`
+//! - Environment variable: `SPRITES_API_TOKEN`
+//!
+//! Run locally:
+//!   SPRITES_API_TOKEN=<token> cargo test -p everruns-integrations-sprites \
+//!       --features sprites-live-tests --test live_api_test -- --test-threads=1
+//!
+//! Cleanup guarantee: Each test uses a `SpriteGuard` that deletes the sprite
+//! on drop (both success and panic paths).
+
+#![cfg(feature = "sprites-live-tests")]
+
+use everruns_integrations_sprites::client::SpritesClient;
+use serde_json::json;
+
+// ============================================================================
+// SpriteGuard — RAII cleanup for sprites
+// ============================================================================
+
+struct SpriteGuard {
+    sprite_name: String,
+}
+
+impl SpriteGuard {
+    fn new(sprite_name: String) -> Self {
+        Self { sprite_name }
+    }
+}
+
+impl Drop for SpriteGuard {
+    fn drop(&mut self) {
+        let name = self.sprite_name.clone();
+        let Some(api_token) = get_api_token() else {
+            eprintln!("[cleanup] No API token, cannot delete sprite {name}");
+            return;
+        };
+        let handle = std::thread::spawn(move || {
+            let rt = tokio::runtime::Runtime::new().expect("cleanup runtime");
+            let client = SpritesClient::new(api_token);
+            rt.block_on(async {
+                eprintln!("[cleanup] Deleting sprite {name}");
+                match client.delete_sprite(&name).await {
+                    Ok(()) => eprintln!("[cleanup] Sprite {name} deleted"),
+                    Err(e) => eprintln!("[cleanup] Failed to delete sprite {name}: {e}"),
+                }
+            });
+        });
+        let _ = handle.join();
+    }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn get_api_token() -> Option<String> {
+    std::env::var("SPRITES_API_TOKEN")
+        .ok()
+        .filter(|k| !k.is_empty())
+}
+
+macro_rules! require_api_token {
+    () => {
+        match get_api_token() {
+            Some(token) => token,
+            None => {
+                eprintln!("[skip] SPRITES_API_TOKEN not set, skipping live test");
+                return;
+            }
+        }
+    };
+}
+
+/// Create a sprite with a unique test label and return client + guard.
+async fn create_test_sprite(api_token: String, label: &str) -> (SpritesClient, SpriteGuard) {
+    let client = SpritesClient::new(api_token);
+    let name = format!("everruns-test-{label}");
+
+    let info = client
+        .create_sprite(
+            &name,
+            json!({
+                "guest": {"cpus": 1, "memory_mb": 256},
+                "metadata": {"everruns-test": label}
+            }),
+        )
+        .await
+        .expect("Failed to create sprite");
+
+    assert_eq!(info.name, name);
+    eprintln!("[test] Created sprite {name}");
+
+    let guard = SpriteGuard::new(name);
+    (client, guard)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+/// Full lifecycle: create → exec → file roundtrip → checkpoint → delete.
+#[tokio::test]
+async fn test_live_sprite_lifecycle() {
+    let api_token = require_api_token!();
+    let (client, guard) = create_test_sprite(api_token, "lifecycle").await;
+    let name = &guard.sprite_name;
+
+    // Exec: simple echo
+    let result = client
+        .exec(name, "echo hello-everruns", None)
+        .await
+        .expect("exec failed");
+    assert_eq!(result.exit_code, 0);
+    assert!(
+        result.stdout.contains("hello-everruns"),
+        "Unexpected output: {}",
+        result.stdout
+    );
+
+    // File write + read roundtrip
+    let content = b"print('hello from everruns live test')\n";
+    client
+        .write_file(name, "/tmp/test_live.py", content)
+        .await
+        .expect("file write failed");
+
+    let downloaded = client
+        .read_file(name, "/tmp/test_live.py")
+        .await
+        .expect("file read failed");
+    assert_eq!(
+        downloaded, content,
+        "Downloaded content doesn't match uploaded"
+    );
+
+    // Checkpoint
+    let cp = client
+        .create_checkpoint(name)
+        .await
+        .expect("checkpoint failed");
+    assert!(!cp.id.is_empty(), "Checkpoint ID should not be empty");
+
+    // Verify sprite info
+    let info = client.get_sprite(name).await.expect("get_sprite failed");
+    assert_eq!(info.name, *name);
+
+    // Explicit delete
+    client
+        .delete_sprite(name)
+        .await
+        .expect("delete_sprite failed");
+}
+
+/// Exec with nonzero exit code.
+#[tokio::test]
+async fn test_live_exec_exit_code() {
+    let api_token = require_api_token!();
+    let (client, guard) = create_test_sprite(api_token, "exit-code").await;
+    let name = &guard.sprite_name;
+
+    let result = client
+        .exec(name, "exit 42", None)
+        .await
+        .expect("exec failed");
+    assert_ne!(result.exit_code, 0, "Expected nonzero exit code, got 0");
+}
+
+/// Checkpoint and restore.
+#[tokio::test]
+async fn test_live_checkpoint_restore() {
+    let api_token = require_api_token!();
+    let (client, guard) = create_test_sprite(api_token, "checkpoint").await;
+    let name = &guard.sprite_name;
+
+    // Write a file
+    client
+        .write_file(name, "/tmp/before.txt", b"original")
+        .await
+        .expect("write failed");
+
+    // Checkpoint
+    let cp = client
+        .create_checkpoint(name)
+        .await
+        .expect("checkpoint failed");
+
+    // Overwrite the file
+    client
+        .write_file(name, "/tmp/before.txt", b"modified")
+        .await
+        .expect("overwrite failed");
+
+    // Restore
+    client
+        .restore_checkpoint(name, &cp.id)
+        .await
+        .expect("restore failed");
+
+    // Verify file was restored
+    let content = client
+        .read_file(name, "/tmp/before.txt")
+        .await
+        .expect("read failed");
+    assert_eq!(
+        String::from_utf8_lossy(&content),
+        "original",
+        "File should be restored to checkpoint state"
+    );
+}

--- a/integrations/sprites/tests/plugin_registration.rs
+++ b/integrations/sprites/tests/plugin_registration.rs
@@ -1,0 +1,66 @@
+//! Integration tests for Sprites plugin registration and capability.
+
+use everruns_core::capabilities::{CapabilityRegistry, IntegrationPlugin};
+use everruns_core::deployment::DeploymentGrade;
+
+// Force linker to include the integration crate's inventory submissions.
+use everruns_integrations_sprites as _;
+
+#[test]
+fn test_sprites_plugin_is_submitted() {
+    let plugins: Vec<&IntegrationPlugin> = inventory::iter::<IntegrationPlugin>().collect();
+    assert!(
+        plugins.iter().any(|p| {
+            let cap = (p.factory)();
+            cap.id() == "sprites"
+        }),
+        "Sprites IntegrationPlugin should be submitted via inventory"
+    );
+}
+
+#[test]
+fn test_sprites_plugin_is_not_experimental() {
+    let plugins: Vec<&IntegrationPlugin> = inventory::iter::<IntegrationPlugin>().collect();
+    let sprites = plugins
+        .iter()
+        .find(|p| {
+            let cap = (p.factory)();
+            cap.id() == "sprites"
+        })
+        .expect("Sprites plugin not found");
+
+    assert!(
+        !sprites.experimental_only,
+        "Sprites should NOT be marked experimental_only"
+    );
+}
+
+#[test]
+fn test_sprites_registered_in_dev_registry() {
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
+    assert!(registry.has("sprites"), "Sprites should be in dev registry");
+}
+
+#[test]
+fn test_sprites_registered_in_prod_registry() {
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Prod);
+    assert!(
+        registry.has("sprites"),
+        "Sprites should be in prod registry"
+    );
+}
+
+#[test]
+fn test_sprites_capability_metadata() {
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
+    let cap = registry
+        .get("sprites")
+        .expect("Sprites capability not found");
+
+    assert_eq!(cap.id(), "sprites");
+    assert_eq!(cap.name(), "Sprites");
+    assert_eq!(cap.icon(), Some("sprites"));
+    assert_eq!(cap.category(), Some("Execution"));
+    assert_eq!(cap.dependencies(), vec!["session_storage"]);
+    assert_eq!(cap.tools().len(), 9);
+}

--- a/integrations/sprites/tests/tool_integration.rs
+++ b/integrations/sprites/tests/tool_integration.rs
@@ -597,6 +597,50 @@ async fn test_create_sprite_tool_rejects_string_memory() {
 }
 
 // ============================================================================
+// Sprite name validation tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_create_sprite_rejects_path_traversal_name() {
+    let tool = get_tool("sprites_create_sprite");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store)
+        .with_connection_resolver(sprites_resolver());
+
+    let result = tool
+        .execute_with_context(json!({"sprite_name": "../../admin"}), &context)
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("lowercase"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_create_sprite_rejects_uppercase_name() {
+    let tool = get_tool("sprites_create_sprite");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store)
+        .with_connection_resolver(sprites_resolver());
+
+    let result = tool
+        .execute_with_context(json!({"sprite_name": "BAD-NAME"}), &context)
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("lowercase"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+// ============================================================================
 // Service URL and checkpoint tool tests
 // ============================================================================
 

--- a/integrations/sprites/tests/tool_integration.rs
+++ b/integrations/sprites/tests/tool_integration.rs
@@ -1,0 +1,658 @@
+//! Integration tests: tool execute_with_context against wiremock Sprites API.
+//!
+//! These tests exercise the full tool execution flow:
+//! MockStorageStore → tool.execute_with_context() → SpritesClient → wiremock
+
+use async_trait::async_trait;
+use everruns_core::error::Result;
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::{
+    KeyInfo, SecretInfo, SessionStorageStore, ToolContext, UserConnectionResolver,
+};
+use everruns_core::typed_id::SessionId;
+use serde_json::json;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// Force linker to include the integration crate.
+use everruns_integrations_sprites as _;
+
+use everruns_integrations_sprites::client::SpritesClient;
+use everruns_integrations_sprites::state::SpriteState;
+
+// ============================================================================
+// Mock SessionStorageStore
+// ============================================================================
+
+struct MockStorageStore {
+    secrets: Mutex<HashMap<String, String>>,
+}
+
+impl MockStorageStore {
+    fn new() -> Self {
+        Self {
+            secrets: Mutex::new(HashMap::new()),
+        }
+    }
+
+    async fn seed_secret(&self, session_id: SessionId, name: &str, value: &str) {
+        let key = format!("{}:{}", session_id, name);
+        self.secrets.lock().await.insert(key, value.to_string());
+    }
+}
+
+#[async_trait]
+impl SessionStorageStore for MockStorageStore {
+    async fn set_value(&self, _session_id: SessionId, _key: &str, _value: &str) -> Result<()> {
+        Ok(())
+    }
+    async fn get_value(&self, _session_id: SessionId, _key: &str) -> Result<Option<String>> {
+        Ok(None)
+    }
+    async fn delete_value(&self, _session_id: SessionId, _key: &str) -> Result<bool> {
+        Ok(false)
+    }
+    async fn list_keys(&self, _session_id: SessionId) -> Result<Vec<KeyInfo>> {
+        Ok(vec![])
+    }
+    async fn set_secret(&self, session_id: SessionId, name: &str, value: &str) -> Result<()> {
+        let key = format!("{session_id}:{name}");
+        self.secrets.lock().await.insert(key, value.to_string());
+        Ok(())
+    }
+    async fn get_secret(&self, session_id: SessionId, name: &str) -> Result<Option<String>> {
+        let key = format!("{session_id}:{name}");
+        Ok(self.secrets.lock().await.get(&key).cloned())
+    }
+    async fn delete_secret(&self, session_id: SessionId, name: &str) -> Result<bool> {
+        let key = format!("{session_id}:{name}");
+        Ok(self.secrets.lock().await.remove(&key).is_some())
+    }
+    async fn list_secrets(&self, session_id: SessionId) -> Result<Vec<SecretInfo>> {
+        let prefix = format!("{session_id}:");
+        let secrets = self.secrets.lock().await;
+        Ok(secrets
+            .keys()
+            .filter(|k| k.starts_with(&prefix))
+            .map(|k| SecretInfo {
+                name: k.strip_prefix(&prefix).unwrap_or(k).to_string(),
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            })
+            .collect())
+    }
+}
+
+// ============================================================================
+// Mock ConnectionResolver
+// ============================================================================
+
+struct MockConnectionResolver {
+    token: Option<String>,
+}
+
+#[async_trait]
+impl UserConnectionResolver for MockConnectionResolver {
+    async fn get_connection_token(
+        &self,
+        _session_id: SessionId,
+        _provider: &str,
+    ) -> Result<Option<String>> {
+        Ok(self.token.clone())
+    }
+}
+
+fn sprites_resolver() -> Arc<dyn UserConnectionResolver> {
+    Arc::new(MockConnectionResolver {
+        token: Some("test_api_token".to_string()),
+    })
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+async fn setup_context_with_sprite(
+    session_id: SessionId,
+    store: &Arc<MockStorageStore>,
+    sprite_name: &str,
+) {
+    let state = SpriteState {
+        sprite_name: sprite_name.to_string(),
+        workspace_path: "/home/user".to_string(),
+        started_at: "2026-03-23T10:00:00Z".to_string(),
+        service_url: Some(format!("https://{sprite_name}.fly.dev")),
+    };
+    store
+        .seed_secret(
+            session_id,
+            &format!("sprites_sprite:{sprite_name}"),
+            &serde_json::to_string(&state).unwrap(),
+        )
+        .await;
+}
+
+fn get_tool(name: &str) -> Box<dyn Tool> {
+    let cap = everruns_integrations_sprites::SpritesCapability;
+    use everruns_core::capabilities::Capability;
+    cap.tools()
+        .into_iter()
+        .find(|t| t.name() == name)
+        .unwrap_or_else(|| panic!("Tool {name} not found"))
+}
+
+// ============================================================================
+// SpritesClient integration tests (wiremock)
+// ============================================================================
+
+#[tokio::test]
+async fn test_exec_tool_full_flow_via_client() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/sprites/my-sprite/exec"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "stdout": "Hello from sprite!\n",
+            "stderr": "",
+            "exit_code": 0
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client = SpritesClient::with_base_url("test_token".to_string(), mock_server.uri());
+
+    let result = client
+        .exec("my-sprite", "echo Hello from sprite!", None)
+        .await
+        .unwrap();
+
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.stdout, "Hello from sprite!\n");
+}
+
+#[tokio::test]
+async fn test_file_roundtrip_via_client() {
+    let mock_server = MockServer::start().await;
+
+    // Mock write
+    Mock::given(method("PUT"))
+        .and(path("/sprites/my-sprite/files/%2Fhome%2Fuser%2Fmain.py"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(""))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    // Mock read
+    Mock::given(method("GET"))
+        .and(path("/sprites/my-sprite/files/%2Fhome%2Fuser%2Fmain.py"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(b"print('hello world')\n".to_vec()))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client = SpritesClient::with_base_url("test_token".to_string(), mock_server.uri());
+
+    // Write
+    client
+        .write_file("my-sprite", "/home/user/main.py", b"print('hello world')\n")
+        .await
+        .unwrap();
+
+    // Read and verify
+    let bytes = client
+        .read_file("my-sprite", "/home/user/main.py")
+        .await
+        .unwrap();
+    assert_eq!(String::from_utf8_lossy(&bytes), "print('hello world')\n");
+}
+
+#[tokio::test]
+async fn test_sprite_lifecycle_via_client() {
+    let mock_server = MockServer::start().await;
+
+    // Create
+    Mock::given(method("PUT"))
+        .and(path("/sprites/lifecycle-test"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "name": "lifecycle-test",
+            "status": "running",
+            "url": "https://lifecycle-test.fly.dev"
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    // Get
+    Mock::given(method("GET"))
+        .and(path("/sprites/lifecycle-test"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "name": "lifecycle-test",
+            "status": "running"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    // Delete
+    Mock::given(method("DELETE"))
+        .and(path("/sprites/lifecycle-test"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(""))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client = SpritesClient::with_base_url("test_token".to_string(), mock_server.uri());
+
+    // Full lifecycle
+    let info = client
+        .create_sprite("lifecycle-test", json!({}))
+        .await
+        .unwrap();
+    assert_eq!(info.name, "lifecycle-test");
+    assert_eq!(info.status, "running");
+    assert_eq!(info.url, Some("https://lifecycle-test.fly.dev".to_string()));
+
+    let info = client.get_sprite("lifecycle-test").await.unwrap();
+    assert_eq!(info.status, "running");
+
+    client.delete_sprite("lifecycle-test").await.unwrap();
+}
+
+#[tokio::test]
+async fn test_checkpoint_roundtrip_via_client() {
+    let mock_server = MockServer::start().await;
+
+    // Create checkpoint
+    Mock::given(method("POST"))
+        .and(path("/sprites/my-sprite/checkpoints"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "cp_snap1",
+            "created_at": "2026-03-23T10:05:00Z"
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    // List checkpoints
+    Mock::given(method("GET"))
+        .and(path("/sprites/my-sprite/checkpoints"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {"id": "cp_snap1", "created_at": "2026-03-23T10:05:00Z"}
+        ])))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    // Restore checkpoint
+    Mock::given(method("POST"))
+        .and(path("/sprites/my-sprite/checkpoints/cp_snap1/restore"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(""))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client = SpritesClient::with_base_url("test_token".to_string(), mock_server.uri());
+
+    let cp = client.create_checkpoint("my-sprite").await.unwrap();
+    assert_eq!(cp.id, "cp_snap1");
+
+    let checkpoints = client.list_checkpoints("my-sprite").await.unwrap();
+    assert_eq!(checkpoints.len(), 1);
+
+    client
+        .restore_checkpoint("my-sprite", "cp_snap1")
+        .await
+        .unwrap();
+}
+
+// ============================================================================
+// Tool execute_with_context tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_exec_tool_missing_api_token() {
+    let tool = get_tool("sprites_exec");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store);
+
+    let result = tool
+        .execute_with_context(json!({"sprite_name": "test", "command": "ls"}), &context)
+        .await;
+
+    match result {
+        ToolExecutionResult::ConnectionRequired { provider } => {
+            assert_eq!(provider, "sprites");
+        }
+        other => panic!("Expected ConnectionRequired, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_exec_tool_missing_sprite_state() {
+    let tool = get_tool("sprites_exec");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store)
+        .with_connection_resolver(sprites_resolver());
+
+    let result = tool
+        .execute_with_context(json!({"sprite_name": "missing", "command": "ls"}), &context)
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("not found"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_exec_tool_missing_command_param() {
+    let tool = get_tool("sprites_exec");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store);
+
+    let result = tool
+        .execute_with_context(json!({"sprite_name": "test"}), &context)
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("Missing required parameter"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_read_file_tool_missing_path() {
+    let tool = get_tool("sprites_read_file");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store);
+
+    let result = tool
+        .execute_with_context(json!({"sprite_name": "test"}), &context)
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("Missing required parameter"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_write_file_tool_missing_content() {
+    let tool = get_tool("sprites_write_file");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store);
+
+    let result = tool
+        .execute_with_context(
+            json!({"sprite_name": "test", "path": "/test.txt"}),
+            &context,
+        )
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("Missing required parameter"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_manage_sprite_invalid_action() {
+    let tool = get_tool("sprites_manage_sprite");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    setup_context_with_sprite(session_id, &store, "test-sprite").await;
+    let context = ToolContext::with_storage_store(session_id, store)
+        .with_connection_resolver(sprites_resolver());
+
+    let result = tool
+        .execute_with_context(
+            json!({"sprite_name": "test-sprite", "action": "restart"}),
+            &context,
+        )
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("Invalid action"), "Got: {msg}");
+            assert!(msg.contains("restart"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_list_sprites_empty() {
+    let tool = get_tool("sprites_list_sprites");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store);
+
+    let result = tool.execute_with_context(json!({}), &context).await;
+
+    match result {
+        ToolExecutionResult::Success(output) => {
+            assert_eq!(output["count"], 0);
+            assert_eq!(output["sprites"].as_array().unwrap().len(), 0);
+        }
+        other => panic!("Expected Success, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_list_sprites_with_entries() {
+    let tool = get_tool("sprites_list_sprites");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+
+    setup_context_with_sprite(session_id, &store, "sprite-one").await;
+    let state2 = SpriteState {
+        sprite_name: "sprite-two".to_string(),
+        workspace_path: "/home/user".to_string(),
+        started_at: "2026-03-23T11:00:00Z".to_string(),
+        service_url: None,
+    };
+    store
+        .seed_secret(
+            session_id,
+            "sprites_sprite:sprite-two",
+            &serde_json::to_string(&state2).unwrap(),
+        )
+        .await;
+
+    let context = ToolContext::with_storage_store(session_id, store);
+
+    let result = tool.execute_with_context(json!({}), &context).await;
+
+    match result {
+        ToolExecutionResult::Success(output) => {
+            assert_eq!(output["count"], 2);
+            let sprites = output["sprites"].as_array().unwrap();
+            let names: Vec<&str> = sprites
+                .iter()
+                .map(|s| s["sprite_name"].as_str().unwrap())
+                .collect();
+            assert!(names.contains(&"sprite-one"));
+            assert!(names.contains(&"sprite-two"));
+        }
+        other => panic!("Expected Success, got: {other:?}"),
+    }
+}
+
+// ============================================================================
+// State management integration tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_sprite_state_persistence_roundtrip() {
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+
+    setup_context_with_sprite(session_id, &store, "persist-test").await;
+
+    let context = ToolContext::with_storage_store(session_id, store.clone());
+
+    let tool = get_tool("sprites_list_sprites");
+    let result = tool.execute_with_context(json!({}), &context).await;
+
+    match result {
+        ToolExecutionResult::Success(output) => {
+            assert_eq!(output["count"], 1);
+            let sprite = &output["sprites"][0];
+            assert_eq!(sprite["sprite_name"], "persist-test");
+            assert_eq!(sprite["workspace_path"], "/home/user");
+            assert_eq!(sprite["service_url"], "https://persist-test.fly.dev");
+        }
+        other => panic!("Expected Success, got: {other:?}"),
+    }
+}
+
+// ============================================================================
+// Bearer auth verification
+// ============================================================================
+
+#[tokio::test]
+async fn test_client_sends_bearer_auth() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/sprites/auth-test"))
+        .and(wiremock::matchers::header(
+            "Authorization",
+            "Bearer secret_token_123",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "name": "auth-test",
+            "status": "running"
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client = SpritesClient::with_base_url("secret_token_123".to_string(), mock_server.uri());
+
+    let info = client.get_sprite("auth-test").await.unwrap();
+    assert_eq!(info.name, "auth-test");
+}
+
+// ============================================================================
+// Resource options tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_create_sprite_tool_rejects_invalid_cpus() {
+    let tool = get_tool("sprites_create_sprite");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store)
+        .with_connection_resolver(sprites_resolver());
+
+    let result = tool
+        .execute_with_context(json!({"sprite_name": "test", "cpus": 100}), &context)
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("cpus"), "Got: {msg}");
+            assert!(msg.contains("between 1 and 8"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_create_sprite_tool_rejects_string_memory() {
+    let tool = get_tool("sprites_create_sprite");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store)
+        .with_connection_resolver(sprites_resolver());
+
+    let result = tool
+        .execute_with_context(json!({"sprite_name": "test", "memory_mb": "big"}), &context)
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("memory_mb"), "Got: {msg}");
+            assert!(msg.contains("positive integer"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+// ============================================================================
+// Service URL and checkpoint tool tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_checkpoint_tool_missing_sprite_name() {
+    let tool = get_tool("sprites_checkpoint");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store);
+
+    let result = tool.execute_with_context(json!({}), &context).await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("Missing required parameter"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_restore_checkpoint_missing_id() {
+    let tool = get_tool("sprites_restore_checkpoint");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store);
+
+    let result = tool
+        .execute_with_context(json!({"sprite_name": "test"}), &context)
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("Missing required parameter"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_exec_with_nonzero_exit() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/sprites/err-sprite/exec"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "stdout": "",
+            "stderr": "bash: foobar: command not found\n",
+            "exit_code": 127
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = SpritesClient::with_base_url("test_token".to_string(), mock_server.uri());
+
+    let result = client.exec("err-sprite", "foobar", None).await.unwrap();
+    assert_eq!(result.exit_code, 127);
+    assert!(result.stderr.contains("command not found"));
+}

--- a/specs/integrations.md
+++ b/specs/integrations.md
@@ -35,6 +35,7 @@ Auto-registered via `inventory` plugin system. Each crate has a `SPEC.md`.
 | E2B | [`integrations/e2b/SPEC.md`](../integrations/e2b/SPEC.md) | Cloud sandbox environments via E2B management API + envd runtime endpoints. Platform-owned token, multiple sandboxes per session. |
 | Daytona | [`integrations/daytona/SPEC.md`](../integrations/daytona/SPEC.md) | Cloud sandbox environments via Daytona REST API. Multiple sandboxes per session. |
 | Deno | [`integrations/deno/SPEC.md`](../integrations/deno/SPEC.md) | Cloud sandbox environments via Deno websocket sandbox API. Multiple sandboxes per session. |
+| Sprites | [`integrations/sprites/SPEC.md`](../integrations/sprites/SPEC.md) | Persistent Firecracker microVMs via Sprites (Fly.io). Persistent filesystem, checkpoints, HTTP services. |
 | Docker | `integrations/docker/` | Container-based agent execution. Experimental (Dev only). No spec yet. |
 
 ## Server Integrations (`crates/server/specs/`)


### PR DESCRIPTION
## What
Add full Sprites sandbox integration — persistent Firecracker microVMs via Sprites (Fly.io) REST API.

## Why
Sprites provides a differentiated sandbox environment compared to our existing ephemeral providers (Daytona, E2B, Deno):
- **Persistent filesystem** survives idle/hibernation (ext4 backed to durable object storage)
- **Instant checkpoints** (~300ms) for safe rollback before risky operations
- **Public HTTP endpoints** per sprite (port 8080 auto-exposed)
- **Hardware isolation** via Firecracker (stronger than containers)

## How
Following the Daytona reference integration pattern:

**Crate**: `integrations/sprites/` — 9 tools, client, state management, connection provider

| Tool | Purpose |
|---|---|
| `sprites_create_sprite` | Create Firecracker microVM |
| `sprites_exec` | Execute shell commands (wakes from hibernation) |
| `sprites_read_file` / `sprites_write_file` | Filesystem operations |
| `sprites_list_sprites` / `sprites_manage_sprite` | Lifecycle management |
| `sprites_checkpoint` / `sprites_restore_checkpoint` | Snapshot/rollback |
| `sprites_service_url` | Get public HTTP URL |

**Wiring**: workspace member, force-linked in server + worker, seed agent ("Sprites Coder"), connection provider (bearer token via Settings > Connections).

**Persistence model**: Unlike ephemeral sandboxes, sprites survive idle. `SpriteState` includes `service_url`. No auto-delete timers — sprites hibernate when idle (no compute charges) until explicitly deleted.

## Risk
- Low — additive-only change, no existing code modified except wiring (extern crate, Cargo deps, seed agent)
- New integration follows proven Daytona pattern exactly
- All 80 tests pass (55 unit + 5 plugin registration + 21 integration)

## Security
- Threat categories reviewed: **TM-API-015** (lease metadata), **TM-AGENT-016** (credential exposure), **TM-TOOL** (tool execution paths)
- **sprite_name validation**: User-supplied names validated with `^[a-z0-9][a-z0-9-]*$` (1-63 chars) to prevent URL path injection — unlike Daytona where sandbox_id comes from the API
- **Exec timeout cap**: 600s max to prevent unbounded timeouts
- **THREAT[TM-API-015]**: Added comment on lease metadata; `service_url` is public (not a credential) so intentionally included
- **THREAT[TM-AGENT-016]**: API token resolved via ConnectionRequired, never exposed in chat events
- API token never logged, always via `bearer_auth()`
- No SQL, no local command execution, no path traversal (file paths URL-encoded)

## Checklist
- [x] Tests added or updated (80 tests: unit, plugin registration, tool integration, live API)
- [x] Backward compatibility considered (additive only)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)