### PR TITLE
feat(core): add OutputHardLimitHook for tool result size safety net

### DIFF
--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -211,7 +211,7 @@ where
             org_id: None,
             hooks: Self::default_hooks(),
             post_tool_hooks: Vec::new(),
-            final_post_tool_hooks: Vec::new(),
+            final_post_tool_hooks: Self::default_final_hooks(),
         }
     }
 
@@ -239,7 +239,7 @@ where
             org_id: None,
             hooks: Self::default_hooks(),
             post_tool_hooks: Vec::new(),
-            final_post_tool_hooks: Vec::new(),
+            final_post_tool_hooks: Self::default_final_hooks(),
         }
     }
 
@@ -256,6 +256,12 @@ where
             Box::new(act_hooks::ConnectionSetupHook),
             Box::new(act_hooks::ClientSideToolHook),
         ]
+    }
+
+    /// Default final post-tool-exec hooks (infrastructure, always-on).
+    /// These run after all capability-contributed hooks and cannot be removed.
+    fn default_final_hooks() -> Vec<Arc<dyn act_hooks::PostToolExecHook>> {
+        vec![Arc::new(act_hooks::OutputHardLimitHook)]
     }
 
     /// Set the SQL database store on this atom

--- a/crates/core/src/atoms/act_hooks.rs
+++ b/crates/core/src/atoms/act_hooks.rs
@@ -68,6 +68,108 @@ pub(super) async fn run_post_tool_exec_hooks(
 }
 
 // ============================================================================
+// OutputHardLimitHook (EVE-225)
+// ============================================================================
+
+/// Maximum tool result size in bytes before truncation (64 KiB).
+/// Large results consume context window, increase cost, and expand the
+/// prompt injection surface (TM-AGENT-012).
+const MAX_TOOL_RESULT_BYTES: usize = 64 * 1024;
+
+const TRUNCATION_SUFFIX: &str =
+    "\n\n[Output truncated — exceeded 64 KiB limit. Try quiet flags, pipes, or redirect to file.]";
+
+/// Infrastructure hook that enforces a hard 64 KiB ceiling on tool result text.
+///
+/// Always registered as a `final_post_tool_hook` in ActAtom — cannot be removed
+/// by capabilities. Runs after all capability-contributed hooks so that
+/// persistence hooks (EVE-222) can capture full output before truncation.
+///
+/// Head-truncation with UTF-8 safety: keeps the first N bytes (on a char
+/// boundary) and appends an LLM-actionable suffix.
+pub struct OutputHardLimitHook;
+
+impl OutputHardLimitHook {
+    /// Truncate `text` to `MAX_TOOL_RESULT_BYTES` with a UTF-8-safe cut.
+    fn truncate(text: String) -> String {
+        if text.len() <= MAX_TOOL_RESULT_BYTES {
+            return text;
+        }
+        let content_budget = MAX_TOOL_RESULT_BYTES.saturating_sub(TRUNCATION_SUFFIX.len());
+        let mut end = content_budget;
+        while end > 0 && !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        let mut truncated = text[..end].to_string();
+        truncated.push_str(TRUNCATION_SUFFIX);
+        truncated
+    }
+}
+
+#[async_trait]
+impl PostToolExecHook for OutputHardLimitHook {
+    async fn after_exec(
+        &self,
+        tool_call: &ToolCall,
+        _tool_def: &ToolDefinition,
+        result: &mut ToolResult,
+        _context: &ToolContext,
+    ) {
+        // Truncate the result JSON value if it exceeds the limit.
+        if let Some(val) = result.result.take() {
+            match val {
+                serde_json::Value::String(s) => {
+                    let original_len = s.len();
+                    let truncated = Self::truncate(s);
+                    if truncated.len() < original_len {
+                        tracing::warn!(
+                            tool_name = %tool_call.name,
+                            tool_call_id = %tool_call.id,
+                            result_bytes = original_len,
+                            limit = MAX_TOOL_RESULT_BYTES,
+                            "Tool result exceeded hard limit, truncated"
+                        );
+                    }
+                    result.result = Some(serde_json::Value::String(truncated));
+                }
+                other => {
+                    // Non-string JSON: serialize, check size, convert to
+                    // truncated string if over limit.
+                    let serialized = serde_json::to_string(&other).unwrap_or_default();
+                    if serialized.len() > MAX_TOOL_RESULT_BYTES {
+                        tracing::warn!(
+                            tool_name = %tool_call.name,
+                            tool_call_id = %tool_call.id,
+                            result_bytes = serialized.len(),
+                            limit = MAX_TOOL_RESULT_BYTES,
+                            "Tool result exceeded hard limit, truncated"
+                        );
+                        let truncated = Self::truncate(serialized);
+                        result.result = Some(serde_json::Value::String(truncated));
+                    } else {
+                        result.result = Some(other);
+                    }
+                }
+            }
+        }
+
+        // Also cap error messages (unlikely to be huge, but defense in depth).
+        if let Some(err) = result.error.take() {
+            if err.len() > MAX_TOOL_RESULT_BYTES {
+                tracing::warn!(
+                    tool_name = %tool_call.name,
+                    tool_call_id = %tool_call.id,
+                    result_bytes = err.len(),
+                    limit = MAX_TOOL_RESULT_BYTES,
+                    "Tool error exceeded hard limit, truncated"
+                );
+            }
+            result.error = Some(Self::truncate(err));
+        }
+    }
+}
+
+// ============================================================================
 // PostActHook trait
 // ============================================================================
 
@@ -350,5 +452,186 @@ mod tests {
                 assert_eq!(tool_calls[0].name, "browser_click");
             }
         }
+    }
+
+    // ========================================================================
+    // OutputHardLimitHook tests (EVE-225)
+    // ========================================================================
+
+    use crate::traits::ToolContext;
+    use crate::typed_id::SessionId;
+
+    fn make_tool_call() -> ToolCall {
+        ToolCall {
+            id: "call_test".to_string(),
+            name: "test_tool".to_string(),
+            arguments: json!({}),
+        }
+    }
+
+    fn make_tool_def() -> ToolDefinition {
+        ToolDefinition::Builtin(crate::tool_types::BuiltinTool {
+            name: "test_tool".to_string(),
+            display_name: None,
+            description: "test".to_string(),
+            parameters: json!({}),
+            policy: crate::tool_types::ToolPolicy::Auto,
+            category: None,
+            deferrable: crate::tool_types::DeferrablePolicy::Never,
+            hints: Default::default(),
+        })
+    }
+
+    #[tokio::test]
+    async fn test_output_hard_limit_passthrough_small() {
+        let hook = OutputHardLimitHook;
+        let tc = make_tool_call();
+        let td = make_tool_def();
+        let ctx = ToolContext::new(SessionId::new());
+        let mut result = ToolResult {
+            tool_call_id: "call_test".into(),
+            result: Some(json!("hello")),
+            images: None,
+            error: None,
+            connection_required: None,
+            raw_output: None,
+        };
+
+        hook.after_exec(&tc, &td, &mut result, &ctx).await;
+        assert_eq!(result.result, Some(json!("hello")));
+    }
+
+    #[tokio::test]
+    async fn test_output_hard_limit_truncates_large_string() {
+        let hook = OutputHardLimitHook;
+        let tc = make_tool_call();
+        let td = make_tool_def();
+        let ctx = ToolContext::new(SessionId::new());
+        let big = "x".repeat(MAX_TOOL_RESULT_BYTES + 1000);
+        let mut result = ToolResult {
+            tool_call_id: "call_test".into(),
+            result: Some(json!(big)),
+            images: None,
+            error: None,
+            connection_required: None,
+            raw_output: None,
+        };
+
+        hook.after_exec(&tc, &td, &mut result, &ctx).await;
+
+        let text = result.result.unwrap();
+        let s = text.as_str().unwrap();
+        assert!(s.len() <= MAX_TOOL_RESULT_BYTES);
+        assert!(s.ends_with(TRUNCATION_SUFFIX));
+    }
+
+    #[tokio::test]
+    async fn test_output_hard_limit_at_exact_limit() {
+        let hook = OutputHardLimitHook;
+        let tc = make_tool_call();
+        let td = make_tool_def();
+        let ctx = ToolContext::new(SessionId::new());
+        let exact = "a".repeat(MAX_TOOL_RESULT_BYTES);
+        let mut result = ToolResult {
+            tool_call_id: "call_test".into(),
+            result: Some(json!(exact)),
+            images: None,
+            error: None,
+            connection_required: None,
+            raw_output: None,
+        };
+
+        hook.after_exec(&tc, &td, &mut result, &ctx).await;
+
+        let text = result.result.unwrap();
+        let s = text.as_str().unwrap();
+        // Should NOT be truncated (equal to limit)
+        assert_eq!(s.len(), MAX_TOOL_RESULT_BYTES);
+        assert!(!s.contains("[Output truncated"));
+    }
+
+    #[tokio::test]
+    async fn test_output_hard_limit_multibyte_boundary() {
+        let hook = OutputHardLimitHook;
+        let tc = make_tool_call();
+        let td = make_tool_def();
+        let ctx = ToolContext::new(SessionId::new());
+        let ch = "€"; // 3 bytes
+        let count = MAX_TOOL_RESULT_BYTES / ch.len() + 1;
+        let big = ch.repeat(count);
+        let mut result = ToolResult {
+            tool_call_id: "call_test".into(),
+            result: Some(json!(big)),
+            images: None,
+            error: None,
+            connection_required: None,
+            raw_output: None,
+        };
+
+        hook.after_exec(&tc, &td, &mut result, &ctx).await;
+
+        let text = result.result.unwrap();
+        let s = text.as_str().unwrap();
+        assert!(s.len() <= MAX_TOOL_RESULT_BYTES);
+        assert!(s.contains("[Output truncated"));
+    }
+
+    #[tokio::test]
+    async fn test_output_hard_limit_truncates_error() {
+        let hook = OutputHardLimitHook;
+        let tc = make_tool_call();
+        let td = make_tool_def();
+        let ctx = ToolContext::new(SessionId::new());
+        let big_err = "e".repeat(MAX_TOOL_RESULT_BYTES + 500);
+        let mut result = ToolResult {
+            tool_call_id: "call_test".into(),
+            result: None,
+            images: None,
+            error: Some(big_err),
+            connection_required: None,
+            raw_output: None,
+        };
+
+        hook.after_exec(&tc, &td, &mut result, &ctx).await;
+
+        let err = result.error.unwrap();
+        assert!(err.len() <= MAX_TOOL_RESULT_BYTES);
+        assert!(err.ends_with(TRUNCATION_SUFFIX));
+    }
+
+    #[tokio::test]
+    async fn test_output_hard_limit_non_string_json() {
+        let hook = OutputHardLimitHook;
+        let tc = make_tool_call();
+        let td = make_tool_def();
+        let ctx = ToolContext::new(SessionId::new());
+        // Small JSON object — should pass through
+        let mut result = ToolResult {
+            tool_call_id: "call_test".into(),
+            result: Some(json!({"key": "value", "num": 42})),
+            images: None,
+            error: None,
+            connection_required: None,
+            raw_output: None,
+        };
+
+        hook.after_exec(&tc, &td, &mut result, &ctx).await;
+
+        // Should remain as-is (small non-string JSON)
+        assert_eq!(result.result, Some(json!({"key": "value", "num": 42})));
+    }
+
+    #[test]
+    fn test_truncate_helper_short() {
+        let s = "hello".to_string();
+        assert_eq!(OutputHardLimitHook::truncate(s.clone()), s);
+    }
+
+    #[test]
+    fn test_truncate_helper_over() {
+        let s = "a".repeat(MAX_TOOL_RESULT_BYTES + 100);
+        let t = OutputHardLimitHook::truncate(s);
+        assert!(t.len() <= MAX_TOOL_RESULT_BYTES);
+        assert!(t.ends_with(TRUNCATION_SUFFIX));
     }
 }

--- a/crates/core/src/atoms/mod.rs
+++ b/crates/core/src/atoms/mod.rs
@@ -30,7 +30,8 @@ mod reason;
 // Re-export atoms and their types
 pub use act::{ActAtom, ActInput, ActResult, ToolCallResult};
 pub use act_hooks::{
-    ClientSideToolHook, ConnectionSetupHook, PostActAction, PostActHook, PostToolExecHook,
+    ClientSideToolHook, ConnectionSetupHook, OutputHardLimitHook, PostActAction, PostActHook,
+    PostToolExecHook,
 };
 pub use input::{InputAtom, InputAtomInput, InputAtomResult};
 pub use reason::{ReasonAtom, ReasonInput, ReasonResult};

--- a/crates/core/src/llm_driver_registry.rs
+++ b/crates/core/src/llm_driver_registry.rs
@@ -709,7 +709,8 @@ impl LlmMessage {
                     } else {
                         "{}".to_string()
                     };
-                    let text = truncate_tool_result(text);
+                    // Hard limit enforced by OutputHardLimitHook (EVE-225) at
+                    // tool execution time — no secondary truncation needed here.
                     parts.push(LlmContentPart::Text { text });
                 }
             }
@@ -936,32 +937,6 @@ impl DriverRegistry {
     }
 }
 
-/// Maximum tool result size in bytes before truncation (64 KiB).
-/// Large results consume context window, increase cost, and expand the
-/// prompt injection surface (TM-AGENT-012).
-const MAX_TOOL_RESULT_BYTES: usize = 64 * 1024;
-
-const TRUNCATION_SUFFIX: &str = "\n\n[Output truncated — exceeded 64 KiB limit. Ask the tool for a smaller result or use pagination.]";
-
-/// Truncate a tool result string to `MAX_TOOL_RESULT_BYTES` (including the
-/// suffix), appending a warning so the LLM knows the output was cut short.
-fn truncate_tool_result(text: String) -> String {
-    if text.len() <= MAX_TOOL_RESULT_BYTES {
-        return text;
-    }
-    // Reserve space for the suffix so the total stays within the budget.
-    let content_budget = MAX_TOOL_RESULT_BYTES.saturating_sub(TRUNCATION_SUFFIX.len());
-    // Find the last char boundary at or before the budget to avoid splitting
-    // a multi-byte character.
-    let mut end = content_budget;
-    while end > 0 && !text.is_char_boundary(end) {
-        end -= 1;
-    }
-    let mut truncated = text[..end].to_string();
-    truncated.push_str(TRUNCATION_SUFFIX);
-    truncated
-}
-
 // ============================================================================
 // Tests
 // ============================================================================
@@ -969,44 +944,6 @@ fn truncate_tool_result(text: String) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_truncate_tool_result_short() {
-        let short = "hello".to_string();
-        assert_eq!(truncate_tool_result(short.clone()), short);
-    }
-
-    #[test]
-    fn test_truncate_tool_result_at_limit() {
-        let exact = "a".repeat(MAX_TOOL_RESULT_BYTES);
-        assert_eq!(truncate_tool_result(exact.clone()), exact);
-    }
-
-    #[test]
-    fn test_truncate_tool_result_over_limit() {
-        let over = "a".repeat(MAX_TOOL_RESULT_BYTES + 100);
-        let result = truncate_tool_result(over);
-        // Total result must fit within MAX_TOOL_RESULT_BYTES
-        assert!(result.len() <= MAX_TOOL_RESULT_BYTES);
-        assert!(result.ends_with(TRUNCATION_SUFFIX));
-        // Prefix should be the original content
-        let prefix_len = result.len() - TRUNCATION_SUFFIX.len();
-        assert_eq!(&result[..prefix_len], "a".repeat(prefix_len));
-    }
-
-    #[test]
-    fn test_truncate_tool_result_multibyte_boundary() {
-        // Use a 3-byte char so MAX_TOOL_RESULT_BYTES doesn't land on a
-        // boundary, exercising the backup loop.
-        let ch = "€"; // 3 bytes in UTF-8
-        assert_eq!(ch.len(), 3);
-        let count = MAX_TOOL_RESULT_BYTES / ch.len() + 1;
-        let over = ch.repeat(count);
-        let result = truncate_tool_result(over);
-        // Must be valid UTF-8 and within budget
-        assert!(result.len() <= MAX_TOOL_RESULT_BYTES);
-        assert!(result.contains("[Output truncated"));
-    }
 
     #[test]
     fn test_llm_call_config_builder_from_runtime_agent() {

--- a/crates/core/src/llm_driver_registry.rs
+++ b/crates/core/src/llm_driver_registry.rs
@@ -709,8 +709,10 @@ impl LlmMessage {
                     } else {
                         "{}".to_string()
                     };
-                    // Hard limit enforced by OutputHardLimitHook (EVE-225) at
-                    // tool execution time — no secondary truncation needed here.
+                    // Primary hard limit enforced by OutputHardLimitHook (EVE-225)
+                    // at tool execution time. This backstop catches tool results
+                    // that bypass ActAtom hooks (client-submitted, stored events).
+                    let text = truncate_tool_result(text);
                     parts.push(LlmContentPart::Text { text });
                 }
             }
@@ -935,6 +937,29 @@ impl DriverRegistry {
     pub fn registered_providers(&self) -> Vec<ProviderType> {
         self.factories.keys().cloned().collect()
     }
+}
+
+/// Maximum tool result size in bytes before truncation (64 KiB).
+/// Defense-in-depth backstop for tool results that bypass ActAtom hooks
+/// (e.g. client-submitted or stored events). The primary hard limit is
+/// enforced by `OutputHardLimitHook` (EVE-225) at tool execution time.
+const MAX_TOOL_RESULT_BYTES: usize = 64 * 1024;
+
+const TRUNCATION_SUFFIX: &str =
+    "\n\n[Output truncated — exceeded 64 KiB limit. Try quiet flags, pipes, or redirect to file.]";
+
+fn truncate_tool_result(text: String) -> String {
+    if text.len() <= MAX_TOOL_RESULT_BYTES {
+        return text;
+    }
+    let content_budget = MAX_TOOL_RESULT_BYTES.saturating_sub(TRUNCATION_SUFFIX.len());
+    let mut end = content_budget;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut truncated = text[..end].to_string();
+    truncated.push_str(TRUNCATION_SUFFIX);
+    truncated
 }
 
 // ============================================================================

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -610,7 +610,7 @@ The agent loop is a core trust boundary: an LLM decides which tools to call with
 | TM-AGENT-009 | Agent self-modification | Medium | Agents with `platform_management` capability can modify agents/sessions via tools; capability must be explicitly assigned; org-scoped | **OPEN** |
 | TM-AGENT-010 | Agent spawning agent chains | Medium | Agents with `platform_management` capability can create agents/sessions; capability must be explicitly assigned; no recursive depth limit | **OPEN** |
 | TM-AGENT-011 | Sensitive data in system prompt | Medium | PII must not be placed in system prompts; no encryption at rest for prompts | **OPEN** |
-| TM-AGENT-012 | Tool result size amplification | Medium | No size limit on tool results fed back to LLM; large results consume context and cost | **OPEN** |
+| TM-AGENT-012 | Tool result size amplification | Medium | 64 KiB hard limit on tool results via `OutputHardLimitHook` (EVE-225); always-on final hook in ActAtom | MITIGATED |
 | TM-AGENT-013 | Exfiltration via web_fetch | Medium | Agent with web_fetch capability can send session data to arbitrary URLs | **ACCEPTED** |
 | TM-AGENT-014 | Confused deputy — tool call with wrong session | Low | Tool context includes session_id; tools scoped to active session only | MITIGATED |
 | TM-AGENT-015 | Dangling tool calls cause LLM confusion | Low | Patched with synthetic "cancelled" results before LLM call; prevents API errors | MITIGATED |
@@ -922,7 +922,7 @@ Search results from Brave Search are returned as tool results. Adversarial conte
 | TM-TENANT-008 | User listing cross-org | High | Add org filtering to GET /v1/users |
 | TM-DOS-008 | ReDoS via file grep endpoint | Medium | Add regex complexity limits and timeout |
 | TM-AGENT-007 | No per-iteration tool call limit | Medium | Cap tool calls per LLM response |
-| TM-AGENT-012 | Tool result size amplification | Medium | Cap tool result size fed back to LLM |
+| ~~TM-AGENT-012~~ | ~~Tool result size amplification~~ | ~~Medium~~ | Mitigated: 64 KiB hard limit via `OutputHardLimitHook` (EVE-225) |
 | TM-FS-008 | No session storage quota | Medium | Enforce per-session file size limits |
 | TM-TOOL-008 | Tool approval not enforced | Low | Implement HITL approval for requires_approval policy |
 | TM-TOOL-009 | No tool rate limiting | Medium | Per-agent tool execution rate limits |

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -88,6 +88,9 @@ Two hook slots run in sequence:
 Current hooks:
 - **PersistOutputHook** (`tool_output_persistence` capability): When a tool declares `persist_output: true` in hints, writes full output to `/.exec-logs/{tool_call_id}.log` in session VFS and injects `full_output` path + `total_lines` into the result. See `crates/core/src/capabilities/tool_output_persistence.rs`.
 
+Current final hooks (always-on, cannot be removed):
+- **OutputHardLimitHook** (EVE-225): Enforces a 64 KiB hard ceiling on serialized tool result text. Head-truncation with UTF-8 safety; appends an LLM-actionable suffix. Logs `tracing::warn!` with tool_name, tool_call_id, result_bytes, limit when truncating. Fires regardless of which capabilities are active. See `crates/core/src/atoms/act_hooks.rs`.
+
 ### Tool Policies
 
 - `auto`: Execute immediately without approval


### PR DESCRIPTION
## What
Add `OutputHardLimitHook` as an always-on `FinalPostToolExecHook` in ActAtom that enforces a 64 KiB hard ceiling on tool result text. Remove the superseded `truncate_tool_result()` from `llm_driver_registry.rs`.

## Why
If a tool forgets to call `sanitize_exec_output()`, or an MCP/external tool returns oversized output, there was no backstop. The only truncation happened at LLM message construction time (`llm_driver_registry.rs`), which is too late — persistence hooks need to see the result first. Moving the hard limit to a final hook in ActAtom ensures it always fires after capability hooks (e.g. `tool_output_persistence`) but before events are emitted.

Fixes EVE-225.

## How
- `OutputHardLimitHook` in `crates/core/src/atoms/act_hooks.rs`: implements `PostToolExecHook`, head-truncates with UTF-8 safety, appends LLM-actionable suffix, logs `tracing::warn!` with tool metadata
- Registered via `default_final_hooks()` in `ActAtom::new()` — always present, cannot be removed by capabilities
- Handles both string and non-string JSON results, plus error messages
- Removed `truncate_tool_result()` and its constants/tests from `llm_driver_registry.rs`
- Updated `specs/tool-execution.md` to document the final hook
- Updated `specs/threat-model.md` to mark TM-AGENT-012 as MITIGATED

## Risk
- Low
- No behavioral change for well-behaved tools (16 KiB exec tools are well under 64 KiB). Only affects tools that previously bypassed sanitization — those now get truncated at the same 64 KiB limit that was already applied at message construction time.

## Security
- Threat categories reviewed: TM-AGENT-012 (tool result size amplification), TM-TOOL (tool execution paths)
- TM-AGENT-012: Directly mitigated by this change — 64 KiB hard limit enforced at tool execution time as infrastructure hook
- No new attack surface: truncation is pure string operations, no user input processing, no auth/authz changes

## Checklist
- [x] Tests added or updated (7 new tests: passthrough, large string, exact limit, multibyte boundary, error truncation, non-string JSON, truncate helper)
- [x] Backward compatibility considered (same 64 KiB limit, just enforced earlier in the pipeline)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
