### PR TITLE
fix(cli): use SDK set_secrets instead of raw reqwest

### DIFF
--- a/crates/cli/src/commands/sessions.rs
+++ b/crates/cli/src/commands/sessions.rs
@@ -103,7 +103,13 @@ async fn create(
             .sessions()
             .set_secrets(&session.id, &secrets)
             .await
-            .context("Failed to store secrets")?;
+            .with_context(|| {
+                format!(
+                    "Failed to store {} secrets for session {}",
+                    secrets.len(),
+                    session.id
+                )
+            })?;
     }
 
     if output.is_text() {

--- a/crates/cli/src/commands/sessions.rs
+++ b/crates/cli/src/commands/sessions.rs
@@ -61,18 +61,14 @@ pub async fn run(
             title,
             model,
             secrets,
-        } => {
-            create(
-                client, output, quiet, harness, agent, title, model, secrets,
-            )
-            .await
-        }
+        } => create(client, output, quiet, harness, agent, title, model, secrets).await,
         SessionsCommand::List => list(client, output).await,
         SessionsCommand::Get { session } => get(client, output, session).await,
         SessionsCommand::Watch { session } => watch(client, output, session).await,
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn create(
     client: &Everruns,
     output: OutputFormat,

--- a/crates/cli/src/commands/sessions.rs
+++ b/crates/cli/src/commands/sessions.rs
@@ -51,8 +51,6 @@ pub enum SessionsCommand {
 pub async fn run(
     command: SessionsCommand,
     client: &Everruns,
-    api_url: &str,
-    api_key: &str,
     output: OutputFormat,
     quiet: bool,
 ) -> Result<()> {
@@ -65,7 +63,7 @@ pub async fn run(
             secrets,
         } => {
             create(
-                client, api_url, api_key, output, quiet, harness, agent, title, model, secrets,
+                client, output, quiet, harness, agent, title, model, secrets,
             )
             .await
         }
@@ -75,11 +73,8 @@ pub async fn run(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 async fn create(
     client: &Everruns,
-    api_url: &str,
-    api_key: &str,
     output: OutputFormat,
     quiet: bool,
     harness_id: Option<String>,
@@ -108,7 +103,11 @@ async fn create(
 
     // Store secrets after session creation
     if !secrets.is_empty() {
-        store_secrets(api_url, api_key, &session.id, &secrets).await?;
+        client
+            .sessions()
+            .set_secrets(&session.id, &secrets)
+            .await
+            .context("Failed to store secrets")?;
     }
 
     if output.is_text() {
@@ -152,34 +151,6 @@ fn parse_secrets(raw: &[String]) -> Result<HashMap<String, String>> {
         map.insert(key.to_string(), value.to_string());
     }
     Ok(map)
-}
-
-/// Store secrets via PUT /v1/sessions/:id/storage/secrets
-// TODO(everruns/sdk#67): Replace raw reqwest with native SDK client.sessions().set_secrets()
-async fn store_secrets(
-    api_url: &str,
-    api_key: &str,
-    session_id: &str,
-    secrets: &HashMap<String, String>,
-) -> Result<()> {
-    let resp = reqwest::Client::new()
-        .put(format!(
-            "{}/v1/sessions/{}/storage/secrets",
-            api_url, session_id
-        ))
-        .header("Authorization", format!("Bearer {}", api_key))
-        .json(&serde_json::json!({ "secrets": secrets }))
-        .send()
-        .await
-        .context("Failed to store secrets")?;
-
-    let status = resp.status();
-    if !status.is_success() {
-        let body = resp.text().await.unwrap_or_default();
-        anyhow::bail!("Failed to store secrets: {} {}", status, body);
-    }
-
-    Ok(())
 }
 
 async fn list(client: &Everruns, output: OutputFormat) -> Result<()> {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -191,15 +191,7 @@ async fn main() -> anyhow::Result<()> {
             commands::capabilities::run(&client, output_format, &status).await
         }
         Commands::Sessions { command } => {
-            commands::sessions::run(
-                command,
-                &client,
-                &api_url,
-                &api_key,
-                output_format,
-                cli.quiet,
-            )
-            .await
+            commands::sessions::run(command, &client, output_format, cli.quiet).await
         }
         Commands::Files { command } => {
             commands::files::run(command, &api_url, &api_key, output_format, cli.quiet).await


### PR DESCRIPTION
## What
Replace the raw reqwest-based `store_secrets()` function in the CLI with the native SDK `client.sessions().set_secrets()` method.

## Why
The `everruns-sdk` v0.1.6 already ships `SessionsClient::set_secrets()`. The CLI was still using a hand-rolled reqwest call with a TODO to migrate. This removes the duplication and aligns with the SDK-first pattern used elsewhere.

## How
- Removed `store_secrets()` helper and its raw reqwest usage
- Updated `create()` to call `client.sessions().set_secrets()` directly
- Removed unused `api_url`/`api_key` parameters from `run()` and `create()`
- Updated caller in `main.rs` accordingly

## Risk
- Low
- No behavioral change — same HTTP PUT to the same endpoint, same auth, same payload shape

## Security
- No security-relevant code changes. This is a pure refactor replacing a raw HTTP call with the equivalent SDK method. No new endpoints, auth changes, or input validation changes.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Closes EVE-233