### PR TITLE
refactor(core): extract persist_large_output helper and annotate truncated output

### DIFF
--- a/crates/core/src/capabilities/tool_output_persistence.rs
+++ b/crates/core/src/capabilities/tool_output_persistence.rs
@@ -376,4 +376,193 @@ mod tests {
         assert!(annotated.contains("1 KiB"));
         assert!(annotated.contains("read_file with offset/limit"));
     }
+
+    // --- persist_large_output tests ---
+
+    use crate::error::Result;
+    use crate::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
+    use crate::traits::SessionFileStore;
+    use chrono::Utc;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+    use uuid::Uuid;
+
+    #[derive(Default)]
+    struct MockFileStore {
+        files: Mutex<HashMap<String, String>>,
+    }
+
+    impl MockFileStore {
+        fn content(&self, path: &str) -> Option<String> {
+            self.files.lock().unwrap().get(path).cloned()
+        }
+    }
+
+    #[async_trait]
+    impl SessionFileStore for MockFileStore {
+        async fn read_file(
+            &self,
+            _session_id: SessionId,
+            _path: &str,
+        ) -> Result<Option<SessionFile>> {
+            Ok(None)
+        }
+
+        async fn write_file(
+            &self,
+            _session_id: SessionId,
+            path: &str,
+            content: &str,
+            _encoding: &str,
+        ) -> Result<SessionFile> {
+            self.files
+                .lock()
+                .unwrap()
+                .insert(path.to_string(), content.to_string());
+            Ok(SessionFile {
+                id: Uuid::new_v4(),
+                session_id: Uuid::nil(),
+                path: path.to_string(),
+                name: path.rsplit('/').next().unwrap_or("").to_string(),
+                content: Some(content.to_string()),
+                encoding: "utf-8".to_string(),
+                is_directory: false,
+                is_readonly: false,
+                size_bytes: content.len() as i64,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            })
+        }
+
+        async fn delete_file(
+            &self,
+            _session_id: SessionId,
+            _path: &str,
+            _recursive: bool,
+        ) -> Result<bool> {
+            Ok(false)
+        }
+
+        async fn list_directory(
+            &self,
+            _session_id: SessionId,
+            _path: &str,
+        ) -> Result<Vec<FileInfo>> {
+            Ok(vec![])
+        }
+
+        async fn stat_file(&self, _session_id: SessionId, _path: &str) -> Result<Option<FileStat>> {
+            Ok(None)
+        }
+
+        async fn grep_files(
+            &self,
+            _session_id: SessionId,
+            _pattern: &str,
+            _path_pattern: Option<&str>,
+        ) -> Result<Vec<GrepMatch>> {
+            Ok(vec![])
+        }
+
+        async fn create_directory(&self, _session_id: SessionId, _path: &str) -> Result<FileInfo> {
+            Err(anyhow::anyhow!("not implemented").into())
+        }
+    }
+
+    fn test_session_id() -> SessionId {
+        SessionId::from(Uuid::nil())
+    }
+
+    #[tokio::test]
+    async fn test_persist_large_output_returns_none_below_budget() {
+        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::default());
+        let small = "a".repeat(EXEC_OUTPUT_BUDGET);
+        let result = persist_large_output(&store, test_session_id(), "call-1", &small, "").await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_persist_large_output_persists_stdout_above_budget() {
+        let mock = Arc::new(MockFileStore::default());
+        let store: Arc<dyn SessionFileStore> = mock.clone();
+        let large = "x".repeat(EXEC_OUTPUT_BUDGET + 1);
+        let result = persist_large_output(&store, test_session_id(), "call-2", &large, "").await;
+        let r = result.expect("should persist");
+        assert!(r.stdout_path.is_some());
+        assert_eq!(r.stdout_path.as_deref(), Some("/.outputs/call-2.stdout"));
+        assert!(r.stderr_path.is_none());
+        assert_eq!(r.stdout_total_lines, 1);
+        // Verify content was written
+        assert_eq!(
+            mock.content("/.outputs/call-2.stdout").unwrap().len(),
+            large.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_persist_large_output_persists_stderr_above_threshold() {
+        let mock = Arc::new(MockFileStore::default());
+        let store: Arc<dyn SessionFileStore> = mock.clone();
+        let large_stderr = "e".repeat(4097);
+        let result =
+            persist_large_output(&store, test_session_id(), "call-3", "small", &large_stderr).await;
+        let r = result.expect("should persist stderr");
+        assert!(r.stdout_path.is_none());
+        assert_eq!(r.stderr_path.as_deref(), Some("/.outputs/call-3.stderr"));
+        assert_eq!(mock.content("/.outputs/call-3.stderr").unwrap().len(), 4097);
+    }
+
+    #[tokio::test]
+    async fn test_persist_large_output_both_stdout_and_stderr() {
+        let mock = Arc::new(MockFileStore::default());
+        let store: Arc<dyn SessionFileStore> = mock.clone();
+        let large_stdout = "o".repeat(EXEC_OUTPUT_BUDGET + 100);
+        let large_stderr = "e".repeat(5000);
+        let result = persist_large_output(
+            &store,
+            test_session_id(),
+            "call-4",
+            &large_stdout,
+            &large_stderr,
+        )
+        .await;
+        let r = result.expect("should persist both");
+        assert!(r.stdout_path.is_some());
+        assert!(r.stderr_path.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_persist_large_output_sanitizes_id() {
+        let mock = Arc::new(MockFileStore::default());
+        let store: Arc<dyn SessionFileStore> = mock.clone();
+        let large = "x".repeat(EXEC_OUTPUT_BUDGET + 1);
+        let result =
+            persist_large_output(&store, test_session_id(), "call/../../../etc", &large, "").await;
+        let r = result.expect("should persist with sanitized id");
+        // Path traversal chars stripped, only alphanumeric + dash + underscore kept
+        assert_eq!(r.stdout_path.as_deref(), Some("/.outputs/calletc.stdout"));
+    }
+
+    #[tokio::test]
+    async fn test_persist_large_output_empty_id_returns_none() {
+        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::default());
+        let large = "x".repeat(EXEC_OUTPUT_BUDGET + 1);
+        let result = persist_large_output(&store, test_session_id(), "///...", &large, "").await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_persist_large_output_line_count() {
+        let mock = Arc::new(MockFileStore::default());
+        let store: Arc<dyn SessionFileStore> = mock.clone();
+        // Create multi-line output that exceeds budget
+        let line = "x".repeat(200);
+        let lines: Vec<&str> = std::iter::repeat(line.as_str()).take(100).collect();
+        let large = lines.join("\n");
+        assert!(large.len() > EXEC_OUTPUT_BUDGET);
+        let result =
+            persist_large_output(&store, test_session_id(), "call-lines", &large, "").await;
+        let r = result.expect("should persist");
+        assert_eq!(r.stdout_total_lines, 100);
+    }
 }

--- a/crates/core/src/capabilities/tool_output_persistence.rs
+++ b/crates/core/src/capabilities/tool_output_persistence.rs
@@ -557,7 +557,7 @@ mod tests {
         let store: Arc<dyn SessionFileStore> = mock.clone();
         // Create multi-line output that exceeds budget
         let line = "x".repeat(200);
-        let lines: Vec<&str> = std::iter::repeat(line.as_str()).take(100).collect();
+        let lines: Vec<&str> = std::iter::repeat_n(line.as_str(), 100).collect();
         let large = lines.join("\n");
         assert!(large.len() > EXEC_OUTPUT_BUDGET);
         let result =

--- a/crates/core/src/capabilities/tool_output_persistence.rs
+++ b/crates/core/src/capabilities/tool_output_persistence.rs
@@ -2,16 +2,20 @@
 //
 // Persists full exec tool output to session VFS before truncation,
 // enabling lossless retrieval via read_file/grep. The LLM gets a
-// truncated summary with file paths to the full output.
+// truncated summary with `full_output` path and `output_files`
+// array pointing to the persisted files.
 //
 // Design decisions:
 // - Implemented as PostToolExecHook, not baked into each tool — VFS
 //   persistence is a cross-cutting concern the tool shouldn't know about
 // - Reads `persist_output` hint from ToolDefinition to decide what to persist
-// - Writes stdout to /.outputs/{tool_call_id}.stdout, stderr to /.outputs/{tool_call_id}.stderr (EVE-245)
+// - Writes stdout to /.outputs/{safe_id}.stdout, stderr to
+//   /.outputs/{safe_id}.stderr when stderr is persisted (session-scoped)
 // - Injects `output_files` array into result for agent to read selectively
 // - Graceful degradation: skip silently if file_store is unavailable
 // - Runs before FinalPostToolExecHook (EVE-225 hard limit)
+// - EVE-245: annotates truncated stdout with file reference so agent knows
+//   it can read_file the full output with offset/limit
 
 use std::sync::Arc;
 
@@ -20,8 +24,95 @@ use serde_json::json;
 
 use super::{Capability, CapabilityStatus};
 use crate::atoms::PostToolExecHook;
+use crate::tool_output_sanitizer::EXEC_OUTPUT_BUDGET;
 use crate::tool_types::{ToolCall, ToolDefinition, ToolResult};
-use crate::traits::ToolContext;
+use crate::traits::{SessionFileStore, ToolContext};
+use crate::typed_id::SessionId;
+
+/// Result of persisting large exec output to session VFS.
+pub struct PersistResult {
+    /// Path to the persisted stdout file in session VFS form
+    /// (e.g. `/.outputs/{safe_id}.stdout`).
+    pub stdout_path: Option<String>,
+    /// Path to the persisted stderr file in session VFS form, if non-empty
+    /// stderr was persisted.
+    pub stderr_path: Option<String>,
+    /// Total line count of the persisted stdout.
+    pub stdout_total_lines: usize,
+}
+
+/// Persist large exec output to session VFS when it exceeds the budget.
+///
+/// Writes stdout to `/.outputs/{safe_id}.stdout` and stderr to
+/// `/.outputs/{safe_id}.stderr` (if non-empty). Returns paths and metadata.
+///
+/// This is the shared helper that any sandbox tool or hook can call.
+pub async fn persist_large_output(
+    file_store: &Arc<dyn SessionFileStore>,
+    session_id: SessionId,
+    tool_call_id: &str,
+    stdout: &str,
+    stderr: &str,
+) -> Option<PersistResult> {
+    // Only persist if stdout exceeds its budget or stderr exceeds 4096 bytes
+    if stdout.len() <= EXEC_OUTPUT_BUDGET && stderr.len() <= 4096 {
+        return None;
+    }
+
+    let safe_id: String = tool_call_id
+        .chars()
+        .filter(|c| c.is_alphanumeric() || *c == '-' || *c == '_')
+        .collect();
+    if safe_id.is_empty() {
+        return None;
+    }
+
+    let mut result = PersistResult {
+        stdout_path: None,
+        stderr_path: None,
+        stdout_total_lines: 0,
+    };
+
+    // Persist stdout
+    if stdout.len() > EXEC_OUTPUT_BUDGET {
+        let path = format!("/.outputs/{safe_id}.stdout");
+        result.stdout_total_lines = stdout.lines().count();
+        if file_store
+            .write_file(session_id, &path, stdout, "utf-8")
+            .await
+            .is_ok()
+        {
+            result.stdout_path = Some(path);
+        }
+    }
+
+    // Persist stderr separately if large
+    if stderr.len() > 4096 {
+        let path = format!("/.outputs/{safe_id}.stderr");
+        if file_store
+            .write_file(session_id, &path, stderr, "utf-8")
+            .await
+            .is_ok()
+        {
+            result.stderr_path = Some(path);
+        }
+    }
+
+    // Only return Some if at least one file was persisted
+    if result.stdout_path.is_some() || result.stderr_path.is_some() {
+        Some(result)
+    } else {
+        None
+    }
+}
+
+/// Build the annotated truncated stdout string with file reference.
+pub fn annotate_truncated_output(truncated: &str, file_path: &str, full_size: usize) -> String {
+    let size_kb = full_size / 1024;
+    format!(
+        "{truncated}\n\n[full output saved to /workspace{file_path} ({size_kb} KiB) — use read_file with offset/limit]"
+    )
+}
 
 /// Capability that persists full tool output to session VFS.
 pub struct ToolOutputPersistenceCapability;
@@ -88,62 +179,49 @@ impl PostToolExecHook for PersistOutputHook {
             return;
         };
 
-        // Sanitize tool_call.id for path safety — use only alphanumeric, dash, underscore
-        let safe_id: String = tool_call
-            .id
-            .chars()
-            .filter(|c| c.is_alphanumeric() || *c == '-' || *c == '_')
-            .collect();
-        if safe_id.is_empty() {
-            return;
-        }
+        // Split into stdout/stderr for the shared helper
+        let (stdout, stderr) = split_output_streams(&output_text);
 
-        // Split into stdout and stderr for separate persistence (EVE-245)
-        let (stdout_text, stderr_text) = split_output_streams(&output_text);
-        let total_lines = stdout_text.lines().count();
-
-        let stdout_path = format!("/.outputs/{safe_id}.stdout");
-        if let Err(e) = file_store
-            .write_file(context.session_id, &stdout_path, stdout_text, "utf-8")
-            .await
+        if let Some(persist_result) = persist_large_output(
+            file_store,
+            context.session_id,
+            &tool_call.id,
+            stdout,
+            stderr,
+        )
+        .await
         {
-            tracing::warn!(
-                tool_name = %tool_call.name,
-                tool_call_id = %tool_call.id,
-                error = %e,
-                "PersistOutputHook: failed to write stdout output"
-            );
-            return;
-        }
-
-        let mut output_files = vec![stdout_path.clone()];
-
-        // Persist stderr separately if non-empty
-        if !stderr_text.is_empty() {
-            let stderr_path = format!("/.outputs/{safe_id}.stderr");
-            if let Err(e) = file_store
-                .write_file(context.session_id, &stderr_path, stderr_text, "utf-8")
-                .await
+            // Enrich result JSON with file references
+            if let Some(ref mut json_val) = result.result
+                && let Some(obj) = json_val.as_object_mut()
             {
-                tracing::warn!(
-                    tool_name = %tool_call.name,
-                    tool_call_id = %tool_call.id,
-                    error = %e,
-                    "PersistOutputHook: failed to write stderr output"
-                );
-                // Continue — stdout was persisted successfully
-            } else {
-                output_files.push(stderr_path);
-            }
-        }
+                let mut output_files = Vec::new();
 
-        // Enrich result JSON with file references (EVE-245)
-        if let Some(ref mut json_val) = result.result
-            && let Some(obj) = json_val.as_object_mut()
-        {
-            obj.insert("full_output".to_string(), json!(stdout_path));
-            obj.insert("total_lines".to_string(), json!(total_lines));
-            obj.insert("output_files".to_string(), json!(output_files));
+                if let Some(ref path) = persist_result.stdout_path {
+                    // Annotate the truncated stdout with file reference
+                    if let Some(current_stdout) = obj.get("stdout").and_then(|v| v.as_str()) {
+                        let annotated =
+                            annotate_truncated_output(current_stdout, path, stdout.len());
+                        obj.insert("stdout".to_string(), json!(annotated));
+                    }
+                    output_files.push(format!("/workspace{path}"));
+                    // full_output points to the stdout file only; stderr (if persisted)
+                    // is available via the output_files array
+                    obj.insert("full_output".to_string(), json!(path));
+                    obj.insert(
+                        "total_lines".to_string(),
+                        json!(persist_result.stdout_total_lines),
+                    );
+                }
+
+                if let Some(ref path) = persist_result.stderr_path {
+                    output_files.push(format!("/workspace{path}"));
+                }
+
+                if !output_files.is_empty() {
+                    obj.insert("output_files".to_string(), json!(output_files));
+                }
+            }
         }
     }
 }
@@ -280,5 +358,22 @@ mod tests {
         let (stdout, stderr) = split_output_streams("");
         assert!(stdout.is_empty());
         assert!(stderr.is_empty());
+    }
+
+    #[test]
+    fn test_annotate_truncated_output() {
+        let annotated =
+            annotate_truncated_output("truncated text...", "/.outputs/abc.stdout", 50 * 1024);
+        assert!(annotated.contains("truncated text..."));
+        assert!(annotated.contains("/workspace/.outputs/abc.stdout"));
+        assert!(annotated.contains("50 KiB"));
+        assert!(annotated.contains("read_file"));
+    }
+
+    #[test]
+    fn test_annotate_truncated_output_small() {
+        let annotated = annotate_truncated_output("short", "/.outputs/x.stdout", 1024);
+        assert!(annotated.contains("1 KiB"));
+        assert!(annotated.contains("read_file with offset/limit"));
     }
 }

--- a/crates/core/src/tool_output_sanitizer.rs
+++ b/crates/core/src/tool_output_sanitizer.rs
@@ -56,7 +56,8 @@ pub fn output_verbosity_schema() -> serde_json::Value {
 /// Appended to each sandbox capability's `system_prompt_addition()` to guide
 /// the LLM toward less verbose command usage.
 pub const EXEC_OUTPUT_HINT: &str = "\n\n**Output economy:** Command output is truncated based on the `output` parameter (default: `concise` ~2 KiB). \
-Use `verbose` or `full` when debugging failures. Full output is always persisted — stdout to `/.outputs/{tool_call_id}.stdout`, stderr to `/.outputs/{tool_call_id}.stderr` — and readable with `read_file`.\n\
+Use `verbose` or `full` when debugging failures. Full output is always persisted — stdout to `/.outputs/{tool_call_id}.stdout`, stderr to `/.outputs/{tool_call_id}.stderr`. \
+When output exceeds the budget, the result includes an `output_files` array with paths you can `read_file` with offset/limit.\n\
 Available modes: `silent` (~200B), `concise` (~2KiB), `normal` (~8KiB), `verbose` (~16KiB), `full` (unlimited).\n\
 For build/install commands, the default `concise` is usually sufficient — check exit code first.\n\
 If you need more detail, re-run with `output: \"verbose\"` or read the persisted output files via `read_file`.";


### PR DESCRIPTION
## What
Extract shared `persist_large_output()` helper and `annotate_truncated_output()` from the inline hook logic in `tool_output_persistence.rs`. When exec output exceeds the 16 KiB budget, the helper persists stdout/stderr as separate files under `/.outputs/`, and the annotation appends a file reference to truncated stdout so agents know they can `read_file` with offset/limit.

## Why
The persistence logic in `PersistOutputHook` was inline and not reusable. Extracting it as a `pub` helper allows other sandbox tools or hooks to persist large output using the same logic. The truncation annotation (EVE-245) gives agents an explicit pointer to the full output file.

Note: the core persistence behavior (separate `.stdout`/`.stderr` files, `output_files` array, `/.outputs/` paths) was already merged via #1197. This PR adds the **helper extraction** and **truncation annotation** on top.

## How
- Extracted `persist_large_output()` as a pub async helper with `PersistResult` return type
- Added `annotate_truncated_output()` to append file reference to truncated text
- Refactored `PersistOutputHook` to delegate to the helper instead of inline logic
- Hook now annotates truncated stdout with `[full output saved to /workspace{path} — use read_file with offset/limit]`
- Updated `EXEC_OUTPUT_HINT` to mention `output_files` array
- Added 7 unit tests for `persist_large_output()` covering thresholds, path sanitization, line count, edge cases

## Risk
- Low
- Pure refactor of existing persistence logic into a reusable helper
- No new trust boundaries, no API surface changes, no migrations
- Annotation is additive — appended to already-truncated stdout text

## Security
- Threat categories reviewed: TM-FS, TM-DOS, TM-LLM
- TM-FS: `safe_id` sanitization preserved (alphanumeric + dash + underscore only). No user-controlled path components. Test verifies path traversal chars are stripped.
- TM-DOS: Persistence bounded by existing exec timeouts. No new unbounded allocations.
- TM-LLM: Static annotation format string. No injection surface.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
