### PR TITLE
fix(scripts): set WORKER_GRPC_AUTH_TOKEN in start-all mode

### DIFF
--- a/scripts/lib/services.sh
+++ b/scripts/lib/services.sh
@@ -527,6 +527,10 @@ case "$cmd" in
     export FRONTEND_URL=${FRONTEND_URL:-$PROXY_URL_DEFAULT}
     export API_BASE_URL=${API_BASE_URL:-"http://127.0.0.1:${API_PORT}"}
     export DEPLOYMENT_GRADE=dev
+    if [ -z "${WORKER_GRPC_AUTH_TOKEN:-}" ]; then
+      WORKER_GRPC_AUTH_TOKEN="$(head -c 32 /dev/urandom | base64 | tr -d '=+/\n\r\t' | head -c 32)"
+    fi
+    export WORKER_GRPC_AUTH_TOKEN
     export RUST_LOG=${RUST_LOG:-info}
     if [ "$NO_WATCH" = true ]; then
       echo "3️⃣  Starting API server (auto-migrates on startup)..."
@@ -807,6 +811,10 @@ case "$cmd" in
     export AUTH_BASE_URL=${AUTH_BASE_URL:-${PROXY_URL_DEFAULT}/api}
     export FRONTEND_URL=${FRONTEND_URL:-$PROXY_URL_DEFAULT}
     export DEPLOYMENT_GRADE=dev
+    if [ -z "${WORKER_GRPC_AUTH_TOKEN:-}" ]; then
+      WORKER_GRPC_AUTH_TOKEN="$(head -c 32 /dev/urandom | base64 | tr -d '=+/\n\r\t' | head -c 32)"
+    fi
+    export WORKER_GRPC_AUTH_TOKEN
     export RUST_LOG=${RUST_LOG:-info}
 
     echo "5️⃣  Starting server (release)..."

--- a/scripts/lib/services.sh
+++ b/scripts/lib/services.sh
@@ -528,7 +528,8 @@ case "$cmd" in
     export API_BASE_URL=${API_BASE_URL:-"http://127.0.0.1:${API_PORT}"}
     export DEPLOYMENT_GRADE=dev
     if [ -z "${WORKER_GRPC_AUTH_TOKEN:-}" ]; then
-      WORKER_GRPC_AUTH_TOKEN="$(head -c 32 /dev/urandom | base64 | tr -d '=+/\n\r\t' | head -c 32)"
+      _raw="$(head -c 32 /dev/urandom | base64 | tr -d '=+/\n\r\t')"
+      WORKER_GRPC_AUTH_TOKEN="${_raw:0:32}"
     fi
     export WORKER_GRPC_AUTH_TOKEN
     export RUST_LOG=${RUST_LOG:-info}
@@ -812,7 +813,8 @@ case "$cmd" in
     export FRONTEND_URL=${FRONTEND_URL:-$PROXY_URL_DEFAULT}
     export DEPLOYMENT_GRADE=dev
     if [ -z "${WORKER_GRPC_AUTH_TOKEN:-}" ]; then
-      WORKER_GRPC_AUTH_TOKEN="$(head -c 32 /dev/urandom | base64 | tr -d '=+/\n\r\t' | head -c 32)"
+      _raw="$(head -c 32 /dev/urandom | base64 | tr -d '=+/\n\r\t')"
+      WORKER_GRPC_AUTH_TOKEN="${_raw:0:32}"
     fi
     export WORKER_GRPC_AUTH_TOKEN
     export RUST_LOG=${RUST_LOG:-info}


### PR DESCRIPTION
## Summary

- `start-all` runs with PostgreSQL (non-dev mode) which requires `WORKER_GRPC_AUTH_TOKEN` for gRPC authentication — without it, `require_grpc_auth_token()` panics on startup
- Generate a random per-run token from `/dev/urandom` when the env var is unset, keeping local dev safe by default (gRPC binds to `0.0.0.0`)

## Test plan

- [ ] `PORT_PREFIX=271 just start-all --no-watch` starts without gRPC panic
- [ ] Worker connects to control-plane successfully
