### PR TITLE
feat(ci): build server and worker binaries for Linux releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,3 +138,12 @@ jobs:
           echo "Triggering CLI binary builds for tag $TAG..."
           gh workflow run cli-binaries.yml --ref "$TAG" -f "tag=$TAG"
           echo "CLI binary builds triggered for $TAG"
+
+      - name: Trigger server & worker binary builds for release tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ steps.version.outputs.version }}"
+          echo "Triggering server & worker binary builds for tag $TAG..."
+          gh workflow run server-worker-binaries.yml --ref "$TAG" -f "tag=$TAG"
+          echo "Server & worker binary builds triggered for $TAG"

--- a/.github/workflows/server-worker-binaries.yml
+++ b/.github/workflows/server-worker-binaries.yml
@@ -58,7 +58,7 @@ jobs:
           shared-key: "${{ matrix.binary }}-${{ matrix.target }}"
 
       - name: Build binary
-        run: cargo build --release --target ${{ matrix.target }} -p ${{ matrix.package }}
+        run: cargo build --release --target ${{ matrix.target }} -p ${{ matrix.package }} --bin ${{ matrix.binary }}
 
       - name: Package binary
         run: |

--- a/.github/workflows/server-worker-binaries.yml
+++ b/.github/workflows/server-worker-binaries.yml
@@ -1,0 +1,77 @@
+name: Publish Server & Worker Binaries
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., v0.8.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.binary }} (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # x86_64
+          - binary: everruns-server
+            package: everruns-server
+            target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            archive: everruns-server-x86_64-unknown-linux-gnu.tar.gz
+          - binary: everruns-worker
+            package: everruns-worker
+            target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            archive: everruns-worker-x86_64-unknown-linux-gnu.tar.gz
+          # aarch64
+          - binary: everruns-server
+            package: everruns-server
+            target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+            archive: everruns-server-aarch64-unknown-linux-gnu.tar.gz
+          - binary: everruns-worker
+            package: everruns-worker
+            target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+            archive: everruns-worker-aarch64-unknown-linux-gnu.tar.gz
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "${{ matrix.binary }}-${{ matrix.target }}"
+
+      - name: Build binary
+        run: cargo build --release --target ${{ matrix.target }} -p ${{ matrix.package }}
+
+      - name: Package binary
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf "$GITHUB_WORKSPACE/${{ matrix.archive }}" ${{ matrix.binary }}
+          cd "$GITHUB_WORKSPACE"
+          shasum -a 256 "${{ matrix.archive }}" > "${{ matrix.archive }}.sha256"
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ inputs.tag }}" \
+            "${{ matrix.archive }}" \
+            "${{ matrix.archive }}.sha256" \
+            --clobber


### PR DESCRIPTION
## What
Add a new GitHub Actions workflow that builds `everruns-server` and `everruns-worker` pre-built binaries for Linux releases, alongside the existing CLI binary builds.

## Why
We already publish pre-built CLI binaries with each release. Server and worker binaries should also be available as pre-built downloads for users deploying outside Docker.

## How
- New `server-worker-binaries.yml` workflow triggered via `workflow_dispatch` (same pattern as `cli-binaries.yml`)
- Builds 4 matrix jobs: 2 binaries × 2 Linux architectures (x86_64, aarch64)
- Uses native GitHub runners: `ubuntu-latest` for x86_64, `ubuntu-24.04-arm` for aarch64
- Packages each binary as `.tar.gz` with `.sha256` checksum, uploads to the GitHub Release
- `release.yml` updated to dispatch the new workflow alongside existing CLI and Docker triggers

## Risk
- Low
- Only adds a new workflow and a dispatch step; no changes to existing build logic

## Security
- No security-relevant code changes. This adds CI workflow files only — no runtime code, no secret handling changes, no new trust boundaries. Existing `GITHUB_TOKEN` permissions pattern is reused from `cli-binaries.yml`.

## Checklist
- [x] Tests added or updated — CI-only change, validated by workflow execution
- [x] Backward compatibility considered — additive only, no existing behavior changed
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)