### PR TITLE
feat(agents): wire addressable names through UI

### DIFF
--- a/apps/ui/src/__tests__/agent-detail-model.test.tsx
+++ b/apps/ui/src/__tests__/agent-detail-model.test.tsx
@@ -52,7 +52,8 @@ jest.mock("@/components/chat/streamdown-message", () => ({
 // Mock data
 const mockAgent: Agent = {
   id: "agent-1",
-  name: "Test Agent",
+  name: "test-agent",
+  display_name: "Test Agent",
   description: "A test agent",
   system_prompt: "You are helpful",
   default_model_id: null,

--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -34,7 +34,7 @@ import { InitialFilesEditor } from "@/components/initial-files-editor";
 import { ModelPicker } from "@/components/models/model-picker";
 import { ArrowLeft, Save, Trash2, Eye, Edit2, Check, X, Loader2 } from "lucide-react";
 import type { AgentCapabilityConfig, InitialFile } from "@/lib/api/types";
-import { isReadOnlyStatus } from "@/lib/entity-lifecycle";
+import { getDisplayName, isReadOnlyStatus } from "@/lib/entity-lifecycle";
 
 interface FormData {
   display_name: string;
@@ -203,7 +203,7 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
     );
   }
 
-  const agentDisplayName = agent.display_name || agent.name;
+  const agentDisplayName = getDisplayName(agent);
 
   return (
     <div className="container mx-auto p-6">

--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -13,13 +13,7 @@ import {
 } from "@/hooks";
 import { usePolicies } from "@/hooks/use-policies";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-} from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -38,16 +32,7 @@ import { CapabilitySelector } from "@/components/agents/capability-selector";
 import { AgentPreview } from "@/components/agents/agent-preview";
 import { InitialFilesEditor } from "@/components/initial-files-editor";
 import { ModelPicker } from "@/components/models/model-picker";
-import {
-  ArrowLeft,
-  Save,
-  Trash2,
-  Eye,
-  Edit2,
-  Check,
-  X,
-  Loader2,
-} from "lucide-react";
+import { ArrowLeft, Save, Trash2, Eye, Edit2, Check, X, Loader2 } from "lucide-react";
 import type { AgentCapabilityConfig, InitialFile } from "@/lib/api/types";
 import { getDisplayName, isReadOnlyStatus } from "@/lib/entity-lifecycle";
 
@@ -60,11 +45,7 @@ interface FormData {
   default_model_id: string;
 }
 
-export default function EditAgentPage({
-  params,
-}: {
-  params: Promise<{ agentId: string }>;
-}) {
+export default function EditAgentPage({ params }: { params: Promise<{ agentId: string }> }) {
   const { agentId } = use(params);
   const router = useRouter();
 
@@ -76,8 +57,7 @@ export default function EditAgentPage({
   const { can: canPolicies } = usePolicies("agents");
 
   // Capabilities data
-  const { data: allCapabilities, isLoading: capabilitiesLoading } =
-    useCapabilities();
+  const { data: allCapabilities, isLoading: capabilitiesLoading } = useCapabilities();
 
   // Tab state
   const [activeTab, setActiveTab] = useState<string>("edit");
@@ -114,19 +94,13 @@ export default function EditAgentPage({
     [initialFormData, formChanges],
   );
 
-  const handleFormChange = useCallback(
-    (field: keyof FormData, value: string) => {
-      setFormChanges((prev) => ({ ...prev, [field]: value }));
-    },
-    [],
-  );
+  const handleFormChange = useCallback((field: keyof FormData, value: string) => {
+    setFormChanges((prev) => ({ ...prev, [field]: value }));
+  }, []);
 
   // Only check availability when name has been changed from original
   const nameChanged = formData.name !== initialFormData.name;
-  const nameAvailability = useAgentNameAvailability(
-    nameChanged ? formData.name : "",
-    agentId,
-  );
+  const nameAvailability = useAgentNameAvailability(nameChanged ? formData.name : "", agentId);
 
   // Capabilities state - now included directly in agent response
   // Use full AgentCapabilityConfig objects to preserve per-agent config
@@ -134,26 +108,16 @@ export default function EditAgentPage({
     return agent?.capabilities ?? [];
   }, [agent?.capabilities]);
 
-  const [localCapabilities, setLocalCapabilities] = useState<
-    AgentCapabilityConfig[] | null
-  >(null);
+  const [localCapabilities, setLocalCapabilities] = useState<AgentCapabilityConfig[] | null>(null);
   const selectedCapabilities = localCapabilities ?? initialCapabilities;
-  const initialFiles = useMemo(
-    () => agent?.initial_files ?? [],
-    [agent?.initial_files],
-  );
-  const [localInitialFiles, setLocalInitialFiles] = useState<
-    InitialFile[] | null
-  >(null);
+  const initialFiles = useMemo(() => agent?.initial_files ?? [], [agent?.initial_files]);
+  const [localInitialFiles, setLocalInitialFiles] = useState<InitialFile[] | null>(null);
   const selectedInitialFiles = localInitialFiles ?? initialFiles;
 
   // Capabilities change handler
-  const handleCapabilitiesChange = useCallback(
-    (newCapabilities: AgentCapabilityConfig[]) => {
-      setLocalCapabilities(newCapabilities);
-    },
-    [],
-  );
+  const handleCapabilitiesChange = useCallback((newCapabilities: AgentCapabilityConfig[]) => {
+    setLocalCapabilities(newCapabilities);
+  }, []);
 
   // Submit handler
   const handleSubmit = async (e: React.FormEvent) => {
@@ -169,8 +133,7 @@ export default function EditAgentPage({
       // Get capabilities to save (already full AgentCapabilityConfig format)
       const capabilitiesToSave = localCapabilities ?? initialCapabilities;
       const capabilitiesChanged =
-        JSON.stringify(capabilitiesToSave) !==
-        JSON.stringify(initialCapabilities);
+        JSON.stringify(capabilitiesToSave) !== JSON.stringify(initialCapabilities);
       const initialFilesToSave = localInitialFiles ?? initialFiles;
       const initialFilesChanged =
         JSON.stringify(initialFilesToSave) !== JSON.stringify(initialFiles);
@@ -293,9 +256,7 @@ export default function EditAgentPage({
                         id="display_name"
                         placeholder="Customer Support Agent"
                         value={formData.display_name}
-                        onChange={(e) =>
-                          handleFormChange("display_name", e.target.value)
-                        }
+                        onChange={(e) => handleFormChange("display_name", e.target.value)}
                         disabled={isSaving || isReadOnly}
                       />
                       <p className="text-xs text-muted-foreground">
@@ -309,9 +270,7 @@ export default function EditAgentPage({
                         id="name"
                         placeholder="customer-support"
                         value={formData.name}
-                        onChange={(e) =>
-                          handleFormChange("name", e.target.value)
-                        }
+                        onChange={(e) => handleFormChange("name", e.target.value)}
                         disabled={isSaving || isReadOnly}
                         required
                       />
@@ -320,16 +279,12 @@ export default function EditAgentPage({
                           {nameAvailability.isChecking ? (
                             <>
                               <Loader2 className="w-3 h-3 animate-spin text-muted-foreground" />
-                              <span className="text-muted-foreground">
-                                Checking availability…
-                              </span>
+                              <span className="text-muted-foreground">Checking availability…</span>
                             </>
                           ) : nameAvailability.available === true ? (
                             <>
                               <Check className="w-3 h-3 text-green-600" />
-                              <span className="text-green-600">
-                                Name is available
-                              </span>
+                              <span className="text-green-600">Name is available</span>
                             </>
                           ) : nameAvailability.available === false ? (
                             <>
@@ -342,8 +297,8 @@ export default function EditAgentPage({
                         </div>
                       )}
                       <p className="text-xs text-muted-foreground">
-                        Unique identifier used in URLs and API. Lowercase
-                        letters, numbers, and hyphens.
+                        Unique identifier used in URLs and API. Lowercase letters, numbers, and
+                        hyphens.
                       </p>
                     </div>
 
@@ -353,9 +308,7 @@ export default function EditAgentPage({
                         id="description"
                         placeholder="Describe what this agent does..."
                         value={formData.description}
-                        onChange={(e) =>
-                          handleFormChange("description", e.target.value)
-                        }
+                        onChange={(e) => handleFormChange("description", e.target.value)}
                         disabled={isSaving || isReadOnly}
                         rows={2}
                       />
@@ -367,29 +320,22 @@ export default function EditAgentPage({
                         id="tags"
                         placeholder="tag1, tag2, tag3"
                         value={formData.tags}
-                        onChange={(e) =>
-                          handleFormChange("tags", e.target.value)
-                        }
+                        onChange={(e) => handleFormChange("tags", e.target.value)}
                         disabled={isSaving || isReadOnly}
                       />
-                      <p className="text-xs text-muted-foreground">
-                        Comma-separated list of tags
-                      </p>
+                      <p className="text-xs text-muted-foreground">Comma-separated list of tags</p>
                     </div>
 
                     <div className="space-y-2">
                       <Label htmlFor="model">Model (optional)</Label>
                       <ModelPicker
                         value={formData.default_model_id || ""}
-                        onChange={(value) =>
-                          handleFormChange("default_model_id", value)
-                        }
+                        onChange={(value) => handleFormChange("default_model_id", value)}
                         disabled={isSaving || isReadOnly}
                         placeholder="Use default model"
                       />
                       <p className="text-xs text-muted-foreground">
-                        Select a specific model or leave empty to use the
-                        default
+                        Select a specific model or leave empty to use the default
                       </p>
                     </div>
 
@@ -399,9 +345,7 @@ export default function EditAgentPage({
                         id="system_prompt"
                         placeholder="You are a helpful assistant..."
                         value={formData.system_prompt}
-                        onChange={(value) =>
-                          handleFormChange("system_prompt", value)
-                        }
+                        onChange={(value) => handleFormChange("system_prompt", value)}
                         disabled={isSaving || isReadOnly}
                         required
                       />
@@ -422,20 +366,14 @@ export default function EditAgentPage({
                 {/* Danger Zone */}
                 <Card className="border-destructive/50">
                   <CardHeader>
-                    <CardTitle className="text-destructive">
-                      Danger Zone
-                    </CardTitle>
-                    <CardDescription>
-                      Irreversible actions that affect this agent
-                    </CardDescription>
+                    <CardTitle className="text-destructive">Danger Zone</CardTitle>
+                    <CardDescription>Irreversible actions that affect this agent</CardDescription>
                   </CardHeader>
                   <CardContent>
                     <div className="flex items-center justify-between">
                       <div>
                         <p className="font-medium">
-                          {agent.status === "archived"
-                            ? "Delete this agent"
-                            : "Archive this agent"}
+                          {agent.status === "archived" ? "Delete this agent" : "Archive this agent"}
                         </p>
                         <p className="text-sm text-muted-foreground">
                           {agent.status === "archived"
@@ -452,9 +390,7 @@ export default function EditAgentPage({
                             disabled={destroyAgent.isPending}
                           >
                             <Trash2 className="w-4 h-4 mr-2" />
-                            {destroyAgent.isPending
-                              ? "Deleting..."
-                              : "Delete Agent"}
+                            {destroyAgent.isPending ? "Deleting..." : "Delete Agent"}
                           </Button>
                         )
                       ) : (
@@ -464,9 +400,7 @@ export default function EditAgentPage({
                           onClick={handleArchive}
                           disabled={deleteAgent.isPending}
                         >
-                          {deleteAgent.isPending
-                            ? "Archiving..."
-                            : "Archive Agent"}
+                          {deleteAgent.isPending ? "Archiving..." : "Archive Agent"}
                         </Button>
                       )}
                     </div>
@@ -492,11 +426,7 @@ export default function EditAgentPage({
 
                 {/* Save button */}
                 <div className="flex gap-4">
-                  <Button
-                    type="submit"
-                    disabled={isSaving || isReadOnly}
-                    className="flex-1"
-                  >
+                  <Button type="submit" disabled={isSaving || isReadOnly} className="flex-1">
                     <Save className="w-4 h-4 mr-2" />
                     {isReadOnly
                       ? "Archived Agents Are Read-Only"
@@ -504,19 +434,13 @@ export default function EditAgentPage({
                         ? "Saving..."
                         : "Save Changes"}
                   </Button>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={() => router.back()}
-                  >
+                  <Button type="button" variant="outline" onClick={() => router.back()}>
                     Cancel
                   </Button>
                 </div>
 
                 {updateAgent.error && (
-                  <p className="text-sm text-destructive">
-                    Error: {updateAgent.error.message}
-                  </p>
+                  <p className="text-sm text-destructive">Error: {updateAgent.error.message}</p>
                 )}
               </div>
             </div>
@@ -573,9 +497,8 @@ export default function EditAgentPage({
               <Card className="border-dashed">
                 <CardContent className="pt-6">
                   <p className="text-sm text-muted-foreground text-center">
-                    This preview shows what the final agent will look like after
-                    applying all capabilities. Switch to the Edit tab to make
-                    changes.
+                    This preview shows what the final agent will look like after applying all
+                    capabilities. Switch to the Edit tab to make changes.
                   </p>
                 </CardContent>
               </Card>
@@ -593,17 +516,10 @@ export default function EditAgentPage({
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setShowDeleteDialog(false)}
-            >
+            <Button variant="outline" onClick={() => setShowDeleteDialog(false)}>
               Cancel
             </Button>
-            <Button
-              variant="destructive"
-              onClick={handleDestroy}
-              disabled={destroyAgent.isPending}
-            >
+            <Button variant="destructive" onClick={handleDestroy} disabled={destroyAgent.isPending}>
               {destroyAgent.isPending ? "Deleting..." : "Delete Agent"}
             </Button>
           </DialogFooter>

--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -9,6 +9,7 @@ import {
   useDeleteAgent,
   useDestroyAgent,
   useCapabilities,
+  useAgentNameAvailability,
 } from "@/hooks";
 import { usePolicies } from "@/hooks/use-policies";
 import { Button } from "@/components/ui/button";
@@ -31,11 +32,12 @@ import { CapabilitySelector } from "@/components/agents/capability-selector";
 import { AgentPreview } from "@/components/agents/agent-preview";
 import { InitialFilesEditor } from "@/components/initial-files-editor";
 import { ModelPicker } from "@/components/models/model-picker";
-import { ArrowLeft, Save, Trash2, Eye, Edit2 } from "lucide-react";
+import { ArrowLeft, Save, Trash2, Eye, Edit2, Check, X, Loader2 } from "lucide-react";
 import type { AgentCapabilityConfig, InitialFile } from "@/lib/api/types";
 import { isReadOnlyStatus } from "@/lib/entity-lifecycle";
 
 interface FormData {
+  display_name: string;
   name: string;
   description: string;
   system_prompt: string;
@@ -67,9 +69,10 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
   // Compute initial values from agent data
   const initialFormData = useMemo((): FormData => {
     if (!agent) {
-      return { name: "", description: "", system_prompt: "", tags: "", default_model_id: "" };
+      return { display_name: "", name: "", description: "", system_prompt: "", tags: "", default_model_id: "" };
     }
     return {
+      display_name: agent.display_name || "",
       name: agent.name,
       description: agent.description || "",
       system_prompt: agent.system_prompt,
@@ -87,6 +90,10 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
   const handleFormChange = useCallback((field: keyof FormData, value: string) => {
     setFormChanges((prev) => ({ ...prev, [field]: value }));
   }, []);
+
+  // Only check availability when name has been changed from original
+  const nameChanged = formData.name !== initialFormData.name;
+  const nameAvailability = useAgentNameAvailability(nameChanged ? formData.name : "", agentId);
 
   // Capabilities state - now included directly in agent response
   // Use full AgentCapabilityConfig objects to preserve per-agent config
@@ -129,6 +136,7 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
         agentId,
         request: {
           name: formData.name,
+          display_name: formData.display_name || undefined,
           description: formData.description || undefined,
           system_prompt: formData.system_prompt,
           tags,
@@ -195,6 +203,8 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
     );
   }
 
+  const agentDisplayName = agent.display_name || agent.name;
+
   return (
     <div className="container mx-auto p-6">
       <Link
@@ -234,15 +244,52 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
                   </CardHeader>
                   <CardContent className="space-y-6">
                     <div className="space-y-2">
+                      <Label htmlFor="display_name">Display Name</Label>
+                      <Input
+                        id="display_name"
+                        placeholder="Customer Support Agent"
+                        value={formData.display_name}
+                        onChange={(e) => handleFormChange("display_name", e.target.value)}
+                        disabled={isSaving || isReadOnly}
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Human-readable name shown in the UI
+                      </p>
+                    </div>
+
+                    <div className="space-y-2">
                       <Label htmlFor="name">Name</Label>
                       <Input
                         id="name"
-                        placeholder="My Agent"
+                        placeholder="customer-support"
                         value={formData.name}
                         onChange={(e) => handleFormChange("name", e.target.value)}
                         disabled={isSaving || isReadOnly}
                         required
                       />
+                      {nameChanged && formData.name.length >= 2 && (
+                        <div className="flex items-center gap-1.5 text-xs">
+                          {nameAvailability.isChecking ? (
+                            <>
+                              <Loader2 className="w-3 h-3 animate-spin text-muted-foreground" />
+                              <span className="text-muted-foreground">Checking availability…</span>
+                            </>
+                          ) : nameAvailability.available === true ? (
+                            <>
+                              <Check className="w-3 h-3 text-green-600" />
+                              <span className="text-green-600">Name is available</span>
+                            </>
+                          ) : nameAvailability.available === false ? (
+                            <>
+                              <X className="w-3 h-3 text-destructive" />
+                              <span className="text-destructive">Name is already taken or invalid</span>
+                            </>
+                          ) : null}
+                        </div>
+                      )}
+                      <p className="text-xs text-muted-foreground">
+                        Unique identifier used in URLs and API. Lowercase letters, numbers, and hyphens.
+                      </p>
                     </div>
 
                     <div className="space-y-2">
@@ -410,8 +457,12 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
                 </CardHeader>
                 <CardContent className="space-y-4">
                   <div>
+                    <p className="text-sm font-medium">Display Name</p>
+                    <p className="text-sm text-muted-foreground">{formData.display_name || "(not set)"}</p>
+                  </div>
+                  <div>
                     <p className="text-sm font-medium">Name</p>
-                    <p className="text-sm text-muted-foreground">{formData.name || "(not set)"}</p>
+                    <p className="text-sm text-muted-foreground font-mono">{formData.name || "(not set)"}</p>
                   </div>
                   <div>
                     <p className="text-sm font-medium">Description</p>
@@ -446,7 +497,7 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
           <DialogHeader>
             <DialogTitle>Delete Agent</DialogTitle>
             <DialogDescription>
-              Permanently delete the archived agent &quot;{agent?.name}&quot;? Existing references
+              Permanently delete the archived agent &quot;{agentDisplayName}&quot;? Existing references
               will render as deleted tombstones.
             </DialogDescription>
           </DialogHeader>

--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -13,7 +13,13 @@ import {
 } from "@/hooks";
 import { usePolicies } from "@/hooks/use-policies";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -32,7 +38,16 @@ import { CapabilitySelector } from "@/components/agents/capability-selector";
 import { AgentPreview } from "@/components/agents/agent-preview";
 import { InitialFilesEditor } from "@/components/initial-files-editor";
 import { ModelPicker } from "@/components/models/model-picker";
-import { ArrowLeft, Save, Trash2, Eye, Edit2, Check, X, Loader2 } from "lucide-react";
+import {
+  ArrowLeft,
+  Save,
+  Trash2,
+  Eye,
+  Edit2,
+  Check,
+  X,
+  Loader2,
+} from "lucide-react";
 import type { AgentCapabilityConfig, InitialFile } from "@/lib/api/types";
 import { getDisplayName, isReadOnlyStatus } from "@/lib/entity-lifecycle";
 
@@ -45,7 +60,11 @@ interface FormData {
   default_model_id: string;
 }
 
-export default function EditAgentPage({ params }: { params: Promise<{ agentId: string }> }) {
+export default function EditAgentPage({
+  params,
+}: {
+  params: Promise<{ agentId: string }>;
+}) {
   const { agentId } = use(params);
   const router = useRouter();
 
@@ -57,7 +76,8 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
   const { can: canPolicies } = usePolicies("agents");
 
   // Capabilities data
-  const { data: allCapabilities, isLoading: capabilitiesLoading } = useCapabilities();
+  const { data: allCapabilities, isLoading: capabilitiesLoading } =
+    useCapabilities();
 
   // Tab state
   const [activeTab, setActiveTab] = useState<string>("edit");
@@ -69,7 +89,14 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
   // Compute initial values from agent data
   const initialFormData = useMemo((): FormData => {
     if (!agent) {
-      return { display_name: "", name: "", description: "", system_prompt: "", tags: "", default_model_id: "" };
+      return {
+        display_name: "",
+        name: "",
+        description: "",
+        system_prompt: "",
+        tags: "",
+        default_model_id: "",
+      };
     }
     return {
       display_name: agent.display_name || "",
@@ -87,13 +114,19 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
     [initialFormData, formChanges],
   );
 
-  const handleFormChange = useCallback((field: keyof FormData, value: string) => {
-    setFormChanges((prev) => ({ ...prev, [field]: value }));
-  }, []);
+  const handleFormChange = useCallback(
+    (field: keyof FormData, value: string) => {
+      setFormChanges((prev) => ({ ...prev, [field]: value }));
+    },
+    [],
+  );
 
   // Only check availability when name has been changed from original
   const nameChanged = formData.name !== initialFormData.name;
-  const nameAvailability = useAgentNameAvailability(nameChanged ? formData.name : "", agentId);
+  const nameAvailability = useAgentNameAvailability(
+    nameChanged ? formData.name : "",
+    agentId,
+  );
 
   // Capabilities state - now included directly in agent response
   // Use full AgentCapabilityConfig objects to preserve per-agent config
@@ -101,16 +134,26 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
     return agent?.capabilities ?? [];
   }, [agent?.capabilities]);
 
-  const [localCapabilities, setLocalCapabilities] = useState<AgentCapabilityConfig[] | null>(null);
+  const [localCapabilities, setLocalCapabilities] = useState<
+    AgentCapabilityConfig[] | null
+  >(null);
   const selectedCapabilities = localCapabilities ?? initialCapabilities;
-  const initialFiles = useMemo(() => agent?.initial_files ?? [], [agent?.initial_files]);
-  const [localInitialFiles, setLocalInitialFiles] = useState<InitialFile[] | null>(null);
+  const initialFiles = useMemo(
+    () => agent?.initial_files ?? [],
+    [agent?.initial_files],
+  );
+  const [localInitialFiles, setLocalInitialFiles] = useState<
+    InitialFile[] | null
+  >(null);
   const selectedInitialFiles = localInitialFiles ?? initialFiles;
 
   // Capabilities change handler
-  const handleCapabilitiesChange = useCallback((newCapabilities: AgentCapabilityConfig[]) => {
-    setLocalCapabilities(newCapabilities);
-  }, []);
+  const handleCapabilitiesChange = useCallback(
+    (newCapabilities: AgentCapabilityConfig[]) => {
+      setLocalCapabilities(newCapabilities);
+    },
+    [],
+  );
 
   // Submit handler
   const handleSubmit = async (e: React.FormEvent) => {
@@ -126,7 +169,8 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
       // Get capabilities to save (already full AgentCapabilityConfig format)
       const capabilitiesToSave = localCapabilities ?? initialCapabilities;
       const capabilitiesChanged =
-        JSON.stringify(capabilitiesToSave) !== JSON.stringify(initialCapabilities);
+        JSON.stringify(capabilitiesToSave) !==
+        JSON.stringify(initialCapabilities);
       const initialFilesToSave = localInitialFiles ?? initialFiles;
       const initialFilesChanged =
         JSON.stringify(initialFilesToSave) !== JSON.stringify(initialFiles);
@@ -249,7 +293,9 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
                         id="display_name"
                         placeholder="Customer Support Agent"
                         value={formData.display_name}
-                        onChange={(e) => handleFormChange("display_name", e.target.value)}
+                        onChange={(e) =>
+                          handleFormChange("display_name", e.target.value)
+                        }
                         disabled={isSaving || isReadOnly}
                       />
                       <p className="text-xs text-muted-foreground">
@@ -263,7 +309,9 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
                         id="name"
                         placeholder="customer-support"
                         value={formData.name}
-                        onChange={(e) => handleFormChange("name", e.target.value)}
+                        onChange={(e) =>
+                          handleFormChange("name", e.target.value)
+                        }
                         disabled={isSaving || isReadOnly}
                         required
                       />
@@ -272,23 +320,30 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
                           {nameAvailability.isChecking ? (
                             <>
                               <Loader2 className="w-3 h-3 animate-spin text-muted-foreground" />
-                              <span className="text-muted-foreground">Checking availability…</span>
+                              <span className="text-muted-foreground">
+                                Checking availability…
+                              </span>
                             </>
                           ) : nameAvailability.available === true ? (
                             <>
                               <Check className="w-3 h-3 text-green-600" />
-                              <span className="text-green-600">Name is available</span>
+                              <span className="text-green-600">
+                                Name is available
+                              </span>
                             </>
                           ) : nameAvailability.available === false ? (
                             <>
                               <X className="w-3 h-3 text-destructive" />
-                              <span className="text-destructive">Name is already taken or invalid</span>
+                              <span className="text-destructive">
+                                Name is already taken or invalid
+                              </span>
                             </>
                           ) : null}
                         </div>
                       )}
                       <p className="text-xs text-muted-foreground">
-                        Unique identifier used in URLs and API. Lowercase letters, numbers, and hyphens.
+                        Unique identifier used in URLs and API. Lowercase
+                        letters, numbers, and hyphens.
                       </p>
                     </div>
 
@@ -298,7 +353,9 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
                         id="description"
                         placeholder="Describe what this agent does..."
                         value={formData.description}
-                        onChange={(e) => handleFormChange("description", e.target.value)}
+                        onChange={(e) =>
+                          handleFormChange("description", e.target.value)
+                        }
                         disabled={isSaving || isReadOnly}
                         rows={2}
                       />
@@ -310,22 +367,29 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
                         id="tags"
                         placeholder="tag1, tag2, tag3"
                         value={formData.tags}
-                        onChange={(e) => handleFormChange("tags", e.target.value)}
+                        onChange={(e) =>
+                          handleFormChange("tags", e.target.value)
+                        }
                         disabled={isSaving || isReadOnly}
                       />
-                      <p className="text-xs text-muted-foreground">Comma-separated list of tags</p>
+                      <p className="text-xs text-muted-foreground">
+                        Comma-separated list of tags
+                      </p>
                     </div>
 
                     <div className="space-y-2">
                       <Label htmlFor="model">Model (optional)</Label>
                       <ModelPicker
                         value={formData.default_model_id || ""}
-                        onChange={(value) => handleFormChange("default_model_id", value)}
+                        onChange={(value) =>
+                          handleFormChange("default_model_id", value)
+                        }
                         disabled={isSaving || isReadOnly}
                         placeholder="Use default model"
                       />
                       <p className="text-xs text-muted-foreground">
-                        Select a specific model or leave empty to use the default
+                        Select a specific model or leave empty to use the
+                        default
                       </p>
                     </div>
 
@@ -335,7 +399,9 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
                         id="system_prompt"
                         placeholder="You are a helpful assistant..."
                         value={formData.system_prompt}
-                        onChange={(value) => handleFormChange("system_prompt", value)}
+                        onChange={(value) =>
+                          handleFormChange("system_prompt", value)
+                        }
                         disabled={isSaving || isReadOnly}
                         required
                       />
@@ -356,14 +422,20 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
                 {/* Danger Zone */}
                 <Card className="border-destructive/50">
                   <CardHeader>
-                    <CardTitle className="text-destructive">Danger Zone</CardTitle>
-                    <CardDescription>Irreversible actions that affect this agent</CardDescription>
+                    <CardTitle className="text-destructive">
+                      Danger Zone
+                    </CardTitle>
+                    <CardDescription>
+                      Irreversible actions that affect this agent
+                    </CardDescription>
                   </CardHeader>
                   <CardContent>
                     <div className="flex items-center justify-between">
                       <div>
                         <p className="font-medium">
-                          {agent.status === "archived" ? "Delete this agent" : "Archive this agent"}
+                          {agent.status === "archived"
+                            ? "Delete this agent"
+                            : "Archive this agent"}
                         </p>
                         <p className="text-sm text-muted-foreground">
                           {agent.status === "archived"
@@ -380,7 +452,9 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
                             disabled={destroyAgent.isPending}
                           >
                             <Trash2 className="w-4 h-4 mr-2" />
-                            {destroyAgent.isPending ? "Deleting..." : "Delete Agent"}
+                            {destroyAgent.isPending
+                              ? "Deleting..."
+                              : "Delete Agent"}
                           </Button>
                         )
                       ) : (
@@ -390,7 +464,9 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
                           onClick={handleArchive}
                           disabled={deleteAgent.isPending}
                         >
-                          {deleteAgent.isPending ? "Archiving..." : "Archive Agent"}
+                          {deleteAgent.isPending
+                            ? "Archiving..."
+                            : "Archive Agent"}
                         </Button>
                       )}
                     </div>
@@ -416,7 +492,11 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
 
                 {/* Save button */}
                 <div className="flex gap-4">
-                  <Button type="submit" disabled={isSaving || isReadOnly} className="flex-1">
+                  <Button
+                    type="submit"
+                    disabled={isSaving || isReadOnly}
+                    className="flex-1"
+                  >
                     <Save className="w-4 h-4 mr-2" />
                     {isReadOnly
                       ? "Archived Agents Are Read-Only"
@@ -424,13 +504,19 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
                         ? "Saving..."
                         : "Save Changes"}
                   </Button>
-                  <Button type="button" variant="outline" onClick={() => router.back()}>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => router.back()}
+                  >
                     Cancel
                   </Button>
                 </div>
 
                 {updateAgent.error && (
-                  <p className="text-sm text-destructive">Error: {updateAgent.error.message}</p>
+                  <p className="text-sm text-destructive">
+                    Error: {updateAgent.error.message}
+                  </p>
                 )}
               </div>
             </div>
@@ -458,11 +544,15 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
                 <CardContent className="space-y-4">
                   <div>
                     <p className="text-sm font-medium">Display Name</p>
-                    <p className="text-sm text-muted-foreground">{formData.display_name || "(not set)"}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {formData.display_name || "(not set)"}
+                    </p>
                   </div>
                   <div>
                     <p className="text-sm font-medium">Name</p>
-                    <p className="text-sm text-muted-foreground font-mono">{formData.name || "(not set)"}</p>
+                    <p className="text-sm text-muted-foreground font-mono">
+                      {formData.name || "(not set)"}
+                    </p>
                   </div>
                   <div>
                     <p className="text-sm font-medium">Description</p>
@@ -483,8 +573,9 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
               <Card className="border-dashed">
                 <CardContent className="pt-6">
                   <p className="text-sm text-muted-foreground text-center">
-                    This preview shows what the final agent will look like after applying all
-                    capabilities. Switch to the Edit tab to make changes.
+                    This preview shows what the final agent will look like after
+                    applying all capabilities. Switch to the Edit tab to make
+                    changes.
                   </p>
                 </CardContent>
               </Card>
@@ -497,15 +588,22 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
           <DialogHeader>
             <DialogTitle>Delete Agent</DialogTitle>
             <DialogDescription>
-              Permanently delete the archived agent &quot;{agentDisplayName}&quot;? Existing references
-              will render as deleted tombstones.
+              Permanently delete the archived agent &quot;{agentDisplayName}
+              &quot;? Existing references will render as deleted tombstones.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setShowDeleteDialog(false)}>
+            <Button
+              variant="outline"
+              onClick={() => setShowDeleteDialog(false)}
+            >
               Cancel
             </Button>
-            <Button variant="destructive" onClick={handleDestroy} disabled={destroyAgent.isPending}>
+            <Button
+              variant="destructive"
+              onClick={handleDestroy}
+              disabled={destroyAgent.isPending}
+            >
               {destroyAgent.isPending ? "Deleting..." : "Delete Agent"}
             </Button>
           </DialogFooter>

--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -23,22 +23,9 @@ import { ProviderIcon } from "@/components/providers/provider-icon";
 import { SessionCard } from "@/components/session/session-card";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { AgentPreview } from "@/components/agents/agent-preview";
-import {
-  ArrowLeft,
-  Plus,
-  Pencil,
-  Download,
-  Copy,
-  Zap,
-  Eye,
-  LayoutDashboard,
-} from "lucide-react";
+import { ArrowLeft, Plus, Pencil, Download, Copy, Zap, Eye, LayoutDashboard } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
-import type {
-  Capability,
-  LlmModelWithProvider,
-  TokenUsage,
-} from "@/lib/api/types";
+import type { Capability, LlmModelWithProvider, TokenUsage } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
 import {
   getDisplayName,
@@ -53,22 +40,15 @@ function totalTokens(usage: TokenUsage): number {
   return usage.input_tokens + usage.output_tokens;
 }
 
-export default function AgentDetailPage({
-  params,
-}: {
-  params: Promise<{ agentId: string }>;
-}) {
+export default function AgentDetailPage({ params }: { params: Promise<{ agentId: string }> }) {
   const { agentId } = use(params);
   const router = useRouter();
   const [activeTab, setActiveTab] = useState("overview");
   const { data: agent, isLoading: agentLoading } = useAgent(agentId);
   // Fetch only top 10 sessions for the overview
-  const { data: sessionsResponse, isLoading: sessionsLoading } = useSessions(
-    agentId,
-    {
-      limit: 10,
-    },
-  );
+  const { data: sessionsResponse, isLoading: sessionsLoading } = useSessions(agentId, {
+    limit: 10,
+  });
   const sessions = sessionsResponse?.data ?? [];
   const totalSessions = sessionsResponse?.total ?? 0;
   const hasMoreSessions = totalSessions > 10;
@@ -87,9 +67,7 @@ export default function AgentDetailPage({
   }, [llmModels]);
 
   // Get the agent's default model
-  const defaultModel = agent?.default_model_id
-    ? modelMap.get(agent.default_model_id)
-    : undefined;
+  const defaultModel = agent?.default_model_id ? modelMap.get(agent.default_model_id) : undefined;
 
   const handleNewSession = async () => {
     const harnessId = organization?.default_harness_id || harnesses?.[0]?.id;
@@ -172,32 +150,18 @@ export default function AgentDetailPage({
       <div className="flex items-start justify-between mb-6">
         <div>
           <h1 className="text-2xl font-bold flex items-center gap-2">
-            <span className={getEntityNameClassName(agent.status)}>
-              {getDisplayName(agent)}
-            </span>
+            <span className={getEntityNameClassName(agent.status)}>{getDisplayName(agent)}</span>
             <CopyButton value={agent.id} />
-            <Badge variant={getEntityStatusBadgeVariant(agent.status)}>
-              {agent.status}
-            </Badge>
+            <Badge variant={getEntityStatusBadgeVariant(agent.status)}>{agent.status}</Badge>
           </h1>
-          <p className="text-sm text-muted-foreground font-mono mt-1">
-            {agent.name}
-          </p>
+          <p className="text-sm text-muted-foreground font-mono mt-1">{agent.name}</p>
         </div>
         <div className="flex gap-2">
-          <Button
-            variant="outline"
-            onClick={handleCopy}
-            disabled={copyAgent.isPending}
-          >
+          <Button variant="outline" onClick={handleCopy} disabled={copyAgent.isPending}>
             <Copy className="w-4 h-4 mr-2" />
             {copyAgent.isPending ? "Copying..." : "Copy"}
           </Button>
-          <Button
-            variant="outline"
-            onClick={handleExport}
-            disabled={exportAgent.isPending}
-          >
+          <Button variant="outline" onClick={handleExport} disabled={exportAgent.isPending}>
             <Download className="w-4 h-4 mr-2" />
             {exportAgent.isPending ? "Exporting..." : "Export"}
           </Button>
@@ -272,11 +236,7 @@ export default function AgentDetailPage({
                         <SessionCard
                           key={session.id}
                           session={session}
-                          model={
-                            session.model_id
-                              ? modelMap.get(session.model_id)
-                              : undefined
-                          }
+                          model={session.model_id ? modelMap.get(session.model_id) : undefined}
                         />
                       ))}
                       {hasMoreSessions && (
@@ -324,9 +284,7 @@ export default function AgentDetailPage({
                             <IconComponent className="w-4 h-4" />
                             <div className="flex-1">
                               <p className="text-sm font-medium">{cap.name}</p>
-                              <p className="text-xs text-muted-foreground">
-                                {cap.description}
-                              </p>
+                              <p className="text-xs text-muted-foreground">{cap.description}</p>
                             </div>
                           </div>
                         );
@@ -345,13 +303,8 @@ export default function AgentDetailPage({
                     <div>
                       <p className="text-sm font-medium mb-2">Default Model</p>
                       <div className="flex items-center gap-2">
-                        <ProviderIcon
-                          providerType={defaultModel.provider_type}
-                          size="sm"
-                        />
-                        <span className="text-sm">
-                          {defaultModel.display_name}
-                        </span>
+                        <ProviderIcon providerType={defaultModel.provider_type} size="sm" />
+                        <span className="text-sm">{defaultModel.display_name}</span>
                       </div>
                     </div>
                   )}
@@ -360,9 +313,7 @@ export default function AgentDetailPage({
                     <div>
                       <p className="text-sm font-medium">Description</p>
                       <div className="text-sm text-muted-foreground">
-                        <InlineStreamdownMessage>
-                          {agent.description}
-                        </InlineStreamdownMessage>
+                        <InlineStreamdownMessage>{agent.description}</InlineStreamdownMessage>
                       </div>
                     </div>
                   )}

--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -23,11 +23,28 @@ import { ProviderIcon } from "@/components/providers/provider-icon";
 import { SessionCard } from "@/components/session/session-card";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { AgentPreview } from "@/components/agents/agent-preview";
-import { ArrowLeft, Plus, Pencil, Download, Copy, Zap, Eye, LayoutDashboard } from "lucide-react";
+import {
+  ArrowLeft,
+  Plus,
+  Pencil,
+  Download,
+  Copy,
+  Zap,
+  Eye,
+  LayoutDashboard,
+} from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
-import type { Capability, LlmModelWithProvider, TokenUsage } from "@/lib/api/types";
+import type {
+  Capability,
+  LlmModelWithProvider,
+  TokenUsage,
+} from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
-import { getDisplayName, getEntityNameClassName, getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
+import {
+  getDisplayName,
+  getEntityNameClassName,
+  getEntityStatusBadgeVariant,
+} from "@/lib/entity-lifecycle";
 import { useOrganization } from "@/hooks/use-organizations";
 import { formatTokens } from "@/lib/formatting";
 
@@ -36,15 +53,22 @@ function totalTokens(usage: TokenUsage): number {
   return usage.input_tokens + usage.output_tokens;
 }
 
-export default function AgentDetailPage({ params }: { params: Promise<{ agentId: string }> }) {
+export default function AgentDetailPage({
+  params,
+}: {
+  params: Promise<{ agentId: string }>;
+}) {
   const { agentId } = use(params);
   const router = useRouter();
   const [activeTab, setActiveTab] = useState("overview");
   const { data: agent, isLoading: agentLoading } = useAgent(agentId);
   // Fetch only top 10 sessions for the overview
-  const { data: sessionsResponse, isLoading: sessionsLoading } = useSessions(agentId, {
-    limit: 10,
-  });
+  const { data: sessionsResponse, isLoading: sessionsLoading } = useSessions(
+    agentId,
+    {
+      limit: 10,
+    },
+  );
   const sessions = sessionsResponse?.data ?? [];
   const totalSessions = sessionsResponse?.total ?? 0;
   const hasMoreSessions = totalSessions > 10;
@@ -63,7 +87,9 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
   }, [llmModels]);
 
   // Get the agent's default model
-  const defaultModel = agent?.default_model_id ? modelMap.get(agent.default_model_id) : undefined;
+  const defaultModel = agent?.default_model_id
+    ? modelMap.get(agent.default_model_id)
+    : undefined;
 
   const handleNewSession = async () => {
     const harnessId = organization?.default_harness_id || harnesses?.[0]?.id;
@@ -146,18 +172,32 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
       <div className="flex items-start justify-between mb-6">
         <div>
           <h1 className="text-2xl font-bold flex items-center gap-2">
-            <span className={getEntityNameClassName(agent.status)}>{getDisplayName(agent)}</span>
+            <span className={getEntityNameClassName(agent.status)}>
+              {getDisplayName(agent)}
+            </span>
             <CopyButton value={agent.id} />
-            <Badge variant={getEntityStatusBadgeVariant(agent.status)}>{agent.status}</Badge>
+            <Badge variant={getEntityStatusBadgeVariant(agent.status)}>
+              {agent.status}
+            </Badge>
           </h1>
-          <p className="text-sm text-muted-foreground font-mono mt-1">{agent.name}</p>
+          <p className="text-sm text-muted-foreground font-mono mt-1">
+            {agent.name}
+          </p>
         </div>
         <div className="flex gap-2">
-          <Button variant="outline" onClick={handleCopy} disabled={copyAgent.isPending}>
+          <Button
+            variant="outline"
+            onClick={handleCopy}
+            disabled={copyAgent.isPending}
+          >
             <Copy className="w-4 h-4 mr-2" />
             {copyAgent.isPending ? "Copying..." : "Copy"}
           </Button>
-          <Button variant="outline" onClick={handleExport} disabled={exportAgent.isPending}>
+          <Button
+            variant="outline"
+            onClick={handleExport}
+            disabled={exportAgent.isPending}
+          >
             <Download className="w-4 h-4 mr-2" />
             {exportAgent.isPending ? "Exporting..." : "Export"}
           </Button>
@@ -232,7 +272,11 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
                         <SessionCard
                           key={session.id}
                           session={session}
-                          model={session.model_id ? modelMap.get(session.model_id) : undefined}
+                          model={
+                            session.model_id
+                              ? modelMap.get(session.model_id)
+                              : undefined
+                          }
                         />
                       ))}
                       {hasMoreSessions && (
@@ -280,7 +324,9 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
                             <IconComponent className="w-4 h-4" />
                             <div className="flex-1">
                               <p className="text-sm font-medium">{cap.name}</p>
-                              <p className="text-xs text-muted-foreground">{cap.description}</p>
+                              <p className="text-xs text-muted-foreground">
+                                {cap.description}
+                              </p>
                             </div>
                           </div>
                         );
@@ -299,8 +345,13 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
                     <div>
                       <p className="text-sm font-medium mb-2">Default Model</p>
                       <div className="flex items-center gap-2">
-                        <ProviderIcon providerType={defaultModel.provider_type} size="sm" />
-                        <span className="text-sm">{defaultModel.display_name}</span>
+                        <ProviderIcon
+                          providerType={defaultModel.provider_type}
+                          size="sm"
+                        />
+                        <span className="text-sm">
+                          {defaultModel.display_name}
+                        </span>
                       </div>
                     </div>
                   )}
@@ -309,7 +360,9 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
                     <div>
                       <p className="text-sm font-medium">Description</p>
                       <div className="text-sm text-muted-foreground">
-                        <InlineStreamdownMessage>{agent.description}</InlineStreamdownMessage>
+                        <InlineStreamdownMessage>
+                          {agent.description}
+                        </InlineStreamdownMessage>
                       </div>
                     </div>
                   )}

--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -27,7 +27,7 @@ import { ArrowLeft, Plus, Pencil, Download, Copy, Zap, Eye, LayoutDashboard } fr
 import { CopyButton } from "@/components/ui/copy-button";
 import type { Capability, LlmModelWithProvider, TokenUsage } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
-import { getEntityNameClassName, getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
+import { getDisplayName, getEntityNameClassName, getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
 import { useOrganization } from "@/hooks/use-organizations";
 import { formatTokens } from "@/lib/formatting";
 
@@ -146,7 +146,7 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
       <div className="flex items-start justify-between mb-6">
         <div>
           <h1 className="text-2xl font-bold flex items-center gap-2">
-            <span className={getEntityNameClassName(agent.status)}>{agent.display_name || agent.name}</span>
+            <span className={getEntityNameClassName(agent.status)}>{getDisplayName(agent)}</span>
             <CopyButton value={agent.id} />
             <Badge variant={getEntityStatusBadgeVariant(agent.status)}>{agent.status}</Badge>
           </h1>

--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -87,7 +87,7 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
       const url = URL.createObjectURL(blob);
       const link = document.createElement("a");
       link.href = url;
-      link.download = `${agent.name.toLowerCase().replace(/\s+/g, "-")}.md`;
+      link.download = `${agent.name}.md`;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
@@ -146,10 +146,11 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
       <div className="flex items-start justify-between mb-6">
         <div>
           <h1 className="text-2xl font-bold flex items-center gap-2">
-            <span className={getEntityNameClassName(agent.status)}>{agent.name}</span>
+            <span className={getEntityNameClassName(agent.status)}>{agent.display_name || agent.name}</span>
             <CopyButton value={agent.id} />
             <Badge variant={getEntityStatusBadgeVariant(agent.status)}>{agent.status}</Badge>
           </h1>
+          <p className="text-sm text-muted-foreground font-mono mt-1">{agent.name}</p>
         </div>
         <div className="flex gap-2">
           <Button variant="outline" onClick={handleCopy} disabled={copyAgent.isPending}>

--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/page.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import { use, useState, useMemo } from "react";
-import {
-  useAgent,
-  useHarnesses,
-  useSessions,
-  useCreateSession,
-  useLlmModels,
-} from "@/hooks";
+import { useAgent, useHarnesses, useSessions, useCreateSession, useLlmModels } from "@/hooks";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
@@ -21,24 +15,17 @@ import { useOrganization } from "@/hooks/use-organizations";
 
 const PAGE_SIZE = 20;
 
-export default function SessionsListPage({
-  params,
-}: {
-  params: Promise<{ agentId: string }>;
-}) {
+export default function SessionsListPage({ params }: { params: Promise<{ agentId: string }> }) {
   const { agentId } = use(params);
   const router = useRouter();
   const [page, setPage] = useState(0);
   const offset = page * PAGE_SIZE;
 
   const { data: agent, isLoading: agentLoading } = useAgent(agentId);
-  const { data: sessionsResponse, isLoading: sessionsLoading } = useSessions(
-    agentId,
-    {
-      offset,
-      limit: PAGE_SIZE,
-    },
-  );
+  const { data: sessionsResponse, isLoading: sessionsLoading } = useSessions(agentId, {
+    offset,
+    limit: PAGE_SIZE,
+  });
   const { data: llmModels } = useLlmModels();
   const createSession = useCreateSession();
   const { data: organization } = useOrganization();
@@ -108,18 +95,12 @@ export default function SessionsListPage({
 
       <div className="flex items-start justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold">
-            {getDisplayName(agent)} - Sessions
-          </h1>
+          <h1 className="text-2xl font-bold">{getDisplayName(agent)} - Sessions</h1>
           <p className="text-muted-foreground">
             {totalSessions} session{totalSessions !== 1 ? "s" : ""} total
           </p>
         </div>
-        <Button
-          variant="accent"
-          onClick={handleNewSession}
-          disabled={createSession.isPending}
-        >
+        <Button variant="accent" onClick={handleNewSession} disabled={createSession.isPending}>
           <Plus className="w-4 h-4 mr-2" />
           {createSession.isPending ? "Creating..." : "New Session"}
         </Button>
@@ -146,11 +127,7 @@ export default function SessionsListPage({
                 <SessionCard
                   key={session.id}
                   session={session}
-                  model={
-                    session.model_id
-                      ? modelMap.get(session.model_id)
-                      : undefined
-                  }
+                  model={session.model_id ? modelMap.get(session.model_id) : undefined}
                 />
               ))}
             </div>
@@ -160,9 +137,8 @@ export default function SessionsListPage({
           {totalPages > 1 && (
             <div className="flex items-center justify-between mt-4 pt-4 border-t">
               <p className="text-sm text-muted-foreground">
-                Showing {offset + 1}-
-                {Math.min(offset + PAGE_SIZE, totalSessions)} of {totalSessions}{" "}
-                sessions
+                Showing {offset + 1}-{Math.min(offset + PAGE_SIZE, totalSessions)} of{" "}
+                {totalSessions} sessions
               </p>
               <div className="flex items-center gap-2">
                 <Button

--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/page.tsx
@@ -10,6 +10,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { SessionCard } from "@/components/session/session-card";
 import { ArrowLeft, Plus, ChevronLeft, ChevronRight } from "lucide-react";
 import type { LlmModelWithProvider } from "@/lib/api/types";
+import { getDisplayName } from "@/lib/entity-lifecycle";
 import { useOrganization } from "@/hooks/use-organizations";
 
 const PAGE_SIZE = 20;
@@ -89,12 +90,12 @@ export default function SessionsListPage({ params }: { params: Promise<{ agentId
         className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-6"
       >
         <ArrowLeft className="w-4 h-4 mr-2" />
-        Back to {agent.display_name || agent.name}
+        Back to {getDisplayName(agent)}
       </Link>
 
       <div className="flex items-start justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold">{agent.display_name || agent.name} - Sessions</h1>
+          <h1 className="text-2xl font-bold">{getDisplayName(agent)} - Sessions</h1>
           <p className="text-muted-foreground">
             {totalSessions} session{totalSessions !== 1 ? "s" : ""} total
           </p>

--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/page.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { use, useState, useMemo } from "react";
-import { useAgent, useHarnesses, useSessions, useCreateSession, useLlmModels } from "@/hooks";
+import {
+  useAgent,
+  useHarnesses,
+  useSessions,
+  useCreateSession,
+  useLlmModels,
+} from "@/hooks";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
@@ -15,17 +21,24 @@ import { useOrganization } from "@/hooks/use-organizations";
 
 const PAGE_SIZE = 20;
 
-export default function SessionsListPage({ params }: { params: Promise<{ agentId: string }> }) {
+export default function SessionsListPage({
+  params,
+}: {
+  params: Promise<{ agentId: string }>;
+}) {
   const { agentId } = use(params);
   const router = useRouter();
   const [page, setPage] = useState(0);
   const offset = page * PAGE_SIZE;
 
   const { data: agent, isLoading: agentLoading } = useAgent(agentId);
-  const { data: sessionsResponse, isLoading: sessionsLoading } = useSessions(agentId, {
-    offset,
-    limit: PAGE_SIZE,
-  });
+  const { data: sessionsResponse, isLoading: sessionsLoading } = useSessions(
+    agentId,
+    {
+      offset,
+      limit: PAGE_SIZE,
+    },
+  );
   const { data: llmModels } = useLlmModels();
   const createSession = useCreateSession();
   const { data: organization } = useOrganization();
@@ -95,12 +108,18 @@ export default function SessionsListPage({ params }: { params: Promise<{ agentId
 
       <div className="flex items-start justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold">{getDisplayName(agent)} - Sessions</h1>
+          <h1 className="text-2xl font-bold">
+            {getDisplayName(agent)} - Sessions
+          </h1>
           <p className="text-muted-foreground">
             {totalSessions} session{totalSessions !== 1 ? "s" : ""} total
           </p>
         </div>
-        <Button variant="accent" onClick={handleNewSession} disabled={createSession.isPending}>
+        <Button
+          variant="accent"
+          onClick={handleNewSession}
+          disabled={createSession.isPending}
+        >
           <Plus className="w-4 h-4 mr-2" />
           {createSession.isPending ? "Creating..." : "New Session"}
         </Button>
@@ -127,7 +146,11 @@ export default function SessionsListPage({ params }: { params: Promise<{ agentId
                 <SessionCard
                   key={session.id}
                   session={session}
-                  model={session.model_id ? modelMap.get(session.model_id) : undefined}
+                  model={
+                    session.model_id
+                      ? modelMap.get(session.model_id)
+                      : undefined
+                  }
                 />
               ))}
             </div>
@@ -137,8 +160,9 @@ export default function SessionsListPage({ params }: { params: Promise<{ agentId
           {totalPages > 1 && (
             <div className="flex items-center justify-between mt-4 pt-4 border-t">
               <p className="text-sm text-muted-foreground">
-                Showing {offset + 1}-{Math.min(offset + PAGE_SIZE, totalSessions)} of{" "}
-                {totalSessions} sessions
+                Showing {offset + 1}-
+                {Math.min(offset + PAGE_SIZE, totalSessions)} of {totalSessions}{" "}
+                sessions
               </p>
               <div className="flex items-center gap-2">
                 <Button

--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/page.tsx
@@ -89,12 +89,12 @@ export default function SessionsListPage({ params }: { params: Promise<{ agentId
         className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-6"
       >
         <ArrowLeft className="w-4 h-4 mr-2" />
-        Back to {agent.name}
+        Back to {agent.display_name || agent.name}
       </Link>
 
       <div className="flex items-start justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold">{agent.name} - Sessions</h1>
+          <h1 className="text-2xl font-bold">{agent.display_name || agent.name} - Sessions</h1>
           <p className="text-muted-foreground">
             {totalSessions} session{totalSessions !== 1 ? "s" : ""} total
           </p>

--- a/apps/ui/src/app/(main)/agents/new/page.tsx
+++ b/apps/ui/src/app/(main)/agents/new/page.tsx
@@ -2,11 +2,7 @@
 
 import { useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import {
-  useCreateAgent,
-  useCapabilities,
-  useAgentNameAvailability,
-} from "@/hooks";
+import { useCreateAgent, useCapabilities, useAgentNameAvailability } from "@/hooks";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -47,17 +43,12 @@ export default function NewAgentPage() {
 
   const nameAvailability = useAgentNameAvailability(formData.name);
 
-  const [selectedCapabilities, setSelectedCapabilities] = useState<
-    AgentCapabilityConfig[]
-  >([]);
+  const [selectedCapabilities, setSelectedCapabilities] = useState<AgentCapabilityConfig[]>([]);
   const [initialFiles, setInitialFiles] = useState<InitialFile[]>([]);
 
-  const handleCapabilitiesChange = useCallback(
-    (capabilities: AgentCapabilityConfig[]) => {
-      setSelectedCapabilities(capabilities);
-    },
-    [],
-  );
+  const handleCapabilitiesChange = useCallback((capabilities: AgentCapabilityConfig[]) => {
+    setSelectedCapabilities(capabilities);
+  }, []);
 
   const handleDisplayNameChange = (value: string) => {
     const updates: Partial<typeof formData> = { display_name: value };
@@ -83,8 +74,7 @@ export default function NewAgentPage() {
         description: formData.description || undefined,
         system_prompt: formData.system_prompt,
         default_model_id: formData.default_model_id || undefined,
-        capabilities:
-          selectedCapabilities.length > 0 ? selectedCapabilities : undefined,
+        capabilities: selectedCapabilities.length > 0 ? selectedCapabilities : undefined,
         initial_files: initialFiles.length > 0 ? initialFiles : undefined,
       });
 
@@ -118,9 +108,7 @@ export default function NewAgentPage() {
                 value={formData.display_name}
                 onChange={(e) => handleDisplayNameChange(e.target.value)}
               />
-              <p className="text-xs text-muted-foreground">
-                Human-readable name shown in the UI
-              </p>
+              <p className="text-xs text-muted-foreground">Human-readable name shown in the UI</p>
             </div>
 
             <div className="space-y-2">
@@ -137,9 +125,7 @@ export default function NewAgentPage() {
                   {nameAvailability.isChecking ? (
                     <>
                       <Loader2 className="w-3 h-3 animate-spin text-muted-foreground" />
-                      <span className="text-muted-foreground">
-                        Checking availability…
-                      </span>
+                      <span className="text-muted-foreground">Checking availability…</span>
                     </>
                   ) : nameAvailability.available === true ? (
                     <>
@@ -149,16 +135,13 @@ export default function NewAgentPage() {
                   ) : nameAvailability.available === false ? (
                     <>
                       <X className="w-3 h-3 text-destructive" />
-                      <span className="text-destructive">
-                        Name is already taken or invalid
-                      </span>
+                      <span className="text-destructive">Name is already taken or invalid</span>
                     </>
                   ) : null}
                 </div>
               )}
               <p className="text-xs text-muted-foreground">
-                Unique identifier used in URLs and API. Lowercase letters,
-                numbers, and hyphens.
+                Unique identifier used in URLs and API. Lowercase letters, numbers, and hyphens.
               </p>
             </div>
 
@@ -168,9 +151,7 @@ export default function NewAgentPage() {
                 id="description"
                 placeholder="Describe what this agent does..."
                 value={formData.description}
-                onChange={(e) =>
-                  setFormData({ ...formData, description: e.target.value })
-                }
+                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
                 rows={2}
               />
             </div>
@@ -179,9 +160,7 @@ export default function NewAgentPage() {
               <Label htmlFor="model">Model (optional)</Label>
               <ModelPicker
                 value={formData.default_model_id}
-                onChange={(value) =>
-                  setFormData({ ...formData, default_model_id: value })
-                }
+                onChange={(value) => setFormData({ ...formData, default_model_id: value })}
                 placeholder="Use default model"
               />
               <p className="text-xs text-muted-foreground">
@@ -199,8 +178,7 @@ export default function NewAgentPage() {
                 label=""
               />
               <p className="text-xs text-muted-foreground">
-                Add capabilities to give your agent tools and specialized
-                behaviors
+                Add capabilities to give your agent tools and specialized behaviors
               </p>
             </div>
 
@@ -210,9 +188,7 @@ export default function NewAgentPage() {
                 id="system_prompt"
                 placeholder="You are a helpful assistant..."
                 value={formData.system_prompt}
-                onChange={(value) =>
-                  setFormData({ ...formData, system_prompt: value })
-                }
+                onChange={(value) => setFormData({ ...formData, system_prompt: value })}
                 required
               />
               <p className="text-xs text-muted-foreground">
@@ -231,19 +207,13 @@ export default function NewAgentPage() {
               <Button type="submit" disabled={createAgent.isPending}>
                 {createAgent.isPending ? "Creating..." : "Create Agent"}
               </Button>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => router.back()}
-              >
+              <Button type="button" variant="outline" onClick={() => router.back()}>
                 Cancel
               </Button>
             </div>
 
             {createAgent.error && (
-              <p className="text-sm text-destructive">
-                Error: {createAgent.error.message}
-              </p>
+              <p className="text-sm text-destructive">Error: {createAgent.error.message}</p>
             )}
           </form>
         </CardContent>

--- a/apps/ui/src/app/(main)/agents/new/page.tsx
+++ b/apps/ui/src/app/(main)/agents/new/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { useCreateAgent, useCapabilities } from "@/hooks";
+import { useCreateAgent, useCapabilities, useAgentNameAvailability } from "@/hooks";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -10,11 +10,20 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { PromptEditor } from "@/components/ui/prompt-editor";
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Check, X, Loader2 } from "lucide-react";
 import { ModelPicker } from "@/components/models/model-picker";
 import { CapabilitySelector } from "@/components/agents/capability-selector";
 import { InitialFilesEditor } from "@/components/initial-files-editor";
 import type { AgentCapabilityConfig, InitialFile } from "@/lib/api/types";
+
+/** Convert a display name to a slug: lowercase, non-alphanumeric → hyphens, deduplicate, trim. */
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+}
 
 export default function NewAgentPage() {
   const router = useRouter();
@@ -22,11 +31,17 @@ export default function NewAgentPage() {
   const { data: allCapabilities = [] } = useCapabilities();
 
   const [formData, setFormData] = useState({
+    display_name: "",
     name: "",
     description: "",
     system_prompt: "",
     default_model_id: "",
   });
+
+  // Track whether the user has manually edited the slug
+  const [nameManuallyEdited, setNameManuallyEdited] = useState(false);
+
+  const nameAvailability = useAgentNameAvailability(formData.name);
 
   const [selectedCapabilities, setSelectedCapabilities] = useState<AgentCapabilityConfig[]>([]);
   const [initialFiles, setInitialFiles] = useState<InitialFile[]>([]);
@@ -35,12 +50,27 @@ export default function NewAgentPage() {
     setSelectedCapabilities(capabilities);
   }, []);
 
+  const handleDisplayNameChange = (value: string) => {
+    const updates: Partial<typeof formData> = { display_name: value };
+    // Auto-derive slug unless user has manually edited it
+    if (!nameManuallyEdited) {
+      updates.name = slugify(value);
+    }
+    setFormData((prev) => ({ ...prev, ...updates }));
+  };
+
+  const handleNameChange = (value: string) => {
+    setNameManuallyEdited(true);
+    setFormData((prev) => ({ ...prev, name: value }));
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
     try {
       const agent = await createAgent.mutateAsync({
         name: formData.name,
+        display_name: formData.display_name || undefined,
         description: formData.description || undefined,
         system_prompt: formData.system_prompt,
         default_model_id: formData.default_model_id || undefined,
@@ -71,14 +101,50 @@ export default function NewAgentPage() {
         <CardContent>
           <form onSubmit={handleSubmit} className="space-y-6">
             <div className="space-y-2">
+              <Label htmlFor="display_name">Display Name</Label>
+              <Input
+                id="display_name"
+                placeholder="Customer Support Agent"
+                value={formData.display_name}
+                onChange={(e) => handleDisplayNameChange(e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                Human-readable name shown in the UI
+              </p>
+            </div>
+
+            <div className="space-y-2">
               <Label htmlFor="name">Name</Label>
               <Input
                 id="name"
-                placeholder="My Agent"
+                placeholder="customer-support"
                 value={formData.name}
-                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                onChange={(e) => handleNameChange(e.target.value)}
                 required
               />
+              {formData.name.length >= 2 && (
+                <div className="flex items-center gap-1.5 text-xs">
+                  {nameAvailability.isChecking ? (
+                    <>
+                      <Loader2 className="w-3 h-3 animate-spin text-muted-foreground" />
+                      <span className="text-muted-foreground">Checking availability…</span>
+                    </>
+                  ) : nameAvailability.available === true ? (
+                    <>
+                      <Check className="w-3 h-3 text-green-600" />
+                      <span className="text-green-600">Name is available</span>
+                    </>
+                  ) : nameAvailability.available === false ? (
+                    <>
+                      <X className="w-3 h-3 text-destructive" />
+                      <span className="text-destructive">Name is already taken or invalid</span>
+                    </>
+                  ) : null}
+                </div>
+              )}
+              <p className="text-xs text-muted-foreground">
+                Unique identifier used in URLs and API. Lowercase letters, numbers, and hyphens.
+              </p>
             </div>
 
             <div className="space-y-2">

--- a/apps/ui/src/app/(main)/agents/new/page.tsx
+++ b/apps/ui/src/app/(main)/agents/new/page.tsx
@@ -2,7 +2,11 @@
 
 import { useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { useCreateAgent, useCapabilities, useAgentNameAvailability } from "@/hooks";
+import {
+  useCreateAgent,
+  useCapabilities,
+  useAgentNameAvailability,
+} from "@/hooks";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -43,12 +47,17 @@ export default function NewAgentPage() {
 
   const nameAvailability = useAgentNameAvailability(formData.name);
 
-  const [selectedCapabilities, setSelectedCapabilities] = useState<AgentCapabilityConfig[]>([]);
+  const [selectedCapabilities, setSelectedCapabilities] = useState<
+    AgentCapabilityConfig[]
+  >([]);
   const [initialFiles, setInitialFiles] = useState<InitialFile[]>([]);
 
-  const handleCapabilitiesChange = useCallback((capabilities: AgentCapabilityConfig[]) => {
-    setSelectedCapabilities(capabilities);
-  }, []);
+  const handleCapabilitiesChange = useCallback(
+    (capabilities: AgentCapabilityConfig[]) => {
+      setSelectedCapabilities(capabilities);
+    },
+    [],
+  );
 
   const handleDisplayNameChange = (value: string) => {
     const updates: Partial<typeof formData> = { display_name: value };
@@ -74,7 +83,8 @@ export default function NewAgentPage() {
         description: formData.description || undefined,
         system_prompt: formData.system_prompt,
         default_model_id: formData.default_model_id || undefined,
-        capabilities: selectedCapabilities.length > 0 ? selectedCapabilities : undefined,
+        capabilities:
+          selectedCapabilities.length > 0 ? selectedCapabilities : undefined,
         initial_files: initialFiles.length > 0 ? initialFiles : undefined,
       });
 
@@ -127,7 +137,9 @@ export default function NewAgentPage() {
                   {nameAvailability.isChecking ? (
                     <>
                       <Loader2 className="w-3 h-3 animate-spin text-muted-foreground" />
-                      <span className="text-muted-foreground">Checking availability…</span>
+                      <span className="text-muted-foreground">
+                        Checking availability…
+                      </span>
                     </>
                   ) : nameAvailability.available === true ? (
                     <>
@@ -137,13 +149,16 @@ export default function NewAgentPage() {
                   ) : nameAvailability.available === false ? (
                     <>
                       <X className="w-3 h-3 text-destructive" />
-                      <span className="text-destructive">Name is already taken or invalid</span>
+                      <span className="text-destructive">
+                        Name is already taken or invalid
+                      </span>
                     </>
                   ) : null}
                 </div>
               )}
               <p className="text-xs text-muted-foreground">
-                Unique identifier used in URLs and API. Lowercase letters, numbers, and hyphens.
+                Unique identifier used in URLs and API. Lowercase letters,
+                numbers, and hyphens.
               </p>
             </div>
 
@@ -153,7 +168,9 @@ export default function NewAgentPage() {
                 id="description"
                 placeholder="Describe what this agent does..."
                 value={formData.description}
-                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                onChange={(e) =>
+                  setFormData({ ...formData, description: e.target.value })
+                }
                 rows={2}
               />
             </div>
@@ -162,7 +179,9 @@ export default function NewAgentPage() {
               <Label htmlFor="model">Model (optional)</Label>
               <ModelPicker
                 value={formData.default_model_id}
-                onChange={(value) => setFormData({ ...formData, default_model_id: value })}
+                onChange={(value) =>
+                  setFormData({ ...formData, default_model_id: value })
+                }
                 placeholder="Use default model"
               />
               <p className="text-xs text-muted-foreground">
@@ -180,7 +199,8 @@ export default function NewAgentPage() {
                 label=""
               />
               <p className="text-xs text-muted-foreground">
-                Add capabilities to give your agent tools and specialized behaviors
+                Add capabilities to give your agent tools and specialized
+                behaviors
               </p>
             </div>
 
@@ -190,7 +210,9 @@ export default function NewAgentPage() {
                 id="system_prompt"
                 placeholder="You are a helpful assistant..."
                 value={formData.system_prompt}
-                onChange={(value) => setFormData({ ...formData, system_prompt: value })}
+                onChange={(value) =>
+                  setFormData({ ...formData, system_prompt: value })
+                }
                 required
               />
               <p className="text-xs text-muted-foreground">
@@ -209,13 +231,19 @@ export default function NewAgentPage() {
               <Button type="submit" disabled={createAgent.isPending}>
                 {createAgent.isPending ? "Creating..." : "Create Agent"}
               </Button>
-              <Button type="button" variant="outline" onClick={() => router.back()}>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => router.back()}
+              >
                 Cancel
               </Button>
             </div>
 
             {createAgent.error && (
-              <p className="text-sm text-destructive">Error: {createAgent.error.message}</p>
+              <p className="text-sm text-destructive">
+                Error: {createAgent.error.message}
+              </p>
             )}
           </form>
         </CardContent>

--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -47,7 +47,17 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { ArrowLeft, Globe, GlobeLock, Trash2, Pencil, Check, X, Rocket, Plus } from "lucide-react";
+import {
+  ArrowLeft,
+  Globe,
+  GlobeLock,
+  Trash2,
+  Pencil,
+  Check,
+  X,
+  Rocket,
+  Plus,
+} from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import { SlackSetupGuidance } from "@/components/apps/slack-setup-guidance";
 import type {
@@ -65,7 +75,11 @@ import {
   isReadOnlyStatus,
 } from "@/lib/entity-lifecycle";
 
-export default function AppDetailPage({ params }: { params: Promise<{ appId: string }> }) {
+export default function AppDetailPage({
+  params,
+}: {
+  params: Promise<{ appId: string }>;
+}) {
   const { appId } = use(params);
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -96,8 +110,10 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
   const [editBotToken, setEditBotToken] = useState("");
   const [editChannelIdField, setEditChannelIdField] = useState("");
   const [editTeamId, setEditTeamId] = useState("");
-  const [editSessionStrategy, setEditSessionStrategy] = useState<SessionStrategy>("per_thread");
-  const [editReplyMode, setEditReplyMode] = useState<SlackReplyMode>("all_messages");
+  const [editSessionStrategy, setEditSessionStrategy] =
+    useState<SessionStrategy>("per_thread");
+  const [editReplyMode, setEditReplyMode] =
+    useState<SlackReplyMode>("all_messages");
 
   const [creatingSlackApp, setCreatingSlackApp] = useState(false);
 
@@ -121,7 +137,10 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
 
   const addChannelMutation = useMutation({
     mutationFn: async (config: SlackChannelConfig) => {
-      return apiAddChannel(appId, { channel_type: "slack", channel_config: config });
+      return apiAddChannel(appId, {
+        channel_type: "slack",
+        channel_config: config,
+      });
     },
     onSuccess: () => {
       invalidateApp();
@@ -145,7 +164,9 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
   const slackChannel = app?.channels?.find(
     (ch: AppChannel) => ch.channel_type === "slack" && ch.enabled,
   );
-  const slackConfig = slackChannel?.channel_config as SlackChannelConfig | undefined;
+  const slackConfig = slackChannel?.channel_config as
+    | SlackChannelConfig
+    | undefined;
   const hasSlackConfig = slackConfig?.signing_secret && slackConfig?.bot_token;
 
   const webhookUrl =
@@ -155,7 +176,8 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
 
   const isLocalhost =
     typeof window !== "undefined" &&
-    (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1");
+    (window.location.hostname === "localhost" ||
+      window.location.hostname === "127.0.0.1");
   const webhookPath = `/api/v1/apps/${appId}/slack/events`;
 
   const handleCreateSlackApp = useCallback(async () => {
@@ -226,7 +248,10 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
       ...(editChannelIdField ? { channel_id: editChannelIdField } : {}),
       ...(editTeamId ? { team_id: editTeamId } : {}),
     };
-    await updateChannelMutation.mutateAsync({ channelId: editingChannelId, config: channelConfig });
+    await updateChannelMutation.mutateAsync({
+      channelId: editingChannelId,
+      config: channelConfig,
+    });
     setEditingChannelId(null);
   };
 
@@ -254,7 +279,9 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
   };
 
   const agent = agents?.find((candidate) => candidate.id === app?.agent_id);
-  const harness = harnesses?.find((candidate) => candidate.id === app?.harness_id);
+  const harness = harnesses?.find(
+    (candidate) => candidate.id === app?.harness_id,
+  );
 
   if (isLoading) {
     return (
@@ -290,7 +317,8 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
           required
         />
         <p className="text-xs text-muted-foreground mt-1">
-          Found in your Slack app &rarr; Settings &rarr; Basic Information &rarr; App Credentials
+          Found in your Slack app &rarr; Settings &rarr; Basic Information
+          &rarr; App Credentials
         </p>
       </div>
 
@@ -305,7 +333,8 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
           required
         />
         <p className="text-xs text-muted-foreground mt-1">
-          Found in your Slack app &rarr; OAuth &amp; Permissions &rarr; Bot User OAuth Token
+          Found in your Slack app &rarr; OAuth &amp; Permissions &rarr; Bot User
+          OAuth Token
         </p>
       </div>
 
@@ -360,7 +389,10 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
 
       <div>
         <Label htmlFor={`reply_mode_${formId}`}>Reply Mode</Label>
-        <Select value={editReplyMode} onValueChange={(v) => setEditReplyMode(v as SlackReplyMode)}>
+        <Select
+          value={editReplyMode}
+          onValueChange={(v) => setEditReplyMode(v as SlackReplyMode)}
+        >
           <SelectTrigger>
             <SelectValue>
               {
@@ -373,7 +405,9 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="all_messages">All Assistant Messages</SelectItem>
-            <SelectItem value="report_progress_only">Report Progress Only</SelectItem>
+            <SelectItem value="report_progress_only">
+              Report Progress Only
+            </SelectItem>
           </SelectContent>
         </Select>
       </div>
@@ -415,11 +449,15 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <p className="text-sm font-medium">Signing Secret</p>
-                <p className="text-sm text-muted-foreground font-mono">{"*".repeat(12)}</p>
+                <p className="text-sm text-muted-foreground font-mono">
+                  {"*".repeat(12)}
+                </p>
               </div>
               <div>
                 <p className="text-sm font-medium">Bot User OAuth Token</p>
-                <p className="text-sm text-muted-foreground font-mono">{"*".repeat(12)}</p>
+                <p className="text-sm text-muted-foreground font-mono">
+                  {"*".repeat(12)}
+                </p>
               </div>
             </div>
 
@@ -428,13 +466,17 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                 {config?.team_id && (
                   <div>
                     <p className="text-sm font-medium">Workspace ID</p>
-                    <p className="text-sm text-muted-foreground font-mono">{config.team_id}</p>
+                    <p className="text-sm text-muted-foreground font-mono">
+                      {config.team_id}
+                    </p>
                   </div>
                 )}
                 {config?.channel_id && (
                   <div>
                     <p className="text-sm font-medium">Channel ID</p>
-                    <p className="text-sm text-muted-foreground font-mono">{config.channel_id}</p>
+                    <p className="text-sm text-muted-foreground font-mono">
+                      {config.channel_id}
+                    </p>
                   </div>
                 )}
               </div>
@@ -505,11 +547,17 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
         <div>
           <h1 className="text-2xl font-bold flex items-center gap-2">
             <Rocket className="w-6 h-6" />
-            <span className={getEntityNameClassName(app.status)}>{app.name}</span>
+            <span className={getEntityNameClassName(app.status)}>
+              {app.name}
+            </span>
             <CopyButton value={app.id} />
-            <Badge variant={getEntityStatusBadgeVariant(app.status)}>{app.status}</Badge>
+            <Badge variant={getEntityStatusBadgeVariant(app.status)}>
+              {app.status}
+            </Badge>
           </h1>
-          {app.description && <p className="text-muted-foreground mt-1">{app.description}</p>}
+          {app.description && (
+            <p className="text-muted-foreground mt-1">{app.description}</p>
+          )}
         </div>
         <div className="flex gap-2">
           {isPublished ? (
@@ -563,17 +611,26 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                   <Badge variant="outline" className="capitalize">
                     {channel.channel_type}
                   </Badge>
-                  {!channel.enabled && <Badge variant="secondary">Disabled</Badge>}
+                  {!channel.enabled && (
+                    <Badge variant="secondary">Disabled</Badge>
+                  )}
                   {(app.channels ?? []).length > 1 && (
-                    <span className="text-xs text-muted-foreground font-mono">{channel.id}</span>
+                    <span className="text-xs text-muted-foreground font-mono">
+                      {channel.id}
+                    </span>
                   )}
                 </CardTitle>
                 <div className="flex gap-1">
                   {editingChannelId !== channel.id && !isReadOnly && (
                     <>
-                      <Button variant="outline" size="sm" onClick={() => startEditChannel(channel)}>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => startEditChannel(channel)}
+                      >
                         <Pencil className="w-3 h-3 mr-1" />
-                        {(channel.channel_config as SlackChannelConfig)?.signing_secret
+                        {(channel.channel_config as SlackChannelConfig)
+                          ?.signing_secret
                           ? "Edit"
                           : "Configure"}
                       </Button>
@@ -581,7 +638,9 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                         <Button
                           variant="outline"
                           size="sm"
-                          onClick={() => deleteChannelMutation.mutate(channel.id)}
+                          onClick={() =>
+                            deleteChannelMutation.mutate(channel.id)
+                          }
                           disabled={deleteChannelMutation.isPending}
                         >
                           <Trash2 className="w-3 h-3" />
@@ -593,7 +652,10 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
               </CardHeader>
               <CardContent>
                 {editingChannelId === channel.id
-                  ? renderChannelForm(updateChannelMutation.isPending, channel.id)
+                  ? renderChannelForm(
+                      updateChannelMutation.isPending,
+                      channel.id,
+                    )
                   : renderChannelDisplay(channel)}
               </CardContent>
             </Card>
@@ -601,7 +663,11 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
 
           {/* Add Channel button */}
           {!isReadOnly && !showAddChannel && (
-            <Button variant="outline" className="w-full" onClick={startAddChannel}>
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={startAddChannel}
+            >
               <Plus className="w-4 h-4 mr-2" />
               Add Channel
             </Button>
@@ -613,7 +679,9 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
               <CardHeader>
                 <CardTitle>Add Slack Channel</CardTitle>
               </CardHeader>
-              <CardContent>{renderChannelForm(addChannelMutation.isPending, "new")}</CardContent>
+              <CardContent>
+                {renderChannelForm(addChannelMutation.isPending, "new")}
+              </CardContent>
             </Card>
           )}
 
@@ -630,7 +698,8 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                 {isLocalhost ? (
                   <>
                     <p className="text-sm text-muted-foreground">
-                      Slack can&apos;t reach <code className="text-xs">localhost</code>. Use{" "}
+                      Slack can&apos;t reach{" "}
+                      <code className="text-xs">localhost</code>. Use{" "}
                       <a
                         href="https://ngrok.com"
                         target="_blank"
@@ -642,10 +711,14 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                       to expose your local server:
                     </p>
                     <div className="bg-muted p-3 rounded-md space-y-1">
-                      <p className="text-xs font-medium text-muted-foreground">1. Start ngrok:</p>
+                      <p className="text-xs font-medium text-muted-foreground">
+                        1. Start ngrok:
+                      </p>
                       <code className="text-xs block">
                         ngrok http{" "}
-                        {typeof window !== "undefined" ? window.location.port || "9300" : "9300"}
+                        {typeof window !== "undefined"
+                          ? window.location.port || "9300"
+                          : "9300"}
                       </code>
                       <p className="text-xs font-medium text-muted-foreground mt-2">
                         2. Copy your Request URL:
@@ -658,12 +731,15 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                 ) : (
                   <>
                     <p className="text-sm text-muted-foreground">
-                      Paste this URL in your Slack app &rarr; <strong>Event Subscriptions</strong>{" "}
-                      &rarr; <strong>Request URL</strong>.
+                      Paste this URL in your Slack app &rarr;{" "}
+                      <strong>Event Subscriptions</strong> &rarr;{" "}
+                      <strong>Request URL</strong>.
                     </p>
                     <div className="flex items-center gap-2 bg-muted p-3 rounded-md">
                       <Globe className="w-4 h-4 shrink-0 text-muted-foreground" />
-                      <code className="text-sm flex-1 truncate">{webhookUrl}</code>
+                      <code className="text-sm flex-1 truncate">
+                        {webhookUrl}
+                      </code>
                       <CopyButton value={webhookUrl} />
                     </div>
                   </>
@@ -709,12 +785,18 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
 
                   <div>
                     <Label>Harness</Label>
-                    <HarnessSelect value={editHarnessId} onValueChange={setEditHarnessId} />
+                    <HarnessSelect
+                      value={editHarnessId}
+                      onValueChange={setEditHarnessId}
+                    />
                   </div>
 
                   <div>
                     <Label>Agent</Label>
-                    <AgentSelect value={editAgentId} onValueChange={setEditAgentId} />
+                    <AgentSelect
+                      value={editAgentId}
+                      onValueChange={setEditAgentId}
+                    />
                   </div>
 
                   <div>
@@ -729,12 +811,21 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                     <Button
                       size="sm"
                       onClick={saveBasic}
-                      disabled={updateApp.isPending || !editName || !editAgentId || !editHarnessId}
+                      disabled={
+                        updateApp.isPending ||
+                        !editName ||
+                        !editAgentId ||
+                        !editHarnessId
+                      }
                     >
                       <Check className="w-3 h-3 mr-1" />
                       {updateApp.isPending ? "Saving..." : "Save"}
                     </Button>
-                    <Button size="sm" variant="outline" onClick={() => setEditingBasic(false)}>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setEditingBasic(false)}
+                    >
                       <X className="w-3 h-3 mr-1" />
                       Cancel
                     </Button>
@@ -772,12 +863,18 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                     <p className="text-sm font-medium">Channels</p>
                     <div className="flex gap-1 flex-wrap">
                       {(app.channels ?? []).map((ch: AppChannel) => (
-                        <Badge key={ch.id} variant="outline" className="capitalize">
+                        <Badge
+                          key={ch.id}
+                          variant="outline"
+                          className="capitalize"
+                        >
                           {ch.channel_type}
                         </Badge>
                       ))}
                       {(app.channels ?? []).length === 0 && (
-                        <span className="text-sm text-muted-foreground">None configured</span>
+                        <span className="text-sm text-muted-foreground">
+                          None configured
+                        </span>
                       )}
                     </div>
                   </div>
@@ -817,12 +914,15 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
           <DialogHeader>
             <DialogTitle>Delete App</DialogTitle>
             <DialogDescription>
-              Permanently delete the archived app &quot;{app.name}&quot;? Existing references will
-              render as deleted tombstones.
+              Permanently delete the archived app &quot;{app.name}&quot;?
+              Existing references will render as deleted tombstones.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setShowDeleteDialog(false)}>
+            <Button
+              variant="outline"
+              onClick={() => setShowDeleteDialog(false)}
+            >
               Cancel
             </Button>
             <Button

--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -47,17 +47,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import {
-  ArrowLeft,
-  Globe,
-  GlobeLock,
-  Trash2,
-  Pencil,
-  Check,
-  X,
-  Rocket,
-  Plus,
-} from "lucide-react";
+import { ArrowLeft, Globe, GlobeLock, Trash2, Pencil, Check, X, Rocket, Plus } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import { SlackSetupGuidance } from "@/components/apps/slack-setup-guidance";
 import type {
@@ -75,11 +65,7 @@ import {
   isReadOnlyStatus,
 } from "@/lib/entity-lifecycle";
 
-export default function AppDetailPage({
-  params,
-}: {
-  params: Promise<{ appId: string }>;
-}) {
+export default function AppDetailPage({ params }: { params: Promise<{ appId: string }> }) {
   const { appId } = use(params);
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -110,10 +96,8 @@ export default function AppDetailPage({
   const [editBotToken, setEditBotToken] = useState("");
   const [editChannelIdField, setEditChannelIdField] = useState("");
   const [editTeamId, setEditTeamId] = useState("");
-  const [editSessionStrategy, setEditSessionStrategy] =
-    useState<SessionStrategy>("per_thread");
-  const [editReplyMode, setEditReplyMode] =
-    useState<SlackReplyMode>("all_messages");
+  const [editSessionStrategy, setEditSessionStrategy] = useState<SessionStrategy>("per_thread");
+  const [editReplyMode, setEditReplyMode] = useState<SlackReplyMode>("all_messages");
 
   const [creatingSlackApp, setCreatingSlackApp] = useState(false);
 
@@ -164,9 +148,7 @@ export default function AppDetailPage({
   const slackChannel = app?.channels?.find(
     (ch: AppChannel) => ch.channel_type === "slack" && ch.enabled,
   );
-  const slackConfig = slackChannel?.channel_config as
-    | SlackChannelConfig
-    | undefined;
+  const slackConfig = slackChannel?.channel_config as SlackChannelConfig | undefined;
   const hasSlackConfig = slackConfig?.signing_secret && slackConfig?.bot_token;
 
   const webhookUrl =
@@ -176,8 +158,7 @@ export default function AppDetailPage({
 
   const isLocalhost =
     typeof window !== "undefined" &&
-    (window.location.hostname === "localhost" ||
-      window.location.hostname === "127.0.0.1");
+    (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1");
   const webhookPath = `/api/v1/apps/${appId}/slack/events`;
 
   const handleCreateSlackApp = useCallback(async () => {
@@ -279,9 +260,7 @@ export default function AppDetailPage({
   };
 
   const agent = agents?.find((candidate) => candidate.id === app?.agent_id);
-  const harness = harnesses?.find(
-    (candidate) => candidate.id === app?.harness_id,
-  );
+  const harness = harnesses?.find((candidate) => candidate.id === app?.harness_id);
 
   if (isLoading) {
     return (
@@ -317,8 +296,7 @@ export default function AppDetailPage({
           required
         />
         <p className="text-xs text-muted-foreground mt-1">
-          Found in your Slack app &rarr; Settings &rarr; Basic Information
-          &rarr; App Credentials
+          Found in your Slack app &rarr; Settings &rarr; Basic Information &rarr; App Credentials
         </p>
       </div>
 
@@ -333,8 +311,7 @@ export default function AppDetailPage({
           required
         />
         <p className="text-xs text-muted-foreground mt-1">
-          Found in your Slack app &rarr; OAuth &amp; Permissions &rarr; Bot User
-          OAuth Token
+          Found in your Slack app &rarr; OAuth &amp; Permissions &rarr; Bot User OAuth Token
         </p>
       </div>
 
@@ -389,10 +366,7 @@ export default function AppDetailPage({
 
       <div>
         <Label htmlFor={`reply_mode_${formId}`}>Reply Mode</Label>
-        <Select
-          value={editReplyMode}
-          onValueChange={(v) => setEditReplyMode(v as SlackReplyMode)}
-        >
+        <Select value={editReplyMode} onValueChange={(v) => setEditReplyMode(v as SlackReplyMode)}>
           <SelectTrigger>
             <SelectValue>
               {
@@ -405,9 +379,7 @@ export default function AppDetailPage({
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="all_messages">All Assistant Messages</SelectItem>
-            <SelectItem value="report_progress_only">
-              Report Progress Only
-            </SelectItem>
+            <SelectItem value="report_progress_only">Report Progress Only</SelectItem>
           </SelectContent>
         </Select>
       </div>
@@ -449,15 +421,11 @@ export default function AppDetailPage({
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <p className="text-sm font-medium">Signing Secret</p>
-                <p className="text-sm text-muted-foreground font-mono">
-                  {"*".repeat(12)}
-                </p>
+                <p className="text-sm text-muted-foreground font-mono">{"*".repeat(12)}</p>
               </div>
               <div>
                 <p className="text-sm font-medium">Bot User OAuth Token</p>
-                <p className="text-sm text-muted-foreground font-mono">
-                  {"*".repeat(12)}
-                </p>
+                <p className="text-sm text-muted-foreground font-mono">{"*".repeat(12)}</p>
               </div>
             </div>
 
@@ -466,17 +434,13 @@ export default function AppDetailPage({
                 {config?.team_id && (
                   <div>
                     <p className="text-sm font-medium">Workspace ID</p>
-                    <p className="text-sm text-muted-foreground font-mono">
-                      {config.team_id}
-                    </p>
+                    <p className="text-sm text-muted-foreground font-mono">{config.team_id}</p>
                   </div>
                 )}
                 {config?.channel_id && (
                   <div>
                     <p className="text-sm font-medium">Channel ID</p>
-                    <p className="text-sm text-muted-foreground font-mono">
-                      {config.channel_id}
-                    </p>
+                    <p className="text-sm text-muted-foreground font-mono">{config.channel_id}</p>
                   </div>
                 )}
               </div>
@@ -547,17 +511,11 @@ export default function AppDetailPage({
         <div>
           <h1 className="text-2xl font-bold flex items-center gap-2">
             <Rocket className="w-6 h-6" />
-            <span className={getEntityNameClassName(app.status)}>
-              {app.name}
-            </span>
+            <span className={getEntityNameClassName(app.status)}>{app.name}</span>
             <CopyButton value={app.id} />
-            <Badge variant={getEntityStatusBadgeVariant(app.status)}>
-              {app.status}
-            </Badge>
+            <Badge variant={getEntityStatusBadgeVariant(app.status)}>{app.status}</Badge>
           </h1>
-          {app.description && (
-            <p className="text-muted-foreground mt-1">{app.description}</p>
-          )}
+          {app.description && <p className="text-muted-foreground mt-1">{app.description}</p>}
         </div>
         <div className="flex gap-2">
           {isPublished ? (
@@ -611,26 +569,17 @@ export default function AppDetailPage({
                   <Badge variant="outline" className="capitalize">
                     {channel.channel_type}
                   </Badge>
-                  {!channel.enabled && (
-                    <Badge variant="secondary">Disabled</Badge>
-                  )}
+                  {!channel.enabled && <Badge variant="secondary">Disabled</Badge>}
                   {(app.channels ?? []).length > 1 && (
-                    <span className="text-xs text-muted-foreground font-mono">
-                      {channel.id}
-                    </span>
+                    <span className="text-xs text-muted-foreground font-mono">{channel.id}</span>
                   )}
                 </CardTitle>
                 <div className="flex gap-1">
                   {editingChannelId !== channel.id && !isReadOnly && (
                     <>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => startEditChannel(channel)}
-                      >
+                      <Button variant="outline" size="sm" onClick={() => startEditChannel(channel)}>
                         <Pencil className="w-3 h-3 mr-1" />
-                        {(channel.channel_config as SlackChannelConfig)
-                          ?.signing_secret
+                        {(channel.channel_config as SlackChannelConfig)?.signing_secret
                           ? "Edit"
                           : "Configure"}
                       </Button>
@@ -638,9 +587,7 @@ export default function AppDetailPage({
                         <Button
                           variant="outline"
                           size="sm"
-                          onClick={() =>
-                            deleteChannelMutation.mutate(channel.id)
-                          }
+                          onClick={() => deleteChannelMutation.mutate(channel.id)}
                           disabled={deleteChannelMutation.isPending}
                         >
                           <Trash2 className="w-3 h-3" />
@@ -652,10 +599,7 @@ export default function AppDetailPage({
               </CardHeader>
               <CardContent>
                 {editingChannelId === channel.id
-                  ? renderChannelForm(
-                      updateChannelMutation.isPending,
-                      channel.id,
-                    )
+                  ? renderChannelForm(updateChannelMutation.isPending, channel.id)
                   : renderChannelDisplay(channel)}
               </CardContent>
             </Card>
@@ -663,11 +607,7 @@ export default function AppDetailPage({
 
           {/* Add Channel button */}
           {!isReadOnly && !showAddChannel && (
-            <Button
-              variant="outline"
-              className="w-full"
-              onClick={startAddChannel}
-            >
+            <Button variant="outline" className="w-full" onClick={startAddChannel}>
               <Plus className="w-4 h-4 mr-2" />
               Add Channel
             </Button>
@@ -679,9 +619,7 @@ export default function AppDetailPage({
               <CardHeader>
                 <CardTitle>Add Slack Channel</CardTitle>
               </CardHeader>
-              <CardContent>
-                {renderChannelForm(addChannelMutation.isPending, "new")}
-              </CardContent>
+              <CardContent>{renderChannelForm(addChannelMutation.isPending, "new")}</CardContent>
             </Card>
           )}
 
@@ -698,8 +636,7 @@ export default function AppDetailPage({
                 {isLocalhost ? (
                   <>
                     <p className="text-sm text-muted-foreground">
-                      Slack can&apos;t reach{" "}
-                      <code className="text-xs">localhost</code>. Use{" "}
+                      Slack can&apos;t reach <code className="text-xs">localhost</code>. Use{" "}
                       <a
                         href="https://ngrok.com"
                         target="_blank"
@@ -711,14 +648,10 @@ export default function AppDetailPage({
                       to expose your local server:
                     </p>
                     <div className="bg-muted p-3 rounded-md space-y-1">
-                      <p className="text-xs font-medium text-muted-foreground">
-                        1. Start ngrok:
-                      </p>
+                      <p className="text-xs font-medium text-muted-foreground">1. Start ngrok:</p>
                       <code className="text-xs block">
                         ngrok http{" "}
-                        {typeof window !== "undefined"
-                          ? window.location.port || "9300"
-                          : "9300"}
+                        {typeof window !== "undefined" ? window.location.port || "9300" : "9300"}
                       </code>
                       <p className="text-xs font-medium text-muted-foreground mt-2">
                         2. Copy your Request URL:
@@ -731,15 +664,12 @@ export default function AppDetailPage({
                 ) : (
                   <>
                     <p className="text-sm text-muted-foreground">
-                      Paste this URL in your Slack app &rarr;{" "}
-                      <strong>Event Subscriptions</strong> &rarr;{" "}
-                      <strong>Request URL</strong>.
+                      Paste this URL in your Slack app &rarr; <strong>Event Subscriptions</strong>{" "}
+                      &rarr; <strong>Request URL</strong>.
                     </p>
                     <div className="flex items-center gap-2 bg-muted p-3 rounded-md">
                       <Globe className="w-4 h-4 shrink-0 text-muted-foreground" />
-                      <code className="text-sm flex-1 truncate">
-                        {webhookUrl}
-                      </code>
+                      <code className="text-sm flex-1 truncate">{webhookUrl}</code>
                       <CopyButton value={webhookUrl} />
                     </div>
                   </>
@@ -785,18 +715,12 @@ export default function AppDetailPage({
 
                   <div>
                     <Label>Harness</Label>
-                    <HarnessSelect
-                      value={editHarnessId}
-                      onValueChange={setEditHarnessId}
-                    />
+                    <HarnessSelect value={editHarnessId} onValueChange={setEditHarnessId} />
                   </div>
 
                   <div>
                     <Label>Agent</Label>
-                    <AgentSelect
-                      value={editAgentId}
-                      onValueChange={setEditAgentId}
-                    />
+                    <AgentSelect value={editAgentId} onValueChange={setEditAgentId} />
                   </div>
 
                   <div>
@@ -811,21 +735,12 @@ export default function AppDetailPage({
                     <Button
                       size="sm"
                       onClick={saveBasic}
-                      disabled={
-                        updateApp.isPending ||
-                        !editName ||
-                        !editAgentId ||
-                        !editHarnessId
-                      }
+                      disabled={updateApp.isPending || !editName || !editAgentId || !editHarnessId}
                     >
                       <Check className="w-3 h-3 mr-1" />
                       {updateApp.isPending ? "Saving..." : "Save"}
                     </Button>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={() => setEditingBasic(false)}
-                    >
+                    <Button size="sm" variant="outline" onClick={() => setEditingBasic(false)}>
                       <X className="w-3 h-3 mr-1" />
                       Cancel
                     </Button>
@@ -863,18 +778,12 @@ export default function AppDetailPage({
                     <p className="text-sm font-medium">Channels</p>
                     <div className="flex gap-1 flex-wrap">
                       {(app.channels ?? []).map((ch: AppChannel) => (
-                        <Badge
-                          key={ch.id}
-                          variant="outline"
-                          className="capitalize"
-                        >
+                        <Badge key={ch.id} variant="outline" className="capitalize">
                           {ch.channel_type}
                         </Badge>
                       ))}
                       {(app.channels ?? []).length === 0 && (
-                        <span className="text-sm text-muted-foreground">
-                          None configured
-                        </span>
+                        <span className="text-sm text-muted-foreground">None configured</span>
                       )}
                     </div>
                   </div>
@@ -914,15 +823,12 @@ export default function AppDetailPage({
           <DialogHeader>
             <DialogTitle>Delete App</DialogTitle>
             <DialogDescription>
-              Permanently delete the archived app &quot;{app.name}&quot;?
-              Existing references will render as deleted tombstones.
+              Permanently delete the archived app &quot;{app.name}&quot;? Existing references will
+              render as deleted tombstones.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setShowDeleteDialog(false)}
-            >
+            <Button variant="outline" onClick={() => setShowDeleteDialog(false)}>
               Cancel
             </Button>
             <Button

--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -761,7 +761,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                     >
                       {getEntityReferenceLabel({
                         kind: "Agent",
-                        name: agent?.name,
+                        name: agent?.display_name || agent?.name,
                         status: agent?.status ?? "deleted",
                       })}
                     </p>

--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -57,6 +57,7 @@ import type {
   SlackReplyMode,
 } from "@/lib/api/types";
 import {
+  getDisplayName,
   getEntityNameClassName,
   getEntityReferenceClassName,
   getEntityReferenceLabel,
@@ -761,7 +762,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                     >
                       {getEntityReferenceLabel({
                         kind: "Agent",
-                        name: agent?.display_name || agent?.name,
+                        name: getDisplayName(agent),
                         status: agent?.status ?? "deleted",
                       })}
                     </p>

--- a/apps/ui/src/app/(main)/evals/page.tsx
+++ b/apps/ui/src/app/(main)/evals/page.tsx
@@ -26,16 +26,12 @@ function EvalCard({ eval: ev, agentName }: { eval: Eval; agentName?: string }) {
         <CardHeader className="pb-2">
           <div className="flex items-center justify-between">
             <CardTitle className="text-base truncate">{ev.name}</CardTitle>
-            <Badge variant={ev.status === "active" ? "default" : "secondary"}>
-              {ev.status}
-            </Badge>
+            <Badge variant={ev.status === "active" ? "default" : "secondary"}>{ev.status}</Badge>
           </div>
         </CardHeader>
         <CardContent className="space-y-2">
           {ev.description && (
-            <p className="text-sm text-muted-foreground line-clamp-2">
-              {ev.description}
-            </p>
+            <p className="text-sm text-muted-foreground line-clamp-2">{ev.description}</p>
           )}
           <div className="flex items-center gap-4 text-xs text-muted-foreground">
             {agentName && <span>Agent: {agentName}</span>}
@@ -43,11 +39,7 @@ function EvalCard({ eval: ev, agentName }: { eval: Eval; agentName?: string }) {
           </div>
           {ev.last_run && (
             <div className="flex items-center gap-3 text-xs">
-              <Badge
-                variant={
-                  ev.last_run.status === "completed" ? "default" : "outline"
-                }
-              >
+              <Badge variant={ev.last_run.status === "completed" ? "default" : "outline"}>
                 {ev.last_run.status}
               </Badge>
               {ev.last_run.summary && (
@@ -74,16 +66,10 @@ function EvalCard({ eval: ev, agentName }: { eval: Eval; agentName?: string }) {
 
 export default function EvalsPage() {
   const evalsEnabled = useFeatureFlag("evals");
-  const {
-    data: evals,
-    isLoading,
-    error,
-  } = useEvals({ includeArchived: false });
+  const { data: evals, isLoading, error } = useEvals({ includeArchived: false });
   const { data: agents } = useAgents({ includeArchived: false });
 
-  const agentMap = new Map(
-    (agents ?? []).map((a) => [a.id, getDisplayName(a)]),
-  );
+  const agentMap = new Map((agents ?? []).map((a) => [a.id, getDisplayName(a)]));
 
   if (!evalsEnabled) {
     return (
@@ -133,11 +119,7 @@ export default function EvalsPage() {
         {(items) => (
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
             {items.map((ev) => (
-              <EvalCard
-                key={ev.id}
-                eval={ev}
-                agentName={agentMap.get(ev.agent_id)}
-              />
+              <EvalCard key={ev.id} eval={ev} agentName={agentMap.get(ev.agent_id)} />
             ))}
           </div>
         )}

--- a/apps/ui/src/app/(main)/evals/page.tsx
+++ b/apps/ui/src/app/(main)/evals/page.tsx
@@ -26,12 +26,16 @@ function EvalCard({ eval: ev, agentName }: { eval: Eval; agentName?: string }) {
         <CardHeader className="pb-2">
           <div className="flex items-center justify-between">
             <CardTitle className="text-base truncate">{ev.name}</CardTitle>
-            <Badge variant={ev.status === "active" ? "default" : "secondary"}>{ev.status}</Badge>
+            <Badge variant={ev.status === "active" ? "default" : "secondary"}>
+              {ev.status}
+            </Badge>
           </div>
         </CardHeader>
         <CardContent className="space-y-2">
           {ev.description && (
-            <p className="text-sm text-muted-foreground line-clamp-2">{ev.description}</p>
+            <p className="text-sm text-muted-foreground line-clamp-2">
+              {ev.description}
+            </p>
           )}
           <div className="flex items-center gap-4 text-xs text-muted-foreground">
             {agentName && <span>Agent: {agentName}</span>}
@@ -39,7 +43,11 @@ function EvalCard({ eval: ev, agentName }: { eval: Eval; agentName?: string }) {
           </div>
           {ev.last_run && (
             <div className="flex items-center gap-3 text-xs">
-              <Badge variant={ev.last_run.status === "completed" ? "default" : "outline"}>
+              <Badge
+                variant={
+                  ev.last_run.status === "completed" ? "default" : "outline"
+                }
+              >
                 {ev.last_run.status}
               </Badge>
               {ev.last_run.summary && (
@@ -66,10 +74,16 @@ function EvalCard({ eval: ev, agentName }: { eval: Eval; agentName?: string }) {
 
 export default function EvalsPage() {
   const evalsEnabled = useFeatureFlag("evals");
-  const { data: evals, isLoading, error } = useEvals({ includeArchived: false });
+  const {
+    data: evals,
+    isLoading,
+    error,
+  } = useEvals({ includeArchived: false });
   const { data: agents } = useAgents({ includeArchived: false });
 
-  const agentMap = new Map((agents ?? []).map((a) => [a.id, getDisplayName(a)]));
+  const agentMap = new Map(
+    (agents ?? []).map((a) => [a.id, getDisplayName(a)]),
+  );
 
   if (!evalsEnabled) {
     return (
@@ -119,7 +133,11 @@ export default function EvalsPage() {
         {(items) => (
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
             {items.map((ev) => (
-              <EvalCard key={ev.id} eval={ev} agentName={agentMap.get(ev.agent_id)} />
+              <EvalCard
+                key={ev.id}
+                eval={ev}
+                agentName={agentMap.get(ev.agent_id)}
+              />
             ))}
           </div>
         )}

--- a/apps/ui/src/app/(main)/evals/page.tsx
+++ b/apps/ui/src/app/(main)/evals/page.tsx
@@ -68,7 +68,7 @@ export default function EvalsPage() {
   const { data: evals, isLoading, error } = useEvals({ includeArchived: false });
   const { data: agents } = useAgents({ includeArchived: false });
 
-  const agentMap = new Map((agents ?? []).map((a) => [a.id, a.name]));
+  const agentMap = new Map((agents ?? []).map((a) => [a.id, a.display_name || a.name]));
 
   if (!evalsEnabled) {
     return (

--- a/apps/ui/src/app/(main)/evals/page.tsx
+++ b/apps/ui/src/app/(main)/evals/page.tsx
@@ -11,6 +11,7 @@ import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { ExperimentalPageBadge } from "@/components/ui/experimental-badge";
 import { useFeatureFlag } from "@/providers/feature-flags-provider";
 import type { Eval } from "@/lib/api/types";
+import { getDisplayName } from "@/lib/entity-lifecycle";
 
 function passRateColor(rate: number): string {
   if (rate >= 0.9) return "text-green-600";
@@ -68,7 +69,7 @@ export default function EvalsPage() {
   const { data: evals, isLoading, error } = useEvals({ includeArchived: false });
   const { data: agents } = useAgents({ includeArchived: false });
 
-  const agentMap = new Map((agents ?? []).map((a) => [a.id, a.display_name || a.name]));
+  const agentMap = new Map((agents ?? []).map((a) => [a.id, getDisplayName(a)]));
 
   if (!evalsEnabled) {
     return (

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
@@ -5,12 +5,7 @@ import { usePathname, useRouter } from "next/navigation";
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Input } from "@/components/ui/input";
 import { buttonVariants } from "@/components/ui/button";
 import {
@@ -56,17 +51,12 @@ interface SessionLayoutProps {
   params: Promise<{ sessionId: string }>;
 }
 
-export default function SessionLayout({
-  children,
-  params,
-}: SessionLayoutProps) {
+export default function SessionLayout({ children, params }: SessionLayoutProps) {
   const { sessionId } = use(params);
 
   return (
     <SessionProvider sessionId={sessionId}>
-      <SessionLayoutContent sessionId={sessionId}>
-        {children}
-      </SessionLayoutContent>
+      <SessionLayoutContent sessionId={sessionId}>{children}</SessionLayoutContent>
     </SessionProvider>
   );
 }
@@ -134,9 +124,7 @@ function EditableSessionTitle({
         <Input
           ref={inputRef}
           value={value}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            setValue(e.target.value)
-          }
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setValue(e.target.value)}
           onKeyDown={(e: React.KeyboardEvent) => {
             if (e.key === "Enter") save();
             if (e.key === "Escape") setEditing(false);
@@ -177,21 +165,11 @@ function EditableSessionTitle({
   );
 }
 
-function SessionLayoutContent({
-  children,
-  sessionId,
-}: SessionLayoutContentProps) {
+function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps) {
   const pathname = usePathname();
   const router = useRouter();
-  const {
-    agent,
-    session,
-    llmModel,
-    sessionLoading,
-    effectiveStatus,
-    liveUsage,
-    agentId,
-  } = useSessionContext();
+  const { agent, session, llmModel, sessionLoading, effectiveStatus, liveUsage, agentId } =
+    useSessionContext();
   const agentReferenceLabel =
     session?.agent_id != null
       ? getEntityReferenceLabel({
@@ -200,8 +178,7 @@ function SessionLayoutContent({
           status: agent?.status ?? "deleted",
         })
       : null;
-  const agentReferenceStatus =
-    session?.agent_id != null ? (agent?.status ?? "deleted") : null;
+  const agentReferenceStatus = session?.agent_id != null ? (agent?.status ?? "deleted") : null;
 
   // Determine active tab from pathname
   const getActiveTab = (): SessionNavKey => {
@@ -219,16 +196,11 @@ function SessionLayoutContent({
   const getNavigationClassName = (isActive: boolean) =>
     cn(
       buttonVariants({ variant: "outline", size: "sm" }),
-      isActive
-        ? "border-primary bg-card text-foreground"
-        : "text-muted-foreground",
+      isActive ? "border-primary bg-card text-foreground" : "text-muted-foreground",
     );
 
   // Compute active feature set from session capabilities
-  const features = useMemo(
-    () => new Set(session?.features ?? []),
-    [session?.features],
-  );
+  const features = useMemo(() => new Set(session?.features ?? []), [session?.features]);
   const hasFeature = (feature: string) => features.has(feature);
   const navigationItems: SessionNavItem[] = [
     {
@@ -296,9 +268,7 @@ function SessionLayoutContent({
   ];
   const chatItem = navigationItems[0];
   const advancedNavigationItems = navigationItems.slice(1);
-  const activeAdvancedItem = advancedNavigationItems.find(
-    (item) => item.key === activeTab,
-  );
+  const activeAdvancedItem = advancedNavigationItems.find((item) => item.key === activeTab);
 
   if (sessionLoading) {
     return (
@@ -314,10 +284,7 @@ function SessionLayoutContent({
     return (
       <div className="container mx-auto p-6">
         <div className="text-destructive">Session not found</div>
-        <Link
-          href="/sessions"
-          className="text-sm text-muted-foreground hover:text-foreground"
-        >
+        <Link href="/sessions" className="text-sm text-muted-foreground hover:text-foreground">
           Back to sessions
         </Link>
       </div>
@@ -351,22 +318,14 @@ function SessionLayoutContent({
                     className="inline-flex items-center gap-1 hover:text-foreground"
                   >
                     <Bot className="icon-sharp h-3 w-3" />
-                    <span
-                      className={getEntityReferenceClassName(
-                        agentReferenceStatus,
-                      )}
-                    >
+                    <span className={getEntityReferenceClassName(agentReferenceStatus)}>
                       {agentReferenceLabel}
                     </span>
                   </Link>
                 ) : (
                   <span className="inline-flex items-center gap-1">
                     <Bot className="icon-sharp h-3 w-3" />
-                    <span
-                      className={getEntityReferenceClassName(
-                        agentReferenceStatus,
-                      )}
-                    >
+                    <span className={getEntityReferenceClassName(agentReferenceStatus)}>
                       {agentReferenceLabel}
                     </span>
                   </span>
@@ -399,19 +358,13 @@ function SessionLayoutContent({
                       {(liveUsage.cache_read_tokens ?? 0) > 0 && (
                         <>
                           <dt className="text-muted-foreground">Cache read</dt>
-                          <dd>
-                            {liveUsage.cache_read_tokens!.toLocaleString()}
-                          </dd>
+                          <dd>{liveUsage.cache_read_tokens!.toLocaleString()}</dd>
                         </>
                       )}
                       {(liveUsage.cache_creation_tokens ?? 0) > 0 && (
                         <>
-                          <dt className="text-muted-foreground">
-                            Cache created
-                          </dt>
-                          <dd>
-                            {liveUsage.cache_creation_tokens!.toLocaleString()}
-                          </dd>
+                          <dt className="text-muted-foreground">Cache created</dt>
+                          <dd>{liveUsage.cache_creation_tokens!.toLocaleString()}</dd>
                         </>
                       )}
                     </dl>
@@ -425,15 +378,9 @@ function SessionLayoutContent({
                 {llmModel.display_name}
               </Badge>
             )}
-            {effectiveStatus === "active" && (
-              <Badge variant="default">Processing...</Badge>
-            )}
-            {effectiveStatus === "idle" && (
-              <Badge variant="secondary">Ready</Badge>
-            )}
-            {effectiveStatus === "started" && (
-              <Badge variant="outline">New</Badge>
-            )}
+            {effectiveStatus === "active" && <Badge variant="default">Processing...</Badge>}
+            {effectiveStatus === "idle" && <Badge variant="secondary">Ready</Badge>}
+            {effectiveStatus === "started" && <Badge variant="outline">New</Badge>}
             <Link
               href={chatItem.href}
               className={getNavigationClassName(activeTab === chatItem.key)}
@@ -472,9 +419,7 @@ function SessionLayoutContent({
                           </span>
                           <span className="flex items-center gap-2">
                             {item.badge && (
-                              <DropdownMenuShortcut>
-                                {item.badge}
-                              </DropdownMenuShortcut>
+                              <DropdownMenuShortcut>{item.badge}</DropdownMenuShortcut>
                             )}
                             {activeTab === item.key && (
                               <Check className="icon-sharp h-4 w-4 text-primary" />

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
@@ -170,7 +170,7 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
     session?.agent_id != null
       ? getEntityReferenceLabel({
           kind: "Agent",
-          name: agent?.name,
+          name: agent?.display_name || agent?.name,
           status: agent?.status ?? "deleted",
         })
       : null;

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
@@ -39,7 +39,7 @@ import { cn, shortenId } from "@/lib/utils";
 import { CopyButton } from "@/components/ui/copy-button";
 import { useUpdateSession } from "@/hooks/use-sessions";
 import { SessionProvider, useSessionContext } from "./session-context";
-import { getEntityReferenceClassName, getEntityReferenceLabel } from "@/lib/entity-lifecycle";
+import { getDisplayName, getEntityReferenceClassName, getEntityReferenceLabel } from "@/lib/entity-lifecycle";
 import { formatTokens } from "@/lib/formatting";
 
 interface SessionLayoutProps {
@@ -170,7 +170,7 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
     session?.agent_id != null
       ? getEntityReferenceLabel({
           kind: "Agent",
-          name: agent?.display_name || agent?.name,
+          name: getDisplayName(agent),
           status: agent?.status ?? "deleted",
         })
       : null;

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
@@ -5,7 +5,12 @@ import { usePathname, useRouter } from "next/navigation";
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Input } from "@/components/ui/input";
 import { buttonVariants } from "@/components/ui/button";
 import {
@@ -39,7 +44,11 @@ import { cn, shortenId } from "@/lib/utils";
 import { CopyButton } from "@/components/ui/copy-button";
 import { useUpdateSession } from "@/hooks/use-sessions";
 import { SessionProvider, useSessionContext } from "./session-context";
-import { getDisplayName, getEntityReferenceClassName, getEntityReferenceLabel } from "@/lib/entity-lifecycle";
+import {
+  getDisplayName,
+  getEntityReferenceClassName,
+  getEntityReferenceLabel,
+} from "@/lib/entity-lifecycle";
 import { formatTokens } from "@/lib/formatting";
 
 interface SessionLayoutProps {
@@ -47,12 +56,17 @@ interface SessionLayoutProps {
   params: Promise<{ sessionId: string }>;
 }
 
-export default function SessionLayout({ children, params }: SessionLayoutProps) {
+export default function SessionLayout({
+  children,
+  params,
+}: SessionLayoutProps) {
   const { sessionId } = use(params);
 
   return (
     <SessionProvider sessionId={sessionId}>
-      <SessionLayoutContent sessionId={sessionId}>{children}</SessionLayoutContent>
+      <SessionLayoutContent sessionId={sessionId}>
+        {children}
+      </SessionLayoutContent>
     </SessionProvider>
   );
 }
@@ -120,7 +134,9 @@ function EditableSessionTitle({
         <Input
           ref={inputRef}
           value={value}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setValue(e.target.value)}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setValue(e.target.value)
+          }
           onKeyDown={(e: React.KeyboardEvent) => {
             if (e.key === "Enter") save();
             if (e.key === "Escape") setEditing(false);
@@ -161,11 +177,21 @@ function EditableSessionTitle({
   );
 }
 
-function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps) {
+function SessionLayoutContent({
+  children,
+  sessionId,
+}: SessionLayoutContentProps) {
   const pathname = usePathname();
   const router = useRouter();
-  const { agent, session, llmModel, sessionLoading, effectiveStatus, liveUsage, agentId } =
-    useSessionContext();
+  const {
+    agent,
+    session,
+    llmModel,
+    sessionLoading,
+    effectiveStatus,
+    liveUsage,
+    agentId,
+  } = useSessionContext();
   const agentReferenceLabel =
     session?.agent_id != null
       ? getEntityReferenceLabel({
@@ -174,7 +200,8 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
           status: agent?.status ?? "deleted",
         })
       : null;
-  const agentReferenceStatus = session?.agent_id != null ? (agent?.status ?? "deleted") : null;
+  const agentReferenceStatus =
+    session?.agent_id != null ? (agent?.status ?? "deleted") : null;
 
   // Determine active tab from pathname
   const getActiveTab = (): SessionNavKey => {
@@ -192,11 +219,16 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
   const getNavigationClassName = (isActive: boolean) =>
     cn(
       buttonVariants({ variant: "outline", size: "sm" }),
-      isActive ? "border-primary bg-card text-foreground" : "text-muted-foreground",
+      isActive
+        ? "border-primary bg-card text-foreground"
+        : "text-muted-foreground",
     );
 
   // Compute active feature set from session capabilities
-  const features = useMemo(() => new Set(session?.features ?? []), [session?.features]);
+  const features = useMemo(
+    () => new Set(session?.features ?? []),
+    [session?.features],
+  );
   const hasFeature = (feature: string) => features.has(feature);
   const navigationItems: SessionNavItem[] = [
     {
@@ -264,7 +296,9 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
   ];
   const chatItem = navigationItems[0];
   const advancedNavigationItems = navigationItems.slice(1);
-  const activeAdvancedItem = advancedNavigationItems.find((item) => item.key === activeTab);
+  const activeAdvancedItem = advancedNavigationItems.find(
+    (item) => item.key === activeTab,
+  );
 
   if (sessionLoading) {
     return (
@@ -280,7 +314,10 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
     return (
       <div className="container mx-auto p-6">
         <div className="text-destructive">Session not found</div>
-        <Link href="/sessions" className="text-sm text-muted-foreground hover:text-foreground">
+        <Link
+          href="/sessions"
+          className="text-sm text-muted-foreground hover:text-foreground"
+        >
           Back to sessions
         </Link>
       </div>
@@ -314,14 +351,22 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
                     className="inline-flex items-center gap-1 hover:text-foreground"
                   >
                     <Bot className="icon-sharp h-3 w-3" />
-                    <span className={getEntityReferenceClassName(agentReferenceStatus)}>
+                    <span
+                      className={getEntityReferenceClassName(
+                        agentReferenceStatus,
+                      )}
+                    >
                       {agentReferenceLabel}
                     </span>
                   </Link>
                 ) : (
                   <span className="inline-flex items-center gap-1">
                     <Bot className="icon-sharp h-3 w-3" />
-                    <span className={getEntityReferenceClassName(agentReferenceStatus)}>
+                    <span
+                      className={getEntityReferenceClassName(
+                        agentReferenceStatus,
+                      )}
+                    >
                       {agentReferenceLabel}
                     </span>
                   </span>
@@ -354,13 +399,19 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
                       {(liveUsage.cache_read_tokens ?? 0) > 0 && (
                         <>
                           <dt className="text-muted-foreground">Cache read</dt>
-                          <dd>{liveUsage.cache_read_tokens!.toLocaleString()}</dd>
+                          <dd>
+                            {liveUsage.cache_read_tokens!.toLocaleString()}
+                          </dd>
                         </>
                       )}
                       {(liveUsage.cache_creation_tokens ?? 0) > 0 && (
                         <>
-                          <dt className="text-muted-foreground">Cache created</dt>
-                          <dd>{liveUsage.cache_creation_tokens!.toLocaleString()}</dd>
+                          <dt className="text-muted-foreground">
+                            Cache created
+                          </dt>
+                          <dd>
+                            {liveUsage.cache_creation_tokens!.toLocaleString()}
+                          </dd>
                         </>
                       )}
                     </dl>
@@ -374,9 +425,15 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
                 {llmModel.display_name}
               </Badge>
             )}
-            {effectiveStatus === "active" && <Badge variant="default">Processing...</Badge>}
-            {effectiveStatus === "idle" && <Badge variant="secondary">Ready</Badge>}
-            {effectiveStatus === "started" && <Badge variant="outline">New</Badge>}
+            {effectiveStatus === "active" && (
+              <Badge variant="default">Processing...</Badge>
+            )}
+            {effectiveStatus === "idle" && (
+              <Badge variant="secondary">Ready</Badge>
+            )}
+            {effectiveStatus === "started" && (
+              <Badge variant="outline">New</Badge>
+            )}
             <Link
               href={chatItem.href}
               className={getNavigationClassName(activeTab === chatItem.key)}
@@ -415,7 +472,9 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
                           </span>
                           <span className="flex items-center gap-2">
                             {item.badge && (
-                              <DropdownMenuShortcut>{item.badge}</DropdownMenuShortcut>
+                              <DropdownMenuShortcut>
+                                {item.badge}
+                              </DropdownMenuShortcut>
                             )}
                             {activeTab === item.key && (
                               <Check className="icon-sharp h-4 w-4 text-primary" />

--- a/apps/ui/src/app/(main)/sessions/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/page.tsx
@@ -31,7 +31,10 @@ import { Label } from "@/components/ui/label";
 import { Plus, ChevronLeft, ChevronRight } from "lucide-react";
 import { exportSessionJsonl } from "@/lib/api/sessions";
 import type { LlmModelWithProvider, Agent } from "@/lib/api/types";
-import { getDisplayName, getEntityReferenceLabel } from "@/lib/entity-lifecycle";
+import {
+  getDisplayName,
+  getEntityReferenceLabel,
+} from "@/lib/entity-lifecycle";
 import { useOrganization } from "@/hooks/use-organizations";
 
 const PAGE_SIZE = 20;
@@ -43,10 +46,13 @@ export default function SessionsPage() {
   const [newSessionDialogOpen, setNewSessionDialogOpen] = useState(false);
   const [newSessionHarnessId, setNewSessionHarnessId] = useState<string>("");
   const [newSessionAgentId, setNewSessionAgentId] = useState<string>("");
-  const [newSessionAgentIdentityId, setNewSessionAgentIdentityId] = useState<string>("");
+  const [newSessionAgentIdentityId, setNewSessionAgentIdentityId] =
+    useState<string>("");
   const offset = page * PAGE_SIZE;
 
-  const { data: agents, isLoading: agentsLoading } = useAgents({ includeArchived: true });
+  const { data: agents, isLoading: agentsLoading } = useAgents({
+    includeArchived: true,
+  });
   const { data: organization } = useOrganization();
   const { data: harnesses } = useHarnesses();
   const { data: sessionsResponse, isLoading: sessionsLoading } = useSessions(
@@ -85,7 +91,9 @@ export default function SessionsPage() {
   const handleOpenNewSessionDialog = () => {
     const defaultHarnessId = organization?.default_harness_id;
     const genericHarness = harnesses?.find((h) => h.name === "Generic");
-    setNewSessionHarnessId(defaultHarnessId || genericHarness?.id || harnesses?.[0]?.id || "");
+    setNewSessionHarnessId(
+      defaultHarnessId || genericHarness?.id || harnesses?.[0]?.id || "",
+    );
     // Pre-select the filtered agent if one is selected, otherwise leave empty (optional)
     setNewSessionAgentId(selectedAgentId || "");
     setNewSessionDialogOpen(true);
@@ -143,7 +151,11 @@ export default function SessionsPage() {
     <div className="container mx-auto p-6">
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold">Sessions</h1>
-        <Button variant="accent" onClick={handleOpenNewSessionDialog} disabled={!harnesses?.length}>
+        <Button
+          variant="accent"
+          onClick={handleOpenNewSessionDialog}
+          disabled={!harnesses?.length}
+        >
           <Plus className="w-4 h-4 mr-2" />
           New Session
         </Button>
@@ -153,13 +165,18 @@ export default function SessionsPage() {
         <CardHeader className="flex flex-row items-center justify-between space-y-0">
           <div>
             <CardTitle>
-              {selectedAgentId ? getDisplayName(agentMap.get(selectedAgentId)) || "Agent" : "All Agents"}
+              {selectedAgentId
+                ? getDisplayName(agentMap.get(selectedAgentId)) || "Agent"
+                : "All Agents"}
             </CardTitle>
             <p className="text-sm text-muted-foreground mt-1">
               {totalSessions} session{totalSessions !== 1 ? "s" : ""}
             </p>
           </div>
-          <AgentFilterMenu value={selectedAgentId} onValueChange={handleAgentFilterChange} />
+          <AgentFilterMenu
+            value={selectedAgentId}
+            onValueChange={handleAgentFilterChange}
+          />
         </CardHeader>
         <CardContent>
           {sessionsLoading || agentsLoading ? (
@@ -175,7 +192,9 @@ export default function SessionsPage() {
           ) : (
             <div className="space-y-2">
               {sessions.map((session) => {
-                const agent = session.agent_id ? agentMap.get(session.agent_id) : undefined;
+                const agent = session.agent_id
+                  ? agentMap.get(session.agent_id)
+                  : undefined;
                 return (
                   <SessionCard
                     key={session.id}
@@ -189,8 +208,16 @@ export default function SessionsPage() {
                           })
                         : undefined
                     }
-                    agentStatus={session.agent_id ? (agent?.status ?? "deleted") : undefined}
-                    model={session.model_id ? modelMap.get(session.model_id) : undefined}
+                    agentStatus={
+                      session.agent_id
+                        ? (agent?.status ?? "deleted")
+                        : undefined
+                    }
+                    model={
+                      session.model_id
+                        ? modelMap.get(session.model_id)
+                        : undefined
+                    }
                     onTogglePin={handleTogglePin}
                     onExport={handleExport}
                   />
@@ -203,8 +230,9 @@ export default function SessionsPage() {
           {totalPages > 1 && (
             <div className="flex items-center justify-between mt-4 pt-4 border-t">
               <p className="text-sm text-muted-foreground">
-                Showing {offset + 1}-{Math.min(offset + PAGE_SIZE, totalSessions)} of{" "}
-                {totalSessions} sessions
+                Showing {offset + 1}-
+                {Math.min(offset + PAGE_SIZE, totalSessions)} of {totalSessions}{" "}
+                sessions
               </p>
               <div className="flex items-center gap-2">
                 <Button
@@ -235,12 +263,16 @@ export default function SessionsPage() {
       </Card>
 
       {/* New Session Dialog */}
-      <Dialog open={newSessionDialogOpen} onOpenChange={setNewSessionDialogOpen}>
+      <Dialog
+        open={newSessionDialogOpen}
+        onOpenChange={setNewSessionDialogOpen}
+      >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>New Session</DialogTitle>
             <DialogDescription>
-              Select a harness and optionally an agent to start a new conversation.
+              Select a harness and optionally an agent to start a new
+              conversation.
             </DialogDescription>
           </DialogHeader>
           <div className="py-4 space-y-4">
@@ -271,7 +303,10 @@ export default function SessionsPage() {
             </div>
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setNewSessionDialogOpen(false)}>
+            <Button
+              variant="outline"
+              onClick={() => setNewSessionDialogOpen(false)}
+            >
               Cancel
             </Button>
             <Button

--- a/apps/ui/src/app/(main)/sessions/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/page.tsx
@@ -31,10 +31,7 @@ import { Label } from "@/components/ui/label";
 import { Plus, ChevronLeft, ChevronRight } from "lucide-react";
 import { exportSessionJsonl } from "@/lib/api/sessions";
 import type { LlmModelWithProvider, Agent } from "@/lib/api/types";
-import {
-  getDisplayName,
-  getEntityReferenceLabel,
-} from "@/lib/entity-lifecycle";
+import { getDisplayName, getEntityReferenceLabel } from "@/lib/entity-lifecycle";
 import { useOrganization } from "@/hooks/use-organizations";
 
 const PAGE_SIZE = 20;
@@ -46,8 +43,7 @@ export default function SessionsPage() {
   const [newSessionDialogOpen, setNewSessionDialogOpen] = useState(false);
   const [newSessionHarnessId, setNewSessionHarnessId] = useState<string>("");
   const [newSessionAgentId, setNewSessionAgentId] = useState<string>("");
-  const [newSessionAgentIdentityId, setNewSessionAgentIdentityId] =
-    useState<string>("");
+  const [newSessionAgentIdentityId, setNewSessionAgentIdentityId] = useState<string>("");
   const offset = page * PAGE_SIZE;
 
   const { data: agents, isLoading: agentsLoading } = useAgents({
@@ -91,9 +87,7 @@ export default function SessionsPage() {
   const handleOpenNewSessionDialog = () => {
     const defaultHarnessId = organization?.default_harness_id;
     const genericHarness = harnesses?.find((h) => h.name === "Generic");
-    setNewSessionHarnessId(
-      defaultHarnessId || genericHarness?.id || harnesses?.[0]?.id || "",
-    );
+    setNewSessionHarnessId(defaultHarnessId || genericHarness?.id || harnesses?.[0]?.id || "");
     // Pre-select the filtered agent if one is selected, otherwise leave empty (optional)
     setNewSessionAgentId(selectedAgentId || "");
     setNewSessionDialogOpen(true);
@@ -151,11 +145,7 @@ export default function SessionsPage() {
     <div className="container mx-auto p-6">
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold">Sessions</h1>
-        <Button
-          variant="accent"
-          onClick={handleOpenNewSessionDialog}
-          disabled={!harnesses?.length}
-        >
+        <Button variant="accent" onClick={handleOpenNewSessionDialog} disabled={!harnesses?.length}>
           <Plus className="w-4 h-4 mr-2" />
           New Session
         </Button>
@@ -173,10 +163,7 @@ export default function SessionsPage() {
               {totalSessions} session{totalSessions !== 1 ? "s" : ""}
             </p>
           </div>
-          <AgentFilterMenu
-            value={selectedAgentId}
-            onValueChange={handleAgentFilterChange}
-          />
+          <AgentFilterMenu value={selectedAgentId} onValueChange={handleAgentFilterChange} />
         </CardHeader>
         <CardContent>
           {sessionsLoading || agentsLoading ? (
@@ -192,9 +179,7 @@ export default function SessionsPage() {
           ) : (
             <div className="space-y-2">
               {sessions.map((session) => {
-                const agent = session.agent_id
-                  ? agentMap.get(session.agent_id)
-                  : undefined;
+                const agent = session.agent_id ? agentMap.get(session.agent_id) : undefined;
                 return (
                   <SessionCard
                     key={session.id}
@@ -208,16 +193,8 @@ export default function SessionsPage() {
                           })
                         : undefined
                     }
-                    agentStatus={
-                      session.agent_id
-                        ? (agent?.status ?? "deleted")
-                        : undefined
-                    }
-                    model={
-                      session.model_id
-                        ? modelMap.get(session.model_id)
-                        : undefined
-                    }
+                    agentStatus={session.agent_id ? (agent?.status ?? "deleted") : undefined}
+                    model={session.model_id ? modelMap.get(session.model_id) : undefined}
                     onTogglePin={handleTogglePin}
                     onExport={handleExport}
                   />
@@ -230,9 +207,8 @@ export default function SessionsPage() {
           {totalPages > 1 && (
             <div className="flex items-center justify-between mt-4 pt-4 border-t">
               <p className="text-sm text-muted-foreground">
-                Showing {offset + 1}-
-                {Math.min(offset + PAGE_SIZE, totalSessions)} of {totalSessions}{" "}
-                sessions
+                Showing {offset + 1}-{Math.min(offset + PAGE_SIZE, totalSessions)} of{" "}
+                {totalSessions} sessions
               </p>
               <div className="flex items-center gap-2">
                 <Button
@@ -263,16 +239,12 @@ export default function SessionsPage() {
       </Card>
 
       {/* New Session Dialog */}
-      <Dialog
-        open={newSessionDialogOpen}
-        onOpenChange={setNewSessionDialogOpen}
-      >
+      <Dialog open={newSessionDialogOpen} onOpenChange={setNewSessionDialogOpen}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>New Session</DialogTitle>
             <DialogDescription>
-              Select a harness and optionally an agent to start a new
-              conversation.
+              Select a harness and optionally an agent to start a new conversation.
             </DialogDescription>
           </DialogHeader>
           <div className="py-4 space-y-4">
@@ -303,10 +275,7 @@ export default function SessionsPage() {
             </div>
           </div>
           <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setNewSessionDialogOpen(false)}
-            >
+            <Button variant="outline" onClick={() => setNewSessionDialogOpen(false)}>
               Cancel
             </Button>
             <Button

--- a/apps/ui/src/app/(main)/sessions/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/page.tsx
@@ -31,7 +31,7 @@ import { Label } from "@/components/ui/label";
 import { Plus, ChevronLeft, ChevronRight } from "lucide-react";
 import { exportSessionJsonl } from "@/lib/api/sessions";
 import type { LlmModelWithProvider, Agent } from "@/lib/api/types";
-import { getEntityReferenceLabel } from "@/lib/entity-lifecycle";
+import { getDisplayName, getEntityReferenceLabel } from "@/lib/entity-lifecycle";
 import { useOrganization } from "@/hooks/use-organizations";
 
 const PAGE_SIZE = 20;
@@ -153,7 +153,7 @@ export default function SessionsPage() {
         <CardHeader className="flex flex-row items-center justify-between space-y-0">
           <div>
             <CardTitle>
-              {selectedAgentId ? agentMap.get(selectedAgentId)?.display_name || agentMap.get(selectedAgentId)?.name || "Agent" : "All Agents"}
+              {selectedAgentId ? getDisplayName(agentMap.get(selectedAgentId)) || "Agent" : "All Agents"}
             </CardTitle>
             <p className="text-sm text-muted-foreground mt-1">
               {totalSessions} session{totalSessions !== 1 ? "s" : ""}
@@ -184,7 +184,7 @@ export default function SessionsPage() {
                       session.agent_id
                         ? getEntityReferenceLabel({
                             kind: "Agent",
-                            name: agent?.display_name || agent?.name,
+                            name: getDisplayName(agent),
                             status: agent?.status ?? "deleted",
                           })
                         : undefined

--- a/apps/ui/src/app/(main)/sessions/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/page.tsx
@@ -153,7 +153,7 @@ export default function SessionsPage() {
         <CardHeader className="flex flex-row items-center justify-between space-y-0">
           <div>
             <CardTitle>
-              {selectedAgentId ? agentMap.get(selectedAgentId)?.name || "Agent" : "All Agents"}
+              {selectedAgentId ? agentMap.get(selectedAgentId)?.display_name || agentMap.get(selectedAgentId)?.name || "Agent" : "All Agents"}
             </CardTitle>
             <p className="text-sm text-muted-foreground mt-1">
               {totalSessions} session{totalSessions !== 1 ? "s" : ""}
@@ -184,7 +184,7 @@ export default function SessionsPage() {
                       session.agent_id
                         ? getEntityReferenceLabel({
                             kind: "Agent",
-                            name: agent?.name,
+                            name: agent?.display_name || agent?.name,
                             status: agent?.status ?? "deleted",
                           })
                         : undefined

--- a/apps/ui/src/components/agent/agent-filter-menu.tsx
+++ b/apps/ui/src/components/agent/agent-filter-menu.tsx
@@ -36,7 +36,8 @@ export function AgentFilterMenu({ value, onValueChange, className }: AgentFilter
     return new Map<string, Agent>(agents.map((a) => [a.id, a]));
   }, [agents]);
 
-  const displayValue = value ? agentMap.get(value)?.name : "All agents";
+  const selected = value ? agentMap.get(value) : undefined;
+  const displayValue = selected ? (selected.display_name || selected.name) : "All agents";
 
   const handleValueChange = (newValue: string) => {
     onValueChange(newValue);
@@ -55,7 +56,7 @@ export function AgentFilterMenu({ value, onValueChange, className }: AgentFilter
             <DropdownMenuRadioItem value="">All agents</DropdownMenuRadioItem>
             {agents.map((agent) => (
               <DropdownMenuRadioItem key={agent.id} value={agent.id}>
-                {agent.name}
+                {agent.display_name || agent.name}
               </DropdownMenuRadioItem>
             ))}
           </DropdownMenuRadioGroup>

--- a/apps/ui/src/components/agent/agent-filter-menu.tsx
+++ b/apps/ui/src/components/agent/agent-filter-menu.tsx
@@ -29,7 +29,11 @@ interface AgentFilterMenuProps {
  * Agent filter dropdown menu for filtering lists by agent.
  * Uses menu pattern (better for filters) instead of form select.
  */
-export function AgentFilterMenu({ value, onValueChange, className }: AgentFilterMenuProps) {
+export function AgentFilterMenu({
+  value,
+  onValueChange,
+  className,
+}: AgentFilterMenuProps) {
   const { data: agents = [] } = useAgents();
   const [open, setOpen] = useState(false);
 
@@ -47,13 +51,18 @@ export function AgentFilterMenu({ value, onValueChange, className }: AgentFilter
 
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
-      <DropdownMenuTrigger className={cn(buttonVariants({ variant: "outline" }), className)}>
+      <DropdownMenuTrigger
+        className={cn(buttonVariants({ variant: "outline" }), className)}
+      >
         {displayValue}
         <ChevronDown className="h-4 w-4 ml-2 opacity-50" />
       </DropdownMenuTrigger>
       <DropdownMenuPositioner align="end">
         <DropdownMenuContent className="w-[200px]">
-          <DropdownMenuRadioGroup value={value} onValueChange={handleValueChange}>
+          <DropdownMenuRadioGroup
+            value={value}
+            onValueChange={handleValueChange}
+          >
             <DropdownMenuRadioItem value="">All agents</DropdownMenuRadioItem>
             {agents.map((agent) => (
               <DropdownMenuRadioItem key={agent.id} value={agent.id}>

--- a/apps/ui/src/components/agent/agent-filter-menu.tsx
+++ b/apps/ui/src/components/agent/agent-filter-menu.tsx
@@ -29,11 +29,7 @@ interface AgentFilterMenuProps {
  * Agent filter dropdown menu for filtering lists by agent.
  * Uses menu pattern (better for filters) instead of form select.
  */
-export function AgentFilterMenu({
-  value,
-  onValueChange,
-  className,
-}: AgentFilterMenuProps) {
+export function AgentFilterMenu({ value, onValueChange, className }: AgentFilterMenuProps) {
   const { data: agents = [] } = useAgents();
   const [open, setOpen] = useState(false);
 
@@ -51,18 +47,13 @@ export function AgentFilterMenu({
 
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
-      <DropdownMenuTrigger
-        className={cn(buttonVariants({ variant: "outline" }), className)}
-      >
+      <DropdownMenuTrigger className={cn(buttonVariants({ variant: "outline" }), className)}>
         {displayValue}
         <ChevronDown className="h-4 w-4 ml-2 opacity-50" />
       </DropdownMenuTrigger>
       <DropdownMenuPositioner align="end">
         <DropdownMenuContent className="w-[200px]">
-          <DropdownMenuRadioGroup
-            value={value}
-            onValueChange={handleValueChange}
-          >
+          <DropdownMenuRadioGroup value={value} onValueChange={handleValueChange}>
             <DropdownMenuRadioItem value="">All agents</DropdownMenuRadioItem>
             {agents.map((agent) => (
               <DropdownMenuRadioItem key={agent.id} value={agent.id}>

--- a/apps/ui/src/components/agent/agent-filter-menu.tsx
+++ b/apps/ui/src/components/agent/agent-filter-menu.tsx
@@ -14,6 +14,7 @@ import { useAgents } from "@/hooks";
 import { ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { Agent } from "@/lib/api/types";
+import { getDisplayName } from "@/lib/entity-lifecycle";
 
 interface AgentFilterMenuProps {
   /** Selected agent ID (empty string = all) */
@@ -37,7 +38,7 @@ export function AgentFilterMenu({ value, onValueChange, className }: AgentFilter
   }, [agents]);
 
   const selected = value ? agentMap.get(value) : undefined;
-  const displayValue = selected ? (selected.display_name || selected.name) : "All agents";
+  const displayValue = selected ? getDisplayName(selected) : "All agents";
 
   const handleValueChange = (newValue: string) => {
     onValueChange(newValue);
@@ -56,7 +57,7 @@ export function AgentFilterMenu({ value, onValueChange, className }: AgentFilter
             <DropdownMenuRadioItem value="">All agents</DropdownMenuRadioItem>
             {agents.map((agent) => (
               <DropdownMenuRadioItem key={agent.id} value={agent.id}>
-                {agent.display_name || agent.name}
+                {getDisplayName(agent)}
               </DropdownMenuRadioItem>
             ))}
           </DropdownMenuRadioGroup>

--- a/apps/ui/src/components/agent/agent-select.tsx
+++ b/apps/ui/src/components/agent/agent-select.tsx
@@ -54,7 +54,10 @@ export function AgentSelect({
     onValueChange(newValue === "all" ? "" : newValue);
   };
 
-  const displayValue = value ? agentMap.get(value)?.name : includeAll ? allLabel : undefined;
+  const selectedAgent = value ? agentMap.get(value) : undefined;
+  const displayValue = selectedAgent
+    ? (selectedAgent.display_name || selectedAgent.name)
+    : includeAll ? allLabel : undefined;
 
   return (
     <Select value={selectValue} onValueChange={handleChange} disabled={disabled}>
@@ -65,7 +68,7 @@ export function AgentSelect({
         {includeAll && <SelectItem value="all">{allLabel}</SelectItem>}
         {agents.map((agent) => (
           <SelectItem key={agent.id} value={agent.id}>
-            {agent.name}
+            {agent.display_name || agent.name}
           </SelectItem>
         ))}
       </SelectContent>

--- a/apps/ui/src/components/agent/agent-select.tsx
+++ b/apps/ui/src/components/agent/agent-select.tsx
@@ -58,10 +58,16 @@ export function AgentSelect({
   const selectedAgent = value ? agentMap.get(value) : undefined;
   const displayValue = selectedAgent
     ? getDisplayName(selectedAgent)
-    : includeAll ? allLabel : undefined;
+    : includeAll
+      ? allLabel
+      : undefined;
 
   return (
-    <Select value={selectValue} onValueChange={handleChange} disabled={disabled}>
+    <Select
+      value={selectValue}
+      onValueChange={handleChange}
+      disabled={disabled}
+    >
       <SelectTrigger className={className}>
         <SelectValue placeholder={placeholder}>{displayValue}</SelectValue>
       </SelectTrigger>

--- a/apps/ui/src/components/agent/agent-select.tsx
+++ b/apps/ui/src/components/agent/agent-select.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/select";
 import { useAgents } from "@/hooks";
 import type { Agent } from "@/lib/api/types";
+import { getDisplayName } from "@/lib/entity-lifecycle";
 
 interface AgentSelectProps {
   /** Selected agent ID */
@@ -56,7 +57,7 @@ export function AgentSelect({
 
   const selectedAgent = value ? agentMap.get(value) : undefined;
   const displayValue = selectedAgent
-    ? (selectedAgent.display_name || selectedAgent.name)
+    ? getDisplayName(selectedAgent)
     : includeAll ? allLabel : undefined;
 
   return (
@@ -68,7 +69,7 @@ export function AgentSelect({
         {includeAll && <SelectItem value="all">{allLabel}</SelectItem>}
         {agents.map((agent) => (
           <SelectItem key={agent.id} value={agent.id}>
-            {agent.display_name || agent.name}
+            {getDisplayName(agent)}
           </SelectItem>
         ))}
       </SelectContent>

--- a/apps/ui/src/components/agent/agent-select.tsx
+++ b/apps/ui/src/components/agent/agent-select.tsx
@@ -63,11 +63,7 @@ export function AgentSelect({
       : undefined;
 
   return (
-    <Select
-      value={selectValue}
-      onValueChange={handleChange}
-      disabled={disabled}
-    >
+    <Select value={selectValue} onValueChange={handleChange} disabled={disabled}>
       <SelectTrigger className={className}>
         <SelectValue placeholder={placeholder}>{displayValue}</SelectValue>
       </SelectTrigger>

--- a/apps/ui/src/components/agents/agent-card.tsx
+++ b/apps/ui/src/components/agents/agent-card.tsx
@@ -10,7 +10,7 @@ import { CopyButton } from "@/components/ui/copy-button";
 import type { Agent, Capability, CapabilityId } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
 import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
-import { getEntityNameClassName, getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
+import { getDisplayName, getEntityNameClassName, getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
 
 interface AgentCardProps {
   agent: Agent;
@@ -39,7 +39,7 @@ export function AgentCard({
           <div className="flex items-center gap-2">
             <CardTitle className={`text-lg ${getEntityNameClassName(agent.status)}`}>
               <Link href={`/agents/${agent.id}`} className="hover:underline">
-                {agent.display_name || agent.name}
+                {getDisplayName(agent)}
               </Link>
             </CardTitle>
             <CopyButton value={agent.id} />

--- a/apps/ui/src/components/agents/agent-card.tsx
+++ b/apps/ui/src/components/agents/agent-card.tsx
@@ -35,13 +35,16 @@ export function AgentCard({
   return (
     <Card className="bg-background transition-colors hover:bg-card">
       <CardHeader className="flex flex-row items-start justify-between space-y-0">
-        <div className="flex items-center gap-2">
-          <CardTitle className={`text-lg ${getEntityNameClassName(agent.status)}`}>
-            <Link href={`/agents/${agent.id}`} className="hover:underline">
-              {agent.name}
-            </Link>
-          </CardTitle>
-          <CopyButton value={agent.id} />
+        <div className="flex flex-col gap-0.5">
+          <div className="flex items-center gap-2">
+            <CardTitle className={`text-lg ${getEntityNameClassName(agent.status)}`}>
+              <Link href={`/agents/${agent.id}`} className="hover:underline">
+                {agent.display_name || agent.name}
+              </Link>
+            </CardTitle>
+            <CopyButton value={agent.id} />
+          </div>
+          <span className="text-xs text-muted-foreground font-mono">{agent.name}</span>
         </div>
         <Badge variant={getEntityStatusBadgeVariant(agent.status)}>{agent.status}</Badge>
       </CardHeader>

--- a/apps/ui/src/components/agents/agent-card.tsx
+++ b/apps/ui/src/components/agents/agent-card.tsx
@@ -4,13 +4,22 @@ import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Pencil } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import type { Agent, Capability, CapabilityId } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
 import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
-import { getDisplayName, getEntityNameClassName, getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
+import {
+  getDisplayName,
+  getEntityNameClassName,
+  getEntityStatusBadgeVariant,
+} from "@/lib/entity-lifecycle";
 
 interface AgentCardProps {
   agent: Agent;
@@ -26,7 +35,9 @@ export function AgentCard({
   compact = false,
 }: AgentCardProps) {
   // Get capability info for display
-  const getCapabilityInfo = (capabilityId: CapabilityId): Capability | undefined =>
+  const getCapabilityInfo = (
+    capabilityId: CapabilityId,
+  ): Capability | undefined =>
     allCapabilities?.find((c) => c.id === capabilityId);
 
   // Capabilities are now directly on the agent
@@ -37,24 +48,34 @@ export function AgentCard({
       <CardHeader className="flex flex-row items-start justify-between space-y-0">
         <div className="flex flex-col gap-0.5">
           <div className="flex items-center gap-2">
-            <CardTitle className={`text-lg ${getEntityNameClassName(agent.status)}`}>
+            <CardTitle
+              className={`text-lg ${getEntityNameClassName(agent.status)}`}
+            >
               <Link href={`/agents/${agent.id}`} className="hover:underline">
                 {getDisplayName(agent)}
               </Link>
             </CardTitle>
             <CopyButton value={agent.id} />
           </div>
-          <span className="text-xs text-muted-foreground font-mono">{agent.name}</span>
+          <span className="text-xs text-muted-foreground font-mono">
+            {agent.name}
+          </span>
         </div>
-        <Badge variant={getEntityStatusBadgeVariant(agent.status)}>{agent.status}</Badge>
+        <Badge variant={getEntityStatusBadgeVariant(agent.status)}>
+          {agent.status}
+        </Badge>
       </CardHeader>
       <CardContent>
         {agent.description ? (
           <div className="text-sm text-muted-foreground mb-3 line-clamp-2">
-            <InlineStreamdownMessage>{agent.description}</InlineStreamdownMessage>
+            <InlineStreamdownMessage>
+              {agent.description}
+            </InlineStreamdownMessage>
           </div>
         ) : (
-          <p className="text-sm text-muted-foreground mb-3 italic">No description provided</p>
+          <p className="text-sm text-muted-foreground mb-3 italic">
+            No description provided
+          </p>
         )}
 
         {/* Capabilities display */}
@@ -74,7 +95,9 @@ export function AgentCard({
                     </TooltipTrigger>
                     <TooltipContent>
                       <p className="font-medium">{cap.name}</p>
-                      <p className="text-xs text-muted-foreground">{cap.description}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {cap.description}
+                      </p>
                     </TooltipContent>
                   </Tooltip>
                 );

--- a/apps/ui/src/components/agents/agent-card.tsx
+++ b/apps/ui/src/components/agents/agent-card.tsx
@@ -4,12 +4,7 @@ import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Pencil } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import type { Agent, Capability, CapabilityId } from "@/lib/api/types";
@@ -35,9 +30,7 @@ export function AgentCard({
   compact = false,
 }: AgentCardProps) {
   // Get capability info for display
-  const getCapabilityInfo = (
-    capabilityId: CapabilityId,
-  ): Capability | undefined =>
+  const getCapabilityInfo = (capabilityId: CapabilityId): Capability | undefined =>
     allCapabilities?.find((c) => c.id === capabilityId);
 
   // Capabilities are now directly on the agent
@@ -48,34 +41,24 @@ export function AgentCard({
       <CardHeader className="flex flex-row items-start justify-between space-y-0">
         <div className="flex flex-col gap-0.5">
           <div className="flex items-center gap-2">
-            <CardTitle
-              className={`text-lg ${getEntityNameClassName(agent.status)}`}
-            >
+            <CardTitle className={`text-lg ${getEntityNameClassName(agent.status)}`}>
               <Link href={`/agents/${agent.id}`} className="hover:underline">
                 {getDisplayName(agent)}
               </Link>
             </CardTitle>
             <CopyButton value={agent.id} />
           </div>
-          <span className="text-xs text-muted-foreground font-mono">
-            {agent.name}
-          </span>
+          <span className="text-xs text-muted-foreground font-mono">{agent.name}</span>
         </div>
-        <Badge variant={getEntityStatusBadgeVariant(agent.status)}>
-          {agent.status}
-        </Badge>
+        <Badge variant={getEntityStatusBadgeVariant(agent.status)}>{agent.status}</Badge>
       </CardHeader>
       <CardContent>
         {agent.description ? (
           <div className="text-sm text-muted-foreground mb-3 line-clamp-2">
-            <InlineStreamdownMessage>
-              {agent.description}
-            </InlineStreamdownMessage>
+            <InlineStreamdownMessage>{agent.description}</InlineStreamdownMessage>
           </div>
         ) : (
-          <p className="text-sm text-muted-foreground mb-3 italic">
-            No description provided
-          </p>
+          <p className="text-sm text-muted-foreground mb-3 italic">No description provided</p>
         )}
 
         {/* Capabilities display */}
@@ -95,9 +78,7 @@ export function AgentCard({
                     </TooltipTrigger>
                     <TooltipContent>
                       <p className="font-medium">{cap.name}</p>
-                      <p className="text-xs text-muted-foreground">
-                        {cap.description}
-                      </p>
+                      <p className="text-xs text-muted-foreground">{cap.description}</p>
                     </TooltipContent>
                   </Tooltip>
                 );

--- a/apps/ui/src/components/dashboard/agent-list-widget.tsx
+++ b/apps/ui/src/components/dashboard/agent-list-widget.tsx
@@ -4,12 +4,7 @@ import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Boxes, Plus } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import type { Agent, Capability, CapabilityId } from "@/lib/api/types";
@@ -23,17 +18,10 @@ interface AgentListWidgetProps {
 
 const MAX_DISPLAYED = 5;
 
-export function AgentListWidget({
-  agents,
-  allCapabilities,
-}: AgentListWidgetProps) {
-  const activeAgents = agents
-    .filter((a) => a.status === "active")
-    .slice(0, MAX_DISPLAYED);
+export function AgentListWidget({ agents, allCapabilities }: AgentListWidgetProps) {
+  const activeAgents = agents.filter((a) => a.status === "active").slice(0, MAX_DISPLAYED);
 
-  const getCapabilityInfo = (
-    capabilityId: CapabilityId,
-  ): Capability | undefined =>
+  const getCapabilityInfo = (capabilityId: CapabilityId): Capability | undefined =>
     allCapabilities?.find((c) => c.id === capabilityId);
 
   return (
@@ -80,26 +68,22 @@ export function AgentListWidget({
                         {agentCapabilities.length > 0 && (
                           <TooltipProvider>
                             <div className="flex gap-0.5">
-                              {agentCapabilities
-                                .slice(0, 3)
-                                .map((capConfig) => {
-                                  const cap = getCapabilityInfo(capConfig.ref);
-                                  if (!cap) return null;
-                                  const IconComponent = getCapabilityIcon(
-                                    cap.icon,
-                                  );
+                              {agentCapabilities.slice(0, 3).map((capConfig) => {
+                                const cap = getCapabilityInfo(capConfig.ref);
+                                if (!cap) return null;
+                                const IconComponent = getCapabilityIcon(cap.icon);
 
-                                  return (
-                                    <Tooltip key={capConfig.ref}>
-                                      <TooltipTrigger className="cursor-default border bg-muted p-0.5">
-                                        <IconComponent className="icon-sharp h-3 w-3 text-muted-foreground" />
-                                      </TooltipTrigger>
-                                      <TooltipContent>
-                                        <p>{cap.name}</p>
-                                      </TooltipContent>
-                                    </Tooltip>
-                                  );
-                                })}
+                                return (
+                                  <Tooltip key={capConfig.ref}>
+                                    <TooltipTrigger className="cursor-default border bg-muted p-0.5">
+                                      <IconComponent className="icon-sharp h-3 w-3 text-muted-foreground" />
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                      <p>{cap.name}</p>
+                                    </TooltipContent>
+                                  </Tooltip>
+                                );
+                              })}
                               {agentCapabilities.length > 3 && (
                                 <span className="text-xs text-muted-foreground ml-1">
                                   +{agentCapabilities.length - 3}
@@ -111,10 +95,7 @@ export function AgentListWidget({
                       </div>
                     </div>
                   </div>
-                  <Badge
-                    variant="outline"
-                    className="border-border bg-muted text-foreground"
-                  >
+                  <Badge variant="outline" className="border-border bg-muted text-foreground">
                     Active
                   </Badge>
                 </Link>

--- a/apps/ui/src/components/dashboard/agent-list-widget.tsx
+++ b/apps/ui/src/components/dashboard/agent-list-widget.tsx
@@ -8,6 +8,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { Boxes, Plus } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import type { Agent, Capability, CapabilityId } from "@/lib/api/types";
+import { getDisplayName } from "@/lib/entity-lifecycle";
 import { getCapabilityIcon } from "@/lib/capability-icons";
 
 interface AgentListWidgetProps {
@@ -59,7 +60,7 @@ export function AgentListWidget({ agents, allCapabilities }: AgentListWidgetProp
                     <Boxes className="icon-sharp h-5 w-5 text-muted-foreground" />
                     <div>
                       <div className="flex items-center gap-1">
-                        <p className="font-medium">{agent.display_name || agent.name}</p>
+                        <p className="font-medium">{getDisplayName(agent)}</p>
                         <CopyButton value={agent.id} />
                       </div>
                       <div className="flex items-center gap-2">

--- a/apps/ui/src/components/dashboard/agent-list-widget.tsx
+++ b/apps/ui/src/components/dashboard/agent-list-widget.tsx
@@ -4,7 +4,12 @@ import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Boxes, Plus } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import type { Agent, Capability, CapabilityId } from "@/lib/api/types";
@@ -18,10 +23,17 @@ interface AgentListWidgetProps {
 
 const MAX_DISPLAYED = 5;
 
-export function AgentListWidget({ agents, allCapabilities }: AgentListWidgetProps) {
-  const activeAgents = agents.filter((a) => a.status === "active").slice(0, MAX_DISPLAYED);
+export function AgentListWidget({
+  agents,
+  allCapabilities,
+}: AgentListWidgetProps) {
+  const activeAgents = agents
+    .filter((a) => a.status === "active")
+    .slice(0, MAX_DISPLAYED);
 
-  const getCapabilityInfo = (capabilityId: CapabilityId): Capability | undefined =>
+  const getCapabilityInfo = (
+    capabilityId: CapabilityId,
+  ): Capability | undefined =>
     allCapabilities?.find((c) => c.id === capabilityId);
 
   return (
@@ -68,22 +80,26 @@ export function AgentListWidget({ agents, allCapabilities }: AgentListWidgetProp
                         {agentCapabilities.length > 0 && (
                           <TooltipProvider>
                             <div className="flex gap-0.5">
-                              {agentCapabilities.slice(0, 3).map((capConfig) => {
-                                const cap = getCapabilityInfo(capConfig.ref);
-                                if (!cap) return null;
-                                const IconComponent = getCapabilityIcon(cap.icon);
+                              {agentCapabilities
+                                .slice(0, 3)
+                                .map((capConfig) => {
+                                  const cap = getCapabilityInfo(capConfig.ref);
+                                  if (!cap) return null;
+                                  const IconComponent = getCapabilityIcon(
+                                    cap.icon,
+                                  );
 
-                                return (
-                                  <Tooltip key={capConfig.ref}>
-                                    <TooltipTrigger className="cursor-default border bg-muted p-0.5">
-                                      <IconComponent className="icon-sharp h-3 w-3 text-muted-foreground" />
-                                    </TooltipTrigger>
-                                    <TooltipContent>
-                                      <p>{cap.name}</p>
-                                    </TooltipContent>
-                                  </Tooltip>
-                                );
-                              })}
+                                  return (
+                                    <Tooltip key={capConfig.ref}>
+                                      <TooltipTrigger className="cursor-default border bg-muted p-0.5">
+                                        <IconComponent className="icon-sharp h-3 w-3 text-muted-foreground" />
+                                      </TooltipTrigger>
+                                      <TooltipContent>
+                                        <p>{cap.name}</p>
+                                      </TooltipContent>
+                                    </Tooltip>
+                                  );
+                                })}
                               {agentCapabilities.length > 3 && (
                                 <span className="text-xs text-muted-foreground ml-1">
                                   +{agentCapabilities.length - 3}
@@ -95,7 +111,10 @@ export function AgentListWidget({ agents, allCapabilities }: AgentListWidgetProp
                       </div>
                     </div>
                   </div>
-                  <Badge variant="outline" className="border-border bg-muted text-foreground">
+                  <Badge
+                    variant="outline"
+                    className="border-border bg-muted text-foreground"
+                  >
                     Active
                   </Badge>
                 </Link>

--- a/apps/ui/src/components/dashboard/agent-list-widget.tsx
+++ b/apps/ui/src/components/dashboard/agent-list-widget.tsx
@@ -59,7 +59,7 @@ export function AgentListWidget({ agents, allCapabilities }: AgentListWidgetProp
                     <Boxes className="icon-sharp h-5 w-5 text-muted-foreground" />
                     <div>
                       <div className="flex items-center gap-1">
-                        <p className="font-medium">{agent.name}</p>
+                        <p className="font-medium">{agent.display_name || agent.name}</p>
                         <CopyButton value={agent.id} />
                       </div>
                       <div className="flex items-center gap-2">

--- a/apps/ui/src/components/dashboard/recent-sessions.tsx
+++ b/apps/ui/src/components/dashboard/recent-sessions.tsx
@@ -7,7 +7,7 @@ import { MessageSquare, Loader2, Zap, Sparkles, Bot } from "lucide-react";
 import { formatRelativeTime, formatTokens } from "@/lib/formatting";
 import { shortenId } from "@/lib/utils";
 import type { Session, Agent, LlmModelWithProvider, TokenUsage } from "@/lib/api/types";
-import { getEntityReferenceClassName, getEntityReferenceLabel } from "@/lib/entity-lifecycle";
+import { getDisplayName, getEntityReferenceClassName, getEntityReferenceLabel } from "@/lib/entity-lifecycle";
 
 interface RecentSessionsProps {
   sessions: Session[];
@@ -76,7 +76,7 @@ export function RecentSessions({ sessions, agents, models = [] }: RecentSessions
               const agentLabel = session.agent_id
                 ? getEntityReferenceLabel({
                     kind: "Agent",
-                    name: agent?.display_name || agent?.name,
+                    name: getDisplayName(agent),
                     status: agent?.status ?? "deleted",
                   })
                 : null;

--- a/apps/ui/src/components/dashboard/recent-sessions.tsx
+++ b/apps/ui/src/components/dashboard/recent-sessions.tsx
@@ -6,8 +6,17 @@ import { Badge } from "@/components/ui/badge";
 import { MessageSquare, Loader2, Zap, Sparkles, Bot } from "lucide-react";
 import { formatRelativeTime, formatTokens } from "@/lib/formatting";
 import { shortenId } from "@/lib/utils";
-import type { Session, Agent, LlmModelWithProvider, TokenUsage } from "@/lib/api/types";
-import { getDisplayName, getEntityReferenceClassName, getEntityReferenceLabel } from "@/lib/entity-lifecycle";
+import type {
+  Session,
+  Agent,
+  LlmModelWithProvider,
+  TokenUsage,
+} from "@/lib/api/types";
+import {
+  getDisplayName,
+  getEntityReferenceClassName,
+  getEntityReferenceLabel,
+} from "@/lib/entity-lifecycle";
 
 interface RecentSessionsProps {
   sessions: Session[];
@@ -27,7 +36,11 @@ function formatTotalTokens(usage: TokenUsage): string {
 
 const MAX_RECENT = 10;
 
-export function RecentSessions({ sessions, agents, models = [] }: RecentSessionsProps) {
+export function RecentSessions({
+  sessions,
+  agents,
+  models = [],
+}: RecentSessionsProps) {
   const recentSessions = sessions.slice(0, MAX_RECENT);
   const agentMap = new Map(agents.map((a) => [a.id, a]));
   const modelMap = new Map(models.map((m) => [m.id, m]));
@@ -71,8 +84,12 @@ export function RecentSessions({ sessions, agents, models = [] }: RecentSessions
         ) : (
           <div className="space-y-2">
             {recentSessions.map((session) => {
-              const agent = session.agent_id ? agentMap.get(session.agent_id) : undefined;
-              const model = session.model_id ? modelMap.get(session.model_id) : undefined;
+              const agent = session.agent_id
+                ? agentMap.get(session.agent_id)
+                : undefined;
+              const model = session.model_id
+                ? modelMap.get(session.model_id)
+                : undefined;
               const agentLabel = session.agent_id
                 ? getEntityReferenceLabel({
                     kind: "Agent",
@@ -106,7 +123,11 @@ export function RecentSessions({ sessions, agents, models = [] }: RecentSessions
                       {agentLabel && (
                         <span className="text-xs text-muted-foreground flex items-center gap-1">
                           <Bot className="icon-sharp h-3 w-3" />
-                          <span className={getEntityReferenceClassName(agent?.status ?? "deleted")}>
+                          <span
+                            className={getEntityReferenceClassName(
+                              agent?.status ?? "deleted",
+                            )}
+                          >
                             {agentLabel}
                           </span>
                         </span>
@@ -137,7 +158,8 @@ export function RecentSessions({ sessions, agents, models = [] }: RecentSessions
                         </span>
                       )}
                       {session.usage &&
-                        (session.usage.input_tokens > 0 || session.usage.output_tokens > 0) && (
+                        (session.usage.input_tokens > 0 ||
+                          session.usage.output_tokens > 0) && (
                           <span className="flex items-center gap-1">
                             <Zap className="icon-sharp h-3 w-3" />
                             {formatTotalTokens(session.usage)}

--- a/apps/ui/src/components/dashboard/recent-sessions.tsx
+++ b/apps/ui/src/components/dashboard/recent-sessions.tsx
@@ -76,7 +76,7 @@ export function RecentSessions({ sessions, agents, models = [] }: RecentSessions
               const agentLabel = session.agent_id
                 ? getEntityReferenceLabel({
                     kind: "Agent",
-                    name: agent?.name,
+                    name: agent?.display_name || agent?.name,
                     status: agent?.status ?? "deleted",
                   })
                 : null;

--- a/apps/ui/src/components/dashboard/recent-sessions.tsx
+++ b/apps/ui/src/components/dashboard/recent-sessions.tsx
@@ -6,12 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { MessageSquare, Loader2, Zap, Sparkles, Bot } from "lucide-react";
 import { formatRelativeTime, formatTokens } from "@/lib/formatting";
 import { shortenId } from "@/lib/utils";
-import type {
-  Session,
-  Agent,
-  LlmModelWithProvider,
-  TokenUsage,
-} from "@/lib/api/types";
+import type { Session, Agent, LlmModelWithProvider, TokenUsage } from "@/lib/api/types";
 import {
   getDisplayName,
   getEntityReferenceClassName,
@@ -36,11 +31,7 @@ function formatTotalTokens(usage: TokenUsage): string {
 
 const MAX_RECENT = 10;
 
-export function RecentSessions({
-  sessions,
-  agents,
-  models = [],
-}: RecentSessionsProps) {
+export function RecentSessions({ sessions, agents, models = [] }: RecentSessionsProps) {
   const recentSessions = sessions.slice(0, MAX_RECENT);
   const agentMap = new Map(agents.map((a) => [a.id, a]));
   const modelMap = new Map(models.map((m) => [m.id, m]));
@@ -84,12 +75,8 @@ export function RecentSessions({
         ) : (
           <div className="space-y-2">
             {recentSessions.map((session) => {
-              const agent = session.agent_id
-                ? agentMap.get(session.agent_id)
-                : undefined;
-              const model = session.model_id
-                ? modelMap.get(session.model_id)
-                : undefined;
+              const agent = session.agent_id ? agentMap.get(session.agent_id) : undefined;
+              const model = session.model_id ? modelMap.get(session.model_id) : undefined;
               const agentLabel = session.agent_id
                 ? getEntityReferenceLabel({
                     kind: "Agent",
@@ -123,11 +110,7 @@ export function RecentSessions({
                       {agentLabel && (
                         <span className="text-xs text-muted-foreground flex items-center gap-1">
                           <Bot className="icon-sharp h-3 w-3" />
-                          <span
-                            className={getEntityReferenceClassName(
-                              agent?.status ?? "deleted",
-                            )}
-                          >
+                          <span className={getEntityReferenceClassName(agent?.status ?? "deleted")}>
                             {agentLabel}
                           </span>
                         </span>
@@ -158,8 +141,7 @@ export function RecentSessions({
                         </span>
                       )}
                       {session.usage &&
-                        (session.usage.input_tokens > 0 ||
-                          session.usage.output_tokens > 0) && (
+                        (session.usage.input_tokens > 0 || session.usage.output_tokens > 0) && (
                           <span className="flex items-center gap-1">
                             <Zap className="icon-sharp h-3 w-3" />
                             {formatTotalTokens(session.usage)}

--- a/apps/ui/src/hooks/use-global-search.ts
+++ b/apps/ui/src/hooks/use-global-search.ts
@@ -48,6 +48,7 @@ import { useCapabilities } from "@/hooks/use-capabilities";
 import { useEvals } from "@/hooks/use-evals";
 import { useApps } from "@/hooks/use-apps";
 import { useAgentIdentities } from "@/hooks/use-agent-identities";
+import { getDisplayName } from "@/lib/entity-lifecycle";
 
 export type SearchResultCategory =
   | "navigation"
@@ -237,7 +238,7 @@ export function useGlobalSearch(query: string) {
         let resolvedName: string | undefined;
         if (prefix === "agent_") {
           const a = agents.find((a) => a.id === idValue);
-          resolvedName = a ? (a.display_name || a.name) : undefined;
+          resolvedName = a ? getDisplayName(a) : undefined;
         } else if (prefix === "session_") {
           const s = sessions.find((s) => s.id === idValue);
           resolvedName = s?.title ?? s?.preview ?? undefined;
@@ -286,7 +287,7 @@ export function useGlobalSearch(query: string) {
     let agentCount = 0;
     for (const agent of agents) {
       if (agentCount >= MAX_PER_CATEGORY) break;
-      const agentDisplayName = agent.display_name || agent.name;
+      const agentDisplayName = getDisplayName(agent);
       if (matchesTokens(tokens, agent.name, agentDisplayName, agent.description, agent.id, "agent")) {
         results.push({
           id: `agent:${agent.id}`,

--- a/apps/ui/src/hooks/use-global-search.ts
+++ b/apps/ui/src/hooks/use-global-search.ts
@@ -81,20 +81,55 @@ interface NavigationPage {
 }
 
 const NAVIGATION_PAGES: NavigationPage[] = [
-  { title: "Dashboard", href: "/dashboard", icon: LayoutDashboard, keywords: ["home", "overview"] },
-  { title: "Sessions", href: "/sessions", icon: MessageSquare, keywords: ["chat", "conversation"] },
-  { title: "Chat", href: "/chat", icon: MessageCircle, keywords: ["global chat"] },
-  { title: "Agents", href: "/agents", icon: Boxes, keywords: ["bot", "assistant"] },
+  {
+    title: "Dashboard",
+    href: "/dashboard",
+    icon: LayoutDashboard,
+    keywords: ["home", "overview"],
+  },
+  {
+    title: "Sessions",
+    href: "/sessions",
+    icon: MessageSquare,
+    keywords: ["chat", "conversation"],
+  },
+  {
+    title: "Chat",
+    href: "/chat",
+    icon: MessageCircle,
+    keywords: ["global chat"],
+  },
+  {
+    title: "Agents",
+    href: "/agents",
+    icon: Boxes,
+    keywords: ["bot", "assistant"],
+  },
   {
     title: "Agent Identities",
     href: "/agent-identities",
     icon: UserRound,
     keywords: ["persona", "principal", "identity"],
   },
-  { title: "Harnesses", href: "/harnesses", icon: Shield, keywords: ["template", "config"] },
-  { title: "Skills", href: "/skills", icon: BookOpen, keywords: ["ability", "tool"] },
+  {
+    title: "Harnesses",
+    href: "/harnesses",
+    icon: Shield,
+    keywords: ["template", "config"],
+  },
+  {
+    title: "Skills",
+    href: "/skills",
+    icon: BookOpen,
+    keywords: ["ability", "tool"],
+  },
   { title: "Capabilities", href: "/capabilities", icon: Puzzle },
-  { title: "Apps", href: "/apps", icon: Rocket, keywords: ["deploy", "channel"] },
+  {
+    title: "Apps",
+    href: "/apps",
+    icon: Rocket,
+    keywords: ["deploy", "channel"],
+  },
   {
     title: "Evals",
     href: "/evals",
@@ -107,7 +142,12 @@ const NAVIGATION_PAGES: NavigationPage[] = [
     icon: Server,
     keywords: ["mcp", "tool", "integration"],
   },
-  { title: "Settings", href: "/settings", icon: Settings, keywords: ["preferences", "config"] },
+  {
+    title: "Settings",
+    href: "/settings",
+    icon: Settings,
+    keywords: ["preferences", "config"],
+  },
   {
     title: "Settings > Profile",
     href: "/settings/profile",
@@ -169,7 +209,11 @@ const ID_PREFIX_MAP: Record<
   mcp_: { category: "mcp_server", label: "MCP Server", path: "/mcp-servers" },
   eval_: { category: "eval", label: "Eval", path: "/evals" },
   app_: { category: "app", label: "App", path: "/apps" },
-  identity_: { category: "agent_identity", label: "Agent Identity", path: "/agent-identities" },
+  identity_: {
+    category: "agent_identity",
+    label: "Agent Identity",
+    path: "/agent-identities",
+  },
 };
 
 /**
@@ -178,7 +222,10 @@ const ID_PREFIX_MAP: Record<
  * matches an agent named "Daytona Coder" because "daytona" hits the name
  * and "agent" hits the category context passed via `extraContext`.
  */
-function matchesTokens(tokens: string[], ...texts: (string | undefined | null)[]): boolean {
+function matchesTokens(
+  tokens: string[],
+  ...texts: (string | undefined | null)[]
+): boolean {
   const combined = texts
     .filter(Boolean)
     .map((t) => t!.toLowerCase())
@@ -232,7 +279,9 @@ export function useGlobalSearch(query: string) {
     for (const [prefix, meta] of Object.entries(ID_PREFIX_MAP)) {
       if (q.startsWith(prefix) || q.startsWith(prefix.replace("_", ""))) {
         // Normalize: allow "session3242" or "session_3242"
-        const idValue = q.startsWith(prefix) ? q : `${prefix}${q.slice(prefix.length - 1)}`;
+        const idValue = q.startsWith(prefix)
+          ? q
+          : `${prefix}${q.slice(prefix.length - 1)}`;
 
         // Try to resolve a friendly name from cached data
         let resolvedName: string | undefined;
@@ -260,7 +309,9 @@ export function useGlobalSearch(query: string) {
           id: `id:${idValue}`,
           category: "id",
           icon: Boxes,
-          title: resolvedName ? `${meta.label}: ${resolvedName}` : `Go to ${meta.label}`,
+          title: resolvedName
+            ? `${meta.label}: ${resolvedName}`
+            : `Go to ${meta.label}`,
           subtitle: idValue,
           href: `${meta.path}/${idValue}`,
         });
@@ -288,7 +339,16 @@ export function useGlobalSearch(query: string) {
     for (const agent of agents) {
       if (agentCount >= MAX_PER_CATEGORY) break;
       const agentDisplayName = getDisplayName(agent);
-      if (matchesTokens(tokens, agent.name, agentDisplayName, agent.description, agent.id, "agent")) {
+      if (
+        matchesTokens(
+          tokens,
+          agent.name,
+          agentDisplayName,
+          agent.description,
+          agent.id,
+          "agent",
+        )
+      ) {
         results.push({
           id: `agent:${agent.id}`,
           category: "agent",
@@ -306,7 +366,9 @@ export function useGlobalSearch(query: string) {
     for (const session of sessions) {
       if (sessionCount >= MAX_PER_CATEGORY) break;
       const title = session.title || session.preview || session.id;
-      if (matchesTokens(tokens, title, session.id, session.preview, "session")) {
+      if (
+        matchesTokens(tokens, title, session.id, session.preview, "session")
+      ) {
         results.push({
           id: `session:${session.id}`,
           category: "session",
@@ -323,7 +385,15 @@ export function useGlobalSearch(query: string) {
     let harnessCount = 0;
     for (const harness of harnesses) {
       if (harnessCount >= MAX_PER_CATEGORY) break;
-      if (matchesTokens(tokens, harness.name, harness.description, harness.id, "harness")) {
+      if (
+        matchesTokens(
+          tokens,
+          harness.name,
+          harness.description,
+          harness.id,
+          "harness",
+        )
+      ) {
         results.push({
           id: `harness:${harness.id}`,
           category: "harness",
@@ -340,7 +410,9 @@ export function useGlobalSearch(query: string) {
     let skillCount = 0;
     for (const skill of skills) {
       if (skillCount >= MAX_PER_CATEGORY) break;
-      if (matchesTokens(tokens, skill.name, skill.description, skill.id, "skill")) {
+      if (
+        matchesTokens(tokens, skill.name, skill.description, skill.id, "skill")
+      ) {
         results.push({
           id: `skill:${skill.id}`,
           category: "skill",
@@ -357,7 +429,15 @@ export function useGlobalSearch(query: string) {
     let mcpCount = 0;
     for (const server of mcpServers) {
       if (mcpCount >= MAX_PER_CATEGORY) break;
-      if (matchesTokens(tokens, server.name, server.description, server.id, "mcp server")) {
+      if (
+        matchesTokens(
+          tokens,
+          server.name,
+          server.description,
+          server.id,
+          "mcp server",
+        )
+      ) {
         results.push({
           id: `mcp:${server.id}`,
           category: "mcp_server",
@@ -435,7 +515,13 @@ export function useGlobalSearch(query: string) {
     for (const identity of agentIdentities) {
       if (identityCount >= MAX_PER_CATEGORY) break;
       if (
-        matchesTokens(tokens, identity.name, identity.description, identity.id, "agent identity")
+        matchesTokens(
+          tokens,
+          identity.name,
+          identity.description,
+          identity.id,
+          "agent identity",
+        )
       ) {
         results.push({
           id: `identity:${identity.id}`,

--- a/apps/ui/src/hooks/use-global-search.ts
+++ b/apps/ui/src/hooks/use-global-search.ts
@@ -236,7 +236,8 @@ export function useGlobalSearch(query: string) {
         // Try to resolve a friendly name from cached data
         let resolvedName: string | undefined;
         if (prefix === "agent_") {
-          resolvedName = agents.find((a) => a.id === idValue)?.name;
+          const a = agents.find((a) => a.id === idValue);
+          resolvedName = a ? (a.display_name || a.name) : undefined;
         } else if (prefix === "session_") {
           const s = sessions.find((s) => s.id === idValue);
           resolvedName = s?.title ?? s?.preview ?? undefined;
@@ -285,13 +286,14 @@ export function useGlobalSearch(query: string) {
     let agentCount = 0;
     for (const agent of agents) {
       if (agentCount >= MAX_PER_CATEGORY) break;
-      if (matchesTokens(tokens, agent.name, agent.description, agent.id, "agent")) {
+      const agentDisplayName = agent.display_name || agent.name;
+      if (matchesTokens(tokens, agent.name, agentDisplayName, agent.description, agent.id, "agent")) {
         results.push({
           id: `agent:${agent.id}`,
           category: "agent",
           icon: Boxes,
-          title: agent.name,
-          subtitle: `Agents > ${agent.name}`,
+          title: agentDisplayName,
+          subtitle: `Agents > ${agentDisplayName}`,
           href: `/agents/${agent.id}`,
         });
         agentCount++;

--- a/apps/ui/src/hooks/use-global-search.ts
+++ b/apps/ui/src/hooks/use-global-search.ts
@@ -222,10 +222,7 @@ const ID_PREFIX_MAP: Record<
  * matches an agent named "Daytona Coder" because "daytona" hits the name
  * and "agent" hits the category context passed via `extraContext`.
  */
-function matchesTokens(
-  tokens: string[],
-  ...texts: (string | undefined | null)[]
-): boolean {
+function matchesTokens(tokens: string[], ...texts: (string | undefined | null)[]): boolean {
   const combined = texts
     .filter(Boolean)
     .map((t) => t!.toLowerCase())
@@ -279,9 +276,7 @@ export function useGlobalSearch(query: string) {
     for (const [prefix, meta] of Object.entries(ID_PREFIX_MAP)) {
       if (q.startsWith(prefix) || q.startsWith(prefix.replace("_", ""))) {
         // Normalize: allow "session3242" or "session_3242"
-        const idValue = q.startsWith(prefix)
-          ? q
-          : `${prefix}${q.slice(prefix.length - 1)}`;
+        const idValue = q.startsWith(prefix) ? q : `${prefix}${q.slice(prefix.length - 1)}`;
 
         // Try to resolve a friendly name from cached data
         let resolvedName: string | undefined;
@@ -309,9 +304,7 @@ export function useGlobalSearch(query: string) {
           id: `id:${idValue}`,
           category: "id",
           icon: Boxes,
-          title: resolvedName
-            ? `${meta.label}: ${resolvedName}`
-            : `Go to ${meta.label}`,
+          title: resolvedName ? `${meta.label}: ${resolvedName}` : `Go to ${meta.label}`,
           subtitle: idValue,
           href: `${meta.path}/${idValue}`,
         });
@@ -340,14 +333,7 @@ export function useGlobalSearch(query: string) {
       if (agentCount >= MAX_PER_CATEGORY) break;
       const agentDisplayName = getDisplayName(agent);
       if (
-        matchesTokens(
-          tokens,
-          agent.name,
-          agentDisplayName,
-          agent.description,
-          agent.id,
-          "agent",
-        )
+        matchesTokens(tokens, agent.name, agentDisplayName, agent.description, agent.id, "agent")
       ) {
         results.push({
           id: `agent:${agent.id}`,
@@ -366,9 +352,7 @@ export function useGlobalSearch(query: string) {
     for (const session of sessions) {
       if (sessionCount >= MAX_PER_CATEGORY) break;
       const title = session.title || session.preview || session.id;
-      if (
-        matchesTokens(tokens, title, session.id, session.preview, "session")
-      ) {
+      if (matchesTokens(tokens, title, session.id, session.preview, "session")) {
         results.push({
           id: `session:${session.id}`,
           category: "session",
@@ -385,15 +369,7 @@ export function useGlobalSearch(query: string) {
     let harnessCount = 0;
     for (const harness of harnesses) {
       if (harnessCount >= MAX_PER_CATEGORY) break;
-      if (
-        matchesTokens(
-          tokens,
-          harness.name,
-          harness.description,
-          harness.id,
-          "harness",
-        )
-      ) {
+      if (matchesTokens(tokens, harness.name, harness.description, harness.id, "harness")) {
         results.push({
           id: `harness:${harness.id}`,
           category: "harness",
@@ -410,9 +386,7 @@ export function useGlobalSearch(query: string) {
     let skillCount = 0;
     for (const skill of skills) {
       if (skillCount >= MAX_PER_CATEGORY) break;
-      if (
-        matchesTokens(tokens, skill.name, skill.description, skill.id, "skill")
-      ) {
+      if (matchesTokens(tokens, skill.name, skill.description, skill.id, "skill")) {
         results.push({
           id: `skill:${skill.id}`,
           category: "skill",
@@ -429,15 +403,7 @@ export function useGlobalSearch(query: string) {
     let mcpCount = 0;
     for (const server of mcpServers) {
       if (mcpCount >= MAX_PER_CATEGORY) break;
-      if (
-        matchesTokens(
-          tokens,
-          server.name,
-          server.description,
-          server.id,
-          "mcp server",
-        )
-      ) {
+      if (matchesTokens(tokens, server.name, server.description, server.id, "mcp server")) {
         results.push({
           id: `mcp:${server.id}`,
           category: "mcp_server",
@@ -515,13 +481,7 @@ export function useGlobalSearch(query: string) {
     for (const identity of agentIdentities) {
       if (identityCount >= MAX_PER_CATEGORY) break;
       if (
-        matchesTokens(
-          tokens,
-          identity.name,
-          identity.description,
-          identity.id,
-          "agent identity",
-        )
+        matchesTokens(tokens, identity.name, identity.description, identity.id, "agent identity")
       ) {
         results.push({
           id: `identity:${identity.id}`,

--- a/apps/ui/src/hooks/use-name-availability.ts
+++ b/apps/ui/src/hooks/use-name-availability.ts
@@ -1,8 +1,9 @@
-// Hook for checking harness name availability with debounce
+// Hooks for checking name availability with debounce
 "use client";
 
 import { useState, useEffect, useRef } from "react";
 import { checkHarnessName } from "@/lib/api/harnesses";
+import { checkAgentName } from "@/lib/api/agents";
 
 interface NameAvailabilityResult {
   /** Whether the name is available. null = not yet checked or checking */
@@ -45,6 +46,61 @@ export function useHarnessNameAvailability(
     const timer = setTimeout(async () => {
       try {
         const result = await checkHarnessName(name, excludeId);
+        // Only apply result if this is still the latest request
+        if (currentRequestId === requestIdRef.current) {
+          setAvailable(result.available);
+          setIsChecking(false);
+        }
+      } catch {
+        if (currentRequestId === requestIdRef.current) {
+          setAvailable(null);
+          setIsChecking(false);
+        }
+      }
+    }, debounceMs);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [name, excludeId, debounceMs]);
+
+  return { available, isChecking };
+}
+
+/**
+ * Debounced agent name availability check.
+ * Uses a request counter to discard stale responses from superseded requests.
+ *
+ * @param name - current name value from the input
+ * @param excludeId - agent ID to exclude (for edit forms)
+ * @param debounceMs - debounce delay (default 300ms)
+ */
+export function useAgentNameAvailability(
+  name: string,
+  excludeId?: string,
+  debounceMs = 300,
+): NameAvailabilityResult {
+  const [available, setAvailable] = useState<boolean | null>(null);
+  const [isChecking, setIsChecking] = useState(false);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    // Reset if name is empty or too short
+    if (!name || name.length < 2) {
+      setAvailable(null);
+      setIsChecking(false);
+      return;
+    }
+
+    setIsChecking(true);
+    setAvailable(null);
+
+    // Increment to invalidate any in-flight request
+    const currentRequestId = ++requestIdRef.current;
+
+    const timer = setTimeout(async () => {
+      try {
+        const result = await checkAgentName(name, excludeId);
         // Only apply result if this is still the latest request
         if (currentRequestId === requestIdRef.current) {
           setAvailable(result.available);

--- a/apps/ui/src/lib/api/agents.ts
+++ b/apps/ui/src/lib/api/agents.ts
@@ -11,11 +11,9 @@ import type {
   UpdateAgentRequest,
 } from "./types";
 
-export const agentsCrudApi = createCrudApi<
-  Agent,
-  CreateAgentRequest,
-  UpdateAgentRequest
->("/v1/agents");
+export const agentsCrudApi = createCrudApi<Agent, CreateAgentRequest, UpdateAgentRequest>(
+  "/v1/agents",
+);
 
 export const createAgent = agentsCrudApi.create;
 export const listAgents = agentsCrudApi.list;
@@ -68,12 +66,7 @@ export async function checkAgentName(
   return response.data;
 }
 
-export async function previewAgent(
-  request: PreviewAgentRequest,
-): Promise<AgentPreviewResponse> {
-  const response = await api.post<AgentPreviewResponse>(
-    "/v1/agents/preview",
-    request,
-  );
+export async function previewAgent(request: PreviewAgentRequest): Promise<AgentPreviewResponse> {
+  const response = await api.post<AgentPreviewResponse>("/v1/agents/preview", request);
   return response.data;
 }

--- a/apps/ui/src/lib/api/agents.ts
+++ b/apps/ui/src/lib/api/agents.ts
@@ -54,6 +54,18 @@ export async function copyAgent(agentId: string): Promise<Agent> {
   return response.data;
 }
 
+export async function checkAgentName(
+  name: string,
+  excludeId?: string,
+): Promise<{ available: boolean }> {
+  const params = new URLSearchParams({ name });
+  if (excludeId) params.set("exclude_id", excludeId);
+  const response = await api.get<{ available: boolean }>(
+    `/v1/agents/check-name?${params.toString()}`,
+  );
+  return response.data;
+}
+
 export async function previewAgent(request: PreviewAgentRequest): Promise<AgentPreviewResponse> {
   const response = await api.post<AgentPreviewResponse>("/v1/agents/preview", request);
   return response.data;

--- a/apps/ui/src/lib/api/agents.ts
+++ b/apps/ui/src/lib/api/agents.ts
@@ -11,9 +11,11 @@ import type {
   UpdateAgentRequest,
 } from "./types";
 
-export const agentsCrudApi = createCrudApi<Agent, CreateAgentRequest, UpdateAgentRequest>(
-  "/v1/agents",
-);
+export const agentsCrudApi = createCrudApi<
+  Agent,
+  CreateAgentRequest,
+  UpdateAgentRequest
+>("/v1/agents");
 
 export const createAgent = agentsCrudApi.create;
 export const listAgents = agentsCrudApi.list;
@@ -66,7 +68,12 @@ export async function checkAgentName(
   return response.data;
 }
 
-export async function previewAgent(request: PreviewAgentRequest): Promise<AgentPreviewResponse> {
-  const response = await api.post<AgentPreviewResponse>("/v1/agents/preview", request);
+export async function previewAgent(
+  request: PreviewAgentRequest,
+): Promise<AgentPreviewResponse> {
+  const response = await api.post<AgentPreviewResponse>(
+    "/v1/agents/preview",
+    request,
+  );
   return response.data;
 }

--- a/apps/ui/src/lib/api/types/agent-types.ts
+++ b/apps/ui/src/lib/api/types/agent-types.ts
@@ -16,7 +16,10 @@ export type AgentStatus = "active" | "archived" | "deleted";
 
 export interface Agent {
   id: string;
+  /** Addressable name (slug): lowercase alphanumeric and hyphens (e.g. "customer-support") */
   name: string;
+  /** Human-readable display name shown in UI. Falls back to name when absent. */
+  display_name: string | null;
   description: string | null;
   system_prompt: string;
   default_model_id: string | null;
@@ -38,7 +41,10 @@ export interface Agent {
 }
 
 export interface CreateAgentRequest {
+  /** Addressable name (slug): lowercase alphanumeric and hyphens */
   name: string;
+  /** Human-readable display name shown in UI */
+  display_name?: string;
   description?: string;
   system_prompt: string;
   default_model_id?: string;
@@ -53,7 +59,10 @@ export interface CreateAgentRequest {
 }
 
 export interface UpdateAgentRequest {
+  /** Addressable name (slug): lowercase alphanumeric and hyphens */
   name?: string;
+  /** Human-readable display name shown in UI */
+  display_name?: string;
   description?: string;
   system_prompt?: string;
   default_model_id?: string;

--- a/apps/ui/src/lib/entity-lifecycle.ts
+++ b/apps/ui/src/lib/entity-lifecycle.ts
@@ -48,9 +48,7 @@ export function getEntityStatusBadgeVariant(
   }
 }
 
-export function getEntityNameClassName(
-  status: EntityLifecycleStatus | string | null | undefined,
-) {
+export function getEntityNameClassName(status: EntityLifecycleStatus | string | null | undefined) {
   return cn(isArchivedStatus(status) && "text-muted-foreground line-through");
 }
 
@@ -78,9 +76,7 @@ export function getEntityReferenceLabel(params: {
   return name;
 }
 
-export function getEntityReferenceClassName(
-  status?: EntityLifecycleStatus | string | null,
-) {
+export function getEntityReferenceClassName(status?: EntityLifecycleStatus | string | null) {
   return cn(
     isArchivedStatus(status) && "text-muted-foreground line-through",
     isDeletedStatus(status) && "text-destructive",

--- a/apps/ui/src/lib/entity-lifecycle.ts
+++ b/apps/ui/src/lib/entity-lifecycle.ts
@@ -52,6 +52,14 @@ export function getEntityNameClassName(status: EntityLifecycleStatus | string | 
   return cn(isArchivedStatus(status) && "text-muted-foreground line-through");
 }
 
+/** Resolve the best display name for an entity with optional display_name. */
+export function getDisplayName(
+  entity: { name: string; display_name?: string | null } | null | undefined,
+): string {
+  if (!entity) return "";
+  return entity.display_name || entity.name;
+}
+
 export function getDeletedEntityLabel(kind: EntityKind): string {
   return `<Deleted ${kind}>`;
 }

--- a/apps/ui/src/lib/entity-lifecycle.ts
+++ b/apps/ui/src/lib/entity-lifecycle.ts
@@ -48,7 +48,9 @@ export function getEntityStatusBadgeVariant(
   }
 }
 
-export function getEntityNameClassName(status: EntityLifecycleStatus | string | null | undefined) {
+export function getEntityNameClassName(
+  status: EntityLifecycleStatus | string | null | undefined,
+) {
   return cn(isArchivedStatus(status) && "text-muted-foreground line-through");
 }
 
@@ -76,7 +78,9 @@ export function getEntityReferenceLabel(params: {
   return name;
 }
 
-export function getEntityReferenceClassName(status?: EntityLifecycleStatus | string | null) {
+export function getEntityReferenceClassName(
+  status?: EntityLifecycleStatus | string | null,
+) {
   return cn(
     isArchivedStatus(status) && "text-muted-foreground line-through",
     isDeletedStatus(status) && "text-destructive",

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -258,6 +258,22 @@ pub struct ListAgentsQuery {
     pub limit: Option<u32>,
 }
 
+/// Query parameters for checking agent name availability.
+#[derive(Debug, Clone, Deserialize, IntoParams)]
+pub struct CheckAgentNameQuery {
+    /// The agent name to check.
+    pub name: String,
+    /// Optional agent ID to exclude (for edit forms where the current agent's own name is valid).
+    pub exclude_id: Option<String>,
+}
+
+/// Response for agent name availability check.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct CheckAgentNameResponse {
+    /// Whether the name is available for use.
+    pub available: bool,
+}
+
 /// Default limit for agent listing
 const DEFAULT_LIMIT: u32 = 20;
 /// Maximum allowed limit for agent listing
@@ -287,6 +303,55 @@ impl AppState {
 
 impl_auth_state!(AppState);
 
+/// GET /v1/agents/check-name
+///
+/// Returns whether an agent name is available for use. Optionally excludes
+/// a specific agent ID (for edit forms where the agent's own name is valid).
+#[utoipa::path(
+    get,
+    path = "/v1/agents/check-name",
+    params(CheckAgentNameQuery),
+    responses(
+        (status = 200, description = "Name availability result", body = CheckAgentNameResponse),
+        (status = 400, description = "Invalid exclude_id", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+    ),
+    tag = "agents"
+)]
+pub async fn check_agent_name(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Query(query): Query<CheckAgentNameQuery>,
+) -> Result<Json<CheckAgentNameResponse>, (StatusCode, Json<ErrorResponse>)> {
+    // Validate format first — if the name is invalid, it's not "available"
+    if validate_agent_name_format(&query.name).is_err() {
+        return Ok(Json(CheckAgentNameResponse { available: false }));
+    }
+
+    let exclude_id = query
+        .exclude_id
+        .as_deref()
+        .map(|id| id.parse::<AgentId>())
+        .transpose()
+        .map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!("Invalid exclude_id: {}", e),
+                }),
+            )
+        })?;
+
+    let caller = Caller::from(&org);
+    let available = state
+        .service
+        .check_name_available(&caller, &query.name, exclude_id)
+        .await
+        .map_policy_or_internal("check agent name")?;
+
+    Ok(Json(CheckAgentNameResponse { available }))
+}
+
 /// GET /v1/agents/config
 #[utoipa::path(
     get,
@@ -313,6 +378,7 @@ pub async fn agent_config(
 pub fn routes(state: AppState) -> Router {
     Router::new()
         .route("/v1/agents", post(create_agent).get(list_agents))
+        .route("/v1/agents/check-name", get(check_agent_name))
         .route("/v1/agents/config", get(agent_config))
         .route("/v1/agents/import", post(import_agent))
         .route("/v1/agents/preview", post(preview_agent))

--- a/crates/server/src/services/agent.rs
+++ b/crates/server/src/services/agent.rs
@@ -515,6 +515,7 @@ impl AgentService {
     }
 
     /// Check whether a name is available (for UI form validation).
+    #[policy(AGENT_VIEW)]
     pub async fn check_name_available(
         &self,
         caller: &Caller,

--- a/crates/server/src/services/agent.rs
+++ b/crates/server/src/services/agent.rs
@@ -514,6 +514,21 @@ impl AgentService {
         }
     }
 
+    /// Check whether a name is available (for UI form validation).
+    pub async fn check_name_available(
+        &self,
+        caller: &Caller,
+        name: &str,
+        exclude_id: Option<AgentId>,
+    ) -> Result<bool> {
+        if let Some(existing) = self.db.get_agent_by_name(caller.org_id, name).await?
+            && exclude_id != Some(existing.id)
+        {
+            return Ok(false);
+        }
+        Ok(true)
+    }
+
     /// Check if a name is already taken by another agent in the org.
     async fn ensure_name_available(
         &self,

--- a/test_cases/api/agents/TC001_create_agent_basic.md
+++ b/test_cases/api/agents/TC001_create_agent_basic.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Verify that an agent can be created with required fields (name, system_prompt) and returns a valid agent object.
+Verify that an agent can be created with required fields (name, system_prompt) plus optional display_name, and returns a valid agent object with both name and display_name.
 
 ## Preconditions
 
@@ -12,17 +12,19 @@ Verify that an agent can be created with required fields (name, system_prompt) a
 
 | Field | Value |
 |-------|-------|
-| Name | Test Agent |
+| Name (slug) | test-agent |
+| Display Name | Test Agent |
 | System Prompt | You are a helpful assistant. |
 
 ## Steps
 
-1. Create agent:
+1. Create agent with both name and display_name:
    ```bash
    curl -s -X POST "http://localhost:9300/api/v1/agents" \
      -H "Content-Type: application/json" \
      -d '{
-       "name": "Test Agent",
+       "name": "test-agent",
+       "display_name": "Test Agent",
        "system_prompt": "You are a helpful assistant."
      }'
    ```
@@ -33,28 +35,49 @@ Verify that an agent can be created with required fields (name, system_prompt) a
    curl -s "http://localhost:9300/api/v1/agents/{id}"
    ```
 
+3. Fetch agent by name:
+   ```bash
+   curl -s "http://localhost:9300/api/v1/agents/test-agent"
+   ```
+
+4. Create agent without display_name (should fall back to name):
+   ```bash
+   curl -s -X POST "http://localhost:9300/api/v1/agents" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "name": "no-display-name",
+       "system_prompt": "Fallback test."
+     }'
+   ```
+
 ## Expected Result
 
 | Check | Expected |
 |-------|----------|
 | HTTP status (create) | 201 |
 | `id` format | Starts with `agent_` |
-| `name` | `"Test Agent"` |
+| `name` | `"test-agent"` |
+| `display_name` | `"Test Agent"` |
 | `system_prompt` | `"You are a helpful assistant."` |
 | `status` | `"active"` |
 | `capabilities` | `[]` (empty) |
 | `tags` | `[]` (empty) |
-| GET returns same agent | Fields match create response |
+| GET by ID returns same agent | Fields match create response |
+| GET by name returns same agent | Fields match create response |
+| Step 4: `display_name` | `null` (not set, UI falls back to name) |
 
 ## Validation Commands
 
 ```bash
-# Assert: agent created with correct name
-curl -s -X POST ".../agents" ... | jq '.name == "Test Agent"'
+# Assert: agent created with correct addressable name
+curl -s -X POST ".../agents" ... | jq '.name == "test-agent"'
+
+# Assert: display_name is set
+curl -s ".../agents/{id}" | jq '.display_name == "Test Agent"'
 
 # Assert: agent is active
 curl -s ".../agents/{id}" | jq '.status == "active"'
 
-# Assert: ID has correct prefix
-curl -s ".../agents/{id}" | jq '.id | startswith("agent_")'
+# Assert: agent accessible by name
+curl -s ".../agents/test-agent" | jq '.name == "test-agent"'
 ```

--- a/test_cases/api/agents/TC002_create_agent_with_capabilities.md
+++ b/test_cases/api/agents/TC002_create_agent_with_capabilities.md
@@ -12,7 +12,8 @@ Verify that an agent can be created with capabilities and that the capabilities 
 
 | Field | Value |
 |-------|-------|
-| Name | Capable Agent |
+| Name | capable-agent |
+| Display Name | Capable Agent |
 | System Prompt | You are an assistant with tools. |
 | Capabilities | `current_time`, `web_fetch` |
 | Tags | `["test", "capable"]` |
@@ -24,7 +25,8 @@ Verify that an agent can be created with capabilities and that the capabilities 
    curl -s -X POST "http://localhost:9300/api/v1/agents" \
      -H "Content-Type: application/json" \
      -d '{
-       "name": "Capable Agent",
+       "name": "capable-agent",
+       "display_name": "Capable Agent",
        "system_prompt": "You are an assistant with tools.",
        "capabilities": [
          {"ref": "current_time"},

--- a/test_cases/api/agents/TC003_list_agents.md
+++ b/test_cases/api/agents/TC003_list_agents.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Verify that agents are listed correctly, with pagination, and that archived agents are excluded by default.
+Verify that agents are listed correctly, with pagination, and that archived agents are excluded by default. Verify both name (slug) and display_name appear in list responses.
 
 ## Preconditions
 
@@ -12,8 +12,10 @@ Verify that agents are listed correctly, with pagination, and that archived agen
 
 | Field | Value |
 |-------|-------|
-| Agent 1 Name | Agent Alpha |
-| Agent 2 Name | Agent Beta |
+| Agent 1 Name | agent-alpha |
+| Agent 1 Display Name | Agent Alpha |
+| Agent 2 Name | agent-beta |
+| Agent 2 Display Name | Agent Beta |
 
 ## Steps
 
@@ -21,11 +23,11 @@ Verify that agents are listed correctly, with pagination, and that archived agen
    ```bash
    curl -s -X POST "http://localhost:9300/api/v1/agents" \
      -H "Content-Type: application/json" \
-     -d '{"name": "Agent Alpha", "system_prompt": "Alpha agent."}'
+     -d '{"name": "agent-alpha", "display_name": "Agent Alpha", "system_prompt": "Alpha agent."}'
 
    curl -s -X POST "http://localhost:9300/api/v1/agents" \
      -H "Content-Type: application/json" \
-     -d '{"name": "Agent Beta", "system_prompt": "Beta agent."}'
+     -d '{"name": "agent-beta", "display_name": "Agent Beta", "system_prompt": "Beta agent."}'
    ```
    Save both `id` values.
 
@@ -54,8 +56,9 @@ Verify that agents are listed correctly, with pagination, and that archived agen
 | Check | Expected |
 |-------|----------|
 | Step 2: both agents in list | `data` contains both agent IDs |
+| Step 2: name fields | Each agent has `name` (slug) and `display_name` |
 | Step 3: archive returns 200 | Agent status becomes `"archived"` |
-| Step 4: archived agent excluded | `data` does not contain Agent Alpha |
-| Step 4: active agent included | `data` contains Agent Beta |
+| Step 4: archived agent excluded | `data` does not contain agent-alpha |
+| Step 4: active agent included | `data` contains agent-beta |
 | Step 5: both agents in list | `data` contains both agents |
-| Step 5: archived agent status | Agent Alpha has `status: "archived"` |
+| Step 5: archived agent status | agent-alpha has `status: "archived"` |

--- a/test_cases/api/agents/TC004_update_agent.md
+++ b/test_cases/api/agents/TC004_update_agent.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Verify that an agent can be partially updated via PATCH and that only specified fields change.
+Verify that an agent can be partially updated via PATCH, including name (slug) and display_name independently, and that only specified fields change.
 
 ## Preconditions
 
@@ -12,8 +12,10 @@ Verify that an agent can be partially updated via PATCH and that only specified 
 
 | Field | Value |
 |-------|-------|
-| Original Name | Original Agent |
-| Updated Name | Updated Agent |
+| Original Name | original-agent |
+| Original Display Name | Original Agent |
+| Updated Name | updated-agent |
+| Updated Display Name | Updated Agent |
 | Original Prompt | You are original. |
 | Updated Prompt | You are updated. |
 
@@ -24,7 +26,8 @@ Verify that an agent can be partially updated via PATCH and that only specified 
    curl -s -X POST "http://localhost:9300/api/v1/agents" \
      -H "Content-Type: application/json" \
      -d '{
-       "name": "Original Agent",
+       "name": "original-agent",
+       "display_name": "Original Agent",
        "system_prompt": "You are original.",
        "tags": ["v1"]
      }'
@@ -35,7 +38,7 @@ Verify that an agent can be partially updated via PATCH and that only specified 
    ```bash
    curl -s -X PATCH "http://localhost:9300/api/v1/agents/{id}" \
      -H "Content-Type: application/json" \
-     -d '{"name": "Updated Agent"}'
+     -d '{"name": "updated-agent"}'
    ```
 
 3. Fetch agent:
@@ -43,7 +46,14 @@ Verify that an agent can be partially updated via PATCH and that only specified 
    curl -s "http://localhost:9300/api/v1/agents/{id}"
    ```
 
-4. Patch agent (update prompt and tags):
+4. Patch agent (update display_name only):
+   ```bash
+   curl -s -X PATCH "http://localhost:9300/api/v1/agents/{id}" \
+     -H "Content-Type: application/json" \
+     -d '{"display_name": "Updated Agent"}'
+   ```
+
+5. Patch agent (update prompt and tags):
    ```bash
    curl -s -X PATCH "http://localhost:9300/api/v1/agents/{id}" \
      -H "Content-Type: application/json" \
@@ -58,9 +68,12 @@ Verify that an agent can be partially updated via PATCH and that only specified 
 | Check | Expected |
 |-------|----------|
 | Step 2: HTTP status | 200 |
-| Step 3: `name` | `"Updated Agent"` |
+| Step 3: `name` | `"updated-agent"` |
+| Step 3: `display_name` | `"Original Agent"` (unchanged) |
 | Step 3: `system_prompt` | `"You are original."` (unchanged) |
 | Step 3: `tags` | `["v1"]` (unchanged) |
-| Step 4: `system_prompt` | `"You are updated."` |
-| Step 4: `tags` | `["v2"]` |
+| Step 4: `display_name` | `"Updated Agent"` |
+| Step 4: `name` | `"updated-agent"` (unchanged) |
+| Step 5: `system_prompt` | `"You are updated."` |
+| Step 5: `tags` | `["v2"]` |
 | `updated_at` | Changes after each PATCH |

--- a/test_cases/api/agents/TC005_delete_agent.md
+++ b/test_cases/api/agents/TC005_delete_agent.md
@@ -14,7 +14,7 @@ Verify the two-stage agent deletion: soft delete (archive) via DELETE, then hard
    ```bash
    curl -s -X POST "http://localhost:9300/api/v1/agents" \
      -H "Content-Type: application/json" \
-     -d '{"name": "Doomed Agent", "system_prompt": "Temporary."}'
+     -d '{"name": "doomed-agent", "display_name": "Doomed Agent", "system_prompt": "Temporary."}'
    ```
    Save `id`.
 

--- a/test_cases/api/agents/TC006_create_agent_validation.md
+++ b/test_cases/api/agents/TC006_create_agent_validation.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Verify that agent creation fails with appropriate errors for missing or invalid fields.
+Verify that agent creation fails with appropriate errors for missing, invalid, or duplicate fields, including addressable name format validation.
 
 ## Preconditions
 
@@ -21,7 +21,7 @@ Verify that agent creation fails with appropriate errors for missing or invalid 
    ```bash
    curl -s -o /dev/null -w "%{http_code}" -X POST "http://localhost:9300/api/v1/agents" \
      -H "Content-Type: application/json" \
-     -d '{"name": "No Prompt Agent"}'
+     -d '{"name": "no-prompt-agent"}'
    ```
 
 3. Create agent with empty body:
@@ -31,6 +31,30 @@ Verify that agent creation fails with appropriate errors for missing or invalid 
      -d '{}'
    ```
 
+4. Create agent with invalid name format (uppercase, spaces):
+   ```bash
+   curl -s -o /dev/null -w "%{http_code}" -X POST "http://localhost:9300/api/v1/agents" \
+     -H "Content-Type: application/json" \
+     -d '{"name": "My Agent!", "system_prompt": "Bad name."}'
+   ```
+
+5. Create agent with consecutive hyphens:
+   ```bash
+   curl -s -o /dev/null -w "%{http_code}" -X POST "http://localhost:9300/api/v1/agents" \
+     -H "Content-Type: application/json" \
+     -d '{"name": "bad--name", "system_prompt": "Bad."}'
+   ```
+
+6. Create agent, then create another with the same name (duplicate):
+   ```bash
+   curl -s -X POST "http://localhost:9300/api/v1/agents" \
+     -H "Content-Type: application/json" \
+     -d '{"name": "unique-agent", "system_prompt": "First."}'
+   curl -s -o /dev/null -w "%{http_code}" -X POST "http://localhost:9300/api/v1/agents" \
+     -H "Content-Type: application/json" \
+     -d '{"name": "unique-agent", "system_prompt": "Duplicate."}'
+   ```
+
 ## Expected Result
 
 | Check | Expected |
@@ -38,4 +62,8 @@ Verify that agent creation fails with appropriate errors for missing or invalid 
 | Step 1: HTTP status | 400 or 422 |
 | Step 2: HTTP status | 400 or 422 |
 | Step 3: HTTP status | 400 or 422 |
-| Error response | Contains field name causing the error |
+| Step 4: HTTP status | 400 (invalid name format) |
+| Step 5: HTTP status | 400 (consecutive hyphens) |
+| Step 6: First create | 201 |
+| Step 6: Second create | 400 or 500 (name already taken) |
+| Error response | Contains field name or reason causing the error |

--- a/test_cases/api/agents/TC006_create_agent_validation.md
+++ b/test_cases/api/agents/TC006_create_agent_validation.md
@@ -65,5 +65,5 @@ Verify that agent creation fails with appropriate errors for missing, invalid, o
 | Step 4: HTTP status | 400 (invalid name format) |
 | Step 5: HTTP status | 400 (consecutive hyphens) |
 | Step 6: First create | 201 |
-| Step 6: Second create | 400 or 500 (name already taken) |
+| Step 6: Second create | 500 (name already taken) |
 | Error response | Contains field name or reason causing the error |

--- a/test_cases/api/agents/TC007_check_agent_name.md
+++ b/test_cases/api/agents/TC007_check_agent_name.md
@@ -1,0 +1,58 @@
+# TC007: Check Agent Name Availability
+
+## Description
+
+Verify the `/v1/agents/check-name` endpoint correctly reports name availability, including format validation and exclude_id support for edit forms.
+
+## Preconditions
+
+- API server running (`just start-dev`)
+
+## Steps
+
+1. Check a name that doesn't exist:
+   ```bash
+   curl -s "http://localhost:9300/api/v1/agents/check-name?name=fresh-agent"
+   ```
+
+2. Create an agent:
+   ```bash
+   curl -s -X POST "http://localhost:9300/api/v1/agents" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "name": "taken-agent",
+       "system_prompt": "Exists."
+     }'
+   ```
+   Save `id` from response.
+
+3. Check the taken name:
+   ```bash
+   curl -s "http://localhost:9300/api/v1/agents/check-name?name=taken-agent"
+   ```
+
+4. Check the taken name with exclude_id (edit form scenario):
+   ```bash
+   curl -s "http://localhost:9300/api/v1/agents/check-name?name=taken-agent&exclude_id={id}"
+   ```
+
+5. Check an invalid name format (uppercase):
+   ```bash
+   curl -s "http://localhost:9300/api/v1/agents/check-name?name=Bad+Name"
+   ```
+
+6. Check a very short name (1 char):
+   ```bash
+   curl -s "http://localhost:9300/api/v1/agents/check-name?name=a"
+   ```
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Step 1: `available` | `true` |
+| Step 3: `available` | `false` (name is taken) |
+| Step 4: `available` | `true` (excluded own ID) |
+| Step 5: `available` | `false` (invalid format) |
+| Step 6: `available` | `false` (too short / invalid) |
+| All steps: HTTP status | 200 |

--- a/test_cases/api/agents/TC007_check_agent_name.md
+++ b/test_cases/api/agents/TC007_check_agent_name.md
@@ -54,5 +54,5 @@ Verify the `/v1/agents/check-name` endpoint correctly reports name availability,
 | Step 3: `available` | `false` (name is taken) |
 | Step 4: `available` | `true` (excluded own ID) |
 | Step 5: `available` | `false` (invalid format) |
-| Step 6: `available` | `false` (too short / invalid) |
+| Step 6: `available` | `true` (single char is valid) |
 | All steps: HTTP status | 200 |

--- a/test_cases/api/sessions/TC001_create_session_for_agent.md
+++ b/test_cases/api/sessions/TC001_create_session_for_agent.md
@@ -13,7 +13,8 @@ Verify that a session can be created for an existing agent and starts in the cor
 
 | Field | Value |
 |-------|-------|
-| Agent Name | Chat Agent |
+| Agent Name | chat-agent |
+| Agent Display Name | Chat Agent |
 | Agent Prompt | You are a helpful chat assistant. |
 
 ## Steps
@@ -23,7 +24,8 @@ Verify that a session can be created for an existing agent and starts in the cor
    curl -s -X POST "http://localhost:9300/api/v1/agents" \
      -H "Content-Type: application/json" \
      -d '{
-       "name": "Chat Agent",
+       "name": "chat-agent",
+       "display_name": "Chat Agent",
        "system_prompt": "You are a helpful chat assistant."
      }'
    ```


### PR DESCRIPTION
## Summary

- **Backend**: Add `GET /v1/agents/check-name` endpoint for real-time name availability validation (mirrors harness `check-name` pattern), plus public `check_name_available` on AgentService.
- **UI forms**: Split agent create/edit forms into "Display Name" (free-form, e.g. `Customer Support Agent`) + "Name" (slug, e.g. `customer-support`) with auto-slug derivation and real-time availability indicator (spinner → green check / red X).
- **UI display**: Update all 17+ locations (agent card, detail page, sessions, session layout, recent sessions, session list, agent select, filter menu, dashboard widget, global search, apps page, evals page) to show `display_name` via a shared `getDisplayName()` helper in `entity-lifecycle.ts`. Agent cards now show display name prominently with the slug underneath.
- **Test cases**: Updated TC001–TC006 to use slug-format names + `display_name`. Added TC007 for `check-name` endpoint.

## Test plan

- [ ] Create an agent via UI — verify Display Name + Name (slug) fields appear, auto-slug works, availability indicator shows
- [ ] Edit an agent — verify both fields populate, name availability checks on change
- [ ] Agent card, detail page, sessions page all show display_name prominently with slug as secondary text
- [ ] `GET /v1/agents/check-name?name=taken-name` returns `{ available: false }`
- [ ] `GET /v1/agents/check-name?name=fresh-name` returns `{ available: true }`
- [ ] Agent select dropdowns, filter menus, global search, dashboard widget show display names
- [ ] Agents without display_name gracefully fall back to slug name everywhere