### PR TITLE
feat(evals): gate evals behind experimental feature flag

### DIFF
--- a/apps/ui/src/app/(main)/evals/page.tsx
+++ b/apps/ui/src/app/(main)/evals/page.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Plus } from "lucide-react";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
+import { ExperimentalPageBadge } from "@/components/ui/experimental-badge";
 import type { Eval } from "@/lib/api/types";
 
 function passRateColor(rate: number): string {
@@ -71,7 +72,10 @@ export default function EvalsPage() {
     <div className="container mx-auto p-6 space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">Evals</h1>
+        <h1 className="text-2xl font-bold flex items-center gap-3">
+          Evals
+          <ExperimentalPageBadge />
+        </h1>
         <Link href="/evals/new">
           <Button variant="accent">
             <Plus className="w-4 h-4 mr-2" />

--- a/apps/ui/src/app/(main)/evals/page.tsx
+++ b/apps/ui/src/app/(main)/evals/page.tsx
@@ -9,6 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { Plus } from "lucide-react";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { ExperimentalPageBadge } from "@/components/ui/experimental-badge";
+import { useFeatureFlag } from "@/providers/feature-flags-provider";
 import type { Eval } from "@/lib/api/types";
 
 function passRateColor(rate: number): string {
@@ -63,10 +64,22 @@ function EvalCard({ eval: ev, agentName }: { eval: Eval; agentName?: string }) {
 }
 
 export default function EvalsPage() {
+  const evalsEnabled = useFeatureFlag("evals");
   const { data: evals, isLoading, error } = useEvals({ includeArchived: false });
   const { data: agents } = useAgents({ includeArchived: false });
 
   const agentMap = new Map((agents ?? []).map((a) => [a.id, a.name]));
+
+  if (!evalsEnabled) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="text-center text-muted-foreground">
+          <p className="text-lg font-medium">Evals is not enabled</p>
+          <p className="text-sm">This feature is currently disabled.</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="container mx-auto p-6 space-y-6">

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -89,7 +89,7 @@ export const defaultBuildingBlocksNavigation: NavigationItem[] = [
   { name: "Capabilities", href: "/capabilities", icon: Puzzle },
   { name: "MCP Servers", href: "/mcp-servers", icon: capabilityIconMap.mcp },
   { name: "Apps", href: "/apps", icon: Rocket, flag: "apps", experimental: true },
-  { name: "Evals", href: "/evals", icon: ClipboardCheck },
+  { name: "Evals", href: "/evals", icon: ClipboardCheck, flag: "evals", experimental: true },
 ];
 
 export const defaultBottomNavigation: NavigationItem[] = [

--- a/apps/ui/src/lib/api/types/auth-types.ts
+++ b/apps/ui/src/lib/api/types/auth-types.ts
@@ -11,6 +11,7 @@ export interface FeatureFlags {
   apps: boolean;
   notifications: boolean;
   mcp_endpoint: boolean;
+  evals: boolean;
 }
 
 export interface AuthConfigResponse {

--- a/apps/ui/src/providers/feature-flags-provider.tsx
+++ b/apps/ui/src/providers/feature-flags-provider.tsx
@@ -16,6 +16,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   apps: false,
   notifications: false,
   mcp_endpoint: false,
+  evals: false,
 };
 
 export interface FeatureFlagsContextValue {

--- a/crates/core/src/feature_flags.rs
+++ b/crates/core/src/feature_flags.rs
@@ -25,6 +25,8 @@ pub struct FeatureFlags {
     pub notifications: bool,
     /// MCP endpoint (POST /mcp — Everruns as an MCP server). Experimental.
     pub mcp_endpoint: bool,
+    /// Evals (user-facing behavioral evals for agents). Experimental.
+    pub evals: bool,
 }
 
 impl FeatureFlags {
@@ -35,6 +37,7 @@ impl FeatureFlags {
             apps: experimental_flag("FEATURE_APPS", grade),
             notifications: standard_flag("FEATURE_NOTIFICATIONS", false),
             mcp_endpoint: experimental_flag("FEATURE_MCP_ENDPOINT", grade),
+            evals: experimental_flag("FEATURE_EVALS", grade),
         }
     }
 
@@ -45,6 +48,7 @@ impl FeatureFlags {
             "apps" => self.apps,
             "notifications" => self.notifications,
             "mcp_endpoint" => self.mcp_endpoint,
+            "evals" => self.evals,
             _ => false,
         }
     }
@@ -57,6 +61,7 @@ impl FeatureFlags {
             apps: true,
             notifications: true,
             mcp_endpoint: true,
+            evals: true,
         }
     }
 }
@@ -107,9 +112,11 @@ mod tests {
         let _lock = lock_env();
         unsafe { std::env::remove_var("FEATURE_GLOBAL_CHAT") };
         unsafe { std::env::remove_var("FEATURE_APPS") };
+        unsafe { std::env::remove_var("FEATURE_EVALS") };
         let flags = FeatureFlags::from_env(&DeploymentGrade::Dev);
         assert!(flags.global_chat);
         assert!(flags.apps);
+        assert!(flags.evals);
     }
 
     #[test]
@@ -117,9 +124,11 @@ mod tests {
         let _lock = lock_env();
         unsafe { std::env::remove_var("FEATURE_GLOBAL_CHAT") };
         unsafe { std::env::remove_var("FEATURE_APPS") };
+        unsafe { std::env::remove_var("FEATURE_EVALS") };
         let flags = FeatureFlags::from_env(&DeploymentGrade::Prod);
         assert!(!flags.global_chat);
         assert!(!flags.apps);
+        assert!(!flags.evals);
     }
 
     #[test]
@@ -147,11 +156,13 @@ mod tests {
             apps: true,
             notifications: true,
             mcp_endpoint: true,
+            evals: true,
         };
         assert!(flags.is_enabled("global_chat"));
         assert!(flags.is_enabled("apps"));
         assert!(flags.is_enabled("notifications"));
         assert!(flags.is_enabled("mcp_endpoint"));
+        assert!(flags.is_enabled("evals"));
         assert!(!flags.is_enabled("nonexistent"));
     }
 
@@ -162,6 +173,7 @@ mod tests {
             apps: true,
             notifications: true,
             mcp_endpoint: true,
+            evals: true,
         };
         let json = serde_json::to_string(&flags).unwrap();
         assert!(json.contains("\"global_chat\":true"));

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -682,7 +682,7 @@ impl ServerAppBuilder {
                 agent_identity_connections_state,
             ))
             .merge(api::apps::routes(apps_state))
-            .merge(api::evals::routes(evals_state))
+            //.merge(api::evals::routes(evals_state)) — conditionally merged below
             .merge(api::harnesses::routes(harnesses_state))
             .merge(api::sessions::routes(sessions_state))
             .merge(api::messages::routes(messages_state))
@@ -728,6 +728,12 @@ impl ServerAppBuilder {
 
         if let Some(notifications_state) = notifications_state {
             api_routes = api_routes.merge(api::notifications::routes(notifications_state));
+        }
+
+        if feature_flags.evals {
+            api_routes = api_routes.merge(api::evals::routes(evals_state));
+        } else {
+            tracing::info!("Evals disabled via feature flag");
         }
 
         if feature_flags.mcp_endpoint {

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -682,7 +682,7 @@ impl ServerAppBuilder {
                 agent_identity_connections_state,
             ))
             .merge(api::apps::routes(apps_state))
-            //.merge(api::evals::routes(evals_state)) — conditionally merged below
+            // Evals routes are conditionally merged below based on feature flag.
             .merge(api::harnesses::routes(harnesses_state))
             .merge(api::sessions::routes(sessions_state))
             .merge(api::messages::routes(messages_state))

--- a/test_cases/ui/evals/TC001_evals_list_loads.md
+++ b/test_cases/ui/evals/TC001_evals_list_loads.md
@@ -1,0 +1,31 @@
+# TC001: Evals - List Page Loads
+
+## Description
+
+Verify that the evals list page loads successfully and displays the eval cards grid with experimental badge.
+
+## Preconditions
+
+- Server running (`just start-dev`)
+- User logged in
+- Feature flag `evals` enabled (`FEATURE_EVALS=true`)
+
+## Test Data
+
+None.
+
+## Steps
+
+1. Navigate to `/evals` via the sidebar
+2. Wait for loading to complete
+3. Observe the page header and content area
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Sidebar | "Evals" link visible with experimental flask icon |
+| Page header | Shows "Evals" with experimental badge |
+| New Eval button | "New Eval" button visible in header |
+| No error | No error messages displayed |
+| Empty state | If no evals exist, shows empty state with prompt to create |

--- a/test_cases/ui/evals/TC002_evals_hidden_without_flag.md
+++ b/test_cases/ui/evals/TC002_evals_hidden_without_flag.md
@@ -23,4 +23,4 @@ None.
 | Check | Expected |
 |-------|----------|
 | Sidebar | "Evals" link is NOT visible |
-| Direct navigation | Navigating to `/evals` returns 404 or empty page (API returns no routes) |
+| Direct navigation | Navigating to `/evals` shows "Evals is not enabled" message with no evals content or actions |

--- a/test_cases/ui/evals/TC002_evals_hidden_without_flag.md
+++ b/test_cases/ui/evals/TC002_evals_hidden_without_flag.md
@@ -1,0 +1,26 @@
+# TC002: Evals - Hidden Without Feature Flag
+
+## Description
+
+Verify that the evals sidebar link is hidden when the `evals` feature flag is disabled.
+
+## Preconditions
+
+- Server running with `FEATURE_EVALS=false` (or production mode without explicit flag)
+- User logged in
+
+## Test Data
+
+None.
+
+## Steps
+
+1. Observe the sidebar navigation
+2. Look for "Evals" link in the Building Blocks section
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Sidebar | "Evals" link is NOT visible |
+| Direct navigation | Navigating to `/evals` returns 404 or empty page (API returns no routes) |

--- a/test_cases/ui/evals/TC003_create_eval.md
+++ b/test_cases/ui/evals/TC003_create_eval.md
@@ -1,0 +1,48 @@
+# TC003: Evals - Create New Eval
+
+## Description
+
+Verify that a new eval can be created with required fields (name, agent, harness).
+
+## Preconditions
+
+- Server running (`just start-dev`)
+- User logged in
+- Feature flag `evals` enabled (`FEATURE_EVALS=true`)
+- At least one agent exists
+- At least one harness exists
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Name | `Test Greeting Eval` |
+| Description | `Verifies the agent greets users correctly` |
+| Agent | (first available agent) |
+| Harness | (first available harness) |
+
+## Steps
+
+1. Navigate to `/evals`
+2. Click "New Eval" button
+3. Verify the create form loads at `/evals/new`
+4. Fill in Name: `Test Greeting Eval`
+5. Fill in Description: `Verifies the agent greets users correctly`
+6. Select an agent from the dropdown
+7. Select a harness from the dropdown
+8. Leave Model Override as "Use agent default"
+9. Click "Create Eval"
+10. Wait for redirect to the eval detail page
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Form fields | Name, Description, Agent, Harness, Model Override, Tags all visible |
+| Agent dropdown | Lists available agents |
+| Harness dropdown | Lists available harnesses |
+| Submit disabled | "Create Eval" button disabled until agent and harness selected |
+| Redirect | After creation, redirects to `/evals/{eval_id}` |
+| Detail page | Shows eval name, description, status "active", agent name |
+| Cases tab | Shows "No test cases yet" empty state |
+| Runs tab | Shows "No runs yet" empty state |

--- a/test_cases/ui/evals/TC004_add_eval_case.md
+++ b/test_cases/ui/evals/TC004_add_eval_case.md
@@ -1,0 +1,45 @@
+# TC004: Evals - Add Test Case
+
+## Description
+
+Verify that a test case can be added to an existing eval with messages and scorers.
+
+## Preconditions
+
+- Server running (`just start-dev`)
+- User logged in
+- Feature flag `evals` enabled (`FEATURE_EVALS=true`)
+- An eval already exists (from TC003 or created via API)
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Case Name | `Greeting test` |
+| Description | `Agent should greet the user` |
+| Messages | `Hello, who are you?` |
+| Scorer type | `contains` |
+| Scorer value | `hello` |
+
+## Steps
+
+1. Navigate to the eval detail page (`/evals/{eval_id}`)
+2. Ensure the "Cases" tab is active
+3. Click "Add Case" button
+4. Fill in Name: `Greeting test`
+5. Fill in Description: `Agent should greet the user`
+6. Enter message: `Hello, who are you?`
+7. Select scorer type: `contains`
+8. Enter scorer value: `hello`
+9. Click "Add Case" submit button
+10. Wait for the case to appear in the cases grid
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Add Case form | Shows name, description, messages, scorer fields |
+| After submit | Form clears and case appears in grid |
+| Case card | Shows name, description, message content, scorer badge |
+| Scorer badge | Displays `contains("hello")` |
+| Case count | Header case count increments by 1 |

--- a/test_cases/ui/evals/TC005_delete_eval_case.md
+++ b/test_cases/ui/evals/TC005_delete_eval_case.md
@@ -1,0 +1,33 @@
+# TC005: Evals - Delete Test Case
+
+## Description
+
+Verify that a test case can be deleted from an eval.
+
+## Preconditions
+
+- Server running (`just start-dev`)
+- User logged in
+- Feature flag `evals` enabled (`FEATURE_EVALS=true`)
+- An eval with at least one test case exists
+
+## Test Data
+
+None.
+
+## Steps
+
+1. Navigate to the eval detail page (`/evals/{eval_id}`)
+2. Ensure the "Cases" tab is active
+3. Note the current case count
+4. Click the trash icon on one of the case cards
+5. Wait for the case to disappear
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Trash icon | Visible on each case card |
+| After delete | Case card removed from the grid |
+| Case count | Header case count decrements by 1 |
+| Empty state | If last case deleted, shows "No test cases yet" |

--- a/test_cases/ui/evals/TC006_start_eval_run.md
+++ b/test_cases/ui/evals/TC006_start_eval_run.md
@@ -1,0 +1,34 @@
+# TC006: Evals - Start Eval Run
+
+## Description
+
+Verify that an eval run can be triggered and the run detail page displays correctly.
+
+## Preconditions
+
+- Server running (`just start-dev`)
+- User logged in
+- Feature flag `evals` enabled (`FEATURE_EVALS=true`)
+- An eval with at least one test case exists
+- An LLM provider is configured
+
+## Test Data
+
+None.
+
+## Steps
+
+1. Navigate to the eval detail page (`/evals/{eval_id}`)
+2. Click "Run Eval" button
+3. Wait for redirect to the run detail page (`/evals/{eval_id}/runs/{run_id}`)
+4. Observe the run status and summary cards
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Run button | "Run Eval" button visible and enabled for active evals |
+| Redirect | After clicking, redirects to run detail page |
+| Run status | Shows "pending" or "running" initially |
+| Summary cards | Displays pass rate, results count, latency, tokens placeholders |
+| Results table | Shows individual case results as they complete |

--- a/test_cases/ui/evals/TC007_eval_runs_tab.md
+++ b/test_cases/ui/evals/TC007_eval_runs_tab.md
@@ -1,0 +1,32 @@
+# TC007: Evals - Runs Tab
+
+## Description
+
+Verify that the Runs tab on the eval detail page lists previous runs with status and metrics.
+
+## Preconditions
+
+- Server running (`just start-dev`)
+- User logged in
+- Feature flag `evals` enabled (`FEATURE_EVALS=true`)
+- An eval with at least one completed run exists
+
+## Test Data
+
+None.
+
+## Steps
+
+1. Navigate to the eval detail page (`/evals/{eval_id}`)
+2. Click the "Runs" tab
+3. Observe the runs list
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Runs tab | Shows count of runs in tab label |
+| Run rows | Each run shows status badge, timestamp, triggered-by |
+| Metrics | Completed runs show pass rate and passed/total count |
+| Clickable | Clicking a run navigates to `/evals/{eval_id}/runs/{run_id}` |
+| Ordering | Most recent run appears first |


### PR DESCRIPTION
## What
Gate the evals feature behind an experimental feature flag (`FEATURE_EVALS`) and add 7 UI test cases covering the evals workflow.

## Why
Evals was shipped without a feature flag, making it unconditionally available in all environments including production. As an experimental feature, it should follow the same pattern as other experimental features (global_chat, apps, mcp_endpoint) — auto-enabled in dev, disabled in prod unless explicitly opted in.

## How
- Added `evals: bool` field to `FeatureFlags` struct as an experimental flag
- Conditionally merge evals API routes in `app_builder.rs` (same pattern as `mcp_endpoint`)
- Added `flag: "evals", experimental: true` to sidebar navigation item
- Added `ExperimentalPageBadge` to evals list page header
- Added `evals: boolean` to TypeScript `FeatureFlags` interface and default flags
- Updated all existing feature flag tests to include the new field
- Created 7 UI test cases: list page, flag gating, create eval, add/delete case, start run, runs tab

## Risk
- Low
- Evals becomes unavailable in production unless `FEATURE_EVALS=true` is set. Dev mode is unaffected (auto-enabled).

## Security
- Threat categories reviewed: TM-API, TM-WEB
- No new endpoints or input handling. Change restricts access by gating routes behind a flag. No injection, auth bypass, or data exposure vectors introduced.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)