### PR TITLE
test(agent-chat): add multi-turn conversation UI test case

### DIFF
--- a/test_cases/ui/MANUAL_TEST_RESULTS_2026-03-25.md
+++ b/test_cases/ui/MANUAL_TEST_RESULTS_2026-03-25.md
@@ -1,0 +1,31 @@
+# Manual UI Test Results - 2026-03-25
+
+## Environment
+
+- **Auth Mode**: None (DEV_MODE)
+- **Stack**: Server + UI + Caddy (in-memory, Doppler for LLM keys)
+- **PORT_PREFIX**: 271
+- **Browser**: Chromium (headless, via agent-browser)
+
+## Test Summary
+
+| Category | Tests | Pass | Fail/Partial | Issues |
+|----------|-------|------|-------------|--------|
+| agent_chat | 1 | 1 | 0 | 0 |
+| **Total** | **1** | **1** | **0** | **0** |
+
+## Detailed Results
+
+### agent_chat (1/1 PASS)
+
+- **TC001 Multi-turn Agent Conversation**: PASS - Created "Dad Jokes" agent, opened new session, sent turn 1 message ("Tell me a dad joke about the current time of day"), received contextual dad joke response. Sent turn 2 ("give me 10 more"), received multiple jokes on varied topics. All 4 messages visible in order. Session persisted after page refresh with all messages intact.
+
+### Evidence
+
+| Step | Screenshot |
+|------|-----------|
+| Agents page with Dad Jokes | `/tmp/test_agent_chat_tc001_step1_agents_page.png` |
+| New session (empty) | `/tmp/test_agent_chat_tc001_step3_new_session.png` |
+| Turn 1 response complete | `/tmp/test_agent_chat_tc001_step5_turn1_complete.png` |
+| Turn 2 response complete | `/tmp/test_agent_chat_tc001_step8_turn2_complete.png` |
+| After page refresh (persistence) | `/tmp/test_agent_chat_tc001_step10_persist.png` |

--- a/test_cases/ui/MANUAL_TEST_RESULTS_2026-03-25.md
+++ b/test_cases/ui/MANUAL_TEST_RESULTS_2026-03-25.md
@@ -18,14 +18,14 @@
 
 ### agent_chat (1/1 PASS)
 
-- **TC001 Multi-turn Agent Conversation**: PASS - Created "Dad Jokes" agent, opened new session, sent turn 1 message ("Tell me a dad joke about the current time of day"), received contextual dad joke response. Sent turn 2 ("give me 10 more"), received multiple jokes on varied topics. All 4 messages visible in order. Session persisted after page refresh with all messages intact.
+- **TC001 Multi-turn Agent Conversation**: PASS - Used existing "Dad Jokes" agent, opened new session, sent turn 1 message ("Tell me a dad joke about the current time of day"), received contextual dad joke response. Sent turn 2 ("give me 10 more"), received multiple jokes on varied topics. All 4 messages visible in order. Session persisted after page refresh with all messages intact.
 
 ### Evidence
 
 | Step | Screenshot |
 |------|-----------|
-| Agents page with Dad Jokes | `/tmp/test_agent_chat_tc001_step1_agents_page.png` |
-| New session (empty) | `/tmp/test_agent_chat_tc001_step3_new_session.png` |
-| Turn 1 response complete | `/tmp/test_agent_chat_tc001_step5_turn1_complete.png` |
-| Turn 2 response complete | `/tmp/test_agent_chat_tc001_step8_turn2_complete.png` |
-| After page refresh (persistence) | `/tmp/test_agent_chat_tc001_step10_persist.png` |
+| Agents page with Dad Jokes | Screenshot captured during test execution |
+| New session (empty) | Screenshot captured during test execution |
+| Turn 1 response complete | Screenshot captured during test execution |
+| Turn 2 response complete | Screenshot captured during test execution |
+| After page refresh (persistence) | Screenshot captured during test execution |

--- a/test_cases/ui/agent_chat/TC001_multi_turn_agent_conversation.md
+++ b/test_cases/ui/agent_chat/TC001_multi_turn_agent_conversation.md
@@ -29,6 +29,9 @@ Verify that a user can open a direct chat session with an agent, send a message,
 7. Send turn 2 message in the same session
 8. Wait for the full streamed response to complete
 9. Verify the response contains multiple jokes
+10. Verify that the conversation thread shows both user messages and both agent responses in chronological order (turn 1 user + agent, then turn 2 user + agent)
+11. Refresh the page (browser reload) or navigate away and return to the same session
+12. Verify that the full conversation history (both turns and responses) is still visible and unchanged
 
 ## Expected Result
 

--- a/test_cases/ui/agent_chat/TC001_multi_turn_agent_conversation.md
+++ b/test_cases/ui/agent_chat/TC001_multi_turn_agent_conversation.md
@@ -1,0 +1,46 @@
+# TC001: Agent Chat - Multi-turn Conversation
+
+## Description
+
+Verify that a user can open a direct chat session with an agent, send a message, wait for the full streamed response, then send a follow-up message in the same session and receive a contextual response.
+
+## Preconditions
+
+- Server running (`just start-dev`)
+- User logged in
+- LLM API keys configured
+- An agent exists with a humor-oriented system prompt (e.g., "Dad Jokes" agent with system prompt: "You are a dad jokes comedian. Tell funny, clean dad jokes. Always stay in character.")
+
+## Test Data
+
+| Turn | User Message |
+|------|-------------|
+| 1 | Tell me a dad joke about the current time of day |
+| 2 | That was great! Now give me 10 more dad jokes on completely different topics |
+
+## Steps
+
+1. Navigate to the Agents page (`/agents`)
+2. Click on the "Dad Jokes" agent to open its detail page
+3. Start a new session / open the chat interface for this agent
+4. Send turn 1 message
+5. Wait for the full streamed response to complete (spinner/typing indicator disappears, message fully rendered)
+6. Verify the response is a dad joke related to time of day
+7. Send turn 2 message in the same session
+8. Wait for the full streamed response to complete
+9. Verify the response contains multiple jokes
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Session created | A new session is created for the Dad Jokes agent |
+| Turn 1 response streams | Response streams in progressively, typing indicator visible during generation |
+| Turn 1 response complete | Full response rendered, no truncation, typing indicator gone |
+| Turn 1 content | Response contains a dad joke referencing time of day |
+| Turn 2 sends in same session | Follow-up message appears in the same conversation thread below turn 1 |
+| Turn 2 response streams | Second response streams in progressively |
+| Turn 2 response complete | Full response rendered with multiple jokes |
+| Turn 2 content | Response contains approximately 10 jokes on varied topics |
+| Conversation history | Both user messages and both agent responses visible in the chat, in correct order |
+| Session persists | Refreshing the page and reopening the session shows the full conversation history |


### PR DESCRIPTION
## What
Add a new UI test case for agent chat multi-turn conversations (`test_cases/ui/agent_chat/TC001_multi_turn_agent_conversation.md`) and manual test execution results.

## Why
Agent chat sessions lacked test coverage for the core multi-turn conversation flow — creating a session, sending messages, receiving streamed responses, and verifying session persistence.

## How
- Created `TC001` covering: session creation from agent detail page, turn 1 message + response, turn 2 follow-up + response, conversation history ordering, and session persistence after page refresh.
- Executed the test case against `just start-dev` with Doppler (for LLM keys) using agent-browser. All checks passed.
- Recorded results in `test_cases/ui/MANUAL_TEST_RESULTS_2026-03-25.md`.

## Risk
- Low
- Test-only change (markdown files). No runtime code affected.

## Security
- No security-relevant code changes. These are test case documentation files (markdown) with no runtime impact.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)