### PR TITLE
fix(ui): remove duplicate Connections header on agent identity page

### DIFF
--- a/apps/ui/src/components/agent-identity/identity-connections.tsx
+++ b/apps/ui/src/components/agent-identity/identity-connections.tsx
@@ -160,13 +160,6 @@ export function IdentityConnections({ identityId }: { identityId: string }) {
 
   return (
     <div className="space-y-4">
-      <div>
-        <h3 className="text-lg font-semibold">Connections</h3>
-        <p className="text-sm text-muted-foreground">
-          Connections assigned to this identity are used in sessions running as this identity.
-        </p>
-      </div>
-
       {error && (
         <div className="bg-destructive/10 text-destructive p-4 rounded-lg">
           Failed to load connections: {error.message}


### PR DESCRIPTION
## What
Remove duplicate "Connections" heading and description on the agent identity detail page.

## Why
The `IdentityConnections` component rendered its own `<h3>Connections</h3>` header and description, while the parent page already wrapped it in a `<Card>` with `<CardTitle>Connections</CardTitle>` and a matching `<CardDescription>`. This caused the heading and subtitle to appear twice.

## How
Deleted the inner heading block (7 lines) from `identity-connections.tsx`. The parent `Card` in `page.tsx` already provides the title and description.

## Risk
- Low
- Pure UI cosmetic fix; no logic, data, or API changes

## Security
- No security-relevant code changes. This is a pure presentational fix removing duplicate DOM elements; no trust boundaries, inputs, or data flows are affected.

## Checklist
- [x] Tests added or updated — N/A (cosmetic fix, verified by successful UI build)
- [x] Backward compatibility considered — N/A (internal UI)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)