### PR TITLE
fix(daytona): wrap exec commands in subshell to prevent session termination

### DIFF
--- a/integrations/daytona/src/client.rs
+++ b/integrations/daytona/src/client.rs
@@ -463,8 +463,8 @@ impl DaytonaClient {
         // long `&&` chains that call `exit` would kill the entire session
         // and force expensive re-establishment. See EVE-251.
         let cmd = match cwd {
-            Some(c) => format!("{SHELL_PROFILE_PREAMBLE}(cd {c} && {command})"),
-            None => format!("{SHELL_PROFILE_PREAMBLE}({command})"),
+            Some(c) => format!("{SHELL_PROFILE_PREAMBLE}( cd {c} && {command} )"),
+            None => format!("{SHELL_PROFILE_PREAMBLE}( {command} )"),
         };
 
         let timeout = timeout_ms.unwrap_or(crate::EXEC_TIMEOUT_MS);
@@ -1525,7 +1525,7 @@ mod tests {
 
         // Exec — match the exact command body to verify preamble is prepended
         // and command is wrapped in a subshell.
-        let expected_cmd = format!("{SHELL_PROFILE_PREAMBLE}(echo hello)");
+        let expected_cmd = format!("{SHELL_PROFILE_PREAMBLE}( echo hello )");
         Mock::given(method("POST"))
             .and(path("/sb_preamble/process/session/everruns-exec/exec"))
             .and(body_json(json!({
@@ -1580,8 +1580,8 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        // With cwd, command should be: PREAMBLE + (cd /tmp && ls)
-        let expected_cmd = format!("{SHELL_PROFILE_PREAMBLE}(cd /tmp && ls)");
+        // With cwd, command should be: PREAMBLE + ( cd /tmp && ls )
+        let expected_cmd = format!("{SHELL_PROFILE_PREAMBLE}( cd /tmp && ls )");
         Mock::given(method("POST"))
             .and(path("/sb_cwd/process/session/everruns-exec/exec"))
             .and(body_json(json!({

--- a/integrations/daytona/src/client.rs
+++ b/integrations/daytona/src/client.rs
@@ -456,9 +456,15 @@ impl DaytonaClient {
     {
         self.ensure_session(sandbox_id).await?;
 
+        // Wrap the user command in a subshell `( ... )` so that `exit`,
+        // SIGPIPE, SIGHUP, and other signals only terminate the subshell,
+        // not the persistent session shell. Without this, commands like
+        // `bash -lc '...; exit'`, pipes to `head`/`sed` (SIGPIPE), and
+        // long `&&` chains that call `exit` would kill the entire session
+        // and force expensive re-establishment. See EVE-251.
         let cmd = match cwd {
-            Some(c) => format!("{SHELL_PROFILE_PREAMBLE}cd {c} && {command}"),
-            None => format!("{SHELL_PROFILE_PREAMBLE}{command}"),
+            Some(c) => format!("{SHELL_PROFILE_PREAMBLE}(cd {c} && {command})"),
+            None => format!("{SHELL_PROFILE_PREAMBLE}({command})"),
         };
 
         let timeout = timeout_ms.unwrap_or(crate::EXEC_TIMEOUT_MS);
@@ -1517,8 +1523,9 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        // Exec — match the exact command body to verify preamble is prepended.
-        let expected_cmd = format!("{SHELL_PROFILE_PREAMBLE}echo hello");
+        // Exec — match the exact command body to verify preamble is prepended
+        // and command is wrapped in a subshell.
+        let expected_cmd = format!("{SHELL_PROFILE_PREAMBLE}(echo hello)");
         Mock::given(method("POST"))
             .and(path("/sb_preamble/process/session/everruns-exec/exec"))
             .and(body_json(json!({
@@ -1573,8 +1580,8 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        // With cwd, command should be: PREAMBLE + cd /tmp && ls
-        let expected_cmd = format!("{SHELL_PROFILE_PREAMBLE}cd /tmp && ls");
+        // With cwd, command should be: PREAMBLE + (cd /tmp && ls)
+        let expected_cmd = format!("{SHELL_PROFILE_PREAMBLE}(cd /tmp && ls)");
         Mock::given(method("POST"))
             .and(path("/sb_cwd/process/session/everruns-exec/exec"))
             .and(body_json(json!({

--- a/integrations/daytona/tests/tool_integration.rs
+++ b/integrations/daytona/tests/tool_integration.rs
@@ -760,7 +760,7 @@ async fn test_exec_session_with_cwd_prepended() {
         "for __f in \"$HOME/.profile\" \"$HOME/.cargo/env\" \"$HOME/.nvm/nvm.sh\"; do ",
         "[ -f \"$__f\" ] && . \"$__f\" >/dev/null 2>&1; ",
         "done; unset __f; ",
-        "cd /workspace && ls -la",
+        "(cd /workspace && ls -la)",
     );
     Mock::given(method("POST"))
         .and(path("/sb_cwd/process/session/everruns-exec/exec"))

--- a/integrations/daytona/tests/tool_integration.rs
+++ b/integrations/daytona/tests/tool_integration.rs
@@ -760,7 +760,7 @@ async fn test_exec_session_with_cwd_prepended() {
         "for __f in \"$HOME/.profile\" \"$HOME/.cargo/env\" \"$HOME/.nvm/nvm.sh\"; do ",
         "[ -f \"$__f\" ] && . \"$__f\" >/dev/null 2>&1; ",
         "done; unset __f; ",
-        "(cd /workspace && ls -la)",
+        "( cd /workspace && ls -la )",
     );
     Mock::given(method("POST"))
         .and(path("/sb_cwd/process/session/everruns-exec/exec"))


### PR DESCRIPTION
## What
Wrap user commands executed via `daytona_exec` in a subshell `( ... )` so that `exit`, SIGPIPE, SIGHUP, and other signals only terminate the subshell, not the persistent session shell.

## Why
During end-to-end testing, `daytona_exec` sessions terminated unexpectedly ~15% of the time when commands contained `bash -lc ...; exit`, pipes to `head`/`sed` (SIGPIPE), or long `&&` chains. Each failure forced expensive session re-establishment and wasted ~20% of agent budgets on retries.

Root cause: commands run directly in the persistent shell session, so any `exit` or fatal signal kills the entire session rather than just the command.

## How
- Wrap the user command in parentheses to run it in a subshell
- The shell profile preamble stays outside the subshell so PATH changes apply to the session
- Updated unit tests and integration test to match the new command format

## Risk
- Low
- Subshells are standard POSIX shell behavior. Edge case: if a command intentionally modifies the session environment, that change will not persist across exec calls. However, the shell profile preamble already re-sources environment on every exec, so this is a non-issue in practice.

## Security
- Threat categories reviewed: TM-BASH (command execution in sandbox)
- No new injection vectors - command string is unchanged, only wrapped in parentheses
- Subshells inherit the same sandbox restrictions; no privilege escalation
- No new data exposure paths

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed

Closes EVE-251