### PR TITLE
fix(auth): return clear error when CLI login user has no orgs

### DIFF
--- a/crates/server/src/auth/cli_auth.rs
+++ b/crates/server/src/auth/cli_auth.rs
@@ -305,11 +305,14 @@ async fn cli_auth_exchange(
             AuthError::unauthorized("Failed to fetch organizations")
         })?;
 
-    // Use default org if user has any
-    let org_id = orgs
-        .first()
-        .map(|o| o.org_id)
-        .unwrap_or(everruns_core::DEFAULT_ORG_ID);
+    // Require at least one org — don't silently fall back to DEFAULT_ORG_ID
+    let org_id = orgs.first().map(|o| o.org_id).ok_or_else(|| {
+        tracing::warn!(user_id = %user_id, "CLI login: user has no organizations");
+        AuthError {
+            error: "You must create an organization before using the CLI. Log in to the web UI to create one.".to_string(),
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+        }
+    })?;
 
     // Generate API key with CLI metadata
     let generated = generate_api_key();

--- a/crates/server/tests/cli_auth_no_org_test.rs
+++ b/crates/server/tests/cli_auth_no_org_test.rs
@@ -1,0 +1,117 @@
+//! Test: CLI exchange returns 422 when user has no organizations.
+//!
+//! Verifies the fix for EVE-195 — CLI login must not silently fall back to
+//! DEFAULT_ORG_ID when the user has zero orgs.
+//!
+//! Run with: cargo test -p everruns-server --test cli_auth_no_org_test
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use chrono::{Duration as ChronoDuration, Utc};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use everruns_server::auth::cli_auth::{CliAuthState, cli_auth_routes};
+use everruns_server::auth::config::{AuthConfig, AuthMode, JwtConfig};
+use everruns_server::auth::{AuthState, BuiltinAuthBackend};
+use everruns_server::seed;
+use everruns_server::storage::{CreateCliAuthSessionRow, CreateUserRow, StorageBackend};
+
+#[tokio::test]
+async fn test_cli_exchange_no_orgs_returns_422() {
+    // 1. Set up in-memory DB and auth router
+    let db = Arc::new(StorageBackend::in_memory());
+    let grade = everruns_core::DeploymentGrade::from_env();
+    seed::seed_all(&db, grade, &seed::SeedAuthContext::default())
+        .await
+        .expect("seed failed");
+
+    let config = AuthConfig {
+        mode: AuthMode::Full,
+        jwt: JwtConfig {
+            secret: "test-secret-cli-no-org".to_string(),
+            access_token_lifetime: Duration::from_secs(900),
+            refresh_token_lifetime: Duration::from_secs(86400),
+        },
+        ..Default::default()
+    };
+
+    let backend = BuiltinAuthBackend::new(config.clone(), db.clone());
+    let auth_state = AuthState::new(config, Arc::new(backend));
+    let cli_state = CliAuthState {
+        db: db.clone(),
+        auth: auth_state,
+        frontend_url: "http://localhost:3000".to_string(),
+        base_url: "http://localhost:9000".to_string(),
+    };
+    let router = cli_auth_routes(cli_state);
+
+    // 2. Create a user directly in DB — no org membership
+    let user = db
+        .create_user(CreateUserRow {
+            email: "no-org-user@example.com".to_string(),
+            name: "No Org User".to_string(),
+            avatar_url: None,
+            roles: vec![],
+            password_hash: Some("unused".to_string()),
+            email_verified: true,
+            auth_provider: None,
+            auth_provider_id: None,
+            external_id: None,
+        })
+        .await
+        .expect("create_user failed");
+
+    // 3. Create a CLI auth session and complete it with this user
+    let exchange_code = "test-exchange-code-no-org";
+    let session = db
+        .create_cli_auth_session(CreateCliAuthSessionRow {
+            state: "test-state-no-org".to_string(),
+            exchange_code: exchange_code.to_string(),
+            redirect_port: 12345,
+            expires_at: Utc::now() + ChronoDuration::seconds(300),
+        })
+        .await
+        .expect("create session failed");
+
+    db.complete_cli_auth_session(session.id, user.id)
+        .await
+        .expect("complete session failed");
+
+    // 4. POST /v1/auth/cli/exchange — should return 422
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/auth/cli/exchange")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_string(&json!({
+                "code": exchange_code,
+                "hostname": "test-machine",
+                "os": "linux"
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let body: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+
+    assert_eq!(
+        status,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "Expected 422 for user with no orgs, got {status}: {body}"
+    );
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("create an organization"),
+        "Error should tell user to create an org: {body}"
+    );
+}


### PR DESCRIPTION
## What
Return a 422 error with a clear message when a user with no organizations attempts CLI login, instead of silently falling back to `DEFAULT_ORG_ID`.

## Why
In `cli_auth_exchange`, API key generation used `unwrap_or(DEFAULT_ORG_ID)` when the user had zero orgs. This created an API key scoped to a potentially non-existent org, producing confusing downstream failures.

Fixes EVE-195

## How
Replace the `unwrap_or(DEFAULT_ORG_ID)` fallback with an `ok_or_else` that returns a 422 Unprocessable Entity error with message: "You must create an organization before using the CLI. Log in to the web UI to create one."

Also logs a warning with the user_id for server-side observability.

## Risk
- Low
- Users with no orgs will now get a clear error instead of a broken API key. No impact on users who have at least one org.

## Security
- Threat categories reviewed: TM-AUTH
- The change is security-positive: removes a silent fallback that could create API keys scoped to a non-existent org. No new attack surface introduced. Error message is generic (no internal details leaked).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)