### PR TITLE
fix(ci): replace deprecated macos-13 runner with macos-latest

### DIFF
--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -25,7 +25,7 @@ jobs:
             runner: macos-latest
             archive: everruns-aarch64-apple-darwin.tar.gz
           - target: x86_64-apple-darwin
-            runner: macos-13
+            runner: macos-latest
             archive: everruns-x86_64-apple-darwin.tar.gz
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-latest


### PR DESCRIPTION
## What
Replace deprecated `macos-13` GitHub Actions runner with `macos-latest` in the CLI binaries workflow.

## Why
GitHub Actions removed the `macos-13` runner. The v0.8.8 release's `cli-binaries.yml` workflow failed on the `x86_64-apple-darwin` build with "The configuration 'macos-13-us-default' is not supported". Since the `update-homebrew` job depends on all builds completing, it was cancelled — leaving the homebrew tap stuck at v0.8.7.

## How
Changed `runner: macos-13` → `runner: macos-latest` for the `x86_64-apple-darwin` matrix entry. `macos-latest` runs on Apple Silicon (arm64), but cross-compilation to x86_64 works natively via Apple's toolchain. The `dtolnay/rust-toolchain` action already installs the x86_64 target.

## Risk
- Low
- If cross-compilation fails on arm64 runners, the x86_64-apple-darwin binary won't be produced. Mitigated by the fact that Rust + Apple toolchain cross-compilation from arm64→x86_64 is well-established.

## Security
- No security-relevant code changes. This is a CI runner configuration change only — no application code, authentication, API surface, or data handling is affected.

## Checklist
- [x] Tests added or updated — N/A (CI config change, validated by next workflow run)
- [x] Backward compatibility considered — N/A
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Follow-up
After merge, re-trigger the CLI binaries workflow for v0.8.8 to update the homebrew tap:
```
gh workflow run cli-binaries.yml --ref v0.8.8 -f tag=v0.8.8
```