### PR TITLE
fix(daytona): surface tool defaults in descriptions

### DIFF
--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -1046,7 +1046,7 @@ impl Tool for DaytonaGitCloneTool {
 
     fn description(&self) -> &str {
         "Clone a git repository into a Daytona sandbox. \
-         Default clone path: /home/daytona/<repo-name>. \
+         Default clone path: /home/daytona/<owner>/<repo>. \
          Automatically uses the user's connected GitHub credentials if available. \
          For private repos, the user must have connected their GitHub account in Settings > Connections."
     }

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -73,7 +73,9 @@ impl Tool for DaytonaCreateSandboxTool {
     }
 
     fn description(&self) -> &str {
-        "Create a new Daytona cloud sandbox. Optionally upload files from session storage."
+        "Create a new Daytona cloud sandbox. Optionally upload files from session storage. \
+         Default size: small (1 vCPU, 1 GiB RAM, 3 GiB disk). \
+         Auto-stops after 5 minutes of inactivity."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -320,7 +322,9 @@ impl Tool for DaytonaExecTool {
     }
 
     fn description(&self) -> &str {
-        "Execute a shell command in a Daytona sandbox. Streams output in real time."
+        "Execute a shell command in a Daytona sandbox. Streams output in real time. \
+         Default timeout: 2 minutes. Working directory defaults to /home/daytona. \
+         For long builds (cargo, npm), pass a larger timeout explicitly."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -672,7 +676,8 @@ impl Tool for DaytonaDownloadWorkspaceTool {
     }
 
     fn description(&self) -> &str {
-        "Download the entire sandbox workspace to session file storage."
+        "Download the entire sandbox workspace to session file storage. \
+         Default sandbox path: /home/daytona. Default session path: /workspace."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -1040,9 +1045,10 @@ impl Tool for DaytonaGitCloneTool {
     }
 
     fn description(&self) -> &str {
-        "Clone a git repository into a Daytona sandbox. Automatically uses the user's \
-         connected GitHub credentials if available. For private repos, \
-         the user must have connected their GitHub account in Settings > Connections."
+        "Clone a git repository into a Daytona sandbox. \
+         Default clone path: /home/daytona/<repo-name>. \
+         Automatically uses the user's connected GitHub credentials if available. \
+         For private repos, the user must have connected their GitHub account in Settings > Connections."
     }
 
     fn parameters_schema(&self) -> Value {


### PR DESCRIPTION
## What
Surface key default values in Daytona tool `description()` strings so LLMs see them upfront without inspecting parameter schemas.

## Why
LLMs read top-level `description()` first. Defaults buried in parameter schema descriptions are often missed, leading to models passing redundant explicit values or guessing incorrectly.

Fixes EVE-231.

## How
Updated `description()` for 4 Daytona tools:
- **daytona_create_sandbox**: added default size (small) and auto-stop (5 min)
- **daytona_exec**: added default timeout (2 min) and working directory (/home/daytona)
- **daytona_download_workspace**: added default sandbox path and session path
- **daytona_git_clone**: added default clone path (/home/daytona/<repo-name>)

## Risk
- Low — description-only change, no behavioral changes

## Security
No security-relevant code changes. Tool descriptions are static strings with no user input.

## Checklist
- [x] Tests added or updated (N/A — description-only change, no logic)
- [x] Backward compatibility considered (no API changes)
- [x] Security review performed
- [x] All review comments addressed