### PR TITLE
feat(cli): add connections and session secrets commands

### DIFF
--- a/crates/cli/src/commands/connections.rs
+++ b/crates/cli/src/commands/connections.rs
@@ -1,0 +1,267 @@
+// Connection management commands
+//
+// Uses raw reqwest for HTTP calls since the SDK doesn't expose
+// connections endpoints yet.
+
+use crate::output::{OutputFormat, print_field, print_table_header, print_table_row};
+use anyhow::{Context, Result};
+use clap::Subcommand;
+use serde::{Deserialize, Serialize};
+
+#[derive(Subcommand)]
+pub enum ConnectionsCommand {
+    /// Set an API key connection for a provider
+    Set {
+        /// Provider name (e.g. daytona, brave_search, browserless, deno, sprites)
+        provider: String,
+
+        /// API key for the provider
+        #[arg(long)]
+        api_key: String,
+    },
+
+    /// List connected providers
+    List,
+
+    /// Remove a connection
+    Remove {
+        /// Provider name (e.g. daytona, brave_search)
+        provider: String,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+struct ConnectionResponse {
+    provider: String,
+    connection_type: String,
+    provider_username: Option<String>,
+    connected_at: String,
+}
+
+#[derive(Debug, Serialize)]
+struct CreateApiKeyRequest {
+    api_key: String,
+}
+
+pub async fn run(
+    command: ConnectionsCommand,
+    api_url: &str,
+    api_key: &str,
+    output: OutputFormat,
+    quiet: bool,
+) -> Result<()> {
+    match command {
+        ConnectionsCommand::Set {
+            provider,
+            api_key: provider_api_key,
+        } => {
+            set(
+                api_url,
+                api_key,
+                output,
+                quiet,
+                &provider,
+                &provider_api_key,
+            )
+            .await
+        }
+        ConnectionsCommand::List => list(api_url, api_key, output).await,
+        ConnectionsCommand::Remove { provider } => {
+            remove(api_url, api_key, output, quiet, &provider).await
+        }
+    }
+}
+
+fn http_client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+async fn set(
+    api_url: &str,
+    api_key: &str,
+    output: OutputFormat,
+    quiet: bool,
+    provider: &str,
+    provider_api_key: &str,
+) -> Result<()> {
+    let resp = http_client()
+        .post(format!("{}/v1/user/connections/{}", api_url, provider))
+        .header("Authorization", format!("Bearer {}", api_key))
+        .json(&CreateApiKeyRequest {
+            api_key: provider_api_key.to_string(),
+        })
+        .send()
+        .await
+        .context("Failed to connect to server")?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!(
+            "Failed to set connection for {}: {} {}",
+            provider,
+            status,
+            body
+        );
+    }
+
+    let conn: ConnectionResponse = resp
+        .json()
+        .await
+        .context("Failed to parse connection response")?;
+
+    if output.is_text() {
+        if quiet {
+            println!("{}", conn.provider);
+        } else {
+            println!("Connected: {}", conn.provider);
+            if let Some(username) = &conn.provider_username {
+                print_field("Username", username);
+            }
+            print_field("Type", &conn.connection_type);
+        }
+    } else {
+        output.print_value(&serde_json::json!({
+            "provider": conn.provider,
+            "connection_type": conn.connection_type,
+            "provider_username": conn.provider_username,
+            "connected_at": conn.connected_at,
+        }));
+    }
+
+    Ok(())
+}
+
+async fn list(api_url: &str, api_key: &str, output: OutputFormat) -> Result<()> {
+    let resp = http_client()
+        .get(format!("{}/v1/user/connections", api_url))
+        .header("Authorization", format!("Bearer {}", api_key))
+        .send()
+        .await
+        .context("Failed to connect to server")?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("Failed to list connections: {} {}", status, body);
+    }
+
+    let connections: Vec<ConnectionResponse> = resp
+        .json()
+        .await
+        .context("Failed to parse connections response")?;
+
+    if output.is_text() {
+        if connections.is_empty() {
+            println!("No connections found");
+            return Ok(());
+        }
+
+        print_table_header(&[
+            ("PROVIDER", 20),
+            ("TYPE", 10),
+            ("USERNAME", 20),
+            ("CONNECTED", 20),
+        ]);
+
+        for conn in &connections {
+            let username = conn.provider_username.as_deref().unwrap_or("-");
+            print_table_row(&[
+                (&conn.provider, 20),
+                (&conn.connection_type, 10),
+                (username, 20),
+                (&conn.connected_at, 20),
+            ]);
+        }
+    } else {
+        output.print_value(&serde_json::json!({
+            "data": connections.iter().map(|c| serde_json::json!({
+                "provider": c.provider,
+                "connection_type": c.connection_type,
+                "provider_username": c.provider_username,
+                "connected_at": c.connected_at,
+            })).collect::<Vec<_>>()
+        }));
+    }
+
+    Ok(())
+}
+
+async fn remove(
+    api_url: &str,
+    api_key: &str,
+    output: OutputFormat,
+    quiet: bool,
+    provider: &str,
+) -> Result<()> {
+    let resp = http_client()
+        .delete(format!("{}/v1/user/connections/{}", api_url, provider))
+        .header("Authorization", format!("Bearer {}", api_key))
+        .send()
+        .await
+        .context("Failed to connect to server")?;
+
+    let status = resp.status();
+    if status == reqwest::StatusCode::NOT_FOUND {
+        anyhow::bail!("Connection not found: {}", provider);
+    }
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("Failed to remove connection: {} {}", status, body);
+    }
+
+    if output.is_text() {
+        if !quiet {
+            println!("Disconnected: {}", provider);
+        }
+    } else {
+        output.print_value(&serde_json::json!({
+            "provider": provider,
+            "status": "disconnected",
+        }));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_api_key_request_serialization() {
+        let req = CreateApiKeyRequest {
+            api_key: "test_key_123".to_string(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("test_key_123"));
+        assert!(json.contains("api_key"));
+    }
+
+    #[test]
+    fn test_connection_response_deserialization() {
+        let json = r#"{
+            "provider": "daytona",
+            "connection_type": "api_key",
+            "provider_username": "user@example.com",
+            "connected_at": "2024-01-01T00:00:00Z"
+        }"#;
+        let conn: ConnectionResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(conn.provider, "daytona");
+        assert_eq!(conn.connection_type, "api_key");
+        assert_eq!(conn.provider_username.as_deref(), Some("user@example.com"));
+    }
+
+    #[test]
+    fn test_connection_response_deserialization_no_username() {
+        let json = r#"{
+            "provider": "brave_search",
+            "connection_type": "api_key",
+            "provider_username": null,
+            "connected_at": "2024-01-01T00:00:00Z"
+        }"#;
+        let conn: ConnectionResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(conn.provider, "brave_search");
+        assert!(conn.provider_username.is_none());
+    }
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod agents;
 pub mod capabilities;
 pub mod chat;
+pub mod connections;
 pub mod files;
 pub mod login;
 pub mod logout;

--- a/crates/cli/src/commands/sessions.rs
+++ b/crates/cli/src/commands/sessions.rs
@@ -1,10 +1,11 @@
 // Session management commands
 
 use crate::output::{OutputFormat, print_field, print_table_header, print_table_row};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Subcommand;
 use everruns_sdk::{CreateSessionRequest, Everruns};
 use futures::StreamExt;
+use std::collections::HashMap;
 
 #[derive(Subcommand)]
 pub enum SessionsCommand {
@@ -25,6 +26,10 @@ pub enum SessionsCommand {
         /// Model ID override (e.g. mod_xxx)
         #[arg(long)]
         model: Option<String>,
+
+        /// Session-scoped secret (repeatable, format: KEY=VALUE)
+        #[arg(long = "secret", value_name = "KEY=VALUE")]
+        secrets: Vec<String>,
     },
 
     /// List sessions
@@ -46,6 +51,8 @@ pub enum SessionsCommand {
 pub async fn run(
     command: SessionsCommand,
     client: &Everruns,
+    api_url: &str,
+    api_key: &str,
     output: OutputFormat,
     quiet: bool,
 ) -> Result<()> {
@@ -55,22 +62,78 @@ pub async fn run(
             agent,
             title,
             model,
-        } => create(client, output, quiet, harness, agent, title, model).await,
+            secrets,
+        } => {
+            create(
+                client, api_url, api_key, output, quiet, harness, agent, title, model, secrets,
+            )
+            .await
+        }
         SessionsCommand::List => list(client, output).await,
         SessionsCommand::Get { session } => get(client, output, session).await,
         SessionsCommand::Watch { session } => watch(client, output, session).await,
     }
 }
 
+/// Parse "KEY=VALUE" strings into a HashMap.
+/// Returns error if any entry is malformed.
+fn parse_secrets(raw: &[String]) -> Result<HashMap<String, String>> {
+    let mut map = HashMap::new();
+    for entry in raw {
+        let (key, value) = entry
+            .split_once('=')
+            .with_context(|| format!("Invalid secret format (expected KEY=VALUE): {}", entry))?;
+        if key.is_empty() {
+            anyhow::bail!("Secret key cannot be empty: {}", entry);
+        }
+        map.insert(key.to_string(), value.to_string());
+    }
+    Ok(map)
+}
+
+/// Store secrets via PUT /v1/sessions/:id/storage/secrets
+async fn store_secrets(
+    api_url: &str,
+    api_key: &str,
+    session_id: &str,
+    secrets: &HashMap<String, String>,
+) -> Result<()> {
+    let resp = reqwest::Client::new()
+        .put(format!(
+            "{}/v1/sessions/{}/storage/secrets",
+            api_url, session_id
+        ))
+        .header("Authorization", format!("Bearer {}", api_key))
+        .json(&serde_json::json!({ "secrets": secrets }))
+        .send()
+        .await
+        .context("Failed to store secrets")?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("Failed to store secrets: {} {}", status, body);
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
 async fn create(
     client: &Everruns,
+    api_url: &str,
+    api_key: &str,
     output: OutputFormat,
     quiet: bool,
     harness_id: Option<String>,
     agent_id: Option<String>,
     title: Option<String>,
     model_id: Option<String>,
+    raw_secrets: Vec<String>,
 ) -> Result<()> {
+    // Parse secrets upfront so we fail early on bad format
+    let secrets = parse_secrets(&raw_secrets)?;
+
     let mut req = CreateSessionRequest::new();
     if let Some(h) = harness_id {
         req = req.harness_id(h);
@@ -87,6 +150,11 @@ async fn create(
 
     let session = client.sessions().create_with_options(req).await?;
 
+    // Store secrets after session creation
+    if !secrets.is_empty() {
+        store_secrets(api_url, api_key, &session.id, &secrets).await?;
+    }
+
     if output.is_text() {
         if quiet {
             println!("{}", session.id);
@@ -97,9 +165,16 @@ async fn create(
             }
             let status = format!("{:?}", session.status).to_lowercase();
             print_field("Status", &status);
+            if !secrets.is_empty() {
+                print_field("Secrets", &format!("{} injected", secrets.len()));
+            }
         }
     } else {
-        output.print_value(&session);
+        let mut json = serde_json::to_value(&session)?;
+        if !secrets.is_empty() {
+            json["secrets_count"] = serde_json::json!(secrets.len());
+        }
+        output.print_value(&json);
     }
 
     Ok(())
@@ -362,5 +437,64 @@ fn capitalize_first(s: &str) -> String {
     match chars.next() {
         None => String::new(),
         Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_secrets_valid() {
+        let raw = vec![
+            "KEY1=value1".to_string(),
+            "KEY2=value2".to_string(),
+            "KEY3=val=with=equals".to_string(),
+        ];
+        let secrets = parse_secrets(&raw).unwrap();
+        assert_eq!(secrets.len(), 3);
+        assert_eq!(secrets["KEY1"], "value1");
+        assert_eq!(secrets["KEY2"], "value2");
+        assert_eq!(secrets["KEY3"], "val=with=equals");
+    }
+
+    #[test]
+    fn test_parse_secrets_empty() {
+        let raw: Vec<String> = vec![];
+        let secrets = parse_secrets(&raw).unwrap();
+        assert!(secrets.is_empty());
+    }
+
+    #[test]
+    fn test_parse_secrets_missing_equals() {
+        let raw = vec!["NOEQUALS".to_string()];
+        let result = parse_secrets(&raw);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Invalid secret format")
+        );
+    }
+
+    #[test]
+    fn test_parse_secrets_empty_key() {
+        let raw = vec!["=value".to_string()];
+        let result = parse_secrets(&raw);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("key cannot be empty")
+        );
+    }
+
+    #[test]
+    fn test_parse_secrets_empty_value_allowed() {
+        let raw = vec!["KEY=".to_string()];
+        let secrets = parse_secrets(&raw).unwrap();
+        assert_eq!(secrets["KEY"], "");
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -68,6 +68,12 @@ pub enum Commands {
         command: commands::agents::AgentsCommand,
     },
 
+    /// Manage provider connections (API keys)
+    Connections {
+        #[command(subcommand)]
+        command: commands::connections::ConnectionsCommand,
+    },
+
     /// Manage capabilities
     Capabilities {
         #[command(subcommand)]
@@ -174,6 +180,9 @@ async fn main() -> anyhow::Result<()> {
             )
             .await
         }
+        Commands::Connections { command } => {
+            commands::connections::run(command, &api_url, &api_key, output_format, cli.quiet).await
+        }
         Commands::Capabilities { command } => {
             let status = match &command {
                 Some(CapabilitiesCommand::List { status }) => status.clone(),
@@ -182,7 +191,15 @@ async fn main() -> anyhow::Result<()> {
             commands::capabilities::run(&client, output_format, &status).await
         }
         Commands::Sessions { command } => {
-            commands::sessions::run(command, &client, output_format, cli.quiet).await
+            commands::sessions::run(
+                command,
+                &client,
+                &api_url,
+                &api_key,
+                output_format,
+                cli.quiet,
+            )
+            .await
         }
         Commands::Files { command } => {
             commands::files::run(command, &api_url, &api_key, output_format, cli.quiet).await
@@ -204,7 +221,7 @@ async fn main() -> anyhow::Result<()> {
             )
             .await
         }
-        // Already handled above
+        // Already handled above (no auth required)
         Commands::Login { .. } | Commands::Logout | Commands::Status | Commands::Orgs { .. } => {
             unreachable!()
         }
@@ -258,12 +275,14 @@ mod tests {
                 agent,
                 title,
                 model,
+                secrets,
             } = command
             {
                 assert_eq!(harness, Some("harness_abc".to_string()));
                 assert_eq!(agent, Some("agt_abc".to_string()));
                 assert_eq!(title, Some("Test Session".to_string()));
                 assert_eq!(model, None);
+                assert!(secrets.is_empty());
             } else {
                 panic!("Expected Create command");
             }
@@ -276,13 +295,92 @@ mod tests {
     fn test_cli_parse_sessions_create_no_harness() {
         let cli = Cli::try_parse_from(["everruns", "sessions", "create"]).unwrap();
         if let Commands::Sessions { command } = cli.command {
-            if let commands::sessions::SessionsCommand::Create { harness, .. } = command {
+            if let commands::sessions::SessionsCommand::Create {
+                harness, secrets, ..
+            } = command
+            {
                 assert_eq!(harness, None); // org default
+                assert!(secrets.is_empty());
             } else {
                 panic!("Expected Create command");
             }
         } else {
             panic!("Expected Sessions command");
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_sessions_create_with_secrets() {
+        let cli = Cli::try_parse_from([
+            "everruns",
+            "sessions",
+            "create",
+            "--agent",
+            "agt_abc",
+            "--secret",
+            "KEY1=value1",
+            "--secret",
+            "KEY2=value2",
+        ])
+        .unwrap();
+        if let Commands::Sessions { command } = cli.command {
+            if let commands::sessions::SessionsCommand::Create { secrets, .. } = command {
+                assert_eq!(secrets.len(), 2);
+                assert_eq!(secrets[0], "KEY1=value1");
+                assert_eq!(secrets[1], "KEY2=value2");
+            } else {
+                panic!("Expected Create command");
+            }
+        } else {
+            panic!("Expected Sessions command");
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_connections_set() {
+        let cli = Cli::try_parse_from([
+            "everruns",
+            "connections",
+            "set",
+            "daytona",
+            "--api-key",
+            "test_key_123",
+        ])
+        .unwrap();
+        if let Commands::Connections { command } = cli.command {
+            if let commands::connections::ConnectionsCommand::Set { provider, api_key } = command {
+                assert_eq!(provider, "daytona");
+                assert_eq!(api_key, "test_key_123");
+            } else {
+                panic!("Expected Set command");
+            }
+        } else {
+            panic!("Expected Connections command");
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_connections_list() {
+        let cli = Cli::try_parse_from(["everruns", "connections", "list"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Connections {
+                command: commands::connections::ConnectionsCommand::List
+            }
+        ));
+    }
+
+    #[test]
+    fn test_cli_parse_connections_remove() {
+        let cli = Cli::try_parse_from(["everruns", "connections", "remove", "daytona"]).unwrap();
+        if let Commands::Connections { command } = cli.command {
+            if let commands::connections::ConnectionsCommand::Remove { provider } = command {
+                assert_eq!(provider, "daytona");
+            } else {
+                panic!("Expected Remove command");
+            }
+        } else {
+            panic!("Expected Connections command");
         }
     }
 

--- a/crates/server/src/api/session_storage.rs
+++ b/crates/server/src/api/session_storage.rs
@@ -4,6 +4,7 @@
 
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::storage::StorageBackend;
+use crate::storage::encryption::EncryptionService;
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -11,11 +12,14 @@ use axum::{
     routing::get,
 };
 use everruns_core::SessionId;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::sync::Arc;
 use utoipa::ToSchema;
 
-use super::common::{ApiResultExt, ListResponse, impl_auth_state, verify_session_ownership};
+use super::common::{
+    ApiResult, ApiResultExt, ErrorResponse, ListResponse, impl_auth_state, verify_session_ownership,
+};
 
 /// Key-value entry info (key and timestamps, no value)
 #[derive(Debug, Clone, Serialize, ToSchema)]
@@ -45,16 +49,39 @@ pub struct SecretInfo {
 #[derive(Clone)]
 pub struct AppState {
     pub db: Arc<StorageBackend>,
+    pub encryption: Option<Arc<EncryptionService>>,
     pub auth: AuthState,
 }
 
 impl AppState {
-    pub fn new(db: Arc<StorageBackend>, auth: AuthState) -> Self {
-        Self { db, auth }
+    pub fn new(
+        db: Arc<StorageBackend>,
+        encryption: Option<Arc<EncryptionService>>,
+        auth: AuthState,
+    ) -> Self {
+        Self {
+            db,
+            encryption,
+            auth,
+        }
     }
 }
 
 impl_auth_state!(AppState);
+
+/// Batch secret set request
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct BatchSetSecretsRequest {
+    /// Map of secret names to values
+    pub secrets: HashMap<String, String>,
+}
+
+/// Batch secret set response
+#[derive(Debug, Serialize, ToSchema)]
+pub struct BatchSetSecretsResponse {
+    /// Number of secrets stored
+    pub count: usize,
+}
 
 /// Create session storage routes (nested under sessions)
 pub fn routes(state: AppState) -> Router {
@@ -62,7 +89,7 @@ pub fn routes(state: AppState) -> Router {
         .route("/v1/sessions/{session_id}/storage/keys", get(list_keys))
         .route(
             "/v1/sessions/{session_id}/storage/secrets",
-            get(list_secrets),
+            get(list_secrets).put(batch_set_secrets),
         )
         .with_state(state)
 }
@@ -158,6 +185,80 @@ pub async fn list_secrets(
     Ok(Json(ListResponse::new(items)))
 }
 
+/// PUT /v1/sessions/{session_id}/storage/secrets - Batch set secrets
+///
+/// Encrypts and stores multiple secrets in a single request.
+/// Existing secrets with the same name are overwritten.
+#[utoipa::path(
+    put,
+    path = "/v1/sessions/{session_id}/storage/secrets",
+    params(
+        ("session_id" = String, Path, description = "Session ID")
+    ),
+    request_body = BatchSetSecretsRequest,
+    responses(
+        (status = 200, description = "Secrets stored", body = BatchSetSecretsResponse),
+        (status = 400, description = "Bad request (encryption not configured or invalid input)"),
+        (status = 404, description = "Session not found"),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = "session-storage"
+)]
+pub async fn batch_set_secrets(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+    Json(body): Json<BatchSetSecretsRequest>,
+) -> ApiResult<BatchSetSecretsResponse> {
+    let session_id: SessionId = session_id.parse().map_err(|_| {
+        ErrorResponse::new("Invalid session ID").into_response(StatusCode::BAD_REQUEST)
+    })?;
+    verify_session_ownership(&state.db, org.org_id, session_id)
+        .await
+        .map_err(|status| ErrorResponse::new("Session not found").into_response(status))?;
+
+    let encryption = state.encryption.as_ref().ok_or_else(|| {
+        ErrorResponse::new(
+            "Encryption not configured. Set SECRETS_ENCRYPTION_KEY environment variable.",
+        )
+        .into_response(StatusCode::BAD_REQUEST)
+    })?;
+
+    if body.secrets.is_empty() {
+        return Ok(Json(BatchSetSecretsResponse { count: 0 }));
+    }
+
+    // Validate key lengths
+    for name in body.secrets.keys() {
+        if name.len() > 255 {
+            return Err(
+                ErrorResponse::new(format!("Secret name too long (max 255): {}", name))
+                    .into_response(StatusCode::BAD_REQUEST),
+            );
+        }
+    }
+
+    let count = body.secrets.len();
+    for (name, value) in &body.secrets {
+        let encrypted = encryption.encrypt_string(value).map_err(|e| {
+            tracing::error!("Encryption failed for secret '{}': {}", name, e);
+            ErrorResponse::internal_error()
+        })?;
+
+        let input = crate::storage::models::UpsertSessionSecret {
+            session_id,
+            name: name.clone(),
+            value_encrypted: encrypted,
+        };
+        state.db.upsert_session_secret(input).await.map_err(|e| {
+            tracing::error!("Failed to store secret '{}': {}", name, e);
+            ErrorResponse::internal_error()
+        })?;
+    }
+
+    Ok(Json(BatchSetSecretsResponse { count }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -186,5 +287,28 @@ mod tests {
         assert!(json.contains("api_key"));
         // Ensure no value field exists
         assert!(!json.contains("value"));
+    }
+
+    #[test]
+    fn test_batch_set_secrets_request_deserialization() {
+        let json = r#"{"secrets":{"KEY1":"value1","KEY2":"value2"}}"#;
+        let req: BatchSetSecretsRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.secrets.len(), 2);
+        assert_eq!(req.secrets["KEY1"], "value1");
+        assert_eq!(req.secrets["KEY2"], "value2");
+    }
+
+    #[test]
+    fn test_batch_set_secrets_response_serialization() {
+        let resp = BatchSetSecretsResponse { count: 3 };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"count\":3"));
+    }
+
+    #[test]
+    fn test_batch_set_secrets_request_empty() {
+        let json = r#"{"secrets":{}}"#;
+        let req: BatchSetSecretsRequest = serde_json::from_str(json).unwrap();
+        assert!(req.secrets.is_empty());
     }
 }

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -566,7 +566,7 @@ impl ServerAppBuilder {
         let session_files_state = api::session_files::AppState::new(db.clone(), auth_state.clone());
         let session_git_state = api::session_git::AppState::new(db.clone(), auth_state.clone());
         let session_storage_state =
-            api::session_storage::AppState::new(db.clone(), auth_state.clone());
+            api::session_storage::AppState::new(db.clone(), encryption.clone(), auth_state.clone());
         let session_databases_state = api::session_databases::AppState::new(
             sqldb_store.clone(),
             db.clone(),

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -229,7 +229,7 @@ impl TestServer {
         let session_files_state = api::session_files::AppState::new(db.clone(), auth_state.clone());
         let session_git_state = api::session_git::AppState::new(db.clone(), auth_state.clone());
         let session_storage_state =
-            api::session_storage::AppState::new(db.clone(), auth_state.clone());
+            api::session_storage::AppState::new(db.clone(), None, auth_state.clone());
         // Session SQL database store (in-memory for all test modes)
         let sqldb_backend = Arc::new(everruns_session_sqldb::InMemorySqlDbBackend::new());
         let sqldb_store: Arc<dyn everruns_core::session_sqldb::SessionSqlDbStore> = Arc::new(


### PR DESCRIPTION
## What
Add two CLI features for headless/CI agent workflows:
1. `everruns connections set/list/remove` — manage API key connections from CLI
2. `everruns sessions create --secret KEY=VALUE` — inject encrypted session-scoped secrets at creation time

Server-side: `PUT /v1/sessions/:id/storage/secrets` batch endpoint for encrypted secret storage.

## Why
Setting up connections and injecting secrets currently requires the UI or raw curl commands. CI pipelines, scripts, and cloud agent environments need first-class CLI support.

Closes EVE-228, EVE-229.

## How

### EVE-228: Connections CLI
- New `commands/connections.rs` module with `Set`, `List`, `Remove` subcommands
- Uses raw `reqwest` calls to existing server endpoints (`POST/GET/DELETE /v1/user/connections/:provider`)
- Wired into `Commands` enum in `main.rs`

### EVE-229: Session Secrets
- **Server**: Added `PUT /v1/sessions/{session_id}/storage/secrets` endpoint in `session_storage.rs` that accepts `{ "secrets": { "KEY": "VALUE" } }`, encrypts each value with the existing `EncryptionService`, and stores via `upsert_session_secret`
- **CLI**: Added `--secret KEY=VALUE` (repeatable) flag to `sessions create`. After session creation, calls the batch secrets endpoint. Parses secrets upfront for early validation.
- `session_storage::AppState` now carries `Option<Arc<EncryptionService>>` for the batch endpoint

### Key design decisions
- Secrets are stored encrypted at rest (AES-256-GCM envelope encryption)
- Secret values never appear in event stream or session metadata
- Empty secrets map is a no-op (no server call)
- Values containing `=` are handled correctly (split on first `=` only)

## Risk
- Low
- Connections commands call existing, well-tested server endpoints
- Secrets endpoint reuses the same encryption path as the `secret_store` tool

## Security
- Threat categories reviewed: TM-AGENT-016 (secrets in events), TM-AUTH (API key auth), TM-ENCRYPT (encryption at rest)
- Secrets are encrypted before storage, never returned in responses or events
- API key for connections is transmitted over TLS to the server
- Batch secrets endpoint requires session ownership verification and encryption configuration

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)