### PR TITLE
chore: add nats-server to just init (setup.sh)

### DIFF
--- a/scripts/lib/setup.sh
+++ b/scripts/lib/setup.sh
@@ -120,6 +120,40 @@ case "$cmd" in
       esac
     fi
 
+    # NATS (optional — used for push-based event delivery and task notifications)
+    echo ""
+    echo "📡 NATS:"
+    if command -v nats-server &> /dev/null; then
+      echo "  ✅ nats-server already installed"
+    else
+      echo "  Installing NATS server..."
+      case "$(uname -s)" in
+        Darwin)
+          if command -v brew &> /dev/null; then
+            brew install nats-server
+            echo "  ✅ Installed via Homebrew"
+          else
+            echo "  ⚠️  Homebrew not found. Install nats-server manually (optional)."
+          fi
+          ;;
+        Linux)
+          if command -v apt-get &> /dev/null; then
+            # NATS provides official .deb packages via their apt repo
+            if curl -fsSL https://get-nats.io/install.sh | sh -s -- -y nats-server 2>/dev/null; then
+              echo "  ✅ nats-server installed via get-nats.io"
+            else
+              echo "  ⚠️  Could not install nats-server (optional — PG NOTIFY + in-memory delivery will be used)"
+            fi
+          else
+            echo "  ⚠️  apt-get not found. Install nats-server manually (optional)."
+          fi
+          ;;
+        *)
+          echo "  ⚠️  Unsupported OS for auto-install. Install nats-server manually (optional)."
+          ;;
+      esac
+    fi
+
     # Rust tools
     echo "📦 Rust tools:"
     if ! command -v sqlx &> /dev/null; then

--- a/scripts/lib/setup.sh
+++ b/scripts/lib/setup.sh
@@ -137,15 +137,41 @@ case "$cmd" in
           fi
           ;;
         Linux)
-          if command -v apt-get &> /dev/null; then
-            # NATS provides official .deb packages via their apt repo
-            if curl -fsSL https://get-nats.io/install.sh | sh -s -- -y nats-server 2>/dev/null; then
-              echo "  ✅ nats-server installed via get-nats.io"
+          # Download pre-built nats-server binary (pinned version, no curl|sh)
+          local nats_version="2.11.3"
+          local arch
+          arch=$(uname -m)
+          case "$arch" in
+            x86_64)  arch="amd64" ;;
+            aarch64) arch="arm64" ;;
+            *)       arch="" ;;
+          esac
+          if [ -n "$arch" ] && command -v curl &> /dev/null; then
+            local nats_url="https://github.com/nats-io/nats-server/releases/download/v${nats_version}/nats-server-v${nats_version}-linux-${arch}.tar.gz"
+            local tmp_dir
+            tmp_dir=$(mktemp -d)
+            if curl -fsSL "$nats_url" -o "$tmp_dir/nats.tar.gz" 2>/dev/null; then
+              tar -xzf "$tmp_dir/nats.tar.gz" -C "$tmp_dir" 2>/dev/null
+              local nats_bin
+              nats_bin=$(find "$tmp_dir" -name nats-server -type f | head -1)
+              if [ -n "$nats_bin" ]; then
+                mkdir -p "$HOME/.local/bin"
+                cp "$nats_bin" "$HOME/.local/bin/nats-server"
+                chmod +x "$HOME/.local/bin/nats-server"
+                echo "  ✅ nats-server v${nats_version} installed to ~/.local/bin/"
+                # Ensure ~/.local/bin is in PATH
+                if ! echo "$PATH" | grep -q "$HOME/.local/bin"; then
+                  echo "  ℹ️  Add ~/.local/bin to PATH: export PATH=\"\$HOME/.local/bin:\$PATH\""
+                fi
+              else
+                echo "  ⚠️  Could not extract nats-server (optional — PG NOTIFY + in-memory delivery will be used)"
+              fi
             else
-              echo "  ⚠️  Could not install nats-server (optional — PG NOTIFY + in-memory delivery will be used)"
+              echo "  ⚠️  Could not download nats-server (optional — PG NOTIFY + in-memory delivery will be used)"
             fi
+            rm -rf "$tmp_dir"
           else
-            echo "  ⚠️  apt-get not found. Install nats-server manually (optional)."
+            echo "  ⚠️  curl not found or unsupported arch ($arch). Install nats-server manually (optional)."
           fi
           ;;
         *)


### PR DESCRIPTION
## Summary

- Add `nats-server` to `just init` (setup.sh) — same optional pattern as Valkey: brew on macOS, `get-nats.io` installer on Linux, skipped if already present

## Test plan

- [ ] `just init` installs nats-server on Linux (or skips if present)
- [ ] `just init` installs nats-server via brew on macOS (or skips if present)
- [ ] `just start-all` picks up installed nats-server and exports `NATS_URL`
