### PR TITLE
refactor(ui): redesign default tool result rendering

### DIFF
--- a/apps/ui/src/__tests__/tool-activity-group.test.tsx
+++ b/apps/ui/src/__tests__/tool-activity-group.test.tsx
@@ -323,7 +323,7 @@ describe("ToolActivityGroup", () => {
     render(<ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />);
 
     expect(screen.getByText("Get DAYTONA_API_KEY")).toBeInTheDocument();
-    expect(screen.getByText("DAYTONA_API_KEY not found")).toBeInTheDocument();
+    expect(screen.getByText("details")).toBeInTheDocument();
     expect(screen.queryByText("Secret Store")).not.toBeInTheDocument();
     expect(screen.queryByText("1 of 1 complete")).not.toBeInTheDocument();
     expect(screen.queryByText(/"found":false/)).not.toBeInTheDocument();

--- a/apps/ui/src/components/chat/grouped-activity-card.tsx
+++ b/apps/ui/src/components/chat/grouped-activity-card.tsx
@@ -26,7 +26,7 @@ export function GroupedActivityCard({
   mode: "server" | "client";
 }) {
   const { backendLocale, t } = useLocale();
-  const [isExpanded, setIsExpanded] = useState(true);
+  const [isExpanded, setIsExpanded] = useState(false);
   const activityCompletedCount = useMemo(
     () => toolCalls.filter((toolCall) => toolResultsMap.has(toolCall.id)).length,
     [toolCalls, toolResultsMap],

--- a/apps/ui/src/components/chat/tool-activity-row.tsx
+++ b/apps/ui/src/components/chat/tool-activity-row.tsx
@@ -6,18 +6,11 @@
 "use client";
 
 import { useState } from "react";
-import {
-  AlertCircle,
-  Check,
-  ChevronDown,
-  ChevronRight,
-  Loader2,
-  MonitorSmartphone,
-} from "lucide-react";
+import { AlertCircle, Check, Loader2, MonitorSmartphone } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { ToolCompletedData } from "@/lib/api/types";
 import type { ToolCallContent } from "./tool-call-utils";
-import { formatResultDetails, getResultPreview, getToolLabel } from "./tool-activity-utils";
+import { formatResultDetails, getToolLabel } from "./tool-activity-utils";
 import { getFullText } from "./tool-call-utils";
 import { useLocale } from "@/providers/locale-provider";
 
@@ -74,33 +67,21 @@ export function ToolActivityRow({
                 {progressMessage ?? (mode === "client" ? t("waiting") : t("running"))}
               </span>
             )}
+            {!isRunning && hasOutput && (
+              <button
+                type="button"
+                onClick={() => setIsExpanded((current) => !current)}
+                aria-expanded={isExpanded}
+                aria-controls={detailsId}
+                className="inline-flex items-center gap-1 text-[10px] uppercase tracking-[0.18em] text-muted-foreground/50 transition-colors hover:text-foreground"
+              >
+                {isExpanded ? t("hide_details") : t("details")}
+              </button>
+            )}
           </div>
 
           {hasToolError && (
             <div className="mt-1 text-xs text-red-600 dark:text-red-400">{toolResult?.error}</div>
-          )}
-
-          {!hasToolError && !isExpanded && hasOutput && (
-            <div className="mt-1 truncate text-xs text-muted-foreground/70">
-              {getResultPreview(toolCall, toolResult)}
-            </div>
-          )}
-
-          {hasOutput && (
-            <button
-              type="button"
-              onClick={() => setIsExpanded((current) => !current)}
-              aria-expanded={isExpanded}
-              aria-controls={detailsId}
-              className="mt-1 inline-flex items-center gap-1 text-[10px] uppercase tracking-[0.18em] text-muted-foreground/65 transition-colors hover:text-foreground"
-            >
-              {isExpanded ? (
-                <ChevronDown className="h-3 w-3" />
-              ) : (
-                <ChevronRight className="h-3 w-3" />
-              )}
-              {isExpanded ? t("hide_details") : t("details")}
-            </button>
           )}
 
           <div

--- a/apps/ui/src/components/chat/tool-activity-utils.ts
+++ b/apps/ui/src/components/chat/tool-activity-utils.ts
@@ -287,7 +287,9 @@ function formatValueForDisplay(value: unknown, indent = 0): string {
     );
     if (entries.length === 0) return "{}";
     const prefix = " ".repeat(indent + 2);
-    return entries.map(([key, val]) => `${prefix}${key}: ${formatValueForDisplay(val, indent + 2)}`).join("\n");
+    return entries
+      .map(([key, val]) => `${prefix}${key}: ${formatValueForDisplay(val, indent + 2)}`)
+      .join("\n");
   }
   return String(value);
 }
@@ -302,9 +304,7 @@ export function formatResultDetails(toolCall: ToolCallContent, fullText: string)
   const entries = Object.entries(masked).filter(([key]) => !HIDDEN_DETAIL_FIELDS.has(key));
   if (entries.length === 0) return fullText;
 
-  return entries
-    .map(([key, value]) => `${key}: ${formatValueForDisplay(value)}`)
-    .join("\n");
+  return entries.map(([key, value]) => `${key}: ${formatValueForDisplay(value)}`).join("\n");
 }
 
 export function getResultPreview(

--- a/apps/ui/src/components/chat/tool-activity-utils.ts
+++ b/apps/ui/src/components/chat/tool-activity-utils.ts
@@ -254,10 +254,57 @@ function summarizeStructuredResult(toolCall: ToolCallContent, parsed: unknown): 
   return preview.length > 120 ? `${preview.slice(0, 120)}...` : preview;
 }
 
+/** Fields filtered from human-friendly details view (noise for the user). */
+const HIDDEN_DETAIL_FIELDS = new Set([
+  "id",
+  "_id",
+  "agent_id",
+  "session_id",
+  "harness_id",
+  "capability_id",
+  "organization_id",
+  "created_at",
+  "updated_at",
+  "deleted_at",
+]);
+
+function formatValueForDisplay(value: unknown, indent = 0): string {
+  if (value === null || value === undefined) return "null";
+  if (typeof value === "boolean") return value ? "yes" : "no";
+  if (typeof value === "number") return String(value);
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "(none)";
+    const items = value.map((item) => {
+      if (typeof item === "string") return item;
+      return JSON.stringify(item);
+    });
+    return items.join(", ");
+  }
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>).filter(
+      ([key]) => !HIDDEN_DETAIL_FIELDS.has(key),
+    );
+    if (entries.length === 0) return "{}";
+    const prefix = " ".repeat(indent + 2);
+    return entries.map(([key, val]) => `${prefix}${key}: ${formatValueForDisplay(val, indent + 2)}`).join("\n");
+  }
+  return String(value);
+}
+
 export function formatResultDetails(toolCall: ToolCallContent, fullText: string): string {
   const parsed = parseStructuredText(fullText);
   if (!parsed) return fullText;
-  return JSON.stringify(maskSensitiveFields(toolCall.name, parsed), null, 2);
+
+  const masked = maskSensitiveFields(toolCall.name, parsed);
+  if (!isRecord(masked)) return fullText;
+
+  const entries = Object.entries(masked).filter(([key]) => !HIDDEN_DETAIL_FIELDS.has(key));
+  if (entries.length === 0) return fullText;
+
+  return entries
+    .map(([key, value]) => `${key}: ${formatValueForDisplay(value)}`)
+    .join("\n");
 }
 
 export function getResultPreview(

--- a/apps/ui/src/components/chat/tool-activity-utils.ts
+++ b/apps/ui/src/components/chat/tool-activity-utils.ts
@@ -275,11 +275,12 @@ function formatValueForDisplay(value: unknown, indent = 0): string {
   if (typeof value === "string") return value;
   if (Array.isArray(value)) {
     if (value.length === 0) return "(none)";
-    const items = value.map((item) => {
-      if (typeof item === "string") return item;
-      return JSON.stringify(item);
-    });
-    return items.join(", ");
+    const items = value.map((item) => formatValueForDisplay(item, indent + 2));
+    if (items.every((item) => !item.includes("\n"))) {
+      return items.join(", ");
+    }
+    const prefix = " ".repeat(indent + 2);
+    return items.map((item) => `${prefix}- ${item}`).join("\n");
   }
   if (typeof value === "object") {
     const entries = Object.entries(value as Record<string, unknown>).filter(
@@ -299,10 +300,10 @@ export function formatResultDetails(toolCall: ToolCallContent, fullText: string)
   if (!parsed) return fullText;
 
   const masked = maskSensitiveFields(toolCall.name, parsed);
-  if (!isRecord(masked)) return fullText;
+  if (!isRecord(masked)) return formatValueForDisplay(masked);
 
   const entries = Object.entries(masked).filter(([key]) => !HIDDEN_DETAIL_FIELDS.has(key));
-  if (entries.length === 0) return fullText;
+  if (entries.length === 0) return "{}";
 
   return entries.map(([key, value]) => `${key}: ${formatValueForDisplay(value)}`).join("\n");
 }


### PR DESCRIPTION
## What
Redesign the default tool activity row rendering to be cleaner and less noisy.

- Remove the JSON preview line below the tool label
- Move the details toggle inline with the label text (`Created agent: Decider DETAILS`)
- Render human-friendly `key: value` format in expanded details instead of raw JSON
- Filter noise fields (IDs, timestamps) from the details view
- Default grouped activity card to collapsed state

## Why
The previous rendering was verbose: a raw JSON preview line cluttered the UI, the details button sat on its own line, and expanding showed unformatted JSON with internal IDs. This made the tool activity feed harder to scan.

## How
- **`tool-activity-row.tsx`**: Removed preview line and chevron icons. Moved the `DETAILS` button into the label flex row so it appears inline after the tool name. Only shown when the tool is complete and has output.
- **`tool-activity-utils.ts`**: Rewrote `formatResultDetails` to produce `key: value` lines. Added `HIDDEN_DETAIL_FIELDS` set to filter internal fields (`id`, `agent_id`, `session_id`, timestamps, etc.). Added `formatValueForDisplay` for recursive human-friendly formatting (booleans → yes/no, arrays → comma-separated, nested objects → indented).
- **`grouped-activity-card.tsx`**: Changed default state from `useState(true)` to `useState(false)`.

## Risk
- Low
- Visual-only change to tool result rendering. No backend, API, or data model changes.

## Security
- No security-relevant code changes. This is a pure UI rendering refactor affecting only how tool results are displayed in the chat transcript. No new inputs, endpoints, or data flows.

## Checklist
- [x] Tests added or updated — visual-only change, verified via build + smoke test
- [x] Backward compatibility considered — N/A, internal UI
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
