### PR TITLE
fix(docs): improve code block syntax highlighting

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -29,6 +29,9 @@ export default defineConfig({
   },
   integrations: [
     starlight({
+      expressiveCode: {
+        themes: ["github-light", "github-dark"],
+      },
       title: "Everruns",
       description:
         "Documentation for Everruns, a durable agentic harness engine for AI agents. Guides for deploying, configuring, and building agent applications with the API.",

--- a/apps/docs/src/styles/custom.css
+++ b/apps/docs/src/styles/custom.css
@@ -127,10 +127,10 @@
 }
 
 :root[data-theme="dark"] {
-  --ec-codeBg: #111111;
-  --ec-frm-trmBg: #111111;
-  --ec-frm-trmTtbBg: #1a1a1a;
-  --ec-frm-edBg: #111111;
+  --ec-codeBg: #161b22;
+  --ec-frm-trmBg: #161b22;
+  --ec-frm-trmTtbBg: #1c2129;
+  --ec-frm-edBg: #161b22;
 }
 
 /* Hide the empty terminal title bar when there is no title text.


### PR DESCRIPTION
## What
Switch docs site code block syntax highlighting from Starlight's default themes to `github-light` / `github-dark` Shiki themes, and adjust dark mode code block backgrounds to complement.

## Why
Code blocks on docs.everruns.com had poor color differentiation — most tokens rendered in similar dark red/maroon tones, making it hard to distinguish keywords, strings, flags, and values.

## How
- Configure Expressive Code in `astro.config.mjs` with `themes: ["github-light", "github-dark"]`
- Update dark mode CSS variables (`--ec-codeBg`, `--ec-frm-trmBg`, etc.) from `#111111` to `#161b22` to match the GitHub Dark palette

## Risk
- Low
- Only affects docs site appearance. No runtime code changes.

## Security
- No security-relevant code changes. This modifies only CSS variables and Shiki theme selection for the documentation site. No code, API, auth, or infrastructure surface is touched.

## Checklist
- [x] Tests added or updated — N/A (docs styling only, verified via `npm run build`)
- [x] Backward compatibility considered — N/A (no API or runtime changes)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)