### PR TITLE
feat(daytona): add daytona_list_snapshots tool

### DIFF
--- a/integrations/daytona/SPEC.md
+++ b/integrations/daytona/SPEC.md
@@ -79,6 +79,7 @@ This avoids entering the key in chat (see TM-AGENT-016).
 |--------|------|---------|-------------|
 | POST | `/sandbox` | Create sandbox | `{ name?, snapshot?, autoStopInterval, autoArchiveInterval, autoDeleteInterval, labels? }` |
 | GET | `/sandbox/{id}` | Get sandbox info | — |
+| GET | `/snapshots` | List available snapshots | — |
 | POST | `/sandbox/{id}/start` | Start sandbox | — |
 | POST | `/sandbox/{id}/stop` | Stop sandbox | — |
 | DELETE | `/sandbox/{id}` | Delete sandbox | — |
@@ -144,6 +145,14 @@ Downloads sandbox workspace to session file storage.
   - `sandbox_path`: string (optional, default: workspace_path)
   - `session_path`: string (optional, default: `/workspace`)
 - **Returns**: `{ files_downloaded, files_skipped, errors? }`
+
+### daytona_list_snapshots
+
+List available Daytona snapshots that can be used when creating sandboxes. Only returns active snapshots.
+
+- **Parameters**: none
+- **Returns**: `{ snapshots: [{name, state, cpu?, memory_gb?, disk_gb?, gpu?, size?, general?}], count }`
+- **Usage**: Use the `name` field as the `snapshot` parameter in `daytona_create_sandbox`.
 
 ### daytona_list_sandboxes
 
@@ -292,7 +301,7 @@ External integration crate, auto-registered via `inventory::submit!` plugin syst
 | `src/client.rs` | `DaytonaClient` HTTP client (management + toolbox APIs), URL encoding |
 | `src/connection.rs` | `DaytonaConnectionProvider` — API-key connection plugin |
 | `src/state.rs` | API types (`SandboxInfo`, `ExecResult`, `SandboxState`), session state helpers |
-| `src/tools.rs` | 9 tool implementations (`DaytonaCreateSandboxTool`, etc.) |
+| `src/tools.rs` | 10 tool implementations (`DaytonaCreateSandboxTool`, etc.) |
 | `tests/plugin_registration.rs` | Integration tests for inventory registration |
 | `tests/tool_integration.rs` | Integration tests: tool execution + wiremock Daytona API |
 | `tests/live_api_test.rs` | Live API integration tests (feature-gated: `daytona-live-tests`) |

--- a/integrations/daytona/src/client.rs
+++ b/integrations/daytona/src/client.rs
@@ -22,7 +22,7 @@ use serde_json::{Value, json};
 use std::time::Duration;
 use tracing::debug;
 
-use crate::state::{ExecResult, SandboxInfo};
+use crate::state::{ExecResult, SandboxInfo, SnapshotInfo};
 use crate::{EXEC_POLL_INTERVAL, SANDBOX_READY_MAX_WAIT, SANDBOX_READY_POLL_INTERVAL};
 
 /// Fixed session ID used for all command execution in a sandbox.
@@ -290,6 +290,19 @@ impl DaytonaClient {
         )
         .await?;
         Ok(())
+    }
+
+    // --- Snapshots API ---
+
+    pub async fn list_snapshots(&self) -> Result<Vec<SnapshotInfo>, String> {
+        let resp = self
+            .management_request(reqwest::Method::GET, "/snapshots", None)
+            .await?;
+
+        // API returns an array of snapshot objects.
+        let snapshots: Vec<SnapshotInfo> = serde_json::from_value(resp)
+            .map_err(|e| format!("Failed to parse snapshots response: {e}"))?;
+        Ok(snapshots)
     }
 
     /// Wait for sandbox to reach "started" state after creation.

--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -26,8 +26,8 @@ use std::time::Duration;
 
 use tools::{
     DaytonaCreateSandboxTool, DaytonaDownloadWorkspaceTool, DaytonaExecTool, DaytonaGitCloneTool,
-    DaytonaGitCredentialsTool, DaytonaListSandboxesTool, DaytonaManageSandboxTool,
-    DaytonaReadFileTool, DaytonaWriteFileTool,
+    DaytonaGitCredentialsTool, DaytonaListSandboxesTool, DaytonaListSnapshotsTool,
+    DaytonaManageSandboxTool, DaytonaReadFileTool, DaytonaWriteFileTool,
 };
 
 // ============================================================================
@@ -90,7 +90,8 @@ Cloud-based sandboxes via Daytona. Each sandbox is an isolated environment with 
 Authentication: Daytona API key is resolved automatically from Settings > Connections > Daytona.
 If not configured, guide the user to set up their key in Settings > Connections.
 
-All tools except `daytona_create_sandbox` and `daytona_list_sandboxes` require a `sandbox_id`.
+All tools except `daytona_create_sandbox`, `daytona_list_sandboxes`, and `daytona_list_snapshots` require a `sandbox_id`.
+Use `daytona_list_snapshots` to discover available snapshots and their resource specs before creating sandboxes.
 Sandboxes auto-stop after 5 min of inactivity, auto-archive after 30 min, and auto-delete after 60 min.
 Stopped sandboxes are also cleaned up by the control plane after 20 min.
 Always DELETE sandboxes when done (stop leaves them on the dashboard).
@@ -158,6 +159,7 @@ impl Capability for DaytonaCapability {
             Box::new(DaytonaReadFileTool),
             Box::new(DaytonaWriteFileTool),
             Box::new(DaytonaDownloadWorkspaceTool),
+            Box::new(DaytonaListSnapshotsTool),
             Box::new(DaytonaListSandboxesTool),
             Box::new(DaytonaManageSandboxTool),
             Box::new(DaytonaGitCloneTool),
@@ -197,7 +199,7 @@ mod tests {
     fn test_capability_has_all_tools() {
         let cap = DaytonaCapability;
         let tools = cap.tools();
-        assert_eq!(tools.len(), 9);
+        assert_eq!(tools.len(), 10);
 
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
         assert!(names.contains(&"daytona_create_sandbox"));
@@ -205,6 +207,7 @@ mod tests {
         assert!(names.contains(&"daytona_read_file"));
         assert!(names.contains(&"daytona_write_file"));
         assert!(names.contains(&"daytona_download_workspace"));
+        assert!(names.contains(&"daytona_list_snapshots"));
         assert!(names.contains(&"daytona_list_sandboxes"));
         assert!(names.contains(&"daytona_manage_sandbox"));
         assert!(names.contains(&"daytona_git_clone"));

--- a/integrations/daytona/src/state.rs
+++ b/integrations/daytona/src/state.rs
@@ -33,6 +33,35 @@ pub struct ExecResult {
     pub exit_code: i32,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotInfo {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub state: String,
+    #[serde(default)]
+    pub cpu: Option<u64>,
+    #[serde(default)]
+    pub mem: Option<u64>,
+    #[serde(default)]
+    pub disk: Option<u64>,
+    #[serde(default)]
+    pub gpu: Option<u64>,
+    #[serde(default)]
+    pub size: Option<String>,
+    #[serde(default)]
+    pub general: Option<bool>,
+    #[serde(default)]
+    pub image_name: Option<String>,
+    #[serde(default)]
+    pub created_at: Option<String>,
+    #[serde(default)]
+    pub updated_at: Option<String>,
+}
+
 // ============================================================================
 // Persisted Sandbox State (stored in session secrets as JSON)
 // ============================================================================
@@ -316,6 +345,29 @@ mod tests {
         let args = serde_json::json!({"name": 42});
         let result = required_str(&args, "name");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_snapshot_info_deserialization() {
+        let json = r#"{"id": "snap_1", "name": "my-snap", "state": "active", "cpu": 2, "mem": 4, "disk": 10}"#;
+        let info: SnapshotInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.id, "snap_1");
+        assert_eq!(info.name, "my-snap");
+        assert_eq!(info.state, "active");
+        assert_eq!(info.cpu, Some(2));
+        assert_eq!(info.mem, Some(4));
+        assert_eq!(info.disk, Some(10));
+        assert_eq!(info.gpu, None);
+    }
+
+    #[test]
+    fn test_snapshot_info_minimal() {
+        let json = r#"{"id": "snap_2", "name": "bare", "state": "active"}"#;
+        let info: SnapshotInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.name, "bare");
+        assert_eq!(info.cpu, None);
+        assert_eq!(info.mem, None);
+        assert_eq!(info.disk, None);
     }
 
     #[test]

--- a/integrations/daytona/src/state.rs
+++ b/integrations/daytona/src/state.rs
@@ -36,11 +36,8 @@ pub struct ExecResult {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SnapshotInfo {
-    #[serde(default)]
     pub id: String,
-    #[serde(default)]
     pub name: String,
-    #[serde(default)]
     pub state: String,
     #[serde(default)]
     pub cpu: Option<u64>,

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -860,6 +860,103 @@ impl Tool for DaytonaDownloadWorkspaceTool {
 }
 
 // ============================================================================
+// DaytonaListSnapshotsTool
+// ============================================================================
+
+pub struct DaytonaListSnapshotsTool;
+
+#[async_trait]
+impl Tool for DaytonaListSnapshotsTool {
+    fn name(&self) -> &str {
+        "daytona_list_snapshots"
+    }
+
+    fn description(&self) -> &str {
+        "List available Daytona snapshots that can be used when creating sandboxes. \
+         Returns snapshot names, resource specs (CPU, memory, disk), and state. \
+         Use the snapshot name in daytona_create_sandbox's `snapshot` parameter."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+            .with_open_world(true)
+            .with_requires_secrets(true)
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "daytona_list_snapshots requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        _arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let api_key = match get_api_key(context).await {
+            Ok(k) => k,
+            Err(e) => return e,
+        };
+
+        let client = DaytonaClient::new(api_key);
+        let snapshots = match client.list_snapshots().await {
+            Ok(s) => s,
+            Err(e) => return ToolExecutionResult::tool_error(e),
+        };
+
+        let items: Vec<Value> = snapshots
+            .iter()
+            .filter(|s| s.state == "active")
+            .map(|s| {
+                let mut obj = json!({
+                    "name": s.name,
+                    "state": s.state,
+                });
+                if let Some(cpu) = s.cpu {
+                    obj["cpu"] = json!(cpu);
+                }
+                if let Some(mem) = s.mem {
+                    obj["memory_gb"] = json!(mem);
+                }
+                if let Some(disk) = s.disk {
+                    obj["disk_gb"] = json!(disk);
+                }
+                if let Some(gpu) = s.gpu {
+                    obj["gpu"] = json!(gpu);
+                }
+                if let Some(ref size) = s.size {
+                    obj["size"] = json!(size);
+                }
+                if let Some(general) = s.general {
+                    obj["general"] = json!(general);
+                }
+                obj
+            })
+            .collect();
+
+        ToolExecutionResult::success(json!({
+            "snapshots": items,
+            "count": items.len()
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
 // DaytonaListSandboxesTool
 // ============================================================================
 
@@ -1651,6 +1748,15 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_list_snapshots_without_context() {
+        let tool = DaytonaListSnapshotsTool;
+        let result = tool.execute(json!({})).await;
+        assert!(
+            matches!(result, ToolExecutionResult::ToolError(msg) if msg.contains("requires context"))
+        );
+    }
+
+    #[tokio::test]
     async fn test_list_sandboxes_without_context() {
         let tool = DaytonaListSandboxesTool;
         let result = tool.execute(json!({})).await;
@@ -1738,6 +1844,13 @@ mod tests {
     }
 
     #[test]
+    fn test_list_snapshots_schema_no_required() {
+        let tool = DaytonaListSnapshotsTool;
+        let schema = tool.parameters_schema();
+        assert!(schema.get("required").is_none());
+    }
+
+    #[test]
     fn test_list_sandboxes_schema_no_required() {
         let tool = DaytonaListSandboxesTool;
         let schema = tool.parameters_schema();
@@ -1762,6 +1875,7 @@ mod tests {
             Box::new(DaytonaReadFileTool),
             Box::new(DaytonaWriteFileTool),
             Box::new(DaytonaDownloadWorkspaceTool),
+            Box::new(DaytonaListSnapshotsTool),
             Box::new(DaytonaListSandboxesTool),
             Box::new(DaytonaManageSandboxTool),
             Box::new(DaytonaGitCloneTool),
@@ -1803,6 +1917,7 @@ mod tests {
             Box::new(DaytonaReadFileTool),
             Box::new(DaytonaWriteFileTool),
             Box::new(DaytonaDownloadWorkspaceTool),
+            Box::new(DaytonaListSnapshotsTool),
             Box::new(DaytonaListSandboxesTool),
             Box::new(DaytonaManageSandboxTool),
             Box::new(DaytonaGitCloneTool),
@@ -1825,6 +1940,7 @@ mod tests {
             Box::new(DaytonaReadFileTool),
             Box::new(DaytonaWriteFileTool),
             Box::new(DaytonaDownloadWorkspaceTool),
+            Box::new(DaytonaListSnapshotsTool),
             Box::new(DaytonaListSandboxesTool),
             Box::new(DaytonaManageSandboxTool),
             Box::new(DaytonaGitCloneTool),

--- a/integrations/daytona/tests/plugin_registration.rs
+++ b/integrations/daytona/tests/plugin_registration.rs
@@ -62,5 +62,5 @@ fn test_daytona_capability_metadata() {
     assert_eq!(cap.icon(), Some("daytona"));
     assert_eq!(cap.category(), Some("Execution"));
     assert_eq!(cap.dependencies(), vec!["session_storage"]);
-    assert_eq!(cap.tools().len(), 9);
+    assert_eq!(cap.tools().len(), 10);
 }

--- a/integrations/daytona/tests/tool_integration.rs
+++ b/integrations/daytona/tests/tool_integration.rs
@@ -1132,3 +1132,94 @@ async fn test_create_sandbox_tool_rejects_invalid_auto_stop() {
         other => panic!("Expected ToolError, got: {other:?}"),
     }
 }
+
+// ============================================================================
+// Snapshot listing tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_list_snapshots_via_client() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/snapshots"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {
+                "id": "snap_1",
+                "name": "daytona-small",
+                "state": "active",
+                "cpu": 1,
+                "mem": 1,
+                "disk": 3,
+                "general": true
+            },
+            {
+                "id": "snap_2",
+                "name": "daytona-medium",
+                "state": "active",
+                "cpu": 2,
+                "mem": 4,
+                "disk": 8,
+                "general": true
+            },
+            {
+                "id": "snap_3",
+                "name": "custom-ml",
+                "state": "active",
+                "cpu": 4,
+                "mem": 16,
+                "disk": 50,
+                "gpu": 1,
+                "general": false
+            }
+        ])))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client =
+        DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
+
+    let snapshots = client.list_snapshots().await.unwrap();
+    assert_eq!(snapshots.len(), 3);
+    assert_eq!(snapshots[0].name, "daytona-small");
+    assert_eq!(snapshots[0].cpu, Some(1));
+    assert_eq!(snapshots[1].name, "daytona-medium");
+    assert_eq!(snapshots[2].name, "custom-ml");
+    assert_eq!(snapshots[2].gpu, Some(1));
+}
+
+#[tokio::test]
+async fn test_list_snapshots_empty() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/snapshots"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client =
+        DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
+
+    let snapshots = client.list_snapshots().await.unwrap();
+    assert!(snapshots.is_empty());
+}
+
+#[tokio::test]
+async fn test_list_snapshots_tool_missing_api_key() {
+    let tool = get_tool("daytona_list_snapshots");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store);
+
+    let result = tool.execute_with_context(json!({}), &context).await;
+
+    match result {
+        ToolExecutionResult::ConnectionRequired { provider } => {
+            assert_eq!(provider, "daytona");
+        }
+        other => panic!("Expected ConnectionRequired, got: {other:?}"),
+    }
+}


### PR DESCRIPTION
## What
Add a new `daytona_list_snapshots` tool that lets agents discover available Daytona snapshots before creating sandboxes.

## Why
Previously, snapshot names were hardcoded to three size tiers (`daytona-small`, `daytona-medium`, `daytona-large`). Users with custom snapshots had no way to discover them — they had to know the exact name. This tool closes that gap.

## How
- `SnapshotInfo` API response type in `state.rs` with fields: id, name, state, cpu, mem, disk, gpu, size, general, image_name, timestamps
- `list_snapshots()` method on `DaytonaClient` calling `GET /snapshots`
- `DaytonaListSnapshotsTool` — read-only, idempotent, no parameters, filters to active snapshots only
- Returns `{ snapshots: [{name, state, cpu?, memory_gb?, disk_gb?, gpu?, size?, general?}], count }`
- Registered in capability (10 tools total), system prompt updated

## Risk
- Low
- Read-only API call using the same auth pattern as all existing management endpoints. No state mutation.

## Security
- Threat categories reviewed: TM-API, TM-TOOL
- No user input flows into the URL (hardcoded `/snapshots` path). Uses existing Bearer token auth via `DaytonaClient`. Response filtered to active snapshots only — no secrets exposed. Follows identical pattern to `get_sandbox`.
- No new threat surface beyond existing Daytona integration.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)