### PR TITLE
feat(harnesses): reserve default in harness name validation

### DIFF
--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -23,7 +23,7 @@ use super::common::{
     ApiOptionExt, ApiPolicyResultExt, ApiResult, ErrorResponse, ListResponse, impl_auth_state,
 };
 use super::validation::{
-    validate_create_agent_input, validate_harness_name, validate_update_agent_input,
+    validate_create_agent_input, validate_harness_name_strict, validate_update_agent_input,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -219,7 +219,7 @@ pub async fn create_harness(
     State(state): State<AppState>,
     Json(req): Json<CreateHarnessRequest>,
 ) -> Result<(StatusCode, Json<Harness>), (StatusCode, Json<ErrorResponse>)> {
-    validate_harness_name(&req.name)?;
+    validate_harness_name_strict(&req.name)?;
     // Reuse agent validation for display_name and other fields
     validate_create_agent_input(
         &req.display_name,
@@ -349,7 +349,7 @@ pub async fn update_harness(
     })?;
 
     if let Some(ref name) = req.name {
-        validate_harness_name(name)?;
+        validate_harness_name_strict(name)?;
     }
     // Reuse agent validation for display_name and other fields
     validate_update_agent_input(

--- a/crates/server/src/api/validation.rs
+++ b/crates/server/src/api/validation.rs
@@ -97,12 +97,32 @@ pub fn validate_agent_name(name: &str) -> Result<(), ValidationError> {
 
 /// Names that cannot be used for user-created harnesses because they have
 /// special meaning (virtual aliases, future system harnesses).
-const RESERVED_HARNESS_NAMES: &[&str] = &["default"];
+pub const RESERVED_HARNESS_NAMES: &[&str] = &["default"];
 
-/// Validate harness name is a valid slug: `[a-z0-9]([a-z0-9-]*[a-z0-9])?`.
+/// Validate harness name/alias is a valid slug: `[a-z0-9]([a-z0-9-]*[a-z0-9])?`.
 /// Max 64 chars, no consecutive hyphens, no leading/trailing hyphens.
-/// Rejects reserved names (see [`RESERVED_HARNESS_NAMES`]).
+/// Accepts reserved names (virtual aliases like "default"). Use this for
+/// endpoints that resolve names, e.g. session creation with `harness_name`.
 pub fn validate_harness_name(name: &str) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    validate_harness_name_inner(name)
+}
+
+/// Validate harness name for create/update — same slug rules as
+/// [`validate_harness_name`] but additionally rejects reserved names.
+pub fn validate_harness_name_strict(name: &str) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    validate_harness_name_inner(name)?;
+    if RESERVED_HARNESS_NAMES.contains(&name) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(format!(
+                "Harness name '{name}' is reserved and cannot be used"
+            ))),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_harness_name_inner(name: &str) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
     if name.is_empty() {
         return Err((
             StatusCode::BAD_REQUEST,
@@ -143,14 +163,6 @@ pub fn validate_harness_name(name: &str) -> Result<(), (StatusCode, Json<ErrorRe
             Json(ErrorResponse::new(
                 "Harness name must not contain consecutive hyphens",
             )),
-        ));
-    }
-    if RESERVED_HARNESS_NAMES.contains(&name) {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse::new(format!(
-                "Harness name '{name}' is reserved and cannot be used"
-            ))),
         ));
     }
     Ok(())
@@ -453,9 +465,18 @@ mod tests {
     }
 
     #[test]
-    fn test_reserved_harness_name_rejected() {
-        let err = validate_harness_name("default").unwrap_err();
+    fn test_harness_name_accepts_reserved_aliases() {
+        // validate_harness_name (non-strict) allows reserved names so that
+        // endpoints accepting aliases (e.g. session creation) can pass them.
+        assert!(validate_harness_name("default").is_ok());
+    }
+
+    #[test]
+    fn test_harness_name_strict_rejects_reserved() {
+        let err = validate_harness_name_strict("default").unwrap_err();
         assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        // Non-reserved names still pass strict validation
+        assert!(validate_harness_name_strict("my-harness").is_ok());
     }
 
     #[test]

--- a/crates/server/src/api/validation.rs
+++ b/crates/server/src/api/validation.rs
@@ -95,8 +95,13 @@ pub fn validate_agent_name(name: &str) -> Result<(), ValidationError> {
     Ok(())
 }
 
+/// Names that cannot be used for user-created harnesses because they have
+/// special meaning (virtual aliases, future system harnesses).
+const RESERVED_HARNESS_NAMES: &[&str] = &["default"];
+
 /// Validate harness name is a valid slug: `[a-z0-9]([a-z0-9-]*[a-z0-9])?`.
 /// Max 64 chars, no consecutive hyphens, no leading/trailing hyphens.
+/// Rejects reserved names (see [`RESERVED_HARNESS_NAMES`]).
 pub fn validate_harness_name(name: &str) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
     if name.is_empty() {
         return Err((
@@ -138,6 +143,14 @@ pub fn validate_harness_name(name: &str) -> Result<(), (StatusCode, Json<ErrorRe
             Json(ErrorResponse::new(
                 "Harness name must not contain consecutive hyphens",
             )),
+        ));
+    }
+    if RESERVED_HARNESS_NAMES.contains(&name) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(format!(
+                "Harness name '{name}' is reserved and cannot be used"
+            ))),
         ));
     }
     Ok(())
@@ -430,6 +443,28 @@ mod tests {
     #[test]
     fn test_invalid_capabilities_count() {
         assert!(validate_agent_capabilities_count(MAX_AGENT_CAPABILITIES + 1).is_err());
+    }
+
+    #[test]
+    fn test_valid_harness_name() {
+        assert!(validate_harness_name("my-harness").is_ok());
+        assert!(validate_harness_name("harness1").is_ok());
+        assert!(validate_harness_name("a").is_ok());
+    }
+
+    #[test]
+    fn test_reserved_harness_name_rejected() {
+        let err = validate_harness_name("default").unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn test_invalid_harness_name() {
+        assert!(validate_harness_name("").is_err());
+        assert!(validate_harness_name("-leading").is_err());
+        assert!(validate_harness_name("trailing-").is_err());
+        assert!(validate_harness_name("bad--double").is_err());
+        assert!(validate_harness_name("UPPERCASE").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## What
Add reserved name validation to `validate_harness_name()` to reject the name "default" (and future reserved names).

## Why
The name "default" will be used as a virtual alias resolving to the org default harness. Users must not be able to create harnesses with this name.

Closes EVE-257

## How
- Add `RESERVED_HARNESS_NAMES` constant with `["default"]`
- Check against it in `validate_harness_name()` after existing format checks
- Returns 400 with clear error message
- Both create and update handlers already call this function

## Risk
- Low
- Only adds a new rejection case to existing validation. No existing harnesses can be named "default" since this is a new constraint on a new-ish feature.

## Security
- Threat categories reviewed: TM-API (input validation at harness name boundary)
- No injection risk — string equality check against a constant array
- No auth/authz, data exposure, or resource exhaustion concerns

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)