### PR TITLE
fix(ui): fix chat message ordering and input typing performance

### DIFF
--- a/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
@@ -384,19 +384,33 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
 
     const merged = [...realChatEvents, ...pendingOptimisticEvents];
     // Sort by sequence to guarantee correct chronological order regardless of
-    // SSE arrival order. Optimistic events use sequence -1, so they naturally
-    // sort before real events — but we want them at the end (they represent the
-    // latest user message). Use timestamp as tiebreaker for equal/missing sequences.
+    // SSE arrival order. Only optimistic events use sequence -1, and they
+    // should appear at the end (they represent the latest user message).
+    // Events missing a sequence fall back to timestamp ordering.
     merged.sort((a, b) => {
-      const seqA = a.sequence ?? -1;
-      const seqB = b.sequence ?? -1;
-      if (seqA !== seqB) {
-        // Push optimistic (sequence -1) to end by treating -1 as Infinity
-        const effA = seqA < 0 ? Number.MAX_SAFE_INTEGER : seqA;
-        const effB = seqB < 0 ? Number.MAX_SAFE_INTEGER : seqB;
-        return effA - effB;
+      const seqA = a.sequence;
+      const seqB = b.sequence;
+      const isOptimisticA = seqA === -1;
+      const isOptimisticB = seqB === -1;
+      const hasSeqA = seqA != null && seqA !== -1;
+      const hasSeqB = seqB != null && seqB !== -1;
+
+      // Optimistic events always sort to the end
+      if (isOptimisticA !== isOptimisticB) {
+        return isOptimisticA ? 1 : -1;
       }
-      // Same sequence — compare by timestamp
+
+      // Both have real sequences — sort numerically
+      if (hasSeqA && hasSeqB && seqA !== seqB) {
+        return seqA - seqB;
+      }
+
+      // One has a sequence and the other doesn't — sequenced first
+      if (hasSeqA !== hasSeqB) {
+        return hasSeqA ? -1 : 1;
+      }
+
+      // Same sequence, both missing, or both optimistic — compare by timestamp
       return a.ts.localeCompare(b.ts);
     });
     return merged;

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
@@ -381,7 +381,24 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
       return !realUserTexts.has(optText);
     });
 
-    return [...realChatEvents, ...pendingOptimisticEvents];
+    const merged = [...realChatEvents, ...pendingOptimisticEvents];
+    // Sort by sequence to guarantee correct chronological order regardless of
+    // SSE arrival order. Optimistic events use sequence -1, so they naturally
+    // sort before real events — but we want them at the end (they represent the
+    // latest user message). Use timestamp as tiebreaker for equal/missing sequences.
+    merged.sort((a, b) => {
+      const seqA = a.sequence ?? -1;
+      const seqB = b.sequence ?? -1;
+      if (seqA !== seqB) {
+        // Push optimistic (sequence -1) to end by treating -1 as Infinity
+        const effA = seqA < 0 ? Number.MAX_SAFE_INTEGER : seqA;
+        const effB = seqB < 0 ? Number.MAX_SAFE_INTEGER : seqB;
+        return effA - effB;
+      }
+      // Same sequence — compare by timestamp
+      return a.ts.localeCompare(b.ts);
+    });
+    return merged;
   }, [events, optimisticEvents]);
 
   // Build tool result lookup by tool_call_id

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
@@ -5,6 +5,7 @@ import {
   useContext,
   useState,
   useMemo,
+  useCallback,
   useEffect,
   useRef,
   type ReactNode,
@@ -525,29 +526,35 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
     ? getReasoningEffortName(reasoningEffortConfig.default)
     : "Medium";
 
-  // Extract text from message event data
-  const getMessageText = (data: InputMessageData | OutputMessageCompletedData): string => {
-    const content = data.message?.content;
-    if (!content) return "";
-    return getTextFromContent(content);
-  };
+  // Extract text from message event data (stable ref — no deps)
+  const getMessageText = useCallback(
+    (data: InputMessageData | OutputMessageCompletedData): string => {
+      const content = data.message?.content;
+      if (!content) return "";
+      return getTextFromContent(content);
+    },
+    [],
+  );
 
-  // Get tool calls from message event data
-  const getToolCalls = (
-    data: OutputMessageCompletedData,
-  ): Array<{
-    id: string;
-    name: string;
-    arguments: Record<string, unknown>;
-  }> => {
-    const content = data.message?.content;
-    if (!content) return [];
-    return content.filter(isToolCallPart).map((part) => ({
-      id: part.id,
-      name: part.name,
-      arguments: part.arguments,
-    }));
-  };
+  // Get tool calls from message event data (stable ref — no deps)
+  const getToolCalls = useCallback(
+    (
+      data: OutputMessageCompletedData,
+    ): Array<{
+      id: string;
+      name: string;
+      arguments: Record<string, unknown>;
+    }> => {
+      const content = data.message?.content;
+      if (!content) return [];
+      return content.filter(isToolCallPart).map((part) => ({
+        id: part.id,
+        name: part.name,
+        arguments: part.arguments,
+      }));
+    },
+    [],
+  );
 
   const value: SessionContextValue = {
     agentId,

--- a/apps/ui/src/components/chat/chat-message-list.tsx
+++ b/apps/ui/src/components/chat/chat-message-list.tsx
@@ -7,7 +7,7 @@
 "use client";
 
 import { Bot, CalendarClock, Loader2 } from "lucide-react";
-import { useMemo } from "react";
+import { memo, useMemo } from "react";
 import type {
   ContentPart,
   Event,
@@ -162,7 +162,7 @@ function renderTurnDivider(
   );
 }
 
-export function ChatMessageList({
+export const ChatMessageList = memo(function ChatMessageList({
   events,
   chatEvents,
   sessionId,
@@ -458,4 +458,4 @@ export function ChatMessageList({
       })}
     </div>
   );
-}
+});

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -37,6 +37,7 @@ export function ChatPanel() {
     isActive,
     reasoningEffort,
     setReasoningEffort,
+    isWaitingForResponse,
     setIsWaitingForResponse,
     isThinking,
     streamingText,
@@ -92,7 +93,7 @@ export function ChatPanel() {
       loadingOlderEvents,
       loadOlderEvents,
       sessionId,
-      scrollDeps: [streamingText, isThinking],
+      scrollDeps: [streamingText, isThinking, isWaitingForResponse],
     });
 
   const { isDraggingOver, dropZoneProps, handlePaste } = useImageDropZone({
@@ -199,7 +200,7 @@ export function ChatPanel() {
           getToolCalls={getToolCalls}
         />
 
-        {(isThinking || streamingText) && (
+        {(isWaitingForResponse || isThinking || streamingText) && (
           <div className="mt-6 flex justify-start">
             <div className={chatSurfaceStyles.agentMessageRow}>
               <div className={chatSurfaceStyles.agentIcon}>
@@ -211,11 +212,11 @@ export function ChatPanel() {
                     {t("iteration", { value: streamingIteration })}
                   </div>
                 )}
-                {isThinking && !streamingText ? (
-                  <ThinkingIndicator />
-                ) : streamingText ? (
+                {streamingText ? (
                   <StreamingMessage text={streamingText} />
-                ) : null}
+                ) : (
+                  <ThinkingIndicator />
+                )}
               </div>
             </div>
           </div>

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -37,7 +37,6 @@ export function ChatPanel() {
     isActive,
     reasoningEffort,
     setReasoningEffort,
-    isWaitingForResponse,
     setIsWaitingForResponse,
     isThinking,
     streamingText,
@@ -93,7 +92,7 @@ export function ChatPanel() {
       loadingOlderEvents,
       loadOlderEvents,
       sessionId,
-      scrollDeps: [streamingText, isThinking, isWaitingForResponse],
+      scrollDeps: [streamingText, isThinking],
     });
 
   const { isDraggingOver, dropZoneProps, handlePaste } = useImageDropZone({
@@ -200,7 +199,7 @@ export function ChatPanel() {
           getToolCalls={getToolCalls}
         />
 
-        {(isWaitingForResponse || isThinking || streamingText) && (
+        {(isThinking || streamingText) && (
           <div className="mt-6 flex justify-start">
             <div className={chatSurfaceStyles.agentMessageRow}>
               <div className={chatSurfaceStyles.agentIcon}>
@@ -212,11 +211,11 @@ export function ChatPanel() {
                     {t("iteration", { value: streamingIteration })}
                   </div>
                 )}
-                {streamingText ? (
-                  <StreamingMessage text={streamingText} />
-                ) : (
+                {isThinking && !streamingText ? (
                   <ThinkingIndicator />
-                )}
+                ) : streamingText ? (
+                  <StreamingMessage text={streamingText} />
+                ) : null}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## What
Fix two chat UI issues: messages rendering out of order during SSE streaming, and laggy typing in the chat input.

## Why
1. **Message ordering:** Chat events were rendered in SSE arrival order rather than by sequence number. When events arrived out of order (e.g. tool calls before user messages), the UI showed messages in wrong positions. Page refresh fixed it because the REST batch comes pre-sorted from the server.
2. **Input lag:** Every keystroke in the chat composer re-rendered the entire ChatMessageList (potentially hundreds of messages) because the component wasn't memoized and received unstable function references as props.

## How
1. **Sort chatEvents by sequence number** in the `useMemo` that builds the array. Optimistic events (sequence -1) are treated as `MAX_SAFE_INTEGER` to sort to the end. Timestamp is used as tiebreaker for equal sequences.
2. **Wrap ChatMessageList in `React.memo`** so it skips re-rendering when props are unchanged (which they are during typing — `inputValue` is local to ChatPanel).
3. **Wrap `getMessageText` and `getToolCalls` in `useCallback`** with empty deps so they have stable references, allowing the memo comparison to succeed.

## Risk
- Low
- Sorting could theoretically change display order for events with identical sequences, but timestamp tiebreaker preserves chronological order. Memo could mask a re-render if a prop mutation occurs, but all props are immutable values or memoized references.

## Security
- No security-relevant code changes. This is a frontend-only rendering and performance fix — no API calls, auth, data handling, or trust boundaries are affected.

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
