### PR TITLE
fix(daytona): auto-source shell profiles before every exec command

### DIFF
--- a/integrations/daytona/SPEC.md
+++ b/integrations/daytona/SPEC.md
@@ -244,6 +244,18 @@ Daytona's `POST /process/execute` is synchronous (blocks until done). To provide
 
 During exec, a background heartbeat task calls `touch_sandbox_lease` every 3 minutes (`LEASE_HEARTBEAT_INTERVAL`) to renew Everruns' leased-resource record for the sandbox. This prevents Everruns' leased-resource cleanup from reclaiming the sandbox during long-running commands (e.g. Rust compilation taking 20+ minutes). The heartbeat is cancelled when the exec completes.
 
+### Shell profile sourcing in exec
+
+Daytona sessions use a bare (non-login) shell. Unlike E2B and Deno — which spawn `bash -l -c` per command and get automatic profile sourcing — Daytona's persistent session never sources login profiles. Tools installed mid-session (e.g. `rustup` writing `~/.cargo/env`, `nvm` writing `~/.nvm/nvm.sh`) aren't visible in `PATH` on subsequent commands.
+
+Three fixes were considered:
+
+1. **Source on session creation** — Only runs once; installs after session creation still broken. Rejected.
+2. **Wrap every command with preamble** — Sources `~/.profile`, `~/.cargo/env`, `~/.nvm/nvm.sh` before each command. ~2ms overhead, handles mid-session installs. **Chosen.** Deliberately excludes `~/.bashrc` — most distros guard it with an interactive-mode check (`case $-`) that returns early in non-interactive exec contexts.
+3. **Login shell for session** — Depends on Daytona API support; same limitation as (1) for mid-session installs. Rejected.
+
+The preamble uses `2>/dev/null` on each source to suppress motd/banner noise. The loop variable (`__f`) is `unset` after sourcing to avoid polluting the command's environment.
+
 ### Configurable auto-stop
 
 `daytona_create_sandbox` accepts an optional `auto_stop_minutes` parameter (1–60, default: 5). Agents running long builds can request a longer inactivity window at sandbox creation time.

--- a/integrations/daytona/SPEC.md
+++ b/integrations/daytona/SPEC.md
@@ -254,7 +254,7 @@ Three fixes were considered:
 2. **Wrap every command with preamble** — Sources `~/.profile`, `~/.cargo/env`, `~/.nvm/nvm.sh` before each command. ~2ms overhead, handles mid-session installs. **Chosen.** Deliberately excludes `~/.bashrc` — most distros guard it with an interactive-mode check (`case $-`) that returns early in non-interactive exec contexts.
 3. **Login shell for session** — Depends on Daytona API support; same limitation as (1) for mid-session installs. Rejected.
 
-The preamble uses `2>/dev/null` on each source to suppress motd/banner noise. The loop variable (`__f`) is `unset` after sourcing to avoid polluting the command's environment.
+The preamble redirects both stdout and stderr to `/dev/null` on each source to suppress noise (motd, banners, etc.). The loop variable (`__f`) is `unset` after sourcing to avoid polluting the command's environment.
 
 ### Configurable auto-stop
 

--- a/integrations/daytona/src/client.rs
+++ b/integrations/daytona/src/client.rs
@@ -5,6 +5,15 @@
 //! so commands always get proper shell interpretation (pipes, redirects,
 //! variable expansion, etc.). The old stateless `/process/execute` endpoint
 //! is NOT used — it doesn't support async execution or output streaming.
+//!
+//! Decision: Every command is prefixed with a shell-profile preamble that
+//! sources common profile files (~/.profile, ~/.bashrc, ~/.cargo/env, etc.).
+//! Daytona sessions use a bare shell (no login flag), so tools installed
+//! mid-session (e.g. rustup writing ~/.cargo/env) aren't visible in PATH.
+//! Unlike E2B and Deno which spawn `bash -l -c` per command, Daytona's
+//! persistent session means even a login shell at creation time wouldn't
+//! pick up later installs. The preamble runs on every exec (~2ms overhead)
+//! and eliminates the entire class of "command not found after install" bugs.
 
 use serde_json::{Value, json};
 use std::time::Duration;
@@ -16,6 +25,25 @@ use crate::{EXEC_POLL_INTERVAL, SANDBOX_READY_MAX_WAIT, SANDBOX_READY_POLL_INTER
 /// Fixed session ID used for all command execution in a sandbox.
 /// One session per sandbox, created on first exec, reused thereafter.
 const EXEC_SESSION_ID: &str = "everruns-exec";
+
+/// Shell-profile preamble sourced before every command.
+///
+/// Daytona sessions use a bare (non-login) shell, so tools installed
+/// mid-session (rustup, nvm, etc.) write profile files that never get
+/// sourced. This preamble sources common profile files if they exist,
+/// making newly-installed tools available immediately.
+///
+/// Deliberately excludes `~/.bashrc` — most distros guard it with a
+/// `case $-` interactive-mode check that causes it to return early in
+/// non-interactive exec contexts. The files listed here are all designed
+/// for non-interactive sourcing (PATH/env exports only).
+///
+/// Profiles are sourced with `2>/dev/null` to suppress any unexpected noise.
+const SHELL_PROFILE_PREAMBLE: &str = concat!(
+    "for __f in ~/.profile ~/.cargo/env ~/.nvm/nvm.sh; do ",
+    "[ -f \"$__f\" ] && . \"$__f\" 2>/dev/null; ",
+    "done; unset __f; ",
+);
 
 // ============================================================================
 // DaytonaClient - HTTP client for Daytona APIs
@@ -412,8 +440,8 @@ impl DaytonaClient {
         self.ensure_session(sandbox_id).await?;
 
         let cmd = match cwd {
-            Some(c) => format!("cd {c} && {command}"),
-            None => command.to_string(),
+            Some(c) => format!("{SHELL_PROFILE_PREAMBLE}cd {c} && {command}"),
+            None => format!("{SHELL_PROFILE_PREAMBLE}{command}"),
         };
 
         let timeout = timeout_ms.unwrap_or(crate::EXEC_TIMEOUT_MS);
@@ -1451,6 +1479,116 @@ mod tests {
         );
         let result = client.ensure_session("sb_test").await;
         assert!(result.is_ok(), "409 should be treated as success");
+    }
+
+    #[tokio::test]
+    async fn test_exec_prepends_shell_profile_preamble() {
+        use wiremock::matchers::body_json;
+
+        let mock_server = MockServer::start().await;
+
+        // Session create
+        Mock::given(method("POST"))
+            .and(path("/sb_preamble/process/session"))
+            .respond_with(ResponseTemplate::new(201))
+            .mount(&mock_server)
+            .await;
+
+        // Exec — match the exact command body to verify preamble is prepended.
+        let expected_cmd = format!("{SHELL_PROFILE_PREAMBLE}echo hello");
+        Mock::given(method("POST"))
+            .and(path("/sb_preamble/process/session/everruns-exec/exec"))
+            .and(body_json(json!({
+                "command": expected_cmd,
+                "runAsync": true
+            })))
+            .respond_with(ResponseTemplate::new(202).set_body_json(json!({"cmdId": "cmd_p1"})))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        // Logs + status
+        Mock::given(method("GET"))
+            .and(path(
+                "/sb_preamble/process/session/everruns-exec/command/cmd_p1/logs",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes({
+                let mut b = vec![0x01, 0x01, 0x01];
+                b.extend_from_slice(b"hello\n");
+                b
+            }))
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/sb_preamble/process/session/everruns-exec/command/cmd_p1",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"exitCode": 0})))
+            .mount(&mock_server)
+            .await;
+
+        let client = DaytonaClient::with_base_urls(
+            "test_key".to_string(),
+            mock_server.uri(),
+            mock_server.uri(),
+        );
+        let result = client
+            .exec("sb_preamble", "echo hello", None, None, |_| {})
+            .await;
+        assert!(result.is_ok(), "exec failed: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn test_exec_preamble_with_cwd() {
+        use wiremock::matchers::body_json;
+
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/sb_cwd/process/session"))
+            .respond_with(ResponseTemplate::new(201))
+            .mount(&mock_server)
+            .await;
+
+        // With cwd, command should be: PREAMBLE + cd /tmp && ls
+        let expected_cmd = format!("{SHELL_PROFILE_PREAMBLE}cd /tmp && ls");
+        Mock::given(method("POST"))
+            .and(path("/sb_cwd/process/session/everruns-exec/exec"))
+            .and(body_json(json!({
+                "command": expected_cmd,
+                "runAsync": true
+            })))
+            .respond_with(ResponseTemplate::new(202).set_body_json(json!({"cmdId": "cmd_c1"})))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path(
+                "/sb_cwd/process/session/everruns-exec/command/cmd_c1/logs",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes({
+                let mut b = vec![0x01, 0x01, 0x01];
+                b.extend_from_slice(b"output\n");
+                b
+            }))
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/sb_cwd/process/session/everruns-exec/command/cmd_c1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"exitCode": 0})))
+            .mount(&mock_server)
+            .await;
+
+        let client = DaytonaClient::with_base_urls(
+            "test_key".to_string(),
+            mock_server.uri(),
+            mock_server.uri(),
+        );
+        let result = client
+            .exec("sb_cwd", "ls", Some("/tmp"), None, |_| {})
+            .await;
+        assert!(result.is_ok(), "exec with cwd failed: {:?}", result.err());
     }
 
     #[test]

--- a/integrations/daytona/src/client.rs
+++ b/integrations/daytona/src/client.rs
@@ -7,13 +7,16 @@
 //! is NOT used — it doesn't support async execution or output streaming.
 //!
 //! Decision: Every command is prefixed with a shell-profile preamble that
-//! sources common profile files (~/.profile, ~/.bashrc, ~/.cargo/env, etc.).
+//! sources common non-interactive profile files (~/.profile, ~/.cargo/env,
+//! ~/.nvm/nvm.sh). `~/.bashrc` is intentionally not sourced because most
+//! distros guard it with an interactive-shell check that returns early in
+//! non-interactive exec contexts.
 //! Daytona sessions use a bare shell (no login flag), so tools installed
 //! mid-session (e.g. rustup writing ~/.cargo/env) aren't visible in PATH.
 //! Unlike E2B and Deno which spawn `bash -l -c` per command, Daytona's
 //! persistent session means even a login shell at creation time wouldn't
 //! pick up later installs. The preamble runs on every exec (~2ms overhead)
-//! and eliminates the entire class of "command not found after install" bugs.
+//! and largely eliminates "command not found after install" bugs.
 
 use serde_json::{Value, json};
 use std::time::Duration;
@@ -38,10 +41,11 @@ const EXEC_SESSION_ID: &str = "everruns-exec";
 /// non-interactive exec contexts. The files listed here are all designed
 /// for non-interactive sourcing (PATH/env exports only).
 ///
-/// Profiles are sourced with `2>/dev/null` to suppress any unexpected noise.
+/// Profiles are sourced with stdout and stderr redirected to `/dev/null`
+/// to suppress any unexpected noise (motd, banners, etc.).
 const SHELL_PROFILE_PREAMBLE: &str = concat!(
-    "for __f in ~/.profile ~/.cargo/env ~/.nvm/nvm.sh; do ",
-    "[ -f \"$__f\" ] && . \"$__f\" 2>/dev/null; ",
+    "for __f in \"$HOME/.profile\" \"$HOME/.cargo/env\" \"$HOME/.nvm/nvm.sh\"; do ",
+    "[ -f \"$__f\" ] && . \"$__f\" >/dev/null 2>&1; ",
     "done; unset __f; ",
 );
 

--- a/integrations/daytona/tests/live_api_test.rs
+++ b/integrations/daytona/tests/live_api_test.rs
@@ -284,6 +284,106 @@ async fn test_live_exec_streaming_returns_output() {
     );
 }
 
+/// Shell profile sourcing: tools installed mid-session are visible in PATH.
+///
+/// Simulates the real-world scenario where an agent installs a tool (e.g. rustup)
+/// and the next command needs it in PATH. Without profile sourcing, every command
+/// after install would need a manual `. ~/.cargo/env &&` prefix.
+#[tokio::test]
+async fn test_live_shell_profile_sourcing() {
+    let api_key = require_api_key!();
+    let (client, guard) = create_test_sandbox(api_key, "profile-sourcing").await;
+    let id = &guard.sandbox_id;
+
+    // 1. Write a fake profile file that exports a custom PATH entry and variable.
+    //    This simulates what rustup/nvm do when installed.
+    //    mkdir -p ~/.cargo first — Daytona sandboxes don't have it by default.
+    let result = client
+        .exec(
+            id,
+            r#"mkdir -p /tmp/fake-tool ~/.cargo && printf '#!/bin/sh\necho fake-tool-output\n' > /tmp/fake-tool/my-tool && chmod +x /tmp/fake-tool/my-tool && printf 'export PATH="/tmp/fake-tool:$PATH"\nexport FAKE_TOOL_VERSION="1.0.0"\n' > ~/.cargo/env"#,
+            None,
+            None,
+            |_| {},
+        )
+        .await
+        .expect("setup fake tool failed");
+    assert_eq!(result.exit_code, 0, "setup failed: {}", result.result);
+
+    // 2. In a subsequent exec, the tool should be in PATH because the preamble
+    //    sources ~/.cargo/env before running the user command.
+    let result = client
+        .exec(id, "my-tool", None, None, |_| {})
+        .await
+        .expect("my-tool exec failed");
+    assert_eq!(
+        result.exit_code, 0,
+        "my-tool not found in PATH — profile sourcing broken. Output: {}",
+        result.result
+    );
+    assert!(
+        result.result.contains("fake-tool-output"),
+        "Expected fake-tool-output, got: {}",
+        result.result
+    );
+
+    // 3. Verify the env var exported by the profile is also available.
+    let result = client
+        .exec(id, "echo $FAKE_TOOL_VERSION", None, None, |_| {})
+        .await
+        .expect("env var check failed");
+    assert_eq!(result.exit_code, 0);
+    assert!(
+        result.result.contains("1.0.0"),
+        "Expected FAKE_TOOL_VERSION=1.0.0, got: {}",
+        result.result
+    );
+}
+
+/// Shell profile sourcing with .profile: env vars exported in .profile are available.
+#[tokio::test]
+async fn test_live_profile_sourcing() {
+    let api_key = require_api_key!();
+    let (client, guard) = create_test_sandbox(api_key, "profile-sourcing-dotprofile").await;
+    let id = &guard.sandbox_id;
+
+    // Write a .profile that exports a custom variable (backup any existing one).
+    let result = client
+        .exec(
+            id,
+            r#"[ -f ~/.profile ] && cp ~/.profile ~/.profile.bak; echo 'export FROM_PROFILE="yes"' >> ~/.profile"#,
+            None,
+            None,
+            |_| {},
+        )
+        .await
+        .expect("profile setup failed");
+    assert_eq!(result.exit_code, 0);
+
+    // Subsequent exec should have the variable available via preamble sourcing.
+    let result = client
+        .exec(id, "echo FROM_PROFILE=$FROM_PROFILE", None, None, |_| {})
+        .await
+        .expect("profile check exec failed");
+    assert_eq!(result.exit_code, 0);
+    assert!(
+        result.result.contains("FROM_PROFILE=yes"),
+        "Expected FROM_PROFILE=yes, got: {}",
+        result.result
+    );
+
+    // Restore .profile.
+    let _ = client
+        .exec(
+            id,
+            "[ -f ~/.profile.bak ] && mv ~/.profile.bak ~/.profile || true",
+            None,
+            None,
+            |_| {},
+        )
+        .await;
+}
+
 /// Stop and start a sandbox.
 #[tokio::test]
 async fn test_live_stop_and_start() {

--- a/integrations/daytona/tests/tool_integration.rs
+++ b/integrations/daytona/tests/tool_integration.rs
@@ -754,11 +754,18 @@ async fn test_exec_session_with_cwd_prepended() {
         .mount(&mock_server)
         .await;
 
-    // Verify the command is prepended with cd
+    // Verify the command is prepended with shell-profile preamble + cd.
+    // The preamble sources common profile files before running the user command.
+    let expected_cmd = concat!(
+        "for __f in ~/.profile ~/.cargo/env ~/.nvm/nvm.sh; do ",
+        "[ -f \"$__f\" ] && . \"$__f\" 2>/dev/null; ",
+        "done; unset __f; ",
+        "cd /workspace && ls -la",
+    );
     Mock::given(method("POST"))
         .and(path("/sb_cwd/process/session/everruns-exec/exec"))
         .and(wiremock::matchers::body_json(json!({
-            "command": "cd /workspace && ls -la",
+            "command": expected_cmd,
             "runAsync": true
         })))
         .respond_with(ResponseTemplate::new(202).set_body_json(json!({

--- a/integrations/daytona/tests/tool_integration.rs
+++ b/integrations/daytona/tests/tool_integration.rs
@@ -757,8 +757,8 @@ async fn test_exec_session_with_cwd_prepended() {
     // Verify the command is prepended with shell-profile preamble + cd.
     // The preamble sources common profile files before running the user command.
     let expected_cmd = concat!(
-        "for __f in ~/.profile ~/.cargo/env ~/.nvm/nvm.sh; do ",
-        "[ -f \"$__f\" ] && . \"$__f\" 2>/dev/null; ",
+        "for __f in \"$HOME/.profile\" \"$HOME/.cargo/env\" \"$HOME/.nvm/nvm.sh\"; do ",
+        "[ -f \"$__f\" ] && . \"$__f\" >/dev/null 2>&1; ",
         "done; unset __f; ",
         "cd /workspace && ls -la",
     );


### PR DESCRIPTION
## What
Prepend a POSIX-compatible shell-profile preamble to every `daytona_exec` command that sources `~/.profile`, `~/.cargo/env`, and `~/.nvm/nvm.sh` if they exist.

## Why
Daytona sessions use a bare (non-login) shell. When an agent installs tools mid-session (e.g. `rustup` writing `~/.cargo/env`), the persistent shell doesn't pick up the new PATH entries. Every subsequent command requires a manual `. $HOME/.cargo/env && ...` prefix — wasting tokens, confusing models, and causing "command not found" errors.

Unlike E2B and Deno which spawn `bash -l -c` per command, Daytona's persistent session model means even a login shell at creation time wouldn't pick up later installs.

## How
- Added `SHELL_PROFILE_PREAMBLE` constant in `client.rs` — a `for` loop that sources common profile files with `[ -f ] &&` guards and `2>/dev/null` suppression.
- Modified `exec()` to prepend the preamble before every command (both with and without `cwd`).
- Deliberately excludes `~/.bashrc` — most distros guard it with an interactive-mode check (`case $-`) that returns early in non-interactive exec contexts. Confirmed this during live testing against real Daytona (which runs zsh).

## Risk
- Low
- The preamble is a static constant with no user input interpolation. ~2ms overhead per exec from 3 file existence checks. All existing tests pass. Verified against real Daytona sandboxes.

## Security
- Threat categories reviewed: TM-BASH (command execution in sandboxes)
- Findings: No new threat surface. The preamble is a static constant — no user input is interpolated into it. User commands are appended after the preamble exactly as before. Sourced files are fixed paths under the sandbox user's home directory. No injection, path traversal, or data exposure risks.

## Checklist
- [x] Tests added or updated
  - 2 new unit tests verifying preamble is prepended (with/without cwd)
  - 2 new live integration tests against real Daytona (cargo/env PATH sourcing, .profile env var sourcing)
  - 1 existing integration test updated for new command format
- [x] Backward compatibility considered — no breaking changes; commands behave identically, just with profile sourcing prepended
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
