### PR TITLE
feat(core): add system prompt guidance for read_file economy

### DIFF
--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -360,14 +360,13 @@ impl Capability for FileSystemCapability {
         Some("File Operations")
     }
 
-    fn system_prompt_addition(&self) -> Option<&'static str> {
+    fn system_prompt_addition(&self) -> Option<&str> {
         use crate::tool_output_sanitizer::READ_ECONOMY_HINT;
-        // Concatenated at compile time via const — single static str
         const BASE: &str = "Session workspace root: `/workspace`. All file paths must start with `/workspace`. Directories are created automatically when writing files.";
-        // Use concat! not possible with const &str, so use a static with lazy init
+        // Build the full prompt lazily on first use by appending the shared read-economy hint.
         static PROMPT: std::sync::LazyLock<String> =
             std::sync::LazyLock::new(|| format!("{}{}", BASE, READ_ECONOMY_HINT));
-        Some(&PROMPT)
+        Some(PROMPT.as_str())
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {

--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -360,10 +360,14 @@ impl Capability for FileSystemCapability {
         Some("File Operations")
     }
 
-    fn system_prompt_addition(&self) -> Option<&str> {
-        Some(
-            r#"Session workspace root: `/workspace`. All file paths must start with `/workspace`. Directories are created automatically when writing files."#,
-        )
+    fn system_prompt_addition(&self) -> Option<&'static str> {
+        use crate::tool_output_sanitizer::READ_ECONOMY_HINT;
+        // Concatenated at compile time via const — single static str
+        const BASE: &str = "Session workspace root: `/workspace`. All file paths must start with `/workspace`. Directories are created automatically when writing files.";
+        // Use concat! not possible with const &str, so use a static with lazy init
+        static PROMPT: std::sync::LazyLock<String> =
+            std::sync::LazyLock::new(|| format!("{}{}", BASE, READ_ECONOMY_HINT));
+        Some(&PROMPT)
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
@@ -1790,6 +1794,9 @@ mod tests {
         let cap = FileSystemCapability;
         let prompt = cap.system_prompt_addition().unwrap();
         assert!(prompt.contains("/workspace"));
+        assert!(prompt.contains("File reading economy"));
+        assert!(prompt.contains("offset"));
+        assert!(prompt.contains("total_lines"));
     }
 
     #[test]

--- a/crates/core/src/tool_output_sanitizer.rs
+++ b/crates/core/src/tool_output_sanitizer.rs
@@ -28,6 +28,17 @@ For build/install commands, prefer quiet flags or pipe through tail:\n\
 - `apt-get install -qq -y`\n\
 Save verbose output to a file and inspect selectively: `cmd > /tmp/out.log 2>&1 && tail -100 /tmp/out.log`";
 
+/// System prompt hint for file reading economy (EVE-244).
+/// Appended to the FileSystem capability's `system_prompt_addition()` to guide
+/// the LLM toward efficient file reading with offset/limit pagination.
+pub const READ_ECONOMY_HINT: &str = "\n\n**File reading economy:** `read_file` returns at most 2000 lines by default.\n\
+Use `offset` and `limit` to read specific sections of large files.\n\
+- Use `grep_files` to find relevant lines before reading\n\
+- Use `list_directory` for file structure\n\
+- Don't read entire large files when you only need a specific section\n\
+- When a read is truncated, check `total_lines` to see how much remains\n\
+- For files you've already read, use offset to continue from where you left off";
+
 /// Strip ANSI escape sequences from text.
 ///
 /// Removes SGR sequences (`\x1b[...m`), CSI sequences (`\x1b[...X`),


### PR DESCRIPTION
## What
Add `READ_ECONOMY_HINT` constant to `tool_output_sanitizer.rs` and append it to the FileSystem capability's `system_prompt_addition()`.

## Why
Even with offset/limit parameters (EVE-243), LLMs won't use them optimally without guidance. Every production coding agent includes system prompt hints for efficient file reading. This closes the gap (EVE-244).

## How
- New `READ_ECONOMY_HINT` constant in `tool_output_sanitizer.rs` following the existing `EXEC_OUTPUT_HINT` pattern
- Appended to FileSystem capability's `system_prompt_addition()` via `LazyLock` (can't use `concat!` with `const &str`)
- Guidance covers: offset/limit usage, grep-before-read, total_lines awareness, continuation reads

## Risk
- Low
- Only adds a static string to the system prompt. No runtime behavior change.

## Security
- Threat categories reviewed: TM-LLM
- The hint is a static string constant appended to the system prompt. No user input, no injection surface, no data exposure. No security concerns.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
