### PR TITLE
fix(llm-drivers): use model profile max_output_tokens instead of hardcoded defaults

### DIFF
--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -351,8 +351,16 @@ impl LlmDriver for AnthropicLlmDriver {
             "AnthropicDriver: building request with thinking config"
         );
 
-        // Calculate max_tokens - respect caller's limit, only increase when thinking requires it
-        let base_max_tokens = config.max_tokens.unwrap_or(4096);
+        // Calculate max_tokens - use caller's limit, or model's max output from profile, or 16384 fallback.
+        // Anthropic requires max_tokens (can't omit), so we look up the model's native limit.
+        let base_max_tokens = config.max_tokens.unwrap_or_else(|| {
+            everruns_core::get_model_profile(
+                &everruns_core::LlmProviderType::Anthropic,
+                &config.model,
+            )
+            .and_then(|p| p.limits.map(|l| l.output as u32))
+            .unwrap_or(16_384)
+        });
         let max_tokens = if let Some(ref thinking_config) = thinking {
             // max_tokens must be > thinking.budget_tokens per Anthropic requirements
             // Only increase if the caller's limit is too low for the thinking budget
@@ -365,7 +373,7 @@ impl LlmDriver for AnthropicLlmDriver {
         // Check if we need interleaved thinking beta header BEFORE moving values
         let needs_interleaved_thinking = thinking.is_some() && tools.is_some();
 
-        let request = AnthropicRequest {
+        let mut request = AnthropicRequest {
             model: config.model.clone(),
             messages: anthropic_messages,
             max_tokens,
@@ -379,6 +387,7 @@ impl LlmDriver for AnthropicLlmDriver {
         // Retry loop for rate limit (429) and transient errors
         let mut retry_metadata = RetryMetadata::default();
         let mut last_error: Option<String> = None;
+        let mut max_tokens_fallback_attempted = false;
 
         let response = loop {
             // Build request with headers (must rebuild each iteration)
@@ -463,6 +472,27 @@ impl LlmDriver for AnthropicLlmDriver {
             // Non-retryable error or max retries exceeded
             let error_text = response.text().await.unwrap_or_default();
             let error_msg = format!("Anthropic API error ({}): {}", status, error_text);
+
+            // Graceful fallback: if max_tokens exceeds model limit (400 error),
+            // retry once with a safe fallback value instead of failing immediately.
+            if status == reqwest::StatusCode::BAD_REQUEST
+                && !max_tokens_fallback_attempted
+                && (error_text.contains("max_tokens")
+                    || error_text.contains("maximum output tokens"))
+            {
+                const FALLBACK_MAX_TOKENS: u32 = 16_384;
+                tracing::warn!(
+                    attempted = request.max_tokens,
+                    fallback = FALLBACK_MAX_TOKENS,
+                    model = %config.model,
+                    "max_tokens exceeds model limit, retrying with fallback. \
+                     Update model profile for {}.",
+                    config.model,
+                );
+                request.max_tokens = FALLBACK_MAX_TOKENS;
+                max_tokens_fallback_attempted = true;
+                continue;
+            }
 
             // Check if this is a model-not-found error (404 with not_found_error)
             if is_anthropic_model_not_found(status, &error_text) {

--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -353,12 +353,19 @@ impl LlmDriver for AnthropicLlmDriver {
 
         // Calculate max_tokens - use caller's limit, or model's max output from profile, or 16384 fallback.
         // Anthropic requires max_tokens (can't omit), so we look up the model's native limit.
+        let max_tokens_from_profile = config.max_tokens.is_none();
         let base_max_tokens = config.max_tokens.unwrap_or_else(|| {
             everruns_core::get_model_profile(
                 &everruns_core::LlmProviderType::Anthropic,
                 &config.model,
             )
-            .and_then(|p| p.limits.map(|l| l.output as u32))
+            .and_then(|p| {
+                p.limits.and_then(|l| {
+                    u32::try_from(l.output)
+                        .ok()
+                        .and_then(|v| if v > 0 { Some(v) } else { None })
+                })
+            })
             .unwrap_or(16_384)
         });
         let max_tokens = if let Some(ref thinking_config) = thinking {
@@ -473,10 +480,11 @@ impl LlmDriver for AnthropicLlmDriver {
             let error_text = response.text().await.unwrap_or_default();
             let error_msg = format!("Anthropic API error ({}): {}", status, error_text);
 
-            // Graceful fallback: if max_tokens exceeds model limit (400 error),
+            // Graceful fallback: if max_tokens derived from profile exceeds model limit (400 error),
             // retry once with a safe fallback value instead of failing immediately.
             if status == reqwest::StatusCode::BAD_REQUEST
                 && !max_tokens_fallback_attempted
+                && max_tokens_from_profile
                 && (error_text.contains("max_tokens")
                     || error_text.contains("maximum output tokens"))
             {
@@ -1923,5 +1931,33 @@ mod tests {
 
         let profile = info.to_discovered_profile();
         assert!(profile.attachment, "PDF-only should still be attachment");
+    }
+
+    #[test]
+    fn test_default_max_tokens_from_known_model() {
+        // Known Anthropic models should resolve max_tokens from profile
+        let profile = everruns_core::get_model_profile(
+            &everruns_core::LlmProviderType::Anthropic,
+            "claude-sonnet-4-5-20250514",
+        );
+        assert!(profile.is_some(), "claude-sonnet-4-5 should have a profile");
+        let limits = profile.unwrap().limits.expect("profile should have limits");
+        assert!(limits.output > 0, "output limit should be positive");
+        // Sonnet 4.5 should have a much higher limit than the old 4096 default
+        assert!(
+            limits.output > 4096,
+            "model output limit ({}) should exceed old hardcoded 4096",
+            limits.output
+        );
+    }
+
+    #[test]
+    fn test_default_max_tokens_unknown_model_falls_back() {
+        // Unknown model should return None (triggering the 16384 fallback)
+        let profile = everruns_core::get_model_profile(
+            &everruns_core::LlmProviderType::Anthropic,
+            "nonexistent-model-xyz",
+        );
+        assert!(profile.is_none(), "unknown model should not have a profile");
     }
 }

--- a/crates/gemini/src/driver.rs
+++ b/crates/gemini/src/driver.rs
@@ -276,7 +276,13 @@ impl LlmDriver for GeminiLlmDriver {
                     &everruns_core::LlmProviderType::Gemini,
                     &config.model,
                 )
-                .and_then(|p| p.limits.map(|l| l.output as u32))
+                .and_then(|p| {
+                    p.limits.and_then(|l| {
+                        u32::try_from(l.output)
+                            .ok()
+                            .and_then(|v| if v > 0 { Some(v) } else { None })
+                    })
+                })
                 .unwrap_or(8_192),
             );
         }
@@ -1201,5 +1207,27 @@ mod tests {
             reqwest::StatusCode::BAD_REQUEST,
             error
         ));
+    }
+
+    #[test]
+    fn test_default_max_tokens_from_known_model() {
+        // Known Gemini models should resolve max_tokens from profile
+        let profile = everruns_core::get_model_profile(
+            &everruns_core::LlmProviderType::Gemini,
+            "gemini-1.5-pro",
+        );
+        assert!(profile.is_some(), "gemini-1.5-pro should have a profile");
+        let limits = profile.unwrap().limits.expect("profile should have limits");
+        assert!(limits.output > 0, "output limit should be positive");
+    }
+
+    #[test]
+    fn test_default_max_tokens_unknown_model_falls_back() {
+        // Unknown model should return None (triggering the 8192 fallback)
+        let profile = everruns_core::get_model_profile(
+            &everruns_core::LlmProviderType::Gemini,
+            "nonexistent-model-xyz",
+        );
+        assert!(profile.is_none(), "unknown model should not have a profile");
     }
 }

--- a/crates/gemini/src/driver.rs
+++ b/crates/gemini/src/driver.rs
@@ -269,9 +269,16 @@ impl LlmDriver for GeminiLlmDriver {
             max_output_tokens: config.max_tokens,
         };
 
-        // If no max_tokens specified, default to 8192
+        // If no max_tokens specified, use model's max output from profile, or 8192 fallback
         if generation_config.max_output_tokens.is_none() {
-            generation_config.max_output_tokens = Some(8192);
+            generation_config.max_output_tokens = Some(
+                everruns_core::get_model_profile(
+                    &everruns_core::LlmProviderType::Gemini,
+                    &config.model,
+                )
+                .and_then(|p| p.limits.map(|l| l.output as u32))
+                .unwrap_or(8_192),
+            );
         }
 
         let request = GeminiRequest {

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -88,6 +88,21 @@ Provider crates register factories at startup. Drivers created on-demand from `P
    - `tools`: Tool definitions
    - `reasoning_effort`: Optional reasoning level (low, medium, high)
 
+### Default `max_tokens` Policy
+
+When `config.max_tokens` is `None`, drivers resolve the default from model profile metadata rather than hardcoding a value:
+
+1. Look up the model via `get_model_profile(provider_type, model_id)`
+2. Use `profile.limits.output` as the default `max_tokens`
+3. If no profile is found, fall back to a safe default (Anthropic: 16,384; Gemini: 8,192)
+4. OpenAI drivers omit `max_tokens` entirely (API decides)
+
+Anthropic requires `max_tokens` in every request (cannot be omitted), so the driver always resolves a value.
+
+**Stale profile fallback**: If the Anthropic API returns 400 because `max_tokens` exceeds the model's actual limit (e.g., stale profile data), the driver retries once with 16,384 and logs a warning to update the model profile. If the retry also fails, the error propagates normally.
+
+Agents can override `max_tokens` via agent config. Cost guardrails should be configurable per-agent or per-org, not baked into driver code.
+
 3. **LlmMessage Extended Fields**:
    - `thinking`: Optional thinking content from extended thinking models
    - `thinking_signature`: Opaque token for multi-turn thinking context (provider-specific)


### PR DESCRIPTION
## What

Anthropic and Gemini drivers now resolve `max_tokens` from model profile metadata instead of using hardcoded defaults (4096 / 8192). Added graceful retry with 16384 fallback when stale profile data causes a 400 error.

## Why

Hardcoded `max_tokens` caps silently truncated agent output. Claude Opus 4.6 supports 128K output tokens but was capped at 4096. This caused agents to hit output limits on every turn during complex tasks (e.g., writing a 23KB audit report).

Fixes EVE-220.

## How

- **Anthropic driver**: `config.max_tokens.unwrap_or(4096)` → lookup via `get_model_profile()` with 16,384 fallback
- **Gemini driver**: hardcoded `Some(8192)` → lookup via `get_model_profile()` with 8,192 fallback
- **Anthropic retry**: On 400 with `max_tokens` in error text, retry once with 16,384 and log a warning
- **Spec**: Added "Default `max_tokens` Policy" section to `specs/llm-drivers.md`

## Risk
- Low
- Stale model profiles could set max_tokens higher than API allows — mitigated by the graceful fallback retry

## Security
- Threat categories reviewed: TM-LLM
- No new secrets, API keys, or prompt injection surfaces. Fallback only lowers max_tokens (safe direction). No sensitive data in logs (only model name and token counts).

## Checklist
- [x] Tests added or updated (existing retry tests cover the pattern; new fallback follows same structure)
- [x] Backward compatibility considered (not needed — internal code)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)