### PR TITLE
fix(ui): fix streaming cursor artifact on next line

### DIFF
--- a/apps/ui/src/components/chat/streamdown-message.css
+++ b/apps/ui/src/components/chat/streamdown-message.css
@@ -181,3 +181,27 @@
 .streamdown .markdown-alert-caution .markdown-alert-title {
   color: #cf222e;
 }
+
+/* Streaming cursor — rendered via ::after so it stays inline with the last
+   text element instead of dropping to the next line as a sibling span would. */
+.streaming-cursor .streamdown > :last-child::after {
+  content: "";
+  display: inline-block;
+  width: 1px;
+  height: 1em;
+  margin-left: 0.25rem;
+  background-color: var(--color-primary);
+  opacity: 0.55;
+  vertical-align: text-bottom;
+  animation: streaming-cursor-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+@keyframes streaming-cursor-pulse {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 0.2;
+  }
+}

--- a/apps/ui/src/components/chat/streamdown-message.css
+++ b/apps/ui/src/components/chat/streamdown-message.css
@@ -181,27 +181,3 @@
 .streamdown .markdown-alert-caution .markdown-alert-title {
   color: #cf222e;
 }
-
-/* Streaming cursor — rendered via ::after so it stays inline with the last
-   text element instead of dropping to the next line as a sibling span would. */
-.streaming-cursor .streamdown > :last-child::after {
-  content: "";
-  display: inline-block;
-  width: 1px;
-  height: 1em;
-  margin-left: 0.25rem;
-  background-color: var(--color-primary);
-  opacity: 0.55;
-  vertical-align: text-bottom;
-  animation: streaming-cursor-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-}
-
-@keyframes streaming-cursor-pulse {
-  0%,
-  100% {
-    opacity: 0.55;
-  }
-  50% {
-    opacity: 0.2;
-  }
-}

--- a/apps/ui/src/components/streaming-message.css
+++ b/apps/ui/src/components/streaming-message.css
@@ -1,0 +1,25 @@
+/* Streaming cursor — rendered via ::after so it stays inline with the last
+   text element instead of dropping to the next line as a sibling span would.
+   Scope to only the final markdown segment to avoid duplicate cursors when a
+   message renders multiple .streamdown blocks (e.g. openui fences). */
+.streaming-cursor .streamdown:last-of-type > :last-child::after {
+  content: "";
+  display: inline-block;
+  width: 1px;
+  height: 1em;
+  margin-left: 0.25rem;
+  background-color: var(--color-primary);
+  opacity: 0.55;
+  vertical-align: text-bottom;
+  animation: streaming-cursor-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+@keyframes streaming-cursor-pulse {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 0.2;
+  }
+}

--- a/apps/ui/src/components/streaming-message.tsx
+++ b/apps/ui/src/components/streaming-message.tsx
@@ -9,6 +9,7 @@
 
 import { cn } from "@/lib/utils";
 import { MessageContent } from "@/components/chat/message-content";
+import "./streaming-message.css";
 
 interface StreamingMessageProps {
   text: string;

--- a/apps/ui/src/components/streaming-message.tsx
+++ b/apps/ui/src/components/streaming-message.tsx
@@ -26,9 +26,8 @@ export function StreamingMessage({ text, className }: StreamingMessageProps) {
         Generating
       </div>
 
-      <div>
+      <div className="streaming-cursor">
         <MessageContent text={text} isStreaming={true} />
-        <span className="ml-1 inline-block h-4 w-px animate-pulse bg-primary/55 align-text-bottom" />
       </div>
     </div>
   );


### PR DESCRIPTION
## What
Fix the streaming cursor (blinking line) appearing as an artifact on the next line below the generating text, instead of inline with it.

## Why
During text streaming, a thin vertical cursor was rendered as a `<span>` sibling after the block-level `<div class="streamdown">`. Block elements force subsequent inline content to a new line, so the cursor always dropped below the text — visible as a stray line that eventually disappeared.

## How
- Removed the explicit `<span>` cursor element from `streaming-message.tsx`
- Added a CSS `::after` pseudo-element on `.streaming-cursor .streamdown > :last-child` in `streamdown-message.css`
- The pseudo-element renders *inside* the last markdown element (e.g. the last `<p>`), keeping the cursor inline with the text
- Custom `streaming-cursor-pulse` keyframes replicate the previous `animate-pulse` behavior

## Risk
- Low
- Only affects the streaming cursor visual during generation; no logic changes

## Security
- No security-relevant code changes — pure CSS/presentation fix with no user input handling, API changes, or data flow modifications.

## Checklist
- [x] Tests added or updated — visual-only fix, no testable logic change
- [x] Backward compatibility considered — N/A, internal UI
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
