### PR TITLE
feat(audit): add audit logging abstraction with domains and AOP macro (EVE-226)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,7 @@ Always make sure you are working on top of latest main from remote.
 - `specs/prometheus-metrics.md` - Prometheus `/metrics` endpoint and scrape configuration
 - `specs/evals.md` - User-facing behavioral evals for agents (cases, scorers, runs)
 - `specs/encryption.md` - Envelope encryption for sensitive data
+- `specs/audit-logging.md` - Audit logging (domains, AOP macro, trait, API)
 - `specs/session-filesystem.md` - Per-session virtual filesystem
 - `specs/cli.md` - CLI specification (commands, file sync, wire protocol)
 - `specs/usage-tracking.md` - LLM token usage tracking

--- a/crates/core/src/audit.rs
+++ b/crates/core/src/audit.rs
@@ -59,8 +59,7 @@ impl std::str::FromStr for AuditDomain {
 /// Typed audit actions grouped by domain.
 ///
 /// Convention: `domain.resource.verb` string form (e.g. `management.member.invited`).
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ManagementAction {
     // Organization
     OrgCreated,
@@ -142,8 +141,7 @@ impl fmt::Display for ManagementAction {
 }
 
 /// Agent-domain audit actions.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AgentAction {
     RunStarted,
     RunCompleted,
@@ -171,8 +169,7 @@ impl fmt::Display for AgentAction {
 }
 
 /// Unified action enum wrapping domain-specific actions.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(untagged)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AuditAction {
     Management(ManagementAction),
     Agent(AgentAction),
@@ -211,6 +208,93 @@ impl From<AgentAction> for AuditAction {
         Self::Agent(a)
     }
 }
+
+// Custom serde: serialize action enums as their `as_str()` dotted string form
+// (e.g. "management.member.invited") for consistency with DB storage.
+
+macro_rules! impl_action_serde {
+    ($ty:ty) => {
+        impl Serialize for $ty {
+            fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                serializer.serialize_str(self.as_str())
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $ty {
+            fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                let s = String::deserialize(deserializer)?;
+                s.parse().map_err(serde::de::Error::custom)
+            }
+        }
+    };
+}
+
+impl std::str::FromStr for ManagementAction {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "management.org.created" => Ok(Self::OrgCreated),
+            "management.org.updated" => Ok(Self::OrgUpdated),
+            "management.org.deleted" => Ok(Self::OrgDeleted),
+            "management.member.invited" => Ok(Self::MemberInvited),
+            "management.member.removed" => Ok(Self::MemberRemoved),
+            "management.member.role_changed" => Ok(Self::MemberRoleChanged),
+            "management.api_key.created" => Ok(Self::ApiKeyCreated),
+            "management.api_key.revoked" => Ok(Self::ApiKeyRevoked),
+            "management.settings.updated" => Ok(Self::SettingsUpdated),
+            "management.agent.created" => Ok(Self::AgentCreated),
+            "management.agent.updated" => Ok(Self::AgentUpdated),
+            "management.agent.deleted" => Ok(Self::AgentDeleted),
+            "management.harness.created" => Ok(Self::HarnessCreated),
+            "management.harness.updated" => Ok(Self::HarnessUpdated),
+            "management.harness.deleted" => Ok(Self::HarnessDeleted),
+            "management.llm_provider.created" => Ok(Self::LlmProviderCreated),
+            "management.llm_provider.updated" => Ok(Self::LlmProviderUpdated),
+            "management.llm_provider.deleted" => Ok(Self::LlmProviderDeleted),
+            "management.mcp_server.created" => Ok(Self::McpServerCreated),
+            "management.mcp_server.updated" => Ok(Self::McpServerUpdated),
+            "management.mcp_server.deleted" => Ok(Self::McpServerDeleted),
+            "management.app.created" => Ok(Self::AppCreated),
+            "management.app.updated" => Ok(Self::AppUpdated),
+            "management.app.deleted" => Ok(Self::AppDeleted),
+            "management.skill.created" => Ok(Self::SkillCreated),
+            "management.skill.updated" => Ok(Self::SkillUpdated),
+            "management.skill.deleted" => Ok(Self::SkillDeleted),
+            other => Err(format!("unknown management action: {other}")),
+        }
+    }
+}
+
+impl std::str::FromStr for AgentAction {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "agent.run.started" => Ok(Self::RunStarted),
+            "agent.run.completed" => Ok(Self::RunCompleted),
+            "agent.run.failed" => Ok(Self::RunFailed),
+            "agent.tool.executed" => Ok(Self::ToolExecuted),
+            "agent.llm.request" => Ok(Self::LlmRequest),
+            other => Err(format!("unknown agent action: {other}")),
+        }
+    }
+}
+
+impl std::str::FromStr for AuditAction {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(a) = s.parse::<ManagementAction>() {
+            return Ok(Self::Management(a));
+        }
+        if let Ok(a) = s.parse::<AgentAction>() {
+            return Ok(Self::Agent(a));
+        }
+        Err(format!("unknown audit action: {s}"))
+    }
+}
+
+impl_action_serde!(ManagementAction);
+impl_action_serde!(AgentAction);
+impl_action_serde!(AuditAction);
 
 // ============================================================================
 // Audit Target

--- a/crates/core/src/audit.rs
+++ b/crates/core/src/audit.rs
@@ -1,0 +1,479 @@
+// Audit logging types and trait (EVE-226)
+//
+// Decision: Two audit domains — Management (admin ops) and Agent (execution ops).
+// Decision: AuditLogger trait is generic enough for SaaS to extend with custom event types.
+// Decision: Fire-and-forget pattern — audit failures never block operations (TM-OBS-007).
+// Decision: Domain-specific builders enforce type safety at compile time.
+// See specs/audit-logging.md for full design.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use uuid::Uuid;
+
+// ============================================================================
+// Audit Domain
+// ============================================================================
+
+/// Top-level audit domain separating management ops from agent execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditDomain {
+    /// Org CRUD, member management, API keys, settings, role changes.
+    Management,
+    /// Agent runs, tool calls, LLM interactions.
+    Agent,
+}
+
+impl AuditDomain {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            AuditDomain::Management => "management",
+            AuditDomain::Agent => "agent",
+        }
+    }
+}
+
+impl fmt::Display for AuditDomain {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for AuditDomain {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "management" => Ok(AuditDomain::Management),
+            "agent" => Ok(AuditDomain::Agent),
+            other => Err(format!("unknown audit domain: {other}")),
+        }
+    }
+}
+
+// ============================================================================
+// Audit Action
+// ============================================================================
+
+/// Typed audit actions grouped by domain.
+///
+/// Convention: `domain.resource.verb` string form (e.g. `management.member.invited`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ManagementAction {
+    // Organization
+    OrgCreated,
+    OrgUpdated,
+    OrgDeleted,
+    // Members
+    MemberInvited,
+    MemberRemoved,
+    MemberRoleChanged,
+    // API keys
+    ApiKeyCreated,
+    ApiKeyRevoked,
+    // Settings
+    SettingsUpdated,
+    // Agents
+    AgentCreated,
+    AgentUpdated,
+    AgentDeleted,
+    // Harnesses
+    HarnessCreated,
+    HarnessUpdated,
+    HarnessDeleted,
+    // LLM Providers
+    LlmProviderCreated,
+    LlmProviderUpdated,
+    LlmProviderDeleted,
+    // MCP Servers
+    McpServerCreated,
+    McpServerUpdated,
+    McpServerDeleted,
+    // Apps
+    AppCreated,
+    AppUpdated,
+    AppDeleted,
+    // Skills
+    SkillCreated,
+    SkillUpdated,
+    SkillDeleted,
+}
+
+impl ManagementAction {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::OrgCreated => "management.org.created",
+            Self::OrgUpdated => "management.org.updated",
+            Self::OrgDeleted => "management.org.deleted",
+            Self::MemberInvited => "management.member.invited",
+            Self::MemberRemoved => "management.member.removed",
+            Self::MemberRoleChanged => "management.member.role_changed",
+            Self::ApiKeyCreated => "management.api_key.created",
+            Self::ApiKeyRevoked => "management.api_key.revoked",
+            Self::SettingsUpdated => "management.settings.updated",
+            Self::AgentCreated => "management.agent.created",
+            Self::AgentUpdated => "management.agent.updated",
+            Self::AgentDeleted => "management.agent.deleted",
+            Self::HarnessCreated => "management.harness.created",
+            Self::HarnessUpdated => "management.harness.updated",
+            Self::HarnessDeleted => "management.harness.deleted",
+            Self::LlmProviderCreated => "management.llm_provider.created",
+            Self::LlmProviderUpdated => "management.llm_provider.updated",
+            Self::LlmProviderDeleted => "management.llm_provider.deleted",
+            Self::McpServerCreated => "management.mcp_server.created",
+            Self::McpServerUpdated => "management.mcp_server.updated",
+            Self::McpServerDeleted => "management.mcp_server.deleted",
+            Self::AppCreated => "management.app.created",
+            Self::AppUpdated => "management.app.updated",
+            Self::AppDeleted => "management.app.deleted",
+            Self::SkillCreated => "management.skill.created",
+            Self::SkillUpdated => "management.skill.updated",
+            Self::SkillDeleted => "management.skill.deleted",
+        }
+    }
+}
+
+impl fmt::Display for ManagementAction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Agent-domain audit actions.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentAction {
+    RunStarted,
+    RunCompleted,
+    RunFailed,
+    ToolExecuted,
+    LlmRequest,
+}
+
+impl AgentAction {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::RunStarted => "agent.run.started",
+            Self::RunCompleted => "agent.run.completed",
+            Self::RunFailed => "agent.run.failed",
+            Self::ToolExecuted => "agent.tool.executed",
+            Self::LlmRequest => "agent.llm.request",
+        }
+    }
+}
+
+impl fmt::Display for AgentAction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Unified action enum wrapping domain-specific actions.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum AuditAction {
+    Management(ManagementAction),
+    Agent(AgentAction),
+}
+
+impl AuditAction {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Management(a) => a.as_str(),
+            Self::Agent(a) => a.as_str(),
+        }
+    }
+
+    pub fn domain(&self) -> AuditDomain {
+        match self {
+            Self::Management(_) => AuditDomain::Management,
+            Self::Agent(_) => AuditDomain::Agent,
+        }
+    }
+}
+
+impl fmt::Display for AuditAction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<ManagementAction> for AuditAction {
+    fn from(a: ManagementAction) -> Self {
+        Self::Management(a)
+    }
+}
+
+impl From<AgentAction> for AuditAction {
+    fn from(a: AgentAction) -> Self {
+        Self::Agent(a)
+    }
+}
+
+// ============================================================================
+// Audit Target
+// ============================================================================
+
+/// Identifies the resource affected by an audit event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditTarget {
+    /// Resource type (e.g. "member", "agent", "harness", "session").
+    pub target_type: String,
+    /// Resource identifier (public ID or UUID string).
+    pub target_id: String,
+}
+
+impl AuditTarget {
+    pub fn new(target_type: impl Into<String>, target_id: impl Into<String>) -> Self {
+        Self {
+            target_type: target_type.into(),
+            target_id: target_id.into(),
+        }
+    }
+}
+
+// ============================================================================
+// Audit Event
+// ============================================================================
+
+/// A complete audit event ready for storage.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditEvent {
+    pub domain: AuditDomain,
+    pub action: AuditAction,
+    pub actor_user_id: Option<Uuid>,
+    pub org_id: i64,
+    pub target: Option<AuditTarget>,
+    pub details: serde_json::Value,
+    pub ip_address: Option<String>,
+    pub timestamp: DateTime<Utc>,
+}
+
+// ============================================================================
+// Builders
+// ============================================================================
+
+/// Builder for constructing audit events with type safety.
+pub struct AuditEventBuilder {
+    domain: AuditDomain,
+    action: AuditAction,
+    actor_user_id: Option<Uuid>,
+    org_id: i64,
+    target: Option<AuditTarget>,
+    details: serde_json::Map<String, serde_json::Value>,
+    ip_address: Option<String>,
+}
+
+impl AuditEventBuilder {
+    pub fn target(mut self, target_type: impl Into<String>, target_id: impl Into<String>) -> Self {
+        self.target = Some(AuditTarget::new(target_type, target_id));
+        self
+    }
+
+    pub fn detail(mut self, key: impl Into<String>, value: impl Into<serde_json::Value>) -> Self {
+        self.details.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn ip(mut self, ip: impl Into<String>) -> Self {
+        self.ip_address = Some(ip.into());
+        self
+    }
+
+    pub fn build(self) -> AuditEvent {
+        AuditEvent {
+            domain: self.domain,
+            action: self.action,
+            actor_user_id: self.actor_user_id,
+            org_id: self.org_id,
+            target: self.target,
+            details: serde_json::Value::Object(self.details),
+            ip_address: self.ip_address,
+            timestamp: Utc::now(),
+        }
+    }
+}
+
+impl AuditEvent {
+    /// Start building a management audit event.
+    pub fn management(
+        action: ManagementAction,
+        org_id: i64,
+        actor: Option<Uuid>,
+    ) -> AuditEventBuilder {
+        AuditEventBuilder {
+            domain: AuditDomain::Management,
+            action: AuditAction::Management(action),
+            actor_user_id: actor,
+            org_id,
+            target: None,
+            details: serde_json::Map::new(),
+            ip_address: None,
+        }
+    }
+
+    /// Start building an agent audit event.
+    pub fn agent(action: AgentAction, org_id: i64, actor: Option<Uuid>) -> AuditEventBuilder {
+        AuditEventBuilder {
+            domain: AuditDomain::Agent,
+            action: AuditAction::Agent(action),
+            actor_user_id: actor,
+            org_id,
+            target: None,
+            details: serde_json::Map::new(),
+            ip_address: None,
+        }
+    }
+}
+
+// ============================================================================
+// HasAuditTargetId — extract target ID from service return values
+// ============================================================================
+
+/// Trait for extracting an audit target ID from a service method result.
+///
+/// Implement on domain types (e.g. `Harness`, `Agent`) so the `#[audit]` macro
+/// can automatically capture the target ID from the `Ok(value)` return.
+pub trait HasAuditTargetId {
+    fn audit_target_id(&self) -> Option<String>;
+}
+
+/// Blanket: if there's no meaningful target, return None.
+impl HasAuditTargetId for () {
+    fn audit_target_id(&self) -> Option<String> {
+        None
+    }
+}
+
+impl HasAuditTargetId for bool {
+    fn audit_target_id(&self) -> Option<String> {
+        None
+    }
+}
+
+impl HasAuditTargetId for String {
+    fn audit_target_id(&self) -> Option<String> {
+        Some(self.clone())
+    }
+}
+
+impl<T: HasAuditTargetId> HasAuditTargetId for Vec<T> {
+    fn audit_target_id(&self) -> Option<String> {
+        None
+    }
+}
+
+// Domain type implementations
+impl HasAuditTargetId for crate::Harness {
+    fn audit_target_id(&self) -> Option<String> {
+        Some(self.id.to_string())
+    }
+}
+
+impl HasAuditTargetId for crate::Agent {
+    fn audit_target_id(&self) -> Option<String> {
+        Some(self.public_id.to_string())
+    }
+}
+
+impl HasAuditTargetId for crate::Session {
+    fn audit_target_id(&self) -> Option<String> {
+        Some(self.id.to_string())
+    }
+}
+
+// ============================================================================
+// AuditLogger Trait
+// ============================================================================
+
+/// Contract for audit log persistence.
+///
+/// Implementations must be non-blocking and failure-tolerant (TM-OBS-007).
+/// The default strategy is fire-and-forget via `tokio::spawn`.
+#[async_trait::async_trait]
+pub trait AuditLogger: Send + Sync {
+    /// Persist an audit event. Implementations should not propagate errors
+    /// to callers — log warnings internally on failure.
+    async fn log_event(&self, event: AuditEvent) -> anyhow::Result<()>;
+
+    /// Fire-and-forget helper: spawns `log_event` on a background task.
+    fn emit(&self, event: AuditEvent)
+    where
+        Self: 'static + Clone,
+    {
+        let this = self.clone();
+        tokio::spawn(async move {
+            if let Err(e) = this.log_event(event).await {
+                tracing::warn!(error = %e, "Failed to write audit log");
+            }
+        });
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn management_builder_produces_correct_domain() {
+        let event = AuditEvent::management(ManagementAction::MemberInvited, 1, Some(Uuid::nil()))
+            .target("member", "usr_abc123")
+            .detail("role", "admin")
+            .build();
+
+        assert_eq!(event.domain, AuditDomain::Management);
+        assert_eq!(event.action.as_str(), "management.member.invited");
+        assert_eq!(event.org_id, 1);
+        assert_eq!(event.actor_user_id, Some(Uuid::nil()));
+        assert!(event.target.is_some());
+        let target = event.target.unwrap();
+        assert_eq!(target.target_type, "member");
+        assert_eq!(target.target_id, "usr_abc123");
+        assert_eq!(event.details["role"], "admin");
+    }
+
+    #[test]
+    fn agent_builder_produces_correct_domain() {
+        let event = AuditEvent::agent(AgentAction::RunStarted, 1, None)
+            .target("session", "ses_abc123")
+            .build();
+
+        assert_eq!(event.domain, AuditDomain::Agent);
+        assert_eq!(event.action.as_str(), "agent.run.started");
+        assert!(event.target.is_some());
+    }
+
+    #[test]
+    fn action_domain_derivation() {
+        let mgmt: AuditAction = ManagementAction::ApiKeyCreated.into();
+        assert_eq!(mgmt.domain(), AuditDomain::Management);
+
+        let agent: AuditAction = AgentAction::ToolExecuted.into();
+        assert_eq!(agent.domain(), AuditDomain::Agent);
+    }
+
+    #[test]
+    fn domain_roundtrip() {
+        assert_eq!(
+            "management".parse::<AuditDomain>().unwrap(),
+            AuditDomain::Management
+        );
+        assert_eq!("agent".parse::<AuditDomain>().unwrap(), AuditDomain::Agent);
+        assert!("unknown".parse::<AuditDomain>().is_err());
+    }
+
+    #[test]
+    fn event_serialization() {
+        let event =
+            AuditEvent::management(ManagementAction::OrgCreated, 1, Some(Uuid::nil())).build();
+
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["domain"], "management");
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -41,6 +41,9 @@ pub mod observation;
 // See specs/id-schema.md for specification
 pub mod typed_id;
 
+// Audit logging types and trait (EVE-226)
+pub mod audit;
+
 // Domain entity types
 // These are DB-agnostic entity types used by both API and worker
 pub mod agent;
@@ -288,6 +291,12 @@ pub use typed_id::{
     EventId, ExecId, HarnessId, IdMarker, IdParseError, ImageId, LeasedResourceId, McpServerId,
     MemoryId, MemoryStoreId, MessageId, ModelId, NotificationId, OrgId, ProviderId, ScheduleId,
     SessionId, SkillId, TurnId, TypedId,
+};
+
+// Audit logging re-exports
+pub use audit::{
+    AgentAction, AuditAction, AuditDomain, AuditEvent, AuditEventBuilder, AuditLogger, AuditTarget,
+    ManagementAction,
 };
 
 // Permissions re-exports

--- a/crates/core/src/permissions.rs
+++ b/crates/core/src/permissions.rs
@@ -882,8 +882,8 @@ mod tests {
 
     #[test]
     fn role_permissions_returns_correct_sets() {
-        assert_eq!(role_permissions(OrgRole::Owner).len(), 16);
-        assert_eq!(role_permissions(OrgRole::Admin).len(), 11);
+        assert_eq!(role_permissions(OrgRole::Owner).len(), 17);
+        assert_eq!(role_permissions(OrgRole::Admin).len(), 12);
         assert_eq!(role_permissions(OrgRole::Member).len(), 6);
     }
 

--- a/crates/core/src/permissions.rs
+++ b/crates/core/src/permissions.rs
@@ -48,6 +48,8 @@ pub enum Permission {
     OrgMembersManage,
     /// CRUD on API keys
     OrgApiKeysManage,
+    /// View audit logs (read-only)
+    OrgAuditLogsView,
 }
 
 impl Permission {
@@ -70,6 +72,7 @@ impl Permission {
             Permission::OrgMembersView => "org:members:view",
             Permission::OrgMembersManage => "org:members:manage",
             Permission::OrgApiKeysManage => "org:api-keys:manage",
+            Permission::OrgAuditLogsView => "org:audit-logs:view",
         }
     }
 
@@ -91,6 +94,7 @@ impl Permission {
         Permission::OrgMembersView,
         Permission::OrgMembersManage,
         Permission::OrgApiKeysManage,
+        Permission::OrgAuditLogsView,
     ];
 }
 
@@ -122,6 +126,7 @@ const OWNER_PERMISSIONS: &[Permission] = &[
     Permission::OrgMembersView,
     Permission::OrgMembersManage,
     Permission::OrgApiKeysManage,
+    Permission::OrgAuditLogsView,
 ];
 
 /// Permissions granted to Admin role.
@@ -137,6 +142,7 @@ const ADMIN_PERMISSIONS: &[Permission] = &[
     Permission::OrgMembersView,
     Permission::OrgMembersManage,
     Permission::OrgApiKeysManage,
+    Permission::OrgAuditLogsView,
 ];
 
 /// Permissions granted to Member role.

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -98,7 +98,8 @@ pub fn policy(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// Emits an audit event after successful execution via fire-and-forget.
 /// The service struct must expose an `audit_logger()` method returning
-/// an `Arc<dyn AuditLogger>` (or similar cloneable type).
+/// a concrete, cloneable type that implements `AuditLogger` (e.g.
+/// `StorageAuditLogger`), not a `dyn AuditLogger` trait object.
 ///
 /// # Syntax
 ///
@@ -158,6 +159,7 @@ pub fn audit(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     }
 
+    let has_target = target_type_str.is_some();
     let target_type_lit = target_type_str.unwrap_or_default();
 
     // Find the &Caller parameter
@@ -192,22 +194,31 @@ pub fn audit(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     // Wrap the function body to emit audit on success
     let original_stmts = &func.block.stmts;
+
+    let target_code = if has_target {
+        quote! {
+            let __target_id = __audit_result.as_ref().ok()
+                .and_then(|r| everruns_core::audit::HasAuditTargetId::audit_target_id(r))
+                .unwrap_or_default();
+            __builder = __builder.target(#target_type_lit, __target_id);
+        }
+    } else {
+        quote! {}
+    };
+
     func.block = syn::parse_quote!({
         let __audit_result = (|| async {
             #(#original_stmts)*
         })().await;
 
         if __audit_result.is_ok() {
-            let __target_id = __audit_result.as_ref().ok()
-                .and_then(|r| everruns_core::audit::HasAuditTargetId::audit_target_id(r))
-                .unwrap_or_default();
-            let __event = everruns_core::AuditEvent::management(
+            let mut __builder = everruns_core::AuditEvent::management(
                 #action_expr,
                 #caller.org_id,
                 #caller.user_id,
-            )
-            .target(#target_type_lit, __target_id)
-            .build();
+            );
+            #target_code
+            let __event = __builder.build();
             self.audit_logger().emit(__event);
         }
 

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -6,7 +6,9 @@
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{FnArg, ItemFn, PatType, Type, TypeReference, parse_macro_input};
+use syn::{
+    FnArg, ItemFn, PatType, Token, Type, TypeReference, parse_macro_input, punctuated::Punctuated,
+};
 
 /// Declarative policy enforcement for service methods.
 ///
@@ -87,6 +89,129 @@ pub fn policy(attr: TokenStream, item: TokenStream) -> TokenStream {
     func.block = syn::parse_quote!({
         #policy_path.evaluate(#caller)?;
         #(#original_stmts)*
+    });
+
+    quote!(#func).into()
+}
+
+/// AOP audit logging for service methods (EVE-226).
+///
+/// Emits an audit event after successful execution via fire-and-forget.
+/// The service struct must expose an `audit_logger()` method returning
+/// an `Arc<dyn AuditLogger>` (or similar cloneable type).
+///
+/// # Syntax
+///
+/// ```rust,ignore
+/// #[audit(ManagementAction::HarnessCreated, target_type = "harness")]
+/// pub async fn create(&self, caller: &Caller, req: Req) -> Result<Harness> { ... }
+/// ```
+///
+/// The macro:
+/// 1. Finds `&Caller` parameter by type
+/// 2. Wraps the body: on `Ok(result)`, builds and emits an audit event
+/// 3. Uses `self.audit_logger()` to get the logger
+/// 4. Extracts `target_id` from the result via `.audit_target_id()` if available,
+///    or falls back to empty string
+///
+/// # Composing with `#[policy]`
+///
+/// Policy runs first (injected at top of body), audit fires after success:
+/// ```rust,ignore
+/// #[policy(HARNESS_MANAGE)]
+/// #[audit(ManagementAction::HarnessCreated, target_type = "harness")]
+/// pub async fn create(&self, caller: &Caller, req: Req) -> Result<Harness> { ... }
+/// ```
+#[proc_macro_attribute]
+pub fn audit(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(attr with Punctuated::<syn::Expr, Token![,]>::parse_terminated);
+    let mut func = parse_macro_input!(item as ItemFn);
+
+    // Parse arguments: first is the action path, then key=value pairs
+    let mut args_iter = args.iter();
+    let action_expr = match args_iter.next() {
+        Some(expr) => expr.clone(),
+        None => {
+            return syn::Error::new_spanned(
+                &func.sig,
+                "#[audit] requires an action as first argument",
+            )
+            .to_compile_error()
+            .into();
+        }
+    };
+
+    let mut target_type_str: Option<String> = None;
+    for expr in args_iter {
+        if let syn::Expr::Assign(assign) = expr
+            && let syn::Expr::Path(path) = assign.left.as_ref()
+        {
+            let key = path.path.segments.last().map(|s| s.ident.to_string());
+            if key.as_deref() == Some("target_type")
+                && let syn::Expr::Lit(syn::ExprLit {
+                    lit: syn::Lit::Str(s),
+                    ..
+                }) = assign.right.as_ref()
+            {
+                target_type_str = Some(s.value());
+            }
+        }
+    }
+
+    let target_type_lit = target_type_str.unwrap_or_default();
+
+    // Find the &Caller parameter
+    let caller_ident = func.sig.inputs.iter().find_map(|arg| {
+        let FnArg::Typed(PatType { pat, ty, .. }) = arg else {
+            return None;
+        };
+        let Type::Reference(TypeReference { elem, .. }) = ty.as_ref() else {
+            return None;
+        };
+        let Type::Path(tp) = elem.as_ref() else {
+            return None;
+        };
+        let is_caller = tp.path.segments.last().is_some_and(|s| s.ident == "Caller");
+        if is_caller && let syn::Pat::Ident(pi) = pat.as_ref() {
+            return Some(pi.ident.clone());
+        }
+        None
+    });
+
+    let caller = match caller_ident {
+        Some(ident) => ident,
+        None => {
+            return syn::Error::new_spanned(
+                &func.sig,
+                "#[audit] requires a `caller: &Caller` parameter",
+            )
+            .to_compile_error()
+            .into();
+        }
+    };
+
+    // Wrap the function body to emit audit on success
+    let original_stmts = &func.block.stmts;
+    func.block = syn::parse_quote!({
+        let __audit_result = (|| async {
+            #(#original_stmts)*
+        })().await;
+
+        if __audit_result.is_ok() {
+            let __target_id = __audit_result.as_ref().ok()
+                .and_then(|r| everruns_core::audit::HasAuditTargetId::audit_target_id(r))
+                .unwrap_or_default();
+            let __event = everruns_core::AuditEvent::management(
+                #action_expr,
+                #caller.org_id,
+                #caller.user_id,
+            )
+            .target(#target_type_lit, __target_id)
+            .build();
+            self.audit_logger().emit(__event);
+        }
+
+        __audit_result
     });
 
     quote!(#func).into()

--- a/crates/server/migrations/010_audit_domains.sql
+++ b/crates/server/migrations/010_audit_domains.sql
@@ -1,0 +1,20 @@
+-- Audit log domains (EVE-226)
+--
+-- Adds domain/action/target columns to the existing audit_logs table.
+-- Existing rows default to domain='management' (auth events are management-domain).
+
+-- New columns for structured audit domains
+ALTER TABLE audit_logs
+    ADD COLUMN IF NOT EXISTS domain TEXT NOT NULL DEFAULT 'management',
+    ADD COLUMN IF NOT EXISTS action TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS target_type TEXT,
+    ADD COLUMN IF NOT EXISTS target_id TEXT;
+
+-- Composite index for domain-scoped queries (primary access pattern)
+CREATE INDEX IF NOT EXISTS idx_audit_logs_org_domain_created
+    ON audit_logs (org_id, domain, created_at DESC);
+
+-- Action-specific queries (e.g. "show all member.invited events")
+CREATE INDEX IF NOT EXISTS idx_audit_logs_org_action_created
+    ON audit_logs (org_id, action, created_at DESC)
+    WHERE action != '';

--- a/crates/server/src/api/audit_logs.rs
+++ b/crates/server/src/api/audit_logs.rs
@@ -1,27 +1,30 @@
-// Audit log query API (TM-OBS-007)
+// Audit log query API (TM-OBS-007, EVE-226)
 //
-// Admin-only endpoint. Audit logs are written by auth routes via auth::audit::emit().
+// Policy-gated endpoint (AUDIT_LOG_VIEW). Supports domain/action filtering.
+// Audit logs are append-only — no mutation endpoints exposed.
 
-use crate::auth::middleware::{AuthState, OrgAdmin};
-use crate::storage::StorageBackend;
+use crate::auth::middleware::{AuthState, ResolvedOrg};
+use crate::services::AuditLogService;
+use crate::storage::models::AuditLogQuery;
 use axum::{Json, Router, extract::State, routing::get};
 use chrono::{DateTime, Utc};
+use everruns_core::Caller;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-use super::common::{ApiResult, ErrorResponse, ListResponse, impl_auth_state};
+use super::common::{ApiPolicyResultExt, ApiResult, ListResponse, impl_auth_state};
 
 #[derive(Clone)]
 pub struct AppState {
-    pub db: Arc<StorageBackend>,
+    pub service: Arc<AuditLogService>,
     pub auth: AuthState,
 }
 
 impl AppState {
-    pub fn new(db: Arc<StorageBackend>, auth: AuthState) -> Self {
-        Self { db, auth }
+    pub fn new(service: Arc<AuditLogService>, auth: AuthState) -> Self {
+        Self { service, auth }
     }
 }
 
@@ -31,8 +34,12 @@ impl_auth_state!(AppState);
 #[derive(Debug, Serialize, ToSchema)]
 pub struct AuditLogResponse {
     pub id: String,
+    pub domain: String,
+    pub action: String,
     pub actor_id: Option<String>,
     pub event_type: String,
+    pub target_type: Option<String>,
+    pub target_id: Option<String>,
     pub ip_address: Option<String>,
     pub metadata: serde_json::Value,
     pub created_at: DateTime<Utc>,
@@ -45,10 +52,14 @@ pub struct ListAuditLogsQuery {
     pub limit: Option<i64>,
     /// Cursor: return entries created before this timestamp
     pub before: Option<DateTime<Utc>>,
-    /// Filter by event type prefix (e.g. "auth.login")
+    /// Filter by event type prefix (e.g. "auth.login") — legacy
     pub event_type: Option<String>,
     /// Filter by actor UUID
     pub actor_id: Option<Uuid>,
+    /// Filter by audit domain ("management" or "agent")
+    pub domain: Option<String>,
+    /// Filter by action string (e.g. "management.member.invited")
+    pub action: Option<String>,
 }
 
 pub fn routes(state: AppState) -> Router {
@@ -57,40 +68,42 @@ pub fn routes(state: AppState) -> Router {
         .with_state(state)
 }
 
-/// GET /v1/orgs/{org}/audit-logs - List audit logs (admin only)
+/// GET /v1/orgs/{org}/audit-logs - List audit logs (policy: AUDIT_LOG_VIEW)
 async fn list_audit_logs(
     State(state): State<AppState>,
-    org: OrgAdmin,
+    org: ResolvedOrg,
     axum::extract::Query(query): axum::extract::Query<ListAuditLogsQuery>,
 ) -> ApiResult<ListResponse<AuditLogResponse>> {
     let limit = query.limit.unwrap_or(50).clamp(1, 200);
+    let caller = Caller::from(&org);
 
     let rows = state
-        .db
-        .list_audit_logs(
-            org.0.org_id,
-            limit,
-            query.before,
-            query.event_type.as_deref(),
-            query.actor_id,
+        .service
+        .list(
+            &caller,
+            AuditLogQuery {
+                org_id: caller.org_id,
+                limit,
+                before: query.before,
+                event_type_prefix: query.event_type.as_deref(),
+                actor_id: query.actor_id,
+                domain: query.domain.as_deref(),
+                action: query.action.as_deref(),
+            },
         )
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to list audit logs: {}", e);
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: "Failed to list audit logs".to_string(),
-                }),
-            )
-        })?;
+        .map_policy_or_internal("list audit logs")?;
 
     let items: Vec<AuditLogResponse> = rows
         .into_iter()
         .map(|r| AuditLogResponse {
             id: r.id.to_string(),
+            domain: r.domain,
+            action: r.action,
             actor_id: r.actor_id.map(|a| a.to_string()),
             event_type: r.event_type,
+            target_type: r.target_type,
+            target_id: r.target_id,
             ip_address: r.ip_address,
             metadata: r.metadata,
             created_at: r.created_at,

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -606,7 +606,9 @@ impl ServerAppBuilder {
             auth_state.clone(),
             platform_definition.built_in_harnesses().to_vec(),
         );
-        let audit_logs_state = api::audit_logs::AppState::new(db.clone(), auth_state.clone());
+        let audit_log_service = Arc::new(crate::services::AuditLogService::new(db.clone()));
+        let audit_logs_state =
+            api::audit_logs::AppState::new(audit_log_service, auth_state.clone());
         let user_connections_state = api::user_connections::AppState::new(
             db.clone(),
             encryption.clone(),

--- a/crates/server/src/auth/audit.rs
+++ b/crates/server/src/auth/audit.rs
@@ -1,4 +1,4 @@
-// Structured audit logging for security-relevant events (TM-OBS-007)
+// Structured audit logging for security-relevant events (TM-OBS-007, EVE-226)
 //
 // Design: fire-and-forget via tokio::spawn. Audit log failures must never
 // block or fail authentication operations. All writes go to the audit_logs
@@ -14,6 +14,7 @@
 use crate::storage::StorageBackend;
 use crate::storage::models::CreateAuditLogRow;
 use axum::http::HeaderMap;
+use everruns_core::{AuditEvent, AuditLogger};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -39,9 +40,9 @@ pub fn client_ip(headers: &HeaderMap) -> Option<String> {
     None
 }
 
-/// Emit an audit log entry. Non-blocking: spawns a background task.
+/// Emit a legacy audit log entry (event_type string format). Non-blocking.
 ///
-/// Failures are logged at warn level but never propagated.
+/// For new code, prefer `emit_event()` with typed `AuditEvent`.
 pub fn emit(
     db: Arc<StorageBackend>,
     org_id: i64,
@@ -51,6 +52,14 @@ pub fn emit(
     metadata: serde_json::Value,
 ) {
     let event_type = event_type.to_string();
+    // Infer domain from event_type prefix
+    let domain = if event_type.starts_with("agent.") {
+        "agent"
+    } else {
+        "management"
+    };
+    let domain_str = domain.to_string();
+    let action = event_type.clone();
     tokio::spawn(async move {
         if let Err(e) = db
             .create_audit_log(CreateAuditLogRow {
@@ -59,12 +68,72 @@ pub fn emit(
                 event_type: event_type.clone(),
                 ip_address,
                 metadata,
+                domain: domain_str,
+                action,
+                target_type: None,
+                target_id: None,
             })
             .await
         {
             tracing::warn!(event_type = %event_type, error = %e, "Failed to write audit log");
         }
     });
+}
+
+/// Emit a typed audit event. Non-blocking (fire-and-forget).
+pub fn emit_event(db: Arc<StorageBackend>, event: AuditEvent) {
+    tokio::spawn(async move {
+        if let Err(e) = db
+            .create_audit_log(CreateAuditLogRow {
+                org_id: event.org_id,
+                actor_id: event.actor_user_id,
+                event_type: event.action.as_str().to_string(),
+                ip_address: event.ip_address,
+                metadata: event.details,
+                domain: event.domain.as_str().to_string(),
+                action: event.action.as_str().to_string(),
+                target_type: event.target.as_ref().map(|t| t.target_type.clone()),
+                target_id: event.target.as_ref().map(|t| t.target_id.clone()),
+            })
+            .await
+        {
+            tracing::warn!(error = %e, "Failed to write audit log");
+        }
+    });
+}
+
+/// `AuditLogger` implementation backed by `StorageBackend`.
+///
+/// Used by the `#[audit]` macro on service methods.
+#[derive(Clone)]
+pub struct StorageAuditLogger {
+    db: Arc<StorageBackend>,
+}
+
+impl StorageAuditLogger {
+    pub fn new(db: Arc<StorageBackend>) -> Self {
+        Self { db }
+    }
+}
+
+#[async_trait::async_trait]
+impl AuditLogger for StorageAuditLogger {
+    async fn log_event(&self, event: AuditEvent) -> anyhow::Result<()> {
+        self.db
+            .create_audit_log(CreateAuditLogRow {
+                org_id: event.org_id,
+                actor_id: event.actor_user_id,
+                event_type: event.action.as_str().to_string(),
+                ip_address: event.ip_address,
+                metadata: event.details,
+                domain: event.domain.as_str().to_string(),
+                action: event.action.as_str().to_string(),
+                target_type: event.target.as_ref().map(|t| t.target_type.clone()),
+                target_id: event.target.as_ref().map(|t| t.target_id.clone()),
+            })
+            .await?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/server/src/services/audit_log.rs
+++ b/crates/server/src/services/audit_log.rs
@@ -1,0 +1,219 @@
+// Audit log service (EVE-226)
+//
+// Provides policy-gated read access to audit logs.
+// Write path is via AuditLogger trait (fire-and-forget from service layer).
+
+use crate::storage::StorageBackend;
+use crate::storage::models::{AuditLogQuery, AuditLogRow};
+use anyhow::Result;
+use everruns_core::{Caller, Permission, Policy, Rule};
+use everruns_macros::policy;
+use std::sync::Arc;
+
+/// Policy: View audit logs (read-only, admin+owner).
+pub const AUDIT_LOG_VIEW: Policy = Policy {
+    id: "audit_log.view",
+    rules: &[Rule::UserHasPermission(Permission::OrgAuditLogsView)],
+};
+
+/// Re-export for API config endpoint.
+pub const fn policies() -> [&'static Policy; 1] {
+    [&AUDIT_LOG_VIEW]
+}
+
+pub struct AuditLogService {
+    db: Arc<StorageBackend>,
+}
+
+impl AuditLogService {
+    pub fn new(db: Arc<StorageBackend>) -> Self {
+        Self { db }
+    }
+
+    #[policy(AUDIT_LOG_VIEW)]
+    pub async fn list(
+        &self,
+        caller: &Caller,
+        query: AuditLogQuery<'_>,
+    ) -> Result<Vec<AuditLogRow>> {
+        self.db.list_audit_logs(query).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::models::CreateAuditLogRow;
+    use everruns_core::{DEFAULT_ORG_ID, organization::OrgRole};
+    use uuid::Uuid;
+
+    fn owner_caller() -> Caller {
+        Caller {
+            org_id: DEFAULT_ORG_ID,
+            org_public_id: "org_00000000000000000000000000000001".to_string(),
+            user_id: Some(Uuid::nil()),
+            role: OrgRole::Owner,
+            is_platform_user: false,
+        }
+    }
+
+    fn member_caller() -> Caller {
+        Caller {
+            org_id: DEFAULT_ORG_ID,
+            org_public_id: "org_00000000000000000000000000000001".to_string(),
+            user_id: Some(Uuid::nil()),
+            role: OrgRole::Member,
+            is_platform_user: false,
+        }
+    }
+
+    async fn make_service() -> AuditLogService {
+        let db = Arc::new(StorageBackend::in_memory());
+        // Seed some audit logs
+        db.create_audit_log(CreateAuditLogRow {
+            org_id: DEFAULT_ORG_ID,
+            actor_id: None,
+            event_type: "management.member.invited".to_string(),
+            ip_address: None,
+            metadata: serde_json::json!({}),
+            domain: "management".to_string(),
+            action: "management.member.invited".to_string(),
+            target_type: Some("member".to_string()),
+            target_id: Some("usr_001".to_string()),
+        })
+        .await
+        .unwrap();
+
+        db.create_audit_log(CreateAuditLogRow {
+            org_id: DEFAULT_ORG_ID,
+            actor_id: None,
+            event_type: "agent.run.started".to_string(),
+            ip_address: None,
+            metadata: serde_json::json!({}),
+            domain: "agent".to_string(),
+            action: "agent.run.started".to_string(),
+            target_type: Some("session".to_string()),
+            target_id: Some("ses_001".to_string()),
+        })
+        .await
+        .unwrap();
+
+        AuditLogService::new(db)
+    }
+
+    #[tokio::test]
+    async fn test_owner_can_list_audit_logs() {
+        let svc = make_service().await;
+        let caller = owner_caller();
+        let logs = svc
+            .list(
+                &caller,
+                AuditLogQuery {
+                    org_id: caller.org_id,
+                    limit: 50,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(logs.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_admin_can_list_audit_logs() {
+        let svc = make_service().await;
+        let caller = Caller {
+            org_id: DEFAULT_ORG_ID,
+            org_public_id: "org_00000000000000000000000000000001".to_string(),
+            user_id: Some(Uuid::nil()),
+            role: OrgRole::Admin,
+            is_platform_user: false,
+        };
+        let logs = svc
+            .list(
+                &caller,
+                AuditLogQuery {
+                    org_id: caller.org_id,
+                    limit: 50,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(logs.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_member_cannot_list_audit_logs() {
+        let svc = make_service().await;
+        let caller = member_caller();
+        let result = svc
+            .list(
+                &caller,
+                AuditLogQuery {
+                    org_id: caller.org_id,
+                    limit: 50,
+                    ..Default::default()
+                },
+            )
+            .await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.downcast_ref::<everruns_core::PolicyError>().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_domain_filter() {
+        let svc = make_service().await;
+        let caller = owner_caller();
+        let mgmt = svc
+            .list(
+                &caller,
+                AuditLogQuery {
+                    org_id: caller.org_id,
+                    limit: 50,
+                    domain: Some("management"),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(mgmt.len(), 1);
+        assert_eq!(mgmt[0].domain, "management");
+
+        let agent = svc
+            .list(
+                &caller,
+                AuditLogQuery {
+                    org_id: caller.org_id,
+                    limit: 50,
+                    domain: Some("agent"),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(agent.len(), 1);
+        assert_eq!(agent[0].domain, "agent");
+    }
+
+    #[tokio::test]
+    async fn test_action_filter() {
+        let svc = make_service().await;
+        let caller = owner_caller();
+        let logs = svc
+            .list(
+                &caller,
+                AuditLogQuery {
+                    org_id: caller.org_id,
+                    limit: 50,
+                    action: Some("management.member.invited"),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].target_type.as_deref(), Some("member"));
+    }
+}

--- a/crates/server/src/services/audit_log.rs
+++ b/crates/server/src/services/audit_log.rs
@@ -34,8 +34,10 @@ impl AuditLogService {
     pub async fn list(
         &self,
         caller: &Caller,
-        query: AuditLogQuery<'_>,
+        mut query: AuditLogQuery<'_>,
     ) -> Result<Vec<AuditLogRow>> {
+        // THREAT[TM-TENANT]: Always use caller's org_id, never trust client-supplied value
+        query.org_id = caller.org_id;
         self.db.list_audit_logs(query).await
     }
 }

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -4,6 +4,7 @@
 pub mod agent;
 pub mod agent_identity;
 pub mod app;
+pub mod audit_log;
 pub mod capability;
 pub(crate) mod capability_validation;
 pub mod eval;
@@ -27,6 +28,7 @@ pub mod usage_tracking;
 pub use agent::AgentService;
 pub use agent_identity::AgentIdentityService;
 pub use app::AppService;
+pub use audit_log::AuditLogService;
 pub use capability::CapabilityService;
 pub use eval::EvalService;
 pub use event::EventService;

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -1874,30 +1874,15 @@ impl StorageBackend {
     }
 
     // ============================================
-    // Audit Logs (TM-OBS-007)
+    // Audit Logs (TM-OBS-007, EVE-226)
     // ============================================
 
     pub async fn create_audit_log(&self, input: CreateAuditLogRow) -> Result<AuditLogRow> {
         dispatch!(self, create_audit_log, input)
     }
 
-    pub async fn list_audit_logs(
-        &self,
-        org_id: i64,
-        limit: i64,
-        before: Option<DateTime<Utc>>,
-        event_type_prefix: Option<&str>,
-        actor_id: Option<Uuid>,
-    ) -> Result<Vec<AuditLogRow>> {
-        dispatch!(
-            self,
-            list_audit_logs,
-            org_id,
-            limit,
-            before,
-            event_type_prefix,
-            actor_id
-        )
+    pub async fn list_audit_logs(&self, query: AuditLogQuery<'_>) -> Result<Vec<AuditLogRow>> {
+        dispatch!(self, list_audit_logs, query)
     }
 
     pub async fn delete_audit_logs_before(&self, before: DateTime<Utc>) -> Result<u64> {

--- a/crates/server/src/storage/memory/audit_logs.rs
+++ b/crates/server/src/storage/memory/audit_logs.rs
@@ -7,7 +7,7 @@ use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
 impl InMemoryDatabase {
-    // Audit Logs (TM-OBS-007)
+    // Audit Logs (TM-OBS-007, EVE-226)
 
     pub async fn create_audit_log(&self, input: CreateAuditLogRow) -> Result<AuditLogRow> {
         let row = AuditLogRow {
@@ -18,33 +18,36 @@ impl InMemoryDatabase {
             ip_address: input.ip_address,
             metadata: input.metadata,
             created_at: Self::now(),
+            domain: input.domain,
+            action: input.action,
+            target_type: input.target_type,
+            target_id: input.target_id,
         };
         self.audit_logs.write().push(row.clone());
         Ok(row)
     }
 
-    pub async fn list_audit_logs(
-        &self,
-        org_id: i64,
-        limit: i64,
-        before: Option<DateTime<Utc>>,
-        event_type_prefix: Option<&str>,
-        actor_id: Option<Uuid>,
-    ) -> Result<Vec<AuditLogRow>> {
+    pub async fn list_audit_logs(&self, query: AuditLogQuery<'_>) -> Result<Vec<AuditLogRow>> {
         let logs = self.audit_logs.read();
-        let before_ts = before.unwrap_or_else(|| Utc::now() + chrono::Duration::seconds(1));
+        let before_ts = query
+            .before
+            .unwrap_or_else(|| Utc::now() + chrono::Duration::seconds(1));
         let mut filtered: Vec<_> = logs
             .iter()
             .filter(|r| {
-                r.org_id == org_id
+                r.org_id == query.org_id
                     && r.created_at < before_ts
-                    && event_type_prefix.is_none_or(|p| r.event_type.starts_with(p))
-                    && actor_id.is_none_or(|a| r.actor_id == Some(a))
+                    && query
+                        .event_type_prefix
+                        .is_none_or(|p| r.event_type.starts_with(p))
+                    && query.actor_id.is_none_or(|a| r.actor_id == Some(a))
+                    && query.domain.is_none_or(|d| r.domain == d)
+                    && query.action.is_none_or(|a| r.action == a)
             })
             .cloned()
             .collect();
         filtered.sort_by(|a, b| b.created_at.cmp(&a.created_at));
-        filtered.truncate(limit as usize);
+        filtered.truncate(query.limit as usize);
         Ok(filtered)
     }
 

--- a/crates/server/src/storage/memory/tests.rs
+++ b/crates/server/src/storage/memory/tests.rs
@@ -1024,6 +1024,10 @@ async fn test_audit_log_create_and_list() {
         event_type: "auth.login.success".to_string(),
         ip_address: Some("1.2.3.4".to_string()),
         metadata: serde_json::json!({"method": "password"}),
+        domain: "management".to_string(),
+        action: "auth.login.success".to_string(),
+        target_type: None,
+        target_id: None,
     })
     .await
     .unwrap();
@@ -1034,13 +1038,21 @@ async fn test_audit_log_create_and_list() {
         event_type: "auth.login.failure".to_string(),
         ip_address: Some("5.6.7.8".to_string()),
         metadata: serde_json::json!({"reason": "invalid_password"}),
+        domain: "management".to_string(),
+        action: "auth.login.failure".to_string(),
+        target_type: None,
+        target_id: None,
     })
     .await
     .unwrap();
 
     // List all
     let logs = db
-        .list_audit_logs(DEFAULT_ORG_ID, 50, None, None, None)
+        .list_audit_logs(AuditLogQuery {
+            org_id: DEFAULT_ORG_ID,
+            limit: 50,
+            ..Default::default()
+        })
         .await
         .unwrap();
     assert_eq!(logs.len(), 2);
@@ -1049,7 +1061,12 @@ async fn test_audit_log_create_and_list() {
 
     // Filter by event type prefix
     let success_only = db
-        .list_audit_logs(DEFAULT_ORG_ID, 50, None, Some("auth.login.success"), None)
+        .list_audit_logs(AuditLogQuery {
+            org_id: DEFAULT_ORG_ID,
+            limit: 50,
+            event_type_prefix: Some("auth.login.success"),
+            ..Default::default()
+        })
         .await
         .unwrap();
     assert_eq!(success_only.len(), 1);
@@ -1057,7 +1074,12 @@ async fn test_audit_log_create_and_list() {
 
     // Filter by actor
     let actor_logs = db
-        .list_audit_logs(DEFAULT_ORG_ID, 50, None, None, Some(user_id))
+        .list_audit_logs(AuditLogQuery {
+            org_id: DEFAULT_ORG_ID,
+            limit: 50,
+            actor_id: Some(user_id),
+            ..Default::default()
+        })
         .await
         .unwrap();
     assert_eq!(actor_logs.len(), 1);
@@ -1065,7 +1087,11 @@ async fn test_audit_log_create_and_list() {
 
     // Limit
     let limited = db
-        .list_audit_logs(DEFAULT_ORG_ID, 1, None, None, None)
+        .list_audit_logs(AuditLogQuery {
+            org_id: DEFAULT_ORG_ID,
+            limit: 1,
+            ..Default::default()
+        })
         .await
         .unwrap();
     assert_eq!(limited.len(), 1);
@@ -1090,6 +1116,10 @@ async fn test_audit_log_org_isolation() {
         event_type: "auth.login.success".to_string(),
         ip_address: None,
         metadata: serde_json::json!({}),
+        domain: "management".to_string(),
+        action: "auth.login.success".to_string(),
+        target_type: None,
+        target_id: None,
     })
     .await
     .unwrap();
@@ -1100,19 +1130,31 @@ async fn test_audit_log_org_isolation() {
         event_type: "auth.login.failure".to_string(),
         ip_address: None,
         metadata: serde_json::json!({}),
+        domain: "management".to_string(),
+        action: "auth.login.failure".to_string(),
+        target_type: None,
+        target_id: None,
     })
     .await
     .unwrap();
 
     let org1_logs = db
-        .list_audit_logs(DEFAULT_ORG_ID, 50, None, None, None)
+        .list_audit_logs(AuditLogQuery {
+            org_id: DEFAULT_ORG_ID,
+            limit: 50,
+            ..Default::default()
+        })
         .await
         .unwrap();
     assert_eq!(org1_logs.len(), 1);
     assert_eq!(org1_logs[0].event_type, "auth.login.success");
 
     let org2_logs = db
-        .list_audit_logs(org2.org_id, 50, None, None, None)
+        .list_audit_logs(AuditLogQuery {
+            org_id: org2.org_id,
+            limit: 50,
+            ..Default::default()
+        })
         .await
         .unwrap();
     assert_eq!(org2_logs.len(), 1);
@@ -1129,6 +1171,10 @@ async fn test_audit_log_retention_delete() {
         event_type: "auth.login.success".to_string(),
         ip_address: None,
         metadata: serde_json::json!({}),
+        domain: "management".to_string(),
+        action: "auth.login.success".to_string(),
+        target_type: None,
+        target_id: None,
     })
     .await
     .unwrap();
@@ -1141,10 +1187,144 @@ async fn test_audit_log_retention_delete() {
     assert_eq!(deleted, 1);
 
     let logs = db
-        .list_audit_logs(DEFAULT_ORG_ID, 50, None, None, None)
+        .list_audit_logs(AuditLogQuery {
+            org_id: DEFAULT_ORG_ID,
+            limit: 50,
+            ..Default::default()
+        })
         .await
         .unwrap();
     assert!(logs.is_empty());
+}
+
+// ─── Audit domain filtering tests (EVE-226) ───
+
+#[tokio::test]
+async fn test_audit_log_domain_filtering() {
+    let db = InMemoryDatabase::new();
+
+    db.create_audit_log(CreateAuditLogRow {
+        org_id: DEFAULT_ORG_ID,
+        actor_id: None,
+        event_type: "management.member.invited".to_string(),
+        ip_address: None,
+        metadata: serde_json::json!({}),
+        domain: "management".to_string(),
+        action: "management.member.invited".to_string(),
+        target_type: Some("member".to_string()),
+        target_id: Some("usr_abc".to_string()),
+    })
+    .await
+    .unwrap();
+
+    db.create_audit_log(CreateAuditLogRow {
+        org_id: DEFAULT_ORG_ID,
+        actor_id: None,
+        event_type: "agent.run.started".to_string(),
+        ip_address: None,
+        metadata: serde_json::json!({}),
+        domain: "agent".to_string(),
+        action: "agent.run.started".to_string(),
+        target_type: Some("session".to_string()),
+        target_id: Some("ses_xyz".to_string()),
+    })
+    .await
+    .unwrap();
+
+    db.create_audit_log(CreateAuditLogRow {
+        org_id: DEFAULT_ORG_ID,
+        actor_id: None,
+        event_type: "management.harness.created".to_string(),
+        ip_address: None,
+        metadata: serde_json::json!({}),
+        domain: "management".to_string(),
+        action: "management.harness.created".to_string(),
+        target_type: Some("harness".to_string()),
+        target_id: Some("harness_001".to_string()),
+    })
+    .await
+    .unwrap();
+
+    // Filter by management domain
+    let mgmt = db
+        .list_audit_logs(AuditLogQuery {
+            org_id: DEFAULT_ORG_ID,
+            limit: 50,
+            domain: Some("management"),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(mgmt.len(), 2);
+
+    // Filter by agent domain
+    let agent = db
+        .list_audit_logs(AuditLogQuery {
+            org_id: DEFAULT_ORG_ID,
+            limit: 50,
+            domain: Some("agent"),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(agent.len(), 1);
+    assert_eq!(agent[0].action, "agent.run.started");
+
+    // Filter by specific action
+    let action = db
+        .list_audit_logs(AuditLogQuery {
+            org_id: DEFAULT_ORG_ID,
+            limit: 50,
+            action: Some("management.member.invited"),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(action.len(), 1);
+    assert_eq!(action[0].target_type.as_deref(), Some("member"));
+    assert_eq!(action[0].target_id.as_deref(), Some("usr_abc"));
+
+    // Domain + action combined
+    let combined = db
+        .list_audit_logs(AuditLogQuery {
+            org_id: DEFAULT_ORG_ID,
+            limit: 50,
+            domain: Some("management"),
+            action: Some("management.harness.created"),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(combined.len(), 1);
+    assert_eq!(combined[0].target_type.as_deref(), Some("harness"));
+}
+
+#[tokio::test]
+async fn test_audit_log_target_fields() {
+    let db = InMemoryDatabase::new();
+
+    let row = db
+        .create_audit_log(CreateAuditLogRow {
+            org_id: DEFAULT_ORG_ID,
+            actor_id: None,
+            event_type: "management.agent.created".to_string(),
+            ip_address: Some("10.0.0.1".to_string()),
+            metadata: serde_json::json!({"name": "test-agent"}),
+            domain: "management".to_string(),
+            action: "management.agent.created".to_string(),
+            target_type: Some("agent".to_string()),
+            target_id: Some("agent_00000000000000000000000000000001".to_string()),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(row.domain, "management");
+    assert_eq!(row.action, "management.agent.created");
+    assert_eq!(row.target_type.as_deref(), Some("agent"));
+    assert_eq!(
+        row.target_id.as_deref(),
+        Some("agent_00000000000000000000000000000001")
+    );
 }
 
 // ─── Search / command-palette tests ───

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -1010,6 +1010,18 @@ pub struct AuditLogRow {
     pub ip_address: Option<String>,
     pub metadata: serde_json::Value,
     pub created_at: DateTime<Utc>,
+    /// Audit domain: "management" or "agent"
+    #[sqlx(default)]
+    pub domain: String,
+    /// Structured action (e.g. "management.member.invited")
+    #[sqlx(default)]
+    pub action: String,
+    /// Target resource type (e.g. "harness", "agent", "member")
+    #[sqlx(default)]
+    pub target_type: Option<String>,
+    /// Target resource ID (public ID or UUID)
+    #[sqlx(default)]
+    pub target_id: Option<String>,
 }
 
 /// Input for creating an audit log entry
@@ -1020,6 +1032,22 @@ pub struct CreateAuditLogRow {
     pub event_type: String,
     pub ip_address: Option<String>,
     pub metadata: serde_json::Value,
+    pub domain: String,
+    pub action: String,
+    pub target_type: Option<String>,
+    pub target_id: Option<String>,
+}
+
+/// Query parameters for listing audit logs
+#[derive(Debug, Clone, Default)]
+pub struct AuditLogQuery<'a> {
+    pub org_id: i64,
+    pub limit: i64,
+    pub before: Option<DateTime<Utc>>,
+    pub event_type_prefix: Option<&'a str>,
+    pub actor_id: Option<Uuid>,
+    pub domain: Option<&'a str>,
+    pub action: Option<&'a str>,
 }
 
 /// Input for creating/updating a session key/value

--- a/crates/server/src/storage/repositories/audit_logs.rs
+++ b/crates/server/src/storage/repositories/audit_logs.rs
@@ -4,16 +4,15 @@ use super::super::models::*;
 use super::Database;
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use uuid::Uuid;
 
 impl Database {
-    // Audit Logs (TM-OBS-007)
+    // Audit Logs (TM-OBS-007, EVE-226)
 
     pub async fn create_audit_log(&self, input: CreateAuditLogRow) -> Result<AuditLogRow> {
         let row = sqlx::query_as::<_, AuditLogRow>(
             r#"
-            INSERT INTO audit_logs (org_id, actor_id, event_type, ip_address, metadata)
-            VALUES ($1, $2, $3, $4, $5)
+            INSERT INTO audit_logs (org_id, actor_id, event_type, ip_address, metadata, domain, action, target_type, target_id)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
             RETURNING *
             "#,
         )
@@ -22,85 +21,43 @@ impl Database {
         .bind(&input.event_type)
         .bind(&input.ip_address)
         .bind(&input.metadata)
+        .bind(&input.domain)
+        .bind(&input.action)
+        .bind(&input.target_type)
+        .bind(&input.target_id)
         .fetch_one(&self.pool)
         .await?;
 
         Ok(row)
     }
 
-    pub async fn list_audit_logs(
-        &self,
-        org_id: i64,
-        limit: i64,
-        before: Option<DateTime<Utc>>,
-        event_type_prefix: Option<&str>,
-        actor_id: Option<Uuid>,
-    ) -> Result<Vec<AuditLogRow>> {
-        // Build query dynamically based on filters
-        let before_ts = before.unwrap_or_else(|| Utc::now() + chrono::Duration::seconds(1));
-        let rows = if let Some(prefix) = event_type_prefix {
-            if let Some(aid) = actor_id {
-                sqlx::query_as::<_, AuditLogRow>(
-                    r#"
-                    SELECT * FROM audit_logs
-                    WHERE org_id = $1 AND created_at < $2 AND event_type LIKE $3 AND actor_id = $4
-                    ORDER BY created_at DESC
-                    LIMIT $5
-                    "#,
-                )
-                .bind(org_id)
-                .bind(before_ts)
-                .bind(format!("{}%", prefix))
-                .bind(aid)
-                .bind(limit)
-                .fetch_all(&self.pool)
-                .await?
-            } else {
-                sqlx::query_as::<_, AuditLogRow>(
-                    r#"
-                    SELECT * FROM audit_logs
-                    WHERE org_id = $1 AND created_at < $2 AND event_type LIKE $3
-                    ORDER BY created_at DESC
-                    LIMIT $4
-                    "#,
-                )
-                .bind(org_id)
-                .bind(before_ts)
-                .bind(format!("{}%", prefix))
-                .bind(limit)
-                .fetch_all(&self.pool)
-                .await?
-            }
-        } else if let Some(aid) = actor_id {
-            sqlx::query_as::<_, AuditLogRow>(
-                r#"
-                SELECT * FROM audit_logs
-                WHERE org_id = $1 AND created_at < $2 AND actor_id = $3
-                ORDER BY created_at DESC
-                LIMIT $4
-                "#,
-            )
-            .bind(org_id)
-            .bind(before_ts)
-            .bind(aid)
-            .bind(limit)
-            .fetch_all(&self.pool)
-            .await?
-        } else {
-            sqlx::query_as::<_, AuditLogRow>(
-                r#"
-                SELECT * FROM audit_logs
-                WHERE org_id = $1 AND created_at < $2
-                ORDER BY created_at DESC
-                LIMIT $3
-                "#,
-            )
-            .bind(org_id)
-            .bind(before_ts)
-            .bind(limit)
-            .fetch_all(&self.pool)
-            .await?
-        };
+    pub async fn list_audit_logs(&self, query: AuditLogQuery<'_>) -> Result<Vec<AuditLogRow>> {
+        let before_ts = query
+            .before
+            .unwrap_or_else(|| Utc::now() + chrono::Duration::seconds(1));
+
+        let rows = sqlx::query_as::<_, AuditLogRow>(
+            r#"
+            SELECT * FROM audit_logs
+            WHERE org_id = $1
+              AND created_at < $2
+              AND ($3::text IS NULL OR event_type LIKE $3)
+              AND ($4::uuid IS NULL OR actor_id = $4)
+              AND ($5::text IS NULL OR domain = $5)
+              AND ($6::text IS NULL OR action = $6)
+            ORDER BY created_at DESC
+            LIMIT $7
+            "#,
+        )
+        .bind(query.org_id)
+        .bind(before_ts)
+        .bind(query.event_type_prefix.map(|p| format!("{p}%")))
+        .bind(query.actor_id)
+        .bind(query.domain)
+        .bind(query.action)
+        .bind(query.limit)
+        .fetch_all(&self.pool)
+        .await?;
 
         Ok(rows)
     }

--- a/specs/audit-logging.md
+++ b/specs/audit-logging.md
@@ -1,0 +1,130 @@
+# Audit Logging
+
+Structured audit logging for security-relevant and operational events.
+
+## Status
+
+Implements [EVE-226](https://linear.app/everruns/issue/EVE-226).
+
+## Overview
+
+Two audit domains cover complementary surfaces:
+
+| Domain | What it tracks | Who writes |
+|--------|---------------|------------|
+| **Management** | Org CRUD, member invite/remove, role change, API key create/revoke, settings changes | Service layer via `#[audit]` macro |
+| **Agent** | Agent runs, tool calls, LLM interactions | Execution engine (future) |
+
+## Core Types
+
+See `crates/core/src/audit.rs` for full definitions.
+
+- `AuditDomain` — enum: `Management`, `Agent`
+- `AuditAction` — typed action per domain (e.g. `MemberInvited`, `AgentRunStarted`)
+- `AuditTarget` — `{ target_type, target_id }` identifying the affected resource
+- `AuditEvent` — full event: domain, action, actor, org, target, details (JSON), timestamp, IP
+- `AuditLogger` trait — `async fn log_event(&self, event: AuditEvent) -> Result<()>`
+
+### Domain-Specific Builders
+
+Type-safe builders prevent mixing domains:
+
+```rust
+AuditEvent::management(action, caller)
+    .target("member", user_id)
+    .detail("role", "admin")
+    .build()
+
+AuditEvent::agent(action, caller)
+    .target("session", session_id)
+    .build()
+```
+
+## AOP: `#[audit]` Proc Macro
+
+Cross-cutting audit logging via attribute macro on service methods. Emits an audit event after successful execution without polluting business logic.
+
+```rust
+#[audit(Management, MemberInvited, target = "member")]
+pub async fn invite_member(&self, caller: &Caller, req: InviteRequest) -> Result<Member> {
+    // business logic only — audit event emitted automatically on success
+}
+```
+
+The macro:
+1. Finds `&Caller` parameter (same as `#[policy]`)
+2. Finds `&self` to access `self.audit_logger`
+3. Wraps the function body: executes original, on `Ok` emits audit event via fire-and-forget `tokio::spawn`
+4. The target ID is extracted from the `Ok` result if it implements `AuditTarget` trait, or from a named field
+
+Composes with `#[policy]`: policy checks run first (injected at top), audit fires after success.
+
+```rust
+#[policy(MEMBER_MANAGE)]
+#[audit(Management, MemberInvited, target = "member")]
+pub async fn invite(&self, caller: &Caller, req: Req) -> Result<Member> { ... }
+```
+
+## Storage
+
+### Migration
+
+Adds columns to existing `audit_logs` table (migration 010):
+
+```sql
+ALTER TABLE audit_logs
+    ADD COLUMN domain TEXT NOT NULL DEFAULT 'management',
+    ADD COLUMN action TEXT NOT NULL DEFAULT '',
+    ADD COLUMN target_type TEXT,
+    ADD COLUMN target_id TEXT;
+
+CREATE INDEX idx_audit_logs_org_domain_created
+    ON audit_logs (org_id, domain, created_at DESC);
+```
+
+### PostgreSQL Implementation
+
+`AuditLogger` implemented on `StorageBackend` — delegates to repo layer. Fire-and-forget via `tokio::spawn` (TM-OBS-007: never blocks caller).
+
+### Retention
+
+Configurable auto-purge via `AUDIT_LOG_RETENTION_DAYS` env var (default: 90 days). Existing `delete_audit_logs_before` method handles cleanup.
+
+## API
+
+### `GET /v1/orgs/{org}/audit-logs`
+
+Paginated, filterable. Requires `OrgAuditLogsView` permission (Owner/Admin only).
+
+Query parameters:
+- `limit` — max entries (default 50, max 200)
+- `before` — cursor timestamp
+- `domain` — filter by domain (`management` or `agent`)
+- `action` — filter by action string
+- `actor_id` — filter by actor UUID
+- `event_type` — legacy filter (prefix match on `event_type`)
+
+Response includes `domain`, `action`, `target_type`, `target_id` fields.
+
+## Permissions
+
+| Permission | Granted to | Purpose |
+|-----------|-----------|---------|
+| `OrgAuditLogsView` | Owner, Admin | Read audit logs via API |
+
+Policy: `AUDIT_LOG_VIEW` requires `OrgAuditLogsView`.
+
+## Security Decisions
+
+- **Fire-and-forget**: Audit failures never block operations (TM-OBS-007)
+- **Tenant isolation**: All queries include `org_id` filter
+- **Admin-only access**: Policy-gated, not just role check
+- **No mutation API**: Audit logs are append-only; no update/delete endpoints
+- **IP tracking**: Client IP captured from proxy headers for forensics
+- **JSONB details**: Freeform but never contains secrets (PII limited to IDs)
+
+## Threat Model References
+
+- TM-OBS-007: Audit log write failures must not block operations
+- TM-TENANT: Org-scoped queries prevent cross-tenant data leaks
+- TM-AUTHZ: Policy enforcement on read endpoint

--- a/specs/audit-logging.md
+++ b/specs/audit-logging.md
@@ -30,12 +30,12 @@ See `crates/core/src/audit.rs` for full definitions.
 Type-safe builders prevent mixing domains:
 
 ```rust
-AuditEvent::management(action, caller)
-    .target("member", user_id)
+AuditEvent::management(ManagementAction::MemberInvited, org_id, Some(user_id))
+    .target("member", target_user_id)
     .detail("role", "admin")
     .build()
 
-AuditEvent::agent(action, caller)
+AuditEvent::agent(AgentAction::RunStarted, org_id, None)
     .target("session", session_id)
     .build()
 ```
@@ -45,7 +45,7 @@ AuditEvent::agent(action, caller)
 Cross-cutting audit logging via attribute macro on service methods. Emits an audit event after successful execution without polluting business logic.
 
 ```rust
-#[audit(Management, MemberInvited, target = "member")]
+#[audit(ManagementAction::MemberInvited, target_type = "member")]
 pub async fn invite_member(&self, caller: &Caller, req: InviteRequest) -> Result<Member> {
     // business logic only — audit event emitted automatically on success
 }
@@ -53,15 +53,16 @@ pub async fn invite_member(&self, caller: &Caller, req: InviteRequest) -> Result
 
 The macro:
 1. Finds `&Caller` parameter (same as `#[policy]`)
-2. Finds `&self` to access `self.audit_logger`
+2. Finds `&self` to access `self.audit_logger()` (must return a concrete cloneable `AuditLogger` type)
 3. Wraps the function body: executes original, on `Ok` emits audit event via fire-and-forget `tokio::spawn`
-4. The target ID is extracted from the `Ok` result if it implements `AuditTarget` trait, or from a named field
+4. When `target_type` is specified, the target ID is extracted from the `Ok` result via `HasAuditTargetId` trait
+5. When `target_type` is omitted, no target is recorded
 
 Composes with `#[policy]`: policy checks run first (injected at top), audit fires after success.
 
 ```rust
 #[policy(MEMBER_MANAGE)]
-#[audit(Management, MemberInvited, target = "member")]
+#[audit(ManagementAction::MemberInvited, target_type = "member")]
 pub async fn invite(&self, caller: &Caller, req: Req) -> Result<Member> { ... }
 ```
 


### PR DESCRIPTION
## What
Add a structured audit logging abstraction supporting two audit domains (Management and Agent) with typed events, domain-specific builders, an `#[audit]` AOP proc macro for service methods, and a policy-gated API endpoint.

Implements [EVE-226](https://linear.app/everruns/issue/EVE-226).

## Why
The existing audit system only supported untyped `event_type` strings for auth events. The platform needs structured audit logging across two domains — management operations (org/member/resource CRUD) and agent execution (runs, tool calls, LLM interactions) — with type safety, AOP-style decoration, and fine-grained access control.

## How

### Core types (`crates/core/src/audit.rs`)
- `AuditDomain` enum: `Management` | `Agent`
- `ManagementAction` (27 typed actions) and `AgentAction` (5 typed actions)
- `AuditEvent` with domain-specific builders for type safety
- `AuditLogger` trait with fire-and-forget `emit()` helper
- `HasAuditTargetId` trait for extracting target IDs from domain types

### AOP: `#[audit]` proc macro (`crates/macros/src/lib.rs`)
- Composes with `#[policy]` — policy checks first, audit fires after success
- Finds `&Caller` and `&self` automatically, emits typed event via `self.audit_logger().emit()`
- Supports `target_type` parameter for resource categorization

### Permission & Policy
- New `OrgAuditLogsView` permission granted to Owner and Admin only
- `AUDIT_LOG_VIEW` policy enforced via `#[policy]` on service methods

### Storage
- Migration 010: adds `domain`, `action`, `target_type`, `target_id` columns to `audit_logs`
- Composite index on `(org_id, domain, created_at DESC)`
- `AuditLogQuery` struct replaces 7-arg function signatures
- PostgreSQL uses `NULL`-coalescing parameterized query for optional filters
- `StorageAuditLogger` implements `AuditLogger` trait

### API
- `GET /v1/orgs/{org}/audit-logs` now supports `domain` and `action` query params
- Migrated from role-based (`OrgAdmin`) to policy-based auth (`AUDIT_LOG_VIEW`)
- Response includes `domain`, `action`, `target_type`, `target_id` fields

### Tests (19 total)
- 5 core unit tests (builders, domain derivation, serialization, roundtrip)
- 5 service tests (owner/admin access, member denial, domain/action filters)
- 5 storage tests (CRUD, org isolation, retention, domain filtering, target fields)
- 4 existing audit tests preserved (client IP extraction)

## Risk
- Low
- Migration adds columns with defaults — backward compatible for existing rows
- Existing `audit::emit()` callers unchanged (new fields populated automatically)
- No mutation API exposed (append-only)

## Security
- Threat categories reviewed: **TM-AUTHZ**, **TM-API**, **TM-TENANT**, **TM-SQL**, **TM-OBS**
- Findings and resolutions:
  - **TM-AUTHZ**: Migrated from role-based `OrgAdmin` extractor to policy-based `#[policy(AUDIT_LOG_VIEW)]` enforcement — stricter and more consistent with codebase patterns. Members explicitly denied (tested).
  - **TM-API**: New query params (`domain`, `action`) validated through parameterized SQL binds — no injection risk. `limit` clamped to 1..200.
  - **TM-TENANT**: All queries include `org_id` filter via `Caller` context. Org isolation tested.
  - **TM-SQL**: All queries use parameterized binds (`$1`..`$7`). `LIKE` pattern for `event_type_prefix` uses bind param with server-side `%` append — safe.
  - **TM-OBS**: Fire-and-forget pattern preserved (TM-OBS-007). Audit failures never block operations.
  - No secrets or PII exposed in audit log details (limited to resource IDs).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)