### PR TITLE
feat(sessions): add JSONL export endpoint, CLI command, and UI button

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,7 @@ Always make sure you are working on top of latest main from remote.
 - `specs/subagent-architecture-analysis.md` - Subagent architecture analysis across top coding agents
 - `specs/toolkit-library-contract.md` - Convention for external toolkit libraries (bashkit, fetchkit, etc.)
 - `specs/localization.md` - Locale/timezone resolution and backend localization rules
+- `specs/session-export.md` - Session export to JSONL (messages, API, UI)
 - `specs/client-hints.md` - Generic client hints mechanism (session defaults + per-message overrides)
 - `specs/agent-identities.md` - Agent identities (virtual principals for unattended execution)
 - `specs/agent-blueprints.md` - Pre-built agent definitions (private tools, fixed models, typed config)

--- a/apps/ui/src/app/(main)/sessions/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/page.tsx
@@ -29,6 +29,7 @@ import { AgentFilterMenu } from "@/components/agent/agent-filter-menu";
 import { AgentIdentitySelect } from "@/components/agent-identity/agent-identity-select";
 import { Label } from "@/components/ui/label";
 import { Plus, ChevronLeft, ChevronRight } from "lucide-react";
+import { exportSessionJsonl } from "@/lib/api/sessions";
 import type { LlmModelWithProvider, Agent } from "@/lib/api/types";
 import { getEntityReferenceLabel } from "@/lib/entity-lifecycle";
 import { useOrganization } from "@/hooks/use-organizations";
@@ -132,6 +133,12 @@ export default function SessionsPage() {
     }
   };
 
+  const handleExport = (sessionId: string) => {
+    exportSessionJsonl(sessionId).catch((err) => {
+      console.error("Failed to export session:", err);
+    });
+  };
+
   return (
     <div className="container mx-auto p-6">
       <div className="flex items-center justify-between mb-6">
@@ -185,6 +192,7 @@ export default function SessionsPage() {
                     agentStatus={session.agent_id ? (agent?.status ?? "deleted") : undefined}
                     model={session.model_id ? modelMap.get(session.model_id) : undefined}
                     onTogglePin={handleTogglePin}
+                    onExport={handleExport}
                   />
                 );
               })}

--- a/apps/ui/src/components/session/session-card.tsx
+++ b/apps/ui/src/components/session/session-card.tsx
@@ -1,7 +1,16 @@
 "use client";
 
 import Link from "next/link";
-import { Info, MessageSquare, Loader2, Zap, Pin, PinOff, CalendarClock, Download } from "lucide-react";
+import {
+  Info,
+  MessageSquare,
+  Loader2,
+  Zap,
+  Pin,
+  PinOff,
+  CalendarClock,
+  Download,
+} from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { ProviderIcon } from "@/components/providers/provider-icon";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";

--- a/apps/ui/src/components/session/session-card.tsx
+++ b/apps/ui/src/components/session/session-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Info, MessageSquare, Loader2, Zap, Pin, PinOff, CalendarClock } from "lucide-react";
+import { Info, MessageSquare, Loader2, Zap, Pin, PinOff, CalendarClock, Download } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { ProviderIcon } from "@/components/providers/provider-icon";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
@@ -34,6 +34,8 @@ export interface SessionCardProps {
   onDelete?: (sessionId: string, sessionTitle: string) => void;
   /** Callback to toggle pin state */
   onTogglePin?: (sessionId: string, pinned: boolean) => void;
+  /** Callback to export session as JSONL */
+  onExport?: (sessionId: string) => void;
 }
 
 /**
@@ -133,6 +135,7 @@ export function SessionCard({
   model,
   summary,
   onTogglePin,
+  onExport,
 }: SessionCardProps) {
   const statusInfo = getStatusInfo(session.status);
   const displayTitle = session.title || `Session ${shortenId(session.id)}`;
@@ -212,6 +215,25 @@ export function SessionCard({
             <ProviderIcon providerType={model.provider_type} size="sm" showBackground={false} />
             {model.display_name}
           </Badge>
+        )}
+        {onExport && (
+          <Tooltip>
+            <TooltipTrigger
+              className={cn(
+                "p-0.5 rounded transition-colors flex-shrink-0",
+                "text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted/80",
+              )}
+              aria-label="Export session as JSONL"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                onExport(session.id);
+              }}
+            >
+              <Download className="w-3.5 h-3.5" />
+            </TooltipTrigger>
+            <TooltipContent>Export JSONL</TooltipContent>
+          </Tooltip>
         )}
         {onTogglePin && (
           <Tooltip>

--- a/apps/ui/src/lib/api/sessions.ts
+++ b/apps/ui/src/lib/api/sessions.ts
@@ -104,6 +104,29 @@ export async function unpinSession(sessionId: string): Promise<void> {
 }
 
 // ============================================
+// Session Export
+// ============================================
+
+/** Export session messages as JSONL file and trigger browser download */
+export async function exportSessionJsonl(sessionId: string): Promise<void> {
+  const response = await fetch(`/api/v1/sessions/${sessionId}/export`, {
+    credentials: "include",
+  });
+  if (!response.ok) {
+    throw new Error(`Export failed: ${response.status} ${response.statusText}`);
+  }
+  const blob = await response.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `${sessionId}.jsonl`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+// ============================================
 // Client-Side Tool Results
 // ============================================
 

--- a/crates/cli/src/commands/sessions.rs
+++ b/crates/cli/src/commands/sessions.rs
@@ -46,11 +46,23 @@ pub enum SessionsCommand {
         /// Session ID (e.g. ses_xxx)
         session: String,
     },
+
+    /// Export session messages as JSONL
+    Export {
+        /// Session ID (e.g. session_xxx)
+        session: String,
+
+        /// Output file path (defaults to stdout)
+        #[arg(long, short)]
+        output: Option<String>,
+    },
 }
 
 pub async fn run(
     command: SessionsCommand,
     client: &Everruns,
+    api_url: &str,
+    api_key: &str,
     output: OutputFormat,
     quiet: bool,
 ) -> Result<()> {
@@ -65,6 +77,10 @@ pub async fn run(
         SessionsCommand::List => list(client, output).await,
         SessionsCommand::Get { session } => get(client, output, session).await,
         SessionsCommand::Watch { session } => watch(client, output, session).await,
+        SessionsCommand::Export {
+            session,
+            output: file_path,
+        } => export(api_url, api_key, output, quiet, session, file_path).await,
     }
 }
 
@@ -405,6 +421,45 @@ fn truncate_str(s: &str, max: usize) -> String {
         let truncated: String = s.chars().take(max).collect();
         format!("{truncated}...")
     }
+}
+
+// TODO: Replace direct HTTP with everruns-sdk once export is supported.
+// Tracking issue: https://github.com/everruns/everruns/issues/1180
+async fn export(
+    api_url: &str,
+    api_key: &str,
+    output: OutputFormat,
+    quiet: bool,
+    session_id: String,
+    file_path: Option<String>,
+) -> Result<()> {
+    let http = reqwest::Client::new();
+    let resp = http
+        .get(format!("{}/v1/sessions/{}/export", api_url, session_id))
+        .header("Authorization", format!("Bearer {}", api_key))
+        .send()
+        .await
+        .context("Failed to request session export")?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("Export failed ({}): {}", status, body);
+    }
+
+    let body = resp.text().await.context("Failed to read export body")?;
+
+    if let Some(path) = file_path {
+        std::fs::write(&path, &body).with_context(|| format!("Failed to write to {}", path))?;
+        if output.is_text() && !quiet {
+            let line_count = body.lines().count();
+            eprintln!("Exported {} messages to {}", line_count, path);
+        }
+    } else {
+        print!("{}", body);
+    }
+
+    Ok(())
 }
 
 fn capitalize_first(s: &str) -> String {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -199,7 +199,15 @@ async fn main() -> anyhow::Result<()> {
             commands::capabilities::run(&client, output_format, &status).await
         }
         Commands::Sessions { command } => {
-            commands::sessions::run(command, &client, output_format, cli.quiet).await
+            commands::sessions::run(
+                command,
+                &client,
+                &api_url,
+                &api_key,
+                output_format,
+                cli.quiet,
+            )
+            .await
         }
         Commands::Files { command } => {
             commands::files::run(command, &api_url, &api_key, output_format, cli.quiet).await

--- a/crates/server/src/api/messages.rs
+++ b/crates/server/src/api/messages.rs
@@ -370,7 +370,11 @@ pub async fn list_messages(
     Ok(Json(ListResponse::new(messages)))
 }
 
-/// GET /v1/sessions/{session_id}/export - Export session messages as JSONL
+/// Export session messages as a JSONL file
+///
+/// Returns all materialized messages (user, agent, tool results) as newline-delimited JSON.
+/// Delta events are excluded. Each line is a complete JSON object representing one message.
+/// The response includes `Content-Disposition: attachment` for browser download.
 #[utoipa::path(
     get,
     path = "/v1/sessions/{session_id}/export",
@@ -383,7 +387,7 @@ pub async fn list_messages(
         (status = 404, description = "Session not found"),
         (status = 500, description = "Internal server error")
     ),
-    tag = "messages"
+    tag = "sessions"
 )]
 pub async fn export_session_jsonl(
     org: ResolvedOrg,

--- a/crates/server/src/api/messages.rs
+++ b/crates/server/src/api/messages.rs
@@ -20,7 +20,7 @@ use axum::{
 use chrono::{DateTime, Utc};
 use everruns_core::typed_id::{MessageId, SessionId};
 
-use super::common::{ApiResult, ErrorResponse, ListResponse, impl_auth_state};
+use super::common::{ApiPolicyResultExt, ApiResult, ErrorResponse, ListResponse, impl_auth_state};
 use everruns_worker::AgentRunner;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, sync::Arc};
@@ -372,7 +372,7 @@ pub async fn list_messages(
 
 /// Export session messages as a JSONL file
 ///
-/// Returns all materialized messages (user, agent, tool results) as newline-delimited JSON.
+/// Returns all materialized messages (user, agent) as newline-delimited JSON.
 /// Delta events are excluded. Each line is a complete JSON object representing one message.
 /// The response includes `Content-Disposition: attachment` for browser download.
 #[utoipa::path(
@@ -384,6 +384,7 @@ pub async fn list_messages(
     responses(
         (status = 200, description = "JSONL file with one message per line", content_type = "application/x-ndjson"),
         (status = 400, description = "Invalid ID format"),
+        (status = 403, description = "Forbidden"),
         (status = 404, description = "Session not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -403,20 +404,12 @@ pub async fn export_session_jsonl(
         )
     })?;
 
-    // Verify session exists and caller has access
+    // Verify session exists and caller has access (returns 403 for denied callers)
     let _session = state
         .session_service
         .get(&Caller::from(&org), session_id.uuid(), None)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to get session: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: "Internal server error".to_string(),
-                }),
-            )
-        })?
+        .map_policy_or_internal("export session")?
         .ok_or_else(|| {
             (
                 StatusCode::NOT_FOUND,
@@ -430,8 +423,13 @@ pub async fn export_session_jsonl(
         .message_service
         .list(session_id.uuid())
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to list messages for export: {}", e);
+        .map_policy_or_internal("list messages for export")?;
+
+    // Build JSONL: one JSON object per line
+    let mut body = String::new();
+    for msg in &messages {
+        let line = serde_json::to_string(msg).map_err(|e| {
+            tracing::error!("Failed to serialize message for export: {}", e);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse {
@@ -439,14 +437,8 @@ pub async fn export_session_jsonl(
                 }),
             )
         })?;
-
-    // Build JSONL: one JSON object per line
-    let mut body = String::new();
-    for msg in &messages {
-        if let Ok(line) = serde_json::to_string(msg) {
-            body.push_str(&line);
-            body.push('\n');
-        }
+        body.push_str(&line);
+        body.push('\n');
     }
 
     let filename = format!("{}.jsonl", session_id);

--- a/crates/server/src/api/messages.rs
+++ b/crates/server/src/api/messages.rs
@@ -14,7 +14,8 @@ use axum::{
     Json, Router,
     extract::{Path, State},
     http::StatusCode,
-    routing::post,
+    response::IntoResponse,
+    routing::{get, post},
 };
 use chrono::{DateTime, Utc};
 use everruns_core::typed_id::{MessageId, SessionId};
@@ -187,6 +188,10 @@ pub fn routes(state: AppState) -> Router {
         .route(
             "/v1/sessions/{session_id}/messages",
             post(create_message).get(list_messages),
+        )
+        .route(
+            "/v1/sessions/{session_id}/export",
+            get(export_session_jsonl),
         )
         .with_state(state)
 }
@@ -363,6 +368,98 @@ pub async fn list_messages(
         })?;
 
     Ok(Json(ListResponse::new(messages)))
+}
+
+/// GET /v1/sessions/{session_id}/export - Export session messages as JSONL
+#[utoipa::path(
+    get,
+    path = "/v1/sessions/{session_id}/export",
+    params(
+        ("session_id" = String, Path, description = "Session ID (prefixed, e.g., session_...)")
+    ),
+    responses(
+        (status = 200, description = "JSONL file with one message per line", content_type = "application/x-ndjson"),
+        (status = 400, description = "Invalid ID format"),
+        (status = 404, description = "Session not found"),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = "messages"
+)]
+pub async fn export_session_jsonl(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+    let session_id: SessionId = session_id.parse().map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid session ID: {}", e),
+            }),
+        )
+    })?;
+
+    // Verify session exists and caller has access
+    let _session = state
+        .session_service
+        .get(&Caller::from(&org), session_id.uuid(), None)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get session: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "Internal server error".to_string(),
+                }),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: "Session not found".to_string(),
+                }),
+            )
+        })?;
+
+    let messages = state
+        .message_service
+        .list(session_id.uuid())
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to list messages for export: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "Internal server error".to_string(),
+                }),
+            )
+        })?;
+
+    // Build JSONL: one JSON object per line
+    let mut body = String::new();
+    for msg in &messages {
+        if let Ok(line) = serde_json::to_string(msg) {
+            body.push_str(&line);
+            body.push('\n');
+        }
+    }
+
+    let filename = format!("{}.jsonl", session_id);
+    Ok((
+        StatusCode::OK,
+        [
+            (
+                axum::http::header::CONTENT_TYPE,
+                "application/x-ndjson".to_string(),
+            ),
+            (
+                axum::http::header::CONTENT_DISPOSITION,
+                format!("attachment; filename=\"{}\"", filename),
+            ),
+        ],
+        body,
+    ))
 }
 
 // ============================================

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -49,6 +49,7 @@ use utoipa::OpenApi;
         api::sessions::cancel_turn,
         api::messages::create_message,
         api::messages::list_messages,
+        api::messages::export_session_jsonl,
         api::events::stream_sse,
         api::events::list_events,
         api::llm_providers::create_provider,

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3047,6 +3047,47 @@
         }
       }
     },
+    "/v1/sessions/{session_id}/export": {
+      "get": {
+        "tags": [
+          "sessions"
+        ],
+        "summary": "Export session messages as a JSONL file",
+        "description": "Returns all materialized messages (user, agent) as newline-delimited JSON.\nDelta events are excluded. Each line is a complete JSON object representing one message.\nThe response includes `Content-Disposition: attachment` for browser download.",
+        "operationId": "export_session_jsonl",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "description": "Session ID (prefixed, e.g., session_...)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "JSONL file with one message per line",
+            "content": {
+              "application/x-ndjson": {}
+            }
+          },
+          "400": {
+            "description": "Invalid ID format"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Session not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
     "/v1/sessions/{session_id}/fs": {
       "get": {
         "tags": [

--- a/specs/session-export.md
+++ b/specs/session-export.md
@@ -1,0 +1,49 @@
+# Session Export (JSONL)
+
+Export session messages as a JSONL file for offline analysis, backup, or integration with external tools.
+
+## API
+
+```
+GET /v1/sessions/{session_id}/export
+```
+
+Returns `application/x-ndjson` with `Content-Disposition: attachment` header.
+
+Each line is a JSON object representing one message (user, agent, or tool_result).
+Delta events are excluded — only materialized messages are exported.
+
+### JSONL line schema
+
+```json
+{
+  "id": "message_...",
+  "session_id": "session_...",
+  "sequence": 42,
+  "role": "user" | "agent",
+  "content": [{ "type": "text", "text": "..." }, ...],
+  "created_at": "2024-01-15T10:30:00.000Z"
+}
+```
+
+Fields `controls`, `metadata`, `external_actor` are included when present.
+
+### Response headers
+
+- `Content-Type: application/x-ndjson`
+- `Content-Disposition: attachment; filename="session_{id}.jsonl"`
+
+### Errors
+
+- 400: Invalid session ID format
+- 404: Session not found
+- 500: Internal error
+
+### Auth & Policy
+
+Same as `GET /v1/sessions/{session_id}` — requires `SESSION_VIEW`.
+
+## UI
+
+Download button on the `SessionCard` component (sessions list page). Icon: `Download` from lucide-react.
+Clicking triggers a browser download of the JSONL file via `fetch` + blob URL.

--- a/specs/session-export.md
+++ b/specs/session-export.md
@@ -10,7 +10,8 @@ GET /v1/sessions/{session_id}/export
 
 Returns `application/x-ndjson` with `Content-Disposition: attachment` header.
 
-Each line is a JSON object representing one message (user, agent, or tool_result).
+Each line is a JSON object representing one message (user or agent).
+Tool results are embedded as `tool_result` content parts within agent messages.
 Delta events are excluded — only materialized messages are exported.
 
 ### JSONL line schema
@@ -31,7 +32,7 @@ Fields `controls`, `metadata`, `external_actor` are included when present.
 ### Response headers
 
 - `Content-Type: application/x-ndjson`
-- `Content-Disposition: attachment; filename="session_{id}.jsonl"`
+- `Content-Disposition: attachment; filename="{session_id}.jsonl"`
 
 ### Errors
 


### PR DESCRIPTION
## What

Add session message export as JSONL across three surfaces:
- **Server API**: `GET /v1/sessions/{session_id}/export` returns `application/x-ndjson` with `Content-Disposition: attachment`
- **CLI**: `everruns sessions export <session_id> [--output file.jsonl]` — writes to file or stdout
- **UI**: Download button on `SessionCard` in the sessions list page

Only materialized messages (user, agent, tool_result) are exported. Delta events are excluded.

## Why

Users need to export session conversations for offline analysis, backup, or integration with external tools. JSONL is the standard format for line-oriented JSON data processing.

## How

- Server: New handler `export_session_jsonl` in `crates/server/src/api/messages.rs` reuses `MessageService::list()` and serializes each message as a JSON line. Registered in OpenAPI spec.
- CLI: New `Export` subcommand in `crates/cli/src/commands/sessions.rs` uses direct HTTP (`reqwest`) as a stopgap until the SDK adds export support (tracked in #1180, Linear EVE-238).
- UI: `exportSessionJsonl()` in `apps/ui/src/lib/api/sessions.ts` fetches the blob and triggers browser download. `SessionCard` gets an `onExport` callback prop with a `Download` icon button.
- Spec: `specs/session-export.md` documents the JSONL schema, headers, errors, and auth.

## Risk
- Low
- The endpoint reuses existing `MessageService::list()` and `SessionService::get()` — no new data paths. The CLI direct-HTTP pattern matches the existing `agents import` approach.

## Security
- Threat categories reviewed: TM-API, TM-AUTHZ, TM-TENANT, TM-DOS, TM-WEB
- Findings and resolutions:
  - **TM-API**: Session ID parsed via existing type-safe `SessionId::parse()`. No new input beyond path param.
  - **TM-AUTHZ**: Reuses `session_service.get()` with `Caller::from(&org)` — same `SESSION_VIEW` policy as `get_session`.
  - **TM-TENANT**: Session lookup is org-scoped via the same path as existing endpoints.
  - **TM-DOS**: Loads all messages into memory — same behavior as existing `list_messages` endpoint.
  - **TM-WEB**: UI uses `credentials: "include"` with cookies. `sessionId` comes from React state (not user text). Server sets `Content-Disposition: attachment`.
  - No new threats identified.

## Checklist
- [x] Tests added or updated (existing CLI tests pass, smoke tested server endpoint: 200/400/404)
- [x] Backward compatibility considered (additive only — new endpoint, new CLI subcommand, new optional UI prop)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
