### PR TITLE
fix(ui): fix streaming cursor artifact rendering on own line

### DIFF
--- a/apps/ui/src/components/streaming-message.css
+++ b/apps/ui/src/components/streaming-message.css
@@ -1,8 +1,10 @@
 /* Streaming cursor — rendered via ::after so it stays inline with the last
    text element instead of dropping to the next line as a sibling span would.
    Scope to only the final markdown segment to avoid duplicate cursors when a
-   message renders multiple .streamdown blocks (e.g. openui fences). */
-.streaming-cursor .streamdown:last-of-type > :last-child::after {
+   message renders multiple .streamdown blocks (e.g. openui fences).
+   Streamdown wraps content in a block-level div, so we traverse two levels
+   (wrapper → last text element like <p>) to keep the cursor inline. */
+.streaming-cursor .streamdown:last-of-type > :last-child > :last-child::after {
   content: "";
   display: inline-block;
   width: 1px;


### PR DESCRIPTION
## What
Fix the streaming cursor pseudo-element appearing as a standalone artifact on its own line below the message text during generation.

## Why
During streaming, the pulsing cursor was rendering on a blank line below the actual text instead of inline at the end of the last word. This was a visual regression from #1230 which moved the cursor to CSS `::after` but targeted the wrong DOM depth.

## How
Streamdown wraps content in a block-level `<div class="space-y-4 ...">` wrapper. The original selector `> :last-child::after` targeted this wrapper div. An `inline-block` pseudo-element on a block container renders in its own anonymous line box — hence the artifact.

The fix adds one more `> :last-child` level to the selector so the `::after` lands on the actual text element (e.g. `<p>`) where it stays inline:

```css
/* Before */
.streaming-cursor .streamdown:last-of-type > :last-child::after {
/* After */
.streaming-cursor .streamdown:last-of-type > :last-child > :last-child::after {
```

Verified with a static HTML reproduction rendered via Playwright screenshot — broken selector shows the artifact, fixed selector keeps cursor inline (single paragraph and multi-paragraph).

## Risk
- Low
- CSS-only change scoped to streaming cursor. No runtime, API, or data impact.

## Security
- No security-relevant code changes. Pure CSS selector fix in a visual-only component.

## Checklist
- [x] Tests added or updated (manual visual verification via Playwright screenshot — no automated e2e added)
- [x] Backward compatibility considered (N/A — internal CSS)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
