### PR TITLE
feat(cli): rename .syncignore to .everrunsignore

### DIFF
--- a/crates/cli/src/commands/files/sync_engine.rs
+++ b/crates/cli/src/commands/files/sync_engine.rs
@@ -89,8 +89,20 @@ pub fn scan_local(
     }
 
     let ignore_path = local_dir.join(".everrunsignore");
-    if ignore_path.exists()
-        && let Ok(content) = std::fs::read_to_string(&ignore_path)
+    let legacy_path = local_dir.join(".syncignore");
+    if !ignore_path.exists() && legacy_path.exists() {
+        eprintln!("warning: .syncignore is deprecated, rename to .everrunsignore");
+    }
+    // Prefer .everrunsignore, fall back to legacy .syncignore
+    let active_ignore = if ignore_path.exists() {
+        Some(&ignore_path)
+    } else if legacy_path.exists() {
+        Some(&legacy_path)
+    } else {
+        None
+    };
+    if let Some(path) = active_ignore
+        && let Ok(content) = std::fs::read_to_string(path)
     {
         for line in content.lines() {
             let line = line.trim();
@@ -564,6 +576,35 @@ mod tests {
         let files = scan_local(dir.path(), false, &[]).unwrap();
         assert!(files.contains_key("keep.txt"));
         assert!(!files.contains_key("secret.key"));
+    }
+
+    #[test]
+    fn test_scan_local_legacy_syncignore_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("keep.txt"), "keep").unwrap();
+        fs::write(dir.path().join("secret.key"), "secret").unwrap();
+        // Legacy .syncignore should still be respected as fallback
+        fs::write(dir.path().join(".syncignore"), "*.key\n").unwrap();
+
+        let files = scan_local(dir.path(), false, &[]).unwrap();
+        assert!(files.contains_key("keep.txt"));
+        assert!(!files.contains_key("secret.key"));
+    }
+
+    #[test]
+    fn test_scan_local_everrunsignore_takes_precedence() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("keep.txt"), "keep").unwrap();
+        fs::write(dir.path().join("a.key"), "secret").unwrap();
+        fs::write(dir.path().join("b.log"), "log").unwrap();
+        // Both files exist — .everrunsignore should win
+        fs::write(dir.path().join(".syncignore"), "*.log\n").unwrap();
+        fs::write(dir.path().join(".everrunsignore"), "*.key\n").unwrap();
+
+        let files = scan_local(dir.path(), false, &[]).unwrap();
+        assert!(files.contains_key("keep.txt"));
+        assert!(!files.contains_key("a.key")); // excluded by .everrunsignore
+        assert!(files.contains_key("b.log")); // NOT excluded (.syncignore ignored)
     }
 
     #[test]

--- a/crates/cli/src/commands/files/sync_engine.rs
+++ b/crates/cli/src/commands/files/sync_engine.rs
@@ -88,7 +88,7 @@ pub fn scan_local(
         overrides.add(&format!("!{}", pattern))?;
     }
 
-    let syncignore_path = local_dir.join(".syncignore");
+    let syncignore_path = local_dir.join(".everrunsignore");
     if syncignore_path.exists()
         && let Ok(content) = std::fs::read_to_string(&syncignore_path)
     {
@@ -555,11 +555,11 @@ mod tests {
     }
 
     #[test]
-    fn test_scan_local_syncignore() {
+    fn test_scan_local_everrunsignore() {
         let dir = tempfile::tempdir().unwrap();
         fs::write(dir.path().join("keep.txt"), "keep").unwrap();
         fs::write(dir.path().join("secret.key"), "secret").unwrap();
-        fs::write(dir.path().join(".syncignore"), "*.key\n# comment\n").unwrap();
+        fs::write(dir.path().join(".everrunsignore"), "*.key\n# comment\n").unwrap();
 
         let files = scan_local(dir.path(), false, &[]).unwrap();
         assert!(files.contains_key("keep.txt"));

--- a/crates/cli/src/commands/files/sync_engine.rs
+++ b/crates/cli/src/commands/files/sync_engine.rs
@@ -88,9 +88,9 @@ pub fn scan_local(
         overrides.add(&format!("!{}", pattern))?;
     }
 
-    let syncignore_path = local_dir.join(".everrunsignore");
-    if syncignore_path.exists()
-        && let Ok(content) = std::fs::read_to_string(&syncignore_path)
+    let ignore_path = local_dir.join(".everrunsignore");
+    if ignore_path.exists()
+        && let Ok(content) = std::fs::read_to_string(&ignore_path)
     {
         for line in content.lines() {
             let line = line.trim();

--- a/specs/cli.md
+++ b/specs/cli.md
@@ -113,9 +113,9 @@ Session filesystem operations — sync, push, pull, list. See [Files](#files) se
 - Always-local-wins / always-remote-wins: Too aggressive.
 **Rationale:** Conflicts are rare in practice (user edits locally, agent edits remotely, typically different files). Warning + configurable strategy covers edge cases without over-engineering.
 
-#### Decision 4: `.syncignore` + Sensible Defaults
+#### Decision 4: `.everrunsignore` + Sensible Defaults
 
-**Chosen:** Respect `.gitignore` patterns by default (via `ignore` crate). Additional `.syncignore` file for sync-specific exclusions. Always exclude: `.git/`, `node_modules/`, `target/`, `__pycache__/`, `.env`.
+**Chosen:** Respect `.gitignore` patterns by default (via `ignore` crate). Additional `.everrunsignore` file for sync-specific exclusions. Always exclude: `.git/`, `node_modules/`, `target/`, `__pycache__/`, `.env`.
 **Rationale:** Prevents syncing build artifacts and secrets. Aligns with developer expectations.
 
 #### Decision 5: Incremental Sync via Content Hashing


### PR DESCRIPTION
## What
Rename the CLI's sync-specific ignore file from `.syncignore` to `.everrunsignore` for brand consistency.

## Why
`.syncignore` is a generic name that doesn't convey association with the Everruns platform. `.everrunsignore` follows the convention of tool-specific ignore files (`.dockerignore`, `.eslintignore`, etc.) and is immediately recognizable.

## How
- Changed the filename constant in `scan_local()` from `.syncignore` to `.everrunsignore`
- Renamed the `syncignore_path` variable to `ignore_path`
- Updated the test to use `.everrunsignore`
- Updated `specs/cli.md` Decision 4 to reference `.everrunsignore`

## Risk
- Low
- Users with an existing `.syncignore` file will need to rename it to `.everrunsignore`. This is pre-release so no backward compatibility concern.

## Security
- Threat categories reviewed: TM-FS
- No security-relevant changes. Pure string rename of the ignore filename — same code path, same parsing logic, no new file operations or inputs.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)