### PR TITLE
feat(harnesses): virtual default alias for harness lookup

### DIFF
--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -273,7 +273,8 @@ pub async fn list_harnesses(
 /// GET /v1/harnesses/{harness_id}
 ///
 /// Accepts either a harness ID (e.g. `harness_01933b5a...`) or an addressable
-/// name (e.g. `generic`). Names are resolved within the caller's org.
+/// name (e.g. `generic`). The virtual name `default` resolves to the org's
+/// configured default harness. Names are resolved within the caller's org.
 #[utoipa::path(
     get,
     path = "/v1/harnesses/{harness_id}",
@@ -308,7 +309,7 @@ pub async fn get_harness(
 
     let harness = state
         .service
-        .get_by_name(&caller, &harness_id_or_name)
+        .get_by_name_or_alias(&caller, &harness_id_or_name)
         .await
         .map_policy_or_internal("get harness by name")?
         .ok_or_not_found_json("Harness")?;

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -323,18 +323,31 @@ pub async fn create_session(
     }
 
     // Resolve harness_name to harness_id if provided.
-    // Input is validated with the same rules as harness CRUD endpoints.
+    // "default" is a virtual alias that resolves to the org's configured
+    // default harness (from org settings). Other names are looked up literally.
     // HARNESS_VIEW policy is not checked here because the existing flow already
     // validates harness access via db.get_harness() below.
     if let Some(ref name) = req.harness_name {
         validation::validate_harness_name(name)?;
-        let row = state
-            .db
-            .get_harness_by_name(org.org_id, name)
-            .await
-            .log_internal_error_json("resolve harness by name")?
-            .ok_or_not_found_json("Harness")?;
-        req.harness_id = Some(row.id);
+        if name == "default" {
+            let settings = state
+                .db
+                .get_organization_settings(org.org_id)
+                .await
+                .log_internal_error_json("resolve org default harness")?;
+            let harness_id = settings
+                .and_then(|s| s.default_harness_id)
+                .ok_or_not_found_json("Default harness not configured for this organization")?;
+            req.harness_id = Some(harness_id);
+        } else {
+            let row = state
+                .db
+                .get_harness_by_name(org.org_id, name)
+                .await
+                .log_internal_error_json("resolve harness by name")?
+                .ok_or_not_found_json("Harness")?;
+            req.harness_id = Some(row.id);
+        }
     }
 
     let harness_id = resolve_session_harness_id(

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -335,9 +335,17 @@ pub async fn create_session(
                 .get_organization_settings(org.org_id)
                 .await
                 .log_internal_error_json("resolve org default harness")?;
-            let harness_id = settings
-                .and_then(|s| s.default_harness_id)
-                .ok_or_not_found_json("Default harness not configured for this organization")?;
+            let harness_id = match settings.and_then(|s| s.default_harness_id) {
+                Some(id) => id,
+                None => {
+                    return Err((
+                        StatusCode::NOT_FOUND,
+                        Json(ErrorResponse::new(
+                            "Default harness not configured for this organization",
+                        )),
+                    ));
+                }
+            };
             req.harness_id = Some(harness_id);
         } else {
             let row = state

--- a/crates/server/src/services/harness.rs
+++ b/crates/server/src/services/harness.rs
@@ -4,6 +4,7 @@
 // Policy enforcement via #[policy] macro — see specs/permissions.md.
 
 use crate::api::harnesses::{CreateHarnessRequest, UpdateHarnessRequest};
+use crate::api::validation::RESERVED_HARNESS_NAMES;
 use crate::errors::ResourceNotFoundError;
 use crate::storage::{
     HarnessRow, StorageBackend,
@@ -155,6 +156,28 @@ impl HarnessService {
             None => Ok(None),
             Some(_) => Ok(None),
         }
+    }
+
+    /// Resolve a harness name that may be a virtual alias (e.g. "default").
+    /// "default" resolves to the org's configured default harness. All other
+    /// names are looked up literally via [`Self::get_by_name`].
+    #[policy(HARNESS_VIEW)]
+    pub async fn get_by_name_or_alias(
+        &self,
+        caller: &Caller,
+        name: &str,
+    ) -> Result<Option<Harness>> {
+        if RESERVED_HARNESS_NAMES.contains(&name) && name == "default" {
+            let settings = self
+                .db
+                .get_organization_settings(caller.org_id)
+                .await?;
+            if let Some(harness_id) = settings.and_then(|s| s.default_harness_id) {
+                return self.get(caller, harness_id.uuid()).await;
+            }
+            return Ok(None);
+        }
+        self.get_by_name(caller, name).await
     }
 
     #[policy(HARNESS_VIEW)]

--- a/crates/server/src/services/harness.rs
+++ b/crates/server/src/services/harness.rs
@@ -4,7 +4,6 @@
 // Policy enforcement via #[policy] macro — see specs/permissions.md.
 
 use crate::api::harnesses::{CreateHarnessRequest, UpdateHarnessRequest};
-use crate::api::validation::RESERVED_HARNESS_NAMES;
 use crate::errors::ResourceNotFoundError;
 use crate::storage::{
     HarnessRow, StorageBackend,
@@ -167,7 +166,7 @@ impl HarnessService {
         caller: &Caller,
         name: &str,
     ) -> Result<Option<Harness>> {
-        if RESERVED_HARNESS_NAMES.contains(&name) && name == "default" {
+        if name == "default" {
             let settings = self.db.get_organization_settings(caller.org_id).await?;
             if let Some(harness_id) = settings.and_then(|s| s.default_harness_id) {
                 return self.get(caller, harness_id.uuid()).await;

--- a/crates/server/src/services/harness.rs
+++ b/crates/server/src/services/harness.rs
@@ -168,10 +168,7 @@ impl HarnessService {
         name: &str,
     ) -> Result<Option<Harness>> {
         if RESERVED_HARNESS_NAMES.contains(&name) && name == "default" {
-            let settings = self
-                .db
-                .get_organization_settings(caller.org_id)
-                .await?;
+            let settings = self.db.get_organization_settings(caller.org_id).await?;
             if let Some(harness_id) = settings.and_then(|s| s.default_harness_id) {
                 return self.get(caller, harness_id.uuid()).await;
             }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1483,7 +1483,7 @@
           "harnesses"
         ],
         "summary": "GET /v1/harnesses/{harness_id}",
-        "description": "Accepts either a harness ID (e.g. `harness_01933b5a...`) or an addressable\nname (e.g. `generic`). Names are resolved within the caller's org.",
+        "description": "Accepts either a harness ID (e.g. `harness_01933b5a...`) or an addressable\nname (e.g. `generic`). The virtual name `default` resolves to the org's\nconfigured default harness. Names are resolved within the caller's org.",
         "operationId": "get_harness",
         "parameters": [
           {


### PR DESCRIPTION
## What
Add virtual "default" alias for harness lookup. `GET /v1/harnesses/default` and `harness_name=default` in session creation now resolve to the org configured default harness.

## Why
Users currently need to read org settings first to find the default harness ID, then use that ID. The "default" alias saves a round-trip. Pairs with EVE-257 (which reserves the name so users cannot create a harness called "default").

Closes EVE-256

## How
- Add `get_by_name_or_alias()` to `HarnessService` that checks if the name is "default" and resolves via `organization_settings.default_harness_id`
- `GET /v1/harnesses/{id}` name fallback now uses alias-aware lookup
- Session creation `harness_name=default` resolves via org settings instead of literal DB name lookup
- Non-reserved names pass through to existing `get_by_name()` unchanged

## Risk
- Low
- Falls back cleanly: if no default configured, returns 404. Existing name lookups unchanged.

## Security
- Threat categories reviewed: TM-API (new virtual name resolution path), TM-AUTHZ (org settings access), TM-TENANT (org scoping)
- The alias resolves within the caller org context — no cross-tenant risk. Org settings query is already org-scoped. Policy checks preserved via existing `#[policy(HARNESS_VIEW)]` on service methods.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)