### PR TITLE
feat(ui): add MCP connect button to sidebar header

### DIFF
--- a/apps/ui/src/components/layout/mcp-connect-button.tsx
+++ b/apps/ui/src/components/layout/mcp-connect-button.tsx
@@ -20,9 +20,13 @@ function CopySnippetButton({ value }: { value: string }) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(value);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard write can fail (permissions, insecure context) — silently ignore
+    }
   };
 
   return (
@@ -85,7 +89,7 @@ export function McpConnectButton() {
 
         <div className="space-y-4">
           <div>
-            <label className="mb-1.5 block text-sm font-medium">MCP Server URL</label>
+            <p className="mb-1.5 text-sm font-medium">MCP Server URL</p>
             <div className="relative">
               <code className="block overflow-x-auto border bg-muted px-3 py-2 pr-9 text-sm">
                 {mcpUrl}
@@ -95,7 +99,7 @@ export function McpConnectButton() {
           </div>
 
           <div>
-            <label className="mb-1.5 block text-sm font-medium">Quick Setup</label>
+            <p className="mb-1.5 text-sm font-medium">Quick Setup</p>
             <p className="mb-2 text-sm text-muted-foreground">
               Add this to your MCP client config:
             </p>

--- a/apps/ui/src/components/layout/mcp-connect-button.tsx
+++ b/apps/ui/src/components/layout/mcp-connect-button.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+import { capabilityIconMap } from "@/lib/capability-icons";
+import { useFeatureFlags } from "@/providers/feature-flags-provider";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+const McpIcon = capabilityIconMap.mcp;
+
+function CopySnippetButton({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(value);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="absolute top-2 right-2 inline-flex h-7 w-7 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
+      aria-label={copied ? "Copied" : "Copy to clipboard"}
+    >
+      {copied ? <Check className="h-3.5 w-3.5 text-green-500" /> : <Copy className="h-3.5 w-3.5" />}
+    </button>
+  );
+}
+
+export function McpConnectButton() {
+  const featureFlags = useFeatureFlags();
+
+  if (!featureFlags.mcp_endpoint) {
+    return null;
+  }
+
+  const mcpUrl = typeof window !== "undefined" ? `${window.location.origin}/api/mcp` : "/api/mcp";
+
+  const configSnippet = JSON.stringify(
+    {
+      mcpServers: {
+        everruns: {
+          url: mcpUrl,
+        },
+      },
+    },
+    null,
+    2,
+  );
+
+  return (
+    <Dialog>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DialogTrigger
+            className="relative inline-flex h-9 w-9 items-center justify-center border border-transparent text-muted-foreground transition-colors hover:border-border hover:bg-background hover:text-foreground"
+            aria-label="Connect via MCP"
+          >
+            <McpIcon className="h-4 w-4" />
+          </DialogTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Connect via MCP</TooltipContent>
+      </Tooltip>
+
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <McpIcon className="h-5 w-5" />
+            Connect via MCP
+          </DialogTitle>
+          <DialogDescription>
+            Use Everruns from Claude Desktop, Cursor, VS Code, or any MCP-compatible client.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">MCP Server URL</label>
+            <div className="relative">
+              <code className="block overflow-x-auto border bg-muted px-3 py-2 pr-9 text-sm">
+                {mcpUrl}
+              </code>
+              <CopySnippetButton value={mcpUrl} />
+            </div>
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">Quick Setup</label>
+            <p className="mb-2 text-sm text-muted-foreground">
+              Add this to your MCP client config:
+            </p>
+            <div className="relative">
+              <pre className="overflow-x-auto border bg-muted px-3 py-2 pr-9 font-mono text-sm">
+                {configSnippet}
+              </pre>
+              <CopySnippetButton value={configSnippet} />
+            </div>
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            Authentication is handled automatically via OAuth when connecting from an MCP client.
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -38,6 +38,7 @@ import {
   Cog,
 } from "lucide-react";
 import { capabilityIconMap } from "@/lib/capability-icons";
+import { McpConnectButton } from "@/components/layout/mcp-connect-button";
 import { NotificationBell } from "@/components/layout/notification-bell";
 import { useCommandPalette } from "@/hooks/use-command-palette";
 import { useLlmProviders } from "@/hooks/use-llm-providers";
@@ -163,7 +164,10 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
           <Image src="/logo.svg" alt="Everruns" width={32} height={32} />
           <span className="text-xl font-bold">Everruns</span>
         </Link>
-        {featureFlags.notifications && <NotificationBell />}
+        <div className="flex items-center gap-1">
+          <McpConnectButton />
+          {featureFlags.notifications && <NotificationBell />}
+        </div>
       </div>
 
       <SidebarOrganizationMenu


### PR DESCRIPTION
## What
Adds an MCP connect button in the sidebar header that opens a dialog with
the MCP server URL and a copy-paste JSON config snippet for Claude Desktop,
Cursor, VS Code, and other MCP-compatible clients.

## Why
Users need a discoverable way to connect their MCP clients to the Everruns
MCP server endpoint. Currently the `/mcp` endpoint exists but there is no
UI affordance to help users find and configure it.

## How
- New `McpConnectButton` component in `apps/ui/src/components/layout/mcp-connect-button.tsx`
- Renders the MCP icon (existing `capabilityIconMap.mcp`) as a button in the sidebar header
- Click opens a dialog with:
  - MCP server URL with copy button
  - Ready-to-paste JSON config snippet with copy button
  - Note about OAuth authentication
- Gated behind the existing `mcp_endpoint` feature flag
- Styled consistently with the notification bell (same dimensions and hover state)

## Risk
- Low
- UI-only change, gated behind feature flag. No backend changes.

## Security
- Threat categories reviewed: TM-WEB
- No security-relevant surface introduced. MCP URL derived from `window.location.origin` (same-origin, no user input). Config snippet generated via `JSON.stringify` (safe serialization). No `dangerouslySetInnerHTML`. Clipboard API is write-only.

## Checklist
- [x] Tests added or updated (UI-only, no new logic requiring tests)
- [x] Backward compatibility considered (feature-flagged, returns null when flag is off)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
