### PR TITLE
fix(ui): show friendly label in parent harness select

### DIFF
--- a/apps/ui/src/components/harness/harness-select.tsx
+++ b/apps/ui/src/components/harness/harness-select.tsx
@@ -57,9 +57,12 @@ export function HarnessSelect({
 
   // Resolve ID → name. When harnesses haven't loaded yet (org switch race),
   // show "Loading…" instead of the raw ID (EVE-142).
+  // When no value is set and includeNoneOption is true, show the noneLabel.
   const displayValue = value
     ? (harnessMap.get(value)?.name ?? (filteredHarnesses.length === 0 ? "Loading…" : value))
-    : undefined;
+    : includeNoneOption
+      ? noneLabel
+      : undefined;
 
   return (
     <Select


### PR DESCRIPTION
## What
Display a user-friendly label (e.g. "No parent harness") instead of the raw `__none__` sentinel value in the Parent Harness dropdown when no parent is selected.

## Why
The `__none__` internal sentinel was leaking into the UI, creating a confusing experience for users creating or editing harnesses.

## How
In `HarnessSelect`, when `value` is empty and `includeNoneOption` is true, set `displayValue` to `noneLabel` instead of `undefined`. This prevents Radix Select from falling back to showing the raw sentinel value.

## Risk
- Low
- Pure display logic change in a single component. No data flow, API, or state changes.

## Security
- No security-relevant code changes. This is a UI display-only fix that changes how an existing string is rendered in a dropdown. No trust boundaries, inputs, or data flows are affected.

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
