### PR TITLE
feat(core): persist exec output to /.outputs/ with separate stdout/stderr (EVE-245)

### DIFF
--- a/crates/core/src/capabilities/tool_output_persistence.rs
+++ b/crates/core/src/capabilities/tool_output_persistence.rs
@@ -8,7 +8,7 @@
 // - Implemented as PostToolExecHook, not baked into each tool — VFS
 //   persistence is a cross-cutting concern the tool shouldn't know about
 // - Reads `persist_output` hint from ToolDefinition to decide what to persist
-// - Writes stdout to /.outputs/{tool_call_id}.stdout, stderr to .stderr (EVE-245)
+// - Writes stdout to /.outputs/{tool_call_id}.stdout, stderr to /.outputs/{tool_call_id}.stderr (EVE-245)
 // - Injects `output_files` array into result for agent to read selectively
 // - Graceful degradation: skip silently if file_store is unavailable
 // - Runs before FinalPostToolExecHook (EVE-225 hard limit)
@@ -104,7 +104,7 @@ impl PostToolExecHook for PersistOutputHook {
 
         let stdout_path = format!("/.outputs/{safe_id}.stdout");
         if let Err(e) = file_store
-            .write_file(context.session_id, &stdout_path, &stdout_text, "utf-8")
+            .write_file(context.session_id, &stdout_path, stdout_text, "utf-8")
             .await
         {
             tracing::warn!(
@@ -122,7 +122,7 @@ impl PostToolExecHook for PersistOutputHook {
         if !stderr_text.is_empty() {
             let stderr_path = format!("/.outputs/{safe_id}.stderr");
             if let Err(e) = file_store
-                .write_file(context.session_id, &stderr_path, &stderr_text, "utf-8")
+                .write_file(context.session_id, &stderr_path, stderr_text, "utf-8")
                 .await
             {
                 tracing::warn!(
@@ -151,16 +151,17 @@ impl PostToolExecHook for PersistOutputHook {
 /// Split combined output text into stdout and stderr streams.
 ///
 /// The raw output from exec tools uses `\n--- stderr ---\n` as a separator
-/// (see `virtual_bash.rs` and other sandbox tools). If no separator is found,
-/// the entire text is treated as stdout.
-fn split_output_streams(text: &str) -> (String, String) {
+/// (see `virtual_bash.rs` and other sandbox tools). Uses `rfind` to split at
+/// the *last* occurrence, since the separator is injected by our tools and
+/// shouldn't appear more than once — but if stdout happens to contain the
+/// marker text, taking the last match minimizes corruption.
+/// If no separator is found, the entire text is treated as stdout.
+fn split_output_streams(text: &str) -> (&str, &str) {
     const STDERR_SEPARATOR: &str = "\n--- stderr ---\n";
-    if let Some(pos) = text.find(STDERR_SEPARATOR) {
-        let stdout = text[..pos].to_string();
-        let stderr = text[pos + STDERR_SEPARATOR.len()..].to_string();
-        (stdout, stderr)
+    if let Some(pos) = text.rfind(STDERR_SEPARATOR) {
+        (&text[..pos], &text[pos + STDERR_SEPARATOR.len()..])
     } else {
-        (text.to_string(), String::new())
+        (text, "")
     }
 }
 

--- a/crates/core/src/capabilities/tool_output_persistence.rs
+++ b/crates/core/src/capabilities/tool_output_persistence.rs
@@ -1,14 +1,15 @@
-// Tool Output Persistence Capability (EVE-222)
+// Tool Output Persistence Capability (EVE-222, EVE-245)
 //
 // Persists full exec tool output to session VFS before truncation,
 // enabling lossless retrieval via read_file/grep. The LLM gets a
-// truncated summary with a `full_output` path to the full log.
+// truncated summary with file paths to the full output.
 //
 // Design decisions:
 // - Implemented as PostToolExecHook, not baked into each tool — VFS
 //   persistence is a cross-cutting concern the tool shouldn't know about
 // - Reads `persist_output` hint from ToolDefinition to decide what to persist
-// - Writes to /.exec-logs/{tool_call_id}.log (dot-prefixed, session-scoped)
+// - Writes stdout to /.outputs/{tool_call_id}.stdout, stderr to .stderr (EVE-245)
+// - Injects `output_files` array into result for agent to read selectively
 // - Graceful degradation: skip silently if file_store is unavailable
 // - Runs before FinalPostToolExecHook (EVE-225 hard limit)
 
@@ -97,29 +98,69 @@ impl PostToolExecHook for PersistOutputHook {
             return;
         }
 
-        let path = format!("/.exec-logs/{safe_id}.log");
-        let total_lines = output_text.lines().count();
+        // Split into stdout and stderr for separate persistence (EVE-245)
+        let (stdout_text, stderr_text) = split_output_streams(&output_text);
+        let total_lines = stdout_text.lines().count();
 
+        let stdout_path = format!("/.outputs/{safe_id}.stdout");
         if let Err(e) = file_store
-            .write_file(context.session_id, &path, &output_text, "utf-8")
+            .write_file(context.session_id, &stdout_path, &stdout_text, "utf-8")
             .await
         {
             tracing::warn!(
                 tool_name = %tool_call.name,
                 tool_call_id = %tool_call.id,
                 error = %e,
-                "PersistOutputHook: failed to write exec log"
+                "PersistOutputHook: failed to write stdout output"
             );
             return;
         }
 
-        // Enrich result JSON with file reference
+        let mut output_files = vec![stdout_path.clone()];
+
+        // Persist stderr separately if non-empty
+        if !stderr_text.is_empty() {
+            let stderr_path = format!("/.outputs/{safe_id}.stderr");
+            if let Err(e) = file_store
+                .write_file(context.session_id, &stderr_path, &stderr_text, "utf-8")
+                .await
+            {
+                tracing::warn!(
+                    tool_name = %tool_call.name,
+                    tool_call_id = %tool_call.id,
+                    error = %e,
+                    "PersistOutputHook: failed to write stderr output"
+                );
+                // Continue — stdout was persisted successfully
+            } else {
+                output_files.push(stderr_path);
+            }
+        }
+
+        // Enrich result JSON with file references (EVE-245)
         if let Some(ref mut json_val) = result.result
             && let Some(obj) = json_val.as_object_mut()
         {
-            obj.insert("full_output".to_string(), json!(path));
+            obj.insert("full_output".to_string(), json!(stdout_path));
             obj.insert("total_lines".to_string(), json!(total_lines));
+            obj.insert("output_files".to_string(), json!(output_files));
         }
+    }
+}
+
+/// Split combined output text into stdout and stderr streams.
+///
+/// The raw output from exec tools uses `\n--- stderr ---\n` as a separator
+/// (see `virtual_bash.rs` and other sandbox tools). If no separator is found,
+/// the entire text is treated as stdout.
+fn split_output_streams(text: &str) -> (String, String) {
+    const STDERR_SEPARATOR: &str = "\n--- stderr ---\n";
+    if let Some(pos) = text.find(STDERR_SEPARATOR) {
+        let stdout = text[..pos].to_string();
+        let stderr = text[pos + STDERR_SEPARATOR.len()..].to_string();
+        (stdout, stderr)
+    } else {
+        (text.to_string(), String::new())
     }
 }
 
@@ -215,5 +256,28 @@ mod tests {
         assert_eq!(cap.id(), "tool_output_persistence");
         assert!(!cap.post_tool_exec_hooks().is_empty());
         assert!(cap.dependencies().contains(&"session_file_system"));
+    }
+
+    #[test]
+    fn test_split_output_streams_both() {
+        let text = "hello world\n--- stderr ---\nwarning: unused";
+        let (stdout, stderr) = split_output_streams(text);
+        assert_eq!(stdout, "hello world");
+        assert_eq!(stderr, "warning: unused");
+    }
+
+    #[test]
+    fn test_split_output_streams_stdout_only() {
+        let text = "hello world\nline two";
+        let (stdout, stderr) = split_output_streams(text);
+        assert_eq!(stdout, "hello world\nline two");
+        assert!(stderr.is_empty());
+    }
+
+    #[test]
+    fn test_split_output_streams_empty() {
+        let (stdout, stderr) = split_output_streams("");
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
     }
 }

--- a/crates/core/src/tool_output_sanitizer.rs
+++ b/crates/core/src/tool_output_sanitizer.rs
@@ -48,7 +48,7 @@ pub fn output_verbosity_schema() -> serde_json::Value {
         "type": "string",
         "enum": ["silent", "concise", "normal", "verbose", "full"],
         "default": "concise",
-        "description": "Output verbosity: silent (~200B, truncated to exit code + minimal output), concise (~2KiB, default), normal (~8KiB), verbose (~16KiB), full (unlimited, capped by 64KiB hard limit). Full logs always available via read_file on /.outputs/."
+        "description": "Output verbosity: silent (~200B, truncated to exit code + minimal output), concise (~2KiB, default), normal (~8KiB), verbose (~16KiB), full (unlimited, capped by 64KiB hard limit). Full output always persisted to /.outputs/{tool_call_id}.stdout (and .stderr) — use read_file to retrieve."
     })
 }
 
@@ -56,10 +56,10 @@ pub fn output_verbosity_schema() -> serde_json::Value {
 /// Appended to each sandbox capability's `system_prompt_addition()` to guide
 /// the LLM toward less verbose command usage.
 pub const EXEC_OUTPUT_HINT: &str = "\n\n**Output economy:** Command output is truncated based on the `output` parameter (default: `concise` ~2 KiB). \
-Use `verbose` or `full` when debugging failures. Full logs are always persisted to `/.outputs/` and readable with `read_file`.\n\
+Use `verbose` or `full` when debugging failures. Full output is always persisted — stdout to `/.outputs/{tool_call_id}.stdout`, stderr to `/.outputs/{tool_call_id}.stderr` — and readable with `read_file`.\n\
 Available modes: `silent` (~200B), `concise` (~2KiB), `normal` (~8KiB), `verbose` (~16KiB), `full` (unlimited).\n\
 For build/install commands, the default `concise` is usually sufficient — check exit code first.\n\
-If you need more detail, re-run with `output: \"verbose\"` or read the full log from `/.outputs/`.";
+If you need more detail, re-run with `output: \"verbose\"` or read the persisted output files via `read_file`.";
 
 /// System prompt hint for file reading economy (EVE-244).
 /// Appended to the FileSystem capability's `system_prompt_addition()` to guide

--- a/crates/core/src/tool_output_sanitizer.rs
+++ b/crates/core/src/tool_output_sanitizer.rs
@@ -48,7 +48,7 @@ pub fn output_verbosity_schema() -> serde_json::Value {
         "type": "string",
         "enum": ["silent", "concise", "normal", "verbose", "full"],
         "default": "concise",
-        "description": "Output verbosity: silent (~200B, truncated to exit code + minimal output), concise (~2KiB, default), normal (~8KiB), verbose (~16KiB), full (unlimited, capped by 64KiB hard limit). Full logs always available via read_file on /.exec-logs/."
+        "description": "Output verbosity: silent (~200B, truncated to exit code + minimal output), concise (~2KiB, default), normal (~8KiB), verbose (~16KiB), full (unlimited, capped by 64KiB hard limit). Full logs always available via read_file on /.outputs/."
     })
 }
 
@@ -56,10 +56,10 @@ pub fn output_verbosity_schema() -> serde_json::Value {
 /// Appended to each sandbox capability's `system_prompt_addition()` to guide
 /// the LLM toward less verbose command usage.
 pub const EXEC_OUTPUT_HINT: &str = "\n\n**Output economy:** Command output is truncated based on the `output` parameter (default: `concise` ~2 KiB). \
-Use `verbose` or `full` when debugging failures. Full logs are always persisted to `/.exec-logs/` and readable with `read_file`.\n\
+Use `verbose` or `full` when debugging failures. Full logs are always persisted to `/.outputs/` and readable with `read_file`.\n\
 Available modes: `silent` (~200B), `concise` (~2KiB), `normal` (~8KiB), `verbose` (~16KiB), `full` (unlimited).\n\
 For build/install commands, the default `concise` is usually sufficient — check exit code first.\n\
-If you need more detail, re-run with `output: \"verbose\"` or read the full log from `/.exec-logs/`.";
+If you need more detail, re-run with `output: \"verbose\"` or read the full log from `/.outputs/`.";
 
 /// System prompt hint for file reading economy (EVE-244).
 /// Appended to the FileSystem capability's `system_prompt_addition()` to guide

--- a/crates/core/src/tool_types.rs
+++ b/crates/core/src/tool_types.rs
@@ -247,9 +247,9 @@ pub struct ToolHints {
     pub long_running: Option<bool>,
 
     /// Tool output should be persisted to session VFS before truncation.
-    /// When set, the `tool_output_persistence` capability (EVE-222) writes the
-    /// full cleaned output to `/.exec-logs/{tool_call_id}.log` and injects a
-    /// `full_output` path into the result so the LLM can retrieve it on demand.
+    /// When set, the `tool_output_persistence` capability (EVE-222, EVE-245) writes
+    /// stdout to `/.outputs/{tool_call_id}.stdout` and stderr to `.stderr`, injecting
+    /// `full_output`, `total_lines`, and `output_files` into the result.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub persist_output: Option<bool>,
 }

--- a/crates/core/src/tool_types.rs
+++ b/crates/core/src/tool_types.rs
@@ -248,8 +248,9 @@ pub struct ToolHints {
 
     /// Tool output should be persisted to session VFS before truncation.
     /// When set, the `tool_output_persistence` capability (EVE-222, EVE-245) writes
-    /// stdout to `/.outputs/{tool_call_id}.stdout` and stderr to `.stderr`, injecting
-    /// `full_output`, `total_lines`, and `output_files` into the result.
+    /// stdout to `/.outputs/{tool_call_id}.stdout` and stderr to
+    /// `/.outputs/{tool_call_id}.stderr`, injecting `full_output`, `total_lines`,
+    /// and `output_files` into the result.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub persist_output: Option<bool>,
 }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -11834,7 +11834,7 @@
               "boolean",
               "null"
             ],
-            "description": "Tool output should be persisted to session VFS before truncation.\nWhen set, the `tool_output_persistence` capability (EVE-222, EVE-245) writes\nstdout to `/.outputs/{tool_call_id}.stdout` and stderr to `.stderr`, injecting\n`full_output`, `total_lines`, and `output_files` into the result."
+            "description": "Tool output should be persisted to session VFS before truncation.\nWhen set, the `tool_output_persistence` capability (EVE-222, EVE-245) writes\nstdout to `/.outputs/{tool_call_id}.stdout` and stderr to\n`/.outputs/{tool_call_id}.stderr`, injecting `full_output`, `total_lines`,\nand `output_files` into the result."
           },
           "readonly": {
             "type": [

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -11834,7 +11834,7 @@
               "boolean",
               "null"
             ],
-            "description": "Tool output should be persisted to session VFS before truncation.\nWhen set, the `tool_output_persistence` capability (EVE-222) writes the\nfull cleaned output to `/.exec-logs/{tool_call_id}.log` and injects a\n`full_output` path into the result so the LLM can retrieve it on demand."
+            "description": "Tool output should be persisted to session VFS before truncation.\nWhen set, the `tool_output_persistence` capability (EVE-222, EVE-245) writes\nstdout to `/.outputs/{tool_call_id}.stdout` and stderr to `.stderr`, injecting\n`full_output`, `total_lines`, and `output_files` into the result."
           },
           "readonly": {
             "type": [

--- a/docs/features/harnesses.md
+++ b/docs/features/harnesses.md
@@ -48,7 +48,7 @@ A general-purpose harness bundling the core capabilities most agents need. This 
 | **[Infinity Context](/capabilities/infinity-context/)** | Trims older messages from the live prompt while exposing earlier history via `query_history` |
 | **[OpenAI Tool Search](/capabilities/openai-tool-search/)** | Defers tool schema loading on supported OpenAI models to reduce prompt size |
 | **[Context Compaction](/advanced/compaction/)** | Auto-compacts context at 85% budget via cascading strategies (observation masking → native → summarization → trim) |
-| **Tool Output Persistence** | Persists full exec tool output to `/.outputs/{tool_call_id}.stdout` (and `.stderr`) before truncation, enabling lossless retrieval via `read_file` |
+| **Tool Output Persistence** | Persists full exec tool output to `/.outputs/{tool_call_id}.stdout` and `/.outputs/{tool_call_id}.stderr` before truncation, enabling lossless retrieval via `read_file` |
 
 Infinity Context and Context Compaction work together to keep long sessions unbounded: Infinity Context windows how many messages are loaded into the prompt, while Compaction reduces the size of what's loaded. See [Context Compaction — Generic Harness Defaults](/advanced/compaction/#generic-harness-defaults) for details.
 

--- a/docs/features/harnesses.md
+++ b/docs/features/harnesses.md
@@ -48,7 +48,7 @@ A general-purpose harness bundling the core capabilities most agents need. This 
 | **[Infinity Context](/capabilities/infinity-context/)** | Trims older messages from the live prompt while exposing earlier history via `query_history` |
 | **[OpenAI Tool Search](/capabilities/openai-tool-search/)** | Defers tool schema loading on supported OpenAI models to reduce prompt size |
 | **[Context Compaction](/advanced/compaction/)** | Auto-compacts context at 85% budget via cascading strategies (observation masking → native → summarization → trim) |
-| **Tool Output Persistence** | Persists full exec tool output to `/.exec-logs/{tool_call_id}.log` before truncation, enabling lossless retrieval via `read_file` |
+| **Tool Output Persistence** | Persists full exec tool output to `/.outputs/{tool_call_id}.stdout` (and `.stderr`) before truncation, enabling lossless retrieval via `read_file` |
 
 Infinity Context and Context Compaction work together to keep long sessions unbounded: Infinity Context windows how many messages are loaded into the prompt, while Compaction reduces the size of what's loaded. See [Context Compaction — Generic Harness Defaults](/advanced/compaction/#generic-harness-defaults) for details.
 

--- a/specs/harness-types.md
+++ b/specs/harness-types.md
@@ -53,7 +53,7 @@ The recommended default harness. Bundles the core capabilities needed for genera
 | `openai_tool_search` | OpenAI Tool Search | Defers tool schema loading on supported OpenAI models | |
 | `budgeting` | Budgeting | Budget-aware behavior: system prompt hints and `check_budget` tool | |
 | `compaction` | Context Compaction | Auto-compacts context at 85% budget via cascading strategies | `{"strategy": "auto", "proactive": true, "budget_percent": 0.85}` |
-| `tool_output_persistence` | Tool Output Persistence | Persists full exec tool output to `/.exec-logs/` before truncation; injects `full_output` path into result | |
+| `tool_output_persistence` | Tool Output Persistence | Persists full exec tool output to `/.outputs/` (stdout + stderr separately) before truncation; injects `full_output`, `total_lines`, and `output_files` into result | |
 
 **Use cases:**
 - Default harness for most agents

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -100,7 +100,7 @@ Two hook slots run in sequence:
 2. **Final hooks** (`final_post_tool_hooks`) — always-on infrastructure (e.g. EVE-225 hard limit)
 
 Current hooks:
-- **PersistOutputHook** (`tool_output_persistence` capability, included in Generic harness): When a tool declares `persist_output: true` in hints, writes stdout to `/.outputs/{tool_call_id}.stdout` and stderr to `.stderr` in session VFS, injecting `full_output`, `total_lines`, and `output_files` into the result. See `crates/core/src/capabilities/tool_output_persistence.rs`.
+- **PersistOutputHook** (`tool_output_persistence` capability, included in Generic harness): When a tool declares `persist_output: true` in hints, writes stdout to `/.outputs/{tool_call_id}.stdout` and stderr to `/.outputs/{tool_call_id}.stderr` in session VFS, injecting `full_output`, `total_lines`, and `output_files` into the result. See `crates/core/src/capabilities/tool_output_persistence.rs`.
 
 Current final hooks (always-on, cannot be removed):
 - **OutputHardLimitHook** (EVE-225): Enforces a 64 KiB hard ceiling on serialized tool result text. Head-truncation with UTF-8 safety; appends an LLM-actionable suffix. Logs `tracing::warn!` with tool_name, tool_call_id, result_bytes, limit when truncating. Fires regardless of which capabilities are active. See `crates/core/src/atoms/act_hooks.rs`.

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -87,7 +87,7 @@ All exec tools accept an `output` parameter controlling how much output is retur
 | `verbose` | ~16 KiB | Test failures, error investigation |
 | `full` | unlimited | Raw output, no truncation — when the LLM needs every line |
 
-Default is `concise`. Budgets apply to stdout; stderr is capped at `min(budget, 4096)` to keep error output proportional. Full logs (both streams) are always persisted to `/.exec-logs/` via `tool_output_persistence` and readable with `read_file`. See `crates/core/src/tool_output_sanitizer.rs` for budget constants and `output_verbosity_budget()`.
+Default is `concise`. Budgets apply to stdout; stderr is capped at `min(budget, 4096)` to keep error output proportional. Full output is always persisted to `/.outputs/` via `tool_output_persistence` — stdout to `/.outputs/{tool_call_id}.stdout`, stderr to `.stderr` — and readable with `read_file`. See `crates/core/src/tool_output_sanitizer.rs` for budget constants and `output_verbosity_budget()`.
 
 This is the tool's responsibility — each tool calls the helpers before constructing `ToolExecutionResult`. See `crates/core/src/tool_output_sanitizer.rs` for the primitives.
 
@@ -100,7 +100,7 @@ Two hook slots run in sequence:
 2. **Final hooks** (`final_post_tool_hooks`) — always-on infrastructure (e.g. EVE-225 hard limit)
 
 Current hooks:
-- **PersistOutputHook** (`tool_output_persistence` capability, included in Generic harness): When a tool declares `persist_output: true` in hints, writes full output to `/.exec-logs/{tool_call_id}.log` in session VFS and injects `full_output` path + `total_lines` into the result. See `crates/core/src/capabilities/tool_output_persistence.rs`.
+- **PersistOutputHook** (`tool_output_persistence` capability, included in Generic harness): When a tool declares `persist_output: true` in hints, writes stdout to `/.outputs/{tool_call_id}.stdout` and stderr to `.stderr` in session VFS, injecting `full_output`, `total_lines`, and `output_files` into the result. See `crates/core/src/capabilities/tool_output_persistence.rs`.
 
 Current final hooks (always-on, cannot be removed):
 - **OutputHardLimitHook** (EVE-225): Enforces a 64 KiB hard ceiling on serialized tool result text. Head-truncation with UTF-8 safety; appends an LLM-actionable suffix. Logs `tracing::warn!` with tool_name, tool_call_id, result_bytes, limit when truncating. Fires regardless of which capabilities are active. See `crates/core/src/atoms/act_hooks.rs`.


### PR DESCRIPTION
## What
Split exec tool output persistence from a single `/.exec-logs/{id}.log` file into separate `/.outputs/{id}.stdout` and `/.outputs/{id}.stderr` files. Adds `output_files` array to result JSON so agents can selectively `read_file` each stream with offset/limit.

## Why
EVE-245: When sandbox exec output exceeds the truncation budget, agents need to selectively re-read stdout and stderr independently. Combining both streams into a single `.log` file forces the agent to parse separator markers. Separate files enable direct `read_file` access per stream.

## How
- Updated `PersistOutputHook` to split raw output at the `\n--- stderr ---\n` separator (already used by all sandbox tools)
- Stdout persisted to `/.outputs/{id}.stdout`, stderr to `/.outputs/{id}.stderr`
- Result JSON enriched with `output_files` array alongside existing `full_output` and `total_lines`
- Updated all path references in system prompt hints, docs, specs, and OpenAPI

## Risk
- Low
- Path change from `/.exec-logs/` to `/.outputs/` — no backward compat needed (internal paths, not user-facing API)
- Agents referencing old `/.exec-logs/` path from system prompt hints will now see `/.outputs/` instead

## Security
- Threat categories reviewed: TM-FS (file paths)
- Path construction uses same sanitized `safe_id` (alphanumeric + dash + underscore only) — no path traversal risk
- Output written to dot-prefixed internal VFS directory, session-scoped
- No new trust boundaries or injection vectors

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Closes EVE-245