### PR TITLE
refactor(core): extract AgentConfigOverlay for composable config merging

### DIFF
--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -26,6 +26,7 @@ use uuid::Uuid;
 
 use super::{Atom, AtomContext};
 use crate::capabilities::CapabilityRegistry;
+use crate::config_layer::AgentConfigOverlay;
 use crate::error::{AgentLoopError, Result};
 use crate::events::{
     EventContext, EventRequest, LlmCompactionInfo, LlmGenerationData, LlmRetryInfo,
@@ -566,21 +567,20 @@ impl ReasonAtom {
             .await?
             .ok_or_else(|| AgentLoopError::session_not_found(session_id))?;
 
-        // 3. Load messages with capability message filters applied.
-        //
-        // Collect only message filter providers from all capability layers
-        // (harness → agent → session). This uses the lightweight path that
-        // skips system prompt contributions and tool collection — those are
-        // expensive (e.g., AGENTS.md filesystem read) and not needed here.
-        let mut all_capability_configs: Vec<crate::AgentCapabilityConfig> =
-            harness.capabilities.clone();
-        if let Some(ref agent) = agent {
-            all_capability_configs.extend(agent.capabilities.iter().cloned());
-        }
-        all_capability_configs.extend(session.capabilities.iter().cloned());
+        // 4. Fold harness → agent → session into a single config overlay.
+        //    Cheap sync merge; reused for message filters, model, and RuntimeAgent.
+        let effective_overlay = {
+            let mut layers: Vec<AgentConfigOverlay> = vec![AgentConfigOverlay::from(&harness)];
+            if let Some(ref agent) = agent {
+                layers.push(AgentConfigOverlay::from(agent));
+            }
+            layers.push(AgentConfigOverlay::from(&session));
+            AgentConfigOverlay::fold(layers)
+        };
 
+        // 5. Load messages with capability message filters applied.
         let collected_filters = crate::capabilities::collect_message_filters_only(
-            &all_capability_configs,
+            &effective_overlay.capabilities,
             &self.capability_registry,
         );
 
@@ -593,7 +593,7 @@ impl ReasonAtom {
             return Err(AgentLoopError::NoMessages);
         }
 
-        // 4. Extract model_id from the last user message's controls (highest priority)
+        // 6. Resolve model: controls > overlay (session > agent > harness) > system default
         let controls_model_id = messages
             .iter()
             .rev()
@@ -601,25 +601,32 @@ impl ReasonAtom {
             .and_then(|m| m.controls.as_ref())
             .and_then(|c| c.model_id);
 
-        // 5. Resolve model: controls > session > agent > harness
-        let agent_model_id = agent.as_ref().and_then(|a| a.default_model_id);
         let (model_with_provider, resolved_model_id) = self
             .resolve_model(
                 controls_model_id,
-                session.model_id,
-                agent_model_id,
-                harness.default_model_id,
+                effective_overlay.default_model_id,
+                None,
+                None,
             )
             .await?;
 
-        // 6. Build runtime agent
+        // 7. Extract compaction config from merged capabilities (before consuming overlay)
+        let compaction_config = {
+            use crate::capabilities::COMPACTION_CAPABILITY_ID;
+            effective_overlay
+                .capabilities
+                .iter()
+                .find(|cap| cap.capability_id() == COMPACTION_CAPABILITY_ID)
+                .map(|cap| crate::capabilities::CompactionConfig::from_json(&cap.config))
+        };
+
+        // 8. Build runtime agent
         let resolved_locale = extract_locale_override(&messages).or_else(|| session.locale.clone());
         let prompt_ctx = crate::capabilities::SystemPromptContext {
             session_id,
             locale: resolved_locale.clone(),
             file_store: self.file_store.clone(),
         };
-
         let mut runtime_agent = if let Some(ref blueprint_id) = session.blueprint_id {
             // Blueprint path: build RuntimeAgent from blueprint definition
             let blueprint = self
@@ -657,89 +664,22 @@ impl ReasonAtom {
                 .with_locale(prompt_ctx.locale.as_deref())
                 .build()
         } else {
-            // Standard path: harness (base) → agent (optional) → session caps
-            let mut builder = RuntimeAgentBuilder::new()
-                .with_harness(&harness, &self.capability_registry, &prompt_ctx)
-                .await;
-            if let Some(ref agent) = agent {
-                builder = builder
-                    .with_agent(agent, &self.capability_registry, &prompt_ctx)
-                    .await;
-            }
-            builder = builder
-                .with_capability_configs(
-                    &session.capabilities,
-                    &self.capability_registry,
-                    &prompt_ctx,
-                )
-                .await
-                .with_locale(prompt_ctx.locale.as_deref())
-                .tools(mcp_tool_definitions.iter().cloned())
-                .model(&model_with_provider.model);
-
-            // Add session-level client-side tools (additive to agent tools)
-            if !session.tools.is_empty() {
-                builder = builder.tools(session.tools.clone());
-            }
-
-            // Prepend session-level system prompt (layers on top of agent prompt)
-            if let Some(ref session_prompt) = session.system_prompt
-                && !session_prompt.is_empty()
-            {
-                builder = builder.prepend_system_prompt(session_prompt);
-            }
-
-            // Resolve max_iterations: session > agent > default (500)
-            let resolved_max_iterations = session
-                .max_iterations
-                .or_else(|| agent.as_ref().and_then(|a| a.max_iterations));
-            if let Some(max_iter) = resolved_max_iterations {
-                builder = builder.max_iterations(max_iter);
-            }
-
-            // Merge network_access: harness ∩ agent ∩ session (each layer narrows)
-            let merged_network_access = {
-                use crate::network_access::merge_network_access;
-                let effective = merge_network_access(
-                    harness.network_access.as_ref(),
-                    agent.as_ref().and_then(|a| a.network_access.as_ref()),
-                );
-                merge_network_access(effective.as_ref(), session.network_access.as_ref())
-            };
-            builder = builder.network_access(merged_network_access);
-
-            builder.build()
+            // Standard path: use the pre-computed effective overlay
+            RuntimeAgentBuilder::from_overlay(
+                effective_overlay,
+                &self.capability_registry,
+                &prompt_ctx,
+            )
+            .await
+            .with_locale(prompt_ctx.locale.as_deref())
+            .tools(mcp_tool_definitions.iter().cloned())
+            .model(&model_with_provider.model)
+            .build()
         };
 
         if crate::progress_reporting::session_uses_report_progress(&session.tags) {
             runtime_agent = crate::progress_reporting::apply_report_progress_mode(runtime_agent);
         }
-
-        // 6b. Extract compaction config from agent/harness/session capabilities
-        let compaction_config = {
-            use crate::capabilities::COMPACTION_CAPABILITY_ID;
-
-            // Search session caps first, then agent, then harness (last-wins)
-            let mut config_json = None;
-            for cap in &harness.capabilities {
-                if cap.capability_id() == COMPACTION_CAPABILITY_ID {
-                    config_json = Some(cap.config.clone());
-                }
-            }
-            if let Some(ref agent) = agent {
-                for cap in &agent.capabilities {
-                    if cap.capability_id() == COMPACTION_CAPABILITY_ID {
-                        config_json = Some(cap.config.clone());
-                    }
-                }
-            }
-            for cap in &session.capabilities {
-                if cap.capability_id() == COMPACTION_CAPABILITY_ID {
-                    config_json = Some(cap.config.clone());
-                }
-            }
-            config_json.map(|json| crate::capabilities::CompactionConfig::from_json(&json))
-        };
 
         // 7. Create LLM driver using factory
         let llm_driver = self.create_llm_driver(&model_with_provider)?;

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -664,7 +664,15 @@ impl ReasonAtom {
                 .with_locale(prompt_ctx.locale.as_deref())
                 .build()
         } else {
-            // Standard path: use the pre-computed effective overlay
+            // Standard path: use the pre-computed effective overlay.
+            //
+            // Tool ordering matters — build() deduplicates by name (last wins).
+            // Extract overlay tools so we can insert MCP tools before them,
+            // preserving legacy precedence where session/agent tools win over
+            // same-named MCP tools.
+            let mut effective_overlay = effective_overlay;
+            let overlay_tools = std::mem::take(&mut effective_overlay.tools);
+
             RuntimeAgentBuilder::from_overlay(
                 effective_overlay,
                 &self.capability_registry,
@@ -673,6 +681,7 @@ impl ReasonAtom {
             .await
             .with_locale(prompt_ctx.locale.as_deref())
             .tools(mcp_tool_definitions.iter().cloned())
+            .tools(overlay_tools)
             .model(&model_with_provider.model)
             .build()
         };

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -541,12 +541,11 @@ impl ReasonAtom {
         previous_response_id: Option<String>,
         iteration: u32,
     ) -> Result<ReasonResult> {
-        // 1. Retrieve harness
-        let harness = self
-            .harness_store
-            .get_harness(harness_id)
-            .await?
-            .ok_or_else(|| AgentLoopError::harness_not_found(harness_id))?;
+        // 1. Retrieve harness chain (root-to-leaf)
+        let harness_chain = self.harness_store.get_harness_chain(harness_id).await?;
+        if harness_chain.is_empty() {
+            return Err(AgentLoopError::harness_not_found(harness_id));
+        }
 
         // 2. Retrieve agent (optional)
         let agent = if let Some(agent_id) = agent_id {
@@ -567,10 +566,11 @@ impl ReasonAtom {
             .await?
             .ok_or_else(|| AgentLoopError::session_not_found(session_id))?;
 
-        // 4. Fold harness → agent → session into a single config overlay.
-        //    Cheap sync merge; reused for message filters, model, and RuntimeAgent.
+        // 4. Fold harness chain → agent → session into a single config overlay.
+        //    Each harness in the inheritance chain is its own overlay.
         let effective_overlay = {
-            let mut layers: Vec<AgentConfigOverlay> = vec![AgentConfigOverlay::from(&harness)];
+            let mut layers: Vec<AgentConfigOverlay> =
+                harness_chain.iter().map(AgentConfigOverlay::from).collect();
             if let Some(ref agent) = agent {
                 layers.push(AgentConfigOverlay::from(agent));
             }

--- a/crates/core/src/config_layer.rs
+++ b/crates/core/src/config_layer.rs
@@ -1,0 +1,489 @@
+// Composable configuration layer for Harness → Agent → Session merging.
+//
+// Design Decision: Harness, Agent, and Session share a common set of additive
+// fields (system_prompt, capabilities, initial_files, network_access, tools,
+// max_iterations, default_model_id). AgentConfigOverlay extracts this shared shape
+// so merge semantics are defined once and tested in one place.
+//
+// Each entity produces a AgentConfigOverlay via From<&T>. Layers fold bottom-up
+// (harness → agent → session) into a single effective config that the
+// RuntimeAgentBuilder resolves into a RuntimeAgent.
+//
+// Merge semantics per field:
+// - system_prompt: base first, overlay appended (concatenate non-empty parts)
+// - capabilities: overlay overrides base by capability ID (last wins)
+// - initial_files: overlay overrides base by normalized path (last wins)
+// - network_access: allowed intersects, blocked unions (can only narrow)
+// - default_model_id: overlay wins if set, else inherit base
+// - tools: additive (overlay appended after base, deduplicated at build time)
+// - max_iterations: overlay wins if set, else inherit base
+
+use crate::agent::Agent;
+use crate::capability_types::AgentCapabilityConfig;
+use crate::harness::Harness;
+use crate::network_access::{self, NetworkAccessList};
+use crate::session::Session;
+use crate::session_file::InitialFile;
+use crate::tool_types::ToolDefinition;
+use crate::typed_id::ModelId;
+
+/// A composable configuration layer.
+///
+/// Produced by Harness, Agent, or Session via `From<&T>`. Layers merge
+/// bottom-up into a single effective config for RuntimeAgent building.
+#[derive(Debug, Clone, Default)]
+pub struct AgentConfigOverlay {
+    /// System prompt fragment for this layer.
+    pub system_prompt: Option<String>,
+    /// Capabilities with per-layer configuration.
+    pub capabilities: Vec<AgentCapabilityConfig>,
+    /// Starter files for the session filesystem.
+    pub initial_files: Vec<InitialFile>,
+    /// Network access restrictions.
+    pub network_access: Option<NetworkAccessList>,
+    /// Default model ID for this layer.
+    pub default_model_id: Option<ModelId>,
+    /// Tool definitions (client-side or capability-provided).
+    pub tools: Vec<ToolDefinition>,
+    /// Max iterations per turn.
+    pub max_iterations: Option<usize>,
+}
+
+impl AgentConfigOverlay {
+    /// Merge an overlay on top of this base layer, producing a new effective layer.
+    ///
+    /// This is the core composition operation. Each field follows its own merge
+    /// semantic (see module-level docs). The result represents the combined
+    /// configuration of both layers.
+    pub fn merge(self, overlay: AgentConfigOverlay) -> AgentConfigOverlay {
+        let system_prompt = merge_system_prompts(self.system_prompt, overlay.system_prompt);
+        let capabilities = merge_capabilities(&self.capabilities, &overlay.capabilities);
+        let initial_files = merge_initial_files(&self.initial_files, &overlay.initial_files);
+        let network_access = network_access::merge_network_access(
+            self.network_access.as_ref(),
+            overlay.network_access.as_ref(),
+        );
+        let default_model_id = overlay.default_model_id.or(self.default_model_id);
+        let max_iterations = overlay.max_iterations.or(self.max_iterations);
+
+        let mut tools = self.tools;
+        tools.extend(overlay.tools);
+
+        AgentConfigOverlay {
+            system_prompt,
+            capabilities,
+            initial_files,
+            network_access,
+            default_model_id,
+            tools,
+            max_iterations,
+        }
+    }
+
+    /// Fold multiple layers bottom-up into a single effective layer.
+    ///
+    /// Layers are applied in order: the first layer is the base, each subsequent
+    /// layer is merged on top.
+    pub fn fold(layers: impl IntoIterator<Item = AgentConfigOverlay>) -> AgentConfigOverlay {
+        layers
+            .into_iter()
+            .fold(AgentConfigOverlay::default(), |acc, layer| acc.merge(layer))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Merge helpers (shared by harness inheritance and config layer merging)
+// ---------------------------------------------------------------------------
+
+/// Merge two optional system prompt fragments. Base first, overlay appended.
+fn merge_system_prompts(base: Option<String>, overlay: Option<String>) -> Option<String> {
+    let base = base.map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
+    let overlay = overlay
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+
+    match (base, overlay) {
+        (None, None) => None,
+        (Some(b), None) => Some(b),
+        (None, Some(o)) => Some(o),
+        (Some(b), Some(o)) => Some(format!("{b}\n\n{o}")),
+    }
+}
+
+/// Merge capabilities: overlay overrides base by capability ID (last wins).
+pub fn merge_capabilities(
+    base: &[AgentCapabilityConfig],
+    overlay: &[AgentCapabilityConfig],
+) -> Vec<AgentCapabilityConfig> {
+    let mut merged = base.to_vec();
+
+    for overlay_cap in overlay {
+        if let Some(existing) = merged
+            .iter_mut()
+            .find(|existing| existing.capability_id() == overlay_cap.capability_id())
+        {
+            *existing = overlay_cap.clone();
+        } else {
+            merged.push(overlay_cap.clone());
+        }
+    }
+
+    merged
+}
+
+/// Merge initial files: overlay overrides base by normalized path (last wins).
+pub fn merge_initial_files(base: &[InitialFile], overlay: &[InitialFile]) -> Vec<InitialFile> {
+    let mut merged = base.to_vec();
+
+    for overlay_file in overlay {
+        let normalized_path = normalize_initial_file_path(&overlay_file.path);
+        if let Some(existing) = merged
+            .iter_mut()
+            .find(|existing| normalize_initial_file_path(&existing.path) == normalized_path)
+        {
+            *existing = overlay_file.clone();
+        } else {
+            merged.push(overlay_file.clone());
+        }
+    }
+
+    merged
+}
+
+/// Normalize an initial file path to a canonical form for comparison.
+///
+/// Strips `/workspace/` prefix, ensures leading `/`.
+pub fn normalize_initial_file_path(path: &str) -> String {
+    if path == "/workspace" {
+        "/".to_string()
+    } else if let Some(stripped) = path.strip_prefix("/workspace/") {
+        format!("/{}", stripped.trim_start_matches('/'))
+    } else if path.starts_with('/') {
+        path.to_string()
+    } else {
+        format!("/{}", path)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// From conversions
+// ---------------------------------------------------------------------------
+
+impl From<&Harness> for AgentConfigOverlay {
+    fn from(h: &Harness) -> Self {
+        AgentConfigOverlay {
+            system_prompt: Some(h.system_prompt.clone()),
+            capabilities: h.capabilities.clone(),
+            initial_files: h.initial_files.clone(),
+            network_access: h.network_access.clone(),
+            default_model_id: h.default_model_id,
+            tools: vec![],
+            max_iterations: None,
+        }
+    }
+}
+
+impl From<&Agent> for AgentConfigOverlay {
+    fn from(a: &Agent) -> Self {
+        AgentConfigOverlay {
+            system_prompt: Some(a.system_prompt.clone()),
+            capabilities: a.capabilities.clone(),
+            initial_files: a.initial_files.clone(),
+            network_access: a.network_access.clone(),
+            default_model_id: a.default_model_id,
+            tools: a.tools.clone(),
+            max_iterations: a.max_iterations,
+        }
+    }
+}
+
+impl From<&Session> for AgentConfigOverlay {
+    fn from(s: &Session) -> Self {
+        AgentConfigOverlay {
+            system_prompt: s.system_prompt.clone(),
+            capabilities: s.capabilities.clone(),
+            initial_files: s.initial_files.clone(),
+            network_access: s.network_access.clone(),
+            default_model_id: s.model_id,
+            tools: s.tools.clone(),
+            max_iterations: s.max_iterations,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capability_types::AgentCapabilityConfig;
+    use crate::network_access::NetworkAccessList;
+    use crate::session_file::InitialFile;
+
+    fn make_file(path: &str, content: &str) -> InitialFile {
+        InitialFile {
+            path: path.to_string(),
+            content: content.to_string(),
+            encoding: "text".to_string(),
+            is_readonly: false,
+        }
+    }
+
+    #[test]
+    fn merge_system_prompts_concatenates() {
+        let base = AgentConfigOverlay {
+            system_prompt: Some("Base prompt.".into()),
+            ..Default::default()
+        };
+        let overlay = AgentConfigOverlay {
+            system_prompt: Some("Overlay prompt.".into()),
+            ..Default::default()
+        };
+        let merged = base.merge(overlay);
+        assert_eq!(
+            merged.system_prompt.as_deref(),
+            Some("Base prompt.\n\nOverlay prompt.")
+        );
+    }
+
+    #[test]
+    fn merge_system_prompts_base_only() {
+        let base = AgentConfigOverlay {
+            system_prompt: Some("Base.".into()),
+            ..Default::default()
+        };
+        let overlay = AgentConfigOverlay::default();
+        let merged = base.merge(overlay);
+        assert_eq!(merged.system_prompt.as_deref(), Some("Base."));
+    }
+
+    #[test]
+    fn merge_system_prompts_overlay_only() {
+        let base = AgentConfigOverlay::default();
+        let overlay = AgentConfigOverlay {
+            system_prompt: Some("Overlay.".into()),
+            ..Default::default()
+        };
+        let merged = base.merge(overlay);
+        assert_eq!(merged.system_prompt.as_deref(), Some("Overlay."));
+    }
+
+    #[test]
+    fn merge_system_prompts_both_empty() {
+        let merged = AgentConfigOverlay::default().merge(AgentConfigOverlay::default());
+        assert!(merged.system_prompt.is_none());
+    }
+
+    #[test]
+    fn merge_capabilities_override_by_id() {
+        let base = AgentConfigOverlay {
+            capabilities: vec![
+                AgentCapabilityConfig::new("session_file_system"),
+                AgentCapabilityConfig::with_config(
+                    "web_fetch",
+                    serde_json::json!({"enable_file_download": true}),
+                ),
+            ],
+            ..Default::default()
+        };
+        let overlay = AgentConfigOverlay {
+            capabilities: vec![
+                AgentCapabilityConfig::with_config(
+                    "web_fetch",
+                    serde_json::json!({"enable_file_download": false}),
+                ),
+                AgentCapabilityConfig::new("current_time"),
+            ],
+            ..Default::default()
+        };
+        let merged = base.merge(overlay);
+
+        assert_eq!(merged.capabilities.len(), 3);
+        assert_eq!(
+            merged.capabilities[0].capability_id(),
+            "session_file_system"
+        );
+        assert_eq!(merged.capabilities[1].capability_id(), "web_fetch");
+        assert_eq!(
+            merged.capabilities[1],
+            AgentCapabilityConfig::with_config(
+                "web_fetch",
+                serde_json::json!({"enable_file_download": false})
+            )
+        );
+        assert_eq!(merged.capabilities[2].capability_id(), "current_time");
+    }
+
+    #[test]
+    fn merge_initial_files_override_by_path() {
+        let base = AgentConfigOverlay {
+            initial_files: vec![
+                make_file("/workspace/README.md", "parent"),
+                make_file("/workspace/config.txt", "parent-config"),
+            ],
+            ..Default::default()
+        };
+        let overlay = AgentConfigOverlay {
+            initial_files: vec![
+                make_file("README.md", "child"),
+                make_file("/notes.txt", "notes"),
+            ],
+            ..Default::default()
+        };
+        let merged = base.merge(overlay);
+
+        assert_eq!(merged.initial_files.len(), 3);
+        assert_eq!(merged.initial_files[0].content, "child"); // overridden
+        assert_eq!(merged.initial_files[1].content, "parent-config"); // kept
+        assert_eq!(merged.initial_files[2].content, "notes"); // added
+    }
+
+    #[test]
+    fn merge_network_access_narrows() {
+        let base = AgentConfigOverlay {
+            network_access: Some(NetworkAccessList::allow_only([
+                "*.example.com",
+                "*.github.com",
+            ])),
+            ..Default::default()
+        };
+        let overlay = AgentConfigOverlay {
+            network_access: Some(NetworkAccessList::allow_only(["api.example.com"])),
+            ..Default::default()
+        };
+        let merged = base.merge(overlay);
+
+        let na = merged.network_access.unwrap();
+        assert_eq!(na.allowed, vec!["api.example.com".to_string()]);
+    }
+
+    #[test]
+    fn merge_model_overlay_wins() {
+        let base = AgentConfigOverlay {
+            default_model_id: Some(ModelId::from_uuid(uuid::Uuid::from_u128(1))),
+            ..Default::default()
+        };
+        let overlay = AgentConfigOverlay {
+            default_model_id: Some(ModelId::from_uuid(uuid::Uuid::from_u128(2))),
+            ..Default::default()
+        };
+        let merged = base.merge(overlay);
+        assert_eq!(
+            merged.default_model_id,
+            Some(ModelId::from_uuid(uuid::Uuid::from_u128(2)))
+        );
+    }
+
+    #[test]
+    fn merge_model_inherits_base() {
+        let base = AgentConfigOverlay {
+            default_model_id: Some(ModelId::from_uuid(uuid::Uuid::from_u128(1))),
+            ..Default::default()
+        };
+        let overlay = AgentConfigOverlay::default();
+        let merged = base.merge(overlay);
+        assert_eq!(
+            merged.default_model_id,
+            Some(ModelId::from_uuid(uuid::Uuid::from_u128(1)))
+        );
+    }
+
+    #[test]
+    fn merge_max_iterations_overlay_wins() {
+        let base = AgentConfigOverlay {
+            max_iterations: Some(100),
+            ..Default::default()
+        };
+        let overlay = AgentConfigOverlay {
+            max_iterations: Some(50),
+            ..Default::default()
+        };
+        let merged = base.merge(overlay);
+        assert_eq!(merged.max_iterations, Some(50));
+    }
+
+    #[test]
+    fn merge_max_iterations_inherits_base() {
+        let base = AgentConfigOverlay {
+            max_iterations: Some(100),
+            ..Default::default()
+        };
+        let overlay = AgentConfigOverlay::default();
+        let merged = base.merge(overlay);
+        assert_eq!(merged.max_iterations, Some(100));
+    }
+
+    #[test]
+    fn merge_tools_additive() {
+        use crate::tool_types::{BuiltinTool, ToolDefinition, ToolPolicy};
+
+        let make_tool = |name: &str| {
+            ToolDefinition::Builtin(BuiltinTool {
+                name: name.to_string(),
+                display_name: None,
+                description: format!("{name} tool"),
+                parameters: serde_json::json!({}),
+                policy: ToolPolicy::Auto,
+                category: None,
+                deferrable: Default::default(),
+                hints: crate::tool_types::ToolHints::default(),
+            })
+        };
+
+        let base = AgentConfigOverlay {
+            tools: vec![make_tool("tool_a")],
+            ..Default::default()
+        };
+        let overlay = AgentConfigOverlay {
+            tools: vec![make_tool("tool_b")],
+            ..Default::default()
+        };
+        let merged = base.merge(overlay);
+        assert_eq!(merged.tools.len(), 2);
+        assert_eq!(merged.tools[0].name(), "tool_a");
+        assert_eq!(merged.tools[1].name(), "tool_b");
+    }
+
+    #[test]
+    fn fold_three_layers() {
+        let harness = AgentConfigOverlay {
+            system_prompt: Some("Harness prompt.".into()),
+            capabilities: vec![AgentCapabilityConfig::new("session_file_system")],
+            initial_files: vec![make_file("/config.txt", "harness")],
+            max_iterations: None,
+            ..Default::default()
+        };
+        let agent = AgentConfigOverlay {
+            system_prompt: Some("Agent prompt.".into()),
+            capabilities: vec![AgentCapabilityConfig::new("current_time")],
+            initial_files: vec![make_file("/config.txt", "agent")],
+            max_iterations: Some(200),
+            ..Default::default()
+        };
+        let session = AgentConfigOverlay {
+            system_prompt: Some("Session prompt.".into()),
+            max_iterations: Some(50),
+            ..Default::default()
+        };
+
+        let effective = AgentConfigOverlay::fold([harness, agent, session]);
+
+        assert_eq!(
+            effective.system_prompt.as_deref(),
+            Some("Harness prompt.\n\nAgent prompt.\n\nSession prompt.")
+        );
+        assert_eq!(effective.capabilities.len(), 2);
+        assert_eq!(effective.initial_files.len(), 1);
+        assert_eq!(effective.initial_files[0].content, "agent");
+        assert_eq!(effective.max_iterations, Some(50));
+    }
+
+    #[test]
+    fn normalize_workspace_prefix() {
+        assert_eq!(
+            normalize_initial_file_path("/workspace/README.md"),
+            "/README.md"
+        );
+        assert_eq!(normalize_initial_file_path("/workspace"), "/");
+        assert_eq!(normalize_initial_file_path("README.md"), "/README.md");
+        assert_eq!(normalize_initial_file_path("/README.md"), "/README.md");
+    }
+}

--- a/crates/core/src/config_layer.rs
+++ b/crates/core/src/config_layer.rs
@@ -1,13 +1,16 @@
-// Composable configuration layer for Harness → Agent → Session merging.
+// Composable configuration overlay for Harness → Agent → Session merging.
 //
-// Design Decision: Harness, Agent, and Session share a common set of additive
-// fields (system_prompt, capabilities, initial_files, network_access, tools,
-// max_iterations, default_model_id). AgentConfigOverlay extracts this shared shape
-// so merge semantics are defined once and tested in one place.
+// See specs/concepts.md#AgentConfigOverlay for design rationale and diagrams.
 //
-// Each entity produces a AgentConfigOverlay via From<&T>. Layers fold bottom-up
-// (harness → agent → session) into a single effective config that the
-// RuntimeAgentBuilder resolves into a RuntimeAgent.
+// Harness, Agent, and Session share additive fields (system_prompt, capabilities,
+// initial_files, network_access, tools, max_iterations, default_model_id).
+// AgentConfigOverlay extracts this shared shape so merge semantics are defined
+// once and tested in one place.
+//
+// Each entity produces an AgentConfigOverlay via From<&T>. Harness inheritance
+// chains produce one overlay per harness. All overlays fold bottom-up into a
+// single effective config that RuntimeAgentBuilder::from_overlay() resolves
+// into a RuntimeAgent.
 //
 // Merge semantics per field:
 // - system_prompt: base first, overlay appended (concatenate non-empty parts)

--- a/crates/core/src/dependency_blocker.rs
+++ b/crates/core/src/dependency_blocker.rs
@@ -51,8 +51,9 @@ pub async fn detect_dependency_blocker(
     harness_id: HarnessId,
     agent_id: Option<AgentId>,
 ) -> Result<Option<DependencyBlocker>> {
-    match harness_store.get_harness(harness_id).await? {
-        Some(harness) => match harness.status {
+    let harness_chain = harness_store.get_harness_chain(harness_id).await?;
+    match harness_chain.last() {
+        Some(leaf) => match leaf.status {
             HarnessStatus::Active => {}
             HarnessStatus::Archived => return Ok(Some(DependencyBlocker::HarnessArchived)),
             HarnessStatus::Deleted => return Ok(Some(DependencyBlocker::HarnessDeleted)),

--- a/crates/core/src/harness.rs
+++ b/crates/core/src/harness.rs
@@ -8,6 +8,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::capability_types::AgentCapabilityConfig;
+use crate::config_layer::{merge_capabilities, merge_initial_files};
 use crate::network_access::{self, NetworkAccessList};
 use crate::session_file::InitialFile;
 use crate::typed_id::{HarnessId, ModelId};
@@ -164,55 +165,8 @@ fn merge_system_prompts(parent: &str, child: &str) -> String {
     }
 }
 
-fn merge_capabilities(
-    parent: &[AgentCapabilityConfig],
-    child: &[AgentCapabilityConfig],
-) -> Vec<AgentCapabilityConfig> {
-    let mut merged = parent.to_vec();
-
-    for child_cap in child {
-        if let Some(existing) = merged
-            .iter_mut()
-            .find(|existing| existing.capability_id() == child_cap.capability_id())
-        {
-            *existing = child_cap.clone();
-        } else {
-            merged.push(child_cap.clone());
-        }
-    }
-
-    merged
-}
-
-fn merge_initial_files(parent: &[InitialFile], child: &[InitialFile]) -> Vec<InitialFile> {
-    let mut merged = parent.to_vec();
-
-    for child_file in child {
-        let normalized_path = normalize_initial_file_path(&child_file.path);
-        if let Some(existing) = merged
-            .iter_mut()
-            .find(|existing| normalize_initial_file_path(&existing.path) == normalized_path)
-        {
-            *existing = child_file.clone();
-        } else {
-            merged.push(child_file.clone());
-        }
-    }
-
-    merged
-}
-
-fn normalize_initial_file_path(path: &str) -> String {
-    if path == "/workspace" {
-        "/".to_string()
-    } else if let Some(stripped) = path.strip_prefix("/workspace/") {
-        format!("/{}", stripped.trim_start_matches('/'))
-    } else if path.starts_with('/') {
-        path.to_string()
-    } else {
-        format!("/{}", path)
-    }
-}
+// merge_capabilities, merge_initial_files, and normalize_initial_file_path
+// live in config_layer.rs and are re-exported from crate root.
 
 #[cfg(test)]
 mod tests {

--- a/crates/core/src/harness.rs
+++ b/crates/core/src/harness.rs
@@ -8,8 +8,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::capability_types::AgentCapabilityConfig;
-use crate::config_layer::{merge_capabilities, merge_initial_files};
-use crate::network_access::{self, NetworkAccessList};
+use crate::network_access::NetworkAccessList;
 use crate::session_file::InitialFile;
 use crate::typed_id::{HarnessId, ModelId};
 
@@ -115,34 +114,33 @@ pub struct Harness {
 /// Merge a parent harness into a child harness, producing the effective child harness.
 ///
 /// Metadata remains child-owned (`id`, `name`, `tags`, status, timestamps). Runtime-affecting
-/// fields compose:
-/// - `system_prompt`: parent first, child appended
-/// - `default_model_id`: child wins, then parent fallback
-/// - `capabilities`: parent baseline, child overrides by capability id
-/// - `initial_files`: parent baseline, child overrides by normalized path
-/// - `network_access`: allowed intersects, blocked unions (child can only narrow)
+/// fields compose via `AgentConfigOverlay::merge()` — same semantics used for the full
+/// harness → agent → session fold.
 pub fn merge_harness(parent: &Harness, child: &Harness) -> Harness {
+    use crate::config_layer::AgentConfigOverlay;
+
+    let effective = AgentConfigOverlay::from(parent).merge(AgentConfigOverlay::from(child));
+
     Harness {
+        // Metadata: always child-owned
         id: child.id,
         name: child.name.clone(),
         display_name: child.display_name.clone(),
         description: child.description.clone(),
-        system_prompt: merge_system_prompts(&parent.system_prompt, &child.system_prompt),
         parent_harness_id: child.parent_harness_id,
-        default_model_id: child.default_model_id.or(parent.default_model_id),
         tags: child.tags.clone(),
-        capabilities: merge_capabilities(&parent.capabilities, &child.capabilities),
-        initial_files: merge_initial_files(&parent.initial_files, &child.initial_files),
-        network_access: network_access::merge_network_access(
-            parent.network_access.as_ref(),
-            child.network_access.as_ref(),
-        ),
         is_built_in: child.is_built_in,
         status: child.status.clone(),
         created_at: child.created_at,
         updated_at: child.updated_at,
         archived_at: child.archived_at,
         deleted_at: child.deleted_at,
+        // Config: from merged overlay
+        system_prompt: effective.system_prompt.unwrap_or_default(),
+        default_model_id: effective.default_model_id,
+        capabilities: effective.capabilities,
+        initial_files: effective.initial_files,
+        network_access: effective.network_access,
     }
 }
 
@@ -152,21 +150,6 @@ pub fn merge_harness_chain(chain: &[Harness]) -> Option<Harness> {
     let first = iter.next()?.clone();
     Some(iter.fold(first, |effective, layer| merge_harness(&effective, layer)))
 }
-
-fn merge_system_prompts(parent: &str, child: &str) -> String {
-    let parent = parent.trim();
-    let child = child.trim();
-
-    match (parent.is_empty(), child.is_empty()) {
-        (true, true) => String::new(),
-        (false, true) => parent.to_string(),
-        (true, false) => child.to_string(),
-        (false, false) => format!("{parent}\n\n{child}"),
-    }
-}
-
-// merge_capabilities, merge_initial_files, and normalize_initial_file_path
-// live in config_layer.rs and are re-exported from crate root.
 
 #[cfg(test)]
 mod tests {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -83,6 +83,7 @@ pub mod url_validation;
 pub mod atoms;
 pub mod capabilities;
 pub mod command;
+pub mod config_layer;
 pub mod dependency_blocker;
 pub mod error;
 pub mod llm_driver_helpers;
@@ -119,6 +120,9 @@ pub mod turn;
 // This enables dependency inversion - provider crates register their drivers at startup.
 
 // Re-exports for convenience
+pub use config_layer::{
+    AgentConfigOverlay, merge_capabilities, merge_initial_files, normalize_initial_file_path,
+};
 pub use error::{AgentLoopError, Result, StoreResultExt, from_json, json_val};
 pub use message::{
     ContentPart, ContentType, Controls, ExternalActor, ImageContentPart, ImageFileContentPart,

--- a/crates/core/src/memory.rs
+++ b/crates/core/src/memory.rs
@@ -299,8 +299,15 @@ impl InMemoryHarnessStore {
 
 #[async_trait]
 impl HarnessStore for InMemoryHarnessStore {
-    async fn get_harness(&self, harness_id: HarnessId) -> Result<Option<Harness>> {
-        Ok(self.harnesses.read().await.get(&harness_id).cloned())
+    async fn get_harness_chain(&self, harness_id: HarnessId) -> Result<Vec<Harness>> {
+        Ok(self
+            .harnesses
+            .read()
+            .await
+            .get(&harness_id)
+            .cloned()
+            .into_iter()
+            .collect())
     }
 }
 

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -2,19 +2,23 @@
 //
 // RuntimeAgent is a DB-agnostic configuration struct that can be:
 // - Created directly for standalone usage
-// - Built from a Harness and/or Agent entity via builder methods
+// - Built from a AgentConfigOverlay via `from_overlay()` (preferred)
+// - Built from individual Harness/Agent entities via builder methods (legacy)
 //
-// Prompt layering order (via prepend pattern):
-// 1. with_harness() - sets harness system_prompt + harness caps
-// 2. with_agent() - prepends agent prompt + agent caps (optional)
-// 3. with_capabilities() - prepends session caps
-// Result: [session_caps] [agent_caps] [agent_prompt] [harness_caps] [harness_prompt]
+// Preferred usage: merge Harness/Agent/Session into a AgentConfigOverlay, then:
+//   RuntimeAgentBuilder::from_overlay(layer, &registry, &ctx).await
+//       .model("gpt-5.2")
+//       .build()
+//
+// Legacy per-entity methods (with_harness, with_agent) are kept for
+// backward compatibility but the AgentConfigOverlay path is canonical.
 
 use crate::agent::Agent;
 use crate::capabilities::{
     CapabilityRegistry, SystemPromptContext, collect_capabilities_with_configs,
     resolve_capability_configs,
 };
+use crate::config_layer::AgentConfigOverlay;
 use crate::harness::Harness;
 use crate::llm_driver_registry::ToolSearchConfig;
 use crate::llm_model_profiles::get_model_profile;
@@ -109,6 +113,58 @@ impl RuntimeAgentBuilder {
         Self {
             runtime_agent: RuntimeAgent::default(),
         }
+    }
+
+    /// Build from a pre-merged AgentConfigOverlay.
+    ///
+    /// This is the preferred way to build a RuntimeAgent. The caller merges
+    /// Harness/Agent/Session into a single AgentConfigOverlay (via `AgentConfigOverlay::fold`),
+    /// then this method resolves capabilities and assembles the final config.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let layer = AgentConfigOverlay::fold([
+    ///     AgentConfigOverlay::from(&harness),
+    ///     AgentConfigOverlay::from(&agent),
+    ///     AgentConfigOverlay::from(&session),
+    /// ]);
+    /// let runtime_agent = RuntimeAgentBuilder::from_overlay(layer, &registry, &ctx)
+    ///     .await
+    ///     .model("gpt-5.2")
+    ///     .build();
+    /// ```
+    pub async fn from_overlay(
+        layer: AgentConfigOverlay,
+        registry: &CapabilityRegistry,
+        ctx: &SystemPromptContext,
+    ) -> Self {
+        let mut builder = Self::new();
+
+        // Set composed system prompt
+        if let Some(ref prompt) = layer.system_prompt {
+            builder = builder.system_prompt(prompt);
+        }
+
+        // Resolve merged capabilities (once, on the effective set)
+        builder = builder
+            .with_capability_configs(&layer.capabilities, registry, ctx)
+            .await;
+
+        // Add tools from all layers
+        if !layer.tools.is_empty() {
+            builder = builder.tools(layer.tools);
+        }
+
+        // Set max_iterations if any layer specified it
+        if let Some(max) = layer.max_iterations {
+            builder = builder.max_iterations(max);
+        }
+
+        // Set merged network_access
+        builder = builder.network_access(layer.network_access);
+
+        builder
     }
 
     /// Apply a Harness's configuration to this builder.

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -141,10 +141,9 @@ impl RuntimeAgentBuilder {
     ) -> Self {
         let mut builder = Self::new();
 
-        // Set composed system prompt
-        if let Some(ref prompt) = layer.system_prompt {
-            builder = builder.system_prompt(prompt);
-        }
+        // Always set system prompt (even to empty) so an intentionally empty
+        // merged prompt clears the builder default instead of leaving it.
+        builder = builder.system_prompt(layer.system_prompt.unwrap_or_default());
 
         // Resolve merged capabilities (once, on the effective set)
         builder = builder

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -48,10 +48,18 @@ pub trait AgentStore: Send + Sync {
 /// Implementations can:
 /// - Load harnesses from a database
 /// - Keep harnesses in memory for testing
+///
+/// Returns the harness inheritance chain (root-to-leaf) so the caller
+/// can fold each harness as an `AgentConfigOverlay`. DB-backed stores
+/// return the raw chain; gRPC-backed stores may return a single
+/// pre-merged harness (functionally equivalent when folded).
 #[async_trait]
 pub trait HarnessStore: Send + Sync {
-    /// Get a harness by ID
-    async fn get_harness(&self, harness_id: HarnessId) -> Result<Option<Harness>>;
+    /// Get the harness inheritance chain, root-to-leaf.
+    ///
+    /// Returns `Ok(vec![])` if the harness does not exist.
+    /// A harness with no parent returns a single-element vec.
+    async fn get_harness_chain(&self, harness_id: HarnessId) -> Result<Vec<Harness>>;
 }
 
 // ============================================================================

--- a/crates/server/src/services/session.rs
+++ b/crates/server/src/services/session.rs
@@ -20,6 +20,7 @@ use everruns_core::{
     AgentCapabilityConfig, AgentId, Caller, CapabilityRegistry, HarnessId, InitialFile, ModelId,
     Permission, Policy, Rule, Session, SessionId, SessionStatus, SubagentStatus, TokenUsage,
     capabilities::{SystemPromptContext, collect_capabilities, compute_features},
+    merge_initial_files, normalize_initial_file_path,
 };
 use everruns_durable::UpdateField;
 use everruns_macros::policy;
@@ -355,47 +356,28 @@ impl SessionService {
         agent_id: Option<Uuid>,
         session_initial_files: &[InitialFile],
     ) -> Result<Vec<InitialFile>> {
-        let mut files = self
+        let harness_files = self
             .resolve_effective_harness(org_id, HarnessId::from_uuid(harness_id))
             .await?
             .map(|harness| harness.initial_files)
             .unwrap_or_default();
 
-        if let Some(agent_id) = agent_id
+        let agent_files = if let Some(agent_id) = agent_id
             && let Some(row) = self
                 .db
                 .get_agent(org_id, AgentId::from_uuid(agent_id))
                 .await?
         {
-            for file in
-                serde_json::from_value::<Vec<InitialFile>>(row.initial_files).unwrap_or_default()
-            {
-                let normalized = normalize_initial_file_path(&file.path);
-                if let Some(existing) = files
-                    .iter_mut()
-                    .find(|existing| normalize_initial_file_path(&existing.path) == normalized)
-                {
-                    *existing = file;
-                } else {
-                    files.push(file);
-                }
-            }
-        }
+            serde_json::from_value::<Vec<InitialFile>>(row.initial_files).unwrap_or_default()
+        } else {
+            vec![]
+        };
 
-        // Session-level initial files layer on top (same additive logic)
-        for file in session_initial_files {
-            let normalized = normalize_initial_file_path(&file.path);
-            if let Some(existing) = files
-                .iter_mut()
-                .find(|existing| normalize_initial_file_path(&existing.path) == normalized)
-            {
-                *existing = file.clone();
-            } else {
-                files.push(file.clone());
-            }
-        }
+        // Fold: harness → agent → session (same merge semantics as AgentConfigOverlay)
+        let merged = merge_initial_files(&harness_files, &agent_files);
+        let merged = merge_initial_files(&merged, session_initial_files);
 
-        Ok(files)
+        Ok(merged)
     }
 
     async fn validate_model_id(
@@ -843,17 +825,7 @@ impl SessionService {
     }
 }
 
-fn normalize_initial_file_path(path: &str) -> String {
-    if path == "/workspace" {
-        "/".to_string()
-    } else if let Some(stripped) = path.strip_prefix("/workspace/") {
-        format!("/{}", stripped.trim_start_matches('/'))
-    } else if path.starts_with('/') {
-        path.to_string()
-    } else {
-        format!("/{}", path)
-    }
-}
+// normalize_initial_file_path is imported from everruns_core::config_layer
 
 #[cfg(test)]
 mod tests {

--- a/crates/server/src/storage/harness_store.rs
+++ b/crates/server/src/storage/harness_store.rs
@@ -10,7 +10,6 @@ use async_trait::async_trait;
 use everruns_core::{
     AgentCapabilityConfig, AgentLoopError, HarnessId, Result, StoreResultExt, from_json,
     harness::{Harness, HarnessStatus},
-    merge_harness,
     traits::HarnessStore,
 };
 use std::collections::HashSet;
@@ -39,7 +38,7 @@ impl DbHarnessStore {
 
 #[async_trait]
 impl HarnessStore for DbHarnessStore {
-    async fn get_harness(&self, harness_id: HarnessId) -> Result<Option<Harness>> {
+    async fn get_harness_chain(&self, harness_id: HarnessId) -> Result<Vec<Harness>> {
         let mut visited = HashSet::new();
         let mut chain = Vec::new();
         let mut cursor = Some(harness_id);
@@ -58,7 +57,7 @@ impl HarnessStore for DbHarnessStore {
                 .store_err()?
             else {
                 if chain.is_empty() {
-                    return Ok(None);
+                    return Ok(vec![]);
                 }
                 return Err(AgentLoopError::store(
                     "Parent harness not found".to_string(),
@@ -100,14 +99,9 @@ impl HarnessStore for DbHarnessStore {
             });
         }
 
-        let Some(mut effective) = chain.pop() else {
-            return Ok(None);
-        };
-        while let Some(layer) = chain.pop() {
-            effective = merge_harness(&effective, &layer);
-        }
-
-        Ok(Some(effective))
+        // Chain is leaf-to-root; reverse to root-to-leaf for overlay folding
+        chain.reverse();
+        Ok(chain)
     }
 }
 

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -381,19 +381,22 @@ pub async fn act_activity(
             }
         } else {
             let harness_store = GrpcHarnessStore::new(grpc_client.clone(), org_id);
-            if let Ok(Some(harness)) =
-                everruns_core::traits::HarnessStore::get_harness(&harness_store, input.harness_id)
-                    .await
-            {
-                harness
-                    .capabilities
-                    .iter()
-                    .map(|c| c.capability_id().to_string())
-                    .filter(|id| !is_mcp_capability(id))
-                    .collect()
-            } else {
-                vec![]
-            }
+            let chain = everruns_core::traits::HarnessStore::get_harness_chain(
+                &harness_store,
+                input.harness_id,
+            )
+            .await
+            .unwrap_or_default();
+            // Fold harness chain into effective overlay to get merged capabilities
+            let overlay = everruns_core::AgentConfigOverlay::fold(
+                chain.iter().map(everruns_core::AgentConfigOverlay::from),
+            );
+            overlay
+                .capabilities
+                .iter()
+                .map(|c| c.capability_id().to_string())
+                .filter(|id| !is_mcp_capability(id))
+                .collect()
         };
 
         if !cap_ids.is_empty() {

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -668,7 +668,10 @@ fn proto_agent_to_agent(proto_agent: proto::Agent) -> Result<Agent> {
 
 #[async_trait]
 impl HarnessStore for GrpcOrgAdapter {
-    async fn get_harness(&self, harness_id: everruns_core::HarnessId) -> Result<Option<Harness>> {
+    async fn get_harness_chain(
+        &self,
+        harness_id: everruns_core::HarnessId,
+    ) -> Result<Vec<Harness>> {
         let mut client = self.client.inner.lock().await;
 
         let request = proto::GetHarnessRequest {
@@ -681,12 +684,13 @@ impl HarnessStore for GrpcOrgAdapter {
             .await
             .map_err(grpc_status_to_error)?;
 
+        // gRPC returns a pre-merged harness; wrap as single-element chain
         match response.into_inner().harness {
             Some(proto_harness) => {
                 let harness = proto_harness_to_harness(proto_harness)?;
-                Ok(Some(harness))
+                Ok(vec![harness])
             }
-            None => Ok(None),
+            None => Ok(vec![]),
         }
     }
 }

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -101,8 +101,13 @@ impl WorkerAdapters for GrpcWorkerAdapters {
 
     async fn get_harness(&self, org_id: i64, harness_id: Uuid) -> Result<Option<Harness>> {
         let store = GrpcHarnessStore::new(self.client.clone(), org_id);
-        everruns_core::traits::HarnessStore::get_harness(&store, HarnessId::from_uuid(harness_id))
-            .await
+        let chain = everruns_core::traits::HarnessStore::get_harness_chain(
+            &store,
+            HarnessId::from_uuid(harness_id),
+        )
+        .await?;
+        // GrpcHarnessStore returns a single pre-merged harness; take it
+        Ok(chain.into_iter().last())
     }
 
     // =========================================================================

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -392,10 +392,14 @@ impl<A: WorkerAdapters> everruns_core::traits::AgentStore for OrgAdapter<A> {
 
 #[async_trait]
 impl<A: WorkerAdapters> everruns_core::traits::HarnessStore for OrgAdapter<A> {
-    async fn get_harness(&self, harness_id: HarnessId) -> Result<Option<Harness>> {
-        self.adapters
+    async fn get_harness_chain(&self, harness_id: HarnessId) -> Result<Vec<Harness>> {
+        // WorkerAdapters returns a pre-merged harness; wrap as single-element chain
+        Ok(self
+            .adapters
             .get_harness(self.org_id, harness_id.uuid())
-            .await
+            .await?
+            .into_iter()
+            .collect())
     }
 }
 

--- a/specs/concepts.md
+++ b/specs/concepts.md
@@ -34,7 +34,7 @@ graph LR
 ```
 
 - **Solid arrows** — configuration ownership: Harness has Agents and Capabilities, Agent has Capabilities
-- **Dashed arrows** — runtime assembly: config merges into RuntimeAgent, which executes in a Session
+- **Dashed arrows** — runtime assembly: each entity produces an `AgentConfigOverlay`, overlays fold into a single effective config, which resolves into a RuntimeAgent (see [AgentConfigOverlay](#agentconfigoverlay))
 - **Purple** — deployment: App binds Harness + Agent to an external channel and creates sessions from incoming messages
 
 ### Harness
@@ -82,7 +82,7 @@ Modular, reusable configuration unit that extends harness, agent, or session beh
 
 ### AgentConfigOverlay
 
-Composable configuration layer shared by Harness, Agent, and Session. Each entity produces an overlay; overlays fold bottom-up (harness → agent → session) into a single effective config that `RuntimeAgentBuilder::from_overlay()` resolves into a RuntimeAgent.
+Composable configuration layer shared by Harness, Agent, and Session. Each entity produces an overlay via `From<&T>`; overlays fold bottom-up into a single effective config that `RuntimeAgentBuilder::from_overlay()` resolves into a RuntimeAgent.
 
 See `crates/core/src/config_layer.rs` for implementation.
 
@@ -97,6 +97,29 @@ See `crates/core/src/config_layer.rs` for implementation.
 | `default_model_id` | Overlay wins if set, else inherit base |
 | `tools` | Additive (deduplicated by name at build time) |
 | `max_iterations` | Overlay wins if set, else inherit base |
+
+**Overlay chain:**
+
+Harnesses support single-parent inheritance. `HarnessStore::get_harness_chain()` returns the full inheritance chain (root-to-leaf). Each harness in the chain becomes its own overlay, folded alongside the optional agent and session overlays.
+
+```
+ harness_root   harness_child   harness_leaf     agent       session
+      │               │               │            │             │
+      ▼               ▼               ▼            ▼             ▼
+   overlay ──► overlay ──► overlay ──► overlay ──► overlay
+                                                       │
+                                          AgentConfigOverlay::fold()
+                                                       │
+                                                       ▼
+                                              effective_overlay
+                                                       │
+                                        RuntimeAgentBuilder::from_overlay()
+                                                       │
+                                                       ▼
+                                                  RuntimeAgent
+```
+
+The fold is associative — a pre-merged harness chain (single overlay) produces the same RuntimeAgent as the full chain (N overlays). This lets gRPC-backed stores return a single pre-merged harness while DB-backed stores return the raw chain.
 
 ### Tool
 

--- a/specs/concepts.md
+++ b/specs/concepts.md
@@ -80,6 +80,24 @@ Modular, reusable configuration unit that extends harness, agent, or session beh
 - MCP servers appear as virtual capabilities with `mcp:{uuid}` IDs
 - Capabilities can depend on other capabilities, resolved in topological order
 
+### AgentConfigOverlay
+
+Composable configuration layer shared by Harness, Agent, and Session. Each entity produces an overlay; overlays fold bottom-up (harness → agent → session) into a single effective config that `RuntimeAgentBuilder::from_overlay()` resolves into a RuntimeAgent.
+
+See `crates/core/src/config_layer.rs` for implementation.
+
+**Fields and merge semantics:**
+
+| Field | Merge rule |
+|-------|-----------|
+| `system_prompt` | Base first, overlay appended |
+| `capabilities` | Overlay overrides base by capability ID |
+| `initial_files` | Overlay overrides base by normalized path |
+| `network_access` | Allowed intersects, blocked unions (can only narrow) |
+| `default_model_id` | Overlay wins if set, else inherit base |
+| `tools` | Additive (deduplicated by name at build time) |
+| `max_iterations` | Overlay wins if set, else inherit base |
+
 ### Tool
 
 A function the agent can invoke during execution. Tools are provided by capabilities.


### PR DESCRIPTION
## What

Extract `AgentConfigOverlay` — a composable configuration layer shared by Harness, Agent, and Session. Each entity produces an overlay via `From<&T>`; overlays fold bottom-up into a single effective config that `RuntimeAgentBuilder::from_overlay()` resolves into a `RuntimeAgent`.

Also changes `HarnessStore::get_harness()` → `get_harness_chain()` returning `Vec<Harness>` (root-to-leaf), so each harness in an inheritance chain becomes its own overlay in the fold.

```
 harness_root   harness_child   harness_leaf     agent       session
      │               │               │            │             │
      ▼               ▼               ▼            ▼             ▼
   overlay ──► overlay ──► overlay ──► overlay ──► overlay
                                                       │
                                          AgentConfigOverlay::fold()
                                                       │
                                                       ▼
                                              effective_overlay
                                                       │
                                        RuntimeAgentBuilder::from_overlay()
                                                       │
                                                       ▼
                                                  RuntimeAgent
```

## Why

Harness, Agent, and Session share 7 additive fields (system_prompt, capabilities, initial_files, network_access, tools, max_iterations, default_model_id) that were merged with identical semantics but in 3+ separate places:

- `merge_harness()` in harness.rs (harness inheritance)
- `RuntimeAgentBuilder` chain in runtime_agent.rs / reason.rs (runtime building)
- `collect_initial_files()` in services/session.rs (session creation)

The merge logic was scattered, partially duplicated, and the `with_agent()` builder method had a bug where it overwrote (instead of composing) the harness system prompt.

## How

- **New:** `crates/core/src/config_layer.rs` with `AgentConfigOverlay` struct, `merge()`, `fold()`, merge helpers, `From<&T>` conversions, and 14 tests
- **New:** `RuntimeAgentBuilder::from_overlay()` — builds RuntimeAgent from a pre-merged overlay
- **Changed:** `HarnessStore::get_harness()` → `get_harness_chain()` returning `Vec<Harness>`
- **Simplified:** `reason.rs` — ~50 lines of ad-hoc wiring → `AgentConfigOverlay::fold()` + `from_overlay()`
- **Simplified:** `merge_harness()` — delegates to `AgentConfigOverlay::merge()` internally
- **Deduplicated:** `collect_initial_files` in session service uses shared `merge_initial_files`
- **Deduplicated:** `normalize_initial_file_path` moved to config_layer.rs, removed from session service
- **Updated:** `specs/concepts.md` documents the overlay pattern and chain diagram

## Risk
- Low
- Pure internal refactoring. No API, schema, or behavioral changes. Merge semantics are identical — same functions, just called from one canonical place. The fold is associative, so gRPC stores returning a pre-merged single harness produce the same result as DB stores returning the raw chain.

## Security
- No security-relevant code changes. This is a pure structural refactoring that moves existing merge logic into a shared type without changing any trust boundaries, input validation, authentication, authorization, prompt construction content, or network access semantics.

## Checklist
- [x] Tests added or updated (14 new tests for AgentConfigOverlay merge semantics)
- [x] Backward compatibility considered (internal code, no API changes)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
