### PR TITLE
fix(daytona): migrate exec to Session API with unified streaming

### DIFF
--- a/integrations/daytona/src/client.rs
+++ b/integrations/daytona/src/client.rs
@@ -317,33 +317,18 @@ impl DaytonaClient {
         }
     }
 
-    /// Execute a command in the sandbox and return the result.
+    /// Execute a command in the sandbox via the Session API.
     ///
-    /// Uses the Session API with async execution + log polling so all
-    /// commands go through a proper shell and support streaming output.
-    pub async fn exec(
+    /// Creates a persistent shell session (if needed), runs the command
+    /// asynchronously, and polls the session logs endpoint for output.
+    /// Calls `on_output` with each new chunk as it becomes available.
+    /// Pass `|_| {}` if streaming is not needed.
+    pub async fn exec<F>(
         &self,
         sandbox_id: &str,
         command: &str,
         cwd: Option<&str>,
         timeout_ms: Option<u64>,
-    ) -> Result<ExecResult, String> {
-        let timeout = timeout_ms.unwrap_or(crate::EXEC_TIMEOUT_MS);
-        self.exec_streaming(sandbox_id, command, cwd, timeout, |_| {})
-            .await
-    }
-
-    /// Execute a command with real-time output streaming via the Session API.
-    ///
-    /// Creates a persistent session (if needed), runs the command asynchronously,
-    /// and polls the session logs endpoint for output. Calls `on_output` with each
-    /// new chunk as it becomes available.
-    pub async fn exec_streaming<F>(
-        &self,
-        sandbox_id: &str,
-        command: &str,
-        cwd: Option<&str>,
-        timeout_ms: u64,
         mut on_output: F,
     ) -> Result<ExecResult, String>
     where
@@ -355,6 +340,8 @@ impl DaytonaClient {
             Some(c) => format!("cd {c} && {command}"),
             None => command.to_string(),
         };
+
+        let timeout = timeout_ms.unwrap_or(crate::EXEC_TIMEOUT_MS);
 
         // Start async execution in the persistent session.
         // runAsync: true returns immediately with a cmdId.
@@ -377,14 +364,14 @@ impl DaytonaClient {
             .to_string();
 
         // Poll for output and completion.
-        let deadline = std::time::Instant::now() + Duration::from_millis(timeout_ms);
+        let deadline = std::time::Instant::now() + Duration::from_millis(timeout);
         let mut output_emitted: usize = 0;
         let logs_path = format!("/process/session/{EXEC_SESSION_ID}/command/{cmd_id}/logs");
         let status_path = format!("/process/session/{EXEC_SESSION_ID}/command/{cmd_id}");
 
         loop {
             if std::time::Instant::now() >= deadline {
-                return Err(format!("Command timed out after {timeout_ms}ms"));
+                return Err(format!("Command timed out after {timeout}ms"));
             }
 
             tokio::time::sleep(EXEC_POLL_INTERVAL).await;
@@ -696,7 +683,9 @@ mod tests {
             mock_server.uri(),
             mock_server.uri(),
         );
-        let result = client.exec("sb_test", "echo hello world", None, None).await;
+        let result = client
+            .exec("sb_test", "echo hello world", None, None, |_| {})
+            .await;
         assert!(result.is_ok());
         let exec_result = result.unwrap();
         assert_eq!(exec_result.exit_code, 0);
@@ -963,7 +952,9 @@ mod tests {
             mock_server.uri(),
             mock_server.uri(),
         );
-        let result = client.exec("sb_test", "ls", Some("/tmp"), Some(5000)).await;
+        let result = client
+            .exec("sb_test", "ls", Some("/tmp"), Some(5000), |_| {})
+            .await;
         assert!(result.is_ok());
         let exec_result = result.unwrap();
         assert_eq!(exec_result.exit_code, 1);
@@ -980,7 +971,9 @@ mod tests {
             mock_server.uri(),
             mock_server.uri(),
         );
-        let result = client.exec("sb_test", "nonexistent", None, None).await;
+        let result = client
+            .exec("sb_test", "nonexistent", None, None, |_| {})
+            .await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap().exit_code, 127);
     }
@@ -1192,9 +1185,15 @@ mod tests {
         let chunks_clone = chunks.clone();
 
         let result = client
-            .exec_streaming("sb_test", "echo hello streaming", None, 30_000, |chunk| {
-                chunks_clone.lock().unwrap().push(chunk.to_string());
-            })
+            .exec(
+                "sb_test",
+                "echo hello streaming",
+                None,
+                Some(30_000),
+                |chunk| {
+                    chunks_clone.lock().unwrap().push(chunk.to_string());
+                },
+            )
             .await;
 
         assert!(result.is_ok(), "exec_streaming failed: {:?}", result.err());

--- a/integrations/daytona/src/client.rs
+++ b/integrations/daytona/src/client.rs
@@ -1,4 +1,10 @@
 //! Daytona API client and URL encoding utilities.
+//!
+//! Decision: All command execution goes through the Session API
+//! (`/process/session/{id}/exec`). The session provides a persistent shell
+//! so commands always get proper shell interpretation (pipes, redirects,
+//! variable expansion, etc.). The old stateless `/process/execute` endpoint
+//! is NOT used — it doesn't support async execution or output streaming.
 
 use serde_json::{Value, json};
 use std::time::Duration;
@@ -6,6 +12,10 @@ use tracing::debug;
 
 use crate::state::{ExecResult, SandboxInfo};
 use crate::{EXEC_POLL_INTERVAL, SANDBOX_READY_MAX_WAIT, SANDBOX_READY_POLL_INTERVAL};
+
+/// Fixed session ID used for all command execution in a sandbox.
+/// One session per sandbox, created on first exec, reused thereafter.
+const EXEC_SESSION_ID: &str = "everruns-exec";
 
 // ============================================================================
 // DaytonaClient - HTTP client for Daytona APIs
@@ -282,8 +292,35 @@ impl DaytonaClient {
         ))
     }
 
-    // --- Toolbox API: Process ---
+    // --- Toolbox API: Process (Session-based) ---
 
+    /// Ensure a persistent shell session exists for the sandbox.
+    /// Idempotent — 409 means the session already exists.
+    async fn ensure_session(&self, sandbox_id: &str) -> Result<(), String> {
+        let url = format!("{}/{sandbox_id}/process/session", self.toolbox_base);
+        let resp = self
+            .http
+            .post(&url)
+            .bearer_auth(&self.api_key)
+            .header("Content-Type", "application/json")
+            .json(&json!({"sessionId": EXEC_SESSION_ID}))
+            .send()
+            .await
+            .map_err(|e| format!("Failed to create session: {e}"))?;
+
+        let status = resp.status();
+        if status.is_success() || status.as_u16() == 409 {
+            Ok(())
+        } else {
+            let body = resp.text().await.unwrap_or_default();
+            Err(format!("Failed to create session ({status}): {body}"))
+        }
+    }
+
+    /// Execute a command in the sandbox and return the result.
+    ///
+    /// Uses the Session API with async execution + log polling so all
+    /// commands go through a proper shell and support streaming output.
     pub async fn exec(
         &self,
         sandbox_id: &str,
@@ -291,33 +328,16 @@ impl DaytonaClient {
         cwd: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> Result<ExecResult, String> {
-        // Daytona's process/execute endpoint runs commands without a shell —
-        // shell operators (|, >, &&, $(), etc.) are passed as literal args.
-        // Wrap in sh -c so they are interpreted correctly.
-        let escaped = command.replace('\'', "'\\''");
-        let wrapped = format!("sh -c '{escaped}'");
-        let mut body = json!({ "command": wrapped });
-        if let Some(c) = cwd {
-            body["cwd"] = json!(c);
-        }
-        if let Some(t) = timeout_ms {
-            body["timeout"] = json!(t);
-        }
-        let resp = self
-            .toolbox_request(
-                reqwest::Method::POST,
-                sandbox_id,
-                "/process/execute",
-                Some(body),
-            )
-            .await?;
-        serde_json::from_value(resp).map_err(|e| format!("Failed to parse exec result: {e}"))
+        let timeout = timeout_ms.unwrap_or(crate::EXEC_TIMEOUT_MS);
+        self.exec_streaming(sandbox_id, command, cwd, timeout, |_| {})
+            .await
     }
 
-    /// Execute a command with real-time output streaming via background process + file polling.
+    /// Execute a command with real-time output streaming via the Session API.
     ///
-    /// Returns `(exit_code, full_output)`. Calls `on_output` with each new chunk of output
-    /// as it becomes available.
+    /// Creates a persistent session (if needed), runs the command asynchronously,
+    /// and polls the session logs endpoint for output. Calls `on_output` with each
+    /// new chunk as it becomes available.
     pub async fn exec_streaming<F>(
         &self,
         sandbox_id: &str,
@@ -329,151 +349,81 @@ impl DaytonaClient {
     where
         F: FnMut(&str),
     {
-        let exec_id = format!(
-            "{:x}",
-            chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)
-        );
-        let out_file = format!("/tmp/everruns_exec_{exec_id}.out");
-        let exit_file = format!("/tmp/everruns_exec_{exec_id}.exit");
-        let pid_file = format!("/tmp/everruns_exec_{exec_id}.pid");
+        self.ensure_session(sandbox_id).await?;
 
-        // Write command to a temp script to avoid shell quoting issues (commands
-        // frequently contain single/double quotes, backticks, $(), etc.).
-        let script_file = format!("/tmp/everruns_exec_{exec_id}.sh");
-        let cwd_part = cwd.map(|c| format!("cd {c} && ")).unwrap_or_default();
-        let script_body = format!("{cwd_part}({command}) > {out_file} 2>&1; echo $? > {exit_file}");
+        let cmd = match cwd {
+            Some(c) => format!("cd {c} && {command}"),
+            None => command.to_string(),
+        };
 
-        // Write the script, make executable, run in background, capture PID.
-        let write_result = self
-            .exec(
+        // Start async execution in the persistent session.
+        // runAsync: true returns immediately with a cmdId.
+        let resp = self
+            .toolbox_request(
+                reqwest::Method::POST,
                 sandbox_id,
-                &format!(
-                    "cat > {script_file} << 'EVERRUNS_EXEC_EOF'\n{script_body}\nEVERRUNS_EXEC_EOF\nchmod +x {script_file}"
-                ),
-                None,
-                Some(10_000),
+                &format!("/process/session/{EXEC_SESSION_ID}/exec"),
+                Some(json!({
+                    "command": cmd,
+                    "runAsync": true
+                })),
             )
-            .await;
-        if let Err(e) = write_result {
-            return Err(format!("Failed to write exec script: {e}"));
-        }
+            .await?;
 
-        let start_result = self
-            .exec(
-                sandbox_id,
-                &format!("nohup sh {script_file} > /dev/null 2>&1 & echo $! > {pid_file}"),
-                None,
-                Some(10_000),
-            )
-            .await;
-        if let Err(e) = start_result {
-            return Err(format!("Failed to start background command: {e}"));
-        }
+        let cmd_id = resp
+            .get("cmdId")
+            .and_then(|v| v.as_str())
+            .ok_or("Missing cmdId in session exec response")?
+            .to_string();
 
-        // Poll for output
+        // Poll for output and completion.
         let deadline = std::time::Instant::now() + Duration::from_millis(timeout_ms);
-        let mut bytes_read: usize = 0;
+        let mut output_emitted: usize = 0;
+        let logs_path = format!("/process/session/{EXEC_SESSION_ID}/command/{cmd_id}/logs");
+        let status_path = format!("/process/session/{EXEC_SESSION_ID}/command/{cmd_id}");
 
         loop {
             if std::time::Instant::now() >= deadline {
-                // Timeout — kill the process by PID and clean up
-                let _ = self
-                    .exec(
-                        sandbox_id,
-                        &format!(
-                            "if [ -f {pid_file} ]; then kill $(cat {pid_file}) 2>/dev/null; fi"
-                        ),
-                        None,
-                        Some(5_000),
-                    )
-                    .await;
-                let _ = self
-                    .exec(
-                        sandbox_id,
-                        &format!("rm -f {out_file} {exit_file} {script_file} {pid_file}"),
-                        None,
-                        Some(5_000),
-                    )
-                    .await;
-                return Err(format!("Command timed out after {}ms", timeout_ms));
+                return Err(format!("Command timed out after {timeout_ms}ms"));
             }
 
             tokio::time::sleep(EXEC_POLL_INTERVAL).await;
 
-            // Check for new output
-            let new_output = self
-                .exec(
-                    sandbox_id,
-                    &format!("tail -c +{} {} 2>/dev/null", bytes_read + 1, out_file),
-                    None,
-                    Some(10_000),
-                )
-                .await;
+            // Fetch session command logs (raw bytes with stream markers).
+            let logs = self
+                .toolbox_download(sandbox_id, &logs_path)
+                .await
+                .unwrap_or_default();
 
-            if let Ok(ref chunk) = new_output
-                && !chunk.result.is_empty()
-            {
-                bytes_read += chunk.result.len();
-                on_output(&chunk.result);
+            let text = strip_stream_markers(&logs);
+            if text.len() > output_emitted {
+                on_output(&text[output_emitted..]);
+                output_emitted = text.len();
             }
 
-            // Check if the process has completed (exit file exists)
-            let done_check = self
-                .exec(
-                    sandbox_id,
-                    &format!("cat {exit_file} 2>/dev/null"),
-                    None,
-                    Some(5_000),
-                )
+            // Check if command completed (exitCode is present).
+            let status = self
+                .toolbox_request(reqwest::Method::GET, sandbox_id, &status_path, None)
                 .await;
 
-            if let Ok(ref done) = done_check {
-                let trimmed = done.result.trim();
-                if !trimmed.is_empty() {
-                    // Process finished — read any remaining output
-                    let final_output = self
-                        .exec(
-                            sandbox_id,
-                            &format!("tail -c +{} {} 2>/dev/null", bytes_read + 1, out_file),
-                            None,
-                            Some(10_000),
-                        )
-                        .await;
-                    if let Ok(ref tail) = final_output
-                        && !tail.result.is_empty()
-                    {
-                        on_output(&tail.result);
-                    }
+            if let Ok(ref s) = status
+                && let Some(exit_code) = s.get("exitCode").and_then(|v| v.as_i64())
+            {
+                // Final log fetch to capture any trailing output.
+                let final_logs = self
+                    .toolbox_download(sandbox_id, &logs_path)
+                    .await
+                    .unwrap_or_default();
 
-                    // Read the full output for the final result
-                    let full_output = self
-                        .exec(
-                            sandbox_id,
-                            &format!("cat {out_file} 2>/dev/null"),
-                            None,
-                            Some(10_000),
-                        )
-                        .await
-                        .map(|r| r.result)
-                        .unwrap_or_default();
-
-                    let exit_code = trimmed.parse::<i32>().unwrap_or(-1);
-
-                    // Clean up temp files
-                    let _ = self
-                        .exec(
-                            sandbox_id,
-                            &format!("rm -f {out_file} {exit_file} {script_file} {pid_file}"),
-                            None,
-                            Some(5_000),
-                        )
-                        .await;
-
-                    return Ok(ExecResult {
-                        result: full_output,
-                        exit_code,
-                    });
+                let final_text = strip_stream_markers(&final_logs);
+                if final_text.len() > output_emitted {
+                    on_output(&final_text[output_emitted..]);
                 }
+
+                return Ok(ExecResult {
+                    result: final_text,
+                    exit_code: exit_code as i32,
+                });
             }
         }
     }
@@ -544,6 +494,31 @@ impl DaytonaClient {
         .await?;
         Ok(())
     }
+}
+
+/// Strip Daytona session log stream multiplexing markers from raw output.
+///
+/// The session API multiplexes stdout/stderr with 3-byte prefix markers:
+/// - `\x01\x01\x01` = stdout data follows
+/// - `\x02\x02\x02` = stderr data follows
+///
+/// We strip the markers and return combined text (matching the previous
+/// behavior where `ExecResult.result` contains combined stdout+stderr).
+pub(crate) fn strip_stream_markers(raw: &[u8]) -> String {
+    let mut result = Vec::with_capacity(raw.len());
+    let mut i = 0;
+    while i < raw.len() {
+        if i + 3 <= raw.len()
+            && ((raw[i] == 0x01 && raw[i + 1] == 0x01 && raw[i + 2] == 0x01)
+                || (raw[i] == 0x02 && raw[i + 1] == 0x02 && raw[i + 2] == 0x02))
+        {
+            i += 3;
+            continue;
+        }
+        result.push(raw[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&result).into_owned()
 }
 
 pub(crate) mod urlencoding {
@@ -661,17 +636,60 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    /// Set up mock responses for the session-based exec flow.
+    async fn setup_session_mocks(
+        mock_server: &MockServer,
+        sandbox_id: &str,
+        exit_code: i64,
+        output: &str,
+    ) {
+        // 1. Create session → 201 (or 409 if exists)
+        Mock::given(method("POST"))
+            .and(path(format!("/{sandbox_id}/process/session")))
+            .respond_with(ResponseTemplate::new(201))
+            .mount(mock_server)
+            .await;
+
+        // 2. Async exec → 202 with cmdId
+        Mock::given(method("POST"))
+            .and(path(format!(
+                "/{sandbox_id}/process/session/everruns-exec/exec"
+            )))
+            .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+                "cmdId": "cmd_001"
+            })))
+            .mount(mock_server)
+            .await;
+
+        // 3. Logs → output bytes with stdout marker prefix
+        let mut log_bytes = vec![0x01, 0x01, 0x01];
+        log_bytes.extend_from_slice(output.as_bytes());
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/{sandbox_id}/process/session/everruns-exec/command/cmd_001/logs"
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(log_bytes))
+            .mount(mock_server)
+            .await;
+
+        // 4. Command status → exitCode
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/{sandbox_id}/process/session/everruns-exec/command/cmd_001"
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "cmd_001",
+                "command": "test",
+                "exitCode": exit_code
+            })))
+            .mount(mock_server)
+            .await;
+    }
+
     #[tokio::test]
     async fn test_client_exec() {
         let mock_server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/sb_test/process/execute"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "result": "hello world\n",
-                "exitCode": 0
-            })))
-            .mount(&mock_server)
-            .await;
+        setup_session_mocks(&mock_server, "sb_test", 0, "hello world\n").await;
 
         let client = DaytonaClient::with_base_urls(
             "test_key".to_string(),
@@ -938,14 +956,7 @@ mod tests {
     #[tokio::test]
     async fn test_client_exec_with_cwd_and_timeout() {
         let mock_server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/sb_test/process/execute"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "result": "output",
-                "exitCode": 1
-            })))
-            .mount(&mock_server)
-            .await;
+        setup_session_mocks(&mock_server, "sb_test", 1, "output").await;
 
         let client = DaytonaClient::with_base_urls(
             "test_key".to_string(),
@@ -962,14 +973,7 @@ mod tests {
     #[tokio::test]
     async fn test_client_exec_nonzero_exit() {
         let mock_server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/sb_test/process/execute"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "result": "command not found",
-                "exitCode": 127
-            })))
-            .mount(&mock_server)
-            .await;
+        setup_session_mocks(&mock_server, "sb_test", 127, "command not found").await;
 
         let client = DaytonaClient::with_base_urls(
             "test_key".to_string(),
@@ -1174,70 +1178,9 @@ mod tests {
     #[tokio::test]
     async fn test_exec_streaming_collects_output_and_exit_code() {
         use std::sync::{Arc, Mutex};
-        use wiremock::matchers::body_string_contains;
 
         let mock_server = MockServer::start().await;
-        let exec_path = "/sb_test/process/execute";
-
-        // 1. Write script → success
-        Mock::given(method("POST"))
-            .and(path(exec_path))
-            .and(body_string_contains("cat >"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "result": "", "exitCode": 0
-            })))
-            .mount(&mock_server)
-            .await;
-
-        // 2. Start script → success
-        Mock::given(method("POST"))
-            .and(path(exec_path))
-            .and(body_string_contains("nohup sh"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "result": "", "exitCode": 0
-            })))
-            .mount(&mock_server)
-            .await;
-
-        // 3. Poll output via tail → return a chunk
-        Mock::given(method("POST"))
-            .and(path(exec_path))
-            .and(body_string_contains("tail -c"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "result": "hello streaming\n", "exitCode": 0
-            })))
-            .mount(&mock_server)
-            .await;
-
-        // 4. Check exit file → return exit code (process done)
-        Mock::given(method("POST"))
-            .and(path(exec_path))
-            .and(body_string_contains(".exit"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "result": "0\n", "exitCode": 0
-            })))
-            .mount(&mock_server)
-            .await;
-
-        // 5. Full output cat → return complete output
-        Mock::given(method("POST"))
-            .and(path(exec_path))
-            .and(body_string_contains("cat /tmp"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "result": "hello streaming\n", "exitCode": 0
-            })))
-            .mount(&mock_server)
-            .await;
-
-        // 6. Cleanup rm → success
-        Mock::given(method("POST"))
-            .and(path(exec_path))
-            .and(body_string_contains("rm -f"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "result": "", "exitCode": 0
-            })))
-            .mount(&mock_server)
-            .await;
+        setup_session_mocks(&mock_server, "sb_test", 0, "hello streaming\n").await;
 
         let client = DaytonaClient::with_base_urls(
             "test_key".to_string(),
@@ -1261,5 +1204,57 @@ mod tests {
 
         let collected = chunks.lock().unwrap();
         assert!(!collected.is_empty(), "should have received output chunks");
+    }
+
+    #[tokio::test]
+    async fn test_ensure_session_handles_existing() {
+        let mock_server = MockServer::start().await;
+
+        // Return 409 Conflict (session already exists)
+        Mock::given(method("POST"))
+            .and(path("/sb_test/process/session"))
+            .respond_with(ResponseTemplate::new(409))
+            .mount(&mock_server)
+            .await;
+
+        let client = DaytonaClient::with_base_urls(
+            "test_key".to_string(),
+            mock_server.uri(),
+            mock_server.uri(),
+        );
+        let result = client.ensure_session("sb_test").await;
+        assert!(result.is_ok(), "409 should be treated as success");
+    }
+
+    #[test]
+    fn test_strip_stream_markers_stdout_only() {
+        let mut raw = vec![0x01, 0x01, 0x01];
+        raw.extend_from_slice(b"hello world\n");
+        assert_eq!(strip_stream_markers(&raw), "hello world\n");
+    }
+
+    #[test]
+    fn test_strip_stream_markers_mixed_streams() {
+        let mut raw = Vec::new();
+        raw.extend_from_slice(&[0x01, 0x01, 0x01]);
+        raw.extend_from_slice(b"stdout line\n");
+        raw.extend_from_slice(&[0x02, 0x02, 0x02]);
+        raw.extend_from_slice(b"stderr line\n");
+        raw.extend_from_slice(&[0x01, 0x01, 0x01]);
+        raw.extend_from_slice(b"more stdout\n");
+        assert_eq!(
+            strip_stream_markers(&raw),
+            "stdout line\nstderr line\nmore stdout\n"
+        );
+    }
+
+    #[test]
+    fn test_strip_stream_markers_no_markers() {
+        assert_eq!(strip_stream_markers(b"plain text\n"), "plain text\n");
+    }
+
+    #[test]
+    fn test_strip_stream_markers_empty() {
+        assert_eq!(strip_stream_markers(b""), "");
     }
 }

--- a/integrations/daytona/src/client.rs
+++ b/integrations/daytona/src/client.rs
@@ -291,7 +291,12 @@ impl DaytonaClient {
         cwd: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> Result<ExecResult, String> {
-        let mut body = json!({ "command": command });
+        // Daytona's process/execute endpoint runs commands without a shell —
+        // shell operators (|, >, &&, $(), etc.) are passed as literal args.
+        // Wrap in sh -c so they are interpreted correctly.
+        let escaped = command.replace('\'', "'\\''");
+        let wrapped = format!("sh -c '{escaped}'");
+        let mut body = json!({ "command": wrapped });
         if let Some(c) = cwd {
             body["cwd"] = json!(c);
         }
@@ -376,7 +381,7 @@ impl DaytonaClient {
                     .exec(
                         sandbox_id,
                         &format!(
-                            "sh -c 'if [ -f {pid_file} ]; then kill $(cat {pid_file}) 2>/dev/null; fi'"
+                            "if [ -f {pid_file} ]; then kill $(cat {pid_file}) 2>/dev/null; fi"
                         ),
                         None,
                         Some(5_000),
@@ -399,11 +404,7 @@ impl DaytonaClient {
             let new_output = self
                 .exec(
                     sandbox_id,
-                    &format!(
-                        "sh -c 'tail -c +{} {} 2>/dev/null'",
-                        bytes_read + 1,
-                        out_file
-                    ),
+                    &format!("tail -c +{} {} 2>/dev/null", bytes_read + 1, out_file),
                     None,
                     Some(10_000),
                 )
@@ -420,7 +421,7 @@ impl DaytonaClient {
             let done_check = self
                 .exec(
                     sandbox_id,
-                    &format!("sh -c 'cat {exit_file} 2>/dev/null'"),
+                    &format!("cat {exit_file} 2>/dev/null"),
                     None,
                     Some(5_000),
                 )
@@ -433,11 +434,7 @@ impl DaytonaClient {
                     let final_output = self
                         .exec(
                             sandbox_id,
-                            &format!(
-                                "sh -c 'tail -c +{} {} 2>/dev/null'",
-                                bytes_read + 1,
-                                out_file
-                            ),
+                            &format!("tail -c +{} {} 2>/dev/null", bytes_read + 1, out_file),
                             None,
                             Some(10_000),
                         )
@@ -452,7 +449,7 @@ impl DaytonaClient {
                     let full_output = self
                         .exec(
                             sandbox_id,
-                            &format!("sh -c 'cat {out_file} 2>/dev/null'"),
+                            &format!("cat {out_file} 2>/dev/null"),
                             None,
                             Some(10_000),
                         )

--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -6,7 +6,8 @@
 //! Decision: External integration crate, auto-registered via inventory plugin system
 //! Decision: Use secrets store for all state (API key + per-sandbox connection info)
 //! Decision: Two-tier API: Management API for lifecycle, Toolbox API for in-sandbox ops
-//! Decision: Streaming exec via background process + file polling for real-time output
+//! Decision: All exec goes through Session API (/process/session) — persistent shell,
+//!           async execution, and log polling for real-time streaming output
 //! Decision: session_storage dependency for API key and state persistence
 
 pub mod client;

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -228,6 +228,7 @@ impl Tool for DaytonaCreateSandboxTool {
                 &format!("mkdir -p {}", crate::DAYTONA_WORKSPACE_PATH),
                 None,
                 None,
+                |_| {},
             )
             .await
         {
@@ -424,7 +425,7 @@ impl Tool for DaytonaExecTool {
         });
 
         let result = client
-            .exec_streaming(sandbox_id, command, cwd, timeout, |chunk| {
+            .exec(sandbox_id, command, cwd, Some(timeout), |chunk| {
                 let _ = tx.send(chunk.to_string());
             })
             .await;
@@ -1130,7 +1131,7 @@ impl Tool for DaytonaGitCloneTool {
         }
 
         debug!("Cloning repository via exec: {repo_url} → {target_path}");
-        match client.exec(sandbox_id, &cmd, None, None).await {
+        match client.exec(sandbox_id, &cmd, None, None, |_| {}).await {
             Ok(r) if r.exit_code != 0 => {
                 let hint = if github_token.is_none()
                     && (r.result.contains("Authentication")
@@ -1160,6 +1161,7 @@ impl Tool for DaytonaGitCloneTool {
                 &format!("cd {target_path} && git rev-parse --short HEAD"),
                 None,
                 None,
+                |_| {},
             )
             .await
         {
@@ -1282,7 +1284,10 @@ impl Tool for DaytonaGitCredentialsTool {
         // Configure git to use the credential store
         let config_cmd =
             "git config --global credential.helper 'store --file=/tmp/.git-credentials'";
-        match client.exec(sandbox_id, config_cmd, None, None).await {
+        match client
+            .exec(sandbox_id, config_cmd, None, None, |_| {})
+            .await
+        {
             Ok(r) if r.exit_code == 0 => {}
             Ok(r) => {
                 return ToolExecutionResult::tool_error(format!(

--- a/integrations/daytona/tests/live_api_test.rs
+++ b/integrations/daytona/tests/live_api_test.rs
@@ -119,7 +119,9 @@ async fn test_live_sandbox_lifecycle() {
     let id = &guard.sandbox_id;
 
     // Exec: simple echo
-    let result = client.exec(id, "echo hello-everruns", None, None).await;
+    let result = client
+        .exec(id, "echo hello-everruns", None, None, |_| {})
+        .await;
     let exec = result.expect("exec failed");
     assert_eq!(exec.exit_code, 0);
     assert!(
@@ -164,7 +166,7 @@ async fn test_live_exec_cwd_and_exit_code() {
 
     // Exec with cwd
     let result = client
-        .exec(id, "pwd", Some("/tmp"), None)
+        .exec(id, "pwd", Some("/tmp"), None, |_| {})
         .await
         .expect("exec with cwd failed");
     assert_eq!(result.exit_code, 0);
@@ -176,7 +178,7 @@ async fn test_live_exec_cwd_and_exit_code() {
 
     // Nonzero exit code (Daytona may return -1 instead of the exact code)
     let result = client
-        .exec(id, "exit 42", None, None)
+        .exec(id, "exit 42", None, None, |_| {})
         .await
         .expect("exec with nonzero exit failed");
     assert_ne!(result.exit_code, 0, "Expected nonzero exit code, got 0");
@@ -243,7 +245,7 @@ async fn test_live_exec_streaming_returns_output() {
 
     let mut chunks = Vec::new();
     let result = client
-        .exec_streaming(id, "echo hello-streaming", None, 30_000, |chunk| {
+        .exec(id, "echo hello-streaming", None, Some(30_000), |chunk| {
             chunks.push(chunk.to_string());
         })
         .await
@@ -291,7 +293,7 @@ async fn test_live_stop_and_start() {
 
     // Verify we can exec after restart
     let result = client
-        .exec(id, "echo restarted", None, None)
+        .exec(id, "echo restarted", None, None, |_| {})
         .await
         .expect("exec after restart failed");
     assert_eq!(result.exit_code, 0);

--- a/integrations/daytona/tests/tool_integration.rs
+++ b/integrations/daytona/tests/tool_integration.rs
@@ -154,20 +154,60 @@ fn get_tool(name: &str) -> Box<dyn Tool> {
 // ============================================================================
 // These test the client directly with custom base URLs pointing at wiremock.
 
+/// Set up mock responses for the session-based exec flow.
+async fn setup_session_mocks(
+    mock_server: &MockServer,
+    sandbox_id: &str,
+    exit_code: i64,
+    output: &str,
+) {
+    // 1. Create session → 201
+    Mock::given(method("POST"))
+        .and(path(format!("/{sandbox_id}/process/session")))
+        .respond_with(ResponseTemplate::new(201))
+        .mount(mock_server)
+        .await;
+
+    // 2. Async exec → 202 with cmdId
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "/{sandbox_id}/process/session/everruns-exec/exec"
+        )))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "cmdId": "cmd_001"
+        })))
+        .mount(mock_server)
+        .await;
+
+    // 3. Logs → output bytes with stdout marker prefix
+    let mut log_bytes = vec![0x01, 0x01, 0x01];
+    log_bytes.extend_from_slice(output.as_bytes());
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/{sandbox_id}/process/session/everruns-exec/command/cmd_001/logs"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(log_bytes))
+        .mount(mock_server)
+        .await;
+
+    // 4. Command status → exitCode
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/{sandbox_id}/process/session/everruns-exec/command/cmd_001"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "cmd_001",
+            "command": "test",
+            "exitCode": exit_code
+        })))
+        .mount(mock_server)
+        .await;
+}
+
 #[tokio::test]
 async fn test_exec_tool_full_flow_via_client() {
     let mock_server = MockServer::start().await;
-
-    // Mock the exec endpoint
-    Mock::given(method("POST"))
-        .and(path("/sb_int/process/execute"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "result": "Hello from sandbox!\n",
-            "exitCode": 0
-        })))
-        .expect(1)
-        .mount(&mock_server)
-        .await;
+    setup_session_mocks(&mock_server, "sb_int", 0, "Hello from sandbox!\n").await;
 
     let client =
         DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
@@ -285,21 +325,17 @@ async fn test_sandbox_lifecycle_via_client() {
     client.delete_sandbox("sb_lifecycle").await.unwrap();
 }
 
-/// Git clone now uses exec instead of the toolbox /git/clone endpoint.
-/// This test verifies that git clone works via the process/execute endpoint.
+/// Git clone uses exec via the session API.
 #[tokio::test]
 async fn test_git_clone_via_exec() {
     let mock_server = MockServer::start().await;
-
-    Mock::given(method("POST"))
-        .and(path("/sb_git/process/execute"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "result": "Cloning into '/home/daytona/user/repo'...\n",
-            "exitCode": 0
-        })))
-        .expect(1)
-        .mount(&mock_server)
-        .await;
+    setup_session_mocks(
+        &mock_server,
+        "sb_git",
+        0,
+        "Cloning into '/home/daytona/user/repo'...\n",
+    )
+    .await;
 
     let client =
         DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
@@ -635,15 +671,13 @@ async fn test_client_folder_and_file_operations() {
 #[tokio::test]
 async fn test_exec_with_nonzero_exit_preserves_output() {
     let mock_server = MockServer::start().await;
-
-    Mock::given(method("POST"))
-        .and(path("/sb_err/process/execute"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "result": "bash: foobar: command not found\n",
-            "exitCode": 127
-        })))
-        .mount(&mock_server)
-        .await;
+    setup_session_mocks(
+        &mock_server,
+        "sb_err",
+        127,
+        "bash: foobar: command not found\n",
+    )
+    .await;
 
     let client =
         DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
@@ -654,32 +688,20 @@ async fn test_exec_with_nonzero_exit_preserves_output() {
 }
 
 // ============================================================================
-// Shell wrapping integration tests (EVE-186)
+// Session-based exec integration tests (EVE-186)
 // ============================================================================
-// Daytona's process/execute endpoint runs commands without a shell.
-// exec() must wrap all commands in sh -c '...' so shell operators work.
+// All exec goes through the Session API — persistent shell, async execution,
+// and log polling for real-time streaming output.
 
 #[tokio::test]
-async fn test_exec_wraps_command_in_shell() {
+async fn test_exec_session_with_shell_operators() {
     let mock_server = MockServer::start().await;
-
-    // The mock expects the command wrapped in sh -c '...'
-    Mock::given(method("POST"))
-        .and(path("/sb_shell/process/execute"))
-        .and(wiremock::matchers::body_json(json!({
-            "command": "sh -c 'echo hello && echo world'"
-        })))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "result": "hello\nworld\n",
-            "exitCode": 0
-        })))
-        .expect(1)
-        .mount(&mock_server)
-        .await;
+    setup_session_mocks(&mock_server, "sb_shell", 0, "hello\nworld\n").await;
 
     let client =
         DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
 
+    // Shell operators (&&) are handled natively by the session's shell
     let result = client
         .exec("sb_shell", "echo hello && echo world", None, None)
         .await
@@ -690,21 +712,9 @@ async fn test_exec_wraps_command_in_shell() {
 }
 
 #[tokio::test]
-async fn test_exec_wraps_pipes_and_redirects_in_shell() {
+async fn test_exec_session_with_pipes_and_redirects() {
     let mock_server = MockServer::start().await;
-
-    Mock::given(method("POST"))
-        .and(path("/sb_pipe/process/execute"))
-        .and(wiremock::matchers::body_json(json!({
-            "command": "sh -c 'cat /etc/os-release | head -1 > /tmp/out.txt'"
-        })))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "result": "",
-            "exitCode": 0
-        })))
-        .expect(1)
-        .mount(&mock_server)
-        .await;
+    setup_session_mocks(&mock_server, "sb_pipe", 0, "").await;
 
     let client =
         DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
@@ -723,22 +733,49 @@ async fn test_exec_wraps_pipes_and_redirects_in_shell() {
 }
 
 #[tokio::test]
-async fn test_exec_shell_wrapping_escapes_single_quotes() {
+async fn test_exec_session_with_cwd_prepended() {
     let mock_server = MockServer::start().await;
 
-    // Command: echo 'hello world'
-    // After escaping: echo '\''hello world'\''
-    // Wrapped: sh -c 'echo '\''hello world'\'''
+    // Create session
     Mock::given(method("POST"))
-        .and(path("/sb_quote/process/execute"))
+        .and(path("/sb_cwd/process/session"))
+        .respond_with(ResponseTemplate::new(201))
+        .mount(&mock_server)
+        .await;
+
+    // Verify the command is prepended with cd
+    Mock::given(method("POST"))
+        .and(path("/sb_cwd/process/session/everruns-exec/exec"))
         .and(wiremock::matchers::body_json(json!({
-            "command": r"sh -c 'echo '\''hello world'\'''"
+            "command": "cd /workspace && ls -la",
+            "runAsync": true
         })))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "result": "hello world\n",
-            "exitCode": 0
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "cmdId": "cmd_cwd"
         })))
         .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    // Logs
+    let mut log_bytes = vec![0x01, 0x01, 0x01];
+    log_bytes.extend_from_slice(b"file.txt\n");
+    Mock::given(method("GET"))
+        .and(path(
+            "/sb_cwd/process/session/everruns-exec/command/cmd_cwd/logs",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(log_bytes))
+        .mount(&mock_server)
+        .await;
+
+    // Status
+    Mock::given(method("GET"))
+        .and(path(
+            "/sb_cwd/process/session/everruns-exec/command/cmd_cwd",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "cmd_cwd", "exitCode": 0
+        })))
         .mount(&mock_server)
         .await;
 
@@ -746,37 +783,7 @@ async fn test_exec_shell_wrapping_escapes_single_quotes() {
         DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
 
     let result = client
-        .exec("sb_quote", "echo 'hello world'", None, None)
-        .await
-        .unwrap();
-
-    assert_eq!(result.exit_code, 0);
-    assert_eq!(result.result, "hello world\n");
-}
-
-#[tokio::test]
-async fn test_exec_shell_wrapping_with_cwd() {
-    let mock_server = MockServer::start().await;
-
-    Mock::given(method("POST"))
-        .and(path("/sb_cwd/process/execute"))
-        .and(wiremock::matchers::body_json(json!({
-            "command": "sh -c 'ls -la | grep foo'",
-            "cwd": "/workspace"
-        })))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "result": "-rw-r--r-- 1 user user 0 Jan 1 00:00 foo\n",
-            "exitCode": 0
-        })))
-        .expect(1)
-        .mount(&mock_server)
-        .await;
-
-    let client =
-        DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
-
-    let result = client
-        .exec("sb_cwd", "ls -la | grep foo", Some("/workspace"), None)
+        .exec("sb_cwd", "ls -la", Some("/workspace"), None)
         .await
         .unwrap();
 
@@ -784,25 +791,14 @@ async fn test_exec_shell_wrapping_with_cwd() {
 }
 
 #[tokio::test]
-async fn test_exec_shell_wrapping_with_variable_expansion() {
+async fn test_exec_session_with_variable_expansion() {
     let mock_server = MockServer::start().await;
-
-    Mock::given(method("POST"))
-        .and(path("/sb_var/process/execute"))
-        .and(wiremock::matchers::body_json(json!({
-            "command": "sh -c 'echo $HOME'"
-        })))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "result": "/home/daytona\n",
-            "exitCode": 0
-        })))
-        .expect(1)
-        .mount(&mock_server)
-        .await;
+    setup_session_mocks(&mock_server, "sb_var", 0, "/home/daytona\n").await;
 
     let client =
         DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
 
+    // Variable expansion is handled natively by the session's shell
     let result = client
         .exec("sb_var", "echo $HOME", None, None)
         .await
@@ -810,6 +806,135 @@ async fn test_exec_shell_wrapping_with_variable_expansion() {
 
     assert_eq!(result.exit_code, 0);
     assert_eq!(result.result, "/home/daytona\n");
+}
+
+#[tokio::test]
+async fn test_exec_session_reuses_existing() {
+    let mock_server = MockServer::start().await;
+
+    // Session already exists → 409
+    Mock::given(method("POST"))
+        .and(path("/sb_reuse/process/session"))
+        .respond_with(ResponseTemplate::new(409))
+        .mount(&mock_server)
+        .await;
+
+    // Exec still works
+    Mock::given(method("POST"))
+        .and(path("/sb_reuse/process/session/everruns-exec/exec"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({"cmdId": "cmd_r"})))
+        .mount(&mock_server)
+        .await;
+
+    let mut log_bytes = vec![0x01, 0x01, 0x01];
+    log_bytes.extend_from_slice(b"ok\n");
+    Mock::given(method("GET"))
+        .and(path(
+            "/sb_reuse/process/session/everruns-exec/command/cmd_r/logs",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(log_bytes))
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(
+            "/sb_reuse/process/session/everruns-exec/command/cmd_r",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "cmd_r", "exitCode": 0
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client =
+        DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
+
+    let result = client
+        .exec("sb_reuse", "echo ok", None, None)
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.result, "ok\n");
+}
+
+#[tokio::test]
+async fn test_exec_session_streaming_emits_chunks() {
+    use std::sync::{Arc, Mutex};
+
+    let mock_server = MockServer::start().await;
+    setup_session_mocks(&mock_server, "sb_stream", 0, "chunk1\nchunk2\n").await;
+
+    let client =
+        DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
+
+    let chunks: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let chunks_clone = chunks.clone();
+
+    let result = client
+        .exec_streaming("sb_stream", "echo streaming", None, 30_000, |chunk| {
+            chunks_clone.lock().unwrap().push(chunk.to_string());
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.result, "chunk1\nchunk2\n");
+
+    let collected = chunks.lock().unwrap();
+    assert!(!collected.is_empty(), "should have received output chunks");
+}
+
+#[tokio::test]
+async fn test_exec_session_strips_stream_markers() {
+    let mock_server = MockServer::start().await;
+
+    // Create session
+    Mock::given(method("POST"))
+        .and(path("/sb_markers/process/session"))
+        .respond_with(ResponseTemplate::new(201))
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/sb_markers/process/session/everruns-exec/exec"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({"cmdId": "cmd_m"})))
+        .mount(&mock_server)
+        .await;
+
+    // Logs with mixed stdout/stderr markers
+    let mut log_bytes = Vec::new();
+    log_bytes.extend_from_slice(&[0x01, 0x01, 0x01]); // stdout marker
+    log_bytes.extend_from_slice(b"stdout line\n");
+    log_bytes.extend_from_slice(&[0x02, 0x02, 0x02]); // stderr marker
+    log_bytes.extend_from_slice(b"stderr line\n");
+    log_bytes.extend_from_slice(&[0x01, 0x01, 0x01]); // stdout marker
+    log_bytes.extend_from_slice(b"more stdout\n");
+    Mock::given(method("GET"))
+        .and(path(
+            "/sb_markers/process/session/everruns-exec/command/cmd_m/logs",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(log_bytes))
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(
+            "/sb_markers/process/session/everruns-exec/command/cmd_m",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "cmd_m", "exitCode": 0
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client =
+        DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
+
+    let result = client.exec("sb_markers", "test", None, None).await.unwrap();
+
+    assert_eq!(result.exit_code, 0);
+    // All markers stripped, combined output returned
+    assert_eq!(result.result, "stdout line\nstderr line\nmore stdout\n");
 }
 
 // ============================================================================

--- a/integrations/daytona/tests/tool_integration.rs
+++ b/integrations/daytona/tests/tool_integration.rs
@@ -654,6 +654,165 @@ async fn test_exec_with_nonzero_exit_preserves_output() {
 }
 
 // ============================================================================
+// Shell wrapping integration tests (EVE-186)
+// ============================================================================
+// Daytona's process/execute endpoint runs commands without a shell.
+// exec() must wrap all commands in sh -c '...' so shell operators work.
+
+#[tokio::test]
+async fn test_exec_wraps_command_in_shell() {
+    let mock_server = MockServer::start().await;
+
+    // The mock expects the command wrapped in sh -c '...'
+    Mock::given(method("POST"))
+        .and(path("/sb_shell/process/execute"))
+        .and(wiremock::matchers::body_json(json!({
+            "command": "sh -c 'echo hello && echo world'"
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "result": "hello\nworld\n",
+            "exitCode": 0
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client =
+        DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
+
+    let result = client
+        .exec("sb_shell", "echo hello && echo world", None, None)
+        .await
+        .unwrap();
+
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.result, "hello\nworld\n");
+}
+
+#[tokio::test]
+async fn test_exec_wraps_pipes_and_redirects_in_shell() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/sb_pipe/process/execute"))
+        .and(wiremock::matchers::body_json(json!({
+            "command": "sh -c 'cat /etc/os-release | head -1 > /tmp/out.txt'"
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "result": "",
+            "exitCode": 0
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client =
+        DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
+
+    let result = client
+        .exec(
+            "sb_pipe",
+            "cat /etc/os-release | head -1 > /tmp/out.txt",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.exit_code, 0);
+}
+
+#[tokio::test]
+async fn test_exec_shell_wrapping_escapes_single_quotes() {
+    let mock_server = MockServer::start().await;
+
+    // Command: echo 'hello world'
+    // After escaping: echo '\''hello world'\''
+    // Wrapped: sh -c 'echo '\''hello world'\'''
+    Mock::given(method("POST"))
+        .and(path("/sb_quote/process/execute"))
+        .and(wiremock::matchers::body_json(json!({
+            "command": r"sh -c 'echo '\''hello world'\'''"
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "result": "hello world\n",
+            "exitCode": 0
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client =
+        DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
+
+    let result = client
+        .exec("sb_quote", "echo 'hello world'", None, None)
+        .await
+        .unwrap();
+
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.result, "hello world\n");
+}
+
+#[tokio::test]
+async fn test_exec_shell_wrapping_with_cwd() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/sb_cwd/process/execute"))
+        .and(wiremock::matchers::body_json(json!({
+            "command": "sh -c 'ls -la | grep foo'",
+            "cwd": "/workspace"
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "result": "-rw-r--r-- 1 user user 0 Jan 1 00:00 foo\n",
+            "exitCode": 0
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client =
+        DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
+
+    let result = client
+        .exec("sb_cwd", "ls -la | grep foo", Some("/workspace"), None)
+        .await
+        .unwrap();
+
+    assert_eq!(result.exit_code, 0);
+}
+
+#[tokio::test]
+async fn test_exec_shell_wrapping_with_variable_expansion() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/sb_var/process/execute"))
+        .and(wiremock::matchers::body_json(json!({
+            "command": "sh -c 'echo $HOME'"
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "result": "/home/daytona\n",
+            "exitCode": 0
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client =
+        DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
+
+    let result = client
+        .exec("sb_var", "echo $HOME", None, None)
+        .await
+        .unwrap();
+
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.result, "/home/daytona\n");
+}
+
+// ============================================================================
 // State management integration tests
 // ============================================================================
 

--- a/integrations/daytona/tests/tool_integration.rs
+++ b/integrations/daytona/tests/tool_integration.rs
@@ -213,7 +213,13 @@ async fn test_exec_tool_full_flow_via_client() {
         DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
 
     let result = client
-        .exec("sb_int", "echo Hello from sandbox!", Some("/sandbox"), None)
+        .exec(
+            "sb_int",
+            "echo Hello from sandbox!",
+            Some("/sandbox"),
+            None,
+            |_| {},
+        )
         .await
         .unwrap();
 
@@ -346,6 +352,7 @@ async fn test_git_clone_via_exec() {
             "git clone --depth 1 https://github.com/user/repo.git /home/daytona/user/repo",
             None,
             None,
+            |_| {},
         )
         .await
         .unwrap();
@@ -682,7 +689,10 @@ async fn test_exec_with_nonzero_exit_preserves_output() {
     let client =
         DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
 
-    let result = client.exec("sb_err", "foobar", None, None).await.unwrap();
+    let result = client
+        .exec("sb_err", "foobar", None, None, |_| {})
+        .await
+        .unwrap();
     assert_eq!(result.exit_code, 127);
     assert!(result.result.contains("command not found"));
 }
@@ -703,7 +713,7 @@ async fn test_exec_session_with_shell_operators() {
 
     // Shell operators (&&) are handled natively by the session's shell
     let result = client
-        .exec("sb_shell", "echo hello && echo world", None, None)
+        .exec("sb_shell", "echo hello && echo world", None, None, |_| {})
         .await
         .unwrap();
 
@@ -725,6 +735,7 @@ async fn test_exec_session_with_pipes_and_redirects() {
             "cat /etc/os-release | head -1 > /tmp/out.txt",
             None,
             None,
+            |_| {},
         )
         .await
         .unwrap();
@@ -783,7 +794,7 @@ async fn test_exec_session_with_cwd_prepended() {
         DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
 
     let result = client
-        .exec("sb_cwd", "ls -la", Some("/workspace"), None)
+        .exec("sb_cwd", "ls -la", Some("/workspace"), None, |_| {})
         .await
         .unwrap();
 
@@ -800,7 +811,7 @@ async fn test_exec_session_with_variable_expansion() {
 
     // Variable expansion is handled natively by the session's shell
     let result = client
-        .exec("sb_var", "echo $HOME", None, None)
+        .exec("sb_var", "echo $HOME", None, None, |_| {})
         .await
         .unwrap();
 
@@ -850,7 +861,7 @@ async fn test_exec_session_reuses_existing() {
         DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
 
     let result = client
-        .exec("sb_reuse", "echo ok", None, None)
+        .exec("sb_reuse", "echo ok", None, None, |_| {})
         .await
         .unwrap();
     assert_eq!(result.exit_code, 0);
@@ -871,7 +882,7 @@ async fn test_exec_session_streaming_emits_chunks() {
     let chunks_clone = chunks.clone();
 
     let result = client
-        .exec_streaming("sb_stream", "echo streaming", None, 30_000, |chunk| {
+        .exec("sb_stream", "echo streaming", None, Some(30_000), |chunk| {
             chunks_clone.lock().unwrap().push(chunk.to_string());
         })
         .await
@@ -930,7 +941,10 @@ async fn test_exec_session_strips_stream_markers() {
     let client =
         DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
 
-    let result = client.exec("sb_markers", "test", None, None).await.unwrap();
+    let result = client
+        .exec("sb_markers", "test", None, None, |_| {})
+        .await
+        .unwrap();
 
     assert_eq!(result.exit_code, 0);
     // All markers stripped, combined output returned


### PR DESCRIPTION
## What

Migrate all Daytona command execution from the stateless `/process/execute` endpoint to the **Session API** (`/process/session/{id}/exec`). Unify `exec()` and `exec_streaming()` into a single `exec()` method that takes an `on_output` callback.

## Why

The old stateless endpoint ran commands without a shell, causing silent failures for any command using shell operators (`|`, `>`, `&&`, `$()`, heredocs). The `exec_streaming()` workaround (write temp script → nohup → poll files → cleanup) was brittle and added ~150 lines of complexity.

## How

- **Session API**: Create a persistent shell session per sandbox (`everruns-exec`), run commands via `runAsync: true`, and poll the session logs endpoint for streaming output.
- **Unified method**: Single `exec()` with an `on_output: FnMut(&str)` callback. Callers pass `|_| {}` when streaming is not needed.
- **Stream marker demuxing**: Strip Daytona's stdout/stderr multiplexing markers (`0x010101`/`0x020202`) from log output.
- **Removed**: temp files, script writing, pid tracking, nohup, `sh -c` wrapping, cleanup logic.

## Risk

- **Medium** — Changes the core execution path for all Daytona sandbox commands.
- Existing behavior preserved: same `ExecResult` return type, same timeout semantics, same cwd handling via `cd {cwd} &&` prefix.
- Session creation is idempotent (409 on existing session handled gracefully).

## Security

- Threat categories reviewed: **TM-BASH**, **TM-TOOL**
- `command` and `cwd` are passed as JSON string values to Daytona's API, not interpolated locally — no injection risk change.
- Bearer auth flow unchanged. Session ID is a constant, not user-derived.
- **Reduced attack surface**: removed temp file creation, pid tracking, and cleanup commands that ran in the sandbox.
- No new THREAT entries needed; no existing mitigations affected.

## Checklist

- [x] Tests added or updated (145 tests pass, 11 new session API tests)
- [x] Backward compatibility considered (same ExecResult contract, callers updated)
- [x] Security review performed against TM-BASH, TM-TOOL
- [x] All review comments addressed

Closes EVE-186