### PR TITLE
feat(ui): align harness display_name with agent pattern

### DIFF
--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -11791,6 +11791,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -755,7 +755,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                     >
                       {getEntityReferenceLabel({
                         kind: "Harness",
-                        name: harness?.name,
+                        name: getDisplayName(harness),
                         status: harness?.status ?? "deleted",
                       })}
                     </p>

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
@@ -504,7 +504,8 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
                   <div>
                     <p className="text-sm font-medium">Parent Harness</p>
                     <p className="text-sm text-muted-foreground">
-                      {(getDisplayName(selectedParentHarness) || formData.parent_harness_id) ||
+                      {getDisplayName(selectedParentHarness) ||
+                        formData.parent_harness_id ||
                         "(none)"}
                     </p>
                   </div>
@@ -535,8 +536,8 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
           <DialogHeader>
             <DialogTitle>Delete Harness</DialogTitle>
             <DialogDescription>
-              Permanently delete the archived harness &quot;{getDisplayName(harness)}&quot;? Existing
-              references will render as deleted tombstones.
+              Permanently delete the archived harness &quot;{getDisplayName(harness)}&quot;?
+              Existing references will render as deleted tombstones.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
@@ -36,9 +36,10 @@ import { InitialFilesEditor } from "@/components/initial-files-editor";
 import { ModelPicker } from "@/components/models/model-picker";
 import { ArrowLeft, Save, Trash2, Eye, Edit2, Check, X, Loader2 } from "lucide-react";
 import type { AgentCapabilityConfig, InitialFile } from "@/lib/api/types";
-import { isReadOnlyStatus } from "@/lib/entity-lifecycle";
+import { getDisplayName, isReadOnlyStatus } from "@/lib/entity-lifecycle";
 
 interface FormData {
+  display_name: string;
   name: string;
   description: string;
   system_prompt: string;
@@ -67,6 +68,7 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
   const initialFormData = useMemo((): FormData => {
     if (!harness) {
       return {
+        display_name: "",
         name: "",
         description: "",
         system_prompt: "",
@@ -76,6 +78,7 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
       };
     }
     return {
+      display_name: harness.display_name || "",
       name: harness.name,
       description: harness.description || "",
       system_prompt: harness.system_prompt,
@@ -139,6 +142,7 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
         harnessId,
         request: {
           name: formData.name,
+          display_name: formData.display_name || undefined,
           description: formData.description || undefined,
           system_prompt: formData.system_prompt,
           parent_harness_id: formData.parent_harness_id || null,
@@ -280,6 +284,20 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
                           ) : null}
                         </div>
                       )}
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label htmlFor="display_name">Display Name</Label>
+                      <Input
+                        id="display_name"
+                        placeholder={formData.name ? undefined : "My Harness"}
+                        value={formData.display_name}
+                        onChange={(e) => handleFormChange("display_name", e.target.value)}
+                        disabled={isSaving || isReadOnly}
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Optional human-readable label shown in the UI. Defaults to name if empty.
+                      </p>
                     </div>
 
                     <div className="space-y-2">
@@ -467,7 +485,15 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
                 <CardContent className="space-y-4">
                   <div>
                     <p className="text-sm font-medium">Name</p>
-                    <p className="text-sm text-muted-foreground">{formData.name || "(not set)"}</p>
+                    <p className="text-sm text-muted-foreground font-mono">
+                      {formData.name || "(not set)"}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium">Display Name</p>
+                    <p className="text-sm text-muted-foreground">
+                      {formData.display_name || "(not set)"}
+                    </p>
                   </div>
                   <div>
                     <p className="text-sm font-medium">Description</p>
@@ -478,7 +504,8 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
                   <div>
                     <p className="text-sm font-medium">Parent Harness</p>
                     <p className="text-sm text-muted-foreground">
-                      {(selectedParentHarness?.name ?? formData.parent_harness_id) || "(none)"}
+                      {(getDisplayName(selectedParentHarness) || formData.parent_harness_id) ||
+                        "(none)"}
                     </p>
                   </div>
                   <div>
@@ -508,7 +535,7 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
           <DialogHeader>
             <DialogTitle>Delete Harness</DialogTitle>
             <DialogDescription>
-              Permanently delete the archived harness &quot;{harness?.name}&quot;? Existing
+              Permanently delete the archived harness &quot;{getDisplayName(harness)}&quot;? Existing
               references will render as deleted tombstones.
             </DialogDescription>
           </DialogHeader>

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
@@ -113,7 +113,9 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
       <div className="flex items-start justify-between mb-6">
         <div>
           <h1 className="text-2xl font-bold flex items-center gap-2">
-            <span className={getEntityNameClassName(harness.status)}>{getDisplayName(harness)}</span>
+            <span className={getEntityNameClassName(harness.status)}>
+              {getDisplayName(harness)}
+            </span>
             <CopyButton value={harness.id} />
             {harness.is_built_in && <Badge variant="outline">Built-in</Badge>}
             <Badge variant={getEntityStatusBadgeVariant(harness.status)}>{harness.status}</Badge>

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
@@ -24,7 +24,11 @@ import { ArrowLeft, Pencil, Copy, Trash2, Eye, LayoutDashboard } from "lucide-re
 import { CopyButton } from "@/components/ui/copy-button";
 import type { Capability, LlmModelWithProvider } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
-import { getEntityNameClassName, getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
+import {
+  getDisplayName,
+  getEntityNameClassName,
+  getEntityStatusBadgeVariant,
+} from "@/lib/entity-lifecycle";
 
 export default function HarnessDetailPage({ params }: { params: Promise<{ harnessId: string }> }) {
   const { harnessId } = use(params);
@@ -109,7 +113,7 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
       <div className="flex items-start justify-between mb-6">
         <div>
           <h1 className="text-2xl font-bold flex items-center gap-2">
-            <span className={getEntityNameClassName(harness.status)}>{harness.name}</span>
+            <span className={getEntityNameClassName(harness.status)}>{getDisplayName(harness)}</span>
             <CopyButton value={harness.id} />
             {harness.is_built_in && <Badge variant="outline">Built-in</Badge>}
             <Badge variant={getEntityStatusBadgeVariant(harness.status)}>{harness.status}</Badge>
@@ -236,7 +240,7 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
                           href={`/harnesses/${parentHarness.id}`}
                           className="text-sm text-primary hover:underline"
                         >
-                          {parentHarness.name}
+                          {getDisplayName(parentHarness)}
                         </Link>
                       ) : (
                         <p className="text-sm text-muted-foreground">{harness.parent_harness_id}</p>

--- a/apps/ui/src/app/(main)/harnesses/new/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/new/page.tsx
@@ -17,12 +17,22 @@ import { HarnessSelect } from "@/components/harness/harness-select";
 import { InitialFilesEditor } from "@/components/initial-files-editor";
 import type { AgentCapabilityConfig, InitialFile } from "@/lib/api/types";
 
+/** Convert a display name to a slug: lowercase, non-alphanumeric → hyphens, deduplicate, trim. */
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+}
+
 export default function NewHarnessPage() {
   const router = useRouter();
   const createHarness = useCreateHarness();
   const { data: allCapabilities = [] } = useCapabilities();
 
   const [formData, setFormData] = useState({
+    display_name: "",
     name: "",
     description: "",
     system_prompt: "",
@@ -31,7 +41,24 @@ export default function NewHarnessPage() {
     tags: "",
   });
 
+  // Track whether the user has manually edited the slug
+  const [nameManuallyEdited, setNameManuallyEdited] = useState(false);
+
   const nameAvailability = useHarnessNameAvailability(formData.name);
+
+  const handleDisplayNameChange = (value: string) => {
+    const updates: Partial<typeof formData> = { display_name: value };
+    // Auto-derive slug unless user has manually edited it
+    if (!nameManuallyEdited) {
+      updates.name = slugify(value);
+    }
+    setFormData((prev) => ({ ...prev, ...updates }));
+  };
+
+  const handleNameChange = (value: string) => {
+    setNameManuallyEdited(true);
+    setFormData((prev) => ({ ...prev, name: value }));
+  };
 
   const [selectedCapabilities, setSelectedCapabilities] = useState<AgentCapabilityConfig[]>([]);
   const [initialFiles, setInitialFiles] = useState<InitialFile[]>([]);
@@ -51,6 +78,7 @@ export default function NewHarnessPage() {
 
       const harness = await createHarness.mutateAsync({
         name: formData.name,
+        display_name: formData.display_name || undefined,
         description: formData.description || undefined,
         system_prompt: formData.system_prompt,
         parent_harness_id: formData.parent_harness_id || undefined,
@@ -88,7 +116,7 @@ export default function NewHarnessPage() {
                 id="name"
                 placeholder="my-harness"
                 value={formData.name}
-                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                onChange={(e) => handleNameChange(e.target.value)}
                 required
               />
               {formData.name.length >= 2 && (
@@ -111,6 +139,22 @@ export default function NewHarnessPage() {
                   ) : null}
                 </div>
               )}
+              <p className="text-xs text-muted-foreground">
+                Unique identifier used in URLs and API. Lowercase letters, numbers, and hyphens.
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="display_name">Display Name</Label>
+              <Input
+                id="display_name"
+                placeholder={formData.name ? undefined : "My Harness"}
+                value={formData.display_name}
+                onChange={(e) => handleDisplayNameChange(e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                Optional human-readable label shown in the UI. Defaults to name if empty.
+              </p>
             </div>
 
             <div className="space-y-2">

--- a/apps/ui/src/components/harness/harness-select.tsx
+++ b/apps/ui/src/components/harness/harness-select.tsx
@@ -60,7 +60,7 @@ export function HarnessSelect({
   // show "Loading…" instead of the raw ID (EVE-142).
   // When no value is set and includeNoneOption is true, show the noneLabel.
   const displayValue = value
-    ? (getDisplayName(harnessMap.get(value)) || (filteredHarnesses.length === 0 ? "Loading…" : value))
+    ? getDisplayName(harnessMap.get(value)) || (filteredHarnesses.length === 0 ? "Loading…" : value)
     : includeNoneOption
       ? noneLabel
       : undefined;

--- a/apps/ui/src/components/harness/harness-select.tsx
+++ b/apps/ui/src/components/harness/harness-select.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/select";
 import { useHarnesses } from "@/hooks";
 import type { Harness } from "@/lib/api/types";
+import { getDisplayName } from "@/lib/entity-lifecycle";
 
 interface HarnessSelectProps {
   /** Selected harness ID */
@@ -59,7 +60,7 @@ export function HarnessSelect({
   // show "Loading…" instead of the raw ID (EVE-142).
   // When no value is set and includeNoneOption is true, show the noneLabel.
   const displayValue = value
-    ? (harnessMap.get(value)?.name ?? (filteredHarnesses.length === 0 ? "Loading…" : value))
+    ? (getDisplayName(harnessMap.get(value)) || (filteredHarnesses.length === 0 ? "Loading…" : value))
     : includeNoneOption
       ? noneLabel
       : undefined;
@@ -77,7 +78,7 @@ export function HarnessSelect({
         {includeNoneOption && <SelectItem value={noneValue}>{noneLabel}</SelectItem>}
         {filteredHarnesses.map((harness) => (
           <SelectItem key={harness.id} value={harness.id}>
-            {harness.name}
+            {getDisplayName(harness)}
           </SelectItem>
         ))}
       </SelectContent>

--- a/apps/ui/src/components/harnesses/harness-card.tsx
+++ b/apps/ui/src/components/harnesses/harness-card.tsx
@@ -10,7 +10,11 @@ import { CopyButton } from "@/components/ui/copy-button";
 import type { Harness, Capability, CapabilityId } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
 import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
-import { getEntityNameClassName, getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
+import {
+  getDisplayName,
+  getEntityNameClassName,
+  getEntityStatusBadgeVariant,
+} from "@/lib/entity-lifecycle";
 
 interface HarnessCardProps {
   harness: Harness;
@@ -36,7 +40,7 @@ export function HarnessCard({
         <div className="flex items-center gap-2">
           <CardTitle className={`text-lg ${getEntityNameClassName(harness.status)}`}>
             <Link href={`/harnesses/${harness.id}`} className="hover:underline">
-              {harness.name}
+              {getDisplayName(harness)}
             </Link>
           </CardTitle>
           <CopyButton value={harness.id} />

--- a/apps/ui/src/hooks/use-global-search.ts
+++ b/apps/ui/src/hooks/use-global-search.ts
@@ -369,13 +369,14 @@ export function useGlobalSearch(query: string) {
     let harnessCount = 0;
     for (const harness of harnesses) {
       if (harnessCount >= MAX_PER_CATEGORY) break;
-      if (matchesTokens(tokens, harness.name, harness.description, harness.id, "harness")) {
+      if (matchesTokens(tokens, harness.name, harness.display_name, harness.description, harness.id, "harness")) {
+        const harnessDisplayName = getDisplayName(harness);
         results.push({
           id: `harness:${harness.id}`,
           category: "harness",
           icon: Shield,
-          title: harness.name,
-          subtitle: `Harnesses > ${harness.name}`,
+          title: harnessDisplayName,
+          subtitle: `Harnesses > ${harnessDisplayName}`,
           href: `/harnesses/${harness.id}`,
         });
         harnessCount++;

--- a/apps/ui/src/hooks/use-global-search.ts
+++ b/apps/ui/src/hooks/use-global-search.ts
@@ -369,7 +369,16 @@ export function useGlobalSearch(query: string) {
     let harnessCount = 0;
     for (const harness of harnesses) {
       if (harnessCount >= MAX_PER_CATEGORY) break;
-      if (matchesTokens(tokens, harness.name, harness.display_name, harness.description, harness.id, "harness")) {
+      if (
+        matchesTokens(
+          tokens,
+          harness.name,
+          harness.display_name,
+          harness.description,
+          harness.id,
+          "harness",
+        )
+      ) {
         const harnessDisplayName = getDisplayName(harness);
         results.push({
           id: `harness:${harness.id}`,

--- a/apps/ui/src/lib/api/types/agent-types.ts
+++ b/apps/ui/src/lib/api/types/agent-types.ts
@@ -113,7 +113,10 @@ export type HarnessStatus = "active" | "archived" | "deleted";
 
 export interface Harness {
   id: string;
+  /** Addressable name (slug): lowercase alphanumeric and hyphens (e.g. "my-harness") */
   name: string;
+  /** Human-readable display name shown in UI. Falls back to name when absent. */
+  display_name: string | null;
   description: string | null;
   system_prompt: string;
   parent_harness_id: string | null;
@@ -134,7 +137,10 @@ export interface Harness {
 }
 
 export interface CreateHarnessRequest {
+  /** Addressable name (slug): lowercase alphanumeric and hyphens */
   name: string;
+  /** Human-readable display name shown in UI */
+  display_name?: string;
   description?: string;
   system_prompt: string;
   parent_harness_id?: string;
@@ -148,7 +154,10 @@ export interface CreateHarnessRequest {
 }
 
 export interface UpdateHarnessRequest {
+  /** Addressable name (slug): lowercase alphanumeric and hyphens */
   name?: string;
+  /** Human-readable display name shown in UI */
+  display_name?: string;
   description?: string;
   system_prompt?: string;
   parent_harness_id?: string | null;


### PR DESCRIPTION
## What
Add `display_name` support to all harness UI surfaces, aligning with the existing agent pattern. The backend and DB already support `display_name` on harnesses but the UI was not using it.

## Why
Agents had full `display_name` support (types, forms, display components, auto-slug) but harnesses were still showing raw slug names everywhere. This inconsistency meant harness display names set via API were invisible in the UI.

## How
- Added `display_name` field to `Harness`, `CreateHarnessRequest`, and `UpdateHarnessRequest` TypeScript interfaces
- Updated all harness display locations to use `getDisplayName()` (falls back to `name` when `display_name` is absent):
  - Harness card, select dropdown, detail page, global search, app detail page
- Added `display_name` form field to harness edit and create pages (matching agent pattern)
- Added auto-slug derivation on harness create page (typing display name auto-generates the slug, same as agents)

## Risk
- Low
- Pure UI change; backend already supports the field. Worst case: a display name renders where a slug used to

## Security
- No security-relevant code changes. All modifications are UI display logic using React JSX (auto-escaped) and an existing utility function (`getDisplayName`). No new backend endpoints, auth paths, or trust boundaries touched.

## Checklist
- [x] Tests added or updated — UI build and TypeScript type-check pass; no new runtime logic requiring unit tests
- [x] Backward compatibility considered — `display_name` is nullable; `getDisplayName()` falls back to `name`
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
