### PR TITLE
refactor(agents): use "import" verb and unify import endpoint

### DIFF
--- a/apps/ui/src/app/(main)/agents/examples/page.tsx
+++ b/apps/ui/src/app/(main)/agents/examples/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useMemo } from "react";
-import { useAgentExamples, useAdoptAgentExample, useCapabilities } from "@/hooks";
+import { useAgentExamples, useImportAgentExample, useCapabilities } from "@/hooks";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
@@ -15,22 +15,22 @@ export default function AllExamplesPage() {
   const [exampleSearch, setExampleSearch] = useState("");
   const { data: allCapabilities } = useCapabilities();
   const { data: examples, isLoading, error } = useAgentExamples();
-  const adoptExample = useAdoptAgentExample();
-  const [adoptingSlug, setAdoptingSlug] = useState<string | null>(null);
+  const importExample = useImportAgentExample();
+  const [importingName, setImportingName] = useState<string | null>(null);
 
-  const handleUse = useCallback(
-    async (slug: string) => {
-      setAdoptingSlug(slug);
+  const handleImport = useCallback(
+    async (name: string) => {
+      setImportingName(name);
       try {
-        const agent = await adoptExample.mutateAsync(slug);
+        const agent = await importExample.mutateAsync(name);
         router.push(`/agents/${agent.id}`);
       } catch (err) {
-        console.error("Failed to use example:", err);
+        console.error("Failed to import example:", err);
       } finally {
-        setAdoptingSlug(null);
+        setImportingName(null);
       }
     },
-    [adoptExample, router],
+    [importExample, router],
   );
 
   const filteredExamples = useMemo(() => {
@@ -38,6 +38,7 @@ export default function AllExamplesPage() {
     const query = exampleSearch.toLowerCase();
     return examples.filter(
       (ex) =>
+        ex.display_name.toLowerCase().includes(query) ||
         ex.name.toLowerCase().includes(query) ||
         ex.description.toLowerCase().includes(query) ||
         ex.tags.some((tag) => tag.toLowerCase().includes(query)),
@@ -83,11 +84,11 @@ export default function AllExamplesPage() {
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
             {items.map((example, index) => (
               <ExampleCard
-                key={example.slug ?? `example-${index}`}
+                key={example.name ?? `example-${index}`}
                 example={example}
                 allCapabilities={allCapabilities}
-                onUse={handleUse}
-                adopting={adoptingSlug === example.slug}
+                onImport={handleImport}
+                adopting={importingName === example.name}
               />
             ))}
           </div>

--- a/apps/ui/src/app/(main)/agents/page.tsx
+++ b/apps/ui/src/app/(main)/agents/page.tsx
@@ -4,7 +4,7 @@ import { useRef, useState, useCallback } from "react";
 import {
   useAgents,
   useAgentExamples,
-  useAdoptAgentExample,
+  useImportAgentExample,
   useCapabilities,
   useImportAgent,
 } from "@/hooks";
@@ -23,10 +23,10 @@ export default function AgentsPage() {
   const { data: allCapabilities } = useCapabilities();
   const { data: examples, isLoading: examplesLoading, error: examplesError } = useAgentExamples();
   const importAgent = useImportAgent();
-  const adoptExample = useAdoptAgentExample();
+  const importExample = useImportAgentExample();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [importError, setImportError] = useState<string | null>(null);
-  const [adoptingSlug, setAdoptingSlug] = useState<string | null>(null);
+  const [importingName, setImportingName] = useState<string | null>(null);
 
   const handleImportClick = useCallback(() => {
     fileInputRef.current?.click();
@@ -55,19 +55,19 @@ export default function AgentsPage() {
     [importAgent, router],
   );
 
-  const handleUse = useCallback(
-    async (slug: string) => {
-      setAdoptingSlug(slug);
+  const handleImport = useCallback(
+    async (name: string) => {
+      setImportingName(name);
       try {
-        const agent = await adoptExample.mutateAsync(slug);
+        const agent = await importExample.mutateAsync(name);
         router.push(`/agents/${agent.id}`);
       } catch (err) {
-        console.error("Failed to use example:", err);
+        console.error("Failed to import example:", err);
       } finally {
-        setAdoptingSlug(null);
+        setImportingName(null);
       }
     },
-    [adoptExample, router],
+    [importExample, router],
   );
 
   const previewAgents = agents?.slice(0, PREVIEW_LIMIT);
@@ -182,11 +182,11 @@ export default function AgentsPage() {
             <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
               {items.map((example, index) => (
                 <ExampleCard
-                  key={example.slug ?? `example-${index}`}
+                  key={example.name ?? `example-${index}`}
                   example={example}
                   allCapabilities={allCapabilities}
-                  onUse={handleUse}
-                  adopting={adoptingSlug === example.slug}
+                  onImport={handleImport}
+                  adopting={importingName === example.name}
                 />
               ))}
             </div>

--- a/apps/ui/src/components/agents/example-card.tsx
+++ b/apps/ui/src/components/agents/example-card.tsx
@@ -4,21 +4,21 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { Plus } from "lucide-react";
+import { Import } from "lucide-react";
 import type { AgentExample, Capability, CapabilityId } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
 
 interface ExampleCardProps {
   example: AgentExample;
   allCapabilities?: Capability[];
-  onUse: (slug: string) => void;
+  onImport: (name: string) => void;
   adopting?: boolean;
 }
 
 export function ExampleCard({
   example,
   allCapabilities,
-  onUse,
+  onImport,
   adopting = false,
 }: ExampleCardProps) {
   const getCapabilityInfo = (capabilityId: CapabilityId): Capability | undefined =>
@@ -27,7 +27,7 @@ export function ExampleCard({
   return (
     <Card className="bg-background transition-colors hover:bg-card">
       <CardHeader className="flex flex-row items-start justify-between space-y-0">
-        <CardTitle className="text-lg">{example.name}</CardTitle>
+        <CardTitle className="text-lg">{example.display_name}</CardTitle>
         {example.dev_only && (
           <Badge variant="outline" className="text-xs">
             dev
@@ -74,16 +74,16 @@ export function ExampleCard({
           </div>
         )}
 
-        {/* Use button */}
+        {/* Import button */}
         <div className="flex items-center justify-end">
           <Button
             variant="accent"
             size="sm"
-            onClick={() => onUse(example.slug)}
+            onClick={() => onImport(example.name)}
             disabled={adopting}
           >
-            <Plus className="w-4 h-4 mr-2" />
-            {adopting ? "Adding..." : "Use"}
+            <Import className="w-4 h-4 mr-2" />
+            {adopting ? "Importing..." : "Import"}
           </Button>
         </div>
       </CardContent>

--- a/apps/ui/src/hooks/use-agent-examples.ts
+++ b/apps/ui/src/hooks/use-agent-examples.ts
@@ -2,7 +2,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { listAgentExamples, adoptAgentExample } from "@/lib/api/agent-examples";
+import { listAgentExamples, importAgentExample } from "@/lib/api/agent-examples";
 import { queryKeys } from "@/lib/query-keys";
 import { useOrg } from "@/providers/org-provider";
 
@@ -22,11 +22,11 @@ export function useAgentExamples() {
   };
 }
 
-export function useAdoptAgentExample() {
+export function useImportAgentExample() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (slug: string) => adoptAgentExample(slug),
+    mutationFn: (name: string) => importAgentExample(name),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
     },

--- a/apps/ui/src/lib/api/agent-examples.ts
+++ b/apps/ui/src/lib/api/agent-examples.ts
@@ -9,8 +9,8 @@ export async function listAgentExamples(): Promise<AgentExample[]> {
 }
 
 export async function importAgentExample(name: string): Promise<Agent> {
-  const response = await api.post<Agent>("/v1/agents/import", undefined, {
-    params: { "from-example": name },
-  });
+  const response = await api.post<Agent>(
+    `/v1/agents/import?from-example=${encodeURIComponent(name)}`,
+  );
   return response.data;
 }

--- a/apps/ui/src/lib/api/agent-examples.ts
+++ b/apps/ui/src/lib/api/agent-examples.ts
@@ -8,7 +8,7 @@ export async function listAgentExamples(): Promise<AgentExample[]> {
   return response.data;
 }
 
-export async function adoptAgentExample(slug: string): Promise<Agent> {
-  const response = await api.post<Agent>(`/v1/agent-examples/${slug}/use`);
+export async function importAgentExample(name: string): Promise<Agent> {
+  const response = await api.post<Agent>(`/v1/agents/import?from-example=${name}`);
   return response.data;
 }

--- a/apps/ui/src/lib/api/agent-examples.ts
+++ b/apps/ui/src/lib/api/agent-examples.ts
@@ -9,6 +9,8 @@ export async function listAgentExamples(): Promise<AgentExample[]> {
 }
 
 export async function importAgentExample(name: string): Promise<Agent> {
-  const response = await api.post<Agent>(`/v1/agents/import?from-example=${name}`);
+  const response = await api.post<Agent>("/v1/agents/import", undefined, {
+    params: { "from-example": name },
+  });
   return response.data;
 }

--- a/apps/ui/src/lib/api/types/agent-types.ts
+++ b/apps/ui/src/lib/api/types/agent-types.ts
@@ -79,8 +79,8 @@ export interface UpdateAgentRequest {
 
 /** Read-only agent example defined in code, adoptable as a real Agent */
 export interface AgentExample {
-  slug: string;
   name: string;
+  display_name: string;
   description: string;
   tags: string[];
   capabilities: AgentCapabilityConfig[];

--- a/crates/server/src/api/agent_examples.rs
+++ b/crates/server/src/api/agent_examples.rs
@@ -113,14 +113,14 @@ mod tests {
     }
 
     #[test]
-    fn test_find_seed_by_name() {
+    fn test_known_seed_exists_by_name() {
         let seed = SEED_AGENTS.iter().find(|s| s.name == "dad-jokes-agent");
         assert!(seed.is_some());
         assert_eq!(seed.unwrap().display_name, "Dad Jokes Agent");
     }
 
     #[test]
-    fn test_find_seed_by_name_not_found() {
+    fn test_unknown_name_returns_none() {
         let seed = SEED_AGENTS.iter().find(|s| s.name == "nonexistent");
         assert!(seed.is_none());
     }

--- a/crates/server/src/api/agent_examples.rs
+++ b/crates/server/src/api/agent_examples.rs
@@ -1,27 +1,18 @@
-// Agent Examples API — read-only examples defined in code, adoptable as real Agents.
+// Agent Examples API — read-only catalogue of built-in examples.
 //
 // Decision: Examples live in code (SEED_AGENTS), not in DB.
-// Decision: "Use" creates a real Agent via the existing create flow
+// Decision: Import is handled by POST /v1/agents/import?from-example={name}
 // Decision: Examples are identified by their name
 
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::seed::{SEED_AGENTS, SeedAgent};
-use crate::services::CapabilityService;
-use axum::{
-    Json, Router,
-    extract::{Path, State},
-    http::StatusCode,
-    routing::{get, post},
-};
-use everruns_core::{Agent, AgentCapabilityConfig, Caller, DeploymentGrade, PlatformDefinition};
+use axum::{Json, Router, extract::State, routing::get};
+use everruns_core::{AgentCapabilityConfig, DeploymentGrade, PlatformDefinition};
 use serde::Serialize;
 use std::sync::Arc;
 use utoipa::ToSchema;
 
-use super::agents::CreateAgentRequest;
-use super::common::{ApiPolicyResultExt, ErrorResponse, impl_auth_state};
-
-use crate::services::AgentService;
+use super::common::impl_auth_state;
 
 /// A read-only agent example defined in code
 #[derive(Debug, Clone, Serialize, ToSchema)]
@@ -58,15 +49,9 @@ fn seed_to_example(seed: &SeedAgent) -> AgentExample {
     }
 }
 
-fn find_seed_by_name(name: &str) -> Option<&'static SeedAgent> {
-    SEED_AGENTS.iter().find(|s| s.name == name)
-}
-
 /// App state for agent example routes
 #[derive(Clone)]
 pub struct AppState {
-    pub agent_service: Arc<AgentService>,
-    pub capability_service: Arc<CapabilityService>,
     pub auth: AuthState,
     pub grade: DeploymentGrade,
     pub platform_definition: Arc<PlatformDefinition>,
@@ -78,7 +63,6 @@ impl_auth_state!(AppState);
 pub fn routes(state: AppState) -> Router {
     Router::new()
         .route("/v1/agent-examples", get(list_examples))
-        .route("/v1/agent-examples/{name}/use", post(use_example))
         .with_state(state)
 }
 
@@ -115,86 +99,6 @@ pub async fn list_examples(
     Json(examples)
 }
 
-/// POST /v1/agent-examples/{name}/use — create a real Agent from an example
-#[utoipa::path(
-    post,
-    path = "/v1/agent-examples/{name}/use",
-    params(
-        ("name" = String, Path, description = "Example name (e.g. dad-jokes-agent)")
-    ),
-    responses(
-        (status = 201, description = "Agent created from example", body = Agent),
-        (status = 404, description = "Example not found"),
-        (status = 403, description = "High-risk capabilities require admin role"),
-    ),
-    tag = "agent-examples"
-)]
-pub async fn use_example(
-    org: ResolvedOrg,
-    State(state): State<AppState>,
-    Path(name): Path<String>,
-) -> Result<(StatusCode, Json<Agent>), (StatusCode, Json<ErrorResponse>)> {
-    let seed = find_seed_by_name(&name)
-        .ok_or_else(|| ErrorResponse::not_found(&format!("agent example '{name}'")))?;
-
-    // Check dev-only
-    if seed.dev_only && !state.grade.experimental_features_enabled() {
-        return Err(ErrorResponse::not_found(&format!("agent example '{name}'")));
-    }
-
-    // Check capabilities registered
-    let missing: Vec<&str> = seed
-        .capabilities
-        .iter()
-        .map(|c| c.id)
-        .filter(|id| !state.platform_definition.capability_registry().has(id))
-        .collect();
-    if !missing.is_empty() {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse {
-                error: format!("Example requires unregistered capabilities: {missing:?}"),
-            }),
-        ));
-    }
-
-    let capabilities: Vec<AgentCapabilityConfig> = seed
-        .capabilities
-        .iter()
-        .map(|cap| {
-            let config = cap.config.map_or_else(|| serde_json::json!({}), |f| f());
-            AgentCapabilityConfig::with_config(cap.id.to_string(), config)
-        })
-        .collect();
-
-    // TM-AGENT-005: High-risk capabilities require admin role
-    super::agents::require_admin_for_high_risk(&org, &capabilities, &state.capability_service)?;
-
-    let req = CreateAgentRequest {
-        id: None,
-        name: seed.name.to_string(),
-        display_name: Some(seed.display_name.to_string()),
-        description: Some(seed.description.to_string()),
-        system_prompt: seed.system_prompt.to_string(),
-        default_model_id: None,
-        tags: seed.tags.iter().map(|s| s.to_string()).collect(),
-        capabilities,
-        initial_files: vec![],
-        tools: vec![],
-        network_access: None,
-        max_iterations: None,
-    };
-
-    let caller = Caller::from(&org);
-    let agent = state
-        .agent_service
-        .create(&caller, None, req)
-        .await
-        .map_policy_or_internal("use agent example")?;
-
-    Ok((StatusCode::CREATED, Json(agent)))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -210,13 +114,14 @@ mod tests {
 
     #[test]
     fn test_find_seed_by_name() {
-        let seed = find_seed_by_name("dad-jokes-agent");
+        let seed = SEED_AGENTS.iter().find(|s| s.name == "dad-jokes-agent");
         assert!(seed.is_some());
         assert_eq!(seed.unwrap().display_name, "Dad Jokes Agent");
     }
 
     #[test]
     fn test_find_seed_by_name_not_found() {
-        assert!(find_seed_by_name("nonexistent").is_none());
+        let seed = SEED_AGENTS.iter().find(|s| s.name == "nonexistent");
+        assert!(seed.is_none());
     }
 }

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -15,8 +15,8 @@ use axum::{
 use chrono::Utc;
 use everruns_core::typed_id::{AgentId, ModelId};
 use everruns_core::{
-    Agent, AgentCapabilityConfig, AgentStatus, Caller, InitialFile, OrgRole,
-    ResourceConfigResponse, ToolDefinition, evaluate_policies_with,
+    Agent, AgentCapabilityConfig, AgentStatus, Caller, DeploymentGrade, InitialFile, OrgRole,
+    PlatformDefinition, ResourceConfigResponse, ToolDefinition, evaluate_policies_with,
 };
 
 use super::common::{
@@ -285,6 +285,8 @@ pub struct AppState {
     pub service: Arc<AgentService>,
     pub capability_service: Arc<CapabilityService>,
     pub auth: AuthState,
+    pub grade: DeploymentGrade,
+    pub platform_definition: Arc<PlatformDefinition>,
 }
 
 impl AppState {
@@ -292,11 +294,15 @@ impl AppState {
         db: Arc<StorageBackend>,
         capability_service: Arc<CapabilityService>,
         auth: AuthState,
+        grade: DeploymentGrade,
+        platform_definition: Arc<PlatformDefinition>,
     ) -> Self {
         Self {
             service: Arc::new(AgentService::new(db)),
             capability_service,
             auth,
+            grade,
+            platform_definition,
         }
     }
 }
@@ -868,9 +874,23 @@ pub async fn export_agent(
         .unwrap())
 }
 
-/// POST /v1/agents/import - Import agent from Markdown, YAML, or JSON
+/// Query parameters for POST /v1/agents/import
+#[derive(Debug, Clone, Deserialize, IntoParams)]
+#[into_params(parameter_in = Query)]
+pub struct ImportAgentQuery {
+    /// Import from a built-in example by name (e.g. `dad-jokes-agent`).
+    /// When set, the request body is ignored.
+    #[serde(rename = "from-example")]
+    pub from_example: Option<String>,
+}
+
+/// POST /v1/agents/import - Import agent from file or built-in example
 ///
-/// Accepts agent definition in multiple formats:
+/// Two modes:
+/// 1. **From example** — `POST /v1/agents/import?from-example={name}` (body ignored)
+/// 2. **From file** — `POST /v1/agents/import` with a text body in Markdown/YAML/JSON
+///
+/// File mode accepts:
 /// - Markdown with YAML front matter (if starts with ---)
 /// - Pure YAML
 /// - Pure JSON
@@ -881,11 +901,14 @@ pub async fn export_agent(
 #[utoipa::path(
     post,
     path = "/v1/agents/import",
+    params(ImportAgentQuery),
     request_body(content = String, content_type = "text/plain"),
     responses(
         (status = 200, description = "Agent updated via import", body = Agent),
         (status = 201, description = "Agent imported successfully", body = Agent),
         (status = 400, description = "Invalid format or input exceeds limits", body = ErrorResponse),
+        (status = 404, description = "Example not found"),
+        (status = 403, description = "High-risk capabilities require admin role"),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     tag = "agents"
@@ -893,6 +916,115 @@ pub async fn export_agent(
 pub async fn import_agent(
     org: ResolvedOrg,
     State(state): State<AppState>,
+    Query(query): Query<ImportAgentQuery>,
+    body: String,
+) -> Result<(StatusCode, Json<Agent>), (StatusCode, Json<ErrorResponse>)> {
+    // Branch: import from built-in example
+    if let Some(name) = query.from_example {
+        return import_from_example(org, &state, &name).await;
+    }
+
+    // Branch: import from file body
+    import_from_file(org, &state, body).await
+}
+
+/// Import an agent from a built-in example by name.
+async fn import_from_example(
+    org: ResolvedOrg,
+    state: &AppState,
+    name: &str,
+) -> Result<(StatusCode, Json<Agent>), (StatusCode, Json<ErrorResponse>)> {
+    use crate::seed::SEED_AGENTS;
+
+    let seed = SEED_AGENTS
+        .iter()
+        .find(|s| s.name == name)
+        .ok_or_else(|| ErrorResponse::not_found(&format!("agent example '{name}'")))?;
+
+    // Check dev-only
+    if seed.dev_only && !state.grade.experimental_features_enabled() {
+        return Err(ErrorResponse::not_found(&format!("agent example '{name}'")));
+    }
+
+    // Check capabilities registered
+    let missing: Vec<&str> = seed
+        .capabilities
+        .iter()
+        .map(|c| c.id)
+        .filter(|id| !state.platform_definition.capability_registry().has(id))
+        .collect();
+    if !missing.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Example requires unregistered capabilities: {missing:?}"),
+            }),
+        ));
+    }
+
+    let capabilities: Vec<AgentCapabilityConfig> = seed
+        .capabilities
+        .iter()
+        .map(|cap| {
+            let config = cap.config.map_or_else(|| serde_json::json!({}), |f| f());
+            AgentCapabilityConfig::with_config(cap.id.to_string(), config)
+        })
+        .collect();
+
+    // TM-AGENT-005: High-risk capabilities require admin role
+    require_admin_for_high_risk(&org, &capabilities, &state.capability_service)?;
+
+    let caller = Caller::from(&org);
+
+    // If an agent with the same name exists, append a random suffix
+    let unique_name = {
+        let base = seed.name;
+        let available = state
+            .service
+            .check_name_available(&caller, base, None)
+            .await
+            .map_err(|_| ErrorResponse::internal_error())?;
+        if available {
+            base.to_string()
+        } else {
+            use rand::Rng;
+            let suffix: String = rand::rng()
+                .sample_iter(&rand::distr::Alphanumeric)
+                .take(5)
+                .map(|c| (c as char).to_ascii_lowercase())
+                .collect();
+            format!("{base}-{suffix}")
+        }
+    };
+
+    let req = CreateAgentRequest {
+        id: None,
+        name: unique_name,
+        display_name: Some(seed.display_name.to_string()),
+        description: Some(seed.description.to_string()),
+        system_prompt: seed.system_prompt.to_string(),
+        default_model_id: None,
+        tags: seed.tags.iter().map(|s| s.to_string()).collect(),
+        capabilities,
+        initial_files: vec![],
+        tools: vec![],
+        network_access: None,
+        max_iterations: None,
+    };
+
+    let agent = state
+        .service
+        .create(&caller, None, req)
+        .await
+        .map_policy_or_internal("import agent from example")?;
+
+    Ok((StatusCode::CREATED, Json(agent)))
+}
+
+/// Import an agent from a file body (Markdown/YAML/JSON).
+async fn import_from_file(
+    org: ResolvedOrg,
+    state: &AppState,
     body: String,
 ) -> Result<(StatusCode, Json<Agent>), (StatusCode, Json<ErrorResponse>)> {
     // Validate import file size (last-resort protection against abuse)

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -907,8 +907,8 @@ pub struct ImportAgentQuery {
         (status = 200, description = "Agent updated via import", body = Agent),
         (status = 201, description = "Agent imported successfully", body = Agent),
         (status = 400, description = "Invalid format or input exceeds limits", body = ErrorResponse),
-        (status = 404, description = "Example not found"),
-        (status = 403, description = "High-risk capabilities require admin role"),
+        (status = 404, description = "Example not found", body = ErrorResponse),
+        (status = 403, description = "High-risk capabilities require admin role", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     tag = "agents"
@@ -976,25 +976,39 @@ async fn import_from_example(
 
     let caller = Caller::from(&org);
 
-    // If an agent with the same name exists, append a random suffix
+    // If an agent with the same name exists, keep trying suffixed variants
+    // to avoid one-shot collisions and reduce failures under concurrency.
     let unique_name = {
+        use rand::Rng;
+
         let base = seed.name;
-        let available = state
-            .service
-            .check_name_available(&caller, base, None)
-            .await
-            .map_err(|_| ErrorResponse::internal_error())?;
-        if available {
-            base.to_string()
-        } else {
-            use rand::Rng;
-            let suffix: String = rand::rng()
-                .sample_iter(&rand::distr::Alphanumeric)
-                .take(5)
-                .map(|c| (c as char).to_ascii_lowercase())
-                .collect();
-            format!("{base}-{suffix}")
+        let mut selected = None;
+
+        for attempt in 0..10 {
+            let candidate = if attempt == 0 {
+                base.to_string()
+            } else {
+                let suffix: String = rand::rng()
+                    .sample_iter(&rand::distr::Alphanumeric)
+                    .take(5)
+                    .map(|c| (c as char).to_ascii_lowercase())
+                    .collect();
+                format!("{base}-{suffix}")
+            };
+
+            let available = state
+                .service
+                .check_name_available(&caller, &candidate, None)
+                .await
+                .map_err(|_| ErrorResponse::internal_error())?;
+
+            if available {
+                selected = Some(candidate);
+                break;
+            }
         }
+
+        selected.ok_or_else(ErrorResponse::internal_error)?
     };
 
     let req = CreateAgentRequest {

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -555,15 +555,19 @@ impl ServerAppBuilder {
         );
         let commands_state =
             api::commands::AppState::new(capability_service.clone(), auth_state.clone());
+        let grade = everruns_core::DeploymentGrade::from_env();
         let agent_examples_state = api::agent_examples::AppState {
-            agent_service: Arc::new(services::AgentService::new(db.clone())),
-            capability_service: capability_service.clone(),
             auth: auth_state.clone(),
-            grade: everruns_core::DeploymentGrade::from_env(),
+            grade,
             platform_definition: platform_definition.clone(),
         };
-        let agents_state =
-            api::agents::AppState::new(db.clone(), capability_service, auth_state.clone());
+        let agents_state = api::agents::AppState::new(
+            db.clone(),
+            capability_service,
+            auth_state.clone(),
+            grade,
+            platform_definition.clone(),
+        );
         let agent_identities_state =
             api::agent_identities::AppState::new(db.clone(), auth_state.clone());
         let agent_identity_connections_state = api::agent_identity_connections::AppState::new(

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -139,7 +139,8 @@ impl TestServer {
 
         // Seed default data synchronously (harnesses, agents, providers, etc.)
         let grade = everruns_core::DeploymentGrade::from_env();
-        let platform_definition = everruns_server::oss_platform_definition_for_grade(grade);
+        let platform_definition =
+            Arc::new(everruns_server::oss_platform_definition_for_grade(grade));
         seed::seed_all(&db, grade, &seed::SeedAuthContext::default())
             .await
             .expect("Failed to seed test data");
@@ -234,8 +235,13 @@ impl TestServer {
             capability_service.clone(),
             auth_state.clone(),
         );
-        let agents_state =
-            api::agents::AppState::new(db.clone(), capability_service, auth_state.clone());
+        let agents_state = api::agents::AppState::new(
+            db.clone(),
+            capability_service,
+            auth_state.clone(),
+            grade,
+            platform_definition.clone(),
+        );
         let session_files_state = api::session_files::AppState::new(
             db.clone(),
             event_service.clone(),

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -207,10 +207,24 @@
             }
           },
           "403": {
-            "description": "High-risk capabilities require admin role"
+            "description": "High-risk capabilities require admin role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Example not found"
+            "description": "Example not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal server error",

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -151,9 +151,20 @@
         "tags": [
           "agents"
         ],
-        "summary": "POST /v1/agents/import - Import agent from Markdown, YAML, or JSON",
-        "description": "Accepts agent definition in multiple formats:\n- Markdown with YAML front matter (if starts with ---)\n- Pure YAML\n- Pure JSON\n- Plain text (treated as system prompt, name auto-generated)\n\nIf the file contains an `id` field and an agent with that ID already exists,\nthe agent is updated (upsert). Returns 201 on create, 200 on update.",
+        "summary": "POST /v1/agents/import - Import agent from file or built-in example",
+        "description": "Two modes:\n1. **From example** — `POST /v1/agents/import?from-example={name}` (body ignored)\n2. **From file** — `POST /v1/agents/import` with a text body in Markdown/YAML/JSON\n\nFile mode accepts:\n- Markdown with YAML front matter (if starts with ---)\n- Pure YAML\n- Pure JSON\n- Plain text (treated as system prompt, name auto-generated)\n\nIf the file contains an `id` field and an agent with that ID already exists,\nthe agent is updated (upsert). Returns 201 on create, 200 on update.",
         "operationId": "import_agent",
+        "parameters": [
+          {
+            "name": "from-example",
+            "in": "query",
+            "description": "Import from a built-in example by name (e.g. `dad-jokes-agent`).\nWhen set, the request body is ignored.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "text/plain": {
@@ -194,6 +205,12 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "High-risk capabilities require admin role"
+          },
+          "404": {
+            "description": "Example not found"
           },
           "500": {
             "description": "Internal server error",


### PR DESCRIPTION
## What
Rename the "Use" verb to "Import" for promoting example agents and unify under a single endpoint: `POST /v1/agents/import?from-example={name}`.

## Why
"Import" better describes the action of bringing a built-in example into the user's agent list. Unifying with the existing `/v1/agents/import` endpoint (which handles file-based import) creates a cleaner REST design — one import endpoint with the source as a parameter.

## How
**API:**
- Remove `POST /v1/agent-examples/{name}/use` endpoint
- Extend `POST /v1/agents/import` with optional `from-example` query param
- When `from-example` is set, import from the built-in example (body ignored)
- When absent, import from request body (Markdown/YAML/JSON) as before
- On name collision, append a 5-char random alphanumeric suffix (e.g. `dad-jokes-agent-bd1en`)

**Backend:**
- `agent_examples.rs` simplified to read-only catalogue (list endpoint only)
- `agents.rs` gains `ImportAgentQuery`, `import_from_example()`, `import_from_file()` split
- `AppState` for agents now includes `grade` and `platform_definition` (needed for example validation)
- Simplified `agent_examples::AppState` (removed `agent_service`, `capability_service`)

**UI:**
- Button text: "Use" → "Import", icon: `Plus` → `Import` (lucide)
- API client calls unified endpoint with query param
- Hook renamed `useAdoptAgentExample` → `useImportAgentExample`
- Props/callbacks renamed: `onUse` → `onImport`, `slug` → `name`
- `AgentExample` type updated: `slug` → `name`, added `display_name`

## Risk
- Low
- Old endpoint gone (no backward compat needed per AGENTS.md)

## Security
- Threat categories reviewed: TM-API, TM-AUTHZ, TM-TENANT
- `from-example` query param validated against static seed list; non-matching names return 404
- Auth, dev-only, capability registration, and high-risk admin role checks preserved from old handler
- Org scoping via `Caller::from(&org)` unchanged
- Random suffix uses `rand::Alphanumeric` — no security sensitivity for agent names

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)