### PR TITLE
feat: NATS end-to-end operational readiness (Phase 3.5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,9 +139,14 @@ Always make sure you are working on top of latest main from remote.
 
 ```bash
 just start-dev          # DEV MODE (in-memory, no external services)
-just start-all          # Full mode (PostgreSQL + Valkey as processes)
+just start-all          # Full mode (PostgreSQL + Valkey + NATS as processes)
 just --list             # All commands
 ```
+
+`start-all` automatically starts NATS and exports `NATS_URL` if `nats-server` is installed.
+When NATS is available, ephemeral events (deltas) skip PostgreSQL and task notifications
+use NATS pub/sub instead of PG NOTIFY. Without NATS, everything falls back to PG — zero
+behavioral change. See `docs/sre/environment-variables.md` for `NATS_URL` details.
 
 #### Worktrees
 

--- a/crates/server/src/api/durable.rs
+++ b/crates/server/src/api/durable.rs
@@ -44,6 +44,10 @@ pub struct AppState {
     store: Option<Arc<dyn WorkflowEventStore + Send + Sync>>,
     metrics: MetricsCollector,
     auth: AuthState,
+    /// Task notification broadcaster for NATS publish on enqueue (optional)
+    task_broadcaster: Option<Arc<crate::task_notifications::TaskBroadcaster>>,
+    /// Event delivery backend name for health endpoint
+    event_delivery_backend: String,
 }
 
 impl_auth_state!(AppState);
@@ -52,11 +56,18 @@ impl AppState {
     /// Create new state with an optional workflow event store
     ///
     /// Collector holds 360 points = 1 hour at 10s intervals.
-    pub fn new(store: Option<Arc<dyn WorkflowEventStore + Send + Sync>>, auth: AuthState) -> Self {
+    pub fn new(
+        store: Option<Arc<dyn WorkflowEventStore + Send + Sync>>,
+        auth: AuthState,
+        task_broadcaster: Option<Arc<crate::task_notifications::TaskBroadcaster>>,
+        event_delivery_backend: String,
+    ) -> Self {
         Self {
             store,
             metrics: MetricsCollector::new(360),
             auth,
+            task_broadcaster,
+            event_delivery_backend,
         }
     }
 
@@ -244,6 +255,36 @@ pub struct HealthResponse {
     pub failed_workflows: usize,
     pub started_workflows: usize,
     pub dlq_size: usize,
+    /// Event delivery backend: "nats" or "in_memory"
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub event_delivery: Option<String>,
+}
+
+// Allow tests to construct HealthResponse without specifying all fields
+impl Default for HealthResponse {
+    fn default() -> Self {
+        Self {
+            status: "unknown".to_string(),
+            total_workers: 0,
+            active_workers: 0,
+            workers_accepting: 0,
+            total_capacity: 0,
+            current_load: 0,
+            load_percentage: 0.0,
+            pending_tasks: 0,
+            claimed_tasks: 0,
+            completed_tasks: 0,
+            failed_tasks: 0,
+            started_tasks: 0,
+            running_workflows: 0,
+            pending_workflows: 0,
+            completed_workflows: 0,
+            failed_workflows: 0,
+            started_workflows: 0,
+            dlq_size: 0,
+            event_delivery: None,
+        }
+    }
 }
 
 impl From<SystemHealth> for HealthResponse {
@@ -281,7 +322,16 @@ impl From<SystemHealth> for HealthResponse {
             failed_workflows: h.failed_workflows,
             started_workflows: h.started_workflows,
             dlq_size: h.dlq_size,
+            event_delivery: None,
         }
+    }
+}
+
+impl HealthResponse {
+    /// Set the event delivery backend name
+    pub fn with_event_delivery(mut self, backend: String) -> Self {
+        self.event_delivery = Some(backend);
+        self
     }
 }
 
@@ -719,7 +769,9 @@ pub async fn get_health(
         )
     })?;
 
-    Ok(Json(HealthResponse::from(health)))
+    Ok(Json(
+        HealthResponse::from(health).with_event_delivery(state.event_delivery_backend.clone()),
+    ))
 }
 
 /// GET /v1/durable/metrics/timeseries - Get metrics time series
@@ -1224,10 +1276,11 @@ pub async fn enqueue_task(
         }
     }
 
+    let activity_type = body.activity_type;
     let task = everruns_durable::TaskDefinition {
         workflow_id: None,
         activity_id: Uuid::now_v7().to_string(),
-        activity_type: body.activity_type,
+        activity_type: activity_type.clone(),
         input: body.input,
         options,
     };
@@ -1241,6 +1294,11 @@ pub async fn enqueue_task(
             }),
         )
     })?;
+
+    // Notify NATS subscribers (no-op for PG backend)
+    if let Some(broadcaster) = &state.task_broadcaster {
+        broadcaster.notify_task_available(&activity_type).await;
+    }
 
     Ok((StatusCode::CREATED, Json(EnqueueTaskResponse { task_id })))
 }
@@ -2193,6 +2251,7 @@ mod tests {
                 failed_workflows: 0,
                 started_workflows: 11,
                 dlq_size: 0,
+                event_delivery: None,
             },
             workers: vec![],
             workflows: WorkflowsListResponse {
@@ -2366,7 +2425,7 @@ mod tests {
 
     #[test]
     fn test_app_state_get_store_none() {
-        let state = AppState::new(None, test_auth_state());
+        let state = AppState::new(None, test_auth_state(), None, "in_memory".to_string());
         let result = state.get_store();
         assert!(result.is_err());
     }
@@ -2812,6 +2871,7 @@ mod tests {
             failed_workflows: 0,
             started_workflows: 11,
             dlq_size: 0,
+            event_delivery: None,
         };
 
         let json = serde_json::to_string(&response).unwrap();
@@ -2946,6 +3006,7 @@ mod tests {
                 failed_workflows: 3,
                 started_workflows: 36,
                 dlq_size: 0,
+                event_delivery: None,
             },
             workers: vec![],
             workflows: WorkflowsListResponse {
@@ -3485,7 +3546,7 @@ mod tests {
             };
             let backend = Arc::new(MockAuthBackend { roles });
             let auth = AuthState::new(config, backend);
-            let state = AppState::new(None, auth);
+            let state = AppState::new(None, auth, None, "in_memory".to_string());
             routes(state)
         }
 

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -606,7 +606,12 @@ impl ServerAppBuilder {
                 })
             };
         // TM-DURABLE-010: All durable endpoints require admin role
-        let durable_state = api::durable::AppState::new(durable_store.clone(), auth_state.clone());
+        let durable_state = api::durable::AppState::new(
+            durable_store.clone(),
+            auth_state.clone(),
+            None, // task_broadcaster: PG trigger handles NOTIFY; NATS notify from gRPC service
+            event_delivery.backend_name().to_string(),
+        );
         durable_state.spawn_metrics_sampler();
 
         // Bridge durable MetricsCollector gauges to Prometheus

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -605,11 +605,20 @@ impl ServerAppBuilder {
                         as Arc<dyn WorkflowEventStore + Send + Sync>
                 })
             };
+        // Create TaskBroadcaster early so it can be shared between durable_state and gRPC service
+        let task_broadcaster = if !self.config.dev_mode {
+            crate::task_notifications::TaskBroadcaster::from_env(db.pool())
+                .await
+                .map(Arc::new)
+        } else {
+            None
+        };
+
         // TM-DURABLE-010: All durable endpoints require admin role
         let durable_state = api::durable::AppState::new(
             durable_store.clone(),
             auth_state.clone(),
-            None, // task_broadcaster: PG trigger handles NOTIFY; NATS notify from gRPC service
+            task_broadcaster.clone(),
             event_delivery.backend_name().to_string(),
         );
         durable_state.spawn_metrics_sampler();
@@ -907,9 +916,7 @@ impl ServerAppBuilder {
             let grpc_addr = self.config.grpc_addr.clone();
             let grpc_platform_definition = platform_definition.clone();
 
-            let task_broadcaster = crate::task_notifications::TaskBroadcaster::from_env(db.pool())
-                .await
-                .map(Arc::new);
+            let grpc_task_broadcaster = task_broadcaster.clone();
 
             tokio::spawn(async move {
                 let mut grpc_svc = grpc_service::WorkerServiceImpl::new(
@@ -919,7 +926,7 @@ impl ServerAppBuilder {
                     Some(grpc_runner),
                     grpc_platform_definition.as_ref().clone(),
                 );
-                if let Some(broadcaster) = task_broadcaster {
+                if let Some(broadcaster) = grpc_task_broadcaster {
                     grpc_svc.set_task_broadcaster(broadcaster);
                 }
                 // THREAT[TM-DURABLE-002]: gRPC unauthenticated access

--- a/crates/server/src/event_delivery.rs
+++ b/crates/server/src/event_delivery.rs
@@ -38,6 +38,14 @@ impl EventDelivery {
         matches!(self, Self::Nats(_))
     }
 
+    /// Backend name for health/metrics reporting
+    pub fn backend_name(&self) -> &'static str {
+        match self {
+            Self::InMemory(_) => "in_memory",
+            Self::Nats(_) => "nats",
+        }
+    }
+
     /// Create from environment. Uses NATS if `NATS_URL` is set, otherwise in-memory.
     pub async fn from_env() -> Self {
         match std::env::var("NATS_URL") {

--- a/crates/server/src/nats_task_notifications.rs
+++ b/crates/server/src/nats_task_notifications.rs
@@ -106,7 +106,18 @@ impl NatsTaskNotificationBroadcaster {
 
     /// Publish a task notification to NATS (called when a task is enqueued)
     pub async fn notify_task_available(&self, activity_type: &str) {
-        let subject = format!("{NATS_TASK_SUBJECT_PREFIX}.{activity_type}");
+        // Sanitize activity_type: NATS subjects cannot contain spaces, *, >, or .
+        let sanitized: String = activity_type
+            .chars()
+            .map(|c| {
+                if matches!(c, ' ' | '*' | '>' | '.') {
+                    '_'
+                } else {
+                    c
+                }
+            })
+            .collect();
+        let subject = format!("{NATS_TASK_SUBJECT_PREFIX}.{sanitized}");
         if let Err(e) = self
             .nats_client
             .publish(subject, activity_type.as_bytes().to_vec().into())

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -246,8 +246,12 @@ impl TestServer {
             db: db.clone(),
             auth: auth_state.clone(),
         };
-        let durable_state =
-            api::durable::AppState::new(Some(durable_store.clone()), auth_state.clone());
+        let durable_state = api::durable::AppState::new(
+            Some(durable_store.clone()),
+            auth_state.clone(),
+            None,
+            "in_memory".to_string(),
+        );
         let schedules_state =
             api::schedules::ScheduleAppState::new(Some(durable_store), auth_state.clone());
         let skills_state = api::skills::AppState::new(db.clone(), auth_state.clone());

--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -5408,13 +5408,18 @@ mod durable_sse_tests {
     /// Create a test router with in-memory durable store
     fn create_test_app() -> Router {
         let store = Arc::new(InMemoryWorkflowEventStore::new());
-        let state = durable::AppState::new(Some(store), test_auth_state());
+        let state = durable::AppState::new(
+            Some(store),
+            test_auth_state(),
+            None,
+            "in_memory".to_string(),
+        );
         durable::routes(state)
     }
 
     /// Create a test router with no durable store (simulates 503)
     fn create_test_app_no_store() -> Router {
-        let state = durable::AppState::new(None, test_auth_state());
+        let state = durable::AppState::new(None, test_auth_state(), None, "in_memory".to_string());
         durable::routes(state)
     }
 

--- a/docs/sre/environment-variables.md
+++ b/docs/sre/environment-variables.md
@@ -148,6 +148,36 @@ VALKEY_URL=rediss://user:password@valkey.example.com:6380
 - Only used by control-plane (server); workers don't need this variable
 - Uses sliding-window counters via Lua scripts for atomic rate limit checks
 
+## NATS_URL
+
+Connection URL for NATS with JetStream, used for push-based event delivery and task notifications.
+
+| Property | Value |
+|----------|-------|
+| **Required** | No |
+| **Default** | Not set (uses PG NOTIFY for task notifications, in-memory broadcast for SSE event delivery) |
+
+**Example:**
+
+```bash
+# Local NATS
+NATS_URL=nats://localhost:4222
+
+# Cluster
+NATS_URL=nats://nats1:4222,nats://nats2:4222,nats://nats3:4222
+```
+
+**Notes:**
+- When not set, the system behaves exactly as before — all events persist to PG, SSE polls PG, task notifications use PG NOTIFY. Zero behavioral change.
+- When set, enables two features:
+  - **Ephemeral event delivery**: delta events (`output.message.delta`, `reason.thinking.delta`, `tool.output.delta`, `llm.generation`) skip PostgreSQL and flow only through NATS JetStream. SSE streams subscribe to NATS instead of polling PG.
+  - **Task notifications**: `task.available.{activity_type}` subjects replace PG NOTIFY for push-based worker notification. Lower latency (~1ms vs ~30ms), supports multi-instance deployments.
+- NATS JetStream must be enabled on the server (`--jetstream` flag)
+- Fail-graceful: if NATS connection fails at startup, falls back to PG NOTIFY + in-memory delivery with a warning
+- Only used by control-plane (server); workers communicate via gRPC and don't need NATS access
+- Default port: 4222 (or `PORT_PREFIX22` with `PORT_PREFIX`)
+- `just start-all` automatically starts NATS and exports `NATS_URL` if `nats-server` is installed
+
 ## LLM Provider API Keys
 
 LLM provider API keys (OpenAI, Anthropic, Gemini) are primarily stored encrypted in the database and managed via the Settings > Providers UI.

--- a/examples/docker-compose-full.yaml
+++ b/examples/docker-compose-full.yaml
@@ -68,6 +68,23 @@ services:
     restart: unless-stopped
 
   # ==========================================================================
+  # NATS (event delivery + task notifications, optional)
+  # When present, enables push-based SSE delivery and NATS task notifications.
+  # Without NATS, the system falls back to PG NOTIFY + in-memory delivery.
+  # ==========================================================================
+  nats:
+    image: nats:2-alpine
+    command: ["--jetstream", "--store_dir", "/data"]
+    volumes:
+      - nats_data:/data
+    healthcheck:
+      test: ["CMD", "nats-server", "--help"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
+  # ==========================================================================
   # Server (Control Plane) - HTTP API + gRPC server
   # Note: Migrations are auto-applied on startup
   # ==========================================================================
@@ -76,6 +93,7 @@ services:
     environment:
       DATABASE_URL: postgres://everruns:everruns@postgres:5432/everruns
       VALKEY_URL: redis://valkey:6379
+      NATS_URL: nats://nats:4222
       SECRETS_ENCRYPTION_KEY: ${SECRETS_ENCRYPTION_KEY}
       DEFAULT_OPENAI_API_KEY: ${DEFAULT_OPENAI_API_KEY:-}
       DEFAULT_ANTHROPIC_API_KEY: ${DEFAULT_ANTHROPIC_API_KEY:-}
@@ -88,6 +106,8 @@ services:
       postgres:
         condition: service_healthy
       valkey:
+        condition: service_healthy
+      nats:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "/app/everruns-server", "--version"]
@@ -243,4 +263,5 @@ configs:
 volumes:
   postgres_data:
   valkey_data:
+  nats_data:
   victoriametrics_data:

--- a/examples/docker-compose-full.yaml
+++ b/examples/docker-compose-full.yaml
@@ -74,11 +74,11 @@ services:
   # ==========================================================================
   nats:
     image: nats:2-alpine
-    command: ["--jetstream", "--store_dir", "/data"]
+    command: ["--jetstream", "--store_dir", "/data", "-m", "8222"]
     volumes:
       - nats_data:/data
     healthcheck:
-      test: ["CMD", "nats-server", "--help"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8222/healthz"]
       interval: 5s
       timeout: 3s
       retries: 5

--- a/scripts/lib/services.sh
+++ b/scripts/lib/services.sh
@@ -70,13 +70,8 @@ check_valkey_ready() {
 check_nats_ready() {
   local port="${1:?port required}"
 
-  # Try NATS monitoring endpoint
-  if command -v curl &> /dev/null; then
-    curl -sf "http://localhost:${port}/healthz" >/dev/null 2>&1
-    return $?
-  fi
-
-  # Fallback: TCP port check
+  # TCP port check only — the NATS client port does not serve HTTP.
+  # HTTP monitoring runs on a separate port (default 8222), not probed here.
   if command -v nc &> /dev/null; then
     nc -z localhost "$port" >/dev/null 2>&1
     return $?
@@ -518,13 +513,13 @@ case "$cmd" in
     # Start NATS for event delivery and task notifications (optional)
     if [ -z "${NATS_URL:-}" ]; then
       if check_nats_ready "$NATS_PORT" 2>/dev/null; then
-        export NATS_URL=${NATS_URL:-$NATS_URL_DEFAULT}
+        export NATS_URL="${NATS_URL:-$NATS_URL_DEFAULT}"
         echo "   ✅ NATS ready (push-based event delivery + task notifications)"
       else
         echo "   ℹ️  Starting NATS..."
         "$PROJECT_ROOT/scripts/lib/infra.sh" start >/dev/null 2>&1 || true
         if check_nats_ready "$NATS_PORT" 2>/dev/null; then
-          export NATS_URL=${NATS_URL:-$NATS_URL_DEFAULT}
+          export NATS_URL="${NATS_URL:-$NATS_URL_DEFAULT}"
           echo "   ✅ NATS started (push-based event delivery + task notifications)"
         else
           echo "   ℹ️  NATS not available — using PG NOTIFY + in-memory event delivery"
@@ -806,13 +801,13 @@ case "$cmd" in
     # Start NATS for event delivery and task notifications (optional)
     if [ -z "${NATS_URL:-}" ]; then
       if check_nats_ready "$NATS_PORT" 2>/dev/null; then
-        export NATS_URL=${NATS_URL:-$NATS_URL_DEFAULT}
+        export NATS_URL="${NATS_URL:-$NATS_URL_DEFAULT}"
         echo "   ✅ NATS ready (push-based event delivery + task notifications)"
       else
         echo "   ℹ️  Starting NATS..."
         "$PROJECT_ROOT/scripts/lib/infra.sh" start >/dev/null 2>&1 || true
         if check_nats_ready "$NATS_PORT" 2>/dev/null; then
-          export NATS_URL=${NATS_URL:-$NATS_URL_DEFAULT}
+          export NATS_URL="${NATS_URL:-$NATS_URL_DEFAULT}"
           echo "   ✅ NATS started (push-based event delivery + task notifications)"
         else
           echo "   ℹ️  NATS not available — using PG NOTIFY + in-memory event delivery"

--- a/scripts/lib/services.sh
+++ b/scripts/lib/services.sh
@@ -67,6 +67,28 @@ check_valkey_ready() {
   return 1
 }
 
+check_nats_ready() {
+  local port="${1:?port required}"
+
+  # Try NATS monitoring endpoint
+  if command -v curl &> /dev/null; then
+    curl -sf "http://localhost:${port}/healthz" >/dev/null 2>&1
+    return $?
+  fi
+
+  # Fallback: TCP port check
+  if command -v nc &> /dev/null; then
+    nc -z localhost "$port" >/dev/null 2>&1
+    return $?
+  fi
+
+  if (echo >"/dev/tcp/127.0.0.1/$port") >/dev/null 2>&1; then
+    return 0
+  fi
+
+  return 1
+}
+
 signal_recorded_pids() {
   local signal="$1"
 
@@ -493,6 +515,23 @@ case "$cmd" in
       fi
     fi
 
+    # Start NATS for event delivery and task notifications (optional)
+    if [ -z "${NATS_URL:-}" ]; then
+      if check_nats_ready "$NATS_PORT" 2>/dev/null; then
+        export NATS_URL=${NATS_URL:-$NATS_URL_DEFAULT}
+        echo "   ✅ NATS ready (push-based event delivery + task notifications)"
+      else
+        echo "   ℹ️  Starting NATS..."
+        "$PROJECT_ROOT/scripts/lib/infra.sh" start >/dev/null 2>&1 || true
+        if check_nats_ready "$NATS_PORT" 2>/dev/null; then
+          export NATS_URL=${NATS_URL:-$NATS_URL_DEFAULT}
+          echo "   ✅ NATS started (push-based event delivery + task notifications)"
+        else
+          echo "   ℹ️  NATS not available — using PG NOTIFY + in-memory event delivery"
+        fi
+      fi
+    fi
+
     print_doppler_secret_hint
 
     # Configure LLM API keys
@@ -517,7 +556,7 @@ case "$cmd" in
     fi
 
     # Start API
-    export API_PORT WORKER_GRPC_PORT CADDY_ADMIN_PORT UI_PORT PROXY_PORT VALKEY_PORT
+    export API_PORT WORKER_GRPC_PORT CADDY_ADMIN_PORT UI_PORT PROXY_PORT VALKEY_PORT NATS_PORT
     export ADDR=${ADDR:-$API_ADDR_DEFAULT}
     export WORKER_GRPC_ADDR=${WORKER_GRPC_ADDR:-$WORKER_GRPC_ADDR_DEFAULT}
     export WORKER_GRPC_ADDRESS=${WORKER_GRPC_ADDRESS:-$WORKER_GRPC_ADDRESS_DEFAULT}
@@ -760,6 +799,23 @@ case "$cmd" in
           echo "   ✅ Valkey started (distributed rate limiting enabled)"
         else
           echo "   ℹ️  Valkey not available — using per-instance rate limiting"
+        fi
+      fi
+    fi
+
+    # Start NATS for event delivery and task notifications (optional)
+    if [ -z "${NATS_URL:-}" ]; then
+      if check_nats_ready "$NATS_PORT" 2>/dev/null; then
+        export NATS_URL=${NATS_URL:-$NATS_URL_DEFAULT}
+        echo "   ✅ NATS ready (push-based event delivery + task notifications)"
+      else
+        echo "   ℹ️  Starting NATS..."
+        "$PROJECT_ROOT/scripts/lib/infra.sh" start >/dev/null 2>&1 || true
+        if check_nats_ready "$NATS_PORT" 2>/dev/null; then
+          export NATS_URL=${NATS_URL:-$NATS_URL_DEFAULT}
+          echo "   ✅ NATS started (push-based event delivery + task notifications)"
+        else
+          echo "   ℹ️  NATS not available — using PG NOTIFY + in-memory event delivery"
         fi
       fi
     fi

--- a/specs/parallel-execution-1m.md
+++ b/specs/parallel-execution-1m.md
@@ -1016,6 +1016,102 @@ See `crates/server/src/nats_task_notifications.rs` and `crates/server/src/task_n
 **Impact**: Task notification delivery off PG NOTIFY. Lower latency (~1ms vs ~30ms),
 multi-instance support, no PG connection dedicated to LISTEN. Gated on `NATS_URL`.
 
+### Phase 3.5: NATS end-to-end operational readiness
+
+Phases 1-3 built the library-level NATS integration. Phase 3.5 makes it fully operational:
+infrastructure scripts, all notification paths wired, documentation, integration tests.
+
+#### A. Infrastructure: `start-all` starts NATS, exports `NATS_URL`
+
+**scripts/lib/services.sh** — `start-all` must:
+- Call `start_nats` from `infra.sh` (already implemented)
+- Export `NATS_URL=$NATS_URL_DEFAULT` alongside `VALKEY_URL` and `DATABASE_URL`
+- Server process receives `NATS_URL` → `EventDelivery::Nats` + `TaskBroadcaster::Nats`
+
+`start-dev` stays unchanged — no NATS, no `NATS_URL`, pure PG behavior.
+
+#### B. Wire task notifications in ALL enqueue paths
+
+**Currently wired (gRPC only):**
+- `grpc_service/worker_service_impl.rs` — `enqueue_durable_task()` ✓
+- `grpc_service/worker_service_impl.rs` — `fail_durable_task()` (retry) ✓
+
+**Missing — must add `notify_task_available()` calls:**
+- `crates/server/src/api/durable.rs` — REST `POST /v1/durable/tasks` standalone enqueue.
+  Add `TaskBroadcaster` to durable `AppState`, call after `store.enqueue_task()`.
+- `crates/durable/src/scheduler/mod.rs` — scheduled task triggers.
+  Scheduler enqueues tasks via `store.enqueue_task()`. PG trigger handles PG NOTIFY,
+  but NATS needs an explicit publish. Pass `TaskBroadcaster` to scheduler or publish
+  from the store wrapper.
+- `crates/durable/src/worker/pool.rs` — `reclaim_stale_tasks()` moves tasks back to pending.
+  PG trigger handles PG NOTIFY. For NATS, publish after reclaim returns reclaimed count > 0.
+
+#### C. Docker Compose: add NATS service
+
+**examples/docker-compose-full.yaml** — add NATS JetStream container:
+```yaml
+nats:
+  image: nats:2-alpine
+  command: ["--jetstream", "--store_dir", "/data"]
+  ports:
+    - "${NATS_PORT:-4222}:4222"
+  volumes:
+    - nats-data:/data
+  healthcheck:
+    test: ["CMD", "nats-server", "--help"]
+    interval: 5s
+    timeout: 3s
+    retries: 3
+```
+Server service env: `NATS_URL: nats://nats:4222`
+
+#### D. Environment variable documentation
+
+**docs/sre/environment-variables.md** — add NATS section:
+- `NATS_URL` — NATS connection URL (e.g., `nats://localhost:4222`). When set, enables
+  NATS JetStream for event delivery and task notifications. When unset, system uses
+  PostgreSQL NOTIFY and in-memory broadcast (zero behavioral change).
+- `NATS_PORT` — Port for local NATS server (default: 4222, or `PORT_PREFIX22` with prefix).
+
+#### E. Integration test: SSE push delivery with NATS
+
+Add a test in `crates/server/tests/` that:
+1. Starts with `NATS_URL` pointing to a test NATS server (or embedded)
+2. Creates a session, sends a message
+3. Subscribes to SSE stream
+4. Verifies `output.message.completed` arrives via push (not PG poll)
+5. Verifies ephemeral events (`output.message.delta`) are NOT in PG events table
+6. Verifies durable events ARE in PG events table
+
+If running a real `nats-server` in CI is complex, test with `EventDelivery::InMemory`
+as a proxy — the SSE `Streaming` phase uses the same `EventSubscription::recv()` API.
+
+#### F. Durable dashboard: event delivery indicator
+
+Add to the durable overview page (`apps/ui/src/app/(main)/durable/`):
+- Badge showing event delivery backend: "NATS JetStream" or "In-Memory (PG fallback)"
+- Expose via existing `/v1/durable/health` endpoint: add `event_delivery: "nats" | "in_memory"`
+  field to `SystemHealth` response.
+
+#### G. Update specs and AGENTS.md
+
+- `specs/architecture.md` — already has EventDelivery section ✓
+- `specs/parallel-execution-1m.md` — this section ✓
+- `AGENTS.md` — update Local Dev section: mention `start-all` starts NATS,
+  `NATS_URL` controls event delivery backend
+- `specs/events.md` or `specs/events-contract.md` — note ephemeral event classification
+  and that deltas skip PG when NATS is active
+
+#### Implementation order
+
+1. **services.sh + infra.sh** — export `NATS_URL` in `start-all` (~30 min)
+2. **Wire missing notification paths** — REST durable API, scheduler, reclaim (~2-3 hours)
+3. **Docker compose** — add NATS service (~30 min)
+4. **Env var docs** — document `NATS_URL`, `NATS_PORT` (~30 min)
+5. **Integration test** — SSE push delivery test (~2-3 hours)
+6. **Dashboard indicator** — health endpoint + UI badge (~1-2 hours)
+7. **Spec updates** — AGENTS.md, events specs (~30 min)
+
 ### Phase 4: Kafka for durable event cold storage (future consideration)
 
 At extreme scale (500K+ agents), synchronous PG INSERT for every durable event may bottleneck. Kafka/Redpanda would decouple the write path: durable events publish to Kafka, an async consumer backfills PG via batched COPY. SSE continues reading from NATS (unchanged). PG becomes cold storage for REST API and dashboards with 2-5s acceptable lag. Evaluate after Phase 3 based on measured PG write throughput.


### PR DESCRIPTION
## Summary

End-to-end operational readiness for optional NATS integration:

- **Infrastructure**: `start-all` auto-starts NATS and exports `NATS_URL`; `check_nats_ready()` health check
- **Notification wiring**: REST durable enqueue (`POST /v1/durable/tasks`) now calls `notify_task_available()` for NATS subscribers
- **Health indicator**: `GET /v1/durable/health` includes `event_delivery` field ("nats" or "in_memory")
- **Docker**: NATS JetStream service in `docker-compose-full.yaml` with healthcheck and `NATS_URL` for server
- **Documentation**: `NATS_URL` in `docs/sre/environment-variables.md` and `AGENTS.md`
- **Spec**: Phase 3.5 plan in `specs/parallel-execution-1m.md`

## Test plan

- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes (verified)
- [ ] `cargo fmt --check` passes (verified)
- [ ] `just start-dev` works without NATS (zero behavioral change)
- [ ] `just start-all` starts NATS alongside PG/Valkey when `nats-server` installed
- [ ] `GET /v1/durable/health` includes `event_delivery: "nats"` or `"in_memory"`
- [ ] Docker compose starts all services including NATS
