### PR TITLE
feat(core): add PostToolExecHook and tool output persistence (EVE-222)

### DIFF
--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -331,12 +331,18 @@ where
         mut self,
         registry: crate::capabilities::CapabilityRegistry,
     ) -> Self {
-        // Collect post-tool-exec hooks from all capabilities in the registry
-        for capability in registry.list() {
-            self.post_tool_hooks
-                .extend(capability.post_tool_exec_hooks());
-        }
         self.capability_registry = Some(registry);
+        self
+    }
+
+    /// Add capability-contributed post-tool-exec hooks.
+    /// Callers should pass hooks from the *active* capabilities for this session,
+    /// not from the full platform registry.
+    pub fn with_post_tool_hooks(
+        mut self,
+        hooks: Vec<Arc<dyn act_hooks::PostToolExecHook>>,
+    ) -> Self {
+        self.post_tool_hooks.extend(hooks);
         self
     }
 
@@ -725,6 +731,7 @@ where
                     images: None,
                     error: Some(error_msg),
                     connection_required: None,
+                    raw_output: None,
                 },
                 success: false,
                 status: "error".to_string(),
@@ -935,6 +942,7 @@ where
                         images: None,
                         error: Some(error_msg),
                         connection_required: None,
+                        raw_output: None,
                     },
                     success: false,
                     status: "error".to_string(),
@@ -1146,6 +1154,7 @@ mod tests {
                     images: None,
                     error: None,
                     connection_required: Some("daytona".to_string()),
+                    raw_output: None,
                 },
                 success: false,
                 status: "success".to_string(),

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -178,6 +178,12 @@ where
     /// Post-act hooks that run after tool execution completes.
     /// Hooks inspect the result and may emit events (e.g. tool.call_requested).
     hooks: Vec<Box<dyn PostActHook>>,
+    /// Post-tool-exec hooks (capability-contributed): run after each individual
+    /// tool execution. Capabilities register these via `post_tool_exec_hooks()`.
+    post_tool_hooks: Vec<Arc<dyn act_hooks::PostToolExecHook>>,
+    /// Final post-tool-exec hooks (infrastructure): run after capability hooks.
+    /// Always registered, cannot be removed by capabilities (EVE-225).
+    final_post_tool_hooks: Vec<Arc<dyn act_hooks::PostToolExecHook>>,
 }
 
 impl<T, E> ActAtom<T, E>
@@ -204,6 +210,8 @@ where
             memory_store: None,
             org_id: None,
             hooks: Self::default_hooks(),
+            post_tool_hooks: Vec::new(),
+            final_post_tool_hooks: Vec::new(),
         }
     }
 
@@ -230,6 +238,8 @@ where
             memory_store: None,
             org_id: None,
             hooks: Self::default_hooks(),
+            post_tool_hooks: Vec::new(),
+            final_post_tool_hooks: Vec::new(),
         }
     }
 
@@ -321,6 +331,11 @@ where
         mut self,
         registry: crate::capabilities::CapabilityRegistry,
     ) -> Self {
+        // Collect post-tool-exec hooks from all capabilities in the registry
+        for capability in registry.list() {
+            self.post_tool_hooks
+                .extend(capability.post_tool_exec_hooks());
+        }
         self.capability_registry = Some(registry);
         self
     }
@@ -768,7 +783,18 @@ where
             .await;
 
         match result {
-            Ok(tool_result) => {
+            Ok(mut tool_result) => {
+                // Run post-tool-exec hooks (capability then final/infrastructure)
+                act_hooks::run_post_tool_exec_hooks(
+                    &self.post_tool_hooks,
+                    &self.final_post_tool_hooks,
+                    &tool_call,
+                    tool_def,
+                    &mut tool_result,
+                    &tool_context,
+                )
+                .await;
+
                 let tool_duration_ms = tool_start.elapsed().as_millis() as u64;
                 let success = tool_result.error.is_none();
                 let status = if success { "success" } else { "error" };

--- a/crates/core/src/atoms/act_hooks.rs
+++ b/crates/core/src/atoms/act_hooks.rs
@@ -247,6 +247,7 @@ mod tests {
                 images: None,
                 error: None,
                 connection_required: connection_required.map(|s| s.to_string()),
+                raw_output: None,
             },
             success: true,
             status: "success".to_string(),

--- a/crates/core/src/atoms/act_hooks.rs
+++ b/crates/core/src/atoms/act_hooks.rs
@@ -6,15 +6,66 @@
 //
 // Decision: Hooks set `waiting_for_tool_results` on ActResult so workers
 // see a single generic flag — they never need to know WHY the act paused.
+//
+// PostToolExecHook (EVE-222): async hooks that run after each individual tool
+// execution. Unlike PostActHook (runs once after all tools), these run per-tool
+// and can mutate the result (e.g. persist output to VFS, inject metadata).
 
 use crate::events::{EventContext, EventRequest, ToolCallRequestedData};
-use crate::tool_types::{ToolCall, ToolDefinition};
-use crate::traits::EventEmitter;
+use crate::tool_types::{ToolCall, ToolDefinition, ToolResult};
+use crate::traits::{EventEmitter, ToolContext};
+use async_trait::async_trait;
 use serde_json::json;
+use std::sync::Arc;
 use uuid::Uuid;
 
 use super::AtomContext;
 use super::act::ActResult;
+
+// ============================================================================
+// PostToolExecHook trait (per-tool, async)
+// ============================================================================
+
+/// Hook that runs after each individual tool execution completes.
+///
+/// Unlike `PostActHook` (which runs once after all tools in a batch),
+/// `PostToolExecHook` runs per-tool and can:
+/// - Persist tool output to session VFS (EVE-222)
+/// - Inject metadata into the result (e.g. `full_output` path)
+/// - Enforce hard limits on result size (EVE-225)
+///
+/// Hooks are async because they may perform I/O (VFS writes).
+/// Capability-contributed hooks run first, then final (infrastructure) hooks.
+#[async_trait]
+pub trait PostToolExecHook: Send + Sync {
+    /// Called after a tool returns its result, before ActAtom emits events.
+    async fn after_exec(
+        &self,
+        tool_call: &ToolCall,
+        tool_def: &ToolDefinition,
+        result: &mut ToolResult,
+        context: &ToolContext,
+    );
+}
+
+/// Execute post-tool-exec hooks on a single tool result.
+///
+/// Runs capability-contributed hooks first, then final (infrastructure) hooks.
+pub(super) async fn run_post_tool_exec_hooks(
+    hooks: &[Arc<dyn PostToolExecHook>],
+    final_hooks: &[Arc<dyn PostToolExecHook>],
+    tool_call: &ToolCall,
+    tool_def: &ToolDefinition,
+    result: &mut ToolResult,
+    context: &ToolContext,
+) {
+    for hook in hooks {
+        hook.after_exec(tool_call, tool_def, result, context).await;
+    }
+    for hook in final_hooks {
+        hook.after_exec(tool_call, tool_def, result, context).await;
+    }
+}
 
 // ============================================================================
 // PostActHook trait

--- a/crates/core/src/atoms/mod.rs
+++ b/crates/core/src/atoms/mod.rs
@@ -29,7 +29,9 @@ mod reason;
 
 // Re-export atoms and their types
 pub use act::{ActAtom, ActInput, ActResult, ToolCallResult};
-pub use act_hooks::{ClientSideToolHook, ConnectionSetupHook, PostActAction, PostActHook};
+pub use act_hooks::{
+    ClientSideToolHook, ConnectionSetupHook, PostActAction, PostActHook, PostToolExecHook,
+};
 pub use input::{InputAtom, InputAtomInput, InputAtomResult};
 pub use reason::{ReasonAtom, ReasonInput, ReasonResult};
 

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -1376,6 +1376,7 @@ mod tests {
             "system_commands",
             "openui",
             "sample_data",
+            "tool_output_persistence",
             "fake_warehouse",
             "fake_aws",
             "fake_crm",

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -100,6 +100,7 @@ mod subagents;
 mod system_commands;
 mod test_math;
 mod test_weather;
+mod tool_output_persistence;
 mod virtual_bash;
 mod web_fetch;
 
@@ -436,6 +437,17 @@ pub trait Capability: Send + Sync {
         None
     }
 
+    /// Returns post-tool execution hooks provided by this capability.
+    ///
+    /// These hooks run after each individual tool completes execution.
+    /// They can persist output, inject metadata, or transform results.
+    /// Capability-contributed hooks run before infrastructure (final) hooks.
+    ///
+    /// By default, returns an empty vector (no hooks).
+    fn post_tool_exec_hooks(&self) -> Vec<Arc<dyn crate::atoms::PostToolExecHook>> {
+        vec![]
+    }
+
     /// Returns the risk level of this capability.
     ///
     /// TM-AGENT-005: High-risk capabilities (code execution, network access)
@@ -631,6 +643,9 @@ impl CapabilityRegistry {
 
         // System commands (/clear, /status, /compact, /model)
         registry.register(SystemCommandsCapability);
+
+        // Tool output persistence (EVE-222: persist exec output to VFS)
+        registry.register(tool_output_persistence::ToolOutputPersistenceCapability);
 
         // OpenUI generative UI (all environments)
         registry.register(OpenUiCapability);

--- a/crates/core/src/capabilities/tool_output_persistence.rs
+++ b/crates/core/src/capabilities/tool_output_persistence.rs
@@ -69,21 +69,35 @@ impl PostToolExecHook for PersistOutputHook {
             return;
         }
 
+        // Take raw_output (pre-truncation cleaned output) if available.
+        // Falls back to extracting from the (truncated) result JSON.
+        let output_text = result.raw_output.take().unwrap_or_else(|| {
+            result
+                .result
+                .as_ref()
+                .map(extract_output_text)
+                .unwrap_or_default()
+        });
+        if output_text.is_empty() {
+            return;
+        }
+
         // Need file_store from context
         let Some(ref file_store) = context.file_store else {
             return;
         };
 
-        // Extract text content from result JSON
-        let Some(ref result_json) = result.result else {
-            return;
-        };
-        let output_text = extract_output_text(result_json);
-        if output_text.is_empty() {
+        // Sanitize tool_call.id for path safety — use only alphanumeric, dash, underscore
+        let safe_id: String = tool_call
+            .id
+            .chars()
+            .filter(|c| c.is_alphanumeric() || *c == '-' || *c == '_')
+            .collect();
+        if safe_id.is_empty() {
             return;
         }
 
-        let path = format!("/.exec-logs/{}.log", tool_call.id);
+        let path = format!("/.exec-logs/{safe_id}.log");
         let total_lines = output_text.lines().count();
 
         if let Err(e) = file_store

--- a/crates/core/src/capabilities/tool_output_persistence.rs
+++ b/crates/core/src/capabilities/tool_output_persistence.rs
@@ -1,0 +1,205 @@
+// Tool Output Persistence Capability (EVE-222)
+//
+// Persists full exec tool output to session VFS before truncation,
+// enabling lossless retrieval via read_file/grep. The LLM gets a
+// truncated summary with a `full_output` path to the full log.
+//
+// Design decisions:
+// - Implemented as PostToolExecHook, not baked into each tool — VFS
+//   persistence is a cross-cutting concern the tool shouldn't know about
+// - Reads `persist_output` hint from ToolDefinition to decide what to persist
+// - Writes to /.exec-logs/{tool_call_id}.log (dot-prefixed, session-scoped)
+// - Graceful degradation: skip silently if file_store is unavailable
+// - Runs before FinalPostToolExecHook (EVE-225 hard limit)
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::json;
+
+use super::{Capability, CapabilityStatus};
+use crate::atoms::PostToolExecHook;
+use crate::tool_types::{ToolCall, ToolDefinition, ToolResult};
+use crate::traits::ToolContext;
+
+/// Capability that persists full tool output to session VFS.
+pub struct ToolOutputPersistenceCapability;
+
+impl Capability for ToolOutputPersistenceCapability {
+    fn id(&self) -> &str {
+        "tool_output_persistence"
+    }
+
+    fn name(&self) -> &str {
+        "Tool Output Persistence"
+    }
+
+    fn description(&self) -> &str {
+        "Persists full exec tool output to session VFS before truncation, \
+         enabling lossless retrieval via read_file or grep."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn dependencies(&self) -> Vec<&'static str> {
+        vec!["session_file_system"]
+    }
+
+    fn post_tool_exec_hooks(&self) -> Vec<Arc<dyn PostToolExecHook>> {
+        vec![Arc::new(PersistOutputHook)]
+    }
+}
+
+/// Hook that persists tool output to VFS when `persist_output` hint is set.
+struct PersistOutputHook;
+
+#[async_trait]
+impl PostToolExecHook for PersistOutputHook {
+    async fn after_exec(
+        &self,
+        tool_call: &ToolCall,
+        tool_def: &ToolDefinition,
+        result: &mut ToolResult,
+        context: &ToolContext,
+    ) {
+        // Only persist if tool declares persist_output hint
+        if tool_def.hints().persist_output != Some(true) {
+            return;
+        }
+
+        // Need file_store from context
+        let Some(ref file_store) = context.file_store else {
+            return;
+        };
+
+        // Extract text content from result JSON
+        let Some(ref result_json) = result.result else {
+            return;
+        };
+        let output_text = extract_output_text(result_json);
+        if output_text.is_empty() {
+            return;
+        }
+
+        let path = format!("/.exec-logs/{}.log", tool_call.id);
+        let total_lines = output_text.lines().count();
+
+        if let Err(e) = file_store
+            .write_file(context.session_id, &path, &output_text, "utf-8")
+            .await
+        {
+            tracing::warn!(
+                tool_name = %tool_call.name,
+                tool_call_id = %tool_call.id,
+                error = %e,
+                "PersistOutputHook: failed to write exec log"
+            );
+            return;
+        }
+
+        // Enrich result JSON with file reference
+        if let Some(ref mut json_val) = result.result
+            && let Some(obj) = json_val.as_object_mut()
+        {
+            obj.insert("full_output".to_string(), json!(path));
+            obj.insert("total_lines".to_string(), json!(total_lines));
+        }
+    }
+}
+
+/// Extract readable text content from a tool result JSON value.
+///
+/// Looks for common exec tool output fields: `stdout`, `stderr`, `output`.
+/// Concatenates them into a single string for persistence.
+fn extract_output_text(json: &serde_json::Value) -> String {
+    let mut parts = Vec::new();
+
+    if let Some(stdout) = json.get("stdout").and_then(|v| v.as_str())
+        && !stdout.is_empty()
+    {
+        parts.push(stdout);
+    }
+    if let Some(stderr) = json.get("stderr").and_then(|v| v.as_str())
+        && !stderr.is_empty()
+    {
+        if !parts.is_empty() {
+            parts.push("\n--- stderr ---\n");
+        }
+        parts.push(stderr);
+    }
+    // Fallback: if no stdout/stderr, try "output" field (daytona_exec)
+    if parts.is_empty()
+        && let Some(output) = json.get("output").and_then(|v| v.as_str())
+        && !output.is_empty()
+    {
+        parts.push(output);
+    }
+
+    parts.join("")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_output_text_stdout_stderr() {
+        let json = json!({
+            "stdout": "hello world",
+            "stderr": "warning: unused variable",
+            "exit_code": 0
+        });
+        let text = extract_output_text(&json);
+        assert!(text.contains("hello world"));
+        assert!(text.contains("warning: unused variable"));
+        assert!(text.contains("--- stderr ---"));
+    }
+
+    #[test]
+    fn test_extract_output_text_stdout_only() {
+        let json = json!({
+            "stdout": "hello",
+            "stderr": "",
+            "exit_code": 0
+        });
+        assert_eq!(extract_output_text(&json), "hello");
+    }
+
+    #[test]
+    fn test_extract_output_text_output_field() {
+        let json = json!({
+            "output": "combined output",
+            "exit_code": 0
+        });
+        assert_eq!(extract_output_text(&json), "combined output");
+    }
+
+    #[test]
+    fn test_extract_output_text_empty() {
+        let json = json!({ "exit_code": 0 });
+        assert_eq!(extract_output_text(&json), "");
+    }
+
+    #[test]
+    fn test_extract_output_text_prefers_stdout_over_output() {
+        let json = json!({
+            "stdout": "from stdout",
+            "output": "from output",
+            "exit_code": 0
+        });
+        // stdout takes precedence — output field is fallback
+        let text = extract_output_text(&json);
+        assert!(text.contains("from stdout"));
+        assert!(!text.contains("from output"));
+    }
+
+    #[test]
+    fn test_capability_metadata() {
+        let cap = ToolOutputPersistenceCapability;
+        assert_eq!(cap.id(), "tool_output_persistence");
+        assert!(!cap.post_tool_exec_hooks().is_empty());
+        assert!(cap.dependencies().contains(&"session_file_system"));
+    }
+}

--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -267,15 +267,28 @@ impl Tool for BashTool {
 
         match result {
             Ok(Ok(output)) => {
-                use crate::tool_output_sanitizer::{EXEC_OUTPUT_BUDGET, sanitize_exec_output};
-                let stdout = sanitize_exec_output(&output.stdout, EXEC_OUTPUT_BUDGET);
-                let stderr = sanitize_exec_output(&output.stderr, 4096);
-                ToolExecutionResult::success(json!({
-                    "stdout": stdout,
-                    "stderr": stderr,
-                    "exit_code": output.exit_code,
-                    "success": output.exit_code == 0
-                }))
+                use crate::tool_output_sanitizer::{
+                    EXEC_OUTPUT_BUDGET, clean_exec_output, middle_truncate,
+                };
+                let clean_stdout = clean_exec_output(&output.stdout);
+                let clean_stderr = clean_exec_output(&output.stderr);
+                let stdout = middle_truncate(&clean_stdout, EXEC_OUTPUT_BUDGET);
+                let stderr = middle_truncate(&clean_stderr, 4096);
+                // Build raw output for persistence hook (cleaned but not truncated)
+                let mut raw = clean_stdout;
+                if !clean_stderr.is_empty() {
+                    raw.push_str("\n--- stderr ---\n");
+                    raw.push_str(&clean_stderr);
+                }
+                ToolExecutionResult::success_with_raw_output(
+                    json!({
+                        "stdout": stdout,
+                        "stderr": stderr,
+                        "exit_code": output.exit_code,
+                        "success": output.exit_code == 0
+                    }),
+                    raw,
+                )
             }
             Ok(Err(e)) => {
                 // Execution error (syntax error, resource limit, etc.)

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -218,8 +218,8 @@ pub use capabilities::{
 // Atoms re-exports (stateless atomic operations)
 pub use atoms::{
     ActAtom, ActInput, ActResult, Atom, AtomContext, ClientSideToolHook, ConnectionSetupHook,
-    InputAtom, InputAtomInput, InputAtomResult, PostActAction, PostActHook, ReasonAtom,
-    ReasonInput, ReasonResult, ToolCallResult,
+    InputAtom, InputAtomInput, InputAtomResult, PostActAction, PostActHook, PostToolExecHook,
+    ReasonAtom, ReasonInput, ReasonResult, ToolCallResult,
 };
 
 // Tool types (runtime types defined in this crate)

--- a/crates/core/src/memory.rs
+++ b/crates/core/src/memory.rs
@@ -511,6 +511,7 @@ impl ToolExecutor for MockToolExecutor {
             images: None,
             error: None,
             connection_required: None,
+            raw_output: None,
         })
     }
 }
@@ -547,6 +548,7 @@ impl ToolExecutor for EchoToolExecutor {
             images: None,
             error: None,
             connection_required: None,
+            raw_output: None,
         })
     }
 }
@@ -590,6 +592,7 @@ impl ToolExecutor for FailingToolExecutor {
             images: None,
             error: Some(self.error_message.clone()),
             connection_required: None,
+            raw_output: None,
         })
     }
 }

--- a/crates/core/src/tool_output_sanitizer.rs
+++ b/crates/core/src/tool_output_sanitizer.rs
@@ -144,11 +144,18 @@ pub fn middle_truncate(text: &str, max_bytes: usize) -> String {
     result
 }
 
+/// Clean exec output: strip ANSI → collapse CR. No truncation.
+/// Use this when you need the full cleaned output (e.g. for VFS persistence)
+/// and will truncate separately.
+pub fn clean_exec_output(text: &str) -> String {
+    let cleaned = strip_ansi(text);
+    collapse_cr_lines(&cleaned)
+}
+
 /// Full sanitization pipeline: strip ANSI → collapse CR → middle-truncate.
 pub fn sanitize_exec_output(text: &str, max_bytes: usize) -> String {
-    let cleaned = strip_ansi(text);
-    let collapsed = collapse_cr_lines(&cleaned);
-    middle_truncate(&collapsed, max_bytes)
+    let cleaned = clean_exec_output(text);
+    middle_truncate(&cleaned, max_bytes)
 }
 
 /// Find the largest byte index ≤ `pos` that is a valid UTF-8 char boundary.

--- a/crates/core/src/tool_types.rs
+++ b/crates/core/src/tool_types.rs
@@ -349,6 +349,12 @@ pub struct ToolResult {
     /// The workflow should pause and prompt the user to configure the connection.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub connection_required: Option<String>,
+    /// Pre-truncation cleaned output for persistence hooks.
+    /// Populated by exec tools (after ANSI strip + CR collapse, before truncation).
+    /// Consumed by PostToolExecHook (e.g. tool_output_persistence) then cleared.
+    /// Never serialized to messages or sent to LLM.
+    #[serde(skip)]
+    pub raw_output: Option<String>,
 }
 
 #[cfg(test)]
@@ -416,6 +422,7 @@ mod tests {
             images: None,
             error: None,
             connection_required: None,
+            raw_output: None,
         };
 
         let json = serde_json::to_string(&result).unwrap();

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -100,6 +100,17 @@ impl ToolExecutionResult {
         ToolExecutionResult::Success(value.into())
     }
 
+    /// Create a successful result with pre-truncation raw output for VFS persistence.
+    /// The raw output is transferred to `ToolResult.raw_output` during `into_tool_result()`.
+    pub fn success_with_raw_output(value: impl Into<Value>, raw_output: String) -> Self {
+        let mut value = value.into();
+        // Embed raw output in a sidecar key — extracted in into_tool_result()
+        if let Some(obj) = value.as_object_mut() {
+            obj.insert("_raw_output".to_string(), Value::String(raw_output));
+        }
+        ToolExecutionResult::Success(value)
+    }
+
     /// Create a successful result with images
     pub fn success_with_images(value: impl Into<Value>, images: Vec<ToolResultImage>) -> Self {
         ToolExecutionResult::SuccessWithImages {
@@ -160,13 +171,21 @@ impl ToolExecutionResult {
     /// Internal errors are logged but replaced with a generic message when returned.
     pub fn into_tool_result(self, tool_call_id: &str, tool_name: &str) -> ToolResult {
         match self {
-            ToolExecutionResult::Success(value) => ToolResult {
-                tool_call_id: tool_call_id.to_string(),
-                result: Some(value),
-                images: None,
-                error: None,
-                connection_required: None,
-            },
+            ToolExecutionResult::Success(mut value) => {
+                // Extract sidecar raw output if present (from success_with_raw_output)
+                let raw_output = value
+                    .as_object_mut()
+                    .and_then(|obj| obj.remove("_raw_output"))
+                    .and_then(|v| v.as_str().map(|s| s.to_string()));
+                ToolResult {
+                    tool_call_id: tool_call_id.to_string(),
+                    result: Some(value),
+                    images: None,
+                    error: None,
+                    connection_required: None,
+                    raw_output,
+                }
+            }
             ToolExecutionResult::SuccessWithImages { result, images } => ToolResult {
                 tool_call_id: tool_call_id.to_string(),
                 result: Some(result),
@@ -177,6 +196,7 @@ impl ToolExecutionResult {
                 },
                 error: None,
                 connection_required: None,
+                raw_output: None,
             },
             ToolExecutionResult::ToolError(message) => ToolResult {
                 tool_call_id: tool_call_id.to_string(),
@@ -184,6 +204,7 @@ impl ToolExecutionResult {
                 images: None,
                 error: None,
                 connection_required: None,
+                raw_output: None,
             },
             ToolExecutionResult::InternalError(err) => {
                 // Log the full error details for debugging
@@ -203,6 +224,7 @@ impl ToolExecutionResult {
                     images: None,
                     error: None,
                     connection_required: None,
+                    raw_output: None,
                 }
             }
             ToolExecutionResult::ConnectionRequired { ref provider } => ToolResult {
@@ -213,6 +235,7 @@ impl ToolExecutionResult {
                 images: None,
                 error: None,
                 connection_required: Some(provider.clone()),
+                raw_output: None,
             },
         }
     }

--- a/crates/core/tests/tool_calling_test.rs
+++ b/crates/core/tests/tool_calling_test.rs
@@ -727,6 +727,7 @@ fn test_tool_result_with_images_serialization() {
         }]),
         error: None,
         connection_required: None,
+        raw_output: None,
     };
 
     let json_str = serde_json::to_string(&result).unwrap();
@@ -777,6 +778,7 @@ fn test_connection_required_serialization_roundtrip() {
         images: None,
         error: None,
         connection_required: Some("daytona".to_string()),
+        raw_output: None,
     };
 
     let json_str = serde_json::to_string(&result).unwrap();

--- a/crates/server/tests/client_side_tools_test.rs
+++ b/crates/server/tests/client_side_tools_test.rs
@@ -339,6 +339,7 @@ fn test_tool_call_and_result_correlation() {
         images: None,
         error: None,
         connection_required: None,
+        raw_output: None,
     };
 
     // IDs correlate

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -449,7 +449,19 @@ pub async fn act_activity(
         .with_leased_resource_store(leased_resource_store)
         .with_schedule_store(schedule_store)
         .with_platform_store(platform_store)
-        .with_capability_registry(platform_definition.capability_registry().clone());
+        .with_capability_registry(platform_definition.capability_registry().clone())
+        // Collect post-tool hooks from all capabilities. Hooks self-gate on tool hints
+        // (e.g. persist_output), so this is safe even though it uses the full registry
+        // rather than only session-active capabilities. A future refinement could pass
+        // only hooks from the active capability set.
+        .with_post_tool_hooks(
+            platform_definition
+                .capability_registry()
+                .list()
+                .iter()
+                .flat_map(|c| c.post_tool_exec_hooks())
+                .collect(),
+        );
 
     atom.execute(input)
         .await
@@ -594,6 +606,7 @@ mod tests {
                     images: None,
                     error: None,
                     connection_required: None,
+                    raw_output: None,
                 },
                 success: true,
                 status: "success".to_string(),

--- a/crates/worker/src/mcp_executor.rs
+++ b/crates/worker/src/mcp_executor.rs
@@ -78,6 +78,7 @@ impl McpToolExecutor {
                 images: None,
                 error: None,
                 connection_required: Some(provider),
+                raw_output: None,
             });
         }
 
@@ -99,6 +100,7 @@ impl McpToolExecutor {
             },
             error: None,
             connection_required: None,
+            raw_output: None,
         })
     }
 

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -442,13 +442,18 @@ impl Tool for DaytonaExecTool {
                 }
                 {
                     use everruns_core::tool_output_sanitizer::{
-                        EXEC_OUTPUT_BUDGET, sanitize_exec_output,
+                        EXEC_OUTPUT_BUDGET, clean_exec_output, middle_truncate,
                     };
-                    let output = sanitize_exec_output(&result.result, EXEC_OUTPUT_BUDGET);
-                    ToolExecutionResult::success(json!({
-                        "exit_code": result.exit_code,
-                        "output": output
-                    }))
+                    let clean_output = clean_exec_output(&result.result);
+                    let output = middle_truncate(&clean_output, EXEC_OUTPUT_BUDGET);
+                    let raw = clean_output;
+                    ToolExecutionResult::success_with_raw_output(
+                        json!({
+                            "exit_code": result.exit_code,
+                            "output": output
+                        }),
+                        raw,
+                    )
                 }
             }
             Err(e) => ToolExecutionResult::tool_error(e),

--- a/integrations/deno/src/tools.rs
+++ b/integrations/deno/src/tools.rs
@@ -281,14 +281,26 @@ impl Tool for DenoExecTool {
         }
 
         {
-            use everruns_core::tool_output_sanitizer::{EXEC_OUTPUT_BUDGET, sanitize_exec_output};
-            let stdout = sanitize_exec_output(&exec.stdout, EXEC_OUTPUT_BUDGET);
-            let stderr = sanitize_exec_output(&exec.stderr, 4096);
-            ToolExecutionResult::success(json!({
-                "exit_code": exec.exit_code,
-                "stdout": stdout,
-                "stderr": stderr,
-            }))
+            use everruns_core::tool_output_sanitizer::{
+                EXEC_OUTPUT_BUDGET, clean_exec_output, middle_truncate,
+            };
+            let clean_stdout = clean_exec_output(&exec.stdout);
+            let clean_stderr = clean_exec_output(&exec.stderr);
+            let stdout = middle_truncate(&clean_stdout, EXEC_OUTPUT_BUDGET);
+            let stderr = middle_truncate(&clean_stderr, 4096);
+            let mut raw = clean_stdout;
+            if !clean_stderr.is_empty() {
+                raw.push_str("\n--- stderr ---\n");
+                raw.push_str(&clean_stderr);
+            }
+            ToolExecutionResult::success_with_raw_output(
+                json!({
+                    "exit_code": exec.exit_code,
+                    "stdout": stdout,
+                    "stderr": stderr,
+                }),
+                raw,
+            )
         }
     }
 

--- a/integrations/docker/src/lib.rs
+++ b/integrations/docker/src/lib.rs
@@ -403,16 +403,28 @@ impl Tool for DockerExecTool {
         let stdout_raw = String::from_utf8_lossy(&output.stdout);
         let stderr_raw = String::from_utf8_lossy(&output.stderr);
 
-        use everruns_core::tool_output_sanitizer::{EXEC_OUTPUT_BUDGET, sanitize_exec_output};
-        let stdout = sanitize_exec_output(&stdout_raw, EXEC_OUTPUT_BUDGET);
-        let stderr = sanitize_exec_output(&stderr_raw, 4096);
+        use everruns_core::tool_output_sanitizer::{
+            EXEC_OUTPUT_BUDGET, clean_exec_output, middle_truncate,
+        };
+        let clean_stdout = clean_exec_output(&stdout_raw);
+        let clean_stderr = clean_exec_output(&stderr_raw);
+        let stdout = middle_truncate(&clean_stdout, EXEC_OUTPUT_BUDGET);
+        let stderr = middle_truncate(&clean_stderr, 4096);
+        let mut raw = clean_stdout;
+        if !clean_stderr.is_empty() {
+            raw.push_str("\n--- stderr ---\n");
+            raw.push_str(&clean_stderr);
+        }
 
-        ToolExecutionResult::success(json!({
-            "stdout": stdout,
-            "stderr": stderr,
-            "exit_code": exit_code,
-            "success": exit_code == 0
-        }))
+        ToolExecutionResult::success_with_raw_output(
+            json!({
+                "stdout": stdout,
+                "stderr": stderr,
+                "exit_code": exit_code,
+                "success": exit_code == 0
+            }),
+            raw,
+        )
     }
 
     fn requires_context(&self) -> bool {

--- a/integrations/e2b/src/tools.rs
+++ b/integrations/e2b/src/tools.rs
@@ -302,17 +302,29 @@ impl Tool for E2BExecTool {
         }
 
         {
-            use everruns_core::tool_output_sanitizer::{EXEC_OUTPUT_BUDGET, sanitize_exec_output};
-            let stdout = sanitize_exec_output(&result.stdout, EXEC_OUTPUT_BUDGET);
-            let stderr = sanitize_exec_output(&result.stderr, 4096);
-            ToolExecutionResult::success(json!({
-                "sandbox_id": sandbox_id,
-                "cwd": cwd.unwrap_or(E2B_DEFAULT_WORKSPACE_PATH),
-                "stdout": stdout,
-                "stderr": stderr,
-                "exit_code": result.exit_code,
-                "error": result.error,
-            }))
+            use everruns_core::tool_output_sanitizer::{
+                EXEC_OUTPUT_BUDGET, clean_exec_output, middle_truncate,
+            };
+            let clean_stdout = clean_exec_output(&result.stdout);
+            let clean_stderr = clean_exec_output(&result.stderr);
+            let stdout = middle_truncate(&clean_stdout, EXEC_OUTPUT_BUDGET);
+            let stderr = middle_truncate(&clean_stderr, 4096);
+            let mut raw = clean_stdout;
+            if !clean_stderr.is_empty() {
+                raw.push_str("\n--- stderr ---\n");
+                raw.push_str(&clean_stderr);
+            }
+            ToolExecutionResult::success_with_raw_output(
+                json!({
+                    "sandbox_id": sandbox_id,
+                    "cwd": cwd.unwrap_or(E2B_DEFAULT_WORKSPACE_PATH),
+                    "stdout": stdout,
+                    "stderr": stderr,
+                    "exit_code": result.exit_code,
+                    "error": result.error,
+                }),
+                raw,
+            )
         }
     }
 

--- a/integrations/sprites/src/tools.rs
+++ b/integrations/sprites/src/tools.rs
@@ -274,15 +274,25 @@ impl Tool for SpritesExecTool {
                     return e;
                 }
                 use everruns_core::tool_output_sanitizer::{
-                    EXEC_OUTPUT_BUDGET, sanitize_exec_output,
+                    EXEC_OUTPUT_BUDGET, clean_exec_output, middle_truncate,
                 };
-                let stdout = sanitize_exec_output(&result.stdout, EXEC_OUTPUT_BUDGET);
-                let stderr = sanitize_exec_output(&result.stderr, 4096);
-                ToolExecutionResult::success(json!({
-                    "exit_code": result.exit_code,
-                    "stdout": stdout,
-                    "stderr": stderr,
-                }))
+                let clean_stdout = clean_exec_output(&result.stdout);
+                let clean_stderr = clean_exec_output(&result.stderr);
+                let stdout = middle_truncate(&clean_stdout, EXEC_OUTPUT_BUDGET);
+                let stderr = middle_truncate(&clean_stderr, 4096);
+                let mut raw = clean_stdout;
+                if !clean_stderr.is_empty() {
+                    raw.push_str("\n--- stderr ---\n");
+                    raw.push_str(&clean_stderr);
+                }
+                ToolExecutionResult::success_with_raw_output(
+                    json!({
+                        "exit_code": result.exit_code,
+                        "stdout": stdout,
+                        "stderr": stderr,
+                    }),
+                    raw,
+                )
             }
             Err(e) => ToolExecutionResult::tool_error(e),
         }

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -77,6 +77,17 @@ The pipeline:
 
 This is the tool's responsibility — each tool calls the helpers before constructing `ToolExecutionResult`. See `crates/core/src/tool_output_sanitizer.rs` for the primitives.
 
+### PostToolExecHook (per-tool hooks)
+
+`PostToolExecHook` is an async hook that runs after each individual tool execution, before ActAtom emits events. Capabilities contribute hooks via `Capability::post_tool_exec_hooks()`.
+
+Two hook slots run in sequence:
+1. **Capability hooks** (`post_tool_hooks`) — from active capabilities (e.g. `tool_output_persistence`)
+2. **Final hooks** (`final_post_tool_hooks`) — always-on infrastructure (e.g. EVE-225 hard limit)
+
+Current hooks:
+- **PersistOutputHook** (`tool_output_persistence` capability): When a tool declares `persist_output: true` in hints, writes full output to `/.exec-logs/{tool_call_id}.log` in session VFS and injects `full_output` path + `total_lines` into the result. See `crates/core/src/capabilities/tool_output_persistence.rs`.
+
 ### Tool Policies
 
 - `auto`: Execute immediately without approval


### PR DESCRIPTION
## What

Introduce `PostToolExecHook` trait for per-tool async hooks and `ToolOutputPersistenceCapability` that persists full exec output to session VFS before truncation.

## Why

EVE-221 truncates exec output to 16 KiB — the LLM loses access to full build output. This capability persists the full cleaned output to `/.exec-logs/{tool_call_id}.log` and injects a `full_output` path into the result, enabling lossless retrieval via `read_file`/`grep`.

Resolves [EVE-222](https://linear.app/everruns/issue/EVE-222).

## How

- New `PostToolExecHook` trait in `act_hooks.rs` — async hooks per-tool (unlike PostActHook per-batch)
- `Capability::post_tool_exec_hooks()` method on the Capability trait
- ActAtom runs hooks after each tool execution, before event emission
- Two hook slots: capability-contributed (first) + final/infrastructure (last, for EVE-225)
- `ToolOutputPersistenceCapability` reads `persist_output` hint, writes to VFS, enriches result
- All 6 exec tools already declare `persist_output: true` (from EVE-221)
- Graceful degradation: skip if file_store unavailable

### Files changed

| File | Change |
|------|--------|
| `crates/core/src/atoms/act_hooks.rs` | New `PostToolExecHook` trait + `run_post_tool_exec_hooks` |
| `crates/core/src/atoms/act.rs` | Hook storage, collection from registry, execution after each tool |
| `crates/core/src/atoms/mod.rs` | Re-export `PostToolExecHook` |
| `crates/core/src/capabilities/mod.rs` | `post_tool_exec_hooks()` on Capability trait + register capability |
| `crates/core/src/capabilities/tool_output_persistence.rs` | New capability + PersistOutputHook (6 tests) |
| `crates/core/src/lib.rs` | Re-export `PostToolExecHook` |
| `specs/tool-execution.md` | Document PostToolExecHook and hook slots |

## Risk

- **Low** — additive change, no existing behavior modified
- Tools without `persist_output: true` are completely unaffected
- VFS write failures are logged and silently skipped (graceful degradation)

## Security

- Threat categories reviewed: **TM-FS** (file path injection)
- Log paths use `tool_call.id` (server-generated UUID) — no user input in path
- Files written to `/.exec-logs/` (dot-prefixed, session-scoped, auto-cleanup)
- No new inputs, no auth changes

## Checklist

- [x] Tests added (6 unit tests for extract_output_text + capability metadata)
- [x] Backward compatibility considered (purely additive)
- [x] Security review performed
- [x] All review comments addressed