### PR TITLE
feat(ci): add Sprites integration workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,7 @@ jobs:
           cargo test -p everruns-integrations-deno
           cargo test -p everruns-integrations-browserless
           cargo test -p everruns-integrations-e2b
+          cargo test -p everruns-integrations-sprites
 
   # Live Daytona API tests — only when integrations/daytona/** changes and secret exists
   daytona-live-test:

--- a/.github/workflows/sprites-integration.yml
+++ b/.github/workflows/sprites-integration.yml
@@ -2,15 +2,13 @@ name: Sprites Integration
 
 on:
   push:
-    branches: [main, claude/evaluate-sprites-integration-E5Tt0]
+    branches: [main]
     paths:
       - 'integrations/sprites/**'
-      - '.github/workflows/sprites-integration.yml'
   pull_request:
     branches: [main]
     paths:
       - 'integrations/sprites/**'
-      - '.github/workflows/sprites-integration.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/sprites-integration.yml
+++ b/.github/workflows/sprites-integration.yml
@@ -2,13 +2,15 @@ name: Sprites Integration
 
 on:
   push:
-    branches: [main]
+    branches: [main, claude/evaluate-sprites-integration-E5Tt0]
     paths:
       - 'integrations/sprites/**'
+      - '.github/workflows/sprites-integration.yml'
   pull_request:
     branches: [main]
     paths:
       - 'integrations/sprites/**'
+      - '.github/workflows/sprites-integration.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/sprites-integration.yml
+++ b/.github/workflows/sprites-integration.yml
@@ -1,0 +1,103 @@
+name: Sprites Integration
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'integrations/sprites/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'integrations/sprites/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  RUSTC_WRAPPER: sccache
+  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+
+jobs:
+  unit-test:
+    name: Sprites Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install protobuf compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.7
+
+      - name: Configure sccache S3 backend
+        if: env.DOPPLER_TOKEN != ''
+        run: ./.github/scripts/ci-sccache-env.sh >> "$GITHUB_ENV"
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "sprites-integration"
+
+      - name: Run unit tests
+        run: cargo test -p everruns-integrations-sprites
+
+  live-test:
+    name: Sprites Live API Tests
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for Doppler token
+        id: check-key
+        run: |
+          if [ -z "$DOPPLER_TOKEN" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "⏭️ DOPPLER_TOKEN not configured, skipping live tests"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Doppler CLI
+        if: steps.check-key.outputs.skip != 'true'
+        uses: dopplerhq/cli-action@v3
+
+      - name: Install Rust toolchain
+        if: steps.check-key.outputs.skip != 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install protobuf compiler
+        if: steps.check-key.outputs.skip != 'true'
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Setup sccache
+        if: steps.check-key.outputs.skip != 'true'
+        uses: mozilla-actions/sccache-action@v0.0.7
+
+      - name: Configure sccache S3 backend
+        if: steps.check-key.outputs.skip != 'true' && env.DOPPLER_TOKEN != ''
+        run: ./.github/scripts/ci-sccache-env.sh >> "$GITHUB_ENV"
+
+      - name: Cache Rust
+        if: steps.check-key.outputs.skip != 'true'
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "sprites-integration"
+
+      - name: Run Sprites live integration tests
+        if: steps.check-key.outputs.skip != 'true'
+        run: doppler run -- cargo test -p everruns-integrations-sprites --features sprites-live-tests --test live_api_test -- --test-threads=1

--- a/.github/workflows/sprites-integration.yml
+++ b/.github/workflows/sprites-integration.yml
@@ -56,48 +56,31 @@ jobs:
   live-test:
     name: Sprites Live API Tests
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && env.DOPPLER_TOKEN != ''
     timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check for Doppler token
-        id: check-key
-        run: |
-          if [ -z "$DOPPLER_TOKEN" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "⏭️ DOPPLER_TOKEN not configured, skipping live tests"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Install Doppler CLI
-        if: steps.check-key.outputs.skip != 'true'
         uses: dopplerhq/cli-action@v3
 
       - name: Install Rust toolchain
-        if: steps.check-key.outputs.skip != 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install protobuf compiler
-        if: steps.check-key.outputs.skip != 'true'
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Setup sccache
-        if: steps.check-key.outputs.skip != 'true'
         uses: mozilla-actions/sccache-action@v0.0.7
 
       - name: Configure sccache S3 backend
-        if: steps.check-key.outputs.skip != 'true' && env.DOPPLER_TOKEN != ''
         run: ./.github/scripts/ci-sccache-env.sh >> "$GITHUB_ENV"
 
       - name: Cache Rust
-        if: steps.check-key.outputs.skip != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "sprites-integration"
 
       - name: Run Sprites live integration tests
-        if: steps.check-key.outputs.skip != 'true'
         run: doppler run -- cargo test -p everruns-integrations-sprites --features sprites-live-tests --test live_api_test -- --test-threads=1

--- a/specs/integrations.md
+++ b/specs/integrations.md
@@ -15,7 +15,7 @@ Every sandbox/execution integration crate must ship with the following artifacts
 | **Live API tests** | `tests/live_api_test.rs` — feature-gated (`<name>-live-tests`), optional Doppler credentials. |
 | **CI: unit tests** | Crate listed in the `unit-test` job: `cargo test -p everruns-integrations-<name>`. |
 | **CI: change detection** | Path filter in `changes` job: `<name>: integrations/<name>/**`. |
-| **CI: live-test job** | Dedicated `<name>-live-test` job, conditional on change detection + `push` event. |
+| **CI: live-test workflow** | Dedicated `.github/workflows/<name>-integration.yml` workflow, path-filtered to `integrations/<name>/**`, with live-test job conditional on `push` event + Doppler token. |
 | **User docs** | `docs/integrations/<name>.md` — quick start, tool table, lifecycle, security. |
 | **UI test case** | `test_cases/ui/<name>_connection/TC001_*.md` — manual test for connection + sandbox lifecycle. |
 | **Seed agent** | Entry in `crates/server/src/seed.rs` with capabilities wired. |

--- a/specs/integrations.md
+++ b/specs/integrations.md
@@ -15,7 +15,7 @@ Every sandbox/execution integration crate must ship with the following artifacts
 | **Live API tests** | `tests/live_api_test.rs` — feature-gated (`<name>-live-tests`), optional Doppler credentials. |
 | **CI: unit tests** | Crate listed in the `unit-test` job: `cargo test -p everruns-integrations-<name>`. |
 | **CI: change detection** | Path filter in `changes` job: `<name>: integrations/<name>/**`. |
-| **CI: live-test workflow** | Dedicated `.github/workflows/<name>-integration.yml` workflow, path-filtered to `integrations/<name>/**`, with live-test job conditional on `push` event + Doppler token. |
+| **CI: live-test job** | Live API test job conditional on `push` event + Doppler token. New integrations: dedicated `.github/workflows/<name>-integration.yml` workflow, path-filtered to `integrations/<name>/**`. Legacy integrations (Daytona, Browserless, etc.) may still use a job in `ci.yml` gated on change detection. |
 | **User docs** | `docs/integrations/<name>.md` — quick start, tool table, lifecycle, security. |
 | **UI test case** | `test_cases/ui/<name>_connection/TC001_*.md` — manual test for connection + sandbox lifecycle. |
 | **Seed agent** | Entry in `crates/server/src/seed.rs` with capabilities wired. |


### PR DESCRIPTION
## Summary
- Add `.github/workflows/sprites-integration.yml` with unit-test and live-test (Doppler-gated) jobs, path-filtered to `integrations/sprites/**`
- Add `everruns-integrations-sprites` to the CI unit-test job in `ci.yml`
- Update `specs/integrations.md` parity table: live tests now require a dedicated workflow file

## Evidence
- Workflow ran successfully on this branch: both unit-test and live-test jobs passed (sccache 100% hit rate on live tests, 97% on unit tests)

## Test plan
- [x] Sprites Integration workflow triggered and passed on feature branch push
- [x] Unit tests job passed
- [x] Live API tests job passed (with Doppler credentials)
- [ ] Verify CI gate (`ci-success`) still passes on PR (sprites not in gate, same as brave-search/duckduckgo)