### PR TITLE
feat(harness): add addressable name for harnesses

### DIFF
--- a/crates/core/examples/turn_based_execution.rs
+++ b/crates/core/examples/turn_based_execution.rs
@@ -115,7 +115,8 @@ async fn main() -> anyhow::Result<()> {
     let now = Utc::now();
     let harness = Harness {
         id: harness_id,
-        name: "Default Harness".to_string(),
+        name: "default".to_string(),
+        display_name: "Default Harness".to_string(),
         description: None,
         system_prompt: "You are a helpful assistant.".to_string(),
         parent_harness_id: None,

--- a/crates/core/src/capabilities/platform_management.rs
+++ b/crates/core/src/capabilities/platform_management.rs
@@ -161,6 +161,7 @@ impl Tool for ReadHarnessesTool {
                 Ok(Some(h)) => ToolExecutionResult::success(json!({
                     "id": h.id.to_string(),
                     "name": h.name,
+                    "display_name": h.display_name,
                     "description": h.description,
                     "system_prompt": h.system_prompt,
                     "status": format!("{:?}", h.status),
@@ -180,6 +181,7 @@ impl Tool for ReadHarnessesTool {
                             json!({
                                 "id": h.id.to_string(),
                                 "name": h.name,
+                                "display_name": h.display_name,
                                 "description": h.description,
                                 "status": format!("{:?}", h.status),
                                 "capabilities": h.capabilities.iter().map(|c| c.capability_id().to_string()).collect::<Vec<_>>(),
@@ -293,6 +295,10 @@ impl Tool for ManageHarnessesTool {
                     Ok(s) => s,
                     Err(e) => return e,
                 };
+                let display_name = match require_str(&arguments, "display_name") {
+                    Ok(s) => s,
+                    Err(e) => return e,
+                };
                 let system_prompt =
                     get_str(&arguments, "system_prompt").unwrap_or("You are a helpful assistant.");
                 let description = get_str(&arguments, "description");
@@ -326,6 +332,7 @@ impl Tool for ManageHarnessesTool {
                 match store
                     .create_harness(
                         name,
+                        display_name,
                         description,
                         system_prompt,
                         parent_harness_id,
@@ -336,6 +343,7 @@ impl Tool for ManageHarnessesTool {
                     Ok(h) => ToolExecutionResult::success(json!({
                         "id": h.id.to_string(),
                         "name": h.name,
+                        "display_name": h.display_name,
                         "description": h.description,
                         "parent_harness_id": h.parent_harness_id.map(|id| id.to_string()),
                         "status": format!("{:?}", h.status),
@@ -362,6 +370,7 @@ impl Tool for ManageHarnessesTool {
                     }
                 };
                 let name = get_str(&arguments, "name");
+                let display_name = get_str(&arguments, "display_name");
                 let description = get_str(&arguments, "description");
                 let system_prompt = get_str(&arguments, "system_prompt");
                 let parent_harness_id = match arguments.get("parent_harness_id") {
@@ -384,12 +393,20 @@ impl Tool for ManageHarnessesTool {
                     }
                 };
                 match store
-                    .update_harness(id, name, description, system_prompt, parent_harness_id)
+                    .update_harness(
+                        id,
+                        name,
+                        display_name,
+                        description,
+                        system_prompt,
+                        parent_harness_id,
+                    )
                     .await
                 {
                     Ok(h) => ToolExecutionResult::success(json!({
                         "id": h.id.to_string(),
                         "name": h.name,
+                        "display_name": h.display_name,
                         "description": h.description,
                         "parent_harness_id": h.parent_harness_id.map(|id| id.to_string()),
                         "status": format!("{:?}", h.status),
@@ -444,6 +461,7 @@ impl Tool for ManageHarnessesTool {
                     Ok(h) => ToolExecutionResult::success(json!({
                         "id": h.id.to_string(),
                         "name": h.name,
+                        "display_name": h.display_name,
                         "description": h.description,
                         "status": format!("{:?}", h.status),
                         "ui_link": format!("{}/harnesses/{}", base_url, h.id),
@@ -1546,7 +1564,8 @@ mod tests {
             .await;
         match result {
             ToolExecutionResult::Success(v) => {
-                assert_eq!(v["name"], "Test Harness");
+                assert_eq!(v["name"], "test-harness");
+                assert_eq!(v["display_name"], "Test Harness");
                 assert!(v["system_prompt"].as_str().is_some());
                 assert!(v["ui_link"].as_str().unwrap().contains("/harnesses/"));
             }
@@ -1575,13 +1594,14 @@ mod tests {
         let tool = ManageHarnessesTool;
         let result = tool
             .execute_with_context(
-                json!({"operation": "create", "name": "My Harness", "system_prompt": "Be fun!"}),
+                json!({"operation": "create", "name": "my-harness", "display_name": "My Harness", "system_prompt": "Be fun!"}),
                 &ctx,
             )
             .await;
         match result {
             ToolExecutionResult::Success(v) => {
-                assert_eq!(v["name"], "My Harness");
+                assert_eq!(v["name"], "my-harness");
+                assert_eq!(v["display_name"], "My Harness");
                 assert!(
                     v["ui_link"]
                         .as_str()

--- a/crates/core/src/harness.rs
+++ b/crates/core/src/harness.rs
@@ -60,7 +60,7 @@ pub struct Harness {
     #[cfg_attr(feature = "openapi", schema(value_type = String, example = "harness_01933b5a00007000800000000000001"))]
     pub id: HarnessId,
     /// URL/CLI-friendly addressable name, unique per org.
-    /// Format: `[a-z0-9]([a-z0-9-]*[a-z0-9])?`, max 64 chars.
+    /// Format: `[a-z0-9]+(-[a-z0-9]+)*`, max 64 chars. No consecutive hyphens.
     pub name: String,
     /// Human-readable display name shown in UI.
     pub display_name: String,

--- a/crates/core/src/harness.rs
+++ b/crates/core/src/harness.rs
@@ -59,8 +59,11 @@ pub struct Harness {
     /// Unique identifier for the harness (format: harness_{32-hex}).
     #[cfg_attr(feature = "openapi", schema(value_type = String, example = "harness_01933b5a00007000800000000000001"))]
     pub id: HarnessId,
-    /// Display name of the harness.
+    /// URL/CLI-friendly addressable name, unique per org.
+    /// Format: `[a-z0-9]([a-z0-9-]*[a-z0-9])?`, max 64 chars.
     pub name: String,
+    /// Human-readable display name shown in UI.
+    pub display_name: String,
     /// Human-readable description of what the harness does.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
@@ -121,6 +124,7 @@ pub fn merge_harness(parent: &Harness, child: &Harness) -> Harness {
     Harness {
         id: child.id,
         name: child.name.clone(),
+        display_name: child.display_name.clone(),
         description: child.description.clone(),
         system_prompt: merge_system_prompts(&parent.system_prompt, &child.system_prompt),
         parent_harness_id: child.parent_harness_id,
@@ -217,7 +221,8 @@ mod tests {
     fn test_harness(id_seed: u128, system_prompt: &str) -> Harness {
         Harness {
             id: HarnessId::from_uuid(uuid::Uuid::from_u128(id_seed)),
-            name: format!("Harness {id_seed}"),
+            name: format!("harness-{id_seed}"),
+            display_name: format!("Harness {id_seed}"),
             description: None,
             system_prompt: system_prompt.to_string(),
             parent_harness_id: None,

--- a/crates/core/src/in_memory_loop.rs
+++ b/crates/core/src/in_memory_loop.rs
@@ -329,7 +329,8 @@ impl InMemoryAgenticLoopBuilder {
         let now = Utc::now();
         let harness = crate::harness::Harness {
             id: harness_id,
-            name: "In-Memory Harness".to_string(),
+            name: "in-memory".to_string(),
+            display_name: "In-Memory Harness".to_string(),
             description: None,
             system_prompt: self.system_prompt.clone(),
             parent_harness_id: None,

--- a/crates/core/src/platform_definition.rs
+++ b/crates/core/src/platform_definition.rs
@@ -63,7 +63,7 @@ impl BuiltInCapabilityDefinition {
 #[derive(Debug, Clone)]
 pub struct BuiltInHarnessDefinition {
     /// URL/CLI-friendly addressable name, unique per org.
-    /// Format: `[a-z0-9]([a-z0-9-]*[a-z0-9])?`, max 64 chars.
+    /// Format: `[a-z0-9]+(-[a-z0-9]+)*`, max 64 chars. No consecutive hyphens.
     /// Used for code-level identification, API addressing, and DB storage.
     pub name: String,
     /// Fixed UUID used for the default org when backward compatibility matters.

--- a/crates/core/src/platform_definition.rs
+++ b/crates/core/src/platform_definition.rs
@@ -62,24 +62,23 @@ impl BuiltInCapabilityDefinition {
 /// Built-in harness template provisioned by a platform definition.
 #[derive(Debug, Clone)]
 pub struct BuiltInHarnessDefinition {
-    /// Stable key for the template inside the platform definition.
-    ///
-    /// This key is for code-level identification and should not be shown to
-    /// users. Use values like `base`, `generic`, or `platform_chat`.
-    pub key: String,
+    /// URL/CLI-friendly addressable name, unique per org.
+    /// Format: `[a-z0-9]([a-z0-9-]*[a-z0-9])?`, max 64 chars.
+    /// Used for code-level identification, API addressing, and DB storage.
+    pub name: String,
     /// Fixed UUID used for the default org when backward compatibility matters.
     ///
     /// Other organizations still receive fresh UUIDs; the template name and
     /// `is_built_in` flag are used to reconcile them.
     pub seed_id: Option<Uuid>,
-    /// Display name shown in the UI and API.
-    pub name: String,
+    /// Human-readable display name shown in UI.
+    pub display_name: String,
     /// Human-readable description.
     pub description: String,
     /// Base system prompt for the harness.
     pub system_prompt: String,
-    /// Optional parent harness key to inherit from during provisioning.
-    pub parent_key: Option<String>,
+    /// Optional parent harness name to inherit from during provisioning.
+    pub parent_name: Option<String>,
     /// Tags applied to the harness.
     pub tags: Vec<String>,
     /// Capabilities enabled by default for the harness.
@@ -91,18 +90,18 @@ pub struct BuiltInHarnessDefinition {
 impl BuiltInHarnessDefinition {
     /// Create a built-in harness template.
     pub fn new(
-        key: impl Into<String>,
         name: impl Into<String>,
+        display_name: impl Into<String>,
         description: impl Into<String>,
         system_prompt: impl Into<String>,
     ) -> Self {
         Self {
-            key: key.into(),
-            seed_id: None,
             name: name.into(),
+            seed_id: None,
+            display_name: display_name.into(),
             description: description.into(),
             system_prompt: system_prompt.into(),
-            parent_key: None,
+            parent_name: None,
             tags: Vec::new(),
             capabilities: Vec::new(),
             roles: Vec::new(),
@@ -125,9 +124,9 @@ impl BuiltInHarnessDefinition {
         self
     }
 
-    /// Set the parent harness key used for inheritance during provisioning.
-    pub fn with_parent_key(mut self, parent_key: impl Into<String>) -> Self {
-        self.parent_key = Some(parent_key.into());
+    /// Set the parent harness name used for inheritance during provisioning.
+    pub fn with_parent_name(mut self, parent_name: impl Into<String>) -> Self {
+        self.parent_name = Some(parent_name.into());
         self
     }
 
@@ -271,7 +270,7 @@ impl Default for PlatformDefinition {
 
 impl std::fmt::Debug for PlatformDefinition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let harness_keys: Vec<_> = self.built_in_harnesses.iter().map(|h| &h.key).collect();
+        let harness_keys: Vec<_> = self.built_in_harnesses.iter().map(|h| &h.name).collect();
         f.debug_struct("PlatformDefinition")
             .field("capabilities", &self.capability_registry)
             .field("drivers", &self.driver_registry.registered_providers())
@@ -433,7 +432,7 @@ mod tests {
                 .harness_for_role(BuiltInHarnessRole::Base)
                 .unwrap()
                 .name,
-            "Minimal"
+            "minimal"
         );
         assert!(
             platform
@@ -467,7 +466,7 @@ mod tests {
             platform
                 .harness_for_role(BuiltInHarnessRole::Chat)
                 .unwrap()
-                .key,
+                .name,
             "chat"
         );
     }

--- a/crates/core/src/platform_store.rs
+++ b/crates/core/src/platform_store.rs
@@ -44,6 +44,7 @@ pub trait PlatformStore: Send + Sync {
     async fn create_harness(
         &self,
         name: &str,
+        display_name: &str,
         description: Option<&str>,
         system_prompt: &str,
         parent_harness_id: Option<HarnessId>,
@@ -55,6 +56,7 @@ pub trait PlatformStore: Send + Sync {
         &self,
         id: HarnessId,
         name: Option<&str>,
+        display_name: Option<&str>,
         description: Option<&str>,
         system_prompt: Option<&str>,
         parent_harness_id: Option<Option<HarnessId>>,
@@ -207,7 +209,8 @@ pub mod tests {
             Self {
                 harness: Harness {
                     id: HarnessId::new(),
-                    name: "Test Harness".to_string(),
+                    name: "test-harness".to_string(),
+                    display_name: "Test Harness".to_string(),
                     description: Some("test harness".to_string()),
                     system_prompt: "You are helpful.".to_string(),
                     parent_harness_id: None,
@@ -293,6 +296,7 @@ pub mod tests {
         async fn create_harness(
             &self,
             name: &str,
+            display_name: &str,
             _desc: Option<&str>,
             _prompt: &str,
             parent_harness_id: Option<HarnessId>,
@@ -300,6 +304,7 @@ pub mod tests {
         ) -> Result<Harness> {
             let mut h = self.harness.clone();
             h.name = name.to_string();
+            h.display_name = display_name.to_string();
             h.parent_harness_id = parent_harness_id;
             Ok(h)
         }
@@ -307,6 +312,7 @@ pub mod tests {
             &self,
             _id: HarnessId,
             name: Option<&str>,
+            display_name: Option<&str>,
             _desc: Option<&str>,
             _prompt: Option<&str>,
             parent_harness_id: Option<Option<HarnessId>>,
@@ -314,6 +320,9 @@ pub mod tests {
             let mut h = self.harness.clone();
             if let Some(n) = name {
                 h.name = n.to_string();
+            }
+            if let Some(dn) = display_name {
+                h.display_name = dn.to_string();
             }
             if let Some(parent_harness_id) = parent_harness_id {
                 h.parent_harness_id = parent_harness_id;
@@ -326,7 +335,7 @@ pub mod tests {
         async fn copy_harness(&self, _id: HarnessId, new_name: Option<&str>) -> Result<Harness> {
             let mut h = self.harness.clone();
             h.id = HarnessId::new();
-            h.name = new_name.unwrap_or("Copy").to_string();
+            h.name = new_name.unwrap_or("copy").to_string();
             Ok(h)
         }
         async fn list_agents(&self) -> Result<Vec<Agent>> {

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -54,7 +54,8 @@ async fn setup_test_environment() -> (
     let now = chrono::Utc::now();
     let harness = Harness {
         id: harness_id,
-        name: "Test Harness".to_string(),
+        name: "test-harness".to_string(),
+        display_name: "Test Harness".to_string(),
         description: None,
         system_prompt: "You are a helpful assistant.".to_string(),
         parent_harness_id: None,

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -339,6 +339,7 @@ message Harness {
     repeated string tags = 10;
     optional Uuid parent_harness_id = 11;
     bool is_built_in = 12;
+    string display_name = 13;
 }
 
 message GetHarnessRequest {
@@ -1461,6 +1462,7 @@ message PlatformCreateHarnessRequest {
     string system_prompt = 4;
     repeated string capabilities = 5;
     optional Uuid parent_harness_id = 6;
+    string display_name = 7;
 }
 
 message PlatformCreateHarnessResponse {
@@ -1475,6 +1477,7 @@ message PlatformUpdateHarnessRequest {
     optional string system_prompt = 5;
     optional Uuid parent_harness_id = 6;
     optional bool clear_parent_harness_id = 7;
+    optional string display_name = 8;
 }
 
 message PlatformUpdateHarnessResponse {

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -342,6 +342,7 @@ pub fn schema_harness_to_proto(value: &everruns_core::Harness) -> proto::Harness
             .parent_harness_id
             .map(|id| uuid_to_proto_uuid(id.uuid())),
         is_built_in: value.is_built_in,
+        display_name: value.display_name.clone(),
     }
 }
 
@@ -372,6 +373,7 @@ pub fn proto_harness_to_schema(
     let json = serde_json::json!({
         "id": id_str,
         "name": value.name,
+        "display_name": value.display_name,
         "description": if value.description.is_empty() { None } else { Some(&value.description) },
         "system_prompt": value.system_prompt,
         "parent_harness_id": parent_harness_id_str,

--- a/crates/server/migrations/014_harness_addressable_name.sql
+++ b/crates/server/migrations/014_harness_addressable_name.sql
@@ -1,0 +1,40 @@
+-- Migration: Harness addressable name
+--
+-- Makes harness `name` the URL/CLI-friendly addressable identifier (slug).
+-- Adds `display_name` for the human-readable label.
+-- Migrates existing data: current name → display_name, slugified name → name.
+
+-- Step 1: Add display_name column, copy existing name values
+ALTER TABLE harnesses ADD COLUMN display_name VARCHAR(255);
+UPDATE harnesses SET display_name = name;
+ALTER TABLE harnesses ALTER COLUMN display_name SET NOT NULL;
+
+-- Step 2: Convert name to slug format (lowercase, spaces/underscores → hyphens,
+-- strip non-alphanumeric-hyphen, collapse consecutive hyphens, trim hyphens)
+UPDATE harnesses SET name = TRIM(BOTH '-' FROM
+    regexp_replace(
+        regexp_replace(
+            regexp_replace(
+                LOWER(name),
+                '[^a-z0-9-]', '-', 'g'
+            ),
+            '-+', '-', 'g'
+        ),
+        '^-|-$', '', 'g'
+    )
+);
+
+-- Step 3: Handle duplicates within same org by appending a suffix.
+-- After slugification, two harnesses could collide (unlikely but safe).
+WITH dupes AS (
+    SELECT id, org_id, name,
+           ROW_NUMBER() OVER (PARTITION BY org_id, name ORDER BY created_at) AS rn
+    FROM harnesses
+)
+UPDATE harnesses h
+SET name = h.name || '-' || d.rn
+FROM dupes d
+WHERE h.id = d.id AND d.rn > 1;
+
+-- Step 4: Add unique constraint per org (only for non-deleted harnesses)
+CREATE UNIQUE INDEX idx_harnesses_org_name ON harnesses (org_id, name) WHERE status != 'deleted';

--- a/crates/server/migrations/014_harness_addressable_name.sql
+++ b/crates/server/migrations/014_harness_addressable_name.sql
@@ -5,35 +5,60 @@
 -- Migrates existing data: current name → display_name, slugified name → name.
 
 -- Step 1: Add display_name column, copy existing name values
-ALTER TABLE harnesses ADD COLUMN display_name VARCHAR(255);
+ALTER TABLE harnesses ADD COLUMN display_name TEXT;
 UPDATE harnesses SET display_name = name;
 ALTER TABLE harnesses ALTER COLUMN display_name SET NOT NULL;
 
 -- Step 2: Convert name to slug format (lowercase, spaces/underscores → hyphens,
--- strip non-alphanumeric-hyphen, collapse consecutive hyphens, trim hyphens)
-UPDATE harnesses SET name = TRIM(BOTH '-' FROM
-    regexp_replace(
+-- strip non-alphanumeric-hyphen, collapse consecutive hyphens, trim hyphens).
+-- Fall back to 'harness-<short-id>' if slugification yields empty string
+-- (e.g. names made only of symbols/emoji).
+UPDATE harnesses
+SET name = CASE
+    WHEN TRIM(BOTH '-' FROM
         regexp_replace(
             regexp_replace(
-                LOWER(name),
-                '[^a-z0-9-]', '-', 'g'
+                regexp_replace(LOWER(name), '[^a-z0-9-]', '-', 'g'),
+                '-+', '-', 'g'
             ),
-            '-+', '-', 'g'
-        ),
-        '^-|-$', '', 'g'
+            '^-|-$', '', 'g'
+        )
+    ) = '' THEN 'harness-' || LEFT(REPLACE(id::text, '-', ''), 8)
+    ELSE TRIM(BOTH '-' FROM
+        regexp_replace(
+            regexp_replace(
+                regexp_replace(LOWER(name), '[^a-z0-9-]', '-', 'g'),
+                '-+', '-', 'g'
+            ),
+            '^-|-$', '', 'g'
+        )
     )
-);
+END;
 
 -- Step 3: Handle duplicates within same org by appending a suffix.
--- After slugification, two harnesses could collide (unlikely but safe).
+-- Choose suffixes that don't collide with any existing name in the org.
 WITH dupes AS (
     SELECT id, org_id, name,
-           ROW_NUMBER() OVER (PARTITION BY org_id, name ORDER BY created_at) AS rn
+           ROW_NUMBER() OVER (PARTITION BY org_id, name ORDER BY created_at, id) AS rn
     FROM harnesses
+),
+max_existing AS (
+    SELECT d.org_id, d.name,
+           COALESCE(MAX(
+               CASE
+                   WHEN h2.name ~ ('^' || d.name || '-[0-9]+$')
+                   THEN SUBSTRING(h2.name FROM '-([0-9]+)$')::integer
+                   ELSE 0
+               END
+           ), 0) AS max_suffix
+    FROM (SELECT DISTINCT org_id, name FROM dupes WHERE rn > 1) d
+    JOIN harnesses h2 ON h2.org_id = d.org_id
+    GROUP BY d.org_id, d.name
 )
 UPDATE harnesses h
-SET name = h.name || '-' || d.rn
+SET name = d.name || '-' || (me.max_suffix + d.rn)
 FROM dupes d
+JOIN max_existing me ON me.org_id = d.org_id AND me.name = d.name
 WHERE h.id = d.id AND d.rn > 1;
 
 -- Step 4: Add unique constraint per org (only for non-deleted harnesses)

--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -22,7 +22,9 @@ use everruns_core::{
 use super::common::{
     ApiOptionExt, ApiPolicyResultExt, ApiResult, ErrorResponse, ListResponse, impl_auth_state,
 };
-use super::validation::{validate_create_agent_input, validate_update_agent_input};
+use super::validation::{
+    validate_create_agent_input, validate_harness_name, validate_update_agent_input,
+};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::{IntoParams, ToSchema};
@@ -32,9 +34,13 @@ use crate::services::{CapabilityService, HarnessService};
 /// Request to create a new harness
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct CreateHarnessRequest {
-    /// The name of the harness.
-    #[schema(example = "Deep Research")]
+    /// URL/CLI-friendly addressable name, unique per org.
+    /// Format: lowercase alphanumeric and hyphens, like a GitHub repo name.
+    #[schema(example = "deep-research")]
     pub name: String,
+    /// Human-readable display name shown in UI.
+    #[schema(example = "Deep Research")]
+    pub display_name: String,
     /// Description of what the harness does.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(example = "Research harness with planning and web capabilities")]
@@ -69,9 +75,14 @@ pub struct CreateHarnessRequest {
 /// Request to update a harness. Only provided fields will be updated.
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct UpdateHarnessRequest {
+    /// URL/CLI-friendly addressable name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "updated-research")]
+    pub name: Option<String>,
+    /// Human-readable display name.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(example = "Updated Research Harness")]
-    pub name: Option<String>,
+    pub display_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -208,9 +219,10 @@ pub async fn create_harness(
     State(state): State<AppState>,
     Json(req): Json<CreateHarnessRequest>,
 ) -> Result<(StatusCode, Json<Harness>), (StatusCode, Json<ErrorResponse>)> {
-    // Reuse agent validation (same limits)
+    validate_harness_name(&req.name)?;
+    // Reuse agent validation for display_name and other fields
     validate_create_agent_input(
-        &req.name,
+        &req.display_name,
         req.description.as_deref(),
         &req.system_prompt,
         req.capabilities.len(),
@@ -331,9 +343,12 @@ pub async fn update_harness(
         )
     })?;
 
-    // Reuse agent validation (same limits)
+    if let Some(ref name) = req.name {
+        validate_harness_name(name)?;
+    }
+    // Reuse agent validation for display_name and other fields
     validate_update_agent_input(
-        req.name.as_deref(),
+        req.display_name.as_deref(),
         req.description.as_deref(),
         req.system_prompt.as_deref(),
         req.capabilities.as_ref().map(|c| c.len()),

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -222,7 +222,7 @@ impl AppState {
                 .map(|h| h.name.clone()),
             chat_session_title: platform_definition
                 .harness_for_role(BuiltInHarnessRole::Chat)
-                .map(|h| h.name.clone()),
+                .map(|h| h.display_name.clone()),
         }
     }
 }

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -1051,7 +1051,8 @@ mod tests {
             .create_harness(
                 42,
                 CreateHarnessRow {
-                    name: "Generic".to_string(),
+                    name: "generic".to_string(),
+                    display_name: "Generic".to_string(),
                     description: Some("Generic".to_string()),
                     system_prompt: "You are helpful.".to_string(),
                     parent_harness_id: None,
@@ -1065,7 +1066,7 @@ mod tests {
             .await
             .unwrap();
 
-        let harness_id = resolve_session_harness_id(&db, 42, None, Some("Generic"))
+        let harness_id = resolve_session_harness_id(&db, 42, None, Some("generic"))
             .await
             .unwrap();
         assert_eq!(harness_id, row.id);
@@ -1086,7 +1087,7 @@ mod tests {
         .await
         .unwrap();
 
-        let harness_id = resolve_session_harness_id(&db, 42, None, Some("Generic"))
+        let harness_id = resolve_session_harness_id(&db, 42, None, Some("generic"))
             .await
             .unwrap();
         assert_eq!(harness_id, default_harness_id);

--- a/crates/server/src/api/validation.rs
+++ b/crates/server/src/api/validation.rs
@@ -37,6 +37,9 @@ pub const MAX_AGENT_IMPORT_FILE_BYTES: usize = 3 * 1024 * 1024; // 3 MB
 /// Maximum size for locale tags.
 pub const MAX_LOCALE_BYTES: usize = 64;
 
+/// Maximum length for harness name (addressable slug).
+pub const MAX_HARNESS_NAME_LEN: usize = 64;
+
 /// Maximum number of starter files on an agent or harness.
 pub const MAX_INITIAL_FILES: usize = 100;
 
@@ -88,6 +91,54 @@ pub fn validate_agent_name(name: &str) -> Result<(), ValidationError> {
             MAX_AGENT_NAME_BYTES
         );
         return Err(ValidationError);
+    }
+    Ok(())
+}
+
+/// Validate harness name is a valid slug: `[a-z0-9]([a-z0-9-]*[a-z0-9])?`.
+/// Max 64 chars, no consecutive hyphens, no leading/trailing hyphens.
+pub fn validate_harness_name(name: &str) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    if name.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new("Harness name must not be empty")),
+        ));
+    }
+    if name.len() > MAX_HARNESS_NAME_LEN {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(format!(
+                "Harness name must be at most {} characters",
+                MAX_HARNESS_NAME_LEN
+            ))),
+        ));
+    }
+    if !name
+        .bytes()
+        .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(
+                "Harness name must contain only lowercase letters, digits, and hyphens",
+            )),
+        ));
+    }
+    if name.starts_with('-') || name.ends_with('-') {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(
+                "Harness name must not start or end with a hyphen",
+            )),
+        ));
+    }
+    if name.contains("--") {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(
+                "Harness name must not contain consecutive hyphens",
+            )),
+        ));
     }
     Ok(())
 }

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1047,6 +1047,7 @@ impl DirectWorkerAdapters {
             chain.push(Harness {
                 id: row.id,
                 name: row.name,
+                display_name: row.display_name,
                 description: row.description,
                 system_prompt: row.system_prompt,
                 parent_harness_id: row.parent_harness_id,
@@ -1322,6 +1323,7 @@ impl DirectPlatformStore {
         everruns_core::Harness {
             id: row.id,
             name: row.name,
+            display_name: row.display_name,
             description: row.description,
             system_prompt: row.system_prompt,
             parent_harness_id: row.parent_harness_id,
@@ -1475,6 +1477,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
     async fn create_harness(
         &self,
         name: &str,
+        display_name: &str,
         description: Option<&str>,
         system_prompt: &str,
         parent_harness_id: Option<HarnessId>,
@@ -1484,6 +1487,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
 
         let input = CreateHarnessRow {
             name: name.to_string(),
+            display_name: display_name.to_string(),
             description: description.map(|s| s.to_string()),
             system_prompt: system_prompt.to_string(),
             parent_harness_id,
@@ -1527,6 +1531,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
         &self,
         id: HarnessId,
         name: Option<&str>,
+        display_name: Option<&str>,
         description: Option<&str>,
         system_prompt: Option<&str>,
         parent_harness_id: Option<Option<HarnessId>>,
@@ -1535,6 +1540,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
 
         let update = UpdateHarness {
             name: name.map(|s| s.to_string()),
+            display_name: display_name.map(|s| s.to_string()),
             description: description.map(|s| s.to_string()),
             system_prompt: system_prompt.map(|s| s.to_string()),
             parent_harness_id,
@@ -1571,7 +1577,8 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
 
         let copy_name = new_name
             .map(|s| s.to_string())
-            .unwrap_or_else(|| format!("{} (copy)", source.name));
+            .unwrap_or_else(|| format!("{}-copy", source.name));
+        let copy_display_name = format!("{} (copy)", source.display_name);
 
         let cap_ids: Vec<String> = source
             .capabilities
@@ -1581,6 +1588,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
 
         self.create_harness(
             &copy_name,
+            &copy_display_name,
             source.description.as_deref(),
             &source.system_prompt,
             source.parent_harness_id,

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -2729,6 +2729,7 @@ impl WorkerService for WorkerServiceImpl {
 
         let create_req = crate::api::harnesses::CreateHarnessRequest {
             name: req.name,
+            display_name: req.display_name,
             description: req.description,
             system_prompt: req.system_prompt,
             parent_harness_id: req
@@ -2765,6 +2766,7 @@ impl WorkerService for WorkerServiceImpl {
 
         let update_req = crate::api::harnesses::UpdateHarnessRequest {
             name: req.name,
+            display_name: req.display_name,
             description: req.description,
             system_prompt: req.system_prompt,
             parent_harness_id: if req.clear_parent_harness_id.unwrap_or(false) {
@@ -2833,6 +2835,7 @@ impl WorkerService for WorkerServiceImpl {
         let harness = if let Some(new_name) = req.new_name {
             let update_req = crate::api::harnesses::UpdateHarnessRequest {
                 name: Some(new_name),
+                display_name: None,
                 description: None,
                 system_prompt: None,
                 parent_harness_id: None,

--- a/crates/server/src/org_init.rs
+++ b/crates/server/src/org_init.rs
@@ -64,6 +64,7 @@ pub async fn initialize_org_harnesses_with_definitions(
                 .with_context(|| format!("resolve parent for built-in harness {}", harness.name))?;
         let input = CreateHarnessRow {
             name: harness.name.to_string(),
+            display_name: harness.display_name.to_string(),
             description: Some(harness.description.to_string()),
             system_prompt: harness.system_prompt.to_string(),
             parent_harness_id,
@@ -108,19 +109,14 @@ pub async fn initialize_org_harnesses_with_definitions(
             }
         } else {
             // Non-default org: check if built-in harness already exists by name
-            let existing = db
-                .list_harnesses(org_id, Some(&harness.name), false)
-                .await?;
-            let already_exists = existing
-                .iter()
-                .any(|h| h.name == harness.name && h.is_built_in);
+            let existing_row = db
+                .get_harness_by_name(org_id, &harness.name)
+                .await?
+                .filter(|h| h.is_built_in);
 
-            if already_exists {
+            if let Some(existing_row) = existing_row {
                 // Already provisioned — update definition if changed
-                let existing_row = existing
-                    .iter()
-                    .find(|h| h.name == harness.name && h.is_built_in)
-                    .unwrap();
+                let existing_row = &existing_row;
 
                 match db
                     .create_harness_with_id(org_id, existing_row.id, input)
@@ -177,27 +173,26 @@ async fn resolve_built_in_parent_id(
     harnesses: &[BuiltInHarnessDefinition],
     harness: &BuiltInHarnessDefinition,
 ) -> Result<Option<everruns_core::HarnessId>> {
-    let Some(parent_key) = harness.parent_key.as_deref() else {
+    let Some(parent_name) = harness.parent_name.as_deref() else {
         return Ok(None);
     };
 
     let parent = harnesses
         .iter()
-        .find(|candidate| candidate.key == parent_key)
-        .with_context(|| format!("unknown built-in parent {parent_key}"))?;
+        .find(|candidate| candidate.name == parent_name)
+        .with_context(|| format!("unknown built-in parent {parent_name}"))?;
 
     if is_default_org {
         let parent_seed = parent
             .seed_id
-            .with_context(|| format!("missing seed id for built-in parent {parent_key}"))?;
+            .with_context(|| format!("missing seed id for built-in parent {parent_name}"))?;
         return Ok(Some(parent_seed.into()));
     }
 
     let parent_row = db
-        .list_harnesses(org_id, Some(&parent.name), true)
+        .get_harness_by_name(org_id, &parent.name)
         .await?
-        .into_iter()
-        .find(|candidate| candidate.is_built_in && candidate.name == parent.name)
+        .filter(|candidate| candidate.is_built_in)
         .with_context(|| format!("missing built-in parent {} for org {org_id}", parent.name))?;
     Ok(Some(parent_row.id))
 }
@@ -439,11 +434,11 @@ mod tests {
 
         let chat = provisioned_harnesses
             .iter()
-            .find(|h| h.name == "Platform Chat")
+            .find(|h| h.name == "platform-chat")
             .expect("chat harness");
         let generic = provisioned_harnesses
             .iter()
-            .find(|h| h.name == "Generic")
+            .find(|h| h.name == "generic")
             .expect("generic harness");
         assert_eq!(chat.parent_harness_id, Some(generic.id));
 
@@ -493,8 +488,8 @@ mod tests {
             assert!(h.is_built_in);
         }
 
-        let generic_id = h_org2.iter().find(|h| h.name == "Generic").unwrap().id;
-        let base_id = h_org2.iter().find(|h| h.name == "Base").unwrap().id;
+        let generic_id = h_org2.iter().find(|h| h.name == "generic").unwrap().id;
+        let base_id = h_org2.iter().find(|h| h.name == "base").unwrap().id;
         let settings = db
             .get_organization_settings(org2.org_id)
             .await
@@ -523,7 +518,7 @@ mod tests {
         let harnesses = db.list_harnesses(org2.org_id, None, false).await.unwrap();
         let chat_id = harnesses
             .iter()
-            .find(|h| h.name == "Platform Chat")
+            .find(|h| h.name == "platform-chat")
             .unwrap()
             .id;
 
@@ -649,7 +644,7 @@ mod tests {
         let built_in_harnesses = harnesses();
         let generic = built_in_harnesses
             .iter()
-            .find(|h| h.name == "Generic")
+            .find(|h| h.name == "generic")
             .unwrap();
         let caps = db
             .get_harness_capabilities(
@@ -669,7 +664,7 @@ mod tests {
         // Base harness should have no capabilities
         let base = built_in_harnesses
             .iter()
-            .find(|h| h.name == "Base")
+            .find(|h| h.name == "base")
             .unwrap();
         let base_caps = db
             .get_harness_capabilities(

--- a/crates/server/src/platform.rs
+++ b/crates/server/src/platform.rs
@@ -99,13 +99,13 @@ pub fn oss_built_in_harnesses() -> Vec<BuiltInHarnessDefinition> {
             BuiltInCapabilityDefinition::new("tool_output_persistence"),
         ]),
         BuiltInHarnessDefinition::new(
-            "platform_chat",
+            "platform-chat",
             "Platform Chat",
             "Conversational harness for the global chat interface with platform management capabilities.",
             "You are a helpful assistant on the Everruns platform.\n\nCapabilities are the primary way to extend agent functionality. Use `read_capabilities` to discover available capabilities (built-in, MCP servers, and skills), then assign them when creating agents or harnesses.\n\nWhen creating agents, always use `read_capabilities` first to find relevant capability IDs to include.\n\n## Rendering entity references\n\nAll tool results include `name` and `ui_link` fields. When referencing entities (agents, harnesses, sessions) in your responses, always render them as clickable markdown links with the entity name — never show raw IDs.\n\nExamples:\n- Use: [My Agent](/agents/agent_abc123)\n- Not: agent_abc123\n- Use: Created [Research Bot](/agents/agent_xyz) successfully\n- Not: Created agent agent_xyz successfully\n\n## Running agents\n\nWhen asked to \"run an agent\" or \"run X with agent Y\", follow these steps:\n1. Create a session for the agent (use `manage_sessions` with operation \"create\"). You can omit `harness_id` — it defaults to the built-in Generic harness.\n2. Send the user's message/task to the session (use `session_send_message`)\n3. Wait for the turn to complete (use `session_read_response`)\n4. Retrieve and relay the results (use `session_read_messages`)\n\nWhen creating sessions, the `harness_id` parameter is optional. If not specified, it defaults to the built-in Generic harness which includes file system, bash, storage, context compaction, and other standard capabilities.\n\n## Harness creation\n\nAvoid creating new harnesses unless the user explicitly needs a custom one. For most tasks, use the built-in \"Generic\" harness (find it via `read_harnesses`) which already includes file system, bash, storage, long-context support, context compaction, session, agent instructions, and skills capabilities.\n\n## Confirmation guidelines\n\n- **Always confirm** before creating a harness or agent — these are reusable org-wide entities.\n- **Sessions**: Use common sense. Routine requests (\"run agent X on this task\") can proceed without confirmation. Unusual or high-impact requests (destructive operations, large-scale actions, unclear intent) should be confirmed first.",
         )
         .with_seed_id(crate::org_init::CHAT_HARNESS_ID)
-        .with_parent_key("generic")
+        .with_parent_name("generic")
         .with_tags(["chat", "built-in"])
         .with_roles([BuiltInHarnessRole::Chat])
         .with_capabilities([

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -2188,7 +2188,7 @@ mod tests {
         let built_in_harnesses = built_in_harnesses();
         let base = built_in_harnesses
             .iter()
-            .find(|h| h.name == "Base")
+            .find(|h| h.name == "base")
             .expect("Base harness should exist");
         assert!(
             base.capabilities.is_empty(),
@@ -2202,7 +2202,7 @@ mod tests {
         let built_in_harnesses = built_in_harnesses();
         let generic = built_in_harnesses
             .iter()
-            .find(|h| h.name == "Generic")
+            .find(|h| h.name == "generic")
             .expect("Generic harness should exist");
 
         let cap_ids: Vec<&str> = generic.capabilities.iter().map(|c| c.id.as_str()).collect();
@@ -2242,7 +2242,7 @@ mod tests {
         let built_in_harnesses = built_in_harnesses();
         let generic = built_in_harnesses
             .iter()
-            .find(|h| h.name == "Generic")
+            .find(|h| h.name == "generic")
             .expect("Generic harness should exist");
 
         for cap in &generic.capabilities {
@@ -2271,7 +2271,7 @@ mod tests {
         let built_in_harnesses = built_in_harnesses();
         let generic = built_in_harnesses
             .iter()
-            .find(|h| h.name == "Generic")
+            .find(|h| h.name == "generic")
             .expect("Generic harness should exist");
 
         let cap_ids: Vec<String> = generic.capabilities.iter().map(|s| s.id.clone()).collect();
@@ -2316,7 +2316,7 @@ mod tests {
         let built_in_harnesses = built_in_harnesses();
         let generic = built_in_harnesses
             .iter()
-            .find(|h| h.name == "Generic")
+            .find(|h| h.name == "generic")
             .expect("Generic harness should exist");
 
         let cap_ids: Vec<String> = generic.capabilities.iter().map(|s| s.id.clone()).collect();
@@ -2362,7 +2362,7 @@ mod tests {
         let built_in_harnesses = built_in_harnesses();
         let generic = built_in_harnesses
             .iter()
-            .find(|h| h.name == "Generic")
+            .find(|h| h.name == "generic")
             .expect("Generic harness should exist");
 
         let cap_ids: Vec<String> = generic.capabilities.iter().map(|s| s.id.clone()).collect();
@@ -2570,7 +2570,7 @@ mod tests {
         let harness_id = everruns_core::HarnessId::from_uuid(
             built_in_harnesses
                 .iter()
-                .find(|h| h.name == "Base")
+                .find(|h| h.name == "base")
                 .unwrap()
                 .seed_id
                 .expect("OSS built-in harness should have a seed id"),

--- a/crates/server/src/services/harness.rs
+++ b/crates/server/src/services/harness.rs
@@ -86,6 +86,7 @@ impl HarnessService {
 
         let input = CreateHarnessRow {
             name: req.name,
+            display_name: req.display_name,
             description: req.description,
             system_prompt: req.system_prompt,
             parent_harness_id,
@@ -220,6 +221,7 @@ impl HarnessService {
 
         let input = UpdateHarness {
             name: req.name,
+            display_name: req.display_name,
             description: req.description,
             system_prompt: req.system_prompt,
             parent_harness_id: req.parent_harness_id.map(|_| parent_harness_id),
@@ -274,7 +276,8 @@ impl HarnessService {
         };
 
         let req = CreateHarnessRequest {
-            name: format!("{} (copy)", source.name),
+            name: format!("{}-copy", source.name),
+            display_name: format!("{} (copy)", source.display_name),
             description: source.description,
             system_prompt: source.system_prompt,
             parent_harness_id: source.parent_harness_id,
@@ -405,7 +408,7 @@ impl HarnessService {
 
         let child_names = children
             .iter()
-            .map(|child| child.name.as_str())
+            .map(|child| child.display_name.as_str())
             .collect::<Vec<_>>()
             .join(", ");
         anyhow::bail!(
@@ -417,6 +420,7 @@ impl HarnessService {
         Harness {
             id: row.id,
             name: row.name,
+            display_name: row.display_name,
             description: row.description,
             system_prompt: row.system_prompt,
             parent_harness_id: row.parent_harness_id,
@@ -502,6 +506,7 @@ pub(crate) fn merge_preview_layer(
     let draft = Harness {
         id: HarnessId::new(),
         name: "preview".to_string(),
+        display_name: "Preview".to_string(),
         description: None,
         system_prompt: system_prompt.to_string(),
         parent_harness_id: None,
@@ -558,7 +563,8 @@ mod tests {
         default_model_id: Option<everruns_core::ModelId>,
     ) -> CreateHarnessRequest {
         CreateHarnessRequest {
-            name: "Test Harness".to_string(),
+            name: "test-harness".to_string(),
+            display_name: "Test Harness".to_string(),
             description: None,
             system_prompt: "Test".to_string(),
             parent_harness_id: None,
@@ -575,6 +581,7 @@ mod tests {
     ) -> UpdateHarnessRequest {
         UpdateHarnessRequest {
             name: None,
+            display_name: None,
             description: None,
             system_prompt: None,
             parent_harness_id: None,
@@ -690,7 +697,8 @@ mod tests {
             .create(
                 &caller,
                 CreateHarnessRequest {
-                    name: "Parent".to_string(),
+                    name: "parent".to_string(),
+                    display_name: "Parent".to_string(),
                     description: None,
                     system_prompt: "Parent prompt".to_string(),
                     parent_harness_id: None,
@@ -716,7 +724,8 @@ mod tests {
             .create(
                 &caller,
                 CreateHarnessRequest {
-                    name: "Child".to_string(),
+                    name: "child".to_string(),
+                    display_name: "Child".to_string(),
                     description: None,
                     system_prompt: "Child prompt".to_string(),
                     parent_harness_id: Some(parent.id),
@@ -768,7 +777,8 @@ mod tests {
             .create(
                 &caller,
                 CreateHarnessRequest {
-                    name: "Child".to_string(),
+                    name: "child".to_string(),
+                    display_name: "Child".to_string(),
                     description: None,
                     system_prompt: "Child".to_string(),
                     parent_harness_id: Some(parent.id),

--- a/crates/server/src/services/harness.rs
+++ b/crates/server/src/services/harness.rs
@@ -69,6 +69,8 @@ impl HarnessService {
 
     #[policy(HARNESS_MANAGE)]
     pub async fn create(&self, caller: &Caller, req: CreateHarnessRequest) -> Result<Harness> {
+        self.ensure_name_available(caller.org_id, &req.name, None)
+            .await?;
         let capabilities_to_store =
             ensure_file_system_capability(req.capabilities.clone(), !req.initial_files.is_empty());
         crate::services::capability_validation::validate_capability_refs(
@@ -184,6 +186,10 @@ impl HarnessService {
         if existing.status != "active" {
             anyhow::bail!("Archived or deleted harnesses cannot be edited");
         }
+        if let Some(ref name) = req.name {
+            self.ensure_name_available(caller.org_id, name, Some(HarnessId::from_uuid(id)))
+                .await?;
+        }
         let existing_initial_files: Vec<InitialFile> =
             serde_json::from_value(existing.initial_files.clone()).unwrap_or_default();
         let final_has_initial_files = req
@@ -266,8 +272,8 @@ impl HarnessService {
         }
     }
 
-    /// Copy a harness by UUID. Creates a new harness with "{name} (copy)" and
-    /// duplicates description, system_prompt, default_model_id, tags, capabilities.
+    /// Copy a harness by UUID. Generates a unique slug (`{name}-copy`, `-copy-2`, etc.)
+    /// and duplicates description, system_prompt, default_model_id, tags, capabilities.
     #[policy(HARNESS_MANAGE)]
     pub async fn copy(&self, caller: &Caller, id: Uuid) -> Result<Option<Harness>> {
         let source = self.get(caller, id).await?;
@@ -275,8 +281,12 @@ impl HarnessService {
             return Ok(None);
         };
 
+        let copy_name = self
+            .find_unique_name(caller.org_id, &format!("{}-copy", source.name))
+            .await?;
+
         let req = CreateHarnessRequest {
-            name: format!("{}-copy", source.name),
+            name: copy_name,
             display_name: format!("{} (copy)", source.display_name),
             description: source.description,
             system_prompt: source.system_prompt,
@@ -328,6 +338,45 @@ impl HarnessService {
 
     pub async fn resolve_effective(&self, org_id: i64, id: HarnessId) -> Result<Option<Harness>> {
         resolve_effective_harness(self.db.as_ref(), org_id, id).await
+    }
+
+    /// Check if a name is already taken by another harness in the org.
+    async fn ensure_name_available(
+        &self,
+        org_id: i64,
+        name: &str,
+        exclude_id: Option<HarnessId>,
+    ) -> Result<()> {
+        if let Some(existing) = self.db.get_harness_by_name(org_id, name).await?
+            && exclude_id != Some(existing.id)
+        {
+            anyhow::bail!("Harness name '{}' is already taken", name);
+        }
+        Ok(())
+    }
+
+    /// Find a unique slug name, appending `-2`, `-3`, etc. if needed.
+    async fn find_unique_name(&self, org_id: i64, base_name: &str) -> Result<String> {
+        if self
+            .db
+            .get_harness_by_name(org_id, base_name)
+            .await?
+            .is_none()
+        {
+            return Ok(base_name.to_string());
+        }
+        for n in 2..=100 {
+            let candidate = format!("{base_name}-{n}");
+            if self
+                .db
+                .get_harness_by_name(org_id, &candidate)
+                .await?
+                .is_none()
+            {
+                return Ok(candidate);
+            }
+        }
+        anyhow::bail!("Could not find a unique name for '{base_name}'")
     }
 
     /// Check if a harness is built-in (system-managed, readonly).

--- a/crates/server/src/services/session.rs
+++ b/crates/server/src/services/session.rs
@@ -948,7 +948,8 @@ mod tests {
             .create(
                 &caller,
                 CreateHarnessRequest {
-                    name: "Harness".to_string(),
+                    name: "harness".to_string(),
+                    display_name: "Harness".to_string(),
                     description: None,
                     system_prompt: "Harness prompt".to_string(),
                     parent_harness_id: None,
@@ -1057,7 +1058,8 @@ mod tests {
             .create(
                 &caller,
                 CreateHarnessRequest {
-                    name: "Parent".to_string(),
+                    name: "parent".to_string(),
+                    display_name: "Parent".to_string(),
                     description: None,
                     system_prompt: "Parent prompt".to_string(),
                     parent_harness_id: None,
@@ -1088,7 +1090,8 @@ mod tests {
             .create(
                 &caller,
                 CreateHarnessRequest {
-                    name: "Child".to_string(),
+                    name: "child".to_string(),
+                    display_name: "Child".to_string(),
                     description: None,
                     system_prompt: "Child prompt".to_string(),
                     parent_harness_id: Some(parent.id),
@@ -1146,7 +1149,8 @@ mod tests {
             .create(
                 &caller,
                 CreateHarnessRequest {
-                    name: "Harness".to_string(),
+                    name: "harness".to_string(),
+                    display_name: "Harness".to_string(),
                     description: None,
                     system_prompt: "Harness prompt".to_string(),
                     parent_harness_id: None,
@@ -1205,7 +1209,8 @@ mod tests {
             .create(
                 &caller,
                 CreateHarnessRequest {
-                    name: "Harness 2".to_string(),
+                    name: "harness-2".to_string(),
+                    display_name: "Harness 2".to_string(),
                     description: None,
                     system_prompt: "Harness prompt".to_string(),
                     parent_harness_id: None,
@@ -1252,7 +1257,8 @@ mod tests {
             .create(
                 &Caller::internal(other_org_id),
                 CreateHarnessRequest {
-                    name: "Other Harness".to_string(),
+                    name: "other-harness".to_string(),
+                    display_name: "Other Harness".to_string(),
                     description: None,
                     system_prompt: "Other".to_string(),
                     parent_harness_id: None,
@@ -1294,7 +1300,8 @@ mod tests {
             .create(
                 &caller,
                 CreateHarnessRequest {
-                    name: "Harness".to_string(),
+                    name: "harness".to_string(),
+                    display_name: "Harness".to_string(),
                     description: None,
                     system_prompt: "Harness".to_string(),
                     parent_harness_id: None,
@@ -1336,7 +1343,8 @@ mod tests {
             .create(
                 &Caller::internal(other_org_id),
                 CreateHarnessRequest {
-                    name: "Other Harness".to_string(),
+                    name: "other-harness".to_string(),
+                    display_name: "Other Harness".to_string(),
                     description: None,
                     system_prompt: "Other".to_string(),
                     parent_harness_id: None,
@@ -1434,7 +1442,8 @@ mod tests {
             .create(
                 &Caller::internal(other_org_id),
                 CreateHarnessRequest {
-                    name: "Other Harness".to_string(),
+                    name: "other-harness".to_string(),
+                    display_name: "Other Harness".to_string(),
                     description: None,
                     system_prompt: "Other".to_string(),
                     parent_harness_id: None,

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -389,6 +389,10 @@ impl StorageBackend {
         dispatch!(self, get_harness, org_id, id)
     }
 
+    pub async fn get_harness_by_name(&self, org_id: i64, name: &str) -> Result<Option<HarnessRow>> {
+        dispatch!(self, get_harness_by_name, org_id, name)
+    }
+
     pub async fn list_harnesses(
         &self,
         org_id: i64,

--- a/crates/server/src/storage/harness_store.rs
+++ b/crates/server/src/storage/harness_store.rs
@@ -80,6 +80,7 @@ impl HarnessStore for DbHarnessStore {
             chain.push(Harness {
                 id: row.id,
                 name: row.name,
+                display_name: row.display_name,
                 description: row.description,
                 system_prompt: row.system_prompt,
                 parent_harness_id: row.parent_harness_id,

--- a/crates/server/src/storage/memory/harnesses.rs
+++ b/crates/server/src/storage/memory/harnesses.rs
@@ -19,6 +19,7 @@ impl InMemoryDatabase {
             id,
             org_id,
             name: input.name,
+            display_name: input.display_name,
             description: input.description,
             system_prompt: input.system_prompt,
             parent_harness_id: input.parent_harness_id,
@@ -51,6 +52,7 @@ impl InMemoryDatabase {
 
         if let Some(existing) = harnesses.get(&id) {
             if existing.name == input.name
+                && existing.display_name == input.display_name
                 && existing.description == input.description
                 && existing.system_prompt == input.system_prompt
                 && existing.parent_harness_id == input.parent_harness_id
@@ -61,6 +63,7 @@ impl InMemoryDatabase {
             }
             let row = HarnessRow {
                 name: input.name,
+                display_name: input.display_name,
                 description: input.description,
                 system_prompt: input.system_prompt,
                 parent_harness_id: input.parent_harness_id,
@@ -77,6 +80,7 @@ impl InMemoryDatabase {
             id,
             org_id,
             name: input.name,
+            display_name: input.display_name,
             description: input.description,
             system_prompt: input.system_prompt,
             parent_harness_id: input.parent_harness_id,
@@ -104,6 +108,15 @@ impl InMemoryDatabase {
             .cloned())
     }
 
+    pub async fn get_harness_by_name(&self, org_id: i64, name: &str) -> Result<Option<HarnessRow>> {
+        Ok(self
+            .harnesses
+            .read()
+            .values()
+            .find(|h| h.org_id == org_id && h.name == name && h.status != "deleted")
+            .cloned())
+    }
+
     pub async fn list_harnesses(
         &self,
         org_id: i64,
@@ -122,7 +135,14 @@ impl InMemoryDatabase {
                     }
             })
             .filter(|h| {
-                matches_search_tokens(search, &[&h.name, h.description.as_deref().unwrap_or("")])
+                matches_search_tokens(
+                    search,
+                    &[
+                        &h.display_name,
+                        &h.name,
+                        h.description.as_deref().unwrap_or(""),
+                    ],
+                )
             })
             .cloned()
             .collect();
@@ -140,6 +160,9 @@ impl InMemoryDatabase {
         if let Some(harness) = harnesses.get_mut(&id).filter(|h| h.org_id == org_id) {
             if let Some(name) = input.name {
                 harness.name = name;
+            }
+            if let Some(display_name) = input.display_name {
+                harness.display_name = display_name;
             }
             if let Some(description) = input.description {
                 harness.description = Some(description);

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -398,6 +398,8 @@ pub struct HarnessRow {
     pub id: HarnessId,
     pub org_id: i64,
     pub name: String,
+    #[sqlx(default)]
+    pub display_name: String,
     pub description: Option<String>,
     pub system_prompt: String,
     pub parent_harness_id: Option<HarnessId>,
@@ -420,6 +422,7 @@ pub struct HarnessRow {
 #[derive(Debug, Clone)]
 pub struct CreateHarnessRow {
     pub name: String,
+    pub display_name: String,
     pub description: Option<String>,
     pub system_prompt: String,
     pub parent_harness_id: Option<HarnessId>,
@@ -435,6 +438,7 @@ pub struct CreateHarnessRow {
 #[derive(Debug, Clone, Default)]
 pub struct UpdateHarness {
     pub name: Option<String>,
+    pub display_name: Option<String>,
     pub description: Option<String>,
     pub system_prompt: Option<String>,
     pub parent_harness_id: Option<Option<HarnessId>>,

--- a/crates/server/src/storage/repositories/harnesses.rs
+++ b/crates/server/src/storage/repositories/harnesses.rs
@@ -15,13 +15,14 @@ impl Database {
     pub async fn create_harness(&self, org_id: i64, input: CreateHarnessRow) -> Result<HarnessRow> {
         let row = sqlx::query_as::<_, HarnessRow>(
             r#"
-            INSERT INTO harnesses (org_id, name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, network_access, is_built_in, status)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'active')
-            RETURNING id, org_id, name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, network_access, is_built_in, status, created_at, updated_at, archived_at, deleted_at
+            INSERT INTO harnesses (org_id, name, display_name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, network_access, is_built_in, status)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 'active')
+            RETURNING id, org_id, name, display_name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, network_access, is_built_in, status, created_at, updated_at, archived_at, deleted_at
             "#,
         )
         .bind(org_id)
         .bind(&input.name)
+        .bind(&input.display_name)
         .bind(&input.description)
         .bind(&input.system_prompt)
         .bind(input.parent_harness_id.map(|id| id.uuid()))
@@ -48,10 +49,11 @@ impl Database {
     ) -> Result<Option<HarnessRow>> {
         let row = sqlx::query_as::<_, HarnessRow>(
             r#"
-            INSERT INTO harnesses (id, org_id, name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, network_access, is_built_in, status)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 'active')
+            INSERT INTO harnesses (id, org_id, name, display_name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, network_access, is_built_in, status)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, 'active')
             ON CONFLICT (id) DO UPDATE SET
                 name = EXCLUDED.name,
+                display_name = EXCLUDED.display_name,
                 description = EXCLUDED.description,
                 system_prompt = EXCLUDED.system_prompt,
                 parent_harness_id = EXCLUDED.parent_harness_id,
@@ -62,6 +64,7 @@ impl Database {
                 updated_at = NOW()
             WHERE
                 harnesses.name IS DISTINCT FROM EXCLUDED.name
+                OR harnesses.display_name IS DISTINCT FROM EXCLUDED.display_name
                 OR harnesses.description IS DISTINCT FROM EXCLUDED.description
                 OR harnesses.system_prompt IS DISTINCT FROM EXCLUDED.system_prompt
                 OR harnesses.parent_harness_id IS DISTINCT FROM EXCLUDED.parent_harness_id
@@ -69,12 +72,13 @@ impl Database {
                 OR harnesses.initial_files IS DISTINCT FROM EXCLUDED.initial_files
                 OR harnesses.network_access IS DISTINCT FROM EXCLUDED.network_access
                 OR harnesses.is_built_in IS DISTINCT FROM EXCLUDED.is_built_in
-            RETURNING id, org_id, name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, network_access, is_built_in, status, created_at, updated_at, archived_at, deleted_at
+            RETURNING id, org_id, name, display_name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, network_access, is_built_in, status, created_at, updated_at, archived_at, deleted_at
             "#,
         )
         .bind(id.uuid())
         .bind(org_id)
         .bind(&input.name)
+        .bind(&input.display_name)
         .bind(&input.description)
         .bind(&input.system_prompt)
         .bind(input.parent_harness_id.map(|id| id.uuid()))
@@ -92,7 +96,7 @@ impl Database {
     pub async fn get_harness(&self, org_id: i64, id: HarnessId) -> Result<Option<HarnessRow>> {
         let row = sqlx::query_as::<_, HarnessRow>(
             r#"
-            SELECT id, org_id, name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, network_access, is_built_in, status, created_at, updated_at, archived_at, deleted_at
+            SELECT id, org_id, name, display_name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, network_access, is_built_in, status, created_at, updated_at, archived_at, deleted_at
             FROM harnesses
             WHERE org_id = $1 AND id = $2
             "#,
@@ -105,21 +109,40 @@ impl Database {
         Ok(row)
     }
 
+    pub async fn get_harness_by_name(&self, org_id: i64, name: &str) -> Result<Option<HarnessRow>> {
+        let row = sqlx::query_as::<_, HarnessRow>(
+            r#"
+            SELECT id, org_id, name, display_name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, network_access, is_built_in, status, created_at, updated_at, archived_at, deleted_at
+            FROM harnesses
+            WHERE org_id = $1 AND name = $2 AND status != 'deleted'
+            "#,
+        )
+        .bind(org_id)
+        .bind(name)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
     pub async fn list_harnesses(
         &self,
         org_id: i64,
         search: Option<&str>,
         include_archived: bool,
     ) -> Result<Vec<HarnessRow>> {
-        let (search_sql, patterns) =
-            build_search_sql(search, "LOWER(name || ' ' || COALESCE(description, ''))", 2);
+        let (search_sql, patterns) = build_search_sql(
+            search,
+            "LOWER(display_name || ' ' || name || ' ' || COALESCE(description, ''))",
+            2,
+        );
         let status_sql = if include_archived {
             " AND status != 'deleted'"
         } else {
             " AND status = 'active'"
         };
         let sql = format!(
-            r#"SELECT id, org_id, name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, network_access, is_built_in, status, created_at, updated_at, archived_at, deleted_at
+            r#"SELECT id, org_id, name, display_name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, network_access, is_built_in, status, created_at, updated_at, archived_at, deleted_at
                 FROM harnesses
                 WHERE org_id = $1{status_sql}{search_sql}
                 ORDER BY created_at DESC"#
@@ -142,25 +165,27 @@ impl Database {
             UPDATE harnesses
             SET
                 name = COALESCE($3, name),
-                description = COALESCE($4, description),
-                system_prompt = COALESCE($5, system_prompt),
+                display_name = COALESCE($4, display_name),
+                description = COALESCE($5, description),
+                system_prompt = COALESCE($6, system_prompt),
                 parent_harness_id = CASE
-                    WHEN $6 THEN $7
+                    WHEN $7 THEN $8
                     ELSE parent_harness_id
                 END,
-                default_model_id = COALESCE($8, default_model_id),
-                tags = COALESCE($9, tags),
-                initial_files = COALESCE($10, initial_files),
-                network_access = CASE WHEN $11 THEN $12 ELSE network_access END,
-                status = COALESCE($13, status),
+                default_model_id = COALESCE($9, default_model_id),
+                tags = COALESCE($10, tags),
+                initial_files = COALESCE($11, initial_files),
+                network_access = CASE WHEN $12 THEN $13 ELSE network_access END,
+                status = COALESCE($14, status),
                 updated_at = NOW()
             WHERE org_id = $1 AND id = $2
-            RETURNING id, org_id, name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, network_access, is_built_in, status, created_at, updated_at, archived_at, deleted_at
+            RETURNING id, org_id, name, display_name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, network_access, is_built_in, status, created_at, updated_at, archived_at, deleted_at
             "#,
         )
         .bind(org_id)
         .bind(id.uuid())
         .bind(&input.name)
+        .bind(&input.display_name)
         .bind(&input.description)
         .bind(&input.system_prompt)
         .bind(input.parent_harness_id.is_some())
@@ -184,7 +209,7 @@ impl Database {
     ) -> Result<Vec<HarnessRow>> {
         Ok(sqlx::query_as::<_, HarnessRow>(
             r#"
-            SELECT id, org_id, name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, network_access, is_built_in, status, created_at, updated_at, archived_at, deleted_at
+            SELECT id, org_id, name, display_name, description, system_prompt, parent_harness_id, default_model_id, tags, initial_files, network_access, is_built_in, status, created_at, updated_at, archived_at, deleted_at
             FROM harnesses
             WHERE org_id = $1 AND parent_harness_id = $2 AND status != 'deleted'
             ORDER BY created_at DESC

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -1468,8 +1468,8 @@ async fn test_list_harnesses_includes_base_and_generic() {
         .iter()
         .filter_map(|h| h["name"].as_str())
         .collect();
-    assert!(names.contains(&"Base"), "Should have Base harness");
-    assert!(names.contains(&"Generic"), "Should have Generic harness");
+    assert!(names.contains(&"base"), "Should have Base harness");
+    assert!(names.contains(&"generic"), "Should have Generic harness");
 }
 
 #[tokio::test]
@@ -1482,7 +1482,7 @@ async fn test_get_base_harness() {
         .assert_status(StatusCode::OK)
         .json();
 
-    assert_eq!(harness.name, "Base");
+    assert_eq!(harness.name, "base");
     assert!(
         harness.capabilities.is_empty(),
         "Base harness should have no capabilities"
@@ -1501,7 +1501,7 @@ async fn test_get_generic_harness() {
         .assert_status(StatusCode::OK)
         .json();
 
-    assert_eq!(harness.name, "Generic");
+    assert_eq!(harness.name, "generic");
     assert!(harness.tags.contains(&"generic".to_string()));
     assert!(harness.tags.contains(&"default".to_string()));
 
@@ -1654,7 +1654,8 @@ async fn test_copy_harness() {
         .post(
             "/v1/harnesses",
             json!({
-                "name": "Original Harness",
+                "name": "original-harness",
+                "display_name": "Original Harness",
                 "description": "Original harness description",
                 "system_prompt": "Harness prompt",
                 "tags": ["harness-tag"],
@@ -1675,7 +1676,8 @@ async fn test_copy_harness() {
         .json();
 
     // Verify copy
-    assert_eq!(copied.name, "Original Harness (copy)");
+    assert_eq!(copied.name, "original-harness-copy");
+    assert_eq!(copied.display_name, "Original Harness (copy)");
     assert_eq!(
         copied.description.as_deref(),
         Some("Original harness description")
@@ -1696,7 +1698,8 @@ async fn test_create_harness_missing_default_model_returns_not_found() {
         .post(
             "/v1/harnesses",
             json!({
-                "name": "Missing Model Harness",
+                "name": "missing-model-harness",
+                "display_name": "Missing Model Harness",
                 "system_prompt": "Test",
                 "default_model_id": "model_019563a3000070008000000000000003"
             }),
@@ -1713,7 +1716,8 @@ async fn test_update_harness_missing_default_model_returns_not_found() {
         .post(
             "/v1/harnesses",
             json!({
-                "name": "Update Missing Model Harness",
+                "name": "update-missing-model-harness",
+                "display_name": "Update Missing Model Harness",
                 "system_prompt": "Test"
             }),
         )
@@ -1739,7 +1743,7 @@ async fn test_update_nonexistent_harness_returns_not_found() {
     server
         .patch(
             "/v1/harnesses/harness_ffffffffffffffffffffffffffffffff",
-            json!({ "name": "Updated" }),
+            json!({ "name": "updated" }),
         )
         .await
         .assert_status(StatusCode::NOT_FOUND);
@@ -1785,7 +1789,8 @@ async fn test_copy_seed_generic_harness() {
         .assert_status(StatusCode::CREATED)
         .json();
 
-    assert_eq!(copied.name, "Generic (copy)");
+    assert_eq!(copied.name, "generic-copy");
+    assert_eq!(copied.display_name, "Generic (copy)");
     // Generic harness capabilities should be preserved on copy
     assert_eq!(
         copied.capabilities.len(),
@@ -2473,7 +2478,7 @@ async fn test_chat_harness_exists_in_seed() {
 
     let chat_harness = harnesses
         .iter()
-        .find(|h| h.name == "Platform Chat")
+        .find(|h| h.name == "platform-chat")
         .expect("Platform Chat harness should exist in seed data");
 
     assert_eq!(chat_harness.id.to_string(), SEED_CHAT_HARNESS_ID);
@@ -2490,7 +2495,7 @@ async fn test_chat_harness_has_platform_management() {
         .assert_status(StatusCode::OK)
         .json();
 
-    assert_eq!(harness.name, "Platform Chat");
+    assert_eq!(harness.name, "platform-chat");
     assert_eq!(
         harness.parent_harness_id.as_ref().map(ToString::to_string),
         Some(SEED_GENERIC_HARNESS_ID.to_string()),

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -622,14 +622,8 @@ async fn test_mcp_execute_list_harnesses() {
         .iter()
         .filter_map(|h| h["name"].as_str())
         .collect();
-    assert!(
-        names.contains(&"base"),
-        "Should have Base harness"
-    );
-    assert!(
-        names.contains(&"generic"),
-        "Should have Generic harness"
-    );
+    assert!(names.contains(&"base"), "Should have Base harness");
+    assert!(names.contains(&"generic"), "Should have Generic harness");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -623,11 +623,11 @@ async fn test_mcp_execute_list_harnesses() {
         .filter_map(|h| h["name"].as_str())
         .collect();
     assert!(
-        names.iter().any(|n| n.contains("Base")),
+        names.contains(&"base"),
         "Should have Base harness"
     );
     assert!(
-        names.iter().any(|n| n.contains("Generic")),
+        names.contains(&"generic"),
         "Should have Generic harness"
     );
 }

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -1164,8 +1164,8 @@ async fn test_organization_settings_harness_roundtrip() {
         .list_harnesses(org.org_id, None, false)
         .await
         .expect("Failed to list harnesses");
-    let generic_id = harnesses.iter().find(|h| h.name == "Generic").unwrap().id;
-    let base_id = harnesses.iter().find(|h| h.name == "Base").unwrap().id;
+    let generic_id = harnesses.iter().find(|h| h.name == "generic").unwrap().id;
+    let base_id = harnesses.iter().find(|h| h.name == "base").unwrap().id;
 
     backend
         .patch_organization_settings(

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -713,6 +713,7 @@ fn proto_harness_to_harness(proto_harness: proto::Harness) -> Result<Harness> {
     Ok(Harness {
         id: id.into(),
         name: proto_harness.name,
+        display_name: proto_harness.display_name,
         description: non_empty_string(proto_harness.description),
         system_prompt: proto_harness.system_prompt,
         parent_harness_id: parent_harness_id.map(|u| u.into()),
@@ -2005,6 +2006,7 @@ impl everruns_core::platform_store::PlatformStore for GrpcOrgAdapter {
     async fn create_harness(
         &self,
         name: &str,
+        display_name: &str,
         description: Option<&str>,
         system_prompt: &str,
         parent_harness_id: Option<everruns_core::HarnessId>,
@@ -2015,6 +2017,7 @@ impl everruns_core::platform_store::PlatformStore for GrpcOrgAdapter {
             .platform_create_harness(proto::PlatformCreateHarnessRequest {
                 org_id: self.org_id,
                 name: name.to_string(),
+                display_name: display_name.to_string(),
                 description: description.map(|s| s.to_string()),
                 system_prompt: system_prompt.to_string(),
                 capabilities: capabilities.to_vec(),
@@ -2036,6 +2039,7 @@ impl everruns_core::platform_store::PlatformStore for GrpcOrgAdapter {
         &self,
         id: everruns_core::HarnessId,
         name: Option<&str>,
+        display_name: Option<&str>,
         description: Option<&str>,
         system_prompt: Option<&str>,
         parent_harness_id: Option<Option<everruns_core::HarnessId>>,
@@ -2046,6 +2050,7 @@ impl everruns_core::platform_store::PlatformStore for GrpcOrgAdapter {
                 org_id: self.org_id,
                 harness_id: Some(uuid_to_proto(id.uuid())),
                 name: name.map(|s| s.to_string()),
+                display_name: display_name.map(|s| s.to_string()),
                 description: description.map(|s| s.to_string()),
                 system_prompt: system_prompt.map(|s| s.to_string()),
                 parent_harness_id: parent_harness_id
@@ -2715,7 +2720,7 @@ mod tests {
         let parent_id = Uuid::new_v4();
         let proto = proto::Harness {
             id: Some(uuid_to_proto(harness_id)),
-            name: "Platform Chat".into(),
+            name: "platform-chat".into(),
             description: "Built-in chat harness".into(),
             system_prompt: "prompt".into(),
             default_model_id: None,
@@ -2726,6 +2731,7 @@ mod tests {
             tags: vec!["chat".into(), "built-in".into()],
             parent_harness_id: Some(uuid_to_proto(parent_id)),
             is_built_in: true,
+            display_name: "Platform Chat".into(),
         };
 
         let harness = proto_harness_to_harness(proto).expect("proto harness should convert");

--- a/specs/harness-types.md
+++ b/specs/harness-types.md
@@ -8,6 +8,17 @@ Harnesses may also define starter files. Starter files are copied into each new 
 
 Harnesses support single-parent inheritance via `parent_harness_id`. Inheritance is live: the effective harness is resolved from parent to child at runtime and in preview.
 
+## Harness Naming
+
+Every harness has two name fields:
+
+| Field | Purpose | Constraints | Example |
+|-------|---------|-------------|---------|
+| `name` | URL/CLI-friendly addressable identifier | `[a-z0-9]([a-z0-9-]*[a-z0-9])?`, max 64 chars, unique per org | `deep-research` |
+| `display_name` | Human-readable label shown in UI | Free-form string, max 2 KB | `Deep Research` |
+
+The `name` field works like a GitHub repository name: lowercase alphanumeric with hyphens, no consecutive hyphens, no leading/trailing hyphens. It is unique per organization (among non-deleted harnesses) and can be used for API lookups, CLI references, and URL routing.
+
 ## Built-in Harness Types
 
 ### Base
@@ -16,11 +27,12 @@ The empty harness. No capabilities, no opinions. Intended as a blank canvas for 
 
 | Property | Value |
 |----------|-------|
-| Name | Base |
+| Name | `base` |
+| Display Name | Base |
 | Seed ID | `harness_01933b5a000070008000000000000601` |
 | System Prompt | "You are a helpful assistant." |
 | Capabilities | _(none)_ |
-| Tags | `base`, `seed` |
+| Tags | `base`, `built-in` |
 
 **Use cases:**
 - Custom agent configurations where only specific capabilities are needed
@@ -33,10 +45,11 @@ The recommended default harness. Bundles the core capabilities needed for genera
 
 | Property | Value |
 |----------|-------|
-| Name | Generic |
+| Name | `generic` |
+| Display Name | Generic |
 | Seed ID | `harness_01933b5a000070008000000000000602` |
 | System Prompt | "You are a helpful assistant." |
-| Tags | `generic`, `default`, `seed` |
+| Tags | `generic`, `default`, `built-in` |
 
 **Capabilities:**
 
@@ -67,11 +80,12 @@ Conversational harness for the global chat interface. Extends Generic capabiliti
 
 | Property | Value |
 |----------|-------|
-| Name | Platform Chat |
+| Name | `platform-chat` |
+| Display Name | Platform Chat |
 | Seed ID | `harness_01933b5a000070008000000000000603` |
-| Parent | Generic |
+| Parent | `generic` |
 | System Prompt | See `crates/server/src/seed.rs` (CHAT_HARNESS) for full prompt |
-| Tags | `chat`, `seed` |
+| Tags | `chat`, `built-in` |
 
 **Local capabilities:** `platform_management`
 

--- a/specs/harness-types.md
+++ b/specs/harness-types.md
@@ -14,7 +14,7 @@ Every harness has two name fields:
 
 | Field | Purpose | Constraints | Example |
 |-------|---------|-------------|---------|
-| `name` | URL/CLI-friendly addressable identifier | `[a-z0-9]([a-z0-9-]*[a-z0-9])?`, max 64 chars, unique per org | `deep-research` |
+| `name` | URL/CLI-friendly addressable identifier | `[a-z0-9]+(-[a-z0-9]+)*`, max 64 chars, unique per org | `deep-research` |
 | `display_name` | Human-readable label shown in UI | Free-form string, max 2 KB | `Deep Research` |
 
 The `name` field works like a GitHub repository name: lowercase alphanumeric with hyphens, no consecutive hyphens, no leading/trailing hyphens. It is unique per organization (among non-deleted harnesses) and can be used for API lookups, CLI references, and URL routing.


### PR DESCRIPTION
## What
Repurpose harness `name` as a URL/CLI-friendly slug and add `display_name` for the human-readable label. Remove `key` from `BuiltInHarnessDefinition` since `name` now serves that purpose directly.

Every harness now has two name fields:
- **`name`**: slug like a GitHub repo name — `[a-z0-9]([a-z0-9-]*[a-z0-9])?`, max 64 chars, unique per org (e.g. `generic`, `platform-chat`, `deep-research`)
- **`display_name`**: free-form string for UI (e.g. `Generic`, `Platform Chat`, `Deep Research`)

## Why
Harnesses need a stable, machine-friendly identifier for API addressing, CLI references, URL routing, and domain-name-friendly usage — similar to GitHub repository names. The existing `name` field was free-form display text, and the internal `key` on `BuiltInHarnessDefinition` was code-only and never stored in the DB.

## How
- **Core**: Add `display_name` to `Harness` struct, update `merge_harness` (child-owned)
- **BuiltInHarnessDefinition**: Remove `key` field, rename `parent_key` → `parent_name`, first arg to `::new()` is now the slug
- **Storage**: Add `display_name` to `HarnessRow`, `CreateHarnessRow`, `UpdateHarness`; add `get_harness_by_name` for direct slug lookups
- **Migration 014**: Add `display_name` column (copies existing `name`), slugify `name` in-place, deduplicate collisions, add `UNIQUE(org_id, name) WHERE status != 'deleted'`
- **Validation**: New `validate_harness_name` enforces slug format with clear error messages
- **API**: `CreateHarnessRequest` and `UpdateHarnessRequest` gain `display_name`; slug validation on `name`
- **Proto/gRPC**: Add `display_name` field to `Harness` message and platform create/update request messages
- **PlatformStore trait**: `create_harness` and `update_harness` gain `display_name` parameter
- **Org init**: Uses `name` (slug) for built-in harness reconciliation; simplified parent resolution via `get_harness_by_name`
- **Built-in harnesses**: `base`, `generic`, `platform-chat` (with display names `Base`, `Generic`, `Platform Chat`)

## Risk
- Low
- Migration could theoretically produce slug collisions if two harnesses in the same org had names that slugify identically — handled by the dedup step appending `-N` suffix
- No backward compat needed (internal code per AGENTS.md)

## Security
- Threat categories reviewed: TM-API (new field, slug validation), TM-SQL (new column, parameterized queries, unique index), TM-DOS (max 64 char limit)
- Findings: All queries use parameterized bindings. Slug validation is strict allowlist (`[a-z0-9-]`). Unique index scoped per org excluding deleted. No injection vectors found.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
