### PR TITLE
fix(cli): replace raw reqwest budget calls with SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1886,9 +1886,9 @@ version = "0.8.8"
 
 [[package]]
 name = "everruns-sdk"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdfd68b84aaa5341a8c5a6b2c8d7ed50f417cbe38435bf8f246f3d885332c77c"
+checksum = "f131ee2ead4a76973f479ab37deac47bb98793034fd6c2ed28e4f9909bccc610"
 dependencies = [
  "async-stream",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ tokio-tungstenite = { version = "0.26", features = ["rustls-tls-native-roots"] }
 futures-util = "0.3"
 
 # Everruns SDK
-everruns-sdk = "0.1.6"
+everruns-sdk = "0.1.7"
 
 # gRPC (tonic)
 tonic = { version = "0.14", features = ["tls-ring"] }

--- a/crates/cli/src/commands/sessions.rs
+++ b/crates/cli/src/commands/sessions.rs
@@ -3,7 +3,7 @@
 use crate::output::{OutputFormat, print_field, print_table_header, print_table_row};
 use anyhow::{Context, Result};
 use clap::Subcommand;
-use everruns_sdk::{CreateSessionRequest, Everruns};
+use everruns_sdk::{CreateBudgetRequest, CreateSessionRequest, Everruns};
 use futures::StreamExt;
 use std::collections::HashMap;
 
@@ -92,8 +92,6 @@ pub async fn run(
         } => {
             create(
                 client,
-                api_url,
-                api_key,
                 output,
                 quiet,
                 harness,
@@ -119,8 +117,6 @@ pub async fn run(
 #[allow(clippy::too_many_arguments)]
 async fn create(
     client: &Everruns,
-    api_url: &str,
-    api_key: &str,
     output: OutputFormat,
     quiet: bool,
     harness_id: Option<String>,
@@ -168,17 +164,14 @@ async fn create(
     // Create budgets after session creation
     let mut created_budgets = Vec::new();
     for spec in &budget_specs {
-        let budget = create_budget(
-            api_url,
-            api_key,
-            &session.id,
-            &spec.currency,
-            spec.limit,
-            spec.soft_limit,
-        )
-        .await
-        .with_context(|| format!("Session {} created but budget creation failed", session.id))?;
-        created_budgets.push(budget);
+        let mut req = CreateBudgetRequest::new("session", &session.id, &spec.currency, spec.limit);
+        if let Some(soft) = spec.soft_limit {
+            req = req.soft_limit(soft);
+        }
+        let budget = client.budgets().create(req).await.with_context(|| {
+            format!("Session {} created but budget creation failed", session.id)
+        })?;
+        created_budgets.push(serde_json::to_value(&budget)?);
     }
 
     if output.is_text() {
@@ -230,47 +223,6 @@ async fn create(
     }
 
     Ok(())
-}
-
-/// Create a budget for a session via the budgets API.
-// TODO(sdk): Replace with client.budgets().create() when SDK adds budget support.
-// Tracked: everruns/sdk#72, EVE-247
-async fn create_budget(
-    api_url: &str,
-    api_key: &str,
-    session_id: &str,
-    currency: &str,
-    limit: f64,
-    soft_limit: Option<f64>,
-) -> Result<serde_json::Value> {
-    let url = format!("{}/v1/budgets", api_url.trim_end_matches('/'));
-    let mut body = serde_json::json!({
-        "subject_type": "session",
-        "subject_id": session_id,
-        "currency": currency,
-        "limit": limit,
-    });
-    if let Some(soft) = soft_limit {
-        body["soft_limit"] = serde_json::json!(soft);
-    }
-
-    let resp = reqwest::Client::new()
-        .post(&url)
-        .bearer_auth(api_key)
-        .json(&body)
-        .send()
-        .await
-        .context("Failed to create budget")?;
-
-    if !resp.status().is_success() {
-        let status = resp.status();
-        let text = resp.text().await.unwrap_or_default();
-        anyhow::bail!("Budget creation failed ({}): {}", status, text);
-    }
-
-    resp.json::<serde_json::Value>()
-        .await
-        .context("Failed to parse budget response")
 }
 
 /// Parsed budget specification from `--budget-limit` and `--budget-soft-limit`.


### PR DESCRIPTION
## What
Replace raw `reqwest` budget creation calls in the CLI with the SDK's `client.budgets().create()`.

## Why
The `create_budget()` helper used raw HTTP because the SDK didn't have budget support. SDK v0.1.7 added it (everruns/sdk#73). This removes 48 lines of manual HTTP/auth/error handling.

## How
- Bump `everruns-sdk` from 0.1.6 to 0.1.7 in workspace `Cargo.toml`
- Replace `create_budget()` raw reqwest function with `client.budgets().create(CreateBudgetRequest::new(...))`
- Remove `api_url`/`api_key` params from `create()` function (no longer needed for budget calls)
- Behavior unchanged: `--budget-limit` and `--budget-soft-limit` flags work identically

## Risk
- Low — pure refactor, SDK handles the same HTTP call internally
- Net -48 lines

## Security
- **TM-API**: Replaced raw HTTP with SDK client. Same auth mechanism (bearer token), less manual surface area. No new endpoints or auth paths.
- **Dependency**: Bumped everruns-sdk minor version (same publisher). No new external deps.

## Checklist
- [x] Tests added or updated (existing behavior unchanged, CLI integration tests cover this)
- [x] Backward compatibility considered (flags unchanged, same API calls)
- [x] Security review performed
- [x] All review comments addressed

Fixes EVE-247