### PR TITLE
feat(memory): add persistent cross-session memory capability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,7 @@ Always make sure you are working on top of latest main from remote.
 - `specs/bashkit-requirements.md` - Bash sandbox capabilities and requirements
 - `specs/events-contract.md` - SSE event format contract
 - `specs/maintenance.md` - Goal-oriented maintenance and release-readiness guidance
+- `specs/memory.md` - Persistent cross-session memory (multi-store, capacity limits, multicontent recall)
 - `specs/shipping.md` - Goal-oriented shipping and merge-readiness guidance
 - `specs/xml-prompt-formatting.md` - XML tags for system prompt structure
 - `specs/skills-registry.md` - Agent Skills registry (agentskills.io format)

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -171,6 +171,10 @@ where
     leased_resource_store: Option<Arc<dyn crate::traits::LeasedResourceStore>>,
     /// Optional capability registry for blueprint lookups in subagent tools
     capability_registry: Option<crate::capabilities::CapabilityRegistry>,
+    /// Optional memory store backend for persistent cross-session memory.
+    memory_store: Option<Arc<dyn crate::memory_store::MemoryStoreBackend>>,
+    /// Optional org ID for org-scoped operations.
+    org_id: Option<crate::typed_id::OrgId>,
     /// Post-act hooks that run after tool execution completes.
     /// Hooks inspect the result and may emit events (e.g. tool.call_requested).
     hooks: Vec<Box<dyn PostActHook>>,
@@ -197,6 +201,8 @@ where
             platform_store: None,
             leased_resource_store: None,
             capability_registry: None,
+            memory_store: None,
+            org_id: None,
             hooks: Self::default_hooks(),
         }
     }
@@ -221,6 +227,8 @@ where
             platform_store: None,
             leased_resource_store: None,
             capability_registry: None,
+            memory_store: None,
+            org_id: None,
             hooks: Self::default_hooks(),
         }
     }
@@ -314,6 +322,21 @@ where
         registry: crate::capabilities::CapabilityRegistry,
     ) -> Self {
         self.capability_registry = Some(registry);
+        self
+    }
+
+    /// Set memory store backend for persistent cross-session memory tools.
+    pub fn with_memory_store(
+        mut self,
+        store: Arc<dyn crate::memory_store::MemoryStoreBackend>,
+    ) -> Self {
+        self.memory_store = Some(store);
+        self
+    }
+
+    /// Set org ID for org-scoped operations.
+    pub fn with_org_id(mut self, org_id: crate::typed_id::OrgId) -> Self {
+        self.org_id = Some(org_id);
         self
     }
 }
@@ -730,6 +753,10 @@ where
         if let Some(ref registry) = self.capability_registry {
             tool_context.capability_registry = Some(registry.clone());
         }
+        if let Some(ref store) = self.memory_store {
+            tool_context.memory_store = Some(store.clone());
+        }
+        tool_context.org_id = self.org_id;
         // Provide event emitter + context so tools can emit tool.progress events
         tool_context.event_emitter = Some(self.event_emitter.clone() as Arc<dyn EventEmitter>);
         tool_context.event_context = Some(event_context.clone());

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -86,6 +86,7 @@ pub mod mcp;
 mod noop;
 mod openai_tool_search;
 mod openui;
+pub mod persistent_memory;
 mod platform_management;
 mod research;
 mod sample_data;
@@ -159,6 +160,9 @@ pub use openai_tool_search::{
     DEFAULT_TOOL_SEARCH_THRESHOLD, OPENAI_TOOL_SEARCH_CAPABILITY_ID, OpenAiToolSearchCapability,
 };
 pub use openui::{OPENUI_CAPABILITY_ID, OpenUiCapability};
+pub use persistent_memory::{
+    ForgetTool, MEMORY_CAPABILITY_ID, MemoryCapability, MemoryConfig, RecallTool, RememberTool,
+};
 pub use platform_management::{
     ManageAgentsTool, ManageHarnessesTool, ManageSessionsTool, PlatformManagementCapability,
     ReadAgentsTool, ReadCapabilitiesTool, ReadHarnessesTool, ReadSessionsTool,
@@ -614,6 +618,7 @@ impl CapabilityRegistry {
         registry.register(SessionScheduleCapability);
         registry.register(InfinityContextCapability);
         registry.register(CompactionCapability);
+        registry.register(MemoryCapability);
 
         // OpenAI tool_search (deferred tool loading, all environments)
         registry.register(OpenAiToolSearchCapability::new());
@@ -1339,6 +1344,7 @@ mod tests {
             "session_schedule",
             "infinity_context",
             "compaction",
+            "memory",
             "openai_tool_search",
             "skills",
             "subagents",

--- a/crates/core/src/capabilities/persistent_memory.rs
+++ b/crates/core/src/capabilities/persistent_memory.rs
@@ -1,0 +1,854 @@
+//! Persistent Memory Capability
+//!
+//! Cross-session persistent memory that agents can write to and read from.
+//! Memories are scoped to org-level memory stores, selected via capability config.
+//! See specs/memory.md for design rationale.
+
+use super::{Capability, CapabilityStatus};
+use crate::memory_store::{MemoryContentPart, MemoryKind, MemoryLimits, MemoryQuery};
+use crate::tool_types::ToolHints;
+use crate::tools::{Tool, ToolExecutionResult};
+use crate::traits::ToolContext;
+use crate::typed_id::MemoryStoreId;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+pub const MEMORY_CAPABILITY_ID: &str = "memory";
+
+// ============================================================================
+// Capability
+// ============================================================================
+
+pub struct MemoryCapability;
+
+impl Capability for MemoryCapability {
+    fn id(&self) -> &str {
+        MEMORY_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Persistent Memory"
+    }
+
+    fn description(&self) -> &str {
+        r#"Cross-session persistent memory. Agents can save and recall facts, preferences, corrections, and procedures that survive beyond individual sessions.
+
+> [!TIP]
+> Use this for agents that learn from interactions and remember user preferences, project context, or accumulated knowledge across sessions."#
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("brain")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Knowledge")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(MEMORY_SYSTEM_PROMPT)
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(RememberTool),
+            Box::new(RecallTool),
+            Box::new(ForgetTool),
+        ]
+    }
+}
+
+const MEMORY_SYSTEM_PROMPT: &str = r#"## Persistent Memory
+
+You have persistent memory across sessions via `remember`, `recall`, and `forget` tools.
+Use `remember` to save important facts, user preferences, corrections, or procedures.
+Use `recall` to search your memory before answering questions where prior context may help.
+Use `forget` to remove outdated or incorrect memories."#;
+
+// ============================================================================
+// Capability Config
+// ============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryConfig {
+    /// Which memory store to use (None = org default).
+    #[serde(default)]
+    pub store: Option<String>,
+    /// Number of memories to auto-inject per turn (0 = disable passive recall).
+    #[serde(default = "default_passive_recall_count")]
+    pub passive_recall_count: usize,
+}
+
+fn default_passive_recall_count() -> usize {
+    5
+}
+
+impl Default for MemoryConfig {
+    fn default() -> Self {
+        Self {
+            store: None,
+            passive_recall_count: default_passive_recall_count(),
+        }
+    }
+}
+
+impl MemoryConfig {
+    pub fn from_json(value: &Value) -> Self {
+        serde_json::from_value(value.clone()).unwrap_or_default()
+    }
+}
+
+// ============================================================================
+// Helper: resolve store ID from config or default
+// ============================================================================
+
+async fn resolve_store_id(
+    config: &MemoryConfig,
+    context: &ToolContext,
+) -> Result<MemoryStoreId, ToolExecutionResult> {
+    let backend = context
+        .memory_store
+        .as_ref()
+        .ok_or_else(|| ToolExecutionResult::tool_error("Memory store not available"))?;
+
+    if let Some(ref store_str) = config.store {
+        store_str
+            .parse::<MemoryStoreId>()
+            .map_err(|_| ToolExecutionResult::tool_error(format!("Invalid store ID: {store_str}")))
+    } else {
+        let org_id = context
+            .org_id
+            .ok_or_else(|| ToolExecutionResult::tool_error("Org ID not available for memory"))?;
+        let store = backend
+            .get_or_create_default_store(org_id)
+            .await
+            .map_err(|e| {
+                ToolExecutionResult::tool_error(format!("Failed to get default store: {e}"))
+            })?;
+        Ok(store.id)
+    }
+}
+
+// ============================================================================
+// Remember Tool
+// ============================================================================
+
+pub struct RememberTool;
+
+#[derive(Debug, Deserialize)]
+struct RememberParams {
+    content: String,
+    #[serde(default)]
+    kind: Option<String>,
+    #[serde(default = "default_importance")]
+    importance: u8,
+    #[serde(default)]
+    tags: Vec<String>,
+    #[serde(default)]
+    images: Vec<RememberImage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RememberImage {
+    base64: String,
+    media_type: String,
+}
+
+fn default_importance() -> u8 {
+    5
+}
+
+#[async_trait]
+impl Tool for RememberTool {
+    fn name(&self) -> &str {
+        "remember"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Remember")
+    }
+
+    fn description(&self) -> &str {
+        "Save a fact, preference, correction, or procedure to persistent memory. Memories survive across sessions."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "maxLength": 2000,
+                    "description": "1-3 sentence knowledge to persist"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": ["fact", "preference", "correction", "procedure", "context"],
+                    "default": "fact",
+                    "description": "Classification of this memory"
+                },
+                "importance": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 10,
+                    "default": 5,
+                    "description": "Importance score (1=low, 10=critical)"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "maxItems": 10,
+                    "description": "Tags for categorization and recall"
+                },
+                "images": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "base64": { "type": "string", "description": "Base64-encoded image data" },
+                            "media_type": { "type": "string", "description": "MIME type (e.g. image/png)" }
+                        },
+                        "required": ["base64", "media_type"],
+                        "additionalProperties": false
+                    },
+                    "maxItems": 4,
+                    "description": "Optional images to attach to this memory"
+                }
+            },
+            "required": ["content"],
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("remember requires session context")
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let params: RememberParams = match serde_json::from_value(arguments) {
+            Ok(p) => p,
+            Err(e) => return ToolExecutionResult::tool_error(format!("Invalid parameters: {e}")),
+        };
+
+        // Build content parts
+        let mut content_parts = vec![MemoryContentPart::text(&params.content)];
+        for img in &params.images {
+            content_parts.push(MemoryContentPart::image(&img.base64, &img.media_type));
+        }
+
+        // Validate limits
+        if let Err(e) = MemoryLimits::validate(&params.content, &params.tags, &content_parts) {
+            return ToolExecutionResult::tool_error(e);
+        }
+
+        let kind = params
+            .kind
+            .as_deref()
+            .and_then(|k| serde_json::from_value(json!(k)).ok())
+            .unwrap_or(MemoryKind::Fact);
+
+        // Parse config from empty (tools don't have direct config access, use defaults)
+        let config = MemoryConfig::default();
+        let store_id = match resolve_store_id(&config, context).await {
+            Ok(id) => id,
+            Err(e) => return e,
+        };
+
+        let backend = context.memory_store.as_ref().unwrap();
+
+        // Check capacity
+        match backend.count_active(store_id).await {
+            Ok(count) if count >= MemoryLimits::MAX_MEMORIES_PER_STORE => {
+                return ToolExecutionResult::tool_error(format!(
+                    "Memory store is full ({} active memories, limit {})",
+                    count,
+                    MemoryLimits::MAX_MEMORIES_PER_STORE
+                ));
+            }
+            Err(e) => {
+                return ToolExecutionResult::tool_error(format!("Failed to check capacity: {e}"));
+            }
+            _ => {}
+        }
+
+        match backend
+            .create_memory(
+                store_id,
+                params.content,
+                content_parts,
+                kind,
+                params.importance,
+                params.tags,
+            )
+            .await
+        {
+            Ok(memory) => ToolExecutionResult::success(json!({
+                "memory_id": memory.id.to_string(),
+                "created": true
+            })),
+            Err(e) => ToolExecutionResult::tool_error(format!("Failed to save memory: {e}")),
+        }
+    }
+}
+
+// ============================================================================
+// Recall Tool
+// ============================================================================
+
+pub struct RecallTool;
+
+#[derive(Debug, Deserialize)]
+struct RecallParams {
+    #[serde(default)]
+    query: Option<String>,
+    #[serde(default)]
+    tags: Option<Vec<String>>,
+    #[serde(default)]
+    kind: Option<String>,
+    #[serde(default = "default_recall_limit")]
+    limit: usize,
+}
+
+fn default_recall_limit() -> usize {
+    10
+}
+
+#[async_trait]
+impl Tool for RecallTool {
+    fn name(&self) -> &str {
+        "recall"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Recall Memory")
+    }
+
+    fn description(&self) -> &str {
+        "Search persistent memory by keyword, tag, or kind. Returns multicontent results including text and images."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Keyword search across memory content"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Filter by tags (AND logic)"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": ["fact", "preference", "correction", "procedure", "context"],
+                    "description": "Filter by memory kind"
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 50,
+                    "default": 10,
+                    "description": "Maximum number of memories to return"
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("recall requires session context")
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let params: RecallParams = match serde_json::from_value(arguments) {
+            Ok(p) => p,
+            Err(e) => return ToolExecutionResult::tool_error(format!("Invalid parameters: {e}")),
+        };
+
+        let config = MemoryConfig::default();
+        let store_id = match resolve_store_id(&config, context).await {
+            Ok(id) => id,
+            Err(e) => return e,
+        };
+
+        let kind: Option<MemoryKind> = params
+            .kind
+            .as_deref()
+            .and_then(|k| serde_json::from_value(json!(k)).ok());
+
+        let query = MemoryQuery {
+            store_id: Some(store_id),
+            query: params.query,
+            tags: params.tags,
+            kind,
+            limit: params.limit.min(50),
+        };
+
+        let backend = context.memory_store.as_ref().unwrap();
+        match backend.recall(query).await {
+            Ok((memories, total)) => {
+                let results: Vec<Value> = memories
+                    .iter()
+                    .map(|m| {
+                        let parts: Vec<Value> = m
+                            .content_parts
+                            .iter()
+                            .map(|p| match p {
+                                MemoryContentPart::Text(t) => json!({
+                                    "type": "text",
+                                    "text": t.text
+                                }),
+                                MemoryContentPart::Image(i) => json!({
+                                    "type": "image",
+                                    "base64": i.base64,
+                                    "media_type": i.media_type
+                                }),
+                            })
+                            .collect();
+
+                        json!({
+                            "id": m.id.to_string(),
+                            "kind": m.kind.to_string(),
+                            "importance": m.importance,
+                            "created_at": m.created_at.to_rfc3339(),
+                            "content_parts": parts,
+                            "tags": m.tags
+                        })
+                    })
+                    .collect();
+
+                ToolExecutionResult::success(json!({
+                    "memories": results,
+                    "total": total
+                }))
+            }
+            Err(e) => ToolExecutionResult::tool_error(format!("Failed to recall memories: {e}")),
+        }
+    }
+}
+
+// ============================================================================
+// Forget Tool
+// ============================================================================
+
+pub struct ForgetTool;
+
+#[derive(Debug, Deserialize)]
+struct ForgetParams {
+    memory_id: String,
+}
+
+#[async_trait]
+impl Tool for ForgetTool {
+    fn name(&self) -> &str {
+        "forget"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Forget Memory")
+    }
+
+    fn description(&self) -> &str {
+        "Deactivate a memory by ID (soft-delete). Use when a memory is outdated or incorrect."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "memory_id": {
+                    "type": "string",
+                    "description": "Memory ID to forget (e.g. mem_...)"
+                }
+            },
+            "required": ["memory_id"],
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("forget requires session context")
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let params: ForgetParams = match serde_json::from_value(arguments) {
+            Ok(p) => p,
+            Err(e) => return ToolExecutionResult::tool_error(format!("Invalid parameters: {e}")),
+        };
+
+        let memory_id = match params.memory_id.parse::<crate::typed_id::MemoryId>() {
+            Ok(id) => id,
+            Err(_) => {
+                return ToolExecutionResult::tool_error(format!(
+                    "Invalid memory ID: {}",
+                    params.memory_id
+                ));
+            }
+        };
+
+        let backend = match context.memory_store.as_ref() {
+            Some(b) => b,
+            None => return ToolExecutionResult::tool_error("Memory store not available"),
+        };
+
+        match backend.forget(memory_id).await {
+            Ok(true) => ToolExecutionResult::success(json!({
+                "forgotten": true,
+                "memory_id": params.memory_id
+            })),
+            Ok(false) => ToolExecutionResult::tool_error(format!(
+                "Memory not found or already forgotten: {}",
+                params.memory_id
+            )),
+            Err(e) => ToolExecutionResult::tool_error(format!("Failed to forget memory: {e}")),
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::InMemoryMemoryStore;
+    use crate::memory_store::MemoryStoreBackend;
+    use crate::typed_id::{MemoryId, OrgId, SessionId};
+    use std::sync::Arc;
+
+    fn test_context() -> (ToolContext, Arc<InMemoryMemoryStore>, OrgId) {
+        let session_id = SessionId::new();
+        let org_id = OrgId::new();
+        let store = Arc::new(InMemoryMemoryStore::new());
+        let ctx = ToolContext::new(session_id)
+            .with_memory_store(store.clone() as Arc<dyn MemoryStoreBackend>)
+            .with_org_id(org_id);
+        (ctx, store, org_id)
+    }
+
+    #[test]
+    fn test_capability_metadata() {
+        let cap = MemoryCapability;
+        assert_eq!(cap.id(), MEMORY_CAPABILITY_ID);
+        assert_eq!(cap.name(), "Persistent Memory");
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+        assert_eq!(cap.category(), Some("Knowledge"));
+        assert_eq!(cap.tools().len(), 3);
+        assert!(cap.system_prompt_addition().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_remember_and_recall() {
+        let (ctx, _, _) = test_context();
+
+        // Remember
+        let result = RememberTool
+            .execute_with_context(
+                json!({
+                    "content": "The project uses Rust edition 2024",
+                    "kind": "fact",
+                    "importance": 7,
+                    "tags": ["rust", "project"]
+                }),
+                &ctx,
+            )
+            .await;
+
+        match &result {
+            ToolExecutionResult::Success(v) => {
+                assert!(v["created"].as_bool().unwrap());
+                assert!(v["memory_id"].as_str().unwrap().starts_with("mem_"));
+            }
+            other => panic!("expected success, got {other:?}"),
+        }
+
+        // Recall by query
+        let result = RecallTool
+            .execute_with_context(json!({"query": "rust"}), &ctx)
+            .await;
+
+        match &result {
+            ToolExecutionResult::Success(v) => {
+                assert_eq!(v["total"], 1);
+                let memories = v["memories"].as_array().unwrap();
+                assert_eq!(memories.len(), 1);
+                let parts = memories[0]["content_parts"].as_array().unwrap();
+                assert_eq!(parts[0]["type"], "text");
+                assert!(parts[0]["text"].as_str().unwrap().contains("Rust edition"));
+            }
+            other => panic!("expected success, got {other:?}"),
+        }
+
+        // Recall by tag
+        let result = RecallTool
+            .execute_with_context(json!({"tags": ["project"]}), &ctx)
+            .await;
+
+        match &result {
+            ToolExecutionResult::Success(v) => {
+                assert_eq!(v["total"], 1);
+            }
+            other => panic!("expected success, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_remember_with_images() {
+        let (ctx, _, _) = test_context();
+
+        let result = RememberTool
+            .execute_with_context(
+                json!({
+                    "content": "Architecture diagram",
+                    "images": [
+                        { "base64": "iVBORw0KGgo=", "media_type": "image/png" }
+                    ]
+                }),
+                &ctx,
+            )
+            .await;
+
+        match &result {
+            ToolExecutionResult::Success(v) => assert!(v["created"].as_bool().unwrap()),
+            other => panic!("expected success, got {other:?}"),
+        }
+
+        // Recall should include image parts
+        let result = RecallTool
+            .execute_with_context(json!({"query": "architecture"}), &ctx)
+            .await;
+
+        match &result {
+            ToolExecutionResult::Success(v) => {
+                let parts = v["memories"][0]["content_parts"].as_array().unwrap();
+                assert_eq!(parts.len(), 2);
+                assert_eq!(parts[0]["type"], "text");
+                assert_eq!(parts[1]["type"], "image");
+                assert_eq!(parts[1]["media_type"], "image/png");
+            }
+            other => panic!("expected success, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_forget() {
+        let (ctx, _, _) = test_context();
+
+        // Create a memory
+        let result = RememberTool
+            .execute_with_context(json!({"content": "temporary fact", "tags": ["temp"]}), &ctx)
+            .await;
+
+        let memory_id = match &result {
+            ToolExecutionResult::Success(v) => v["memory_id"].as_str().unwrap().to_string(),
+            other => panic!("expected success, got {other:?}"),
+        };
+
+        // Forget it
+        let result = ForgetTool
+            .execute_with_context(json!({"memory_id": memory_id}), &ctx)
+            .await;
+
+        match &result {
+            ToolExecutionResult::Success(v) => assert!(v["forgotten"].as_bool().unwrap()),
+            other => panic!("expected success, got {other:?}"),
+        }
+
+        // Recall should return nothing
+        let result = RecallTool
+            .execute_with_context(json!({"query": "temporary"}), &ctx)
+            .await;
+
+        match &result {
+            ToolExecutionResult::Success(v) => assert_eq!(v["total"], 0),
+            other => panic!("expected success, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_remember_validates_content_length() {
+        let (ctx, _, _) = test_context();
+
+        let long_content = "x".repeat(2001);
+        let result = RememberTool
+            .execute_with_context(json!({"content": long_content}), &ctx)
+            .await;
+
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("character limit"));
+            }
+            other => panic!("expected tool error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_remember_validates_too_many_tags() {
+        let (ctx, _, _) = test_context();
+
+        let tags: Vec<String> = (0..11).map(|i| format!("tag{i}")).collect();
+        let result = RememberTool
+            .execute_with_context(json!({"content": "test", "tags": tags}), &ctx)
+            .await;
+
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("Too many tags"));
+            }
+            other => panic!("expected tool error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_recall_empty_store() {
+        let (ctx, _, _) = test_context();
+
+        let result = RecallTool.execute_with_context(json!({}), &ctx).await;
+
+        match &result {
+            ToolExecutionResult::Success(v) => {
+                assert_eq!(v["total"], 0);
+                assert!(v["memories"].as_array().unwrap().is_empty());
+            }
+            other => panic!("expected success, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_forget_nonexistent() {
+        let (ctx, _, _) = test_context();
+
+        let fake_id = MemoryId::new().to_string();
+        let result = ForgetTool
+            .execute_with_context(json!({"memory_id": fake_id}), &ctx)
+            .await;
+
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("not found"));
+            }
+            other => panic!("expected tool error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_remember_without_context_errors() {
+        let result = RememberTool.execute(json!({"content": "test"})).await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => {
+                assert!(msg.contains("requires session context"));
+            }
+            other => panic!("expected tool error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_recall_by_kind() {
+        let (ctx, _, _) = test_context();
+
+        RememberTool
+            .execute_with_context(
+                json!({"content": "User prefers dark mode", "kind": "preference"}),
+                &ctx,
+            )
+            .await;
+
+        RememberTool
+            .execute_with_context(json!({"content": "The sky is blue", "kind": "fact"}), &ctx)
+            .await;
+
+        let result = RecallTool
+            .execute_with_context(json!({"kind": "preference"}), &ctx)
+            .await;
+
+        match &result {
+            ToolExecutionResult::Success(v) => {
+                assert_eq!(v["total"], 1);
+                assert_eq!(v["memories"][0]["kind"], "preference");
+            }
+            other => panic!("expected success, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_memory_limits_validate_ok() {
+        let parts = vec![MemoryContentPart::text("hello")];
+        assert!(MemoryLimits::validate("short", &[], &parts).is_ok());
+    }
+
+    #[test]
+    fn test_memory_limits_validate_image_count() {
+        let parts: Vec<MemoryContentPart> = (0..5)
+            .map(|_| MemoryContentPart::image("data", "image/png"))
+            .collect();
+        let result = MemoryLimits::validate("test", &[], &parts);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Too many images"));
+    }
+
+    #[test]
+    fn test_memory_config_defaults() {
+        let config = MemoryConfig::default();
+        assert_eq!(config.passive_recall_count, 5);
+        assert!(config.store.is_none());
+    }
+
+    #[test]
+    fn test_memory_config_from_json() {
+        let config = MemoryConfig::from_json(&json!({"passive_recall_count": 10}));
+        assert_eq!(config.passive_recall_count, 10);
+    }
+
+    #[test]
+    fn test_tools_require_context() {
+        assert!(RememberTool.requires_context());
+        assert!(RecallTool.requires_context());
+        assert!(ForgetTool.requires_context());
+    }
+}

--- a/crates/core/src/capabilities/persistent_memory.rs
+++ b/crates/core/src/capabilities/persistent_memory.rs
@@ -117,9 +117,26 @@ async fn resolve_store_id(
         .ok_or_else(|| ToolExecutionResult::tool_error("Memory store not available"))?;
 
     if let Some(ref store_str) = config.store {
-        store_str
-            .parse::<MemoryStoreId>()
-            .map_err(|_| ToolExecutionResult::tool_error(format!("Invalid store ID: {store_str}")))
+        let store_id = store_str.parse::<MemoryStoreId>().map_err(|_| {
+            ToolExecutionResult::tool_error(format!("Invalid store ID: {store_str}"))
+        })?;
+        // Verify the store exists and belongs to this org
+        let org_id = context
+            .org_id
+            .ok_or_else(|| ToolExecutionResult::tool_error("Org ID not available for memory"))?;
+        let store = backend
+            .get_store(store_id)
+            .await
+            .map_err(|e| ToolExecutionResult::tool_error(format!("Failed to get store: {e}")))?
+            .ok_or_else(|| {
+                ToolExecutionResult::tool_error(format!("Memory store not found: {store_str}"))
+            })?;
+        if store.org_id != org_id {
+            return Err(ToolExecutionResult::tool_error(format!(
+                "Memory store not found: {store_str}"
+            )));
+        }
+        Ok(store_id)
     } else {
         let org_id = context
             .org_id
@@ -174,7 +191,7 @@ impl Tool for RememberTool {
     }
 
     fn description(&self) -> &str {
-        "Save a fact, preference, correction, or procedure to persistent memory. Memories survive across sessions."
+        "Save a fact, preference, correction, or procedure to persistent memory. Creates a new memory in the active store."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -258,13 +275,21 @@ impl Tool for RememberTool {
             return ToolExecutionResult::tool_error(e);
         }
 
-        let kind = params
-            .kind
-            .as_deref()
-            .and_then(|k| serde_json::from_value(json!(k)).ok())
-            .unwrap_or(MemoryKind::Fact);
+        let kind = match params.kind.as_deref() {
+            Some(k) => match serde_json::from_value::<MemoryKind>(json!(k)) {
+                Ok(kind) => kind,
+                Err(_) => {
+                    return ToolExecutionResult::tool_error(format!(
+                        "Invalid memory kind: \"{k}\". Expected one of: fact, preference, correction, procedure, context"
+                    ));
+                }
+            },
+            None => MemoryKind::Fact,
+        };
 
-        // Parse config from empty (tools don't have direct config access, use defaults)
+        // TODO(V1): Resolve MemoryConfig from agent/harness capability config
+        // instead of using defaults. Tools don't currently have access to the
+        // per-agent AgentCapabilityConfig; requires ToolContext extension.
         let config = MemoryConfig::default();
         let store_id = match resolve_store_id(&config, context).await {
             Ok(id) => id,
@@ -398,16 +423,24 @@ impl Tool for RecallTool {
             Err(e) => return ToolExecutionResult::tool_error(format!("Invalid parameters: {e}")),
         };
 
+        // TODO(V1): Resolve MemoryConfig from agent/harness capability config
         let config = MemoryConfig::default();
         let store_id = match resolve_store_id(&config, context).await {
             Ok(id) => id,
             Err(e) => return e,
         };
 
-        let kind: Option<MemoryKind> = params
-            .kind
-            .as_deref()
-            .and_then(|k| serde_json::from_value(json!(k)).ok());
+        let kind: Option<MemoryKind> = match params.kind.as_deref() {
+            Some(k) => match serde_json::from_value::<MemoryKind>(json!(k)) {
+                Ok(kind) => Some(kind),
+                Err(_) => {
+                    return ToolExecutionResult::tool_error(format!(
+                        "Invalid memory kind filter: \"{k}\". Expected one of: fact, preference, correction, procedure, context"
+                    ));
+                }
+            },
+            None => None,
+        };
 
         let query = MemoryQuery {
             store_id: Some(store_id),
@@ -531,12 +564,19 @@ impl Tool for ForgetTool {
             }
         };
 
+        // TODO(V1): Resolve MemoryConfig from agent/harness capability config
+        let config = MemoryConfig::default();
+        let store_id = match resolve_store_id(&config, context).await {
+            Ok(id) => id,
+            Err(e) => return e,
+        };
+
         let backend = match context.memory_store.as_ref() {
             Some(b) => b,
             None => return ToolExecutionResult::tool_error("Memory store not available"),
         };
 
-        match backend.forget(memory_id).await {
+        match backend.forget(store_id, memory_id).await {
             Ok(true) => ToolExecutionResult::success(json!({
                 "forgotten": true,
                 "memory_id": params.memory_id

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -54,6 +54,7 @@ pub mod leased_resource;
 pub mod llm_model_profiles;
 pub mod llm_models;
 pub mod mcp_server;
+pub mod memory_store;
 pub mod organization;
 pub mod session;
 pub mod session_file;
@@ -125,6 +126,12 @@ pub use traits::{
     ModelWithProvider, NoopEventEmitter, ResolvedImage, SecretInfo, SessionFileStore,
     SessionMutator, SessionSqlDbStoreRef, SessionStorageStore, SessionStore, ToolContext,
     ToolExecutor, UserConnectionResolver,
+};
+
+// Memory store re-exports
+pub use memory_store::{
+    Memory, MemoryContentPart, MemoryImagePart, MemoryKind, MemoryLimits, MemoryQuery,
+    MemoryStoreBackend, MemoryStoreEntity, MemoryTextPart,
 };
 
 // Channel abstraction re-exports
@@ -275,8 +282,8 @@ pub use skill::{
 };
 pub use typed_id::{
     AgentId, AgentIdentityId, AppId, EventId, ExecId, HarnessId, IdMarker, IdParseError, ImageId,
-    LeasedResourceId, McpServerId, MessageId, ModelId, NotificationId, OrgId, ProviderId,
-    ScheduleId, SessionId, SkillId, TurnId, TypedId,
+    LeasedResourceId, McpServerId, MemoryId, MemoryStoreId, MessageId, ModelId, NotificationId,
+    OrgId, ProviderId, ScheduleId, SessionId, SkillId, TurnId, TypedId,
 };
 
 // Permissions re-exports

--- a/crates/core/src/memory.rs
+++ b/crates/core/src/memory.rs
@@ -1176,9 +1176,12 @@ impl MemoryStoreBackend for InMemoryMemoryStore {
         Ok((results, total))
     }
 
-    async fn forget(&self, memory_id: MemoryId) -> Result<bool> {
+    async fn forget(&self, store_id: MemoryStoreId, memory_id: MemoryId) -> Result<bool> {
         let mut memories = self.memories.write().await;
-        if let Some(m) = memories.iter_mut().find(|m| m.id == memory_id && m.active) {
+        if let Some(m) = memories
+            .iter_mut()
+            .find(|m| m.id == memory_id && m.store_id == store_id && m.active)
+        {
             m.active = false;
             m.updated_at = chrono::Utc::now();
             Ok(true)

--- a/crates/core/src/memory.rs
+++ b/crates/core/src/memory.rs
@@ -1049,3 +1049,151 @@ mod tests {
         assert_eq!(emitter.event_count().await, 0);
     }
 }
+
+// ============================================================================
+// InMemoryMemoryStore — for dev mode and testing
+// ============================================================================
+
+use crate::memory_store::{
+    Memory, MemoryContentPart, MemoryKind, MemoryQuery, MemoryStoreBackend, MemoryStoreEntity,
+};
+use crate::typed_id::{MemoryId, MemoryStoreId, OrgId};
+
+/// In-memory implementation of `MemoryStoreBackend` for dev mode and testing.
+#[derive(Debug, Default, Clone)]
+pub struct InMemoryMemoryStore {
+    stores: Arc<RwLock<Vec<MemoryStoreEntity>>>,
+    memories: Arc<RwLock<Vec<Memory>>>,
+}
+
+impl InMemoryMemoryStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl MemoryStoreBackend for InMemoryMemoryStore {
+    async fn get_or_create_default_store(&self, org_id: OrgId) -> Result<MemoryStoreEntity> {
+        let mut stores = self.stores.write().await;
+        if let Some(store) = stores.iter().find(|s| s.org_id == org_id && s.is_default) {
+            return Ok(store.clone());
+        }
+        let store = MemoryStoreEntity {
+            id: MemoryStoreId::new(),
+            org_id,
+            name: "default".to_string(),
+            is_default: true,
+            created_at: chrono::Utc::now(),
+        };
+        stores.push(store.clone());
+        Ok(store)
+    }
+
+    async fn get_store(&self, store_id: MemoryStoreId) -> Result<Option<MemoryStoreEntity>> {
+        Ok(self
+            .stores
+            .read()
+            .await
+            .iter()
+            .find(|s| s.id == store_id)
+            .cloned())
+    }
+
+    async fn create_memory(
+        &self,
+        store_id: MemoryStoreId,
+        content: String,
+        content_parts: Vec<MemoryContentPart>,
+        kind: MemoryKind,
+        importance: u8,
+        tags: Vec<String>,
+    ) -> Result<Memory> {
+        let now = chrono::Utc::now();
+        let memory = Memory {
+            id: MemoryId::new(),
+            store_id,
+            content,
+            content_parts,
+            kind,
+            importance: importance.clamp(1, 10),
+            tags,
+            active: true,
+            created_at: now,
+            updated_at: now,
+        };
+        self.memories.write().await.push(memory.clone());
+        Ok(memory)
+    }
+
+    async fn recall(&self, query: MemoryQuery) -> Result<(Vec<Memory>, usize)> {
+        let memories = self.memories.read().await;
+        let mut results: Vec<&Memory> = memories
+            .iter()
+            .filter(|m| m.active)
+            .filter(|m| {
+                if let Some(ref sid) = query.store_id {
+                    m.store_id == *sid
+                } else {
+                    true
+                }
+            })
+            .filter(|m| {
+                if let Some(ref kind) = query.kind {
+                    m.kind == *kind
+                } else {
+                    true
+                }
+            })
+            .filter(|m| {
+                if let Some(ref tags) = query.tags {
+                    tags.iter().all(|t| m.tags.contains(t))
+                } else {
+                    true
+                }
+            })
+            .filter(|m| {
+                if let Some(ref q) = query.query {
+                    let q_lower = q.to_lowercase();
+                    m.content.to_lowercase().contains(&q_lower)
+                        || m.tags.iter().any(|t| t.to_lowercase().contains(&q_lower))
+                } else {
+                    true
+                }
+            })
+            .collect();
+
+        // Sort by importance desc, then by created_at desc
+        results.sort_by(|a, b| {
+            b.importance
+                .cmp(&a.importance)
+                .then_with(|| b.created_at.cmp(&a.created_at))
+        });
+
+        let total = results.len();
+        let limit = if query.limit > 0 { query.limit } else { 10 };
+        let results: Vec<Memory> = results.into_iter().take(limit).cloned().collect();
+        Ok((results, total))
+    }
+
+    async fn forget(&self, memory_id: MemoryId) -> Result<bool> {
+        let mut memories = self.memories.write().await;
+        if let Some(m) = memories.iter_mut().find(|m| m.id == memory_id && m.active) {
+            m.active = false;
+            m.updated_at = chrono::Utc::now();
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    async fn count_active(&self, store_id: MemoryStoreId) -> Result<usize> {
+        Ok(self
+            .memories
+            .read()
+            .await
+            .iter()
+            .filter(|m| m.store_id == store_id && m.active)
+            .count())
+    }
+}

--- a/crates/core/src/memory_store.rs
+++ b/crates/core/src/memory_store.rs
@@ -256,7 +256,14 @@ pub trait MemoryStoreBackend: Send + Sync {
     async fn recall(&self, query: MemoryQuery) -> crate::error::Result<(Vec<Memory>, usize)>;
 
     /// Soft-delete (deactivate) a memory.
-    async fn forget(&self, memory_id: MemoryId) -> crate::error::Result<bool>;
+    ///
+    /// `store_id` is required so implementations can enforce org-scoped
+    /// ownership: the memory must belong to the given store.
+    async fn forget(
+        &self,
+        store_id: MemoryStoreId,
+        memory_id: MemoryId,
+    ) -> crate::error::Result<bool>;
 
     /// Count active memories in a store.
     async fn count_active(&self, store_id: MemoryStoreId) -> crate::error::Result<usize>;

--- a/crates/core/src/memory_store.rs
+++ b/crates/core/src/memory_store.rs
@@ -1,0 +1,263 @@
+// Memory store module — persistent cross-session memory for agents.
+// See specs/memory.md for design rationale.
+//
+// Decision: MemoryContentPart reuses same shape as message ContentPart (text + image)
+//   but is a separate type to exclude tool-call/tool-result variants.
+// Decision: Multiple stores per org, selected via capability config.
+// Decision: Capacity limits enforced on write (remember tool + REST API).
+
+use crate::typed_id::{MemoryId, MemoryStoreId, OrgId};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "openapi")]
+use utoipa::ToSchema;
+
+// ============================================================================
+// Memory Content Parts (multicontent for recall)
+// ============================================================================
+
+/// Content part for memory entries — same discriminated-union shape as message
+/// `ContentPart` but restricted to text and image variants.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum MemoryContentPart {
+    /// Text content
+    Text(MemoryTextPart),
+    /// Image content (inline base64)
+    Image(MemoryImagePart),
+}
+
+/// Text content within a memory.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct MemoryTextPart {
+    pub text: String,
+}
+
+/// Image content within a memory (base64-encoded).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct MemoryImagePart {
+    /// Base64-encoded image data
+    pub base64: String,
+    /// MIME type (e.g. "image/png")
+    pub media_type: String,
+}
+
+impl MemoryContentPart {
+    pub fn text(text: impl Into<String>) -> Self {
+        Self::Text(MemoryTextPart { text: text.into() })
+    }
+
+    pub fn image(base64: impl Into<String>, media_type: impl Into<String>) -> Self {
+        Self::Image(MemoryImagePart {
+            base64: base64.into(),
+            media_type: media_type.into(),
+        })
+    }
+
+    /// Estimated size in bytes (for capacity limit checks).
+    pub fn estimated_size(&self) -> usize {
+        match self {
+            Self::Text(t) => t.text.len(),
+            Self::Image(i) => i.base64.len(),
+        }
+    }
+}
+
+// ============================================================================
+// Memory Kind
+// ============================================================================
+
+/// Classification of a memory entry.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryKind {
+    #[default]
+    Fact,
+    Preference,
+    Correction,
+    Procedure,
+    Context,
+}
+
+impl std::fmt::Display for MemoryKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Fact => write!(f, "fact"),
+            Self::Preference => write!(f, "preference"),
+            Self::Correction => write!(f, "correction"),
+            Self::Procedure => write!(f, "procedure"),
+            Self::Context => write!(f, "context"),
+        }
+    }
+}
+
+// ============================================================================
+// Memory Entity
+// ============================================================================
+
+/// A single memory entry within a store.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct Memory {
+    pub id: MemoryId,
+    pub store_id: MemoryStoreId,
+    pub content: String,
+    pub content_parts: Vec<MemoryContentPart>,
+    pub kind: MemoryKind,
+    /// 1-10 importance score (higher = more important)
+    pub importance: u8,
+    pub tags: Vec<String>,
+    pub active: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+// ============================================================================
+// Memory Store Entity
+// ============================================================================
+
+/// An org-scoped container for memories.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct MemoryStoreEntity {
+    pub id: MemoryStoreId,
+    pub org_id: OrgId,
+    pub name: String,
+    pub is_default: bool,
+    pub created_at: DateTime<Utc>,
+}
+
+// ============================================================================
+// Capacity Limits
+// ============================================================================
+
+/// Capacity limits for memory operations.
+pub struct MemoryLimits;
+
+impl MemoryLimits {
+    /// Max characters in memory content field.
+    pub const MAX_CONTENT_LENGTH: usize = 2_000;
+    /// Max tags per memory.
+    pub const MAX_TAGS: usize = 10;
+    /// Max image content parts per memory.
+    pub const MAX_IMAGE_PARTS: usize = 4;
+    /// Max single image size (5 MB base64).
+    pub const MAX_IMAGE_SIZE: usize = 5 * 1024 * 1024;
+    /// Max total image data per memory (10 MB base64).
+    pub const MAX_TOTAL_IMAGE_SIZE: usize = 10 * 1024 * 1024;
+    /// Max active memories per store.
+    pub const MAX_MEMORIES_PER_STORE: usize = 10_000;
+    /// Max stores per org.
+    pub const MAX_STORES_PER_ORG: usize = 50;
+
+    /// Validate a memory before creation/update.
+    pub fn validate(
+        content: &str,
+        tags: &[String],
+        parts: &[MemoryContentPart],
+    ) -> Result<(), String> {
+        if content.len() > Self::MAX_CONTENT_LENGTH {
+            return Err(format!(
+                "Memory content exceeds {} character limit (got {})",
+                Self::MAX_CONTENT_LENGTH,
+                content.len()
+            ));
+        }
+        if tags.len() > Self::MAX_TAGS {
+            return Err(format!(
+                "Too many tags: max {}, got {}",
+                Self::MAX_TAGS,
+                tags.len()
+            ));
+        }
+
+        let mut image_count = 0;
+        let mut total_image_size = 0;
+        for part in parts {
+            if let MemoryContentPart::Image(img) = part {
+                image_count += 1;
+                let size = img.base64.len();
+                if size > Self::MAX_IMAGE_SIZE {
+                    return Err(format!(
+                        "Image exceeds {} byte limit (got {})",
+                        Self::MAX_IMAGE_SIZE,
+                        size
+                    ));
+                }
+                total_image_size += size;
+            }
+        }
+        if image_count > Self::MAX_IMAGE_PARTS {
+            return Err(format!(
+                "Too many images: max {}, got {}",
+                Self::MAX_IMAGE_PARTS,
+                image_count
+            ));
+        }
+        if total_image_size > Self::MAX_TOTAL_IMAGE_SIZE {
+            return Err(format!(
+                "Total image data exceeds {} byte limit (got {})",
+                Self::MAX_TOTAL_IMAGE_SIZE,
+                total_image_size
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Store Trait
+// ============================================================================
+
+/// Query parameters for recalling memories.
+#[derive(Debug, Default)]
+pub struct MemoryQuery {
+    pub store_id: Option<MemoryStoreId>,
+    pub query: Option<String>,
+    pub tags: Option<Vec<String>>,
+    pub kind: Option<MemoryKind>,
+    pub limit: usize,
+}
+
+/// Trait for persistent memory storage backends.
+#[async_trait]
+pub trait MemoryStoreBackend: Send + Sync {
+    /// Get or create the default store for an org.
+    async fn get_or_create_default_store(
+        &self,
+        org_id: OrgId,
+    ) -> crate::error::Result<MemoryStoreEntity>;
+
+    /// Get a store by ID.
+    async fn get_store(
+        &self,
+        store_id: MemoryStoreId,
+    ) -> crate::error::Result<Option<MemoryStoreEntity>>;
+
+    /// Create a memory in a store.
+    async fn create_memory(
+        &self,
+        store_id: MemoryStoreId,
+        content: String,
+        content_parts: Vec<MemoryContentPart>,
+        kind: MemoryKind,
+        importance: u8,
+        tags: Vec<String>,
+    ) -> crate::error::Result<Memory>;
+
+    /// Search/recall memories.
+    async fn recall(&self, query: MemoryQuery) -> crate::error::Result<(Vec<Memory>, usize)>;
+
+    /// Soft-delete (deactivate) a memory.
+    async fn forget(&self, memory_id: MemoryId) -> crate::error::Result<bool>;
+
+    /// Count active memories in a store.
+    async fn count_active(&self, store_id: MemoryStoreId) -> crate::error::Result<usize>;
+}

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -803,6 +803,8 @@ impl std::fmt::Debug for ToolContext {
                 &self.leased_resource_store.is_some(),
             )
             .field("event_emitter", &self.event_emitter.is_some())
+            .field("memory_store", &self.memory_store.is_some())
+            .field("org_id", &self.org_id)
             .finish()
     }
 }

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -532,6 +532,12 @@ pub struct ToolContext {
     pub tool_call_id: Option<String>,
     /// Optional capability registry for blueprint lookups.
     pub capability_registry: Option<crate::capabilities::CapabilityRegistry>,
+
+    /// Optional memory store backend for persistent cross-session memory.
+    pub memory_store: Option<Arc<dyn crate::memory_store::MemoryStoreBackend>>,
+
+    /// Optional org ID for org-scoped operations (memory stores, etc.).
+    pub org_id: Option<crate::typed_id::OrgId>,
 }
 
 impl ToolContext {
@@ -554,6 +560,8 @@ impl ToolContext {
             event_context: None,
             tool_call_id: None,
             capability_registry: None,
+            memory_store: None,
+            org_id: None,
         }
     }
 
@@ -576,6 +584,8 @@ impl ToolContext {
             event_context: None,
             tool_call_id: None,
             capability_registry: None,
+            memory_store: None,
+            org_id: None,
         }
     }
 
@@ -601,6 +611,8 @@ impl ToolContext {
             event_context: None,
             tool_call_id: None,
             capability_registry: None,
+            memory_store: None,
+            org_id: None,
         }
     }
 
@@ -627,6 +639,8 @@ impl ToolContext {
             event_context: None,
             tool_call_id: None,
             capability_registry: None,
+            memory_store: None,
+            org_id: None,
         }
     }
 
@@ -687,6 +701,21 @@ impl ToolContext {
     /// Add a leased resource store to this context.
     pub fn with_leased_resource_store(mut self, store: Arc<dyn LeasedResourceStore>) -> Self {
         self.leased_resource_store = Some(store);
+        self
+    }
+
+    /// Add a memory store backend for persistent cross-session memory.
+    pub fn with_memory_store(
+        mut self,
+        store: Arc<dyn crate::memory_store::MemoryStoreBackend>,
+    ) -> Self {
+        self.memory_store = Some(store);
+        self
+    }
+
+    /// Set org ID for org-scoped operations.
+    pub fn with_org_id(mut self, org_id: crate::typed_id::OrgId) -> Self {
+        self.org_id = Some(org_id);
         self
     }
 

--- a/crates/core/src/typed_id.rs
+++ b/crates/core/src/typed_id.rs
@@ -413,6 +413,20 @@ impl IdMarker for NotificationIdMarker {
     const PREFIX: &'static str = "notification";
 }
 
+/// Marker for Memory Store IDs
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct MemoryStoreIdMarker;
+impl IdMarker for MemoryStoreIdMarker {
+    const PREFIX: &'static str = "mst";
+}
+
+/// Marker for Memory IDs
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct MemoryIdMarker;
+impl IdMarker for MemoryIdMarker {
+    const PREFIX: &'static str = "mem";
+}
+
 // ============================================================================
 // Type aliases for convenience
 // ============================================================================
@@ -453,6 +467,8 @@ pub type LeasedResourceId = TypedId<LeasedResourceIdMarker>;
 pub type AppId = TypedId<AppIdMarker>;
 /// Notification ID
 pub type NotificationId = TypedId<NotificationIdMarker>;
+pub type MemoryStoreId = TypedId<MemoryStoreIdMarker>;
+pub type MemoryId = TypedId<MemoryIdMarker>;
 
 // ============================================================================
 // Well-known IDs (for seeding and defaults)

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -68,6 +68,7 @@ mod seed_ids {
         Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000010d);
     pub const TASK_ORCHESTRATOR_AGENT: Uuid =
         Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000010e);
+    pub const KNOWLEDGE_BASE_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000112);
 
     // MCP Servers (0x500-0x5FF)
     pub const MS_LEARN_MCP: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000501);
@@ -1096,6 +1097,38 @@ User: "Analyze my codebase and suggest improvements"
         tags: &["orchestration", "subagents", "demo", "seed"],
         capabilities: &[
             SeedCapability::new("subagents"),
+            SeedCapability::new("current_time"),
+        ],
+        dev_only: false,
+    },
+    SeedAgent {
+        id: seed_ids::KNOWLEDGE_BASE_AGENT,
+        name: "Knowledge Base Agent",
+        description: "An agent with persistent memory that learns from conversations, remembers facts, preferences, and corrections across sessions.",
+        system_prompt: r#"You are a Knowledge Base Agent with persistent memory. You learn from every
+conversation and remember important information across sessions.
+
+## How You Work
+
+1. **Remember**: When a user shares important facts, preferences, corrections, or procedures,
+   save them with `remember`. Tag memories for easy retrieval.
+2. **Recall**: Before answering questions, use `recall` to search your memory for relevant
+   prior knowledge. This helps you give consistent, personalized responses.
+3. **Forget**: If a user tells you something is outdated or wrong, use `forget` to remove
+   the incorrect memory, then `remember` the corrected version.
+
+## Guidelines
+
+- Proactively recall relevant memories when the user asks a question
+- Save user preferences (communication style, technical level, tools they use)
+- Save corrections ("Actually, we use PostgreSQL not MySQL") immediately
+- Tag memories descriptively for better recall (e.g. ["database", "preference"])
+- Rate importance honestly: critical project facts = 8-10, nice-to-know = 3-5
+- Don't save trivial or ephemeral information
+- Tell the user when you're recalling something from a previous session"#,
+        tags: &["memory", "knowledge", "learning", "seed"],
+        capabilities: &[
+            SeedCapability::new("memory"),
             SeedCapability::new("current_time"),
         ],
         dev_only: false,

--- a/specs/memory.md
+++ b/specs/memory.md
@@ -1,0 +1,157 @@
+# Memory Capability
+
+Cross-session persistent memory that agents can write to and read from.
+Memories survive beyond individual sessions and are scoped to **memory stores**
+within an organization.
+
+## Concepts
+
+- **Memory Store** — Named, org-scoped container for memories. An org can have
+  many stores (e.g. "team-knowledge", "ops-runbooks"). Agents select which
+  store(s) to use via capability config. A default org-wide store is created
+  automatically.
+- **Memory** — A single unit of knowledge: short text content plus optional
+  rich content parts (images, references). Tagged, importance-scored,
+  deduplicated on write.
+- **MemoryContentPart** — Reuses the same discriminated-union shape as message
+  `ContentPart` (text + image variants). Recall returns multicontent so the LLM
+  sees both text and images inline.
+
+## Capability Config
+
+```json
+{
+  "ref": "memory",
+  "config": {
+    "store": "memstore_abc123",
+    "passive_recall_count": 5
+  }
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `store` | `MemoryStoreId?` | org default store | Which store to read/write |
+| `passive_recall_count` | `usize` | `5` | Memories auto-injected per turn (0 = disable) |
+
+When `store` is omitted, the agent uses the org's default memory store.
+
+## Tools
+
+### `remember`
+
+Create or update a memory.
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "content": { "type": "string", "maxLength": 2000, "description": "1-3 sentence knowledge to persist" },
+    "kind": { "type": "string", "enum": ["fact", "preference", "correction", "procedure", "context"], "default": "fact" },
+    "importance": { "type": "integer", "minimum": 1, "maximum": 10, "default": 5 },
+    "tags": { "type": "array", "items": { "type": "string" }, "maxItems": 10 }
+  },
+  "required": ["content"],
+  "additionalProperties": false
+}
+```
+
+Returns `{ "memory_id": "mem_xxx", "created": true }` or
+`{ "memory_id": "mem_xxx", "created": false, "note": "merged with existing similar memory" }`.
+
+### `recall`
+
+Search memories by keyword, tag, or kind. Returns multicontent parts.
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "query": { "type": "string", "description": "Keyword search across memory content" },
+    "tags": { "type": "array", "items": { "type": "string" }, "description": "Filter by tags (AND)" },
+    "kind": { "type": "string", "enum": ["fact", "preference", "correction", "procedure", "context"] },
+    "limit": { "type": "integer", "minimum": 1, "maximum": 50, "default": 10 }
+  },
+  "additionalProperties": false
+}
+```
+
+Response uses `MemoryContentPart` array per memory (same shape as message `ContentPart`):
+
+```json
+{
+  "memories": [
+    {
+      "id": "mem_xxx",
+      "kind": "correction",
+      "importance": 8,
+      "created_at": "2026-03-24T12:00:00Z",
+      "content_parts": [
+        { "type": "text", "text": "Don't use unwrap() in production code..." },
+        { "type": "image", "url": "data:image/png;base64,...", "media_type": "image/png" }
+      ],
+      "tags": ["rust", "error-handling"]
+    }
+  ],
+  "total": 42
+}
+```
+
+### `forget`
+
+Deactivate a memory by ID (soft-delete).
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "memory_id": { "type": "string", "description": "Memory ID to forget" }
+  },
+  "required": ["memory_id"],
+  "additionalProperties": false
+}
+```
+
+## Data Model
+
+See `crates/core/src/memory_store.rs` for full type definitions.
+
+Core types:
+- `MemoryStoreId` — prefixed typed ID (`mst_...`)
+- `MemoryId` — prefixed typed ID (`mem_...`)
+- `MemoryStore` — org-scoped named store with capacity config
+- `Memory` — content, kind, importance, tags, active flag, store FK
+- `MemoryContentPart` — text or image (same shape as `ContentPart`, minus tool variants)
+
+## Capacity Limits
+
+| Limit | Default | Scope | Notes |
+|-------|---------|-------|-------|
+| Active memories per store | 10,000 | Per-store | Oldest low-importance auto-archived beyond this |
+| Stores per org | 50 | Per-org | |
+| Memory content length | 2,000 chars | Per-memory | Hard cap |
+| Tags per memory | 10 | Per-memory | |
+| Image attachments per memory | 4 | Per-memory | Inline base64 in content_parts |
+| Max single image | 5 MB | Per-image | |
+| Total image data per memory | 10 MB | Per-memory | Sum of all image parts |
+
+Enforcement: checked on write (`remember` tool + REST API). Returns clear
+`ToolError` when exceeded.
+
+## Storage
+
+In-memory implementation for dev mode (`InMemoryMemoryStore`).
+PostgreSQL implementation for production (future migration `012_memory.sql`).
+
+## System Prompt
+
+When memory capability is enabled, a section is injected:
+
+```
+## Persistent Memory
+
+You have persistent memory across sessions via `remember` and `recall` tools.
+Use `remember` to save important facts, user preferences, corrections, or
+procedures. Use `recall` to search your memory before answering questions where
+prior context may help. Use `forget` to remove outdated or incorrect memories.
+```

--- a/specs/memory.md
+++ b/specs/memory.md
@@ -12,7 +12,7 @@ within an organization.
   automatically.
 - **Memory** — A single unit of knowledge: short text content plus optional
   rich content parts (images, references). Tagged, importance-scored,
-  deduplicated on write.
+  validated on write.
 - **MemoryContentPart** — Reuses the same discriminated-union shape as message
   `ContentPart` (text + image variants). Recall returns multicontent so the LLM
   sees both text and images inline.
@@ -23,7 +23,7 @@ within an organization.
 {
   "ref": "memory",
   "config": {
-    "store": "memstore_abc123",
+    "store": "mst_abc123",
     "passive_recall_count": 5
   }
 }
@@ -40,7 +40,7 @@ When `store` is omitted, the agent uses the org's default memory store.
 
 ### `remember`
 
-Create or update a memory.
+Create a memory in the active store.
 
 ```json
 {
@@ -49,15 +49,15 @@ Create or update a memory.
     "content": { "type": "string", "maxLength": 2000, "description": "1-3 sentence knowledge to persist" },
     "kind": { "type": "string", "enum": ["fact", "preference", "correction", "procedure", "context"], "default": "fact" },
     "importance": { "type": "integer", "minimum": 1, "maximum": 10, "default": 5 },
-    "tags": { "type": "array", "items": { "type": "string" }, "maxItems": 10 }
+    "tags": { "type": "array", "items": { "type": "string" }, "maxItems": 10 },
+    "images": { "type": "array", "items": { "type": "object", "properties": { "base64": { "type": "string" }, "media_type": { "type": "string" } }, "required": ["base64", "media_type"] }, "maxItems": 4, "description": "Optional image attachments" }
   },
   "required": ["content"],
   "additionalProperties": false
 }
 ```
 
-Returns `{ "memory_id": "mem_xxx", "created": true }` or
-`{ "memory_id": "mem_xxx", "created": false, "note": "merged with existing similar memory" }`.
+Returns `{ "memory_id": "mem_xxx", "created": true }`.
 
 ### `recall`
 
@@ -88,7 +88,7 @@ Response uses `MemoryContentPart` array per memory (same shape as message `Conte
       "created_at": "2026-03-24T12:00:00Z",
       "content_parts": [
         { "type": "text", "text": "Don't use unwrap() in production code..." },
-        { "type": "image", "url": "data:image/png;base64,...", "media_type": "image/png" }
+        { "type": "image", "base64": "iVBORw0KGgo=...", "media_type": "image/png" }
       ],
       "tags": ["rust", "error-handling"]
     }
@@ -127,7 +127,7 @@ Core types:
 
 | Limit | Default | Scope | Notes |
 |-------|---------|-------|-------|
-| Active memories per store | 10,000 | Per-store | Oldest low-importance auto-archived beyond this |
+| Active memories per store | 10,000 | Per-store | Hard cap; `remember` returns error when full |
 | Stores per org | 50 | Per-org | |
 | Memory content length | 2,000 chars | Per-memory | Hard cap |
 | Tags per memory | 10 | Per-memory | |


### PR DESCRIPTION
## Summary

- Add persistent cross-session memory capability with multi-store support per org (selected via capability config)
- Implement `remember`, `recall`, `forget` tools with capacity limits (2K char content, 4 images/memory, 10K memories/store, 50 stores/org)
- Recall returns multicontent `MemoryContentPart` (text + image variants, same shape as message `ContentPart`)
- Add `MemoryStoreBackend` trait, `InMemoryMemoryStore` impl, typed IDs (`mst_`/`mem_`), and full ToolContext wiring
- Add "Knowledge Base Agent" seed example and `specs/memory.md` specification

## Review comments addressed

All 11 Copilot reviewer comments addressed in second commit:
- **Tenant isolation**: `forget()` now requires `store_id`; `resolve_store_id` verifies store exists and belongs to caller's org before returning
- **Input validation**: Invalid `kind` values now return `ToolError` instead of silently defaulting (both `remember` and `recall`)
- **Spec accuracy**: Fixed store ID prefix (`mst_`), added `images` to remember schema, fixed recall image shape (`base64`/`media_type` not `url`), corrected capacity wording (hard cap not auto-archive), removed dedup claims (create-only for V1)
- **Debug impl**: Added `memory_store`/`org_id` to `ToolContext` Debug output
- **Config resolution**: Documented as V1 TODO — requires ToolContext extension for per-agent capability config

## Security

Threat categories reviewed: **TM-TENANT**, **TM-API**, **TM-TOOL**

- **TM-TENANT**: `resolve_store_id` now verifies `store.org_id == context.org_id` before allowing access to a configured store. `forget` passes `store_id` to backend so implementations enforce memory-to-store ownership. Error messages use generic "not found" to avoid leaking cross-org store existence.
- **TM-API**: All tool inputs validated — content length, tag count, image count/size, kind enum values. Invalid kind returns explicit error. Memory ID parsing validates `mem_` prefix.
- **TM-TOOL**: Tools require context (`requires_context() = true`), fail cleanly without memory store or org_id. No new external service calls or sandbox escapes.

No new threats introduced. No changes to `specs/threat-model.md` needed (memory stores are a new internal capability, not a new external trust boundary).

## Test plan

- [x] 15 unit tests covering remember/recall/forget, image attachments, capacity limit validation, kind filtering, edge cases
- [x] All core lib tests pass (including updated capability registry tests)
- [x] Server seed agent tests pass (unique slugs, find by slug)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] CI green
