### PR TITLE
chore(deps): bump bashkit v0.1.14 → v0.1.15, adopt max_memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,8 +445,8 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.1.14"
-source = "git+https://github.com/everruns/bashkit?tag=v0.1.14#7b7e2a018b17967421edebadf7f3eca3194dff0a"
+version = "0.1.15"
+source = "git+https://github.com/everruns/bashkit?tag=v0.1.15#34cf2c259cf65da335e26ab06862f40c08aeed4a"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -65,7 +65,7 @@ fetchkit = { version = "0.2.0", features = ["bot-auth"] }
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 
 # Virtual bash interpreter
-bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.1.14" }
+bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.1.15" }
 
 # Tree-sitter for structural outlines (EVE-248)
 tree-sitter = { version = "0.24", optional = true }

--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -246,6 +246,7 @@ impl Tool for BashTool {
             .env("WORKSPACE", "/workspace")
             .env("LANG", locale)
             .limits(execution_limits())
+            .max_memory(10 * 1024 * 1024) // 10 MB — prevent OOM from untrusted input
             .trace_mode(TraceMode::Redacted)
             .build();
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -65,7 +65,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 urlencoding = "2"
 git2.workspace = true
 
-bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.1.14", features = ["scripted_tool"] }
+bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.1.15", features = ["scripted_tool"] }
 
 everruns-config = { path = "../config" }
 everruns-core = { path = "../core", features = ["openapi", "sqlx", "tree-sitter-outlines"] }


### PR DESCRIPTION
## What

Bump bashkit from v0.1.14 to v0.1.15 and adopt the new `max_memory()` builder to cap interpreter memory at 10 MB for agent-facing virtual bash execution.

## Why

v0.1.15 includes 20+ security hardening fixes (regex size limits, AWK/sed/grep memory exhaustion caps, TOCTOU sandbox escape fix, credential leak prevention in curl redirects, header injection mitigation) plus parser/interpreter correctness improvements. The new `max_memory` API provides OOM protection from untrusted agent input that was previously unavailable.

## How

- Bumped `bashkit` tag from `v0.1.14` to `v0.1.15` in `crates/core/Cargo.toml` and `crates/server/Cargo.toml`
- Added `.max_memory(10 * 1024 * 1024)` to the `Bash::builder()` in `virtual_bash.rs`
- Updated `Cargo.lock`

New opt-in features available but not adopted (SSH, TypeScript, snapshot/resume, bot-auth, HttpHandler) — these are feature-gated and can be enabled later if needed.

## Risk

- Low
- Bashkit is a well-tested dependency with its own CI. The only code change is adding a memory cap, which is strictly additive protection. Compilation verified clean.

## Security

- Threat categories reviewed: TM-BASH (sandbox configuration), TM-DOS (resource limits)
- Findings: The bump strictly improves security posture — picks up upstream fixes for sandbox escape (TOCTOU in RealFs::resolve), memory exhaustion (AWK/sed/grep caps), regex bomb protection, credential leak prevention, and header injection mitigation. The new `max_memory(10 MB)` adds OOM defense for agent bash execution. No new attack surface introduced.

## Checklist

- [x] Tests added or updated (upstream bashkit tests cover the changes; no new everruns-side behavior to test)
- [x] Backward compatibility considered (patch bump, no API breaking changes)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)