### PR TITLE
chore(agents): add GitHub token guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ export CARGO_INCREMENTAL=0
 
 All cloud secrets are in Doppler (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`, `LINEAR_API_KEY`).
 
-### GitHub Token — NEVER claim it is unavailable
+### GitHub Token
 
 **`GITHUB_TOKEN` is always available via Doppler.** If GitHub auth fails, do NOT tell the user the token expired. Instead, use Doppler: `doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" <command>'`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,22 @@ export CARGO_INCREMENTAL=0
 
 All cloud secrets are in Doppler (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`, `LINEAR_API_KEY`).
 
+### GitHub Token — NEVER claim it is unavailable
+
+**The `GITHUB_TOKEN` is always available via Doppler.** If a GitHub MCP server tool fails with an auth/token error, do NOT tell the user the token expired or is unavailable. Instead, re-authenticate by running:
+
+```bash
+doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" gh auth status'
+```
+
+For any command that needs GitHub access, wrap it with Doppler:
+
+```bash
+doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" <your-command>'
+```
+
+This applies to `gh` CLI, GitHub API calls, and any tool that needs a GitHub token. The token is managed by Doppler and does not expire in the way MCP server tokens do.
+
 ### Linear
 
 We use [Linear](https://linear.app) for issue tracking (project: **OSS**, team: **EVE**). MCP server configured in `.mcp.json`. Token (`LINEAR_API_KEY`) is in Doppler. Use [`/process-issues`](.claude/skills/process-issues/SKILL.md) to process open issues (one PR per issue, up to 5 in parallel). All issues for this repo belong to the OSS project.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,19 +19,7 @@ All cloud secrets are in Doppler (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GITHUB
 
 ### GitHub Token — NEVER claim it is unavailable
 
-**The `GITHUB_TOKEN` is always available via Doppler.** If a GitHub MCP server tool fails with an auth/token error, do NOT tell the user the token expired or is unavailable. Instead, re-authenticate by running:
-
-```bash
-doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" gh auth status'
-```
-
-For any command that needs GitHub access, wrap it with Doppler:
-
-```bash
-doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" <your-command>'
-```
-
-This applies to `gh` CLI, GitHub API calls, and any tool that needs a GitHub token. The token is managed by Doppler and does not expire in the way MCP server tokens do.
+**`GITHUB_TOKEN` is always available via Doppler.** If GitHub auth fails, do NOT tell the user the token expired. Instead, use Doppler: `doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" <command>'`.
 
 ### Linear
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,12 +25,6 @@ All cloud secrets are in Doppler (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GITHUB
 
 We use [Linear](https://linear.app) for issue tracking (project: **OSS**, team: **EVE**). MCP server configured in `.mcp.json`. Token (`LINEAR_API_KEY`) is in Doppler. Use [`/process-issues`](.claude/skills/process-issues/SKILL.md) to process open issues (one PR per issue, up to 5 in parallel). All issues for this repo belong to the OSS project.
 
-For GitHub CLI, map token explicitly:
-
-```bash
-doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" gh auth status'
-```
-
 Quickcheck:
 
 ```bash


### PR DESCRIPTION
## What
Add a dedicated "GitHub Token" section to AGENTS.md clarifying that `GITHUB_TOKEN` is always available via Doppler.

## Why
Coding agents sometimes incorrectly report the GitHub token as expired/unavailable instead of using Doppler to resolve auth issues.

## How
Added a short section with the Doppler command pattern right after the secrets list.

## Risk
- Low
- Documentation-only change, nothing can break

## Security
- No security-relevant code changes — documentation only
- Findings and resolutions: N/A

## Checklist
- [x] Tests added or updated — N/A (docs only)
- [x] Backward compatibility considered — N/A
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)