### PR TITLE
fix(server): publish input.message events to shared EventDelivery

### DIFF
--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -268,6 +268,7 @@ impl AppState {
                 db.clone(),
                 runner.clone(),
                 notifications_enabled,
+                event_delivery.clone(),
             )),
             event_service: Arc::new(EventService::new(db.clone(), event_delivery)),
             db,

--- a/crates/server/src/api/messages.rs
+++ b/crates/server/src/api/messages.rs
@@ -171,10 +171,16 @@ impl AppState {
         runner: Arc<dyn AgentRunner>,
         auth: AuthState,
         notifications_enabled: bool,
+        event_delivery: crate::event_delivery::EventDelivery,
     ) -> Self {
         Self {
             session_service: Arc::new(SessionService::new(db.clone())),
-            message_service: Arc::new(MessageService::new(db, runner, notifications_enabled)),
+            message_service: Arc::new(MessageService::new(
+                db,
+                runner,
+                notifications_enabled,
+                event_delivery,
+            )),
             auth,
         }
     }

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -216,6 +216,7 @@ impl SlackState {
                 db.clone(),
                 runner,
                 notifications_enabled,
+                event_delivery.clone(),
             )),
             event_service: Arc::new(EventService::new(db.clone(), event_delivery)),
             db,

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -482,6 +482,7 @@ impl ServerAppBuilder {
             runner.clone(),
             auth_state.clone(),
             notifications_enabled,
+            event_delivery.clone(),
         );
         let tool_results_state = api::tool_results::AppState::new(
             db.clone(),

--- a/crates/server/src/services/message.rs
+++ b/crates/server/src/services/message.rs
@@ -43,11 +43,9 @@ impl MessageService {
         db: Arc<StorageBackend>,
         runner: Arc<dyn AgentRunner>,
         notifications_enabled: bool,
+        event_delivery: crate::event_delivery::EventDelivery,
     ) -> Self {
-        let event_service = EventService::new(
-            db.clone(),
-            crate::event_delivery::EventDelivery::in_memory(),
-        );
+        let event_service = EventService::new(db.clone(), event_delivery);
         let notification_service = NotificationService::new(db.clone());
         Self {
             db,

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -172,10 +172,14 @@ impl TestServer {
         // Create driver registry
         let driver_registry = Arc::new(platform_definition.driver_registry().clone());
 
+        // Shared event delivery — mirrors production wiring where all services
+        // publish to the same broadcast backend that SSE subscribers listen on.
+        let event_delivery = everruns_server::EventDelivery::in_memory();
+
         // Create event listeners (minimal for tests)
         let event_service = Arc::new(services::EventService::with_listeners(
             db.clone(),
-            everruns_server::EventDelivery::in_memory(),
+            event_delivery.clone(),
             vec![],
         ));
         let feature_flags = everruns_core::FeatureFlags::from_env(&grade);
@@ -186,14 +190,14 @@ impl TestServer {
             runner.clone(),
             auth_state.clone(),
             &platform_definition,
-            everruns_server::EventDelivery::in_memory(),
+            event_delivery.clone(),
         );
         let messages_state = api::messages::AppState::new(
             db.clone(),
             runner.clone(),
             auth_state.clone(),
             feature_flags.notifications,
-            everruns_server::EventDelivery::in_memory(),
+            event_delivery.clone(),
         );
         let sse_tracker = Arc::new(everruns_server::api::sse::SseConnectionTracker::new(
             everruns_server::api::sse::SseConnectionLimits::default(),

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -193,6 +193,7 @@ impl TestServer {
             runner.clone(),
             auth_state.clone(),
             feature_flags.notifications,
+            everruns_server::EventDelivery::in_memory(),
         );
         let sse_tracker = Arc::new(everruns_server::api::sse::SseConnectionTracker::new(
             everruns_server::api::sse::SseConnectionLimits::default(),


### PR DESCRIPTION
## What
Fix `input.message` events never being delivered to the browser via SSE, causing chat messages to appear in wrong order or be invisible.

## Why
`MessageService::new()` created its own private `EventDelivery::in_memory()` instance. The `input.message` event was published to that private broadcast channel where no SSE subscriber was listening, so `broadcast::send()` silently dropped it.

The user's message only appeared after page refresh (REST loads from DB) or via the optimistic event (which has no real sequence number and sorts incorrectly relative to output events). During live streaming:
- User messages appeared **below** agent responses (wrong order)
- First message's user bubble was completely invisible
- Page refresh fixed the ordering (REST loads events from DB in correct sequence order)

## How
Accept the shared `EventDelivery` instance in `MessageService::new()` instead of creating a private one. Thread the shared instance from all 4 callers: `app_builder`, `slack_events`, `mcp_endpoint`, and `test_harness`.

## Validation
- **Reproduced on UI before fix:** Sent messages in Global Chat via `agent-browser`. User messages appeared below agent responses or were invisible. SSE stream confirmed: `input.message` events were missing entirely.
- **Verified after fix:** Same test — user messages now appear correctly above agent responses. SSE stream confirmed: `input.message` events are delivered with correct sequence numbers.
- **API-level confirmation:** `curl` SSE test showed `input.message` (seq N) arriving before `session.activated` (seq N+1) in correct order.
- `cargo clippy -p everruns-server -- -D warnings` — clean
- `cargo fmt --check` — clean

## Risk
- Low
- The change only threads an existing `EventDelivery` instance through to `MessageService` — no new logic, no behavioral change for other event types
- Test harness updated to pass `EventDelivery::in_memory()` to maintain test isolation

## Security
- Threat categories reviewed: TM-API (message creation endpoint delivers events correctly now)
- No new attack surface: the `EventDelivery` instance was already available at each call site; we're just passing it through instead of creating a private one
- No auth/authz changes, no new endpoints, no data exposure changes

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
