### PR TITLE
feat(cli): add connections command for headless API key management

### DIFF
--- a/crates/cli/src/commands/connections.rs
+++ b/crates/cli/src/commands/connections.rs
@@ -76,6 +76,11 @@ fn http_client() -> reqwest::Client {
     reqwest::Client::new()
 }
 
+/// Build a connection API URL, normalizing trailing slashes.
+fn connection_url(api_url: &str, path: &str) -> String {
+    format!("{}{}", api_url.trim_end_matches('/'), path)
+}
+
 async fn set(
     api_url: &str,
     api_key: &str,
@@ -85,7 +90,10 @@ async fn set(
     provider_api_key: &str,
 ) -> Result<()> {
     let resp = http_client()
-        .post(format!("{}/v1/user/connections/{}", api_url, provider))
+        .post(connection_url(
+            api_url,
+            &format!("/v1/user/connections/{}", provider),
+        ))
         .header("Authorization", format!("Bearer {}", api_key))
         .json(&CreateApiKeyRequest {
             api_key: provider_api_key.to_string(),
@@ -134,7 +142,7 @@ async fn set(
 
 async fn list(api_url: &str, api_key: &str, output: OutputFormat) -> Result<()> {
     let resp = http_client()
-        .get(format!("{}/v1/user/connections", api_url))
+        .get(connection_url(api_url, "/v1/user/connections"))
         .header("Authorization", format!("Bearer {}", api_key))
         .send()
         .await
@@ -195,7 +203,10 @@ async fn remove(
     provider: &str,
 ) -> Result<()> {
     let resp = http_client()
-        .delete(format!("{}/v1/user/connections/{}", api_url, provider))
+        .delete(connection_url(
+            api_url,
+            &format!("/v1/user/connections/{}", provider),
+        ))
         .header("Authorization", format!("Bearer {}", api_key))
         .send()
         .await

--- a/crates/cli/src/commands/connections.rs
+++ b/crates/cli/src/commands/connections.rs
@@ -2,6 +2,7 @@
 //
 // Uses raw reqwest for HTTP calls since the SDK doesn't expose
 // connections endpoints yet.
+// TODO(everruns/sdk#66): Replace raw reqwest with native SDK client.connections() methods
 
 use crate::output::{OutputFormat, print_field, print_table_header, print_table_row};
 use anyhow::{Context, Result};

--- a/crates/cli/src/commands/connections.rs
+++ b/crates/cli/src/commands/connections.rs
@@ -1,0 +1,267 @@
+// Connection management commands
+//
+// Uses raw reqwest for HTTP calls since the SDK doesn't expose
+// connections endpoints yet.
+
+use crate::output::{OutputFormat, print_field, print_table_header, print_table_row};
+use anyhow::{Context, Result};
+use clap::Subcommand;
+use serde::{Deserialize, Serialize};
+
+#[derive(Subcommand)]
+pub enum ConnectionsCommand {
+    /// Set an API key connection for a provider
+    Set {
+        /// Provider name (e.g. daytona, brave_search, browserless, deno, sprites)
+        provider: String,
+
+        /// API key for the provider
+        #[arg(long)]
+        api_key: String,
+    },
+
+    /// List connected providers
+    List,
+
+    /// Remove a connection
+    Remove {
+        /// Provider name (e.g. daytona, brave_search)
+        provider: String,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+struct ConnectionResponse {
+    provider: String,
+    connection_type: String,
+    provider_username: Option<String>,
+    connected_at: String,
+}
+
+#[derive(Debug, Serialize)]
+struct CreateApiKeyRequest {
+    api_key: String,
+}
+
+pub async fn run(
+    command: ConnectionsCommand,
+    api_url: &str,
+    api_key: &str,
+    output: OutputFormat,
+    quiet: bool,
+) -> Result<()> {
+    match command {
+        ConnectionsCommand::Set {
+            provider,
+            api_key: provider_api_key,
+        } => {
+            set(
+                api_url,
+                api_key,
+                output,
+                quiet,
+                &provider,
+                &provider_api_key,
+            )
+            .await
+        }
+        ConnectionsCommand::List => list(api_url, api_key, output).await,
+        ConnectionsCommand::Remove { provider } => {
+            remove(api_url, api_key, output, quiet, &provider).await
+        }
+    }
+}
+
+fn http_client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+async fn set(
+    api_url: &str,
+    api_key: &str,
+    output: OutputFormat,
+    quiet: bool,
+    provider: &str,
+    provider_api_key: &str,
+) -> Result<()> {
+    let resp = http_client()
+        .post(format!("{}/v1/user/connections/{}", api_url, provider))
+        .header("Authorization", format!("Bearer {}", api_key))
+        .json(&CreateApiKeyRequest {
+            api_key: provider_api_key.to_string(),
+        })
+        .send()
+        .await
+        .context("Failed to connect to server")?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!(
+            "Failed to set connection for {}: {} {}",
+            provider,
+            status,
+            body
+        );
+    }
+
+    let conn: ConnectionResponse = resp
+        .json()
+        .await
+        .context("Failed to parse connection response")?;
+
+    if output.is_text() {
+        if quiet {
+            println!("{}", conn.provider);
+        } else {
+            println!("Connected: {}", conn.provider);
+            if let Some(username) = &conn.provider_username {
+                print_field("Username", username);
+            }
+            print_field("Type", &conn.connection_type);
+        }
+    } else {
+        output.print_value(&serde_json::json!({
+            "provider": conn.provider,
+            "connection_type": conn.connection_type,
+            "provider_username": conn.provider_username,
+            "connected_at": conn.connected_at,
+        }));
+    }
+
+    Ok(())
+}
+
+async fn list(api_url: &str, api_key: &str, output: OutputFormat) -> Result<()> {
+    let resp = http_client()
+        .get(format!("{}/v1/user/connections", api_url))
+        .header("Authorization", format!("Bearer {}", api_key))
+        .send()
+        .await
+        .context("Failed to connect to server")?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("Failed to list connections: {} {}", status, body);
+    }
+
+    let connections: Vec<ConnectionResponse> = resp
+        .json()
+        .await
+        .context("Failed to parse connections response")?;
+
+    if output.is_text() {
+        if connections.is_empty() {
+            println!("No connections found");
+            return Ok(());
+        }
+
+        print_table_header(&[
+            ("PROVIDER", 20),
+            ("TYPE", 10),
+            ("USERNAME", 20),
+            ("CONNECTED", 20),
+        ]);
+
+        for conn in &connections {
+            let username = conn.provider_username.as_deref().unwrap_or("-");
+            print_table_row(&[
+                (&conn.provider, 20),
+                (&conn.connection_type, 10),
+                (username, 20),
+                (&conn.connected_at, 20),
+            ]);
+        }
+    } else {
+        output.print_value(&serde_json::json!({
+            "data": connections.iter().map(|c| serde_json::json!({
+                "provider": c.provider,
+                "connection_type": c.connection_type,
+                "provider_username": c.provider_username,
+                "connected_at": c.connected_at,
+            })).collect::<Vec<_>>()
+        }));
+    }
+
+    Ok(())
+}
+
+async fn remove(
+    api_url: &str,
+    api_key: &str,
+    output: OutputFormat,
+    quiet: bool,
+    provider: &str,
+) -> Result<()> {
+    let resp = http_client()
+        .delete(format!("{}/v1/user/connections/{}", api_url, provider))
+        .header("Authorization", format!("Bearer {}", api_key))
+        .send()
+        .await
+        .context("Failed to connect to server")?;
+
+    let status = resp.status();
+    if status == reqwest::StatusCode::NOT_FOUND {
+        anyhow::bail!("Connection not found: {}", provider);
+    }
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("Failed to remove connection: {} {}", status, body);
+    }
+
+    if output.is_text() {
+        if !quiet {
+            println!("Disconnected: {}", provider);
+        }
+    } else {
+        output.print_value(&serde_json::json!({
+            "provider": provider,
+            "status": "disconnected",
+        }));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_api_key_request_serialization() {
+        let req = CreateApiKeyRequest {
+            api_key: "test_key_123".to_string(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("test_key_123"));
+        assert!(json.contains("api_key"));
+    }
+
+    #[test]
+    fn test_connection_response_deserialization() {
+        let json = r#"{
+            "provider": "daytona",
+            "connection_type": "api_key",
+            "provider_username": "user@example.com",
+            "connected_at": "2024-01-01T00:00:00Z"
+        }"#;
+        let conn: ConnectionResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(conn.provider, "daytona");
+        assert_eq!(conn.connection_type, "api_key");
+        assert_eq!(conn.provider_username.as_deref(), Some("user@example.com"));
+    }
+
+    #[test]
+    fn test_connection_response_deserialization_no_username() {
+        let json = r#"{
+            "provider": "brave_search",
+            "connection_type": "api_key",
+            "provider_username": null,
+            "connected_at": "2024-01-01T00:00:00Z"
+        }"#;
+        let conn: ConnectionResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(conn.provider, "brave_search");
+        assert!(conn.provider_username.is_none());
+    }
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod agents;
 pub mod capabilities;
 pub mod chat;
+pub mod connections;
 pub mod files;
 pub mod login;
 pub mod logout;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -68,6 +68,12 @@ pub enum Commands {
         command: commands::agents::AgentsCommand,
     },
 
+    /// Manage provider connections (API keys)
+    Connections {
+        #[command(subcommand)]
+        command: commands::connections::ConnectionsCommand,
+    },
+
     /// Manage capabilities
     Capabilities {
         #[command(subcommand)]
@@ -174,6 +180,9 @@ async fn main() -> anyhow::Result<()> {
             )
             .await
         }
+        Commands::Connections { command } => {
+            commands::connections::run(command, &api_url, &api_key, output_format, cli.quiet).await
+        }
         Commands::Capabilities { command } => {
             let status = match &command {
                 Some(CapabilitiesCommand::List { status }) => status.clone(),
@@ -206,7 +215,7 @@ async fn main() -> anyhow::Result<()> {
         }
         // Already handled above
         Commands::Login { .. } | Commands::Logout | Commands::Status | Commands::Orgs { .. } => {
-            unreachable!()
+            unreachable!();
         }
     }
 }
@@ -599,5 +608,53 @@ mod tests {
     fn test_cli_parse_profile() {
         let cli = Cli::try_parse_from(["everruns", "--profile", "staging", "status"]).unwrap();
         assert_eq!(cli.profile, "staging");
+    }
+
+    #[test]
+    fn test_cli_parse_connections_set() {
+        let cli = Cli::try_parse_from([
+            "everruns",
+            "connections",
+            "set",
+            "daytona",
+            "--api-key",
+            "test_key_123",
+        ])
+        .unwrap();
+        if let Commands::Connections { command } = cli.command {
+            if let commands::connections::ConnectionsCommand::Set { provider, api_key } = command {
+                assert_eq!(provider, "daytona");
+                assert_eq!(api_key, "test_key_123");
+            } else {
+                panic!("Expected Set command");
+            }
+        } else {
+            panic!("Expected Connections command");
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_connections_list() {
+        let cli = Cli::try_parse_from(["everruns", "connections", "list"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Connections {
+                command: commands::connections::ConnectionsCommand::List
+            }
+        ));
+    }
+
+    #[test]
+    fn test_cli_parse_connections_remove() {
+        let cli = Cli::try_parse_from(["everruns", "connections", "remove", "daytona"]).unwrap();
+        if let Commands::Connections { command } = cli.command {
+            if let commands::connections::ConnectionsCommand::Remove { provider } = command {
+                assert_eq!(provider, "daytona");
+            } else {
+                panic!("Expected Remove command");
+            }
+        } else {
+            panic!("Expected Connections command");
+        }
     }
 }


### PR DESCRIPTION
## What
Add `everruns connections set/list/remove` subcommands for managing API key connections from the CLI.

```bash
everruns connections set daytona --api-key "$DAYTONA_API_KEY"
everruns connections list
everruns connections remove daytona
```

Closes EVE-228.

## Why
Setting up connections for headless/CI-driven agents currently requires the UI or raw curl. CI pipelines and cloud agent environments need first-class CLI support.

## How
- New `commands/connections.rs` module with `Set`, `List`, `Remove` subcommands
- Uses raw `reqwest` calls to existing server endpoints (`POST/GET/DELETE /v1/user/connections/:provider`)
- Wired into `Commands` enum in `main.rs`
- Supports `-o json` and `--quiet` output modes

No server changes — all endpoints already exist.

## Risk
- Low
- CLI-only change calling existing, well-tested server endpoints
- No new attack surface

## Security
- Threat categories reviewed: TM-AUTH (API key auth)
- API key transmitted over TLS to the server
- No secrets stored locally by the CLI
- No security-relevant code changes beyond calling existing endpoints

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)