### PR TITLE
fix(daytona): bump default exec timeout from 2m to 5m

### DIFF
--- a/integrations/daytona/SPEC.md
+++ b/integrations/daytona/SPEC.md
@@ -117,7 +117,7 @@ Executes a shell command in a sandbox with real-time output streaming.
   - `sandbox_id`: string (required)
   - `command`: string (required) — shell command
   - `cwd`: string (optional) — working directory
-  - `timeout`: integer (optional) — timeout in ms (default: 120000)
+  - `timeout`: integer (optional) — timeout in ms (default: 300000)
 - **Returns**: `{ exit_code, output }`
 - **Streaming**: Emits `tool.output.delta` events with partial combined stdout/stderr output (emitted on stream `"stdout"`) as the command runs (polled every ~1s). The final tool result contains the complete combined output.
 

--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -55,7 +55,7 @@ inventory::submit! {
 const DAYTONA_API_BASE: &str = "https://app.daytona.io/api";
 const DAYTONA_TOOLBOX_BASE: &str = "https://proxy.app.daytona.io/toolbox";
 const DAYTONA_SANDBOX_SECRET_PREFIX: &str = "daytona_sandbox:";
-const EXEC_TIMEOUT_MS: u64 = 120_000;
+const EXEC_TIMEOUT_MS: u64 = 300_000;
 /// Interval for polling streaming exec output from the sandbox.
 const EXEC_POLL_INTERVAL: Duration = Duration::from_millis(1_000);
 /// Number of consecutive stale polls (no exitCode, no new output) before

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -345,7 +345,7 @@ impl Tool for DaytonaExecTool {
                 },
                 "timeout": {
                     "type": "integer",
-                    "description": "Timeout in milliseconds (optional, default: 120000)"
+                    "description": "Timeout in milliseconds (optional, default: 300000)"
                 }
             },
             "required": ["sandbox_id", "command"],


### PR DESCRIPTION
## Summary

- Bump `EXEC_TIMEOUT_MS` from 120s to 300s
- 2 minutes is too short for common sandbox commands (`cargo build`, `npm install`, `playwright install`)
- Agents had to pass explicit `timeout` on every call — now the default covers most build commands
- The `timeout` parameter remains optional for unusually long commands

## Test plan

- [ ] Existing Daytona unit tests pass (no timeout-sensitive assertions on the default)
- [ ] Agent sandbox sessions don't need explicit timeout for typical build commands
