### PR TITLE
fix(ci): wrap linux url/sha256 in CPU conditional

### DIFF
--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -132,8 +132,10 @@ jobs:
 
             on_linux do
               depends_on arch: :x86_64
-              url "${BASE_URL}/everruns-x86_64-unknown-linux-gnu.tar.gz"
-              sha256 "${SHA_LINUX}"
+              if Hardware::CPU.intel?
+                url "${BASE_URL}/everruns-x86_64-unknown-linux-gnu.tar.gz"
+                sha256 "${SHA_LINUX}"
+              end
             end
 
             def install


### PR DESCRIPTION
## Summary
- Wrap `url`/`sha256` inside `on_linux` block in a `Hardware::CPU.intel?` conditional
- `brew style` flags `url`/`sha256` as disallowed direct children of `on_linux`; wrapping in a conditional matches the existing `on_macos` pattern

## Test plan
- Next release should generate a formula that passes `brew style`