### PR TITLE
fix(core): empty id/search crash in read_capabilities and tool error logging

### DIFF
--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -1093,6 +1093,25 @@ mod tests {
         })
     }
 
+    fn read_capabilities_tool_def() -> crate::ToolDefinition {
+        crate::ToolDefinition::Builtin(crate::BuiltinTool {
+            name: "read_capabilities".to_string(),
+            display_name: None,
+            description: "List capabilities".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "search": {"type": "string"}
+                }
+            }),
+            policy: Default::default(),
+            category: None,
+            deferrable: Default::default(),
+            hints: crate::tool_types::ToolHints::default(),
+        })
+    }
+
     #[tokio::test]
     async fn test_act_atom_platform_tool_works_with_platform_store() {
         use crate::capabilities::{Capability, PlatformManagementCapability};
@@ -1117,10 +1136,10 @@ mod tests {
             agent_id: None,
             tool_calls: vec![ToolCall {
                 id: "call_1".to_string(),
-                name: "manage_harnesses".to_string(),
-                arguments: json!({"operation": "list"}),
+                name: "read_capabilities".to_string(),
+                arguments: json!({}),
             }],
-            tool_definitions: vec![manage_harnesses_tool_def()],
+            tool_definitions: vec![read_capabilities_tool_def()],
             locale: None,
             blueprint_id: None,
             network_access: None,
@@ -1132,15 +1151,14 @@ mod tests {
         assert_eq!(result.results.len(), 1);
         assert!(
             result.results[0].success,
-            "manage_harnesses should succeed when platform_store is wired: {:?}",
+            "read_capabilities should succeed when platform_store is wired: {:?}",
             result.results[0].result.error
         );
     }
 
     /// Regression test: `manage_harnesses` called through ActAtom WITHOUT
     /// `platform_store` should produce an error message in the result body.
-    /// ToolErrors are "normal" results (success=true) by design, but the
-    /// result body contains `{"error": "..."}` that the LLM sees.
+    /// ToolErrors set error field so they are logged as failures in events.
     #[tokio::test]
     async fn test_act_atom_platform_tool_fails_without_platform_store() {
         use crate::capabilities::{Capability, PlatformManagementCapability};
@@ -1176,10 +1194,9 @@ mod tests {
 
         assert!(result.completed);
         assert_eq!(result.results.len(), 1);
-        // ToolErrors produce result body with {"error": "..."} but the ActAtom
-        // treats them as successful completions (error field is None).
-        let result_body = result.results[0].result.result.as_ref().unwrap();
-        let err_msg = result_body["error"].as_str().unwrap();
+        // ToolErrors set error field and are logged as failures
+        assert!(!result.results[0].success);
+        let err_msg = result.results[0].result.error.as_deref().unwrap();
         assert!(
             err_msg.contains("Platform management not available"),
             "Expected platform management error, got: {err_msg}"

--- a/crates/core/src/capabilities/platform_management.rs
+++ b/crates/core/src/capabilities/platform_management.rs
@@ -82,7 +82,9 @@ fn get_platform_store(
 }
 
 fn get_str<'a>(args: &'a Value, key: &str) -> Option<&'a str> {
-    args.get(key).and_then(|v| v.as_str())
+    args.get(key)
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
 }
 
 fn require_str<'a>(args: &'a Value, key: &str) -> Result<&'a str, ToolExecutionResult> {
@@ -2234,6 +2236,37 @@ mod tests {
         match result {
             ToolExecutionResult::Success(v) => {
                 assert_eq!(v["count"], 0);
+            }
+            other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn read_capabilities_empty_id_returns_all() {
+        let ctx = mock_context();
+        let tool = ReadCapabilitiesTool;
+        // LLMs sometimes send empty strings for optional params — must not crash
+        let result = tool
+            .execute_with_context(json!({"id": "", "search": ""}), &ctx)
+            .await;
+        match result {
+            ToolExecutionResult::Success(v) => {
+                let count = v["count"].as_u64().unwrap();
+                assert!(count > 0, "empty id/search should return all capabilities");
+            }
+            other => panic!("expected success with all capabilities, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn read_capabilities_empty_id_only_returns_all() {
+        let ctx = mock_context();
+        let tool = ReadCapabilitiesTool;
+        let result = tool.execute_with_context(json!({"id": ""}), &ctx).await;
+        match result {
+            ToolExecutionResult::Success(v) => {
+                let count = v["count"].as_u64().unwrap();
+                assert!(count > 0, "empty id should return all capabilities");
             }
             other => panic!("expected success, got: {other:?}"),
         }

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -216,13 +216,14 @@ impl ToolExecutionResult {
                 );
 
                 // Return generic error message to LLM, packaged as {"error": "..."}
+                let generic_msg = "An internal error occurred while executing the tool";
                 ToolResult {
                     tool_call_id: tool_call_id.to_string(),
                     result: Some(serde_json::json!({
-                        "error": "An internal error occurred while executing the tool"
+                        "error": generic_msg
                     })),
                     images: None,
-                    error: None,
+                    error: Some(generic_msg.to_string()),
                     connection_required: None,
                     raw_output: None,
                 }
@@ -884,7 +885,10 @@ mod tests {
         // Internal error (packaged as {"error": "..."} with generic message)
         let result = ToolExecutionResult::internal_error_msg("Secret database error");
         let tool_result = result.into_tool_result("call_3", "test_tool");
-        assert!(tool_result.error.is_none());
+        assert_eq!(
+            tool_result.error.as_deref(),
+            Some("An internal error occurred while executing the tool")
+        );
         assert_eq!(
             tool_result.result.unwrap(),
             serde_json::json!({"error": "An internal error occurred while executing the tool"})

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -200,9 +200,9 @@ impl ToolExecutionResult {
             },
             ToolExecutionResult::ToolError(message) => ToolResult {
                 tool_call_id: tool_call_id.to_string(),
-                result: Some(serde_json::json!({ "error": message })),
+                result: Some(serde_json::json!({ "error": &message })),
                 images: None,
-                error: None,
+                error: Some(message),
                 connection_required: None,
                 raw_output: None,
             },
@@ -872,10 +872,10 @@ mod tests {
         assert!(tool_result.error.is_none());
         assert_eq!(tool_result.result.unwrap()["value"], 42);
 
-        // Tool error (packaged as {"error": "..."} in result field)
+        // Tool error (packaged as {"error": "..."} in result field, also sets error)
         let result = ToolExecutionResult::tool_error("Invalid input");
         let tool_result = result.into_tool_result("call_2", "test_tool");
-        assert!(tool_result.error.is_none());
+        assert_eq!(tool_result.error.as_deref(), Some("Invalid input"));
         assert_eq!(
             tool_result.result.unwrap(),
             serde_json::json!({"error": "Invalid input"})

--- a/crates/core/tests/tool_calling_test.rs
+++ b/crates/core/tests/tool_calling_test.rs
@@ -145,8 +145,11 @@ async fn test_internal_error_is_hidden() {
     // Execute and verify internal error is hidden (packaged as {"error": "..."} with generic message)
     let result = registry.execute(&tool_call, &tool_def).await.unwrap();
 
-    assert!(result.error.is_none());
-    // Internal error message should be replaced with generic message in result field
+    // Internal error sets generic message in error field (real details are only logged)
+    assert_eq!(
+        result.error.as_deref(),
+        Some("An internal error occurred while executing the tool")
+    );
     assert_eq!(
         result.result,
         Some(json!({"error": "An internal error occurred while executing the tool"}))

--- a/crates/core/tests/tool_calling_test.rs
+++ b/crates/core/tests/tool_calling_test.rs
@@ -111,7 +111,7 @@ async fn test_tool_error_handling() {
     // Execute and verify error is packaged as {"error": "..."} in result field
     let result = registry.execute(&tool_call, &tool_def).await.unwrap();
 
-    assert!(result.error.is_none());
+    assert_eq!(result.error.as_deref(), Some("Expected test failure"));
     assert_eq!(
         result.result,
         Some(json!({"error": "Expected test failure"}))


### PR DESCRIPTION
## What

Fix two bugs in tool execution:

1. `read_capabilities` crashes with `"Capability not found: "` when LLM sends empty strings for `id`/`search` parameters.
2. `ToolExecutionResult::ToolError` is logged as `success: true` in `tool.completed` events instead of `success: false`.

## Why

LLMs frequently send empty strings for optional parameters. The `get_str` helper returned `Some("")` for these, causing the exact-match branch in `read_capabilities` to trigger with an empty ID — which matches nothing, producing a confusing error.

Separately, `ToolError` results set `error: None` in `ToolResult`, so the event emission code (`tool_result.error.is_none()`) classified them as successes. This made tool errors invisible in event logs and the chat UI.

## How

1. Added `.filter(|s| !s.is_empty())` to `get_str()` so empty strings are treated as `None` (same as missing parameters).
2. Set `error: Some(message)` in `ToolResult` for `ToolExecutionResult::ToolError`, so `tool.completed` events correctly report `success: false`.
3. Fixed a stale test (`manage_harnesses list`) that was only passing because of bug #2 — it used a removed operation but appeared successful due to the masking bug.

## Risk

- Low
- The `get_str` change is scoped to platform management tools. Empty-string filtering is strictly more defensive.
- The `ToolError` → `error: Some(...)` change affects event logging and `ToolCallResult.success` flag. LLM-facing behavior is unchanged (the `result` field still contains `{"error": "..."}`).

## Security

- Threat categories reviewed: TM-TOOL (tool execution paths, result handling)
- No new attack surface. Both changes are defensive corrections. No auth, injection, or data exposure implications.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)