### PR TITLE
fix(daytona): increase stale-session threshold for long builds

### DIFF
--- a/integrations/daytona/src/client.rs
+++ b/integrations/daytona/src/client.rs
@@ -892,7 +892,7 @@ mod tests {
             mock_server.uri(),
         );
         let result = client
-            .exec("sb_dead", "exit 1", None, Some(30_000), |_| {})
+            .exec("sb_dead", "exit 1", None, Some(60_000), |_| {})
             .await;
         assert!(result.is_err(), "Should detect dead session");
         let err = result.unwrap_err();

--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -59,9 +59,9 @@ const EXEC_TIMEOUT_MS: u64 = 120_000;
 const EXEC_POLL_INTERVAL: Duration = Duration::from_millis(1_000);
 /// Number of consecutive stale polls (no exitCode, no new output) before
 /// probing session health with a heartbeat command.
-const SESSION_STALE_THRESHOLD: u32 = 5;
+const SESSION_STALE_THRESHOLD: u32 = 30;
 /// Timeout (ms) for the heartbeat probe command (`true`).
-const SESSION_HEARTBEAT_TIMEOUT_MS: u64 = 5_000;
+const SESSION_HEARTBEAT_TIMEOUT_MS: u64 = 15_000;
 const SANDBOX_READY_POLL_INTERVAL: Duration = Duration::from_secs(2);
 const SANDBOX_READY_MAX_WAIT: Duration = Duration::from_secs(60);
 /// Auto-stop after 5 minutes of inactivity (safety net)

--- a/scripts/lib/services.sh
+++ b/scripts/lib/services.sh
@@ -527,7 +527,10 @@ case "$cmd" in
     export FRONTEND_URL=${FRONTEND_URL:-$PROXY_URL_DEFAULT}
     export API_BASE_URL=${API_BASE_URL:-"http://127.0.0.1:${API_PORT}"}
     export DEPLOYMENT_GRADE=dev
-    export WORKER_GRPC_AUTH_TOKEN=${WORKER_GRPC_AUTH_TOKEN:-local-dev-token}
+    if [ -z "${WORKER_GRPC_AUTH_TOKEN:-}" ]; then
+      WORKER_GRPC_AUTH_TOKEN="$(head -c 32 /dev/urandom | base64 | tr -d '=+/\n\r\t' | head -c 32)"
+    fi
+    export WORKER_GRPC_AUTH_TOKEN
     export RUST_LOG=${RUST_LOG:-info}
     if [ "$NO_WATCH" = true ]; then
       echo "3️⃣  Starting API server (auto-migrates on startup)..."
@@ -808,7 +811,10 @@ case "$cmd" in
     export AUTH_BASE_URL=${AUTH_BASE_URL:-${PROXY_URL_DEFAULT}/api}
     export FRONTEND_URL=${FRONTEND_URL:-$PROXY_URL_DEFAULT}
     export DEPLOYMENT_GRADE=dev
-    export WORKER_GRPC_AUTH_TOKEN=${WORKER_GRPC_AUTH_TOKEN:-local-dev-token}
+    if [ -z "${WORKER_GRPC_AUTH_TOKEN:-}" ]; then
+      WORKER_GRPC_AUTH_TOKEN="$(head -c 32 /dev/urandom | base64 | tr -d '=+/\n\r\t' | head -c 32)"
+    fi
+    export WORKER_GRPC_AUTH_TOKEN
     export RUST_LOG=${RUST_LOG:-info}
 
     echo "5️⃣  Starting server (release)..."

--- a/scripts/lib/services.sh
+++ b/scripts/lib/services.sh
@@ -527,6 +527,7 @@ case "$cmd" in
     export FRONTEND_URL=${FRONTEND_URL:-$PROXY_URL_DEFAULT}
     export API_BASE_URL=${API_BASE_URL:-"http://127.0.0.1:${API_PORT}"}
     export DEPLOYMENT_GRADE=dev
+    export WORKER_GRPC_AUTH_TOKEN=${WORKER_GRPC_AUTH_TOKEN:-local-dev-token}
     export RUST_LOG=${RUST_LOG:-info}
     if [ "$NO_WATCH" = true ]; then
       echo "3️⃣  Starting API server (auto-migrates on startup)..."
@@ -807,6 +808,7 @@ case "$cmd" in
     export AUTH_BASE_URL=${AUTH_BASE_URL:-${PROXY_URL_DEFAULT}/api}
     export FRONTEND_URL=${FRONTEND_URL:-$PROXY_URL_DEFAULT}
     export DEPLOYMENT_GRADE=dev
+    export WORKER_GRPC_AUTH_TOKEN=${WORKER_GRPC_AUTH_TOKEN:-local-dev-token}
     export RUST_LOG=${RUST_LOG:-info}
 
     echo "5️⃣  Starting server (release)..."


### PR DESCRIPTION
## Summary

- **Daytona stale-session detection**: Increase `SESSION_STALE_THRESHOLD` from 5→30 polls and `SESSION_HEARTBEAT_TIMEOUT_MS` from 5s→15s. The previous values falsely declared sandbox shells dead during compilation commands (`cargo build`, `npm install`) that produce no output for 10-30s during linking phases.
- **start-all gRPC auth**: Set `WORKER_GRPC_AUTH_TOKEN` with a dev default in `start-all` mode. Without it, the gRPC server panics on startup because `require_grpc_auth_token()` enforces the token in non-dev (Postgres) mode.

## Test plan

- [ ] `just pre-push` passes
- [ ] `start-all --no-watch` starts without gRPC panic
- [ ] Daytona sandbox exec with long-running commands (e.g. `cargo build`) no longer triggers false dead-session detection
