### PR TITLE
feat(harness): expose stable name in API, CLI, and OpenAPI

### DIFF
--- a/crates/cli/src/commands/sessions.rs
+++ b/crates/cli/src/commands/sessions.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 pub enum SessionsCommand {
     /// Create a new session
     Create {
-        /// Harness ID (e.g. harness_xxx). Omit to use org default.
+        /// Harness ID or name (e.g. harness_xxx or "generic"). Omit to use org default.
         #[arg(long, short = 'H')]
         harness: Option<String>,
 
@@ -92,6 +92,8 @@ pub async fn run(
         } => {
             create(
                 client,
+                api_url,
+                api_key,
                 output,
                 quiet,
                 harness,
@@ -117,9 +119,11 @@ pub async fn run(
 #[allow(clippy::too_many_arguments)]
 async fn create(
     client: &Everruns,
+    api_url: &str,
+    api_key: &str,
     output: OutputFormat,
     quiet: bool,
-    harness_id: Option<String>,
+    harness: Option<String>,
     agent_id: Option<String>,
     title: Option<String>,
     model_id: Option<String>,
@@ -129,6 +133,17 @@ async fn create(
 ) -> Result<()> {
     let secrets = parse_secrets(&raw_secrets)?;
     let budget_specs = parse_budget_limits(&raw_budget_limits, &raw_budget_soft_limits)?;
+
+    // Resolve harness: if the value looks like a prefixed ID, use it directly.
+    // Otherwise treat it as an addressable name and look it up via the API.
+    let harness_id = match harness {
+        Some(h) if h.starts_with("harness_") => Some(h),
+        Some(name) => {
+            let resolved = resolve_harness_name(api_url, api_key, &name).await?;
+            Some(resolved)
+        }
+        None => None,
+    };
 
     let mut req = CreateSessionRequest::new();
     if let Some(h) = harness_id {
@@ -616,6 +631,30 @@ async fn export(
     }
 
     Ok(())
+}
+
+/// Resolve a harness name to its ID via the GET /v1/harnesses/{name} endpoint.
+async fn resolve_harness_name(api_url: &str, api_key: &str, name: &str) -> Result<String> {
+    let http = reqwest::Client::new();
+    let resp = http
+        .get(format!("{}/v1/harnesses/{}", api_url, name))
+        .header("Authorization", format!("Bearer {}", api_key))
+        .send()
+        .await
+        .context("Failed to resolve harness name")?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("Harness '{name}' not found ({status}): {body}");
+    }
+
+    let harness: serde_json::Value = resp.json().await.context("Invalid harness response")?;
+    harness
+        .get("id")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .context(format!("Harness '{name}' response missing id field"))
 }
 
 fn capitalize_first(s: &str) -> String {

--- a/crates/cli/src/commands/sessions.rs
+++ b/crates/cli/src/commands/sessions.rs
@@ -134,10 +134,11 @@ async fn create(
     let secrets = parse_secrets(&raw_secrets)?;
     let budget_specs = parse_budget_limits(&raw_budget_limits, &raw_budget_soft_limits)?;
 
-    // Resolve harness: if the value looks like a prefixed ID, use it directly.
-    // Otherwise treat it as an addressable name and look it up via the API.
+    // Resolve harness: if it looks like a prefixed ID (harness_ + 32 hex chars),
+    // use it directly. Otherwise resolve via the server's GET /v1/harnesses/{id_or_name}
+    // endpoint (which handles both IDs and names).
     let harness_id = match harness {
-        Some(h) if h.starts_with("harness_") => Some(h),
+        Some(h) if h.starts_with("harness_") && h.len() == 40 => Some(h),
         Some(name) => {
             let resolved = resolve_harness_name(api_url, api_key, &name).await?;
             Some(resolved)
@@ -634,10 +635,13 @@ async fn export(
 }
 
 /// Resolve a harness name to its ID via the GET /v1/harnesses/{name} endpoint.
+/// Harness names are `[a-z0-9-]` only, so no percent-encoding is needed for path
+/// segments. We strip trailing slashes from the base URL to avoid double slashes.
 async fn resolve_harness_name(api_url: &str, api_key: &str, name: &str) -> Result<String> {
+    let base = api_url.trim_end_matches('/');
     let http = reqwest::Client::new();
     let resp = http
-        .get(format!("{}/v1/harnesses/{}", api_url, name))
+        .get(format!("{base}/v1/harnesses/{name}"))
         .header("Authorization", format!("Bearer {}", api_key))
         .send()
         .await

--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -271,11 +271,14 @@ pub async fn list_harnesses(
 }
 
 /// GET /v1/harnesses/{harness_id}
+///
+/// Accepts either a harness ID (e.g. `harness_01933b5a...`) or an addressable
+/// name (e.g. `generic`). Names are resolved within the caller's org.
 #[utoipa::path(
     get,
     path = "/v1/harnesses/{harness_id}",
     params(
-        ("harness_id" = String, Path, description = "Harness ID (prefixed)")
+        ("harness_id" = String, Path, description = "Harness ID (prefixed) or addressable name")
     ),
     responses(
         (status = 200, description = "Harness found", body = Harness),
@@ -289,23 +292,26 @@ pub async fn list_harnesses(
 pub async fn get_harness(
     org: ResolvedOrg,
     State(state): State<AppState>,
-    Path(harness_id): Path<String>,
+    Path(harness_id_or_name): Path<String>,
 ) -> ApiResult<Harness> {
-    let harness_id: HarnessId = harness_id.parse().map_err(|e| {
-        (
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse {
-                error: format!("Invalid harness ID: {}", e),
-            }),
-        )
-    })?;
-
     let caller = Caller::from(&org);
+
+    // Try parsing as a prefixed ID first; fall back to name lookup.
+    if let Ok(harness_id) = harness_id_or_name.parse::<HarnessId>() {
+        let harness = state
+            .service
+            .get(&caller, harness_id.uuid())
+            .await
+            .map_policy_or_internal("get harness")?
+            .ok_or_not_found_json("Harness")?;
+        return Ok(Json(harness));
+    }
+
     let harness = state
         .service
-        .get(&caller, harness_id.uuid())
+        .get_by_name(&caller, &harness_id_or_name)
         .await
-        .map_policy_or_internal("get harness")?
+        .map_policy_or_internal("get harness by name")?
         .ok_or_not_found_json("Harness")?;
 
     Ok(Json(harness))

--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -282,7 +282,6 @@ pub async fn list_harnesses(
     ),
     responses(
         (status = 200, description = "Harness found", body = Harness),
-        (status = 400, description = "Invalid harness ID"),
         (status = 403, description = "Forbidden"),
         (status = 404, description = "Harness not found"),
         (status = 500, description = "Internal server error")

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -449,6 +449,7 @@ async fn tool_agent_run(
     // Create session
     let session_req = CreateSessionRequest {
         harness_id: Some(harness_id),
+        harness_name: None,
         agent_id,
         agent_identity_id: None,
         title,

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -39,9 +39,16 @@ use utoipa::{IntoParams, ToSchema};
 pub struct CreateSessionRequest {
     /// ID of the harness for this session (format: harness_{32-hex}).
     /// If omitted, the org default harness is used. New orgs default that to Generic.
+    /// Mutually exclusive with `harness_name`.
     #[serde(default)]
     #[schema(value_type = Option<String>, example = "harness_01933b5a00007000800000000000001")]
     pub harness_id: Option<HarnessId>,
+    /// Addressable name of the harness (e.g. "generic", "deep-research").
+    /// Alternative to `harness_id` — looked up by stable name within the org.
+    /// Mutually exclusive with `harness_id`.
+    #[serde(default)]
+    #[schema(example = "generic")]
+    pub harness_name: Option<String>,
     /// ID of the agent to work in this session (optional, format: agent_{32-hex}).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(value_type = Option<String>, example = "agent_01933b5a00007000800000000000001")]
@@ -304,6 +311,27 @@ pub async fn create_session(
 ) -> Result<(StatusCode, Json<Session>), (StatusCode, Json<ErrorResponse>)> {
     req.locale = normalize_locale(req.locale)
         .map_err(|err| -> (StatusCode, Json<ErrorResponse>) { err.into() })?;
+
+    // Reject if both harness_id and harness_name are specified
+    if req.harness_id.is_some() && req.harness_name.is_some() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(
+                "Cannot specify both harness_id and harness_name",
+            )),
+        ));
+    }
+
+    // Resolve harness_name to harness_id if provided
+    if let Some(ref name) = req.harness_name {
+        let row = state
+            .db
+            .get_harness_by_name(org.org_id, name)
+            .await
+            .log_internal_error_json("resolve harness by name")?
+            .ok_or_not_found_json("Harness")?;
+        req.harness_id = Some(row.id);
+    }
 
     let harness_id = resolve_session_harness_id(
         &state.db,

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -322,8 +322,12 @@ pub async fn create_session(
         ));
     }
 
-    // Resolve harness_name to harness_id if provided
+    // Resolve harness_name to harness_id if provided.
+    // Input is validated with the same rules as harness CRUD endpoints.
+    // HARNESS_VIEW policy is not checked here because the existing flow already
+    // validates harness access via db.get_harness() below.
     if let Some(ref name) = req.harness_name {
+        validation::validate_harness_name(name)?;
         let row = state
             .db
             .get_harness_by_name(org.org_id, name)

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -564,6 +564,7 @@ async fn process_slack_message(
                 let title = build_session_title(slack_config, event);
                 let req = CreateSessionRequest {
                     harness_id: Some(app.harness_id),
+                    harness_name: None,
                     agent_id: Some(app.agent_id),
                     title: Some(title),
                     locale: None,

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -3043,6 +3043,7 @@ impl WorkerService for WorkerServiceImpl {
 
         let create_req = crate::api::sessions::CreateSessionRequest {
             harness_id: Some(everruns_core::HarnessId::from_uuid(harness_id)),
+            harness_name: None,
             agent_id: agent_public_id,
             agent_identity_id: None,
             title: req.title,

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -100,6 +100,15 @@ use utoipa::OpenApi;
         api::schedules::list_schedule_executions,
         api::schedules::get_execution,
         api::schedules::get_schedule_stats,
+        // Harnesses
+        api::harnesses::create_harness,
+        api::harnesses::list_harnesses,
+        api::harnesses::get_harness,
+        api::harnesses::update_harness,
+        api::harnesses::delete_harness,
+        api::harnesses::copy_harness,
+        api::harnesses::preview_harness,
+        api::harnesses::harness_config,
         // Agents - additional
         api::agents::preview_agent,
         api::agents::upsert_agent,
@@ -172,6 +181,13 @@ use utoipa::OpenApi;
             api::llm_models::UpdateLlmModelRequest,
             CapabilityInfo,
             ListResponse<CapabilityInfo>,
+            // Harness types
+            everruns_core::Harness, everruns_core::HarnessStatus, everruns_core::ResourceConfigResponse,
+            api::harnesses::CreateHarnessRequest,
+            api::harnesses::UpdateHarnessRequest,
+            api::harnesses::PreviewHarnessRequest,
+            api::harnesses::HarnessPreviewResponse,
+            ListResponse<everruns_core::Harness>,
             api::users::User,
             api::users::ListUsersQuery,
             ListResponse<api::users::User>,
@@ -243,6 +259,7 @@ use utoipa::OpenApi;
         (name = "images", description = "Image upload and management endpoints"),
         (name = "session-databases", description = "Session-scoped SQL database endpoints"),
         (name = "session-storage", description = "Session key-value storage endpoints"),
+        (name = "harnesses", description = "Harness management endpoints"),
         (name = "skills", description = "Skills registry endpoints"),
     ),
     info(

--- a/crates/server/src/services/harness.rs
+++ b/crates/server/src/services/harness.rs
@@ -145,6 +145,19 @@ impl HarnessService {
     }
 
     #[policy(HARNESS_VIEW)]
+    pub async fn get_by_name(&self, caller: &Caller, name: &str) -> Result<Option<Harness>> {
+        let row = self.db.get_harness_by_name(caller.org_id, name).await?;
+        match row {
+            Some(row) if row.status != "deleted" => {
+                let capabilities = self.get_capabilities(row.id.uuid()).await?;
+                Ok(Some(Self::row_to_harness(row, capabilities)))
+            }
+            None => Ok(None),
+            Some(_) => Ok(None),
+        }
+    }
+
+    #[policy(HARNESS_VIEW)]
     pub async fn list(
         &self,
         caller: &Caller,

--- a/crates/server/src/services/session.rs
+++ b/crates/server/src/services/session.rs
@@ -872,6 +872,7 @@ mod tests {
     ) -> CreateSessionRequest {
         CreateSessionRequest {
             harness_id: Some(harness_id),
+            harness_name: None,
             agent_id,
             agent_identity_id: None,
             title: Some("Test Session".to_string()),

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1507,9 +1507,6 @@
               }
             }
           },
-          "400": {
-            "description": "Invalid harness ID"
-          },
           "403": {
             "description": "Forbidden"
           },

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1302,6 +1302,414 @@
         }
       }
     },
+    "/v1/harnesses": {
+      "get": {
+        "tags": [
+          "harnesses"
+        ],
+        "summary": "GET /v1/harnesses",
+        "operationId": "list_harnesses",
+        "parameters": [
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Search by name or description (case-insensitive substring match).",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "name": "include_archived",
+            "in": "query",
+            "description": "Include archived harnesses. Deleted harnesses never appear in lists.",
+            "required": false,
+            "schema": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of harnesses",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponse_Harness"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "harnesses"
+        ],
+        "summary": "POST /v1/harnesses",
+        "operationId": "create_harness",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateHarnessRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Harness created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Harness"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/harnesses/config": {
+      "get": {
+        "tags": [
+          "harnesses"
+        ],
+        "summary": "GET /v1/harnesses/config",
+        "description": "Returns which harness policies the caller satisfies.\nUI uses this to show/hide controls (e.g. delete button).",
+        "operationId": "harness_config",
+        "responses": {
+          "200": {
+            "description": "Resource config for harnesses",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceConfigResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/harnesses/preview": {
+      "post": {
+        "tags": [
+          "harnesses"
+        ],
+        "summary": "POST /v1/harnesses/preview",
+        "operationId": "preview_harness",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PreviewHarnessRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Harness preview generated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HarnessPreviewResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/harnesses/{harness_id}": {
+      "get": {
+        "tags": [
+          "harnesses"
+        ],
+        "summary": "GET /v1/harnesses/{harness_id}",
+        "description": "Accepts either a harness ID (e.g. `harness_01933b5a...`) or an addressable\nname (e.g. `generic`). Names are resolved within the caller's org.",
+        "operationId": "get_harness",
+        "parameters": [
+          {
+            "name": "harness_id",
+            "in": "path",
+            "description": "Harness ID (prefixed) or addressable name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Harness found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Harness"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid harness ID"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Harness not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "harnesses"
+        ],
+        "summary": "DELETE /v1/harnesses/{harness_id}",
+        "operationId": "delete_harness",
+        "parameters": [
+          {
+            "name": "harness_id",
+            "in": "path",
+            "description": "Harness ID (prefixed)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Harness archived"
+          },
+          "400": {
+            "description": "Invalid harness ID"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Harness not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "harnesses"
+        ],
+        "summary": "PATCH /v1/harnesses/{harness_id}",
+        "operationId": "update_harness",
+        "parameters": [
+          {
+            "name": "harness_id",
+            "in": "path",
+            "description": "Harness ID (prefixed)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateHarnessRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Harness updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Harness"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Harness not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/harnesses/{harness_id}/copy": {
+      "post": {
+        "tags": [
+          "harnesses"
+        ],
+        "summary": "POST /v1/harnesses/{harness_id}/copy - Copy a harness",
+        "description": "Creates a new harness with the same configuration as the source harness.\nThe new harness's name will be \"{original name} (copy)\".",
+        "operationId": "copy_harness",
+        "parameters": [
+          {
+            "name": "harness_id",
+            "in": "path",
+            "description": "Source harness ID to copy",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Harness copied successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Harness"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid harness ID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Source harness not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/images": {
       "get": {
         "tags": [
@@ -5737,6 +6145,102 @@
           }
         }
       },
+      "CreateHarnessRequest": {
+        "type": "object",
+        "description": "Request to create a new harness",
+        "required": [
+          "name",
+          "display_name",
+          "system_prompt"
+        ],
+        "properties": {
+          "capabilities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentCapabilityConfig"
+            },
+            "description": "Capabilities to enable with per-harness configuration.",
+            "example": [
+              {
+                "config": {},
+                "ref": "current_time"
+              },
+              {
+                "config": {},
+                "ref": "web_fetch"
+              }
+            ]
+          },
+          "default_model_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Default LLM model ID for this harness. Lowest priority in model chain.",
+            "example": "model_01933b5a00007000800000000000001"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Description of what the harness does.",
+            "example": "Research harness with planning and web capabilities"
+          },
+          "display_name": {
+            "type": "string",
+            "description": "Human-readable display name shown in UI.",
+            "example": "Deep Research"
+          },
+          "initial_files": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InitialFile"
+            },
+            "description": "Starter files copied into each new session for this harness."
+          },
+          "name": {
+            "type": "string",
+            "description": "URL/CLI-friendly addressable name, unique per org.\nFormat: lowercase alphanumeric and hyphens, like a GitHub repo name.",
+            "example": "deep-research"
+          },
+          "network_access": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/NetworkAccessList",
+                "description": "Network access list controlling which hosts/URLs sessions can reach."
+              }
+            ]
+          },
+          "parent_harness_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional parent harness to inherit from.",
+            "example": "harness_01933b5a000070008000000000000602"
+          },
+          "system_prompt": {
+            "type": "string",
+            "description": "The system prompt defining the harness's base behavior.",
+            "example": "You are a research assistant with deep analytical capabilities."
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Tags for organizing harnesses.",
+            "example": [
+              "research",
+              "planning"
+            ]
+          }
+        }
+      },
       "CreateLlmModelRequest": {
         "type": "object",
         "description": "Request to create a new LLM model for a provider",
@@ -6041,8 +6545,16 @@
               "string",
               "null"
             ],
-            "description": "ID of the harness for this session (format: harness_{32-hex}).\nIf omitted, the org default harness is used. New orgs default that to Generic.",
+            "description": "ID of the harness for this session (format: harness_{32-hex}).\nIf omitted, the org default harness is used. New orgs default that to Generic.\nMutually exclusive with `harness_name`.",
             "example": "harness_01933b5a00007000800000000000001"
+          },
+          "harness_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Addressable name of the harness (e.g. \"generic\", \"deep-research\").\nAlternative to `harness_id` — looked up by stable name within the org.\nMutually exclusive with `harness_id`.",
+            "example": "generic"
           },
           "hints": {
             "type": [
@@ -6848,6 +7360,155 @@
             "type": "string"
           }
         }
+      },
+      "Harness": {
+        "type": "object",
+        "description": "Harness configuration for sessions.\nA harness defines the base behavior and capabilities that apply to all sessions.",
+        "required": [
+          "id",
+          "name",
+          "display_name",
+          "system_prompt",
+          "status",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "archived_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "Timestamp when the harness was archived."
+          },
+          "capabilities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentCapabilityConfig"
+            },
+            "description": "Capabilities enabled for this harness with per-harness configuration."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the harness was created."
+          },
+          "default_model_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Default LLM model ID for this harness.\nLowest priority in chain: controls > session > agent > harness.",
+            "example": "model_01933b5a00007000800000000000001"
+          },
+          "deleted_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "Timestamp when the harness was deleted."
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable description of what the harness does."
+          },
+          "display_name": {
+            "type": "string",
+            "description": "Human-readable display name shown in UI."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the harness (format: harness_{32-hex}).",
+            "example": "harness_01933b5a00007000800000000000001"
+          },
+          "initial_files": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InitialFile"
+            },
+            "description": "Starter files copied into each new session for this harness."
+          },
+          "is_built_in": {
+            "type": "boolean",
+            "description": "Whether this harness is built-in (system-managed, readonly).\nBuilt-in harnesses are provisioned during org initialization and\ncannot be modified or deleted via the API. Users can copy them."
+          },
+          "name": {
+            "type": "string",
+            "description": "URL/CLI-friendly addressable name, unique per org.\nFormat: `[a-z0-9]+(-[a-z0-9]+)*`, max 64 chars. No consecutive hyphens."
+          },
+          "network_access": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/NetworkAccessList",
+                "description": "Network access list controlling which hosts/URLs sessions can reach.\nMerged with agent and session layers (allowed: intersect, blocked: union)."
+              }
+            ]
+          },
+          "parent_harness_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional parent harness that this harness inherits from.",
+            "example": "harness_01933b5a000070008000000000000602"
+          },
+          "status": {
+            "$ref": "#/components/schemas/HarnessStatus",
+            "description": "Current lifecycle status of the harness."
+          },
+          "system_prompt": {
+            "type": "string",
+            "description": "System prompt that defines the harness's base behavior.\nForms the foundation of the prompt stack."
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Tags for organizing and filtering harnesses."
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the harness was last updated."
+          }
+        }
+      },
+      "HarnessPreviewResponse": {
+        "type": "object",
+        "description": "Preview response showing merged prompt and tools",
+        "required": [
+          "system_prompt",
+          "tools"
+        ],
+        "properties": {
+          "system_prompt": {
+            "type": "string"
+          },
+          "tools": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "HarnessStatus": {
+        "type": "string",
+        "description": "Harness lifecycle status.\n- `active`: Harness is available for use\n- `archived`: Harness is hidden from listings and cannot be modified or assigned\n- `deleted`: Harness is a tombstone kept only for historical references",
+        "enum": [
+          "active",
+          "archived",
+          "deleted"
+        ]
       },
       "ImageContentPart": {
         "type": "object",
@@ -7721,6 +8382,140 @@
                 },
                 "path": {
                   "type": "string"
+                }
+              }
+            },
+            "description": "Array of items returned by the list operation."
+          }
+        }
+      },
+      "ListResponse_Harness": {
+        "type": "object",
+        "description": "Response wrapper for list endpoints.\nAll list endpoints return responses wrapped in a `data` field.",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "description": "Harness configuration for sessions.\nA harness defines the base behavior and capabilities that apply to all sessions.",
+              "required": [
+                "id",
+                "name",
+                "display_name",
+                "system_prompt",
+                "status",
+                "created_at",
+                "updated_at"
+              ],
+              "properties": {
+                "archived_at": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "format": "date-time",
+                  "description": "Timestamp when the harness was archived."
+                },
+                "capabilities": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AgentCapabilityConfig"
+                  },
+                  "description": "Capabilities enabled for this harness with per-harness configuration."
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Timestamp when the harness was created."
+                },
+                "default_model_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Default LLM model ID for this harness.\nLowest priority in chain: controls > session > agent > harness.",
+                  "example": "model_01933b5a00007000800000000000001"
+                },
+                "deleted_at": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "format": "date-time",
+                  "description": "Timestamp when the harness was deleted."
+                },
+                "description": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Human-readable description of what the harness does."
+                },
+                "display_name": {
+                  "type": "string",
+                  "description": "Human-readable display name shown in UI."
+                },
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier for the harness (format: harness_{32-hex}).",
+                  "example": "harness_01933b5a00007000800000000000001"
+                },
+                "initial_files": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/InitialFile"
+                  },
+                  "description": "Starter files copied into each new session for this harness."
+                },
+                "is_built_in": {
+                  "type": "boolean",
+                  "description": "Whether this harness is built-in (system-managed, readonly).\nBuilt-in harnesses are provisioned during org initialization and\ncannot be modified or deleted via the API. Users can copy them."
+                },
+                "name": {
+                  "type": "string",
+                  "description": "URL/CLI-friendly addressable name, unique per org.\nFormat: `[a-z0-9]+(-[a-z0-9]+)*`, max 64 chars. No consecutive hyphens."
+                },
+                "network_access": {
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "#/components/schemas/NetworkAccessList",
+                      "description": "Network access list controlling which hosts/URLs sessions can reach.\nMerged with agent and session layers (allowed: intersect, blocked: union)."
+                    }
+                  ]
+                },
+                "parent_harness_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Optional parent harness that this harness inherits from.",
+                  "example": "harness_01933b5a000070008000000000000602"
+                },
+                "status": {
+                  "$ref": "#/components/schemas/HarnessStatus",
+                  "description": "Current lifecycle status of the harness."
+                },
+                "system_prompt": {
+                  "type": "string",
+                  "description": "System prompt that defines the harness's base behavior.\nForms the foundation of the prompt stack."
+                },
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Tags for organizing and filtering harnesses."
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Timestamp when the harness was last updated."
                 }
               }
             },
@@ -10161,6 +10956,32 @@
           }
         }
       },
+      "PreviewHarnessRequest": {
+        "type": "object",
+        "description": "Request to preview harness shape with capabilities applied",
+        "required": [
+          "system_prompt"
+        ],
+        "properties": {
+          "capabilities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentCapabilityConfig"
+            }
+          },
+          "parent_harness_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "example": "harness_01933b5a000070008000000000000602"
+          },
+          "system_prompt": {
+            "type": "string",
+            "example": "You are a research assistant."
+          }
+        }
+      },
       "ReasonCompletedData": {
         "type": "object",
         "description": "Data for reason.completed event",
@@ -10380,6 +11201,25 @@
           "value": {
             "$ref": "#/components/schemas/ReasoningEffort",
             "description": "The API value (e.g., \"low\", \"medium\")"
+          }
+        }
+      },
+      "ResourceConfigResponse": {
+        "type": "object",
+        "description": "Response type for per-resource config endpoints.\n\nEvery resource exposes `GET /v1/{resource}/config` returning this type.\nUI uses it to gate controls (create/edit/delete buttons, admin panels).",
+        "required": [
+          "policies"
+        ],
+        "properties": {
+          "policies": {
+            "type": "object",
+            "description": "Map of policy ID → whether the caller satisfies it.",
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
           }
         }
       },
@@ -12266,6 +13106,100 @@
           }
         }
       },
+      "UpdateHarnessRequest": {
+        "type": "object",
+        "description": "Request to update a harness. Only provided fields will be updated.",
+        "properties": {
+          "capabilities": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AgentCapabilityConfig"
+            }
+          },
+          "default_model_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "display_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable display name.",
+            "example": "Updated Research Harness"
+          },
+          "initial_files": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/InitialFile"
+            }
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "URL/CLI-friendly addressable name.",
+            "example": "updated-research"
+          },
+          "network_access": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/NetworkAccessList",
+                "description": "Network access list. Send `{}` (empty object) to clear. Omit to leave unchanged."
+              }
+            ]
+          },
+          "parent_harness_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/HarnessStatus"
+              }
+            ]
+          },
+          "system_prompt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "tags": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "UpdateLlmModelRequest": {
         "type": "object",
         "description": "Request to update an LLM model. Only provided fields will be updated.",
@@ -12764,6 +13698,10 @@
     {
       "name": "session-storage",
       "description": "Session key-value storage endpoints"
+    },
+    {
+      "name": "harnesses",
+      "description": "Harness management endpoints"
     },
     {
       "name": "skills",

--- a/docs/features/harnesses.md
+++ b/docs/features/harnesses.md
@@ -63,6 +63,15 @@ Infinity Context and Context Compaction work together to keep long sessions unbo
 | Testing capability behavior | Base |
 | Custom tool composition | Base |
 
+## Harness Naming
+
+Every harness has two names:
+
+- **`name`** — A stable, URL-friendly slug (e.g. `generic`, `deep-research`). Unique per org. Use this in API calls, CLI commands, and code.
+- **`display_name`** — A human-readable label (e.g. "Generic", "Deep Research"). Shown in the UI.
+
+The `name` field follows the format `[a-z0-9]+(-[a-z0-9]+)*` (max 64 chars, no consecutive hyphens) — similar to a GitHub repo name.
+
 ## Managing Harnesses
 
 ### Via API
@@ -73,13 +82,24 @@ List available harnesses:
 curl http://localhost:9300/api/v1/harnesses
 ```
 
+Get a harness by name or ID:
+
+```bash
+# By name
+curl http://localhost:9300/api/v1/harnesses/generic
+
+# By ID
+curl http://localhost:9300/api/v1/harnesses/harness_01933b5a000070008000000000000602
+```
+
 Create a custom harness:
 
 ```bash
 curl -X POST http://localhost:9300/api/v1/harnesses \
   -H "Content-Type: application/json" \
   -d '{
-    "name": "My Custom Harness",
+    "name": "research-assistant",
+    "display_name": "Research Assistant",
     "description": "Harness with research capabilities",
     "system_prompt": "You are a research assistant.",
     "capabilities": [
@@ -93,12 +113,31 @@ curl -X POST http://localhost:9300/api/v1/harnesses \
 Use a harness when creating a session:
 
 ```bash
+# By name
 curl -X POST http://localhost:9300/api/v1/sessions \
   -H "Content-Type: application/json" \
   -d '{
-    "harness_id": "harness_...",
+    "harness_name": "generic",
     "agent_id": "agent_..."
   }'
+
+# By ID
+curl -X POST http://localhost:9300/api/v1/sessions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "harness_id": "harness_01933b5a000070008000000000000602",
+    "agent_id": "agent_..."
+  }'
+```
+
+### Via CLI
+
+```bash
+# By name
+everruns sessions create --harness generic
+
+# By ID
+everruns sessions create --harness harness_01933b5a000070008000000000000602
 ```
 
 ### Preview a Harness

--- a/specs/harness-types.md
+++ b/specs/harness-types.md
@@ -19,6 +19,12 @@ Every harness has two name fields:
 
 The `name` field works like a GitHub repository name: lowercase alphanumeric with hyphens, no consecutive hyphens, no leading/trailing hyphens. It is unique per organization (among non-deleted harnesses) and can be used for API lookups, CLI references, and URL routing.
 
+### Name-based access
+
+- **GET /v1/harnesses/{id_or_name}** — Accepts either a prefixed ID (`harness_...`) or a stable name (`generic`). The server tries parsing as ID first, then falls back to name lookup.
+- **POST /v1/sessions** — Accepts `harness_name` as an alternative to `harness_id`. The two fields are mutually exclusive.
+- **CLI** — `everruns sessions create --harness generic` accepts both IDs and names. Non-ID values are resolved via `GET /v1/harnesses/{name}` before session creation.
+
 ## Built-in Harness Types
 
 ### Base


### PR DESCRIPTION
## What

Expose harness stable names across all consumer surfaces: API, CLI, OpenAPI spec, and docs.

## Why

Harnesses now have stable addressable names (e.g. `generic`, `deep-research`) but consumers could only reference them by opaque UUID-based IDs. This makes the API harder to use and requires clients to list+search harnesses to find IDs.

## How

1. **API: GET /v1/harnesses/{id_or_name}** — accepts either a prefixed ID (`harness_...`) or stable name. Tries ID parse first, falls back to `HarnessService::get_by_name()` with `HARNESS_VIEW` policy.

2. **API: POST /v1/sessions** — new `harness_name` field as alternative to `harness_id`. Mutually exclusive (400 if both set). Resolved to ID via `get_harness_by_name()` before existing flow.

3. **OpenAPI** — all 8 harness endpoints added to spec (`openapi.rs` + exported `openapi.json`).

4. **CLI** — `--harness` flag accepts names. Non-ID values resolved via `GET /v1/harnesses/{name}` before SDK call. Will be simplified once SDK adds `harness_name` support (#1211).

5. **Docs/specs** — updated `docs/features/harnesses.md` with naming section and name-based examples. Updated `specs/harness-types.md` with name-based access documentation.

## Risk

- Low
- Existing ID-based access is unchanged. Name-based access is additive.
- CLI uses raw HTTP for name resolution (workaround until SDK update #1211).

## Security

- Threat categories reviewed: TM-API, TM-AUTHZ, TM-TENANT
- All name lookups are org-scoped via `caller.org_id` from auth context — no cross-tenant leaks
- `get_by_name` uses same `HARNESS_VIEW` policy as `get` — no authz bypass
- `harness_name` DB lookup uses parameterized queries — no SQL injection
- Mutual exclusion of `harness_id`/`harness_name` explicitly enforced (400 if both)
- No new secrets, no prompt injection surface, no unbounded inputs

## Checklist

- [x] Tests added or updated (30 harness unit tests pass; smoke tested all 7 scenarios end-to-end)
- [x] Backward compatibility considered (additive only, existing ID-based access unchanged)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Follow-up

- SDK: #1211 — add `harness_name` to `CreateSessionRequest` and harness client to `everruns-sdk`
