### PR TITLE
fix(tools): disambiguate session read_file from sandbox file tools

### DIFF
--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -449,7 +449,7 @@ impl Capability for FileSystemCapability {
 
     fn system_prompt_addition(&self) -> Option<&str> {
         use crate::tool_output_sanitizer::READ_ECONOMY_HINT;
-        const BASE: &str = "Session workspace root: `/workspace`. All file paths must start with `/workspace`. Directories are created automatically when writing files.";
+        const BASE: &str = "Session workspace root: `/workspace`. All file paths must start with `/workspace`. Directories are created automatically when writing files. These tools (read_file, write_file, etc.) operate on the session workspace ONLY — to read or write files inside a cloud sandbox, use the sandbox-specific tools (e.g. daytona_read_file, e2b_read_file).";
         // Build the full prompt lazily on first use by appending the shared read-economy hint.
         static PROMPT: std::sync::LazyLock<String> =
             std::sync::LazyLock::new(|| format!("{}{}", BASE, READ_ECONOMY_HINT));
@@ -491,7 +491,7 @@ impl Tool for ReadFileTool {
     }
 
     fn description(&self) -> &str {
-        "Read the content of a file. Returns text content directly. For image files (PNG, JPEG, GIF, WebP), the image is returned as a native image so you can see it visually."
+        "Read a file from the session workspace (/workspace). Returns text content directly. For image files (PNG, JPEG, GIF, WebP), the image is returned as a native image so you can see it visually. This is NOT for reading files in cloud sandboxes — use the sandbox-specific read tool instead."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -751,7 +751,7 @@ impl Tool for WriteFileTool {
     }
 
     fn description(&self) -> &str {
-        "Create a new file or update an existing file's content. Parent directories are created automatically."
+        "Create or update a file in the session workspace (/workspace). Parent directories are created automatically. This is NOT for writing files in cloud sandboxes."
     }
 
     fn parameters_schema(&self) -> Value {

--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -449,7 +449,14 @@ impl Capability for FileSystemCapability {
 
     fn system_prompt_addition(&self) -> Option<&str> {
         use crate::tool_output_sanitizer::READ_ECONOMY_HINT;
-        const BASE: &str = "Session workspace root: `/workspace`. All file paths must start with `/workspace`. Directories are created automatically when writing files. These tools (read_file, write_file, etc.) operate on the session workspace ONLY — to read or write files inside a cloud sandbox, use the sandbox-specific tools (e.g. daytona_read_file, e2b_read_file).";
+        const BASE: &str = concat!(
+            "Session workspace root: `/workspace`. ",
+            "All file paths must start with `/workspace`. ",
+            "Directories are created automatically when writing files. ",
+            "These tools (read_file, write_file, etc.) operate on the session workspace ONLY — ",
+            "to read or write files inside a cloud sandbox, use the sandbox-specific tools ",
+            "(e.g. daytona_read_file, e2b_read_file).",
+        );
         // Build the full prompt lazily on first use by appending the shared read-economy hint.
         static PROMPT: std::sync::LazyLock<String> =
             std::sync::LazyLock::new(|| format!("{}{}", BASE, READ_ECONOMY_HINT));
@@ -751,7 +758,7 @@ impl Tool for WriteFileTool {
     }
 
     fn description(&self) -> &str {
-        "Create or update a file in the session workspace (/workspace). Parent directories are created automatically. This is NOT for writing files in cloud sandboxes."
+        "Create or update a file in the session workspace (/workspace). Parent directories are created automatically. This is NOT for writing files in cloud sandboxes — use sandbox-specific write tools (e.g. daytona_write_file, e2b_write_file) instead."
     }
 
     fn parameters_schema(&self) -> Value {

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -491,7 +491,7 @@ impl Tool for DaytonaReadFileTool {
     }
 
     fn description(&self) -> &str {
-        "Read a file from a Daytona sandbox filesystem."
+        "Read a file from a remote Daytona sandbox filesystem (NOT the session /workspace). Requires sandbox_id."
     }
 
     fn parameters_schema(&self) -> Value {

--- a/integrations/deno/src/tools.rs
+++ b/integrations/deno/src/tools.rs
@@ -329,7 +329,7 @@ impl Tool for DenoReadFileTool {
     }
 
     fn description(&self) -> &str {
-        "Read a text file from a Deno sandbox filesystem."
+        "Read a text file from a remote Deno sandbox filesystem (NOT the session /workspace). Requires sandbox_id."
     }
 
     fn parameters_schema(&self) -> Value {

--- a/integrations/e2b/src/tools.rs
+++ b/integrations/e2b/src/tools.rs
@@ -353,7 +353,7 @@ impl Tool for E2BReadFileTool {
     }
 
     fn description(&self) -> &str {
-        "Read a file from an E2B sandbox."
+        "Read a file from a remote E2B sandbox filesystem (NOT the session /workspace). Requires sandbox_id."
     }
 
     fn parameters_schema(&self) -> Value {

--- a/integrations/sprites/src/tools.rs
+++ b/integrations/sprites/src/tools.rs
@@ -327,7 +327,7 @@ impl Tool for SpritesReadFileTool {
     }
 
     fn description(&self) -> &str {
-        "Read a file from a Sprites microVM filesystem."
+        "Read a file from a remote Sprites microVM filesystem (NOT the session /workspace). Requires sprite_name."
     }
 
     fn parameters_schema(&self) -> Value {


### PR DESCRIPTION
## What
Improve tool descriptions to prevent LLM agents from confusing session workspace `read_file`/`write_file` with sandbox-specific file tools (`daytona_read_file`, `e2b_read_file`, etc.).

## Why
When both session filesystem and sandbox capabilities are enabled, agents frequently call `read_file` (session `/workspace`) when they intend to read from a cloud sandbox, or vice versa. The generic descriptions ("Read the content of a file") gave no signal about which filesystem each tool targets.

## How
Three layers of disambiguation, all via description string changes only:

1. **Session tools** (`read_file`, `write_file`): descriptions now explicitly say "session workspace (/workspace)" and warn "NOT for cloud sandboxes"
2. **Sandbox tools** (`daytona_read_file`, `e2b_read_file`, `sprites_read_file`, `deno_read_file`): descriptions now say "NOT the session /workspace" and mention the required ID parameter
3. **Session FS system prompt**: added explicit guidance — "These tools operate on the session workspace ONLY — use sandbox-specific tools for cloud sandboxes"

## Risk
- Low
- Pure string-literal changes to tool descriptions and one system prompt. No logic, execution paths, or APIs changed.

## Security
- No security-relevant code changes. All modifications are static description strings (`fn description() -> &str` and a `const BASE` prompt). No trust boundaries, input handling, or execution paths are affected.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)