### PR TITLE
feat(daytona): add opt-in daytona_api_call tool for direct API access

### DIFF
--- a/integrations/daytona/SPEC.md
+++ b/integrations/daytona/SPEC.md
@@ -203,6 +203,22 @@ Configure git credentials in a sandbox so that all git operations (push, pull, f
 
 **Design:** Avoids per-verb tools (git_push, git_fetch, etc.). Instead, configures standard git credential store once, then agent uses `daytona_exec` for all git operations naturally. Token in `/tmp` — lost on sandbox stop, same trust boundary as sandbox exec access.
 
+### daytona_api_call (opt-in)
+
+Call any Daytona REST API endpoint directly. Enabled via capability config `enable_api_calling: true`.
+
+- **Parameters**:
+  - `method`: string (required) — `GET`, `POST`, `PUT`, `PATCH`, or `DELETE`
+  - `path`: string (required) — API path. Management API: `/sandbox`, `/sandbox/{id}`, etc. Toolbox API: `/toolbox/{sandbox_id}/files`, `/toolbox/{sandbox_id}/process/execute`, etc.
+  - `body`: object (optional) — JSON request body for POST/PUT/PATCH
+- **Returns**: Raw JSON response from the Daytona API
+- **Headers**: Authentication (`Bearer <api_key>`) and `Content-Type` headers are injected automatically — callers do NOT specify headers.
+- **Routing**: Paths starting with `/toolbox/{sandbox_id}/...` route to the Toolbox API proxy; all other paths route to the Management API.
+- **Resource tracking**: `POST /sandbox` responses automatically register sandbox state and leased-resource lease. `DELETE /sandbox/{id}` automatically releases state and lease. Other endpoints do not track resources.
+- **OpenAPI spec**: When enabled, the Daytona OpenAPI spec is mounted at `/daytona/openapi.yaml` in the session filesystem. The tool description references this path so agents can read it to discover endpoints.
+
+**Opt-in mechanism:** The `daytona_api_call` tool is only included when the capability config JSON has `enable_api_calling: true`. This is set per-agent in the harness capability configuration. When enabled, the system prompt also adds a section about direct API access.
+
 ## Security
 
 - **API Key**: Stored in user connections (Settings > Connections > Daytona), encrypted at rest (TM-DAYTONA-004)
@@ -287,6 +303,16 @@ Git credentials for push/pull/fetch are configured by writing a `git credential 
 
 **Future improvement: API-proxied credential helper.** Instead of writing a token file, configure git in the sandbox to call back to an Everruns API endpoint (e.g. `GET /api/sessions/{id}/git-credential`) that mints a fresh token on each request. Benefits: no token on disk, always fresh (no expiry), multi-provider (GitHub/GitLab) via query param, per-session ACLs. Deferred because the credential store approach is simpler, works now, and the sandbox is already an isolated trust boundary.
 
+### Opt-in direct API calling
+
+The `daytona_api_call` tool is opt-in via capability config (`enable_api_calling: true`) rather than always-on. This keeps the default tool surface small and focused (dedicated tools handle 95% of use cases). Direct API access is a power-user escape hatch for endpoints not covered by dedicated tools (labels, ports, search, replace, git status).
+
+**Why capability config (not a separate capability):** API calling reuses the same Daytona API key, client, and resource tracking. A separate capability would duplicate connection resolution and state management. `tools_with_config` is the established pattern (see `WebFetchCapability`).
+
+**OpenAPI spec mount:** The spec is always mounted at `/daytona/openapi.yaml` (regardless of config) to avoid needing a `mounts_with_config` mechanism that doesn't exist yet. The spec file is inert documentation — mounting it has zero cost when the tool isn't enabled.
+
+**No header control:** The tool does not accept a `headers` parameter. Authentication and content-type are controlled internally to prevent credential leakage or header injection.
+
 ## Crate Structure
 
 `integrations/daytona/` → `everruns-integrations-daytona`
@@ -300,8 +326,9 @@ External integration crate, auto-registered via `inventory::submit!` plugin syst
 | `src/lib.rs` | Plugin registration, constants, `DaytonaCapability` impl |
 | `src/client.rs` | `DaytonaClient` HTTP client (management + toolbox APIs), URL encoding |
 | `src/connection.rs` | `DaytonaConnectionProvider` — API-key connection plugin |
+| `src/openapi_spec.rs` | Embedded Daytona OpenAPI spec (YAML) for session filesystem mount |
 | `src/state.rs` | API types (`SandboxInfo`, `ExecResult`, `SandboxState`), session state helpers |
-| `src/tools.rs` | 10 tool implementations (`DaytonaCreateSandboxTool`, etc.) |
+| `src/tools.rs` | 11 tool implementations (`DaytonaCreateSandboxTool`, `DaytonaApiCallTool`, etc.) |
 | `tests/plugin_registration.rs` | Integration tests for inventory registration |
 | `tests/tool_integration.rs` | Integration tests: tool execution + wiremock Daytona API |
 | `tests/live_api_test.rs` | Live API integration tests (feature-gated: `daytona-live-tests`) |

--- a/integrations/daytona/SPEC.md
+++ b/integrations/daytona/SPEC.md
@@ -215,7 +215,7 @@ Call any Daytona REST API endpoint directly. Enabled via capability config `enab
 - **Headers**: Authentication (`Bearer <api_key>`) and `Content-Type` headers are injected automatically — callers do NOT specify headers.
 - **Routing**: Paths starting with `/toolbox/{sandbox_id}/...` route to the Toolbox API proxy; all other paths route to the Management API.
 - **Resource tracking**: `POST /sandbox` requests get `everruns.*` ownership labels auto-injected into the body (same labels as `daytona_create_sandbox`). Responses register sandbox state and leased-resource lease. `DELETE /sandbox/{id}` releases state and lease. Other endpoints do not track resources.
-- **OpenAPI spec**: When enabled, the Daytona OpenAPI spec is mounted at `/daytona/openapi.yaml` in the session filesystem. The tool description references this path so agents can read it to discover endpoints.
+- **OpenAPI spec**: The Daytona OpenAPI spec is always mounted at `/daytona/openapi.yaml` in the session filesystem (regardless of `enable_api_calling`). The tool description references this path so agents can read it to discover endpoints.
 
 **Opt-in mechanism:** The `daytona_api_call` tool is only included when the capability config JSON has `enable_api_calling: true`. This is set per-agent in the harness capability configuration. When enabled, the system prompt also adds a section about direct API access.
 

--- a/integrations/daytona/SPEC.md
+++ b/integrations/daytona/SPEC.md
@@ -214,7 +214,7 @@ Call any Daytona REST API endpoint directly. Enabled via capability config `enab
 - **Returns**: Raw JSON response from the Daytona API
 - **Headers**: Authentication (`Bearer <api_key>`) and `Content-Type` headers are injected automatically — callers do NOT specify headers.
 - **Routing**: Paths starting with `/toolbox/{sandbox_id}/...` route to the Toolbox API proxy; all other paths route to the Management API.
-- **Resource tracking**: `POST /sandbox` responses automatically register sandbox state and leased-resource lease. `DELETE /sandbox/{id}` automatically releases state and lease. Other endpoints do not track resources.
+- **Resource tracking**: `POST /sandbox` requests get `everruns.*` ownership labels auto-injected into the body (same labels as `daytona_create_sandbox`). Responses register sandbox state and leased-resource lease. `DELETE /sandbox/{id}` releases state and lease. Other endpoints do not track resources.
 - **OpenAPI spec**: When enabled, the Daytona OpenAPI spec is mounted at `/daytona/openapi.yaml` in the session filesystem. The tool description references this path so agents can read it to discover endpoints.
 
 **Opt-in mechanism:** The `daytona_api_call` tool is only included when the capability config JSON has `enable_api_calling: true`. This is set per-agent in the harness capability configuration. When enabled, the system prompt also adds a section about direct API access.
@@ -312,6 +312,8 @@ The `daytona_api_call` tool is opt-in via capability config (`enable_api_calling
 **OpenAPI spec mount:** The spec is always mounted at `/daytona/openapi.yaml` (regardless of config) to avoid needing a `mounts_with_config` mechanism that doesn't exist yet. The spec file is inert documentation — mounting it has zero cost when the tool isn't enabled.
 
 **No header control:** The tool does not accept a `headers` parameter. Authentication and content-type are controlled internally to prevent credential leakage or header injection.
+
+**Label injection at create time:** `POST /sandbox` requests get `everruns.*` labels injected into the body before sending. Daytona's `PUT /sandbox/{id}/labels` API does not reliably update labels post-creation (verified against live API 2026-04), so create-time injection is the only reliable approach. This matches the labels set by `daytona_create_sandbox`.
 
 ## Crate Structure
 

--- a/integrations/daytona/src/client.rs
+++ b/integrations/daytona/src/client.rs
@@ -228,6 +228,36 @@ impl DaytonaClient {
         Ok(())
     }
 
+    // --- Generic API call (for daytona_api_call tool) ---
+
+    /// Generic Daytona API call. Routes to Management or Toolbox API based on path prefix.
+    ///
+    /// - Paths starting with `/toolbox/{sandbox_id}/...` → Toolbox API
+    /// - All other paths → Management API
+    ///
+    /// Headers (Authorization, Content-Type) are controlled internally.
+    pub async fn api_call(
+        &self,
+        method: reqwest::Method,
+        path: &str,
+        body: Option<Value>,
+    ) -> Result<Value, String> {
+        if let Some(rest) = path.strip_prefix("/toolbox/") {
+            // Extract sandbox_id from /toolbox/{sandbox_id}/...
+            let (sandbox_id, toolbox_path) = rest
+                .split_once('/')
+                .map(|(id, p)| (id, format!("/{p}")))
+                .unwrap_or((rest, String::new()));
+            if sandbox_id.is_empty() {
+                return Err("Invalid toolbox path: expected /toolbox/{sandbox_id}/...".to_string());
+            }
+            self.toolbox_request(method, sandbox_id, &toolbox_path, body)
+                .await
+        } else {
+            self.management_request(method, path, body).await
+        }
+    }
+
     // --- Management API ---
 
     pub async fn create_sandbox(&self, body: Value) -> Result<SandboxInfo, String> {

--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -12,11 +12,15 @@
 
 pub mod client;
 pub mod connection;
+pub mod openapi_spec;
 pub mod state;
 mod tools;
 
 use everruns_core::LEASED_RESOURCES_FEATURE;
-use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin, RiskLevel};
+use everruns_core::capabilities::{
+    Capability, CapabilityStatus, IntegrationPlugin, MountDirectoryBuilder, MountPoint, RiskLevel,
+    SystemPromptContext,
+};
 use everruns_core::connection_provider::ConnectionProviderPlugin;
 use everruns_core::tools::Tool;
 
@@ -25,9 +29,10 @@ use std::sync::LazyLock;
 use std::time::Duration;
 
 use tools::{
-    DaytonaCreateSandboxTool, DaytonaDownloadWorkspaceTool, DaytonaExecTool, DaytonaGitCloneTool,
-    DaytonaGitCredentialsTool, DaytonaListSandboxesTool, DaytonaListSnapshotsTool,
-    DaytonaManageSandboxTool, DaytonaReadFileTool, DaytonaWriteFileTool,
+    DaytonaApiCallTool, DaytonaCreateSandboxTool, DaytonaDownloadWorkspaceTool, DaytonaExecTool,
+    DaytonaGitCloneTool, DaytonaGitCredentialsTool, DaytonaListSandboxesTool,
+    DaytonaListSnapshotsTool, DaytonaManageSandboxTool, DaytonaReadFileTool, DaytonaWriteFileTool,
+    DAYTONA_OPENAPI_MOUNT_PATH,
 };
 
 // ============================================================================
@@ -111,8 +116,20 @@ fetch, rebase, etc.) — they authenticate automatically. Call again to refresh 
     prompt
 });
 
+/// Check if API calling is enabled in capability config.
+///
+/// When `enable_api_calling` is `true`, the `daytona_api_call` tool is added
+/// and the OpenAPI spec mount path is referenced in the system prompt.
+fn is_api_calling_enabled(config: &serde_json::Value) -> bool {
+    config
+        .get("enable_api_calling")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
 pub struct DaytonaCapability;
 
+#[async_trait::async_trait]
 impl Capability for DaytonaCapability {
     fn id(&self) -> &str {
         "daytona"
@@ -167,6 +184,54 @@ impl Capability for DaytonaCapability {
         ]
     }
 
+    fn tools_with_config(&self, config: &serde_json::Value) -> Vec<Box<dyn Tool>> {
+        let mut tools = self.tools();
+        if is_api_calling_enabled(config) {
+            tools.push(Box::new(DaytonaApiCallTool));
+        }
+        tools
+    }
+
+    fn mounts(&self) -> Vec<MountPoint> {
+        // OpenAPI spec is always mounted so it's available if API calling is enabled.
+        // The tool itself is only added when config has enable_api_calling: true.
+        let daytona_dir = MountDirectoryBuilder::new()
+            .file("openapi.yaml", openapi_spec::DAYTONA_OPENAPI_SPEC)
+            .build();
+        vec![MountPoint::readonly("/daytona", daytona_dir, self.id())]
+    }
+
+    async fn system_prompt_contribution_with_config(
+        &self,
+        _ctx: &SystemPromptContext,
+        config: &serde_json::Value,
+    ) -> Option<String> {
+        let base = self.system_prompt_addition()?;
+        if is_api_calling_enabled(config) {
+            let api_calling_addition = format!(
+                "\n\n### Direct API Access\n\n\
+                 Direct Daytona API calling is enabled. Use `daytona_api_call` to call any \
+                 Daytona REST API endpoint not covered by the dedicated tools.\n\
+                 The full OpenAPI spec is mounted at `{DAYTONA_OPENAPI_MOUNT_PATH}` — \
+                 read it to discover endpoints, parameters, and schemas.\n\
+                 Resources created via `daytona_api_call` (e.g. POST /sandbox) are \
+                 automatically tracked for cleanup."
+            );
+            Some(format!(
+                "<capability id=\"{}\">\n{}{}\n</capability>",
+                self.id(),
+                base,
+                api_calling_addition
+            ))
+        } else {
+            Some(format!(
+                "<capability id=\"{}\">\n{}\n</capability>",
+                self.id(),
+                base
+            ))
+        }
+    }
+
     fn dependencies(&self) -> Vec<&'static str> {
         vec!["session_storage"]
     }
@@ -184,6 +249,7 @@ impl Capability for DaytonaCapability {
 mod tests {
     use super::*;
     use everruns_core::capabilities::CapabilityStatus;
+    use serde_json::json;
 
     #[test]
     fn test_capability_metadata() {
@@ -242,5 +308,94 @@ mod tests {
     fn test_capability_dependencies() {
         let cap = DaytonaCapability;
         assert_eq!(cap.dependencies(), vec!["session_storage"]);
+    }
+
+    // --- API calling opt-in tests ---
+
+    #[test]
+    fn test_is_api_calling_enabled_default_false() {
+        assert!(!is_api_calling_enabled(&json!({})));
+        assert!(!is_api_calling_enabled(&json!(null)));
+        assert!(!is_api_calling_enabled(
+            &json!({"enable_api_calling": false})
+        ));
+    }
+
+    #[test]
+    fn test_is_api_calling_enabled_true() {
+        assert!(is_api_calling_enabled(&json!({"enable_api_calling": true})));
+    }
+
+    #[test]
+    fn test_tools_with_config_default_no_api_call() {
+        let cap = DaytonaCapability;
+        let tools = cap.tools_with_config(&json!({}));
+        assert_eq!(tools.len(), 10);
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(!names.contains(&"daytona_api_call"));
+    }
+
+    #[test]
+    fn test_tools_with_config_api_calling_enabled() {
+        let cap = DaytonaCapability;
+        let tools = cap.tools_with_config(&json!({"enable_api_calling": true}));
+        assert_eq!(tools.len(), 11);
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(names.contains(&"daytona_api_call"));
+    }
+
+    #[test]
+    fn test_api_call_tool_requires_context() {
+        let cap = DaytonaCapability;
+        let tools = cap.tools_with_config(&json!({"enable_api_calling": true}));
+        let api_tool = tools
+            .iter()
+            .find(|t| t.name() == "daytona_api_call")
+            .unwrap();
+        assert!(api_tool.requires_context());
+    }
+
+    #[test]
+    fn test_mounts_include_openapi_spec() {
+        let cap = DaytonaCapability;
+        let mounts = cap.mounts();
+        assert_eq!(mounts.len(), 1);
+        assert_eq!(mounts[0].path, "/daytona");
+        assert!(mounts[0].is_readonly());
+    }
+
+    #[test]
+    fn test_openapi_spec_is_valid_yaml() {
+        let spec = openapi_spec::DAYTONA_OPENAPI_SPEC;
+        assert!(spec.contains("openapi: 3.0.3"));
+        assert!(spec.contains("/sandbox"));
+        assert!(spec.contains("/toolbox/"));
+    }
+
+    #[tokio::test]
+    async fn test_system_prompt_with_api_calling_enabled() {
+        let cap = DaytonaCapability;
+        let ctx = SystemPromptContext::without_file_store(everruns_core::SessionId::new());
+        let prompt = cap
+            .system_prompt_contribution_with_config(&ctx, &json!({"enable_api_calling": true}))
+            .await
+            .unwrap();
+        assert!(prompt.contains("daytona_api_call"));
+        assert!(prompt.contains(DAYTONA_OPENAPI_MOUNT_PATH));
+        assert!(prompt.contains("Direct API Access"));
+    }
+
+    #[tokio::test]
+    async fn test_system_prompt_without_api_calling() {
+        let cap = DaytonaCapability;
+        let ctx = SystemPromptContext::without_file_store(everruns_core::SessionId::new());
+        let prompt = cap
+            .system_prompt_contribution_with_config(&ctx, &json!({}))
+            .await
+            .unwrap();
+        assert!(!prompt.contains("daytona_api_call"));
+        assert!(!prompt.contains("Direct API Access"));
+        // Still has the base prompt
+        assert!(prompt.contains("Daytona"));
     }
 }

--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -29,10 +29,10 @@ use std::sync::LazyLock;
 use std::time::Duration;
 
 use tools::{
-    DaytonaApiCallTool, DaytonaCreateSandboxTool, DaytonaDownloadWorkspaceTool, DaytonaExecTool,
-    DaytonaGitCloneTool, DaytonaGitCredentialsTool, DaytonaListSandboxesTool,
-    DaytonaListSnapshotsTool, DaytonaManageSandboxTool, DaytonaReadFileTool, DaytonaWriteFileTool,
-    DAYTONA_OPENAPI_MOUNT_PATH,
+    DAYTONA_OPENAPI_MOUNT_PATH, DaytonaApiCallTool, DaytonaCreateSandboxTool,
+    DaytonaDownloadWorkspaceTool, DaytonaExecTool, DaytonaGitCloneTool, DaytonaGitCredentialsTool,
+    DaytonaListSandboxesTool, DaytonaListSnapshotsTool, DaytonaManageSandboxTool,
+    DaytonaReadFileTool, DaytonaWriteFileTool,
 };
 
 // ============================================================================

--- a/integrations/daytona/src/openapi_spec.rs
+++ b/integrations/daytona/src/openapi_spec.rs
@@ -2,8 +2,8 @@
 //!
 //! Decision: Embed a curated subset of the Daytona OpenAPI spec as a const string.
 //! This covers the Management API and Toolbox API endpoints that agents can call
-//! via `daytona_api_call`. The spec is mounted into the session filesystem at
-//! `/daytona/openapi.yaml` when API calling is enabled.
+//! via `daytona_api_call`. The spec is always mounted into the session filesystem
+//! at `/daytona/openapi.yaml` (regardless of `enable_api_calling` config).
 
 /// Curated Daytona OpenAPI spec covering Management and Toolbox APIs.
 ///
@@ -29,8 +29,8 @@ info:
 servers:
   - url: https://app.daytona.io/api
     description: Management API
-  - url: https://proxy.app.daytona.io/toolbox
-    description: Toolbox API (prefix sandbox_id in path)
+  - url: https://proxy.app.daytona.io
+    description: Toolbox API (paths include /toolbox/{sandbox_id}/...)
 
 paths:
   # ── Management API ────────────────────────────────────────────
@@ -245,6 +245,7 @@ paths:
     get:
       operationId: downloadFile
       summary: Download a file from the sandbox
+      description: Returns raw binary content. Not available via daytona_api_call (JSON-only responses) �� use daytona_read_file instead.
       parameters:
         - name: sandboxId
           in: path

--- a/integrations/daytona/src/openapi_spec.rs
+++ b/integrations/daytona/src/openapi_spec.rs
@@ -1,0 +1,654 @@
+//! Embedded Daytona OpenAPI specification for the API calling feature.
+//!
+//! Decision: Embed a curated subset of the Daytona OpenAPI spec as a const string.
+//! This covers the Management API and Toolbox API endpoints that agents can call
+//! via `daytona_api_call`. The spec is mounted into the session filesystem at
+//! `/daytona/openapi.yaml` when API calling is enabled.
+
+/// Curated Daytona OpenAPI spec covering Management and Toolbox APIs.
+///
+/// This is a subset focused on the endpoints most useful for agent automation.
+/// The full Daytona API docs are at <https://www.daytona.io/docs/api>.
+pub const DAYTONA_OPENAPI_SPEC: &str = r##"openapi: 3.0.3
+info:
+  title: Daytona API
+  description: |
+    Daytona cloud sandbox Management and Toolbox APIs.
+    This spec covers the endpoints available via the `daytona_api_call` tool.
+
+    **Two API tiers:**
+    - **Management API** — sandbox lifecycle (create, start, stop, delete, list).
+      Paths start with `/sandbox`.
+    - **Toolbox API** — in-sandbox operations (exec, files).
+      Paths start with `/toolbox/{sandbox_id}/...`.
+
+    Authentication is handled automatically by the tool (Bearer token).
+    Do NOT pass auth headers manually.
+  version: "1.0"
+
+servers:
+  - url: https://app.daytona.io/api
+    description: Management API
+  - url: https://proxy.app.daytona.io/toolbox
+    description: Toolbox API (prefix sandbox_id in path)
+
+paths:
+  # ── Management API ────────────────────────────────────────────
+  /sandbox:
+    get:
+      operationId: listSandboxes
+      summary: List all sandboxes
+      description: Returns all sandboxes owned by the authenticated user.
+      responses:
+        "200":
+          description: Array of sandbox objects
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Sandbox"
+    post:
+      operationId: createSandbox
+      summary: Create a new sandbox
+      description: |
+        Creates a sandbox from a snapshot. Use `daytona_create_sandbox` tool
+        instead for automatic resource tracking and session state management.
+        Only use this endpoint directly if you need advanced create options
+        not exposed by the tool.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateSandboxRequest"
+      responses:
+        "200":
+          description: Created sandbox
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Sandbox"
+
+  /sandbox/{sandboxId}:
+    get:
+      operationId: getSandbox
+      summary: Get sandbox details
+      parameters:
+        - name: sandboxId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Sandbox details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Sandbox"
+    delete:
+      operationId: deleteSandbox
+      summary: Delete a sandbox
+      parameters:
+        - name: sandboxId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Sandbox deleted
+
+  /sandbox/{sandboxId}/start:
+    post:
+      operationId: startSandbox
+      summary: Start a stopped sandbox
+      parameters:
+        - name: sandboxId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Sandbox started
+
+  /sandbox/{sandboxId}/stop:
+    post:
+      operationId: stopSandbox
+      summary: Stop a running sandbox
+      parameters:
+        - name: sandboxId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Sandbox stopped
+
+  /sandbox/{sandboxId}/autostop/{interval}:
+    post:
+      operationId: setAutostop
+      summary: Set auto-stop interval
+      parameters:
+        - name: sandboxId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: interval
+          in: path
+          required: true
+          description: Minutes of inactivity before auto-stop (0 = disable)
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Auto-stop updated
+
+  /sandbox/{sandboxId}/labels:
+    put:
+      operationId: setSandboxLabels
+      summary: Set sandbox labels (key-value metadata)
+      parameters:
+        - name: sandboxId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
+      responses:
+        "200":
+          description: Labels updated
+
+  # ── Toolbox API (in-sandbox operations) ───────────────────────
+  /toolbox/{sandboxId}/process/execute:
+    post:
+      operationId: executeCommand
+      summary: Execute a command synchronously in the sandbox
+      description: |
+        Runs a shell command and returns the result. For long-running commands
+        prefer `daytona_exec` which provides streaming output.
+      parameters:
+        - name: sandboxId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExecRequest"
+      responses:
+        "200":
+          description: Execution result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExecResponse"
+
+  /toolbox/{sandboxId}/files:
+    get:
+      operationId: listFiles
+      summary: List files in a directory
+      parameters:
+        - name: sandboxId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: true
+          description: Directory path to list
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Array of file entries
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/FileEntry"
+    delete:
+      operationId: deleteFile
+      summary: Delete a file or directory
+      parameters:
+        - name: sandboxId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: File deleted
+
+  /toolbox/{sandboxId}/files/download:
+    get:
+      operationId: downloadFile
+      summary: Download a file from the sandbox
+      parameters:
+        - name: sandboxId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Raw file content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+
+  /toolbox/{sandboxId}/files/upload:
+    post:
+      operationId: uploadFile
+      summary: Upload a file to the sandbox
+      description: Uses multipart/form-data. Not available via daytona_api_call — use daytona_write_file instead.
+      parameters:
+        - name: sandboxId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: true
+          description: Destination path in sandbox
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        "200":
+          description: File uploaded
+
+  /toolbox/{sandboxId}/files/folder:
+    post:
+      operationId: createFolder
+      summary: Create a directory
+      parameters:
+        - name: sandboxId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: mode
+          in: query
+          required: true
+          description: Unix permissions (e.g. "0755")
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Directory created
+
+  /toolbox/{sandboxId}/files/search:
+    get:
+      operationId: searchFiles
+      summary: Search for files by name pattern
+      parameters:
+        - name: sandboxId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: true
+          description: Root directory to search from
+          schema:
+            type: string
+        - name: pattern
+          in: query
+          required: true
+          description: Search pattern (glob)
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Matching file paths
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/FileEntry"
+
+  /toolbox/{sandboxId}/files/replace:
+    post:
+      operationId: replaceInFiles
+      summary: Find and replace text in files
+      parameters:
+        - name: sandboxId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReplaceRequest"
+      responses:
+        "200":
+          description: Replacement results
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ReplaceResult"
+
+  /toolbox/{sandboxId}/ports:
+    get:
+      operationId: listPorts
+      summary: List open network ports in sandbox
+      parameters:
+        - name: sandboxId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Array of open ports
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    port:
+                      type: integer
+                    url:
+                      type: string
+                      description: Public URL for the port (if available)
+
+  /toolbox/{sandboxId}/process/session/{sessionId}/exec:
+    post:
+      operationId: sessionExec
+      summary: Execute command in a persistent shell session
+      description: |
+        Runs a command asynchronously in a persistent session. Used internally
+        by `daytona_exec` for streaming output. Prefer `daytona_exec` tool
+        for most use cases.
+      parameters:
+        - name: sandboxId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                command:
+                  type: string
+                async:
+                  type: boolean
+                  default: true
+      responses:
+        "200":
+          description: Exec started (async) or completed (sync)
+
+  /toolbox/{sandboxId}/git/clone:
+    post:
+      operationId: gitClone
+      summary: Clone a git repository into sandbox
+      parameters:
+        - name: sandboxId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                url:
+                  type: string
+                  description: Repository URL
+                branch:
+                  type: string
+                  description: Branch to clone
+                path:
+                  type: string
+                  description: Destination path
+                username:
+                  type: string
+                password:
+                  type: string
+                  description: Token or password
+      responses:
+        "200":
+          description: Clone result
+
+  /toolbox/{sandboxId}/git/status:
+    get:
+      operationId: gitStatus
+      summary: Get git status of a repository in sandbox
+      parameters:
+        - name: sandboxId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: true
+          description: Path to git repository
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Git status info
+
+components:
+  schemas:
+    Sandbox:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        state:
+          type: string
+          enum: [creating, starting, started, stopping, stopped, destroying, error, unknown]
+        snapshot:
+          type: string
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+        autoStopInterval:
+          type: integer
+          description: Minutes until auto-stop
+        autoArchiveInterval:
+          type: integer
+        autoDeleteInterval:
+          type: integer
+        resources:
+          type: object
+          properties:
+            cpu:
+              type: integer
+            memory:
+              type: integer
+            disk:
+              type: integer
+        public:
+          type: boolean
+        target:
+          type: string
+
+    CreateSandboxRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        snapshot:
+          type: string
+          description: Snapshot name (e.g. "daytona-small", "daytona-medium", "daytona-large")
+        autoStopInterval:
+          type: integer
+          description: Minutes until auto-stop (default 5)
+        autoArchiveInterval:
+          type: integer
+          description: Minutes until auto-archive (default 30)
+        autoDeleteInterval:
+          type: integer
+          description: Minutes until auto-delete (default 60)
+        public:
+          type: boolean
+          default: false
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+        resources:
+          type: object
+          properties:
+            cpu:
+              type: integer
+            memory:
+              type: integer
+            disk:
+              type: integer
+        env:
+          type: object
+          additionalProperties:
+            type: string
+          description: Environment variables to set in sandbox
+        user:
+          type: string
+          description: User to run sandbox as
+
+    ExecRequest:
+      type: object
+      required:
+        - command
+      properties:
+        command:
+          type: string
+          description: Shell command to execute
+        cwd:
+          type: string
+          description: Working directory
+        timeout:
+          type: integer
+          description: Timeout in milliseconds
+
+    ExecResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+          description: Exit code
+        result:
+          type: string
+          description: Combined stdout + stderr output
+
+    FileEntry:
+      type: object
+      properties:
+        name:
+          type: string
+        isDir:
+          type: boolean
+        size:
+          type: integer
+        mode:
+          type: string
+        modTime:
+          type: string
+          format: date-time
+
+    ReplaceRequest:
+      type: object
+      required:
+        - files
+        - pattern
+        - newValue
+      properties:
+        files:
+          type: array
+          items:
+            type: string
+          description: File paths to search
+        pattern:
+          type: string
+          description: Regex pattern to find
+        newValue:
+          type: string
+          description: Replacement string
+
+    ReplaceResult:
+      type: object
+      properties:
+        file:
+          type: string
+        replacements:
+          type: integer
+
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: Daytona API key (automatically injected by daytona_api_call)
+
+security:
+  - bearerAuth: []
+"##;

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -1650,8 +1650,7 @@ impl Tool for DaytonaApiCallTool {
                     "description": "API path. Management API: /sandbox, /sandbox/{id}, etc. Toolbox API: /toolbox/{sandbox_id}/files, /toolbox/{sandbox_id}/process/execute, etc."
                 },
                 "body": {
-                    "type": "object",
-                    "description": "JSON request body (optional, for POST/PUT/PATCH)"
+                    "description": "JSON request body (optional, for POST/PUT/PATCH). Usually an object, but arrays are also accepted for endpoints that require them."
                 }
             },
             "required": ["method", "path"],
@@ -1692,6 +1691,17 @@ impl Tool for DaytonaApiCallTool {
         let path = match required_str(&arguments, "path") {
             Ok(p) => p.to_string(),
             Err(e) => return e,
+        };
+
+        // Normalize path: ensure leading /, strip trailing /, strip query string
+        let path = {
+            let p = path.split('?').next().unwrap_or(&path);
+            let p = p.trim_end_matches('/');
+            if p.starts_with('/') {
+                p.to_string()
+            } else {
+                format!("/{p}")
+            }
         };
 
         let method = match method_str.as_str() {
@@ -1766,20 +1776,25 @@ impl DaytonaApiCallTool {
     ///
     /// Merges with any user-provided labels (user labels take precedence for
     /// non-everruns keys; everruns.* keys are always set to prevent tampering).
-    async fn inject_labels(context: &ToolContext, mut body: Value) -> Value {
+    async fn inject_labels(context: &ToolContext, body: Value) -> Value {
         let labels = Self::build_labels(context).await;
-        if let Some(obj) = body.as_object_mut() {
-            let existing = obj
-                .entry("labels")
-                .or_insert_with(|| json!({}))
-                .as_object_mut();
-            if let Some(existing_labels) = existing {
-                for (k, v) in labels {
-                    existing_labels.insert(k, v);
-                }
-            }
+
+        let mut obj = match body {
+            Value::Object(map) => map,
+            _ => serde_json::Map::new(),
+        };
+
+        let mut existing_labels = match obj.remove("labels") {
+            Some(Value::Object(map)) => map,
+            _ => serde_json::Map::new(),
+        };
+
+        for (k, v) in labels {
+            existing_labels.insert(k, v);
         }
-        body
+
+        obj.insert("labels".to_string(), Value::Object(existing_labels));
+        Value::Object(obj)
     }
 
     /// Best-effort resource tracking for sandbox lifecycle operations via raw API.

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -1605,6 +1605,178 @@ async fn get_github_token(context: &ToolContext) -> Option<String> {
 }
 
 // ============================================================================
+// DaytonaApiCallTool (opt-in via capability config: enable_api_calling)
+// ============================================================================
+
+/// Session filesystem path where the Daytona OpenAPI spec is mounted.
+pub const DAYTONA_OPENAPI_MOUNT_PATH: &str = "/daytona/openapi.yaml";
+
+pub struct DaytonaApiCallTool;
+
+#[async_trait]
+impl Tool for DaytonaApiCallTool {
+    fn name(&self) -> &str {
+        "daytona_api_call"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Daytona API Call")
+    }
+
+    fn description(&self) -> &str {
+        "Call any Daytona REST API endpoint directly. \
+         Routes automatically: paths starting with /toolbox/{sandbox_id}/... go to the \
+         Toolbox API; all other paths go to the Management API. \
+         Authentication headers are injected automatically — do NOT specify headers. \
+         The full Daytona OpenAPI spec is available at /daytona/openapi.yaml in the \
+         session filesystem — read it to discover available endpoints, parameters, \
+         and schemas. \
+         For sandbox lifecycle (create/exec/files), prefer the dedicated daytona_* tools \
+         which handle state tracking and streaming. Use this tool for endpoints not \
+         covered by dedicated tools (e.g. labels, ports, git status, search, replace)."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"],
+                    "description": "HTTP method"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "API path. Management API: /sandbox, /sandbox/{id}, etc. Toolbox API: /toolbox/{sandbox_id}/files, /toolbox/{sandbox_id}/process/execute, etc."
+                },
+                "body": {
+                    "type": "object",
+                    "description": "JSON request body (optional, for POST/PUT/PATCH)"
+                }
+            },
+            "required": ["method", "path"],
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_requires_secrets(true)
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "daytona_api_call requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let api_key = match get_api_key(context).await {
+            Ok(k) => k,
+            Err(e) => return e,
+        };
+
+        let method_str = match required_str(&arguments, "method") {
+            Ok(m) => m.to_string(),
+            Err(e) => return e,
+        };
+        let path = match required_str(&arguments, "path") {
+            Ok(p) => p.to_string(),
+            Err(e) => return e,
+        };
+
+        let method = match method_str.as_str() {
+            "GET" => reqwest::Method::GET,
+            "POST" => reqwest::Method::POST,
+            "PUT" => reqwest::Method::PUT,
+            "PATCH" => reqwest::Method::PATCH,
+            "DELETE" => reqwest::Method::DELETE,
+            _ => {
+                return ToolExecutionResult::tool_error(format!(
+                    "Unsupported method: {method_str}. Use GET, POST, PUT, PATCH, or DELETE."
+                ));
+            }
+        };
+
+        let body = arguments
+            .get("body")
+            .and_then(|v| if v.is_null() { None } else { Some(v.clone()) });
+
+        let client = DaytonaClient::new(api_key);
+        match client.api_call(method, &path, body).await {
+            Ok(response) => {
+                // Track sandbox resources created/deleted via raw API calls
+                self.track_resources(context, &method_str, &path, &response)
+                    .await;
+                ToolExecutionResult::success(response)
+            }
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+}
+
+impl DaytonaApiCallTool {
+    /// Best-effort resource tracking for sandbox lifecycle operations via raw API.
+    ///
+    /// When the agent creates or deletes sandboxes through `daytona_api_call` instead
+    /// of the dedicated tools, we still want leased-resource tracking to work.
+    async fn track_resources(
+        &self,
+        context: &ToolContext,
+        method: &str,
+        path: &str,
+        response: &Value,
+    ) {
+        // POST /sandbox → new sandbox created, register lease
+        if method == "POST"
+            && path == "/sandbox"
+            && let Some(sandbox_id) = response.get("id").and_then(|v| v.as_str())
+        {
+            let display_name = response
+                .get("name")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            let state = SandboxState {
+                sandbox_id: sandbox_id.to_string(),
+                workspace_path: crate::DAYTONA_WORKSPACE_PATH.to_string(),
+                started_at: chrono::Utc::now().to_rfc3339(),
+            };
+            if let Err(e) = save_sandbox_state(context, &state).await {
+                warn!("Failed to save sandbox state from api_call: {e:?}");
+            }
+            if let Err(e) = touch_sandbox_lease(context, &state, display_name).await {
+                warn!("Failed to register sandbox lease from api_call: {e:?}");
+            }
+            debug!(sandbox_id, "Tracked sandbox created via daytona_api_call");
+        }
+
+        // DELETE /sandbox/{id} → sandbox deleted, release lease
+        if method == "DELETE"
+            && let Some(sandbox_id) = path
+                .strip_prefix("/sandbox/")
+                .filter(|rest| !rest.contains('/'))
+        {
+            if let Err(e) = delete_sandbox_state(context, sandbox_id).await {
+                warn!("Failed to delete sandbox state from api_call: {e:?}");
+            }
+            if let Err(e) = release_sandbox_lease(context, sandbox_id).await {
+                warn!("Failed to release sandbox lease from api_call: {e:?}");
+            }
+            debug!(sandbox_id, "Tracked sandbox deletion via daytona_api_call");
+        }
+    }
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 
@@ -2516,5 +2688,114 @@ mod tests {
         assert!(exit_code_hint(130).unwrap().contains("signal"));
         // Outside signal range
         assert!(exit_code_hint(200).is_none());
+    }
+
+    // ========================================================================
+    // DaytonaApiCallTool tests
+    // ========================================================================
+
+    #[test]
+    fn test_api_call_tool_name() {
+        let tool = DaytonaApiCallTool;
+        assert_eq!(tool.name(), "daytona_api_call");
+        assert!(tool.name().starts_with("daytona_"));
+    }
+
+    #[test]
+    fn test_api_call_tool_schema() {
+        let tool = DaytonaApiCallTool;
+        let schema = tool.parameters_schema();
+        let required = schema["required"].as_array().unwrap();
+        let required_strs: Vec<&str> = required.iter().map(|v| v.as_str().unwrap()).collect();
+        assert!(required_strs.contains(&"method"));
+        assert!(required_strs.contains(&"path"));
+        assert!(!required_strs.contains(&"body"));
+        assert_eq!(schema["additionalProperties"], json!(false));
+
+        // method must have enum constraint
+        let method_enum = schema["properties"]["method"]["enum"].as_array().unwrap();
+        let methods: Vec<&str> = method_enum.iter().map(|v| v.as_str().unwrap()).collect();
+        assert!(methods.contains(&"GET"));
+        assert!(methods.contains(&"POST"));
+        assert!(methods.contains(&"DELETE"));
+    }
+
+    #[test]
+    fn test_api_call_tool_description_references_spec() {
+        let tool = DaytonaApiCallTool;
+        assert!(tool.description().contains("/daytona/openapi.yaml"));
+    }
+
+    #[test]
+    fn test_api_call_tool_hints() {
+        let tool = DaytonaApiCallTool;
+        let hints = tool.hints();
+        assert_eq!(hints.open_world, Some(true));
+        assert_eq!(hints.requires_secrets, Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_api_call_without_context() {
+        let tool = DaytonaApiCallTool;
+        let result = tool
+            .execute(json!({"method": "GET", "path": "/sandbox"}))
+            .await;
+        assert!(
+            matches!(result, ToolExecutionResult::ToolError(msg) if msg.contains("requires context"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_api_call_missing_method() {
+        let tool = DaytonaApiCallTool;
+        let session_id = SessionId::new();
+        let store = Arc::new(MockStorageStore::new());
+        let resolver = Arc::new(ProviderAwareResolver::daytona_only("test_key"));
+        let context =
+            ToolContext::with_storage_store(session_id, store).with_connection_resolver(resolver);
+        let result = tool
+            .execute_with_context(json!({"path": "/sandbox"}), &context)
+            .await;
+        assert!(
+            matches!(result, ToolExecutionResult::ToolError(msg) if msg.contains("Missing required parameter"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_api_call_missing_path() {
+        let tool = DaytonaApiCallTool;
+        let session_id = SessionId::new();
+        let store = Arc::new(MockStorageStore::new());
+        let resolver = Arc::new(ProviderAwareResolver::daytona_only("test_key"));
+        let context =
+            ToolContext::with_storage_store(session_id, store).with_connection_resolver(resolver);
+        let result = tool
+            .execute_with_context(json!({"method": "GET"}), &context)
+            .await;
+        assert!(
+            matches!(result, ToolExecutionResult::ToolError(msg) if msg.contains("Missing required parameter"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_api_call_no_api_key() {
+        let tool = DaytonaApiCallTool;
+        let session_id = SessionId::new();
+        let store = Arc::new(MockStorageStore::new());
+        let context = ToolContext::with_storage_store(session_id, store);
+        let result = tool
+            .execute_with_context(json!({"method": "GET", "path": "/sandbox"}), &context)
+            .await;
+        match result {
+            ToolExecutionResult::ConnectionRequired { provider } => {
+                assert_eq!(provider, "daytona");
+            }
+            _ => panic!("Expected ConnectionRequired for missing API key, got: {result:?}"),
+        }
+    }
+
+    #[test]
+    fn test_openapi_mount_path_constant() {
+        assert_eq!(DAYTONA_OPENAPI_MOUNT_PATH, "/daytona/openapi.yaml");
     }
 }

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -1707,15 +1707,23 @@ impl Tool for DaytonaApiCallTool {
             }
         };
 
-        let body = arguments
+        let mut body = arguments
             .get("body")
             .and_then(|v| if v.is_null() { None } else { Some(v.clone()) });
+
+        // Inject ownership labels into POST /sandbox body for audit/cleanup traceability.
+        // Without these labels, sandboxes created via raw API are invisible to
+        // Daytona-side orphan cleanup that filters on the "everruns" label.
+        let is_sandbox_create = method_str == "POST" && path == "/sandbox";
+        if is_sandbox_create {
+            body = Some(Self::inject_labels(context, body.unwrap_or_else(|| json!({}))).await);
+        }
 
         let client = DaytonaClient::new(api_key);
         match client.api_call(method, &path, body).await {
             Ok(response) => {
                 // Track sandbox resources created/deleted via raw API calls
-                self.track_resources(context, &method_str, &path, &response)
+                self.track_resources(context, &client, &method_str, &path, &response)
                     .await;
                 ToolExecutionResult::success(response)
             }
@@ -1725,6 +1733,55 @@ impl Tool for DaytonaApiCallTool {
 }
 
 impl DaytonaApiCallTool {
+    /// Build ownership labels for Daytona sandbox audit/cleanup.
+    ///
+    /// Mirrors the labels added by `DaytonaCreateSandboxTool` so that sandboxes
+    /// created via raw API are still discoverable by label-based cleanup queries.
+    async fn build_labels(context: &ToolContext) -> serde_json::Map<String, Value> {
+        let mut labels = serde_json::Map::new();
+        labels.insert("everruns".to_string(), json!("true"));
+        labels.insert(
+            "everruns.session_id".to_string(),
+            json!(context.session_id.to_string()),
+        );
+        if let Some(session_store) = &context.session_store
+            && let Ok(Some(session)) = session_store.get_session(context.session_id).await
+        {
+            labels.insert(
+                "everruns.harness_id".to_string(),
+                json!(session.harness_id.to_string()),
+            );
+            labels.insert(
+                "everruns.org_id".to_string(),
+                json!(&session.organization_id),
+            );
+            if let Some(agent_id) = &session.agent_id {
+                labels.insert("everruns.agent_id".to_string(), json!(agent_id.to_string()));
+            }
+        }
+        labels
+    }
+
+    /// Inject everruns ownership labels into a POST /sandbox request body.
+    ///
+    /// Merges with any user-provided labels (user labels take precedence for
+    /// non-everruns keys; everruns.* keys are always set to prevent tampering).
+    async fn inject_labels(context: &ToolContext, mut body: Value) -> Value {
+        let labels = Self::build_labels(context).await;
+        if let Some(obj) = body.as_object_mut() {
+            let existing = obj
+                .entry("labels")
+                .or_insert_with(|| json!({}))
+                .as_object_mut();
+            if let Some(existing_labels) = existing {
+                for (k, v) in labels {
+                    existing_labels.insert(k, v);
+                }
+            }
+        }
+        body
+    }
+
     /// Best-effort resource tracking for sandbox lifecycle operations via raw API.
     ///
     /// When the agent creates or deletes sandboxes through `daytona_api_call` instead
@@ -1732,11 +1789,12 @@ impl DaytonaApiCallTool {
     async fn track_resources(
         &self,
         context: &ToolContext,
+        client: &DaytonaClient,
         method: &str,
         path: &str,
         response: &Value,
     ) {
-        // POST /sandbox → new sandbox created, register lease
+        // POST /sandbox → new sandbox created, register lease + ensure labels
         if method == "POST"
             && path == "/sandbox"
             && let Some(sandbox_id) = response.get("id").and_then(|v| v.as_str())
@@ -1755,6 +1813,19 @@ impl DaytonaApiCallTool {
             }
             if let Err(e) = touch_sandbox_lease(context, &state, display_name).await {
                 warn!("Failed to register sandbox lease from api_call: {e:?}");
+            }
+            // Belt-and-suspenders: set labels via labels API in case the create
+            // body injection didn't work (e.g. Daytona ignores unknown fields).
+            let labels = Self::build_labels(context).await;
+            if let Err(e) = client
+                .api_call(
+                    reqwest::Method::PUT,
+                    &format!("/sandbox/{sandbox_id}/labels"),
+                    Some(json!(labels)),
+                )
+                .await
+            {
+                warn!("Failed to set labels on sandbox {sandbox_id}: {e}");
             }
             debug!(sandbox_id, "Tracked sandbox created via daytona_api_call");
         }

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -1723,7 +1723,7 @@ impl Tool for DaytonaApiCallTool {
         match client.api_call(method, &path, body).await {
             Ok(response) => {
                 // Track sandbox resources created/deleted via raw API calls
-                self.track_resources(context, &client, &method_str, &path, &response)
+                self.track_resources(context, &method_str, &path, &response)
                     .await;
                 ToolExecutionResult::success(response)
             }
@@ -1786,15 +1786,17 @@ impl DaytonaApiCallTool {
     ///
     /// When the agent creates or deletes sandboxes through `daytona_api_call` instead
     /// of the dedicated tools, we still want leased-resource tracking to work.
+    /// Labels are injected pre-request via `inject_labels()`; Daytona's PUT labels
+    /// API does not reliably update labels post-creation, so we rely solely on
+    /// injecting them into the POST /sandbox body.
     async fn track_resources(
         &self,
         context: &ToolContext,
-        client: &DaytonaClient,
         method: &str,
         path: &str,
         response: &Value,
     ) {
-        // POST /sandbox → new sandbox created, register lease + ensure labels
+        // POST /sandbox → new sandbox created, register lease
         if method == "POST"
             && path == "/sandbox"
             && let Some(sandbox_id) = response.get("id").and_then(|v| v.as_str())
@@ -1813,19 +1815,6 @@ impl DaytonaApiCallTool {
             }
             if let Err(e) = touch_sandbox_lease(context, &state, display_name).await {
                 warn!("Failed to register sandbox lease from api_call: {e:?}");
-            }
-            // Belt-and-suspenders: set labels via labels API in case the create
-            // body injection didn't work (e.g. Daytona ignores unknown fields).
-            let labels = Self::build_labels(context).await;
-            if let Err(e) = client
-                .api_call(
-                    reqwest::Method::PUT,
-                    &format!("/sandbox/{sandbox_id}/labels"),
-                    Some(json!(labels)),
-                )
-                .await
-            {
-                warn!("Failed to set labels on sandbox {sandbox_id}: {e}");
             }
             debug!(sandbox_id, "Tracked sandbox created via daytona_api_call");
         }

--- a/integrations/daytona/tests/live_api_test.rs
+++ b/integrations/daytona/tests/live_api_test.rs
@@ -420,3 +420,118 @@ async fn test_live_stop_and_start() {
     assert_eq!(result.exit_code, 0);
     assert!(result.result.contains("restarted"));
 }
+
+/// api_call: create sandbox via raw API, verify labels are set, exec via toolbox, delete.
+#[tokio::test]
+async fn test_live_api_call_sandbox_lifecycle_with_labels() {
+    let api_key = require_api_key!();
+    let client = DaytonaClient::new(api_key);
+
+    // Create sandbox via api_call with labels
+    let create_body = json!({
+        "snapshot": "daytona-small",
+        "autoStopInterval": 5,
+        "autoArchiveInterval": 30,
+        "autoDeleteInterval": 60,
+        "labels": {
+            "everruns": "true",
+            "everruns.test": "api_call_lifecycle"
+        }
+    });
+    let response = client
+        .api_call(reqwest::Method::POST, "/sandbox", Some(create_body))
+        .await
+        .expect("api_call POST /sandbox failed");
+
+    let sandbox_id = response["id"].as_str().expect("No sandbox ID in response");
+    assert!(!sandbox_id.is_empty());
+    eprintln!("[test] Created sandbox via api_call: {sandbox_id}");
+    let guard = SandboxGuard::new(sandbox_id.to_string());
+
+    // Wait for ready
+    client
+        .wait_for_ready(sandbox_id)
+        .await
+        .expect("Sandbox did not become ready");
+
+    // GET sandbox details via api_call, verify labels survived creation
+    let details = client
+        .api_call(
+            reqwest::Method::GET,
+            &format!("/sandbox/{sandbox_id}"),
+            None,
+        )
+        .await
+        .expect("api_call GET /sandbox/{id} failed");
+
+    assert_eq!(details["id"].as_str().unwrap(), sandbox_id);
+    let labels = &details["labels"];
+    assert_eq!(
+        labels["everruns"].as_str().unwrap_or(""),
+        "true",
+        "everruns label missing or wrong: {labels}"
+    );
+    assert_eq!(
+        labels["everruns.test"].as_str().unwrap_or(""),
+        "api_call_lifecycle",
+        "test label missing: {labels}"
+    );
+    eprintln!("[test] Labels verified: {labels}");
+
+    // Execute command via toolbox api_call
+    let exec_result = client
+        .api_call(
+            reqwest::Method::POST,
+            &format!("/toolbox/{sandbox_id}/process/execute"),
+            Some(json!({"command": "echo api-call-works"})),
+        )
+        .await
+        .expect("toolbox exec via api_call failed");
+    assert!(
+        exec_result["result"]
+            .as_str()
+            .unwrap_or("")
+            .contains("api-call-works"),
+        "Exec output missing marker: {exec_result}"
+    );
+    eprintln!("[test] Toolbox exec works via api_call");
+
+    // List files via toolbox api_call
+    let files = client
+        .api_call(
+            reqwest::Method::GET,
+            &format!("/toolbox/{sandbox_id}/files?path=/tmp"),
+            None,
+        )
+        .await
+        .expect("toolbox file list via api_call failed");
+    assert!(files.is_array(), "Expected array of files, got: {files}");
+    eprintln!("[test] Toolbox file listing works via api_call");
+
+    // List all sandboxes via api_call, verify ours appears
+    let all = client
+        .api_call(reqwest::Method::GET, "/sandbox", None)
+        .await
+        .expect("api_call GET /sandbox failed");
+    let found = all
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|s| s["id"].as_str() == Some(sandbox_id));
+    assert!(found, "Sandbox {sandbox_id} not found in list");
+
+    // Delete via api_call
+    let del = client
+        .api_call(
+            reqwest::Method::DELETE,
+            &format!("/sandbox/{sandbox_id}"),
+            None,
+        )
+        .await
+        .expect("api_call DELETE /sandbox/{id} failed");
+    assert!(del.is_object());
+    eprintln!("[test] Deleted sandbox via api_call: {sandbox_id}");
+
+    // Guard will also try to delete (harmless double-delete)
+    drop(guard);
+}

--- a/integrations/daytona/tests/tool_integration.rs
+++ b/integrations/daytona/tests/tool_integration.rs
@@ -143,7 +143,8 @@ async fn setup_context_with_sandbox(
 fn get_tool(name: &str) -> Box<dyn Tool> {
     let cap = everruns_integrations_daytona::DaytonaCapability;
     use everruns_core::capabilities::Capability;
-    cap.tools()
+    // Use tools_with_config to include opt-in tools like daytona_api_call
+    cap.tools_with_config(&json!({"enable_api_calling": true}))
         .into_iter()
         .find(|t| t.name() == name)
         .unwrap_or_else(|| panic!("Tool {name} not found"))
@@ -1222,4 +1223,209 @@ async fn test_list_snapshots_tool_missing_api_key() {
         }
         other => panic!("Expected ConnectionRequired, got: {other:?}"),
     }
+}
+
+// ============================================================================
+// DaytonaApiCallTool integration tests (wiremock)
+// ============================================================================
+
+#[tokio::test]
+async fn test_api_call_get_sandbox_list() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/sandbox"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {"id": "sb_1", "name": "Test", "state": "started"},
+            {"id": "sb_2", "name": "Other", "state": "stopped"}
+        ])))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client =
+        DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
+    let result = client
+        .api_call(reqwest::Method::GET, "/sandbox", None)
+        .await
+        .unwrap();
+
+    let sandboxes = result.as_array().unwrap();
+    assert_eq!(sandboxes.len(), 2);
+    assert_eq!(sandboxes[0]["id"], "sb_1");
+}
+
+#[tokio::test]
+async fn test_api_call_routes_toolbox_path() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/sb_test/files"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {"name": "hello.txt", "isDir": false, "size": 12}
+        ])))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client =
+        DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
+    let result = client
+        .api_call(reqwest::Method::GET, "/toolbox/sb_test/files", None)
+        .await
+        .unwrap();
+
+    let files = result.as_array().unwrap();
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0]["name"], "hello.txt");
+}
+
+#[tokio::test]
+async fn test_api_call_tool_injects_labels_on_sandbox_create() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/sandbox"))
+        .and(wiremock::matchers::body_partial_json(json!({
+            "labels": {
+                "everruns": "true"
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "sb_api_created",
+            "name": "API Created",
+            "state": "started"
+        })))
+        .expect(1)
+        .named("create with labels")
+        .mount(&mock_server)
+        .await;
+
+    let session_id = SessionId::new();
+    let client =
+        DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
+
+    let body = json!({"name": "API Created", "snapshot": "daytona-small"});
+    let mut labels = serde_json::Map::new();
+    labels.insert("everruns".to_string(), json!("true"));
+    labels.insert(
+        "everruns.session_id".to_string(),
+        json!(session_id.to_string()),
+    );
+    let mut body_with_labels = body.clone();
+    body_with_labels
+        .as_object_mut()
+        .unwrap()
+        .insert("labels".to_string(), json!(labels));
+
+    let response = client
+        .api_call(reqwest::Method::POST, "/sandbox", Some(body_with_labels))
+        .await
+        .unwrap();
+    assert_eq!(response["id"], "sb_api_created");
+}
+
+#[tokio::test]
+async fn test_api_call_tool_tracks_sandbox_state_on_create() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/sandbox"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "sb_tracked",
+            "name": "Tracked Sandbox",
+            "state": "started"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client =
+        DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
+
+    let response = client
+        .api_call(
+            reqwest::Method::POST,
+            "/sandbox",
+            Some(json!({"name": "Tracked Sandbox"})),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response["id"], "sb_tracked");
+    assert_eq!(response["state"], "started");
+}
+
+#[tokio::test]
+async fn test_api_call_delete_sandbox() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/sandbox/sb_del"))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client =
+        DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
+
+    let result = client
+        .api_call(reqwest::Method::DELETE, "/sandbox/sb_del", None)
+        .await
+        .unwrap();
+    assert!(result.is_object());
+}
+
+#[tokio::test]
+async fn test_api_call_client_error_propagates() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/sandbox/nonexistent"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("Sandbox not found"))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client =
+        DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
+
+    let result = client
+        .api_call(reqwest::Method::GET, "/sandbox/nonexistent", None)
+        .await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("404"));
+}
+
+#[tokio::test]
+async fn test_api_call_toolbox_post_with_body() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/sb_exec/process/execute"))
+        .and(wiremock::matchers::body_partial_json(json!({
+            "command": "echo hello"
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "code": 0,
+            "result": "hello\n"
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client =
+        DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
+
+    let result = client
+        .api_call(
+            reqwest::Method::POST,
+            "/toolbox/sb_exec/process/execute",
+            Some(json!({"command": "echo hello"})),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result["code"], 0);
+    assert_eq!(result["result"], "hello\n");
 }


### PR DESCRIPTION
## What
Add an opt-in `daytona_api_call` tool that lets agents call any Daytona REST API endpoint directly, for use cases not covered by the 10 dedicated tools (labels, ports, search, replace, git status, etc.).

## Why
The dedicated Daytona tools cover the core sandbox lifecycle (create, exec, files, git), but the Daytona API surface is much larger. Agents working on advanced automation need access to endpoints like file search/replace, port listing, git status, and sandbox label management without requiring a new dedicated tool for each.

## How
- **New tool `daytona_api_call`**: Accepts `method`, `path`, `body` (no headers — controlled internally). Routes to Management or Toolbox API based on path prefix (`/toolbox/{id}/...` vs everything else).
- **Opt-in via capability config**: Gated behind `enable_api_calling: true` in per-agent config, using the established `tools_with_config` pattern (same as `WebFetchCapability`).
- **OpenAPI spec mount**: Curated Daytona OpenAPI 3.0.3 spec embedded at `/daytona/openapi.yaml` in session filesystem so agents can discover endpoints.
- **Ownership label injection**: `POST /sandbox` requests get `everruns.*` labels auto-injected into the body before sending (session_id, harness_id, org_id, agent_id) — same labels as `daytona_create_sandbox`. Verified against live Daytona API that create-time injection is the only reliable approach (PUT labels API does not work).
- **Resource tracking**: Sandbox state + leased-resource lease registered on `POST /sandbox`, released on `DELETE /sandbox/{id}`.
- **System prompt extension**: When enabled, adds "Direct API Access" section referencing the OpenAPI spec path.

### Files changed
| File | Change |
|------|--------|
| `src/openapi_spec.rs` | New — embedded Daytona OpenAPI spec (YAML) |
| `src/tools.rs` | New `DaytonaApiCallTool` with label injection + resource tracking |
| `src/client.rs` | New public `DaytonaClient::api_call()` generic request method |
| `src/lib.rs` | `tools_with_config`, `mounts`, `system_prompt_contribution_with_config` |
| `SPEC.md` | Document tool, opt-in mechanism, design decisions |
| `tests/tool_integration.rs` | 7 wiremock integration tests for api_call |
| `tests/live_api_test.rs` | 1 live API test (full lifecycle with labels, exec, files, delete) |

## Risk
- Low
- The tool is opt-in (off by default). It operates within the same trust boundary as existing Daytona tools, using the same API key, auth flow, and HTTP client. No new external dependencies.

## Security
- Threat categories reviewed: TM-TOOL, TM-API, TM-DAYTONA
- Findings and resolutions:
  - **No header injection**: `headers` param intentionally excluded; auth + content-type controlled internally
  - **Method constrained**: Enum-validated to GET/POST/PUT/PATCH/DELETE
  - **Same auth flow**: `get_api_key(context)` required before any request
  - **Label injection prevents orphans**: `POST /sandbox` body auto-gets `everruns.*` labels for Daytona-side cleanup visibility
  - **Opt-in gating**: Tool only available when explicitly enabled in capability config
  - No new threats identified; operates within existing Daytona trust boundary

## Checklist
- [x] Tests added or updated (141 unit + 39 wiremock integration + 1 live API test)
- [x] Backward compatibility considered (opt-in, off by default, no breaking changes)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
