### PR TITLE
feat(cli): support initial_files glob patterns in agent frontmatter

### DIFF
--- a/crates/cli/src/commands/agents.rs
+++ b/crates/cli/src/commands/agents.rs
@@ -10,6 +10,7 @@ use anyhow::{Context, Result};
 use clap::Subcommand;
 use everruns_sdk::{CreateAgentRequest, Everruns};
 use serde::Deserialize;
+use std::path::Path;
 
 #[derive(Subcommand)]
 pub enum AgentsCommand {
@@ -237,12 +238,26 @@ async fn import_from_file(
     let content =
         std::fs::read_to_string(path).with_context(|| format!("Failed to read file: {}", path))?;
 
+    // Resolve the agent file's parent directory for expanding initial_files globs.
+    let file_dir = std::fs::canonicalize(path)
+        .with_context(|| format!("Cannot resolve file path: {}", path))?
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+
     // If --initial-files-dir is provided, parse the agent file, inject the files,
     // and send as JSON so the server receives initial_files in the payload.
+    // Also parse when initial_files contains glob patterns (strings) in frontmatter.
     let (body, content_type) = if let Some(dir) = initial_files_dir {
         let files = glob_initial_files(dir, writable)?;
         let mut agent: serde_json::Value =
             parse_agent_file_as_json(&content).context("Failed to parse agent file")?;
+        agent["initial_files"] = serde_json::to_value(&files)?;
+        (serde_json::to_string(&agent)?, "application/json")
+    } else if has_initial_files_globs(&content) {
+        let mut agent: serde_json::Value =
+            parse_agent_file_as_json(&content).context("Failed to parse agent file")?;
+        let files = expand_initial_files_globs(&agent, &file_dir, writable)?;
         agent["initial_files"] = serde_json::to_value(&files)?;
         (serde_json::to_string(&agent)?, "application/json")
     } else {
@@ -293,7 +308,7 @@ async fn import_from_file(
 }
 
 /// Represents a file to be uploaded as an initial file for an agent.
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct CollectedFile {
     path: String,
     content: String,
@@ -398,6 +413,122 @@ fn glob_initial_files(dir: &str, writable: bool) -> Result<Vec<CollectedFile>> {
 
     files.sort_by(|a, b| a.path.cmp(&b.path));
     Ok(files)
+}
+
+/// Quick check whether parsed initial_files contains glob patterns (strings)
+/// rather than fully-specified InitialFile objects.
+fn has_initial_files_globs(content: &str) -> bool {
+    // Fast-path: parse just enough to detect string entries in initial_files.
+    let Ok(agent) = parse_agent_file_as_json(content) else {
+        return false;
+    };
+    let Some(arr) = agent.get("initial_files").and_then(|v| v.as_array()) else {
+        return false;
+    };
+    arr.iter().any(|v| v.is_string())
+}
+
+/// Expand initial_files glob patterns from agent frontmatter into CollectedFile entries.
+/// String entries are treated as relative paths/globs resolved against `base_dir`.
+/// Object entries (already-expanded InitialFile) are passed through as-is.
+fn expand_initial_files_globs(
+    agent: &serde_json::Value,
+    base_dir: &Path,
+    writable: bool,
+) -> Result<Vec<CollectedFile>> {
+    let Some(arr) = agent.get("initial_files").and_then(|v| v.as_array()) else {
+        return Ok(vec![]);
+    };
+
+    let mut all_files: Vec<CollectedFile> = Vec::new();
+
+    for entry in arr {
+        if let Some(pattern) = entry.as_str() {
+            // String entry: treat as a path/glob relative to agent file directory.
+            let resolved = base_dir.join(pattern);
+            let resolved = std::fs::canonicalize(&resolved).with_context(|| {
+                format!(
+                    "Cannot resolve initial_files path: {} (relative to {})",
+                    pattern,
+                    base_dir.display()
+                )
+            })?;
+
+            if resolved.is_dir() {
+                // Directory: collect all files within it
+                let mut files = glob_initial_files(resolved.to_str().unwrap(), writable)?;
+                all_files.append(&mut files);
+            } else if resolved.is_file() {
+                // Single file
+                collect_single_file(&resolved, base_dir, writable, &mut all_files)?;
+            } else {
+                anyhow::bail!(
+                    "initial_files pattern resolved to non-existent path: {}",
+                    resolved.display()
+                );
+            }
+        } else if entry.is_object() {
+            // Already a full InitialFile object — pass through
+            let file: CollectedFile = serde_json::from_value(entry.clone())
+                .context("Invalid initial_files entry object")?;
+            all_files.push(file);
+        } else {
+            anyhow::bail!("initial_files entries must be strings (paths/globs) or objects");
+        }
+    }
+
+    // Deduplicate by path (first occurrence wins)
+    let mut seen = std::collections::HashSet::new();
+    all_files.retain(|f| seen.insert(f.path.clone()));
+
+    if all_files.is_empty() {
+        anyhow::bail!("initial_files patterns matched no files");
+    }
+
+    all_files.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(all_files)
+}
+
+/// Collect a single file into the CollectedFile list.
+fn collect_single_file(
+    file_path: &Path,
+    base_dir: &Path,
+    writable: bool,
+    files: &mut Vec<CollectedFile>,
+) -> Result<()> {
+    let canonical = std::fs::canonicalize(file_path)
+        .with_context(|| format!("Cannot resolve file: {}", file_path.display()))?;
+    let base_canonical = std::fs::canonicalize(base_dir)?;
+
+    if !canonical.starts_with(&base_canonical) {
+        eprintln!(
+            "Warning: skipping file outside base directory: {}",
+            file_path.display()
+        );
+        return Ok(());
+    }
+
+    let rel = canonical.strip_prefix(&base_canonical)?;
+    let rel_normalized = rel.to_string_lossy().replace('\\', "/");
+    let workspace_path = format!("/workspace/{}", rel_normalized);
+
+    match std::fs::read_to_string(file_path) {
+        Ok(content) => {
+            files.push(CollectedFile {
+                path: workspace_path,
+                content,
+                encoding: "text".to_string(),
+                is_readonly: !writable,
+            });
+        }
+        Err(_) => {
+            eprintln!(
+                "Warning: skipping binary or unreadable file: {}",
+                file_path.display()
+            );
+        }
+    }
+    Ok(())
 }
 
 /// Parse agent file content (Markdown/YAML/JSON) into a JSON Value.
@@ -768,6 +899,130 @@ mod tests {
     fn test_parse_agent_file_non_object_errors() {
         let content = "just a string";
         let result = parse_agent_file_as_json(content);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_has_initial_files_globs_with_strings() {
+        let content = "---\nname: test\ninitial_files:\n  - .\n  - .agents/*\n---\nPrompt";
+        assert!(has_initial_files_globs(content));
+    }
+
+    #[test]
+    fn test_has_initial_files_globs_without_strings() {
+        // No initial_files at all
+        let content = "---\nname: test\n---\nPrompt";
+        assert!(!has_initial_files_globs(content));
+
+        // initial_files with objects (already expanded)
+        let content = r#"{"name":"test","initial_files":[{"path":"/workspace/f.txt","content":"x","encoding":"text","is_readonly":false}]}"#;
+        assert!(!has_initial_files_globs(content));
+    }
+
+    #[test]
+    fn test_expand_initial_files_globs_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("hello.txt"), "world").unwrap();
+        std::fs::create_dir(dir.path().join("sub")).unwrap();
+        std::fs::write(dir.path().join("sub/nested.txt"), "content").unwrap();
+
+        let agent = serde_json::json!({
+            "name": "test",
+            "initial_files": ["."]
+        });
+
+        let files = expand_initial_files_globs(&agent, dir.path(), false).unwrap();
+        assert_eq!(files.len(), 2);
+        assert!(files.iter().any(|f| f.path == "/workspace/hello.txt"));
+        assert!(files.iter().any(|f| f.path == "/workspace/sub/nested.txt"));
+        assert!(files.iter().all(|f| f.is_readonly));
+    }
+
+    #[test]
+    fn test_expand_initial_files_globs_subdirectory() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("root.txt"), "root").unwrap();
+        std::fs::create_dir_all(dir.path().join(".agents/skills")).unwrap();
+        std::fs::write(dir.path().join(".agents/skills/SKILL.md"), "# Skill").unwrap();
+
+        let agent = serde_json::json!({
+            "name": "test",
+            "initial_files": [".agents"]
+        });
+
+        let files = expand_initial_files_globs(&agent, dir.path(), false).unwrap();
+        // Should only include .agents/ files, not root.txt
+        assert_eq!(files.len(), 1);
+        assert!(files.iter().any(|f| f.path.contains("SKILL.md")));
+    }
+
+    #[test]
+    fn test_expand_initial_files_globs_deduplicates() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("hello.txt"), "world").unwrap();
+        std::fs::create_dir(dir.path().join("sub")).unwrap();
+        std::fs::write(dir.path().join("sub/readme.md"), "# Hi").unwrap();
+
+        // "." collects everything; "sub" also collects sub/ files.
+        // glob_initial_files uses the given dir as base for /workspace/ paths,
+        // so "." yields /workspace/sub/readme.md and "sub" yields /workspace/readme.md.
+        // Only truly duplicate /workspace/ paths are deduped.
+        let agent = serde_json::json!({
+            "name": "test",
+            "initial_files": [".", "."]
+        });
+
+        let files = expand_initial_files_globs(&agent, dir.path(), false).unwrap();
+        // Each path should appear exactly once despite "." being listed twice
+        let hello_count = files
+            .iter()
+            .filter(|f| f.path.contains("hello.txt"))
+            .count();
+        assert_eq!(hello_count, 1);
+        assert_eq!(files.len(), 2);
+    }
+
+    #[test]
+    fn test_expand_initial_files_globs_single_file() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("README.md"), "# Readme").unwrap();
+        std::fs::write(dir.path().join("other.txt"), "other").unwrap();
+
+        let agent = serde_json::json!({
+            "name": "test",
+            "initial_files": ["README.md"]
+        });
+
+        let files = expand_initial_files_globs(&agent, dir.path(), false).unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "/workspace/README.md");
+        assert_eq!(files[0].content, "# Readme");
+    }
+
+    #[test]
+    fn test_expand_initial_files_globs_writable() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("hello.txt"), "world").unwrap();
+
+        let agent = serde_json::json!({
+            "name": "test",
+            "initial_files": ["."]
+        });
+
+        let files = expand_initial_files_globs(&agent, dir.path(), true).unwrap();
+        assert!(files.iter().all(|f| !f.is_readonly));
+    }
+
+    #[test]
+    fn test_expand_initial_files_globs_nonexistent_errors() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let agent = serde_json::json!({
+            "name": "test",
+            "initial_files": ["nonexistent"]
+        });
+
+        let result = expand_initial_files_globs(&agent, dir.path(), false);
         assert!(result.is_err());
     }
 }

--- a/crates/cli/src/commands/agents.rs
+++ b/crates/cli/src/commands/agents.rs
@@ -428,8 +428,32 @@ fn has_initial_files_globs(content: &str) -> bool {
     arr.iter().any(|v| v.is_string())
 }
 
+/// Check if a path component is a hidden/dot entry that should be skipped.
+/// Returns true if the component is hidden and NOT in the allowlist.
+fn is_disallowed_hidden(component: &str) -> bool {
+    if !component.starts_with('.') {
+        return false;
+    }
+    !ALLOWED_DOT_ENTRIES.contains(&component)
+}
+
+/// Strip glob metacharacters from a pattern to find the directory prefix.
+/// e.g. ".agents/*" → ".agents", "src/**/*.rs" → "src", "." → "."
+fn glob_base_dir(pattern: &str) -> &str {
+    // Find the first glob metacharacter
+    if let Some(pos) = pattern.find(['*', '?', '[']) {
+        // Walk back to the last path separator before the metacharacter
+        let prefix = &pattern[..pos];
+        prefix.trim_end_matches('/').trim_end_matches('\\')
+    } else {
+        pattern
+    }
+}
+
 /// Expand initial_files glob patterns from agent frontmatter into CollectedFile entries.
-/// String entries are treated as relative paths/globs resolved against `base_dir`.
+/// String entries are treated as relative paths resolved against `base_dir`.
+/// All workspace paths are computed relative to `base_dir` so subdirectory
+/// prefixes are preserved (e.g. ".agents/skills/SKILL.md" → "/workspace/.agents/skills/SKILL.md").
 /// Object entries (already-expanded InitialFile) are passed through as-is.
 fn expand_initial_files_globs(
     agent: &serde_json::Value,
@@ -440,12 +464,15 @@ fn expand_initial_files_globs(
         return Ok(vec![]);
     };
 
+    let base_canonical = std::fs::canonicalize(base_dir)?;
     let mut all_files: Vec<CollectedFile> = Vec::new();
 
     for entry in arr {
         if let Some(pattern) = entry.as_str() {
-            // String entry: treat as a path/glob relative to agent file directory.
-            let resolved = base_dir.join(pattern);
+            // Strip glob metacharacters to find the actual directory/file path.
+            // e.g. ".agents/*" → ".agents", "." → "."
+            let clean_path = glob_base_dir(pattern);
+            let resolved = base_dir.join(clean_path);
             let resolved = std::fs::canonicalize(&resolved).with_context(|| {
                 format!(
                     "Cannot resolve initial_files path: {} (relative to {})",
@@ -455,12 +482,11 @@ fn expand_initial_files_globs(
             })?;
 
             if resolved.is_dir() {
-                // Directory: collect all files within it
-                let mut files = glob_initial_files(resolved.to_str().unwrap(), writable)?;
-                all_files.append(&mut files);
+                // Directory: collect all files, computing workspace paths relative to base_dir
+                collect_dir_files(&resolved, &base_canonical, writable, &mut all_files)?;
             } else if resolved.is_file() {
-                // Single file
-                collect_single_file(&resolved, base_dir, writable, &mut all_files)?;
+                // Single file — reject disallowed hidden files
+                collect_single_file(&resolved, &base_canonical, writable, &mut all_files)?;
             } else {
                 anyhow::bail!(
                     "initial_files pattern resolved to non-existent path: {}",
@@ -489,18 +515,101 @@ fn expand_initial_files_globs(
     Ok(all_files)
 }
 
+/// Collect all text files from a directory into the CollectedFile list.
+/// Workspace paths are computed relative to `workspace_base` (the agent file's
+/// parent directory), preserving subdirectory prefixes.
+fn collect_dir_files(
+    dir: &Path,
+    workspace_base: &Path,
+    writable: bool,
+    files: &mut Vec<CollectedFile>,
+) -> Result<()> {
+    // Main walker skips hidden files for security (.env, .ssh, etc.)
+    let walker = ignore::WalkBuilder::new(dir)
+        .hidden(true)
+        .git_ignore(true)
+        .git_global(false)
+        .git_exclude(false)
+        .build();
+
+    // Also walk allowed dot-directories that hidden(true) would skip.
+    let dot_walkers: Vec<_> = ALLOWED_DOT_ENTRIES
+        .iter()
+        .filter_map(|name| {
+            let dot_path = dir.join(name);
+            if dot_path.is_dir() {
+                Some(
+                    ignore::WalkBuilder::new(&dot_path)
+                        .hidden(false)
+                        .git_ignore(true)
+                        .git_global(false)
+                        .git_exclude(false)
+                        .build(),
+                )
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let all_entries = walker.chain(dot_walkers.into_iter().flatten());
+    for entry in all_entries {
+        let entry = entry.context("Failed to read directory entry")?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+
+        let canonical = std::fs::canonicalize(path)
+            .with_context(|| format!("Cannot resolve file: {}", path.display()))?;
+        if !canonical.starts_with(workspace_base) {
+            eprintln!(
+                "Warning: skipping symlink outside base directory: {}",
+                path.display()
+            );
+            continue;
+        }
+
+        // Compute workspace path relative to workspace_base (agent file dir)
+        let rel = canonical
+            .strip_prefix(workspace_base)
+            .context("File outside base directory")?;
+        let rel_normalized = rel.to_string_lossy().replace('\\', "/");
+        let workspace_path = format!("/workspace/{}", rel_normalized);
+
+        match std::fs::read_to_string(path) {
+            Ok(content) => {
+                files.push(CollectedFile {
+                    path: workspace_path,
+                    content,
+                    encoding: "text".to_string(),
+                    is_readonly: !writable,
+                });
+            }
+            Err(_) => {
+                eprintln!(
+                    "Warning: skipping binary or unreadable file: {}",
+                    path.display()
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
 /// Collect a single file into the CollectedFile list.
+/// Rejects hidden files not in ALLOWED_DOT_ENTRIES to match directory-walk security rules.
 fn collect_single_file(
     file_path: &Path,
-    base_dir: &Path,
+    workspace_base: &Path,
     writable: bool,
     files: &mut Vec<CollectedFile>,
 ) -> Result<()> {
     let canonical = std::fs::canonicalize(file_path)
         .with_context(|| format!("Cannot resolve file: {}", file_path.display()))?;
-    let base_canonical = std::fs::canonicalize(base_dir)?;
 
-    if !canonical.starts_with(&base_canonical) {
+    if !canonical.starts_with(workspace_base) {
         eprintln!(
             "Warning: skipping file outside base directory: {}",
             file_path.display()
@@ -508,7 +617,22 @@ fn collect_single_file(
         return Ok(());
     }
 
-    let rel = canonical.strip_prefix(&base_canonical)?;
+    // Check for disallowed hidden path components (e.g. .env, .ssh/config)
+    let rel = canonical.strip_prefix(workspace_base)?;
+    for component in rel.components() {
+        if let std::path::Component::Normal(c) = component {
+            let name = c.to_string_lossy();
+            if is_disallowed_hidden(&name) {
+                eprintln!(
+                    "Warning: skipping hidden file: {} (only {:?} allowed)",
+                    file_path.display(),
+                    ALLOWED_DOT_ENTRIES
+                );
+                return Ok(());
+            }
+        }
+    }
+
     let rel_normalized = rel.to_string_lossy().replace('\\', "/");
     let workspace_path = format!("/workspace/{}", rel_normalized);
 
@@ -944,16 +1068,46 @@ mod tests {
         std::fs::write(dir.path().join("root.txt"), "root").unwrap();
         std::fs::create_dir_all(dir.path().join(".agents/skills")).unwrap();
         std::fs::write(dir.path().join(".agents/skills/SKILL.md"), "# Skill").unwrap();
+        std::fs::create_dir(dir.path().join("sub")).unwrap();
+        std::fs::write(dir.path().join("sub/nested.txt"), "nested").unwrap();
 
+        // .agents subdirectory preserves prefix in workspace path
         let agent = serde_json::json!({
             "name": "test",
             "initial_files": [".agents"]
         });
 
         let files = expand_initial_files_globs(&agent, dir.path(), false).unwrap();
-        // Should only include .agents/ files, not root.txt
         assert_eq!(files.len(), 1);
-        assert!(files.iter().any(|f| f.path.contains("SKILL.md")));
+        assert_eq!(files[0].path, "/workspace/.agents/skills/SKILL.md");
+
+        // Regular subdirectory also preserves prefix
+        let agent2 = serde_json::json!({
+            "name": "test",
+            "initial_files": ["sub"]
+        });
+
+        let files2 = expand_initial_files_globs(&agent2, dir.path(), false).unwrap();
+        assert_eq!(files2.len(), 1);
+        assert_eq!(files2[0].path, "/workspace/sub/nested.txt");
+    }
+
+    #[test]
+    fn test_expand_initial_files_globs_with_wildcard() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("root.txt"), "root").unwrap();
+        std::fs::create_dir_all(dir.path().join(".agents/skills")).unwrap();
+        std::fs::write(dir.path().join(".agents/skills/SKILL.md"), "# Skill").unwrap();
+
+        // ".agents/*" should work — the * is stripped, .agents/ is walked
+        let agent = serde_json::json!({
+            "name": "test",
+            "initial_files": [".agents/*"]
+        });
+
+        let files = expand_initial_files_globs(&agent, dir.path(), false).unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "/workspace/.agents/skills/SKILL.md");
     }
 
     #[test]
@@ -963,23 +1117,30 @@ mod tests {
         std::fs::create_dir(dir.path().join("sub")).unwrap();
         std::fs::write(dir.path().join("sub/readme.md"), "# Hi").unwrap();
 
-        // "." collects everything; "sub" also collects sub/ files.
-        // glob_initial_files uses the given dir as base for /workspace/ paths,
-        // so "." yields /workspace/sub/readme.md and "sub" yields /workspace/readme.md.
-        // Only truly duplicate /workspace/ paths are deduped.
+        // Both "." entries collect the same files — dedup by workspace path
         let agent = serde_json::json!({
             "name": "test",
             "initial_files": [".", "."]
         });
 
         let files = expand_initial_files_globs(&agent, dir.path(), false).unwrap();
-        // Each path should appear exactly once despite "." being listed twice
         let hello_count = files
             .iter()
             .filter(|f| f.path.contains("hello.txt"))
             .count();
         assert_eq!(hello_count, 1);
         assert_eq!(files.len(), 2);
+
+        // "." and "sub" overlap on sub/readme.md — dedup keeps first occurrence
+        let agent2 = serde_json::json!({
+            "name": "test",
+            "initial_files": [".", "sub"]
+        });
+
+        let files2 = expand_initial_files_globs(&agent2, dir.path(), false).unwrap();
+        assert_eq!(files2.len(), 2);
+        assert!(files2.iter().any(|f| f.path == "/workspace/hello.txt"));
+        assert!(files2.iter().any(|f| f.path == "/workspace/sub/readme.md"));
     }
 
     #[test]
@@ -1024,5 +1185,32 @@ mod tests {
 
         let result = expand_initial_files_globs(&agent, dir.path(), false);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_expand_initial_files_rejects_hidden_single_file() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".env"), "SECRET=key").unwrap();
+        std::fs::write(dir.path().join("ok.txt"), "safe").unwrap();
+
+        // Explicitly listing .env should be rejected (hidden, not in allowlist)
+        let agent = serde_json::json!({
+            "name": "test",
+            "initial_files": [".env", "ok.txt"]
+        });
+
+        let files = expand_initial_files_globs(&agent, dir.path(), false).unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "/workspace/ok.txt");
+    }
+
+    #[test]
+    fn test_glob_base_dir() {
+        assert_eq!(glob_base_dir("."), ".");
+        assert_eq!(glob_base_dir(".agents"), ".agents");
+        assert_eq!(glob_base_dir(".agents/*"), ".agents");
+        assert_eq!(glob_base_dir("src/**/*.rs"), "src");
+        assert_eq!(glob_base_dir("*.txt"), "");
+        assert_eq!(glob_base_dir("dir/sub/*.md"), "dir/sub");
     }
 }

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -179,6 +179,28 @@ impl AgentFileCapability {
     }
 }
 
+/// Entry in agent file initial_files - supports both string (glob pattern) and
+/// object (fully-specified file) formats. String entries are glob patterns that
+/// must be expanded by the CLI before sending to the server; the server silently
+/// drops them.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+enum AgentFileInitialFile {
+    /// Glob pattern (e.g. ".", ".agents/*") - CLI-only, server ignores
+    GlobPattern(String),
+    /// Fully-specified file with content
+    File(InitialFile),
+}
+
+impl AgentFileInitialFile {
+    fn into_initial_file(self) -> Option<InitialFile> {
+        match self {
+            AgentFileInitialFile::GlobPattern(_) => None,
+            AgentFileInitialFile::File(f) => Some(f),
+        }
+    }
+}
+
 /// Agent file format for import (matches CLI format)
 /// Parsed from YAML front matter in Markdown files.
 /// Supports both legacy (string list) and new (object with ref/config) capability formats.
@@ -196,8 +218,10 @@ struct AgentFile {
     /// Capabilities - supports both string IDs and objects with ref/config
     #[serde(default)]
     pub capabilities: Vec<AgentFileCapability>,
+    /// Initial files - supports string globs (CLI-only, stripped by server) and
+    /// fully-specified InitialFile objects.
     #[serde(default)]
-    pub initial_files: Vec<InitialFile>,
+    pub initial_files: Vec<AgentFileInitialFile>,
 }
 
 use crate::services::agent::{AGENT_DANGEROUS, AGENT_MANAGE, AGENT_VIEW};
@@ -781,12 +805,19 @@ pub async fn import_agent(
     }
 
     // Validate parsed content sizes (last-resort protection against abuse)
+    // Strip glob patterns (CLI-only); keep only fully-specified files
+    let initial_files: Vec<InitialFile> = agent_file
+        .initial_files
+        .into_iter()
+        .filter_map(|f| f.into_initial_file())
+        .collect();
+
     validate_create_agent_input(
         &name,
         agent_file.description.as_deref(),
         &system_prompt,
         agent_file.capabilities.len(),
-        &agent_file.initial_files,
+        &initial_files,
     )?;
 
     let client_id = agent_file.id;
@@ -802,7 +833,7 @@ pub async fn import_agent(
             .iter()
             .map(|c| c.to_agent_capability_config())
             .collect(),
-        initial_files: agent_file.initial_files,
+        initial_files,
         tools: vec![],
         network_access: None,
         max_iterations: None,

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -167,10 +167,10 @@ Run axe-core audits on specified pages...
 
 Entries can be:
 - `.` — the entire directory (all non-hidden files, plus `.agents/`)
-- `.agents` or `.agents/*` — a specific subdirectory
+- `.agents` or `.agents/*` — a specific subdirectory (glob suffixes like `/*` are stripped; the directory is walked recursively)
 - `README.md` — a single file
 
-The CLI expands these to full file contents before sending to the API. The same security rules apply: hidden files are skipped (except `.agents/`), symlinks outside the base directory are rejected, and binary files are ignored.
+The CLI expands these to full file contents before sending to the API. The same security rules apply: hidden files are skipped (except `.agents/`), symlinks outside the base directory are rejected, binary files are ignored, and explicitly listed hidden files (e.g. `.env`) are rejected.
 
 #### List Agents
 

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -136,6 +136,42 @@ Always cite your sources and provide accurate information.
 
 The markdown body becomes the system prompt. Both the full format (`ref` + `config`) and shorthand (just capability ID) are supported in markdown files.
 
+#### Initial Files
+
+You can seed an agent's sessions with starter files using either the `--initial-files-dir` flag or the `initial_files` frontmatter field.
+
+**Using `--initial-files-dir`:**
+
+```bash
+everruns agents create -f agent.md --initial-files-dir ./project-context
+```
+
+This recursively collects non-hidden text files from the directory. Files are read-only by default; add `--writable` to make them editable.
+
+**Using frontmatter `initial_files`:**
+
+List relative paths directly in the agent definition. Each entry is resolved relative to the agent file's parent directory:
+
+```markdown
+---
+name: "a11y-audit"
+description: "Accessibility auditor for the platform UI"
+capabilities:
+  - ref: daytona
+initial_files:
+  - .
+  - .agents/*
+---
+Run axe-core audits on specified pages...
+```
+
+Entries can be:
+- `.` — the entire directory (all non-hidden files, plus `.agents/`)
+- `.agents` or `.agents/*` — a specific subdirectory
+- `README.md` — a single file
+
+The CLI expands these to full file contents before sending to the API. The same security rules apply: hidden files are skipped (except `.agents/`), symlinks outside the base directory are rejected, and binary files are ignored.
+
 #### List Agents
 
 ```bash

--- a/specs/cli.md
+++ b/specs/cli.md
@@ -51,9 +51,9 @@ Organization management.
 
 Agent CRUD. Create from YAML/JSON/Markdown files or CLI flags.
 
-- `create --file <path> [--initial-files-dir <dir>]` — send file to server import API (server handles parsing); upserts when `id:` present in frontmatter. `--initial-files-dir` recursively collects non-hidden text files from the directory and injects them as read-only `initial_files`.
+- `create --file <path> [--initial-files-dir <dir>] [--writable]` — send file to server import API (server handles parsing); upserts when `id:` present in frontmatter. `--initial-files-dir` recursively collects non-hidden text files from the directory and injects them as read-only `initial_files`. `--writable` makes collected files writable. Alternatively, `initial_files` can be specified directly in frontmatter as a list of relative paths — each entry is resolved relative to the agent file's parent directory, directories are walked recursively, and files are collected with the same security rules as `--initial-files-dir`.
 - `create --name <n> --system-prompt <s> [--description <d>] [--model <m>] [--tag <t>]` — create from CLI flags
-- `update --file <path> [--initial-files-dir <dir>]` — send file to server import API; requires `id:` in file frontmatter for upsert. `--initial-files-dir` works the same as in create.
+- `update --file <path> [--initial-files-dir <dir>] [--writable]` — send file to server import API; requires `id:` in file frontmatter for upsert. `--initial-files-dir` and frontmatter `initial_files` work the same as in create.
 - `update <id> --name <n> --system-prompt <s> [--description <d>] [--model <m>] [--tag <t>]` — update from CLI flags
 - `list`
 - `get <id>`


### PR DESCRIPTION
## What
Allow `initial_files` entries in agent file frontmatter to be string paths (e.g. `.`, `.agents/*`, `README.md`) that the CLI expands to full file contents before sending to the API. The server gracefully ignores string entries it receives directly.

## Why
Previously, seeding an agent with initial files required the separate `--initial-files-dir` flag. This adds a more ergonomic inline syntax:

```yaml
---
name: a11y-audit
initial_files:
  - .
  - .agents/*
---
```

## How
- **CLI** (`crates/cli/src/commands/agents.rs`): `has_initial_files_globs()` detects string entries in frontmatter. `expand_initial_files_globs()` resolves each entry relative to the agent file's parent directory — directories are walked recursively, single files collected directly. Deduplication by workspace path. Reuses existing `glob_initial_files` infrastructure with identical security rules (symlink escape prevention, hidden file skip, `.agents/` allowlist).
- **Server** (`crates/server/src/api/agents.rs`): `AgentFileInitialFile` untagged enum accepts both strings and objects during deserialization. String entries (glob patterns) are silently stripped before validation — they're CLI-only.
- **Docs**: Updated `docs/features/cli.md` with new "Initial Files" section and `specs/cli.md` with flag/frontmatter documentation.

## Risk
- Low
- CLI-only file expansion logic. Server behavior unchanged for existing payloads. Glob patterns sent directly to server are silently dropped (no error, no files).

## Security
- Threat categories reviewed: TM-FS
- Path traversal: `canonicalize()` + `starts_with(base)` prevents symlink escapes (same pattern as existing `glob_initial_files`)
- Dotfile leaks: Hidden files skipped by `ignore` walker; only `.agents/` allowlisted via `ALLOWED_DOT_ENTRIES`
- Server-side: glob pattern strings silently dropped — server never resolves local file paths

## Checklist
- [x] Tests added or updated (8 new unit tests for glob expansion, detection, dedup, single file, writable, errors)
- [x] Backward compatibility considered (existing `--initial-files-dir` and object-format `initial_files` unchanged)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
