### PR TITLE
fix(daytona): use snapshot-based sizing instead of ignored resource params

### DIFF
--- a/integrations/daytona/SPEC.md
+++ b/integrations/daytona/SPEC.md
@@ -77,7 +77,7 @@ This avoids entering the key in chat (see TM-AGENT-016).
 
 | Method | Path | Purpose | Request Body |
 |--------|------|---------|-------------|
-| POST | `/sandbox` | Create sandbox | `{ name?, image?, resources?: { cpu?, memory?, disk? }, autoStopInterval, autoArchiveInterval, autoDeleteInterval, labels? }` |
+| POST | `/sandbox` | Create sandbox | `{ name?, snapshot?, autoStopInterval, autoArchiveInterval, autoDeleteInterval, labels? }` |
 | GET | `/sandbox/{id}` | Get sandbox info | — |
 | POST | `/sandbox/{id}/start` | Start sandbox | — |
 | POST | `/sandbox/{id}/stop` | Stop sandbox | — |
@@ -103,13 +103,11 @@ Creates a new sandbox. Optionally uploads files from session storage.
 
 - **Parameters**:
   - `title`: string (optional) — sandbox name
-  - `image`: string (optional) — container image
-  - `cpu`: integer (optional) — vCPUs, 1-4 (default: 1)
-  - `memory`: integer (optional) — GiB RAM, 1-8 (default: 1)
-  - `disk`: integer (optional) — GiB disk, 1-10 (default: 3)
+  - `size`: string (optional) — sandbox size tier: `small` (1 vCPU, 1 GiB RAM, 3 GiB disk), `medium` (2 vCPU, 4 GiB RAM, 8 GiB disk), `large` (4 vCPU, 8 GiB RAM, 10 GiB disk). Default: `small`.
+  - `snapshot`: string (optional) — explicit Daytona snapshot name (advanced, overrides `size`)
   - `upload_files`: array (optional) — `[{session_path, sandbox_path}]`
 - **Returns**: `{ sandbox_id, status, workspace_path }`
-- **Resource mapping**: When any of `cpu`/`memory`/`disk` are specified, they are sent as a `resources` object in the Daytona API request body. Only specified fields are included; omitted fields use Daytona defaults. Values are validated client-side (type + range) before the API call.
+- **Resource mapping**: The `size` parameter maps to a pre-built Daytona snapshot with the appropriate resources. The Daytona REST API does not support per-sandbox resource overrides for snapshot-based creation (see [daytonaio/daytona#2296](https://github.com/daytonaio/daytona/issues/2296)), so we use tiered snapshots instead.
 
 ### daytona_exec
 

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -18,6 +18,25 @@ use crate::{
     EXEC_TIMEOUT_MS, LEASE_HEARTBEAT_INTERVAL,
 };
 
+// Daytona REST API does not support per-sandbox resource overrides for snapshot-based creation.
+// Instead, select a pre-built snapshot that matches the desired resource tier.
+// See: https://github.com/daytonaio/daytona/issues/2296
+
+/// Map a size tier to the corresponding Daytona snapshot name.
+fn snapshot_for_size(size: &str) -> Result<&'static str, String> {
+    match size {
+        "small" => Ok("daytona-small"),
+        "medium" => Ok("daytona-medium"),
+        "large" => Ok("daytona-large"),
+        _ => Err(
+            "Invalid 'size': must be one of: small (1 vCPU, 1 GiB RAM, 3 GiB disk), \
+             medium (2 vCPU, 4 GiB RAM, 8 GiB disk), \
+             large (4 vCPU, 8 GiB RAM, 10 GiB disk)"
+                .to_string(),
+        ),
+    }
+}
+
 /// Parse an optional integer resource parameter, validating type and range.
 fn parse_resource_param(
     arguments: &Value,
@@ -64,30 +83,15 @@ impl Tool for DaytonaCreateSandboxTool {
                     "type": "string",
                     "description": "Sandbox name (optional)"
                 },
-                "image": {
+                "size": {
                     "type": "string",
-                    "description": "Container image (optional, uses Daytona default if omitted)"
+                    "description": "Sandbox size: small (1 vCPU, 1 GiB RAM, 3 GiB disk), medium (2 vCPU, 4 GiB RAM, 8 GiB disk), or large (4 vCPU, 8 GiB RAM, 10 GiB disk). Default: small.",
+                    "enum": ["small", "medium", "large"],
+                    "default": "small"
                 },
-                "cpu": {
-                    "type": "integer",
-                    "description": "Number of vCPUs (1-4, default: 1)",
-                    "minimum": 1,
-                    "maximum": 4,
-                    "default": 1
-                },
-                "memory": {
-                    "type": "integer",
-                    "description": "Memory in GiB (1-8, default: 1)",
-                    "minimum": 1,
-                    "maximum": 8,
-                    "default": 1
-                },
-                "disk": {
-                    "type": "integer",
-                    "description": "Disk size in GiB (1-10, default: 3)",
-                    "minimum": 1,
-                    "maximum": 10,
-                    "default": 3
+                "snapshot": {
+                    "type": "string",
+                    "description": "Daytona snapshot name (advanced, overrides size). Use size parameter for standard tiers."
                 },
                 "auto_stop_minutes": {
                     "type": "integer",
@@ -179,35 +183,27 @@ impl Tool for DaytonaCreateSandboxTool {
             "autoDeleteInterval": AUTO_DELETE_INTERVAL_MINUTES,
             "labels": labels,
         });
-        if let Some(image) = arguments.get("image").and_then(|v| v.as_str()) {
-            create_body["image"] = json!(image);
-        }
+        // Resolve snapshot: explicit snapshot > size tier > default
+        let explicit_snapshot = arguments
+            .get("snapshot")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let size = arguments.get("size").and_then(|v| v.as_str());
 
-        // Parse and validate resource constraints
-        let cpu = match parse_resource_param(&arguments, "cpu", 1, 4) {
-            Ok(v) => v,
-            Err(e) => return ToolExecutionResult::tool_error(&e),
-        };
-        let memory = match parse_resource_param(&arguments, "memory", 1, 8) {
-            Ok(v) => v,
-            Err(e) => return ToolExecutionResult::tool_error(&e),
-        };
-        let disk = match parse_resource_param(&arguments, "disk", 1, 10) {
-            Ok(v) => v,
-            Err(e) => return ToolExecutionResult::tool_error(&e),
-        };
-        if cpu.is_some() || memory.is_some() || disk.is_some() {
-            let mut resources = serde_json::Map::new();
-            if let Some(cpu) = cpu {
-                resources.insert("cpu".to_string(), json!(cpu));
+        let snapshot_name = if let Some(snap) = &explicit_snapshot {
+            snap.clone()
+        } else if let Some(sz) = size {
+            match snapshot_for_size(sz) {
+                Ok(name) => name.to_string(),
+                Err(e) => return ToolExecutionResult::tool_error(&e),
             }
-            if let Some(memory) = memory {
-                resources.insert("memory".to_string(), json!(memory));
-            }
-            if let Some(disk) = disk {
-                resources.insert("disk".to_string(), json!(disk));
-            }
-            create_body["resources"] = json!(resources);
+        } else {
+            // Default: no explicit snapshot, Daytona uses its org default
+            String::new()
+        };
+
+        if !snapshot_name.is_empty() {
+            create_body["snapshot"] = json!(snapshot_name);
         }
 
         // Create sandbox

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -183,28 +183,25 @@ impl Tool for DaytonaCreateSandboxTool {
             "autoDeleteInterval": AUTO_DELETE_INTERVAL_MINUTES,
             "labels": labels,
         });
-        // Resolve snapshot: explicit snapshot > size tier > default
+        // Resolve snapshot: explicit snapshot > size tier > default (small)
         let explicit_snapshot = arguments
             .get("snapshot")
             .and_then(|v| v.as_str())
+            .filter(|s| !s.trim().is_empty())
             .map(|s| s.to_string());
         let size = arguments.get("size").and_then(|v| v.as_str());
 
         let snapshot_name = if let Some(snap) = &explicit_snapshot {
             snap.clone()
-        } else if let Some(sz) = size {
+        } else {
+            let sz = size.unwrap_or("small");
             match snapshot_for_size(sz) {
                 Ok(name) => name.to_string(),
                 Err(e) => return ToolExecutionResult::tool_error(&e),
             }
-        } else {
-            // Default: no explicit snapshot, Daytona uses its org default
-            String::new()
         };
 
-        if !snapshot_name.is_empty() {
-            create_body["snapshot"] = json!(snapshot_name);
-        }
+        create_body["snapshot"] = json!(snapshot_name);
 
         // Create sandbox
         debug!("Creating Daytona sandbox: {title}");

--- a/integrations/daytona/tests/live_api_test.rs
+++ b/integrations/daytona/tests/live_api_test.rs
@@ -84,8 +84,7 @@ async fn create_test_sandbox(api_key: String, label: &str) -> (DaytonaClient, Sa
 
     let info = client
         .create_sandbox(json!({
-            "image": "ubuntu:22.04",
-            "cpu": 1, "memory": 1,
+            "snapshot": "daytona-small",
             "labels": {"everruns-test": label}
         }))
         .await

--- a/integrations/daytona/tests/live_api_test.rs
+++ b/integrations/daytona/tests/live_api_test.rs
@@ -85,7 +85,7 @@ async fn create_test_sandbox(api_key: String, label: &str) -> (DaytonaClient, Sa
     let info = client
         .create_sandbox(json!({
             "image": "ubuntu:22.04",
-            "resources": {"cpu": 1, "memory": 1},
+            "cpu": 1, "memory": 1,
             "labels": {"everruns-test": label}
         }))
         .await

--- a/integrations/daytona/tests/tool_integration.rs
+++ b/integrations/daytona/tests/tool_integration.rs
@@ -723,11 +723,12 @@ async fn test_client_sends_bearer_auth() {
 async fn test_create_sandbox_with_resources_via_client() {
     let mock_server = MockServer::start().await;
 
+    // Daytona REST API expects cpu/memory/disk as top-level fields
     Mock::given(method("POST"))
         .and(path("/sandbox"))
         .and(wiremock::matchers::body_json(json!({
             "name": "Resource Test",
-            "resources": {"cpu": 2, "memory": 4, "disk": 8}
+            "cpu": 2, "memory": 4, "disk": 8
         })))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "id": "sb_resource",
@@ -744,7 +745,7 @@ async fn test_create_sandbox_with_resources_via_client() {
     let info = client
         .create_sandbox(json!({
             "name": "Resource Test",
-            "resources": {"cpu": 2, "memory": 4, "disk": 8}
+            "cpu": 2, "memory": 4, "disk": 8
         }))
         .await
         .unwrap();
@@ -755,11 +756,12 @@ async fn test_create_sandbox_with_resources_via_client() {
 async fn test_create_sandbox_partial_resources_via_client() {
     let mock_server = MockServer::start().await;
 
+    // Daytona REST API expects disk as a top-level field
     Mock::given(method("POST"))
         .and(path("/sandbox"))
         .and(wiremock::matchers::body_json(json!({
             "name": "Partial",
-            "resources": {"disk": 5}
+            "disk": 5
         })))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "id": "sb_partial",
@@ -775,7 +777,7 @@ async fn test_create_sandbox_partial_resources_via_client() {
     let info = client
         .create_sandbox(json!({
             "name": "Partial",
-            "resources": {"disk": 5}
+            "disk": 5
         }))
         .await
         .unwrap();
@@ -783,7 +785,7 @@ async fn test_create_sandbox_partial_resources_via_client() {
 }
 
 #[tokio::test]
-async fn test_create_sandbox_tool_rejects_invalid_cpu() {
+async fn test_create_sandbox_tool_rejects_invalid_size() {
     let tool = get_tool("daytona_create_sandbox");
     let session_id = SessionId::new();
     let store = Arc::new(MockStorageStore::new());
@@ -791,55 +793,15 @@ async fn test_create_sandbox_tool_rejects_invalid_cpu() {
         .with_connection_resolver(daytona_resolver());
 
     let result = tool
-        .execute_with_context(json!({"cpu": 10}), &context)
+        .execute_with_context(json!({"size": "huge"}), &context)
         .await;
 
     match result {
         ToolExecutionResult::ToolError(msg) => {
-            assert!(msg.contains("cpu"), "Got: {msg}");
-            assert!(msg.contains("between 1 and 4"), "Got: {msg}");
-        }
-        other => panic!("Expected ToolError, got: {other:?}"),
-    }
-}
-
-#[tokio::test]
-async fn test_create_sandbox_tool_rejects_zero_memory() {
-    let tool = get_tool("daytona_create_sandbox");
-    let session_id = SessionId::new();
-    let store = Arc::new(MockStorageStore::new());
-    let context = ToolContext::with_storage_store(session_id, store)
-        .with_connection_resolver(daytona_resolver());
-
-    let result = tool
-        .execute_with_context(json!({"memory": 0}), &context)
-        .await;
-
-    match result {
-        ToolExecutionResult::ToolError(msg) => {
-            assert!(msg.contains("memory"), "Got: {msg}");
-            assert!(msg.contains("between 1 and 8"), "Got: {msg}");
-        }
-        other => panic!("Expected ToolError, got: {other:?}"),
-    }
-}
-
-#[tokio::test]
-async fn test_create_sandbox_tool_rejects_string_disk() {
-    let tool = get_tool("daytona_create_sandbox");
-    let session_id = SessionId::new();
-    let store = Arc::new(MockStorageStore::new());
-    let context = ToolContext::with_storage_store(session_id, store)
-        .with_connection_resolver(daytona_resolver());
-
-    let result = tool
-        .execute_with_context(json!({"disk": "big"}), &context)
-        .await;
-
-    match result {
-        ToolExecutionResult::ToolError(msg) => {
-            assert!(msg.contains("disk"), "Got: {msg}");
-            assert!(msg.contains("positive integer"), "Got: {msg}");
+            assert!(msg.contains("size"), "Got: {msg}");
+            assert!(msg.contains("small"), "Got: {msg}");
+            assert!(msg.contains("medium"), "Got: {msg}");
+            assert!(msg.contains("large"), "Got: {msg}");
         }
         other => panic!("Expected ToolError, got: {other:?}"),
     }


### PR DESCRIPTION
## What

Replace the silently-ignored `cpu`/`memory`/`disk` resource parameters in `daytona_create_sandbox` with a `size` tier (`small`/`medium`/`large`) that maps to pre-built Daytona snapshots, plus an optional `snapshot` parameter for advanced use.

## Why

The Daytona REST API does not support per-sandbox resource overrides for snapshot-based creation ([daytonaio/daytona#2296](https://github.com/daytonaio/daytona/issues/2296)). All sandboxes are snapshot-based. The previous `resources: { cpu, memory, disk }` object was silently ignored, so `disk: 10` always resulted in 3 GiB — blocking workloads needing >3 GB (e.g. Rust builds requiring 5–8 GB).

Closes EVE-171

## How

- Add `snapshot_for_size()` that maps `small`→`daytona-small`, `medium`→`daytona-medium`, `large`→`daytona-large`
- Replace `cpu`/`memory`/`disk` schema params with `size` (enum) and `snapshot` (string)
- Always default to `daytona-small` when neither `size` nor `snapshot` is provided
- Validate empty/whitespace `snapshot` strings
- Update SPEC.md, integration tests, and live API test to match

| Size | Snapshot | vCPU | RAM | Disk |
|------|----------|------|-----|------|
| small (default) | daytona-small | 1 | 1 GiB | 3 GiB |
| medium | daytona-medium | 2 | 4 GiB | 8 GiB |
| large | daytona-large | 4 | 8 GiB | 10 GiB |

## Risk

- Low
- Agents using `cpu`/`memory`/`disk` params will get a schema validation error (the params no longer exist). This is correct — those params never worked, so surfacing the error is better than silent failure.

## Security

- Threat categories reviewed: TM-TOOL (tool parameter schema change)
- No new trust boundaries, auth changes, injection vectors, or secrets handling. The `snapshot` string is validated server-side by Daytona. The `size` param is validated via enum match.

## Checklist

- [x] Tests added or updated (22 pass, invalid-size validation test added)
- [x] Backward compatibility considered (breaking change is intentional — old params never worked)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation

- [x] Live API: `daytona-large` → `df -h /` shows `overlay 10G` (was `3.0G`)
- [x] Live API: `daytona-medium` → `df -h /` shows `overlay 8.0G`
- [x] `just pre-push` passes
- [x] `cargo test -p everruns-integrations-daytona` — 22/22 pass
