### PR TITLE
test(mcp): add integration tests for MCP endpoint

### DIFF
--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -1,0 +1,973 @@
+//! Integration tests for the MCP endpoint (POST /mcp)
+//!
+//! Tests the Everruns MCP server: JSON-RPC protocol, Tier 1 tools
+//! (agent_run, session_send_message, session_get_status), and Tier 2 tools
+//! (discover, execute with catalog operations).
+//!
+//! Run with: cargo test -p everruns-server --test mcp_endpoint_test -- --test-threads=1
+//!
+//! Requirements:
+//! - PostgreSQL running with DATABASE_URL set
+//! - Migrations applied
+
+mod test_harness;
+
+use serde_json::{Value, json};
+use test_harness::TestServer;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Make a JSON-RPC 2.0 call to POST /mcp via the in-process TestServer.
+async fn mcp_call(server: &TestServer, method: &str, params: Value) -> Value {
+    server
+        .post(
+            "/mcp",
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": method,
+                "params": params
+            }),
+        )
+        .await
+        .assert_success()
+        .json()
+}
+
+/// Call tools/call with a given tool name and arguments.
+async fn mcp_tool_call(server: &TestServer, tool: &str, arguments: Value) -> Value {
+    mcp_call(
+        server,
+        "tools/call",
+        json!({ "name": tool, "arguments": arguments }),
+    )
+    .await
+}
+
+/// Extract the text content from a tools/call result.
+fn tool_text(resp: &Value) -> String {
+    resp["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or("")
+        .to_string()
+}
+
+/// Check if a tools/call result is an error.
+fn tool_is_error(resp: &Value) -> bool {
+    resp["result"]["isError"].as_bool().unwrap_or(false)
+}
+
+/// Parse the text content of a tool result as JSON.
+fn tool_json(resp: &Value) -> Value {
+    let text = tool_text(resp);
+    serde_json::from_str(&text).unwrap_or_else(|e| panic!("Bad JSON in tool result: {e}\n{text}"))
+}
+
+/// Make a JSON-RPC call via HTTP to a serving TestServer.
+async fn mcp_call_http(base_url: &str, method: &str, params: Value) -> Value {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{base_url}/mcp"))
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": method,
+            "params": params
+        }))
+        .send()
+        .await
+        .expect("HTTP request failed");
+    assert!(resp.status().is_success());
+    resp.json().await.expect("Failed to parse JSON response")
+}
+
+async fn mcp_tool_call_http(base_url: &str, tool: &str, arguments: Value) -> Value {
+    mcp_call_http(
+        base_url,
+        "tools/call",
+        json!({ "name": tool, "arguments": arguments }),
+    )
+    .await
+}
+
+// ============================================================================
+// Protocol tests
+// ============================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_initialize() {
+    let server = TestServer::new().await;
+    let resp = mcp_call(&server, "initialize", json!({})).await;
+
+    assert_eq!(resp["jsonrpc"], "2.0");
+    assert_eq!(resp["id"], 1);
+    assert_eq!(resp["result"]["protocolVersion"], "2025-03-26");
+    assert_eq!(resp["result"]["serverInfo"]["name"], "everruns");
+    assert!(resp["result"]["serverInfo"]["version"].is_string());
+    assert!(resp["result"]["capabilities"]["tools"].is_object());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_ping() {
+    let server = TestServer::new().await;
+    let resp = mcp_call(&server, "ping", json!({})).await;
+
+    assert_eq!(resp["jsonrpc"], "2.0");
+    assert_eq!(resp["result"], json!({}));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_tools_list() {
+    let server = TestServer::new().await;
+    let resp = mcp_call(&server, "tools/list", json!({})).await;
+
+    let tools = resp["result"]["tools"]
+        .as_array()
+        .expect("Expected tools array");
+    assert_eq!(tools.len(), 5, "Expected 5 MCP tools");
+
+    let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+    assert!(names.contains(&"agent_run"), "Missing agent_run");
+    assert!(
+        names.contains(&"session_send_message"),
+        "Missing session_send_message"
+    );
+    assert!(
+        names.contains(&"session_get_status"),
+        "Missing session_get_status"
+    );
+    assert!(names.contains(&"discover"), "Missing discover");
+    assert!(names.contains(&"execute"), "Missing execute");
+
+    // Verify each tool has inputSchema
+    for tool in tools {
+        assert!(
+            tool["inputSchema"].is_object(),
+            "Tool {} missing inputSchema",
+            tool["name"]
+        );
+        assert_eq!(tool["inputSchema"]["type"], "object");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_invalid_jsonrpc_version() {
+    let server = TestServer::new().await;
+    let resp: Value = server
+        .post(
+            "/mcp",
+            json!({
+                "jsonrpc": "1.0",
+                "id": 1,
+                "method": "ping"
+            }),
+        )
+        .await
+        .assert_success()
+        .json();
+
+    assert!(resp["error"].is_object());
+    assert_eq!(resp["error"]["code"], -32600);
+    assert!(resp["error"]["message"].as_str().unwrap().contains("2.0"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_unknown_method() {
+    let server = TestServer::new().await;
+    let resp = mcp_call(&server, "nonexistent/method", json!({})).await;
+
+    assert!(resp["error"].is_object());
+    assert_eq!(resp["error"]["code"], -32601);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_tools_call_unknown_tool() {
+    let server = TestServer::new().await;
+    let resp = mcp_tool_call(&server, "nonexistent_tool", json!({})).await;
+
+    assert!(tool_is_error(&resp), "Expected isError for unknown tool");
+    assert!(tool_text(&resp).contains("Unknown tool"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_tools_call_missing_name() {
+    let server = TestServer::new().await;
+    let resp = mcp_call(&server, "tools/call", json!({})).await;
+
+    assert!(resp["error"].is_object());
+    assert_eq!(resp["error"]["code"], -32602);
+}
+
+// ============================================================================
+// Tier 1: agent_run
+// ============================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_agent_run() {
+    let server = TestServer::new().await;
+
+    // Create an agent first via the REST API
+    let agent: Value = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": "MCP Test Agent",
+                "system_prompt": "You are a test agent."
+            }),
+        )
+        .await
+        .assert_success()
+        .json();
+    let agent_id = agent["id"].as_str().unwrap();
+
+    // Run via MCP
+    let resp = mcp_tool_call(
+        &server,
+        "agent_run",
+        json!({
+            "agent_id": agent_id,
+            "message": "Hello from MCP test",
+            "title": "MCP Integration Test"
+        }),
+    )
+    .await;
+
+    assert!(
+        !tool_is_error(&resp),
+        "agent_run failed: {}",
+        tool_text(&resp)
+    );
+
+    let result = tool_json(&resp);
+    assert!(
+        result["session_id"]
+            .as_str()
+            .unwrap()
+            .starts_with("session_")
+    );
+    assert!(
+        result["message_id"]
+            .as_str()
+            .unwrap()
+            .starts_with("message_")
+    );
+    assert!(result["hint"].is_string());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_agent_run_without_agent() {
+    let server = TestServer::new().await;
+
+    // agent_run without agent_id should still work (uses base harness)
+    let resp = mcp_tool_call(
+        &server,
+        "agent_run",
+        json!({ "message": "Hello without agent" }),
+    )
+    .await;
+
+    assert!(
+        !tool_is_error(&resp),
+        "agent_run failed: {}",
+        tool_text(&resp)
+    );
+    let result = tool_json(&resp);
+    assert!(
+        result["session_id"]
+            .as_str()
+            .unwrap()
+            .starts_with("session_")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_agent_run_missing_message() {
+    let server = TestServer::new().await;
+    let resp = mcp_tool_call(&server, "agent_run", json!({})).await;
+
+    assert!(tool_is_error(&resp), "Expected error for missing message");
+    assert!(tool_text(&resp).contains("message"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_agent_run_invalid_agent_id() {
+    let server = TestServer::new().await;
+    let resp = mcp_tool_call(
+        &server,
+        "agent_run",
+        json!({
+            "agent_id": "not-a-valid-id",
+            "message": "Hello"
+        }),
+    )
+    .await;
+
+    assert!(tool_is_error(&resp), "Expected error for invalid agent_id");
+}
+
+// ============================================================================
+// Tier 1: session_send_message
+// ============================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_session_send_message() {
+    let server = TestServer::new().await;
+
+    // Create a session via agent_run
+    let run_resp = mcp_tool_call(
+        &server,
+        "agent_run",
+        json!({ "message": "Initial message" }),
+    )
+    .await;
+    let session_id = tool_json(&run_resp)["session_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Send a follow-up message
+    let resp = mcp_tool_call(
+        &server,
+        "session_send_message",
+        json!({
+            "session_id": session_id,
+            "message": "Follow-up message"
+        }),
+    )
+    .await;
+
+    assert!(
+        !tool_is_error(&resp),
+        "session_send_message failed: {}",
+        tool_text(&resp)
+    );
+    let result = tool_json(&resp);
+    assert!(
+        result["message_id"]
+            .as_str()
+            .unwrap()
+            .starts_with("message_")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_session_send_message_missing_params() {
+    let server = TestServer::new().await;
+
+    // Missing session_id
+    let resp = mcp_tool_call(
+        &server,
+        "session_send_message",
+        json!({ "message": "Hello" }),
+    )
+    .await;
+    assert!(tool_is_error(&resp));
+
+    // Missing message
+    let resp = mcp_tool_call(
+        &server,
+        "session_send_message",
+        json!({ "session_id": "session_00000000000000000000000000000000" }),
+    )
+    .await;
+    assert!(tool_is_error(&resp));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_session_send_message_nonexistent_session() {
+    let server = TestServer::new().await;
+    let resp = mcp_tool_call(
+        &server,
+        "session_send_message",
+        json!({
+            "session_id": "session_00000000000000000000000000000000",
+            "message": "Hello"
+        }),
+    )
+    .await;
+
+    assert!(
+        tool_is_error(&resp),
+        "Expected error for nonexistent session"
+    );
+}
+
+// ============================================================================
+// Tier 1: session_get_status
+// ============================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_session_get_status() {
+    let server = TestServer::new().await;
+
+    // Create a session
+    let run_resp = mcp_tool_call(&server, "agent_run", json!({ "message": "Status test" })).await;
+    let session_id = tool_json(&run_resp)["session_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Get status
+    let resp = mcp_tool_call(
+        &server,
+        "session_get_status",
+        json!({ "session_id": session_id }),
+    )
+    .await;
+
+    assert!(
+        !tool_is_error(&resp),
+        "session_get_status failed: {}",
+        tool_text(&resp)
+    );
+    let result = tool_json(&resp);
+    assert_eq!(result["session_id"], session_id);
+    assert!(result["status"].is_string());
+    assert!(result["events"].is_array());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_session_get_status_with_event_filter() {
+    let server = TestServer::new().await;
+
+    // Create a session
+    let run_resp = mcp_tool_call(&server, "agent_run", json!({ "message": "Filter test" })).await;
+    let session_id = tool_json(&run_resp)["session_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Get status with event type filter
+    let resp = mcp_tool_call(
+        &server,
+        "session_get_status",
+        json!({
+            "session_id": session_id,
+            "event_types": ["session.idled"]
+        }),
+    )
+    .await;
+
+    assert!(
+        !tool_is_error(&resp),
+        "session_get_status failed: {}",
+        tool_text(&resp)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_session_get_status_missing_session_id() {
+    let server = TestServer::new().await;
+    let resp = mcp_tool_call(&server, "session_get_status", json!({})).await;
+    assert!(tool_is_error(&resp));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_session_get_status_nonexistent() {
+    let server = TestServer::new().await;
+    let resp = mcp_tool_call(
+        &server,
+        "session_get_status",
+        json!({ "session_id": "session_00000000000000000000000000000000" }),
+    )
+    .await;
+    assert!(
+        tool_is_error(&resp),
+        "Expected error for nonexistent session"
+    );
+}
+
+// ============================================================================
+// Tier 2: discover
+// ============================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_discover_agents() {
+    let server = TestServer::new().await;
+    let resp = mcp_tool_call(&server, "discover", json!({ "query": "agents" })).await;
+
+    assert!(
+        !tool_is_error(&resp),
+        "discover failed: {}",
+        tool_text(&resp)
+    );
+    let text = tool_text(&resp);
+    assert!(
+        text.contains("list_agents"),
+        "discover should find list_agents, got: {text}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_discover_sessions() {
+    let server = TestServer::new().await;
+    let resp = mcp_tool_call(&server, "discover", json!({ "query": "sessions" })).await;
+
+    assert!(
+        !tool_is_error(&resp),
+        "discover failed: {}",
+        tool_text(&resp)
+    );
+    let text = tool_text(&resp);
+    // "sessions" matches list_sessions, create_session, get_session, etc.
+    assert!(
+        text.contains("list_sessions"),
+        "discover should find list_sessions, got: {text}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_discover_harnesses() {
+    let server = TestServer::new().await;
+    let resp = mcp_tool_call(&server, "discover", json!({ "query": "harnesses" })).await;
+
+    assert!(
+        !tool_is_error(&resp),
+        "discover failed: {}",
+        tool_text(&resp)
+    );
+    let text = tool_text(&resp);
+    assert!(
+        text.contains("list_harnesses"),
+        "discover should find list_harnesses"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_discover_mcp_servers() {
+    let server = TestServer::new().await;
+    let resp = mcp_tool_call(&server, "discover", json!({ "query": "mcp" })).await;
+
+    assert!(
+        !tool_is_error(&resp),
+        "discover failed: {}",
+        tool_text(&resp)
+    );
+    let text = tool_text(&resp);
+    assert!(
+        text.contains("mcp"),
+        "discover should find MCP-related operations"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_discover_missing_query() {
+    let server = TestServer::new().await;
+    let resp = mcp_tool_call(&server, "discover", json!({})).await;
+    assert!(tool_is_error(&resp), "Expected error for missing query");
+}
+
+// ============================================================================
+// Tier 2: execute — requires a real TCP server for HTTP callbacks
+// ============================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_execute_health_check() {
+    let (_server, url) = TestServer::serving().await;
+
+    let resp = mcp_tool_call_http(&url, "execute", json!({ "command": "health_check" })).await;
+    assert!(
+        !tool_is_error(&resp),
+        "execute health_check failed: {}",
+        tool_text(&resp)
+    );
+
+    let result = tool_json(&resp);
+    assert!(
+        result["success"].as_bool().unwrap(),
+        "health_check should succeed"
+    );
+    let stdout: Value = serde_json::from_str(result["stdout"].as_str().unwrap())
+        .expect("stdout should be valid JSON");
+    assert_eq!(stdout["status"], "ok");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_execute_list_harnesses() {
+    let (_server, url) = TestServer::serving().await;
+
+    let resp = mcp_tool_call_http(&url, "execute", json!({ "command": "list_harnesses" })).await;
+    assert!(
+        !tool_is_error(&resp),
+        "execute list_harnesses failed: {}",
+        tool_text(&resp)
+    );
+
+    let result = tool_json(&resp);
+    assert!(result["success"].as_bool().unwrap());
+    let stdout: Value = serde_json::from_str(result["stdout"].as_str().unwrap())
+        .expect("stdout should be valid JSON");
+    let harnesses = stdout["data"].as_array().expect("Expected harnesses array");
+    assert!(!harnesses.is_empty(), "Should have seed harnesses");
+
+    // Verify seed harnesses exist (Base and Generic are always seeded)
+    let names: Vec<&str> = harnesses
+        .iter()
+        .filter_map(|h| h["name"].as_str())
+        .collect();
+    assert!(
+        names.iter().any(|n| n.contains("Base")),
+        "Should have Base harness"
+    );
+    assert!(
+        names.iter().any(|n| n.contains("Generic")),
+        "Should have Generic harness"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_execute_list_agents() {
+    let (_server, url) = TestServer::serving().await;
+
+    let resp = mcp_tool_call_http(&url, "execute", json!({ "command": "list_agents" })).await;
+    assert!(
+        !tool_is_error(&resp),
+        "execute list_agents failed: {}",
+        tool_text(&resp)
+    );
+
+    let result = tool_json(&resp);
+    assert!(result["success"].as_bool().unwrap());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_execute_create_and_get_agent() {
+    let (_server, url) = TestServer::serving().await;
+
+    // Create agent via execute
+    let resp = mcp_tool_call_http(
+        &url,
+        "execute",
+        json!({
+            "command": "create_agent --name 'MCP Execute Agent' --system_prompt 'Test prompt'"
+        }),
+    )
+    .await;
+    assert!(
+        !tool_is_error(&resp),
+        "create_agent failed: {}",
+        tool_text(&resp)
+    );
+
+    let result = tool_json(&resp);
+    assert!(result["success"].as_bool().unwrap());
+    let created: Value = serde_json::from_str(result["stdout"].as_str().unwrap()).unwrap();
+    let agent_id = created["id"].as_str().unwrap();
+    assert!(agent_id.starts_with("agent_"));
+
+    // Get agent by ID
+    let resp = mcp_tool_call_http(
+        &url,
+        "execute",
+        json!({ "command": format!("get_agent --id {agent_id}") }),
+    )
+    .await;
+    assert!(
+        !tool_is_error(&resp),
+        "get_agent failed: {}",
+        tool_text(&resp)
+    );
+
+    let result = tool_json(&resp);
+    let fetched: Value = serde_json::from_str(result["stdout"].as_str().unwrap()).unwrap();
+    assert_eq!(fetched["name"], "MCP Execute Agent");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_execute_list_models() {
+    let (_server, url) = TestServer::serving().await;
+
+    let resp = mcp_tool_call_http(&url, "execute", json!({ "command": "list_models" })).await;
+    assert!(
+        !tool_is_error(&resp),
+        "execute list_models failed: {}",
+        tool_text(&resp)
+    );
+
+    let result = tool_json(&resp);
+    assert!(result["success"].as_bool().unwrap());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_execute_list_capabilities() {
+    let (_server, url) = TestServer::serving().await;
+
+    let resp = mcp_tool_call_http(&url, "execute", json!({ "command": "list_capabilities" })).await;
+    assert!(
+        !tool_is_error(&resp),
+        "execute list_capabilities failed: {}",
+        tool_text(&resp)
+    );
+
+    let result = tool_json(&resp);
+    assert!(result["success"].as_bool().unwrap());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_execute_list_mcp_servers() {
+    let (_server, url) = TestServer::serving().await;
+
+    let resp = mcp_tool_call_http(&url, "execute", json!({ "command": "list_mcp_servers" })).await;
+    assert!(
+        !tool_is_error(&resp),
+        "execute list_mcp_servers failed: {}",
+        tool_text(&resp)
+    );
+
+    let result = tool_json(&resp);
+    assert!(result["success"].as_bool().unwrap());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_execute_create_mcp_server() {
+    let (_server, url) = TestServer::serving().await;
+
+    // Use unique name to avoid conflicts with prior test runs
+    let unique_name = format!(
+        "Test MCP {}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+    );
+    let resp = mcp_tool_call_http(
+        &url,
+        "execute",
+        json!({
+            "command": format!("create_mcp_server --name '{unique_name}' --url 'https://mcp.test.com/v1'")
+        }),
+    )
+    .await;
+    assert!(
+        !tool_is_error(&resp),
+        "create_mcp_server failed: {}",
+        tool_text(&resp)
+    );
+
+    let result = tool_json(&resp);
+    assert!(result["success"].as_bool().unwrap());
+    let created: Value = serde_json::from_str(result["stdout"].as_str().unwrap()).unwrap();
+    assert_eq!(created["name"], unique_name);
+    assert!(created["id"].as_str().unwrap().starts_with("mcp_"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_execute_bash_pipe() {
+    let (_server, url) = TestServer::serving().await;
+
+    // Use a pipe to count harnesses (tests bash pipe support in execute)
+    let resp = mcp_tool_call_http(
+        &url,
+        "execute",
+        json!({ "command": "list_harnesses | jq '.data | length'" }),
+    )
+    .await;
+    assert!(!tool_is_error(&resp), "pipe failed: {}", tool_text(&resp));
+
+    let result = tool_json(&resp);
+    assert!(result["success"].as_bool().unwrap());
+    let count: i64 = result["stdout"].as_str().unwrap().trim().parse().unwrap();
+    assert!(count >= 2, "Should have at least 2 harnesses, got {count}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_execute_bash_script() {
+    let (_server, url) = TestServer::serving().await;
+
+    // Multi-line script: create agent then list to verify
+    let script = r#"
+        create_agent --name 'Script Agent' --system_prompt 'scripted' > /dev/null
+        list_agents | jq '.data | length'
+    "#;
+
+    let resp = mcp_tool_call_http(&url, "execute", json!({ "command": script })).await;
+    assert!(
+        !tool_is_error(&resp),
+        "bash script failed: {}",
+        tool_text(&resp)
+    );
+
+    let result = tool_json(&resp);
+    assert!(result["success"].as_bool().unwrap());
+    let count: i64 = result["stdout"].as_str().unwrap().trim().parse().unwrap();
+    assert!(count >= 1, "Should have at least 1 agent after creation");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_execute_list_providers() {
+    let (_server, url) = TestServer::serving().await;
+
+    let resp = mcp_tool_call_http(&url, "execute", json!({ "command": "list_providers" })).await;
+    assert!(
+        !tool_is_error(&resp),
+        "list_providers failed: {}",
+        tool_text(&resp)
+    );
+
+    let result = tool_json(&resp);
+    assert!(result["success"].as_bool().unwrap());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_execute_list_orgs() {
+    let (_server, url) = TestServer::serving().await;
+
+    let resp = mcp_tool_call_http(&url, "execute", json!({ "command": "list_orgs" })).await;
+    assert!(
+        !tool_is_error(&resp),
+        "list_orgs failed: {}",
+        tool_text(&resp)
+    );
+
+    let result = tool_json(&resp);
+    assert!(result["success"].as_bool().unwrap());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_execute_discover_categories() {
+    let (_server, url) = TestServer::serving().await;
+
+    let resp = mcp_tool_call_http(
+        &url,
+        "execute",
+        json!({ "command": "discover --categories" }),
+    )
+    .await;
+    assert!(
+        !tool_is_error(&resp),
+        "discover --categories failed: {}",
+        tool_text(&resp)
+    );
+
+    let result = tool_json(&resp);
+    assert!(result["success"].as_bool().unwrap());
+    let stdout = result["stdout"].as_str().unwrap();
+    assert!(stdout.contains("agents"), "Should list agents category");
+    assert!(stdout.contains("sessions"), "Should list sessions category");
+    assert!(
+        stdout.contains("harnesses"),
+        "Should list harnesses category"
+    );
+}
+
+// ============================================================================
+// Tier 2: execute — CRUD workflow via MCP
+// ============================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_execute_agent_crud_workflow() {
+    let (_server, url) = TestServer::serving().await;
+
+    // Create
+    let resp = mcp_tool_call_http(
+        &url,
+        "execute",
+        json!({
+            "command": "create_agent --name 'CRUD Agent' --system_prompt 'CRUD test'"
+        }),
+    )
+    .await;
+    let result = tool_json(&resp);
+    assert!(result["success"].as_bool().unwrap(), "create failed");
+    let created: Value = serde_json::from_str(result["stdout"].as_str().unwrap()).unwrap();
+    let agent_id = created["id"].as_str().unwrap().to_string();
+
+    // Update
+    let resp = mcp_tool_call_http(
+        &url,
+        "execute",
+        json!({
+            "command": format!("update_agent --id {agent_id} --name 'Updated CRUD Agent'")
+        }),
+    )
+    .await;
+    let result = tool_json(&resp);
+    assert!(result["success"].as_bool().unwrap(), "update failed");
+    let updated: Value = serde_json::from_str(result["stdout"].as_str().unwrap()).unwrap();
+    assert_eq!(updated["name"], "Updated CRUD Agent");
+
+    // Delete (archive)
+    let resp = mcp_tool_call_http(
+        &url,
+        "execute",
+        json!({ "command": format!("delete_agent --id {agent_id}") }),
+    )
+    .await;
+    let result = tool_json(&resp);
+    assert!(result["success"].as_bool().unwrap(), "delete failed");
+}
+
+// ============================================================================
+// Tier 1 + Tier 2 combined: full flow via MCP
+// ============================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_full_flow_agent_run_then_status() {
+    let server = TestServer::new().await;
+
+    // Create agent
+    let agent: Value = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": "Flow Agent",
+                "system_prompt": "You are a flow test agent."
+            }),
+        )
+        .await
+        .assert_success()
+        .json();
+    let agent_id = agent["id"].as_str().unwrap();
+
+    // agent_run
+    let run_resp = mcp_tool_call(
+        &server,
+        "agent_run",
+        json!({
+            "agent_id": agent_id,
+            "message": "What is 2+2?",
+            "title": "Math test"
+        }),
+    )
+    .await;
+    assert!(!tool_is_error(&run_resp));
+    let run_result = tool_json(&run_resp);
+    let session_id = run_result["session_id"].as_str().unwrap();
+
+    // session_get_status
+    let status_resp = mcp_tool_call(
+        &server,
+        "session_get_status",
+        json!({ "session_id": session_id }),
+    )
+    .await;
+    assert!(!tool_is_error(&status_resp));
+    let status = tool_json(&status_resp);
+    assert_eq!(status["session_id"], session_id);
+
+    // session_send_message
+    let msg_resp = mcp_tool_call(
+        &server,
+        "session_send_message",
+        json!({
+            "session_id": session_id,
+            "message": "And what is 3+3?"
+        }),
+    )
+    .await;
+    assert!(!tool_is_error(&msg_resp));
+
+    // Check status again — should have more events
+    let status2_resp = mcp_tool_call(
+        &server,
+        "session_get_status",
+        json!({ "session_id": session_id }),
+    )
+    .await;
+    assert!(!tool_is_error(&status2_resp));
+    let status2 = tool_json(&status2_resp);
+    let event_count = status2["event_count"].as_i64().unwrap();
+    assert!(event_count >= 0, "Should have events after messages");
+}

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -322,6 +322,11 @@ async fn test_mcp_session_send_message() {
         json!({ "message": "Initial message" }),
     )
     .await;
+    assert!(
+        !tool_is_error(&run_resp),
+        "agent_run failed: {}",
+        tool_text(&run_resp)
+    );
     let session_id = tool_json(&run_resp)["session_id"]
         .as_str()
         .unwrap()
@@ -404,6 +409,11 @@ async fn test_mcp_session_get_status() {
 
     // Create a session
     let run_resp = mcp_tool_call(&server, "agent_run", json!({ "message": "Status test" })).await;
+    assert!(
+        !tool_is_error(&run_resp),
+        "agent_run failed: {}",
+        tool_text(&run_resp)
+    );
     let session_id = tool_json(&run_resp)["session_id"]
         .as_str()
         .unwrap()
@@ -434,6 +444,11 @@ async fn test_mcp_session_get_status_with_event_filter() {
 
     // Create a session
     let run_resp = mcp_tool_call(&server, "agent_run", json!({ "message": "Filter test" })).await;
+    assert!(
+        !tool_is_error(&run_resp),
+        "agent_run failed: {}",
+        tool_text(&run_resp)
+    );
     let session_id = tool_json(&run_resp)["session_id"]
         .as_str()
         .unwrap()
@@ -869,6 +884,11 @@ async fn test_mcp_execute_agent_crud_workflow() {
         }),
     )
     .await;
+    assert!(
+        !tool_is_error(&resp),
+        "create_agent failed: {}",
+        tool_text(&resp)
+    );
     let result = tool_json(&resp);
     assert!(result["success"].as_bool().unwrap(), "create failed");
     let created: Value = serde_json::from_str(result["stdout"].as_str().unwrap()).unwrap();
@@ -883,6 +903,11 @@ async fn test_mcp_execute_agent_crud_workflow() {
         }),
     )
     .await;
+    assert!(
+        !tool_is_error(&resp),
+        "update_agent failed: {}",
+        tool_text(&resp)
+    );
     let result = tool_json(&resp);
     assert!(result["success"].as_bool().unwrap(), "update failed");
     let updated: Value = serde_json::from_str(result["stdout"].as_str().unwrap()).unwrap();
@@ -968,6 +993,10 @@ async fn test_mcp_full_flow_agent_run_then_status() {
     .await;
     assert!(!tool_is_error(&status2_resp));
     let status2 = tool_json(&status2_resp);
-    let event_count = status2["event_count"].as_i64().unwrap();
-    assert!(event_count >= 0, "Should have events after messages");
+    let first_event_count = status["event_count"].as_i64().unwrap_or(0);
+    let second_event_count = status2["event_count"].as_i64().unwrap();
+    assert!(
+        second_event_count > first_event_count,
+        "Expected more events after send_message (before={first_event_count}, after={second_event_count})"
+    );
 }

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -64,15 +64,38 @@ pub struct TestServer {
 impl TestServer {
     /// Create a new test server with PostgreSQL backend
     pub async fn new() -> Self {
-        Self::with_mode(TestMode::Postgres).await
+        Self::with_mode_and_url(TestMode::Postgres, "http://127.0.0.1:0".to_string()).await
     }
 
     /// Create a new test server in dev mode (in-memory storage)
     pub async fn in_memory() -> Self {
-        Self::with_mode(TestMode::InMemory).await
+        Self::with_mode_and_url(TestMode::InMemory, "http://127.0.0.1:0".to_string()).await
     }
 
-    async fn with_mode(mode: TestMode) -> Self {
+    /// Create a test server backed by a real TCP listener.
+    ///
+    /// Returns `(server, base_url)`. The server is served on a random port
+    /// and the MCP endpoint's `execute` tool can make HTTP callbacks to it.
+    pub async fn serving() -> (Self, String) {
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("Failed to bind TCP listener");
+        let addr = listener.local_addr().unwrap();
+        let base_url = format!("http://{addr}");
+
+        let server = Self::with_mode_and_url(TestMode::Postgres, base_url.clone()).await;
+        let router = server.router.clone();
+
+        tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+
+        (server, base_url)
+    }
+
+    async fn with_mode_and_url(mode: TestMode, api_base_url: String) -> Self {
         // Create storage backend based on mode
         let (db, pool, durable_store) = match mode {
             TestMode::Postgres => {
@@ -261,6 +284,14 @@ impl TestServer {
             None, // No delivery dispatcher in tests
             feature_flags.notifications,
         );
+        let mcp_endpoint_state = api::mcp_endpoint::AppState::new(
+            db.clone(),
+            runner.clone(),
+            auth_state.clone(),
+            &platform_definition,
+            feature_flags.notifications,
+            api_base_url,
+        );
 
         // Build API routes
         let mut api_routes = Router::new()
@@ -292,6 +323,7 @@ impl TestServer {
             .merge(api::feature_flags::routes(feature_flags_state))
             .merge(api::user_connections::routes(user_connections_state))
             .merge(api::slack_events::routes(slack_state))
+            .merge(api::mcp_endpoint::routes(mcp_endpoint_state))
             .merge(auth::routes(auth_backend));
 
         if let Some(notifications_state) = notifications_state {

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -88,9 +88,23 @@ impl TestServer {
         let server = Self::with_mode_and_url(TestMode::Postgres, base_url.clone()).await;
         let router = server.router.clone();
 
-        tokio::spawn(async move {
-            axum::serve(listener, router).await.unwrap();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router)
+                .with_graceful_shutdown(async { drop(shutdown_rx.await) })
+                .await
+                .unwrap();
         });
+
+        // Store shutdown handle so caller can drop it; stash in a leaked box
+        // so the server task is cleaned up when the process exits.
+        // Also wait briefly for the server to start accepting connections.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Leak the handles — tests are short-lived processes and this avoids
+        // adding lifetime complexity to TestServer. The graceful shutdown +
+        // oneshot still ensures the server stops promptly on drop.
+        std::mem::forget((shutdown_tx, handle));
 
         (server, base_url)
     }


### PR DESCRIPTION
## Summary

- Add 38 integration tests for the MCP endpoint (`POST /mcp`) covering all exposed tools
- Add MCP endpoint routes to `TestServer` and a `serving()` method for tests needing real TCP listeners (execute tool HTTP callbacks)

### Test coverage

| Layer | Tests | What's covered |
|-------|-------|----------------|
| Protocol | 7 | initialize, ping, tools/list, invalid jsonrpc version, unknown method, unknown tool, missing tool name |
| Tier 1: agent_run | 4 | with agent, without agent, missing message, invalid agent_id |
| Tier 1: session_send_message | 3 | success, missing params, nonexistent session |
| Tier 1: session_get_status | 4 | success, event type filter, missing session_id, nonexistent session |
| Tier 2: discover | 5 | agents, sessions, harnesses, mcp servers, missing query |
| Tier 2: execute | 14 | health_check, list_harnesses, create/get agent, list models/capabilities/mcp_servers/providers/orgs, create mcp_server, bash pipes, multi-line scripts, discover --categories, agent CRUD workflow |
| Full flow | 1 | agent_run → session_get_status → session_send_message → status |

## Test plan

- [x] All 38 tests pass locally (`cargo test -p everruns-server --test mcp_endpoint_test -- --test-threads=1`)
- [x] `just pre-push` passes (fmt, clippy, lockfile)
- [ ] CI green