### PR TITLE
fix(daytona): add diagnostic hints for signal-based exit codes

### DIFF
--- a/integrations/daytona/src/client.rs
+++ b/integrations/daytona/src/client.rs
@@ -487,7 +487,10 @@ impl DaytonaClient {
 
         loop {
             if std::time::Instant::now() >= deadline {
-                return Err(format!("Command timed out after {timeout}ms"));
+                return Err(format!(
+                    "Command timed out after {timeout}ms. \
+                     Increase the timeout parameter or break the command into smaller steps."
+                ));
             }
 
             tokio::time::sleep(EXEC_POLL_INTERVAL).await;
@@ -561,15 +564,18 @@ impl DaytonaClient {
                          resetting session"
                     );
                     return match self.reset_session(sandbox_id).await {
-                        Ok(()) => Err("Session terminated by command (the command likely ran \
-                             `exit` which killed the shell)"
+                        Ok(()) => Err("Session shell terminated unexpectedly. Common causes: \
+                             the command ran `exit`, a subshell crashed, or the process \
+                             was OOM-killed. The session has been automatically reset — \
+                             your next command will work. To avoid this, do not use \
+                             `exit` in commands and avoid excessive memory usage."
                             .to_string()),
                         Err(e) => {
                             debug!("Failed to reset session {EXEC_SESSION_ID}: {e}");
                             Err(format!(
-                                "Session terminated by command (the command likely \
-                                 ran `exit` which killed the shell); additionally, \
-                                 failed to reset session: {e}"
+                                "Session shell terminated unexpectedly. Common causes: \
+                                 the command ran `exit`, a subshell crashed, or the process \
+                                 was OOM-killed. Additionally, failed to reset session: {e}"
                             ))
                         }
                     };
@@ -939,7 +945,7 @@ mod tests {
         assert!(result.is_err(), "Should detect dead session");
         let err = result.unwrap_err();
         assert!(
-            err.contains("Session terminated"),
+            err.contains("Session shell terminated unexpectedly"),
             "Error should mention session termination, got: {err}"
         );
 

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -38,6 +38,32 @@ fn snapshot_for_size(size: &str) -> Result<&'static str, String> {
     }
 }
 
+/// Return a diagnostic hint for signal-based or notable exit codes.
+///
+/// Exit codes 128+N indicate the process was killed by signal N.
+/// Common cases: 137 = SIGKILL (often OOM), 141 = SIGPIPE (pipe closed early),
+/// 139 = SIGSEGV, 143 = SIGTERM. Providing these hints lets agents adapt
+/// their retry strategy instead of blindly retrying. See EVE-252.
+fn exit_code_hint(exit_code: i32) -> Option<&'static str> {
+    match exit_code {
+        0 => None,
+        137 => Some(
+            "Process was killed (SIGKILL). This usually means the process ran out of memory (OOM). Reduce memory usage or request a larger sandbox.",
+        ),
+        139 => Some("Process crashed with a segmentation fault (SIGSEGV)."),
+        141 => Some(
+            "Broken pipe (SIGPIPE). A downstream command (e.g. head, sed, tail) closed the pipe before the upstream command finished writing. This is usually harmless — check if the partial output is sufficient.",
+        ),
+        143 => Some(
+            "Process was terminated (SIGTERM). It may have been stopped by the system or another process.",
+        ),
+        126 => Some("Command found but not executable. Check file permissions."),
+        127 => Some("Command not found. Check that the tool is installed and in PATH."),
+        _ if exit_code > 128 && exit_code <= 192 => Some("Process was killed by a signal."),
+        _ => None,
+    }
+}
+
 /// Parse an optional integer resource parameter, validating type and range.
 fn parse_resource_param(
     arguments: &Value,
@@ -460,13 +486,16 @@ impl Tool for DaytonaExecTool {
                         clean_output.clone()
                     };
                     let raw = clean_output;
-                    ToolExecutionResult::success_with_raw_output(
-                        json!({
-                            "exit_code": result.exit_code,
-                            "output": output
-                        }),
-                        raw,
-                    )
+                    let mut response = json!({
+                        "exit_code": result.exit_code,
+                        "output": output
+                    });
+                    // Add diagnostic hint for signal-based exit codes so agents
+                    // can adapt their retry strategy. See EVE-252.
+                    if let Some(hint) = exit_code_hint(result.exit_code) {
+                        response["hint"] = json!(hint);
+                    }
+                    ToolExecutionResult::success_with_raw_output(response, raw)
                 }
             }
             Err(e) => ToolExecutionResult::tool_error(e),
@@ -2355,5 +2384,21 @@ mod tests {
             ToolContext::with_storage_store(session_id, store).with_connection_resolver(resolver);
         let token = get_github_token(&context).await;
         assert_eq!(token, Some("fallback".to_string()));
+    }
+
+    #[test]
+    fn test_exit_code_hint_signals() {
+        assert!(exit_code_hint(0).is_none());
+        assert!(exit_code_hint(1).is_none());
+        assert!(exit_code_hint(137).unwrap().contains("SIGKILL"));
+        assert!(exit_code_hint(139).unwrap().contains("SIGSEGV"));
+        assert!(exit_code_hint(141).unwrap().contains("SIGPIPE"));
+        assert!(exit_code_hint(143).unwrap().contains("SIGTERM"));
+        assert!(exit_code_hint(126).unwrap().contains("not executable"));
+        assert!(exit_code_hint(127).unwrap().contains("not found"));
+        // Generic signal range
+        assert!(exit_code_hint(130).unwrap().contains("signal"));
+        // Outside signal range
+        assert!(exit_code_hint(200).is_none());
     }
 }


### PR DESCRIPTION
## What
Add diagnostic `hint` field to `daytona_exec` responses for signal-based exit codes and improve timeout/dead-session error messages with actionable guidance.

## Why
Agents seeing generic errors like "Session terminated by command" could not distinguish between OOM kills, SIGPIPE, timeouts, or shell exits. This caused ~20% budget waste on blind retries because agents had no information to adapt their strategy.

## How
- Added `exit_code_hint()` function that maps signal exit codes to diagnostic messages:
  - 137 (SIGKILL/OOM), 141 (SIGPIPE), 139 (SIGSEGV), 143 (SIGTERM), 126 (not executable), 127 (not found)
  - Generic hint for any signal in the 129-192 range
- The `hint` field is included in the JSON response alongside `exit_code` and `output`
- Improved timeout error to suggest increasing timeout or breaking into smaller steps
- Improved dead-session error to list common causes and confirm auto-recovery

## Risk
- Low
- Additive change: new optional `hint` field in response JSON. No behavioral changes.
- Existing error detection logic unchanged.

## Security
- Threat categories reviewed: TM-BASH - command execution in sandbox
- No new attack surface: hint strings are static constants, not derived from user input
- No data exposure: hints describe generic signal semantics, not sandbox internals

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed

Closes EVE-252
