### PR TITLE
feat(core): add offset/limit pagination to read_file

### DIFF
--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -520,7 +520,11 @@ impl Tool for ReadFileTool {
                 let raw_content = file.content.as_deref().unwrap_or("");
                 let (formatted, total_lines, truncated) = format_lines(raw_content, offset, limit);
 
-                let start_line = offset.min(total_lines) + 1;
+                let start_line = if total_lines == 0 || offset >= total_lines {
+                    0
+                } else {
+                    offset + 1
+                };
                 let end_line = (offset + limit).min(total_lines);
 
                 ToolExecutionResult::success(json!({

--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -411,6 +411,16 @@ impl Tool for ReadFileTool {
                 "path": {
                     "type": "string",
                     "description": "Absolute path to the file (e.g., '/workspace/docs/readme.txt')"
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": "Starting line number (0-indexed). Default: 0",
+                    "default": 0
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max lines to return. Default: 2000",
+                    "default": 2000
                 }
             },
             "required": ["path"],
@@ -435,10 +445,21 @@ impl Tool for ReadFileTool {
         arguments: Value,
         context: &ToolContext,
     ) -> ToolExecutionResult {
+        use crate::tool_output_sanitizer::{READ_FILE_DEFAULT_LIMIT, format_lines};
+
         let path = match arguments.get("path").and_then(|v| v.as_str()) {
             Some(p) => p,
             None => return ToolExecutionResult::tool_error("Missing required parameter: path"),
         };
+
+        let offset = arguments
+            .get("offset")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize;
+        let limit = arguments
+            .get("limit")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(READ_FILE_DEFAULT_LIMIT as u64) as usize;
 
         let file_store = match &context.file_store {
             Some(store) => store,
@@ -495,10 +516,22 @@ impl Tool for ReadFileTool {
                     Ok(hash) => hash,
                     Err(e) => return ToolExecutionResult::internal_error(e),
                 };
+
+                let raw_content = file.content.as_deref().unwrap_or("");
+                let (formatted, total_lines, truncated) = format_lines(raw_content, offset, limit);
+
+                let start_line = offset.min(total_lines) + 1;
+                let end_line = (offset + limit).min(total_lines);
+
                 ToolExecutionResult::success(json!({
                     "path": display_path,
-                    "content": file.content,
-                    "encoding": file.encoding,
+                    "content": formatted,
+                    "total_lines": total_lines,
+                    "lines_shown": {
+                        "start": start_line,
+                        "end": end_line
+                    },
+                    "truncated": truncated,
                     "size_bytes": file.size_bytes,
                     "content_hash": content_hash
                 }))
@@ -1826,12 +1859,62 @@ mod tests {
         let value = expect_success(result);
 
         assert_eq!(value["path"], "/workspace/notes.txt");
-        assert_eq!(value["encoding"], "text");
-        assert_eq!(value["content"], "hello world");
+        assert_eq!(value["content"], "1|hello world");
+        assert_eq!(value["total_lines"], 1);
+        assert_eq!(value["truncated"], false);
         assert_eq!(
             value["content_hash"].as_str().unwrap(),
             file_content_hash("hello world", "text").unwrap()
         );
+    }
+
+    #[tokio::test]
+    async fn test_read_file_offset_limit() {
+        let store = Arc::new(MockFileStore::default());
+        let content = (1..=100)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+        store.add_text_file("/big.txt", &content);
+        let context = make_context(store);
+
+        // Read lines 10-14 (0-indexed offset=9, limit=5)
+        let result = ReadFileTool
+            .execute_with_context(
+                json!({"path": "/workspace/big.txt", "offset": 9, "limit": 5}),
+                &context,
+            )
+            .await;
+        let value = expect_success(result);
+
+        assert_eq!(value["total_lines"], 100);
+        assert_eq!(value["truncated"], true);
+        assert_eq!(value["lines_shown"]["start"], 10);
+        assert_eq!(value["lines_shown"]["end"], 14);
+        let content_str = value["content"].as_str().unwrap();
+        assert!(content_str.starts_with("10|line 10"));
+        assert!(content_str.ends_with("14|line 14"));
+    }
+
+    #[tokio::test]
+    async fn test_read_file_default_limit_truncates() {
+        let store = Arc::new(MockFileStore::default());
+        let content = (1..=2500)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+        store.add_text_file("/huge.txt", &content);
+        let context = make_context(store);
+
+        let result = ReadFileTool
+            .execute_with_context(json!({"path": "/workspace/huge.txt"}), &context)
+            .await;
+        let value = expect_success(result);
+
+        assert_eq!(value["total_lines"], 2500);
+        assert_eq!(value["truncated"], true);
+        assert_eq!(value["lines_shown"]["start"], 1);
+        assert_eq!(value["lines_shown"]["end"], 2000);
     }
 
     #[tokio::test]

--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -415,12 +415,14 @@ impl Tool for ReadFileTool {
                 "offset": {
                     "type": "integer",
                     "description": "Starting line number (0-indexed). Default: 0",
-                    "default": 0
+                    "default": 0,
+                    "minimum": 0
                 },
                 "limit": {
                     "type": "integer",
                     "description": "Max lines to return. Default: 2000",
-                    "default": 2000
+                    "default": 2000,
+                    "minimum": 1
                 }
             },
             "required": ["path"],
@@ -517,15 +519,26 @@ impl Tool for ReadFileTool {
                     Err(e) => return ToolExecutionResult::internal_error(e),
                 };
 
+                // Non-image binary files: return raw base64 without line formatting
+                if file.encoding == "base64" {
+                    return ToolExecutionResult::success(json!({
+                        "path": display_path,
+                        "content": file.content.as_deref().unwrap_or(""),
+                        "encoding": "base64",
+                        "size_bytes": file.size_bytes,
+                        "content_hash": content_hash
+                    }));
+                }
+
                 let raw_content = file.content.as_deref().unwrap_or("");
                 let (formatted, total_lines, truncated) = format_lines(raw_content, offset, limit);
 
-                let start_line = if total_lines == 0 || offset >= total_lines {
-                    0
+                let shown_count = total_lines.saturating_sub(offset).min(limit);
+                let (start_line, end_line) = if shown_count == 0 {
+                    (0, 0)
                 } else {
-                    offset + 1
+                    (offset + 1, offset + shown_count)
                 };
-                let end_line = (offset + limit).min(total_lines);
 
                 ToolExecutionResult::success(json!({
                     "path": display_path,

--- a/crates/core/src/tool_output_sanitizer.rs
+++ b/crates/core/src/tool_output_sanitizer.rs
@@ -163,6 +163,49 @@ pub fn clean_exec_output(text: &str) -> String {
     collapse_cr_lines(&cleaned)
 }
 
+/// Default line limit for read_file (industry standard: 2000 lines).
+pub const READ_FILE_DEFAULT_LIMIT: usize = 2000;
+
+/// Hard byte cap for read_file (50 KB safety net for pathological cases like minified files).
+pub const READ_FILE_HARD_BYTE_CAP: usize = 50 * 1024;
+
+/// Format file content with compact line numbers: `N|content`.
+///
+/// Applies offset/limit pagination. Returns (formatted_content, total_lines, truncated).
+/// Line numbers are 1-based in output regardless of offset.
+pub fn format_lines(content: &str, offset: usize, limit: usize) -> (String, usize, bool) {
+    let lines: Vec<&str> = content.lines().collect();
+    let total_lines = lines.len();
+
+    // Clamp offset to total
+    let start = offset.min(total_lines);
+    let end = (start + limit).min(total_lines);
+    let truncated = end < total_lines;
+
+    let selected = &lines[start..end];
+
+    let mut result = String::new();
+    for (i, line) in selected.iter().enumerate() {
+        if i > 0 {
+            result.push('\n');
+        }
+        // 1-based line numbers
+        let line_num = start + i + 1;
+        result.push_str(&line_num.to_string());
+        result.push('|');
+        result.push_str(line);
+    }
+
+    // Apply hard byte cap
+    if result.len() > READ_FILE_HARD_BYTE_CAP {
+        let cut = utf8_floor(&result, READ_FILE_HARD_BYTE_CAP);
+        result.truncate(cut);
+        return (result, total_lines, true);
+    }
+
+    (result, total_lines, truncated)
+}
+
 /// Full sanitization pipeline: strip ANSI → collapse CR → middle-truncate.
 pub fn sanitize_exec_output(text: &str, max_bytes: usize) -> String {
     let cleaned = clean_exec_output(text);
@@ -412,5 +455,57 @@ mod tests {
     #[test]
     fn test_utf8_ceil_beyond_len() {
         assert_eq!(utf8_ceil("abc", 100), 3);
+    }
+
+    // ====================================================================
+    // format_lines
+    // ====================================================================
+
+    #[test]
+    fn test_format_lines_basic() {
+        let (content, total, truncated) = format_lines("alpha\nbeta\ngamma", 0, 2000);
+        assert_eq!(content, "1|alpha\n2|beta\n3|gamma");
+        assert_eq!(total, 3);
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn test_format_lines_with_offset() {
+        let (content, total, truncated) = format_lines("a\nb\nc\nd\ne", 2, 2);
+        assert_eq!(content, "3|c\n4|d");
+        assert_eq!(total, 5);
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_format_lines_offset_beyond_end() {
+        let (content, total, truncated) = format_lines("a\nb", 10, 5);
+        assert_eq!(content, "");
+        assert_eq!(total, 2);
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn test_format_lines_limit_clips() {
+        let (content, total, truncated) = format_lines("a\nb\nc\nd\ne", 0, 3);
+        assert_eq!(content, "1|a\n2|b\n3|c");
+        assert_eq!(total, 5);
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_format_lines_empty_content() {
+        let (content, total, truncated) = format_lines("", 0, 2000);
+        assert_eq!(content, "");
+        assert_eq!(total, 0);
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn test_format_lines_single_line() {
+        let (content, total, truncated) = format_lines("hello", 0, 2000);
+        assert_eq!(content, "1|hello");
+        assert_eq!(total, 1);
+        assert!(!truncated);
     }
 }

--- a/crates/core/src/tool_output_sanitizer.rs
+++ b/crates/core/src/tool_output_sanitizer.rs
@@ -173,28 +173,32 @@ pub const READ_FILE_HARD_BYTE_CAP: usize = 50 * 1024;
 ///
 /// Applies offset/limit pagination. Returns (formatted_content, total_lines, truncated).
 /// Line numbers are 1-based in output regardless of offset.
+/// Single-pass: counts total lines while only formatting the requested window.
 pub fn format_lines(content: &str, offset: usize, limit: usize) -> (String, usize, bool) {
-    let lines: Vec<&str> = content.lines().collect();
-    let total_lines = lines.len();
-
-    // Clamp offset to total
-    let start = offset.min(total_lines);
-    let end = (start + limit).min(total_lines);
-    let truncated = end < total_lines;
-
-    let selected = &lines[start..end];
-
+    let window_end = offset.saturating_add(limit);
+    let mut total_lines = 0;
     let mut result = String::new();
-    for (i, line) in selected.iter().enumerate() {
-        if i > 0 {
+
+    for (idx, line) in content.lines().enumerate() {
+        total_lines = idx + 1;
+
+        if idx < offset || idx >= window_end {
+            continue;
+        }
+
+        if !result.is_empty() {
             result.push('\n');
         }
+
         // 1-based line numbers
-        let line_num = start + i + 1;
+        let line_num = idx + 1;
         result.push_str(&line_num.to_string());
         result.push('|');
         result.push_str(line);
     }
+
+    let end = offset.saturating_add(limit).min(total_lines);
+    let truncated = end < total_lines;
 
     // Apply hard byte cap
     if result.len() > READ_FILE_HARD_BYTE_CAP {
@@ -499,6 +503,22 @@ mod tests {
         assert_eq!(content, "");
         assert_eq!(total, 0);
         assert!(!truncated);
+    }
+
+    #[test]
+    fn test_format_lines_hard_byte_cap() {
+        // Create content that exceeds 50 KB when formatted
+        let big_line = "x".repeat(1000);
+        let content = (0..100)
+            .map(|_| big_line.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let (formatted, total, truncated) = format_lines(&content, 0, 100);
+        assert_eq!(total, 100);
+        assert!(truncated);
+        assert!(formatted.len() <= READ_FILE_HARD_BYTE_CAP);
+        // Must be valid UTF-8 (would panic on access if not)
+        assert!(formatted.is_char_boundary(formatted.len()));
     }
 
     #[test]


### PR DESCRIPTION
## What
Add `offset` and `limit` parameters to `ReadFileTool` with compact `N|content` line-numbered output format. Shared `format_lines()` helper in `tool_output_sanitizer.rs`.

## Why
Every production coding agent (Claude Code, Cursor, Copilot, OpenCode, Amp) implements line-limited reads with offset/pagination. Our `read_file` returned full file content with no limits — the single biggest gap vs. industry standard (EVE-243).

## How
- `ReadFileTool` schema gains optional `offset` (0-indexed, default 0) and `limit` (default 2000) parameters
- Response uses compact `N|content` line-numbered format (~70% less token overhead than padded `cat -n`)
- Response includes `total_lines`, `lines_shown` (start/end), `truncated`, `size_bytes`, `content_hash`
- Shared `format_lines()` helper in `tool_output_sanitizer.rs` (reusable by EVE-245 exec output persistence)
- 50 KB hard byte cap as safety net for pathological cases (e.g. minified single-line files)
- `encoding` field removed from response (was only "text" for text files; images still handled separately)

## Risk
- Low
- UI `read-file-tool-call-card.tsx` parses `content` from response — now receives `N|content` formatted text which renders correctly. The removed `encoding` field is handled gracefully (only used for `=== "base64"` check on image path).
- Any external consumers of `read_file` that depended on raw `content` or `encoding` field will see changed format. No backward compat needed per AGENTS.md (internal code).

## Security
- Threat categories reviewed: TM-DOS, TM-FS
- TM-DOS: `offset` and `limit` are clamped to `total_lines` (no unbounded allocation). Hard byte cap (50 KB) prevents pathological single-line files from consuming excessive context.
- TM-FS: No path handling changes — same `normalize_path` / `add_workspace_prefix` flow. Offset/limit only affect post-read formatting.
- No new trust boundaries, no auth changes, no injection surface.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
