### PR TITLE
fix(daytona): wrap exec polling commands in sh -c for shell redirection

### DIFF
--- a/integrations/daytona/src/client.rs
+++ b/integrations/daytona/src/client.rs
@@ -376,7 +376,7 @@ impl DaytonaClient {
                     .exec(
                         sandbox_id,
                         &format!(
-                            "if [ -f {pid_file} ]; then kill $(cat {pid_file}) 2>/dev/null; fi"
+                            "sh -c 'if [ -f {pid_file} ]; then kill $(cat {pid_file}) 2>/dev/null; fi'"
                         ),
                         None,
                         Some(5_000),
@@ -399,7 +399,11 @@ impl DaytonaClient {
             let new_output = self
                 .exec(
                     sandbox_id,
-                    &format!("tail -c +{} {out_file} 2>/dev/null", bytes_read + 1),
+                    &format!(
+                        "sh -c 'tail -c +{} {} 2>/dev/null'",
+                        bytes_read + 1,
+                        out_file
+                    ),
                     None,
                     Some(10_000),
                 )
@@ -416,7 +420,7 @@ impl DaytonaClient {
             let done_check = self
                 .exec(
                     sandbox_id,
-                    &format!("cat {exit_file} 2>/dev/null"),
+                    &format!("sh -c 'cat {exit_file} 2>/dev/null'"),
                     None,
                     Some(5_000),
                 )
@@ -429,7 +433,11 @@ impl DaytonaClient {
                     let final_output = self
                         .exec(
                             sandbox_id,
-                            &format!("tail -c +{} {out_file} 2>/dev/null", bytes_read + 1),
+                            &format!(
+                                "sh -c 'tail -c +{} {} 2>/dev/null'",
+                                bytes_read + 1,
+                                out_file
+                            ),
                             None,
                             Some(10_000),
                         )
@@ -444,7 +452,7 @@ impl DaytonaClient {
                     let full_output = self
                         .exec(
                             sandbox_id,
-                            &format!("cat {out_file} 2>/dev/null"),
+                            &format!("sh -c 'cat {out_file} 2>/dev/null'"),
                             None,
                             Some(10_000),
                         )

--- a/integrations/daytona/tests/live_api_test.rs
+++ b/integrations/daytona/tests/live_api_test.rs
@@ -234,6 +234,33 @@ async fn test_live_folder_and_list() {
     );
 }
 
+/// exec_streaming: shell redirections (`2>/dev/null`) must not leak as literal filenames (EVE-185).
+#[tokio::test]
+async fn test_live_exec_streaming_returns_output() {
+    let api_key = require_api_key!();
+    let (client, guard) = create_test_sandbox(api_key, "exec-streaming").await;
+    let id = &guard.sandbox_id;
+
+    let mut chunks = Vec::new();
+    let result = client
+        .exec_streaming(id, "echo hello-streaming", None, 30_000, |chunk| {
+            chunks.push(chunk.to_string());
+        })
+        .await
+        .expect("exec_streaming failed");
+
+    assert_eq!(result.exit_code, 0, "Expected exit code 0");
+    assert!(
+        result.result.contains("hello-streaming"),
+        "Full output missing marker: {}",
+        result.result
+    );
+    assert!(
+        !chunks.is_empty() || result.result.contains("hello-streaming"),
+        "Expected at least one output chunk or full output"
+    );
+}
+
 /// Stop and start a sandbox.
 #[tokio::test]
 async fn test_live_stop_and_start() {

--- a/integrations/daytona/tests/live_api_test.rs
+++ b/integrations/daytona/tests/live_api_test.rs
@@ -256,8 +256,8 @@ async fn test_live_exec_streaming_returns_output() {
         result.result
     );
     assert!(
-        !chunks.is_empty() || result.result.contains("hello-streaming"),
-        "Expected at least one output chunk or full output"
+        !chunks.is_empty(),
+        "Expected at least one output chunk from streaming callback"
     );
 }
 


### PR DESCRIPTION
## What
Wrap all `exec_streaming` polling commands (`tail`, `cat`, `kill`) in `sh -c '...'` so shell redirections like `2>/dev/null` are interpreted correctly.

## Why
Daytona's exec API passes commands without a shell, so `2>/dev/null` was treated as a literal filename argument to `tail`/`cat`, causing `tail: cannot open '2>/dev/null' for reading: No such file or directory`.

Fixes EVE-185

## How
Prefixed each polling/cleanup command that uses shell redirections or constructs with `sh -c '...'`. Five call sites in `exec_streaming`:
- Timeout kill (line 379)
- Output polling tail (line 402)
- Exit file check cat (line 419)
- Final output tail (line 432)
- Full output cat (line 447)

Added a live integration test (`test_live_exec_streaming_returns_output`) that exercises `exec_streaming` against real Daytona, verifying output is returned correctly.

## Risk
- Low
- Only affects Daytona exec polling commands; the `sh -c` wrapper is the standard way to ensure shell interpretation

## Security
- Threat categories reviewed: TM-BASH (command execution)
- All interpolated values in the `sh -c` commands are internally generated (hex timestamp filenames, integer byte counters) — no user input reaches these format strings. No injection vector. No new threat surface.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)