### PR TITLE
refactor(seed): non-blocking multi-org harness reconciliation

### DIFF
--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -305,7 +305,6 @@ impl ServerAppBuilder {
             },
             platform_definition.as_ref().clone(),
         );
-        seed::spawn_harness_reconciliation_task(db.clone(), platform_definition.as_ref().clone());
 
         let sqldb_backend = Arc::new(everruns_session_sqldb::InMemorySqlDbBackend::new());
         let sqldb_store: Arc<dyn everruns_core::session_sqldb::SessionSqlDbStore> = Arc::new(

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -305,6 +305,7 @@ impl ServerAppBuilder {
             },
             platform_definition.as_ref().clone(),
         );
+        seed::spawn_harness_reconciliation_task(db.clone(), platform_definition.as_ref().clone());
 
         let sqldb_backend = Arc::new(everruns_session_sqldb::InMemorySqlDbBackend::new());
         let sqldb_store: Arc<dyn everruns_core::session_sqldb::SessionSqlDbStore> = Arc::new(

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -1842,6 +1842,11 @@ pub fn spawn_seed_task_with_platform_definition(
                         "Seeding complete (all items up to date)"
                     );
                 }
+
+                // After seed succeeds, reconcile harnesses for non-default orgs.
+                // This runs here (not as a separate task) so ordering is deterministic:
+                // the default org and its harnesses are guaranteed to exist.
+                reconcile_non_default_org_harnesses(&db, &platform_definition).await;
             }
             Err(e) => {
                 tracing::warn!(
@@ -1853,81 +1858,71 @@ pub fn spawn_seed_task_with_platform_definition(
     });
 }
 
-/// Reconcile built-in harnesses across all orgs in a background task.
+/// Reconcile built-in harnesses for every non-default org.
 ///
-/// This is separate from seeding because it scales with the number of orgs (O(n))
-/// and must not block server startup. Each org is reconciled independently so a
-/// single failure does not prevent other orgs from being updated.
-pub fn spawn_harness_reconciliation_task(
-    db: Arc<StorageBackend>,
-    platform_definition: PlatformDefinition,
+/// Called after seeding completes (inside the seed task) so the default org and
+/// its harnesses are guaranteed to exist. Each org is reconciled independently;
+/// a single failure is logged but does not prevent other orgs from updating.
+async fn reconcile_non_default_org_harnesses(
+    db: &StorageBackend,
+    platform_definition: &PlatformDefinition,
 ) {
-    tokio::spawn(async move {
-        // Let seed finish first so the default org and its harnesses exist.
-        tokio::time::sleep(Duration::from_secs(2)).await;
-
-        let harnesses = platform_definition.built_in_harnesses();
-        let orgs = match db.list_organizations().await {
-            Ok(orgs) => orgs,
-            Err(e) => {
-                tracing::warn!(error = %e, "Harness reconciliation: failed to list orgs (non-fatal)");
-                return;
-            }
-        };
-
-        // Skip the default org — already handled synchronously during seed.
-        let orgs: Vec<_> = orgs
-            .into_iter()
-            .filter(|o| o.org_id != everruns_core::DEFAULT_ORG_ID)
-            .collect();
-
-        if orgs.is_empty() {
-            tracing::debug!("No non-default orgs to reconcile harnesses for");
+    let harnesses = platform_definition.built_in_harnesses();
+    let mut orgs = match db.list_organizations().await {
+        Ok(orgs) => orgs,
+        Err(e) => {
+            tracing::warn!(error = %e, "Harness reconciliation: failed to list orgs (non-fatal)");
             return;
         }
+    };
 
-        let mut created = 0usize;
-        let mut updated = 0usize;
-        let mut unchanged = 0usize;
-        let mut errors = 0usize;
+    // Skip the default org — already handled synchronously during seed.
+    orgs.retain(|o| o.org_id != everruns_core::DEFAULT_ORG_ID);
 
-        for org in &orgs {
-            match org_init::initialize_org_harnesses_with_definitions(&db, org.org_id, harnesses)
-                .await
-            {
-                Ok(r) => {
-                    created += r.created;
-                    updated += r.updated;
-                    unchanged += r.unchanged;
-                }
-                Err(e) => {
-                    errors += 1;
-                    tracing::warn!(
-                        org_id = org.org_id,
-                        error = %e,
-                        "Harness reconciliation failed for org (non-fatal)"
-                    );
-                }
+    if orgs.is_empty() {
+        tracing::debug!("No non-default orgs to reconcile harnesses for");
+        return;
+    }
+
+    let mut created = 0usize;
+    let mut updated = 0usize;
+    let mut unchanged = 0usize;
+    let mut errors = 0usize;
+
+    for org in &orgs {
+        match org_init::initialize_org_harnesses_with_definitions(db, org.org_id, harnesses).await {
+            Ok(r) => {
+                created += r.created;
+                updated += r.updated;
+                unchanged += r.unchanged;
+            }
+            Err(e) => {
+                errors += 1;
+                tracing::warn!(
+                    org_id = org.org_id,
+                    error = %e,
+                    "Harness reconciliation failed for org (non-fatal)"
+                );
             }
         }
+    }
 
-        if created > 0 || updated > 0 || errors > 0 {
-            tracing::info!(
-                org_count = orgs.len(),
-                created,
-                updated,
-                unchanged,
-                errors,
-                "Background harness reconciliation complete"
-            );
-        } else {
-            tracing::debug!(
-                org_count = orgs.len(),
-                unchanged,
-                "Background harness reconciliation complete (all up to date)"
-            );
-        }
-    });
+    if created > 0 || updated > 0 || errors > 0 {
+        tracing::info!(
+            org_count = orgs.len(),
+            created,
+            updated,
+            unchanged,
+            errors,
+            "Background harness reconciliation complete"
+        );
+    } else {
+        tracing::debug!(
+            org_count = orgs.len(),
+            unchanged,
+            "Background harness reconciliation complete (all up to date)"
+        );
+    }
 }
 
 /// Run seeding with retry logic for transient errors
@@ -2602,5 +2597,59 @@ mod tests {
             }
             .has_changes()
         );
+    }
+
+    // --- Multi-org harness reconciliation ---
+
+    #[tokio::test]
+    async fn test_reconcile_non_default_org_harnesses() {
+        use crate::storage::models::CreateOrganizationRow;
+
+        let db = make_db();
+        // Seed default org first (creates harnesses for DEFAULT_ORG_ID).
+        seed_all(&db, DeploymentGrade::Dev, &SeedAuthContext::default())
+            .await
+            .unwrap();
+
+        // Create a second org.
+        let second_org = db
+            .create_organization(CreateOrganizationRow {
+                public_id: "org-second".into(),
+                name: "Second Org".into(),
+                created_by: None,
+            })
+            .await
+            .unwrap();
+
+        // Before reconciliation, second org should have no harnesses.
+        let before = db
+            .list_harnesses(second_org.org_id, None, false)
+            .await
+            .unwrap();
+        assert!(
+            before.is_empty(),
+            "second org should start with no harnesses"
+        );
+
+        // Run reconciliation.
+        let pd = crate::platform::oss_platform_definition_for_grade(DeploymentGrade::Dev);
+        reconcile_non_default_org_harnesses(&db, &pd).await;
+
+        // After reconciliation, second org should have the built-in harnesses.
+        let after = db
+            .list_harnesses(second_org.org_id, None, false)
+            .await
+            .unwrap();
+        assert!(
+            !after.is_empty(),
+            "second org should have harnesses after reconciliation"
+        );
+
+        // Default org harness count should match.
+        let default_harnesses = db
+            .list_harnesses(DEFAULT_ORG_ID, None, false)
+            .await
+            .unwrap();
+        assert_eq!(after.len(), default_harnesses.len());
     }
 }

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -1853,6 +1853,83 @@ pub fn spawn_seed_task_with_platform_definition(
     });
 }
 
+/// Reconcile built-in harnesses across all orgs in a background task.
+///
+/// This is separate from seeding because it scales with the number of orgs (O(n))
+/// and must not block server startup. Each org is reconciled independently so a
+/// single failure does not prevent other orgs from being updated.
+pub fn spawn_harness_reconciliation_task(
+    db: Arc<StorageBackend>,
+    platform_definition: PlatformDefinition,
+) {
+    tokio::spawn(async move {
+        // Let seed finish first so the default org and its harnesses exist.
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let harnesses = platform_definition.built_in_harnesses();
+        let orgs = match db.list_organizations().await {
+            Ok(orgs) => orgs,
+            Err(e) => {
+                tracing::warn!(error = %e, "Harness reconciliation: failed to list orgs (non-fatal)");
+                return;
+            }
+        };
+
+        // Skip the default org — already handled synchronously during seed.
+        let orgs: Vec<_> = orgs
+            .into_iter()
+            .filter(|o| o.org_id != everruns_core::DEFAULT_ORG_ID)
+            .collect();
+
+        if orgs.is_empty() {
+            tracing::debug!("No non-default orgs to reconcile harnesses for");
+            return;
+        }
+
+        let mut created = 0usize;
+        let mut updated = 0usize;
+        let mut unchanged = 0usize;
+        let mut errors = 0usize;
+
+        for org in &orgs {
+            match org_init::initialize_org_harnesses_with_definitions(&db, org.org_id, harnesses)
+                .await
+            {
+                Ok(r) => {
+                    created += r.created;
+                    updated += r.updated;
+                    unchanged += r.unchanged;
+                }
+                Err(e) => {
+                    errors += 1;
+                    tracing::warn!(
+                        org_id = org.org_id,
+                        error = %e,
+                        "Harness reconciliation failed for org (non-fatal)"
+                    );
+                }
+            }
+        }
+
+        if created > 0 || updated > 0 || errors > 0 {
+            tracing::info!(
+                org_count = orgs.len(),
+                created,
+                updated,
+                unchanged,
+                errors,
+                "Background harness reconciliation complete"
+            );
+        } else {
+            tracing::debug!(
+                org_count = orgs.len(),
+                unchanged,
+                "Background harness reconciliation complete (all up to date)"
+            );
+        }
+    });
+}
+
 /// Run seeding with retry logic for transient errors
 async fn run_seed_with_retry(
     db: &StorageBackend,
@@ -2001,9 +2078,12 @@ pub async fn seed_all_with_platform_definition(
     );
     result.merge(mcp_result);
 
-    // Reconcile built-in harnesses across all orgs (before agents, sessions may reference them)
-    let harness_result = org_init::reconcile_built_in_harnesses_with_definitions(
+    // Initialize built-in harnesses for the default org (fast, O(1)).
+    // Multi-org reconciliation runs as a separate background task
+    // (spawn_harness_reconciliation_task) so it does not block startup.
+    let harness_result = org_init::initialize_org_harnesses_with_definitions(
         db,
+        DEFAULT_ORG_ID,
         platform_definition.built_in_harnesses(),
     )
     .await?;
@@ -2011,7 +2091,7 @@ pub async fn seed_all_with_platform_definition(
         created = harness_result.created,
         updated = harness_result.updated,
         unchanged = harness_result.unchanged,
-        "Built-in harnesses reconciled"
+        "Default org built-in harnesses seeded"
     );
     result.created += harness_result.created;
     result.updated += harness_result.updated;


### PR DESCRIPTION
## What
Move multi-org harness reconciliation out of the synchronous seed path into a non-blocking background flow that runs after seed completes.

## Why
`reconcile_built_in_harnesses_with_definitions` iterated all orgs synchronously inside `seed_all`, blocking startup. At scale (many orgs) this adds unacceptable latency to server start.

## How
- `seed_all_with_platform_definition` now only initializes harnesses for `DEFAULT_ORG_ID` (O(1), fast).
- After seed succeeds, `reconcile_non_default_org_harnesses` runs within the same background seed task — deterministic ordering, no brittle sleep.
- Each org is reconciled independently; single-org failures are logged and non-fatal.
- Uses `retain()` for in-place filtering instead of `filter+collect`.

## Risk
- Low
- If reconciliation fails for a non-default org, that org won't have updated harnesses until next restart. Logged as warning.

## Security
- Threat categories reviewed: TM-DOS (startup performance), TM-TENANT (org scoping)
- No new trust boundaries, auth surfaces, or API changes. Reconciliation uses existing org-scoped `initialize_org_harnesses_with_definitions`.
- No security-relevant findings.

## Checklist
- [x] Tests added or updated (`test_reconcile_non_default_org_harnesses`)
- [x] Backward compatibility considered (no API changes, internal refactor only)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)