### PR TITLE
feat(orgs): accept harness name when setting org default

### DIFF
--- a/crates/server/src/api/organizations.rs
+++ b/crates/server/src/api/organizations.rs
@@ -424,7 +424,7 @@ pub async fn update_organization(
         ));
     }
     if let Some(ref harness_name) = default_harness_name {
-        super::validation::validate_harness_name(harness_name)?;
+        super::validation::validate_harness_name_strict(harness_name)?;
         let row = state
             .db
             .get_harness_by_name(org_row.org_id, harness_name)
@@ -434,7 +434,7 @@ pub async fn update_organization(
         default_harness_id = Some(row.id);
     }
 
-    // Validate referenced IDs exist
+    // Validate referenced IDs exist (skip if already resolved from name)
     if let Some(ref model_id) = default_model_id {
         // Verify the model exists and is installed
         let model = state
@@ -457,7 +457,9 @@ pub async fn update_organization(
             ));
         }
     }
-    if let Some(default_harness_id) = default_harness_id {
+    if default_harness_name.is_none()
+        && let Some(default_harness_id) = default_harness_id
+    {
         state
             .db
             .get_harness(org_row.org_id, default_harness_id)

--- a/crates/server/src/api/organizations.rs
+++ b/crates/server/src/api/organizations.rs
@@ -80,9 +80,15 @@ pub struct UpdateOrganizationRequest {
     #[schema(value_type = Option<String>, example = "model_01933b5a00007000800000000000001")]
     pub default_model_id: Option<everruns_core::ModelId>,
     /// Default harness to preselect in the UI for new sessions.
+    /// Mutually exclusive with `default_harness_name`.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(value_type = Option<String>, example = "harness_01933b5a000070008000000000000602")]
     pub default_harness_id: Option<everruns_core::HarnessId>,
+    /// Alternative to `default_harness_id` — looked up by stable name within the org.
+    /// Mutually exclusive with `default_harness_id`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "generic")]
+    pub default_harness_name: Option<String>,
     /// Base harness to use when a session is started without an explicit harness_id.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(value_type = Option<String>, example = "harness_01933b5a000070008000000000000601")]
@@ -403,9 +409,30 @@ pub async fn update_organization(
     let UpdateOrganizationRequest {
         name,
         default_model_id,
-        default_harness_id,
+        mut default_harness_id,
+        default_harness_name,
         base_harness_id,
     } = req;
+
+    // Resolve default_harness_name to default_harness_id (mutually exclusive)
+    if default_harness_id.is_some() && default_harness_name.is_some() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(
+                "Cannot specify both default_harness_id and default_harness_name",
+            )),
+        ));
+    }
+    if let Some(ref harness_name) = default_harness_name {
+        super::validation::validate_harness_name(harness_name)?;
+        let row = state
+            .db
+            .get_harness_by_name(org_row.org_id, harness_name)
+            .await
+            .log_internal_error_json("resolve default harness by name")?
+            .ok_or_not_found_json("Harness")?;
+        default_harness_id = Some(row.id);
+    }
 
     // Validate referenced IDs exist
     if let Some(ref model_id) = default_model_id {

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -13418,8 +13418,16 @@
               "string",
               "null"
             ],
-            "description": "Default harness to preselect in the UI for new sessions.",
+            "description": "Default harness to preselect in the UI for new sessions.\nMutually exclusive with `default_harness_name`.",
             "example": "harness_01933b5a000070008000000000000602"
+          },
+          "default_harness_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Alternative to `default_harness_id` — looked up by stable name within the org.\nMutually exclusive with `default_harness_id`.",
+            "example": "generic"
           },
           "default_model_id": {
             "type": [


### PR DESCRIPTION
## What
Add `default_harness_name` field to `PATCH /v1/orgs/{org}` as an alternative to `default_harness_id` when configuring the org default harness.

## Why
Users must currently look up a harness by name, get its ID, then PATCH with the ID — two API calls. Accepting the name directly saves a round-trip.

Closes EVE-258

## How
- Add `default_harness_name: Option<String>` to `UpdateOrganizationRequest`
- Validate mutual exclusivity with `default_harness_id`
- Resolve name to ID server-side via `get_harness_by_name()`
- Use `validate_harness_name_strict()` to reject reserved aliases
- Skip redundant DB lookup when ID was resolved from name
- Follows the same pattern as session creation (`harness_id` / `harness_name`)
- Regenerated OpenAPI spec

## Risk
- Low
- Additive field, existing `default_harness_id` behavior unchanged.

## Security
- Threat categories reviewed: TM-API (new input field), TM-TENANT (org-scoped name resolution)
- Name is validated with `validate_harness_name_strict()` before use. DB lookup is scoped to caller org. No cross-tenant risk.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)