### PR TITLE
fix(capabilities): resolve dependencies in collect_capabilities

### DIFF
--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -1865,7 +1865,12 @@ mod tests {
 
         assert_eq!(collected.mounts.len(), 1);
         // Verify expected capabilities were applied (including auto-resolved dependency)
-        assert!(collected.applied_ids.iter().any(|id| id == "session_file_system"));
+        assert!(
+            collected
+                .applied_ids
+                .iter()
+                .any(|id| id == "session_file_system")
+        );
         assert!(collected.applied_ids.iter().any(|id| id == "sample_data"));
         assert!(collected.applied_ids.iter().any(|id| id == "current_time"));
     }
@@ -2441,7 +2446,10 @@ mod tests {
 
         // Verify the transitive dependency capability itself was applied
         assert!(
-            collected.applied_ids.iter().any(|id| id == "session_file_system"),
+            collected
+                .applied_ids
+                .iter()
+                .any(|id| id == "session_file_system"),
             "collect_capabilities must apply session_file_system as a dependency; applied_ids: {:?}",
             collected.applied_ids
         );

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -1094,9 +1094,9 @@ pub fn get_dependencies(cap_id: &str, registry: &CapabilityRegistry) -> Vec<Stri
 
 /// Collect contributions from capabilities without applying them.
 ///
-/// Calls `system_prompt_contribution()` (async) on each capability, enabling
-/// dynamic content generation based on session context (e.g., reading AGENTS.md,
-/// discovering skills).
+/// Resolves dependencies first, then calls `system_prompt_contribution()` (async)
+/// on each capability, enabling dynamic content generation based on session context
+/// (e.g., reading AGENTS.md, discovering skills).
 ///
 /// Note: This function does not collect message filter providers since it doesn't
 /// have access to per-agent capability configs. Use `collect_capabilities_with_configs`
@@ -1112,8 +1112,18 @@ pub async fn collect_capabilities(
     registry: &CapabilityRegistry,
     ctx: &SystemPromptContext,
 ) -> CollectedCapabilities {
+    // Resolve dependencies so that transitive capabilities (e.g. session_storage
+    // via browserless) are included automatically.
+    let resolved_ids = match resolve_dependencies(capability_ids, registry) {
+        Ok(resolved) => resolved.resolved_ids,
+        Err(e) => {
+            tracing::warn!("Failed to resolve capability dependencies: {}", e);
+            capability_ids.to_vec()
+        }
+    };
+
     // Convert to AgentCapabilityConfig with empty configs
-    let configs: Vec<AgentCapabilityConfig> = capability_ids
+    let configs: Vec<AgentCapabilityConfig> = resolved_ids
         .iter()
         .map(|id| AgentCapabilityConfig {
             capability_ref: CapabilityId::new(id),
@@ -1844,7 +1854,8 @@ mod tests {
     async fn test_collect_capabilities_combines_mounts() {
         let registry = CapabilityRegistry::with_builtins();
 
-        // Collect from multiple capabilities - only sample_data has mounts
+        // Collect from multiple capabilities - only sample_data has mounts.
+        // sample_data depends on session_file_system, which is auto-resolved.
         let collected = collect_capabilities(
             &["sample_data".to_string(), "current_time".to_string()],
             &registry,
@@ -1853,7 +1864,8 @@ mod tests {
         .await;
 
         assert_eq!(collected.mounts.len(), 1);
-        assert_eq!(collected.applied_ids.len(), 2);
+        // 3 = session_file_system (dependency) + sample_data + current_time
+        assert_eq!(collected.applied_ids.len(), 3);
     }
 
     #[test]
@@ -2411,6 +2423,38 @@ mod tests {
             "tool implementations ({}) must match tool definitions ({})",
             collected.tools.len(),
             collected.tool_definitions.len(),
+        );
+    }
+
+    /// Regression test for EVE-189: collect_capabilities must resolve dependencies
+    /// so that transitive capabilities (e.g. session_storage via browserless) register
+    /// their tools even when not explicitly listed.
+    #[tokio::test]
+    async fn test_collect_capabilities_resolves_dependencies() {
+        // sample_data depends on session_file_system
+        // Passing only sample_data should still include session_file_system tools
+        let registry = CapabilityRegistry::with_builtins();
+        let collected =
+            collect_capabilities(&["sample_data".to_string()], &registry, &test_ctx()).await;
+
+        let tool_names: Vec<&str> = collected
+            .tool_definitions
+            .iter()
+            .map(|t| t.name())
+            .collect();
+
+        // session_file_system provides these tools
+        assert!(
+            tool_names.contains(&"read_file") || tool_names.contains(&"write_file"),
+            "collect_capabilities must resolve dependencies and include dependency tools, got: {:?}",
+            tool_names
+        );
+
+        // Also verify tool implementations match definitions (dependency tools are executable)
+        assert_eq!(
+            collected.tools.len(),
+            collected.tool_definitions.len(),
+            "dependency-added tools must have implementations, not just definitions"
         );
     }
 

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -1864,8 +1864,10 @@ mod tests {
         .await;
 
         assert_eq!(collected.mounts.len(), 1);
-        // 3 = session_file_system (dependency) + sample_data + current_time
-        assert_eq!(collected.applied_ids.len(), 3);
+        // Verify expected capabilities were applied (including auto-resolved dependency)
+        assert!(collected.applied_ids.iter().any(|id| id == "session_file_system"));
+        assert!(collected.applied_ids.iter().any(|id| id == "sample_data"));
+        assert!(collected.applied_ids.iter().any(|id| id == "current_time"));
     }
 
     #[test]
@@ -2427,8 +2429,8 @@ mod tests {
     }
 
     /// Regression test for EVE-189: collect_capabilities must resolve dependencies
-    /// so that transitive capabilities (e.g. session_storage via browserless) register
-    /// their tools even when not explicitly listed.
+    /// so that transitive capabilities register their tools even when not explicitly
+    /// listed. Uses sample_data (depends on session_file_system) as the test case.
     #[tokio::test]
     async fn test_collect_capabilities_resolves_dependencies() {
         // sample_data depends on session_file_system
@@ -2437,15 +2439,22 @@ mod tests {
         let collected =
             collect_capabilities(&["sample_data".to_string()], &registry, &test_ctx()).await;
 
+        // Verify the transitive dependency capability itself was applied
+        assert!(
+            collected.applied_ids.iter().any(|id| id == "session_file_system"),
+            "collect_capabilities must apply session_file_system as a dependency; applied_ids: {:?}",
+            collected.applied_ids
+        );
+
         let tool_names: Vec<&str> = collected
             .tool_definitions
             .iter()
             .map(|t| t.name())
             .collect();
 
-        // session_file_system provides these tools
+        // session_file_system provides these tools; both should be present
         assert!(
-            tool_names.contains(&"read_file") || tool_names.contains(&"write_file"),
+            tool_names.contains(&"read_file") && tool_names.contains(&"write_file"),
             "collect_capabilities must resolve dependencies and include dependency tools, got: {:?}",
             tool_names
         );


### PR DESCRIPTION
## What
`collect_capabilities` now resolves transitive dependencies before collecting tools, prompts, and mounts from capabilities.

## Why
When an agent has `browserless` (which declares `session_storage` as a dependency) but does not explicitly list `session_storage`, the `secret_store` and `kv_store` tools were missing at runtime — calls failed with `Tool not found: secret_store`.

The root cause: `collect_capabilities` iterated over raw capability IDs without calling `resolve_dependencies` first. The preview path (`capability.rs`) and `RuntimeAgent` builder both resolved dependencies correctly, but the four runtime tool-registration call sites in `direct_worker_adapters.rs`, `worker_adapters.rs`, `grpc_worker_adapters.rs`, and `activities.rs` all called `collect_capabilities` with unresolved IDs.

Closes EVE-189

## How
Added `resolve_dependencies` call inside `collect_capabilities` (the shared entry point for all four runtime paths). On error, falls back to the original unresolved list with a warning log. This makes the function consistent with `runtime_agent.rs` which already resolved before collecting.

Updated one existing test (`test_collect_capabilities_combines_mounts`) whose assertion counted applied IDs without accounting for auto-resolved dependencies.

Added a regression test (`test_collect_capabilities_resolves_dependencies`) that verifies dependency tools are included when only the parent capability is listed.

## Risk
- Low
- Callers that already pass resolved IDs get a no-op second resolution (dependencies already present). No behavioral change for them.

## Security
- Threat categories reviewed: TM-TOOL (tool registration paths)
- No new attack surface. The fix applies the same `resolve_dependencies` function already used in other paths. No injection, auth bypass, or data exposure risks.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
