### PR TITLE
feat(browserless): configurable API and WebSocket base URLs

### DIFF
--- a/integrations/browserless/SPEC.md
+++ b/integrations/browserless/SPEC.md
@@ -63,7 +63,7 @@ Browserless registers as a `ConnectionProviderPlugin` (API-key type). Users conf
 
 ### REST Endpoints
 
-Base URL: `https://production-sfo.browserless.io`
+Base URL: `https://production-sfo.browserless.io` (configurable via `BROWSERLESS_API_BASE` env var)
 
 Auth: `?token=<api_token>` query parameter on all requests.
 
@@ -76,7 +76,7 @@ Auth: `?token=<api_token>` query parameter on all requests.
 
 ### CDP (WebSocket) Protocol
 
-Base URL: `wss://production-sfo.browserless.io`
+Base URL: `wss://production-sfo.browserless.io` (configurable via `BROWSERLESS_WS_BASE` env var)
 
 New browser sessions connect to `/chromium` path (Browserless v2 requirement).
 Reconnect endpoints use the path returned by `Browserless.reconnect`.

--- a/integrations/browserless/src/client.rs
+++ b/integrations/browserless/src/client.rs
@@ -20,7 +20,7 @@ pub struct BrowserlessClient {
 
 impl BrowserlessClient {
     pub fn new(api_token: String) -> Self {
-        Self::with_base_url(api_token, crate::BROWSERLESS_API_BASE.to_string())
+        Self::with_base_url(api_token, crate::browserless_api_base())
     }
 
     pub fn with_base_url(api_token: String, api_base: String) -> Self {

--- a/integrations/browserless/src/connection.rs
+++ b/integrations/browserless/src/connection.rs
@@ -13,8 +13,6 @@ use everruns_core::connection_provider::{
 };
 use tracing::warn;
 
-use crate::BROWSERLESS_API_BASE;
-
 pub struct BrowserlessConnectionProvider;
 
 #[async_trait]
@@ -60,7 +58,10 @@ impl ConnectionProvider for BrowserlessConnectionProvider {
     async fn validate(&self, credential: &str) -> Result<ConnectionValidation, String> {
         let client = reqwest::Client::new();
         let response = client
-            .get(format!("{BROWSERLESS_API_BASE}/active?token={credential}"))
+            .get(format!(
+                "{}/active?token={credential}",
+                crate::browserless_api_base()
+            ))
             .send()
             .await
             .map_err(|e| format!("Failed to reach Browserless API: {e}"))?;
@@ -86,7 +87,8 @@ impl ConnectionProvider for BrowserlessConnectionProvider {
         // This catches tokens that work for REST but not for CDP sessions.
         let cdp_probe = client
             .get(format!(
-                "{BROWSERLESS_API_BASE}{}?token={credential}",
+                "{}{}?token={credential}",
+                crate::browserless_api_base(),
                 crate::BROWSERLESS_CDP_PATH
             ))
             .send()

--- a/integrations/browserless/src/connection.rs
+++ b/integrations/browserless/src/connection.rs
@@ -57,11 +57,9 @@ impl ConnectionProvider for BrowserlessConnectionProvider {
 
     async fn validate(&self, credential: &str) -> Result<ConnectionValidation, String> {
         let client = reqwest::Client::new();
+        let api_base = crate::browserless_api_base();
         let response = client
-            .get(format!(
-                "{}/active?token={credential}",
-                crate::browserless_api_base()
-            ))
+            .get(format!("{api_base}/active?token={credential}"))
             .send()
             .await
             .map_err(|e| format!("Failed to reach Browserless API: {e}"))?;
@@ -87,8 +85,7 @@ impl ConnectionProvider for BrowserlessConnectionProvider {
         // This catches tokens that work for REST but not for CDP sessions.
         let cdp_probe = client
             .get(format!(
-                "{}{}?token={credential}",
-                crate::browserless_api_base(),
+                "{api_base}{}?token={credential}",
                 crate::BROWSERLESS_CDP_PATH
             ))
             .send()

--- a/integrations/browserless/src/lib.rs
+++ b/integrations/browserless/src/lib.rs
@@ -66,15 +66,31 @@ const DEFAULT_WS_BASE: &str = "wss://production-sfo.browserless.io";
 const BROWSERLESS_CDP_PATH: &str = "/chromium";
 
 /// REST API base URL. Reads `BROWSERLESS_API_BASE` env var with fallback
-/// to the default production SFO endpoint.
+/// to the default production SFO endpoint. Strips trailing slashes and
+/// falls back to the default if the env var is empty.
 pub fn browserless_api_base() -> String {
-    std::env::var("BROWSERLESS_API_BASE").unwrap_or_else(|_| DEFAULT_API_BASE.to_string())
+    read_base_url("BROWSERLESS_API_BASE", DEFAULT_API_BASE)
 }
 
 /// WebSocket base URL. Reads `BROWSERLESS_WS_BASE` env var with fallback
-/// to the default production SFO endpoint.
+/// to the default production SFO endpoint. Strips trailing slashes and
+/// falls back to the default if the env var is empty.
 pub fn browserless_ws_base() -> String {
-    std::env::var("BROWSERLESS_WS_BASE").unwrap_or_else(|_| DEFAULT_WS_BASE.to_string())
+    read_base_url("BROWSERLESS_WS_BASE", DEFAULT_WS_BASE)
+}
+
+fn read_base_url(env_var: &str, default: &str) -> String {
+    match std::env::var(env_var) {
+        Ok(val) => {
+            let trimmed = val.trim_end_matches('/');
+            if trimmed.is_empty() {
+                default.to_string()
+            } else {
+                trimmed.to_string()
+            }
+        }
+        Err(_) => default.to_string(),
+    }
 }
 
 // ============================================================================
@@ -225,6 +241,30 @@ mod tests {
         // New CDP sessions must connect to /chromium — root path returns 400
         let full_url = format!("{}{}", DEFAULT_WS_BASE, BROWSERLESS_CDP_PATH);
         assert_eq!(full_url, "wss://production-sfo.browserless.io/chromium");
+    }
+
+    #[test]
+    fn test_read_base_url_defaults_when_unset() {
+        // Use a unique env var name that's guaranteed not to be set
+        let result = read_base_url(
+            "_TEST_BROWSERLESS_URL_NEVER_SET",
+            "https://default.example.com",
+        );
+        assert_eq!(result, "https://default.example.com");
+    }
+
+    #[test]
+    fn test_read_base_url_strips_trailing_slash() {
+        // Test the trimming logic directly
+        let input = "https://custom.example.com/";
+        assert_eq!(input.trim_end_matches('/'), "https://custom.example.com");
+    }
+
+    #[test]
+    fn test_read_base_url_falls_back_on_empty() {
+        // Test the empty-string fallback logic directly
+        let trimmed = "".trim_end_matches('/');
+        assert!(trimmed.is_empty());
     }
 
     #[test]

--- a/integrations/browserless/src/lib.rs
+++ b/integrations/browserless/src/lib.rs
@@ -58,12 +58,24 @@ inventory::submit! {
 // Constants
 // ============================================================================
 
-const BROWSERLESS_API_BASE: &str = "https://production-sfo.browserless.io";
-const BROWSERLESS_WS_BASE: &str = "wss://production-sfo.browserless.io";
+const DEFAULT_API_BASE: &str = "https://production-sfo.browserless.io";
+const DEFAULT_WS_BASE: &str = "wss://production-sfo.browserless.io";
 
 /// Path for new CDP browser sessions. Browserless v2 requires `/chromium` —
 /// the root path returns 400 Bad Request for WebSocket upgrades.
 const BROWSERLESS_CDP_PATH: &str = "/chromium";
+
+/// REST API base URL. Reads `BROWSERLESS_API_BASE` env var with fallback
+/// to the default production SFO endpoint.
+pub fn browserless_api_base() -> String {
+    std::env::var("BROWSERLESS_API_BASE").unwrap_or_else(|_| DEFAULT_API_BASE.to_string())
+}
+
+/// WebSocket base URL. Reads `BROWSERLESS_WS_BASE` env var with fallback
+/// to the default production SFO endpoint.
+pub fn browserless_ws_base() -> String {
+    std::env::var("BROWSERLESS_WS_BASE").unwrap_or_else(|_| DEFAULT_WS_BASE.to_string())
+}
 
 // ============================================================================
 // BrowserlessCapability
@@ -211,7 +223,7 @@ mod tests {
     fn test_cdp_path_is_set() {
         assert_eq!(BROWSERLESS_CDP_PATH, "/chromium");
         // New CDP sessions must connect to /chromium — root path returns 400
-        let full_url = format!("{}{}", BROWSERLESS_WS_BASE, BROWSERLESS_CDP_PATH);
+        let full_url = format!("{}{}", DEFAULT_WS_BASE, BROWSERLESS_CDP_PATH);
         assert_eq!(full_url, "wss://production-sfo.browserless.io/chromium");
     }
 

--- a/integrations/browserless/src/session_tools.rs
+++ b/integrations/browserless/src/session_tools.rs
@@ -209,7 +209,7 @@ impl Tool for BrowserlessOpenBrowserTool {
 
         let ws_url = format!(
             "{}{}?token={}",
-            crate::BROWSERLESS_WS_BASE,
+            crate::browserless_ws_base(),
             crate::BROWSERLESS_CDP_PATH,
             api_token
         );


### PR DESCRIPTION
## What
Add `browserless_api_base()` and `browserless_ws_base()` functions that read `BROWSERLESS_API_BASE` and `BROWSERLESS_WS_BASE` env vars with fallback to default production SFO endpoints.

## Why
Closes EVE-213. Base URLs were hardcoded, breaking deployments behind proxies, different Browserless regions, or self-hosted instances.

## How
- Add `browserless_api_base()` / `browserless_ws_base()` in `lib.rs`
- Replace all hardcoded constant references in `client.rs`, `session_tools.rs`, `connection.rs`
- Update SPEC.md to document the env vars

## Risk
- Low
- Backward compatible: without env vars set, behavior is identical to before

## Security
- Threat categories reviewed: TM-API (external service URLs)
- URLs are read from env vars at runtime, following the same pattern as other configurable endpoints. No new trust boundaries — the Browserless integration already makes external HTTP/WS calls.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)