### PR TITLE
feat(api): add configurable resource limits for orgs, members, API keys

### DIFF
--- a/crates/server/src/api/organizations.rs
+++ b/crates/server/src/api/organizations.rs
@@ -30,6 +30,7 @@ pub struct AppState {
     pub db: Arc<StorageBackend>,
     pub auth: AuthState,
     pub built_in_harnesses: Vec<BuiltInHarnessDefinition>,
+    pub resource_limits: crate::server::ResourceLimitsConfig,
 }
 
 impl AppState {
@@ -38,6 +39,7 @@ impl AppState {
             db,
             auth,
             built_in_harnesses: crate::platform::oss_built_in_harnesses(),
+            resource_limits: crate::server::ResourceLimitsConfig::from_env(),
         }
     }
 
@@ -50,6 +52,7 @@ impl AppState {
             db,
             auth,
             built_in_harnesses,
+            resource_limits: crate::server::ResourceLimitsConfig::from_env(),
         }
     }
 }
@@ -205,6 +208,22 @@ pub async fn create_organization(
             Json(ErrorResponse::new(
                 "Organization name cannot exceed 255 characters",
             )),
+        ));
+    }
+
+    // Enforce org-per-user limit
+    let org_count = state
+        .db
+        .count_user_organizations(user.id)
+        .await
+        .log_internal_error_json("count user organizations")?;
+    if org_count >= state.resource_limits.max_orgs_per_user {
+        return Err((
+            StatusCode::CONFLICT,
+            Json(ErrorResponse::new(format!(
+                "Organization limit reached (max {})",
+                state.resource_limits.max_orgs_per_user
+            ))),
         ));
     }
 
@@ -603,6 +622,22 @@ pub async fn add_member(
         return Err((
             StatusCode::CONFLICT,
             Json(ErrorResponse::new("User is already a member")),
+        ));
+    }
+
+    // Enforce member-per-org limit
+    let member_count = state
+        .db
+        .count_organization_members(org.org_id)
+        .await
+        .log_internal_error_json("count organization members")?;
+    if member_count >= state.resource_limits.max_members_per_org {
+        return Err((
+            StatusCode::CONFLICT,
+            Json(ErrorResponse::new(format!(
+                "Member limit reached (max {})",
+                state.resource_limits.max_members_per_org
+            ))),
         ));
     }
 

--- a/crates/server/src/api/organizations.rs
+++ b/crates/server/src/api/organizations.rs
@@ -211,12 +211,12 @@ pub async fn create_organization(
         ));
     }
 
-    // Enforce org-per-user limit
+    // Enforce org-per-user limit (counts orgs created by this user, not memberships)
     let org_count = state
         .db
-        .count_user_organizations(user.id)
+        .count_user_created_organizations(user.id)
         .await
-        .log_internal_error_json("count user organizations")?;
+        .log_internal_error_json("count user created organizations")?;
     if org_count >= state.resource_limits.max_orgs_per_user {
         return Err((
             StatusCode::CONFLICT,

--- a/crates/server/src/auth/builtin.rs
+++ b/crates/server/src/auth/builtin.rs
@@ -35,6 +35,7 @@ pub struct BuiltinAuthBackend {
     pub jwt_service: Arc<JwtService>,
     pub db: Arc<StorageBackend>,
     pub rate_limiter: AuthRateLimiter,
+    pub resource_limits: crate::server::ResourceLimitsConfig,
     /// In-process cache: key_hash -> AuthUser. Avoids 4 sequential DB queries per API-key request.
     api_key_cache: Cache<String, AuthUser>,
 }
@@ -55,6 +56,7 @@ impl BuiltinAuthBackend {
             jwt_service,
             db,
             rate_limiter: AuthRateLimiter::new(),
+            resource_limits: crate::server::ResourceLimitsConfig::from_env(),
             api_key_cache: build_api_key_cache(),
         }
     }
@@ -67,6 +69,7 @@ impl BuiltinAuthBackend {
             jwt_service,
             db,
             rate_limiter: AuthRateLimiter::with_valkey(valkey),
+            resource_limits: crate::server::ResourceLimitsConfig::from_env(),
             api_key_cache: build_api_key_cache(),
         }
     }

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -890,20 +890,22 @@ pub async fn create_api_key_route(
     }
 
     // Enforce API key limit per user per org
-    let limits = crate::server::ResourceLimitsConfig::from_env();
     let key_count = state
         .db
         .count_api_keys_for_user_in_org(user.id, org.org_id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to count API keys: {e}");
-            AuthError::unauthorized("Failed to create API key")
+            AuthError {
+                error: "Internal server error".to_string(),
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+            }
         })?;
-    if key_count >= limits.max_api_keys_per_user_per_org {
+    if key_count >= state.resource_limits.max_api_keys_per_user_per_org {
         return Err(AuthError {
             error: format!(
                 "API key limit reached (max {})",
-                limits.max_api_keys_per_user_per_org
+                state.resource_limits.max_api_keys_per_user_per_org
             ),
             status: StatusCode::CONFLICT,
         });

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -889,6 +889,26 @@ pub async fn create_api_key_route(
         ));
     }
 
+    // Enforce API key limit per user per org
+    let limits = crate::server::ResourceLimitsConfig::from_env();
+    let key_count = state
+        .db
+        .count_api_keys_for_user_in_org(user.id, org.org_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to count API keys: {e}");
+            AuthError::unauthorized("Failed to create API key")
+        })?;
+    if key_count >= limits.max_api_keys_per_user_per_org {
+        return Err(AuthError {
+            error: format!(
+                "API key limit reached (max {})",
+                limits.max_api_keys_per_user_per_org
+            ),
+            status: StatusCode::CONFLICT,
+        });
+    }
+
     let generated = generate_api_key();
 
     let scopes = if req.scopes.is_empty() {

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -4,7 +4,7 @@
 
 use axum::Router;
 use axum::http::HeaderValue;
-use everruns_config::{env_bool, env_list, env_string};
+use everruns_config::{env_bool, env_list, env_or, env_string};
 
 /// Configurable resource limits for orgs, members, API keys.
 ///
@@ -28,29 +28,15 @@ impl Default for ResourceLimitsConfig {
 
 impl ResourceLimitsConfig {
     pub fn from_env() -> Self {
-        let defaults = Self::default();
         Self {
-            max_orgs_per_user: parse_env_i64(
-                "RESOURCE_LIMIT_MAX_ORGS_PER_USER",
-                defaults.max_orgs_per_user,
-            ),
-            max_members_per_org: parse_env_i64(
-                "RESOURCE_LIMIT_MAX_MEMBERS_PER_ORG",
-                defaults.max_members_per_org,
-            ),
-            max_api_keys_per_user_per_org: parse_env_i64(
+            max_orgs_per_user: env_or("RESOURCE_LIMIT_MAX_ORGS_PER_USER", 5),
+            max_members_per_org: env_or("RESOURCE_LIMIT_MAX_MEMBERS_PER_ORG", 50),
+            max_api_keys_per_user_per_org: env_or(
                 "RESOURCE_LIMIT_MAX_API_KEYS_PER_USER_PER_ORG",
-                defaults.max_api_keys_per_user_per_org,
+                10,
             ),
         }
     }
-}
-
-fn parse_env_i64(var: &str, default: i64) -> i64 {
-    std::env::var(var)
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(default)
 }
 
 /// Server configuration loaded from environment

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -6,6 +6,53 @@ use axum::Router;
 use axum::http::HeaderValue;
 use everruns_config::{env_bool, env_list, env_string};
 
+/// Configurable resource limits for orgs, members, API keys.
+///
+/// Defaults are sane for self-hosted. SaaS overrides per plan.
+#[derive(Debug, Clone)]
+pub struct ResourceLimitsConfig {
+    pub max_orgs_per_user: i64,
+    pub max_members_per_org: i64,
+    pub max_api_keys_per_user_per_org: i64,
+}
+
+impl Default for ResourceLimitsConfig {
+    fn default() -> Self {
+        Self {
+            max_orgs_per_user: 5,
+            max_members_per_org: 50,
+            max_api_keys_per_user_per_org: 10,
+        }
+    }
+}
+
+impl ResourceLimitsConfig {
+    pub fn from_env() -> Self {
+        let defaults = Self::default();
+        Self {
+            max_orgs_per_user: parse_env_i64(
+                "RESOURCE_LIMIT_MAX_ORGS_PER_USER",
+                defaults.max_orgs_per_user,
+            ),
+            max_members_per_org: parse_env_i64(
+                "RESOURCE_LIMIT_MAX_MEMBERS_PER_ORG",
+                defaults.max_members_per_org,
+            ),
+            max_api_keys_per_user_per_org: parse_env_i64(
+                "RESOURCE_LIMIT_MAX_API_KEYS_PER_USER_PER_ORG",
+                defaults.max_api_keys_per_user_per_org,
+            ),
+        }
+    }
+}
+
+fn parse_env_i64(var: &str, default: i64) -> i64 {
+    std::env::var(var)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(default)
+}
+
 /// Server configuration loaded from environment
 pub struct ServerConfig {
     pub dev_mode: bool,

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -1527,8 +1527,8 @@ impl StorageBackend {
         dispatch!(self, count_organization_owners, org_id)
     }
 
-    pub async fn count_user_organizations(&self, user_id: Uuid) -> Result<i64> {
-        dispatch!(self, count_user_organizations, user_id)
+    pub async fn count_user_created_organizations(&self, user_id: Uuid) -> Result<i64> {
+        dispatch!(self, count_user_created_organizations, user_id)
     }
 
     pub async fn count_organization_members(&self, org_id: i64) -> Result<i64> {

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -1527,6 +1527,18 @@ impl StorageBackend {
         dispatch!(self, count_organization_owners, org_id)
     }
 
+    pub async fn count_user_organizations(&self, user_id: Uuid) -> Result<i64> {
+        dispatch!(self, count_user_organizations, user_id)
+    }
+
+    pub async fn count_organization_members(&self, org_id: i64) -> Result<i64> {
+        dispatch!(self, count_organization_members, org_id)
+    }
+
+    pub async fn count_api_keys_for_user_in_org(&self, user_id: Uuid, org_id: i64) -> Result<i64> {
+        dispatch!(self, count_api_keys_for_user_in_org, user_id, org_id)
+    }
+
     pub async fn list_user_organizations(
         &self,
         user_id: Uuid,

--- a/crates/server/src/storage/memory/auth.rs
+++ b/crates/server/src/storage/memory/auth.rs
@@ -39,6 +39,15 @@ impl InMemoryDatabase {
             .cloned())
     }
 
+    pub async fn count_api_keys_for_user_in_org(&self, user_id: Uuid, org_id: i64) -> Result<i64> {
+        let keys = self.api_keys.read();
+        let count = keys
+            .values()
+            .filter(|k| k.user_id == user_id && k.org_id == org_id)
+            .count();
+        Ok(count as i64)
+    }
+
     pub async fn list_api_keys_for_user(&self, user_id: Uuid) -> Result<Vec<ApiKeyRow>> {
         let keys = self.api_keys.read();
         let mut result: Vec<_> = keys

--- a/crates/server/src/storage/memory/organizations.rs
+++ b/crates/server/src/storage/memory/organizations.rs
@@ -273,6 +273,18 @@ impl InMemoryDatabase {
         Ok(count as i64)
     }
 
+    pub async fn count_user_organizations(&self, user_id: Uuid) -> Result<i64> {
+        let members = self.organization_members.read();
+        let count = members.values().filter(|m| m.user_id == user_id).count();
+        Ok(count as i64)
+    }
+
+    pub async fn count_organization_members(&self, org_id: i64) -> Result<i64> {
+        let members = self.organization_members.read();
+        let count = members.values().filter(|m| m.org_id == org_id).count();
+        Ok(count as i64)
+    }
+
     pub async fn list_user_organizations(
         &self,
         user_id: Uuid,

--- a/crates/server/src/storage/memory/organizations.rs
+++ b/crates/server/src/storage/memory/organizations.rs
@@ -273,9 +273,12 @@ impl InMemoryDatabase {
         Ok(count as i64)
     }
 
-    pub async fn count_user_organizations(&self, user_id: Uuid) -> Result<i64> {
-        let members = self.organization_members.read();
-        let count = members.values().filter(|m| m.user_id == user_id).count();
+    pub async fn count_user_created_organizations(&self, user_id: Uuid) -> Result<i64> {
+        let orgs = self.organizations.read();
+        let count = orgs
+            .values()
+            .filter(|o| o.created_by == Some(user_id))
+            .count();
         Ok(count as i64)
     }
 

--- a/crates/server/src/storage/repositories/auth.rs
+++ b/crates/server/src/storage/repositories/auth.rs
@@ -48,6 +48,17 @@ impl Database {
         Ok(row)
     }
 
+    /// Count API keys for a user within a specific org (for resource limits).
+    pub async fn count_api_keys_for_user_in_org(&self, user_id: Uuid, org_id: i64) -> Result<i64> {
+        let row: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM api_keys WHERE user_id = $1 AND org_id = $2")
+                .bind(user_id)
+                .bind(org_id)
+                .fetch_one(&self.pool)
+                .await?;
+        Ok(row.0)
+    }
+
     pub async fn list_api_keys_for_user(&self, user_id: Uuid) -> Result<Vec<ApiKeyRow>> {
         let rows = sqlx::query_as::<_, ApiKeyRow>(
             r#"

--- a/crates/server/src/storage/repositories/organizations.rs
+++ b/crates/server/src/storage/repositories/organizations.rs
@@ -377,6 +377,26 @@ impl Database {
         Ok(row.0)
     }
 
+    /// Count organizations a user belongs to (for resource limits).
+    pub async fn count_user_organizations(&self, user_id: Uuid) -> Result<i64> {
+        let row: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM organization_members WHERE user_id = $1")
+                .bind(user_id)
+                .fetch_one(&self.pool)
+                .await?;
+        Ok(row.0)
+    }
+
+    /// Count members in an organization (for resource limits).
+    pub async fn count_organization_members(&self, org_id: i64) -> Result<i64> {
+        let row: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM organization_members WHERE org_id = $1")
+                .bind(org_id)
+                .fetch_one(&self.pool)
+                .await?;
+        Ok(row.0)
+    }
+
     pub async fn list_user_organizations(
         &self,
         user_id: Uuid,

--- a/crates/server/src/storage/repositories/organizations.rs
+++ b/crates/server/src/storage/repositories/organizations.rs
@@ -377,10 +377,10 @@ impl Database {
         Ok(row.0)
     }
 
-    /// Count organizations a user belongs to (for resource limits).
-    pub async fn count_user_organizations(&self, user_id: Uuid) -> Result<i64> {
+    /// Count organizations created by a user (for resource limits).
+    pub async fn count_user_created_organizations(&self, user_id: Uuid) -> Result<i64> {
         let row: (i64,) =
-            sqlx::query_as("SELECT COUNT(*) FROM organization_members WHERE user_id = $1")
+            sqlx::query_as("SELECT COUNT(*) FROM organizations WHERE created_by = $1")
                 .bind(user_id)
                 .fetch_one(&self.pool)
                 .await?;


### PR DESCRIPTION
## What
Add configurable resource limits enforced in API handlers with sane defaults.

## Why
No limits existed on org creation, member addition, or API key creation. Self-hosters and SaaS both need protection against resource abuse.

Fixes EVE-192

## How
- Added `ResourceLimitsConfig` struct in `server.rs` with env var loading
- Added count methods to storage layer (PostgreSQL + in-memory):
  - `count_user_organizations(user_id)`
  - `count_organization_members(org_id)`
  - `count_api_keys_for_user_in_org(user_id, org_id)`
- Enforced limits in three handlers:
  - `create_organization`: max 5 orgs per user
  - `add_member`: max 50 members per org
  - `create_api_key_route`: max 10 API keys per user per org
- All configurable via env vars: `RESOURCE_LIMIT_MAX_ORGS_PER_USER`, `RESOURCE_LIMIT_MAX_MEMBERS_PER_ORG`, `RESOURCE_LIMIT_MAX_API_KEYS_PER_USER_PER_ORG`

## Risk
- Low
- Existing deployments with >5 orgs/user, >50 members, or >10 API keys won't lose existing resources but won't be able to create more until limits are raised via env vars
- No migrations needed — count queries use existing tables

## Security
- Threat categories reviewed: TM-DOS (resource exhaustion), TM-API (new validation), TM-SQL (new queries)
- This change is itself a security improvement: prevents resource exhaustion via unbounded creation
- SQL queries use parameterized binds (no injection risk)
- Count checks happen before resource creation (no TOCTOU concern in single-request scope)

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)