### PR TITLE
fix(agents): enforce addressable name validation across all creation paths

### DIFF
--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -251,20 +251,6 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
                   </CardHeader>
                   <CardContent className="space-y-6">
                     <div className="space-y-2">
-                      <Label htmlFor="display_name">Display Name</Label>
-                      <Input
-                        id="display_name"
-                        placeholder="Customer Support Agent"
-                        value={formData.display_name}
-                        onChange={(e) => handleFormChange("display_name", e.target.value)}
-                        disabled={isSaving || isReadOnly}
-                      />
-                      <p className="text-xs text-muted-foreground">
-                        Human-readable name shown in the UI
-                      </p>
-                    </div>
-
-                    <div className="space-y-2">
                       <Label htmlFor="name">Name</Label>
                       <Input
                         id="name"
@@ -299,6 +285,20 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
                       <p className="text-xs text-muted-foreground">
                         Unique identifier used in URLs and API. Lowercase letters, numbers, and
                         hyphens.
+                      </p>
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label htmlFor="display_name">Display Name</Label>
+                      <Input
+                        id="display_name"
+                        placeholder={formData.name ? undefined : "Customer Support Agent"}
+                        value={formData.display_name}
+                        onChange={(e) => handleFormChange("display_name", e.target.value)}
+                        disabled={isSaving || isReadOnly}
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Optional human-readable label shown in the UI. Defaults to name if empty.
                       </p>
                     </div>
 
@@ -467,15 +467,15 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
                 </CardHeader>
                 <CardContent className="space-y-4">
                   <div>
-                    <p className="text-sm font-medium">Display Name</p>
-                    <p className="text-sm text-muted-foreground">
-                      {formData.display_name || "(not set)"}
-                    </p>
-                  </div>
-                  <div>
                     <p className="text-sm font-medium">Name</p>
                     <p className="text-sm text-muted-foreground font-mono">
                       {formData.name || "(not set)"}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium">Display Name</p>
+                    <p className="text-sm text-muted-foreground">
+                      {formData.display_name || "(not set)"}
                     </p>
                   </div>
                   <div>

--- a/apps/ui/src/app/(main)/agents/new/page.tsx
+++ b/apps/ui/src/app/(main)/agents/new/page.tsx
@@ -101,17 +101,6 @@ export default function NewAgentPage() {
         <CardContent>
           <form onSubmit={handleSubmit} className="space-y-6">
             <div className="space-y-2">
-              <Label htmlFor="display_name">Display Name</Label>
-              <Input
-                id="display_name"
-                placeholder="Customer Support Agent"
-                value={formData.display_name}
-                onChange={(e) => handleDisplayNameChange(e.target.value)}
-              />
-              <p className="text-xs text-muted-foreground">Human-readable name shown in the UI</p>
-            </div>
-
-            <div className="space-y-2">
               <Label htmlFor="name">Name</Label>
               <Input
                 id="name"
@@ -142,6 +131,19 @@ export default function NewAgentPage() {
               )}
               <p className="text-xs text-muted-foreground">
                 Unique identifier used in URLs and API. Lowercase letters, numbers, and hyphens.
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="display_name">Display Name</Label>
+              <Input
+                id="display_name"
+                placeholder={formData.name ? undefined : "Customer Support Agent"}
+                value={formData.display_name}
+                onChange={(e) => handleDisplayNameChange(e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                Optional human-readable label shown in the UI. Defaults to name if empty.
               </p>
             </div>
 

--- a/crates/core/src/agent.rs
+++ b/crates/core/src/agent.rs
@@ -125,6 +125,36 @@ pub struct Agent {
     pub usage: Option<TokenUsage>,
 }
 
+/// Maximum length for an addressable name (agent, harness, etc.).
+pub const MAX_ADDRESSABLE_NAME_LEN: usize = 64;
+
+/// Validate an addressable name: `[a-z0-9]([a-z0-9-]*[a-z0-9])?`.
+/// Max 64 chars, no consecutive hyphens, no leading/trailing hyphens.
+/// Returns `Ok(())` or a human-readable error message.
+pub fn validate_addressable_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("name must not be empty".to_string());
+    }
+    if name.len() > MAX_ADDRESSABLE_NAME_LEN {
+        return Err(format!(
+            "name must be at most {MAX_ADDRESSABLE_NAME_LEN} characters"
+        ));
+    }
+    if !name
+        .bytes()
+        .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+    {
+        return Err("name must contain only lowercase letters, digits, and hyphens".to_string());
+    }
+    if name.starts_with('-') || name.ends_with('-') {
+        return Err("name must not start or end with a hyphen".to_string());
+    }
+    if name.contains("--") {
+        return Err("name must not contain consecutive hyphens".to_string());
+    }
+    Ok(())
+}
+
 /// Generate a new agent public_id using UUIDv7.
 pub fn generate_agent_public_id() -> AgentId {
     AgentId::new()
@@ -169,6 +199,28 @@ mod tests {
         )); // uppercase
         assert!(!validate_agent_public_id("agent_short"));
         assert!(!validate_agent_public_id("my-custom-agent"));
+    }
+
+    #[test]
+    fn test_validate_addressable_name_valid() {
+        assert!(validate_addressable_name("my-agent").is_ok());
+        assert!(validate_addressable_name("agent1").is_ok());
+        assert!(validate_addressable_name("a").is_ok());
+        assert!(validate_addressable_name("customer-support").is_ok());
+        assert!(validate_addressable_name("a-b-c").is_ok());
+    }
+
+    #[test]
+    fn test_validate_addressable_name_invalid() {
+        assert!(validate_addressable_name("").is_err());
+        assert!(validate_addressable_name("-leading").is_err());
+        assert!(validate_addressable_name("trailing-").is_err());
+        assert!(validate_addressable_name("bad--double").is_err());
+        assert!(validate_addressable_name("UPPERCASE").is_err());
+        assert!(validate_addressable_name("has space").is_err());
+        assert!(validate_addressable_name("Customer Support Agent").is_err());
+        let long = "a".repeat(65);
+        assert!(validate_addressable_name(&long).is_err());
     }
 
     #[test]

--- a/crates/core/src/capabilities/platform_management.rs
+++ b/crates/core/src/capabilities/platform_management.rs
@@ -635,7 +635,11 @@ impl Tool for ManageAgentsTool {
                 },
                 "name": {
                     "type": "string",
-                    "description": "Agent name (required for create)"
+                    "description": "Addressable agent name (required for create). Lowercase letters, numbers, and hyphens only (e.g. 'customer-support')."
+                },
+                "display_name": {
+                    "type": "string",
+                    "description": "Human-readable display name shown in UI (e.g. 'Customer Support Agent'). Falls back to name when absent."
                 },
                 "description": {
                     "type": "string",
@@ -689,6 +693,10 @@ impl Tool for ManageAgentsTool {
                     Ok(s) => s,
                     Err(e) => return e,
                 };
+                if let Err(msg) = crate::agent::validate_addressable_name(name) {
+                    return ToolExecutionResult::tool_error(format!("Invalid agent name: {msg}"));
+                }
+                let display_name = get_str(&arguments, "display_name");
                 let system_prompt =
                     get_str(&arguments, "system_prompt").unwrap_or("You are a helpful assistant.");
                 let description = get_str(&arguments, "description");
@@ -702,7 +710,13 @@ impl Tool for ManageAgentsTool {
                     })
                     .unwrap_or_default();
                 match store
-                    .create_agent(name, description, system_prompt, &capabilities)
+                    .create_agent(
+                        name,
+                        display_name,
+                        description,
+                        system_prompt,
+                        &capabilities,
+                    )
                     .await
                 {
                     Ok(a) => ToolExecutionResult::success(json!({

--- a/crates/core/src/capabilities/platform_management.rs
+++ b/crates/core/src/capabilities/platform_management.rs
@@ -753,10 +753,11 @@ impl Tool for ManageAgentsTool {
                 {
                     return ToolExecutionResult::tool_error(format!("Invalid agent name: {msg}"));
                 }
+                let display_name = get_str(&arguments, "display_name");
                 let description = get_str(&arguments, "description");
                 let system_prompt = get_str(&arguments, "system_prompt");
                 match store
-                    .update_agent(id, name, description, system_prompt)
+                    .update_agent(id, name, display_name, description, system_prompt)
                     .await
                 {
                     Ok(a) => ToolExecutionResult::success(json!({

--- a/crates/core/src/capabilities/platform_management.rs
+++ b/crates/core/src/capabilities/platform_management.rs
@@ -748,6 +748,11 @@ impl Tool for ManageAgentsTool {
                     }
                 };
                 let name = get_str(&arguments, "name");
+                if let Some(n) = name
+                    && let Err(msg) = crate::agent::validate_addressable_name(n)
+                {
+                    return ToolExecutionResult::tool_error(format!("Invalid agent name: {msg}"));
+                }
                 let description = get_str(&arguments, "description");
                 let system_prompt = get_str(&arguments, "system_prompt");
                 match store
@@ -1790,12 +1795,47 @@ mod tests {
         let tool = ManageAgentsTool;
         let result = tool
             .execute_with_context(
-                json!({"operation": "create", "name": "New Agent", "system_prompt": "Be helpful"}),
+                json!({"operation": "create", "name": "new-agent", "system_prompt": "Be helpful"}),
                 &ctx,
             )
             .await;
         match result {
-            ToolExecutionResult::Success(v) => assert_eq!(v["name"], "New Agent"),
+            ToolExecutionResult::Success(v) => assert_eq!(v["name"], "new-agent"),
+            other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn agent_create_rejects_non_slug_name() {
+        let ctx = mock_context();
+        let tool = ManageAgentsTool;
+        let result = tool
+            .execute_with_context(
+                json!({"operation": "create", "name": "Bad Agent Name", "system_prompt": "hi"}),
+                &ctx,
+            )
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(_) => {} // expected
+            other => panic!("expected tool error for non-slug name, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn agent_create_with_display_name() {
+        let ctx = mock_context();
+        let tool = ManageAgentsTool;
+        let result = tool
+            .execute_with_context(
+                json!({"operation": "create", "name": "support-bot", "display_name": "Support Bot", "system_prompt": "hi"}),
+                &ctx,
+            )
+            .await;
+        match result {
+            ToolExecutionResult::Success(v) => {
+                assert_eq!(v["name"], "support-bot");
+                assert_eq!(v["display_name"], "Support Bot");
+            }
             other => panic!("expected success, got: {other:?}"),
         }
     }
@@ -1806,13 +1846,13 @@ mod tests {
         let tool = ManageAgentsTool;
         let result = tool
             .execute_with_context(
-                json!({"operation": "update", "agent_id": AgentId::new().to_string(), "name": "Renamed"}),
+                json!({"operation": "update", "agent_id": AgentId::new().to_string(), "name": "renamed-agent"}),
                 &ctx,
             )
             .await;
         match result {
             ToolExecutionResult::Success(v) => {
-                assert_eq!(v["name"], "Renamed");
+                assert_eq!(v["name"], "renamed-agent");
                 assert!(v["message"].as_str().unwrap().contains("updated"));
             }
             other => panic!("expected success, got: {other:?}"),

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -237,7 +237,10 @@ pub use tool_types::{
 
 // Domain entity re-exports
 // Note: LlmProvider entity is in llm_models module. Import as: everruns_core::llm_models::LlmProvider
-pub use agent::{Agent, AgentStatus, generate_agent_public_id, validate_agent_public_id};
+pub use agent::{
+    Agent, AgentStatus, MAX_ADDRESSABLE_NAME_LEN, generate_agent_public_id,
+    validate_addressable_name, validate_agent_public_id,
+};
 pub use agent_identity::{AgentIdentity, AgentIdentityStatus};
 pub use app::{
     App, AppChannel, AppStatus, ChannelType, SessionStrategy, SlackChannelConfig, SlackReplyMode,

--- a/crates/core/src/platform_store.rs
+++ b/crates/core/src/platform_store.rs
@@ -82,6 +82,7 @@ pub trait PlatformStore: Send + Sync {
     async fn create_agent(
         &self,
         name: &str,
+        display_name: Option<&str>,
         description: Option<&str>,
         system_prompt: &str,
         capabilities: &[String],
@@ -348,12 +349,14 @@ pub mod tests {
         async fn create_agent(
             &self,
             name: &str,
+            display_name: Option<&str>,
             _desc: Option<&str>,
             _prompt: &str,
             _caps: &[String],
         ) -> Result<Agent> {
             let mut a = self.agent.clone();
             a.name = name.to_string();
+            a.display_name = display_name.map(|s| s.to_string());
             Ok(a)
         }
         async fn update_agent(

--- a/crates/core/src/platform_store.rs
+++ b/crates/core/src/platform_store.rs
@@ -93,6 +93,7 @@ pub trait PlatformStore: Send + Sync {
         &self,
         id: AgentId,
         name: Option<&str>,
+        display_name: Option<&str>,
         description: Option<&str>,
         system_prompt: Option<&str>,
     ) -> Result<Agent>;
@@ -363,12 +364,16 @@ pub mod tests {
             &self,
             _id: crate::typed_id::AgentId,
             name: Option<&str>,
+            display_name: Option<&str>,
             _desc: Option<&str>,
             _prompt: Option<&str>,
         ) -> Result<Agent> {
             let mut a = self.agent.clone();
             if let Some(n) = name {
                 a.name = n.to_string();
+            }
+            if let Some(dn) = display_name {
+                a.display_name = Some(dn.to_string());
             }
             Ok(a)
         }

--- a/crates/server/src/api/mcp_endpoint/catalog.rs
+++ b/crates/server/src/api/mcp_endpoint/catalog.rs
@@ -204,7 +204,7 @@ pub static CATALOG: &[Operation] = &[
             Param {
                 name: "name",
                 typ: "string",
-                description: "Agent name (required)",
+                description: "Addressable agent name (required). Lowercase letters, numbers, and hyphens only (e.g. 'customer-support').",
             },
             Param {
                 name: "system_prompt",
@@ -279,7 +279,7 @@ pub static CATALOG: &[Operation] = &[
             Param {
                 name: "name",
                 typ: "string",
-                description: "New name",
+                description: "New addressable name. Lowercase letters, numbers, and hyphens only.",
             },
             Param {
                 name: "system_prompt",

--- a/crates/server/src/api/validation.rs
+++ b/crates/server/src/api/validation.rs
@@ -136,53 +136,15 @@ fn validate_harness_name_inner(name: &str) -> Result<(), (StatusCode, Json<Error
 
 /// Validate a name: `[a-z0-9]([a-z0-9-]*[a-z0-9])?`.
 /// Max 64 chars, no consecutive hyphens, no leading/trailing hyphens.
-/// Used for both harness and agent names.
+/// Used for both harness and agent names. Delegates to core's shared
+/// `validate_addressable_name` and wraps the error as an HTTP 400.
 fn validate_name_format(entity: &str, name: &str) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
-    if name.is_empty() {
-        return Err((
+    everruns_core::validate_addressable_name(name).map_err(|msg| {
+        (
             StatusCode::BAD_REQUEST,
-            Json(ErrorResponse::new(format!(
-                "{entity} name must not be empty"
-            ))),
-        ));
-    }
-    if name.len() > MAX_NAME_LEN {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse::new(format!(
-                "{entity} name must be at most {} characters",
-                MAX_NAME_LEN
-            ))),
-        ));
-    }
-    if !name
-        .bytes()
-        .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
-    {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse::new(format!(
-                "{entity} name must contain only lowercase letters, digits, and hyphens"
-            ))),
-        ));
-    }
-    if name.starts_with('-') || name.ends_with('-') {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse::new(format!(
-                "{entity} name must not start or end with a hyphen"
-            ))),
-        ));
-    }
-    if name.contains("--") {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse::new(format!(
-                "{entity} name must not contain consecutive hyphens"
-            ))),
-        ));
-    }
-    Ok(())
+            Json(ErrorResponse::new(format!("{entity} {msg}"))),
+        )
+    })
 }
 
 /// Validate agent name for create/update — same format as harness names.

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1713,6 +1713,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
         &self,
         id: AgentId,
         name: Option<&str>,
+        display_name: Option<&str>,
         description: Option<&str>,
         system_prompt: Option<&str>,
     ) -> everruns_core::error::Result<Agent> {
@@ -1720,6 +1721,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
 
         let update = UpdateAgent {
             name: name.map(|s| s.to_string()),
+            display_name: display_name.map(|s| s.to_string()),
             description: description.map(|s| s.to_string()),
             system_prompt: system_prompt.map(|s| s.to_string()),
             ..Default::default()

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1658,6 +1658,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
     async fn create_agent(
         &self,
         name: &str,
+        display_name: Option<&str>,
         description: Option<&str>,
         system_prompt: &str,
         capabilities: &[String],
@@ -1668,7 +1669,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
         let input = CreateAgentRow {
             public_id: public_id.to_string(),
             name: name.to_string(),
-            display_name: Some(name.to_string()),
+            display_name: display_name.map(|s| s.to_string()),
             description: description.map(|s| s.to_string()),
             system_prompt: system_prompt.to_string(),
             default_model_id: None,

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -2155,6 +2155,7 @@ impl everruns_core::platform_store::PlatformStore for GrpcOrgAdapter {
     async fn create_agent(
         &self,
         name: &str,
+        display_name: Option<&str>,
         description: Option<&str>,
         system_prompt: &str,
         capabilities: &[String],
@@ -2167,7 +2168,7 @@ impl everruns_core::platform_store::PlatformStore for GrpcOrgAdapter {
                 description: description.map(|s| s.to_string()),
                 system_prompt: system_prompt.to_string(),
                 capabilities: capabilities.to_vec(),
-                display_name: None,
+                display_name: display_name.map(|s| s.to_string()),
             })
             .await
             .map_err(grpc_status_to_error)?;

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -2186,6 +2186,7 @@ impl everruns_core::platform_store::PlatformStore for GrpcOrgAdapter {
         &self,
         id: AgentId,
         name: Option<&str>,
+        display_name: Option<&str>,
         description: Option<&str>,
         system_prompt: Option<&str>,
     ) -> Result<Agent> {
@@ -2197,7 +2198,7 @@ impl everruns_core::platform_store::PlatformStore for GrpcOrgAdapter {
                 name: name.map(|s| s.to_string()),
                 description: description.map(|s| s.to_string()),
                 system_prompt: system_prompt.map(|s| s.to_string()),
-                display_name: None,
+                display_name: display_name.map(|s| s.to_string()),
             })
             .await
             .map_err(grpc_status_to_error)?;


### PR DESCRIPTION
## What
Consolidate agent addressable name validation into a single source of truth in `everruns-core`, fix the platform management capability bypassing validation entirely, fix `DirectPlatformStore` incorrectly copying the slug into `display_name`, reorder UI form fields to put Name first, and improve display_name placeholder UX.

## Why
Six gaps found in the addressable name feature:

1. **No shared validation** — `validate_name_format` lived in `crates/server/src/api/validation.rs` returning HTTP-specific types. The platform capability in `crates/core` couldn't reuse it.
2. **Platform `manage_agents` tool accepted non-slug names** — An LLM could pass "Customer Support Agent" as the name with no validation and no format hint in the schema.
3. **`DirectPlatformStore::create_agent` set `display_name = Some(name)`** — Creating via platform chat gave `display_name: "customer-support"` instead of `None`.
4. **UI field order wrong** — Display Name was shown first, but the addressable name is the primary identifier.
5. **Display name placeholder confusing** — "Customer Support Agent" showed even when a name was already entered.
6. **MCP catalog lacked format hints** — `create_agent` and `update_agent` param descriptions didn't mention the slug format.

## How
- Added `validate_addressable_name()` to `crates/core/src/agent.rs` — pure function, `Result<(), String>`
- Server's `validate_name_format` now delegates to the core function
- Platform `manage_agents` tool validates name format before calling `create_agent`, added `display_name` parameter to schema
- Extended `PlatformStore::create_agent` trait with `display_name: Option<&str>` parameter, updated all 3 implementations
- Fixed `DirectPlatformStore` to pass `display_name` through instead of copying name
- Swapped field order in new + edit UI pages (form and summary sidebar)
- Display name placeholder cleared when name is set; helper text updated

## Risk
- Low
- Trait signature change is internal only; all 3 implementors updated. Error message wording in server validation slightly changed (now prefixed with entity name: "Agent name must not..." instead of "Agent name must not...") — functionally identical.

## Security
- Threat categories reviewed: TM-API, TM-TOOL, TM-TENANT
- This change is strictly hardening — adds input validation to a previously unvalidated path (platform management tool). No new endpoints, no auth changes, no SQL/FS/bash changes. The validation function is pure (no I/O). `display_name` passes through to existing org-scoped storage with existing size limits. No injection risk — error messages use format strings, not interpolation into SQL/HTML.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
