### PR TITLE
fix(ui,docs): fix code block empty header bar and background contrast

### DIFF
--- a/apps/docs/src/styles/custom.css
+++ b/apps/docs/src/styles/custom.css
@@ -115,6 +115,36 @@
   border: 1px solid var(--sl-color-hairline);
 }
 
+/* Light-mode code block overrides:
+   - White background for readable contrast against page bg
+   - Hide the empty terminal title bar (dots row stays via header ::before) */
+:root,
+:root[data-theme="light"] {
+  --ec-codeBg: #ffffff;
+  --ec-frm-trmBg: #ffffff;
+  --ec-frm-trmTtbBg: #f5f5f5;
+  --ec-frm-edBg: #ffffff;
+}
+
+:root[data-theme="dark"] {
+  --ec-codeBg: #111111;
+  --ec-frm-trmBg: #111111;
+  --ec-frm-trmTtbBg: #1a1a1a;
+  --ec-frm-edBg: #111111;
+}
+
+/* Hide the empty terminal title bar when there is no title text.
+   Expressive Code injects a non-breaking space via :empty::before,
+   so target .title that has no real text content. */
+.expressive-code .frame.is-terminal:not(.has-title) .header {
+  display: none;
+}
+.expressive-code .frame.is-terminal:not(.has-title) pre {
+  border-top: 1px solid var(--sl-color-hairline);
+  border-top-left-radius: calc(var(--ec-brdRad) + var(--ec-brdWd));
+  border-top-right-radius: calc(var(--ec-brdRad) + var(--ec-brdWd));
+}
+
 /* Table styling - clean minimal look with proper specificity */
 .sl-markdown-content table:not(:where(.not-content *)) {
   display: table;

--- a/apps/ui/src/app/globals.css
+++ b/apps/ui/src/app/globals.css
@@ -40,8 +40,8 @@
     --border: 0 0% 88%;
     --input: 0 0% 85%;
     --ring: 43 60% 53%;
-    /* Sidebar: used by Streamdown code blocks — slightly darker than muted for contrast */
-    --sidebar: 0 0% 93%;
+    /* Sidebar: used by Streamdown code blocks — white for clean contrast against muted bg */
+    --sidebar: 0 0% 100%;
     --sidebar-foreground: 0 0% 10%;
     /* Sharp corners */
     --radius: 0px;

--- a/apps/ui/src/components/chat/streamdown-message.css
+++ b/apps/ui/src/components/chat/streamdown-message.css
@@ -112,7 +112,9 @@
    Streamdown always renders a <span> child so :empty never matches.
    When language is undefined the data-language attr is omitted entirely;
    when empty string it is data-language="". Target both via the parent. */
-.streamdown [data-streamdown="code-block"]:not([data-language]) [data-streamdown="code-block-header"],
+.streamdown
+  [data-streamdown="code-block"]:not([data-language])
+  [data-streamdown="code-block-header"],
 .streamdown [data-streamdown="code-block"][data-language=""] [data-streamdown="code-block-header"] {
   display: none;
 }

--- a/apps/ui/src/components/chat/streamdown-message.css
+++ b/apps/ui/src/components/chat/streamdown-message.css
@@ -108,8 +108,12 @@
   display: inline-flex;
   border-bottom: 1px solid var(--color-border);
 }
-/* Hide the header bar when it has no language label (empty gray bar) */
-.streamdown [data-streamdown="code-block-header"]:empty {
+/* Hide the header bar when code block has no language label.
+   Streamdown always renders a <span> child so :empty never matches.
+   When language is undefined the data-language attr is omitted entirely;
+   when empty string it is data-language="". Target both via the parent. */
+.streamdown [data-streamdown="code-block"]:not([data-language]) [data-streamdown="code-block-header"],
+.streamdown [data-streamdown="code-block"][data-language=""] [data-streamdown="code-block-header"] {
   display: none;
 }
 .streamdown [data-streamdown="code-block-actions"] {


### PR DESCRIPTION
## What

Fix code block styling issues in both the main UI (streamdown) and the docs site (Expressive Code):
- Remove the empty grey header bar that appears above code blocks with no language label
- Fix unreadable code block backgrounds by using white (light) / near-black (dark)

## Why

Code blocks without a language label showed an empty grey bar at the top. The code block background was too close to the surrounding container color, making text hard to read.

## How

**Main UI (`apps/ui`):**
- The `:empty` CSS selector never matched because streamdown always renders a `<span>` child inside the header. Changed to target the parent `[data-streamdown="code-block"]` element's `data-language` attribute — when no language is set, the attribute is omitted entirely.
- Changed `--sidebar` HSL from `0 0% 93%` to `0 0% 100%` (white) so code blocks have clean contrast against the `bg-muted` message container.

**Docs site (`apps/docs`):**
- Hid the Expressive Code terminal title bar (`.header`) for frames without `.has-title`, removing the empty grey bar with dots.
- Overrode `--ec-codeBg`, `--ec-frm-trmBg`, `--ec-frm-edBg` to white (light) and `#111111` (dark) for readable contrast.

## Risk
- Low
- Visual-only CSS changes. No logic, no data flow, no API changes.

## Security
- No security-relevant code changes. All changes are CSS-only (color values and display rules) with no impact on authentication, authorization, data handling, or trust boundaries.

## Checklist
- [x] Tests added or updated — CSS-only changes; verified via UI build, docs build, and lint
- [x] Backward compatibility considered — N/A, internal CSS
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
