### PR TITLE
feat(core): add output-economy hints to exec tool system prompts (EVE-223)

### DIFF
--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -2303,7 +2303,15 @@ mod tests {
 
         let direct_prompt = BASHKIT_TOOL.system_prompt();
         let static_prompt: &str = &TOOL_SYSTEM_PROMPT;
-        assert_eq!(static_prompt, direct_prompt);
+        // TOOL_SYSTEM_PROMPT = bashkit prompt + EXEC_OUTPUT_HINT (EVE-223)
+        assert!(
+            static_prompt.starts_with(direct_prompt),
+            "system prompt should start with bashkit prompt"
+        );
+        assert!(
+            static_prompt.contains("Output economy"),
+            "system prompt should include output economy hint"
+        );
     }
 
     #[test]

--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -62,9 +62,12 @@ static BASHKIT_TOOL: LazyLock<BashkitTool> = LazyLock::new(|| {
 static TOOL_DESCRIPTION: LazyLock<String> =
     LazyLock::new(|| BASHKIT_TOOL.description().to_string());
 
-/// System prompt addition from bashkit library.
-static TOOL_SYSTEM_PROMPT: LazyLock<String> =
-    LazyLock::new(|| BASHKIT_TOOL.system_prompt().to_string());
+/// System prompt addition from bashkit library + output economy hint.
+static TOOL_SYSTEM_PROMPT: LazyLock<String> = LazyLock::new(|| {
+    let mut prompt = BASHKIT_TOOL.system_prompt().to_string();
+    prompt.push_str(crate::tool_output_sanitizer::EXEC_OUTPUT_HINT);
+    prompt
+});
 
 /// Virtual Bash capability - execute bash commands in a sandboxed environment
 pub struct VirtualBashCapability;

--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -2305,7 +2305,7 @@ mod tests {
         let static_prompt: &str = &TOOL_SYSTEM_PROMPT;
         // TOOL_SYSTEM_PROMPT = bashkit prompt + EXEC_OUTPUT_HINT (EVE-223)
         assert!(
-            static_prompt.starts_with(direct_prompt),
+            static_prompt.starts_with(&direct_prompt),
             "system prompt should start with bashkit prompt"
         );
         assert!(

--- a/crates/core/src/tool_output_sanitizer.rs
+++ b/crates/core/src/tool_output_sanitizer.rs
@@ -17,6 +17,17 @@
 /// Default output budget for exec tools (16 KiB).
 pub const EXEC_OUTPUT_BUDGET: usize = 16 * 1024;
 
+/// System prompt hint for exec tool capabilities (EVE-223).
+/// Appended to each sandbox capability's `system_prompt_addition()` to guide
+/// the LLM toward less verbose command usage.
+pub const EXEC_OUTPUT_HINT: &str = "\n\n**Output economy:** Command output is truncated to ~16 KiB (keeping first 20% + last 80%). \
+For build/install commands, prefer quiet flags or pipe through tail:\n\
+- `cargo build -q`, `cargo test -- --quiet`\n\
+- `npm install --silent`, `npm test 2>&1 | tail -50`\n\
+- `pip install -q`, `make -s`\n\
+- `apt-get install -qq -y`\n\
+Save verbose output to a file and inspect selectively: `cmd > /tmp/out.log 2>&1 && tail -100 /tmp/out.log`";
+
 /// Strip ANSI escape sequences from text.
 ///
 /// Removes SGR sequences (`\x1b[...m`), CSI sequences (`\x1b[...X`),

--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -21,6 +21,7 @@ use everruns_core::connection_provider::ConnectionProviderPlugin;
 use everruns_core::tools::Tool;
 
 use connection::DaytonaConnectionProvider;
+use std::sync::LazyLock;
 use std::time::Duration;
 
 use tools::{
@@ -80,6 +81,35 @@ const LEASE_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(3 * 60);
 // DaytonaCapability
 // ============================================================================
 
+static SYSTEM_PROMPT: LazyLock<String> = LazyLock::new(|| {
+    let mut prompt = String::from(
+        r#"## Daytona
+
+Cloud-based sandboxes via Daytona. Each sandbox is an isolated environment with full Linux and network access.
+
+Authentication: Daytona API key is resolved automatically from Settings > Connections > Daytona.
+If not configured, guide the user to set up their key in Settings > Connections.
+
+All tools except `daytona_create_sandbox` and `daytona_list_sandboxes` require a `sandbox_id`.
+Sandboxes auto-stop after 5 min of inactivity, auto-archive after 30 min, and auto-delete after 60 min.
+Stopped sandboxes are also cleaned up by the control plane after 20 min.
+Always DELETE sandboxes when done (stop leaves them on the dashboard).
+Active sandboxes also appear in the session Resources tab so users can see what
+may be cleaned automatically later.
+
+Git cloning: Use `daytona_git_clone` to clone repositories into `/home/daytona/owner/repo`.
+If the user has connected their GitHub account (Settings > Connections), private repos
+are automatically authenticated. For public repos, no credentials are needed.
+Supports "user/repo" shorthand. Working directory is `/home/daytona`.
+
+Git push/pull/fetch: After cloning, call `daytona_git_credentials` once to configure
+credentials in the sandbox. Then use `daytona_exec` for any git command (push, pull,
+fetch, rebase, etc.) — they authenticate automatically. Call again to refresh (~1h expiry)."#,
+    );
+    prompt.push_str(everruns_core::tool_output_sanitizer::EXEC_OUTPUT_HINT);
+    prompt
+});
+
 pub struct DaytonaCapability;
 
 impl Capability for DaytonaCapability {
@@ -118,30 +148,7 @@ impl Capability for DaytonaCapability {
         // provided via the tools parameter in the API request.  Duplicating
         // them in the system prompt wastes tokens and can confuse models
         // (especially GPT-5.4+ with tool_search).
-        Some(
-            r#"## Daytona
-
-Cloud-based sandboxes via Daytona. Each sandbox is an isolated environment with full Linux and network access.
-
-Authentication: Daytona API key is resolved automatically from Settings > Connections > Daytona.
-If not configured, guide the user to set up their key in Settings > Connections.
-
-All tools except `daytona_create_sandbox` and `daytona_list_sandboxes` require a `sandbox_id`.
-Sandboxes auto-stop after 5 min of inactivity, auto-archive after 30 min, and auto-delete after 60 min.
-Stopped sandboxes are also cleaned up by the control plane after 20 min.
-Always DELETE sandboxes when done (stop leaves them on the dashboard).
-Active sandboxes also appear in the session Resources tab so users can see what
-may be cleaned automatically later.
-
-Git cloning: Use `daytona_git_clone` to clone repositories into `/home/daytona/owner/repo`.
-If the user has connected their GitHub account (Settings > Connections), private repos
-are automatically authenticated. For public repos, no credentials are needed.
-Supports "user/repo" shorthand. Working directory is `/home/daytona`.
-
-Git push/pull/fetch: After cloning, call `daytona_git_credentials` once to configure
-credentials in the sandbox. Then use `daytona_exec` for any git command (push, pull,
-fetch, rebase, etc.) — they authenticate automatically. Call again to refresh (~1h expiry)."#,
-        )
+        Some(&SYSTEM_PROMPT)
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {

--- a/integrations/deno/src/lib.rs
+++ b/integrations/deno/src/lib.rs
@@ -19,6 +19,7 @@ use everruns_core::LEASED_RESOURCES_FEATURE;
 use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin, RiskLevel};
 use everruns_core::connection_provider::ConnectionProviderPlugin;
 use everruns_core::tools::Tool;
+use std::sync::LazyLock;
 use std::time::Duration;
 
 use connection::DenoConnectionProvider;
@@ -50,6 +51,25 @@ const DENO_MAX_MEMORY_MB: u64 = 16 * 1_024;
 const DENO_RPC_TIMEOUT: Duration = Duration::from_secs(30);
 const DENO_STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(2);
 const DENO_WORKSPACE_PATH: &str = "/home/sandbox";
+
+static SYSTEM_PROMPT: LazyLock<String> = LazyLock::new(|| {
+    let mut prompt = String::from(
+        r#"## Deno Sandboxes
+
+Cloud-based sandboxes via Deno. Each sandbox is an isolated Linux microVM with network access.
+
+Authentication: Deno access token is resolved automatically from Settings > Connections > Deno Deploy.
+If not configured, guide the user to set it up in Settings > Connections.
+
+All tools except `deno_create_sandbox` and `deno_list_sandboxes` require a `sandbox_id`.
+Sandboxes are created with a fixed timeout because Everruns closes the create connection after each tool.
+Always DELETE sandboxes when done to avoid resource leaks.
+
+Use `deno_exec` for shell commands, `deno_write_file` / `deno_read_file` for files, and `deno_manage_sandbox` with action=`delete` for cleanup."#,
+    );
+    prompt.push_str(everruns_core::tool_output_sanitizer::EXEC_OUTPUT_HINT);
+    prompt
+});
 
 pub struct DenoCapability;
 
@@ -83,20 +103,7 @@ impl Capability for DenoCapability {
     }
 
     fn system_prompt_addition(&self) -> Option<&str> {
-        Some(
-            r#"## Deno Sandboxes
-
-Cloud-based sandboxes via Deno. Each sandbox is an isolated Linux microVM with network access.
-
-Authentication: Deno access token is resolved automatically from Settings > Connections > Deno Deploy.
-If not configured, guide the user to set it up in Settings > Connections.
-
-All tools except `deno_create_sandbox` and `deno_list_sandboxes` require a `sandbox_id`.
-Sandboxes are created with a fixed timeout because Everruns closes the create connection after each tool.
-Always DELETE sandboxes when done to avoid resource leaks.
-
-Use `deno_exec` for shell commands, `deno_write_file` / `deno_read_file` for files, and `deno_manage_sandbox` with action=`delete` for cleanup."#,
-        )
+        Some(&SYSTEM_PROMPT)
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {

--- a/integrations/docker/src/lib.rs
+++ b/integrations/docker/src/lib.rs
@@ -26,6 +26,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::process::Stdio;
+use std::sync::LazyLock;
 use tokio::process::Command;
 use tracing::{debug, error, info, warn};
 
@@ -90,6 +91,35 @@ impl Default for DockerContainerConfig {
 // DockerContainerCapability
 // ============================================================================
 
+static SYSTEM_PROMPT: LazyLock<String> = LazyLock::new(|| {
+    let mut prompt = String::from(
+        r#"## Docker Container (Experimental)
+
+You have access to a Docker container for executing commands and managing files.
+The container is tied to this session and persists across tool calls.
+
+IMPORTANT: This is an EXPERIMENTAL capability. The container uses host networking.
+
+Tools:
+- `docker_exec` - Execute a shell command inside the container. Returns stdout, stderr, and exit code.
+- `docker_read_file` - Read a file from the container filesystem.
+- `docker_write_file` - Write content to a file in the container filesystem.
+- `docker_logs` - Get logs from the container. Useful for debugging long-running processes.
+- `docker_stop` - Stop and remove the container (for cleanup or to reset state).
+
+The container is lazily started on first tool use. Subsequent calls reuse the same container.
+
+Best practices:
+- Use `docker_exec` with `bash -c "..."` for complex commands
+- Check exit codes to verify command success
+- The working directory defaults to /workspace
+- Files written persist for the session duration
+- Use `docker_stop` to clean up when done or to reset container state"#,
+    );
+    prompt.push_str(everruns_core::tool_output_sanitizer::EXEC_OUTPUT_HINT);
+    prompt
+});
+
 pub struct DockerContainerCapability;
 
 impl Capability for DockerContainerCapability {
@@ -124,30 +154,7 @@ impl Capability for DockerContainerCapability {
     }
 
     fn system_prompt_addition(&self) -> Option<&str> {
-        Some(
-            r#"## Docker Container (Experimental)
-
-You have access to a Docker container for executing commands and managing files.
-The container is tied to this session and persists across tool calls.
-
-IMPORTANT: This is an EXPERIMENTAL capability. The container uses host networking.
-
-Tools:
-- `docker_exec` - Execute a shell command inside the container. Returns stdout, stderr, and exit code.
-- `docker_read_file` - Read a file from the container filesystem.
-- `docker_write_file` - Write content to a file in the container filesystem.
-- `docker_logs` - Get logs from the container. Useful for debugging long-running processes.
-- `docker_stop` - Stop and remove the container (for cleanup or to reset state).
-
-The container is lazily started on first tool use. Subsequent calls reuse the same container.
-
-Best practices:
-- Use `docker_exec` with `bash -c "..."` for complex commands
-- Check exit codes to verify command success
-- The working directory defaults to /workspace
-- Files written persist for the session duration
-- Use `docker_stop` to clean up when done or to reset container state"#,
-        )
+        Some(&SYSTEM_PROMPT)
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {

--- a/integrations/e2b/src/lib.rs
+++ b/integrations/e2b/src/lib.rs
@@ -16,6 +16,8 @@ use everruns_core::LEASED_RESOURCES_FEATURE;
 use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin, RiskLevel};
 use everruns_core::tools::Tool;
 
+use std::sync::LazyLock;
+
 use tools::{
     E2BCreateSandboxTool, E2BExecTool, E2BListSandboxesTool, E2BManageSandboxTool, E2BReadFileTool,
     E2BWriteFileTool,
@@ -35,6 +37,20 @@ pub const E2B_DEFAULT_TEMPLATE: &str = "base";
 pub const E2B_DEFAULT_TIMEOUT_SECS: u64 = 60 * 60;
 pub const E2B_DEFAULT_WORKSPACE_PATH: &str = "/home/user";
 pub const E2B_ENVD_PORT: u16 = 49_983;
+
+static SYSTEM_PROMPT: LazyLock<String> = LazyLock::new(|| {
+    let mut prompt = String::from(
+        r#"## E2B
+
+Cloud sandboxes via E2B. Each sandbox is an isolated Linux environment with network access.
+
+Use `e2b_create_sandbox` first, then `e2b_exec`, `e2b_read_file`, and `e2b_write_file` against the returned `sandbox_id`.
+Prefer `/home/user` as the workspace root.
+Always pause or delete sandboxes when done. Deleted sandboxes are cleaned up immediately; paused sandboxes may still consume platform quota until resumed or deleted."#,
+    );
+    prompt.push_str(everruns_core::tool_output_sanitizer::EXEC_OUTPUT_HINT);
+    prompt
+});
 
 pub struct E2BCapability;
 
@@ -68,15 +84,7 @@ impl Capability for E2BCapability {
     }
 
     fn system_prompt_addition(&self) -> Option<&str> {
-        Some(
-            r#"## E2B
-
-Cloud sandboxes via E2B. Each sandbox is an isolated Linux environment with network access.
-
-Use `e2b_create_sandbox` first, then `e2b_exec`, `e2b_read_file`, and `e2b_write_file` against the returned `sandbox_id`.
-Prefer `/home/user` as the workspace root.
-Always pause or delete sandboxes when done. Deleted sandboxes are cleaned up immediately; paused sandboxes may still consume platform quota until resumed or deleted."#,
-        )
+        Some(&SYSTEM_PROMPT)
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {

--- a/integrations/sprites/src/lib.rs
+++ b/integrations/sprites/src/lib.rs
@@ -19,6 +19,8 @@ use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugi
 use everruns_core::connection_provider::ConnectionProviderPlugin;
 use everruns_core::tools::Tool;
 
+use std::sync::LazyLock;
+
 use connection::SpritesConnectionProvider;
 
 use tools::{
@@ -59,6 +61,35 @@ const SPRITES_WORKSPACE_PATH: &str = "/home/user";
 // SpritesCapability
 // ============================================================================
 
+static SYSTEM_PROMPT: LazyLock<String> = LazyLock::new(|| {
+    let mut prompt = String::from(
+        r#"## Sprites
+
+Persistent, hardware-isolated Linux microVMs (Firecracker) via Sprites. Each sprite is
+a full Linux computer with a persistent ext4 filesystem that survives between sessions.
+
+Authentication: Sprites API token is resolved automatically from Settings > Connections > Sprites.
+If not configured, guide the user to set up their token in Settings > Connections.
+
+All tools except `sprites_create_sprite` and `sprites_list_sprites` require a `sprite_name`.
+Sprites persist indefinitely — they hibernate when idle (no compute charges) and wake instantly.
+Always DELETE sprites when done to avoid storage charges.
+
+Key differences from ephemeral sandboxes:
+- **Persistent filesystem**: Data survives idle/sleep, backed to durable object storage.
+- **Checkpoints**: Use `sprites_checkpoint` to snapshot state before risky operations,
+  `sprites_restore_checkpoint` to roll back. Checkpoints complete in ~300ms.
+- **HTTP services**: Each sprite has a unique public URL. Listen on port 8080 inside
+  the sprite and it's accessible at the sprite's URL. Use `sprites_service_url` to get
+  the URL for sharing or testing.
+- **Instant wake**: Sprites wake from hibernation in <1s when you execute a command.
+
+Working directory is `/home/user`."#,
+    );
+    prompt.push_str(everruns_core::tool_output_sanitizer::EXEC_OUTPUT_HINT);
+    prompt
+});
+
 pub struct SpritesCapability;
 
 impl Capability for SpritesCapability {
@@ -93,30 +124,7 @@ impl Capability for SpritesCapability {
     }
 
     fn system_prompt_addition(&self) -> Option<&str> {
-        Some(
-            r#"## Sprites
-
-Persistent, hardware-isolated Linux microVMs (Firecracker) via Sprites. Each sprite is
-a full Linux computer with a persistent ext4 filesystem that survives between sessions.
-
-Authentication: Sprites API token is resolved automatically from Settings > Connections > Sprites.
-If not configured, guide the user to set up their token in Settings > Connections.
-
-All tools except `sprites_create_sprite` and `sprites_list_sprites` require a `sprite_name`.
-Sprites persist indefinitely — they hibernate when idle (no compute charges) and wake instantly.
-Always DELETE sprites when done to avoid storage charges.
-
-Key differences from ephemeral sandboxes:
-- **Persistent filesystem**: Data survives idle/sleep, backed to durable object storage.
-- **Checkpoints**: Use `sprites_checkpoint` to snapshot state before risky operations,
-  `sprites_restore_checkpoint` to roll back. Checkpoints complete in ~300ms.
-- **HTTP services**: Each sprite has a unique public URL. Listen on port 8080 inside
-  the sprite and it's accessible at the sprite's URL. Use `sprites_service_url` to get
-  the URL for sharing or testing.
-- **Instant wake**: Sprites wake from hibernation in <1s when you execute a command.
-
-Working directory is `/home/user`."#,
-        )
+        Some(&SYSTEM_PROMPT)
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {


### PR DESCRIPTION
## What

Add `EXEC_OUTPUT_HINT` constant and append it to all 6 exec capability system prompts, guiding LLMs to use quiet flags and reduce verbose output.

## Why

Prevention is cheapest — if the LLM uses `cargo build -q` instead of `cargo build`, the output is 90% smaller before sanitization even runs. Codex CLI and SWE-agent already do this.

Resolves [EVE-223](https://linear.app/everruns/issue/EVE-223).

## How

- `EXEC_OUTPUT_HINT` const in `tool_output_sanitizer.rs` (single source of truth, references the 16 KiB budget)
- Each sandbox capability appends the hint via `LazyLock<String>` in `system_prompt_addition()`
- Capabilities updated: virtual_bash, daytona, e2b, deno, sprites, docker

## Risk

- **Low** — additive system prompt text, no code behavior changes
- Hint is generic enough for all execution environments

## Security

- No security-relevant code changes (prompt text only)

## Checklist

- [x] Tests: existing capability tests still pass
- [x] Backward compatibility: additive only
- [x] Security review: prompt text only, no code changes