### PR TITLE
feat(cli): add --secret flag for session-scoped secrets

### DIFF
--- a/crates/cli/src/commands/sessions.rs
+++ b/crates/cli/src/commands/sessions.rs
@@ -1,10 +1,11 @@
 // Session management commands
 
 use crate::output::{OutputFormat, print_field, print_table_header, print_table_row};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Subcommand;
 use everruns_sdk::{CreateSessionRequest, Everruns};
 use futures::StreamExt;
+use std::collections::HashMap;
 
 #[derive(Subcommand)]
 pub enum SessionsCommand {
@@ -25,6 +26,10 @@ pub enum SessionsCommand {
         /// Model ID override (e.g. mod_xxx)
         #[arg(long)]
         model: Option<String>,
+
+        /// Session-scoped secret (repeatable, format: KEY=VALUE)
+        #[arg(long = "secret", value_name = "KEY=VALUE")]
+        secrets: Vec<String>,
     },
 
     /// List sessions
@@ -46,6 +51,8 @@ pub enum SessionsCommand {
 pub async fn run(
     command: SessionsCommand,
     client: &Everruns,
+    api_url: &str,
+    api_key: &str,
     output: OutputFormat,
     quiet: bool,
 ) -> Result<()> {
@@ -55,22 +62,34 @@ pub async fn run(
             agent,
             title,
             model,
-        } => create(client, output, quiet, harness, agent, title, model).await,
+            secrets,
+        } => {
+            create(
+                client, api_url, api_key, output, quiet, harness, agent, title, model, secrets,
+            )
+            .await
+        }
         SessionsCommand::List => list(client, output).await,
         SessionsCommand::Get { session } => get(client, output, session).await,
         SessionsCommand::Watch { session } => watch(client, output, session).await,
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn create(
     client: &Everruns,
+    api_url: &str,
+    api_key: &str,
     output: OutputFormat,
     quiet: bool,
     harness_id: Option<String>,
     agent_id: Option<String>,
     title: Option<String>,
     model_id: Option<String>,
+    raw_secrets: Vec<String>,
 ) -> Result<()> {
+    let secrets = parse_secrets(&raw_secrets)?;
+
     let mut req = CreateSessionRequest::new();
     if let Some(h) = harness_id {
         req = req.harness_id(h);
@@ -87,6 +106,11 @@ async fn create(
 
     let session = client.sessions().create_with_options(req).await?;
 
+    // Store secrets after session creation
+    if !secrets.is_empty() {
+        store_secrets(api_url, api_key, &session.id, &secrets).await?;
+    }
+
     if output.is_text() {
         if quiet {
             println!("{}", session.id);
@@ -97,9 +121,58 @@ async fn create(
             }
             let status = format!("{:?}", session.status).to_lowercase();
             print_field("Status", &status);
+            if !secrets.is_empty() {
+                print_field("Secrets", &format!("{} injected", secrets.len()));
+            }
         }
     } else {
-        output.print_value(&session);
+        let mut json = serde_json::to_value(&session)?;
+        if !secrets.is_empty() {
+            json["secrets_count"] = serde_json::json!(secrets.len());
+        }
+        output.print_value(&json);
+    }
+
+    Ok(())
+}
+
+/// Parse "KEY=VALUE" strings into a HashMap.
+fn parse_secrets(raw: &[String]) -> Result<HashMap<String, String>> {
+    let mut map = HashMap::new();
+    for entry in raw {
+        let (key, value) = entry
+            .split_once('=')
+            .with_context(|| format!("Invalid secret format (expected KEY=VALUE): {}", entry))?;
+        if key.is_empty() {
+            anyhow::bail!("Secret key cannot be empty: {}", entry);
+        }
+        map.insert(key.to_string(), value.to_string());
+    }
+    Ok(map)
+}
+
+/// Store secrets via PUT /v1/sessions/:id/storage/secrets
+async fn store_secrets(
+    api_url: &str,
+    api_key: &str,
+    session_id: &str,
+    secrets: &HashMap<String, String>,
+) -> Result<()> {
+    let resp = reqwest::Client::new()
+        .put(format!(
+            "{}/v1/sessions/{}/storage/secrets",
+            api_url, session_id
+        ))
+        .header("Authorization", format!("Bearer {}", api_key))
+        .json(&serde_json::json!({ "secrets": secrets }))
+        .send()
+        .await
+        .context("Failed to store secrets")?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("Failed to store secrets: {} {}", status, body);
     }
 
     Ok(())
@@ -362,5 +435,48 @@ fn capitalize_first(s: &str) -> String {
     match chars.next() {
         None => String::new(),
         Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_secrets_valid() {
+        let raw = vec![
+            "KEY1=value1".to_string(),
+            "KEY2=value2".to_string(),
+            "KEY3=val=with=equals".to_string(),
+        ];
+        let secrets = parse_secrets(&raw).unwrap();
+        assert_eq!(secrets.len(), 3);
+        assert_eq!(secrets["KEY1"], "value1");
+        assert_eq!(secrets["KEY3"], "val=with=equals");
+    }
+
+    #[test]
+    fn test_parse_secrets_empty() {
+        let secrets = parse_secrets(&[]).unwrap();
+        assert!(secrets.is_empty());
+    }
+
+    #[test]
+    fn test_parse_secrets_missing_equals() {
+        let raw = vec!["NOEQUALS".to_string()];
+        assert!(parse_secrets(&raw).is_err());
+    }
+
+    #[test]
+    fn test_parse_secrets_empty_key() {
+        let raw = vec!["=value".to_string()];
+        assert!(parse_secrets(&raw).is_err());
+    }
+
+    #[test]
+    fn test_parse_secrets_empty_value_allowed() {
+        let raw = vec!["KEY=".to_string()];
+        let secrets = parse_secrets(&raw).unwrap();
+        assert_eq!(secrets["KEY"], "");
     }
 }

--- a/crates/cli/src/commands/sessions.rs
+++ b/crates/cli/src/commands/sessions.rs
@@ -146,6 +146,9 @@ fn parse_secrets(raw: &[String]) -> Result<HashMap<String, String>> {
         if key.is_empty() {
             anyhow::bail!("Secret key cannot be empty: {}", entry);
         }
+        if map.contains_key(key) {
+            anyhow::bail!("Duplicate secret key: {}", key);
+        }
         map.insert(key.to_string(), value.to_string());
     }
     Ok(map)
@@ -478,5 +481,18 @@ mod tests {
         let raw = vec!["KEY=".to_string()];
         let secrets = parse_secrets(&raw).unwrap();
         assert_eq!(secrets["KEY"], "");
+    }
+
+    #[test]
+    fn test_parse_secrets_duplicate_key() {
+        let raw = vec!["KEY=value1".to_string(), "KEY=value2".to_string()];
+        let result = parse_secrets(&raw);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Duplicate secret key")
+        );
     }
 }

--- a/crates/cli/src/commands/sessions.rs
+++ b/crates/cli/src/commands/sessions.rs
@@ -155,6 +155,7 @@ fn parse_secrets(raw: &[String]) -> Result<HashMap<String, String>> {
 }
 
 /// Store secrets via PUT /v1/sessions/:id/storage/secrets
+// TODO(everruns/sdk#67): Replace raw reqwest with native SDK client.sessions().set_secrets()
 async fn store_secrets(
     api_url: &str,
     api_key: &str,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -182,7 +182,15 @@ async fn main() -> anyhow::Result<()> {
             commands::capabilities::run(&client, output_format, &status).await
         }
         Commands::Sessions { command } => {
-            commands::sessions::run(command, &client, output_format, cli.quiet).await
+            commands::sessions::run(
+                command,
+                &client,
+                &api_url,
+                &api_key,
+                output_format,
+                cli.quiet,
+            )
+            .await
         }
         Commands::Files { command } => {
             commands::files::run(command, &api_url, &api_key, output_format, cli.quiet).await
@@ -258,12 +266,14 @@ mod tests {
                 agent,
                 title,
                 model,
+                secrets,
             } = command
             {
                 assert_eq!(harness, Some("harness_abc".to_string()));
                 assert_eq!(agent, Some("agt_abc".to_string()));
                 assert_eq!(title, Some("Test Session".to_string()));
                 assert_eq!(model, None);
+                assert!(secrets.is_empty());
             } else {
                 panic!("Expected Create command");
             }
@@ -276,8 +286,39 @@ mod tests {
     fn test_cli_parse_sessions_create_no_harness() {
         let cli = Cli::try_parse_from(["everruns", "sessions", "create"]).unwrap();
         if let Commands::Sessions { command } = cli.command {
-            if let commands::sessions::SessionsCommand::Create { harness, .. } = command {
+            if let commands::sessions::SessionsCommand::Create {
+                harness, secrets, ..
+            } = command
+            {
                 assert_eq!(harness, None); // org default
+                assert!(secrets.is_empty());
+            } else {
+                panic!("Expected Create command");
+            }
+        } else {
+            panic!("Expected Sessions command");
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_sessions_create_with_secrets() {
+        let cli = Cli::try_parse_from([
+            "everruns",
+            "sessions",
+            "create",
+            "--agent",
+            "agt_abc",
+            "--secret",
+            "KEY1=value1",
+            "--secret",
+            "KEY2=value2",
+        ])
+        .unwrap();
+        if let Commands::Sessions { command } = cli.command {
+            if let commands::sessions::SessionsCommand::Create { secrets, .. } = command {
+                assert_eq!(secrets.len(), 2);
+                assert_eq!(secrets[0], "KEY1=value1");
+                assert_eq!(secrets[1], "KEY2=value2");
             } else {
                 panic!("Expected Create command");
             }

--- a/crates/server/src/api/session_storage.rs
+++ b/crates/server/src/api/session_storage.rs
@@ -4,6 +4,7 @@
 
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::storage::StorageBackend;
+use crate::storage::encryption::EncryptionService;
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -11,11 +12,14 @@ use axum::{
     routing::get,
 };
 use everruns_core::SessionId;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::sync::Arc;
 use utoipa::ToSchema;
 
-use super::common::{ApiResultExt, ListResponse, impl_auth_state, verify_session_ownership};
+use super::common::{
+    ApiResult, ApiResultExt, ErrorResponse, ListResponse, impl_auth_state, verify_session_ownership,
+};
 
 /// Key-value entry info (key and timestamps, no value)
 #[derive(Debug, Clone, Serialize, ToSchema)]
@@ -41,16 +45,39 @@ pub struct SecretInfo {
     pub updated_at: String,
 }
 
+/// Batch secret set request
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct BatchSetSecretsRequest {
+    /// Map of secret names to values
+    pub secrets: HashMap<String, String>,
+}
+
+/// Batch secret set response
+#[derive(Debug, Serialize, ToSchema)]
+pub struct BatchSetSecretsResponse {
+    /// Number of secrets stored
+    pub count: usize,
+}
+
 /// App state for session storage routes
 #[derive(Clone)]
 pub struct AppState {
     pub db: Arc<StorageBackend>,
+    pub encryption: Option<Arc<EncryptionService>>,
     pub auth: AuthState,
 }
 
 impl AppState {
-    pub fn new(db: Arc<StorageBackend>, auth: AuthState) -> Self {
-        Self { db, auth }
+    pub fn new(
+        db: Arc<StorageBackend>,
+        encryption: Option<Arc<EncryptionService>>,
+        auth: AuthState,
+    ) -> Self {
+        Self {
+            db,
+            encryption,
+            auth,
+        }
     }
 }
 
@@ -62,7 +89,7 @@ pub fn routes(state: AppState) -> Router {
         .route("/v1/sessions/{session_id}/storage/keys", get(list_keys))
         .route(
             "/v1/sessions/{session_id}/storage/secrets",
-            get(list_secrets),
+            get(list_secrets).put(batch_set_secrets),
         )
         .with_state(state)
 }
@@ -158,6 +185,80 @@ pub async fn list_secrets(
     Ok(Json(ListResponse::new(items)))
 }
 
+/// PUT /v1/sessions/{session_id}/storage/secrets - Batch set secrets
+///
+/// Encrypts and stores multiple secrets in a single request.
+/// Existing secrets with the same name are overwritten.
+#[utoipa::path(
+    put,
+    path = "/v1/sessions/{session_id}/storage/secrets",
+    params(
+        ("session_id" = String, Path, description = "Session ID")
+    ),
+    request_body = BatchSetSecretsRequest,
+    responses(
+        (status = 200, description = "Secrets stored", body = BatchSetSecretsResponse),
+        (status = 400, description = "Bad request (encryption not configured or invalid input)"),
+        (status = 404, description = "Session not found"),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = "session-storage"
+)]
+pub async fn batch_set_secrets(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+    Json(body): Json<BatchSetSecretsRequest>,
+) -> ApiResult<BatchSetSecretsResponse> {
+    let session_id: SessionId = session_id.parse().map_err(|_| {
+        ErrorResponse::new("Invalid session ID").into_response(StatusCode::BAD_REQUEST)
+    })?;
+    verify_session_ownership(&state.db, org.org_id, session_id)
+        .await
+        .map_err(|status| ErrorResponse::new("Session not found").into_response(status))?;
+
+    let encryption = state.encryption.as_ref().ok_or_else(|| {
+        ErrorResponse::new(
+            "Encryption not configured. Set SECRETS_ENCRYPTION_KEY environment variable.",
+        )
+        .into_response(StatusCode::BAD_REQUEST)
+    })?;
+
+    if body.secrets.is_empty() {
+        return Ok(Json(BatchSetSecretsResponse { count: 0 }));
+    }
+
+    // Validate key lengths
+    for name in body.secrets.keys() {
+        if name.len() > 255 {
+            return Err(
+                ErrorResponse::new(format!("Secret name too long (max 255): {}", name))
+                    .into_response(StatusCode::BAD_REQUEST),
+            );
+        }
+    }
+
+    let count = body.secrets.len();
+    for (name, value) in &body.secrets {
+        let encrypted = encryption.encrypt_string(value).map_err(|e| {
+            tracing::error!("Encryption failed for secret '{}': {}", name, e);
+            ErrorResponse::internal_error()
+        })?;
+
+        let input = crate::storage::models::UpsertSessionSecret {
+            session_id,
+            name: name.clone(),
+            value_encrypted: encrypted,
+        };
+        state.db.upsert_session_secret(input).await.map_err(|e| {
+            tracing::error!("Failed to store secret '{}': {}", name, e);
+            ErrorResponse::internal_error()
+        })?;
+    }
+
+    Ok(Json(BatchSetSecretsResponse { count }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -186,5 +287,28 @@ mod tests {
         assert!(json.contains("api_key"));
         // Ensure no value field exists
         assert!(!json.contains("value"));
+    }
+
+    #[test]
+    fn test_batch_set_secrets_request_deserialization() {
+        let json = r#"{"secrets":{"KEY1":"value1","KEY2":"value2"}}"#;
+        let req: BatchSetSecretsRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.secrets.len(), 2);
+        assert_eq!(req.secrets["KEY1"], "value1");
+        assert_eq!(req.secrets["KEY2"], "value2");
+    }
+
+    #[test]
+    fn test_batch_set_secrets_response_serialization() {
+        let resp = BatchSetSecretsResponse { count: 3 };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"count\":3"));
+    }
+
+    #[test]
+    fn test_batch_set_secrets_request_empty() {
+        let json = r#"{"secrets":{}}"#;
+        let req: BatchSetSecretsRequest = serde_json::from_str(json).unwrap();
+        assert!(req.secrets.is_empty());
     }
 }

--- a/crates/server/src/api/session_storage.rs
+++ b/crates/server/src/api/session_storage.rs
@@ -215,7 +215,12 @@ pub async fn batch_set_secrets(
     })?;
     verify_session_ownership(&state.db, org.org_id, session_id)
         .await
-        .map_err(|status| ErrorResponse::new("Session not found").into_response(status))?;
+        .map_err(|status| match status {
+            StatusCode::NOT_FOUND => {
+                ErrorResponse::new("Session not found").into_response(StatusCode::NOT_FOUND)
+            }
+            _ => ErrorResponse::internal_error(),
+        })?;
 
     let encryption = state.encryption.as_ref().ok_or_else(|| {
         ErrorResponse::new(
@@ -228,13 +233,15 @@ pub async fn batch_set_secrets(
         return Ok(Json(BatchSetSecretsResponse { count: 0 }));
     }
 
-    // Validate key lengths
+    // Validate secret names
     for name in body.secrets.keys() {
-        if name.len() > 255 {
-            return Err(
-                ErrorResponse::new(format!("Secret name too long (max 255): {}", name))
-                    .into_response(StatusCode::BAD_REQUEST),
-            );
+        let trimmed = name.trim();
+        if trimmed.is_empty() || trimmed.len() > 255 {
+            return Err(ErrorResponse::new(format!(
+                "Secret name must be between 1 and 255 non-whitespace characters: '{}'",
+                name
+            ))
+            .into_response(StatusCode::BAD_REQUEST));
         }
     }
 

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -566,7 +566,7 @@ impl ServerAppBuilder {
         let session_files_state = api::session_files::AppState::new(db.clone(), auth_state.clone());
         let session_git_state = api::session_git::AppState::new(db.clone(), auth_state.clone());
         let session_storage_state =
-            api::session_storage::AppState::new(db.clone(), auth_state.clone());
+            api::session_storage::AppState::new(db.clone(), encryption.clone(), auth_state.clone());
         let session_databases_state = api::session_databases::AppState::new(
             sqldb_store.clone(),
             db.clone(),

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -229,7 +229,7 @@ impl TestServer {
         let session_files_state = api::session_files::AppState::new(db.clone(), auth_state.clone());
         let session_git_state = api::session_git::AppState::new(db.clone(), auth_state.clone());
         let session_storage_state =
-            api::session_storage::AppState::new(db.clone(), auth_state.clone());
+            api::session_storage::AppState::new(db.clone(), None, auth_state.clone());
         // Session SQL database store (in-memory for all test modes)
         let sqldb_backend = Arc::new(everruns_session_sqldb::InMemorySqlDbBackend::new());
         let sqldb_store: Arc<dyn everruns_core::session_sqldb::SessionSqlDbStore> = Arc::new(


### PR DESCRIPTION
## What
Add `--secret KEY=VALUE` (repeatable) flag to `everruns sessions create` for injecting encrypted session-scoped secrets at creation time.

```bash
everruns sessions create \
  --agent agt_test_runner \
  --secret STAGING_URL="https://staging.example.com" \
  --secret STAGING_API_KEY="sk_staging_xxx"
```

Server-side: new `PUT /v1/sessions/:id/storage/secrets` batch endpoint.

Closes EVE-229.

## Why
Agents sometimes need session-scoped secrets (test credentials, API tokens, environment config) that aren't tied to a connection provider. Currently there's no way to inject these at session creation time from the CLI — the agent has to ask in chat (which stores them plaintext in events, TM-AGENT-016).

## How

### Server
- Added `PUT /v1/sessions/{session_id}/storage/secrets` endpoint in `session_storage.rs`
- Accepts `{ "secrets": { "KEY": "VALUE" } }`, encrypts each value with existing `EncryptionService` (AES-256-GCM envelope encryption), stores via `upsert_session_secret`
- `session_storage::AppState` now carries `Option<Arc<EncryptionService>>`
- Returns clear error if encryption not configured

### CLI
- Added `--secret KEY=VALUE` (repeatable) flag to `sessions create`
- Parses secrets upfront for early validation (split on first `=`)
- After session creation, calls the batch secrets endpoint
- Text output shows "N injected", JSON output includes `secrets_count`

## Risk
- Low
- Secrets endpoint reuses the same encryption path as the `secret_store` tool
- No new key material or crypto primitives

## Security
- Threat categories reviewed: TM-AGENT-016 (secrets in events), TM-ENCRYPT (encryption at rest)
- Secrets encrypted before storage, never returned in responses or events
- Endpoint requires session ownership verification
- Returns 400 if encryption not configured (no silent fallback to plaintext)

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)