### PR TITLE
test(ui): update test cases for addressable naming

### DIFF
--- a/test_cases/ui/agent_chat/TC001_multi_turn_agent_conversation.md
+++ b/test_cases/ui/agent_chat/TC001_multi_turn_agent_conversation.md
@@ -9,7 +9,7 @@ Verify that a user can open a direct chat session with an agent, send a message,
 - Server running (`just start-dev`)
 - User logged in
 - LLM API keys configured
-- An agent exists with a humor-oriented system prompt (e.g., "Dad Jokes" agent with system prompt: "You are a dad jokes comedian. Tell funny, clean dad jokes. Always stay in character.")
+- An agent exists with a humor-oriented system prompt (e.g., display name "Dad Jokes", slug `dad-jokes`, system prompt: "You are a dad jokes comedian. Tell funny, clean dad jokes. Always stay in character.")
 
 ## Test Data
 
@@ -21,7 +21,7 @@ Verify that a user can open a direct chat session with an agent, send a message,
 ## Steps
 
 1. Navigate to the Agents page (`/agents`)
-2. Click on the "Dad Jokes" agent to open its detail page
+2. Click on the "Dad Jokes" agent card (display name shown prominently, slug `dad-jokes` in monospace underneath) to open its detail page
 3. Start a new session / open the chat interface for this agent
 4. Send turn 1 message
 5. Wait for the full streamed response to complete (spinner/typing indicator disappears, message fully rendered)

--- a/test_cases/ui/daytona_connection/TC001_daytona_openui_connection_sandbox.md
+++ b/test_cases/ui/daytona_connection/TC001_daytona_openui_connection_sandbox.md
@@ -16,14 +16,14 @@ Verify that the Daytona Coder agent prompts for a Daytona API key via the inline
 
 | Field | Value |
 |-------|-------|
-| Agent | Daytona Coder (seed agent) |
+| Agent | Daytona Coder (seed agent, slug: `daytona-coder`, display name: "Daytona Coder") |
 | First Message | Create a sandbox and calculate the result of 123 * 456. Do NOT delete the sandbox after - I want to keep it running. |
 | Daytona API Key | *(use a valid Daytona API key)* |
 | Cleanup Message | Delete the sandbox |
 
 ## Steps
 
-1. Navigate to the Agents page and locate **Daytona Coder**
+1. Navigate to the Agents page and locate **Daytona Coder** (card shows display name "Daytona Coder" with slug `daytona-coder` underneath)
 2. Click **Run** to start a new session
 3. Send the message: `Create a sandbox and calculate the result of 123 * 456. Do NOT delete the sandbox after - I want to keep it running.`
 4. Wait for the inline **Setup Connection** card to appear in the chat (OpenUI connection prompt for Daytona)

--- a/test_cases/ui/deno_connection/TC001_deno_openui_connection_sandbox.md
+++ b/test_cases/ui/deno_connection/TC001_deno_openui_connection_sandbox.md
@@ -16,14 +16,14 @@ Verify that an agent with Deno capability prompts for a Deno access token via th
 
 | Field | Value |
 |-------|-------|
-| Agent | Deno Coder (seed agent) |
+| Agent | Deno Coder (seed agent, slug: `deno-coder`, display name: "Deno Coder") |
 | First Message | Create a sandbox and calculate the result of 123 * 456. Do NOT delete the sandbox after - I want to keep it running. |
 | Deno Access Token | *(use a valid Deno organization token, `ddo_...`)* |
 | Cleanup Message | Delete the sandbox |
 
 ## Steps
 
-1. Navigate to the Agents page and locate **Deno Coder**
+1. Navigate to the Agents page and locate **Deno Coder** (card shows display name "Deno Coder" with slug `deno-coder` underneath)
 2. Click **Run** to start a new session
 3. Send the message: `Create a sandbox and calculate the result of 123 * 456. Do NOT delete the sandbox after - I want to keep it running.`
 4. Wait for the inline **Setup Connection** card to appear in the chat (OpenUI connection prompt for Deno)

--- a/test_cases/ui/evals/TC003_create_eval.md
+++ b/test_cases/ui/evals/TC003_create_eval.md
@@ -43,6 +43,6 @@ Verify that a new eval can be created with required fields (name, agent, harness
 | Harness dropdown | Lists available harnesses |
 | Submit disabled | "Create Eval" button disabled until agent and harness selected |
 | Redirect | After creation, redirects to `/evals/{eval_id}` |
-| Detail page | Shows eval name, description, status "active", agent name |
+| Detail page | Shows eval name, description, status "active", agent display name |
 | Cases tab | Shows "No test cases yet" empty state |
 | Runs tab | Shows "No runs yet" empty state |

--- a/test_cases/ui/global_chat/TC002_create_agent_via_chat.md
+++ b/test_cases/ui/global_chat/TC002_create_agent_via_chat.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Verify that the global chat agent can create a new agent when asked, using the `manage_agents` platform management tool.
+Verify that the global chat agent can create a new agent when asked, using the `manage_agents` platform management tool. Agents have an addressable name (slug) and an optional display name.
 
 ## Preconditions
 
@@ -31,7 +31,7 @@ Verify that the global chat agent can create a new agent when asked, using the `
 |-------|----------|
 | Agent created | Response mentions agent creation success |
 | Agent link | Response contains markdown link `[Weather Bot](/agents/agent_...)` |
-| Navigate to link | Agent detail page loads with name "Weather Bot" |
+| Navigate to link | Agent detail page loads with display name "Weather Bot" shown prominently and slug `weather-bot` in monospace underneath |
 | Agent prompt | System prompt is "You answer weather questions." |
 | Agent status | `active` |
-| Agents list | New agent visible at `/agents` |
+| Agents list | New agent visible at `/agents` — card shows display name "Weather Bot" with slug `weather-bot` beneath |

--- a/test_cases/ui/global_chat/TC003_create_10_random_agents.md
+++ b/test_cases/ui/global_chat/TC003_create_10_random_agents.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Verify that the global chat agent can create 10 distinct agents in a single conversation when asked. Each agent should have a unique name and system prompt.
+Verify that the global chat agent can create 10 distinct agents in a single conversation when asked. Each agent should have a unique addressable name (slug) and optional display name, plus a system prompt.
 
 ## Preconditions
 
@@ -30,15 +30,15 @@ Verify that the global chat agent can create 10 distinct agents in a single conv
 | Check | Expected |
 |-------|----------|
 | All 10 created | Response confirms 10 agents created |
-| Unique names | Each agent has a distinct name matching the requested names |
+| Unique names | Each agent has a distinct slug (e.g. `code-reviewer`) and display name (e.g. "Code Reviewer") |
 | Agent links | Response contains 10 clickable agent links |
-| Agents list | Navigate to `/agents` — all 10 visible |
+| Agents list | Navigate to `/agents` — all 10 visible with display names shown prominently and slugs in monospace underneath |
 | Each agent active | Each agent has `status: active` |
 | System prompts | Each agent has a system prompt relevant to its name |
 
 ## Validation Commands
 
 ```bash
-# Assert: 10 agents exist (excluding any pre-existing agents)
-curl -s "http://localhost:9300/api/v1/agents" | jq '[.data[] | select(.name | test("Code Reviewer|Data Analyst|Writing Editor|Math Tutor|DevOps Helper|Security Auditor|API Designer|Test Writer|Debug Assistant|Doc Generator"))] | length == 10'
+# Assert: 10 agents exist by slug (excluding any pre-existing agents)
+curl -s "http://localhost:9300/api/v1/agents" | jq '[.data[] | select(.name | test("code-reviewer|data-analyst|writing-editor|math-tutor|devops-helper|security-auditor|api-designer|test-writer|debug-assistant|doc-generator"))] | length == 10'
 ```

--- a/test_cases/ui/global_chat/TC003_create_10_random_agents.md
+++ b/test_cases/ui/global_chat/TC003_create_10_random_agents.md
@@ -39,6 +39,6 @@ Verify that the global chat agent can create 10 distinct agents in a single conv
 ## Validation Commands
 
 ```bash
-# Assert: 10 agents exist by slug (excluding any pre-existing agents)
-curl -s "http://localhost:9300/api/v1/agents" | jq '[.data[] | select(.name | test("code-reviewer|data-analyst|writing-editor|math-tutor|devops-helper|security-auditor|api-designer|test-writer|debug-assistant|doc-generator"))] | length == 10'
+# Assert: 10 agents exist by exact slug (excluding any pre-existing agents)
+curl -s "http://localhost:9300/api/v1/agents" | jq '[.data[] | select(.name | test("^(code-reviewer|data-analyst|writing-editor|math-tutor|devops-helper|security-auditor|api-designer|test-writer|debug-assistant|doc-generator)$"))] | length == 10'
 ```

--- a/test_cases/ui/global_chat/TC004_run_agent_via_chat.md
+++ b/test_cases/ui/global_chat/TC004_run_agent_via_chat.md
@@ -37,4 +37,4 @@ Verify that the global chat agent can run a previously created agent by creating
 | Message sent | Task forwarded to the session |
 | Result relayed | Response includes the Math Tutor's answer (mentions "12") |
 | Session link | Response contains link to the session |
-| Session visible | New session appears at `/sessions` with Math Tutor agent |
+| Session visible | New session appears at `/sessions` showing agent display name "Math Tutor" |

--- a/test_cases/ui/global_chat/TC006_verify_agents_in_agents_page.md
+++ b/test_cases/ui/global_chat/TC006_verify_agents_in_agents_page.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-After creating agents via global chat, verify they appear correctly in the Agents listing page with proper names, status, and details.
+After creating agents via global chat, verify they appear correctly in the Agents listing page with proper display names, slugs, status, and details.
 
 ## Preconditions
 
@@ -12,32 +12,34 @@ After creating agents via global chat, verify they appear correctly in the Agent
 
 ## Test Data
 
-| Agent Name | Expected Status |
-|------------|----------------|
-| Code Reviewer | active |
-| Data Analyst | active |
-| Writing Editor | active |
-| Math Tutor | active |
-| DevOps Helper | active |
-| Security Auditor | active |
-| API Designer | active |
-| Test Writer | active |
-| Debug Assistant | active |
-| Doc Generator | active |
+| Display Name | Slug | Expected Status |
+|------------|------|----------------|
+| Code Reviewer | `code-reviewer` | active |
+| Data Analyst | `data-analyst` | active |
+| Writing Editor | `writing-editor` | active |
+| Math Tutor | `math-tutor` | active |
+| DevOps Helper | `devops-helper` | active |
+| Security Auditor | `security-auditor` | active |
+| API Designer | `api-designer` | active |
+| Test Writer | `test-writer` | active |
+| Debug Assistant | `debug-assistant` | active |
+| Doc Generator | `doc-generator` | active |
 
 ## Steps
 
 1. Navigate to `/agents`
 2. Observe the agents list
-3. Click on each agent to view its detail page
-4. Verify name, system prompt, and status for each
+3. Verify each agent card shows display name prominently and slug in monospace underneath
+4. Click on each agent to view its detail page
+5. Verify display name, slug, system prompt, and status for each
 
 ## Expected Result
 
 | Check | Expected |
 |-------|----------|
 | All 10 visible | All 10 agents appear in the list |
-| Names match | Each agent name matches what was requested |
+| Display names | Each card shows the human-readable display name (e.g. "Code Reviewer") as the title |
+| Slugs shown | Each card shows the slug (e.g. `code-reviewer`) in monospace below the display name |
 | Status | All show `active` status |
 | System prompts | Each has a non-empty system prompt relevant to its purpose |
-| Detail pages load | Clicking each agent navigates to `/agents/{id}` without errors |
+| Detail pages load | Clicking each agent navigates to `/agents/{id}` — detail page shows display name as heading with slug underneath |

--- a/test_cases/ui/global_chat/TC007_verify_sessions_created.md
+++ b/test_cases/ui/global_chat/TC007_verify_sessions_created.md
@@ -19,7 +19,7 @@ None (uses sessions created by TC005).
 1. Navigate to `/sessions`
 2. Observe the sessions list
 3. For each of the 10 agent-linked sessions:
-   - Verify agent name is displayed
+   - Verify agent display name is displayed (e.g. "Math Tutor")
    - Click into the session
    - Check session status and messages
 

--- a/test_cases/ui/global_chat/TC007_verify_sessions_created.md
+++ b/test_cases/ui/global_chat/TC007_verify_sessions_created.md
@@ -28,7 +28,7 @@ None (uses sessions created by TC005).
 | Check | Expected |
 |-------|----------|
 | 10 agent sessions | At least 10 sessions with agent assignments visible |
-| Agent names | Each session shows the correct agent name |
+| Agent names | Each session shows the correct agent display name (e.g. "Math Tutor", not the slug) |
 | Status | All sessions are `idle` (turn completed) |
 | Messages | Each session has >= 2 messages (user + agent response) |
 | Chat history | Clicking a session shows the conversation with task and response |

--- a/test_cases/ui/global_chat/TC008_chat_multi_turn_agent_management.md
+++ b/test_cases/ui/global_chat/TC008_chat_multi_turn_agent_management.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Verify that global chat supports multi-turn conversation for agent management: create an agent, run it, check results, then update the agent — all in one conversation.
+Verify that global chat supports multi-turn conversation for agent management: create an agent, run it, check results, then update the agent — all in one conversation. Agents have an addressable name (slug) and optional display name.
 
 ## Preconditions
 
@@ -24,7 +24,7 @@ Verify that global chat supports multi-turn conversation for agent management: c
 
 1. Navigate to `/chat`
 2. Send turn 1 message, confirm creation if asked
-3. Wait for response, verify agent created
+3. Wait for response, verify agent created with display name "Joke Bot" and slug `joke-bot`
 4. Send turn 2 message
 5. Wait for response, verify Joke Bot ran and returned a joke
 6. Send turn 3 message
@@ -36,7 +36,7 @@ Verify that global chat supports multi-turn conversation for agent management: c
 
 | Check | Expected |
 |-------|----------|
-| Turn 1 | Agent "Joke Bot" created with link |
+| Turn 1 | Agent created with display name "Joke Bot" (slug `joke-bot`), response contains link |
 | Turn 2 | Session created, joke returned |
 | Turn 3 | Chat agent recalls the joke from previous turn |
 | Turn 4 | Agent list returned, includes Joke Bot |

--- a/test_cases/ui/org_creation/TC003_setup_page_progress.md
+++ b/test_cases/ui/org_creation/TC003_setup_page_progress.md
@@ -19,7 +19,7 @@ Verify that the org setup page displays three sequential setup steps with animat
 - Page header shows "Setting up <org name>" with a Building icon
 - Three steps appear in sequence:
   1. "Organisation created" — "Your new organisation has been provisioned"
-  2. "Harnesses initialised" — "Built-in harnesses (Base, Generic, Platform Chat) are ready"
+  2. "Harnesses initialised" — "Built-in harnesses (base, generic, platform-chat) are ready"
   3. "Default settings configured" — "Default and base harnesses have been assigned"
 - Each step transitions from pending (faded) to a spinner to a green checkmark
 - After all steps complete, a "Go to dashboard" button appears

--- a/test_cases/ui/org_creation/TC004_verify_harnesses_after_setup.md
+++ b/test_cases/ui/org_creation/TC004_verify_harnesses_after_setup.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Verify that built-in harnesses are provisioned for the new organisation by navigating to the Harnesses page after setup.
+Verify that built-in harnesses are provisioned for the new organisation by navigating to the Harnesses page after setup. Harnesses now use addressable names (slugs) with separate display names.
 
 ## Preconditions
 
@@ -17,5 +17,6 @@ Verify that built-in harnesses are provisioned for the new organisation by navig
 ## Expected Result
 
 - Dashboard loads without errors
-- Harnesses page shows at least three built-in harnesses: Base, Generic, Platform Chat
+- Harnesses page shows at least three built-in harnesses with names: `base`, `generic`, `platform-chat`
+- Each harness card shows a "Built-in" badge
 - Each harness card is clickable and links to a detail page

--- a/test_cases/ui/org_creation/TC006_org_settings_after_creation.md
+++ b/test_cases/ui/org_creation/TC006_org_settings_after_creation.md
@@ -19,7 +19,7 @@ Verify that Settings > Organisation shows correct details for a newly created or
 ## Expected Result
 
 - Organisation name matches the name entered during creation
-- Default Harness dropdown has a harness selected (not empty)
-- Base Harness dropdown has a harness selected (not empty)
+- Default Harness dropdown has a harness selected (not empty) — displays the harness slug (e.g. `generic`)
+- Base Harness dropdown has a harness selected (not empty) — displays the harness slug (e.g. `base`)
 - Organisation ID is displayed and starts with `org_`
 - A copy button is present next to the Organisation ID


### PR DESCRIPTION
## What
Update 13 UI test cases to reflect the new addressable naming system (slug `name` + optional `display_name`) for agents and harnesses.

## Why
Recent PRs (#1209, #1228, #1229, #1231, #1232) introduced addressable names for agents and harnesses. Agents now show display name prominently with slug in monospace underneath. Harness cards/selects show the slug. The existing UI test cases still referenced the old single-name pattern and would fail validation.

## How
- Agent test cases updated to verify both display name (card title, detail heading) and slug (monospace subtitle)
- Harness test cases updated to reference slugs (`base`, `generic`, `platform-chat`) instead of old display names
- Validation commands in TC003 updated to match slug patterns instead of free-form names
- Connection sandbox tests (Deno, Daytona) annotated with seed agent slug/display name
- Evals TC003 updated to reference "agent display name" on detail page

## Risk
- Low
- Test-case-only change (markdown files). No code, no runtime behavior change.

## Security
- No security-relevant code changes. This PR modifies only manual test case markdown files under `test_cases/ui/`. No code, configuration, or infrastructure is touched.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)