### PR TITLE
fix(daytona): detect dead session shell and auto-recover

### DIFF
--- a/integrations/daytona/src/client.rs
+++ b/integrations/daytona/src/client.rs
@@ -317,6 +317,81 @@ impl DaytonaClient {
         }
     }
 
+    /// Probe session health by running a trivial command and checking if
+    /// it completes within a few seconds. Returns `true` if the session
+    /// shell is responsive, `false` if the heartbeat stalls (dead shell).
+    async fn session_heartbeat(&self, sandbox_id: &str) -> bool {
+        // Fire a heartbeat command.
+        let resp = self
+            .toolbox_request(
+                reqwest::Method::POST,
+                sandbox_id,
+                &format!("/process/session/{EXEC_SESSION_ID}/exec"),
+                Some(json!({
+                    "command": "true",
+                    "runAsync": true
+                })),
+            )
+            .await;
+
+        let cmd_id = match resp {
+            Ok(ref v) => match v.get("cmdId").and_then(|v| v.as_str()) {
+                Some(id) => id.to_string(),
+                None => return false,
+            },
+            Err(_) => return false,
+        };
+
+        let status_path = format!("/process/session/{EXEC_SESSION_ID}/command/{cmd_id}");
+
+        // Poll for up to SESSION_HEARTBEAT_TIMEOUT.
+        let deadline =
+            std::time::Instant::now() + Duration::from_millis(crate::SESSION_HEARTBEAT_TIMEOUT_MS);
+
+        while std::time::Instant::now() < deadline {
+            tokio::time::sleep(EXEC_POLL_INTERVAL).await;
+            if let Ok(s) = self
+                .toolbox_request(reqwest::Method::GET, sandbox_id, &status_path, None)
+                .await
+                && s.get("exitCode").is_some()
+            {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Delete the persistent session. Used to reset a dead session whose
+    /// shell was terminated by a command like `exit`.
+    async fn delete_session(&self, sandbox_id: &str) -> Result<(), String> {
+        let url = format!(
+            "{}/{sandbox_id}/process/session/{EXEC_SESSION_ID}",
+            self.toolbox_base
+        );
+        let resp = self
+            .http
+            .delete(&url)
+            .bearer_auth(&self.api_key)
+            .send()
+            .await
+            .map_err(|e| format!("Failed to delete session: {e}"))?;
+
+        let status = resp.status();
+        if status.is_success() || status.as_u16() == 404 {
+            Ok(())
+        } else {
+            let body = resp.text().await.unwrap_or_default();
+            Err(format!("Failed to delete session ({status}): {body}"))
+        }
+    }
+
+    /// Reset a dead session by deleting and re-creating it.
+    async fn reset_session(&self, sandbox_id: &str) -> Result<(), String> {
+        self.delete_session(sandbox_id).await?;
+        self.ensure_session(sandbox_id).await
+    }
+
     /// Execute a command in the sandbox via the Session API.
     ///
     /// Creates a persistent shell session (if needed), runs the command
@@ -364,8 +439,17 @@ impl DaytonaClient {
             .to_string();
 
         // Poll for output and completion.
+        //
+        // Dead-session detection: When a command like `exit` kills the
+        // persistent shell, Daytona keeps the session metadata alive (GET
+        // returns 200) but the command never gets an exitCode and logs stay
+        // empty. We detect this by tracking consecutive "stale" polls — polls
+        // where there is no exitCode and no new output. After enough stale
+        // polls we probe with a heartbeat command; if it also stalls, we
+        // know the session is dead and reset it.
         let deadline = std::time::Instant::now() + Duration::from_millis(timeout);
         let mut output_emitted: usize = 0;
+        let mut stale_polls: u32 = 0;
         let logs_path = format!("/process/session/{EXEC_SESSION_ID}/command/{cmd_id}/logs");
         let status_path = format!("/process/session/{EXEC_SESSION_ID}/command/{cmd_id}");
 
@@ -383,7 +467,8 @@ impl DaytonaClient {
                 .unwrap_or_default();
 
             let text = strip_stream_markers(&logs);
-            if text.len() > output_emitted {
+            let had_new_output = text.len() > output_emitted;
+            if had_new_output {
                 on_output(&text[output_emitted..]);
                 output_emitted = text.len();
             }
@@ -411,6 +496,37 @@ impl DaytonaClient {
                     result: final_text,
                     exit_code: exit_code as i32,
                 });
+            }
+
+            // Track stale polls: no exitCode and no new output.
+            if had_new_output {
+                stale_polls = 0;
+            } else {
+                stale_polls += 1;
+            }
+
+            // After several stale polls, probe session health with a
+            // heartbeat. If the heartbeat doesn't complete quickly, the
+            // session shell is dead.
+            if stale_polls >= crate::SESSION_STALE_THRESHOLD {
+                debug!(
+                    "Command {cmd_id} stale for {stale_polls} polls, \
+                     probing session health"
+                );
+                if self.session_heartbeat(sandbox_id).await {
+                    // Session is alive; command is just slow. Reset counter
+                    // so we don't probe again for a while.
+                    stale_polls = 0;
+                } else {
+                    debug!(
+                        "Session {EXEC_SESSION_ID} is dead (heartbeat failed); \
+                         resetting session"
+                    );
+                    let _ = self.reset_session(sandbox_id).await;
+                    return Err("Session terminated by command (the command likely ran \
+                         `exit` which killed the shell)"
+                        .to_string());
+                }
             }
         }
     }
@@ -690,6 +806,89 @@ mod tests {
         let exec_result = result.unwrap();
         assert_eq!(exec_result.exit_code, 0);
         assert_eq!(exec_result.result, "hello world\n");
+    }
+
+    /// Simulates Daytona's real behavior when `exit` kills the session shell:
+    /// - Session metadata stays alive (GET /session → 200)
+    /// - Command status returns 200 with no exitCode (forever)
+    /// - Logs return 200 with empty body
+    /// - Heartbeat exec accepts (202) but never completes
+    /// After enough stale polls + failed heartbeat, the client detects
+    /// the dead session, resets it (DELETE + POST), and returns an error.
+    #[tokio::test]
+    async fn test_client_exec_detects_dead_session() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        let mock_server = MockServer::start().await;
+        let exec_call_count = std::sync::Arc::new(AtomicU32::new(0));
+
+        // 1. Create session → 201
+        Mock::given(method("POST"))
+            .and(path("/sb_dead/process/session"))
+            .respond_with(ResponseTemplate::new(201))
+            .mount(&mock_server)
+            .await;
+
+        // 2. All exec calls → 202 with unique cmdId (both the real command
+        //    and the heartbeat probe). Use a counter to generate unique IDs.
+        let counter = exec_call_count.clone();
+        Mock::given(method("POST"))
+            .and(path("/sb_dead/process/session/everruns-exec/exec"))
+            .respond_with(move |_: &wiremock::Request| {
+                let n = counter.fetch_add(1, Ordering::SeqCst);
+                ResponseTemplate::new(202).set_body_json(json!({
+                    "cmdId": format!("cmd_{n}")
+                }))
+            })
+            .mount(&mock_server)
+            .await;
+
+        // 3. All command logs → 200 with empty body (dead shell produces nothing)
+        Mock::given(method("GET"))
+            .and(wiremock::matchers::path_regex(
+                r"/sb_dead/process/session/everruns-exec/command/cmd_\d+/logs",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(vec![]))
+            .mount(&mock_server)
+            .await;
+
+        // 4. All command status → 200 with no exitCode (dead shell never reports)
+        Mock::given(method("GET"))
+            .and(wiremock::matchers::path_regex(
+                r"/sb_dead/process/session/everruns-exec/command/cmd_\d+$",
+            ))
+            .respond_with(|req: &wiremock::Request| {
+                let path = req.url.path();
+                let cmd_id = path.rsplit('/').next().unwrap_or("unknown");
+                ResponseTemplate::new(200).set_body_json(json!({
+                    "id": cmd_id,
+                    "command": "exit 1"
+                }))
+            })
+            .mount(&mock_server)
+            .await;
+
+        // 5. DELETE session → 204
+        Mock::given(method("DELETE"))
+            .and(path("/sb_dead/process/session/everruns-exec"))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&mock_server)
+            .await;
+
+        let client = DaytonaClient::with_base_urls(
+            "test_key".to_string(),
+            mock_server.uri(),
+            mock_server.uri(),
+        );
+        let result = client
+            .exec("sb_dead", "exit 1", None, Some(30_000), |_| {})
+            .await;
+        assert!(result.is_err(), "Should detect dead session");
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("Session terminated"),
+            "Error should mention session termination, got: {err}"
+        );
     }
 
     #[tokio::test]

--- a/integrations/daytona/src/client.rs
+++ b/integrations/daytona/src/client.rs
@@ -461,12 +461,12 @@ impl DaytonaClient {
             tokio::time::sleep(EXEC_POLL_INTERVAL).await;
 
             // Fetch session command logs (raw bytes with stream markers).
-            let logs = self
-                .toolbox_download(sandbox_id, &logs_path)
-                .await
-                .unwrap_or_default();
+            let logs_ok = self.toolbox_download(sandbox_id, &logs_path).await.ok();
 
-            let text = strip_stream_markers(&logs);
+            let text = logs_ok
+                .as_deref()
+                .map(strip_stream_markers)
+                .unwrap_or_default();
             let had_new_output = text.len() > output_emitted;
             if had_new_output {
                 on_output(&text[output_emitted..]);
@@ -499,9 +499,11 @@ impl DaytonaClient {
             }
 
             // Track stale polls: no exitCode and no new output.
+            // Only count polls where both log and status calls succeeded —
+            // transient HTTP failures should not trigger dead-session detection.
             if had_new_output {
                 stale_polls = 0;
-            } else {
+            } else if status.is_ok() && logs_ok.is_some() {
                 stale_polls += 1;
             }
 
@@ -522,10 +524,19 @@ impl DaytonaClient {
                         "Session {EXEC_SESSION_ID} is dead (heartbeat failed); \
                          resetting session"
                     );
-                    let _ = self.reset_session(sandbox_id).await;
-                    return Err("Session terminated by command (the command likely ran \
-                         `exit` which killed the shell)"
-                        .to_string());
+                    return match self.reset_session(sandbox_id).await {
+                        Ok(()) => Err("Session terminated by command (the command likely ran \
+                             `exit` which killed the shell)"
+                            .to_string()),
+                        Err(e) => {
+                            debug!("Failed to reset session {EXEC_SESSION_ID}: {e}");
+                            Err(format!(
+                                "Session terminated by command (the command likely \
+                                 ran `exit` which killed the shell); additionally, \
+                                 failed to reset session: {e}"
+                            ))
+                        }
+                    };
                 }
             }
         }
@@ -888,6 +899,14 @@ mod tests {
         assert!(
             err.contains("Session terminated"),
             "Error should mention session termination, got: {err}"
+        );
+
+        // Verify the heartbeat was attempted (at least 2 exec calls: the
+        // original command + the heartbeat probe).
+        assert!(
+            exec_call_count.load(Ordering::SeqCst) >= 2,
+            "Expected at least 2 exec calls (command + heartbeat), got {}",
+            exec_call_count.load(Ordering::SeqCst)
         );
     }
 

--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -57,6 +57,11 @@ const DAYTONA_SANDBOX_SECRET_PREFIX: &str = "daytona_sandbox:";
 const EXEC_TIMEOUT_MS: u64 = 120_000;
 /// Interval for polling streaming exec output from the sandbox.
 const EXEC_POLL_INTERVAL: Duration = Duration::from_millis(1_000);
+/// Number of consecutive stale polls (no exitCode, no new output) before
+/// probing session health with a heartbeat command.
+const SESSION_STALE_THRESHOLD: u32 = 5;
+/// Timeout (ms) for the heartbeat probe command (`true`).
+const SESSION_HEARTBEAT_TIMEOUT_MS: u64 = 5_000;
 const SANDBOX_READY_POLL_INTERVAL: Duration = Duration::from_secs(2);
 const SANDBOX_READY_MAX_WAIT: Duration = Duration::from_secs(60);
 /// Auto-stop after 5 minutes of inactivity (safety net)

--- a/integrations/daytona/tests/live_api_test.rs
+++ b/integrations/daytona/tests/live_api_test.rs
@@ -157,7 +157,7 @@ async fn test_live_sandbox_lifecycle() {
         .expect("delete_sandbox failed");
 }
 
-/// Exec with working directory and nonzero exit code.
+/// Exec with working directory, nonzero exit code, and session death recovery.
 #[tokio::test]
 async fn test_live_exec_cwd_and_exit_code() {
     let api_key = require_api_key!();
@@ -176,12 +176,33 @@ async fn test_live_exec_cwd_and_exit_code() {
         result.result
     );
 
-    // Nonzero exit code (Daytona may return -1 instead of the exact code)
+    // Nonzero exit code — use `bash -c` to run in a subshell so the
+    // persistent session shell is not killed by `exit`.
     let result = client
-        .exec(id, "exit 42", None, None, |_| {})
+        .exec(id, "bash -c 'exit 42'", None, None, |_| {})
         .await
         .expect("exec with nonzero exit failed");
     assert_ne!(result.exit_code, 0, "Expected nonzero exit code, got 0");
+
+    // Bare `exit` kills the persistent session shell. The client must
+    // detect the dead session and return an error instead of hanging.
+    let result = client.exec(id, "exit 1", None, None, |_| {}).await;
+    assert!(
+        result.is_err(),
+        "bare `exit` should be detected as session termination"
+    );
+
+    // Subsequent exec should recover — ensure_session re-creates it.
+    let result = client
+        .exec(id, "echo recovered", None, None, |_| {})
+        .await
+        .expect("exec after session recovery failed");
+    assert_eq!(result.exit_code, 0);
+    assert!(
+        result.result.contains("recovered"),
+        "Expected 'recovered' in output: {}",
+        result.result
+    );
 }
 
 /// Folder creation and file listing.

--- a/integrations/daytona/tests/live_api_test.rs
+++ b/integrations/daytona/tests/live_api_test.rs
@@ -176,10 +176,10 @@ async fn test_live_exec_cwd_and_exit_code() {
         result.result
     );
 
-    // Nonzero exit code — use `bash -c` to run in a subshell so the
+    // Nonzero exit code — use `sh -c` to run in a subshell so the
     // persistent session shell is not killed by `exit`.
     let result = client
-        .exec(id, "bash -c 'exit 42'", None, None, |_| {})
+        .exec(id, "sh -c 'exit 42'", None, None, |_| {})
         .await
         .expect("exec with nonzero exit failed");
     assert_ne!(result.exit_code, 0, "Expected nonzero exit code, got 0");


### PR DESCRIPTION
## What
Detect when a Daytona persistent session shell dies (e.g. from a bare `exit` command) and auto-recover instead of hanging until timeout.

## Why
CI on main was red — `test_live_exec_cwd_and_exit_code` timed out after 120s because `exit 42` killed the persistent session shell. The polling loop waited for an `exitCode` that would never arrive since Daytona keeps session metadata alive (GET returns 200) but the dead shell never reports command completion.

## How
1. **Stale poll tracking** — count consecutive polls where command status has no `exitCode` and no new output appears.
2. **Heartbeat probe** — after 5 stale polls, run a trivial `true` command. If it completes within 5s, the session is alive (command is just slow). If it stalls, the shell is dead.
3. **Auto-reset** — `DELETE /process/session/{id}` + `POST /process/session` to create a fresh session, then return an error to the caller.
4. **Auto-recovery** — subsequent `exec` calls use `ensure_session` which creates the new session transparently.

Approach validated by writing a diagnostic test against the real Daytona API to observe actual behavior (session metadata persists after shell death, command status returns 200 with no exitCode forever, new exec accepts 202 but never completes). Only DELETE + re-create restores functionality.

### New methods
- `session_heartbeat` — runs `true` async, polls for exitCode within 5s
- `delete_session` — `DELETE /process/session/{sessionId}`
- `reset_session` — delete + ensure_session

### Test changes
- Mock test simulates Daytona's real dead-session behavior (200 with no exitCode, empty logs, heartbeat stalls)
- Live test: `bash -c 'exit 42'` for nonzero exit, bare `exit 1` detected as session death, recovery verified with follow-up `echo recovered`
- All 5 live integration tests pass against real Daytona API, sandboxes cleaned up

## Risk
- Low
- False positive on slow commands: mitigated by requiring 5 consecutive stale polls (5s) + failed 5s heartbeat before declaring dead. A truly slow command would need 10s of zero output AND a failed heartbeat.

## Security
- Threat categories reviewed: TM-TOOL (tool execution paths)
- No new trust boundaries, user inputs, or injection vectors. All new methods use the same auth pattern (bearer token) and call existing Daytona Toolbox API endpoints.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)