### PR TITLE
fix(ui): fix list key props in agent pages

### DIFF
--- a/apps/ui/src/app/(main)/agents/all/page.tsx
+++ b/apps/ui/src/app/(main)/agents/all/page.tsx
@@ -55,9 +55,9 @@ export default function AllAgentsPage() {
       >
         {(items) => (
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {items.map((agent) => (
+            {items.map((agent, index) => (
               <AgentCard
-                key={agent.id}
+                key={agent.id ?? `agent-${index}`}
                 agent={agent}
                 allCapabilities={allCapabilities}
                 showEditButton

--- a/apps/ui/src/app/(main)/agents/examples/page.tsx
+++ b/apps/ui/src/app/(main)/agents/examples/page.tsx
@@ -81,9 +81,9 @@ export default function AllExamplesPage() {
       >
         {(items) => (
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {items.map((example) => (
+            {items.map((example, index) => (
               <ExampleCard
-                key={example.slug}
+                key={example.slug ?? `example-${index}`}
                 example={example}
                 allCapabilities={allCapabilities}
                 onUse={handleUse}

--- a/apps/ui/src/app/(main)/agents/page.tsx
+++ b/apps/ui/src/app/(main)/agents/page.tsx
@@ -136,9 +136,9 @@ export default function AgentsPage() {
         >
           {(items) => (
             <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-              {items.map((agent) => (
+              {items.map((agent, index) => (
                 <AgentCard
-                  key={agent.id}
+                  key={agent.id ?? `agent-${index}`}
                   agent={agent}
                   allCapabilities={allCapabilities}
                   showEditButton
@@ -180,9 +180,9 @@ export default function AgentsPage() {
         >
           {(items) => (
             <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-              {items.map((example) => (
+              {items.map((example, index) => (
                 <ExampleCard
-                  key={example.slug}
+                  key={example.slug ?? `example-${index}`}
                   example={example}
                   allCapabilities={allCapabilities}
                   onUse={handleUse}

--- a/apps/ui/src/components/query-state-wrapper.tsx
+++ b/apps/ui/src/components/query-state-wrapper.tsx
@@ -97,5 +97,5 @@ export function QueryStateWrapper<T>({
     return emptyState ?? <DefaultEmpty message={emptyMessage} />;
   }
 
-  return children(data);
+  return children(data) ?? null;
 }

--- a/apps/ui/src/components/query-state-wrapper.tsx
+++ b/apps/ui/src/components/query-state-wrapper.tsx
@@ -97,5 +97,5 @@ export function QueryStateWrapper<T>({
     return emptyState ?? <DefaultEmpty message={emptyMessage} />;
   }
 
-  return <>{children(data)}</>;
+  return children(data);
 }


### PR DESCRIPTION
## What
Add index-based fallback keys to `.map()` calls in agent list pages and remove unnecessary Fragment wrapper from `QueryStateWrapper`.

## Why
React console error "Each child in a list should have a unique key prop" on the `/agents` page. The `key` props relied on `example.slug` / `agent.id` which can be `undefined` at runtime, causing `key={undefined}` (treated as no key by React).

## How
- Add nullish coalescing fallback keys: `key={agent.id ?? \`agent-${index}\`}` and `key={example.slug ?? \`example-${index}\`}`
- Remove redundant `<>{children(data)}</>` Fragment in `QueryStateWrapper`, returning `children(data)` directly

## Risk
- Low
- Minimal surface: only React key attributes changed. Fallback keys use stable index values for the rare undefined case.

## Security
- Threat categories reviewed: TM-WEB (frontend rendering)
- No security-relevant code changes. Pure React key-prop fix with no auth, API, input validation, or trust boundary impact.

## Checklist
- [x] Tests added or updated (no new tests needed — key prop fix only)
- [x] Backward compatibility considered (no breaking changes)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)