### PR TITLE
feat(ci): auto-update Homebrew formula after CLI releases

### DIFF
--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -24,6 +24,9 @@ jobs:
           - target: aarch64-apple-darwin
             runner: macos-latest
             archive: everruns-aarch64-apple-darwin.tar.gz
+          - target: x86_64-apple-darwin
+            runner: macos-13
+            archive: everruns-x86_64-apple-darwin.tar.gz
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-latest
             archive: everruns-x86_64-unknown-linux-gnu.tar.gz
@@ -61,3 +64,92 @@ jobs:
             "${{ matrix.archive }}" \
             "${{ matrix.archive }}.sha256" \
             --clobber
+
+  update-homebrew:
+    name: Update Homebrew formula
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download SHA256 checksums from release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ inputs.tag }}"
+          for target in aarch64-apple-darwin x86_64-apple-darwin x86_64-unknown-linux-gnu; do
+            gh release download "$TAG" \
+              --repo everruns/everruns \
+              --pattern "everruns-${target}.tar.gz.sha256"
+          done
+
+      - name: Generate Homebrew formula
+        run: |
+          TAG="${{ inputs.tag }}"
+          VERSION="${TAG#v}"
+
+          SHA_ARM64=$(awk '{print $1}' everruns-aarch64-apple-darwin.tar.gz.sha256)
+          SHA_X86_64_MACOS=$(awk '{print $1}' everruns-x86_64-apple-darwin.tar.gz.sha256)
+          SHA_LINUX=$(awk '{print $1}' everruns-x86_64-unknown-linux-gnu.tar.gz.sha256)
+
+          BASE_URL="https://github.com/everruns/everruns/releases/download/${TAG}"
+
+          cat > everruns.rb <<FORMULA
+          # typed: false
+          # frozen_string_literal: true
+
+          class Everruns < Formula
+            desc "Open-source AI agent platform"
+            homepage "https://github.com/everruns/everruns"
+            version "${VERSION}"
+            license "Apache-2.0"
+
+            on_macos do
+              if Hardware::CPU.arm?
+                url "${BASE_URL}/everruns-aarch64-apple-darwin.tar.gz"
+                sha256 "${SHA_ARM64}"
+              else
+                url "${BASE_URL}/everruns-x86_64-apple-darwin.tar.gz"
+                sha256 "${SHA_X86_64_MACOS}"
+              end
+            end
+
+            on_linux do
+              if Hardware::CPU.intel?
+                url "${BASE_URL}/everruns-x86_64-unknown-linux-gnu.tar.gz"
+                sha256 "${SHA_LINUX}"
+              end
+            end
+
+            def install
+              bin.install "everruns"
+            end
+
+            test do
+              assert_match version.to_s, shell_output("#{bin}/everruns --version")
+            end
+          end
+          FORMULA
+
+          # Remove leading whitespace from heredoc
+          sed -i 's/^          //' everruns.rb
+
+          echo "Generated formula:"
+          cat everruns.rb
+
+      - name: Push formula to homebrew-tap
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          TAG="${{ inputs.tag }}"
+          VERSION="${TAG#v}"
+
+          # Clone the tap repo
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/everruns/homebrew-tap.git" tap
+          cp everruns.rb tap/Formula/everruns.rb
+
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/everruns.rb
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          git commit -m "everruns ${VERSION}"
+          git push origin main

--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -69,6 +69,8 @@ jobs:
     name: Update Homebrew formula
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Download SHA256 checksums from release
         env:
@@ -77,7 +79,7 @@ jobs:
           TAG="${{ inputs.tag }}"
           for target in aarch64-apple-darwin x86_64-apple-darwin x86_64-unknown-linux-gnu; do
             gh release download "$TAG" \
-              --repo everruns/everruns \
+              --repo "${{ github.repository }}" \
               --pattern "everruns-${target}.tar.gz.sha256"
           done
 
@@ -86,11 +88,28 @@ jobs:
           TAG="${{ inputs.tag }}"
           VERSION="${TAG#v}"
 
+          # Validate checksum files exist and are non-empty
+          for f in everruns-aarch64-apple-darwin.tar.gz.sha256 \
+                   everruns-x86_64-apple-darwin.tar.gz.sha256 \
+                   everruns-x86_64-unknown-linux-gnu.tar.gz.sha256; do
+            if [[ ! -s "$f" ]]; then
+              echo "Error: checksum file '$f' is missing or empty." >&2
+              exit 1
+            fi
+          done
+
           SHA_ARM64=$(awk '{print $1}' everruns-aarch64-apple-darwin.tar.gz.sha256)
           SHA_X86_64_MACOS=$(awk '{print $1}' everruns-x86_64-apple-darwin.tar.gz.sha256)
           SHA_LINUX=$(awk '{print $1}' everruns-x86_64-unknown-linux-gnu.tar.gz.sha256)
 
-          BASE_URL="https://github.com/everruns/everruns/releases/download/${TAG}"
+          for var in SHA_ARM64 SHA_X86_64_MACOS SHA_LINUX; do
+            if [[ -z "${!var}" ]]; then
+              echo "Error: extracted $var is empty." >&2
+              exit 1
+            fi
+          done
+
+          BASE_URL="${{ github.server_url }}/${{ github.repository }}/releases/download/${TAG}"
 
           cat > everruns.rb <<FORMULA
           # typed: false
@@ -98,7 +117,7 @@ jobs:
 
           class Everruns < Formula
             desc "Open-source AI agent platform"
-            homepage "https://github.com/everruns/everruns"
+            homepage "${{ github.server_url }}/${{ github.repository }}"
             version "${VERSION}"
             license "Apache-2.0"
 
@@ -113,10 +132,9 @@ jobs:
             end
 
             on_linux do
-              if Hardware::CPU.intel?
-                url "${BASE_URL}/everruns-x86_64-unknown-linux-gnu.tar.gz"
-                sha256 "${SHA_LINUX}"
-              end
+              depends_on arch: :x86_64
+              url "${BASE_URL}/everruns-x86_64-unknown-linux-gnu.tar.gz"
+              sha256 "${SHA_LINUX}"
             end
 
             def install

--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -135,15 +135,21 @@ jobs:
           echo "Generated formula:"
           cat everruns.rb
 
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@v3
+
       - name: Push formula to homebrew-tap
         env:
-          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: |
           TAG="${{ inputs.tag }}"
           VERSION="${TAG#v}"
 
+          # Fetch the GitHub PAT from Doppler (has push access to homebrew-tap)
+          GH_PAT=$(doppler secrets get GITHUB_TOKEN --plain)
+
           # Clone the tap repo
-          git clone "https://x-access-token:${GH_TOKEN}@github.com/everruns/homebrew-tap.git" tap
+          git clone "https://x-access-token:${GH_PAT}@github.com/everruns/homebrew-tap.git" tap
           cp everruns.rb tap/Formula/everruns.rb
 
           cd tap

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -83,7 +83,7 @@ Each archive contains the `everruns` binary. SHA-256 checksums (`.sha256` files)
 
 After all CLI binaries are built and uploaded, the `Publish CLI Binaries` workflow automatically updates the Homebrew formula at `everruns/homebrew-tap`. It downloads the SHA-256 checksums from the release, generates an updated `Formula/everruns.rb`, and pushes it to the tap repository.
 
-**Requires:** A `HOMEBREW_TAP_TOKEN` repository secret with push access to `everruns/homebrew-tap`.
+**Auth:** Uses the `GITHUB_TOKEN` PAT from Doppler (via `DOPPLER_TOKEN` secret), which has push access to `everruns/homebrew-tap`.
 
 ### Docker Image Tagging
 

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -79,6 +79,12 @@ The `Publish CLI Binaries` workflow builds and attaches pre-built CLI binaries t
 
 Each archive contains the `everruns` binary. SHA-256 checksums (`.sha256` files) are included for verification. These assets are used by the Homebrew formula for installation.
 
+### Homebrew Formula Update
+
+After all CLI binaries are built and uploaded, the `Publish CLI Binaries` workflow automatically updates the Homebrew formula at `everruns/homebrew-tap`. It downloads the SHA-256 checksums from the release, generates an updated `Formula/everruns.rb`, and pushes it to the tap repository.
+
+**Requires:** A `HOMEBREW_TAP_TOKEN` repository secret with push access to `everruns/homebrew-tap`.
+
 ### Docker Image Tagging
 
 | Event | Tags Generated |


### PR DESCRIPTION
## What
Add an `update-homebrew` job to the `Publish CLI Binaries` workflow that automatically generates and pushes an updated Homebrew formula to `everruns/homebrew-tap` after CLI binaries are built.

Also adds an `x86_64-apple-darwin` (Intel Mac) build target to the matrix.

## Why
Currently the Homebrew formula must be updated manually after each release. This automates the entire flow: download checksums from the release, generate the formula with correct SHAs, and push to the tap repo.

## How
- New `update-homebrew` job in `.github/workflows/cli-binaries.yml` that runs after all `build` jobs complete
- Downloads `.sha256` files from the GitHub release
- Generates `Formula/everruns.rb` with platform-specific URLs and checksums (arm64 macOS, x86_64 macOS, x86_64 Linux)
- Uses Doppler to fetch `GITHUB_TOKEN` PAT with push access to `everruns/homebrew-tap`
- Pushes the updated formula to the tap repo's main branch
- Updated `specs/release-process.md` to document the new automation

## Risk
- Low
- If Doppler token or PAT is misconfigured, the homebrew update step fails but binary uploads still succeed (separate job)

## Security
- Threat categories reviewed: TM-AUTH (secret handling in CI)
- Secrets (`DOPPLER_TOKEN`, `GITHUB_TOKEN`) passed via `env:` blocks, never logged. PAT fetched at runtime from Doppler, used only in git clone URL within ephemeral CI runner. No new application threat surface.

## Checklist
- [x] Tests added or updated (CI workflow — validated by running the workflow)
- [x] Backward compatibility considered (additive change, existing build job unchanged)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)