### PR TITLE
feat(evals): replace harness_id/agent_id with EvalTarget

### DIFF
--- a/apps/ui/src/app/(main)/evals/[evalId]/page.tsx
+++ b/apps/ui/src/app/(main)/evals/[evalId]/page.tsx
@@ -8,7 +8,6 @@ import {
   useCreateEvalCase,
   useDeleteEvalCase,
   useCreateEvalRun,
-  useAgents,
 } from "@/hooks";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
@@ -23,7 +22,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { CopyButton } from "@/components/ui/copy-button";
 import { ArrowLeft, Pencil, Play, Plus, Trash2, ListChecks, BarChart3 } from "lucide-react";
 import { getEntityNameClassName, getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
-import type { EvalCase, EvalRun, Scorer, EvalInputMessage } from "@/lib/api/types";
+import type { EvalCase, EvalRun, Scorer, EvalInputMessage, EvalTarget } from "@/lib/api/types";
 
 function passRateColor(rate: number): string {
   if (rate >= 0.9) return "text-green-600";
@@ -71,6 +70,32 @@ function scorerLabel(scorer: Scorer): string {
   }
 }
 
+function TargetBadge({ target }: { target?: EvalTarget }) {
+  if (!target) return null;
+  switch (target.type) {
+    case "harness":
+      return (
+        <Badge variant="outline" className="text-xs">
+          harness
+        </Badge>
+      );
+    case "session_params":
+      return (
+        <Badge variant="outline" className="text-xs">
+          session_params
+        </Badge>
+      );
+    case "app":
+      return (
+        <Badge variant="outline" className="text-xs">
+          app: {target.app_id}
+        </Badge>
+      );
+    default:
+      return null;
+  }
+}
+
 function CaseCard({
   evalCase,
   onDelete,
@@ -98,6 +123,12 @@ function CaseCard({
       <CardContent className="space-y-3">
         {evalCase.description && (
           <p className="text-sm text-muted-foreground">{evalCase.description}</p>
+        )}
+        {evalCase.target && (
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-muted-foreground">Target override:</span>
+            <TargetBadge target={evalCase.target} />
+          </div>
         )}
         <div className="space-y-1">
           <p className="text-xs font-medium text-muted-foreground">Messages</p>
@@ -148,6 +179,7 @@ function RunRow({ evalId, run }: { evalId: string; run: EvalRun }) {
               {new Date(run.created_at).toLocaleString()}
             </span>
             <span className="text-xs text-muted-foreground">by {run.triggered_by}</span>
+            {run.target && <TargetBadge target={run.target} />}
           </div>
           <div className="flex items-center gap-4 text-sm">
             {run.summary && (
@@ -296,11 +328,8 @@ export default function EvalDetailPage({ params }: { params: Promise<{ evalId: s
   const { data: ev, isLoading: evalLoading } = useEval(evalId);
   const { data: cases, isLoading: casesLoading } = useEvalCases(evalId);
   const { data: runs, isLoading: runsLoading } = useEvalRuns(evalId);
-  const { data: agents } = useAgents({ includeArchived: false });
   const deleteCase = useDeleteEvalCase(evalId);
   const createRun = useCreateEvalRun(evalId);
-
-  const agentName = agents?.find((a) => a.id === ev?.agent_id)?.name;
 
   const handleDeleteCase = useCallback(
     async (caseId: string) => {
@@ -362,7 +391,7 @@ export default function EvalDetailPage({ params }: { params: Promise<{ evalId: s
           </h1>
           {ev.description && <p className="text-muted-foreground mt-1">{ev.description}</p>}
           <div className="flex items-center gap-4 mt-2 text-sm text-muted-foreground">
-            {agentName && <span>Agent: {agentName}</span>}
+            <TargetBadge target={ev.target} />
             <span>{ev.case_count} cases</span>
             {ev.tags.length > 0 && (
               <div className="flex gap-1">

--- a/apps/ui/src/app/(main)/evals/[evalId]/page.tsx
+++ b/apps/ui/src/app/(main)/evals/[evalId]/page.tsx
@@ -73,16 +73,10 @@ function scorerLabel(scorer: Scorer): string {
 function TargetBadge({ target }: { target?: EvalTarget }) {
   if (!target) return null;
   switch (target.type) {
-    case "harness":
+    case "session":
       return (
         <Badge variant="outline" className="text-xs">
-          harness
-        </Badge>
-      );
-    case "session_params":
-      return (
-        <Badge variant="outline" className="text-xs">
-          session_params
+          session
         </Badge>
       );
     case "app":

--- a/apps/ui/src/app/(main)/evals/[evalId]/runs/[runId]/page.tsx
+++ b/apps/ui/src/app/(main)/evals/[evalId]/runs/[runId]/page.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ArrowLeft, Square, ExternalLink } from "lucide-react";
-import type { EvalCaseResult, EvalRunStatus } from "@/lib/api/types";
+import type { EvalCaseResult, EvalRunStatus, EvalTarget } from "@/lib/api/types";
 
 function passRateColor(rate: number): string {
   if (rate >= 0.9) return "text-green-600";
@@ -54,6 +54,21 @@ function formatDuration(ms: number): string {
   return `${(ms / 1000).toFixed(1)}s`;
 }
 
+function TargetBadge({ target }: { target?: EvalTarget }) {
+  if (!target) return null;
+  const label =
+    target.type === "app"
+      ? `app: ${target.app_id}`
+      : target.type === "session_params"
+        ? "session_params"
+        : "harness";
+  return (
+    <Badge variant="outline" className="text-xs">
+      {label}
+    </Badge>
+  );
+}
+
 function ResultRow({ result }: { result: EvalCaseResult }) {
   return (
     <tr className="border-b last:border-b-0">
@@ -69,6 +84,9 @@ function ResultRow({ result }: { result: EvalCaseResult }) {
       </td>
       <td className="py-3 px-4">
         <Badge variant={resultStatusVariant(result.status)}>{result.status}</Badge>
+      </td>
+      <td className="py-3 px-4 text-sm text-muted-foreground">
+        <TargetBadge target={result.target_snapshot} />
       </td>
       <td className="py-3 px-4 text-sm text-muted-foreground">{result.turns ?? "-"}</td>
       <td className="py-3 px-4 text-sm text-muted-foreground">
@@ -159,6 +177,7 @@ export default function EvalRunDetailPage({
           <h1 className="text-2xl font-bold flex items-center gap-2">
             Run
             <Badge variant={runStatusVariant(run.status)}>{run.status}</Badge>
+            {run.target && <TargetBadge target={run.target} />}
           </h1>
           <div className="flex items-center gap-4 mt-2 text-sm text-muted-foreground">
             <span>
@@ -241,6 +260,7 @@ export default function EvalRunDetailPage({
                   <tr className="border-b text-left">
                     <th className="py-2 px-4 text-sm font-medium text-muted-foreground">Case</th>
                     <th className="py-2 px-4 text-sm font-medium text-muted-foreground">Status</th>
+                    <th className="py-2 px-4 text-sm font-medium text-muted-foreground">Target</th>
                     <th className="py-2 px-4 text-sm font-medium text-muted-foreground">Turns</th>
                     <th className="py-2 px-4 text-sm font-medium text-muted-foreground">Latency</th>
                     <th className="py-2 px-4 text-sm font-medium text-muted-foreground">Input</th>

--- a/apps/ui/src/app/(main)/evals/[evalId]/runs/[runId]/page.tsx
+++ b/apps/ui/src/app/(main)/evals/[evalId]/runs/[runId]/page.tsx
@@ -56,12 +56,7 @@ function formatDuration(ms: number): string {
 
 function TargetBadge({ target }: { target?: EvalTarget }) {
   if (!target) return null;
-  const label =
-    target.type === "app"
-      ? `app: ${target.app_id}`
-      : target.type === "session_params"
-        ? "session_params"
-        : "harness";
+  const label = target.type === "app" ? `app: ${target.app_id}` : "session";
   return (
     <Badge variant="outline" className="text-xs">
       {label}

--- a/apps/ui/src/app/(main)/evals/new/page.tsx
+++ b/apps/ui/src/app/(main)/evals/new/page.tsx
@@ -173,11 +173,7 @@ export default function NewEvalPage() {
 
                   <div className="space-y-2">
                     <Label>Model (optional)</Label>
-                    <ModelPicker
-                      value={modelId}
-                      onChange={setModelId}
-                      placeholder="Use default"
-                    />
+                    <ModelPicker value={modelId} onChange={setModelId} placeholder="Use default" />
                   </div>
 
                   <div className="space-y-2">

--- a/apps/ui/src/app/(main)/evals/new/page.tsx
+++ b/apps/ui/src/app/(main)/evals/new/page.tsx
@@ -16,7 +16,7 @@ import { AgentSelect } from "@/components/agent/agent-select";
 import { HarnessSelect } from "@/components/harness/harness-select";
 import type { EvalTarget, CreateEvalRequest } from "@/lib/api/types";
 
-type TargetType = "harness" | "session_params" | "app";
+type TargetType = "session" | "app";
 
 export default function NewEvalPage() {
   const router = useRouter();
@@ -26,7 +26,7 @@ export default function NewEvalPage() {
     description: "",
     model_override: "",
   });
-  const [targetType, setTargetType] = useState<TargetType>("harness");
+  const [targetType, setTargetType] = useState<TargetType>("session");
   const [harnessId, setHarnessId] = useState("");
   const [agentId, setAgentId] = useState("");
   const [appId, setAppId] = useState("");
@@ -56,18 +56,10 @@ export default function NewEvalPage() {
 
   const buildTarget = (): EvalTarget | undefined => {
     switch (targetType) {
-      case "harness":
-        if (!harnessId) return undefined;
+      case "session":
         return {
-          type: "harness",
-          harness_id: harnessId,
-          agent_id: agentId || undefined,
-        };
-      case "session_params":
-        if (!harnessId) return undefined;
-        return {
-          type: "session_params",
-          harness_id: harnessId,
+          type: "session",
+          harness_id: harnessId || undefined,
           agent_id: agentId || undefined,
           model_id: modelId || undefined,
           system_prompt: systemPrompt || undefined,
@@ -99,9 +91,7 @@ export default function NewEvalPage() {
     }
   };
 
-  const canSubmit =
-    formData.name &&
-    (targetType === "app" ? !!appId : targetType === "harness" || targetType === "session_params");
+  const canSubmit = formData.name && (targetType === "app" ? !!appId : true);
 
   return (
     <div className="container mx-auto p-6">
@@ -145,7 +135,7 @@ export default function NewEvalPage() {
             <div className="space-y-4">
               <Label>Target Type</Label>
               <div className="flex gap-2">
-                {(["harness", "session_params", "app"] as TargetType[]).map((t) => (
+                {(["session", "app"] as TargetType[]).map((t) => (
                   <Button
                     key={t}
                     type="button"
@@ -153,24 +143,20 @@ export default function NewEvalPage() {
                     size="sm"
                     onClick={() => setTargetType(t)}
                   >
-                    {t === "harness"
-                      ? "Harness"
-                      : t === "session_params"
-                        ? "Session Params"
-                        : "App"}
+                    {t === "session" ? "Session" : "App"}
                   </Button>
                 ))}
               </div>
 
-              {/* Harness / Session Params fields */}
-              {(targetType === "harness" || targetType === "session_params") && (
+              {/* Session fields (mirrors session creation params) */}
+              {targetType === "session" && (
                 <div className="space-y-4 border rounded-lg p-4">
                   <div className="space-y-2">
-                    <Label>Harness</Label>
+                    <Label>Harness (optional)</Label>
                     <HarnessSelect
                       value={harnessId}
                       onValueChange={setHarnessId}
-                      placeholder="Select a harness"
+                      placeholder="Use org default"
                       className="w-full"
                     />
                   </div>
@@ -185,28 +171,24 @@ export default function NewEvalPage() {
                     />
                   </div>
 
-                  {targetType === "session_params" && (
-                    <>
-                      <div className="space-y-2">
-                        <Label>Model (optional)</Label>
-                        <ModelPicker
-                          value={modelId}
-                          onChange={setModelId}
-                          placeholder="Use default"
-                        />
-                      </div>
+                  <div className="space-y-2">
+                    <Label>Model (optional)</Label>
+                    <ModelPicker
+                      value={modelId}
+                      onChange={setModelId}
+                      placeholder="Use default"
+                    />
+                  </div>
 
-                      <div className="space-y-2">
-                        <Label>System Prompt (optional)</Label>
-                        <Textarea
-                          placeholder="Override system prompt..."
-                          value={systemPrompt}
-                          onChange={(e) => setSystemPrompt(e.target.value)}
-                          rows={3}
-                        />
-                      </div>
-                    </>
-                  )}
+                  <div className="space-y-2">
+                    <Label>System Prompt (optional)</Label>
+                    <Textarea
+                      placeholder="Override system prompt..."
+                      value={systemPrompt}
+                      onChange={(e) => setSystemPrompt(e.target.value)}
+                      rows={3}
+                    />
+                  </div>
                 </div>
               )}
 

--- a/apps/ui/src/app/(main)/evals/new/page.tsx
+++ b/apps/ui/src/app/(main)/evals/new/page.tsx
@@ -14,6 +14,9 @@ import { ArrowLeft, X } from "lucide-react";
 import { ModelPicker } from "@/components/models/model-picker";
 import { AgentSelect } from "@/components/agent/agent-select";
 import { HarnessSelect } from "@/components/harness/harness-select";
+import type { EvalTarget, CreateEvalRequest } from "@/lib/api/types";
+
+type TargetType = "harness" | "session_params" | "app";
 
 export default function NewEvalPage() {
   const router = useRouter();
@@ -21,10 +24,14 @@ export default function NewEvalPage() {
   const [formData, setFormData] = useState({
     name: "",
     description: "",
-    agent_id: "",
-    harness_id: "",
     model_override: "",
   });
+  const [targetType, setTargetType] = useState<TargetType>("harness");
+  const [harnessId, setHarnessId] = useState("");
+  const [agentId, setAgentId] = useState("");
+  const [appId, setAppId] = useState("");
+  const [systemPrompt, setSystemPrompt] = useState("");
+  const [modelId, setModelId] = useState("");
   const [tags, setTags] = useState<string[]>([]);
   const [tagInput, setTagInput] = useState("");
 
@@ -47,24 +54,54 @@ export default function NewEvalPage() {
     }
   };
 
+  const buildTarget = (): EvalTarget | undefined => {
+    switch (targetType) {
+      case "harness":
+        if (!harnessId) return undefined;
+        return {
+          type: "harness",
+          harness_id: harnessId,
+          agent_id: agentId || undefined,
+        };
+      case "session_params":
+        if (!harnessId) return undefined;
+        return {
+          type: "session_params",
+          harness_id: harnessId,
+          agent_id: agentId || undefined,
+          model_id: modelId || undefined,
+          system_prompt: systemPrompt || undefined,
+        };
+      case "app":
+        if (!appId) return undefined;
+        return { type: "app", app_id: appId };
+    }
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    try {
-      const ev = await createEval.mutateAsync({
-        name: formData.name,
-        description: formData.description || undefined,
-        agent_id: formData.agent_id,
-        harness_id: formData.harness_id,
-        model_override: formData.model_override || undefined,
-        tags: tags.length > 0 ? tags : undefined,
-      });
+    const target = buildTarget();
 
+    const req: CreateEvalRequest = {
+      name: formData.name,
+      description: formData.description || undefined,
+      target,
+      model_override: formData.model_override || undefined,
+      tags: tags.length > 0 ? tags : undefined,
+    };
+
+    try {
+      const ev = await createEval.mutateAsync(req);
       router.push(`/evals/${ev.id}`);
     } catch (error) {
       console.error("Failed to create eval:", error);
     }
   };
+
+  const canSubmit =
+    formData.name &&
+    (targetType === "app" ? !!appId : targetType === "harness" || targetType === "session_params");
 
   return (
     <div className="container mx-auto p-6">
@@ -104,24 +141,89 @@ export default function NewEvalPage() {
               />
             </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="agent">Agent</Label>
-              <AgentSelect
-                value={formData.agent_id}
-                onValueChange={(value) => setFormData({ ...formData, agent_id: value })}
-                placeholder="Select an agent"
-                className="w-full"
-              />
-            </div>
+            {/* Target type selector */}
+            <div className="space-y-4">
+              <Label>Target Type</Label>
+              <div className="flex gap-2">
+                {(["harness", "session_params", "app"] as TargetType[]).map((t) => (
+                  <Button
+                    key={t}
+                    type="button"
+                    variant={targetType === t ? "default" : "outline"}
+                    size="sm"
+                    onClick={() => setTargetType(t)}
+                  >
+                    {t === "harness"
+                      ? "Harness"
+                      : t === "session_params"
+                        ? "Session Params"
+                        : "App"}
+                  </Button>
+                ))}
+              </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="harness">Harness</Label>
-              <HarnessSelect
-                value={formData.harness_id}
-                onValueChange={(value) => setFormData({ ...formData, harness_id: value })}
-                placeholder="Select a harness"
-                className="w-full"
-              />
+              {/* Harness / Session Params fields */}
+              {(targetType === "harness" || targetType === "session_params") && (
+                <div className="space-y-4 border rounded-lg p-4">
+                  <div className="space-y-2">
+                    <Label>Harness</Label>
+                    <HarnessSelect
+                      value={harnessId}
+                      onValueChange={setHarnessId}
+                      placeholder="Select a harness"
+                      className="w-full"
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label>Agent (optional)</Label>
+                    <AgentSelect
+                      value={agentId}
+                      onValueChange={setAgentId}
+                      placeholder="Select an agent"
+                      className="w-full"
+                    />
+                  </div>
+
+                  {targetType === "session_params" && (
+                    <>
+                      <div className="space-y-2">
+                        <Label>Model (optional)</Label>
+                        <ModelPicker
+                          value={modelId}
+                          onChange={setModelId}
+                          placeholder="Use default"
+                        />
+                      </div>
+
+                      <div className="space-y-2">
+                        <Label>System Prompt (optional)</Label>
+                        <Textarea
+                          placeholder="Override system prompt..."
+                          value={systemPrompt}
+                          onChange={(e) => setSystemPrompt(e.target.value)}
+                          rows={3}
+                        />
+                      </div>
+                    </>
+                  )}
+                </div>
+              )}
+
+              {/* App fields */}
+              {targetType === "app" && (
+                <div className="space-y-4 border rounded-lg p-4">
+                  <div className="space-y-2">
+                    <Label>App ID</Label>
+                    <Input
+                      placeholder="app_01933b5a..."
+                      value={appId}
+                      onChange={(e) => setAppId(e.target.value)}
+                      required
+                    />
+                  </div>
+                </div>
+              )}
             </div>
 
             <div className="space-y-2">
@@ -164,10 +266,7 @@ export default function NewEvalPage() {
             </div>
 
             <div className="flex gap-4">
-              <Button
-                type="submit"
-                disabled={createEval.isPending || !formData.agent_id || !formData.harness_id}
-              >
+              <Button type="submit" disabled={createEval.isPending || !canSubmit}>
                 {createEval.isPending ? "Creating..." : "Create Eval"}
               </Button>
               <Button type="button" variant="outline" onClick={() => router.back()}>

--- a/apps/ui/src/app/(main)/evals/page.tsx
+++ b/apps/ui/src/app/(main)/evals/page.tsx
@@ -33,13 +33,7 @@ function targetLabel(target?: EvalTarget, agentMap?: Map<string, string>): strin
   }
 }
 
-function EvalCard({
-  eval: ev,
-  agentMap,
-}: {
-  eval: Eval;
-  agentMap: Map<string, string>;
-}) {
+function EvalCard({ eval: ev, agentMap }: { eval: Eval; agentMap: Map<string, string> }) {
   const label = targetLabel(ev.target, agentMap);
 
   return (

--- a/apps/ui/src/app/(main)/evals/page.tsx
+++ b/apps/ui/src/app/(main)/evals/page.tsx
@@ -10,7 +10,7 @@ import { Plus } from "lucide-react";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { ExperimentalPageBadge } from "@/components/ui/experimental-badge";
 import { useFeatureFlag } from "@/providers/feature-flags-provider";
-import type { Eval } from "@/lib/api/types";
+import type { Eval, EvalTarget } from "@/lib/api/types";
 import { getDisplayName } from "@/lib/entity-lifecycle";
 
 function passRateColor(rate: number): string {
@@ -19,7 +19,30 @@ function passRateColor(rate: number): string {
   return "text-red-600";
 }
 
-function EvalCard({ eval: ev, agentName }: { eval: Eval; agentName?: string }) {
+function targetLabel(target?: EvalTarget, agentMap?: Map<string, string>): string | undefined {
+  if (!target) return undefined;
+  switch (target.type) {
+    case "harness":
+    case "session_params": {
+      const agentName = target.agent_id ? agentMap?.get(target.agent_id) : undefined;
+      return agentName ?? target.agent_id ?? undefined;
+    }
+    case "app":
+      return `App: ${target.app_id}`;
+    default:
+      return undefined;
+  }
+}
+
+function EvalCard({
+  eval: ev,
+  agentMap,
+}: {
+  eval: Eval;
+  agentMap: Map<string, string>;
+}) {
+  const label = targetLabel(ev.target, agentMap);
+
   return (
     <Link href={`/evals/${ev.id}`}>
       <Card className="hover:border-primary/50 transition-colors cursor-pointer h-full">
@@ -34,7 +57,12 @@ function EvalCard({ eval: ev, agentName }: { eval: Eval; agentName?: string }) {
             <p className="text-sm text-muted-foreground line-clamp-2">{ev.description}</p>
           )}
           <div className="flex items-center gap-4 text-xs text-muted-foreground">
-            {agentName && <span>Agent: {agentName}</span>}
+            {label && <span>{label}</span>}
+            {ev.target?.type && (
+              <Badge variant="outline" className="text-xs">
+                {ev.target.type}
+              </Badge>
+            )}
             <span>{ev.case_count} cases</span>
           </div>
           {ev.last_run && (
@@ -119,7 +147,7 @@ export default function EvalsPage() {
         {(items) => (
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
             {items.map((ev) => (
-              <EvalCard key={ev.id} eval={ev} agentName={agentMap.get(ev.agent_id)} />
+              <EvalCard key={ev.id} eval={ev} agentMap={agentMap} />
             ))}
           </div>
         )}

--- a/apps/ui/src/app/(main)/evals/page.tsx
+++ b/apps/ui/src/app/(main)/evals/page.tsx
@@ -22,8 +22,7 @@ function passRateColor(rate: number): string {
 function targetLabel(target?: EvalTarget, agentMap?: Map<string, string>): string | undefined {
   if (!target) return undefined;
   switch (target.type) {
-    case "harness":
-    case "session_params": {
+    case "session": {
       const agentName = target.agent_id ? agentMap?.get(target.agent_id) : undefined;
       return agentName ?? target.agent_id ?? undefined;
     }

--- a/apps/ui/src/lib/api/types/eval-types.ts
+++ b/apps/ui/src/lib/api/types/eval-types.ts
@@ -1,11 +1,30 @@
 // Eval domain types matching Rust Eval, EvalCase, EvalRun, EvalCaseResult
+// EvalTarget defines how to instantiate sessions for eval cases.
+// Resolution: EvalRun.target → EvalCase.target → Eval.target → org default harness.
+
+export type EvalTarget =
+  | {
+      type: "session_params";
+      harness_id: string;
+      agent_id?: string;
+      model_id?: string;
+      system_prompt?: string;
+    }
+  | {
+      type: "app";
+      app_id: string;
+    }
+  | {
+      type: "harness";
+      harness_id: string;
+      agent_id?: string;
+    };
 
 export interface Eval {
   id: string;
   name: string;
   description?: string;
-  agent_id: string;
-  harness_id: string;
+  target?: EvalTarget;
   model_override?: string;
   tags: string[];
   status: "active" | "archived" | "deleted";
@@ -41,6 +60,7 @@ export interface EvalCase {
   id: string;
   name: string;
   description?: string;
+  target?: EvalTarget;
   tags: string[];
   conversation: EvalInputMessage[];
   scorers: Scorer[];
@@ -68,6 +88,7 @@ export type Scorer =
 
 export interface EvalRun {
   id: string;
+  target?: EvalTarget;
   model_override?: string;
   filter_tags?: string[];
   status: EvalRunStatus;
@@ -85,6 +106,8 @@ export interface EvalCaseResult {
   eval_case_id: string;
   case_name?: string;
   session_id?: string;
+  target?: EvalTarget;
+  target_snapshot?: EvalTarget;
   status: "pending" | "running" | "passed" | "failed" | "errored" | "timeout";
   scores?: Record<string, { pass: boolean; value: number; reason: string }>;
   turns?: number;
@@ -100,8 +123,7 @@ export interface EvalCaseResult {
 export interface CreateEvalRequest {
   name: string;
   description?: string;
-  agent_id: string;
-  harness_id: string;
+  target?: EvalTarget;
   model_override?: string;
   tags?: string[];
 }
@@ -109,8 +131,7 @@ export interface CreateEvalRequest {
 export interface UpdateEvalRequest {
   name?: string;
   description?: string;
-  agent_id?: string;
-  harness_id?: string;
+  target?: EvalTarget;
   model_override?: string;
   tags?: string[];
 }
@@ -118,6 +139,7 @@ export interface UpdateEvalRequest {
 export interface CreateEvalCaseRequest {
   name: string;
   description?: string;
+  target?: EvalTarget;
   tags?: string[];
   conversation: EvalInputMessage[];
   scorers: Scorer[];
@@ -127,5 +149,6 @@ export interface CreateEvalCaseRequest {
 }
 
 export interface CreateEvalRunRequest {
+  target?: EvalTarget;
   model_override?: string;
 }

--- a/apps/ui/src/lib/api/types/eval-types.ts
+++ b/apps/ui/src/lib/api/types/eval-types.ts
@@ -4,20 +4,17 @@
 
 export type EvalTarget =
   | {
-      type: "session_params";
-      harness_id: string;
+      type: "session";
+      harness_id?: string;
+      harness_name?: string;
       agent_id?: string;
       model_id?: string;
       system_prompt?: string;
+      max_iterations?: number;
     }
   | {
       type: "app";
       app_id: string;
-    }
-  | {
-      type: "harness";
-      harness_id: string;
-      agent_id?: string;
     };
 
 export interface Eval {

--- a/crates/core/src/eval.rs
+++ b/crates/core/src/eval.rs
@@ -6,7 +6,7 @@
 //
 // Design Decision: EvalTarget is the session setup contract.
 // Resolution order: EvalRun.target → EvalCase.target → Eval.target → org default harness.
-// EvalTarget can be: full session params, an app reference, or a harness+agent reference.
+// EvalTarget::Session mirrors CreateSessionRequest params; EvalTarget::App references a deployed app.
 // EvalCaseResult stores both a live reference and a frozen snapshot for reproducibility.
 //
 // See specs/evals.md for full specification.
@@ -28,39 +28,42 @@ use utoipa::ToSchema;
 
 /// Defines how to instantiate a session for an eval case.
 ///
+/// Two modes:
+/// - `Session`: mirrors `CreateSessionRequest` — full control over session creation parameters.
+/// - `App`: references a deployed app by ID.
+///
 /// Resolution order: EvalRun.target → EvalCase.target → Eval.target → org default harness.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum EvalTarget {
-    /// Full session input parameters for maximum control.
-    SessionParams {
-        /// Harness to use for the session.
-        #[cfg_attr(feature = "openapi", schema(value_type = String))]
-        harness_id: HarnessId,
-        /// Optional agent.
+    /// Session creation parameters (mirrors CreateSessionRequest).
+    Session {
+        /// Harness for the session. If omitted, org default harness is used.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "openapi", schema(value_type = Option<String>))]
+        harness_id: Option<HarnessId>,
+        /// Addressable harness name (alternative to harness_id).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        harness_name: Option<String>,
+        /// Agent to work in this session.
         #[serde(skip_serializing_if = "Option::is_none")]
         #[cfg_attr(feature = "openapi", schema(value_type = Option<String>))]
         agent_id: Option<AgentId>,
-        /// Model override.
+        /// LLM model override.
         #[serde(skip_serializing_if = "Option::is_none")]
         model_id: Option<String>,
-        /// System prompt override.
+        /// System prompt override (prepended to agent prompt).
         #[serde(skip_serializing_if = "Option::is_none")]
         system_prompt: Option<String>,
+        /// Max LLM iterations per turn.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        max_iterations: Option<usize>,
     },
     /// Reference to a deployed app.
     App {
         #[cfg_attr(feature = "openapi", schema(value_type = String))]
         app_id: AppId,
-    },
-    /// Simple harness + optional agent reference (no extra session params).
-    Harness {
-        #[cfg_attr(feature = "openapi", schema(value_type = String))]
-        harness_id: HarnessId,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        #[cfg_attr(feature = "openapi", schema(value_type = Option<String>))]
-        agent_id: Option<AgentId>,
     },
 }
 
@@ -627,18 +630,42 @@ mod tests {
     }
 
     #[test]
-    fn test_eval_target_serde_roundtrip() {
-        let target = EvalTarget::SessionParams {
-            harness_id: HarnessId::from_uuid(Uuid::nil()),
+    fn test_eval_target_session_serde_roundtrip() {
+        let target = EvalTarget::Session {
+            harness_id: Some(HarnessId::from_uuid(Uuid::nil())),
+            harness_name: None,
             agent_id: Some(AgentId::from_uuid(Uuid::nil())),
             model_id: Some("gpt-4".to_string()),
             system_prompt: None,
+            max_iterations: None,
         };
         let json = serde_json::to_value(&target).unwrap();
-        assert_eq!(json["type"], "session_params");
+        assert_eq!(json["type"], "session");
         assert!(json.get("harness_id").is_some());
         assert!(json.get("model_id").is_some());
         assert!(json.get("system_prompt").is_none()); // skip_serializing_if
+        assert!(json.get("harness_name").is_none());
+        assert!(json.get("max_iterations").is_none());
+
+        let parsed: EvalTarget = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed, target);
+    }
+
+    #[test]
+    fn test_eval_target_session_minimal() {
+        // Session with just harness_name, no other params
+        let target = EvalTarget::Session {
+            harness_id: None,
+            harness_name: Some("generic".to_string()),
+            agent_id: None,
+            model_id: None,
+            system_prompt: None,
+            max_iterations: None,
+        };
+        let json = serde_json::to_value(&target).unwrap();
+        assert_eq!(json["type"], "session");
+        assert_eq!(json["harness_name"], "generic");
+        assert!(json.get("harness_id").is_none());
 
         let parsed: EvalTarget = serde_json::from_value(json).unwrap();
         assert_eq!(parsed, target);
@@ -658,21 +685,6 @@ mod tests {
     }
 
     #[test]
-    fn test_eval_target_harness_variant() {
-        let target = EvalTarget::Harness {
-            harness_id: HarnessId::from_uuid(Uuid::nil()),
-            agent_id: None,
-        };
-        let json = serde_json::to_value(&target).unwrap();
-        assert_eq!(json["type"], "harness");
-        assert!(json.get("harness_id").is_some());
-        assert!(json.get("agent_id").is_none());
-
-        let parsed: EvalTarget = serde_json::from_value(json).unwrap();
-        assert_eq!(parsed, target);
-    }
-
-    #[test]
     fn test_eval_serde_skips_internal_fields() {
         let eval = Eval {
             public_id: EvalId::from_uuid(Uuid::nil()),
@@ -680,9 +692,13 @@ mod tests {
             org_id: 1,
             name: "test".into(),
             description: None,
-            target: Some(EvalTarget::Harness {
-                harness_id: HarnessId::from_uuid(Uuid::nil()),
+            target: Some(EvalTarget::Session {
+                harness_id: Some(HarnessId::from_uuid(Uuid::nil())),
+                harness_name: None,
                 agent_id: Some(AgentId::from_uuid(Uuid::nil())),
+                model_id: None,
+                system_prompt: None,
+                max_iterations: None,
             }),
             model_override: None,
             tags: vec![],

--- a/crates/core/src/eval.rs
+++ b/crates/core/src/eval.rs
@@ -3,16 +3,66 @@
 // Design Decision: Evals are user-facing behavioral tests for agents.
 // Each eval case creates a real session — same behavior as production, debuggable.
 // Scorers return 0.0–1.0 (not binary) to support nuanced grading.
+//
+// Design Decision: EvalTarget is the session setup contract.
+// Resolution order: EvalRun.target → EvalCase.target → Eval.target → org default harness.
+// EvalTarget can be: full session params, an app reference, or a harness+agent reference.
+// EvalCaseResult stores both a live reference and a frozen snapshot for reproducibility.
+//
 // See specs/evals.md for full specification.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::typed_id::{AgentId, EvalCaseId, EvalId, EvalResultId, EvalRunId, HarnessId, SessionId};
+use crate::typed_id::{
+    AgentId, AppId, EvalCaseId, EvalId, EvalResultId, EvalRunId, HarnessId, SessionId,
+};
 
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
+
+// ============================================
+// Eval Target
+// ============================================
+
+/// Defines how to instantiate a session for an eval case.
+///
+/// Resolution order: EvalRun.target → EvalCase.target → Eval.target → org default harness.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum EvalTarget {
+    /// Full session input parameters for maximum control.
+    SessionParams {
+        /// Harness to use for the session.
+        #[cfg_attr(feature = "openapi", schema(value_type = String))]
+        harness_id: HarnessId,
+        /// Optional agent.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "openapi", schema(value_type = Option<String>))]
+        agent_id: Option<AgentId>,
+        /// Model override.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        model_id: Option<String>,
+        /// System prompt override.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        system_prompt: Option<String>,
+    },
+    /// Reference to a deployed app.
+    App {
+        #[cfg_attr(feature = "openapi", schema(value_type = String))]
+        app_id: AppId,
+    },
+    /// Simple harness + optional agent reference (no extra session params).
+    Harness {
+        #[cfg_attr(feature = "openapi", schema(value_type = String))]
+        harness_id: HarnessId,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "openapi", schema(value_type = Option<String>))]
+        agent_id: Option<AgentId>,
+    },
+}
 
 // ============================================
 // Eval Status
@@ -281,12 +331,9 @@ pub struct Eval {
     /// Optional description.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    /// Agent under test.
-    #[cfg_attr(feature = "openapi", schema(value_type = String))]
-    pub agent_id: AgentId,
-    /// Harness for test sessions.
-    #[cfg_attr(feature = "openapi", schema(value_type = String))]
-    pub harness_id: HarnessId,
+    /// Session setup target. Defines how to create sessions for eval cases.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<EvalTarget>,
     /// Optional default model override for runs.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model_override: Option<String>,
@@ -335,6 +382,9 @@ pub struct EvalCase {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Optional per-case target override.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<EvalTarget>,
     #[serde(default)]
     pub tags: Vec<String>,
     /// Input messages sent sequentially.
@@ -364,6 +414,9 @@ pub struct EvalRun {
     pub internal_id: Uuid,
     #[serde(skip, default)]
     pub org_id: i64,
+    /// Optional per-run target override.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<EvalTarget>,
     /// Model override for this run.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model_override: Option<String>,
@@ -406,6 +459,12 @@ pub struct EvalCaseResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "openapi", schema(value_type = Option<String>))]
     pub session_id: Option<SessionId>,
+    /// Resolved target used for this result (live reference).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<EvalTarget>,
+    /// Frozen snapshot of the resolved target at execution time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_snapshot: Option<EvalTarget>,
     pub status: CaseResultStatus,
     /// Per-scorer results.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -568,6 +627,52 @@ mod tests {
     }
 
     #[test]
+    fn test_eval_target_serde_roundtrip() {
+        let target = EvalTarget::SessionParams {
+            harness_id: HarnessId::from_uuid(Uuid::nil()),
+            agent_id: Some(AgentId::from_uuid(Uuid::nil())),
+            model_id: Some("gpt-4".to_string()),
+            system_prompt: None,
+        };
+        let json = serde_json::to_value(&target).unwrap();
+        assert_eq!(json["type"], "session_params");
+        assert!(json.get("harness_id").is_some());
+        assert!(json.get("model_id").is_some());
+        assert!(json.get("system_prompt").is_none()); // skip_serializing_if
+
+        let parsed: EvalTarget = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed, target);
+    }
+
+    #[test]
+    fn test_eval_target_app_variant() {
+        let target = EvalTarget::App {
+            app_id: AppId::from_uuid(Uuid::nil()),
+        };
+        let json = serde_json::to_value(&target).unwrap();
+        assert_eq!(json["type"], "app");
+        assert!(json.get("app_id").is_some());
+
+        let parsed: EvalTarget = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed, target);
+    }
+
+    #[test]
+    fn test_eval_target_harness_variant() {
+        let target = EvalTarget::Harness {
+            harness_id: HarnessId::from_uuid(Uuid::nil()),
+            agent_id: None,
+        };
+        let json = serde_json::to_value(&target).unwrap();
+        assert_eq!(json["type"], "harness");
+        assert!(json.get("harness_id").is_some());
+        assert!(json.get("agent_id").is_none());
+
+        let parsed: EvalTarget = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed, target);
+    }
+
+    #[test]
     fn test_eval_serde_skips_internal_fields() {
         let eval = Eval {
             public_id: EvalId::from_uuid(Uuid::nil()),
@@ -575,8 +680,10 @@ mod tests {
             org_id: 1,
             name: "test".into(),
             description: None,
-            agent_id: AgentId::from_uuid(Uuid::nil()),
-            harness_id: HarnessId::from_uuid(Uuid::nil()),
+            target: Some(EvalTarget::Harness {
+                harness_id: HarnessId::from_uuid(Uuid::nil()),
+                agent_id: Some(AgentId::from_uuid(Uuid::nil())),
+            }),
             model_override: None,
             tags: vec![],
             status: EvalStatus::Active,
@@ -591,6 +698,7 @@ mod tests {
         assert!(json.get("id").is_some());
         assert!(json.get("internal_id").is_none());
         assert!(json.get("org_id").is_none());
+        assert!(json.get("target").is_some());
         assert!(json.get("description").is_none());
         assert!(json.get("model_override").is_none());
     }

--- a/crates/server/migrations/011_evals_target.sql
+++ b/crates/server/migrations/011_evals_target.sql
@@ -11,7 +11,7 @@
 ALTER TABLE evals ADD COLUMN target JSONB;
 
 UPDATE evals SET target = jsonb_build_object(
-    'type', 'harness',
+    'type', 'session',
     'harness_id', (SELECT public_id FROM harnesses WHERE harnesses.id = evals.harness_id),
     'agent_id', (SELECT public_id FROM agents WHERE agents.id = evals.agent_id)
 ) WHERE agent_id IS NOT NULL AND harness_id IS NOT NULL;

--- a/crates/server/migrations/011_v0.8.10.sql
+++ b/crates/server/migrations/011_v0.8.10.sql
@@ -1,0 +1,42 @@
+-- v0.8.10: Eval target refactor
+-- Replace harness_id + agent_id on evals with JSONB target column.
+-- Add target to eval_cases, eval_runs, eval_case_results.
+-- Resolution: run.target → case.target → eval.target → org default harness.
+
+-- ============================================
+-- evals: replace agent_id/harness_id with target JSONB
+-- ============================================
+
+-- Migrate existing data into target column
+ALTER TABLE evals ADD COLUMN target JSONB;
+
+UPDATE evals SET target = jsonb_build_object(
+    'type', 'harness',
+    'harness_id', (SELECT public_id FROM harnesses WHERE harnesses.id = evals.harness_id),
+    'agent_id', (SELECT public_id FROM agents WHERE agents.id = evals.agent_id)
+) WHERE agent_id IS NOT NULL AND harness_id IS NOT NULL;
+
+-- Drop old FK constraints and columns
+ALTER TABLE evals DROP CONSTRAINT IF EXISTS evals_agent_id_fk;
+ALTER TABLE evals DROP CONSTRAINT IF EXISTS evals_harness_id_fk;
+ALTER TABLE evals DROP COLUMN agent_id;
+ALTER TABLE evals DROP COLUMN harness_id;
+
+-- ============================================
+-- eval_cases: add target JSONB
+-- ============================================
+
+ALTER TABLE eval_cases ADD COLUMN target JSONB;
+
+-- ============================================
+-- eval_runs: add target JSONB
+-- ============================================
+
+ALTER TABLE eval_runs ADD COLUMN target JSONB;
+
+-- ============================================
+-- eval_case_results: add target + target_snapshot JSONB
+-- ============================================
+
+ALTER TABLE eval_case_results ADD COLUMN target JSONB;
+ALTER TABLE eval_case_results ADD COLUMN target_snapshot JSONB;

--- a/crates/server/src/api/evals.rs
+++ b/crates/server/src/api/evals.rs
@@ -8,7 +8,7 @@ use axum::{Json, Router};
 use serde::Deserialize;
 
 use everruns_core::eval::*;
-use everruns_core::typed_id::{AgentId, EvalCaseId, EvalId, EvalRunId, HarnessId};
+use everruns_core::typed_id::{EvalCaseId, EvalId, EvalRunId};
 
 use crate::api::common::{
     ApiOptionExt, ApiPolicyResultExt, ApiResult, ErrorResponse, ListResponse,
@@ -52,10 +52,9 @@ pub struct CreateEvalRequest {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[schema(value_type = String)]
-    pub agent_id: AgentId,
-    #[schema(value_type = String)]
-    pub harness_id: HarnessId,
+    /// Session setup target (harness+agent, app, or full session params).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<EvalTarget>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model_override: Option<String>,
     #[serde(default)]
@@ -69,12 +68,9 @@ pub struct UpdateEvalRequest {
     pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Session setup target (harness+agent, app, or full session params).
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = Option<String>)]
-    pub agent_id: Option<AgentId>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = Option<String>)]
-    pub harness_id: Option<HarnessId>,
+    pub target: Option<EvalTarget>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model_override: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -87,6 +83,9 @@ pub struct CreateEvalCaseRequest {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Optional per-case target override.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<EvalTarget>,
     #[serde(default)]
     pub tags: Option<Vec<String>>,
     pub conversation: Vec<EvalInputMessage>,
@@ -106,6 +105,9 @@ pub struct UpdateEvalCaseRequest {
     pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Optional per-case target override.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<EvalTarget>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -123,6 +125,9 @@ pub struct UpdateEvalCaseRequest {
 /// Request to create an eval run
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct CreateEvalRunRequest {
+    /// Optional per-run target override.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<EvalTarget>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model_override: Option<String>,
 }

--- a/crates/server/src/services/eval.rs
+++ b/crates/server/src/services/eval.rs
@@ -1,6 +1,7 @@
 // Eval service for business logic
 // Decision: Evals reuse the same permission policies as agents (OrgAgentsManage)
 // Decision: Each eval case creates a real session — no mock execution
+// Decision: EvalTarget replaces harness_id + agent_id. Resolution: run → case → eval → org default.
 
 use crate::api::evals::{
     CreateEvalCaseRequest, CreateEvalRequest, CreateEvalRunRequest, UpdateEvalCaseRequest,
@@ -15,7 +16,7 @@ use crate::storage::models::{
 use anyhow::Result;
 use everruns_core::eval::*;
 use everruns_core::typed_id::{EvalCaseId, EvalId, EvalResultId, EvalRunId, SessionId};
-use everruns_core::{AgentId, Caller, HarnessId, Permission, Policy, Rule};
+use everruns_core::{Caller, Permission, Policy, Rule};
 use everruns_macros::policy;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -47,35 +48,20 @@ impl EvalService {
 
     #[policy(EVAL_MANAGE)]
     pub async fn create(&self, caller: &Caller, req: CreateEvalRequest) -> Result<Eval> {
-        // Validate agent exists
-        let agent_row = self
-            .db
-            .get_agent_by_public_id(caller.org_id, &req.agent_id.to_string())
-            .await?
-            .ok_or_else(|| ResourceNotFoundError::new("Agent"))?;
-        if agent_row.status != "active" {
-            anyhow::bail!("Archived or deleted agents cannot be assigned to evals");
-        }
-
-        // Validate harness exists
-        let harness_row = self
-            .db
-            .get_harness(caller.org_id, req.harness_id)
-            .await?
-            .ok_or_else(|| ResourceNotFoundError::new("Harness"))?;
-        if harness_row.status != "active" {
-            anyhow::bail!("Archived or deleted harnesses cannot be assigned to evals");
-        }
-
         let internal_uuid = Uuid::now_v7();
         let public_id = EvalId::from_uuid(internal_uuid);
+
+        let target_json = req
+            .target
+            .as_ref()
+            .map(serde_json::to_value)
+            .transpose()?;
 
         let input = CreateEvalRow {
             public_id: public_id.to_string(),
             name: req.name,
             description: req.description,
-            agent_id: agent_row.id.uuid(),
-            harness_id: harness_row.id.uuid(),
+            target: target_json,
             model_override: req.model_override,
             tags: req.tags.unwrap_or_default(),
         };
@@ -127,39 +113,16 @@ impl EvalService {
             .await?
             .ok_or_else(|| ResourceNotFoundError::new("Eval"))?;
 
-        let agent_id = if let Some(ref agent_id) = req.agent_id {
-            let agent_row = self
-                .db
-                .get_agent_by_public_id(caller.org_id, &agent_id.to_string())
-                .await?
-                .ok_or_else(|| ResourceNotFoundError::new("Agent"))?;
-            if agent_row.status != "active" {
-                anyhow::bail!("Archived or deleted agents cannot be assigned to evals");
-            }
-            Some(agent_row.id.uuid())
-        } else {
-            None
-        };
-
-        let harness_id = if let Some(ref harness_id) = req.harness_id {
-            let harness_row = self
-                .db
-                .get_harness(caller.org_id, *harness_id)
-                .await?
-                .ok_or_else(|| ResourceNotFoundError::new("Harness"))?;
-            if harness_row.status != "active" {
-                anyhow::bail!("Archived or deleted harnesses cannot be assigned to evals");
-            }
-            Some(harness_row.id.uuid())
-        } else {
-            None
-        };
+        let target_json = req
+            .target
+            .as_ref()
+            .map(serde_json::to_value)
+            .transpose()?;
 
         let input = UpdateEvalRow {
             name: req.name,
             description: req.description,
-            agent_id,
-            harness_id,
+            target: target_json,
             model_override: req.model_override,
             tags: req.tags,
             status: None,
@@ -209,10 +172,17 @@ impl EvalService {
 
         let case_count = self.db.count_eval_cases(eval.id).await?;
 
+        let target_json = req
+            .target
+            .as_ref()
+            .map(serde_json::to_value)
+            .transpose()?;
+
         let input = CreateEvalCaseRow {
             public_id: case_public_id.to_string(),
             name: req.name,
             description: req.description,
+            target: target_json,
             tags: req.tags.unwrap_or_default(),
             conversation: serde_json::to_value(&req.conversation)?,
             scorers: serde_json::to_value(&req.scorers)?,
@@ -277,9 +247,16 @@ impl EvalService {
             .await?
             .ok_or_else(|| ResourceNotFoundError::new("EvalCase"))?;
 
+        let target_json = req
+            .target
+            .as_ref()
+            .map(serde_json::to_value)
+            .transpose()?;
+
         let input = UpdateEvalCaseRow {
             name: req.name,
             description: req.description,
+            target: target_json,
             tags: req.tags,
             conversation: req.conversation.map(serde_json::to_value).transpose()?,
             scorers: req.scorers.map(serde_json::to_value).transpose()?,
@@ -335,9 +312,16 @@ impl EvalService {
         let run_uuid = Uuid::now_v7();
         let run_public_id = EvalRunId::from_uuid(run_uuid);
 
+        let target_json = req
+            .target
+            .as_ref()
+            .map(serde_json::to_value)
+            .transpose()?;
+
         let input = CreateEvalRunRow {
             public_id: run_public_id.to_string(),
             eval_id: eval.id,
+            target: target_json,
             model_override: req.model_override,
             filter_tags: None, // Phase 2: tag-based partial runs
             triggered_by: "user".to_string(),
@@ -345,15 +329,38 @@ impl EvalService {
 
         let run_row = self.db.create_eval_run(caller.org_id, input).await?;
 
-        // Create pending case results for each case
+        // Load eval-level target for resolution
+        let eval_target: Option<EvalTarget> = eval
+            .target
+            .as_ref()
+            .and_then(|v| serde_json::from_value(v.clone()).ok());
+        let run_target: Option<EvalTarget> = req.target.clone();
+
+        // Create pending case results for each case, resolving target per case
         let cases = self.db.list_eval_cases(eval.id).await?;
         for case in &cases {
             let result_uuid = Uuid::now_v7();
             let result_public_id = EvalResultId::from_uuid(result_uuid);
+
+            // Resolve target: run → case → eval
+            let case_target: Option<EvalTarget> = case
+                .target
+                .as_ref()
+                .and_then(|v| serde_json::from_value(v.clone()).ok());
+
+            let resolved = run_target.clone().or(case_target).or(eval_target.clone());
+
+            let resolved_json = resolved
+                .as_ref()
+                .map(serde_json::to_value)
+                .transpose()?;
+
             let result_input = CreateEvalCaseResultRow {
                 public_id: result_public_id.to_string(),
                 eval_run_id: run_row.id,
                 eval_case_id: case.id,
+                target: resolved_json.clone(),
+                target_snapshot: resolved_json,
             };
             self.db.create_eval_case_result(result_input).await?;
         }
@@ -472,9 +479,10 @@ impl EvalService {
             created_at: r.created_at,
         });
 
-        // Resolve agent and harness public IDs
-        let agent_id = AgentId::from_uuid(row.agent_id);
-        let harness_id = HarnessId::from_uuid(row.harness_id);
+        let target: Option<EvalTarget> = row
+            .target
+            .as_ref()
+            .and_then(|v| serde_json::from_value(v.clone()).ok());
 
         let public_id: EvalId = row
             .public_id
@@ -487,8 +495,7 @@ impl EvalService {
             org_id: row.org_id,
             name: row.name,
             description: row.description,
-            agent_id,
-            harness_id,
+            target,
             model_override: row.model_override,
             tags: row.tags,
             status: EvalStatus::from(row.status.as_str()),
@@ -503,6 +510,11 @@ impl EvalService {
 }
 
 fn case_row_to_case(row: crate::storage::models::EvalCaseRow) -> EvalCase {
+    let target: Option<EvalTarget> = row
+        .target
+        .as_ref()
+        .and_then(|v| serde_json::from_value(v.clone()).ok());
+
     EvalCase {
         public_id: row
             .public_id
@@ -511,6 +523,7 @@ fn case_row_to_case(row: crate::storage::models::EvalCaseRow) -> EvalCase {
         internal_id: row.id,
         name: row.name,
         description: row.description,
+        target,
         tags: row.tags,
         conversation: serde_json::from_value(row.conversation).unwrap_or_default(),
         scorers: serde_json::from_value(row.scorers).unwrap_or_default(),
@@ -526,6 +539,11 @@ fn run_row_to_run(
     row: crate::storage::models::EvalRunRow,
     results: Vec<EvalCaseResult>,
 ) -> EvalRun {
+    let target: Option<EvalTarget> = row
+        .target
+        .as_ref()
+        .and_then(|v| serde_json::from_value(v.clone()).ok());
+
     EvalRun {
         public_id: row
             .public_id
@@ -533,6 +551,7 @@ fn run_row_to_run(
             .unwrap_or_else(|_| EvalRunId::from_uuid(row.id)),
         internal_id: row.id,
         org_id: row.org_id,
+        target,
         model_override: row.model_override,
         filter_tags: row.filter_tags,
         status: EvalRunStatus::from(row.status.as_str()),
@@ -550,6 +569,15 @@ fn result_row_to_result(
     row: crate::storage::models::EvalCaseResultRow,
     case_name: Option<String>,
 ) -> EvalCaseResult {
+    let target: Option<EvalTarget> = row
+        .target
+        .as_ref()
+        .and_then(|v| serde_json::from_value(v.clone()).ok());
+    let target_snapshot: Option<EvalTarget> = row
+        .target_snapshot
+        .as_ref()
+        .and_then(|v| serde_json::from_value(v.clone()).ok());
+
     EvalCaseResult {
         public_id: row
             .public_id
@@ -559,6 +587,8 @@ fn result_row_to_result(
         eval_case_id: EvalCaseId::from_uuid(row.eval_case_id),
         case_name,
         session_id: row.session_id.map(SessionId::from_uuid),
+        target,
+        target_snapshot,
         status: CaseResultStatus::from(row.status.as_str()),
         scores: row.scores,
         turns: row.turns.map(|v| v as u32),

--- a/crates/server/src/services/eval.rs
+++ b/crates/server/src/services/eval.rs
@@ -37,6 +37,21 @@ pub struct EvalService {
     db: Arc<StorageBackend>,
 }
 
+/// Validates an EvalTarget if present. Returns error on invalid combinations.
+fn validate_target(target: &Option<EvalTarget>) -> Result<()> {
+    if let Some(EvalTarget::Session {
+        harness_id,
+        harness_name,
+        ..
+    }) = target
+        && harness_id.is_some()
+        && harness_name.is_some()
+    {
+        anyhow::bail!("harness_id and harness_name are mutually exclusive in eval target");
+    }
+    Ok(())
+}
+
 impl EvalService {
     pub fn new(db: Arc<StorageBackend>) -> Self {
         Self { db }
@@ -48,6 +63,8 @@ impl EvalService {
 
     #[policy(EVAL_MANAGE)]
     pub async fn create(&self, caller: &Caller, req: CreateEvalRequest) -> Result<Eval> {
+        validate_target(&req.target)?;
+
         let internal_uuid = Uuid::now_v7();
         let public_id = EvalId::from_uuid(internal_uuid);
 
@@ -103,6 +120,8 @@ impl EvalService {
         public_id: &str,
         req: UpdateEvalRequest,
     ) -> Result<Option<Eval>> {
+        validate_target(&req.target)?;
+
         let existing = self
             .db
             .get_eval_by_public_id(caller.org_id, public_id)
@@ -153,6 +172,8 @@ impl EvalService {
         eval_public_id: &str,
         req: CreateEvalCaseRequest,
     ) -> Result<EvalCase> {
+        validate_target(&req.target)?;
+
         let eval = self
             .db
             .get_eval_by_public_id(caller.org_id, eval_public_id)
@@ -223,6 +244,8 @@ impl EvalService {
         case_public_id: &str,
         req: UpdateEvalCaseRequest,
     ) -> Result<Option<EvalCase>> {
+        validate_target(&req.target)?;
+
         let eval = self
             .db
             .get_eval_by_public_id(caller.org_id, eval_public_id)
@@ -287,6 +310,8 @@ impl EvalService {
         eval_public_id: &str,
         req: CreateEvalRunRequest,
     ) -> Result<EvalRun> {
+        validate_target(&req.target)?;
+
         let eval = self
             .db
             .get_eval_by_public_id(caller.org_id, eval_public_id)
@@ -316,28 +341,38 @@ impl EvalService {
             .and_then(|v| serde_json::from_value(v.clone()).ok());
         let run_target: Option<EvalTarget> = req.target.clone();
 
-        // Create pending case results for each case, resolving target per case
+        // Create pending case results for each case, resolving target per case.
+        // target_snapshot must always store a concrete resolved target so results
+        // remain reproducible and do not depend on future default changes.
         let cases = self.db.list_eval_cases(eval.id).await?;
         for case in &cases {
             let result_uuid = Uuid::now_v7();
             let result_public_id = EvalResultId::from_uuid(result_uuid);
 
-            // Resolve target: run → case → eval
+            // Resolve target: run → case → eval. Fail if nothing resolved.
             let case_target: Option<EvalTarget> = case
                 .target
                 .as_ref()
                 .and_then(|v| serde_json::from_value(v.clone()).ok());
 
-            let resolved = run_target.clone().or(case_target).or(eval_target.clone());
+            let resolved = run_target
+                .clone()
+                .or(case_target)
+                .or(eval_target.clone())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "no eval target configured — set a target on the eval, case, or run"
+                    )
+                })?;
 
-            let resolved_json = resolved.as_ref().map(serde_json::to_value).transpose()?;
+            let resolved_json = serde_json::to_value(&resolved)?;
 
             let result_input = CreateEvalCaseResultRow {
                 public_id: result_public_id.to_string(),
                 eval_run_id: run_row.id,
                 eval_case_id: case.id,
-                target: resolved_json.clone(),
-                target_snapshot: resolved_json,
+                target: Some(resolved_json.clone()),
+                target_snapshot: Some(resolved_json),
             };
             self.db.create_eval_case_result(result_input).await?;
         }

--- a/crates/server/src/services/eval.rs
+++ b/crates/server/src/services/eval.rs
@@ -51,11 +51,7 @@ impl EvalService {
         let internal_uuid = Uuid::now_v7();
         let public_id = EvalId::from_uuid(internal_uuid);
 
-        let target_json = req
-            .target
-            .as_ref()
-            .map(serde_json::to_value)
-            .transpose()?;
+        let target_json = req.target.as_ref().map(serde_json::to_value).transpose()?;
 
         let input = CreateEvalRow {
             public_id: public_id.to_string(),
@@ -113,11 +109,7 @@ impl EvalService {
             .await?
             .ok_or_else(|| ResourceNotFoundError::new("Eval"))?;
 
-        let target_json = req
-            .target
-            .as_ref()
-            .map(serde_json::to_value)
-            .transpose()?;
+        let target_json = req.target.as_ref().map(serde_json::to_value).transpose()?;
 
         let input = UpdateEvalRow {
             name: req.name,
@@ -172,11 +164,7 @@ impl EvalService {
 
         let case_count = self.db.count_eval_cases(eval.id).await?;
 
-        let target_json = req
-            .target
-            .as_ref()
-            .map(serde_json::to_value)
-            .transpose()?;
+        let target_json = req.target.as_ref().map(serde_json::to_value).transpose()?;
 
         let input = CreateEvalCaseRow {
             public_id: case_public_id.to_string(),
@@ -247,11 +235,7 @@ impl EvalService {
             .await?
             .ok_or_else(|| ResourceNotFoundError::new("EvalCase"))?;
 
-        let target_json = req
-            .target
-            .as_ref()
-            .map(serde_json::to_value)
-            .transpose()?;
+        let target_json = req.target.as_ref().map(serde_json::to_value).transpose()?;
 
         let input = UpdateEvalCaseRow {
             name: req.name,
@@ -312,11 +296,7 @@ impl EvalService {
         let run_uuid = Uuid::now_v7();
         let run_public_id = EvalRunId::from_uuid(run_uuid);
 
-        let target_json = req
-            .target
-            .as_ref()
-            .map(serde_json::to_value)
-            .transpose()?;
+        let target_json = req.target.as_ref().map(serde_json::to_value).transpose()?;
 
         let input = CreateEvalRunRow {
             public_id: run_public_id.to_string(),
@@ -350,10 +330,7 @@ impl EvalService {
 
             let resolved = run_target.clone().or(case_target).or(eval_target.clone());
 
-            let resolved_json = resolved
-                .as_ref()
-                .map(serde_json::to_value)
-                .transpose()?;
+            let resolved_json = resolved.as_ref().map(serde_json::to_value).transpose()?;
 
             let result_input = CreateEvalCaseResultRow {
                 public_id: result_public_id.to_string(),

--- a/crates/server/src/storage/memory/evals.rs
+++ b/crates/server/src/storage/memory/evals.rs
@@ -20,8 +20,7 @@ impl InMemoryDatabase {
             public_id: input.public_id,
             name: input.name,
             description: input.description,
-            agent_id: input.agent_id,
-            harness_id: input.harness_id,
+            target: input.target,
             model_override: input.model_override,
             tags: input.tags,
             status: "active".to_string(),
@@ -91,11 +90,8 @@ impl InMemoryDatabase {
         if let Some(description) = input.description {
             eval.description = Some(description);
         }
-        if let Some(agent_id) = input.agent_id {
-            eval.agent_id = agent_id;
-        }
-        if let Some(harness_id) = input.harness_id {
-            eval.harness_id = harness_id;
+        if let Some(target) = input.target {
+            eval.target = Some(target);
         }
         if let Some(model_override) = input.model_override {
             eval.model_override = Some(model_override);
@@ -141,6 +137,7 @@ impl InMemoryDatabase {
             public_id: input.public_id,
             name: input.name,
             description: input.description,
+            target: input.target,
             tags: input.tags,
             conversation: input.conversation,
             scorers: input.scorers,
@@ -196,6 +193,9 @@ impl InMemoryDatabase {
         if let Some(description) = input.description {
             case.description = Some(description);
         }
+        if let Some(target) = input.target {
+            case.target = Some(target);
+        }
         if let Some(tags) = input.tags {
             case.tags = tags;
         }
@@ -245,6 +245,7 @@ impl InMemoryDatabase {
             eval_id: input.eval_id,
             org_id,
             public_id: input.public_id,
+            target: input.target,
             model_override: input.model_override,
             filter_tags: input.filter_tags,
             status: "pending".to_string(),
@@ -331,6 +332,8 @@ impl InMemoryDatabase {
             eval_case_id: input.eval_case_id,
             public_id: input.public_id,
             session_id: None,
+            target: input.target,
+            target_snapshot: input.target_snapshot,
             status: "pending".to_string(),
             scores: None,
             turns: None,
@@ -370,6 +373,12 @@ impl InMemoryDatabase {
         };
         if let Some(session_id) = input.session_id {
             result.session_id = Some(session_id);
+        }
+        if let Some(target) = input.target {
+            result.target = Some(target);
+        }
+        if let Some(target_snapshot) = input.target_snapshot {
+            result.target_snapshot = Some(target_snapshot);
         }
         if let Some(status) = input.status {
             result.status = status;

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -1542,8 +1542,7 @@ pub struct EvalRow {
     pub public_id: String,
     pub name: String,
     pub description: Option<String>,
-    pub agent_id: Uuid,
-    pub harness_id: Uuid,
+    pub target: Option<serde_json::Value>,
     pub model_override: Option<String>,
     pub tags: Vec<String>,
     pub status: String,
@@ -1559,8 +1558,7 @@ pub struct CreateEvalRow {
     pub public_id: String,
     pub name: String,
     pub description: Option<String>,
-    pub agent_id: Uuid,
-    pub harness_id: Uuid,
+    pub target: Option<serde_json::Value>,
     pub model_override: Option<String>,
     pub tags: Vec<String>,
 }
@@ -1570,8 +1568,7 @@ pub struct CreateEvalRow {
 pub struct UpdateEvalRow {
     pub name: Option<String>,
     pub description: Option<String>,
-    pub agent_id: Option<Uuid>,
-    pub harness_id: Option<Uuid>,
+    pub target: Option<serde_json::Value>,
     pub model_override: Option<String>,
     pub tags: Option<Vec<String>>,
     pub status: Option<String>,
@@ -1585,6 +1582,7 @@ pub struct EvalCaseRow {
     pub public_id: String,
     pub name: String,
     pub description: Option<String>,
+    pub target: Option<serde_json::Value>,
     pub tags: Vec<String>,
     pub conversation: serde_json::Value,
     pub scorers: serde_json::Value,
@@ -1601,6 +1599,7 @@ pub struct CreateEvalCaseRow {
     pub public_id: String,
     pub name: String,
     pub description: Option<String>,
+    pub target: Option<serde_json::Value>,
     pub tags: Vec<String>,
     pub conversation: serde_json::Value,
     pub scorers: serde_json::Value,
@@ -1614,6 +1613,7 @@ pub struct CreateEvalCaseRow {
 pub struct UpdateEvalCaseRow {
     pub name: Option<String>,
     pub description: Option<String>,
+    pub target: Option<serde_json::Value>,
     pub tags: Option<Vec<String>>,
     pub conversation: Option<serde_json::Value>,
     pub scorers: Option<serde_json::Value>,
@@ -1629,6 +1629,7 @@ pub struct EvalRunRow {
     pub eval_id: Uuid,
     pub org_id: i64,
     pub public_id: String,
+    pub target: Option<serde_json::Value>,
     pub model_override: Option<String>,
     pub filter_tags: Option<Vec<String>>,
     pub status: String,
@@ -1645,6 +1646,7 @@ pub struct EvalRunRow {
 pub struct CreateEvalRunRow {
     pub public_id: String,
     pub eval_id: Uuid,
+    pub target: Option<serde_json::Value>,
     pub model_override: Option<String>,
     pub filter_tags: Option<Vec<String>>,
     pub triggered_by: String,
@@ -1658,6 +1660,8 @@ pub struct EvalCaseResultRow {
     pub eval_case_id: Uuid,
     pub public_id: String,
     pub session_id: Option<Uuid>,
+    pub target: Option<serde_json::Value>,
+    pub target_snapshot: Option<serde_json::Value>,
     pub status: String,
     pub scores: Option<serde_json::Value>,
     pub turns: Option<i32>,
@@ -1675,12 +1679,16 @@ pub struct CreateEvalCaseResultRow {
     pub public_id: String,
     pub eval_run_id: Uuid,
     pub eval_case_id: Uuid,
+    pub target: Option<serde_json::Value>,
+    pub target_snapshot: Option<serde_json::Value>,
 }
 
 /// Input for updating an eval case result
 #[derive(Debug, Clone, Default)]
 pub struct UpdateEvalCaseResultRow {
     pub session_id: Option<Uuid>,
+    pub target: Option<serde_json::Value>,
+    pub target_snapshot: Option<serde_json::Value>,
     pub status: Option<String>,
     pub scores: Option<serde_json::Value>,
     pub turns: Option<i32>,

--- a/crates/server/src/storage/repositories/evals.rs
+++ b/crates/server/src/storage/repositories/evals.rs
@@ -15,9 +15,9 @@ impl Database {
     pub async fn create_eval(&self, org_id: i64, input: CreateEvalRow) -> Result<EvalRow> {
         let row = sqlx::query_as::<_, EvalRow>(
             r#"
-            INSERT INTO evals (org_id, public_id, name, description, agent_id, harness_id, model_override, tags)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-            RETURNING id, org_id, public_id, name, description, agent_id, harness_id,
+            INSERT INTO evals (org_id, public_id, name, description, target, model_override, tags)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            RETURNING id, org_id, public_id, name, description, target,
                       model_override, tags, status, created_at, updated_at, archived_at, deleted_at
             "#,
         )
@@ -25,8 +25,7 @@ impl Database {
         .bind(&input.public_id)
         .bind(&input.name)
         .bind(&input.description)
-        .bind(input.agent_id)
-        .bind(input.harness_id)
+        .bind(&input.target)
         .bind(&input.model_override)
         .bind(&input.tags)
         .fetch_one(&self.pool)
@@ -41,7 +40,7 @@ impl Database {
     ) -> Result<Option<EvalRow>> {
         let row = sqlx::query_as::<_, EvalRow>(
             r#"
-            SELECT id, org_id, public_id, name, description, agent_id, harness_id,
+            SELECT id, org_id, public_id, name, description, target,
                    model_override, tags, status, created_at, updated_at, archived_at, deleted_at
             FROM evals
             WHERE org_id = $1 AND public_id = $2
@@ -68,7 +67,7 @@ impl Database {
             " AND status NOT IN ('archived', 'deleted')"
         };
         let sql = format!(
-            r#"SELECT id, org_id, public_id, name, description, agent_id, harness_id,
+            r#"SELECT id, org_id, public_id, name, description, target,
                       model_override, tags, status, created_at, updated_at, archived_at, deleted_at
                FROM evals
                WHERE org_id = $1{status_sql}{search_sql}
@@ -93,14 +92,13 @@ impl Database {
             SET
                 name = COALESCE($3, name),
                 description = COALESCE($4, description),
-                agent_id = COALESCE($5, agent_id),
-                harness_id = COALESCE($6, harness_id),
-                model_override = COALESCE($7, model_override),
-                tags = COALESCE($8, tags),
-                status = COALESCE($9, status),
+                target = COALESCE($5, target),
+                model_override = COALESCE($6, model_override),
+                tags = COALESCE($7, tags),
+                status = COALESCE($8, status),
                 updated_at = NOW()
             WHERE org_id = $1 AND id = $2
-            RETURNING id, org_id, public_id, name, description, agent_id, harness_id,
+            RETURNING id, org_id, public_id, name, description, target,
                       model_override, tags, status, created_at, updated_at, archived_at, deleted_at
             "#,
         )
@@ -108,8 +106,7 @@ impl Database {
         .bind(id)
         .bind(&input.name)
         .bind(&input.description)
-        .bind(input.agent_id)
-        .bind(input.harness_id)
+        .bind(&input.target)
         .bind(&input.model_override)
         .bind(&input.tags)
         .bind(&input.status)
@@ -144,9 +141,9 @@ impl Database {
     ) -> Result<EvalCaseRow> {
         let row = sqlx::query_as::<_, EvalCaseRow>(
             r#"
-            INSERT INTO eval_cases (eval_id, public_id, name, description, tags, conversation, scorers, max_turns, timeout_seconds, position)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-            RETURNING id, eval_id, public_id, name, description, tags, conversation, scorers,
+            INSERT INTO eval_cases (eval_id, public_id, name, description, target, tags, conversation, scorers, max_turns, timeout_seconds, position)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            RETURNING id, eval_id, public_id, name, description, target, tags, conversation, scorers,
                       max_turns, timeout_seconds, position, created_at, updated_at
             "#,
         )
@@ -154,6 +151,7 @@ impl Database {
         .bind(&input.public_id)
         .bind(&input.name)
         .bind(&input.description)
+        .bind(&input.target)
         .bind(&input.tags)
         .bind(&input.conversation)
         .bind(&input.scorers)
@@ -168,7 +166,7 @@ impl Database {
     pub async fn list_eval_cases(&self, eval_id: Uuid) -> Result<Vec<EvalCaseRow>> {
         let rows = sqlx::query_as::<_, EvalCaseRow>(
             r#"
-            SELECT id, eval_id, public_id, name, description, tags, conversation, scorers,
+            SELECT id, eval_id, public_id, name, description, target, tags, conversation, scorers,
                    max_turns, timeout_seconds, position, created_at, updated_at
             FROM eval_cases
             WHERE eval_id = $1
@@ -188,7 +186,7 @@ impl Database {
     ) -> Result<Option<EvalCaseRow>> {
         let row = sqlx::query_as::<_, EvalCaseRow>(
             r#"
-            SELECT id, eval_id, public_id, name, description, tags, conversation, scorers,
+            SELECT id, eval_id, public_id, name, description, target, tags, conversation, scorers,
                    max_turns, timeout_seconds, position, created_at, updated_at
             FROM eval_cases
             WHERE eval_id = $1 AND public_id = $2
@@ -212,21 +210,23 @@ impl Database {
             SET
                 name = COALESCE($2, name),
                 description = COALESCE($3, description),
-                tags = COALESCE($4, tags),
-                conversation = COALESCE($5, conversation),
-                scorers = COALESCE($6, scorers),
-                max_turns = COALESCE($7, max_turns),
-                timeout_seconds = COALESCE($8, timeout_seconds),
-                position = COALESCE($9, position),
+                target = COALESCE($4, target),
+                tags = COALESCE($5, tags),
+                conversation = COALESCE($6, conversation),
+                scorers = COALESCE($7, scorers),
+                max_turns = COALESCE($8, max_turns),
+                timeout_seconds = COALESCE($9, timeout_seconds),
+                position = COALESCE($10, position),
                 updated_at = NOW()
             WHERE id = $1
-            RETURNING id, eval_id, public_id, name, description, tags, conversation, scorers,
+            RETURNING id, eval_id, public_id, name, description, target, tags, conversation, scorers,
                       max_turns, timeout_seconds, position, created_at, updated_at
             "#,
         )
         .bind(id)
         .bind(&input.name)
         .bind(&input.description)
+        .bind(&input.target)
         .bind(&input.tags)
         .bind(&input.conversation)
         .bind(&input.scorers)
@@ -265,15 +265,16 @@ impl Database {
     ) -> Result<EvalRunRow> {
         let row = sqlx::query_as::<_, EvalRunRow>(
             r#"
-            INSERT INTO eval_runs (eval_id, org_id, public_id, model_override, filter_tags, triggered_by)
-            VALUES ($1, $2, $3, $4, $5, $6)
-            RETURNING id, eval_id, org_id, public_id, model_override, filter_tags, status,
+            INSERT INTO eval_runs (eval_id, org_id, public_id, target, model_override, filter_tags, triggered_by)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            RETURNING id, eval_id, org_id, public_id, target, model_override, filter_tags, status,
                       triggered_by, started_at, completed_at, summary, created_at, updated_at
             "#,
         )
         .bind(input.eval_id)
         .bind(org_id)
         .bind(&input.public_id)
+        .bind(&input.target)
         .bind(&input.model_override)
         .bind(&input.filter_tags)
         .bind(&input.triggered_by)
@@ -285,7 +286,7 @@ impl Database {
     pub async fn list_eval_runs(&self, eval_id: Uuid) -> Result<Vec<EvalRunRow>> {
         let rows = sqlx::query_as::<_, EvalRunRow>(
             r#"
-            SELECT id, eval_id, org_id, public_id, model_override, filter_tags, status,
+            SELECT id, eval_id, org_id, public_id, target, model_override, filter_tags, status,
                    triggered_by, started_at, completed_at, summary, created_at, updated_at
             FROM eval_runs
             WHERE eval_id = $1
@@ -305,7 +306,7 @@ impl Database {
     ) -> Result<Option<EvalRunRow>> {
         let row = sqlx::query_as::<_, EvalRunRow>(
             r#"
-            SELECT id, eval_id, org_id, public_id, model_override, filter_tags, status,
+            SELECT id, eval_id, org_id, public_id, target, model_override, filter_tags, status,
                    triggered_by, started_at, completed_at, summary, created_at, updated_at
             FROM eval_runs
             WHERE org_id = $1 AND public_id = $2
@@ -341,7 +342,7 @@ impl Database {
                 summary = COALESCE($5, summary),
                 updated_at = NOW()
             WHERE id = $1
-            RETURNING id, eval_id, org_id, public_id, model_override, filter_tags, status,
+            RETURNING id, eval_id, org_id, public_id, target, model_override, filter_tags, status,
                       triggered_by, started_at, completed_at, summary, created_at, updated_at
             "#,
         )
@@ -358,7 +359,7 @@ impl Database {
     pub async fn get_latest_eval_run(&self, eval_id: Uuid) -> Result<Option<EvalRunRow>> {
         let row = sqlx::query_as::<_, EvalRunRow>(
             r#"
-            SELECT id, eval_id, org_id, public_id, model_override, filter_tags, status,
+            SELECT id, eval_id, org_id, public_id, target, model_override, filter_tags, status,
                    triggered_by, started_at, completed_at, summary, created_at, updated_at
             FROM eval_runs
             WHERE eval_id = $1
@@ -382,16 +383,18 @@ impl Database {
     ) -> Result<EvalCaseResultRow> {
         let row = sqlx::query_as::<_, EvalCaseResultRow>(
             r#"
-            INSERT INTO eval_case_results (eval_run_id, eval_case_id, public_id)
-            VALUES ($1, $2, $3)
-            RETURNING id, eval_run_id, eval_case_id, public_id, session_id, status,
-                      scores, turns, latency_ms, input_tokens, output_tokens, error_message,
+            INSERT INTO eval_case_results (eval_run_id, eval_case_id, public_id, target, target_snapshot)
+            VALUES ($1, $2, $3, $4, $5)
+            RETURNING id, eval_run_id, eval_case_id, public_id, session_id, target, target_snapshot,
+                      status, scores, turns, latency_ms, input_tokens, output_tokens, error_message,
                       created_at, updated_at
             "#,
         )
         .bind(input.eval_run_id)
         .bind(input.eval_case_id)
         .bind(&input.public_id)
+        .bind(&input.target)
+        .bind(&input.target_snapshot)
         .fetch_one(&self.pool)
         .await?;
         Ok(row)
@@ -404,6 +407,7 @@ impl Database {
         let rows = sqlx::query_as::<_, EvalCaseResultRow>(
             r#"
             SELECT ecr.id, ecr.eval_run_id, ecr.eval_case_id, ecr.public_id, ecr.session_id,
+                   ecr.target, ecr.target_snapshot,
                    ecr.status, ecr.scores, ecr.turns, ecr.latency_ms,
                    ecr.input_tokens, ecr.output_tokens, ecr.error_message,
                    ecr.created_at, ecr.updated_at
@@ -428,22 +432,26 @@ impl Database {
             UPDATE eval_case_results
             SET
                 session_id = COALESCE($2, session_id),
-                status = COALESCE($3, status),
-                scores = COALESCE($4, scores),
-                turns = COALESCE($5, turns),
-                latency_ms = COALESCE($6, latency_ms),
-                input_tokens = COALESCE($7, input_tokens),
-                output_tokens = COALESCE($8, output_tokens),
-                error_message = COALESCE($9, error_message),
+                target = COALESCE($3, target),
+                target_snapshot = COALESCE($4, target_snapshot),
+                status = COALESCE($5, status),
+                scores = COALESCE($6, scores),
+                turns = COALESCE($7, turns),
+                latency_ms = COALESCE($8, latency_ms),
+                input_tokens = COALESCE($9, input_tokens),
+                output_tokens = COALESCE($10, output_tokens),
+                error_message = COALESCE($11, error_message),
                 updated_at = NOW()
             WHERE id = $1
-            RETURNING id, eval_run_id, eval_case_id, public_id, session_id, status,
-                      scores, turns, latency_ms, input_tokens, output_tokens, error_message,
+            RETURNING id, eval_run_id, eval_case_id, public_id, session_id, target, target_snapshot,
+                      status, scores, turns, latency_ms, input_tokens, output_tokens, error_message,
                       created_at, updated_at
             "#,
         )
         .bind(id)
         .bind(input.session_id)
+        .bind(&input.target)
+        .bind(&input.target_snapshot)
         .bind(&input.status)
         .bind(&input.scores)
         .bind(input.turns)

--- a/specs/evals.md
+++ b/specs/evals.md
@@ -10,7 +10,7 @@
   - No dataset management — evals are small, curated collections
   - No cross-org visibility — evals are org-scoped like all other entities
   - EvalTarget replaces harness_id + agent_id — unified session setup contract
-  - EvalTarget can be: SessionParams (full session params), App (app reference), or Harness (simple reference)
+  - EvalTarget::Session mirrors CreateSessionRequest; EvalTarget::App references a deployed app
   - Resolution order: EvalRun.target → EvalCase.target → Eval.target → org default harness
   - EvalCaseResult stores both target (live reference) and target_snapshot (frozen copy at execution time)
 -->
@@ -25,11 +25,10 @@ Each eval case creates a real session with the target agent and harness. Failed 
 
 ### EvalTarget
 
-Defines how to instantiate a session for eval cases. Three variants:
+Defines how to instantiate a session for eval cases. Two variants:
 
-- **`session_params`**: Full session input parameters — `harness_id` (required), `agent_id`, `model_id`, `system_prompt`. Maximum control over session setup.
+- **`session`**: Mirrors `CreateSessionRequest` — `harness_id` or `harness_name` (optional, defaults to org default), `agent_id`, `model_id`, `system_prompt`, `max_iterations`. Full control over session setup.
 - **`app`**: Reference to a deployed App — `app_id`. Session created via the app's configuration.
-- **`harness`**: Simple harness + optional agent reference — `harness_id` (required), `agent_id`. No extra session params.
 
 **Resolution order**: `EvalRun.target` → `EvalCase.target` → `Eval.target` → org default harness.
 
@@ -255,9 +254,8 @@ POST /v1/evals/{eval_id}/runs
   │  For each case (bounded concurrency = 5):
   │    1. Update CaseResult status → running
   │    2. Create session from resolved EvalTarget:
-  │       - session_params: use harness_id, agent_id, model_id, system_prompt
+  │       - session: use harness_id/harness_name, agent_id, model_id, system_prompt, max_iterations
   │       - app: create session via app
-  │       - harness: use harness_id + agent_id
   │       Tags: ["eval", "eval:{eval_id}"]
   │    3. For each message in case.conversation:
   │       a. POST message to session
@@ -321,11 +319,10 @@ Select two runs from the runs tab → side-by-side view:
 
 ### Create Eval Form (`/evals/new`)
 
-Fields: name, description, target type selector (harness / session_params / app), target fields (varies by type), model override (optional), tags.
+Fields: name, description, target type selector (session / app), target fields (varies by type), model override (optional), tags.
 
 Target type selector:
-- **Harness**: harness (select), agent (optional select)
-- **Session Params**: harness (select), agent (optional select), model (optional), system prompt (optional textarea)
+- **Session**: harness (optional select, defaults to org default), agent (optional select), model (optional), system prompt (optional textarea)
 - **App**: app ID (text input)
 
 Cases added after creation on the detail page (simpler flow, avoids complex nested form).

--- a/specs/evals.md
+++ b/specs/evals.md
@@ -27,7 +27,7 @@ Each eval case creates a real session with the target agent and harness. Failed 
 
 Defines how to instantiate a session for eval cases. Two variants:
 
-- **`session`**: Mirrors `CreateSessionRequest` — `harness_id` or `harness_name` (optional, defaults to org default), `agent_id`, `model_id`, `system_prompt`, `max_iterations`. Full control over session setup.
+- **`session`**: Mirrors `CreateSessionRequest` — `harness_id` and `harness_name` are optional but mutually exclusive (if both are provided, validation fails; if neither, the org default harness is used). Other fields: `agent_id`, `model_id`, `system_prompt`, `max_iterations`. Full control over session setup.
 - **`app`**: Reference to a deployed App — `app_id`. Session created via the app's configuration.
 
 **Resolution order**: `EvalRun.target` → `EvalCase.target` → `Eval.target` → org default harness.
@@ -71,8 +71,8 @@ A single execution of all (or a tagged subset of) cases in an eval.
 The outcome of a single case within a run.
 
 - Links to the actual session created for this case (browsable in UI)
-- `target`: resolved EvalTarget used (live reference, may change if eval is edited)
-- `target_snapshot`: frozen copy of the resolved target at execution time (immutable, for reproducibility)
+- `target`: resolved EvalTarget at execution time (always concrete, never NULL)
+- `target_snapshot`: identical frozen copy for immutability (both set at run creation, both equal initially; `target_snapshot` must never be overwritten)
 - Contains per-scorer scores with pass/fail, value (0.0–1.0), and reason
 - Captures efficiency metrics: turn count, latency, token usage
 
@@ -179,8 +179,8 @@ See `crates/core/src/eval.rs` for full field definitions.
 | `eval_run_id` | UUID | FK to parent run |
 | `eval_case_id` | UUID | FK to the case |
 | `session_id` | Option\<UUID\> | FK to session created for this case |
-| `target` | Option\<EvalTarget\> | Resolved target (live reference, JSONB) |
-| `target_snapshot` | Option\<EvalTarget\> | Frozen target at execution time (JSONB) |
+| `target` | EvalTarget | Resolved target at execution time (JSONB, always concrete) |
+| `target_snapshot` | EvalTarget | Frozen copy of resolved target (JSONB, immutable) |
 | `status` | CaseResultStatus | `pending`, `running`, `passed`, `failed`, `errored`, `timeout` |
 | `scores` | Option\<Map\<String, Score\>\> | Per-scorer results (JSONB) |
 | `turns` | Option\<u32\> | Turn count |

--- a/specs/evals.md
+++ b/specs/evals.md
@@ -9,6 +9,10 @@
   - LLM-as-judge scorer deferred to Phase 2 (requires model call inside scoring)
   - No dataset management — evals are small, curated collections
   - No cross-org visibility — evals are org-scoped like all other entities
+  - EvalTarget replaces harness_id + agent_id — unified session setup contract
+  - EvalTarget can be: SessionParams (full session params), App (app reference), or Harness (simple reference)
+  - Resolution order: EvalRun.target → EvalCase.target → Eval.target → org default harness
+  - EvalCaseResult stores both target (live reference) and target_snapshot (frozen copy at execution time)
 -->
 
 ## Abstract
@@ -19,12 +23,24 @@ Each eval case creates a real session with the target agent and harness. Failed 
 
 ## Concepts
 
+### EvalTarget
+
+Defines how to instantiate a session for eval cases. Three variants:
+
+- **`session_params`**: Full session input parameters — `harness_id` (required), `agent_id`, `model_id`, `system_prompt`. Maximum control over session setup.
+- **`app`**: Reference to a deployed App — `app_id`. Session created via the app's configuration.
+- **`harness`**: Simple harness + optional agent reference — `harness_id` (required), `agent_id`. No extra session params.
+
+**Resolution order**: `EvalRun.target` → `EvalCase.target` → `Eval.target` → org default harness.
+
+All three levels (Eval, EvalCase, EvalRun) have an optional `target` field. The first non-null target in the resolution chain is used. This allows running the same eval cases against different targets per run, or defining per-case overrides for heterogeneous test suites.
+
 ### Eval
 
-Top-level entity. Targets a specific agent and harness combination. Contains cases that define expected behaviors.
+Top-level entity. Contains cases that define expected behaviors.
 
 - Org-scoped, follows standard building-block lifecycle (`active → archived → deleted`)
-- References one agent (required) and one harness (required)
+- Optional `target` (EvalTarget) — the default session setup for all cases
 - Optional `model_override` for baseline model selection
 - Tagged for organization and filtering
 
@@ -33,6 +49,7 @@ Top-level entity. Targets a specific agent and harness combination. Contains cas
 A single test within an eval. Defines input messages, scoring criteria, and execution bounds.
 
 - Each case has a `description` explaining what behavior it measures (self-documenting)
+- Optional `target` (EvalTarget) — per-case override
 - `conversation`: one or more input messages sent sequentially (multi-turn support)
 - `scorers`: list of scoring rules applied after execution completes
 - `max_turns`: optional bound on agent turns (default: 10)
@@ -44,6 +61,7 @@ A single test within an eval. Defines input messages, scoring criteria, and exec
 A single execution of all (or a tagged subset of) cases in an eval.
 
 - Creates one session per case
+- Optional `target` (EvalTarget) — per-run override (e.g., test same cases against a different app)
 - Supports model override per run (compare models without editing the eval)
 - Tracks aggregate metrics: pass rate, average score, turns, latency, tokens
 - Triggered by user action, API call, or scheduled task
@@ -54,6 +72,8 @@ A single execution of all (or a tagged subset of) cases in an eval.
 The outcome of a single case within a run.
 
 - Links to the actual session created for this case (browsable in UI)
+- `target`: resolved EvalTarget used (live reference, may change if eval is edited)
+- `target_snapshot`: frozen copy of the resolved target at execution time (immutable, for reproducibility)
 - Contains per-scorer scores with pass/fail, value (0.0–1.0), and reason
 - Captures efficiency metrics: turn count, latency, token usage
 
@@ -92,8 +112,7 @@ See `crates/core/src/eval.rs` for full field definitions.
 | `org_id` | i64 | Owning organization |
 | `name` | String | Display name |
 | `description` | Option\<String\> | Optional description |
-| `agent_id` | UUID | FK to agent under test |
-| `harness_id` | UUID | FK to harness for test sessions |
+| `target` | Option\<EvalTarget\> | Session setup target (JSONB) |
 | `model_override` | Option\<String\> | Optional default model for runs |
 | `tags` | Vec\<String\> | Organization tags |
 | `status` | EvalStatus | `active`, `archived`, `deleted` |
@@ -110,6 +129,7 @@ See `crates/core/src/eval.rs` for full field definitions.
 | `eval_id` | UUID | FK to parent eval |
 | `name` | String | Case name |
 | `description` | Option\<String\> | What behavior this measures |
+| `target` | Option\<EvalTarget\> | Per-case target override (JSONB) |
 | `tags` | Vec\<String\> | Tags for subset runs |
 | `conversation` | Vec\<InputMessage\> | Input messages (sequential) |
 | `scorers` | Vec\<Scorer\> | Scoring rules (JSONB) |
@@ -126,6 +146,7 @@ See `crates/core/src/eval.rs` for full field definitions.
 | `id` / `public_id` | UUID / EvalRunId | Dual-ID pattern (`evalrun_` prefix) |
 | `eval_id` | UUID | FK to parent eval |
 | `org_id` | i64 | Owning organization |
+| `target` | Option\<EvalTarget\> | Per-run target override (JSONB) |
 | `model_override` | Option\<String\> | Model override for this run |
 | `filter_tags` | Option\<Vec\<String\>\> | Only run cases matching these tags |
 | `status` | EvalRunStatus | `pending`, `running`, `completed`, `failed`, `cancelled` |
@@ -159,6 +180,8 @@ See `crates/core/src/eval.rs` for full field definitions.
 | `eval_run_id` | UUID | FK to parent run |
 | `eval_case_id` | UUID | FK to the case |
 | `session_id` | Option\<UUID\> | FK to session created for this case |
+| `target` | Option\<EvalTarget\> | Resolved target (live reference, JSONB) |
+| `target_snapshot` | Option\<EvalTarget\> | Frozen target at execution time (JSONB) |
 | `status` | CaseResultStatus | `pending`, `running`, `passed`, `failed`, `errored`, `timeout` |
 | `scores` | Option\<Map\<String, Score\>\> | Per-scorer results (JSONB) |
 | `turns` | Option\<u32\> | Turn count |
@@ -223,13 +246,19 @@ All endpoints under `/v1/evals`. See `crates/server/src/api/evals.rs`.
 ```
 POST /v1/evals/{eval_id}/runs
   │
-  ├─ Create EvalRun (status: pending)
-  ├─ Create EvalCaseResult per case (status: pending)
+  ├─ Create EvalRun (status: pending, target from request body)
+  ├─ For each case:
+  │    ├─ Resolve target: run.target → case.target → eval.target → org default
+  │    └─ Create EvalCaseResult (status: pending, target + target_snapshot = resolved target)
   ├─ Start durable workflow: RunEvalWorkflow
   │
   │  For each case (bounded concurrency = 5):
   │    1. Update CaseResult status → running
-  │    2. Create session (harness_id, agent_id, model_override, tags: ["eval", "eval:{eval_id}"])
+  │    2. Create session from resolved EvalTarget:
+  │       - session_params: use harness_id, agent_id, model_id, system_prompt
+  │       - app: create session via app
+  │       - harness: use harness_id + agent_id
+  │       Tags: ["eval", "eval:{eval_id}"]
   │    3. For each message in case.conversation:
   │       a. POST message to session
   │       b. Wait for session.idled event
@@ -292,7 +321,12 @@ Select two runs from the runs tab → side-by-side view:
 
 ### Create Eval Form (`/evals/new`)
 
-Fields: name, description, agent (select), harness (select), model override (optional select), tags.
+Fields: name, description, target type selector (harness / session_params / app), target fields (varies by type), model override (optional), tags.
+
+Target type selector:
+- **Harness**: harness (select), agent (optional select)
+- **Session Params**: harness (select), agent (optional select), model (optional), system prompt (optional textarea)
+- **App**: app ID (text input)
 
 Cases added after creation on the detail page (simpler flow, avoids complex nested form).
 


### PR DESCRIPTION
## What
Introduce `EvalTarget` enum as the unified session setup contract for evals. Replaces the previous required `agent_id` + `harness_id` fields on `Eval` with an optional `target` field on `Eval`, `EvalCase`, and `EvalRun`.

Two variants:
- **`Session`** — mirrors `CreateSessionRequest`: `harness_id`, `harness_name`, `agent_id`, `model_id`, `system_prompt`, `max_iterations` (all optional)
- **`App`** — references a deployed app by `app_id`

Resolution chain: `EvalRun.target` → `EvalCase.target` → `Eval.target` → org default harness.

`EvalCaseResult` stores both a live `target` reference and a frozen `target_snapshot` for reproducibility.

## Why
The old model forced every eval to have exactly one agent + one harness. This was too rigid:
- No way to test the same cases against different targets per run
- No way to test against an App
- No per-case target overrides for heterogeneous test suites
- Session params like `model_id`, `system_prompt`, `max_iterations` couldn't be specified

## How
- **Core** (`crates/core/src/eval.rs`): Added `EvalTarget` enum. Replaced `agent_id`/`harness_id` on `Eval` with `Option<EvalTarget>`. Added `target` to `EvalCase`, `EvalRun`, and `target`+`target_snapshot` to `EvalCaseResult`.
- **Storage**: All row types updated to use `target: Option<serde_json::Value>` (JSONB). Both PostgreSQL and in-memory implementations updated.
- **Migration** (`011_evals_target.sql`): Migrates existing data from `agent_id`/`harness_id` columns to `EvalTarget::Session` JSONB, then drops old columns and FK constraints.
- **Service**: Target resolution during `create_run` resolves per-case target from run → case → eval chain and stores resolved target + snapshot on each `EvalCaseResult`.
- **API**: All request types accept optional `EvalTarget` instead of required `agent_id`/`harness_id`.
- **UI**: New eval form has target type selector (Session / App) with contextual fields. List/detail/run pages show target badges. Results table shows per-result target snapshot.
- **Spec**: Updated with EvalTarget concept, resolution chain, data model tables.

## Risk
- Medium
- Breaking change: removes `agent_id` and `harness_id` columns from `evals` table. Migration converts existing data. API consumers sending `agent_id`/`harness_id` in create/update requests will get errors.

## Security
- Threat categories reviewed: TM-API (new JSONB field accepts user input), TM-AUTH (no permission model changes — same OrgAgentsManage policy)
- Findings and resolutions: EvalTarget is deserialized from JSONB via serde with tagged enum — invalid variants are rejected. No new external API surface beyond existing eval endpoints. No secrets or credentials in target.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)