### PR TITLE
feat(core): add loop detection capability via MessageFilterProvider

### DIFF
--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -562,8 +562,35 @@ impl ReasonAtom {
             .await?
             .ok_or_else(|| AgentLoopError::session_not_found(session_id))?;
 
-        // 3. Load messages (needed for controls.model_id extraction)
-        let messages = self.message_retriever.load(session_id).await?;
+        // 3. Load messages with capability message filters applied.
+        //
+        // Collect message filter providers from all capability layers
+        // (harness → agent → session) so that post_load hooks (e.g. loop
+        // detection) can inspect and modify messages after loading.
+        let prompt_ctx_for_filters = crate::capabilities::SystemPromptContext {
+            session_id,
+            locale: None,
+            file_store: self.file_store.clone(),
+        };
+
+        let mut all_capability_configs: Vec<crate::AgentCapabilityConfig> =
+            harness.capabilities.clone();
+        if let Some(ref agent) = agent {
+            all_capability_configs.extend(agent.capabilities.iter().cloned());
+        }
+        all_capability_configs.extend(session.capabilities.iter().cloned());
+
+        let collected_caps = crate::capabilities::collect_capabilities_with_configs(
+            &all_capability_configs,
+            &self.capability_registry,
+            &prompt_ctx_for_filters,
+        )
+        .await;
+
+        let mut query = crate::message_filter::MessageQuery::new(session_id);
+        collected_caps.apply_message_filters(&mut query);
+        let mut messages = self.message_retriever.load_filtered(query).await?;
+        collected_caps.apply_post_load_filters(&mut messages);
 
         if messages.is_empty() {
             return Err(AgentLoopError::NoMessages);

--- a/crates/core/src/capabilities/loop_detection.rs
+++ b/crates/core/src/capabilities/loop_detection.rs
@@ -1,0 +1,258 @@
+// Loop detection capability (EVE-227)
+//
+// Detects repeated identical tool calls and injects a warning to break the loop.
+// Uses MessageFilterProvider::post_load to scan loaded messages for repeated
+// tool-call batches. When N consecutive assistant messages carry the same
+// tool-call signature, a system warning is appended telling the model to
+// change its approach.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use crate::capabilities::Capability;
+use crate::message::{Message, MessageRole, ToolCallContentPart};
+use crate::message_filter::{MessageFilterProvider, MessageQuery};
+
+/// Default threshold: 3 consecutive identical tool call batches triggers warning.
+const DEFAULT_THRESHOLD: usize = 3;
+
+pub struct LoopDetectionCapability;
+
+impl Capability for LoopDetectionCapability {
+    fn id(&self) -> &str {
+        "loop_detection"
+    }
+
+    fn name(&self) -> &str {
+        "Tool Loop Detection"
+    }
+
+    fn description(&self) -> &str {
+        "Detects repeated identical tool calls and injects a warning to break the loop."
+    }
+
+    fn message_filter_provider(&self) -> Option<Arc<dyn MessageFilterProvider>> {
+        Some(Arc::new(LoopDetectionFilter))
+    }
+}
+
+struct LoopDetectionFilter;
+
+impl MessageFilterProvider for LoopDetectionFilter {
+    fn priority(&self) -> i32 {
+        35
+    }
+
+    fn apply_filters(&self, _query: &mut MessageQuery, _config: &serde_json::Value) {
+        // No query-time filters needed
+    }
+
+    fn post_load(&self, messages: &mut Vec<Message>, config: &serde_json::Value) {
+        let threshold = config
+            .get("threshold")
+            .and_then(|v| v.as_u64())
+            .map(|v| v as usize)
+            .unwrap_or(DEFAULT_THRESHOLD);
+
+        // Collect tool call signature hashes from recent agent messages (reverse order).
+        let mut recent_hashes: Vec<u64> = Vec::new();
+        for msg in messages.iter().rev() {
+            if msg.role != MessageRole::Agent {
+                continue;
+            }
+            let tool_calls = msg.tool_calls();
+            if tool_calls.is_empty() {
+                // Agent message without tool calls breaks the pattern
+                break;
+            }
+            recent_hashes.push(hash_tool_calls(&tool_calls));
+        }
+
+        // recent_hashes is in reverse chronological order.
+        // Check for `threshold` consecutive identical hashes.
+        if recent_hashes.len() >= threshold {
+            let target = recent_hashes[0];
+            let consecutive = recent_hashes.iter().take_while(|&&h| h == target).count();
+            if consecutive >= threshold {
+                tracing::warn!(
+                    consecutive,
+                    threshold,
+                    "Loop detected: identical tool calls repeated"
+                );
+                messages.push(Message::system(
+                    "\u{26a0} Loop detected: you called the same tool(s) with identical arguments \
+                     multiple times in a row. The approach is not working. \
+                     Try a different command, different arguments, or report the blocker.",
+                ));
+            }
+        }
+    }
+}
+
+/// Hash a set of tool calls into a single u64 for comparison.
+/// Tool calls are sorted by (name, arguments) so ordering doesn't matter.
+fn hash_tool_calls(calls: &[&ToolCallContentPart]) -> u64 {
+    let mut h = DefaultHasher::new();
+    let mut sorted: Vec<_> = calls
+        .iter()
+        .map(|tc| (&tc.name, tc.arguments.to_string()))
+        .collect();
+    sorted.sort();
+    for (name, args) in &sorted {
+        name.hash(&mut h);
+        args.hash(&mut h);
+    }
+    h.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::{ContentPart, ToolCallContentPart};
+
+    /// Helper: build an agent message with the given tool calls.
+    fn agent_msg_with_calls(calls: Vec<(&str, serde_json::Value)>) -> Message {
+        let content = calls
+            .into_iter()
+            .map(|(name, args)| {
+                ContentPart::ToolCall(ToolCallContentPart::new(
+                    uuid::Uuid::new_v4().to_string(),
+                    name,
+                    args,
+                ))
+            })
+            .collect();
+        Message {
+            id: crate::typed_id::MessageId::new(),
+            role: MessageRole::Agent,
+            content,
+            phase: None,
+            thinking: None,
+            thinking_signature: None,
+            controls: None,
+            metadata: None,
+            external_actor: None,
+            created_at: chrono::Utc::now(),
+        }
+    }
+
+    fn default_config() -> serde_json::Value {
+        serde_json::json!({})
+    }
+
+    #[test]
+    fn test_no_loop_different_tool_calls() {
+        let filter = LoopDetectionFilter;
+        let mut messages = vec![
+            Message::user("hello"),
+            agent_msg_with_calls(vec![("tool_a", serde_json::json!({"x": 1}))]),
+            Message::user("ok"),
+            agent_msg_with_calls(vec![("tool_b", serde_json::json!({"x": 2}))]),
+            Message::user("ok"),
+            agent_msg_with_calls(vec![("tool_c", serde_json::json!({"x": 3}))]),
+        ];
+        let original_len = messages.len();
+        filter.post_load(&mut messages, &default_config());
+        // No warning should be injected
+        assert_eq!(messages.len(), original_len);
+    }
+
+    #[test]
+    fn test_loop_detected_three_identical_calls() {
+        let filter = LoopDetectionFilter;
+        let mut messages = vec![
+            Message::user("do something"),
+            agent_msg_with_calls(vec![("read_file", serde_json::json!({"path": "/foo"}))]),
+            agent_msg_with_calls(vec![("read_file", serde_json::json!({"path": "/foo"}))]),
+            agent_msg_with_calls(vec![("read_file", serde_json::json!({"path": "/foo"}))]),
+        ];
+        let original_len = messages.len();
+        filter.post_load(&mut messages, &default_config());
+        // Warning should be injected
+        assert_eq!(messages.len(), original_len + 1);
+        let last = messages.last().unwrap();
+        assert_eq!(last.role, MessageRole::System);
+        assert!(last.text().unwrap().contains("Loop detected"));
+    }
+
+    #[test]
+    fn test_loop_broken_by_different_call() {
+        let filter = LoopDetectionFilter;
+        let mut messages = vec![
+            Message::user("do something"),
+            agent_msg_with_calls(vec![("read_file", serde_json::json!({"path": "/foo"}))]),
+            agent_msg_with_calls(vec![("read_file", serde_json::json!({"path": "/foo"}))]),
+            // Different call breaks the streak
+            agent_msg_with_calls(vec![("write_file", serde_json::json!({"path": "/bar"}))]),
+        ];
+        let original_len = messages.len();
+        filter.post_load(&mut messages, &default_config());
+        // No warning
+        assert_eq!(messages.len(), original_len);
+    }
+
+    #[test]
+    fn test_configurable_threshold() {
+        let filter = LoopDetectionFilter;
+        let mut messages = vec![
+            agent_msg_with_calls(vec![("tool_a", serde_json::json!({}))]),
+            agent_msg_with_calls(vec![("tool_a", serde_json::json!({}))]),
+        ];
+
+        // Default threshold is 3, so 2 identical calls should NOT trigger
+        let original_len = messages.len();
+        filter.post_load(&mut messages, &default_config());
+        assert_eq!(messages.len(), original_len);
+
+        // With threshold = 2, it should trigger
+        let config = serde_json::json!({"threshold": 2});
+        filter.post_load(&mut messages, &config);
+        assert_eq!(messages.len(), original_len + 1);
+        assert!(
+            messages
+                .last()
+                .unwrap()
+                .text()
+                .unwrap()
+                .contains("Loop detected")
+        );
+    }
+
+    #[test]
+    fn test_hash_tool_calls_deterministic_sorted_args() {
+        let tc1 = ToolCallContentPart::new("id1", "tool_a", serde_json::json!({"x": 1}));
+        let tc2 = ToolCallContentPart::new("id2", "tool_b", serde_json::json!({"y": 2}));
+
+        // Order should not matter due to sorting
+        let h1 = hash_tool_calls(&[&tc1, &tc2]);
+        let h2 = hash_tool_calls(&[&tc2, &tc1]);
+        assert_eq!(h1, h2);
+
+        // Different calls should produce different hashes
+        let tc3 = ToolCallContentPart::new("id3", "tool_c", serde_json::json!({"z": 3}));
+        let h3 = hash_tool_calls(&[&tc1, &tc3]);
+        assert_ne!(h1, h3);
+    }
+
+    #[test]
+    fn test_loop_not_triggered_by_non_agent_messages() {
+        let filter = LoopDetectionFilter;
+        // Only user messages, no agent messages with tool calls
+        let mut messages = vec![
+            Message::user("hello"),
+            Message::user("hello"),
+            Message::user("hello"),
+        ];
+        let original_len = messages.len();
+        filter.post_load(&mut messages, &default_config());
+        assert_eq!(messages.len(), original_len);
+    }
+
+    #[test]
+    fn test_capability_provides_filter() {
+        let cap = LoopDetectionCapability;
+        assert_eq!(cap.id(), "loop_detection");
+        assert!(cap.message_filter_provider().is_some());
+    }
+}

--- a/crates/core/src/capabilities/loop_detection.rs
+++ b/crates/core/src/capabilities/loop_detection.rs
@@ -53,7 +53,8 @@ impl MessageFilterProvider for LoopDetectionFilter {
             .get("threshold")
             .and_then(|v| v.as_u64())
             .map(|v| v as usize)
-            .unwrap_or(DEFAULT_THRESHOLD);
+            .unwrap_or(DEFAULT_THRESHOLD)
+            .max(1); // Clamp to at least 1 to avoid indexing empty vec
 
         // Collect tool call signature hashes from recent agent messages (reverse order).
         let mut recent_hashes: Vec<u64> = Vec::new();

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -82,6 +82,7 @@ mod fake_financial;
 mod fake_warehouse;
 mod file_system;
 mod infinity_context;
+mod loop_detection;
 pub mod mcp;
 mod noop;
 mod openai_tool_search;
@@ -152,6 +153,7 @@ pub use file_system::{
 pub use infinity_context::{
     INFINITY_CONTEXT_CAPABILITY_ID, InfinityContextCapability, QueryHistoryTool,
 };
+pub use loop_detection::LoopDetectionCapability;
 pub use mcp::{
     MCP_CAPABILITY_PREFIX, McpCapability, is_mcp_capability, mcp_capability_id,
     parse_mcp_capability_id,
@@ -646,6 +648,9 @@ impl CapabilityRegistry {
 
         // Tool output persistence (EVE-222: persist exec output to VFS)
         registry.register(tool_output_persistence::ToolOutputPersistenceCapability);
+
+        // Loop detection (EVE-227: detect repeated identical tool calls)
+        registry.register(LoopDetectionCapability);
 
         // OpenUI generative UI (all environments)
         registry.register(OpenUiCapability);
@@ -1389,6 +1394,7 @@ mod tests {
             "fake_aws",
             "fake_crm",
             "fake_financial",
+            "loop_detection",
         ]
         .into_iter()
         .collect()

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -844,6 +844,14 @@ impl CollectedCapabilities {
         }
     }
 
+    /// Apply post-load transforms from all message filter providers.
+    /// Called after messages are loaded, filtered, and injected.
+    pub fn apply_post_load_filters(&self, messages: &mut Vec<crate::message::Message>) {
+        for (provider, config) in &self.message_filter_providers {
+            provider.post_load(messages, config);
+        }
+    }
+
     /// Check if any capabilities contribute message filters.
     pub fn has_message_filters(&self) -> bool {
         !self.message_filter_providers.is_empty()

--- a/crates/core/src/message_filter.rs
+++ b/crates/core/src/message_filter.rs
@@ -456,6 +456,13 @@ pub trait MessageFilterProvider: Send + Sync {
     /// * `config` - Per-agent capability configuration from the database
     fn apply_filters(&self, query: &mut MessageQuery, config: &serde_json::Value);
 
+    /// Post-load transform: inspect and optionally modify loaded messages.
+    /// Called after messages are loaded and query filters/injections applied.
+    /// Default is no-op.
+    fn post_load(&self, messages: &mut Vec<Message>, config: &serde_json::Value) {
+        let _ = (messages, config);
+    }
+
     /// Priority for filter application (lower = earlier).
     ///
     /// Filters from lower-priority providers are applied first.

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -461,6 +461,14 @@ Following the agentskills.io specification:
 2. **Activation**: `activate_skill` loads full SKILL.md instructions (<5000 tokens recommended)
 3. **Resources**: Bundled files listed in activation response, accessible via existing session filesystem tools
 
+#### LoopDetection
+
+- **ID**: `loop_detection`
+- **Purpose**: Detects repeated identical tool calls and injects a warning to break the loop
+- **Tools**: None (uses `MessageFilterProvider::post_load` only)
+- **Config**: `{"threshold": N}` — number of consecutive identical tool-call batches before warning (default 3)
+- **Source**: `crates/core/src/capabilities/loop_detection.rs`
+
 ### MCP Virtual Capabilities
 
 MCP servers (see `specs/mcp-servers.md`) are integrated as "virtual capabilities" alongside built-in capabilities. This allows agents to use MCP tools through the same capability selection UI.

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -91,6 +91,16 @@ Current hooks:
 Current final hooks (always-on, cannot be removed):
 - **OutputHardLimitHook** (EVE-225): Enforces a 64 KiB hard ceiling on serialized tool result text. Head-truncation with UTF-8 safety; appends an LLM-actionable suffix. Logs `tracing::warn!` with tool_name, tool_call_id, result_bytes, limit when truncating. Fires regardless of which capabilities are active. See `crates/core/src/atoms/act_hooks.rs`.
 
+### Loop Detection (EVE-227)
+
+The `loop_detection` capability detects repeated identical tool calls and injects a system warning to break the loop. It uses `MessageFilterProvider::post_load` to scan loaded messages.
+
+**Mechanism:** After messages are loaded, the filter scans recent agent messages in reverse. If `threshold` (default 3) consecutive agent messages carry tool calls with identical signatures (name + arguments, order-independent), a system message is appended warning the model to try a different approach.
+
+**Configuration:** `{"threshold": 5}` to change the default repeat count.
+
+See `crates/core/src/capabilities/loop_detection.rs`.
+
 ### Tool Policies
 
 - `auto`: Execute immediately without approval


### PR DESCRIPTION
## What
Add `LoopDetectionCapability` that detects repeated identical tool calls and injects a system warning to break LLM tool-call loops. Extends `MessageFilterProvider` with `post_load` hook and wires capability message filters into `ReasonAtom`.

## Why
When an LLM gets stuck calling the same tool with the same arguments repeatedly, the only safeguard was `max_iterations` (default 100). A targeted loop detector catches this specific failure mode while allowing legitimate work to continue.

Fixes EVE-227.

## How
- `MessageFilterProvider::post_load`: new default no-op method to inspect/modify messages after loading
- `CollectedCapabilities::apply_post_load_filters`: wires post_load into the capability pipeline
- `ReasonAtom`: now uses `load_filtered` + `apply_post_load_filters` instead of bare `load`
- `LoopDetectionCapability`: scans recent agent messages, hashes tool call signatures, injects system warning when N consecutive identical batches detected (default: 3)
- Registered as built-in capability in `CapabilityRegistry`

## Risk
- Low
- post_load is no-op by default; existing capabilities unaffected
- Loop detection only appends a system message, never removes/modifies existing messages

## Security
- Threat categories reviewed: TM-AGENT-006, TM-LLM, TM-DOS
- TM-AGENT-006: Directly mitigated — targeted intervention for runaway tool loops
- TM-LLM: Static warning text, no injection risk
- TM-DOS: O(n) scan bounded by conversation length; threshold clamped to min 1

## Checklist
- [x] Tests added or updated (7 new tests)
- [x] Backward compatibility considered
- [x] Security review performed
- [x] All review comments addressed