### PR TITLE
feat(events): add tool.output.delta for streamed tool output

### DIFF
--- a/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
@@ -23,7 +23,6 @@ import type {
   ReasoningEffort,
   ToolCompletedData,
   ToolProgressData,
-  ToolOutputDeltaData,
   InputMessageData,
   OutputMessageCompletedData,
   Message,

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
@@ -410,23 +410,31 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
     return map;
   }, [events]);
 
-  // Accumulate streamed tool output by tool_call_id (concatenates deltas per stream)
+  // Accumulate streamed tool output by tool_call_id.
+  // Uses chunk arrays and joins once per tool to avoid O(n²) string concatenation.
   const toolOutputMap = useMemo(() => {
-    const map = new Map<string, ToolOutputStreams>();
-    if (!events) return map;
+    const chunkMap = new Map<string, { stdoutChunks: string[]; stderrChunks: string[] }>();
+    if (!events) return new Map<string, ToolOutputStreams>();
     for (const event of events) {
       const data = getEventData(event, "tool.output.delta");
-      if (data) {
-        const existing = map.get(data.tool_call_id) ?? { stdout: "", stderr: "" };
-        if (data.stream === "stdout") {
-          existing.stdout += data.delta;
-        } else if (data.stream === "stderr") {
-          existing.stderr += data.delta;
-        }
-        map.set(data.tool_call_id, existing);
+      if (!data) continue;
+      const existing = chunkMap.get(data.tool_call_id) ?? { stdoutChunks: [], stderrChunks: [] };
+      if (data.stream === "stderr") {
+        existing.stderrChunks.push(data.delta);
+      } else {
+        // stdout and any unknown streams default to stdout
+        existing.stdoutChunks.push(data.delta);
       }
+      chunkMap.set(data.tool_call_id, existing);
     }
-    return map;
+    const result = new Map<string, ToolOutputStreams>();
+    for (const [toolCallId, streams] of chunkMap.entries()) {
+      result.set(toolCallId, {
+        stdout: streams.stdoutChunks.join(""),
+        stderr: streams.stderrChunks.join(""),
+      });
+    }
+    return result;
   }, [events]);
 
   // Incremental token usage accumulation — O(1) per new event instead of O(n).

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
@@ -23,6 +23,7 @@ import type {
   ReasoningEffort,
   ToolCompletedData,
   ToolProgressData,
+  ToolOutputDeltaData,
   InputMessageData,
   OutputMessageCompletedData,
   Message,
@@ -30,6 +31,12 @@ import type {
 } from "@/lib/api/types";
 import { getTextFromContent, isToolCallPart, getEventData } from "@/lib/api/types";
 import type { UseMutationResult } from "@tanstack/react-query";
+
+/** Accumulated streamed output for a single tool call */
+export interface ToolOutputStreams {
+  stdout: string;
+  stderr: string;
+}
 
 interface SessionContextValue {
   // IDs
@@ -43,6 +50,7 @@ interface SessionContextValue {
   chatEvents: Event[];
   toolResultsMap: Map<string, ToolCompletedData>;
   toolProgressMap: Map<string, ToolProgressData>;
+  toolOutputMap: Map<string, ToolOutputStreams>;
   // Loading states
   sessionLoading: boolean;
   eventsLoading: boolean;
@@ -403,6 +411,25 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
     return map;
   }, [events]);
 
+  // Accumulate streamed tool output by tool_call_id (concatenates deltas per stream)
+  const toolOutputMap = useMemo(() => {
+    const map = new Map<string, ToolOutputStreams>();
+    if (!events) return map;
+    for (const event of events) {
+      const data = getEventData(event, "tool.output.delta");
+      if (data) {
+        const existing = map.get(data.tool_call_id) ?? { stdout: "", stderr: "" };
+        if (data.stream === "stdout") {
+          existing.stdout += data.delta;
+        } else if (data.stream === "stderr") {
+          existing.stderr += data.delta;
+        }
+        map.set(data.tool_call_id, existing);
+      }
+    }
+    return map;
+  }, [events]);
+
   // Incremental token usage accumulation — O(1) per new event instead of O(n).
   // Tracks how many events have been processed so only new events are scanned.
   const usageRef = useRef({
@@ -508,6 +535,7 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
     chatEvents,
     toolResultsMap,
     toolProgressMap,
+    toolOutputMap,
     sessionLoading,
     eventsLoading,
     effectiveStatus,

--- a/apps/ui/src/components/chat/bash-tool-call-card.tsx
+++ b/apps/ui/src/components/chat/bash-tool-call-card.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Check, Loader2, ChevronDown, ChevronRight, Terminal } from "lucide-react";
 import type { ToolCompletedData } from "@/lib/api/types";
+import type { ToolOutputStreams } from "@/app/(main)/sessions/[sessionId]/session-context";
 import { useLocale } from "@/providers/locale-provider";
 import { cn } from "@/lib/utils";
 import { getFullText, type ToolCallContent } from "./tool-call-utils";
@@ -13,6 +14,8 @@ export { isBashTool } from "@/lib/tool-registry";
 interface BashToolCallCardProps {
   toolCall: ToolCallContent;
   toolResult?: ToolCompletedData;
+  /** Streamed output received via tool.output.delta events during execution */
+  streamedOutput?: ToolOutputStreams;
 }
 
 export interface BashOutput {
@@ -122,7 +125,7 @@ export function BashToolResultDetails({
  * Shows: `$ command` with status icon, collapsed output toggle.
  * Output separates stdout/stderr with visual distinction.
  */
-export function BashToolCallCard({ toolCall, toolResult }: BashToolCallCardProps) {
+export function BashToolCallCard({ toolCall, toolResult, streamedOutput }: BashToolCallCardProps) {
   const { t } = useLocale();
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -135,12 +138,21 @@ export function BashToolCallCard({ toolCall, toolResult }: BashToolCallCardProps
   const fullText = toolResult?.result ? getFullText(toolResult.result) : "";
   const bashOutput = fullText ? parseBashOutput(fullText) : null;
 
+  // Streamed output available while tool is still running
+  const hasStreamedOutput = !isComplete && streamedOutput &&
+    (streamedOutput.stdout.length > 0 || streamedOutput.stderr.length > 0);
+
+  // Auto-expand when streamed output arrives
+  useEffect(() => {
+    if (hasStreamedOutput) setIsExpanded(true);
+  }, [hasStreamedOutput]);
+
   // Determine if there's meaningful output to show
   const hasStdout = !!bashOutput?.stdout;
   const hasStderr = !!bashOutput?.stderr;
   const hasOutput = bashOutput
     ? hasStdout || hasStderr || bashOutput.exit_code !== 0
-    : fullText.length > 0;
+    : fullText.length > 0 || !!hasStreamedOutput;
   const exitedWithError = bashOutput ? !bashOutput.success : hasError;
   const exitCodeLabel =
     bashOutput && bashOutput.exit_code !== 0
@@ -216,11 +228,39 @@ export function BashToolCallCard({ toolCall, toolResult }: BashToolCallCardProps
         </div>
       )}
 
-      {/* Expanded output */}
-      {isExpanded && (
+      {/* Expanded output: streamed (while running) or final (when complete) */}
+      {isExpanded && hasStreamedOutput && (
+        <div className="mt-1 ml-[22px] space-y-2">
+          <StreamedOutputDetails streamedOutput={streamedOutput} />
+        </div>
+      )}
+      {isExpanded && isComplete && (
         <div className="mt-1 ml-[22px] space-y-2">
           <BashToolResultDetails fullText={fullText} showExitCode={false} />
         </div>
+      )}
+    </div>
+  );
+}
+
+/** Render streamed output received via tool.output.delta events while a tool is running. */
+function StreamedOutputDetails({ streamedOutput }: { streamedOutput: ToolOutputStreams }) {
+  return (
+    <div className="space-y-0 rounded bg-muted/20 p-1.5 text-[10px] leading-tight">
+      {streamedOutput.stdout && (
+        <pre className="max-h-60 overflow-x-auto whitespace-pre-wrap break-all text-inherit">
+          {streamedOutput.stdout}
+        </pre>
+      )}
+      {streamedOutput.stderr && (
+        <pre
+          className={cn(
+            "max-h-40 overflow-x-auto whitespace-pre-wrap break-all text-red-600/80 dark:text-red-400/80",
+            streamedOutput.stdout && "mt-3 border-t border-red-400/20 pt-3",
+          )}
+        >
+          {streamedOutput.stderr}
+        </pre>
       )}
     </div>
   );

--- a/apps/ui/src/components/chat/bash-tool-call-card.tsx
+++ b/apps/ui/src/components/chat/bash-tool-call-card.tsx
@@ -139,7 +139,9 @@ export function BashToolCallCard({ toolCall, toolResult, streamedOutput }: BashT
   const bashOutput = fullText ? parseBashOutput(fullText) : null;
 
   // Streamed output available while tool is still running
-  const hasStreamedOutput = !isComplete && streamedOutput &&
+  const hasStreamedOutput =
+    !isComplete &&
+    streamedOutput &&
     (streamedOutput.stdout.length > 0 || streamedOutput.stderr.length > 0);
 
   // Auto-expand when streamed output arrives

--- a/apps/ui/src/components/chat/chat-message-list.tsx
+++ b/apps/ui/src/components/chat/chat-message-list.tsx
@@ -17,6 +17,7 @@ import type {
   ToolCompletedData,
   ToolProgressData,
 } from "@/lib/api/types";
+import type { ToolOutputStreams } from "@/app/(main)/sessions/[sessionId]/session-context";
 import { getEventData, isImageFilePart } from "@/lib/api/types";
 import { MessageInfoIcon } from "@/components/chat/message-info-icon";
 import { MessageImage } from "@/components/chat/image-attachments";
@@ -42,6 +43,7 @@ interface ChatMessageListProps {
   sessionId: string;
   toolResultsMap: Map<string, ToolCompletedData>;
   toolProgressMap: Map<string, ToolProgressData>;
+  toolOutputMap: Map<string, ToolOutputStreams>;
   eventsLoading: boolean;
   hasMoreEvents: boolean;
   loadingOlderEvents: boolean;
@@ -166,6 +168,7 @@ export function ChatMessageList({
   sessionId,
   toolResultsMap,
   toolProgressMap,
+  toolOutputMap,
   eventsLoading,
   hasMoreEvents,
   loadingOlderEvents,
@@ -323,6 +326,7 @@ export function ChatMessageList({
                     toolCalls={otherCalls}
                     toolResultsMap={toolResultsMap}
                     toolProgressMap={toolProgressMap}
+                    toolOutputMap={toolOutputMap}
                     mode="client"
                   />
                 )}
@@ -366,6 +370,7 @@ export function ChatMessageList({
                   toolCalls={toolCalls}
                   toolResultsMap={toolResultsMap}
                   toolProgressMap={toolProgressMap}
+                  toolOutputMap={toolOutputMap}
                 />
               </div>
               {renderTurnDivider(
@@ -442,6 +447,7 @@ export function ChatMessageList({
                   toolCalls={toolCalls}
                   toolResultsMap={toolResultsMap}
                   toolProgressMap={toolProgressMap}
+                  toolOutputMap={toolOutputMap}
                 />
               </div>
             )}

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -32,6 +32,7 @@ export function ChatPanel() {
     chatEvents,
     toolResultsMap,
     toolProgressMap,
+    toolOutputMap,
     eventsLoading,
     isActive,
     reasoningEffort,
@@ -190,6 +191,7 @@ export function ChatPanel() {
           sessionId={sessionId}
           toolResultsMap={toolResultsMap}
           toolProgressMap={toolProgressMap}
+          toolOutputMap={toolOutputMap}
           eventsLoading={eventsLoading}
           hasMoreEvents={hasMoreEvents}
           loadingOlderEvents={loadingOlderEvents}

--- a/apps/ui/src/components/chat/tool-activity-group.tsx
+++ b/apps/ui/src/components/chat/tool-activity-group.tsx
@@ -11,6 +11,7 @@
 
 import { useMemo } from "react";
 import type { ToolCompletedData, ToolProgressData } from "@/lib/api/types";
+import type { ToolOutputStreams } from "@/app/(main)/sessions/[sessionId]/session-context";
 import { isWriteTodosTool } from "@/lib/tool-registry";
 import { BashToolCallCard } from "./bash-tool-call-card";
 import { GroupedActivityCard } from "./grouped-activity-card";
@@ -24,6 +25,7 @@ interface ToolActivityGroupProps {
   toolCalls: ToolCallContent[];
   toolResultsMap: Map<string, ToolCompletedData>;
   toolProgressMap?: Map<string, ToolProgressData>;
+  toolOutputMap?: Map<string, ToolOutputStreams>;
   mode?: "server" | "client";
 }
 
@@ -31,6 +33,7 @@ export function ToolActivityGroup({
   toolCalls,
   toolResultsMap,
   toolProgressMap,
+  toolOutputMap,
   mode = "server",
 }: ToolActivityGroupProps) {
   const todoToolCalls = toolCalls.filter((toolCall) => isWriteTodosTool(toolCall.name));
@@ -51,6 +54,7 @@ export function ToolActivityGroup({
               key={segment.toolCall.id}
               toolCall={segment.toolCall}
               toolResult={toolResultsMap.get(segment.toolCall.id)}
+              streamedOutput={toolOutputMap?.get(segment.toolCall.id)}
             />
           );
         }

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -214,6 +214,7 @@ const SSE_EVENT_TYPES = [
   "act.completed",
   "tool.started",
   "tool.completed",
+  "tool.output.delta",
   "tool.call_requested",
   "llm.generation",
   "session.started",

--- a/apps/ui/src/lib/api/types/event-types.ts
+++ b/apps/ui/src/lib/api/types/event-types.ts
@@ -192,6 +192,16 @@ export interface ToolProgressData {
   display_name?: string;
 }
 
+/** Data for tool.output.delta event (streamed output chunks during execution) */
+export interface ToolOutputDeltaData {
+  tool_call_id: string;
+  tool_name: string;
+  /** Incremental output chunk */
+  delta: string;
+  /** Output stream identifier (e.g., "stdout", "stderr") */
+  stream: string;
+}
+
 /** Data for tool.completed event */
 export interface ToolCompletedData {
   tool_call_id: string;
@@ -339,6 +349,7 @@ export type EventData =
   | ToolStartedData
   | ToolCallRequestedData
   | ToolProgressData
+  | ToolOutputDeltaData
   | ToolCompletedData
   | LlmGenerationData
   | SessionStartedData
@@ -373,6 +384,7 @@ export interface EventTypeMap {
   "tool.started": ToolStartedData;
   "tool.call_requested": ToolCallRequestedData;
   "tool.progress": ToolProgressData;
+  "tool.output.delta": ToolOutputDeltaData;
   "tool.completed": ToolCompletedData;
   "llm.generation": LlmGenerationData;
   "session.started": SessionStartedData;

--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -95,6 +95,27 @@ pub async fn run(
                     eprintln!("  [{tool}] {message}");
                 }
 
+                // Handle tool.output.delta event (streamed tool output)
+                if event.event_type == "tool.output.delta"
+                    && let Some(delta) = event.data.get("delta").and_then(|d| d.as_str())
+                {
+                    let stream = event
+                        .data
+                        .get("stream")
+                        .and_then(|s| s.as_str())
+                        .unwrap_or("stdout");
+                    let tool = event
+                        .data
+                        .get("tool_name")
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("tool");
+                    if stream == "stderr" {
+                        eprint!("  [{tool}:stderr] {delta}");
+                    } else {
+                        eprint!("  [{tool}] {delta}");
+                    }
+                }
+
                 // Handle turn.completed event
                 if event.event_type == "turn.completed" {
                     if !agent_content.is_empty() {

--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -95,7 +95,10 @@ pub async fn run(
                     eprintln!("  [{tool}] {message}");
                 }
 
-                // Handle tool.output.delta event (streamed tool output)
+                // Handle tool.output.delta event (streamed tool output).
+                // Deltas from bashkit include trailing newlines when appropriate.
+                // Use eprintln! to ensure each chunk ends on its own line even if
+                // the delta itself lacks a trailing newline.
                 if event.event_type == "tool.output.delta"
                     && let Some(delta) = event.data.get("delta").and_then(|d| d.as_str())
                 {
@@ -109,10 +112,11 @@ pub async fn run(
                         .get("tool_name")
                         .and_then(|t| t.as_str())
                         .unwrap_or("tool");
+                    let trimmed = delta.trim_end_matches('\n');
                     if stream == "stderr" {
-                        eprint!("  [{tool}:stderr] {delta}");
+                        eprintln!("  [{tool}:stderr] {trimmed}");
                     } else {
-                        eprint!("  [{tool}] {delta}");
+                        eprintln!("  [{tool}] {trimmed}");
                     }
                 }
 

--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -22,8 +22,9 @@ use crate::typed_id::SessionId;
 use async_trait::async_trait;
 use bashkit::{
     Bash, BashTool as BashkitTool, DirEntry, ExecutionLimits, FileSystem, FileSystemExt, FileType,
-    Metadata, SearchCapabilities, SearchCapable, SearchMatch as BashkitSearchMatch, SearchProvider,
-    SearchQuery, SearchResults, Tool as BashkitToolTrait,
+    Metadata, OutputCallback, SearchCapabilities, SearchCapable,
+    SearchMatch as BashkitSearchMatch, SearchProvider, SearchQuery, SearchResults,
+    Tool as BashkitToolTrait,
 };
 use serde_json::{Value, json};
 use std::path::{Path, PathBuf};
@@ -226,35 +227,50 @@ impl Tool for BashTool {
             .limits(execution_limits())
             .build();
 
-        // Execute with timeout
+        // Stream output via tool.output.delta events for live UI/CLI rendering.
+        // bashkit's exec_streaming calls OutputCallback with (stdout_chunk, stderr_chunk)
+        // after each command completes. We bridge to async emit via a channel.
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<(String, String)>();
+
+        let output_callback: OutputCallback = Box::new(move |stdout_chunk: &str, stderr_chunk: &str| {
+            // Best-effort: if receiver dropped, we just ignore
+            let _ = tx.send((stdout_chunk.to_string(), stderr_chunk.to_string()));
+        });
+
+        // Spawn a task that reads chunks from the channel and emits events
+        let emit_context = context.clone();
+        let emit_task = tokio::spawn(async move {
+            while let Some((stdout_chunk, stderr_chunk)) = rx.recv().await {
+                if !stdout_chunk.is_empty() {
+                    emit_context
+                        .emit_tool_output("bash", &stdout_chunk, "stdout")
+                        .await;
+                }
+                if !stderr_chunk.is_empty() {
+                    emit_context
+                        .emit_tool_output("bash", &stderr_chunk, "stderr")
+                        .await;
+                }
+            }
+        });
+
+        // Execute with timeout using streaming callback
         let result = tokio::time::timeout(
             std::time::Duration::from_millis(timeout_ms),
-            bash.exec(command),
+            bash.exec_streaming(command, output_callback),
         )
         .await;
 
+        // Wait for all buffered chunks to be emitted (sender dropped when exec completes)
+        let _ = emit_task.await;
+
         match result {
-            Ok(Ok(output)) => {
-                // Emit output deltas for live rendering in UI/CLI.
-                // bashkit returns all output at once; when bashkit adds streaming
-                // support (output_stream()), these will become incremental chunks.
-                if !output.stdout.is_empty() {
-                    context
-                        .emit_tool_output("bash", &output.stdout, "stdout")
-                        .await;
-                }
-                if !output.stderr.is_empty() {
-                    context
-                        .emit_tool_output("bash", &output.stderr, "stderr")
-                        .await;
-                }
-                ToolExecutionResult::success(json!({
-                    "stdout": output.stdout,
-                    "stderr": output.stderr,
-                    "exit_code": output.exit_code,
-                    "success": output.exit_code == 0
-                }))
-            }
+            Ok(Ok(output)) => ToolExecutionResult::success(json!({
+                "stdout": output.stdout,
+                "stderr": output.stderr,
+                "exit_code": output.exit_code,
+                "success": output.exit_code == 0
+            })),
             Ok(Err(e)) => {
                 // Execution error (syntax error, resource limit, etc.)
                 ToolExecutionResult::tool_error(format!("Bash execution error: {}", e))

--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -234,12 +234,27 @@ impl Tool for BashTool {
         .await;
 
         match result {
-            Ok(Ok(output)) => ToolExecutionResult::success(json!({
-                "stdout": output.stdout,
-                "stderr": output.stderr,
-                "exit_code": output.exit_code,
-                "success": output.exit_code == 0
-            })),
+            Ok(Ok(output)) => {
+                // Emit output deltas for live rendering in UI/CLI.
+                // bashkit returns all output at once; when bashkit adds streaming
+                // support (output_stream()), these will become incremental chunks.
+                if !output.stdout.is_empty() {
+                    context
+                        .emit_tool_output("bash", &output.stdout, "stdout")
+                        .await;
+                }
+                if !output.stderr.is_empty() {
+                    context
+                        .emit_tool_output("bash", &output.stderr, "stderr")
+                        .await;
+                }
+                ToolExecutionResult::success(json!({
+                    "stdout": output.stdout,
+                    "stderr": output.stderr,
+                    "exit_code": output.exit_code,
+                    "success": output.exit_code == 0
+                }))
+            }
             Ok(Err(e)) => {
                 // Execution error (syntax error, resource limit, etc.)
                 ToolExecutionResult::tool_error(format!("Bash execution error: {}", e))

--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -22,9 +22,8 @@ use crate::typed_id::SessionId;
 use async_trait::async_trait;
 use bashkit::{
     Bash, BashTool as BashkitTool, DirEntry, ExecutionLimits, FileSystem, FileSystemExt, FileType,
-    Metadata, OutputCallback, SearchCapabilities, SearchCapable,
-    SearchMatch as BashkitSearchMatch, SearchProvider, SearchQuery, SearchResults,
-    Tool as BashkitToolTrait,
+    Metadata, OutputCallback, SearchCapabilities, SearchCapable, SearchMatch as BashkitSearchMatch,
+    SearchProvider, SearchQuery, SearchResults, Tool as BashkitToolTrait,
 };
 use serde_json::{Value, json};
 use std::path::{Path, PathBuf};
@@ -232,10 +231,11 @@ impl Tool for BashTool {
         // after each command completes. We bridge to async emit via a channel.
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<(String, String)>();
 
-        let output_callback: OutputCallback = Box::new(move |stdout_chunk: &str, stderr_chunk: &str| {
-            // Best-effort: if receiver dropped, we just ignore
-            let _ = tx.send((stdout_chunk.to_string(), stderr_chunk.to_string()));
-        });
+        let output_callback: OutputCallback =
+            Box::new(move |stdout_chunk: &str, stderr_chunk: &str| {
+                // Best-effort: if receiver dropped, we just ignore
+                let _ = tx.send((stdout_chunk.to_string(), stderr_chunk.to_string()));
+            });
 
         // Spawn a task that reads chunks from the channel and emits events
         let emit_context = context.clone();

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -54,6 +54,7 @@ pub const ACT_COMPLETED: &str = "act.completed";
 pub const TOOL_STARTED: &str = "tool.started";
 pub const TOOL_COMPLETED: &str = "tool.completed";
 pub const TOOL_PROGRESS: &str = "tool.progress";
+pub const TOOL_OUTPUT_DELTA: &str = "tool.output.delta";
 pub const TOOL_CALL_REQUESTED: &str = "tool.call_requested";
 
 // LLM events
@@ -101,6 +102,7 @@ pub const VALID_EVENT_TYPES: &[&str] = &[
     TOOL_STARTED,
     TOOL_COMPLETED,
     TOOL_PROGRESS,
+    TOOL_OUTPUT_DELTA,
     TOOL_CALL_REQUESTED,
     LLM_GENERATION,
     REASON_THINKING_STARTED,
@@ -916,6 +918,31 @@ pub struct ToolProgressData {
     pub display_name: Option<String>,
 }
 
+/// Data for tool.output.delta event.
+///
+/// Emitted by tools during execution to stream incremental output chunks.
+/// This enables live output rendering (e.g., bash stdout/stderr, command output)
+/// between tool.started and tool.completed. Generic — usable by any tool that
+/// produces streamed output (bashkit, Daytona exec, subagent speech, etc.).
+///
+/// The consumer accumulates deltas by tool_call_id for display. The final
+/// tool.completed result is authoritative — deltas are informational only.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct ToolOutputDeltaData {
+    /// Tool call ID this output belongs to
+    pub tool_call_id: String,
+
+    /// Tool name
+    pub tool_name: String,
+
+    /// Incremental output chunk
+    pub delta: String,
+
+    /// Output stream identifier (e.g., "stdout", "stderr")
+    pub stream: String,
+}
+
 /// Data for tool.call_requested event
 ///
 /// Emitted when the agent needs client-side tool calls executed.
@@ -1599,6 +1626,7 @@ pub struct ContextCompactedData {
 /// - `act.completed` → ActCompletedData
 /// - `tool.started` → ToolStartedData
 /// - `tool.completed` → ToolCompletedData
+/// - `tool.output.delta` → ToolOutputDeltaData
 /// - `tool.call_requested` → ToolCallRequestedData
 /// - `llm.generation` → LlmGenerationData
 /// - `reason.thinking.started` → ReasonThinkingStartedData
@@ -1645,6 +1673,7 @@ pub enum EventData {
     ToolStarted(ToolStartedData),
     ToolCompleted(ToolCompletedData),
     ToolProgress(ToolProgressData),
+    ToolOutputDelta(ToolOutputDeltaData),
     ToolCallRequested(ToolCallRequestedData),
 
     // LLM events
@@ -1711,6 +1740,7 @@ impl EventData {
             EventData::ToolStarted(_) => TOOL_STARTED,
             EventData::ToolCompleted(_) => TOOL_COMPLETED,
             EventData::ToolProgress(_) => TOOL_PROGRESS,
+            EventData::ToolOutputDelta(_) => TOOL_OUTPUT_DELTA,
             EventData::ToolCallRequested(_) => TOOL_CALL_REQUESTED,
             EventData::LlmGeneration(_) => LLM_GENERATION,
             EventData::ReasonThinkingDelta(_) => REASON_THINKING_DELTA,
@@ -1800,6 +1830,8 @@ pub fn deserialize_event_data(event_type: &str, data: serde_json::Value) -> Even
                 .map(EventData::ToolCompleted),
             TOOL_PROGRESS => serde_json::from_value::<ToolProgressData>(data.clone())
                 .map(EventData::ToolProgress),
+            TOOL_OUTPUT_DELTA => serde_json::from_value::<ToolOutputDeltaData>(data.clone())
+                .map(EventData::ToolOutputDelta),
             TOOL_CALL_REQUESTED => serde_json::from_value::<ToolCallRequestedData>(data.clone())
                 .map(EventData::ToolCallRequested),
             LLM_GENERATION => serde_json::from_value::<LlmGenerationData>(data.clone())
@@ -1878,6 +1910,7 @@ impl_from_event_data! {
     ToolStartedData => ToolStarted,
     ToolCompletedData => ToolCompleted,
     ToolProgressData => ToolProgress,
+    ToolOutputDeltaData => ToolOutputDelta,
     ToolCallRequestedData => ToolCallRequested,
     LlmGenerationData => LlmGeneration,
     ReasonThinkingStartedData => ReasonThinkingStarted,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -236,10 +236,10 @@ pub use events::{
     ReasonCompletedData, ReasonStartedData, ReasonThinkingCompletedData, ReasonThinkingDeltaData,
     ReasonThinkingStartedData, SESSION_ACTIVATED, SESSION_IDLED, SESSION_STARTED,
     SessionActivatedData, SessionIdledData, SessionStartedData, TOOL_CALL_REQUESTED,
-    TOOL_COMPLETED, TOOL_PROGRESS, TOOL_STARTED, TURN_CANCELLED, TURN_COMPLETED, TURN_FAILED,
-    TURN_STARTED, TokenUsage, ToolCallRequestedData, ToolCallSummary, ToolCompletedData,
-    ToolProgressData, ToolStartedData, TurnCancelledData, TurnCompletedData, TurnFailedData,
-    TurnStartedData, VALID_EVENT_TYPES,
+    TOOL_COMPLETED, TOOL_OUTPUT_DELTA, TOOL_PROGRESS, TOOL_STARTED, TURN_CANCELLED, TURN_COMPLETED,
+    TURN_FAILED, TURN_STARTED, TokenUsage, ToolCallRequestedData, ToolCallSummary,
+    ToolCompletedData, ToolOutputDeltaData, ToolProgressData, ToolStartedData, TurnCancelledData,
+    TurnCompletedData, TurnFailedData, TurnStartedData, VALID_EVENT_TYPES,
 };
 pub use harness::{Harness, HarnessStatus, merge_harness, merge_harness_chain};
 pub use leased_resource::{

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -721,6 +721,38 @@ impl ToolContext {
             );
         }
     }
+
+    /// Emit a `tool.output.delta` event if an event emitter and context are available.
+    ///
+    /// Streams incremental output chunks (e.g., stdout/stderr lines) for live
+    /// rendering in UI and CLI. Best-effort: failures are logged, not propagated.
+    pub async fn emit_tool_output(&self, tool_name: &str, delta: &str, stream: &str) {
+        let (Some(emitter), Some(ctx), Some(call_id)) =
+            (&self.event_emitter, &self.event_context, &self.tool_call_id)
+        else {
+            return;
+        };
+        if let Err(e) = emitter
+            .emit(EventRequest::new(
+                self.session_id,
+                ctx.clone(),
+                crate::events::ToolOutputDeltaData {
+                    tool_call_id: call_id.clone(),
+                    tool_name: tool_name.to_string(),
+                    delta: delta.to_string(),
+                    stream: stream.to_string(),
+                },
+            ))
+            .await
+        {
+            tracing::debug!(
+                tool_call_id = call_id,
+                tool_name,
+                error = %e,
+                "Failed to emit tool.output.delta event"
+            );
+        }
+    }
 }
 
 impl std::fmt::Debug for ToolContext {

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -226,6 +226,7 @@ fn serialize_event_data(data: &everruns_core::EventData) -> serde_json::Value {
         EventData::ToolStarted(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::ToolCompleted(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::ToolProgress(d) => serde_json::to_value(d).unwrap_or_default(),
+        EventData::ToolOutputDelta(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::ToolCallRequested(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::LlmGeneration(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::ReasonThinkingStarted(d) => serde_json::to_value(d).unwrap_or_default(),

--- a/crates/server/src/api/events.rs
+++ b/crates/server/src/api/events.rs
@@ -1018,7 +1018,7 @@ mod tests {
 
     #[test]
     fn test_validate_too_many_types_rejected() {
-        let types: Vec<String> = (0..31).map(|i| format!("type.{i}")).collect();
+        let types: Vec<String> = (0..41).map(|i| format!("type.{i}")).collect();
         let query = EventsQuery {
             since_id: None,
             types,
@@ -1033,7 +1033,7 @@ mod tests {
 
     #[test]
     fn test_validate_too_many_exclude_rejected() {
-        let exclude: Vec<String> = (0..31).map(|i| format!("type.{i}")).collect();
+        let exclude: Vec<String> = (0..41).map(|i| format!("type.{i}")).collect();
         let query = EventsQuery {
             since_id: None,
             types: vec![],

--- a/crates/server/src/api/events.rs
+++ b/crates/server/src/api/events.rs
@@ -74,7 +74,7 @@ impl EventsQuery {
 }
 
 /// Max event types per filter parameter. There are ~27 known types; 30 is generous.
-const MAX_EVENT_TYPE_FILTER_SIZE: usize = 30;
+const MAX_EVENT_TYPE_FILTER_SIZE: usize = 40;
 
 /// Validate a list of event type strings: checks size limit and known types.
 fn validate_event_type_list(

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -6237,6 +6237,9 @@
             "$ref": "#/components/schemas/ToolProgressData"
           },
           {
+            "$ref": "#/components/schemas/ToolOutputDeltaData"
+          },
+          {
             "$ref": "#/components/schemas/ToolCallRequestedData"
           },
           {
@@ -11513,6 +11516,34 @@
               "null"
             ],
             "description": "Tool requires API keys, credentials, or other secrets to function.\nUseful for UI to show connection prompts and for LLMs to anticipate\nauthentication failures."
+          }
+        }
+      },
+      "ToolOutputDeltaData": {
+        "type": "object",
+        "description": "Data for tool.output.delta event.\n\nEmitted by tools during execution to stream incremental output chunks.\nThis enables live output rendering (e.g., bash stdout/stderr, command output)\nbetween tool.started and tool.completed. Generic — usable by any tool that\nproduces streamed output (bashkit, Daytona exec, subagent speech, etc.).\n\nThe consumer accumulates deltas by tool_call_id for display. The final\ntool.completed result is authoritative — deltas are informational only.",
+        "required": [
+          "tool_call_id",
+          "tool_name",
+          "delta",
+          "stream"
+        ],
+        "properties": {
+          "delta": {
+            "type": "string",
+            "description": "Incremental output chunk"
+          },
+          "stream": {
+            "type": "string",
+            "description": "Output stream identifier (e.g., \"stdout\", \"stderr\")"
+          },
+          "tool_call_id": {
+            "type": "string",
+            "description": "Tool call ID this output belongs to"
+          },
+          "tool_name": {
+            "type": "string",
+            "description": "Tool name"
           }
         }
       },

--- a/specs/events.md
+++ b/specs/events.md
@@ -94,7 +94,7 @@ turn (root span)
 | `reason.started/completed` | reason_span_id | turn_id | turn_id |
 | `llm.generation` | llm_span_id | reason_span_id | turn_id |
 | `act.started/completed` | act_span_id | turn_id | turn_id |
-| `tool.started/completed` | tool_span_id | act_span_id | turn_id |
+| `tool.started/completed/output.delta` | tool_span_id | act_span_id | turn_id |
 
 **Key Properties:**
 
@@ -575,6 +575,33 @@ For failed tool calls:
 }
 ```
 
+#### `tool.output.delta`
+
+Streamed incremental output from a tool during execution. Emitted between `tool.started` and `tool.completed`. Generic — usable by any tool that produces streamed output (bash stdout/stderr, remote command output, subagent speech, etc.).
+
+The consumer accumulates deltas by `tool_call_id` for live rendering. The final `tool.completed` result is authoritative — deltas are informational only.
+
+```json
+{
+  "type": "tool.output.delta",
+  "session_id": "...",
+  "context": { "turn_id": "...", "exec_id": "..." },
+  "data": {
+    "tool_call_id": "call_789",
+    "tool_name": "bash",
+    "delta": "Installing dependencies...\n",
+    "stream": "stdout"
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `tool_call_id` | string | yes | References the tool call producing output |
+| `tool_name` | string | yes | Tool name |
+| `delta` | string | yes | Incremental output chunk |
+| `stream` | string | yes | Stream identifier (e.g., `"stdout"`, `"stderr"`) |
+
 ### LLM Events
 
 LLM events provide visibility into the actual LLM API calls.
@@ -901,6 +928,7 @@ This approach provides real-time feedback as tokens are consumed during LLM call
 | `act.completed` | Atom | ActAtom completed |
 | `tool.started` | Atom | Individual tool started |
 | `tool.completed` | Atom | Individual tool completed (includes result) |
+| `tool.output.delta` | Atom | Incremental streamed output from a tool |
 | `llm.generation` | LLM | Full LLM API call with messages and response |
 | `reason.thinking.started` | Thinking | Extended thinking started (thinking indicator) |
 | `reason.thinking.delta` | Thinking | Incremental reasoning content from extended thinking models |


### PR DESCRIPTION
## Summary

- Add generic `tool.output.delta` event type that streams incremental output chunks (stdout/stderr) from tools during execution, enabling live output rendering between `tool.started` and `tool.completed`
- Wire end-to-end: backend emission → SSE transport → UI rendering → CLI output
- Virtual bash uses bashkit's `exec_streaming` with `OutputCallback` for real-time incremental chunks

## Changes

### Backend (`crates/core`)
- `ToolOutputDeltaData` struct: `tool_call_id`, `tool_name`, `delta`, `stream`
- `ToolContext::emit_tool_output()` — best-effort helper matching `emit_progress()` pattern
- `TOOL_OUTPUT_DELTA` constant, `VALID_EVENT_TYPES` entry, `EventData` enum variant
- Virtual bash uses `exec_streaming` + `OutputCallback` bridged via mpsc channel to emit incremental stdout/stderr deltas as they are produced

### Frontend (`apps/ui`)
- `ToolOutputDeltaData` TypeScript interface in event types
- `toolOutputMap: Map<string, ToolOutputStreams>` in `SessionContext` — accumulates deltas by `tool_call_id`
- `BashToolCallCard` accepts `streamedOutput` prop, auto-expands and renders live output via `StreamedOutputDetails`
- Prop threaded through `ChatPanel → ChatMessageList → ToolActivityGroup → BashToolCallCard`

### CLI (`crates/cli`)
- Prints `tool.output.delta` chunks to stderr: `[tool] delta` / `[tool:stderr] delta`

### Specs
- `specs/events.md` — documented `tool.output.delta` with schema table and example JSON

## Design decisions

- **New event type** (not extending `tool.progress`): different semantics (raw output vs status message), different data shape (delta + stream vs message), different rendering (terminal output vs pulsing text)
- **Delta-only** (no `accumulated` field): tool output can be large; O(n²) bandwidth from accumulated would be wasteful. Frontend concatenates deltas instead
- **`stream` field**: generic identifier (`stdout`, `stderr`, or future values) — not bash-specific
- **Authoritative result**: `tool.completed` remains the source of truth; deltas are informational for live rendering only
- **exec_streaming**: bashkit v0.1.12 already supports `exec_streaming(script, OutputCallback)` which calls the callback after each command completes. Sync callback bridged to async event emission via unbounded mpsc channel + spawned task

## Security

- **TM-BASH**: No new trust boundary. Same bashkit sandbox, same `ExecutionLimits`, same `SessionFileSystemAdapter`. Only change is using `exec_streaming` instead of `exec` — same execution path with an added callback.
- **TM-DOS**: `OutputCallback` uses an unbounded channel, but output volume is bounded by bashkit's `ExecutionLimits` (output size caps). No new amplification vector.
- No new user input parsing, no injection vectors, no auth changes, no data exposure.

## Test plan

- [x] `cargo test -p everruns-core --lib capabilities::virtual_bash` — 69 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `just pre-push` — all 6 checks green
- [ ] Verify `tool.output.delta` events appear in SSE stream during bash tool execution
- [ ] Verify `BashToolCallCard` auto-expands and shows streamed output while tool runs
- [ ] Verify CLI prints output chunks to stderr
