### PR TITLE
chore: remove protoc build dependency

### DIFF
--- a/.github/workflows/brave-search-integration.yml
+++ b/.github/workflows/brave-search-integration.yml
@@ -35,9 +35,6 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install protobuf compiler
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,9 +122,6 @@ jobs:
         with:
           components: clippy
 
-      - name: Install protobuf compiler
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.7
 
@@ -153,9 +150,6 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-
-      - name: Install protobuf compiler
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.7
@@ -207,10 +201,6 @@ jobs:
         if: steps.check-key.outputs.skip != 'true'
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install protobuf compiler
-        if: steps.check-key.outputs.skip != 'true'
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-
       - name: Setup sccache
         if: steps.check-key.outputs.skip != 'true'
         uses: mozilla-actions/sccache-action@v0.0.7
@@ -257,10 +247,6 @@ jobs:
       - name: Install Rust toolchain
         if: steps.check-key.outputs.skip != 'true'
         uses: dtolnay/rust-toolchain@stable
-
-      - name: Install protobuf compiler
-        if: steps.check-key.outputs.skip != 'true'
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Setup sccache
         if: steps.check-key.outputs.skip != 'true'
@@ -309,10 +295,6 @@ jobs:
         if: steps.check-key.outputs.skip != 'true'
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install protobuf compiler
-        if: steps.check-key.outputs.skip != 'true'
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-
       - name: Setup sccache
         if: steps.check-key.outputs.skip != 'true'
         uses: mozilla-actions/sccache-action@v0.0.7
@@ -359,10 +341,6 @@ jobs:
       - name: Install Rust toolchain
         if: steps.check-key.outputs.skip != 'true'
         uses: dtolnay/rust-toolchain@stable
-
-      - name: Install protobuf compiler
-        if: steps.check-key.outputs.skip != 'true'
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Setup sccache
         if: steps.check-key.outputs.skip != 'true'
@@ -417,8 +395,6 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install protobuf compiler
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.7
@@ -481,8 +457,6 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install protobuf compiler
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.7
@@ -561,8 +535,6 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install protobuf compiler
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.7

--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -38,14 +38,6 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install protobuf compiler (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-
-      - name: Install protobuf compiler (macOS)
-        if: runner.os == 'macOS'
-        run: brew install protobuf
-
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/duckduckgo-integration.yml
+++ b/.github/workflows/duckduckgo-integration.yml
@@ -34,9 +34,6 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install protobuf compiler
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/sprites-integration.yml
+++ b/.github/workflows/sprites-integration.yml
@@ -35,8 +35,6 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install protobuf compiler
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.7
@@ -68,8 +66,6 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install protobuf compiler
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1681,6 +1681,8 @@ dependencies = [
  "http",
  "http-body",
  "inventory",
+ "prost",
+ "protox",
  "reqwest 0.13.2",
  "rustls",
  "rustls-native-certs",

--- a/crates/server/Dockerfile
+++ b/crates/server/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     libssl-dev \
     curl \
-    protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
 RUN rustup component add rustfmt

--- a/crates/worker/Dockerfile
+++ b/crates/worker/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     libssl-dev \
     curl \
-    protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
 RUN rustup component add rustfmt

--- a/docker/Dockerfile.unified
+++ b/docker/Dockerfile.unified
@@ -24,7 +24,6 @@ RUN apt-get update && apt-get install -y \
     clang \
     lld \
     curl \
-    protobuf-compiler \
     libssl-dev \
     && xx-apt-get install -y \
     gcc \

--- a/integrations/e2b/Cargo.toml
+++ b/integrations/e2b/Cargo.toml
@@ -30,7 +30,7 @@ everruns-core = { path = "../../crates/core" }
 [build-dependencies]
 connectrpc-build = "0.2.0"
 protox = "0.9"
-prost = "0.14"
+prost.workspace = true
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/integrations/e2b/Cargo.toml
+++ b/integrations/e2b/Cargo.toml
@@ -29,6 +29,8 @@ everruns-core = { path = "../../crates/core" }
 
 [build-dependencies]
 connectrpc-build = "0.2.0"
+protox = "0.9"
+prost = "0.14"
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/integrations/e2b/build.rs
+++ b/integrations/e2b/build.rs
@@ -1,10 +1,22 @@
+// Uses protox (pure Rust protobuf compiler) to avoid requiring external protoc binary.
+// Compiles proto to a FileDescriptorSet, then feeds it to connectrpc-build.
 fn main() {
     println!("cargo:rerun-if-changed=proto/process.proto");
 
+    // Compile proto with protox (pure Rust, no protoc needed)
+    let fds = protox::compile(["proto/process.proto"], ["proto"])
+        .expect("failed to compile E2B process proto with protox");
+
+    // Serialize the FileDescriptorSet to a temp file for connectrpc-build
+    use prost::Message;
+    let fds_bytes = fds.encode_to_vec();
+    let fds_path = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("e2b.fds.bin");
+    std::fs::write(&fds_path, &fds_bytes).expect("failed to write descriptor set");
+
     connectrpc_build::Config::new()
-        .files(&["proto/process.proto"])
-        .includes(&["proto"])
+        .descriptor_set(&fds_path)
+        .files(&["process.proto"])
         .include_file("_e2b.rs")
         .compile()
-        .expect("failed to compile E2B process proto");
+        .expect("failed to generate E2B connectrpc code");
 }


### PR DESCRIPTION
## What
Remove the `protoc` (protobuf-compiler) system dependency from all CI workflows and Dockerfiles. The E2B integration's build.rs is updated to use `protox` (pure Rust protobuf compiler) instead of shelling out to `protoc`.

## Why
`protoc` is installed in 13 places across CI and Docker but neither proto-using crate actually needs it:
- `crates/internal-protocol` already uses `protox` (pure Rust)
- `integrations/e2b` used `connectrpc-build` which defaults to shelling out to `protoc`, but supports a `descriptor_set()` mode that accepts pre-compiled descriptors

Removing the system dependency simplifies builds, eliminates `apt-get update` round-trips in CI (faster jobs), and removes a version-skew risk between system protoc and the Rust protobuf libraries.

## How
- **E2B build.rs**: Use `protox` to compile `process.proto` into a `FileDescriptorSet`, serialize it to `$OUT_DIR/e2b.fds.bin`, then pass it to `connectrpc_build::Config::descriptor_set()`. Added `protox` and `prost` (workspace) as build-dependencies.
- **CI workflows**: Removed `Install protobuf compiler` steps from `ci.yml` (10 jobs), `cli-binaries.yml` (Linux + macOS), `duckduckgo/brave-search/sprites integration`.
- **Dockerfiles**: Removed `protobuf-compiler` from `docker/Dockerfile.unified`, `crates/server/Dockerfile`, `crates/worker/Dockerfile`.

## Risk
- Low
- Proto compilation could theoretically differ between protox and protoc, but protox is already used by internal-protocol without issues, and the wire format is standardized

## Security
- No security-relevant code changes. Build tooling only; no runtime behavior changes.

## Checklist
- [x] Tests added or updated (no new tests needed — existing CI builds and unit tests exercise proto compilation)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)