### PR TITLE
feat(compaction): lower keep_recent_tool_outputs default from 5 to 2 (EVE-224)

### DIFF
--- a/crates/core/src/capabilities/compaction.rs
+++ b/crates/core/src/capabilities/compaction.rs
@@ -78,7 +78,10 @@ impl Default for ObservationMaskingConfig {
 }
 
 fn default_keep_recent_tool_outputs() -> usize {
-    5
+    // Lowered from 5 to 2 (EVE-224). With EVE-221 capping exec output at 16 KiB,
+    // keeping 2 recent (~8K tokens) instead of 5 (~20K tokens) significantly reduces
+    // stale exec output accumulation. Older tool results are masked to one-line summaries.
+    2
 }
 
 /// Summarization settings.
@@ -968,7 +971,7 @@ mod tests {
         assert_eq!(config.strategy, CompactionStrategy::Auto);
         assert!(config.proactive);
         assert!((config.budget_percent - 0.85).abs() < f32::EPSILON);
-        assert_eq!(config.observation_masking.keep_recent_tool_outputs, 5);
+        assert_eq!(config.observation_masking.keep_recent_tool_outputs, 2);
         assert_eq!(
             config.observation_masking.summary_format,
             MaskingSummaryFormat::OneLine

--- a/specs/compaction.md
+++ b/specs/compaction.md
@@ -120,7 +120,7 @@ Compaction is configured as a capability on agents and harnesses, following the 
         "proactive": true,
         "budget_percent": 0.85,
         "observation_masking": {
-          "keep_recent_tool_outputs": 5,
+          "keep_recent_tool_outputs": 2,
           "summary_format": "one_line"
         },
         "summarization": {
@@ -165,7 +165,7 @@ pub struct CompactionConfig {
 pub struct ObservationMaskingConfig {
     /// Number of recent tool outputs to keep verbatim.
     #[serde(default = "default_keep_recent")]
-    pub keep_recent_tool_outputs: usize,  // default: 5
+    pub keep_recent_tool_outputs: usize,  // default: 2
 
     /// Format for masked tool output summaries.
     #[serde(default)]
@@ -239,7 +239,7 @@ When the `compaction` capability is present with no config (or `{}`):
 | `strategy` | `auto` | Adapts to provider |
 | `proactive` | `true` | Don't wait for errors |
 | `budget_percent` | `0.85` | 15% headroom |
-| `keep_recent_tool_outputs` | `5` | Recent context stays verbatim |
+| `keep_recent_tool_outputs` | `2` | Recent context stays verbatim |
 | `summarization.model` | `null` (same model) | Simplest default |
 | `summarization.preserve` | `["decisions", "files_modified", "errors", "current_plan"]` | Key agent context |
 

--- a/specs/compaction.md
+++ b/specs/compaction.md
@@ -164,7 +164,7 @@ pub struct CompactionConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ObservationMaskingConfig {
     /// Number of recent tool outputs to keep verbatim.
-    #[serde(default = "default_keep_recent")]
+    #[serde(default = "default_keep_recent_tool_outputs")]
     pub keep_recent_tool_outputs: usize,  // default: 2
 
     /// Format for masked tool output summaries.


### PR DESCRIPTION
## What

Lower `keep_recent_tool_outputs` default from 5 to 2 in compaction observation masking config.

## Why

With EVE-221 capping exec output at 16 KiB, keeping 5 recent tool outputs verbatim (~20K tokens) wastes context on stale exec results. Lowering to 2 (~8K tokens) means older tool results are masked to one-line summaries sooner, reducing token accumulation between compaction triggers.

Resolves [EVE-224](https://linear.app/everruns/issue/EVE-224).

## How

- Change `default_keep_recent_tool_outputs()` from 5 to 2
- Update tests and `specs/compaction.md`
- Existing sessions with explicit `keep_recent_tool_outputs` config are unaffected

## Risk

- **Low** — config default change only, no code logic changes
- Sessions that relied on 5 recent verbatim outputs will now see 2 (with older outputs masked to summaries)
- Users can override via `AgentCapabilityConfig.config.observation_masking.keep_recent_tool_outputs: 5`

## Security

- No security-relevant code changes (config default only)

## Checklist

- [x] Tests updated (71 compaction tests pass)
- [x] Backward compatibility: explicit config overrides are unaffected
- [x] Security review: config-only change