### PR TITLE
fix(deno): force HTTP/1.1 ALPN and add proxy auth for WebSocket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1629,6 +1629,8 @@ dependencies = [
  "http",
  "inventory",
  "reqwest 0.13.2",
+ "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_json",
  "tokio",

--- a/integrations/deno/Cargo.toml
+++ b/integrations/deno/Cargo.toml
@@ -21,6 +21,11 @@ chrono.workspace = true
 tracing.workspace = true
 futures-util.workspace = true
 tokio-tungstenite.workspace = true
+
+# TLS: custom rustls config to force http/1.1 ALPN for WebSocket
+rustls.workspace = true
+rustls-native-certs = "0.8"
+
 base64.workspace = true
 http = "1"
 urlencoding = "2.1"

--- a/integrations/deno/src/client.rs
+++ b/integrations/deno/src/client.rs
@@ -5,6 +5,8 @@
 //! Decision: open a fresh websocket per tool call; operations are short-lived
 //! and this keeps session state small and deterministic.
 
+use std::sync::Arc;
+
 use base64::Engine;
 use futures_util::{SinkExt, StreamExt};
 use http::Request;
@@ -13,7 +15,7 @@ use serde_json::{Value, json};
 use tokio::net::TcpStream;
 use tokio::time::{Duration, timeout};
 use tokio_tungstenite::{
-    MaybeTlsStream, WebSocketStream, client_async_tls,
+    Connector, MaybeTlsStream, WebSocketStream, client_async_tls_with_config,
     tungstenite::{self, Message, client::IntoClientRequest},
 };
 
@@ -28,6 +30,7 @@ type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
 async fn connect_async_all_addrs(
     request: Request<()>,
+    connector: Connector,
 ) -> Result<(WsStream, http::Response<Option<Vec<u8>>>), String> {
     let uri = request.uri().clone();
     let host = uri
@@ -44,7 +47,7 @@ async fn connect_async_all_addrs(
 
     if let Some(proxy) = proxy_url_for_scheme(uri.scheme_str())? {
         let stream = connect_via_http_proxy(&proxy, &host, port).await?;
-        return client_async_tls(request, stream)
+        return client_async_tls_with_config(request, stream, None, Some(connector))
             .await
             .map_err(map_ws_error);
     }
@@ -56,10 +59,19 @@ async fn connect_async_all_addrs(
 
     for addr in addrs {
         match TcpStream::connect(addr).await {
-            Ok(stream) => match client_async_tls(request.clone(), stream).await {
-                Ok((ws, response)) => return Ok((ws, response)),
-                Err(error) => last_error = Some(map_ws_error(error)),
-            },
+            Ok(stream) => {
+                match client_async_tls_with_config(
+                    request.clone(),
+                    stream,
+                    None,
+                    Some(connector.clone()),
+                )
+                .await
+                {
+                    Ok((ws, response)) => return Ok((ws, response)),
+                    Err(error) => last_error = Some(map_ws_error(error)),
+                }
+            }
             Err(error) => {
                 last_error = Some(format!(
                     "Failed to connect to Deno sandbox websocket address {addr}: {error}"
@@ -103,9 +115,23 @@ async fn connect_via_http_proxy(
         .await
         .map_err(|e| format!("Failed to connect to proxy {proxy_host}:{proxy_port}: {e}"))?;
 
-    let connect_request = format!(
-        "CONNECT {target_host}:{target_port} HTTP/1.1\r\nHost: {target_host}:{target_port}\r\n\r\n"
+    let mut connect_request = format!(
+        "CONNECT {target_host}:{target_port} HTTP/1.1\r\nHost: {target_host}:{target_port}\r\n"
     );
+    if !proxy.username().is_empty() || proxy.password().is_some() {
+        let credentials = format!(
+            "{}:{}",
+            proxy.username(),
+            proxy.password().unwrap_or_default()
+        );
+        let encoded = base64::Engine::encode(
+            &base64::engine::general_purpose::STANDARD,
+            credentials.as_bytes(),
+        );
+        connect_request.push_str(&format!("Proxy-Authorization: Basic {encoded}\r\n"));
+    }
+    connect_request.push_str("\r\n");
+
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     stream
         .write_all(connect_request.as_bytes())
@@ -439,7 +465,8 @@ impl DenoClient {
                     .map_err(|e| format!("Invalid x-deno-sandbox-config header: {e}"))?,
             );
         }
-        let (ws, response) = connect_async_all_addrs(request).await?;
+        let connector = build_http11_tls_connector()?;
+        let (ws, response) = connect_async_all_addrs(request, connector).await?;
         let sandbox_id = response
             .headers()
             .get("x-deno-sandbox-id")
@@ -672,10 +699,40 @@ fn decode_message(message: Message) -> Result<Option<Value>, String> {
     }
 }
 
+/// Build a rustls TLS connector that advertises only `http/1.1` ALPN.
+///
+/// WebSocket upgrade (RFC 6455) requires HTTP/1.1. If the TLS handshake
+/// negotiates h2, proxies silently convert the upgrade into a plain HTTP/2
+/// GET, which returns 400 Bad Request ("invalid upgrade request").
+fn build_http11_tls_connector() -> Result<Connector, String> {
+    let mut root_store = rustls::RootCertStore::empty();
+    for cert in rustls_native_certs::load_native_certs().certs {
+        let _ = root_store.add(cert);
+    }
+    let provider = rustls::crypto::ring::default_provider();
+    let mut config = rustls::ClientConfig::builder_with_provider(provider.into())
+        .with_safe_default_protocol_versions()
+        .map_err(|e| format!("Failed to build TLS config: {e}"))?
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    config.alpn_protocols = vec![b"http/1.1".to_vec()];
+    Ok(Connector::Rustls(Arc::new(config)))
+}
+
 fn map_ws_error(error: tungstenite::Error) -> String {
     match error {
         tungstenite::Error::Http(response) => {
-            format!("Deno sandbox websocket HTTP error: {}", response.status())
+            let status = response.status();
+            let body = response
+                .body()
+                .as_ref()
+                .map(|b| String::from_utf8_lossy(b))
+                .unwrap_or_default();
+            if body.is_empty() {
+                format!("Deno sandbox websocket HTTP error: {status}")
+            } else {
+                format!("Deno sandbox websocket HTTP error: {status} — {body}")
+            }
         }
         other => format!("Failed to connect to Deno sandbox websocket: {other}"),
     }

--- a/integrations/deno/src/client.rs
+++ b/integrations/deno/src/client.rs
@@ -206,6 +206,7 @@ pub struct DenoClient {
     sandbox_base_domain: String,
     rpc_timeout: Duration,
     stream_idle_timeout: Duration,
+    tls_connector: Connector,
 }
 
 impl DenoClient {
@@ -224,6 +225,8 @@ impl DenoClient {
         console_api_base: String,
         sandbox_base_domain: String,
     ) -> Self {
+        let tls_connector = build_http11_tls_connector()
+            .expect("Failed to build TLS connector for Deno sandbox WebSocket");
         Self {
             http: reqwest::Client::new(),
             token,
@@ -232,6 +235,7 @@ impl DenoClient {
             sandbox_base_domain,
             rpc_timeout: DENO_RPC_TIMEOUT,
             stream_idle_timeout: DENO_STREAM_IDLE_TIMEOUT,
+            tls_connector,
         }
     }
 
@@ -465,8 +469,7 @@ impl DenoClient {
                     .map_err(|e| format!("Invalid x-deno-sandbox-config header: {e}"))?,
             );
         }
-        let connector = build_http11_tls_connector()?;
-        let (ws, response) = connect_async_all_addrs(request, connector).await?;
+        let (ws, response) = connect_async_all_addrs(request, self.tls_connector.clone()).await?;
         let sandbox_id = response
             .headers()
             .get("x-deno-sandbox-id")
@@ -726,7 +729,16 @@ fn map_ws_error(error: tungstenite::Error) -> String {
             let body = response
                 .body()
                 .as_ref()
-                .map(|b| String::from_utf8_lossy(b))
+                .map(|b| {
+                    let s = String::from_utf8_lossy(b);
+                    // Sanitize: collapse whitespace and truncate to keep errors readable
+                    let sanitized: String = s.split_whitespace().collect::<Vec<_>>().join(" ");
+                    if sanitized.len() > 256 {
+                        format!("{}…", &sanitized[..256])
+                    } else {
+                        sanitized
+                    }
+                })
                 .unwrap_or_default();
             if body.is_empty() {
                 format!("Deno sandbox websocket HTTP error: {status}")

--- a/integrations/deno/src/client.rs
+++ b/integrations/deno/src/client.rs
@@ -927,4 +927,94 @@ mod tests {
         };
         assert_eq!(request.memory_mb.unwrap_or(DENO_DEFAULT_MEMORY_MB), 1_280);
     }
+
+    #[test]
+    fn tls_connector_sets_http11_alpn() {
+        let connector = build_http11_tls_connector().expect("build connector");
+        let Connector::Rustls(config) = connector else {
+            panic!("Expected Connector::Rustls");
+        };
+        assert_eq!(config.alpn_protocols, vec![b"http/1.1".to_vec()]);
+    }
+
+    /// Verify that connect_via_http_proxy sends Proxy-Authorization when
+    /// credentials are present in the proxy URL.
+    #[tokio::test]
+    async fn proxy_connect_sends_authorization() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept");
+            let mut buf = vec![0u8; 4096];
+            let n = stream.read(&mut buf).await.expect("read");
+            let request = String::from_utf8_lossy(&buf[..n]).to_string();
+            // Respond with 200 so the function returns Ok
+            stream
+                .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+                .await
+                .expect("write");
+            request
+        });
+
+        let proxy_url =
+            reqwest::Url::parse(&format!("http://user:secret@127.0.0.1:{}", addr.port()))
+                .expect("parse proxy URL");
+        let _ = connect_via_http_proxy(&proxy_url, "example.com", 443).await;
+
+        let request = server.await.expect("server join");
+        assert!(
+            request.contains("CONNECT example.com:443 HTTP/1.1"),
+            "missing CONNECT line: {request}"
+        );
+        assert!(
+            request.contains("Proxy-Authorization: Basic "),
+            "missing Proxy-Authorization header: {request}"
+        );
+        // "user:secret" in base64
+        let expected =
+            base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"user:secret");
+        assert!(request.contains(&expected), "wrong credentials: {request}");
+    }
+
+    /// Verify no Proxy-Authorization header when proxy URL has no credentials.
+    #[tokio::test]
+    async fn proxy_connect_omits_auth_without_credentials() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept");
+            let mut buf = vec![0u8; 4096];
+            let n = stream.read(&mut buf).await.expect("read");
+            let request = String::from_utf8_lossy(&buf[..n]).to_string();
+            stream
+                .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+                .await
+                .expect("write");
+            request
+        });
+
+        let proxy_url = reqwest::Url::parse(&format!("http://127.0.0.1:{}", addr.port()))
+            .expect("parse proxy URL");
+        let _ = connect_via_http_proxy(&proxy_url, "example.com", 443).await;
+
+        let request = server.await.expect("server join");
+        assert!(
+            request.contains("CONNECT example.com:443 HTTP/1.1"),
+            "missing CONNECT line: {request}"
+        );
+        assert!(
+            !request.contains("Proxy-Authorization"),
+            "should not contain Proxy-Authorization: {request}"
+        );
+    }
 }


### PR DESCRIPTION
## What

Force `http/1.1` ALPN in the rustls TLS config for Deno sandbox WebSocket connections, add proxy authentication to HTTP CONNECT requests, and improve WebSocket error reporting.

## Why

`deno_create_sandbox` failed with `400 Bad Request — "invalid upgrade request"`. The default rustls TLS config sends no ALPN extension during the TLS handshake. TLS-inspecting proxies that see no ALPN may negotiate h2, which silently converts the HTTP/1.1 WebSocket upgrade into a plain HTTP/2 GET — the server then rejects it as an invalid upgrade request.

Additionally, the HTTP CONNECT proxy tunnel did not send `Proxy-Authorization` credentials from the proxy URL, causing 407 errors in environments requiring proxy authentication.

Same root cause and fix pattern as the browserless CDP fix in #1112.

Fixes: EVE-190

## How

1. **ALPN fix**: Build a custom `rustls::ClientConfig` with `alpn_protocols = ["http/1.1"]`, wrap it in `Connector::Rustls`, and pass it to `client_async_tls_with_config` (replacing `client_async_tls` which used the default config without ALPN).

2. **Proxy auth**: Extract username/password from the proxy URL and send `Proxy-Authorization: Basic` header in the HTTP CONNECT request, matching the browserless implementation.

3. **Error reporting**: Include the HTTP response body in `map_ws_error` for better debugging of WebSocket connection failures.

## Risk

- Low
- Regression in WebSocket connections if the custom TLS config is misconfigured. Mitigated by unit test `tls_connector_sets_http11_alpn` that verifies the ALPN protocol is set correctly.

## Security

- Threat categories reviewed: TM-AUTH (proxy credential handling)
- The proxy credentials come from the `HTTPS_PROXY`/`HTTP_PROXY` environment variable (set by infrastructure), not user input. They are sent as standard HTTP Basic auth over the proxy tunnel, matching curl's behavior. No credentials are logged. The `map_ws_error` improvement includes the response body which could theoretically contain sensitive info from the server, but this only appears in error messages (same pattern as other integrations).
- No new trust boundaries introduced. The custom TLS config loads the same native root certificates as the default tokio-tungstenite config.

## Checklist

- [x] Tests added or updated (3 new unit tests: ALPN verification, proxy auth with credentials, proxy auth without credentials)
- [x] Backward compatibility considered (no API changes, same behavior with correct ALPN)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)