### PR TITLE
docs: update context management docs for Generic harness

### DIFF
--- a/docs/advanced/compaction.md
+++ b/docs/advanced/compaction.md
@@ -90,6 +90,43 @@ You can configure:
 
 Last resort. Drops the oldest messages to fit within the token budget. The system prompt and the most recent messages are always preserved. This is lossy — dropped messages cannot be recovered unless Infinity Context is enabled.
 
+## Generic Harness Defaults
+
+The built-in **Generic** harness enables both `compaction` and `infinity_context` by default. Together they keep long sessions unbounded without manual configuration.
+
+| Capability | Role | Default in Generic |
+|---|---|---|
+| **Infinity Context** | Limits how many messages are loaded from the database into the prompt; provides `query_history` for retrieval | `context_budget_tokens: 100000`, `min_recent_messages: 10` |
+| **Context Compaction** | Reduces the size of messages that *are* in the prompt — masking tool outputs, summarizing, or trimming | `strategy: auto`, `proactive: true`, `budget_percent: 0.85` |
+
+The flow for a long-running Generic session:
+
+```
+1. Session has 500 messages in the database
+       │
+       ▼
+2. Infinity Context loads only the most recent
+   messages that fit ~100k tokens
+       │
+       ▼
+3. Compaction checks: does the loaded context
+   exceed 85% of the model's window?
+       │
+   No ──► Send to LLM as-is
+       │
+   Yes ─► Run cascade:
+          a. Mask old tool outputs (free)
+          b. Native provider compaction (if available)
+          c. Summarize older turns (LLM call)
+          d. Aggressive trim (last resort)
+       │
+       ▼
+4. Messages trimmed or summarized away remain
+   queryable via query_history
+```
+
+No configuration is needed — creating a session with the Generic harness gives you this behavior out of the box. To customize, override either capability's config on the agent or session level.
+
 ## Configuration
 
 Compaction is a capability configured per agent or harness via `AgentCapabilityConfig`.

--- a/docs/advanced/compaction.md
+++ b/docs/advanced/compaction.md
@@ -122,7 +122,7 @@ The flow for a long-running Generic session:
        │
        ▼
 4. Messages trimmed or summarized away remain
-   queryable via query_history
+   queryable via `query_history`
 ```
 
 No configuration is needed — creating a session with the Generic harness gives you this behavior out of the box. To customize, override either capability's config on the agent or session level.

--- a/docs/capabilities/infinity-context.md
+++ b/docs/capabilities/infinity-context.md
@@ -73,5 +73,6 @@ Custom budget:
 
 ## See Also
 
+- [Context Compaction](/advanced/compaction/) — Complementary capability that reduces the size of messages in the prompt; see [Generic Harness Defaults](/advanced/compaction/#generic-harness-defaults) for how they work together
 - [Capabilities Overview](/capabilities/)
 - [Harnesses](/features/harnesses/)

--- a/docs/features/harnesses.md
+++ b/docs/features/harnesses.md
@@ -40,9 +40,16 @@ A general-purpose harness bundling the core capabilities most agents need. This 
 |------------|-----------------|
 | **File System** | Read, write, list, grep, and delete files in the session workspace (`/workspace`) |
 | **Virtual Bash** | Sandboxed bash shell for running commands, scripts, and text processing |
+| **Web Fetch** | Fetch web content with file download support (`enable_file_download: true`) |
 | **Storage** | Key/value store for general data and encrypted secret storage for API keys and credentials |
 | **Session** | Access session metadata and manage session title |
-| **Infinity Context** | Keeps long sessions within prompt budget while exposing older history via `query_history` |
+| **AGENTS.md** | Reads AGENTS.md from workspace and injects project-level instructions into the system prompt |
+| **Skills** | Discover and activate skills from `/.agents/skills/` in the session filesystem |
+| **[Infinity Context](/capabilities/infinity-context/)** | Trims older messages from the live prompt while exposing earlier history via `query_history` |
+| **[OpenAI Tool Search](/capabilities/tool-search/)** | Defers tool schema loading on supported OpenAI models to reduce prompt size |
+| **[Context Compaction](/advanced/compaction/)** | Auto-compacts context at 85% budget via cascading strategies (observation masking → native → summarization → trim) |
+
+Infinity Context and Context Compaction work together to keep long sessions unbounded: Infinity Context windows how many messages are loaded into the prompt, while Compaction reduces the size of what's loaded. See [Context Compaction — Generic Harness Defaults](/advanced/compaction/#generic-harness-defaults) for details.
 
 ## Choosing a Harness
 

--- a/docs/features/harnesses.md
+++ b/docs/features/harnesses.md
@@ -46,7 +46,7 @@ A general-purpose harness bundling the core capabilities most agents need. This 
 | **AGENTS.md** | Reads AGENTS.md from workspace and injects project-level instructions into the system prompt |
 | **Skills** | Discover and activate skills from `/.agents/skills/` in the session filesystem |
 | **[Infinity Context](/capabilities/infinity-context/)** | Trims older messages from the live prompt while exposing earlier history via `query_history` |
-| **[OpenAI Tool Search](/capabilities/tool-search/)** | Defers tool schema loading on supported OpenAI models to reduce prompt size |
+| **[OpenAI Tool Search](/capabilities/openai-tool-search/)** | Defers tool schema loading on supported OpenAI models to reduce prompt size |
 | **[Context Compaction](/advanced/compaction/)** | Auto-compacts context at 85% budget via cascading strategies (observation masking → native → summarization → trim) |
 
 Infinity Context and Context Compaction work together to keep long sessions unbounded: Infinity Context windows how many messages are loaded into the prompt, while Compaction reduces the size of what's loaded. See [Context Compaction — Generic Harness Defaults](/advanced/compaction/#generic-harness-defaults) for details.


### PR DESCRIPTION
## What
Update public docs to accurately reflect all capabilities in the Generic harness and explain how compaction and infinity context work together.

## Why
The harnesses doc was missing 5 capabilities from the Generic harness table (Web Fetch, AGENTS.md, Skills, OpenAI Tool Search, Context Compaction). There was no single place explaining how compaction and infinity context interact in the default setup.

## How
- **`docs/features/harnesses.md`** — Added all 10 Generic capabilities to the table (was showing only 5). Added a paragraph explaining the compaction + infinity context interaction with a link to the new section.
- **`docs/advanced/compaction.md`** — Added "Generic Harness Defaults" section before Configuration, with a comparison table and ASCII flow diagram showing the end-to-end message lifecycle in a long-running Generic session.
- **`docs/capabilities/infinity-context.md`** — Added cross-reference to compaction doc in See Also.

## Risk
- Low
- Docs-only change. No runtime behavior affected.

## Security
- No security-relevant code changes — purely markdown documentation updates, no code/config/infrastructure touched.

## Checklist
- [x] Tests added or updated — N/A (docs only, verified with `npm run build`)
- [x] Backward compatibility considered — N/A
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
