### PR TITLE
feat(apps): support multiple channels per app

### DIFF
--- a/apps/ui/src/__tests__/use-apps.test.tsx
+++ b/apps/ui/src/__tests__/use-apps.test.tsx
@@ -46,16 +46,26 @@ function makeApp(overrides: Partial<App> = {}): App {
     description: "Slack bot",
     harness_id: "hrs-123",
     agent_id: "agt-123",
-    channel_type: "slack",
-    channel_config: {
-      signing_secret: "secret",
-      bot_token: "xoxb-test",
-      session_strategy: "per_thread",
-    },
+    channels: [
+      {
+        id: "appchan-123",
+        channel_type: "slack",
+        channel_config: {
+          signing_secret: "secret",
+          bot_token: "xoxb-test",
+          session_strategy: "per_thread",
+        },
+        enabled: true,
+        created_at: "2026-03-08T22:23:38Z",
+        updated_at: "2026-03-08T22:23:38Z",
+      },
+    ],
     status: "draft",
     published_at: null,
     created_at: "2026-03-08T22:23:38Z",
     updated_at: "2026-03-08T22:24:23Z",
+    archived_at: null,
+    deleted_at: null,
     ...overrides,
   };
 }

--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -146,8 +146,6 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
   );
   const slackConfig = slackChannel?.channel_config as SlackChannelConfig | undefined;
   const hasSlackConfig = slackConfig?.signing_secret && slackConfig?.bot_token;
-  const webhookVerified = !!slackConfig?.webhook_verified_at;
-  const firstMessageReceived = !!slackConfig?.first_message_received_at;
 
   const webhookUrl =
     typeof window !== "undefined"

--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -278,12 +278,12 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
     );
   }
 
-  const renderChannelForm = (isSaving: boolean) => (
+  const renderChannelForm = (isSaving: boolean, formId: string = "default") => (
     <div className="space-y-4">
       <div>
-        <Label htmlFor="signing_secret">Signing Secret</Label>
+        <Label htmlFor={`signing_secret_${formId}`}>Signing Secret</Label>
         <Input
-          id="signing_secret"
+          id={`signing_secret_${formId}`}
           type="password"
           value={editSigningSecret}
           onChange={(e) => setEditSigningSecret(e.target.value)}
@@ -296,9 +296,9 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
       </div>
 
       <div>
-        <Label htmlFor="bot_token">Bot User OAuth Token</Label>
+        <Label htmlFor={`bot_token_${formId}`}>Bot User OAuth Token</Label>
         <Input
-          id="bot_token"
+          id={`bot_token_${formId}`}
           type="password"
           value={editBotToken}
           onChange={(e) => setEditBotToken(e.target.value)}
@@ -314,9 +314,9 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
 
       <div className="grid grid-cols-2 gap-4">
         <div>
-          <Label htmlFor="team_id">Workspace ID (optional)</Label>
+          <Label htmlFor={`team_id_${formId}`}>Workspace ID (optional)</Label>
           <Input
-            id="team_id"
+            id={`team_id_${formId}`}
             value={editTeamId}
             onChange={(e) => setEditTeamId(e.target.value)}
             placeholder="T0123456789"
@@ -324,9 +324,9 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
         </div>
 
         <div>
-          <Label htmlFor="channel_id">Channel ID (optional)</Label>
+          <Label htmlFor={`channel_id_${formId}`}>Channel ID (optional)</Label>
           <Input
-            id="channel_id"
+            id={`channel_id_${formId}`}
             value={editChannelIdField}
             onChange={(e) => setEditChannelIdField(e.target.value)}
             placeholder="C0123456789"
@@ -335,7 +335,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
       </div>
 
       <div>
-        <Label htmlFor="session_strategy">Session Strategy</Label>
+        <Label htmlFor={`session_strategy_${formId}`}>Session Strategy</Label>
         <Select
           value={editSessionStrategy}
           onValueChange={(v) => setEditSessionStrategy(v as SessionStrategy)}
@@ -360,7 +360,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
       </div>
 
       <div>
-        <Label htmlFor="reply_mode">Reply Mode</Label>
+        <Label htmlFor={`reply_mode_${formId}`}>Reply Mode</Label>
         <Select value={editReplyMode} onValueChange={(v) => setEditReplyMode(v as SlackReplyMode)}>
           <SelectTrigger>
             <SelectValue>
@@ -594,7 +594,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
               </CardHeader>
               <CardContent>
                 {editingChannelId === channel.id
-                  ? renderChannelForm(updateChannelMutation.isPending)
+                  ? renderChannelForm(updateChannelMutation.isPending, channel.id)
                   : renderChannelDisplay(channel)}
               </CardContent>
             </Card>
@@ -614,7 +614,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
               <CardHeader>
                 <CardTitle>Add Slack Channel</CardTitle>
               </CardHeader>
-              <CardContent>{renderChannelForm(addChannelMutation.isPending)}</CardContent>
+              <CardContent>{renderChannelForm(addChannelMutation.isPending, "new")}</CardContent>
             </Card>
           )}
 

--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -12,8 +12,15 @@ import {
 import { usePolicies } from "@/hooks/use-policies";
 import { useAgents } from "@/hooks";
 import { useHarnesses } from "@/hooks/use-harnesses";
-import { getSlackManifest } from "@/lib/api/apps";
+import {
+  getSlackManifest,
+  updateChannel as apiUpdateChannel,
+  addChannel as apiAddChannel,
+  deleteChannel as apiDeleteChannel,
+} from "@/lib/api/apps";
 import { useRouter } from "next/navigation";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "@/lib/query-keys";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -40,14 +47,14 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { ArrowLeft, Globe, GlobeLock, Copy, Trash2, Pencil, Check, X, Rocket } from "lucide-react";
+import { ArrowLeft, Globe, GlobeLock, Trash2, Pencil, Check, X, Rocket, Plus } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import { SlackSetupGuidance } from "@/components/apps/slack-setup-guidance";
 import type {
+  AppChannel,
   SessionStrategy,
   SlackChannelConfig,
   SlackReplyMode,
-  UpdateAppRequest,
 } from "@/lib/api/types";
 import {
   getEntityNameClassName,
@@ -60,6 +67,7 @@ import {
 export default function AppDetailPage({ params }: { params: Promise<{ appId: string }> }) {
   const { appId } = use(params);
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { data: app, isLoading } = useApp(appId);
   const { data: agents } = useAgents({ includeArchived: true });
   const { data: harnesses } = useHarnesses({ includeArchived: true });
@@ -71,8 +79,9 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
   const { can: canPolicies } = usePolicies("apps");
 
   const [editingBasic, setEditingBasic] = useState(false);
-  const [editingSlack, setEditingSlack] = useState(false);
+  const [editingChannelId, setEditingChannelId] = useState<string | null>(null);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [showAddChannel, setShowAddChannel] = useState(false);
 
   // Basic info edit state
   const [editName, setEditName] = useState("");
@@ -81,21 +90,61 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
   const [editHarnessId, setEditHarnessId] = useState("");
   const [editAgentIdentityId, setEditAgentIdentityId] = useState("");
 
-  // Slack config edit state
+  // Channel config edit state (shared for edit and add)
   const [editSigningSecret, setEditSigningSecret] = useState("");
   const [editBotToken, setEditBotToken] = useState("");
-  const [editChannelId, setEditChannelId] = useState("");
+  const [editChannelIdField, setEditChannelIdField] = useState("");
   const [editTeamId, setEditTeamId] = useState("");
   const [editSessionStrategy, setEditSessionStrategy] = useState<SessionStrategy>("per_thread");
   const [editReplyMode, setEditReplyMode] = useState<SlackReplyMode>("all_messages");
 
   const [creatingSlackApp, setCreatingSlackApp] = useState(false);
 
+  const invalidateApp = () => {
+    queryClient.invalidateQueries({ queryKey: queryKeys.apps.detail(appId) });
+    queryClient.invalidateQueries({ queryKey: queryKeys.apps.all });
+  };
+
+  const updateChannelMutation = useMutation({
+    mutationFn: async ({
+      channelId,
+      config,
+    }: {
+      channelId: string;
+      config: SlackChannelConfig;
+    }) => {
+      return apiUpdateChannel(appId, channelId, { channel_config: config });
+    },
+    onSuccess: invalidateApp,
+  });
+
+  const addChannelMutation = useMutation({
+    mutationFn: async (config: SlackChannelConfig) => {
+      return apiAddChannel(appId, { channel_type: "slack", channel_config: config });
+    },
+    onSuccess: () => {
+      invalidateApp();
+      setShowAddChannel(false);
+    },
+  });
+
+  const deleteChannelMutation = useMutation({
+    mutationFn: async (channelId: string) => {
+      return apiDeleteChannel(appId, channelId);
+    },
+    onSuccess: invalidateApp,
+  });
+
   const isPublished = app?.status === "published";
   const isArchived = app?.status === "archived";
   const isReadOnly = isReadOnlyStatus(app?.status);
   const canDangerousDelete = canPolicies("app.dangerous");
-  const slackConfig = app?.channel_config as SlackChannelConfig | undefined;
+
+  // Find first Slack channel for backward-compat checks
+  const slackChannel = app?.channels?.find(
+    (ch: AppChannel) => ch.channel_type === "slack" && ch.enabled,
+  );
+  const slackConfig = slackChannel?.channel_config as SlackChannelConfig | undefined;
   const hasSlackConfig = slackConfig?.signing_secret && slackConfig?.bot_token;
   const webhookVerified = !!slackConfig?.webhook_verified_at;
   const firstMessageReceived = !!slackConfig?.first_message_received_at;
@@ -147,31 +196,51 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
     setEditingBasic(false);
   };
 
-  const startEditSlack = () => {
-    setEditSigningSecret(slackConfig?.signing_secret ?? "");
-    setEditBotToken(slackConfig?.bot_token ?? "");
-    setEditChannelId(slackConfig?.channel_id ?? "");
-    setEditTeamId(slackConfig?.team_id ?? "");
-    setEditSessionStrategy(slackConfig?.session_strategy ?? "per_thread");
-    setEditReplyMode(slackConfig?.reply_mode ?? "all_messages");
-    setEditingSlack(true);
+  const startEditChannel = (channel: AppChannel) => {
+    const config = channel.channel_config as SlackChannelConfig;
+    setEditSigningSecret(config?.signing_secret ?? "");
+    setEditBotToken(config?.bot_token ?? "");
+    setEditChannelIdField(config?.channel_id ?? "");
+    setEditTeamId(config?.team_id ?? "");
+    setEditSessionStrategy(config?.session_strategy ?? "per_thread");
+    setEditReplyMode(config?.reply_mode ?? "all_messages");
+    setEditingChannelId(channel.id);
   };
 
-  const saveSlack = async () => {
-    if (!app) return;
+  const startAddChannel = () => {
+    setEditSigningSecret("");
+    setEditBotToken("");
+    setEditChannelIdField("");
+    setEditTeamId("");
+    setEditSessionStrategy("per_thread");
+    setEditReplyMode("all_messages");
+    setShowAddChannel(true);
+  };
+
+  const saveChannel = async () => {
+    if (!editingChannelId) return;
     const channelConfig: SlackChannelConfig = {
       signing_secret: editSigningSecret,
       bot_token: editBotToken,
       session_strategy: editSessionStrategy,
       reply_mode: editReplyMode,
-      ...(editChannelId ? { channel_id: editChannelId } : {}),
+      ...(editChannelIdField ? { channel_id: editChannelIdField } : {}),
       ...(editTeamId ? { team_id: editTeamId } : {}),
     };
-    await updateApp.mutateAsync({
-      appId: app.id,
-      data: { channel_config: channelConfig } as UpdateAppRequest,
-    });
-    setEditingSlack(false);
+    await updateChannelMutation.mutateAsync({ channelId: editingChannelId, config: channelConfig });
+    setEditingChannelId(null);
+  };
+
+  const saveNewChannel = async () => {
+    const channelConfig: SlackChannelConfig = {
+      signing_secret: editSigningSecret,
+      bot_token: editBotToken,
+      session_strategy: editSessionStrategy,
+      reply_mode: editReplyMode,
+      ...(editChannelIdField ? { channel_id: editChannelIdField } : {}),
+      ...(editTeamId ? { team_id: editTeamId } : {}),
+    };
+    await addChannelMutation.mutateAsync(channelConfig);
   };
 
   const handleDelete = async () => {
@@ -208,6 +277,220 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
       </div>
     );
   }
+
+  const renderChannelForm = (isSaving: boolean) => (
+    <div className="space-y-4">
+      <div>
+        <Label htmlFor="signing_secret">Signing Secret</Label>
+        <Input
+          id="signing_secret"
+          type="password"
+          value={editSigningSecret}
+          onChange={(e) => setEditSigningSecret(e.target.value)}
+          placeholder="Your Slack app's signing secret"
+          required
+        />
+        <p className="text-xs text-muted-foreground mt-1">
+          Found in your Slack app &rarr; Settings &rarr; Basic Information &rarr; App Credentials
+        </p>
+      </div>
+
+      <div>
+        <Label htmlFor="bot_token">Bot User OAuth Token</Label>
+        <Input
+          id="bot_token"
+          type="password"
+          value={editBotToken}
+          onChange={(e) => setEditBotToken(e.target.value)}
+          placeholder="xoxb-..."
+          required
+        />
+        <p className="text-xs text-muted-foreground mt-1">
+          Found in your Slack app &rarr; OAuth &amp; Permissions &rarr; Bot User OAuth Token
+        </p>
+      </div>
+
+      <Separator />
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <Label htmlFor="team_id">Workspace ID (optional)</Label>
+          <Input
+            id="team_id"
+            value={editTeamId}
+            onChange={(e) => setEditTeamId(e.target.value)}
+            placeholder="T0123456789"
+          />
+        </div>
+
+        <div>
+          <Label htmlFor="channel_id">Channel ID (optional)</Label>
+          <Input
+            id="channel_id"
+            value={editChannelIdField}
+            onChange={(e) => setEditChannelIdField(e.target.value)}
+            placeholder="C0123456789"
+          />
+        </div>
+      </div>
+
+      <div>
+        <Label htmlFor="session_strategy">Session Strategy</Label>
+        <Select
+          value={editSessionStrategy}
+          onValueChange={(v) => setEditSessionStrategy(v as SessionStrategy)}
+        >
+          <SelectTrigger>
+            <SelectValue>
+              {
+                {
+                  per_thread: "Per Thread (default)",
+                  per_channel: "Per Channel",
+                  per_user: "Per User",
+                }[editSessionStrategy]
+              }
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="per_thread">Per Thread (default)</SelectItem>
+            <SelectItem value="per_channel">Per Channel</SelectItem>
+            <SelectItem value="per_user">Per User</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div>
+        <Label htmlFor="reply_mode">Reply Mode</Label>
+        <Select value={editReplyMode} onValueChange={(v) => setEditReplyMode(v as SlackReplyMode)}>
+          <SelectTrigger>
+            <SelectValue>
+              {
+                {
+                  all_messages: "All Assistant Messages",
+                  report_progress_only: "Report Progress Only",
+                }[editReplyMode]
+              }
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all_messages">All Assistant Messages</SelectItem>
+            <SelectItem value="report_progress_only">Report Progress Only</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex gap-2 pt-2">
+        <Button
+          size="sm"
+          onClick={editingChannelId ? saveChannel : saveNewChannel}
+          disabled={isSaving || !editSigningSecret || !editBotToken}
+        >
+          <Check className="w-3 h-3 mr-1" />
+          {isSaving ? "Saving..." : "Save"}
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => {
+            setEditingChannelId(null);
+            setShowAddChannel(false);
+          }}
+        >
+          <X className="w-3 h-3 mr-1" />
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+
+  const renderChannelDisplay = (channel: AppChannel) => {
+    const config = channel.channel_config as SlackChannelConfig;
+    const chHasConfig = config?.signing_secret && config?.bot_token;
+    const chWebhookVerified = !!config?.webhook_verified_at;
+    const chFirstMsg = !!config?.first_message_received_at;
+
+    return (
+      <div key={channel.id} className="space-y-4">
+        {chHasConfig ? (
+          <>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <p className="text-sm font-medium">Signing Secret</p>
+                <p className="text-sm text-muted-foreground font-mono">{"*".repeat(12)}</p>
+              </div>
+              <div>
+                <p className="text-sm font-medium">Bot User OAuth Token</p>
+                <p className="text-sm text-muted-foreground font-mono">{"*".repeat(12)}</p>
+              </div>
+            </div>
+
+            {(config?.team_id || config?.channel_id) && (
+              <div className="grid grid-cols-2 gap-4">
+                {config?.team_id && (
+                  <div>
+                    <p className="text-sm font-medium">Workspace ID</p>
+                    <p className="text-sm text-muted-foreground font-mono">{config.team_id}</p>
+                  </div>
+                )}
+                {config?.channel_id && (
+                  <div>
+                    <p className="text-sm font-medium">Channel ID</p>
+                    <p className="text-sm text-muted-foreground font-mono">{config.channel_id}</p>
+                  </div>
+                )}
+              </div>
+            )}
+
+            <div>
+              <p className="text-sm font-medium">Session Strategy</p>
+              <p className="text-sm text-muted-foreground">
+                {config?.session_strategy === "per_thread"
+                  ? "Per Thread"
+                  : config?.session_strategy === "per_channel"
+                    ? "Per Channel"
+                    : "Per User"}
+              </p>
+            </div>
+
+            <div>
+              <p className="text-sm font-medium">Reply Mode</p>
+              <p className="text-sm text-muted-foreground">
+                {config?.reply_mode === "report_progress_only"
+                  ? "Report Progress Only"
+                  : "All Assistant Messages"}
+              </p>
+            </div>
+
+            <SlackSetupGuidance
+              hasSlackConfig={true}
+              isPublished={isPublished}
+              webhookVerified={chWebhookVerified}
+              firstMessageReceived={chFirstMsg}
+              webhookUrl={webhookUrl}
+              webhookPath={webhookPath}
+              isLocalhost={isLocalhost}
+              onCreateSlackApp={handleCreateSlackApp}
+              creatingSlackApp={creatingSlackApp}
+              onConfigure={() => startEditChannel(channel)}
+            />
+          </>
+        ) : (
+          <SlackSetupGuidance
+            hasSlackConfig={false}
+            isPublished={isPublished}
+            webhookVerified={chWebhookVerified}
+            firstMessageReceived={chFirstMsg}
+            webhookUrl={webhookUrl}
+            webhookPath={webhookPath}
+            isLocalhost={isLocalhost}
+            onCreateSlackApp={handleCreateSlackApp}
+            creatingSlackApp={creatingSlackApp}
+            onConfigure={() => startEditChannel(channel)}
+          />
+        )}
+      </div>
+    );
+  };
 
   return (
     <div className="container mx-auto p-6">
@@ -273,235 +556,67 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
 
       <div className="grid gap-6 lg:grid-cols-3">
         <div className="lg:col-span-2 space-y-6">
-          {/* Slack Integration Card */}
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between">
-              <CardTitle>Slack Integration</CardTitle>
-              {!editingSlack && !isReadOnly && (
-                <Button variant="outline" size="sm" onClick={startEditSlack}>
-                  <Pencil className="w-3 h-3 mr-1" />
-                  {hasSlackConfig ? "Edit" : "Configure"}
-                </Button>
-              )}
-            </CardHeader>
-            <CardContent>
-              {editingSlack ? (
-                <div className="space-y-4">
-                  <div>
-                    <Label htmlFor="signing_secret">Signing Secret</Label>
-                    <Input
-                      id="signing_secret"
-                      type="password"
-                      value={editSigningSecret}
-                      onChange={(e) => setEditSigningSecret(e.target.value)}
-                      placeholder="Your Slack app's signing secret"
-                      required
-                    />
-                    <p className="text-xs text-muted-foreground mt-1">
-                      Found in your Slack app &rarr; Settings &rarr; Basic Information &rarr; App
-                      Credentials
-                    </p>
-                  </div>
-
-                  <div>
-                    <Label htmlFor="bot_token">Bot User OAuth Token</Label>
-                    <Input
-                      id="bot_token"
-                      type="password"
-                      value={editBotToken}
-                      onChange={(e) => setEditBotToken(e.target.value)}
-                      placeholder="xoxb-..."
-                      required
-                    />
-                    <p className="text-xs text-muted-foreground mt-1">
-                      Found in your Slack app &rarr; OAuth &amp; Permissions &rarr; Bot User OAuth
-                      Token
-                    </p>
-                  </div>
-
-                  <Separator />
-
-                  <div className="grid grid-cols-2 gap-4">
-                    <div>
-                      <Label htmlFor="team_id">Workspace ID (optional)</Label>
-                      <Input
-                        id="team_id"
-                        value={editTeamId}
-                        onChange={(e) => setEditTeamId(e.target.value)}
-                        placeholder="T0123456789"
-                      />
-                      <p className="text-xs text-muted-foreground mt-1">
-                        Your Slack workspace (team) ID
-                      </p>
-                    </div>
-
-                    <div>
-                      <Label htmlFor="channel_id">Channel ID (optional)</Label>
-                      <Input
-                        id="channel_id"
-                        value={editChannelId}
-                        onChange={(e) => setEditChannelId(e.target.value)}
-                        placeholder="C0123456789"
-                      />
-                      <p className="text-xs text-muted-foreground mt-1">
-                        Restrict to a specific channel
-                      </p>
-                    </div>
-                  </div>
-
-                  <div>
-                    <Label htmlFor="session_strategy">Session Strategy</Label>
-                    <Select
-                      value={editSessionStrategy}
-                      onValueChange={(v) => setEditSessionStrategy(v as SessionStrategy)}
-                    >
-                      <SelectTrigger>
-                        <SelectValue>
-                          {
-                            {
-                              per_thread: "Per Thread (default)",
-                              per_channel: "Per Channel",
-                              per_user: "Per User",
-                            }[editSessionStrategy]
-                          }
-                        </SelectValue>
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="per_thread">Per Thread (default)</SelectItem>
-                        <SelectItem value="per_channel">Per Channel</SelectItem>
-                        <SelectItem value="per_user">Per User</SelectItem>
-                      </SelectContent>
-                    </Select>
-                    <p className="text-xs text-muted-foreground mt-1">
-                      Controls how Slack messages are grouped into sessions
-                    </p>
-                  </div>
-
-                  <div>
-                    <Label htmlFor="reply_mode">Reply Mode</Label>
-                    <Select
-                      value={editReplyMode}
-                      onValueChange={(v) => setEditReplyMode(v as SlackReplyMode)}
-                    >
-                      <SelectTrigger>
-                        <SelectValue>
-                          {
-                            {
-                              all_messages: "All Assistant Messages",
-                              report_progress_only: "Report Progress Only",
-                            }[editReplyMode]
-                          }
-                        </SelectValue>
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="all_messages">All Assistant Messages</SelectItem>
-                        <SelectItem value="report_progress_only">Report Progress Only</SelectItem>
-                      </SelectContent>
-                    </Select>
-                    <p className="text-xs text-muted-foreground mt-1">
-                      Report-progress mode sends a fast handoff acknowledgement and only forwards
-                      deterministic `report_progress` updates to Slack.
-                    </p>
-                  </div>
-
-                  <div className="flex gap-2 pt-2">
-                    <Button
-                      size="sm"
-                      onClick={saveSlack}
-                      disabled={updateApp.isPending || !editSigningSecret || !editBotToken}
-                    >
-                      <Check className="w-3 h-3 mr-1" />
-                      {updateApp.isPending ? "Saving..." : "Save"}
-                    </Button>
-                    <Button size="sm" variant="outline" onClick={() => setEditingSlack(false)}>
-                      <X className="w-3 h-3 mr-1" />
-                      Cancel
-                    </Button>
-                  </div>
-                </div>
-              ) : hasSlackConfig ? (
-                <div className="space-y-4">
-                  <div className="grid grid-cols-2 gap-4">
-                    <div>
-                      <p className="text-sm font-medium">Signing Secret</p>
-                      <p className="text-sm text-muted-foreground font-mono">{"*".repeat(12)}</p>
-                    </div>
-                    <div>
-                      <p className="text-sm font-medium">Bot User OAuth Token</p>
-                      <p className="text-sm text-muted-foreground font-mono">{"*".repeat(12)}</p>
-                    </div>
-                  </div>
-
-                  {(slackConfig?.team_id || slackConfig?.channel_id) && (
-                    <div className="grid grid-cols-2 gap-4">
-                      {slackConfig?.team_id && (
-                        <div>
-                          <p className="text-sm font-medium">Workspace ID</p>
-                          <p className="text-sm text-muted-foreground font-mono">
-                            {slackConfig.team_id}
-                          </p>
-                        </div>
-                      )}
-                      {slackConfig?.channel_id && (
-                        <div>
-                          <p className="text-sm font-medium">Channel ID</p>
-                          <p className="text-sm text-muted-foreground font-mono">
-                            {slackConfig.channel_id}
-                          </p>
-                        </div>
-                      )}
-                    </div>
+          {/* Channels */}
+          {(app.channels ?? []).map((channel: AppChannel) => (
+            <Card key={channel.id}>
+              <CardHeader className="flex flex-row items-center justify-between">
+                <CardTitle className="flex items-center gap-2">
+                  <Badge variant="outline" className="capitalize">
+                    {channel.channel_type}
+                  </Badge>
+                  {!channel.enabled && <Badge variant="secondary">Disabled</Badge>}
+                  {(app.channels ?? []).length > 1 && (
+                    <span className="text-xs text-muted-foreground font-mono">{channel.id}</span>
                   )}
-
-                  <div>
-                    <p className="text-sm font-medium">Session Strategy</p>
-                    <p className="text-sm text-muted-foreground">
-                      {slackConfig?.session_strategy === "per_thread"
-                        ? "Per Thread"
-                        : slackConfig?.session_strategy === "per_channel"
-                          ? "Per Channel"
-                          : "Per User"}
-                    </p>
-                  </div>
-
-                  <div>
-                    <p className="text-sm font-medium">Reply Mode</p>
-                    <p className="text-sm text-muted-foreground">
-                      {slackConfig?.reply_mode === "report_progress_only"
-                        ? "Report Progress Only"
-                        : "All Assistant Messages"}
-                    </p>
-                  </div>
-
-                  <SlackSetupGuidance
-                    hasSlackConfig={true}
-                    isPublished={isPublished}
-                    webhookVerified={webhookVerified}
-                    firstMessageReceived={firstMessageReceived}
-                    webhookUrl={webhookUrl}
-                    webhookPath={webhookPath}
-                    isLocalhost={isLocalhost}
-                    onCreateSlackApp={handleCreateSlackApp}
-                    creatingSlackApp={creatingSlackApp}
-                    onConfigure={startEditSlack}
-                  />
+                </CardTitle>
+                <div className="flex gap-1">
+                  {editingChannelId !== channel.id && !isReadOnly && (
+                    <>
+                      <Button variant="outline" size="sm" onClick={() => startEditChannel(channel)}>
+                        <Pencil className="w-3 h-3 mr-1" />
+                        {(channel.channel_config as SlackChannelConfig)?.signing_secret
+                          ? "Edit"
+                          : "Configure"}
+                      </Button>
+                      {(app.channels ?? []).length > 1 && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => deleteChannelMutation.mutate(channel.id)}
+                          disabled={deleteChannelMutation.isPending}
+                        >
+                          <Trash2 className="w-3 h-3" />
+                        </Button>
+                      )}
+                    </>
+                  )}
                 </div>
-              ) : (
-                <SlackSetupGuidance
-                  hasSlackConfig={false}
-                  isPublished={isPublished}
-                  webhookVerified={webhookVerified}
-                  firstMessageReceived={firstMessageReceived}
-                  webhookUrl={webhookUrl}
-                  webhookPath={webhookPath}
-                  isLocalhost={isLocalhost}
-                  onCreateSlackApp={handleCreateSlackApp}
-                  creatingSlackApp={creatingSlackApp}
-                  onConfigure={startEditSlack}
-                />
-              )}
-            </CardContent>
-          </Card>
+              </CardHeader>
+              <CardContent>
+                {editingChannelId === channel.id
+                  ? renderChannelForm(updateChannelMutation.isPending)
+                  : renderChannelDisplay(channel)}
+              </CardContent>
+            </Card>
+          ))}
+
+          {/* Add Channel button */}
+          {!isReadOnly && !showAddChannel && (
+            <Button variant="outline" className="w-full" onClick={startAddChannel}>
+              <Plus className="w-4 h-4 mr-2" />
+              Add Channel
+            </Button>
+          )}
+
+          {/* Add Channel form */}
+          {showAddChannel && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Add Slack Channel</CardTitle>
+              </CardHeader>
+              <CardContent>{renderChannelForm(addChannelMutation.isPending)}</CardContent>
+            </Card>
+          )}
 
           {/* Webhook URL Card - shown when published and configured */}
           {isPublished && hasSlackConfig && (
@@ -540,52 +655,20 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                         https://&lt;your-id&gt;.ngrok-free.app{webhookPath}
                       </code>
                     </div>
-                    <p className="text-sm text-muted-foreground">
-                      Paste that URL in your Slack app &rarr; <strong>Event Subscriptions</strong>{" "}
-                      &rarr; <strong>Request URL</strong>. Then subscribe to bot events:{" "}
-                      <code className="text-xs">message.channels</code>,{" "}
-                      <code className="text-xs">message.groups</code>,{" "}
-                      <code className="text-xs">message.im</code>,{" "}
-                      <code className="text-xs">app_mention</code>.
-                    </p>
-                    <div className="flex items-center gap-2 bg-muted p-2 rounded-md">
-                      <code className="text-xs flex-1 truncate text-muted-foreground">
-                        {webhookPath}
-                      </code>
-                      <button
-                        className="shrink-0 hover:text-foreground text-muted-foreground"
-                        onClick={() => navigator.clipboard.writeText(webhookPath)}
-                      >
-                        <Copy className="w-4 h-4" />
-                      </button>
-                    </div>
                   </>
                 ) : (
                   <>
                     <p className="text-sm text-muted-foreground">
                       Paste this URL in your Slack app &rarr; <strong>Event Subscriptions</strong>{" "}
-                      &rarr; <strong>Request URL</strong>. Then subscribe to bot events:{" "}
-                      <code className="text-xs">message.channels</code>,{" "}
-                      <code className="text-xs">message.groups</code>,{" "}
-                      <code className="text-xs">message.im</code>,{" "}
-                      <code className="text-xs">app_mention</code>.
+                      &rarr; <strong>Request URL</strong>.
                     </p>
                     <div className="flex items-center gap-2 bg-muted p-3 rounded-md">
                       <Globe className="w-4 h-4 shrink-0 text-muted-foreground" />
                       <code className="text-sm flex-1 truncate">{webhookUrl}</code>
-                      <button
-                        className="shrink-0 hover:text-foreground text-muted-foreground"
-                        onClick={() => navigator.clipboard.writeText(webhookUrl)}
-                      >
-                        <Copy className="w-4 h-4" />
-                      </button>
+                      <CopyButton value={webhookUrl} />
                     </div>
                   </>
                 )}
-                <p className="text-xs text-muted-foreground">
-                  After saving, invite the bot to a channel (<code>/invite @{app?.name}</code>) and
-                  send a message to test.
-                </p>
               </CardContent>
             </Card>
           )}
@@ -687,8 +770,17 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                   </div>
 
                   <div>
-                    <p className="text-sm font-medium">Channel</p>
-                    <Badge variant="outline">Slack</Badge>
+                    <p className="text-sm font-medium">Channels</p>
+                    <div className="flex gap-1 flex-wrap">
+                      {(app.channels ?? []).map((ch: AppChannel) => (
+                        <Badge key={ch.id} variant="outline" className="capitalize">
+                          {ch.channel_type}
+                        </Badge>
+                      ))}
+                      {(app.channels ?? []).length === 0 && (
+                        <span className="text-sm text-muted-foreground">None configured</span>
+                      )}
+                    </div>
                   </div>
 
                   <div>

--- a/apps/ui/src/lib/api/apps.ts
+++ b/apps/ui/src/lib/api/apps.ts
@@ -3,7 +3,14 @@
 
 import { api } from "./client";
 import { createCrudApi } from "./crud";
-import type { App, CreateAppRequest, UpdateAppRequest } from "./types";
+import type {
+  AddChannelRequest,
+  App,
+  AppChannel,
+  CreateAppRequest,
+  UpdateAppRequest,
+  UpdateChannelRequest,
+} from "./types";
 
 export const appsCrudApi = createCrudApi<App, CreateAppRequest, UpdateAppRequest>("/v1/apps");
 
@@ -22,6 +29,26 @@ export async function publishApp(appId: string): Promise<App> {
 export async function unpublishApp(appId: string): Promise<App> {
   const response = await api.post<App>(`/v1/apps/${appId}/unpublish`);
   return response.data;
+}
+
+// Channel CRUD
+
+export async function addChannel(appId: string, req: AddChannelRequest): Promise<AppChannel> {
+  const response = await api.post<AppChannel>(`/v1/apps/${appId}/channels`, req);
+  return response.data;
+}
+
+export async function updateChannel(
+  appId: string,
+  channelId: string,
+  req: UpdateChannelRequest,
+): Promise<AppChannel> {
+  const response = await api.patch<AppChannel>(`/v1/apps/${appId}/channels/${channelId}`, req);
+  return response.data;
+}
+
+export async function deleteChannel(appId: string, channelId: string): Promise<void> {
+  await api.delete(`/v1/apps/${appId}/channels/${channelId}`);
 }
 
 /** Get the Slack App manifest for an app. Returns manifest YAML and create URL. */

--- a/apps/ui/src/lib/api/types/app-types.ts
+++ b/apps/ui/src/lib/api/types/app-types.ts
@@ -1,4 +1,4 @@
-// App types (deployable agent+harness bundles)
+// App types (deployable agent+harness bundles with multi-channel support)
 
 export type AppStatus = "draft" | "published" | "archived" | "deleted";
 export type ChannelType = "slack";
@@ -16,6 +16,15 @@ export interface SlackChannelConfig {
   first_message_received_at?: string | null;
 }
 
+export interface AppChannel {
+  id: string;
+  channel_type: ChannelType;
+  channel_config: SlackChannelConfig | Record<string, unknown>;
+  enabled: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface App {
   id: string;
   name: string;
@@ -23,8 +32,7 @@ export interface App {
   harness_id: string;
   agent_id: string;
   agent_identity_id?: string | null;
-  channel_type: ChannelType;
-  channel_config: SlackChannelConfig | Record<string, unknown>;
+  channels: AppChannel[];
   status: AppStatus;
   published_at: string | null;
   created_at: string;
@@ -49,7 +57,17 @@ export interface UpdateAppRequest {
   harness_id?: string;
   agent_id?: string;
   agent_identity_id?: string | null;
+  status?: AppStatus;
+}
+
+export interface AddChannelRequest {
+  channel_type: ChannelType;
+  channel_config?: SlackChannelConfig | Record<string, unknown>;
+  enabled?: boolean;
+}
+
+export interface UpdateChannelRequest {
   channel_type?: ChannelType;
   channel_config?: SlackChannelConfig | Record<string, unknown>;
-  status?: AppStatus;
+  enabled?: boolean;
 }

--- a/crates/core/src/app.rs
+++ b/crates/core/src/app.rs
@@ -15,7 +15,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::typed_id::{AgentId, AgentIdentityId, AppId, HarnessId};
+use crate::typed_id::{AgentId, AgentIdentityId, AppChannelId, AppId, HarnessId};
 
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
@@ -112,11 +112,9 @@ pub struct App {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "identity_01933b5a00007000800000000000001"))]
     pub agent_identity_id: Option<AgentIdentityId>,
-    /// Distribution channel type.
-    pub channel_type: ChannelType,
-    /// Channel-specific configuration (validated per channel type).
+    /// Distribution channels attached to this app.
     #[serde(default)]
-    pub channel_config: serde_json::Value,
+    pub channels: Vec<AppChannel>,
     /// Current lifecycle status.
     pub status: AppStatus,
     /// Timestamp when the app was last published.
@@ -132,6 +130,61 @@ pub struct App {
     /// Timestamp when the app was deleted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deleted_at: Option<DateTime<Utc>>,
+}
+
+/// A single distribution channel attached to an App.
+/// Each channel has its own type, config, and lifecycle status.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct AppChannel {
+    /// External identifier (appchan_<32-hex>). Shown as "id" in API.
+    #[serde(rename = "id")]
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "appchan_01933b5a000070008000000000000001"))]
+    pub public_id: AppChannelId,
+    /// Internal UUID primary key. Never exposed in API.
+    #[serde(skip, default = "Uuid::nil")]
+    pub internal_id: Uuid,
+    /// Channel type (e.g. slack).
+    pub channel_type: ChannelType,
+    /// Channel-specific configuration (validated per channel type).
+    #[serde(default)]
+    pub channel_config: serde_json::Value,
+    /// Whether this channel is enabled.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Timestamp when this channel was created.
+    pub created_at: DateTime<Utc>,
+    /// Timestamp when this channel was last updated.
+    pub updated_at: DateTime<Utc>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl AppChannel {
+    /// Parse channel_config as SlackChannelConfig. Returns None if not a Slack channel
+    /// or if the config is invalid.
+    pub fn slack_config(&self) -> Option<SlackChannelConfig> {
+        if self.channel_type != ChannelType::Slack {
+            return None;
+        }
+        serde_json::from_value(self.channel_config.clone()).ok()
+    }
+}
+
+impl App {
+    /// Find the first Slack channel on this app.
+    pub fn slack_channel(&self) -> Option<&AppChannel> {
+        self.channels
+            .iter()
+            .find(|ch| ch.channel_type == ChannelType::Slack && ch.enabled)
+    }
+
+    /// Find a channel by its public ID.
+    pub fn channel_by_id(&self, id: &AppChannelId) -> Option<&AppChannel> {
+        self.channels.iter().find(|ch| ch.public_id == *id)
+    }
 }
 
 /// Session strategy for incoming messages (how messages map to sessions).
@@ -231,17 +284,6 @@ pub struct SlackChannelConfig {
     /// Set when the first real message is received from Slack.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub first_message_received_at: Option<DateTime<Utc>>,
-}
-
-impl App {
-    /// Parse channel_config as SlackChannelConfig. Returns None if not a Slack app
-    /// or if the config is invalid.
-    pub fn slack_config(&self) -> Option<SlackChannelConfig> {
-        if self.channel_type != ChannelType::Slack {
-            return None;
-        }
-        serde_json::from_value(self.channel_config.clone()).ok()
-    }
 }
 
 #[cfg(test)]
@@ -390,13 +432,8 @@ mod tests {
         assert!(serde_json::from_str::<SlackChannelConfig>(json).is_err());
     }
 
-    #[test]
-    fn test_app_slack_config_valid() {
-        let config_json = serde_json::json!({
-            "signing_secret": "sec",
-            "bot_token": "tok"
-        });
-        let app = App {
+    fn test_app(channels: Vec<AppChannel>) -> App {
+        App {
             public_id: AppId::from_uuid(Uuid::nil()),
             internal_id: Uuid::nil(),
             org_id: 1,
@@ -405,62 +442,63 @@ mod tests {
             harness_id: HarnessId::from_uuid(Uuid::nil()),
             agent_id: AgentId::from_uuid(Uuid::nil()),
             agent_identity_id: None,
-            channel_type: ChannelType::Slack,
-            channel_config: config_json,
+            channels,
             status: AppStatus::Draft,
             published_at: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
             archived_at: None,
             deleted_at: None,
-        };
-        let config = app.slack_config().unwrap();
+        }
+    }
+
+    fn test_channel(channel_type: ChannelType, config: serde_json::Value) -> AppChannel {
+        AppChannel {
+            public_id: AppChannelId::from_uuid(Uuid::nil()),
+            internal_id: Uuid::nil(),
+            channel_type,
+            channel_config: config,
+            enabled: true,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_app_channel_slack_config_valid() {
+        let ch = test_channel(
+            ChannelType::Slack,
+            serde_json::json!({"signing_secret": "sec", "bot_token": "tok"}),
+        );
+        let config = ch.slack_config().unwrap();
         assert_eq!(config.signing_secret, "sec");
     }
 
     #[test]
-    fn test_app_slack_config_invalid_json() {
-        let app = App {
-            public_id: AppId::from_uuid(Uuid::nil()),
-            internal_id: Uuid::nil(),
-            org_id: 1,
-            name: "test".into(),
-            description: None,
-            harness_id: HarnessId::from_uuid(Uuid::nil()),
-            agent_id: AgentId::from_uuid(Uuid::nil()),
-            agent_identity_id: None,
-            channel_type: ChannelType::Slack,
-            channel_config: serde_json::json!({"bad": "data"}),
-            status: AppStatus::Draft,
-            published_at: None,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            archived_at: None,
-            deleted_at: None,
-        };
-        assert!(app.slack_config().is_none());
+    fn test_app_channel_slack_config_invalid_json() {
+        let ch = test_channel(ChannelType::Slack, serde_json::json!({"bad": "data"}));
+        assert!(ch.slack_config().is_none());
+    }
+
+    #[test]
+    fn test_app_slack_channel_lookup() {
+        let ch = test_channel(
+            ChannelType::Slack,
+            serde_json::json!({"signing_secret": "s", "bot_token": "t"}),
+        );
+        let app = test_app(vec![ch]);
+        assert!(app.slack_channel().is_some());
+    }
+
+    #[test]
+    fn test_app_slack_channel_none_when_empty() {
+        let app = test_app(vec![]);
+        assert!(app.slack_channel().is_none());
     }
 
     #[test]
     fn test_app_serde_skips_internal_fields() {
-        let app = App {
-            public_id: AppId::from_uuid(Uuid::nil()),
-            internal_id: Uuid::nil(),
-            org_id: 42,
-            name: "test".into(),
-            description: None,
-            harness_id: HarnessId::from_uuid(Uuid::nil()),
-            agent_id: AgentId::from_uuid(Uuid::nil()),
-            agent_identity_id: None,
-            channel_type: ChannelType::Slack,
-            channel_config: serde_json::json!({}),
-            status: AppStatus::Draft,
-            published_at: None,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            archived_at: None,
-            deleted_at: None,
-        };
+        let app = test_app(vec![]);
         let json = serde_json::to_value(&app).unwrap();
         assert!(json.get("id").is_some()); // public_id serialized as "id"
         assert!(json.get("internal_id").is_none()); // skipped

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -229,7 +229,9 @@ pub use tool_types::{
 // Note: LlmProvider entity is in llm_models module. Import as: everruns_core::llm_models::LlmProvider
 pub use agent::{Agent, AgentStatus, generate_agent_public_id, validate_agent_public_id};
 pub use agent_identity::{AgentIdentity, AgentIdentityStatus};
-pub use app::{App, AppStatus, ChannelType, SessionStrategy, SlackChannelConfig, SlackReplyMode};
+pub use app::{
+    App, AppChannel, AppStatus, ChannelType, SessionStrategy, SlackChannelConfig, SlackReplyMode,
+};
 pub use capability_dto::{AgentCapability, CapabilityInfo};
 pub use events::{
     ACT_COMPLETED, ACT_STARTED, ActCompletedData, ActStartedData, CONTEXT_COMPACTED,
@@ -281,8 +283,9 @@ pub use skill::{
     SkillValidationResult, parse_skill_md, validate_skill_md, validate_skill_name,
 };
 pub use typed_id::{
-    AgentId, AgentIdentityId, AppId, EventId, ExecId, HarnessId, IdMarker, IdParseError, ImageId,
-    LeasedResourceId, McpServerId, MemoryId, MemoryStoreId, MessageId, ModelId, NotificationId,
+    AgentId, AgentIdentityId, AppChannelId, AppId, EventId, ExecId, HarnessId, IdMarker,
+    IdParseError, ImageId, LeasedResourceId, McpServerId, MemoryId, MemoryStoreId, MessageId,
+    ModelId, NotificationId,
     OrgId, ProviderId, ScheduleId, SessionId, SkillId, TurnId, TypedId,
 };
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -285,8 +285,7 @@ pub use skill::{
 pub use typed_id::{
     AgentId, AgentIdentityId, AppChannelId, AppId, EventId, ExecId, HarnessId, IdMarker,
     IdParseError, ImageId, LeasedResourceId, McpServerId, MemoryId, MemoryStoreId, MessageId,
-    ModelId, NotificationId,
-    OrgId, ProviderId, ScheduleId, SessionId, SkillId, TurnId, TypedId,
+    ModelId, NotificationId, OrgId, ProviderId, ScheduleId, SessionId, SkillId, TurnId, TypedId,
 };
 
 // Permissions re-exports

--- a/crates/core/src/typed_id.rs
+++ b/crates/core/src/typed_id.rs
@@ -406,6 +406,13 @@ impl IdMarker for AppIdMarker {
     const PREFIX: &'static str = "app";
 }
 
+/// Marker for App Channel IDs
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct AppChannelIdMarker;
+impl IdMarker for AppChannelIdMarker {
+    const PREFIX: &'static str = "appchan";
+}
+
 /// Marker for Notification IDs
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct NotificationIdMarker;
@@ -465,6 +472,8 @@ pub type ScheduleId = TypedId<ScheduleIdMarker>;
 pub type LeasedResourceId = TypedId<LeasedResourceIdMarker>;
 /// App ID
 pub type AppId = TypedId<AppIdMarker>;
+/// App Channel ID
+pub type AppChannelId = TypedId<AppChannelIdMarker>;
 /// Notification ID
 pub type NotificationId = TypedId<NotificationIdMarker>;
 pub type MemoryStoreId = TypedId<MemoryStoreIdMarker>;

--- a/crates/server/migrations/012_app_channels.sql
+++ b/crates/server/migrations/012_app_channels.sql
@@ -1,0 +1,50 @@
+-- Migration 012: Extract app channels into a separate table
+-- Supports multiple channels per app (multi-channel messaging).
+-- Data migration: copy existing channel_type/channel_config from apps into app_channels.
+
+-- ============================================
+-- App Channels table
+-- ============================================
+
+CREATE TABLE app_channels (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    app_id UUID NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+    -- Dual-ID pattern: internal UUID (id) + external public_id (API-facing)
+    public_id TEXT NOT NULL,
+    -- Channel type: slack, discord, etc.
+    channel_type VARCHAR(50) NOT NULL CHECK (channel_type IN ('slack')),
+    -- Channel-specific config (JSON)
+    channel_config JSONB NOT NULL DEFAULT '{}'::jsonb,
+    -- Encrypted channel config (envelope-encrypted JSON)
+    channel_config_encrypted BYTEA,
+    -- Whether this channel is active
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- Unique public_id globally (for webhook lookup without app context)
+    UNIQUE (public_id)
+);
+
+CREATE INDEX idx_app_channels_app_id ON app_channels(app_id);
+CREATE INDEX idx_app_channels_public_id ON app_channels(public_id);
+
+CREATE TRIGGER update_app_channels_updated_at
+    BEFORE UPDATE ON app_channels
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- ============================================
+-- Data migration: copy existing app channels
+-- ============================================
+-- Generate a new UUIDv7 public_id for each existing app's channel.
+-- Use the app's public_id to derive a deterministic channel public_id.
+
+INSERT INTO app_channels (app_id, public_id, channel_type, channel_config, channel_config_encrypted, enabled)
+SELECT
+    a.id,
+    'appchan_' || REPLACE(gen_random_uuid()::text, '-', ''),
+    a.channel_type,
+    a.channel_config,
+    a.channel_config_encrypted,
+    true
+FROM apps a
+WHERE a.status != 'deleted';

--- a/crates/server/migrations/012_app_channels.sql
+++ b/crates/server/migrations/012_app_channels.sql
@@ -22,11 +22,12 @@ CREATE TABLE app_channels (
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     -- Unique public_id globally (for webhook lookup without app context)
-    UNIQUE (public_id)
+    UNIQUE (public_id),
+    -- Enforce typed-ID format
+    CONSTRAINT app_channels_public_id_format CHECK (public_id ~ '^appchan_[0-9a-f]{32}$')
 );
 
 CREATE INDEX idx_app_channels_app_id ON app_channels(app_id);
-CREATE INDEX idx_app_channels_public_id ON app_channels(public_id);
 
 CREATE TRIGGER update_app_channels_updated_at
     BEFORE UPDATE ON app_channels
@@ -35,8 +36,9 @@ CREATE TRIGGER update_app_channels_updated_at
 -- ============================================
 -- Data migration: copy existing app channels
 -- ============================================
--- Generate a new UUIDv7 public_id for each existing app's channel.
--- Use the app's public_id to derive a deterministic channel public_id.
+-- Each existing app gets one channel row. Uses gen_random_uuid() (v4) for
+-- the public_id suffix since UUIDv7 generation is not available in pure SQL
+-- on all Postgres versions. The typed-ID prefix 'appchan_' is prepended.
 
 INSERT INTO app_channels (app_id, public_id, channel_type, channel_config, channel_config_encrypted, enabled)
 SELECT

--- a/crates/server/migrations/013_app_channels.sql
+++ b/crates/server/migrations/013_app_channels.sql
@@ -1,4 +1,4 @@
--- Migration 012: Extract app channels into a separate table
+-- Migration 013: Extract app channels into a separate table
 -- Supports multiple channels per app (multi-channel messaging).
 -- Data migration: copy existing channel_type/channel_config from apps into app_channels.
 

--- a/crates/server/src/api/apps.rs
+++ b/crates/server/src/api/apps.rs
@@ -13,7 +13,7 @@ use axum::{
 };
 use everruns_core::typed_id::{AgentId, AgentIdentityId, AppId, HarnessId};
 use everruns_core::{
-    App, AppStatus, Caller, ChannelType, ResourceConfigResponse, evaluate_policies_with,
+    App, AppChannel, AppStatus, Caller, ChannelType, ResourceConfigResponse, evaluate_policies_with,
 };
 
 use super::common::{
@@ -47,9 +47,9 @@ pub struct CreateAppRequest {
     #[serde(default)]
     #[schema(value_type = Option<String>, example = "identity_01933b5a00007000800000000000001")]
     pub agent_identity_id: Option<AgentIdentityId>,
-    /// Distribution channel type.
+    /// Initial channel type (creates the first channel on the app).
     pub channel_type: ChannelType,
-    /// Channel-specific configuration.
+    /// Initial channel configuration.
     #[serde(default)]
     pub channel_config: Option<serde_json::Value>,
 }
@@ -75,15 +75,36 @@ pub struct UpdateAppRequest {
     #[serde(default, deserialize_with = "deserialize_nullable_update_field")]
     #[schema(value_type = Option<String>, nullable = true)]
     pub agent_identity_id: UpdateField<AgentIdentityId>,
-    /// Distribution channel type.
+    /// Lifecycle status (draft or archived). Use publish/unpublish endpoints for publishing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<AppStatus>,
+}
+
+/// Request to add a channel to an app.
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct AddChannelRequest {
+    /// Channel type.
+    pub channel_type: ChannelType,
+    /// Channel-specific configuration.
+    #[serde(default)]
+    pub channel_config: Option<serde_json::Value>,
+    /// Whether the channel is enabled (default: true).
+    #[serde(default)]
+    pub enabled: Option<bool>,
+}
+
+/// Request to update a channel.
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct UpdateChannelRequest {
+    /// Channel type.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub channel_type: Option<ChannelType>,
     /// Channel-specific configuration.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub channel_config: Option<serde_json::Value>,
-    /// Lifecycle status (draft or archived). Use publish/unpublish endpoints for publishing.
+    /// Whether the channel is enabled.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<AppStatus>,
+    pub enabled: Option<bool>,
 }
 
 /// Query parameters for listing apps.
@@ -129,6 +150,12 @@ pub fn routes(state: AppState) -> Router {
         .route("/v1/apps/{app_id}/delete", post(destroy_app))
         .route("/v1/apps/{app_id}/publish", post(publish_app))
         .route("/v1/apps/{app_id}/unpublish", post(unpublish_app))
+        // Channel sub-routes
+        .route("/v1/apps/{app_id}/channels", post(add_channel))
+        .route(
+            "/v1/apps/{app_id}/channels/{channel_id}",
+            axum::routing::patch(update_channel).delete(delete_channel),
+        )
         .with_state(state)
 }
 
@@ -402,6 +429,77 @@ pub async fn unpublish_app(
         .ok_or_not_found_json("App")?;
 
     Ok(Json(app))
+}
+
+// ============================================
+// Channel sub-routes
+// ============================================
+
+/// POST /v1/apps/{app_id}/channels - Add a channel to an app
+pub async fn add_channel(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(app_id): Path<String>,
+    Json(req): Json<AddChannelRequest>,
+) -> Result<(StatusCode, Json<AppChannel>), (StatusCode, Json<ErrorResponse>)> {
+    let app_id: AppId = app_id.parse().map_err(|e| {
+        ErrorResponse::new(format!("Invalid app ID: {}", e)).into_response(StatusCode::BAD_REQUEST)
+    })?;
+
+    let caller = Caller::from(&org);
+    let channel: AppChannel = state
+        .service
+        .add_channel(&caller, &app_id.to_string(), req)
+        .await
+        .map_policy_or_internal("add channel")?;
+
+    Ok((StatusCode::CREATED, Json(channel)))
+}
+
+/// PATCH /v1/apps/{app_id}/channels/{channel_id} - Update a channel
+pub async fn update_channel(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path((app_id, channel_id)): Path<(String, String)>,
+    Json(req): Json<UpdateChannelRequest>,
+) -> ApiResult<AppChannel> {
+    let app_id: AppId = app_id.parse().map_err(|e| {
+        ErrorResponse::new(format!("Invalid app ID: {}", e)).into_response(StatusCode::BAD_REQUEST)
+    })?;
+
+    let caller = Caller::from(&org);
+    let channel: AppChannel = state
+        .service
+        .update_channel(&caller, &app_id.to_string(), &channel_id, req)
+        .await
+        .map_policy_or_internal("update channel")?
+        .ok_or_not_found_json("Channel")?;
+
+    Ok(Json(channel))
+}
+
+/// DELETE /v1/apps/{app_id}/channels/{channel_id} - Remove a channel
+pub async fn delete_channel(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path((app_id, channel_id)): Path<(String, String)>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let app_id: AppId = app_id.parse().map_err(|e| {
+        ErrorResponse::new(format!("Invalid app ID: {}", e)).into_response(StatusCode::BAD_REQUEST)
+    })?;
+
+    let caller = Caller::from(&org);
+    let deleted = state
+        .service
+        .delete_channel(&caller, &app_id.to_string(), &channel_id)
+        .await
+        .map_policy_or_internal("delete channel")?;
+
+    if deleted {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(ErrorResponse::new("Channel not found").into_response(StatusCode::NOT_FOUND))
+    }
 }
 
 #[cfg(test)]

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -30,9 +30,7 @@ use everruns_core::channel::{
     build_session_routing_tag,
 };
 use everruns_core::progress_reporting::sync_slack_reply_mode_tags;
-use everruns_core::{
-    App, AppStatus, Caller, ChannelType, SessionStrategy, SlackChannelConfig, SlackReplyMode,
-};
+use everruns_core::{App, AppStatus, Caller, SessionStrategy, SlackChannelConfig, SlackReplyMode};
 use everruns_worker::AgentRunner;
 use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
@@ -49,7 +47,7 @@ use crate::services::{
 };
 use crate::slack_delivery::SlackDeliveryDispatcher;
 use crate::storage::StorageBackend;
-use crate::storage::models::{UpdateApp, UpdateSession};
+use crate::storage::models::{UpdateAppChannel, UpdateSession};
 
 use super::common::ErrorResponse;
 
@@ -348,23 +346,23 @@ async fn handle_slack_event(
         })?
         .ok_or_else(|| ErrorResponse::new("App not found").into_response(StatusCode::NOT_FOUND))?;
 
-    // 2. Verify app is published and is a Slack channel
+    // 2. Verify app is published and has a Slack channel
     if app.status != AppStatus::Published {
         return Err(ErrorResponse::new("App is not published").into_response(StatusCode::FORBIDDEN));
     }
-    if app.channel_type != ChannelType::Slack {
-        return Err(
-            ErrorResponse::new("App is not a Slack channel").into_response(StatusCode::BAD_REQUEST)
-        );
-    }
+    let slack_channel = app.slack_channel().ok_or_else(|| {
+        ErrorResponse::new("App has no enabled Slack channel")
+            .into_response(StatusCode::BAD_REQUEST)
+    })?;
 
     // 3. Parse Slack channel config
-    let slack_config: SlackChannelConfig = serde_json::from_value(app.channel_config.clone())
-        .map_err(|e| {
+    let slack_config: SlackChannelConfig =
+        serde_json::from_value(slack_channel.channel_config.clone()).map_err(|e| {
             tracing::error!(app_id = %app_id, error = %e, "Invalid Slack channel config");
             ErrorResponse::new("Invalid Slack channel configuration")
                 .into_response(StatusCode::INTERNAL_SERVER_ERROR)
         })?;
+    let slack_channel_internal_id = slack_channel.internal_id;
 
     // 4. Verify Slack signing secret // THREAT[TM-SLACK-001]
     verify_slack_signature(&headers, &body, &slack_config.signing_secret).map_err(|e| {
@@ -389,13 +387,13 @@ async fn handle_slack_event(
                 let mut updated_config = slack_config.clone();
                 updated_config.webhook_verified_at = Some(Utc::now());
                 if let Ok(config_json) = serde_json::to_value(&updated_config) {
-                    let input = UpdateApp {
+                    let input = UpdateAppChannel {
                         channel_config: Some(config_json),
                         ..Default::default()
                     };
                     if let Err(e) = state
                         .db
-                        .update_app(app.org_id, app.internal_id, input)
+                        .update_app_channel(slack_channel_internal_id, input)
                         .await
                     {
                         tracing::warn!(app_id = %app_id, error = %e, "Failed to record webhook verification");
@@ -441,13 +439,13 @@ async fn handle_slack_event(
                     let mut updated_config = slack_config.clone();
                     updated_config.first_message_received_at = Some(Utc::now());
                     if let Ok(config_json) = serde_json::to_value(&updated_config) {
-                        let input = UpdateApp {
+                        let input = UpdateAppChannel {
                             channel_config: Some(config_json),
                             ..Default::default()
                         };
                         if let Err(e) = state
                             .db
-                            .update_app(app.org_id, app.internal_id, input)
+                            .update_app_channel(slack_channel_internal_id, input)
                             .await
                         {
                             tracing::warn!(app_id = %app_id, error = %e, "Failed to record first message timestamp");
@@ -1879,8 +1877,10 @@ mod tests {
 
     // Test helpers
     fn test_app() -> App {
-        use everruns_core::typed_id::{AgentId, AppId, HarnessId};
+        use everruns_core::typed_id::{AgentId, AppChannelId, AppId, HarnessId};
+        use everruns_core::{AppChannel, ChannelType};
 
+        let now = chrono::Utc::now();
         App {
             public_id: AppId::from_uuid(uuid::Uuid::nil()),
             internal_id: uuid::Uuid::nil(),
@@ -1890,12 +1890,19 @@ mod tests {
             harness_id: HarnessId::from_uuid(uuid::Uuid::nil()),
             agent_id: AgentId::from_uuid(uuid::Uuid::nil()),
             agent_identity_id: None,
-            channel_type: ChannelType::Slack,
-            channel_config: serde_json::json!({}),
+            channels: vec![AppChannel {
+                public_id: AppChannelId::from_uuid(uuid::Uuid::nil()),
+                internal_id: uuid::Uuid::nil(),
+                channel_type: ChannelType::Slack,
+                channel_config: serde_json::json!({}),
+                enabled: true,
+                created_at: now,
+                updated_at: now,
+            }],
             status: AppStatus::Published,
             published_at: None,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
+            created_at: now,
+            updated_at: now,
             archived_at: None,
             deleted_at: None,
         }

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -47,7 +47,7 @@ use crate::services::{
 };
 use crate::slack_delivery::SlackDeliveryDispatcher;
 use crate::storage::StorageBackend;
-use crate::storage::models::{UpdateAppChannel, UpdateSession};
+use crate::storage::models::UpdateSession;
 
 use super::common::ErrorResponse;
 
@@ -386,18 +386,13 @@ async fn handle_slack_event(
             if slack_config.webhook_verified_at.is_none() {
                 let mut updated_config = slack_config.clone();
                 updated_config.webhook_verified_at = Some(Utc::now());
-                if let Ok(config_json) = serde_json::to_value(&updated_config) {
-                    let input = UpdateAppChannel {
-                        channel_config: Some(config_json),
-                        ..Default::default()
-                    };
-                    if let Err(e) = state
-                        .db
-                        .update_app_channel(slack_channel_internal_id, input)
+                if let Ok(config_json) = serde_json::to_value(&updated_config)
+                    && let Err(e) = state
+                        .app_service
+                        .update_channel_config_unscoped(slack_channel_internal_id, &config_json)
                         .await
-                    {
-                        tracing::warn!(app_id = %app_id, error = %e, "Failed to record webhook verification");
-                    }
+                {
+                    tracing::warn!(app_id = %app_id, error = %e, "Failed to record webhook verification");
                 }
             }
 
@@ -438,18 +433,13 @@ async fn handle_slack_event(
                 if slack_config.first_message_received_at.is_none() {
                     let mut updated_config = slack_config.clone();
                     updated_config.first_message_received_at = Some(Utc::now());
-                    if let Ok(config_json) = serde_json::to_value(&updated_config) {
-                        let input = UpdateAppChannel {
-                            channel_config: Some(config_json),
-                            ..Default::default()
-                        };
-                        if let Err(e) = state
-                            .db
-                            .update_app_channel(slack_channel_internal_id, input)
+                    if let Ok(config_json) = serde_json::to_value(&updated_config)
+                        && let Err(e) = state
+                            .app_service
+                            .update_channel_config_unscoped(slack_channel_internal_id, &config_json)
                             .await
-                        {
-                            tracing::warn!(app_id = %app_id, error = %e, "Failed to record first message timestamp");
-                        }
+                    {
+                        tracing::warn!(app_id = %app_id, error = %e, "Failed to record first message timestamp");
                     }
                 }
 

--- a/crates/server/src/services/app.rs
+++ b/crates/server/src/services/app.rs
@@ -426,6 +426,25 @@ impl AppService {
         self.db.delete_app_channel(channel_row.id).await
     }
 
+    /// Update channel config with proper encryption handling.
+    /// Used by webhook handlers (unauthenticated, no caller context).
+    pub async fn update_channel_config_unscoped(
+        &self,
+        channel_internal_id: Uuid,
+        config: &serde_json::Value,
+    ) -> Result<()> {
+        let (stored_plaintext, encrypted) = self.prepare_channel_config(config)?;
+        let input = UpdateAppChannel {
+            channel_config: Some(stored_plaintext),
+            channel_config_encrypted: encrypted,
+            ..Default::default()
+        };
+        self.db
+            .update_app_channel(channel_internal_id, input)
+            .await?;
+        Ok(())
+    }
+
     // ============================================
     // Lifecycle
     // ============================================
@@ -529,12 +548,44 @@ impl AppService {
             .parse()
             .unwrap_or_else(|_| AppId::from_uuid(row.id));
 
-        // Load channels from app_channels table
-        let channel_rows = self.db.list_app_channels(row.id).await.unwrap_or_default();
-        let channels: Vec<AppChannel> = channel_rows
-            .into_iter()
-            .map(|ch| self.channel_row_to_channel(ch))
-            .collect();
+        // Load channels from app_channels table; fall back to legacy columns
+        let channel_rows = match self.db.list_app_channels(row.id).await {
+            Ok(rows) => rows,
+            Err(err) => {
+                tracing::error!(
+                    app_id = %row.public_id,
+                    error = %err,
+                    "Failed to load app_channels; falling back to legacy columns"
+                );
+                Vec::new()
+            }
+        };
+        let channels: Vec<AppChannel> = if channel_rows.is_empty() {
+            // Fallback: synthesize a channel from legacy apps columns when no
+            // app_channels rows exist (e.g. incomplete migration, DB restore).
+            if let Some(ct) = ChannelType::from_str_opt(&row.channel_type) {
+                let config = self.decrypt_channel_config(
+                    row.channel_config_encrypted.as_deref(),
+                    &row.channel_config,
+                );
+                vec![AppChannel {
+                    public_id: AppChannelId::from_uuid(row.id),
+                    internal_id: row.id,
+                    channel_type: ct,
+                    channel_config: config,
+                    enabled: true,
+                    created_at: row.created_at,
+                    updated_at: row.updated_at,
+                }]
+            } else {
+                Vec::new()
+            }
+        } else {
+            channel_rows
+                .into_iter()
+                .map(|ch| self.channel_row_to_channel(ch))
+                .collect()
+        };
 
         App {
             public_id,

--- a/crates/server/src/services/app.rs
+++ b/crates/server/src/services/app.rs
@@ -1,22 +1,27 @@
 // App service for business logic
 // Decision: channel_config secrets encrypted via EncryptionService (EVE-158)
 // Decision: encrypt on write, decrypt in row_to_app; fallback to plaintext for migration
+// Decision: multi-channel support — channels live in app_channels table (one-to-many)
 
 use crate::errors::ResourceNotFoundError;
 use crate::storage::{
-    AppRow, EncryptionService, StorageBackend,
-    models::{CreateAppRow, UpdateApp},
+    AppChannelRow, AppRow, EncryptionService, StorageBackend,
+    models::{CreateAppChannelRow, CreateAppRow, UpdateApp, UpdateAppChannel},
 };
 use anyhow::Result;
 use chrono::Utc;
-use everruns_core::typed_id::{AgentId, AgentIdentityId, HarnessId};
-use everruns_core::{App, AppId, AppStatus, Caller, ChannelType, Permission, Policy, Rule};
+use everruns_core::typed_id::{AgentId, AgentIdentityId, AppChannelId, HarnessId};
+use everruns_core::{
+    App, AppChannel, AppId, AppStatus, Caller, ChannelType, Permission, Policy, Rule,
+};
 use everruns_durable::UpdateField;
 use everruns_macros::policy;
 use std::sync::Arc;
 use uuid::Uuid;
 
-use crate::api::apps::{CreateAppRequest, UpdateAppRequest};
+use crate::api::apps::{
+    AddChannelRequest, CreateAppRequest, UpdateAppRequest, UpdateChannelRequest,
+};
 
 /// Policy: View apps (read-only).
 pub const APP_VIEW: Policy = Policy {
@@ -65,18 +70,14 @@ impl AppService {
 
     /// Decrypt channel_config from encrypted bytes. Falls back to the plaintext
     /// column only for rows that haven't been migrated yet or when encryption
-    /// is not configured (dev/test mode). If encrypted data is present but
-    /// decryption/parsing fails, log and return null instead of silently
-    /// reading from the plaintext column.
+    /// is not configured (dev/test mode).
     fn decrypt_channel_config(
         &self,
         encrypted: Option<&[u8]>,
         plaintext_fallback: &serde_json::Value,
     ) -> serde_json::Value {
         match (encrypted, self.encryption.as_ref()) {
-            // Pre-migration rows or dev/test mode: use plaintext column.
             (None, _) | (_, None) => plaintext_fallback.clone(),
-            // Encrypted data with an available encryption service.
             (Some(data), Some(enc)) => {
                 let json = match enc.decrypt_to_string(data) {
                     Ok(json) => json,
@@ -100,6 +101,20 @@ impl AppService {
                 }
             }
         }
+    }
+
+    /// Prepare channel_config for storage: encrypt if possible, redact plaintext when encrypted.
+    fn prepare_channel_config(
+        &self,
+        config: &serde_json::Value,
+    ) -> Result<(serde_json::Value, Option<Vec<u8>>)> {
+        let encrypted = self.encrypt_channel_config(config)?;
+        let stored_plaintext = if encrypted.is_some() {
+            serde_json::Value::Object(Default::default())
+        } else {
+            config.clone()
+        };
+        Ok((stored_plaintext, encrypted))
     }
 
     #[policy(APP_MANAGE)]
@@ -138,16 +153,10 @@ impl AppService {
             None
         };
 
-        let channel_config = req.channel_config.unwrap_or_default();
-        let channel_config_encrypted = self.encrypt_channel_config(&channel_config)?;
-
-        // When encryption produced ciphertext, redact the plaintext column
-        // so secrets are not stored in both columns.
-        let stored_plaintext = if channel_config_encrypted.is_some() {
-            serde_json::Value::Object(Default::default())
-        } else {
-            channel_config
-        };
+        // Create the app (channel_type/config kept for backward compat in DB)
+        let channel_config = req.channel_config.clone().unwrap_or_default();
+        let (stored_plaintext, channel_config_encrypted) =
+            self.prepare_channel_config(&channel_config)?;
 
         let input = CreateAppRow {
             public_id: public_id.to_string(),
@@ -157,11 +166,24 @@ impl AppService {
             agent_id: agent_row.id.uuid(),
             agent_identity_id,
             channel_type: req.channel_type.to_string(),
-            channel_config: stored_plaintext,
-            channel_config_encrypted,
+            channel_config: stored_plaintext.clone(),
+            channel_config_encrypted: channel_config_encrypted.clone(),
         };
 
         let row = self.db.create_app(caller.org_id, input).await?;
+
+        // Create the initial channel in app_channels table
+        let channel_uuid = Uuid::now_v7();
+        let channel_public_id = AppChannelId::from_uuid(channel_uuid);
+        let channel_input = CreateAppChannelRow {
+            public_id: channel_public_id.to_string(),
+            channel_type: req.channel_type.to_string(),
+            channel_config: stored_plaintext,
+            channel_config_encrypted,
+            enabled: true,
+        };
+        self.db.create_app_channel(row.id, channel_input).await?;
+
         Ok(self.row_to_app(row, caller.org_id).await)
     }
 
@@ -181,7 +203,6 @@ impl AppService {
     }
 
     /// Lookup app by public_id without org scoping (for unauthenticated webhooks).
-    /// The org_id is derived from the row itself.
     pub async fn get_by_public_id_unscoped(&self, public_id: &str) -> Result<Option<App>> {
         let row = self.db.get_app_by_public_id_unscoped(public_id).await?;
         match row {
@@ -230,7 +251,6 @@ impl AppService {
             anyhow::bail!("Archived or deleted apps cannot be edited");
         }
 
-        // Resolve harness/agent IDs if provided
         let harness_id = if let Some(hid) = req.harness_id {
             let h = self
                 .db
@@ -259,31 +279,6 @@ impl AppService {
             None
         };
 
-        // Encrypt channel_config. If the request provides a new config, encrypt it.
-        // Otherwise, opportunistically encrypt the existing plaintext config for
-        // pre-migration rows (when encryption is configured but encrypted column is NULL).
-        let (channel_config, channel_config_encrypted) = if let Some(config) = req.channel_config {
-            let encrypted = self.encrypt_channel_config(&config)?;
-            // Redact plaintext when encryption produced ciphertext
-            let stored_plaintext = if encrypted.is_some() {
-                Some(serde_json::Value::Object(Default::default()))
-            } else {
-                Some(config)
-            };
-            (stored_plaintext, encrypted)
-        } else if existing.channel_config_encrypted.is_none() && self.encryption.is_some() {
-            // Opportunistic migration: encrypt existing plaintext on any update
-            let encrypted = self.encrypt_channel_config(&existing.channel_config)?;
-            let stored_plaintext = if encrypted.is_some() {
-                Some(serde_json::Value::Object(Default::default()))
-            } else {
-                None
-            };
-            (stored_plaintext, encrypted)
-        } else {
-            (None, None)
-        };
-
         let agent_identity_id = match req.agent_identity_id {
             UpdateField::Set(identity_id) => {
                 let identity = self
@@ -306,9 +301,9 @@ impl AppService {
             harness_id,
             agent_id,
             agent_identity_id,
-            channel_type: req.channel_type.map(|ct| ct.to_string()),
-            channel_config,
-            channel_config_encrypted,
+            channel_type: None,
+            channel_config: None,
+            channel_config_encrypted: None,
             status: req.status.map(|s| s.to_string()),
             published_at: UpdateField::Unchanged,
         };
@@ -322,6 +317,118 @@ impl AppService {
             None => Ok(None),
         }
     }
+
+    // ============================================
+    // Channel CRUD
+    // ============================================
+
+    #[policy(APP_MANAGE)]
+    pub async fn add_channel(
+        &self,
+        caller: &Caller,
+        app_public_id: &str,
+        req: AddChannelRequest,
+    ) -> Result<AppChannel> {
+        let app = self
+            .db
+            .get_app_by_public_id(caller.org_id, app_public_id)
+            .await?
+            .ok_or_else(|| ResourceNotFoundError::new("App"))?;
+        if !matches!(app.status.as_str(), "draft" | "published") {
+            anyhow::bail!("Archived or deleted apps cannot be edited");
+        }
+
+        let channel_config = req.channel_config.unwrap_or_default();
+        let (stored_plaintext, encrypted) = self.prepare_channel_config(&channel_config)?;
+
+        let channel_uuid = Uuid::now_v7();
+        let channel_public_id = AppChannelId::from_uuid(channel_uuid);
+        let input = CreateAppChannelRow {
+            public_id: channel_public_id.to_string(),
+            channel_type: req.channel_type.to_string(),
+            channel_config: stored_plaintext,
+            channel_config_encrypted: encrypted,
+            enabled: req.enabled.unwrap_or(true),
+        };
+        let row = self.db.create_app_channel(app.id, input).await?;
+        Ok(self.channel_row_to_channel(row))
+    }
+
+    #[policy(APP_MANAGE)]
+    pub async fn update_channel(
+        &self,
+        caller: &Caller,
+        app_public_id: &str,
+        channel_public_id: &str,
+        req: UpdateChannelRequest,
+    ) -> Result<Option<AppChannel>> {
+        let app = self
+            .db
+            .get_app_by_public_id(caller.org_id, app_public_id)
+            .await?
+            .ok_or_else(|| ResourceNotFoundError::new("App"))?;
+        if !matches!(app.status.as_str(), "draft" | "published") {
+            anyhow::bail!("Archived or deleted apps cannot be edited");
+        }
+
+        let channel_row = self
+            .db
+            .get_app_channel_by_public_id(channel_public_id)
+            .await?
+            .ok_or_else(|| ResourceNotFoundError::new("Channel"))?;
+        if channel_row.app_id != app.id {
+            anyhow::bail!("Channel does not belong to this app");
+        }
+
+        let (channel_config, channel_config_encrypted) = if let Some(config) = req.channel_config {
+            let (stored, encrypted) = self.prepare_channel_config(&config)?;
+            (Some(stored), encrypted)
+        } else {
+            (None, None)
+        };
+
+        let input = UpdateAppChannel {
+            channel_type: req.channel_type.map(|ct| ct.to_string()),
+            channel_config,
+            channel_config_encrypted,
+            enabled: req.enabled,
+        };
+
+        let row = self.db.update_app_channel(channel_row.id, input).await?;
+        Ok(row.map(|r| self.channel_row_to_channel(r)))
+    }
+
+    #[policy(APP_MANAGE)]
+    pub async fn delete_channel(
+        &self,
+        caller: &Caller,
+        app_public_id: &str,
+        channel_public_id: &str,
+    ) -> Result<bool> {
+        let app = self
+            .db
+            .get_app_by_public_id(caller.org_id, app_public_id)
+            .await?
+            .ok_or_else(|| ResourceNotFoundError::new("App"))?;
+        if !matches!(app.status.as_str(), "draft" | "published") {
+            anyhow::bail!("Archived or deleted apps cannot be edited");
+        }
+
+        let channel_row = self
+            .db
+            .get_app_channel_by_public_id(channel_public_id)
+            .await?
+            .ok_or_else(|| ResourceNotFoundError::new("Channel"))?;
+        if channel_row.app_id != app.id {
+            anyhow::bail!("Channel does not belong to this app");
+        }
+
+        self.db.delete_app_channel(channel_row.id).await
+    }
+
+    // ============================================
+    // Lifecycle
+    // ============================================
 
     #[policy(APP_DANGEROUS)]
     pub async fn delete(&self, caller: &Caller, public_id: &str) -> Result<bool> {
@@ -401,11 +508,13 @@ impl AppService {
         }
     }
 
+    // ============================================
+    // Row conversions
+    // ============================================
+
     async fn row_to_app(&self, row: AppRow, org_id: i64) -> App {
-        // Harness uses HarnessId directly (no dual-ID pattern)
         let harness_id = HarnessId::from_uuid(row.harness_id);
 
-        // Agent uses dual-ID pattern — resolve internal UUID to public_id
         let agent_id = self
             .db
             .get_agent_public_id(org_id, AgentId::from_uuid(row.agent_id))
@@ -420,6 +529,13 @@ impl AppService {
             .parse()
             .unwrap_or_else(|_| AppId::from_uuid(row.id));
 
+        // Load channels from app_channels table
+        let channel_rows = self.db.list_app_channels(row.id).await.unwrap_or_default();
+        let channels: Vec<AppChannel> = channel_rows
+            .into_iter()
+            .map(|ch| self.channel_row_to_channel(ch))
+            .collect();
+
         App {
             public_id,
             internal_id: row.id,
@@ -429,18 +545,34 @@ impl AppService {
             harness_id,
             agent_id,
             agent_identity_id: row.agent_identity_id.map(AgentIdentityId::from_uuid),
-            channel_type: ChannelType::from_str_opt(&row.channel_type)
-                .unwrap_or(ChannelType::Slack),
-            channel_config: self.decrypt_channel_config(
-                row.channel_config_encrypted.as_deref(),
-                &row.channel_config,
-            ),
+            channels,
             status: AppStatus::from(row.status.as_str()),
             published_at: row.published_at,
             created_at: row.created_at,
             updated_at: row.updated_at,
             archived_at: row.archived_at,
             deleted_at: row.deleted_at,
+        }
+    }
+
+    fn channel_row_to_channel(&self, row: AppChannelRow) -> AppChannel {
+        let public_id: AppChannelId = row
+            .public_id
+            .parse()
+            .unwrap_or_else(|_| AppChannelId::from_uuid(row.id));
+
+        let channel_config = self
+            .decrypt_channel_config(row.channel_config_encrypted.as_deref(), &row.channel_config);
+
+        AppChannel {
+            public_id,
+            internal_id: row.id,
+            channel_type: ChannelType::from_str_opt(&row.channel_type)
+                .unwrap_or(ChannelType::Slack),
+            channel_config,
+            enabled: row.enabled,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
         }
     }
 }

--- a/crates/server/src/slack_delivery.rs
+++ b/crates/server/src/slack_delivery.rs
@@ -357,7 +357,11 @@ impl SlackDeliveryDispatcher {
                 }
             };
 
-            let slack_config = match app.slack_config() {
+            let slack_channel = match app.slack_channel() {
+                Some(ch) => ch,
+                None => continue,
+            };
+            let slack_config = match slack_channel.slack_config() {
                 Some(cfg) => cfg,
                 None => continue,
             };

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -1860,4 +1860,39 @@ impl StorageBackend {
     pub async fn destroy_app(&self, org_id: i64, id: Uuid) -> Result<bool> {
         dispatch!(self, destroy_app, org_id, id)
     }
+
+    // ============================================
+    // App Channel CRUD
+    // ============================================
+
+    pub async fn create_app_channel(
+        &self,
+        app_id: Uuid,
+        input: CreateAppChannelRow,
+    ) -> Result<AppChannelRow> {
+        dispatch!(self, create_app_channel, app_id, input)
+    }
+
+    pub async fn list_app_channels(&self, app_id: Uuid) -> Result<Vec<AppChannelRow>> {
+        dispatch!(self, list_app_channels, app_id)
+    }
+
+    pub async fn get_app_channel_by_public_id(
+        &self,
+        public_id: &str,
+    ) -> Result<Option<AppChannelRow>> {
+        dispatch!(self, get_app_channel_by_public_id, public_id)
+    }
+
+    pub async fn update_app_channel(
+        &self,
+        id: Uuid,
+        input: UpdateAppChannel,
+    ) -> Result<Option<AppChannelRow>> {
+        dispatch!(self, update_app_channel, id, input)
+    }
+
+    pub async fn delete_app_channel(&self, id: Uuid) -> Result<bool> {
+        dispatch!(self, delete_app_channel, id)
+    }
 }

--- a/crates/server/src/storage/encryption.rs
+++ b/crates/server/src/storage/encryption.rs
@@ -401,6 +401,12 @@ pub const ENCRYPTED_COLUMNS: &[EncryptedColumn] = &[
         column: "channel_config_encrypted",
         id_column: "id",
     },
+    // App channel config (multi-channel) — same secrets, per-channel
+    EncryptedColumn {
+        table: "app_channels",
+        column: "channel_config_encrypted",
+        id_column: "id",
+    },
     // Agent identity connection access tokens are encrypted at rest
     EncryptedColumn {
         table: "agent_identity_connections",

--- a/crates/server/src/storage/memory/app_channels.rs
+++ b/crates/server/src/storage/memory/app_channels.rs
@@ -1,0 +1,86 @@
+// In-memory storage: App Channel CRUD
+
+use super::super::models::*;
+use super::InMemoryDatabase;
+use anyhow::Result;
+use uuid::Uuid;
+
+impl InMemoryDatabase {
+    // ============================================
+    // App Channel CRUD
+    // ============================================
+
+    pub async fn create_app_channel(
+        &self,
+        app_id: Uuid,
+        input: CreateAppChannelRow,
+    ) -> Result<AppChannelRow> {
+        let now = Self::now();
+        let id = Uuid::now_v7();
+        let row = AppChannelRow {
+            id,
+            app_id,
+            public_id: input.public_id,
+            channel_type: input.channel_type,
+            channel_config: input.channel_config,
+            channel_config_encrypted: input.channel_config_encrypted,
+            enabled: input.enabled,
+            created_at: now,
+            updated_at: now,
+        };
+        self.app_channels.write().insert(id, row.clone());
+        Ok(row)
+    }
+
+    pub async fn list_app_channels(&self, app_id: Uuid) -> Result<Vec<AppChannelRow>> {
+        let channels = self.app_channels.read();
+        let mut result: Vec<AppChannelRow> = channels
+            .values()
+            .filter(|ch| ch.app_id == app_id)
+            .cloned()
+            .collect();
+        result.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        Ok(result)
+    }
+
+    pub async fn get_app_channel_by_public_id(
+        &self,
+        public_id: &str,
+    ) -> Result<Option<AppChannelRow>> {
+        let channels = self.app_channels.read();
+        Ok(channels
+            .values()
+            .find(|ch| ch.public_id == public_id)
+            .cloned())
+    }
+
+    pub async fn update_app_channel(
+        &self,
+        id: Uuid,
+        input: UpdateAppChannel,
+    ) -> Result<Option<AppChannelRow>> {
+        let mut channels = self.app_channels.write();
+        let Some(ch) = channels.get_mut(&id) else {
+            return Ok(None);
+        };
+        if let Some(channel_type) = input.channel_type {
+            ch.channel_type = channel_type;
+        }
+        if let Some(channel_config) = input.channel_config {
+            ch.channel_config = channel_config;
+        }
+        if let Some(encrypted) = input.channel_config_encrypted {
+            ch.channel_config_encrypted = Some(encrypted);
+        }
+        if let Some(enabled) = input.enabled {
+            ch.enabled = enabled;
+        }
+        ch.updated_at = Self::now();
+        Ok(Some(ch.clone()))
+    }
+
+    pub async fn delete_app_channel(&self, id: Uuid) -> Result<bool> {
+        let mut channels = self.app_channels.write();
+        Ok(channels.remove(&id).is_some())
+    }
+}

--- a/crates/server/src/storage/memory/mod.rs
+++ b/crates/server/src/storage/memory/mod.rs
@@ -10,6 +10,7 @@
 mod agent_identities;
 mod agent_identity_connections;
 mod agents;
+mod app_channels;
 mod apps;
 mod audit_logs;
 mod auth;
@@ -116,6 +117,8 @@ pub struct InMemoryDatabase {
     audit_logs: RwLock<Vec<AuditLogRow>>,
     // Apps (deployable agent+harness bundles)
     apps: RwLock<HashMap<Uuid, AppRow>>,
+    // App channels (distribution channels per app)
+    app_channels: RwLock<HashMap<Uuid, AppChannelRow>>,
     // Agent identities (virtual principals)
     agent_identities: RwLock<HashMap<AgentIdentityId, AgentIdentityRow>>,
     // Agent identity connections (identity-scoped external accounts)
@@ -176,6 +179,7 @@ impl Default for InMemoryDatabase {
             leased_resources: RwLock::new(HashMap::new()),
             audit_logs: RwLock::new(Vec::new()),
             apps: RwLock::new(HashMap::new()),
+            app_channels: RwLock::new(HashMap::new()),
             agent_identities: RwLock::new(HashMap::new()),
             agent_identity_connections: RwLock::new(HashMap::new()),
             org_settings: RwLock::new(HashMap::new()),

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -1348,3 +1348,40 @@ pub struct UpdateApp {
     pub status: Option<String>,
     pub published_at: UpdateField<DateTime<Utc>>,
 }
+
+// ============================================
+// App Channel models
+// ============================================
+
+/// App channel row from database
+#[derive(Debug, Clone, FromRow)]
+pub struct AppChannelRow {
+    pub id: Uuid,
+    pub app_id: Uuid,
+    pub public_id: String,
+    pub channel_type: String,
+    pub channel_config: serde_json::Value,
+    pub channel_config_encrypted: Option<Vec<u8>>,
+    pub enabled: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Input for creating an app channel
+#[derive(Debug, Clone)]
+pub struct CreateAppChannelRow {
+    pub public_id: String,
+    pub channel_type: String,
+    pub channel_config: serde_json::Value,
+    pub channel_config_encrypted: Option<Vec<u8>>,
+    pub enabled: bool,
+}
+
+/// Input for updating an app channel
+#[derive(Debug, Clone, Default)]
+pub struct UpdateAppChannel {
+    pub channel_type: Option<String>,
+    pub channel_config: Option<serde_json::Value>,
+    pub channel_config_encrypted: Option<Vec<u8>>,
+    pub enabled: Option<bool>,
+}

--- a/crates/server/src/storage/repositories/app_channels.rs
+++ b/crates/server/src/storage/repositories/app_channels.rs
@@ -1,0 +1,108 @@
+// PostgreSQL repository: App Channel CRUD
+
+use super::super::models::*;
+use super::Database;
+use anyhow::Result;
+use uuid::Uuid;
+
+impl Database {
+    // ============================================
+    // App Channel CRUD
+    // ============================================
+
+    pub async fn create_app_channel(
+        &self,
+        app_id: Uuid,
+        input: CreateAppChannelRow,
+    ) -> Result<AppChannelRow> {
+        let row = sqlx::query_as::<_, AppChannelRow>(
+            r#"
+            INSERT INTO app_channels (app_id, public_id, channel_type, channel_config, channel_config_encrypted, enabled)
+            VALUES ($1, $2, $3, $4, $5, $6)
+            RETURNING id, app_id, public_id, channel_type, channel_config, channel_config_encrypted, enabled, created_at, updated_at
+            "#,
+        )
+        .bind(app_id)
+        .bind(&input.public_id)
+        .bind(&input.channel_type)
+        .bind(&input.channel_config)
+        .bind(&input.channel_config_encrypted)
+        .bind(input.enabled)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    pub async fn list_app_channels(&self, app_id: Uuid) -> Result<Vec<AppChannelRow>> {
+        let rows = sqlx::query_as::<_, AppChannelRow>(
+            r#"
+            SELECT id, app_id, public_id, channel_type, channel_config, channel_config_encrypted, enabled, created_at, updated_at
+            FROM app_channels
+            WHERE app_id = $1
+            ORDER BY created_at ASC
+            "#,
+        )
+        .bind(app_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
+    pub async fn get_app_channel_by_public_id(
+        &self,
+        public_id: &str,
+    ) -> Result<Option<AppChannelRow>> {
+        let row = sqlx::query_as::<_, AppChannelRow>(
+            r#"
+            SELECT id, app_id, public_id, channel_type, channel_config, channel_config_encrypted, enabled, created_at, updated_at
+            FROM app_channels
+            WHERE public_id = $1
+            "#,
+        )
+        .bind(public_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    pub async fn update_app_channel(
+        &self,
+        id: Uuid,
+        input: UpdateAppChannel,
+    ) -> Result<Option<AppChannelRow>> {
+        let row = sqlx::query_as::<_, AppChannelRow>(
+            r#"
+            UPDATE app_channels
+            SET
+                channel_type = COALESCE($2, channel_type),
+                channel_config = COALESCE($3, channel_config),
+                channel_config_encrypted = COALESCE($4, channel_config_encrypted),
+                enabled = COALESCE($5, enabled),
+                updated_at = NOW()
+            WHERE id = $1
+            RETURNING id, app_id, public_id, channel_type, channel_config, channel_config_encrypted, enabled, created_at, updated_at
+            "#,
+        )
+        .bind(id)
+        .bind(&input.channel_type)
+        .bind(&input.channel_config)
+        .bind(&input.channel_config_encrypted)
+        .bind(input.enabled)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    pub async fn delete_app_channel(&self, id: Uuid) -> Result<bool> {
+        let result = sqlx::query("DELETE FROM app_channels WHERE id = $1")
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+}

--- a/crates/server/src/storage/repositories/mod.rs
+++ b/crates/server/src/storage/repositories/mod.rs
@@ -4,6 +4,7 @@
 mod agent_identities;
 mod agent_identity_connections;
 mod agents;
+mod app_channels;
 mod apps;
 mod audit_logs;
 mod auth;

--- a/specs/apps.md
+++ b/specs/apps.md
@@ -8,18 +8,27 @@ An App is a deployable unit that binds a Harness and Agent to a distribution cha
 
 ### App
 
-Top-level deployment entity. Composes existing building blocks (Harness, Agent) with channel-specific configuration.
+Top-level deployment entity. Composes existing building blocks (Harness, Agent) with one or more distribution channels.
 
 - Each App references exactly one Harness (required)
 - Each App references exactly one Agent (required)
-- Each App has a channel type and channel-specific config (JSON)
+- Each App has zero or more **Channels** (stored in `app_channels` table)
 - Apps have a publish lifecycle: `draft` → `published` → `draft`
 - Apps also participate in the default building-block lifecycle: `active/draft/published -> archived -> deleted`
 - Only published apps accept incoming requests
 
+### App Channel
+
+A distribution channel attached to an App. Each channel has its own type, config, and enabled flag.
+
+- Stored in `app_channels` table (one-to-many with `apps`)
+- Uses dual-ID pattern: `appchan_` prefix
+- Creating an App with `channel_type` creates the first channel automatically
+- Channels can be added, updated, or removed via `/v1/apps/{app_id}/channels`
+
 ### Channel Types
 
-Initially: `slack`. Future: `whatsapp`, `web_widget`, `api_endpoint`, etc.
+Initially: `slack`. Future: `whatsapp`, `web_widget`, `api_endpoint`, `discord`, etc.
 
 Channel config is stored as JSONB and validated at the application layer per channel type.
 
@@ -71,12 +80,17 @@ Key fields:
 - `description`: Optional
 - `harness_id`: Required FK to harness
 - `agent_id`: Required FK to agent
-- `channel_type`: Enum string (`slack`, etc.)
-- `channel_config`: JSONB with channel-specific settings
-- Slack `channel_config.reply_mode`: `all_messages` or `report_progress_only`
+- `channels`: Vec of `AppChannel` (loaded from `app_channels` table)
 - `status`: `draft` | `published` | `archived` | `deleted`
 - `archived_at`, `deleted_at`: Lifecycle timestamps
 - `published_at`: Timestamp when last published
+- `created_at`, `updated_at`: Standard timestamps
+
+AppChannel fields:
+- `id` / `public_id`: Dual-ID pattern, prefix `appchan_`
+- `channel_type`: Enum string (`slack`, etc.)
+- `channel_config`: JSONB with channel-specific settings
+- `enabled`: Whether the channel is active
 - `created_at`, `updated_at`: Standard timestamps
 
 ## API
@@ -93,9 +107,13 @@ All endpoints under `/v1/apps`. See `crates/server/src/api/apps.rs`.
 | POST | `/v1/apps/{app_id}/delete` | Dangerous delete of archived app |
 | POST | `/v1/apps/{app_id}/publish` | Publish app |
 | POST | `/v1/apps/{app_id}/unpublish` | Unpublish app |
+| POST | `/v1/apps/{app_id}/channels` | Add a channel |
+| PATCH | `/v1/apps/{app_id}/channels/{channel_id}` | Update a channel |
+| DELETE | `/v1/apps/{app_id}/channels/{channel_id}` | Remove a channel |
 
 ## ID Schema
 
 | Entity | Prefix | Example |
 |--------|--------|---------|
 | App | `app_` | `app_01933b5a00007000800000000000001` |
+| App Channel | `appchan_` | `appchan_01933b5a00007000800000000000002` |

--- a/specs/messaging-integrations.md
+++ b/specs/messaging-integrations.md
@@ -101,7 +101,7 @@ crates/server/src/
       types.rs          — Slack-specific types (event envelope, file, attachment)
 ```
 
-Core abstraction types remain in `crates/core/src/channel.rs`. Platform-specific channel configs (e.g. `SlackChannelConfig`) remain in `crates/core/src/app.rs`.
+Core abstraction types remain in `crates/core/src/channel.rs`. Platform-specific channel configs (e.g. `SlackChannelConfig`) remain in `crates/core/src/app.rs`. Each `AppChannel` holds its own `channel_type` and `channel_config`, enabling multiple channels per app (e.g. two Slack bots, or Slack + future Discord).
 
 ## Concrete Implementations
 


### PR DESCRIPTION
## What
Extract channel configuration from the `apps` table into a separate `app_channels` table with a one-to-many relationship. An App can now have multiple distribution channels (e.g. two Slack bots, or Slack + future Discord).

## Why
Previously each App was limited to exactly one channel — `channel_type` and `channel_config` were scalar columns on the `apps` table. This made it impossible to expose a single agent as two Slack bots or across different messaging platforms within one App.

## How
- **New `AppChannelId` typed ID** (`appchan_` prefix) in `crates/core/src/typed_id.rs`
- **New `AppChannel` model** on `App.channels: Vec<AppChannel>` replacing the old `channel_type`/`channel_config` scalars
- **Migration 013**: creates `app_channels` table, copies existing channel data from `apps`, adds indexes and FK with `ON DELETE CASCADE`
- **Storage layer**: new `AppChannelRow`, `CreateAppChannelRow`, `UpdateAppChannel` models; PostgreSQL + in-memory CRUD; `StorageBackend` dispatch
- **AppService**: `add_channel`, `update_channel`, `delete_channel` methods with encryption support; `row_to_app` loads channels from `app_channels` with legacy fallback
- **API**: new sub-routes `POST/PATCH/DELETE /v1/apps/{app_id}/channels/{channel_id}`
- **Slack handlers**: `slack_events.rs` uses `app.slack_channel()` instead of direct field access; config updates route through `AppService::update_channel_config_unscoped()` for proper encrypt/redact
- **UI**: detail page renders per-channel cards with edit/delete; "Add Channel" button; types updated with `AppChannel` interface
- **Specs**: updated `apps.md`, `messaging-integrations.md`
- **Encryption**: `app_channels.channel_config_encrypted` registered in encryption registry

## Risk
- Medium
- Existing apps: migration copies channel data; backward compat maintained (legacy `channel_type`/`channel_config` columns kept in DB). `row_to_app` synthesizes a channel from legacy columns if no `app_channels` rows exist (incomplete migration/DB restore).
- Slack webhook handler resolves config from `app_channels` via `app.slack_channel()` (first enabled Slack channel). Multi-Slack routing (channel_id in webhook URL) is a follow-up.

## Security
- Threat categories reviewed: TM-API, TM-AUTHZ, TM-TENANT, TM-SQL, TM-AUTH
- All new channel endpoints enforce `#[policy(APP_MANAGE)]` (requires `OrgAgentsManage` permission)
- Channel operations verify org scoping via `get_app_by_public_id(caller.org_id, ...)` + cross-check `channel_row.app_id != app.id`
- All SQL queries use parameterized statements (sqlx `$N` placeholders)
- Slack signing secret verification preserved — now loaded from `AppChannel.channel_config` via `app.slack_channel()`
- Webhook timestamp updates route through `update_channel_config_unscoped()` which encrypts/redacts before writing
- `public_id` format enforced via CHECK constraint (`'^appchan_[0-9a-f]{32}$'`)
- No new dependencies added

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
