### PR TITLE
feat(harnesses): add interactive name availability check

### DIFF
--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
@@ -10,6 +10,7 @@ import {
   useDeleteHarness,
   useDestroyHarness,
   useCapabilities,
+  useHarnessNameAvailability,
 } from "@/hooks";
 import { usePolicies } from "@/hooks/use-policies";
 import { Button } from "@/components/ui/button";
@@ -33,7 +34,7 @@ import { HarnessSelect } from "@/components/harness/harness-select";
 import { HarnessPreview } from "@/components/harnesses/harness-preview";
 import { InitialFilesEditor } from "@/components/initial-files-editor";
 import { ModelPicker } from "@/components/models/model-picker";
-import { ArrowLeft, Save, Trash2, Eye, Edit2 } from "lucide-react";
+import { ArrowLeft, Save, Trash2, Eye, Edit2, Check, X, Loader2 } from "lucide-react";
 import type { AgentCapabilityConfig, InitialFile } from "@/lib/api/types";
 import { isReadOnlyStatus } from "@/lib/entity-lifecycle";
 
@@ -95,6 +96,10 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
         : undefined,
     [formData.parent_harness_id, harnesses],
   );
+
+  // Only check availability when name has been changed from original
+  const nameChanged = formData.name !== initialFormData.name;
+  const nameAvailability = useHarnessNameAvailability(nameChanged ? formData.name : "", harnessId);
 
   const handleFormChange = useCallback((field: keyof FormData, value: string) => {
     setFormChanges((prev) => ({ ...prev, [field]: value }));
@@ -247,12 +252,34 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
                       <Label htmlFor="name">Name</Label>
                       <Input
                         id="name"
-                        placeholder="My Harness"
+                        placeholder="my-harness"
                         value={formData.name}
                         onChange={(e) => handleFormChange("name", e.target.value)}
                         disabled={isSaving || isReadOnly}
                         required
                       />
+                      {nameChanged && formData.name.length >= 2 && (
+                        <div className="flex items-center gap-1.5 text-xs">
+                          {nameAvailability.isChecking ? (
+                            <>
+                              <Loader2 className="w-3 h-3 animate-spin text-muted-foreground" />
+                              <span className="text-muted-foreground">Checking availability…</span>
+                            </>
+                          ) : nameAvailability.available === true ? (
+                            <>
+                              <Check className="w-3 h-3 text-green-600" />
+                              <span className="text-green-600">Name is available</span>
+                            </>
+                          ) : nameAvailability.available === false ? (
+                            <>
+                              <X className="w-3 h-3 text-destructive" />
+                              <span className="text-destructive">
+                                Name is already taken or invalid
+                              </span>
+                            </>
+                          ) : null}
+                        </div>
+                      )}
                     </div>
 
                     <div className="space-y-2">

--- a/apps/ui/src/app/(main)/harnesses/new/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/new/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { useCreateHarness, useCapabilities } from "@/hooks";
+import { useCreateHarness, useCapabilities, useHarnessNameAvailability } from "@/hooks";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -10,7 +10,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { PromptEditor } from "@/components/ui/prompt-editor";
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Check, X, Loader2 } from "lucide-react";
 import { ModelPicker } from "@/components/models/model-picker";
 import { CapabilitySelector } from "@/components/agents/capability-selector";
 import { HarnessSelect } from "@/components/harness/harness-select";
@@ -30,6 +30,8 @@ export default function NewHarnessPage() {
     default_model_id: "",
     tags: "",
   });
+
+  const nameAvailability = useHarnessNameAvailability(formData.name);
 
   const [selectedCapabilities, setSelectedCapabilities] = useState<AgentCapabilityConfig[]>([]);
   const [initialFiles, setInitialFiles] = useState<InitialFile[]>([]);
@@ -84,11 +86,31 @@ export default function NewHarnessPage() {
               <Label htmlFor="name">Name</Label>
               <Input
                 id="name"
-                placeholder="My Harness"
+                placeholder="my-harness"
                 value={formData.name}
                 onChange={(e) => setFormData({ ...formData, name: e.target.value })}
                 required
               />
+              {formData.name.length >= 2 && (
+                <div className="flex items-center gap-1.5 text-xs">
+                  {nameAvailability.isChecking ? (
+                    <>
+                      <Loader2 className="w-3 h-3 animate-spin text-muted-foreground" />
+                      <span className="text-muted-foreground">Checking availability…</span>
+                    </>
+                  ) : nameAvailability.available === true ? (
+                    <>
+                      <Check className="w-3 h-3 text-green-600" />
+                      <span className="text-green-600">Name is available</span>
+                    </>
+                  ) : nameAvailability.available === false ? (
+                    <>
+                      <X className="w-3 h-3 text-destructive" />
+                      <span className="text-destructive">Name is already taken or invalid</span>
+                    </>
+                  ) : null}
+                </div>
+              )}
             </div>
 
             <div className="space-y-2">

--- a/apps/ui/src/hooks/index.ts
+++ b/apps/ui/src/hooks/index.ts
@@ -21,3 +21,4 @@ export * from "./use-image-drop-zone";
 export * from "./use-chat-model-selection";
 export * from "./use-agent-identities";
 export * from "./use-evals";
+export * from "./use-name-availability";

--- a/apps/ui/src/hooks/use-name-availability.ts
+++ b/apps/ui/src/hooks/use-name-availability.ts
@@ -1,0 +1,68 @@
+// Hook for checking harness name availability with debounce
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { checkHarnessName } from "@/lib/api/harnesses";
+
+interface NameAvailabilityResult {
+  /** Whether the name is available. null = not yet checked or checking */
+  available: boolean | null;
+  /** Whether a check is currently in-flight */
+  isChecking: boolean;
+}
+
+/**
+ * Debounced harness name availability check.
+ *
+ * @param name - current name value from the input
+ * @param excludeId - harness ID to exclude (for edit forms)
+ * @param debounceMs - debounce delay (default 300ms)
+ */
+export function useHarnessNameAvailability(
+  name: string,
+  excludeId?: string,
+  debounceMs = 300,
+): NameAvailabilityResult {
+  const [available, setAvailable] = useState<boolean | null>(null);
+  const [isChecking, setIsChecking] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    // Reset if name is empty or too short
+    if (!name || name.length < 2) {
+      setAvailable(null);
+      setIsChecking(false);
+      return;
+    }
+
+    setIsChecking(true);
+    setAvailable(null);
+
+    const timer = setTimeout(async () => {
+      // Cancel any in-flight request
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      try {
+        const result = await checkHarnessName(name, excludeId);
+        if (!controller.signal.aborted) {
+          setAvailable(result.available);
+          setIsChecking(false);
+        }
+      } catch {
+        if (!controller.signal.aborted) {
+          setAvailable(null);
+          setIsChecking(false);
+        }
+      }
+    }, debounceMs);
+
+    return () => {
+      clearTimeout(timer);
+      abortRef.current?.abort();
+    };
+  }, [name, excludeId, debounceMs]);
+
+  return { available, isChecking };
+}

--- a/apps/ui/src/hooks/use-name-availability.ts
+++ b/apps/ui/src/hooks/use-name-availability.ts
@@ -13,6 +13,7 @@ interface NameAvailabilityResult {
 
 /**
  * Debounced harness name availability check.
+ * Uses a request counter to discard stale responses from superseded requests.
  *
  * @param name - current name value from the input
  * @param excludeId - harness ID to exclude (for edit forms)
@@ -25,7 +26,7 @@ export function useHarnessNameAvailability(
 ): NameAvailabilityResult {
   const [available, setAvailable] = useState<boolean | null>(null);
   const [isChecking, setIsChecking] = useState(false);
-  const abortRef = useRef<AbortController | null>(null);
+  const requestIdRef = useRef(0);
 
   useEffect(() => {
     // Reset if name is empty or too short
@@ -38,20 +39,19 @@ export function useHarnessNameAvailability(
     setIsChecking(true);
     setAvailable(null);
 
-    const timer = setTimeout(async () => {
-      // Cancel any in-flight request
-      abortRef.current?.abort();
-      const controller = new AbortController();
-      abortRef.current = controller;
+    // Increment to invalidate any in-flight request
+    const currentRequestId = ++requestIdRef.current;
 
+    const timer = setTimeout(async () => {
       try {
         const result = await checkHarnessName(name, excludeId);
-        if (!controller.signal.aborted) {
+        // Only apply result if this is still the latest request
+        if (currentRequestId === requestIdRef.current) {
           setAvailable(result.available);
           setIsChecking(false);
         }
       } catch {
-        if (!controller.signal.aborted) {
+        if (currentRequestId === requestIdRef.current) {
           setAvailable(null);
           setIsChecking(false);
         }
@@ -60,7 +60,6 @@ export function useHarnessNameAvailability(
 
     return () => {
       clearTimeout(timer);
-      abortRef.current?.abort();
     };
   }, [name, excludeId, debounceMs]);
 

--- a/apps/ui/src/lib/api/harnesses.ts
+++ b/apps/ui/src/lib/api/harnesses.ts
@@ -22,6 +22,18 @@ export const updateHarness = harnessesCrudApi.update;
 export const deleteHarness = harnessesCrudApi.delete;
 export const destroyHarness = harnessesCrudApi.destroy;
 
+export async function checkHarnessName(
+  name: string,
+  excludeId?: string,
+): Promise<{ available: boolean }> {
+  const params = new URLSearchParams({ name });
+  if (excludeId) params.set("exclude_id", excludeId);
+  const response = await api.get<{ available: boolean }>(
+    `/v1/harnesses/check-name?${params.toString()}`,
+  );
+  return response.data;
+}
+
 export async function copyHarness(harnessId: string): Promise<Harness> {
   const response = await api.post<Harness>(`/v1/harnesses/${harnessId}/copy`, {});
   return response.data;

--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -228,7 +228,8 @@ pub async fn harness_config(
     params(CheckNameQuery),
     responses(
         (status = 200, description = "Name availability result", body = CheckNameResponse),
-        (status = 400, description = "Invalid name format", body = ErrorResponse),
+        (status = 400, description = "Invalid exclude_id", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
     ),
     tag = "harnesses"
 )]
@@ -256,15 +257,12 @@ pub async fn check_harness_name(
             )
         })?;
 
+    let caller = Caller::from(&org);
     let existing = state
         .service
-        .check_name_available(org.org_id, &query.name, exclude_id)
+        .check_name_available(&caller, &query.name, exclude_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to check harness name: {}", e);
-            ErrorResponse::new("Internal server error")
-                .into_response(StatusCode::INTERNAL_SERVER_ERROR)
-        })?;
+        .map_policy_or_internal("check harness name")?;
 
     Ok(Json(CheckNameResponse {
         available: existing,

--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -135,6 +135,22 @@ pub struct ListHarnessesQuery {
     pub include_archived: Option<bool>,
 }
 
+/// Query parameters for checking harness name availability.
+#[derive(Debug, Clone, Deserialize, IntoParams)]
+pub struct CheckNameQuery {
+    /// The harness name to check.
+    pub name: String,
+    /// Optional harness ID to exclude (for edit forms where the current harness's own name is valid).
+    pub exclude_id: Option<String>,
+}
+
+/// Response for name availability check.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct CheckNameResponse {
+    /// Whether the name is available for use.
+    pub available: bool,
+}
+
 /// App state for harness routes
 #[derive(Clone)]
 pub struct AppState {
@@ -163,6 +179,7 @@ impl_auth_state!(AppState);
 pub fn routes(state: AppState) -> Router {
     Router::new()
         .route("/v1/harnesses", post(create_harness).get(list_harnesses))
+        .route("/v1/harnesses/check-name", get(check_harness_name))
         .route("/v1/harnesses/config", get(harness_config))
         .route("/v1/harnesses/preview", post(preview_harness))
         .route(
@@ -199,6 +216,59 @@ pub async fn harness_config(
         &[&HARNESS_VIEW, &HARNESS_MANAGE, &HARNESS_DANGEROUS],
     );
     Json(ResourceConfigResponse { policies })
+}
+
+/// GET /v1/harnesses/check-name
+///
+/// Returns whether a harness name is available for use. Optionally excludes
+/// a specific harness ID (for edit forms where the harness's own name is valid).
+#[utoipa::path(
+    get,
+    path = "/v1/harnesses/check-name",
+    params(CheckNameQuery),
+    responses(
+        (status = 200, description = "Name availability result", body = CheckNameResponse),
+        (status = 400, description = "Invalid name format", body = ErrorResponse),
+    ),
+    tag = "harnesses"
+)]
+pub async fn check_harness_name(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Query(query): Query<CheckNameQuery>,
+) -> Result<Json<CheckNameResponse>, (StatusCode, Json<ErrorResponse>)> {
+    // Validate format first — if the name is invalid, it's not "available"
+    if validate_harness_name_strict(&query.name).is_err() {
+        return Ok(Json(CheckNameResponse { available: false }));
+    }
+
+    let exclude_id = query
+        .exclude_id
+        .as_deref()
+        .map(|id| id.parse::<HarnessId>())
+        .transpose()
+        .map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!("Invalid exclude_id: {}", e),
+                }),
+            )
+        })?;
+
+    let existing = state
+        .service
+        .check_name_available(org.org_id, &query.name, exclude_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to check harness name: {}", e);
+            ErrorResponse::new("Internal server error")
+                .into_response(StatusCode::INTERNAL_SERVER_ERROR)
+        })?;
+
+    Ok(Json(CheckNameResponse {
+        available: existing,
+    }))
 }
 
 /// POST /v1/harnesses

--- a/crates/server/src/services/harness.rs
+++ b/crates/server/src/services/harness.rs
@@ -372,6 +372,21 @@ impl HarnessService {
         resolve_effective_harness(self.db.as_ref(), org_id, id).await
     }
 
+    /// Check if a harness name is available (public, for the check-name endpoint).
+    pub async fn check_name_available(
+        &self,
+        org_id: i64,
+        name: &str,
+        exclude_id: Option<HarnessId>,
+    ) -> Result<bool> {
+        if let Some(existing) = self.db.get_harness_by_name(org_id, name).await?
+            && exclude_id != Some(existing.id)
+        {
+            return Ok(false);
+        }
+        Ok(true)
+    }
+
     /// Check if a name is already taken by another harness in the org.
     async fn ensure_name_available(
         &self,

--- a/crates/server/src/services/harness.rs
+++ b/crates/server/src/services/harness.rs
@@ -373,13 +373,14 @@ impl HarnessService {
     }
 
     /// Check if a harness name is available (public, for the check-name endpoint).
+    #[policy(HARNESS_VIEW)]
     pub async fn check_name_available(
         &self,
-        org_id: i64,
+        caller: &Caller,
         name: &str,
         exclude_id: Option<HarnessId>,
     ) -> Result<bool> {
-        if let Some(existing) = self.db.get_harness_by_name(org_id, name).await?
+        if let Some(existing) = self.db.get_harness_by_name(caller.org_id, name).await?
             && exclude_id != Some(existing.id)
         {
             return Ok(false);

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -1642,6 +1642,89 @@ async fn test_copy_agent_not_found() {
 }
 
 // ============================================
+// Check Harness Name Tests
+// ============================================
+
+#[tokio::test]
+async fn test_check_harness_name_available() {
+    let server = TestServer::new().await;
+
+    let data: Value = server
+        .get("/v1/harnesses/check-name?name=fresh-new-name")
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    assert_eq!(data["available"], true);
+}
+
+#[tokio::test]
+async fn test_check_harness_name_taken() {
+    let server = TestServer::new().await;
+
+    // "generic" is a built-in harness name
+    let data: Value = server
+        .get("/v1/harnesses/check-name?name=generic")
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    assert_eq!(data["available"], false);
+}
+
+#[tokio::test]
+async fn test_check_harness_name_taken_with_exclude_id() {
+    let server = TestServer::new().await;
+
+    // Create a harness
+    let harness: Harness = server
+        .post(
+            "/v1/harnesses",
+            json!({
+                "name": "check-name-test",
+                "display_name": "Check Name Test",
+                "system_prompt": "Test"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    // Without exclude_id — should be taken
+    let data: Value = server
+        .get("/v1/harnesses/check-name?name=check-name-test")
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    assert_eq!(data["available"], false);
+
+    // With exclude_id (self) — should be available
+    let data: Value = server
+        .get(&format!(
+            "/v1/harnesses/check-name?name=check-name-test&exclude_id={}",
+            harness.id
+        ))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    assert_eq!(data["available"], true);
+}
+
+#[tokio::test]
+async fn test_check_harness_name_invalid_format() {
+    let server = TestServer::new().await;
+
+    // Uppercase is invalid for harness names
+    let data: Value = server
+        .get("/v1/harnesses/check-name?name=INVALID")
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    assert_eq!(data["available"], false);
+}
+
+// ============================================
 // Copy Harness Tests
 // ============================================
 


### PR DESCRIPTION
## What
Add real-time harness name availability checking. When users type a harness name in create or edit forms, a debounced check shows whether the name is available (green check), taken/invalid (red X), or loading (spinner).

## Why
Previously, name conflicts were only surfaced as a generic error after form submission. This gives immediate inline feedback while typing.

## How
- **Backend**: New `GET /v1/harnesses/check-name?name=foo&exclude_id=harness_xxx` endpoint. Validates name format via `validate_harness_name_strict`, then checks uniqueness via `db.get_harness_by_name`. Returns `{ available: bool }`.
- **Frontend**: New `useHarnessNameAvailability` hook with 300ms debounce + abort controller. Added to both harness create and edit forms with inline indicator.
- **Edit form**: Only shows the indicator when the name has been changed from its original value, and passes `excludeId` so the harness's own name doesn't conflict.
- **Agents not included**: Agent names are free-form (no uniqueness constraint). Tracked in #1227 for when agent name uniqueness is added.

## Risk
- Low
- Read-only endpoint, single DB lookup, no mutations

## Security
- Threat categories reviewed: TM-API (new endpoint), TM-TENANT (org-scoped query)
- Findings: None. Endpoint requires authentication (ResolvedOrg), name input is validated by existing strict validator (alphanumeric + hyphens), query is org-scoped. No cross-tenant exposure.

## Checklist
- [x] Tests added or updated (smoke tested endpoint: available, taken, exclude_id, invalid format)
- [x] Backward compatibility considered (new endpoint, no breaking changes)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)