### PR TITLE
fix(daytona): use proper encoding for binary files in download_workspace

### DIFF
--- a/integrations/daytona/SPEC.md
+++ b/integrations/daytona/SPEC.md
@@ -126,7 +126,7 @@ Executes a shell command in a sandbox with real-time output streaming.
 Read a file from sandbox filesystem.
 
 - **Parameters**: `sandbox_id` (required), `path` (required)
-- **Returns**: `{ path, content }`
+- **Returns**: `{ path, content, encoding }` — `encoding` is `"text"` for UTF-8 text files or `"base64"` for binary files (auto-detected via null-byte heuristic)
 
 ### daytona_write_file
 

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -1,5 +1,6 @@
 //! Tool implementations for Daytona sandbox operations.
 
+use everruns_core::SessionFile;
 use everruns_core::ToolHints;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
@@ -529,10 +530,11 @@ impl Tool for DaytonaReadFileTool {
                 if let Err(e) = touch_sandbox_lease(context, &state, None).await {
                     return e;
                 }
-                let content = String::from_utf8_lossy(&bytes).to_string();
+                let (content, encoding) = SessionFile::encode_content(&bytes);
                 ToolExecutionResult::success(json!({
                     "path": path,
-                    "content": content
+                    "content": content,
+                    "encoding": encoding
                 }))
             }
             Err(e) => ToolExecutionResult::tool_error(e),
@@ -774,7 +776,7 @@ impl Tool for DaytonaDownloadWorkspaceTool {
                     // Download file
                     match client.file_download(sandbox_id, &full_path).await {
                         Ok(bytes) => {
-                            let content = String::from_utf8_lossy(&bytes).to_string();
+                            let (content, encoding) = SessionFile::encode_content(&bytes);
                             let relative =
                                 full_path.strip_prefix(sandbox_root).unwrap_or(&full_path);
                             let session_dest = format!(
@@ -788,7 +790,7 @@ impl Tool for DaytonaDownloadWorkspaceTool {
                             );
 
                             match file_store
-                                .write_file(context.session_id, &session_dest, &content, "utf-8")
+                                .write_file(context.session_id, &session_dest, &content, &encoding)
                                 .await
                             {
                                 Ok(_) => downloaded += 1,

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -1708,6 +1708,25 @@ mod tests {
     }
 
     #[test]
+    fn test_encode_content_text_files() {
+        let text_bytes = b"hello world\nline two\n";
+        let (content, encoding) = SessionFile::encode_content(text_bytes);
+        assert_eq!(encoding, "text");
+        assert_eq!(content, "hello world\nline two\n");
+    }
+
+    #[test]
+    fn test_encode_content_binary_files() {
+        // PNG-like header with null bytes
+        let binary_bytes: &[u8] = &[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00];
+        let (content, encoding) = SessionFile::encode_content(binary_bytes);
+        assert_eq!(encoding, "base64");
+        // Verify round-trip
+        let decoded = SessionFile::decode_content(&content, &encoding).unwrap();
+        assert_eq!(decoded, binary_bytes);
+    }
+
+    #[test]
     fn test_all_tools_have_descriptions() {
         let tools: Vec<Box<dyn Tool>> = vec![
             Box::new(DaytonaCreateSandboxTool),


### PR DESCRIPTION
## What
Replace `String::from_utf8_lossy` with `SessionFile::encode_content` in both `daytona_download_workspace` and `daytona_read_file` tools to correctly handle binary files.

## Why
Binary files (PNG screenshots, etc.) downloaded from Daytona sandboxes were silently corrupted. `String::from_utf8_lossy` strips null bytes and mangles non-UTF-8 sequences, so files appeared to download successfully but were unreadable. The hardcoded `"utf-8"` encoding parameter also bypassed the session filesystem's designed encoding system.

Fixes EVE-215

## How
- Use `SessionFile::encode_content(&bytes)` which auto-detects binary content (null byte heuristic) and returns base64-encoded data with `"base64"` encoding for binary, or UTF-8 text with `"text"` encoding for text files.
- Pass the correct encoding to `file_store.write_file()` instead of hardcoded `"utf-8"`.
- Add `encoding` field to `daytona_read_file` JSON response so callers know the content encoding.

## Risk
- Low
- Encoding detection uses the same `SessionFile::encode_content` already used elsewhere in the codebase. Text files continue to work identically. Binary files now work correctly instead of silently corrupting.

## Security
- Threat categories reviewed: TM-FS (file paths/sandbox boundaries)
- No new threat surface. Path handling unchanged. Only the content encoding changed from lossy UTF-8 to proper binary-aware encoding using an existing, well-tested utility.

## Checklist
- [x] Tests added or updated — existing `SessionFile::encode_content` tests cover the encoding logic; all 29 daytona crate tests pass
- [x] Backward compatibility considered — N/A, internal code
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)