### PR TITLE
feat(ui): replace thinking indicator with combo wave bar

### DIFF
--- a/apps/ui/src/app/dev/page.tsx
+++ b/apps/ui/src/app/dev/page.tsx
@@ -10,6 +10,7 @@ import {
   FileText,
   Gauge,
   FileCode,
+  Sparkles,
 } from "lucide-react";
 
 // Check if we're in development mode
@@ -52,6 +53,12 @@ const devPages = [
     description: "LLM model selection component with favorite models support",
     href: "/dev/model-picker",
     icon: Star,
+  },
+  {
+    title: "Thinking Animations",
+    description: "Combo wave bar thinking indicator with brand gradient",
+    href: "/dev/thinking-animations",
+    icon: Sparkles,
   },
   {
     title: "File Previews",

--- a/apps/ui/src/app/dev/thinking-animations/page.tsx
+++ b/apps/ui/src/app/dev/thinking-animations/page.tsx
@@ -9,6 +9,7 @@
 
 import { Bot } from "lucide-react";
 import { ThinkingIndicator } from "@/components/thinking-indicator";
+import { DevPageShell } from "@/app/dev/_components/dev-page-shell";
 
 // ---------------------------------------------------------------------------
 // Chat context wrapper — shows the indicator inside a mock agent message
@@ -40,48 +41,37 @@ function ChatContextMock({ children }: { children: React.ReactNode }) {
 // ---------------------------------------------------------------------------
 export default function ThinkingAnimationsPage() {
   return (
-    <div className="min-h-screen bg-background bg-brand-dots px-4 py-8">
-      <div className="mx-auto max-w-2xl">
-        {/* Header */}
-        <div className="mb-10 space-y-2">
-          <p className="text-[11px] uppercase tracking-[0.3em] text-muted-foreground">
-            Thinking Animations
-          </p>
-          <h1 className="text-3xl font-semibold tracking-tight text-foreground">
-            Wave bar thinking indicator
-          </h1>
-          <p className="text-sm leading-6 text-muted-foreground">
-            Production combo variant: fast 0.7s wave bars with brand navy-to-gold gradient. Toggle
-            dark mode to compare both themes.
-          </p>
+    <DevPageShell
+      eyebrow="Thinking Animations"
+      title="Wave bar thinking indicator"
+      description="Production combo variant: fast 0.7s wave bars with brand navy-to-gold color ramp. Toggle dark mode to compare both themes."
+      widthClassName="max-w-2xl"
+    >
+      <div className="space-y-8">
+        {/* Standalone preview */}
+        <div className="space-y-3">
+          <h2 className="text-sm font-medium text-foreground">Standalone</h2>
+          <div className="flex items-center justify-center h-16 border border-dashed border-border bg-background">
+            <ThinkingIndicator />
+          </div>
         </div>
 
-        <div className="space-y-8">
-          {/* Standalone preview */}
-          <div className="space-y-3">
-            <h2 className="text-sm font-medium text-foreground">Standalone</h2>
-            <div className="flex items-center justify-center h-16 border border-dashed border-border bg-background">
-              <ThinkingIndicator />
-            </div>
-          </div>
+        {/* In-chat context */}
+        <div className="space-y-3">
+          <h2 className="text-sm font-medium text-foreground">In chat context</h2>
+          <ChatContextMock>
+            <ThinkingIndicator />
+          </ChatContextMock>
+        </div>
 
-          {/* In-chat context */}
-          <div className="space-y-3">
-            <h2 className="text-sm font-medium text-foreground">In chat context</h2>
-            <ChatContextMock>
-              <ThinkingIndicator />
-            </ChatContextMock>
-          </div>
-
-          {/* With model name */}
-          <div className="space-y-3">
-            <h2 className="text-sm font-medium text-foreground">With model name</h2>
-            <div className="flex items-center justify-center h-16 border border-dashed border-border bg-background">
-              <ThinkingIndicator model="claude-opus-4-6" />
-            </div>
+        {/* With model name */}
+        <div className="space-y-3">
+          <h2 className="text-sm font-medium text-foreground">With model name</h2>
+          <div className="flex items-center justify-center h-16 border border-dashed border-border bg-background">
+            <ThinkingIndicator model="claude-opus-4-6" />
           </div>
         </div>
       </div>
-    </div>
+    </DevPageShell>
   );
 }

--- a/apps/ui/src/app/dev/thinking-animations/page.tsx
+++ b/apps/ui/src/app/dev/thinking-animations/page.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+/**
+ * Dev page: Thinking Animation
+ *
+ * Preview of the production ThinkingIndicator (combo wave bar)
+ * in both standalone and in-chat context.
+ */
+
+import { Bot } from "lucide-react";
+import { ThinkingIndicator } from "@/components/thinking-indicator";
+
+// ---------------------------------------------------------------------------
+// Chat context wrapper — shows the indicator inside a mock agent message
+// ---------------------------------------------------------------------------
+function ChatContextMock({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="border border-border bg-background p-3">
+      {/* User message */}
+      <div className="flex justify-end mb-3">
+        <div className="border-r-2 border-r-accent bg-secondary/50 px-3 py-2 text-xs max-w-[70%]">
+          Refactor the auth module to use JWTs
+        </div>
+      </div>
+      {/* Agent response area */}
+      <div className="flex items-start gap-2">
+        <div className="mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center border border-border bg-primary text-primary-foreground">
+          <Bot className="h-3 w-3" />
+        </div>
+        <div className="px-3 py-2 min-w-[120px] border-l-2 border-l-primary bg-card">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+export default function ThinkingAnimationsPage() {
+  return (
+    <div className="min-h-screen bg-background bg-brand-dots px-4 py-8">
+      <div className="mx-auto max-w-2xl">
+        {/* Header */}
+        <div className="mb-10 space-y-2">
+          <p className="text-[11px] uppercase tracking-[0.3em] text-muted-foreground">
+            Thinking Animations
+          </p>
+          <h1 className="text-3xl font-semibold tracking-tight text-foreground">
+            Wave bar thinking indicator
+          </h1>
+          <p className="text-sm leading-6 text-muted-foreground">
+            Production combo variant: fast 0.7s wave bars with brand navy-to-gold gradient. Toggle
+            dark mode to compare both themes.
+          </p>
+        </div>
+
+        <div className="space-y-8">
+          {/* Standalone preview */}
+          <div className="space-y-3">
+            <h2 className="text-sm font-medium text-foreground">Standalone</h2>
+            <div className="flex items-center justify-center h-16 border border-dashed border-border bg-background">
+              <ThinkingIndicator />
+            </div>
+          </div>
+
+          {/* In-chat context */}
+          <div className="space-y-3">
+            <h2 className="text-sm font-medium text-foreground">In chat context</h2>
+            <ChatContextMock>
+              <ThinkingIndicator />
+            </ChatContextMock>
+          </div>
+
+          {/* With model name */}
+          <div className="space-y-3">
+            <h2 className="text-sm font-medium text-foreground">With model name</h2>
+            <div className="flex items-center justify-center h-16 border border-dashed border-border bg-background">
+              <ThinkingIndicator model="claude-opus-4-6" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/app/globals.css
+++ b/apps/ui/src/app/globals.css
@@ -238,3 +238,61 @@
   background: linear-gradient(90deg, transparent, hsl(var(--accent) / 0.14), transparent);
   animation: tool-progress-sheen 1.8s ease-in-out infinite;
 }
+
+/* -----------------------------------------------------------------------
+   Thinking indicator — combo wave bar animation
+   ----------------------------------------------------------------------- */
+@keyframes loading-wave {
+  0%,
+  100% {
+    height: 4px;
+    opacity: 0.3;
+  }
+  50% {
+    height: 14px;
+    opacity: 1;
+  }
+}
+
+.loading-wave-bar {
+  display: block;
+  background: hsl(var(--primary));
+  animation: loading-wave 1.2s ease-in-out infinite;
+}
+
+.dark .loading-wave-bar {
+  background: hsl(var(--accent));
+}
+
+/* Combo wave bar — per-bar brand gradient (navy → gold light, slate → gold dark) */
+.loading-wave-bar-0 {
+  background: hsl(220 62% 13%);
+}
+.loading-wave-bar-1 {
+  background: hsl(176 61.5% 23%);
+}
+.loading-wave-bar-2 {
+  background: hsl(132 61% 33%);
+}
+.loading-wave-bar-3 {
+  background: hsl(88 60.5% 43%);
+}
+.loading-wave-bar-4 {
+  background: hsl(44 60% 53%);
+}
+
+.dark .loading-wave-bar-0 {
+  background: hsl(220 30% 50%);
+}
+.dark .loading-wave-bar-1 {
+  background: hsl(190 40% 50%);
+}
+.dark .loading-wave-bar-2 {
+  background: hsl(140 45% 50%);
+}
+.dark .loading-wave-bar-3 {
+  background: hsl(80 50% 52%);
+}
+.dark .loading-wave-bar-4 {
+  background: hsl(44 60% 53%);
+}

--- a/apps/ui/src/app/globals.css
+++ b/apps/ui/src/app/globals.css
@@ -245,17 +245,19 @@
 @keyframes loading-wave {
   0%,
   100% {
-    height: 4px;
+    transform: scaleY(0.286);
     opacity: 0.3;
   }
   50% {
-    height: 14px;
+    transform: scaleY(1);
     opacity: 1;
   }
 }
 
 .loading-wave-bar {
   display: block;
+  height: 14px;
+  transform-origin: bottom;
   background: hsl(var(--primary));
   animation: loading-wave 1.2s ease-in-out infinite;
 }
@@ -264,7 +266,7 @@
   background: hsl(var(--accent));
 }
 
-/* Combo wave bar — per-bar brand gradient (navy → gold light, slate → gold dark) */
+/* Combo wave bar — per-bar brand color ramp (navy → gold light, slate → gold dark) */
 .loading-wave-bar-0 {
   background: hsl(220 62% 13%);
 }

--- a/apps/ui/src/components/thinking-indicator.tsx
+++ b/apps/ui/src/components/thinking-indicator.tsx
@@ -5,7 +5,7 @@
  *
  * Shows an animated equalizer-style wave bar while the agent is generating.
  * Uses brand colors: navy → gold in light mode, slate → gold in dark mode.
- * Relies on the `loading-wave-bar` keyframes in globals.css.
+ * Relies on the `loading-wave` keyframes in globals.css.
  */
 
 import { cn } from "@/lib/utils";

--- a/apps/ui/src/components/thinking-indicator.tsx
+++ b/apps/ui/src/components/thinking-indicator.tsx
@@ -1,14 +1,17 @@
 "use client";
 
 /**
- * ThinkingIndicator - Animated indicator shown while agent is generating
+ * ThinkingIndicator — Combo wave bar animation (fast + navy-to-gold gradient)
  *
- * Shows a bouncing animation with 3 small dots to indicate the agent is "thinking"
- * (generating a response). Used before any streaming text arrives.
+ * Shows an animated equalizer-style wave bar while the agent is generating.
+ * Uses brand colors: navy → gold in light mode, slate → gold in dark mode.
+ * Relies on the `loading-wave-bar` keyframes in globals.css.
  */
 
 import { cn } from "@/lib/utils";
 import { useLocale } from "@/providers/locale-provider";
+
+const BAR_DELAYS = [0, 80, 160, 240, 320];
 
 interface ThinkingIndicatorProps {
   className?: string;
@@ -19,22 +22,22 @@ interface ThinkingIndicatorProps {
 export function ThinkingIndicator({ className, model }: ThinkingIndicatorProps) {
   const { t } = useLocale();
   return (
-    <div className={cn("flex items-center gap-1", className)}>
-      <span className="text-xs text-muted-foreground/60">{t("thinking")}</span>
-      {model && <span className="text-xs text-muted-foreground/40">{model}</span>}
-      <span className="flex gap-0.5 ml-0.5">
-        <span
-          className="w-1 h-1 bg-muted-foreground/40 rounded-full animate-bounce"
-          style={{ animationDelay: "0ms" }}
-        />
-        <span
-          className="w-1 h-1 bg-muted-foreground/40 rounded-full animate-bounce"
-          style={{ animationDelay: "150ms" }}
-        />
-        <span
-          className="w-1 h-1 bg-muted-foreground/40 rounded-full animate-bounce"
-          style={{ animationDelay: "300ms" }}
-        />
+    <div className={cn("flex items-center gap-2", className)}>
+      <div className="flex items-end gap-[2px] h-4">
+        {BAR_DELAYS.map((delay, i) => (
+          <span
+            key={delay}
+            className={`loading-wave-bar w-[3px] rounded-[1px] loading-wave-bar-${i}`}
+            style={{
+              animationDelay: `${delay}ms`,
+              animationDuration: "0.7s",
+            }}
+          />
+        ))}
+      </div>
+      <span className="text-xs text-accent-foreground/60">
+        {t("thinking")}
+        {model && <span className="ml-1 text-muted-foreground/40">{model}</span>}
       </span>
     </div>
   );


### PR DESCRIPTION
## What
Replace the bouncing-dots ThinkingIndicator with a brand combo wave bar animation.

## Why
The bouncing dots felt generic. The wave bar animation is more distinctive, brand-aligned (navy-to-gold gradient), and visually smoother.

## How
- `ThinkingIndicator` component now renders 5 animated bars with per-bar CSS color classes (`loading-wave-bar-0` through `loading-wave-bar-4`)
- Fast 0.7s animation with 80ms stagger between bars
- `loading-wave` keyframes and per-bar gradient colors defined in `globals.css`
- Light mode: navy → gold gradient; Dark mode: slate → gold gradient
- Dev page at `/dev/thinking-animations` shows standalone + in-chat preview
- Cleaned up exploration variants — only production component remains

## Risk
- Low
- Visual-only change. If CSS fails to load, bars render as unstyled blocks (graceful degradation).

## Security
- No security-relevant code changes. This is a purely visual change (CSS animations + static React markup). No user input, API calls, or data handling involved.

## Checklist
- [x] Tests added or updated (visual-only, no logic to test)
- [x] Backward compatibility considered (same component interface, drop-in replacement)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)