### PR TITLE
fix(cli): replace chat polling with SSE streaming

### DIFF
--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -15,6 +15,16 @@ pub async fn run(
     timeout_secs: Option<u64>,
     no_stream: bool,
 ) -> Result<()> {
+    // Snapshot the last event ID *before* sending the message so the polling
+    // loop only sees events from the new turn, not replayed events from
+    // earlier turns.
+    let mut last_event_id: Option<String> = if no_stream {
+        None
+    } else {
+        let existing = client.events().list(&session_id).await?;
+        existing.data.last().map(|e| e.id.clone())
+    };
+
     // Create the message
     client.messages().create(&session_id, &message).await?;
 
@@ -30,7 +40,6 @@ pub async fn run(
     let start = Instant::now();
     let timeout = timeout_secs.map(Duration::from_secs);
     let poll_interval = Duration::from_millis(500);
-    let mut last_event_id: Option<String> = None;
     let mut agent_content = String::new();
 
     loop {

--- a/crates/cli/src/commands/chat.rs
+++ b/crates/cli/src/commands/chat.rs
@@ -1,8 +1,16 @@
 // Chat command - send message and stream response
+//
+// Uses SSE streaming with since_id for efficient event delivery.
+// The snapshot-before-send pattern avoids replaying earlier turns:
+//   1. Snapshot the last event ID (limit=1, efficient)
+//   2. Send the message (may start a new turn or steer an existing one)
+//   3. Stream events via SSE with since_id = snapshotted ID
+//   4. Exit on turn.completed / turn.failed / timeout
 
 use crate::output::OutputFormat;
 use anyhow::Result;
 use everruns_sdk::Everruns;
+use futures::StreamExt;
 use std::time::{Duration, Instant};
 
 #[allow(clippy::too_many_arguments)]
@@ -15,17 +23,24 @@ pub async fn run(
     timeout_secs: Option<u64>,
     no_stream: bool,
 ) -> Result<()> {
-    // Snapshot the last event ID *before* sending the message so the polling
-    // loop only sees events from the new turn, not replayed events from
-    // earlier turns.
-    let mut last_event_id: Option<String> = if no_stream {
+    // Snapshot the last event ID *before* sending the message so the SSE
+    // stream only sees events produced after this point — whether the
+    // message starts a new turn or steers an existing one.
+    let snapshot_id: Option<String> = if no_stream {
         None
     } else {
-        let existing = client.events().list(&session_id).await?;
+        let opts = everruns_sdk::client::ListEventsOptions {
+            limit: Some(1),
+            ..Default::default()
+        };
+        let existing = client
+            .events()
+            .list_with_options(&session_id, &opts)
+            .await?;
         existing.data.last().map(|e| e.id.clone())
     };
 
-    // Create the message
+    // Create the message (may start a new turn or continue an existing one)
     client.messages().create(&session_id, &message).await?;
 
     if !quiet && output.is_text() {
@@ -36,138 +51,159 @@ pub async fn run(
         return Ok(());
     }
 
-    // Poll for events until turn.completed or timeout
+    // Stream events via SSE with since_id for server-side filtering.
+    // This replaces the old polling loop that fetched all events every 500ms.
+    let mut stream_opts = everruns_sdk::sse::StreamOptions::exclude_deltas().with_max_retries(10);
+    if let Some(id) = snapshot_id {
+        stream_opts = stream_opts.with_since_id(id);
+    }
+
+    let mut stream = client
+        .events()
+        .stream_with_options(&session_id, stream_opts);
+
     let start = Instant::now();
     let timeout = timeout_secs.map(Duration::from_secs);
-    let poll_interval = Duration::from_millis(500);
     let mut agent_content = String::new();
 
     loop {
+        // Check timeout before waiting for next event
         if let Some(timeout) = timeout
             && start.elapsed() > timeout
         {
+            stream.stop();
             if output.is_text() {
                 eprintln!("\nTimeout waiting for response");
             }
             anyhow::bail!("Timeout waiting for response");
         }
 
-        // Fetch events via SDK (ListResponse pagination fields are optional since SDK v0.1.5)
-        let response = client.events().list(&session_id).await?;
-
-        // Filter events since last seen.
-        // Use position-based lookup instead of skip_while: if last_event_id
-        // is no longer in the response (server-side truncation/retention),
-        // treat all returned events as new rather than silently dropping them.
-        let events = if let Some(ref last_id) = last_event_id {
-            let mut data = response.data;
-            match data.iter().position(|e| &e.id == last_id) {
-                Some(idx) => data.split_off(idx + 1),
-                None => data, // last seen event was evicted; all events are new
-            }
+        let next = if let Some(t) = timeout {
+            let remaining = t.saturating_sub(start.elapsed());
+            tokio::time::timeout(remaining, stream.next()).await
         } else {
-            response.data
+            Ok(stream.next().await)
         };
 
-        for event in events {
-            last_event_id = Some(event.id.clone());
+        let item = match next {
+            Ok(Some(item)) => item,
+            Ok(None) => {
+                // Stream ended without turn completion
+                if output.is_text() && !agent_content.is_empty() {
+                    println!("Agent: {}", agent_content);
+                }
+                anyhow::bail!("Event stream ended before turn completed");
+            }
+            Err(_) => {
+                // Timeout
+                stream.stop();
+                if output.is_text() {
+                    eprintln!("\nTimeout waiting for response");
+                }
+                anyhow::bail!("Timeout waiting for response");
+            }
+        };
 
-            if output.is_text() {
-                // Handle output.message.completed events
-                if event.event_type == "output.message.completed" {
-                    // Content may be at data.content or data.message.content
-                    let content = event
-                        .data
-                        .get("content")
-                        .or_else(|| event.data.get("message").and_then(|m| m.get("content")));
-                    if let Some(content) = content
-                        && let Some(parts) = content.as_array()
-                    {
-                        for part in parts {
-                            if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
-                                agent_content.push_str(text);
-                            }
+        let event = match item {
+            Ok(event) => event,
+            Err(e) => {
+                // SSE reconnection errors are handled internally by EventStream.
+                // If we get an error here, reconnection was exhausted.
+                eprintln!("Stream error: {e}");
+                continue;
+            }
+        };
+
+        if output.is_text() {
+            // Handle output.message.completed events
+            if event.event_type == "output.message.completed" {
+                // Content may be at data.content or data.message.content
+                let content = event
+                    .data
+                    .get("content")
+                    .or_else(|| event.data.get("message").and_then(|m| m.get("content")));
+                if let Some(content) = content
+                    && let Some(parts) = content.as_array()
+                {
+                    for part in parts {
+                        if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
+                            agent_content.push_str(text);
                         }
                     }
                 }
+            }
 
-                // Handle tool.progress event
-                if event.event_type == "tool.progress"
-                    && let Some(message) = event.data.get("message").and_then(|m| m.as_str())
-                {
-                    let tool = event
-                        .data
-                        .get("display_name")
-                        .or_else(|| event.data.get("tool_name"))
-                        .and_then(|t| t.as_str())
-                        .unwrap_or("tool");
-                    eprintln!("  [{tool}] {message}");
-                }
+            // Handle tool.progress event
+            if event.event_type == "tool.progress"
+                && let Some(message) = event.data.get("message").and_then(|m| m.as_str())
+            {
+                let tool = event
+                    .data
+                    .get("display_name")
+                    .or_else(|| event.data.get("tool_name"))
+                    .and_then(|t| t.as_str())
+                    .unwrap_or("tool");
+                eprintln!("  [{tool}] {message}");
+            }
 
-                // Handle tool.output.delta event (streamed tool output).
-                // Deltas from bashkit include trailing newlines when appropriate.
-                // Use eprintln! to ensure each chunk ends on its own line even if
-                // the delta itself lacks a trailing newline.
-                if event.event_type == "tool.output.delta"
-                    && let Some(delta) = event.data.get("delta").and_then(|d| d.as_str())
-                {
-                    let stream = event
-                        .data
-                        .get("stream")
-                        .and_then(|s| s.as_str())
-                        .unwrap_or("stdout");
-                    let tool = event
-                        .data
-                        .get("tool_name")
-                        .and_then(|t| t.as_str())
-                        .unwrap_or("tool");
-                    let trimmed = delta.trim_end_matches('\n');
-                    if stream == "stderr" {
-                        eprintln!("  [{tool}:stderr] {trimmed}");
-                    } else {
-                        eprintln!("  [{tool}] {trimmed}");
-                    }
-                }
-
-                // Handle turn.completed event
-                if event.event_type == "turn.completed" {
-                    if !agent_content.is_empty() {
-                        println!("Agent: {}", agent_content);
-                    }
-                    return Ok(());
-                }
-
-                // Handle turn.failed event
-                if event.event_type == "turn.failed" {
-                    let error = event
-                        .data
-                        .get("error")
-                        .and_then(|e| e.as_str())
-                        .unwrap_or("Unknown error");
-                    eprintln!("\nTurn failed: {}", error);
-                    anyhow::bail!("Turn failed: {}", error);
-                }
-            } else {
-                // JSON/YAML output: print each event as JSON
-                let event_json = serde_json::json!({
-                    "id": event.id,
-                    "type": event.event_type,
-                    "ts": event.ts,
-                    "session_id": event.session_id,
-                    "data": event.data,
-                });
-                output.print_value(&event_json);
-
-                if event.event_type == "turn.completed" {
-                    return Ok(());
-                }
-
-                if event.event_type == "turn.failed" {
-                    anyhow::bail!("Turn failed");
+            // Handle tool.output.delta event (streamed tool output)
+            if event.event_type == "tool.output.delta"
+                && let Some(delta) = event.data.get("delta").and_then(|d| d.as_str())
+            {
+                let stream_name = event
+                    .data
+                    .get("stream")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("stdout");
+                let tool = event
+                    .data
+                    .get("tool_name")
+                    .and_then(|t| t.as_str())
+                    .unwrap_or("tool");
+                let trimmed = delta.trim_end_matches('\n');
+                if stream_name == "stderr" {
+                    eprintln!("  [{tool}:stderr] {trimmed}");
+                } else {
+                    eprintln!("  [{tool}] {trimmed}");
                 }
             }
-        }
 
-        tokio::time::sleep(poll_interval).await;
+            // Handle turn.completed event
+            if event.event_type == "turn.completed" {
+                if !agent_content.is_empty() {
+                    println!("Agent: {}", agent_content);
+                }
+                return Ok(());
+            }
+
+            // Handle turn.failed event
+            if event.event_type == "turn.failed" {
+                let error = event
+                    .data
+                    .get("error")
+                    .and_then(|e| e.as_str())
+                    .unwrap_or("Unknown error");
+                eprintln!("\nTurn failed: {}", error);
+                anyhow::bail!("Turn failed: {}", error);
+            }
+        } else {
+            // JSON/YAML output: print each event
+            let event_json = serde_json::json!({
+                "id": event.id,
+                "type": event.event_type,
+                "ts": event.ts,
+                "session_id": event.session_id,
+                "data": event.data,
+            });
+            output.print_value(&event_json);
+
+            if event.event_type == "turn.completed" {
+                return Ok(());
+            }
+
+            if event.event_type == "turn.failed" {
+                anyhow::bail!("Turn failed");
+            }
+        }
     }
 }

--- a/crates/cli/tests/chat_integration_test.rs
+++ b/crates/cli/tests/chat_integration_test.rs
@@ -1,0 +1,38 @@
+//! Integration tests for CLI chat command.
+//!
+//! Tests the chat subcommand's argument handling and basic invocation.
+//! Full end-to-end tests with a running server are in the server crate's
+//! workflow tests; these verify the CLI binary's interface.
+
+#[test]
+fn test_cli_chat_help() {
+    let output = std::process::Command::new("cargo")
+        .args(["run", "-p", "everruns-cli", "--", "chat", "--help"])
+        .output()
+        .expect("Failed to run cargo");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--session"), "Should have --session flag");
+    assert!(stdout.contains("--timeout"), "Should have --timeout flag");
+    assert!(
+        stdout.contains("--no-stream"),
+        "Should have --no-stream flag"
+    );
+}
+
+#[test]
+fn test_cli_chat_requires_session_and_message() {
+    // Chat without --session should fail
+    let output = std::process::Command::new("cargo")
+        .args(["run", "-p", "everruns-cli", "--", "chat"])
+        .output()
+        .expect("Failed to run cargo");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "Should fail without required args"
+    );
+    assert!(
+        stderr.contains("--session") || stderr.contains("required"),
+        "Should mention missing --session"
+    );
+}

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -918,6 +918,207 @@ async fn test_list_events() {
     assert!(data["data"].is_array());
 }
 
+/// Tests the events endpoint with limit=1 returns only the last event
+/// (used by CLI chat to efficiently snapshot before sending a message).
+#[tokio::test]
+async fn test_list_events_limit_one_returns_last_event() {
+    let server = TestServer::in_memory().await;
+
+    // Create agent and session
+    let agent: Agent = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": "Events Limit Test Agent",
+                "system_prompt": "Test"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let session: Session = server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": SEED_BASE_HARNESS_ID,
+                "agent_id": agent.public_id
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    // Create a message to generate events
+    let _: Value = server
+        .post(
+            &format!("/v1/sessions/{}/messages", session.id),
+            json!({
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "First message"}]
+                }
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    // Get all events
+    let all_events: Value = server
+        .get(&format!("/v1/sessions/{}/events", session.id))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    let all_data = all_events["data"].as_array().unwrap();
+    assert!(
+        !all_data.is_empty(),
+        "Should have at least one event after message creation"
+    );
+    let last_event_id = all_data.last().unwrap()["id"].as_str().unwrap();
+
+    // Get events with limit=1 — should return only the last event
+    let limited: Value = server
+        .get(&format!("/v1/sessions/{}/events?limit=1", session.id))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    let limited_data = limited["data"].as_array().unwrap();
+    assert_eq!(
+        limited_data.len(),
+        1,
+        "limit=1 should return exactly one event"
+    );
+    assert_eq!(
+        limited_data[0]["id"].as_str().unwrap(),
+        last_event_id,
+        "limit=1 should return the last event"
+    );
+}
+
+/// Tests the events endpoint with since_id returns only events after the given ID
+/// (used by CLI chat SSE streaming to avoid replaying old events).
+#[tokio::test]
+async fn test_list_events_since_id_filters_old_events() {
+    let server = TestServer::in_memory().await;
+
+    // Create agent and session
+    let agent: Agent = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": "Events SinceId Test Agent",
+                "system_prompt": "Test"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let session: Session = server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": SEED_BASE_HARNESS_ID,
+                "agent_id": agent.public_id
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    // Create first message
+    let _: Value = server
+        .post(
+            &format!("/v1/sessions/{}/messages", session.id),
+            json!({
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "First message"}]
+                }
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    // Snapshot the last event ID
+    let events_after_first: Value = server
+        .get(&format!("/v1/sessions/{}/events?limit=1", session.id))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    let snapshot_id = events_after_first["data"][0]["id"].as_str().unwrap();
+
+    // Get count of events before second message
+    let all_before: Value = server
+        .get(&format!("/v1/sessions/{}/events", session.id))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    let count_before = all_before["data"].as_array().unwrap().len();
+
+    // Create second message
+    let _: Value = server
+        .post(
+            &format!("/v1/sessions/{}/messages", session.id),
+            json!({
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "Second message"}]
+                }
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    // Get events since snapshot — should NOT include events from the first message
+    let events_since: Value = server
+        .get(&format!(
+            "/v1/sessions/{}/events?since_id={}",
+            session.id, snapshot_id
+        ))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    let since_data = events_since["data"].as_array().unwrap();
+
+    // Should have new events from the second message, but none from before the snapshot
+    assert!(
+        !since_data.is_empty(),
+        "Should have events after second message"
+    );
+
+    // Verify no event ID matches the snapshot or any earlier event
+    let all_before_ids: Vec<&str> = all_before["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|e| e["id"].as_str().unwrap())
+        .collect();
+    for event in since_data {
+        let event_id = event["id"].as_str().unwrap();
+        assert!(
+            !all_before_ids.contains(&event_id),
+            "since_id should exclude event {event_id} which existed before snapshot"
+        );
+    }
+
+    // Total events should be: before + new since events
+    let all_after: Value = server
+        .get(&format!("/v1/sessions/{}/events", session.id))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    let count_after = all_after["data"].as_array().unwrap().len();
+    assert_eq!(
+        count_after,
+        count_before + since_data.len(),
+        "All events = events before snapshot + events since snapshot"
+    );
+}
+
 // ============================================
 // LLM Provider Tests
 // ============================================


### PR DESCRIPTION
## Summary

- **Replace 500ms polling loop with SSE streaming** — uses the SDK's `EventStream` with automatic reconnection, backoff, and idle timeout detection instead of fetching all events every 500ms
- **Efficient snapshot** — use `limit=1` on the events endpoint to get just the last event ID before sending (was fetching ALL events just to read the last element)
- **Server-side filtering via `since_id`** — the SSE stream connects with `since_id` so the server only sends events after the snapshot point (was fetching all events and filtering client-side on every poll)
- Works for both new turns (user message) and continuing turns (tool results steering existing turn)

## Test plan

- [x] Integration test: `test_list_events_limit_one_returns_last_event` — verifies `limit=1` returns only the last event
- [x] Integration test: `test_list_events_since_id_filters_old_events` — verifies `since_id` excludes events before the snapshot
- [x] CLI integration test: `test_cli_chat_help` and `test_cli_chat_requires_session_and_message`
- [x] `just pre-push` passes (fmt, clippy, lockfile, author attribution)
- [x] Smoke test: `everruns chat --no-stream` sends message, exits cleanly
- [x] Smoke test: `everruns chat` SSE streaming receives `turn.failed` from dev server (no LLM), no replay of first message's events on second message

## Security

Reviewed threat categories: TM-API (since_id query param — server-validated, SDK URL-encodes), TM-AUTH (unchanged), TM-TENANT (unchanged), TM-DOS (SSE with max_retries + exponential backoff + stream.stop() on timeout — better than old unbounded polling).

No new dependencies, trust boundaries, or security-relevant surface.

Closes EVE-184