### PR TITLE
fix(daytona): handle empty path/branch and quote shell args in git_clone

### DIFF
--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -1078,7 +1078,12 @@ impl Tool for DaytonaGitCloneTool {
             Err(e) => return e,
         };
         let repo_url_raw = match required_str(&arguments, "repo_url") {
-            Ok(s) => s,
+            Ok(s) if !s.trim().is_empty() => s,
+            Ok(_) => {
+                return ToolExecutionResult::tool_error(
+                    "repo_url must not be empty".to_string(),
+                );
+            }
             Err(e) => return e,
         };
         let branch = arguments
@@ -1132,10 +1137,13 @@ impl Tool for DaytonaGitCloneTool {
             repo_url.clone()
         };
 
-        // Build git clone command (quote args to handle special characters)
-        let mut cmd = format!("git clone --depth 1 '{clone_url}' '{target_path}'");
+        // Build git clone command (shell-escape args to handle special characters)
+        let esc_url = shell_escape(&clone_url);
+        let esc_path = shell_escape(target_path);
+        let mut cmd = format!("git clone --depth 1 {esc_url} {esc_path}");
         if let Some(b) = branch {
-            cmd = format!("git clone --depth 1 --branch '{b}' '{clone_url}' '{target_path}'");
+            let esc_branch = shell_escape(b);
+            cmd = format!("git clone --depth 1 --branch {esc_branch} {esc_url} {esc_path}");
         }
 
         debug!("Cloning repository via exec: {repo_url} → {target_path}");
@@ -1166,7 +1174,7 @@ impl Tool for DaytonaGitCloneTool {
         let commit_sha = match client
             .exec(
                 sandbox_id,
-                &format!("cd {target_path} && git rev-parse --short HEAD"),
+                &format!("cd {} && git rev-parse --short HEAD", shell_escape(target_path)),
                 None,
                 None,
                 |_| {},
@@ -1331,6 +1339,12 @@ impl Tool for DaytonaGitCredentialsTool {
 // ============================================================================
 // Git Clone Helpers
 // ============================================================================
+
+/// Escape a string for safe use inside POSIX single quotes.
+/// Replaces `'` with `'\''` (end quote, escaped quote, start quote).
+fn shell_escape(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
 
 /// Normalize repository URL: "user/repo" → "https://github.com/user/repo.git"
 fn normalize_repo_url(url: &str) -> String {
@@ -1852,6 +1866,21 @@ mod tests {
     fn test_normalize_repo_url_http() {
         let url = "http://github.com/user/repo";
         assert_eq!(normalize_repo_url(url), url);
+    }
+
+    #[test]
+    fn test_shell_escape_simple() {
+        assert_eq!(shell_escape("hello"), "'hello'");
+    }
+
+    #[test]
+    fn test_shell_escape_with_single_quote() {
+        assert_eq!(shell_escape("it's"), "'it'\\''s'");
+    }
+
+    #[test]
+    fn test_shell_escape_with_spaces() {
+        assert_eq!(shell_escape("path with spaces"), "'path with spaces'");
     }
 
     #[test]

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -1081,8 +1081,14 @@ impl Tool for DaytonaGitCloneTool {
             Ok(s) => s,
             Err(e) => return e,
         };
-        let branch = arguments.get("branch").and_then(|v| v.as_str());
-        let clone_path = arguments.get("path").and_then(|v| v.as_str());
+        let branch = arguments
+            .get("branch")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty());
+        let clone_path = arguments
+            .get("path")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty());
 
         let api_key = match get_api_key(context).await {
             Ok(k) => k,
@@ -1126,10 +1132,10 @@ impl Tool for DaytonaGitCloneTool {
             repo_url.clone()
         };
 
-        // Build git clone command
-        let mut cmd = format!("git clone --depth 1 {clone_url} {target_path}");
+        // Build git clone command (quote args to handle special characters)
+        let mut cmd = format!("git clone --depth 1 '{clone_url}' '{target_path}'");
         if let Some(b) = branch {
-            cmd = format!("git clone --depth 1 --branch {b} {clone_url} {target_path}");
+            cmd = format!("git clone --depth 1 --branch '{b}' '{clone_url}' '{target_path}'");
         }
 
         debug!("Cloning repository via exec: {repo_url} → {target_path}");
@@ -1845,6 +1851,13 @@ mod tests {
     #[test]
     fn test_normalize_repo_url_http() {
         let url = "http://github.com/user/repo";
+        assert_eq!(normalize_repo_url(url), url);
+    }
+
+    #[test]
+    fn test_normalize_repo_url_https_without_git_suffix() {
+        // HTTPS URLs without .git are valid and returned as-is
+        let url = "https://github.com/user/repo";
         assert_eq!(normalize_repo_url(url), url);
     }
 

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -1080,9 +1080,7 @@ impl Tool for DaytonaGitCloneTool {
         let repo_url_raw = match required_str(&arguments, "repo_url") {
             Ok(s) if !s.trim().is_empty() => s,
             Ok(_) => {
-                return ToolExecutionResult::tool_error(
-                    "repo_url must not be empty".to_string(),
-                );
+                return ToolExecutionResult::tool_error("repo_url must not be empty".to_string());
             }
             Err(e) => return e,
         };
@@ -1174,7 +1172,10 @@ impl Tool for DaytonaGitCloneTool {
         let commit_sha = match client
             .exec(
                 sandbox_id,
-                &format!("cd {} && git rev-parse --short HEAD", shell_escape(target_path)),
+                &format!(
+                    "cd {} && git rev-parse --short HEAD",
+                    shell_escape(target_path)
+                ),
                 None,
                 None,
                 |_| {},


### PR DESCRIPTION
## What
Fix `daytona_git_clone` to handle empty string parameters and quote shell arguments in the clone command.

## Why
LLMs frequently pass empty strings for optional `path` and `branch` parameters instead of omitting them. An empty `path` string bypassed the default path logic, causing `git clone` to fail with "You must specify a repository to clone". Unquoted shell arguments could also break on URLs with special characters.

Fixes EVE-216

## How
- Filter empty strings for `path` and `branch` via `.filter(|s| !s.is_empty())` so the default clone path kicks in
- Quote `clone_url`, `target_path`, and `branch` with single quotes in the shell command
- Add test for HTTPS URLs without `.git` suffix

## Risk
- Low
- Only affects the git_clone tool's command construction. Default path logic and URL normalization were already correct — just needed empty string handling.

## Security
- Threat categories reviewed: TM-BASH (command execution), TM-AUTH (token in URL)
- **Finding (positive)**: Quoting shell arguments is strictly safer than the previous unquoted interpolation. Token embedding in clone URLs is unchanged from prior behavior.
- No new threat surface introduced.

## Checklist
- [x] Tests added or updated — added `test_normalize_repo_url_https_without_git_suffix`
- [x] Backward compatibility considered — N/A, internal code
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)