### PR TITLE
fix(daytona): normalize session paths in download_workspace

### DIFF
--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -731,10 +731,14 @@ impl Tool for DaytonaDownloadWorkspaceTool {
             .get("sandbox_path")
             .and_then(|v| v.as_str())
             .unwrap_or(&state.workspace_path);
-        let session_root = arguments
+        let session_root_raw = arguments
             .get("session_path")
             .and_then(|v| v.as_str())
             .unwrap_or("/workspace");
+        // Normalize: strip /workspace prefix to match session filesystem conventions.
+        // The session_file_system capability strips /workspace/ from all paths, so
+        // files stored here must use the same normalized form to be discoverable.
+        let session_root = normalize_session_path(session_root_raw);
 
         let client = DaytonaClient::new(api_key);
 
@@ -1338,6 +1342,23 @@ impl Tool for DaytonaGitCredentialsTool {
 }
 
 // ============================================================================
+// Session Path Helpers
+// ============================================================================
+
+/// Normalize a session filesystem path by stripping the `/workspace` prefix.
+/// The session_file_system capability stores paths without /workspace, so
+/// daytona tools must match this convention for files to be discoverable.
+fn normalize_session_path(path: &str) -> String {
+    if path == "/workspace" {
+        "/".to_string()
+    } else if let Some(stripped) = path.strip_prefix("/workspace/") {
+        format!("/{stripped}")
+    } else {
+        path.to_string()
+    }
+}
+
+// ============================================================================
 // Git Clone Helpers
 // ============================================================================
 
@@ -1842,6 +1863,33 @@ mod tests {
         assert!(schema["properties"]["branch"].is_object());
         assert!(schema["properties"]["path"].is_object());
     }
+
+    // --- Session path normalization tests ---
+
+    #[test]
+    fn test_normalize_session_path_workspace() {
+        assert_eq!(normalize_session_path("/workspace"), "/");
+    }
+
+    #[test]
+    fn test_normalize_session_path_workspace_subpath() {
+        assert_eq!(
+            normalize_session_path("/workspace/reports/chat"),
+            "/reports/chat"
+        );
+    }
+
+    #[test]
+    fn test_normalize_session_path_no_prefix() {
+        assert_eq!(normalize_session_path("/reports/chat"), "/reports/chat");
+    }
+
+    #[test]
+    fn test_normalize_session_path_root() {
+        assert_eq!(normalize_session_path("/"), "/");
+    }
+
+    // --- Git URL normalization tests ---
 
     #[test]
     fn test_normalize_repo_url_shorthand() {


### PR DESCRIPTION
## What
Strip `/workspace/` prefix from session paths in `daytona_download_workspace` to match the session filesystem convention.

## Why
The `session_file_system` capability's tools (read_file, write_file, list_directory) all strip `/workspace/` from paths before storage. But `download_workspace` was writing files with the raw `/workspace/` prefix, causing a path mismatch. Files written by `download_workspace` at `/workspace/reports/foo.png` were invisible to `read_file /workspace/reports/foo.png` because `read_file` normalized to `/reports/foo.png`.

Fixes EVE-218

## How
- Add `normalize_session_path()` helper that strips `/workspace` prefix (same logic as `session_file_system` capability's `normalize_path`)
- Apply it to `session_root` in `download_workspace` before any file writes
- Add 4 tests covering workspace root, subpath, no-prefix, and root path cases

## Risk
- Low
- This is a path prefix stripping fix. Files are now stored at the same paths that other tools expect, resolving the invisible-files bug.

## Security
- Threat categories reviewed: TM-FS (file paths)
- The normalization is purely additive — it makes download_workspace consistent with the existing session filesystem path convention. No path traversal risk since the stripping only removes a known prefix.

## Checklist
- [x] Tests added or updated — 4 tests for normalize_session_path
- [x] Backward compatibility considered — files previously stored with /workspace/ prefix were inaccessible anyway, so this is strictly a fix
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)