### PR TITLE
fix(scripts): remove invalid `local` outside function in setup.sh

### DIFF
--- a/scripts/lib/setup.sh
+++ b/scripts/lib/setup.sh
@@ -53,7 +53,6 @@ case "$cmd" in
     echo ""
     echo "🐘 PostgreSQL:"
     if command -v pg_ctl &> /dev/null || [ -d "/usr/lib/postgresql" ]; then
-      local pg_ver
       pg_ver=$(pg_ctl --version 2>/dev/null | grep -oE '[0-9]+' | head -1 || ls /usr/lib/postgresql 2>/dev/null | sort -V | tail -1)
       echo "  ✅ PostgreSQL $pg_ver already installed"
     else


### PR DESCRIPTION
## What
Remove `local` keyword used outside a function in `scripts/lib/setup.sh`.

## Why
`just init` fails at line 56 with `local: can only be used in a function` because `local pg_ver` is inside a `case` block, not a function.

## How
Removed the `local pg_ver` declaration, keeping the direct assignment on the next line. The variable is only used within the same block so scoping is not a concern.

## Risk
- Low
- No behavior change; the variable assignment is identical, just without `local` scoping

## Security
- No security-relevant code changes — shell script fix for a variable declaration keyword

## Checklist
- [x] Tests added or updated — N/A (shell script fix, verified by reading)
- [x] Backward compatibility considered — N/A
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed