### PR TITLE
feat(mcp): ScriptedTool-backed MCP endpoint at /mcp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,6 +1790,7 @@ dependencies = [
  "axum",
  "axum-extra",
  "base64",
+ "bashkit",
  "chrono",
  "clap",
  "cron",

--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -65,6 +65,7 @@ jest.mock("@/providers/feature-flags-provider", () => ({
   useFeatureFlags: () => ({
     global_chat: true,
     apps: true,
+    mcp_endpoint: true,
   }),
 }));
 

--- a/apps/ui/src/lib/api/types/auth-types.ts
+++ b/apps/ui/src/lib/api/types/auth-types.ts
@@ -10,6 +10,7 @@ export interface FeatureFlags {
   global_chat: boolean;
   apps: boolean;
   notifications: boolean;
+  mcp_endpoint: boolean;
 }
 
 export interface AuthConfigResponse {

--- a/apps/ui/src/providers/feature-flags-provider.tsx
+++ b/apps/ui/src/providers/feature-flags-provider.tsx
@@ -15,6 +15,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   global_chat: false,
   apps: false,
   notifications: false,
+  mcp_endpoint: false,
 };
 
 export interface FeatureFlagsContextValue {

--- a/crates/core/src/feature_flags.rs
+++ b/crates/core/src/feature_flags.rs
@@ -23,6 +23,8 @@ pub struct FeatureFlags {
     pub apps: bool,
     /// In-app notifications (bell, toasts, notification SSE). Standard.
     pub notifications: bool,
+    /// MCP endpoint (POST /mcp — Everruns as an MCP server). Experimental.
+    pub mcp_endpoint: bool,
 }
 
 impl FeatureFlags {
@@ -32,6 +34,7 @@ impl FeatureFlags {
             global_chat: experimental_flag("FEATURE_GLOBAL_CHAT", grade),
             apps: experimental_flag("FEATURE_APPS", grade),
             notifications: standard_flag("FEATURE_NOTIFICATIONS", false),
+            mcp_endpoint: experimental_flag("FEATURE_MCP_ENDPOINT", grade),
         }
     }
 
@@ -41,6 +44,7 @@ impl FeatureFlags {
             "global_chat" => self.global_chat,
             "apps" => self.apps,
             "notifications" => self.notifications,
+            "mcp_endpoint" => self.mcp_endpoint,
             _ => false,
         }
     }
@@ -52,6 +56,7 @@ impl FeatureFlags {
             global_chat: true,
             apps: true,
             notifications: true,
+            mcp_endpoint: true,
         }
     }
 }
@@ -141,10 +146,12 @@ mod tests {
             global_chat: true,
             apps: true,
             notifications: true,
+            mcp_endpoint: true,
         };
         assert!(flags.is_enabled("global_chat"));
         assert!(flags.is_enabled("apps"));
         assert!(flags.is_enabled("notifications"));
+        assert!(flags.is_enabled("mcp_endpoint"));
         assert!(!flags.is_enabled("nonexistent"));
     }
 
@@ -154,6 +161,7 @@ mod tests {
             global_chat: true,
             apps: true,
             notifications: true,
+            mcp_endpoint: true,
         };
         let json = serde_json::to_string(&flags).unwrap();
         assert!(json.contains("\"global_chat\":true"));

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -62,6 +62,8 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 urlencoding = "2"
 git2.workspace = true
 
+bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.1.12" }
+
 everruns-config = { path = "../config" }
 everruns-core = { path = "../core", features = ["openapi", "sqlx"] }
 everruns-macros = { path = "../macros" }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -62,7 +62,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 urlencoding = "2"
 git2.workspace = true
 
-bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.1.12" }
+bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.1.12", features = ["scripted_tool"] }
 
 everruns-config = { path = "../config" }
 everruns-core = { path = "../core", features = ["openapi", "sqlx"] }

--- a/crates/server/src/api/mcp_endpoint/catalog.rs
+++ b/crates/server/src/api/mcp_endpoint/catalog.rs
@@ -1,19 +1,20 @@
-// API operations catalog for the MCP `discover` tool
+// API operations catalog — each entry becomes a ScriptedTool builtin
 //
-// Static catalog of all Everruns API operations. Each entry has enough detail
-// for an LLM to construct the correct curl command for the `execute` tool.
-//
-// Curl examples use $EVERRUNS_API_BASE and $EVERRUNS_API_KEY which are
-// pre-configured environment variables in the execute tool's bashkit sandbox.
+// Every Operation has a `name` used as the bash command name in the
+// ScriptedTool interpreter, plus enough metadata to generate the ToolDef
+// and the HTTP callback.
+
+use bashkit::{ScriptedTool, ToolArgs, ToolDef};
+use serde_json::json;
 
 /// A single API operation in the catalog.
 pub struct Operation {
+    pub name: &'static str,
     pub method: &'static str,
     pub path: &'static str,
     pub category: &'static str,
     pub description: &'static str,
     pub params: &'static [Param],
-    pub curl_example: &'static str,
 }
 
 /// A parameter for an API operation.
@@ -23,37 +24,178 @@ pub struct Param {
     pub description: &'static str,
 }
 
-/// Search the catalog by query string and optional category.
-pub fn search(query: &str, category: Option<&str>) -> Vec<&'static Operation> {
-    let terms: Vec<&str> = query.split_whitespace().collect();
+/// Build a ScriptedTool with all catalog operations registered as builtins.
+///
+/// Each operation becomes a command callable from bash scripts.  The callback
+/// for each command makes an HTTP request to the local API.
+pub fn build_scripted_tool(api_base: &str, api_key: &str) -> ScriptedTool {
+    let mut builder = ScriptedTool::builder("everruns")
+        .short_description("Everruns API operations as bash builtins")
+        .env("EVERRUNS_API_BASE", api_base)
+        .env("EVERRUNS_API_KEY", api_key)
+        .limits(
+            bashkit::ExecutionLimits::new()
+                .max_commands(500)
+                .max_loop_iterations(5000)
+                .max_function_depth(50)
+                .max_input_bytes(500_000)
+                .max_ast_depth(50)
+                .parser_timeout(std::time::Duration::from_secs(3)),
+        );
 
-    CATALOG
-        .iter()
-        .filter(|op| {
-            // Category filter
-            if let Some(cat) = category
-                && !op.category.eq_ignore_ascii_case(cat)
-            {
-                return false;
+    for op in CATALOG {
+        let def = op_to_def(op);
+        let callback = make_http_callback(op.method, op.path, api_base, api_key);
+        builder = builder.tool(def, callback);
+    }
+
+    builder.build()
+}
+
+/// Convert an Operation to a bashkit ToolDef.
+fn op_to_def(op: &Operation) -> ToolDef {
+    let mut properties = serde_json::Map::new();
+    let mut required = Vec::new();
+
+    for p in op.params {
+        let prop_type = match p.typ {
+            "array" => "array",
+            "object" => "object",
+            "integer" => "integer",
+            "boolean" => "boolean",
+            _ => "string", // path, query, string all become string
+        };
+        properties.insert(
+            p.name.to_string(),
+            json!({ "type": prop_type, "description": p.description }),
+        );
+        // Path params are always required
+        if p.typ == "path" {
+            required.push(p.name.to_string());
+        }
+    }
+
+    let schema = json!({
+        "type": "object",
+        "properties": properties,
+        "required": required,
+    });
+
+    ToolDef::new(op.name, op.description)
+        .with_schema(schema)
+        .with_category(op.category)
+}
+
+/// Create an HTTP callback for an API operation.
+///
+/// Uses `tokio::task::block_in_place` to bridge sync callback → async reqwest.
+fn make_http_callback(
+    method: &'static str,
+    path_template: &'static str,
+    api_base: &str,
+    api_key: &str,
+) -> impl Fn(&ToolArgs) -> Result<String, String> + Send + Sync + 'static {
+    let api_base = api_base.to_string();
+    let api_key = api_key.to_string();
+
+    move |args: &ToolArgs| {
+        let params = &args.params;
+
+        // Substitute path parameters into the URL template
+        let mut path = path_template.to_string();
+        let mut body_params = serde_json::Map::new();
+        let mut query_parts = Vec::new();
+
+        if let Some(obj) = params.as_object() {
+            for (key, value) in obj {
+                let placeholder = format!("{{{key}}}");
+                if path.contains(&placeholder) {
+                    // Path parameter — substitute into URL
+                    let val_str = value.as_str().unwrap_or(&value.to_string()).to_string();
+                    path = path.replace(&placeholder, &val_str);
+                } else if is_query_param(path_template, key)
+                    || method == "GET"
+                    || method == "DELETE"
+                {
+                    // Query parameter
+                    let val_str = value.as_str().unwrap_or(&value.to_string()).to_string();
+                    query_parts.push(format!("{}={}", key, urlencoding::encode(&val_str)));
+                } else {
+                    // Body parameter
+                    body_params.insert(key.clone(), value.clone());
+                }
             }
-            // All query terms must match somewhere (method, path, description, category)
-            terms.iter().all(|term| {
-                op.method.to_lowercase().contains(term)
-                    || op.path.to_lowercase().contains(term)
-                    || op.description.to_lowercase().contains(term)
-                    || op.category.to_lowercase().contains(term)
+        }
+
+        let mut url = format!("{api_base}{path}");
+        if !query_parts.is_empty() {
+            url.push('?');
+            url.push_str(&query_parts.join("&"));
+        }
+
+        // Make the HTTP request (sync bridge)
+        let api_key = api_key.clone();
+        tokio::task::block_in_place(|| {
+            let handle = tokio::runtime::Handle::current();
+            handle.block_on(async {
+                let client = reqwest::Client::new();
+                let mut req = match method {
+                    "POST" => client.post(&url),
+                    "PUT" => client.put(&url),
+                    "PATCH" => client.patch(&url),
+                    "DELETE" => client.delete(&url),
+                    _ => client.get(&url),
+                };
+
+                req = req.header("Authorization", format!("Bearer {api_key}"));
+
+                if !body_params.is_empty() {
+                    req = req
+                        .header("Content-Type", "application/json")
+                        .json(&body_params);
+                }
+
+                let resp = req
+                    .timeout(std::time::Duration::from_secs(30))
+                    .send()
+                    .await
+                    .map_err(|e| format!("HTTP error: {e}"))?;
+
+                let status = resp.status();
+                let body = resp
+                    .text()
+                    .await
+                    .map_err(|e| format!("Failed to read response: {e}"))?;
+
+                if status.is_success() {
+                    Ok(body)
+                } else {
+                    Err(format!("HTTP {status}: {body}"))
+                }
             })
         })
-        .collect()
+    }
+}
+
+/// Check if a param name maps to a query-typed parameter in the catalog.
+fn is_query_param(path_template: &str, param_name: &str) -> bool {
+    CATALOG.iter().any(|op| {
+        op.path == path_template
+            && op
+                .params
+                .iter()
+                .any(|p| p.name == param_name && p.typ == "query")
+    })
 }
 
 // ============================================================================
 // Catalog entries
 // ============================================================================
 
-static CATALOG: &[Operation] = &[
+pub static CATALOG: &[Operation] = &[
     // ── Agents ──────────────────────────────────────────────────────────
     Operation {
+        name: "create_agent",
         method: "POST",
         path: "/v1/agents",
         category: "agents",
@@ -80,13 +222,13 @@ static CATALOG: &[Operation] = &[
                 description: "Default model ID",
             },
         ],
-        curl_example: "curl -s -X POST -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"name\": \"My Agent\", \"system_prompt\": \"You are helpful.\"}' $EVERRUNS_API_BASE/v1/agents",
     },
     Operation {
+        name: "list_agents",
         method: "GET",
         path: "/v1/agents",
         category: "agents",
-        description: "List all active agents. Use ?search= for name search, ?include_archived=true to include archived.",
+        description: "List all active agents. Use search for name search, include_archived=true to include archived.",
         params: &[
             Param {
                 name: "search",
@@ -109,9 +251,9 @@ static CATALOG: &[Operation] = &[
                 description: "Page size (default: 20, max: 100)",
             },
         ],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/agents",
     },
     Operation {
+        name: "get_agent",
         method: "GET",
         path: "/v1/agents/{id}",
         category: "agents",
@@ -121,9 +263,9 @@ static CATALOG: &[Operation] = &[
             typ: "path",
             description: "Agent ID (format: agent_{32-hex})",
         }],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/agents/AGENT_ID",
     },
     Operation {
+        name: "update_agent",
         method: "PATCH",
         path: "/v1/agents/{id}",
         category: "agents",
@@ -145,9 +287,9 @@ static CATALOG: &[Operation] = &[
                 description: "New system prompt",
             },
         ],
-        curl_example: "curl -s -X PATCH -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"name\": \"Updated Agent\"}' $EVERRUNS_API_BASE/v1/agents/AGENT_ID",
     },
     Operation {
+        name: "delete_agent",
         method: "DELETE",
         path: "/v1/agents/{id}",
         category: "agents",
@@ -157,9 +299,9 @@ static CATALOG: &[Operation] = &[
             typ: "path",
             description: "Agent ID",
         }],
-        curl_example: "curl -s -X DELETE -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/agents/AGENT_ID",
     },
     Operation {
+        name: "upsert_agent",
         method: "PUT",
         path: "/v1/agents/{id}",
         category: "agents",
@@ -181,9 +323,9 @@ static CATALOG: &[Operation] = &[
                 description: "System prompt",
             },
         ],
-        curl_example: "curl -s -X PUT -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"name\": \"My Agent\"}' $EVERRUNS_API_BASE/v1/agents/AGENT_ID",
     },
     Operation {
+        name: "copy_agent",
         method: "POST",
         path: "/v1/agents/{id}/copy",
         category: "agents",
@@ -193,9 +335,9 @@ static CATALOG: &[Operation] = &[
             typ: "path",
             description: "Source agent ID",
         }],
-        curl_example: "curl -s -X POST -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/agents/AGENT_ID/copy",
     },
     Operation {
+        name: "export_agent",
         method: "GET",
         path: "/v1/agents/{id}/export",
         category: "agents",
@@ -205,9 +347,9 @@ static CATALOG: &[Operation] = &[
             typ: "path",
             description: "Agent ID",
         }],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/agents/AGENT_ID/export",
     },
     Operation {
+        name: "import_agent",
         method: "POST",
         path: "/v1/agents/import",
         category: "agents",
@@ -217,9 +359,9 @@ static CATALOG: &[Operation] = &[
             typ: "string",
             description: "Markdown content to import",
         }],
-        curl_example: "curl -s -X POST -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"content\": \"# Agent\\n...\"}' $EVERRUNS_API_BASE/v1/agents/import",
     },
     Operation {
+        name: "preview_agent",
         method: "POST",
         path: "/v1/agents/preview",
         category: "agents",
@@ -236,10 +378,10 @@ static CATALOG: &[Operation] = &[
                 description: "Capability configs",
             },
         ],
-        curl_example: "curl -s -X POST -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"system_prompt\": \"You are helpful.\", \"capabilities\": []}' $EVERRUNS_API_BASE/v1/agents/preview",
     },
     // ── Sessions ────────────────────────────────────────────────────────
     Operation {
+        name: "create_session",
         method: "POST",
         path: "/v1/sessions",
         category: "sessions",
@@ -266,9 +408,9 @@ static CATALOG: &[Operation] = &[
                 description: "Model override",
             },
         ],
-        curl_example: "curl -s -X POST -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"agent_id\": \"AGENT_ID\", \"title\": \"My Session\"}' $EVERRUNS_API_BASE/v1/sessions",
     },
     Operation {
+        name: "list_sessions",
         method: "GET",
         path: "/v1/sessions",
         category: "sessions",
@@ -295,9 +437,9 @@ static CATALOG: &[Operation] = &[
                 description: "Page size (max 100)",
             },
         ],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/sessions",
     },
     Operation {
+        name: "get_session",
         method: "GET",
         path: "/v1/sessions/{session_id}",
         category: "sessions",
@@ -307,9 +449,9 @@ static CATALOG: &[Operation] = &[
             typ: "path",
             description: "Session ID",
         }],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/sessions/SESSION_ID",
     },
     Operation {
+        name: "update_session",
         method: "PATCH",
         path: "/v1/sessions/{session_id}",
         category: "sessions",
@@ -331,9 +473,9 @@ static CATALOG: &[Operation] = &[
                 description: "New tags",
             },
         ],
-        curl_example: "curl -s -X PATCH -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"title\": \"New Title\"}' $EVERRUNS_API_BASE/v1/sessions/SESSION_ID",
     },
     Operation {
+        name: "delete_session",
         method: "DELETE",
         path: "/v1/sessions/{session_id}",
         category: "sessions",
@@ -343,9 +485,9 @@ static CATALOG: &[Operation] = &[
             typ: "path",
             description: "Session ID",
         }],
-        curl_example: "curl -s -X DELETE -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/sessions/SESSION_ID",
     },
     Operation {
+        name: "cancel_session",
         method: "POST",
         path: "/v1/sessions/{session_id}/cancel",
         category: "sessions",
@@ -355,10 +497,10 @@ static CATALOG: &[Operation] = &[
             typ: "path",
             description: "Session ID",
         }],
-        curl_example: "curl -s -X POST -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/sessions/SESSION_ID/cancel",
     },
     // ── Messages ────────────────────────────────────────────────────────
     Operation {
+        name: "create_message",
         method: "POST",
         path: "/v1/sessions/{session_id}/messages",
         category: "messages",
@@ -370,19 +512,14 @@ static CATALOG: &[Operation] = &[
                 description: "Session ID",
             },
             Param {
-                name: "message.role",
-                typ: "string",
-                description: "Always 'user'",
-            },
-            Param {
-                name: "message.content",
-                typ: "array",
-                description: "[{\"type\": \"text\", \"text\": \"...\"}]",
+                name: "message",
+                typ: "object",
+                description: "{\"role\": \"user\", \"content\": [{\"type\": \"text\", \"text\": \"...\"}]}",
             },
         ],
-        curl_example: "curl -s -X POST -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"message\": {\"role\": \"user\", \"content\": [{\"type\": \"text\", \"text\": \"Hello\"}]}}' $EVERRUNS_API_BASE/v1/sessions/SESSION_ID/messages",
     },
     Operation {
+        name: "list_messages",
         method: "GET",
         path: "/v1/sessions/{session_id}/messages",
         category: "messages",
@@ -392,10 +529,10 @@ static CATALOG: &[Operation] = &[
             typ: "path",
             description: "Session ID",
         }],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/sessions/SESSION_ID/messages",
     },
     // ── Events ──────────────────────────────────────────────────────────
     Operation {
+        name: "list_events",
         method: "GET",
         path: "/v1/sessions/{session_id}/events",
         category: "events",
@@ -427,9 +564,9 @@ static CATALOG: &[Operation] = &[
                 description: "Max events (1-1000)",
             },
         ],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' '$EVERRUNS_API_BASE/v1/sessions/SESSION_ID/events?limit=20'",
     },
     Operation {
+        name: "stream_sse",
         method: "GET",
         path: "/v1/sessions/{session_id}/sse",
         category: "events",
@@ -451,10 +588,10 @@ static CATALOG: &[Operation] = &[
                 description: "Filter by event types",
             },
         ],
-        curl_example: "curl -s -N -H 'Authorization: Bearer $EVERRUNS_API_KEY' '$EVERRUNS_API_BASE/v1/sessions/SESSION_ID/sse'",
     },
     // ── Harnesses ───────────────────────────────────────────────────────
     Operation {
+        name: "list_harnesses",
         method: "GET",
         path: "/v1/harnesses",
         category: "harnesses",
@@ -464,9 +601,9 @@ static CATALOG: &[Operation] = &[
             typ: "query",
             description: "Include archived (default: false)",
         }],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/harnesses",
     },
     Operation {
+        name: "get_harness",
         method: "GET",
         path: "/v1/harnesses/{id}",
         category: "harnesses",
@@ -476,18 +613,18 @@ static CATALOG: &[Operation] = &[
             typ: "path",
             description: "Harness ID",
         }],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/harnesses/HARNESS_ID",
     },
     // ── LLM Models ──────────────────────────────────────────────────────
     Operation {
+        name: "list_models",
         method: "GET",
         path: "/v1/llm-models",
         category: "models",
         description: "List all LLM models across all providers.",
         params: &[],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/llm-models",
     },
     Operation {
+        name: "get_model",
         method: "GET",
         path: "/v1/llm-models/{id}",
         category: "models",
@@ -497,18 +634,18 @@ static CATALOG: &[Operation] = &[
             typ: "path",
             description: "Model ID",
         }],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/llm-models/MODEL_ID",
     },
     // ── LLM Providers ───────────────────────────────────────────────────
     Operation {
+        name: "list_providers",
         method: "GET",
         path: "/v1/llm-providers",
         category: "providers",
         description: "List configured LLM providers (OpenAI, Anthropic, etc.).",
         params: &[],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/llm-providers",
     },
     Operation {
+        name: "create_provider",
         method: "POST",
         path: "/v1/llm-providers",
         category: "providers",
@@ -530,10 +667,10 @@ static CATALOG: &[Operation] = &[
                 description: "API key for the provider",
             },
         ],
-        curl_example: "curl -s -X POST -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"name\": \"OpenAI\", \"provider_type\": \"openai\", \"api_key\": \"sk-...\"}' $EVERRUNS_API_BASE/v1/llm-providers",
     },
     // ── MCP Servers ─────────────────────────────────────────────────────
     Operation {
+        name: "list_mcp_servers",
         method: "GET",
         path: "/v1/mcp-servers",
         category: "mcp_servers",
@@ -543,9 +680,9 @@ static CATALOG: &[Operation] = &[
             typ: "query",
             description: "Search by name",
         }],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/mcp-servers",
     },
     Operation {
+        name: "create_mcp_server",
         method: "POST",
         path: "/v1/mcp-servers",
         category: "mcp_servers",
@@ -567,9 +704,9 @@ static CATALOG: &[Operation] = &[
                 description: "Description (optional)",
             },
         ],
-        curl_example: "curl -s -X POST -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"name\": \"my-mcp\", \"url\": \"https://example.com/mcp\"}' $EVERRUNS_API_BASE/v1/mcp-servers",
     },
     Operation {
+        name: "get_mcp_server",
         method: "GET",
         path: "/v1/mcp-servers/{id}",
         category: "mcp_servers",
@@ -579,18 +716,18 @@ static CATALOG: &[Operation] = &[
             typ: "path",
             description: "MCP server ID",
         }],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/mcp-servers/MCP_ID",
     },
     // ── Capabilities ────────────────────────────────────────────────────
     Operation {
+        name: "list_capabilities",
         method: "GET",
         path: "/v1/capabilities",
         category: "capabilities",
         description: "List all available capabilities (virtual bash, web fetch, MCP, etc.).",
         params: &[],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/capabilities",
     },
     Operation {
+        name: "get_capability",
         method: "GET",
         path: "/v1/capabilities/{id}",
         category: "capabilities",
@@ -600,10 +737,10 @@ static CATALOG: &[Operation] = &[
             typ: "path",
             description: "Capability ID",
         }],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/capabilities/CAPABILITY_ID",
     },
     // ── Skills ──────────────────────────────────────────────────────────
     Operation {
+        name: "list_skills",
         method: "GET",
         path: "/v1/skills",
         category: "skills",
@@ -613,9 +750,9 @@ static CATALOG: &[Operation] = &[
             typ: "query",
             description: "Include archived",
         }],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/skills",
     },
     Operation {
+        name: "create_skill",
         method: "POST",
         path: "/v1/skills",
         category: "skills",
@@ -637,18 +774,18 @@ static CATALOG: &[Operation] = &[
                 description: "inline, url, or github",
             },
         ],
-        curl_example: "curl -s -X POST -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"name\": \"my-skill\", \"description\": \"...\", \"source_type\": \"inline\"}' $EVERRUNS_API_BASE/v1/skills",
     },
     // ── Images ──────────────────────────────────────────────────────────
     Operation {
+        name: "list_images",
         method: "GET",
         path: "/v1/images",
         category: "images",
         description: "List uploaded images.",
         params: &[],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/images",
     },
     Operation {
+        name: "get_image",
         method: "GET",
         path: "/v1/images/{id}",
         category: "images",
@@ -658,18 +795,18 @@ static CATALOG: &[Operation] = &[
             typ: "path",
             description: "Image ID",
         }],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/images/IMAGE_ID",
     },
     // ── Schedules ───────────────────────────────────────────────────────
     Operation {
+        name: "list_schedules",
         method: "GET",
         path: "/v1/schedules",
         category: "schedules",
         description: "List durable scheduled tasks.",
         params: &[],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/schedules",
     },
     Operation {
+        name: "create_schedule",
         method: "POST",
         path: "/v1/schedules",
         category: "schedules",
@@ -691,18 +828,18 @@ static CATALOG: &[Operation] = &[
                 description: "Schedule target configuration",
             },
         ],
-        curl_example: "curl -s -X POST -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"name\": \"daily-check\", \"cron\": \"0 9 * * *\", \"target\": {}}' $EVERRUNS_API_BASE/v1/schedules",
     },
     // ── Organizations ───────────────────────────────────────────────────
     Operation {
+        name: "list_orgs",
         method: "GET",
         path: "/v1/orgs",
         category: "organizations",
         description: "List organizations for the current user.",
         params: &[],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/orgs",
     },
     Operation {
+        name: "get_org",
         method: "GET",
         path: "/v1/orgs/{org}",
         category: "organizations",
@@ -712,19 +849,19 @@ static CATALOG: &[Operation] = &[
             typ: "path",
             description: "Organization ID or slug",
         }],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/orgs/ORG_ID",
     },
     // ── Users ───────────────────────────────────────────────────────────
     Operation {
+        name: "list_users",
         method: "GET",
         path: "/v1/users",
         category: "users",
         description: "List users in the current organization.",
         params: &[],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/users",
     },
     // ── Session Files ───────────────────────────────────────────────────
     Operation {
+        name: "list_session_files",
         method: "GET",
         path: "/v1/sessions/{session_id}/files",
         category: "files",
@@ -734,9 +871,9 @@ static CATALOG: &[Operation] = &[
             typ: "path",
             description: "Session ID",
         }],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/sessions/SESSION_ID/files",
     },
     Operation {
+        name: "get_session_file",
         method: "GET",
         path: "/v1/sessions/{session_id}/files/{path}",
         category: "files",
@@ -753,10 +890,10 @@ static CATALOG: &[Operation] = &[
                 description: "File path",
             },
         ],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/sessions/SESSION_ID/files/path/to/file",
     },
     // ── Session Databases ───────────────────────────────────────────────
     Operation {
+        name: "list_session_databases",
         method: "GET",
         path: "/v1/sessions/{session_id}/databases",
         category: "databases",
@@ -766,10 +903,10 @@ static CATALOG: &[Operation] = &[
             typ: "path",
             description: "Session ID",
         }],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/sessions/SESSION_ID/databases",
     },
     // ── Session Storage ─────────────────────────────────────────────────
     Operation {
+        name: "list_session_storage",
         method: "GET",
         path: "/v1/sessions/{session_id}/storage/keys",
         category: "storage",
@@ -779,10 +916,10 @@ static CATALOG: &[Operation] = &[
             typ: "path",
             description: "Session ID",
         }],
-        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/sessions/SESSION_ID/storage/keys",
     },
     // ── Tool Results ────────────────────────────────────────────────────
     Operation {
+        name: "submit_tool_results",
         method: "POST",
         path: "/v1/sessions/{session_id}/tool-results",
         category: "tool_results",
@@ -799,15 +936,14 @@ static CATALOG: &[Operation] = &[
                 description: "Array of {tool_call_id, output} objects",
             },
         ],
-        curl_example: "curl -s -X POST -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"results\": [{\"tool_call_id\": \"...\", \"output\": \"...\"}]}' $EVERRUNS_API_BASE/v1/sessions/SESSION_ID/tool-results",
     },
     // ── Health ──────────────────────────────────────────────────────────
     Operation {
+        name: "health_check",
         method: "GET",
         path: "/health",
         category: "system",
         description: "Health check endpoint. Returns server version and runner mode.",
         params: &[],
-        curl_example: "curl -s $EVERRUNS_API_BASE/health",
     },
 ];

--- a/crates/server/src/api/mcp_endpoint/catalog.rs
+++ b/crates/server/src/api/mcp_endpoint/catalog.rs
@@ -1,0 +1,813 @@
+// API operations catalog for the MCP `discover` tool
+//
+// Static catalog of all Everruns API operations. Each entry has enough detail
+// for an LLM to construct the correct curl command for the `execute` tool.
+//
+// Curl examples use $EVERRUNS_API_BASE and $EVERRUNS_API_KEY which are
+// pre-configured environment variables in the execute tool's bashkit sandbox.
+
+/// A single API operation in the catalog.
+pub struct Operation {
+    pub method: &'static str,
+    pub path: &'static str,
+    pub category: &'static str,
+    pub description: &'static str,
+    pub params: &'static [Param],
+    pub curl_example: &'static str,
+}
+
+/// A parameter for an API operation.
+pub struct Param {
+    pub name: &'static str,
+    pub typ: &'static str,
+    pub description: &'static str,
+}
+
+/// Search the catalog by query string and optional category.
+pub fn search(query: &str, category: Option<&str>) -> Vec<&'static Operation> {
+    let terms: Vec<&str> = query.split_whitespace().collect();
+
+    CATALOG
+        .iter()
+        .filter(|op| {
+            // Category filter
+            if let Some(cat) = category
+                && !op.category.eq_ignore_ascii_case(cat)
+            {
+                return false;
+            }
+            // All query terms must match somewhere (method, path, description, category)
+            terms.iter().all(|term| {
+                op.method.to_lowercase().contains(term)
+                    || op.path.to_lowercase().contains(term)
+                    || op.description.to_lowercase().contains(term)
+                    || op.category.to_lowercase().contains(term)
+            })
+        })
+        .collect()
+}
+
+// ============================================================================
+// Catalog entries
+// ============================================================================
+
+static CATALOG: &[Operation] = &[
+    // ── Agents ──────────────────────────────────────────────────────────
+    Operation {
+        method: "POST",
+        path: "/v1/agents",
+        category: "agents",
+        description: "Create a new agent with a name, system prompt, and optional capabilities.",
+        params: &[
+            Param {
+                name: "name",
+                typ: "string",
+                description: "Agent name (required)",
+            },
+            Param {
+                name: "system_prompt",
+                typ: "string",
+                description: "System prompt for the agent",
+            },
+            Param {
+                name: "capabilities",
+                typ: "array",
+                description: "Capability configs [{\"ref\": \"...\"}]",
+            },
+            Param {
+                name: "default_model_id",
+                typ: "string",
+                description: "Default model ID",
+            },
+        ],
+        curl_example: "curl -s -X POST -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"name\": \"My Agent\", \"system_prompt\": \"You are helpful.\"}' $EVERRUNS_API_BASE/v1/agents",
+    },
+    Operation {
+        method: "GET",
+        path: "/v1/agents",
+        category: "agents",
+        description: "List all active agents. Use ?search= for name search, ?include_archived=true to include archived.",
+        params: &[
+            Param {
+                name: "search",
+                typ: "query",
+                description: "Search by name (optional)",
+            },
+            Param {
+                name: "include_archived",
+                typ: "query",
+                description: "Include archived agents (default: false)",
+            },
+            Param {
+                name: "offset",
+                typ: "query",
+                description: "Pagination offset (default: 0)",
+            },
+            Param {
+                name: "limit",
+                typ: "query",
+                description: "Page size (default: 20, max: 100)",
+            },
+        ],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/agents",
+    },
+    Operation {
+        method: "GET",
+        path: "/v1/agents/{id}",
+        category: "agents",
+        description: "Get a single agent by ID.",
+        params: &[Param {
+            name: "id",
+            typ: "path",
+            description: "Agent ID (format: agent_{32-hex})",
+        }],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/agents/AGENT_ID",
+    },
+    Operation {
+        method: "PATCH",
+        path: "/v1/agents/{id}",
+        category: "agents",
+        description: "Update an agent. Only provided fields are changed.",
+        params: &[
+            Param {
+                name: "id",
+                typ: "path",
+                description: "Agent ID",
+            },
+            Param {
+                name: "name",
+                typ: "string",
+                description: "New name",
+            },
+            Param {
+                name: "system_prompt",
+                typ: "string",
+                description: "New system prompt",
+            },
+        ],
+        curl_example: "curl -s -X PATCH -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"name\": \"Updated Agent\"}' $EVERRUNS_API_BASE/v1/agents/AGENT_ID",
+    },
+    Operation {
+        method: "DELETE",
+        path: "/v1/agents/{id}",
+        category: "agents",
+        description: "Archive an agent (soft delete). Can be restored.",
+        params: &[Param {
+            name: "id",
+            typ: "path",
+            description: "Agent ID",
+        }],
+        curl_example: "curl -s -X DELETE -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/agents/AGENT_ID",
+    },
+    Operation {
+        method: "PUT",
+        path: "/v1/agents/{id}",
+        category: "agents",
+        description: "Upsert agent — create (201) or update (200) by ID.",
+        params: &[
+            Param {
+                name: "id",
+                typ: "path",
+                description: "Agent ID",
+            },
+            Param {
+                name: "name",
+                typ: "string",
+                description: "Agent name",
+            },
+            Param {
+                name: "system_prompt",
+                typ: "string",
+                description: "System prompt",
+            },
+        ],
+        curl_example: "curl -s -X PUT -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"name\": \"My Agent\"}' $EVERRUNS_API_BASE/v1/agents/AGENT_ID",
+    },
+    Operation {
+        method: "POST",
+        path: "/v1/agents/{id}/copy",
+        category: "agents",
+        description: "Copy an agent with a new ID and '{name} (copy)' name.",
+        params: &[Param {
+            name: "id",
+            typ: "path",
+            description: "Source agent ID",
+        }],
+        curl_example: "curl -s -X POST -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/agents/AGENT_ID/copy",
+    },
+    Operation {
+        method: "GET",
+        path: "/v1/agents/{id}/export",
+        category: "agents",
+        description: "Export agent definition as Markdown.",
+        params: &[Param {
+            name: "id",
+            typ: "path",
+            description: "Agent ID",
+        }],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/agents/AGENT_ID/export",
+    },
+    Operation {
+        method: "POST",
+        path: "/v1/agents/import",
+        category: "agents",
+        description: "Import agent from Markdown file content.",
+        params: &[Param {
+            name: "content",
+            typ: "string",
+            description: "Markdown content to import",
+        }],
+        curl_example: "curl -s -X POST -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"content\": \"# Agent\\n...\"}' $EVERRUNS_API_BASE/v1/agents/import",
+    },
+    Operation {
+        method: "POST",
+        path: "/v1/agents/preview",
+        category: "agents",
+        description: "Preview final agent shape (system prompt + tools) without persisting.",
+        params: &[
+            Param {
+                name: "system_prompt",
+                typ: "string",
+                description: "System prompt",
+            },
+            Param {
+                name: "capabilities",
+                typ: "array",
+                description: "Capability configs",
+            },
+        ],
+        curl_example: "curl -s -X POST -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"system_prompt\": \"You are helpful.\", \"capabilities\": []}' $EVERRUNS_API_BASE/v1/agents/preview",
+    },
+    // ── Sessions ────────────────────────────────────────────────────────
+    Operation {
+        method: "POST",
+        path: "/v1/sessions",
+        category: "sessions",
+        description: "Create a new session. Optionally assign an agent and harness.",
+        params: &[
+            Param {
+                name: "agent_id",
+                typ: "string",
+                description: "Agent ID (optional)",
+            },
+            Param {
+                name: "harness_id",
+                typ: "string",
+                description: "Harness ID (optional, defaults to org base)",
+            },
+            Param {
+                name: "title",
+                typ: "string",
+                description: "Session title",
+            },
+            Param {
+                name: "model_id",
+                typ: "string",
+                description: "Model override",
+            },
+        ],
+        curl_example: "curl -s -X POST -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"agent_id\": \"AGENT_ID\", \"title\": \"My Session\"}' $EVERRUNS_API_BASE/v1/sessions",
+    },
+    Operation {
+        method: "GET",
+        path: "/v1/sessions",
+        category: "sessions",
+        description: "List sessions. Filter by agent_id, search by title.",
+        params: &[
+            Param {
+                name: "agent_id",
+                typ: "query",
+                description: "Filter by agent (optional)",
+            },
+            Param {
+                name: "search",
+                typ: "query",
+                description: "Search by title (optional)",
+            },
+            Param {
+                name: "offset",
+                typ: "query",
+                description: "Pagination offset",
+            },
+            Param {
+                name: "limit",
+                typ: "query",
+                description: "Page size (max 100)",
+            },
+        ],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/sessions",
+    },
+    Operation {
+        method: "GET",
+        path: "/v1/sessions/{session_id}",
+        category: "sessions",
+        description: "Get session details including status, agent, harness, and model.",
+        params: &[Param {
+            name: "session_id",
+            typ: "path",
+            description: "Session ID",
+        }],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/sessions/SESSION_ID",
+    },
+    Operation {
+        method: "PATCH",
+        path: "/v1/sessions/{session_id}",
+        category: "sessions",
+        description: "Update session title, tags, or locale.",
+        params: &[
+            Param {
+                name: "session_id",
+                typ: "path",
+                description: "Session ID",
+            },
+            Param {
+                name: "title",
+                typ: "string",
+                description: "New title",
+            },
+            Param {
+                name: "tags",
+                typ: "array",
+                description: "New tags",
+            },
+        ],
+        curl_example: "curl -s -X PATCH -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"title\": \"New Title\"}' $EVERRUNS_API_BASE/v1/sessions/SESSION_ID",
+    },
+    Operation {
+        method: "DELETE",
+        path: "/v1/sessions/{session_id}",
+        category: "sessions",
+        description: "Delete a session.",
+        params: &[Param {
+            name: "session_id",
+            typ: "path",
+            description: "Session ID",
+        }],
+        curl_example: "curl -s -X DELETE -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/sessions/SESSION_ID",
+    },
+    Operation {
+        method: "POST",
+        path: "/v1/sessions/{session_id}/cancel",
+        category: "sessions",
+        description: "Cancel the currently executing turn in a session.",
+        params: &[Param {
+            name: "session_id",
+            typ: "path",
+            description: "Session ID",
+        }],
+        curl_example: "curl -s -X POST -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/sessions/SESSION_ID/cancel",
+    },
+    // ── Messages ────────────────────────────────────────────────────────
+    Operation {
+        method: "POST",
+        path: "/v1/sessions/{session_id}/messages",
+        category: "messages",
+        description: "Create a user message in a session. Triggers the agent workflow.",
+        params: &[
+            Param {
+                name: "session_id",
+                typ: "path",
+                description: "Session ID",
+            },
+            Param {
+                name: "message.role",
+                typ: "string",
+                description: "Always 'user'",
+            },
+            Param {
+                name: "message.content",
+                typ: "array",
+                description: "[{\"type\": \"text\", \"text\": \"...\"}]",
+            },
+        ],
+        curl_example: "curl -s -X POST -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"message\": {\"role\": \"user\", \"content\": [{\"type\": \"text\", \"text\": \"Hello\"}]}}' $EVERRUNS_API_BASE/v1/sessions/SESSION_ID/messages",
+    },
+    Operation {
+        method: "GET",
+        path: "/v1/sessions/{session_id}/messages",
+        category: "messages",
+        description: "List all messages in a session (user and agent messages).",
+        params: &[Param {
+            name: "session_id",
+            typ: "path",
+            description: "Session ID",
+        }],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/sessions/SESSION_ID/messages",
+    },
+    // ── Events ──────────────────────────────────────────────────────────
+    Operation {
+        method: "GET",
+        path: "/v1/sessions/{session_id}/events",
+        category: "events",
+        description: "List events for a session (JSON). Supports filtering by type and pagination.",
+        params: &[
+            Param {
+                name: "session_id",
+                typ: "path",
+                description: "Session ID",
+            },
+            Param {
+                name: "since_id",
+                typ: "query",
+                description: "Return events after this event ID",
+            },
+            Param {
+                name: "types",
+                typ: "query",
+                description: "Filter by event types (repeatable)",
+            },
+            Param {
+                name: "exclude",
+                typ: "query",
+                description: "Exclude event types (repeatable)",
+            },
+            Param {
+                name: "limit",
+                typ: "query",
+                description: "Max events (1-1000)",
+            },
+        ],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' '$EVERRUNS_API_BASE/v1/sessions/SESSION_ID/events?limit=20'",
+    },
+    Operation {
+        method: "GET",
+        path: "/v1/sessions/{session_id}/sse",
+        category: "events",
+        description: "Stream events via SSE (Server-Sent Events). Real-time event streaming.",
+        params: &[
+            Param {
+                name: "session_id",
+                typ: "path",
+                description: "Session ID",
+            },
+            Param {
+                name: "since_id",
+                typ: "query",
+                description: "Resume from event ID",
+            },
+            Param {
+                name: "types",
+                typ: "query",
+                description: "Filter by event types",
+            },
+        ],
+        curl_example: "curl -s -N -H 'Authorization: Bearer $EVERRUNS_API_KEY' '$EVERRUNS_API_BASE/v1/sessions/SESSION_ID/sse'",
+    },
+    // ── Harnesses ───────────────────────────────────────────────────────
+    Operation {
+        method: "GET",
+        path: "/v1/harnesses",
+        category: "harnesses",
+        description: "List harnesses (base environments for sessions).",
+        params: &[Param {
+            name: "include_archived",
+            typ: "query",
+            description: "Include archived (default: false)",
+        }],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/harnesses",
+    },
+    Operation {
+        method: "GET",
+        path: "/v1/harnesses/{id}",
+        category: "harnesses",
+        description: "Get a harness by ID.",
+        params: &[Param {
+            name: "id",
+            typ: "path",
+            description: "Harness ID",
+        }],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/harnesses/HARNESS_ID",
+    },
+    // ── LLM Models ──────────────────────────────────────────────────────
+    Operation {
+        method: "GET",
+        path: "/v1/llm-models",
+        category: "models",
+        description: "List all LLM models across all providers.",
+        params: &[],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/llm-models",
+    },
+    Operation {
+        method: "GET",
+        path: "/v1/llm-models/{id}",
+        category: "models",
+        description: "Get a single LLM model by ID.",
+        params: &[Param {
+            name: "id",
+            typ: "path",
+            description: "Model ID",
+        }],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/llm-models/MODEL_ID",
+    },
+    // ── LLM Providers ───────────────────────────────────────────────────
+    Operation {
+        method: "GET",
+        path: "/v1/llm-providers",
+        category: "providers",
+        description: "List configured LLM providers (OpenAI, Anthropic, etc.).",
+        params: &[],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/llm-providers",
+    },
+    Operation {
+        method: "POST",
+        path: "/v1/llm-providers",
+        category: "providers",
+        description: "Create a new LLM provider configuration.",
+        params: &[
+            Param {
+                name: "name",
+                typ: "string",
+                description: "Provider name",
+            },
+            Param {
+                name: "provider_type",
+                typ: "string",
+                description: "openai, anthropic, google, azure_openai, custom",
+            },
+            Param {
+                name: "api_key",
+                typ: "string",
+                description: "API key for the provider",
+            },
+        ],
+        curl_example: "curl -s -X POST -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"name\": \"OpenAI\", \"provider_type\": \"openai\", \"api_key\": \"sk-...\"}' $EVERRUNS_API_BASE/v1/llm-providers",
+    },
+    // ── MCP Servers ─────────────────────────────────────────────────────
+    Operation {
+        method: "GET",
+        path: "/v1/mcp-servers",
+        category: "mcp_servers",
+        description: "List registered MCP servers.",
+        params: &[Param {
+            name: "search",
+            typ: "query",
+            description: "Search by name",
+        }],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/mcp-servers",
+    },
+    Operation {
+        method: "POST",
+        path: "/v1/mcp-servers",
+        category: "mcp_servers",
+        description: "Register a new MCP server.",
+        params: &[
+            Param {
+                name: "name",
+                typ: "string",
+                description: "Server name (unique per org)",
+            },
+            Param {
+                name: "url",
+                typ: "string",
+                description: "Server URL (HTTP)",
+            },
+            Param {
+                name: "description",
+                typ: "string",
+                description: "Description (optional)",
+            },
+        ],
+        curl_example: "curl -s -X POST -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"name\": \"my-mcp\", \"url\": \"https://example.com/mcp\"}' $EVERRUNS_API_BASE/v1/mcp-servers",
+    },
+    Operation {
+        method: "GET",
+        path: "/v1/mcp-servers/{id}",
+        category: "mcp_servers",
+        description: "Get an MCP server by ID.",
+        params: &[Param {
+            name: "id",
+            typ: "path",
+            description: "MCP server ID",
+        }],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/mcp-servers/MCP_ID",
+    },
+    // ── Capabilities ────────────────────────────────────────────────────
+    Operation {
+        method: "GET",
+        path: "/v1/capabilities",
+        category: "capabilities",
+        description: "List all available capabilities (virtual bash, web fetch, MCP, etc.).",
+        params: &[],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/capabilities",
+    },
+    Operation {
+        method: "GET",
+        path: "/v1/capabilities/{id}",
+        category: "capabilities",
+        description: "Get capability details by ID.",
+        params: &[Param {
+            name: "id",
+            typ: "path",
+            description: "Capability ID",
+        }],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/capabilities/CAPABILITY_ID",
+    },
+    // ── Skills ──────────────────────────────────────────────────────────
+    Operation {
+        method: "GET",
+        path: "/v1/skills",
+        category: "skills",
+        description: "List registered skills.",
+        params: &[Param {
+            name: "include_archived",
+            typ: "query",
+            description: "Include archived",
+        }],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/skills",
+    },
+    Operation {
+        method: "POST",
+        path: "/v1/skills",
+        category: "skills",
+        description: "Create a new skill.",
+        params: &[
+            Param {
+                name: "name",
+                typ: "string",
+                description: "Skill name",
+            },
+            Param {
+                name: "description",
+                typ: "string",
+                description: "Description",
+            },
+            Param {
+                name: "source_type",
+                typ: "string",
+                description: "inline, url, or github",
+            },
+        ],
+        curl_example: "curl -s -X POST -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"name\": \"my-skill\", \"description\": \"...\", \"source_type\": \"inline\"}' $EVERRUNS_API_BASE/v1/skills",
+    },
+    // ── Images ──────────────────────────────────────────────────────────
+    Operation {
+        method: "GET",
+        path: "/v1/images",
+        category: "images",
+        description: "List uploaded images.",
+        params: &[],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/images",
+    },
+    Operation {
+        method: "GET",
+        path: "/v1/images/{id}",
+        category: "images",
+        description: "Get image data by ID.",
+        params: &[Param {
+            name: "id",
+            typ: "path",
+            description: "Image ID",
+        }],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/images/IMAGE_ID",
+    },
+    // ── Schedules ───────────────────────────────────────────────────────
+    Operation {
+        method: "GET",
+        path: "/v1/schedules",
+        category: "schedules",
+        description: "List durable scheduled tasks.",
+        params: &[],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/schedules",
+    },
+    Operation {
+        method: "POST",
+        path: "/v1/schedules",
+        category: "schedules",
+        description: "Create a new durable scheduled task with a cron expression.",
+        params: &[
+            Param {
+                name: "name",
+                typ: "string",
+                description: "Schedule name",
+            },
+            Param {
+                name: "cron",
+                typ: "string",
+                description: "Cron expression",
+            },
+            Param {
+                name: "target",
+                typ: "object",
+                description: "Schedule target configuration",
+            },
+        ],
+        curl_example: "curl -s -X POST -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"name\": \"daily-check\", \"cron\": \"0 9 * * *\", \"target\": {}}' $EVERRUNS_API_BASE/v1/schedules",
+    },
+    // ── Organizations ───────────────────────────────────────────────────
+    Operation {
+        method: "GET",
+        path: "/v1/orgs",
+        category: "organizations",
+        description: "List organizations for the current user.",
+        params: &[],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/orgs",
+    },
+    Operation {
+        method: "GET",
+        path: "/v1/orgs/{org}",
+        category: "organizations",
+        description: "Get organization details.",
+        params: &[Param {
+            name: "org",
+            typ: "path",
+            description: "Organization ID or slug",
+        }],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/orgs/ORG_ID",
+    },
+    // ── Users ───────────────────────────────────────────────────────────
+    Operation {
+        method: "GET",
+        path: "/v1/users",
+        category: "users",
+        description: "List users in the current organization.",
+        params: &[],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/users",
+    },
+    // ── Session Files ───────────────────────────────────────────────────
+    Operation {
+        method: "GET",
+        path: "/v1/sessions/{session_id}/files",
+        category: "files",
+        description: "Get the root directory listing of session files.",
+        params: &[Param {
+            name: "session_id",
+            typ: "path",
+            description: "Session ID",
+        }],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/sessions/SESSION_ID/files",
+    },
+    Operation {
+        method: "GET",
+        path: "/v1/sessions/{session_id}/files/{path}",
+        category: "files",
+        description: "Get a file or directory at a path in the session filesystem.",
+        params: &[
+            Param {
+                name: "session_id",
+                typ: "path",
+                description: "Session ID",
+            },
+            Param {
+                name: "path",
+                typ: "path",
+                description: "File path",
+            },
+        ],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/sessions/SESSION_ID/files/path/to/file",
+    },
+    // ── Session Databases ───────────────────────────────────────────────
+    Operation {
+        method: "GET",
+        path: "/v1/sessions/{session_id}/databases",
+        category: "databases",
+        description: "List session-scoped SQL databases.",
+        params: &[Param {
+            name: "session_id",
+            typ: "path",
+            description: "Session ID",
+        }],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/sessions/SESSION_ID/databases",
+    },
+    // ── Session Storage ─────────────────────────────────────────────────
+    Operation {
+        method: "GET",
+        path: "/v1/sessions/{session_id}/storage/keys",
+        category: "storage",
+        description: "List key-value pairs in session storage.",
+        params: &[Param {
+            name: "session_id",
+            typ: "path",
+            description: "Session ID",
+        }],
+        curl_example: "curl -s -H 'Authorization: Bearer $EVERRUNS_API_KEY' $EVERRUNS_API_BASE/v1/sessions/SESSION_ID/storage/keys",
+    },
+    // ── Tool Results ────────────────────────────────────────────────────
+    Operation {
+        method: "POST",
+        path: "/v1/sessions/{session_id}/tool-results",
+        category: "tool_results",
+        description: "Submit client-side tool results back to a waiting session.",
+        params: &[
+            Param {
+                name: "session_id",
+                typ: "path",
+                description: "Session ID",
+            },
+            Param {
+                name: "results",
+                typ: "array",
+                description: "Array of {tool_call_id, output} objects",
+            },
+        ],
+        curl_example: "curl -s -X POST -H 'Authorization: Bearer $EVERRUNS_API_KEY' -H 'Content-Type: application/json' -d '{\"results\": [{\"tool_call_id\": \"...\", \"output\": \"...\"}]}' $EVERRUNS_API_BASE/v1/sessions/SESSION_ID/tool-results",
+    },
+    // ── Health ──────────────────────────────────────────────────────────
+    Operation {
+        method: "GET",
+        path: "/health",
+        category: "system",
+        description: "Health check endpoint. Returns server version and runner mode.",
+        params: &[],
+        curl_example: "curl -s $EVERRUNS_API_BASE/health",
+    },
+];

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -1,12 +1,13 @@
 // MCP Endpoint — exposes Everruns as an MCP server (Streamable HTTP transport)
 //
 // Design decisions:
-// - JSON-RPC 2.0 over POST /v1/mcp (Streamable HTTP, per MCP spec)
+// - JSON-RPC 2.0 over POST /mcp (Streamable HTTP, per MCP spec)
 // - Tier 1 tools: agent_run, session_send_message, session_get_status
 //   → Direct service calls, first-class support for the agent conversation loop
 // - Tier 2 tools: discover, execute
-//   → discover: search the full API catalog, returns operation details + curl examples
-//   → execute: run a bash script via bashkit with $EVERRUNS_API_BASE and auth pre-set
+//   → Backed by bashkit ScriptedTool with all API operations as builtins
+//   → discover: uses ScriptedTool's built-in `discover` command
+//   → execute: runs bash scripts through ScriptedTool (all API ops available as commands)
 // - Auth: same as rest of API (API key or session cookie via ResolvedOrg)
 // - No MCP session state — stateless request/response per JSON-RPC call
 
@@ -14,6 +15,7 @@ use crate::auth::{AuthState, ResolvedOrg};
 use crate::services::{EventService, MessageService, SessionService};
 use crate::storage::StorageBackend;
 use axum::{Json, Router, extract::State, routing::post};
+use bashkit::{ScriptedTool, Tool as ScriptedToolTrait};
 use everruns_core::typed_id::{AgentId, EventId, HarnessId, SessionId};
 use everruns_core::{Caller, PlatformDefinition};
 use everruns_worker::AgentRunner;
@@ -172,11 +174,9 @@ fn tool_definitions() -> Value {
             "name": "discover",
             "description": concat!(
                 "Search the Everruns API catalog to find available operations. ",
-                "Returns matching API operations with their HTTP method, path, description, parameters, and example curl commands. ",
-                "Use this to find the right API call before using the 'execute' tool.\n\n",
-                "Example queries: 'list agents', 'create session', 'delete', 'events', 'mcp servers', 'models', 'capabilities'\n\n",
-                "The results include ready-to-use curl snippets that work with the 'execute' tool. ",
-                "In execute, $EVERRUNS_API_BASE and $EVERRUNS_API_KEY are pre-configured environment variables."
+                "Returns matching API operations with their description, parameters, and usage.\n\n",
+                "Example queries: 'list agents', 'create session', 'events', 'mcp servers', 'models'\n\n",
+                "The discovered operations are available as bash builtins in the 'execute' tool."
             ),
             "inputSchema": {
                 "type": "object",
@@ -184,10 +184,6 @@ fn tool_definitions() -> Value {
                     "query": {
                         "type": "string",
                         "description": "Search query to find API operations (e.g., 'list agents', 'session events', 'mcp')."
-                    },
-                    "category": {
-                        "type": "string",
-                        "description": "Optional category filter: agents, sessions, messages, events, harnesses, models, providers, mcp_servers, capabilities, skills, images, schedules, organizations, users, files, databases, storage"
                     }
                 },
                 "required": ["query"]
@@ -196,14 +192,15 @@ fn tool_definitions() -> Value {
         {
             "name": "execute",
             "description": concat!(
-                "Execute a bash script to interact with the Everruns API. ",
-                "Runs in a sandboxed bashkit environment with curl available and these pre-set environment variables:\n\n",
-                "  $EVERRUNS_API_BASE — API base URL (e.g. http://localhost:9301)\n",
-                "  $EVERRUNS_API_KEY  — Bearer token for authentication\n\n",
-                "Use 'discover' first to find the right API endpoint, then construct a curl command.\n\n",
+                "Execute a bash script with all Everruns API operations available as built-in commands.\n\n",
+                "Available commands include: list_agents, create_agent, get_agent, list_sessions, ",
+                "create_session, list_events, list_models, and many more.\n\n",
+                "Use 'discover' to find available commands, or run `discover --categories` inside the script.\n\n",
                 "Example:\n",
-                "  curl -s -H \"Authorization: Bearer $EVERRUNS_API_KEY\" $EVERRUNS_API_BASE/v1/agents | jq .\n\n",
-                "The script can use pipes, jq for JSON processing, and other standard bash features. ",
+                "  list_agents | jq '.data[] | .name'\n",
+                "  get_agent --id agent_abc123\n",
+                "  create_session --agent_id agent_abc123 --title 'Test' | jq .id\n\n",
+                "Scripts can use pipes, jq, loops, conditionals, and other bash features. ",
                 "Results are returned as {stdout, stderr, exit_code, success}."
             ),
             "inputSchema": {
@@ -211,7 +208,7 @@ fn tool_definitions() -> Value {
                 "properties": {
                     "command": {
                         "type": "string",
-                        "description": "Bash script to execute. Use curl with $EVERRUNS_API_BASE and $EVERRUNS_API_KEY for API calls."
+                        "description": "Bash script to execute. API operations are available as built-in commands."
                     },
                     "timeout_ms": {
                         "type": "integer",
@@ -279,7 +276,7 @@ impl_auth_state!(AppState);
 
 pub fn routes(state: AppState) -> Router {
     Router::new()
-        .route("/v1/mcp", post(handle_mcp))
+        .route("/mcp", post(handle_mcp))
         .with_state(state)
 }
 
@@ -355,7 +352,7 @@ async fn handle_tools_call(
         "agent_run" => tool_agent_run(&arguments, org, state).await,
         "session_send_message" => tool_session_send_message(&arguments, org, state).await,
         "session_get_status" => tool_session_get_status(&arguments, org, state).await,
-        "discover" => tool_discover(&arguments),
+        "discover" => tool_discover(&arguments, org, state).await,
         "execute" => tool_execute(&arguments, org, state).await,
         _ => Err(format!("Unknown tool: {tool_name}")),
     };
@@ -658,47 +655,26 @@ async fn tool_session_get_status(
 }
 
 // ============================================================================
-// Tier 2: discover
+// Tier 2: discover — delegates to ScriptedTool's built-in `discover` command
 // ============================================================================
 
-fn tool_discover(args: &Value) -> Result<String, String> {
+async fn tool_discover(
+    args: &Value,
+    org: &ResolvedOrg,
+    state: &AppState,
+) -> Result<String, String> {
     let query = args
         .get("query")
         .and_then(|v| v.as_str())
-        .ok_or("Missing required parameter: query")?
-        .to_lowercase();
+        .ok_or("Missing required parameter: query")?;
 
-    let category = args
-        .get("category")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_lowercase());
-
-    let operations = catalog::search(&query, category.as_deref());
-
-    if operations.is_empty() {
-        return Ok(format!(
-            "No API operations found matching '{query}'. Try broader terms like 'agents', 'sessions', 'events', 'models', 'mcp'."
-        ));
-    }
-
-    let mut output = format!("Found {} API operations:\n\n", operations.len());
-    for op in &operations {
-        output.push_str(&format!("### {} {}\n", op.method, op.path));
-        output.push_str(&format!("{}\n", op.description));
-        if !op.params.is_empty() {
-            output.push_str("Parameters:\n");
-            for p in op.params {
-                output.push_str(&format!("  - {}: {} {}\n", p.name, p.typ, p.description));
-            }
-        }
-        output.push_str(&format!("Example:\n  {}\n\n", op.curl_example));
-    }
-
-    Ok(output)
+    let tool = build_scripted_tool(org, state);
+    let script = format!("discover --search {}", shell_escape(query));
+    execute_script(&tool, &script, 10_000).await
 }
 
 // ============================================================================
-// Tier 2: execute
+// Tier 2: execute — delegates to ScriptedTool
 // ============================================================================
 
 async fn tool_execute(args: &Value, org: &ResolvedOrg, state: &AppState) -> Result<String, String> {
@@ -713,50 +689,62 @@ async fn tool_execute(args: &Value, org: &ResolvedOrg, state: &AppState) -> Resu
         .unwrap_or(30000)
         .min(60000);
 
-    // Build auth header value from the org context.
-    // For API key auth, reconstruct the bearer token.
-    // For session auth, we pass a generated internal token.
-    let api_key = format!("org-{}", org.public_id);
+    let tool = build_scripted_tool(org, state);
+    execute_script(&tool, command, timeout_ms).await
+}
 
-    // Create a bashkit instance with API env vars pre-configured
-    let fs = Arc::new(bashkit::InMemoryFs::new());
-    let mut bash = bashkit::Bash::builder()
-        .fs(fs)
-        .cwd("/tmp")
-        .username("everruns")
-        .hostname("mcp")
-        .env("HOME", "/tmp")
-        .env("SHELL", "/bin/bash")
-        .env("PATH", "/usr/local/bin:/usr/bin:/bin")
-        .env("EVERRUNS_API_BASE", &state.api_base_url)
-        .env("EVERRUNS_API_KEY", &api_key)
-        .limits(
-            bashkit::ExecutionLimits::new()
-                .max_commands(500)
-                .max_loop_iterations(5000)
-                .max_function_depth(50)
-                .max_input_bytes(500_000)
-                .max_ast_depth(50)
-                .parser_timeout(std::time::Duration::from_secs(3)),
-        )
-        .build();
+// ============================================================================
+// ScriptedTool helpers
+// ============================================================================
+
+/// Build a ScriptedTool for the given org context.
+fn build_scripted_tool(org: &ResolvedOrg, state: &AppState) -> ScriptedTool {
+    let api_key = format!("org-{}", org.public_id);
+    catalog::build_scripted_tool(&state.api_base_url, &api_key)
+}
+
+/// Execute a script through a ScriptedTool and return formatted output.
+async fn execute_script(
+    tool: &ScriptedTool,
+    command: &str,
+    timeout_ms: u64,
+) -> Result<String, String> {
+    let request = bashkit::ToolRequest::new(command);
 
     let result = tokio::time::timeout(
         std::time::Duration::from_millis(timeout_ms),
-        bash.exec(command),
+        tool.execute(request),
     )
     .await;
 
     match result {
-        Ok(Ok(output)) => Ok(serde_json::to_string_pretty(&json!({
-            "stdout": output.stdout,
-            "stderr": output.stderr,
-            "exit_code": output.exit_code,
-            "success": output.exit_code == 0
-        }))
-        .unwrap()),
-        Ok(Err(e)) => Err(format!("Bash execution error: {e}")),
+        Ok(response) => {
+            let output = serde_json::to_string_pretty(&json!({
+                "stdout": response.stdout,
+                "stderr": response.stderr,
+                "exit_code": response.exit_code,
+                "success": response.exit_code == 0
+            }))
+            .unwrap();
+
+            if response.exit_code == 0 {
+                Ok(output)
+            } else {
+                Err(output)
+            }
+        }
         Err(_) => Err(format!("Command timed out after {timeout_ms}ms")),
+    }
+}
+
+/// Simple shell escaping for a single argument.
+fn shell_escape(s: &str) -> String {
+    if s.chars()
+        .all(|c| c.is_alphanumeric() || c == '_' || c == '-' || c == '.')
+    {
+        s.to_string()
+    } else {
+        format!("'{}'", s.replace('\'', "'\\''"))
     }
 }
 

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -1,0 +1,785 @@
+// MCP Endpoint — exposes Everruns as an MCP server (Streamable HTTP transport)
+//
+// Design decisions:
+// - JSON-RPC 2.0 over POST /v1/mcp (Streamable HTTP, per MCP spec)
+// - Tier 1 tools: agent_run, session_send_message, session_get_status
+//   → Direct service calls, first-class support for the agent conversation loop
+// - Tier 2 tools: discover, execute
+//   → discover: search the full API catalog, returns operation details + curl examples
+//   → execute: run a bash script via bashkit with $EVERRUNS_API_BASE and auth pre-set
+// - Auth: same as rest of API (API key or session cookie via ResolvedOrg)
+// - No MCP session state — stateless request/response per JSON-RPC call
+
+use crate::auth::{AuthState, ResolvedOrg};
+use crate::services::{EventService, MessageService, SessionService};
+use crate::storage::StorageBackend;
+use axum::{Json, Router, extract::State, routing::post};
+use everruns_core::typed_id::{AgentId, EventId, HarnessId, SessionId};
+use everruns_core::{Caller, PlatformDefinition};
+use everruns_worker::AgentRunner;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::sync::Arc;
+
+use super::common::impl_auth_state;
+use super::messages::{CreateMessageRequest, InputMessage, MessageRole};
+use super::sessions::CreateSessionRequest;
+
+mod catalog;
+
+// ============================================================================
+// JSON-RPC 2.0 types
+// ============================================================================
+
+#[derive(Debug, Deserialize)]
+pub struct JsonRpcRequest {
+    pub jsonrpc: String,
+    pub id: Option<Value>,
+    pub method: String,
+    #[serde(default)]
+    pub params: Value,
+}
+
+#[derive(Debug, Serialize)]
+pub struct JsonRpcResponse {
+    pub jsonrpc: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+impl JsonRpcResponse {
+    fn success(id: Option<Value>, result: Value) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    fn error(id: Option<Value>, code: i32, message: impl Into<String>) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id,
+            result: None,
+            error: Some(JsonRpcError {
+                code,
+                message: message.into(),
+                data: None,
+            }),
+        }
+    }
+
+    fn method_not_found(id: Option<Value>) -> Self {
+        Self::error(id, -32601, "Method not found")
+    }
+
+    fn invalid_params(id: Option<Value>, msg: impl Into<String>) -> Self {
+        Self::error(id, -32602, msg)
+    }
+}
+
+// ============================================================================
+// MCP Tool definitions
+// ============================================================================
+
+const MCP_SERVER_NAME: &str = "everruns";
+const MCP_SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
+const MCP_PROTOCOL_VERSION: &str = "2025-03-26";
+
+fn tool_definitions() -> Value {
+    json!([
+        {
+            "name": "agent_run",
+            "description": "Create a new session and send the first message to an agent. Returns the session ID and message ID. Use session_get_status to poll for the agent's response, or connect to the SSE stream at /v1/sessions/{session_id}/sse for real-time events.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "agent_id": {
+                        "type": "string",
+                        "description": "Agent ID (format: agent_{32-hex}). The agent to run."
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "The initial user message to send to the agent."
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "Optional session title."
+                    },
+                    "model_id": {
+                        "type": "string",
+                        "description": "Optional model override (format: model_{32-hex})."
+                    }
+                },
+                "required": ["message"]
+            }
+        },
+        {
+            "name": "session_send_message",
+            "description": "Send a follow-up message to an existing session. The agent will process the message and generate a response. Use session_get_status to poll for completion, or connect to the SSE stream.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Session ID (format: session_{32-hex})."
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "The user message to send."
+                    }
+                },
+                "required": ["session_id", "message"]
+            }
+        },
+        {
+            "name": "session_get_status",
+            "description": "Get the current status of a session and its recent events. Returns the session status (started/active/idle), the latest agent message if available, and recent events. Use this to poll for agent responses after sending a message.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Session ID (format: session_{32-hex})."
+                    },
+                    "since_event_id": {
+                        "type": "string",
+                        "description": "Only return events after this event ID (for incremental polling)."
+                    },
+                    "event_types": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Filter to specific event types. Useful types: turn.completed, output.message.completed, tool.completed, session.idled"
+                    }
+                },
+                "required": ["session_id"]
+            }
+        },
+        {
+            "name": "discover",
+            "description": concat!(
+                "Search the Everruns API catalog to find available operations. ",
+                "Returns matching API operations with their HTTP method, path, description, parameters, and example curl commands. ",
+                "Use this to find the right API call before using the 'execute' tool.\n\n",
+                "Example queries: 'list agents', 'create session', 'delete', 'events', 'mcp servers', 'models', 'capabilities'\n\n",
+                "The results include ready-to-use curl snippets that work with the 'execute' tool. ",
+                "In execute, $EVERRUNS_API_BASE and $EVERRUNS_API_KEY are pre-configured environment variables."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Search query to find API operations (e.g., 'list agents', 'session events', 'mcp')."
+                    },
+                    "category": {
+                        "type": "string",
+                        "description": "Optional category filter: agents, sessions, messages, events, harnesses, models, providers, mcp_servers, capabilities, skills, images, schedules, organizations, users, files, databases, storage"
+                    }
+                },
+                "required": ["query"]
+            }
+        },
+        {
+            "name": "execute",
+            "description": concat!(
+                "Execute a bash script to interact with the Everruns API. ",
+                "Runs in a sandboxed bashkit environment with curl available and these pre-set environment variables:\n\n",
+                "  $EVERRUNS_API_BASE — API base URL (e.g. http://localhost:9301)\n",
+                "  $EVERRUNS_API_KEY  — Bearer token for authentication\n\n",
+                "Use 'discover' first to find the right API endpoint, then construct a curl command.\n\n",
+                "Example:\n",
+                "  curl -s -H \"Authorization: Bearer $EVERRUNS_API_KEY\" $EVERRUNS_API_BASE/v1/agents | jq .\n\n",
+                "The script can use pipes, jq for JSON processing, and other standard bash features. ",
+                "Results are returned as {stdout, stderr, exit_code, success}."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "command": {
+                        "type": "string",
+                        "description": "Bash script to execute. Use curl with $EVERRUNS_API_BASE and $EVERRUNS_API_KEY for API calls."
+                    },
+                    "timeout_ms": {
+                        "type": "integer",
+                        "description": "Execution timeout in milliseconds (default: 30000, max: 60000)."
+                    }
+                },
+                "required": ["command"]
+            }
+        }
+    ])
+}
+
+// ============================================================================
+// App State
+// ============================================================================
+
+#[derive(Clone)]
+pub struct AppState {
+    pub db: Arc<StorageBackend>,
+    pub session_service: Arc<SessionService>,
+    pub message_service: Arc<MessageService>,
+    pub event_service: Arc<EventService>,
+    pub runner: Arc<dyn AgentRunner>,
+    pub auth: AuthState,
+    pub api_base_url: String,
+    pub fallback_base_harness_name: Option<String>,
+}
+
+impl AppState {
+    pub fn new(
+        db: Arc<StorageBackend>,
+        runner: Arc<dyn AgentRunner>,
+        auth: AuthState,
+        platform_definition: &PlatformDefinition,
+        notifications_enabled: bool,
+        api_base_url: String,
+    ) -> Self {
+        Self {
+            session_service: Arc::new(SessionService::with_registry(
+                db.clone(),
+                platform_definition.capability_registry().clone(),
+            )),
+            message_service: Arc::new(MessageService::new(
+                db.clone(),
+                runner.clone(),
+                notifications_enabled,
+            )),
+            event_service: Arc::new(EventService::new(db.clone())),
+            db,
+            runner,
+            auth,
+            api_base_url,
+            fallback_base_harness_name: platform_definition
+                .harness_for_role(everruns_core::BuiltInHarnessRole::Base)
+                .map(|h| h.name.clone()),
+        }
+    }
+}
+
+impl_auth_state!(AppState);
+
+// ============================================================================
+// Routes
+// ============================================================================
+
+pub fn routes(state: AppState) -> Router {
+    Router::new()
+        .route("/v1/mcp", post(handle_mcp))
+        .with_state(state)
+}
+
+// ============================================================================
+// Main handler
+// ============================================================================
+
+async fn handle_mcp(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Json(req): Json<JsonRpcRequest>,
+) -> Json<JsonRpcResponse> {
+    if req.jsonrpc != "2.0" {
+        return Json(JsonRpcResponse::error(
+            req.id,
+            -32600,
+            "Invalid Request: jsonrpc must be \"2.0\"",
+        ));
+    }
+
+    let response = match req.method.as_str() {
+        "initialize" => handle_initialize(req.id),
+        "tools/list" => handle_tools_list(req.id),
+        "tools/call" => handle_tools_call(req.id.clone(), req.params, &org, &state).await,
+        "ping" => JsonRpcResponse::success(req.id, json!({})),
+        _ => JsonRpcResponse::method_not_found(req.id),
+    };
+
+    Json(response)
+}
+
+// ============================================================================
+// Protocol handlers
+// ============================================================================
+
+fn handle_initialize(id: Option<Value>) -> JsonRpcResponse {
+    JsonRpcResponse::success(
+        id,
+        json!({
+            "protocolVersion": MCP_PROTOCOL_VERSION,
+            "capabilities": {
+                "tools": {}
+            },
+            "serverInfo": {
+                "name": MCP_SERVER_NAME,
+                "version": MCP_SERVER_VERSION
+            }
+        }),
+    )
+}
+
+fn handle_tools_list(id: Option<Value>) -> JsonRpcResponse {
+    JsonRpcResponse::success(id, json!({ "tools": tool_definitions() }))
+}
+
+async fn handle_tools_call(
+    id: Option<Value>,
+    params: Value,
+    org: &ResolvedOrg,
+    state: &AppState,
+) -> JsonRpcResponse {
+    let tool_name = match params.get("name").and_then(|v| v.as_str()) {
+        Some(name) => name,
+        None => return JsonRpcResponse::invalid_params(id, "Missing 'name' in params"),
+    };
+
+    let arguments = params
+        .get("arguments")
+        .cloned()
+        .unwrap_or(Value::Object(Default::default()));
+
+    let result = match tool_name {
+        "agent_run" => tool_agent_run(&arguments, org, state).await,
+        "session_send_message" => tool_session_send_message(&arguments, org, state).await,
+        "session_get_status" => tool_session_get_status(&arguments, org, state).await,
+        "discover" => tool_discover(&arguments),
+        "execute" => tool_execute(&arguments, org, state).await,
+        _ => Err(format!("Unknown tool: {tool_name}")),
+    };
+
+    match result {
+        Ok(content) => JsonRpcResponse::success(
+            id,
+            json!({
+                "content": [{ "type": "text", "text": content }]
+            }),
+        ),
+        Err(msg) => JsonRpcResponse::success(
+            id,
+            json!({
+                "content": [{ "type": "text", "text": msg }],
+                "isError": true
+            }),
+        ),
+    }
+}
+
+// ============================================================================
+// Tier 1: agent_run
+// ============================================================================
+
+async fn tool_agent_run(
+    args: &Value,
+    org: &ResolvedOrg,
+    state: &AppState,
+) -> Result<String, String> {
+    let message_text = args
+        .get("message")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing required parameter: message")?;
+
+    let agent_id: Option<AgentId> = args
+        .get("agent_id")
+        .and_then(|v| v.as_str())
+        .map(|s| s.parse())
+        .transpose()
+        .map_err(|e| format!("Invalid agent_id: {e}"))?;
+
+    let title = args.get("title").and_then(|v| v.as_str()).map(String::from);
+
+    let model_id = args
+        .get("model_id")
+        .and_then(|v| v.as_str())
+        .map(|s| s.parse())
+        .transpose()
+        .map_err(|e| format!("Invalid model_id: {e}"))?;
+
+    // Resolve harness
+    let harness_id = resolve_base_harness(
+        &state.db,
+        org.org_id,
+        state.fallback_base_harness_name.as_deref(),
+    )
+    .await
+    .map_err(|e| format!("Failed to resolve harness: {e}"))?;
+
+    // Resolve agent internal ID
+    let (agent_internal_id, agent_public_id) = if let Some(ref aid) = agent_id {
+        let agent_row = state
+            .db
+            .get_agent_by_public_id(org.org_id, &aid.to_string())
+            .await
+            .map_err(|e| format!("Failed to resolve agent: {e}"))?
+            .ok_or("Agent not found")?;
+
+        let public_id: AgentId = agent_row
+            .public_id
+            .parse()
+            .unwrap_or_else(|_| AgentId::from_uuid(agent_row.id.uuid()));
+        (Some(agent_row.id.uuid()), Some(public_id))
+    } else {
+        (None, None)
+    };
+
+    let caller = Caller::from(org);
+
+    // Create session
+    let session_req = CreateSessionRequest {
+        harness_id: Some(harness_id),
+        agent_id,
+        agent_identity_id: None,
+        title,
+        locale: None,
+        tags: vec![],
+        model_id,
+        capabilities: vec![],
+        tools: vec![],
+        hints: None,
+    };
+
+    let session = state
+        .session_service
+        .create(
+            &caller,
+            harness_id.uuid(),
+            agent_internal_id,
+            agent_public_id,
+            session_req,
+        )
+        .await
+        .map_err(|e| format!("Failed to create session: {e}"))?;
+
+    // Send first message
+    let msg_req = CreateMessageRequest {
+        message: InputMessage {
+            role: MessageRole::User,
+            content: vec![everruns_core::InputContentPart::text(message_text)],
+        },
+        controls: None,
+        metadata: None,
+        tags: None,
+        external_actor: None,
+    };
+
+    let message = state
+        .message_service
+        .create(
+            crate::services::CreateMessageContext {
+                org_id: org.org_id,
+                user_id: org.user_id,
+                harness_id: session.harness_id.uuid(),
+                agent_id: session.agent_id.map(|a| a.uuid()),
+                session_id: session.id.uuid(),
+                event_metadata: None,
+            },
+            msg_req,
+        )
+        .await
+        .map_err(|e| format!("Failed to send message: {e}"))?;
+
+    Ok(serde_json::to_string_pretty(&json!({
+        "session_id": session.id.to_string(),
+        "message_id": message.id.to_string(),
+        "status": session.status.to_string(),
+        "hint": "Use session_get_status to poll for the agent's response, or connect to SSE at /v1/sessions/{session_id}/sse"
+    }))
+    .unwrap())
+}
+
+// ============================================================================
+// Tier 1: session_send_message
+// ============================================================================
+
+async fn tool_session_send_message(
+    args: &Value,
+    org: &ResolvedOrg,
+    state: &AppState,
+) -> Result<String, String> {
+    let session_id: SessionId = args
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing required parameter: session_id")?
+        .parse()
+        .map_err(|e| format!("Invalid session_id: {e}"))?;
+
+    let message_text = args
+        .get("message")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing required parameter: message")?;
+
+    let caller = Caller::from(org);
+
+    // Verify session exists
+    let session = state
+        .session_service
+        .get(&caller, session_id.uuid(), None)
+        .await
+        .map_err(|e| format!("Failed to get session: {e}"))?
+        .ok_or("Session not found")?;
+
+    let msg_req = CreateMessageRequest {
+        message: InputMessage {
+            role: MessageRole::User,
+            content: vec![everruns_core::InputContentPart::text(message_text)],
+        },
+        controls: None,
+        metadata: None,
+        tags: None,
+        external_actor: None,
+    };
+
+    let message = state
+        .message_service
+        .create(
+            crate::services::CreateMessageContext {
+                org_id: org.org_id,
+                user_id: org.user_id,
+                harness_id: session.harness_id.uuid(),
+                agent_id: session.agent_id.map(|a| a.uuid()),
+                session_id: session_id.uuid(),
+                event_metadata: None,
+            },
+            msg_req,
+        )
+        .await
+        .map_err(|e| format!("Failed to send message: {e}"))?;
+
+    Ok(serde_json::to_string_pretty(&json!({
+        "message_id": message.id.to_string(),
+        "session_status": session.status.to_string(),
+        "hint": "Use session_get_status to poll for completion"
+    }))
+    .unwrap())
+}
+
+// ============================================================================
+// Tier 1: session_get_status
+// ============================================================================
+
+async fn tool_session_get_status(
+    args: &Value,
+    org: &ResolvedOrg,
+    state: &AppState,
+) -> Result<String, String> {
+    let session_id: SessionId = args
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing required parameter: session_id")?
+        .parse()
+        .map_err(|e| format!("Invalid session_id: {e}"))?;
+
+    let since_event_id: Option<EventId> = args
+        .get("since_event_id")
+        .and_then(|v| v.as_str())
+        .map(|s| s.parse())
+        .transpose()
+        .map_err(|e| format!("Invalid since_event_id: {e}"))?;
+
+    let event_types: Vec<String> = args
+        .get("event_types")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let caller = Caller::from(org);
+
+    // Get session
+    let session = state
+        .session_service
+        .get(&caller, session_id.uuid(), None)
+        .await
+        .map_err(|e| format!("Failed to get session: {e}"))?
+        .ok_or("Session not found")?;
+
+    // Get recent events
+    let since_id = since_event_id.map(|id| id.uuid());
+
+    let events = state
+        .event_service
+        .list(
+            session_id.uuid(),
+            None,         // since_sequence
+            since_id,     // since_id (UUID)
+            &event_types, // filter_types
+            &[],          // exclude_types
+            None,         // before_sequence
+            Some(50),     // limit
+        )
+        .await
+        .map_err(|e| format!("Failed to list events: {e}"))?;
+
+    // Extract the latest agent message text from events if available
+    let latest_output = events
+        .iter()
+        .rev()
+        .find(|e| e.event_type == "output.message.completed")
+        .and_then(|e| {
+            if let everruns_core::EventData::OutputMessageCompleted(data) = &e.data {
+                data.message.text().map(String::from)
+            } else {
+                None
+            }
+        });
+
+    let last_event_id = events.last().map(|e| e.id.to_string());
+
+    Ok(serde_json::to_string_pretty(&json!({
+        "session_id": session.id.to_string(),
+        "status": session.status.to_string(),
+        "agent_id": session.agent_id.map(|a| a.to_string()),
+        "title": session.title,
+        "latest_output": latest_output,
+        "last_event_id": last_event_id,
+        "event_count": events.len(),
+        "events": events.iter().map(|e| json!({
+            "id": e.id.to_string(),
+            "type": e.event_type,
+            "ts": e.ts.to_rfc3339(),
+        })).collect::<Vec<_>>()
+    }))
+    .unwrap())
+}
+
+// ============================================================================
+// Tier 2: discover
+// ============================================================================
+
+fn tool_discover(args: &Value) -> Result<String, String> {
+    let query = args
+        .get("query")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing required parameter: query")?
+        .to_lowercase();
+
+    let category = args
+        .get("category")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_lowercase());
+
+    let operations = catalog::search(&query, category.as_deref());
+
+    if operations.is_empty() {
+        return Ok(format!(
+            "No API operations found matching '{query}'. Try broader terms like 'agents', 'sessions', 'events', 'models', 'mcp'."
+        ));
+    }
+
+    let mut output = format!("Found {} API operations:\n\n", operations.len());
+    for op in &operations {
+        output.push_str(&format!("### {} {}\n", op.method, op.path));
+        output.push_str(&format!("{}\n", op.description));
+        if !op.params.is_empty() {
+            output.push_str("Parameters:\n");
+            for p in op.params {
+                output.push_str(&format!("  - {}: {} {}\n", p.name, p.typ, p.description));
+            }
+        }
+        output.push_str(&format!("Example:\n  {}\n\n", op.curl_example));
+    }
+
+    Ok(output)
+}
+
+// ============================================================================
+// Tier 2: execute
+// ============================================================================
+
+async fn tool_execute(args: &Value, org: &ResolvedOrg, state: &AppState) -> Result<String, String> {
+    let command = args
+        .get("command")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing required parameter: command")?;
+
+    let timeout_ms = args
+        .get("timeout_ms")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(30000)
+        .min(60000);
+
+    // Build auth header value from the org context.
+    // For API key auth, reconstruct the bearer token.
+    // For session auth, we pass a generated internal token.
+    let api_key = format!("org-{}", org.public_id);
+
+    // Create a bashkit instance with API env vars pre-configured
+    let fs = Arc::new(bashkit::InMemoryFs::new());
+    let mut bash = bashkit::Bash::builder()
+        .fs(fs)
+        .cwd("/tmp")
+        .username("everruns")
+        .hostname("mcp")
+        .env("HOME", "/tmp")
+        .env("SHELL", "/bin/bash")
+        .env("PATH", "/usr/local/bin:/usr/bin:/bin")
+        .env("EVERRUNS_API_BASE", &state.api_base_url)
+        .env("EVERRUNS_API_KEY", &api_key)
+        .limits(
+            bashkit::ExecutionLimits::new()
+                .max_commands(500)
+                .max_loop_iterations(5000)
+                .max_function_depth(50)
+                .max_input_bytes(500_000)
+                .max_ast_depth(50)
+                .parser_timeout(std::time::Duration::from_secs(3)),
+        )
+        .build();
+
+    let result = tokio::time::timeout(
+        std::time::Duration::from_millis(timeout_ms),
+        bash.exec(command),
+    )
+    .await;
+
+    match result {
+        Ok(Ok(output)) => Ok(serde_json::to_string_pretty(&json!({
+            "stdout": output.stdout,
+            "stderr": output.stderr,
+            "exit_code": output.exit_code,
+            "success": output.exit_code == 0
+        }))
+        .unwrap()),
+        Ok(Err(e)) => Err(format!("Bash execution error: {e}")),
+        Err(_) => Err(format!("Command timed out after {timeout_ms}ms")),
+    }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+async fn resolve_base_harness(
+    db: &StorageBackend,
+    org_id: i64,
+    fallback_name: Option<&str>,
+) -> anyhow::Result<HarnessId> {
+    let settings = db.get_organization_settings(org_id).await?;
+    if let Some(harness_id) = settings.and_then(|row| row.base_harness_id) {
+        return Ok(harness_id);
+    }
+
+    if let Some(name) = fallback_name {
+        let harnesses = db.list_harnesses(org_id, Some(name), false).await?;
+        if let Some(h) = harnesses.first() {
+            return Ok(h.id);
+        }
+    }
+
+    anyhow::bail!("No base harness configured for this organization")
+}

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -20,6 +20,7 @@ pub mod images;
 pub mod internal_images;
 pub mod llm_models;
 pub mod llm_providers;
+pub mod mcp_endpoint;
 pub mod mcp_servers;
 pub mod messages;
 pub mod notifications;

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -692,11 +692,16 @@ impl ServerAppBuilder {
             .merge(api::audit_logs::routes(audit_logs_state))
             .merge(api::commands::routes(commands_state))
             .merge(api::slack_events::routes(slack_state))
-            .merge(api::feature_flags::routes(feature_flags_state))
-            .merge(api::mcp_endpoint::routes(mcp_endpoint_state));
+            .merge(api::feature_flags::routes(feature_flags_state));
 
         if let Some(notifications_state) = notifications_state {
             api_routes = api_routes.merge(api::notifications::routes(notifications_state));
+        }
+
+        if feature_flags.mcp_endpoint {
+            api_routes = api_routes.merge(api::mcp_endpoint::routes(mcp_endpoint_state));
+        } else {
+            tracing::info!("MCP endpoint disabled via feature flag");
         }
 
         // Auth-specific routes

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -598,6 +598,25 @@ impl ServerAppBuilder {
         let session_resources_state =
             api::session_resources::AppState::new(leased_resource_service, auth_state.clone());
 
+        // MCP endpoint: derive API base URL from addr config or MCP_API_BASE_URL env var
+        let mcp_api_base_url = std::env::var("MCP_API_BASE_URL").unwrap_or_else(|_| {
+            let addr = &self.config.addr;
+            let host = if addr.starts_with("0.0.0.0") {
+                addr.replacen("0.0.0.0", "127.0.0.1", 1)
+            } else {
+                addr.to_string()
+            };
+            format!("http://{host}")
+        });
+        let mcp_endpoint_state = api::mcp_endpoint::AppState::new(
+            db.clone(),
+            runner.clone(),
+            auth_state.clone(),
+            platform_definition.as_ref(),
+            notifications_enabled,
+            mcp_api_base_url,
+        );
+
         let health_state = HealthState {
             auth_mode: format!("{:?}", auth_config.mode),
         };
@@ -673,7 +692,8 @@ impl ServerAppBuilder {
             .merge(api::audit_logs::routes(audit_logs_state))
             .merge(api::commands::routes(commands_state))
             .merge(api::slack_events::routes(slack_state))
-            .merge(api::feature_flags::routes(feature_flags_state));
+            .merge(api::feature_flags::routes(feature_flags_state))
+            .merge(api::mcp_endpoint::routes(mcp_endpoint_state));
 
         if let Some(notifications_state) = notifications_state {
             api_routes = api_routes.merge(api::notifications::routes(notifications_state));

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -16,6 +16,14 @@ All endpoints are prefixed with `/v1/`.
 |--------|------|-------------|
 | GET | `/health` | Server health check (includes version and runner mode) |
 
+### MCP Endpoint
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/mcp` | MCP server (Streamable HTTP transport, JSON-RPC 2.0) |
+
+Exposes Everruns as an MCP server. Tier 1 tools (`agent_run`, `session_send_message`, `session_get_status`) handle the agent conversation loop via direct service calls. Tier 2 tools (`discover`, `execute`) are backed by a bashkit `ScriptedTool` with all API operations registered as builtins — run `discover --categories` to list them, or call them directly in bash scripts via `execute`. See `crates/server/src/api/mcp_endpoint/mod.rs` for implementation.
+
 ### Authentication
 
 | Method | Path | Description |

--- a/specs/feature-flags.md
+++ b/specs/feature-flags.md
@@ -31,6 +31,7 @@ System-level feature flags that control feature availability across the platform
 | `global_chat` | `FEATURE_GLOBAL_CHAT` | Experimental | Per-user singleton chat session |
 | `apps` | `FEATURE_APPS` | Experimental | Apps (agent deployment to distribution channels) |
 | `notifications` | `FEATURE_NOTIFICATIONS` | Standard | In-app notifications (bell, toast, notification SSE) |
+| `mcp_endpoint` | `FEATURE_MCP_ENDPOINT` | Experimental | MCP endpoint (POST /mcp — Everruns as an MCP server) |
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

- Move MCP endpoint from `POST /v1/mcp` to `POST /mcp`
- Gate behind `mcp_endpoint` experimental feature flag (`FEATURE_MCP_ENDPOINT` env var, auto-enabled in dev)
- Replace Tier 2 discover/execute with bashkit `ScriptedTool`: each API operation (40+ endpoints) is a registered builtin callable from bash scripts
- `discover` delegates to ScriptedTool built-in `discover` command (categories, search)
- `execute` runs bash through ScriptedTool — no more raw curl needed, just `list_agents | jq .`
- Enable `scripted_tool` feature on bashkit dependency
- Document in `specs/apis.md` and `specs/feature-flags.md`

## Test plan

- [x] `POST /mcp` initialize → returns protocol version + server info
- [x] `POST /mcp` tools/list → returns 5 tools
- [x] `POST /v1/mcp` → 404 (old route removed)
- [x] discover tool → `discover --search agent` returns matching operations
- [x] discover categories → `discover --categories` lists 19 categories, 45 tools
- [x] execute `list_agents`, `list_models`, piping, multi-step scripts — all work
- [x] Feature flag enabled (dev default) → endpoint works
- [x] Feature flag disabled (`FEATURE_MCP_ENDPOINT=false`) → endpoint returns 404
- [x] `GET /v1/feature-flags` returns `mcp_endpoint` field
- [x] Feature flag unit tests pass (10/10)
- [x] `cargo clippy` clean, `just pre-push` passes