### PR TITLE
feat(core): wire session locale to bashkit builder

### DIFF
--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -1290,6 +1290,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_bash_lang_env_default() {
+        let (context, _) = create_context_with_mock_store();
+        let tool = BashTool;
+
+        // Default locale (None) should set LANG to en-US
+        let result = tool
+            .execute_with_context(json!({"commands": "echo $LANG"}), &context)
+            .await;
+        if let ToolExecutionResult::Success(output) = result {
+            assert_eq!(output["stdout"], "en-US\n");
+        } else {
+            panic!("Expected success");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_bash_lang_env_from_context_locale() {
+        let (mut context, _) = create_context_with_mock_store();
+        context.locale = Some("uk-UA".to_string());
+        let tool = BashTool;
+
+        let result = tool
+            .execute_with_context(json!({"commands": "echo $LANG"}), &context)
+            .await;
+        if let ToolExecutionResult::Success(output) = result {
+            assert_eq!(output["stdout"], "uk-UA\n");
+        } else {
+            panic!("Expected success");
+        }
+    }
+
+    #[tokio::test]
     async fn test_bash_write_and_read_file() {
         let (context, _) = create_context_with_mock_store();
         let tool = BashTool;

--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -219,6 +219,9 @@ impl Tool for BashTool {
             file_store,
         ));
 
+        // Resolve locale from context (defaults to en-US).
+        let locale = context.locale.as_deref().unwrap_or("en-US");
+
         // Configure bash with resource limits (uses shared execution_limits)
         let mut bash = Bash::builder()
             .fs(session_fs)
@@ -229,6 +232,7 @@ impl Tool for BashTool {
             .env("SHELL", "/bin/bash")
             .env("PATH", "/usr/local/bin:/usr/bin:/bin")
             .env("WORKSPACE", "/workspace")
+            .env("LANG", locale)
             .limits(execution_limits())
             .build();
 

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -542,6 +542,11 @@ pub struct ToolContext {
     /// Merged network access list (harness ∩ agent ∩ session).
     /// When set, tools that make HTTP requests must check URLs against this list.
     pub network_access: Option<crate::network_access::NetworkAccessList>,
+
+    /// Resolved locale for localized tool behavior (BCP 47, e.g. `uk-UA`).
+    /// When set, tools that support localization use this to produce
+    /// locale-appropriate descriptions, error messages, and prompts.
+    pub locale: Option<String>,
 }
 
 impl ToolContext {
@@ -567,6 +572,7 @@ impl ToolContext {
             memory_store: None,
             org_id: None,
             network_access: None,
+            locale: None,
         }
     }
 
@@ -592,6 +598,7 @@ impl ToolContext {
             memory_store: None,
             org_id: None,
             network_access: None,
+            locale: None,
         }
     }
 
@@ -620,6 +627,7 @@ impl ToolContext {
             memory_store: None,
             org_id: None,
             network_access: None,
+            locale: None,
         }
     }
 
@@ -649,6 +657,7 @@ impl ToolContext {
             memory_store: None,
             org_id: None,
             network_access: None,
+            locale: None,
         }
     }
 


### PR DESCRIPTION
## What
Add `locale` field to `ToolContext` and pass it as `LANG` env var to the bashkit `Bash` builder.

## Why
bashkit supports locale-aware behavior but everruns never passes the session locale to it. The `BASHKIT_TOOL` static is built once with no locale, and the per-execution `Bash::builder()` doesn't set LANG.

Fixes EVE-242.

## How
- Added `locale: Option<String>` to `ToolContext` (with `None` in all constructors)
- In `BashTool::execute_with_context`, resolve locale from context (defaulting to en-US) and pass as `LANG` env var to `Bash::builder()`
- BashToolBuilder metadata (description, system_prompt) remains en-US since the Tool trait does not support per-session metadata — that requires a deeper refactor

## Risk
- Low
- Default behavior unchanged (LANG defaults to en-US)
- New field is `Option<String>` initialized to `None` everywhere

## Security
- Threat categories reviewed: TM-BASH
- LANG env var is set from session locale, not user input. No command injection risk. No sandbox boundary changes.

## Checklist
- [x] Tests added or updated (74 existing bash tests pass)
- [x] Backward compatibility considered (new field defaults to None)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)