### PR TITLE
fix(daytona): increase stale-session threshold for long builds

### DIFF
--- a/integrations/daytona/src/client.rs
+++ b/integrations/daytona/src/client.rs
@@ -509,8 +509,12 @@ impl DaytonaClient {
 
             // After several stale polls, probe session health with a
             // heartbeat. If the heartbeat doesn't complete quickly, the
-            // session shell is dead.
-            if stale_polls >= crate::SESSION_STALE_THRESHOLD {
+            // session shell is dead. Skip the probe if remaining time is
+            // less than the heartbeat timeout to avoid exceeding deadline.
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            if stale_polls >= crate::SESSION_STALE_THRESHOLD
+                && remaining > Duration::from_millis(crate::SESSION_HEARTBEAT_TIMEOUT_MS)
+            {
                 debug!(
                     "Command {cmd_id} stale for {stale_polls} polls, \
                      probing session health"
@@ -891,8 +895,14 @@ mod tests {
             mock_server.uri(),
             mock_server.uri(),
         );
+        // Timeout must exceed stale detection window + heartbeat so the
+        // dead-session path fires before the exec timeout path.
+        let detection_window_ms = (crate::SESSION_STALE_THRESHOLD as u64)
+            * crate::EXEC_POLL_INTERVAL.as_millis() as u64
+            + crate::SESSION_HEARTBEAT_TIMEOUT_MS
+            + 5_000; // buffer
         let result = client
-            .exec("sb_dead", "exit 1", None, Some(60_000), |_| {})
+            .exec("sb_dead", "exit 1", None, Some(detection_window_ms), |_| {})
             .await;
         assert!(result.is_err(), "Should detect dead session");
         let err = result.unwrap_err();

--- a/integrations/daytona/src/client.rs
+++ b/integrations/daytona/src/client.rs
@@ -892,7 +892,7 @@ mod tests {
             mock_server.uri(),
         );
         let result = client
-            .exec("sb_dead", "exit 1", None, Some(30_000), |_| {})
+            .exec("sb_dead", "exit 1", None, Some(60_000), |_| {})
             .await;
         assert!(result.is_err(), "Should detect dead session");
         let err = result.unwrap_err();

--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -59,9 +59,9 @@ const EXEC_TIMEOUT_MS: u64 = 120_000;
 const EXEC_POLL_INTERVAL: Duration = Duration::from_millis(1_000);
 /// Number of consecutive stale polls (no exitCode, no new output) before
 /// probing session health with a heartbeat command.
-const SESSION_STALE_THRESHOLD: u32 = 5;
+const SESSION_STALE_THRESHOLD: u32 = 30;
 /// Timeout (ms) for the heartbeat probe command (`true`).
-const SESSION_HEARTBEAT_TIMEOUT_MS: u64 = 5_000;
+const SESSION_HEARTBEAT_TIMEOUT_MS: u64 = 15_000;
 const SANDBOX_READY_POLL_INTERVAL: Duration = Duration::from_secs(2);
 const SANDBOX_READY_MAX_WAIT: Duration = Duration::from_secs(60);
 /// Auto-stop after 5 minutes of inactivity (safety net)


### PR DESCRIPTION
## Summary

- Increase `SESSION_STALE_THRESHOLD` from 5→30 polls (30s) and `SESSION_HEARTBEAT_TIMEOUT_MS` from 5s→15s
- The previous values falsely declared sandbox shells dead during compilation commands (`cargo build`, `npm install`) that produce no output for 10-30s during linking phases
- Bump `test_client_exec_detects_dead_session` timeout from 30s→60s to accommodate new thresholds

## Test plan

- [ ] `cargo test -p everruns-integrations-daytona` passes (including dead-session test)
- [ ] Daytona sandbox exec with long-running commands no longer triggers false dead-session detection
