### PR TITLE
fix(server): look up agents by public_id, not internal UUID

### DIFF
--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -802,17 +802,13 @@ impl WorkerAdapters for DirectWorkerAdapters {
             .await?
             .ok_or_else(|| store_error("Session not found"))?;
 
-        // Load agent by public_id, then fetch capabilities using the internal UUID
+        // session.agent_id from get_session() is the internal UUID (raw DB FK).
+        // Use get_agent() which queries by internal id.
         let (agent, mcp_tool_definitions) = if let Some(agent_id) = session.agent_id {
-            let public_id = agent_id.to_string();
-            let agent_row = self
-                .db
-                .get_agent_by_public_id(org_id, &public_id)
-                .await
-                .map_err(|e| {
-                    tracing::error!("Failed to get agent: {}", e);
-                    store_error("Failed to get agent")
-                })?;
+            let agent_row = self.db.get_agent(org_id, agent_id).await.map_err(|e| {
+                tracing::error!("Failed to get agent: {}", e);
+                store_error("Failed to get agent")
+            })?;
 
             if let Some(row) = agent_row {
                 let capability_rows = self

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -192,13 +192,28 @@ impl WorkerAdapters for DirectWorkerAdapters {
     }
 
     async fn get_agent(&self, org_id: i64, agent_id: Uuid) -> Result<Option<Agent>> {
-        let capabilities = self
+        // Look up by public_id, then fetch capabilities using internal id from the row.
+        let public_id = format!("agent_{}", agent_id.simple());
+        let row = self
             .db
-            .get_agent_capabilities(agent_id)
+            .get_agent_by_public_id(org_id, &public_id)
             .await
-            .unwrap_or_default();
-        self.get_agent_with_capabilities(org_id, agent_id, capabilities)
-            .await
+            .map_err(|e| {
+                tracing::error!("Failed to get agent: {}", e);
+                store_error("Failed to get agent")
+            })?;
+        match row {
+            Some(r) => {
+                let capabilities = self
+                    .db
+                    .get_agent_capabilities(r.id.uuid())
+                    .await
+                    .unwrap_or_default();
+                self.get_agent_with_capabilities(org_id, agent_id, capabilities)
+                    .await
+            }
+            None => Ok(None),
+        }
     }
 
     // =========================================================================
@@ -788,24 +803,38 @@ impl WorkerAdapters for DirectWorkerAdapters {
             .await?
             .ok_or_else(|| store_error("Session not found"))?;
 
-        // Load agent capabilities once, reuse for get_agent + build_mcp_tool_definitions
+        // Load agent by public_id, then fetch capabilities using the internal UUID
         let (agent, mcp_tool_definitions) = if let Some(agent_id) = session.agent_id {
-            let capability_rows = self
+            let public_id = agent_id.to_string();
+            let agent_row = self
                 .db
-                .get_agent_capabilities(agent_id.uuid())
+                .get_agent_by_public_id(org_id, &public_id)
                 .await
-                .unwrap_or_default();
+                .map_err(|e| {
+                    tracing::error!("Failed to get agent: {}", e);
+                    store_error("Failed to get agent")
+                })?;
 
-            let agent = self
-                .get_agent_with_capabilities(org_id, agent_id.uuid(), capability_rows.clone())
-                .await?;
+            if let Some(ref row) = agent_row {
+                let capability_rows = self
+                    .db
+                    .get_agent_capabilities(row.id.uuid())
+                    .await
+                    .unwrap_or_default();
 
-            let mcp_tools = self
-                .build_mcp_tool_definitions_with_capabilities(org_id, &capability_rows)
-                .await
-                .unwrap_or_default();
+                let agent = self
+                    .get_agent_with_capabilities(org_id, agent_id.uuid(), capability_rows.clone())
+                    .await?;
 
-            (agent, mcp_tools)
+                let mcp_tools = self
+                    .build_mcp_tool_definitions_with_capabilities(org_id, &capability_rows)
+                    .await
+                    .unwrap_or_default();
+
+                (agent, mcp_tools)
+            } else {
+                (None, vec![])
+            }
         } else {
             (None, vec![])
         };
@@ -956,10 +985,23 @@ impl WorkerAdapters for DirectWorkerAdapters {
             .is_some())
     }
 
-    async fn build_tool_registry(&self, _org_id: i64, agent_id: Uuid) -> Result<ToolRegistry> {
+    async fn build_tool_registry(&self, org_id: i64, agent_id: Uuid) -> Result<ToolRegistry> {
+        // agent_id is a public UUID — resolve to internal UUID for capability lookup
+        let public_id = format!("agent_{}", agent_id.simple());
+        let internal_id = self
+            .db
+            .get_agent_by_public_id(org_id, &public_id)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to resolve agent: {}", e);
+                store_error("Failed to resolve agent")
+            })?
+            .map(|r| r.id.uuid())
+            .unwrap_or(agent_id); // fall back to input UUID for backwards compat
+
         let capability_rows = self
             .db
-            .get_agent_capabilities(agent_id)
+            .get_agent_capabilities(internal_id)
             .await
             .map_err(|e| {
                 tracing::error!("Failed to get agent capabilities: {}", e);
@@ -1051,29 +1093,17 @@ impl DirectWorkerAdapters {
         agent_id: Uuid,
         capability_rows: Vec<AgentCapabilityRow>,
     ) -> Result<Option<Agent>> {
-        let agent_id_typed = AgentId::from_uuid(agent_id);
-        let mut row = self
+        // Look up by public_id — the UUID comes from a public AgentId,
+        // which may differ from the internal UUID for imported agents.
+        let public_id = format!("agent_{}", agent_id.simple());
+        let row = self
             .db
-            .get_agent(org_id, agent_id_typed)
+            .get_agent_by_public_id(org_id, &public_id)
             .await
             .map_err(|e| {
-                tracing::error!("Failed to get agent: {}", e);
+                tracing::error!("Failed to get agent by public_id: {}", e);
                 store_error("Failed to get agent")
             })?;
-
-        // Fallback: try public_id lookup when internal UUID doesn't match
-        // (happens with imported agents that have custom public IDs)
-        if row.is_none() {
-            let public_id = format!("agent_{}", agent_id.simple());
-            row = self
-                .db
-                .get_agent_by_public_id(org_id, &public_id)
-                .await
-                .map_err(|e| {
-                    tracing::error!("Failed to get agent by public_id: {}", e);
-                    store_error("Failed to get agent by public_id")
-                })?;
-        }
 
         Ok(row.map(|r| Agent {
             public_id: r
@@ -1594,21 +1624,13 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
     }
 
     async fn get_agent_by_id(&self, id: AgentId) -> everruns_core::error::Result<Option<Agent>> {
-        let mut row = self
+        // AgentId is always a public ID — look up by public_id column.
+        let public_id = id.to_string();
+        let row = self
             .db
-            .get_agent(self.org_id, id)
+            .get_agent_by_public_id(self.org_id, &public_id)
             .await
             .map_err(|e| store_error(format!("Failed to get agent: {e}")))?;
-
-        // Fallback: try public_id lookup when internal UUID doesn't match
-        if row.is_none() {
-            let public_id = format!("agent_{}", id.uuid().simple());
-            row = self
-                .db
-                .get_agent_by_public_id(self.org_id, &public_id)
-                .await
-                .map_err(|e| store_error(format!("Failed to get agent by public_id: {e}")))?;
-        }
 
         match row {
             Some(row) => {
@@ -1764,7 +1786,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
         {
             let agent = self
                 .db
-                .get_agent(self.org_id, agent_id)
+                .get_agent_by_public_id(self.org_id, &agent_id.to_string())
                 .await
                 .map_err(|e| store_error(format!("Failed to get agent: {e}")))?
                 .ok_or_else(|| store_error("Agent not found"))?;

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1052,7 +1052,7 @@ impl DirectWorkerAdapters {
         capability_rows: Vec<AgentCapabilityRow>,
     ) -> Result<Option<Agent>> {
         let agent_id_typed = AgentId::from_uuid(agent_id);
-        let row = self
+        let mut row = self
             .db
             .get_agent(org_id, agent_id_typed)
             .await
@@ -1060,6 +1060,20 @@ impl DirectWorkerAdapters {
                 tracing::error!("Failed to get agent: {}", e);
                 store_error("Failed to get agent")
             })?;
+
+        // Fallback: try public_id lookup when internal UUID doesn't match
+        // (happens with imported agents that have custom public IDs)
+        if row.is_none() {
+            let public_id = format!("agent_{}", agent_id.simple());
+            row = self
+                .db
+                .get_agent_by_public_id(org_id, &public_id)
+                .await
+                .map_err(|e| {
+                    tracing::error!("Failed to get agent by public_id: {}", e);
+                    store_error("Failed to get agent by public_id")
+                })?;
+        }
 
         Ok(row.map(|r| Agent {
             public_id: r
@@ -1580,11 +1594,21 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
     }
 
     async fn get_agent_by_id(&self, id: AgentId) -> everruns_core::error::Result<Option<Agent>> {
-        let row = self
+        let mut row = self
             .db
             .get_agent(self.org_id, id)
             .await
             .map_err(|e| store_error(format!("Failed to get agent: {e}")))?;
+
+        // Fallback: try public_id lookup when internal UUID doesn't match
+        if row.is_none() {
+            let public_id = format!("agent_{}", id.uuid().simple());
+            row = self
+                .db
+                .get_agent_by_public_id(self.org_id, &public_id)
+                .await
+                .map_err(|e| store_error(format!("Failed to get agent by public_id: {e}")))?;
+        }
 
         match row {
             Some(row) => {

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -30,7 +30,7 @@ use uuid::Uuid;
 use crate::org_init::BASE_HARNESS_ID;
 use crate::services::{EventService, LlmResolverService, McpServerService};
 use crate::storage::StorageBackend;
-use crate::storage::models::{AgentCapabilityRow, UpdateSession};
+use crate::storage::models::{AgentCapabilityRow, AgentRow, UpdateSession};
 
 // Helper to create store errors
 fn store_error(msg: impl Into<String>) -> AgentLoopError {
@@ -193,7 +193,7 @@ impl WorkerAdapters for DirectWorkerAdapters {
 
     async fn get_agent(&self, org_id: i64, agent_id: Uuid) -> Result<Option<Agent>> {
         // Look up by public_id, then fetch capabilities using internal id from the row.
-        let public_id = format!("agent_{}", agent_id.simple());
+        let public_id = AgentId::from_uuid(agent_id).to_string();
         let row = self
             .db
             .get_agent_by_public_id(org_id, &public_id)
@@ -209,8 +209,7 @@ impl WorkerAdapters for DirectWorkerAdapters {
                     .get_agent_capabilities(r.id.uuid())
                     .await
                     .unwrap_or_default();
-                self.get_agent_with_capabilities(org_id, agent_id, capabilities)
-                    .await
+                Ok(Some(Self::row_to_agent(r, capabilities)))
             }
             None => Ok(None),
         }
@@ -815,23 +814,21 @@ impl WorkerAdapters for DirectWorkerAdapters {
                     store_error("Failed to get agent")
                 })?;
 
-            if let Some(ref row) = agent_row {
+            if let Some(row) = agent_row {
                 let capability_rows = self
                     .db
                     .get_agent_capabilities(row.id.uuid())
                     .await
                     .unwrap_or_default();
 
-                let agent = self
-                    .get_agent_with_capabilities(org_id, agent_id.uuid(), capability_rows.clone())
-                    .await?;
-
                 let mcp_tools = self
                     .build_mcp_tool_definitions_with_capabilities(org_id, &capability_rows)
                     .await
                     .unwrap_or_default();
 
-                (agent, mcp_tools)
+                let agent = Self::row_to_agent(row, capability_rows);
+
+                (Some(agent), mcp_tools)
             } else {
                 (None, vec![])
             }
@@ -986,27 +983,26 @@ impl WorkerAdapters for DirectWorkerAdapters {
     }
 
     async fn build_tool_registry(&self, org_id: i64, agent_id: Uuid) -> Result<ToolRegistry> {
-        // agent_id is a public UUID — resolve to internal UUID for capability lookup
-        let public_id = format!("agent_{}", agent_id.simple());
-        let internal_id = self
+        // Resolve public UUID → internal UUID for capability lookup (org-scoped)
+        let public_id = AgentId::from_uuid(agent_id).to_string();
+        let capability_rows = match self
             .db
             .get_agent_by_public_id(org_id, &public_id)
             .await
             .map_err(|e| {
                 tracing::error!("Failed to resolve agent: {}", e);
                 store_error("Failed to resolve agent")
-            })?
-            .map(|r| r.id.uuid())
-            .unwrap_or(agent_id); // fall back to input UUID for backwards compat
-
-        let capability_rows = self
-            .db
-            .get_agent_capabilities(internal_id)
-            .await
-            .map_err(|e| {
-                tracing::error!("Failed to get agent capabilities: {}", e);
-                store_error("Failed to get agent capabilities")
-            })?;
+            })? {
+            Some(row) => self
+                .db
+                .get_agent_capabilities(row.id.uuid())
+                .await
+                .map_err(|e| {
+                    tracing::error!("Failed to get agent capabilities: {}", e);
+                    store_error("Failed to get agent capabilities")
+                })?,
+            None => vec![],
+        };
         self.build_tool_registry_with_capabilities(&capability_rows)
             .await
     }
@@ -1087,25 +1083,9 @@ impl DirectWorkerAdapters {
     ///
     /// Used by both `get_agent` (standalone) and `load_turn_context`
     /// (where capabilities are loaded once and shared across consumers).
-    async fn get_agent_with_capabilities(
-        &self,
-        org_id: i64,
-        agent_id: Uuid,
-        capability_rows: Vec<AgentCapabilityRow>,
-    ) -> Result<Option<Agent>> {
-        // Look up by public_id — the UUID comes from a public AgentId,
-        // which may differ from the internal UUID for imported agents.
-        let public_id = format!("agent_{}", agent_id.simple());
-        let row = self
-            .db
-            .get_agent_by_public_id(org_id, &public_id)
-            .await
-            .map_err(|e| {
-                tracing::error!("Failed to get agent by public_id: {}", e);
-                store_error("Failed to get agent")
-            })?;
-
-        Ok(row.map(|r| Agent {
+    /// Convert an AgentRow + capability rows into an Agent domain object.
+    fn row_to_agent(r: AgentRow, capability_rows: Vec<AgentCapabilityRow>) -> Agent {
+        Agent {
             public_id: r
                 .public_id
                 .parse()
@@ -1134,7 +1114,7 @@ impl DirectWorkerAdapters {
             archived_at: r.archived_at,
             deleted_at: r.deleted_at,
             usage: None,
-        }))
+        }
     }
 
     /// Build a tool registry from pre-loaded capability rows.
@@ -2088,31 +2068,27 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_agent_with_capabilities_returns_none_for_missing_agent() {
+    async fn get_agent_returns_none_for_missing_agent() {
         let adapters = test_adapters();
         let result = adapters
-            .get_agent_with_capabilities(everruns_core::DEFAULT_ORG_ID, Uuid::new_v4(), vec![])
+            .get_agent(everruns_core::DEFAULT_ORG_ID, Uuid::new_v4())
             .await
             .unwrap();
         assert!(result.is_none());
     }
 
     #[tokio::test]
-    async fn get_agent_with_capabilities_attaches_supplied_capabilities() {
+    async fn get_agent_resolves_by_public_id() {
         let adapters = test_adapters();
-        // Seed an agent in the in-memory DB
         let agent_id = seed_agent(&adapters.db).await;
 
-        let cap_rows = vec![fake_capability_row(agent_id, "web_search")];
-
         let agent = adapters
-            .get_agent_with_capabilities(everruns_core::DEFAULT_ORG_ID, agent_id, cap_rows)
+            .get_agent(everruns_core::DEFAULT_ORG_ID, agent_id)
             .await
             .unwrap()
             .expect("agent should exist");
 
-        assert_eq!(agent.capabilities.len(), 1);
-        assert_eq!(agent.capabilities[0].capability_id(), "web_search");
+        assert_eq!(agent.name, "test-agent");
     }
 
     #[tokio::test]
@@ -2282,15 +2258,14 @@ mod tests {
 
     // ---- helpers ----
 
-    /// Seed a minimal agent into the in-memory store and return its UUID.
-    /// Seed a test agent, returning the internal UUID.
+    /// Seed a test agent, returning its UUID.
     ///
     /// Uses `create_agent_with_id` so public_id matches the internal UUID,
     /// consistent with normal agent creation via the API.
     async fn seed_agent(db: &StorageBackend) -> Uuid {
         use crate::storage::models::CreateAgentRow;
         let id = AgentId::new();
-        let public_id = format!("agent_{}", id.uuid().simple());
+        let public_id = id.to_string();
         let create = CreateAgentRow {
             public_id,
             name: "test-agent".to_string(),

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -2283,10 +2283,16 @@ mod tests {
     // ---- helpers ----
 
     /// Seed a minimal agent into the in-memory store and return its UUID.
+    /// Seed a test agent, returning the internal UUID.
+    ///
+    /// Uses `create_agent_with_id` so public_id matches the internal UUID,
+    /// consistent with normal agent creation via the API.
     async fn seed_agent(db: &StorageBackend) -> Uuid {
         use crate::storage::models::CreateAgentRow;
+        let id = AgentId::new();
+        let public_id = format!("agent_{}", id.uuid().simple());
         let create = CreateAgentRow {
-            public_id: AgentId::new().to_string(),
+            public_id,
             name: "test-agent".to_string(),
             description: None,
             system_prompt: String::new(),
@@ -2296,11 +2302,11 @@ mod tests {
             tools: serde_json::Value::Array(vec![]),
             max_iterations: None,
         };
-        let row = db
-            .create_agent(everruns_core::DEFAULT_ORG_ID, create)
+        db.create_agent_with_id(everruns_core::DEFAULT_ORG_ID, id, create)
             .await
-            .expect("seed agent");
-        row.id.uuid()
+            .expect("seed agent")
+            .expect("seed agent should create");
+        id.uuid()
     }
 
     // =========================================================================

--- a/crates/server/src/services/agent.rs
+++ b/crates/server/src/services/agent.rs
@@ -158,8 +158,25 @@ impl AgentService {
                 let capabilities = self.get_capabilities(id).await?;
                 Ok(Some(Self::row_to_agent(row, capabilities)))
             }
-            None => Ok(None),
             Some(_) => Ok(None),
+            None => {
+                // Fallback: the UUID might be from a public AgentId (happens when
+                // an agent was imported with a custom id that differs from the
+                // internal UUID). Try looking up by public_id.
+                let public_id = format!("agent_{}", id.simple());
+                let row = self
+                    .db
+                    .get_agent_by_public_id(caller.org_id, &public_id)
+                    .await?;
+                match row {
+                    Some(row) if row.status != "deleted" => {
+                        let capabilities =
+                            self.get_capabilities(row.id.uuid()).await?;
+                        Ok(Some(Self::row_to_agent(row, capabilities)))
+                    }
+                    _ => Ok(None),
+                }
+            }
         }
     }
 

--- a/crates/server/src/services/agent.rs
+++ b/crates/server/src/services/agent.rs
@@ -151,7 +151,7 @@ impl AgentService {
     pub async fn get(&self, caller: &Caller, id: Uuid) -> Result<Option<Agent>> {
         // Look up by public_id — the UUID comes from a public AgentId,
         // which may differ from the internal UUID for imported agents.
-        let public_id = format!("agent_{}", id.simple());
+        let public_id = AgentId::from_uuid(id).to_string();
         self.get_by_public_id(caller, &public_id).await
     }
 

--- a/crates/server/src/services/agent.rs
+++ b/crates/server/src/services/agent.rs
@@ -149,35 +149,10 @@ impl AgentService {
 
     #[policy(AGENT_VIEW)]
     pub async fn get(&self, caller: &Caller, id: Uuid) -> Result<Option<Agent>> {
-        let row = self
-            .db
-            .get_agent(caller.org_id, AgentId::from_uuid(id))
-            .await?;
-        match row {
-            Some(row) if row.status != "deleted" => {
-                let capabilities = self.get_capabilities(id).await?;
-                Ok(Some(Self::row_to_agent(row, capabilities)))
-            }
-            Some(_) => Ok(None),
-            None => {
-                // Fallback: the UUID might be from a public AgentId (happens when
-                // an agent was imported with a custom id that differs from the
-                // internal UUID). Try looking up by public_id.
-                let public_id = format!("agent_{}", id.simple());
-                let row = self
-                    .db
-                    .get_agent_by_public_id(caller.org_id, &public_id)
-                    .await?;
-                match row {
-                    Some(row) if row.status != "deleted" => {
-                        let capabilities =
-                            self.get_capabilities(row.id.uuid()).await?;
-                        Ok(Some(Self::row_to_agent(row, capabilities)))
-                    }
-                    _ => Ok(None),
-                }
-            }
-        }
+        // Look up by public_id — the UUID comes from a public AgentId,
+        // which may differ from the internal UUID for imported agents.
+        let public_id = format!("agent_{}", id.simple());
+        self.get_by_public_id(caller, &public_id).await
     }
 
     #[policy(AGENT_VIEW)]


### PR DESCRIPTION
## What
All agent lookups in the worker path now use `public_id` instead of querying the internal `id` column. Internal UUIDs no longer leak out of the storage layer.

## Why
When agents are imported with a custom `id` in `.agent.md`, the public_id UUID differs from the auto-generated internal UUID. The `Session` struct resolves `agent_id` to the public `AgentId`, but worker code was passing this public UUID to `get_agent` which queried `WHERE id = $2` against the internal UUID column — returning "agent not found" → "agent deleted."

This broke all imported agents (any agent created via `everruns agents create --file` with an `id:` field in the frontmatter).

## How
- `AgentService::get(caller, uuid)` now delegates to `get_by_public_id`, constructing the prefixed public_id string from the UUID.
- `DirectWorkerAdapters::get_agent` resolves by `public_id` first, then uses the row's internal UUID for capability lookups.
- `DirectWorkerAdapters::load_turn_context` same pattern — resolve agent row by `public_id`, fetch capabilities via internal id.
- `DirectWorkerAdapters::build_tool_registry` resolves public UUID → internal UUID before querying `agent_capabilities`.
- `PlatformStore::get_agent_by_id` and `create_session` agent validation use `public_id`.
- Test `seed_agent` updated to use `create_agent_with_id` so `public_id` matches the internal UUID, consistent with real creation.

## Risk
- Low
- Regression: agent lookups that previously worked (internal == public UUID) still work because the `public_id` column contains the same UUID in prefixed form. Only the lookup path changes (indexed column `public_id` instead of PK `id`).
- The `idx_agents_org_public_id` unique index covers the new query pattern.

## Security
- Threat categories reviewed: TM-TENANT (org-scoped agent lookups)
- All `get_agent_by_public_id` calls include `org_id` scoping, preserving cross-org isolation. No new input parsing, no new endpoints, no secrets handling changes.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)