### PR TITLE
fix(ci): remove redundant version from generated Homebrew formula

### DIFF
--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -118,7 +118,6 @@ jobs:
           class Everruns < Formula
             desc "Open-source AI agent platform"
             homepage "${{ github.server_url }}/${{ github.repository }}"
-            version "${VERSION}"
             license "Apache-2.0"
 
             on_macos do


### PR DESCRIPTION
## Summary
- Remove explicit `version` line from the generated Homebrew formula in cli-binaries.yml
- Homebrew infers the version from the download URL (`/vX.Y.Z/`), so the explicit declaration triggers `brew audit --strict` failure: *Stable: version is redundant with version scanned from URL*

## Test plan
- Next release should generate a formula without `version` line
- `brew audit --strict` should pass in homebrew-tap CI