### PR TITLE
feat(budgeting): implement real check_budget tool via gRPC

### DIFF
--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -180,6 +180,8 @@ where
     org_id: Option<crate::typed_id::OrgId>,
     /// Merged network access list for URL filtering in tools.
     network_access: Option<crate::network_access::NetworkAccessList>,
+    /// Optional budget checker for the check_budget tool.
+    budget_checker: Option<Arc<dyn crate::traits::BudgetChecker>>,
     /// Post-act hooks that run after tool execution completes.
     /// Hooks inspect the result and may emit events (e.g. tool.call_requested).
     hooks: Vec<Box<dyn PostActHook>>,
@@ -215,6 +217,7 @@ where
             memory_store: None,
             org_id: None,
             network_access: None,
+            budget_checker: None,
             hooks: Self::default_hooks(),
             post_tool_hooks: Vec::new(),
             final_post_tool_hooks: Self::default_final_hooks(),
@@ -244,6 +247,7 @@ where
             memory_store: None,
             org_id: None,
             network_access: None,
+            budget_checker: None,
             hooks: Self::default_hooks(),
             post_tool_hooks: Vec::new(),
             final_post_tool_hooks: Self::default_final_hooks(),
@@ -380,6 +384,12 @@ where
         network_access: Option<crate::network_access::NetworkAccessList>,
     ) -> Self {
         self.network_access = network_access;
+        self
+    }
+
+    /// Set the budget checker for the check_budget tool.
+    pub fn with_budget_checker(mut self, checker: Arc<dyn crate::traits::BudgetChecker>) -> Self {
+        self.budget_checker = Some(checker);
         self
     }
 }
@@ -803,6 +813,9 @@ where
         }
         if let Some(ref store) = self.memory_store {
             tool_context.memory_store = Some(store.clone());
+        }
+        if let Some(ref checker) = self.budget_checker {
+            tool_context.budget_checker = Some(checker.clone());
         }
         tool_context.org_id = self.org_id;
         // Input network_access (per-session, merged from harness+agent+session) takes precedence

--- a/crates/core/src/budget.rs
+++ b/crates/core/src/budget.rs
@@ -219,3 +219,31 @@ impl BudgetCheckResult {
         self.action == "pause"
     }
 }
+
+// ============================================================================
+// Budget tool response (returned by check_budget tool)
+// ============================================================================
+
+/// Summary of a single budget for the check_budget tool response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BudgetSummary {
+    pub currency: String,
+    pub limit: f64,
+    pub balance: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub soft_limit: Option<f64>,
+    pub percent_remaining: f64,
+    pub status: String,
+}
+
+/// Full response from the check_budget tool.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BudgetToolResponse {
+    /// Overall status: "active", "warning", "paused", "exhausted", "no_budgets"
+    pub status: String,
+    /// Per-budget summaries
+    pub budgets: Vec<BudgetSummary>,
+    /// Human-readable hint for the agent
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hint: Option<String>,
+}

--- a/crates/core/src/capabilities/budgeting.rs
+++ b/crates/core/src/capabilities/budgeting.rs
@@ -13,6 +13,7 @@
 use super::{Capability, CapabilityStatus};
 use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
+use crate::traits::ToolContext;
 use async_trait::async_trait;
 use serde_json::Value;
 
@@ -112,12 +113,37 @@ impl Tool for CheckBudgetTool {
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
-        // This is a placeholder implementation. Real budget data requires
-        // worker-side tool interception, planned for a future iteration.
+        // Fallback when no context is available (shouldn't happen in practice).
         ToolExecutionResult::success(serde_json::json!({
             "status": "no_budgets",
             "message": "No budgets are configured for this session. You can proceed without budget constraints."
         }))
+    }
+
+    async fn execute_with_context(
+        &self,
+        _arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let Some(ref checker) = context.budget_checker else {
+            // No budget checker wired — return the no_budgets fallback.
+            return self.execute(_arguments).await;
+        };
+
+        let session_id = context.session_id.to_string();
+
+        match checker.check_budgets(&session_id).await
+        {
+            Ok(response) => ToolExecutionResult::success(
+                serde_json::to_value(&response).unwrap_or_else(|_| {
+                    serde_json::json!({"status": "error", "message": "Failed to serialize budget data"})
+                }),
+            ),
+            Err(e) => ToolExecutionResult::success(serde_json::json!({
+                "status": "error",
+                "message": format!("Failed to check budgets: {e}")
+            })),
+        }
     }
 }
 
@@ -161,9 +187,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_check_budget_tool_no_budgets() {
+    async fn test_check_budget_tool_no_budgets_fallback() {
         let tool = CheckBudgetTool;
+        // Without context, falls back to no_budgets
         let result = tool.execute(serde_json::json!({})).await;
+        if let ToolExecutionResult::Success(value) = result {
+            assert_eq!(value.get("status").unwrap().as_str().unwrap(), "no_budgets");
+        } else {
+            panic!("Expected success");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_check_budget_tool_with_context_no_checker() {
+        use crate::typed_id::SessionId;
+        let tool = CheckBudgetTool;
+        // With context but no budget_checker, also falls back
+        let context = ToolContext::new(SessionId::new());
+        let result = tool
+            .execute_with_context(serde_json::json!({}), &context)
+            .await;
         if let ToolExecutionResult::Success(value) = result {
             assert_eq!(value.get("status").unwrap().as_str().unwrap(), "no_budgets");
         } else {

--- a/crates/core/src/capabilities/budgeting.rs
+++ b/crates/core/src/capabilities/budgeting.rs
@@ -114,9 +114,11 @@ impl Tool for CheckBudgetTool {
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
         // Fallback when no context is available (shouldn't happen in practice).
+        // Returns the same BudgetToolResponse shape for contract stability.
         ToolExecutionResult::success(serde_json::json!({
             "status": "no_budgets",
-            "message": "No budgets are configured for this session. You can proceed without budget constraints."
+            "budgets": [],
+            "hint": "No budgets are configured for this session. You can proceed without budget constraints."
         }))
     }
 
@@ -132,17 +134,15 @@ impl Tool for CheckBudgetTool {
 
         let session_id = context.session_id.to_string();
 
-        match checker.check_budgets(&session_id).await
-        {
-            Ok(response) => ToolExecutionResult::success(
-                serde_json::to_value(&response).unwrap_or_else(|_| {
-                    serde_json::json!({"status": "error", "message": "Failed to serialize budget data"})
-                }),
+        match checker.check_budgets(&session_id).await {
+            Ok(response) => {
+                ToolExecutionResult::success(serde_json::to_value(&response).unwrap_or_else(
+                    |_| serde_json::json!({"status": "no_budgets", "budgets": [], "hint": null}),
+                ))
+            }
+            Err(_) => ToolExecutionResult::tool_error(
+                "Budget check is temporarily unavailable. You can proceed normally.",
             ),
-            Err(e) => ToolExecutionResult::success(serde_json::json!({
-                "status": "error",
-                "message": format!("Failed to check budgets: {e}")
-            })),
         }
     }
 }
@@ -189,10 +189,12 @@ mod tests {
     #[tokio::test]
     async fn test_check_budget_tool_no_budgets_fallback() {
         let tool = CheckBudgetTool;
-        // Without context, falls back to no_budgets
+        // Without context, falls back to no_budgets with stable shape
         let result = tool.execute(serde_json::json!({})).await;
         if let ToolExecutionResult::Success(value) = result {
             assert_eq!(value.get("status").unwrap().as_str().unwrap(), "no_budgets");
+            assert!(value.get("budgets").unwrap().as_array().unwrap().is_empty());
+            assert!(value.get("hint").is_some());
         } else {
             panic!("Expected success");
         }
@@ -209,6 +211,71 @@ mod tests {
             .await;
         if let ToolExecutionResult::Success(value) = result {
             assert_eq!(value.get("status").unwrap().as_str().unwrap(), "no_budgets");
+            assert!(value.get("budgets").unwrap().as_array().unwrap().is_empty());
+        } else {
+            panic!("Expected success");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_check_budget_tool_with_mock_checker() {
+        use crate::budget::{BudgetSummary, BudgetToolResponse};
+        use crate::traits::BudgetChecker;
+        use crate::typed_id::SessionId;
+        use std::sync::Arc;
+
+        struct MockBudgetChecker;
+
+        #[async_trait]
+        impl BudgetChecker for MockBudgetChecker {
+            async fn check_budgets(
+                &self,
+                _session_id: &str,
+            ) -> crate::error::Result<BudgetToolResponse> {
+                Ok(BudgetToolResponse {
+                    status: "active".into(),
+                    budgets: vec![BudgetSummary {
+                        currency: "usd".into(),
+                        limit: 5.0,
+                        balance: 2.56,
+                        soft_limit: None,
+                        percent_remaining: 51.2,
+                        status: "active".into(),
+                    }],
+                    hint: Some("51.2% of budget remaining.".into()),
+                })
+            }
+        }
+
+        let tool = CheckBudgetTool;
+        let mut context = ToolContext::new(SessionId::new());
+        context.budget_checker = Some(Arc::new(MockBudgetChecker));
+
+        let result = tool
+            .execute_with_context(serde_json::json!({}), &context)
+            .await;
+        if let ToolExecutionResult::Success(value) = result {
+            assert_eq!(value.get("status").unwrap().as_str().unwrap(), "active");
+            let budgets = value.get("budgets").unwrap().as_array().unwrap();
+            assert_eq!(budgets.len(), 1);
+            assert_eq!(budgets[0].get("currency").unwrap().as_str().unwrap(), "usd");
+            assert_eq!(budgets[0].get("balance").unwrap().as_f64().unwrap(), 2.56);
+            assert_eq!(
+                budgets[0]
+                    .get("percent_remaining")
+                    .unwrap()
+                    .as_f64()
+                    .unwrap(),
+                51.2
+            );
+            assert!(
+                value
+                    .get("hint")
+                    .unwrap()
+                    .as_str()
+                    .unwrap()
+                    .contains("51.2%")
+            );
         } else {
             panic!("Expected success");
         }

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -474,6 +474,21 @@ pub trait UserConnectionResolver: Send + Sync {
     }
 }
 
+// ============================================================================
+// BudgetChecker - For querying budget status from tools
+// ============================================================================
+
+/// Trait for checking budget status from within tool execution.
+///
+/// Implemented by gRPC adapters (worker → server) and direct adapters (in-process).
+/// Used by the `check_budget` tool to return real budget data to agents.
+/// The org_id is captured at construction time by the implementing adapter.
+#[async_trait]
+pub trait BudgetChecker: Send + Sync {
+    /// Check all budgets for a session and return a tool-friendly response.
+    async fn check_budgets(&self, session_id: &str) -> Result<crate::budget::BudgetToolResponse>;
+}
+
 /// Runtime context provided to tools during execution.
 ///
 /// This context contains:
@@ -547,6 +562,9 @@ pub struct ToolContext {
     /// When set, tools that support localization use this to produce
     /// locale-appropriate descriptions, error messages, and prompts.
     pub locale: Option<String>,
+
+    /// Optional budget checker for the check_budget tool.
+    pub budget_checker: Option<Arc<dyn BudgetChecker>>,
 }
 
 impl ToolContext {
@@ -573,6 +591,7 @@ impl ToolContext {
             org_id: None,
             network_access: None,
             locale: None,
+            budget_checker: None,
         }
     }
 
@@ -599,6 +618,7 @@ impl ToolContext {
             org_id: None,
             network_access: None,
             locale: None,
+            budget_checker: None,
         }
     }
 
@@ -628,6 +648,7 @@ impl ToolContext {
             org_id: None,
             network_access: None,
             locale: None,
+            budget_checker: None,
         }
     }
 
@@ -658,6 +679,7 @@ impl ToolContext {
             org_id: None,
             network_access: None,
             locale: None,
+            budget_checker: None,
         }
     }
 

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -241,6 +241,10 @@ service WorkerService {
 
     // Base URL for UI links
     rpc PlatformGetBaseUrl(PlatformGetBaseUrlRequest) returns (PlatformGetBaseUrlResponse);
+
+    // === Budget operations ===
+    // Check budget status for a session (used by check_budget tool)
+    rpc CheckBudgetsForSession(CheckBudgetsForSessionRequest) returns (CheckBudgetsForSessionResponse);
 }
 
 // ============================================================================
@@ -1631,4 +1635,27 @@ message PlatformGetBaseUrlRequest {}
 
 message PlatformGetBaseUrlResponse {
     string base_url = 1;
+}
+
+// === Budget check messages ===
+
+message CheckBudgetsForSessionRequest {
+    int64 org_id = 1;
+    string session_id = 2;
+    optional string agent_id = 3;
+}
+
+message BudgetSummaryProto {
+    string currency = 1;
+    double limit = 2;
+    double balance = 3;
+    optional double soft_limit = 4;
+    double percent_remaining = 5;
+    string status = 6;
+}
+
+message CheckBudgetsForSessionResponse {
+    string status = 1;
+    repeated BudgetSummaryProto budgets = 2;
+    optional string hint = 3;
 }

--- a/crates/server/src/grpc_service/mod.rs
+++ b/crates/server/src/grpc_service/mod.rs
@@ -31,9 +31,13 @@ use everruns_internal_protocol::proto::{
     self,
     AddMessageRequest,
     AddMessageResponse,
+    BudgetSummaryProto,
     // Session schedule operations
     CancelSessionScheduleRequest,
     CancelSessionScheduleResponse,
+    // Budget operations
+    CheckBudgetsForSessionRequest,
+    CheckBudgetsForSessionResponse,
     CheckCircuitBreakerRequest,
     CheckCircuitBreakerResponse,
     CircuitBreakerState as ProtoCircuitBreakerState,
@@ -351,6 +355,8 @@ pub struct WorkerServiceImpl {
     api_base_url: Option<String>,
     /// Signing secret for presigned URLs (WORKER_GRPC_AUTH_TOKEN)
     presign_secret: Option<String>,
+    /// Budget service for check_budget tool
+    budget_service: Arc<crate::services::BudgetService>,
 }
 
 impl WorkerServiceImpl {
@@ -422,6 +428,8 @@ impl WorkerServiceImpl {
             .ok()
             .filter(|s| !s.is_empty());
 
+        let budget_service = Arc::new(crate::services::BudgetService::new(db.clone()));
+
         Self {
             event_service,
             agent_service,
@@ -440,6 +448,7 @@ impl WorkerServiceImpl {
             connection_resolver,
             api_base_url,
             presign_secret,
+            budget_service,
         }
     }
 

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -3334,6 +3334,102 @@ impl WorkerService for WorkerServiceImpl {
 
         Ok(Response::new(PlatformGetBaseUrlResponse { base_url }))
     }
+
+    // =========================================================================
+    // Budget Operations
+    // =========================================================================
+
+    async fn check_budgets_for_session(
+        &self,
+        request: Request<CheckBudgetsForSessionRequest>,
+    ) -> Result<Response<CheckBudgetsForSessionResponse>, Status> {
+        let req = request.into_inner();
+
+        // Get the full budget rows for detailed response
+        let session_budgets = self
+            .db
+            .list_budgets(req.org_id, Some("session"), Some(&req.session_id))
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to list session budgets: {}", e);
+                Status::internal("Failed to list session budgets")
+            })?;
+
+        let mut all_budgets = session_budgets;
+        if let Some(ref agent_id) = req.agent_id
+            && let Ok(agent_budgets) = self
+                .db
+                .list_budgets(req.org_id, Some("agent"), Some(agent_id))
+                .await
+        {
+            all_budgets.extend(agent_budgets);
+        }
+
+        if all_budgets.is_empty() {
+            return Ok(Response::new(CheckBudgetsForSessionResponse {
+                status: "no_budgets".into(),
+                budgets: vec![],
+                hint: Some(
+                    "No budgets are configured for this session. You can proceed without budget constraints.".into(),
+                ),
+            }));
+        }
+
+        // Also run the action check to determine overall status
+        let check_result = self
+            .budget_service
+            .check_budgets_for_session(req.org_id, &req.session_id, req.agent_id.as_deref())
+            .await;
+
+        let summaries: Vec<BudgetSummaryProto> = all_budgets
+            .iter()
+            .map(|b| {
+                let pct = if b.limit > 0.0 {
+                    (b.balance / b.limit * 100.0).clamp(0.0, 100.0)
+                } else {
+                    100.0
+                };
+                BudgetSummaryProto {
+                    currency: b.currency.clone(),
+                    limit: b.limit,
+                    balance: b.balance,
+                    soft_limit: b.soft_limit,
+                    percent_remaining: (pct * 10.0).round() / 10.0,
+                    status: b.status.clone(),
+                }
+            })
+            .collect();
+
+        let overall_status = match check_result.action.as_str() {
+            "stop" => "exhausted",
+            "pause" => "paused",
+            "warn" => "warning",
+            _ => "active",
+        };
+
+        let hint = if overall_status == "active" {
+            let min_pct = summaries
+                .iter()
+                .map(|s| s.percent_remaining)
+                .min_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+                .unwrap_or(100.0);
+            if min_pct < 50.0 {
+                Some(format!(
+                    "{min_pct}% of budget remaining. Consider prioritizing task completion."
+                ))
+            } else {
+                Some(format!("{min_pct}% of budget remaining."))
+            }
+        } else {
+            check_result.message.clone()
+        };
+
+        Ok(Response::new(CheckBudgetsForSessionResponse {
+            status: overall_status.into(),
+            budgets: summaries,
+            hint,
+        }))
+    }
 }
 
 // Helper functions for status conversion

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -3356,13 +3356,17 @@ impl WorkerService for WorkerServiceImpl {
             })?;
 
         let mut all_budgets = session_budgets;
-        if let Some(ref agent_id) = req.agent_id
-            && let Ok(agent_budgets) = self
+        if let Some(ref agent_id) = req.agent_id {
+            match self
                 .db
                 .list_budgets(req.org_id, Some("agent"), Some(agent_id))
                 .await
-        {
-            all_budgets.extend(agent_budgets);
+            {
+                Ok(agent_budgets) => all_budgets.extend(agent_budgets),
+                Err(e) => {
+                    tracing::error!("Failed to list agent budgets for {agent_id}: {e}");
+                }
+            }
         }
 
         if all_budgets.is_empty() {

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -439,8 +439,10 @@ pub async fn act_activity(
         Arc::new(GrpcScheduleStore::new(grpc_client.clone(), org_id));
     let platform_store: Arc<dyn everruns_core::platform_store::PlatformStore> =
         Arc::new(GrpcPlatformStore::new(grpc_client.clone(), org_id));
-    let budget_checker: Arc<dyn everruns_core::traits::BudgetChecker> =
-        Arc::new(GrpcBudgetChecker::new(grpc_client, org_id));
+    let budget_checker: Arc<dyn everruns_core::traits::BudgetChecker> = Arc::new(
+        GrpcBudgetChecker::new(grpc_client, org_id)
+            .with_agent_id(input.agent_id.map(|id| id.to_string())),
+    );
 
     let atom = ActAtom::with_file_store(tool_executor, event_emitter, file_store)
         .with_storage_store(storage_store)

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -21,10 +21,10 @@ use everruns_core::{Message, PlatformDefinition};
 use std::sync::Arc;
 
 use crate::grpc_adapters::{
-    GrpcAgentStore, GrpcClient, GrpcConnectionResolver, GrpcEventEmitter, GrpcHarnessStore,
-    GrpcImageResolver, GrpcLeasedResourceStore, GrpcLlmProviderStore, GrpcMessageRetriever,
-    GrpcPlatformStore, GrpcScheduleStore, GrpcSessionFileStore, GrpcSessionMutator,
-    GrpcSessionSqlDbStore, GrpcSessionStorageStore, GrpcSessionStore,
+    GrpcAgentStore, GrpcBudgetChecker, GrpcClient, GrpcConnectionResolver, GrpcEventEmitter,
+    GrpcHarnessStore, GrpcImageResolver, GrpcLeasedResourceStore, GrpcLlmProviderStore,
+    GrpcMessageRetriever, GrpcPlatformStore, GrpcScheduleStore, GrpcSessionFileStore,
+    GrpcSessionMutator, GrpcSessionSqlDbStore, GrpcSessionStorageStore, GrpcSessionStore,
 };
 
 // Re-export atom types for activity callers
@@ -438,7 +438,9 @@ pub async fn act_activity(
     let schedule_store: Arc<dyn everruns_core::traits::SessionScheduleStore> =
         Arc::new(GrpcScheduleStore::new(grpc_client.clone(), org_id));
     let platform_store: Arc<dyn everruns_core::platform_store::PlatformStore> =
-        Arc::new(GrpcPlatformStore::new(grpc_client, org_id));
+        Arc::new(GrpcPlatformStore::new(grpc_client.clone(), org_id));
+    let budget_checker: Arc<dyn everruns_core::traits::BudgetChecker> =
+        Arc::new(GrpcBudgetChecker::new(grpc_client, org_id));
 
     let atom = ActAtom::with_file_store(tool_executor, event_emitter, file_store)
         .with_storage_store(storage_store)
@@ -450,6 +452,7 @@ pub async fn act_activity(
         .with_leased_resource_store(leased_resource_store)
         .with_schedule_store(schedule_store)
         .with_platform_store(platform_store)
+        .with_budget_checker(budget_checker)
         .with_capability_registry(platform_definition.capability_registry().clone())
         // Collect post-tool hooks from all capabilities. Hooks self-gate on tool hints
         // (e.g. persist_output), so this is safe even though it uses the full registry

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -376,15 +376,26 @@ pub type GrpcImageResolver = GrpcOrgAdapter;
 pub type GrpcSessionMutator = GrpcOrgAdapter;
 pub type GrpcScheduleStore = GrpcOrgAdapter;
 pub type GrpcPlatformStore = GrpcOrgAdapter;
-/// Budget checker that carries org_id (captured at construction) for gRPC calls.
+/// Budget checker that carries org_id and optional agent_id (captured at
+/// construction) for gRPC calls.
 pub struct GrpcBudgetChecker {
     client: GrpcClient,
     org_id: i64,
+    agent_id: Option<String>,
 }
 
 impl GrpcBudgetChecker {
     pub fn new(client: GrpcClient, org_id: i64) -> Self {
-        Self { client, org_id }
+        Self {
+            client,
+            org_id,
+            agent_id: None,
+        }
+    }
+
+    pub fn with_agent_id(mut self, agent_id: Option<String>) -> Self {
+        self.agent_id = agent_id;
+        self
     }
 }
 
@@ -2667,7 +2678,7 @@ impl everruns_core::traits::BudgetChecker for GrpcBudgetChecker {
         let request = proto::CheckBudgetsForSessionRequest {
             org_id: self.org_id,
             session_id: session_id.to_string(),
-            agent_id: None,
+            agent_id: self.agent_id.clone(),
         };
         let response = client
             .check_budgets_for_session(request)

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -376,6 +376,17 @@ pub type GrpcImageResolver = GrpcOrgAdapter;
 pub type GrpcSessionMutator = GrpcOrgAdapter;
 pub type GrpcScheduleStore = GrpcOrgAdapter;
 pub type GrpcPlatformStore = GrpcOrgAdapter;
+/// Budget checker that carries org_id (captured at construction) for gRPC calls.
+pub struct GrpcBudgetChecker {
+    client: GrpcClient,
+    org_id: i64,
+}
+
+impl GrpcBudgetChecker {
+    pub fn new(client: GrpcClient, org_id: i64) -> Self {
+        Self { client, org_id }
+    }
+}
 
 // ============================================================================
 // Helper functions for proto conversion
@@ -2639,6 +2650,46 @@ fn proto_value_to_json(value: prost_types::Value) -> serde_json::Value {
             serde_json::Value::Object(map)
         }
         None => serde_json::Value::Null,
+    }
+}
+
+// ============================================================================
+// BudgetChecker — check budget status from check_budget tool
+// ============================================================================
+
+#[async_trait]
+impl everruns_core::traits::BudgetChecker for GrpcBudgetChecker {
+    async fn check_budgets(
+        &self,
+        session_id: &str,
+    ) -> everruns_core::error::Result<everruns_core::budget::BudgetToolResponse> {
+        let mut client = self.client.inner.lock().await;
+        let request = proto::CheckBudgetsForSessionRequest {
+            org_id: self.org_id,
+            session_id: session_id.to_string(),
+            agent_id: None,
+        };
+        let response = client
+            .check_budgets_for_session(request)
+            .await
+            .map_err(grpc_status_to_error)?;
+        let resp = response.into_inner();
+        Ok(everruns_core::budget::BudgetToolResponse {
+            status: resp.status,
+            budgets: resp
+                .budgets
+                .into_iter()
+                .map(|b| everruns_core::budget::BudgetSummary {
+                    currency: b.currency,
+                    limit: b.limit,
+                    balance: b.balance,
+                    soft_limit: b.soft_limit,
+                    percent_remaining: b.percent_remaining,
+                    status: b.status,
+                })
+                .collect(),
+            hint: resp.hint,
+        })
     }
 }
 


### PR DESCRIPTION
## What
Wire the `check_budget` tool through the full gRPC stack so agents see real budget data instead of a hardcoded "no_budgets" placeholder.

## Why
The `check_budget` tool always returned `{"status": "no_budgets"}` regardless of actual budget state (EVE-253). Agents had no way to know their remaining budget, leading to blind retries and silent budget exhaustion.

## How
- **Core trait**: Add `BudgetChecker` trait + `BudgetToolResponse`/`BudgetSummary` types
- **ToolContext**: Add `budget_checker` field, wired through `ActAtom`
- **gRPC**: Add `CheckBudgetsForSession` RPC to internal protocol
- **Server handler**: Query `list_budgets` for per-budget details + `check_budgets_for_session` for overall action
- **Worker adapter**: `GrpcBudgetChecker` captures `org_id` at construction, implements `BudgetChecker`
- **Tool**: `CheckBudgetTool::execute_with_context` delegates to checker; falls back to no_budgets when no checker is wired

Response format:
```json
{
  "status": "active",
  "budgets": [{"currency": "usd", "limit": 5.0, "balance": 2.56, "percent_remaining": 51.2, "status": "active"}],
  "hint": "51.2% of budget remaining."
}
```

## Risk
- Low
- Fallback behavior unchanged: sessions without budgets or without the checker wired still get `no_budgets`
- New gRPC RPC is internal-only (worker ↔ server), no external API surface change

## Security
- Threat categories reviewed: TM-TOOL, TM-TENANT, TM-API
- TM-TOOL: New tool execution path delegates to gRPC; no user-controlled input reaches the tool
- TM-TENANT: Budget queries scoped by `org_id` (captured from worker context) + `session_id`. No cross-tenant exposure
- TM-API: No new external endpoints. Internal gRPC only, authenticated by existing worker auth
- No findings requiring mitigation

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Closes EVE-253