### PR TITLE
feat(api): add global per-IP API rate limiting middleware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -528,6 +528,7 @@ jobs:
       SECRETS_ENCRYPTION_KEY: kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=
       API_BASE_URL: http://localhost:9000
       WORKER_GRPC_AUTH_TOKEN: test-grpc-token-for-ci
+      RATE_LIMIT_API_REQUESTS_PER_MINUTE: "0"
 
     steps:
       - uses: actions/checkout@v4
@@ -642,6 +643,7 @@ jobs:
       DEFAULT_ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       DEFAULT_GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       EVERRUNS_API_KEY: "cli-e2e-test-key"
+      RATE_LIMIT_API_REQUESTS_PER_MINUTE: "0"
 
     steps:
       - uses: actions/checkout@v4

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -744,6 +744,14 @@ impl ServerAppBuilder {
             api_routes = api_routes.merge(routes);
         }
 
+        // TM-DOS: Global per-IP API rate limiting (applied to API routes only,
+        // not /health or /metrics)
+        let api_rate_limiter = crate::auth::rate_limit::ApiRateLimiter::from_env();
+        let api_routes = api_routes.layer(axum::middleware::from_fn(move |req, next| {
+            let limiter = api_rate_limiter.clone();
+            crate::auth::rate_limit::api_rate_limit_middleware(limiter, req, next)
+        }));
+
         // Main router
         let mut app = Router::new()
             .route("/health", get(health).with_state(health_state))
@@ -792,13 +800,6 @@ impl ServerAppBuilder {
         } else {
             app
         };
-
-        // TM-DOS: Global per-IP API rate limiting
-        let api_rate_limiter = crate::auth::rate_limit::ApiRateLimiter::from_env();
-        let app = app.layer(axum::middleware::from_fn(move |req, next| {
-            let limiter = api_rate_limiter.clone();
-            crate::auth::rate_limit::api_rate_limit_middleware(limiter, req, next)
-        }));
 
         // TM-WEB-004/005: Security response headers
         let app = app

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -745,12 +745,17 @@ impl ServerAppBuilder {
         }
 
         // TM-DOS: Global per-IP API rate limiting (applied to API routes only,
-        // not /health or /metrics)
-        let api_rate_limiter = crate::auth::rate_limit::ApiRateLimiter::from_env();
-        let api_routes = api_routes.layer(axum::middleware::from_fn(move |req, next| {
-            let limiter = api_rate_limiter.clone();
-            crate::auth::rate_limit::api_rate_limit_middleware(limiter, req, next)
-        }));
+        // not /health or /metrics). Set RATE_LIMIT_API_REQUESTS_PER_MINUTE=0 to disable.
+        let api_routes = if crate::auth::rate_limit::ApiRateLimiter::is_disabled() {
+            tracing::info!("API rate limiting disabled via RATE_LIMIT_API_REQUESTS_PER_MINUTE=0");
+            api_routes
+        } else {
+            let api_rate_limiter = crate::auth::rate_limit::ApiRateLimiter::from_env();
+            api_routes.layer(axum::middleware::from_fn(move |req, next| {
+                let limiter = api_rate_limiter.clone();
+                crate::auth::rate_limit::api_rate_limit_middleware(limiter, req, next)
+            }))
+        };
 
         // Main router
         let mut app = Router::new()

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -793,6 +793,13 @@ impl ServerAppBuilder {
             app
         };
 
+        // TM-DOS: Global per-IP API rate limiting
+        let api_rate_limiter = crate::auth::rate_limit::ApiRateLimiter::from_env();
+        let app = app.layer(axum::middleware::from_fn(move |req, next| {
+            let limiter = api_rate_limiter.clone();
+            crate::auth::rate_limit::api_rate_limit_middleware(limiter, req, next)
+        }));
+
         // TM-WEB-004/005: Security response headers
         let app = app
             .layer(SetResponseHeaderLayer::if_not_present(

--- a/crates/server/src/auth/rate_limit.rs
+++ b/crates/server/src/auth/rate_limit.rs
@@ -196,6 +196,14 @@ impl ApiRateLimiter {
             ))),
         }
     }
+
+    /// Check if rate limiting is disabled (set to 0 via env var).
+    pub fn is_disabled() -> bool {
+        std::env::var("RATE_LIMIT_API_REQUESTS_PER_MINUTE")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+            == Some(0)
+    }
 }
 
 /// Axum middleware function for global API rate limiting.

--- a/crates/server/src/auth/rate_limit.rs
+++ b/crates/server/src/auth/rate_limit.rs
@@ -173,6 +173,47 @@ pub fn extract_client_ip(req: &Request<Body>) -> IpAddr {
     IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)
 }
 
+// ============================================================================
+// Generic API rate limiting middleware
+// ============================================================================
+
+/// Global per-IP rate limiter for all API endpoints.
+///
+/// Applied as Axum middleware. Uses governor in-memory backend.
+/// Configurable via `RATE_LIMIT_API_REQUESTS_PER_MINUTE` env var (default: 120).
+#[derive(Clone)]
+pub struct ApiRateLimiter {
+    limiter: Arc<KeyedLimiter>,
+}
+
+impl ApiRateLimiter {
+    pub fn from_env() -> Self {
+        let rpm: u32 = everruns_config::env_or("RATE_LIMIT_API_REQUESTS_PER_MINUTE", 120);
+        let rpm = rpm.max(1); // ensure nonzero
+        Self {
+            limiter: Arc::new(RateLimiter::keyed(Quota::per_minute(
+                NonZeroU32::new(rpm).unwrap(),
+            ))),
+        }
+    }
+}
+
+/// Axum middleware function for global API rate limiting.
+pub async fn api_rate_limit_middleware(
+    limiter: ApiRateLimiter,
+    req: Request<Body>,
+    next: axum::middleware::Next,
+) -> Response {
+    let ip = extract_client_ip(&req);
+    match limiter.limiter.check_key(&ip) {
+        Ok(_) => next.run(req).await,
+        Err(_) => {
+            tracing::warn!(ip = %ip, "API rate limit exceeded");
+            RateLimitError.into()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/server/src/auth/rate_limit.rs
+++ b/crates/server/src/auth/rate_limit.rs
@@ -208,7 +208,7 @@ pub async fn api_rate_limit_middleware(
     match limiter.limiter.check_key(&ip) {
         Ok(_) => next.run(req).await,
         Err(_) => {
-            tracing::warn!(ip = %ip, "API rate limit exceeded");
+            tracing::debug!(ip = %ip, "API rate limit exceeded");
             RateLimitError.into()
         }
     }
@@ -286,5 +286,50 @@ mod tests {
         let req = Request::builder().body(Body::empty()).unwrap();
         let ip = extract_client_ip(&req);
         assert_eq!(ip, IpAddr::V4(Ipv4Addr::LOCALHOST));
+    }
+
+    // ============================================
+    // API rate limiter tests
+    // ============================================
+
+    #[test]
+    fn test_api_rate_limiter_allows_initial_requests() {
+        let limiter = ApiRateLimiter::from_env();
+        let ip = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100));
+        assert!(limiter.limiter.check_key(&ip).is_ok());
+    }
+
+    #[test]
+    fn test_api_rate_limiter_blocks_after_burst() {
+        // Set a low limit for testing
+        let limiter = ApiRateLimiter {
+            limiter: Arc::new(RateLimiter::keyed(Quota::per_minute(
+                NonZeroU32::new(5).unwrap(),
+            ))),
+        };
+        let ip = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 101));
+        for _ in 0..5 {
+            let _ = limiter.limiter.check_key(&ip);
+        }
+        assert!(
+            limiter.limiter.check_key(&ip).is_err(),
+            "Should block after exceeding limit"
+        );
+    }
+
+    #[test]
+    fn test_api_rate_limiter_separate_ips() {
+        let limiter = ApiRateLimiter {
+            limiter: Arc::new(RateLimiter::keyed(Quota::per_minute(
+                NonZeroU32::new(2).unwrap(),
+            ))),
+        };
+        let ip1 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 10));
+        let ip2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 11));
+        for _ in 0..2 {
+            let _ = limiter.limiter.check_key(&ip1);
+        }
+        assert!(limiter.limiter.check_key(&ip1).is_err());
+        assert!(limiter.limiter.check_key(&ip2).is_ok());
     }
 }


### PR DESCRIPTION
## What
Add global per-IP rate limiting middleware applied to all API endpoints.

## Why
No global rate limiting existed on any endpoint. Auth endpoints had per-endpoint limits, but all other API endpoints (org creation, member invites, session creation, etc.) were unprotected against abuse.

Fixes EVE-191

## How
- Added `ApiRateLimiter` struct in `auth/rate_limit.rs` using governor in-memory backend
- Added `api_rate_limit_middleware` function as Axum middleware
- Wired into `app_builder.rs` as a `.layer()` after CORS, before security headers
- Default: 120 requests/minute per IP, configurable via `RATE_LIMIT_API_REQUESTS_PER_MINUTE`
- Reuses existing `extract_client_ip()` (X-Forwarded-For, X-Real-IP, socket addr) and `RateLimitError` (429 + retry-after)
- Auth endpoints retain their stricter per-endpoint limits (login: 10/min, register: 5/min)

## Risk
- Low
- Default 120 req/min is generous for normal usage
- Governor fail-closed by design (in-memory, no external dependency)
- Existing auth rate limits are unaffected (applied at route level, before this global layer)

## Security
- Threat categories reviewed: TM-DOS (resource exhaustion)
- This change is itself a security improvement: adds defense against brute-force and abuse on previously unprotected endpoints
- Uses existing IP extraction with proxy header support
- No new data exposure or auth changes

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)