### PR TITLE
feat(fs): add virtual readonly mounts for session filesystem

### DIFF
--- a/crates/core/src/capabilities/skills.rs
+++ b/crates/core/src/capabilities/skills.rs
@@ -1528,6 +1528,9 @@ mod tests {
                         walk(store, session_id, &path, &entry.source);
                     }
                 }
+                MountSource::Virtual { .. } => {
+                    // Virtual mounts are not materialized in tests
+                }
             }
         }
         walk(store, session_id, &mount.path, &mount.source);

--- a/crates/core/src/capability_types.rs
+++ b/crates/core/src/capability_types.rs
@@ -16,6 +16,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::Arc;
 
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
@@ -156,6 +157,125 @@ impl From<String> for AgentCapabilityConfig {
 // Mount Point Types
 // ============================================================================
 
+// ============================================================================
+// Virtual File Tree
+// ============================================================================
+
+/// A read-only, path-indexed tree of file content. Built once at startup,
+/// shared across all sessions via `Arc`. Used by `MountSource::Virtual` to
+/// serve files from memory without writing rows to `session_files`.
+#[derive(Debug, Clone)]
+pub struct VirtualFileTree {
+    files: HashMap<String, VirtualFile>,
+}
+
+/// A single file in a virtual file tree.
+#[derive(Debug, Clone)]
+pub struct VirtualFile {
+    pub content: Vec<u8>,
+    pub is_directory: bool,
+}
+
+impl VirtualFileTree {
+    pub fn new() -> Self {
+        Self {
+            files: HashMap::new(),
+        }
+    }
+
+    /// Insert a text file at the given path (must start with "/").
+    pub fn insert_text(&mut self, path: impl Into<String>, content: impl Into<String>) {
+        let path = path.into();
+        self.ensure_parent_dirs(&path);
+        self.files.insert(
+            path,
+            VirtualFile {
+                content: content.into().into_bytes(),
+                is_directory: false,
+            },
+        );
+    }
+
+    /// Insert a directory entry at the given path.
+    pub fn insert_directory(&mut self, path: impl Into<String>) {
+        self.files.insert(
+            path.into(),
+            VirtualFile {
+                content: Vec::new(),
+                is_directory: true,
+            },
+        );
+    }
+
+    /// Get a file by path.
+    pub fn get(&self, path: &str) -> Option<&VirtualFile> {
+        self.files.get(path)
+    }
+
+    /// List entries directly under the given directory path.
+    pub fn list_directory(&self, dir_path: &str) -> Vec<(String, &VirtualFile)> {
+        let prefix = if dir_path == "/" {
+            "/".to_string()
+        } else {
+            format!("{dir_path}/")
+        };
+        self.files
+            .iter()
+            .filter(|(p, _)| {
+                if let Some(rest) = p.strip_prefix(&prefix) {
+                    !rest.is_empty() && !rest.contains('/')
+                } else {
+                    false
+                }
+            })
+            .map(|(p, f)| (p.clone(), f))
+            .collect()
+    }
+
+    /// Iterate all files (non-directory entries) for grep.
+    pub fn all_files(&self) -> impl Iterator<Item = (&str, &VirtualFile)> {
+        self.files
+            .iter()
+            .filter(|(_, f)| !f.is_directory)
+            .map(|(p, f)| (p.as_str(), f))
+    }
+
+    /// Number of entries in the tree.
+    pub fn len(&self) -> usize {
+        self.files.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.files.is_empty()
+    }
+
+    fn ensure_parent_dirs(&mut self, path: &str) {
+        let parts: Vec<&str> = path.trim_start_matches('/').split('/').collect();
+        let mut current = String::new();
+        for part in &parts[..parts.len().saturating_sub(1)] {
+            current = format!("{current}/{part}");
+            self.files.entry(current.clone()).or_insert(VirtualFile {
+                content: Vec::new(),
+                is_directory: true,
+            });
+        }
+    }
+}
+
+impl Default for VirtualFileTree {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PartialEq for VirtualFileTree {
+    fn eq(&self, other: &Self) -> bool {
+        self.files.len() == other.files.len()
+    }
+}
+
+impl Eq for VirtualFileTree {}
+
 /// Access mode for mounted files/directories
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
@@ -191,6 +311,9 @@ pub enum MountSource {
         /// Map of filename to mount entry
         entries: HashMap<String, MountEntry>,
     },
+    /// A virtual file tree served from memory. Read-only, shared across sessions via Arc.
+    /// No DB rows created — content is served directly from the in-memory tree.
+    Virtual { tree: Arc<VirtualFileTree> },
 }
 
 impl MountSource {
@@ -215,9 +338,14 @@ impl MountSource {
         Self::InlineDirectory { entries }
     }
 
+    /// Create a virtual mount source from a shared file tree
+    pub fn virtual_tree(tree: Arc<VirtualFileTree>) -> Self {
+        Self::Virtual { tree }
+    }
+
     /// Check if this source is a directory
     pub fn is_directory(&self) -> bool {
-        matches!(self, Self::InlineDirectory { .. })
+        matches!(self, Self::InlineDirectory { .. } | Self::Virtual { .. })
     }
 }
 

--- a/crates/core/src/capability_types.rs
+++ b/crates/core/src/capability_types.rs
@@ -170,7 +170,7 @@ pub struct VirtualFileTree {
 }
 
 /// A single file in a virtual file tree.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VirtualFile {
     pub content: Vec<u8>,
     pub is_directory: bool,
@@ -270,7 +270,7 @@ impl Default for VirtualFileTree {
 
 impl PartialEq for VirtualFileTree {
     fn eq(&self, other: &Self) -> bool {
-        self.files.len() == other.files.len()
+        self.files == other.files
     }
 }
 

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -28,6 +28,7 @@ pub mod session_git;
 pub mod session_schedule;
 pub mod skill;
 pub mod usage_tracking;
+pub mod virtual_mount_registry;
 
 pub use agent::AgentService;
 pub use agent_identity::AgentIdentityService;

--- a/crates/server/src/services/session_file.rs
+++ b/crates/server/src/services/session_file.rs
@@ -58,11 +58,23 @@ pub struct GrepInput {
 
 pub struct SessionFileService {
     db: Arc<StorageBackend>,
+    virtual_registry: Option<Arc<crate::services::virtual_mount_registry::VirtualMountRegistry>>,
 }
 
 impl SessionFileService {
     pub fn new(db: Arc<StorageBackend>) -> Self {
-        Self { db }
+        Self {
+            db,
+            virtual_registry: None,
+        }
+    }
+
+    pub fn with_virtual_registry(
+        mut self,
+        registry: Arc<crate::services::virtual_mount_registry::VirtualMountRegistry>,
+    ) -> Self {
+        self.virtual_registry = Some(registry);
+        self
     }
 
     /// Normalize a path: ensure it starts with /, no trailing slash, no double slashes
@@ -262,6 +274,28 @@ impl SessionFileService {
     /// Read a file
     pub async fn read_file(&self, session_id: Uuid, path: &str) -> Result<Option<SessionFile>> {
         let path = Self::normalize_path(path);
+
+        // Check virtual mounts first
+        if let Some(registry) = &self.virtual_registry
+            && let Some(vf) = registry.read_file(&session_id, &path)
+        {
+            let now = chrono::Utc::now();
+            let (content, encoding) = SessionFile::encode_content(&vf.content);
+            return Ok(Some(SessionFile {
+                id: uuid::Uuid::nil(),
+                session_id,
+                path: vf.path.clone(),
+                name: FileInfo::name_from_path(&vf.path),
+                content: Some(content),
+                encoding,
+                is_directory: vf.is_directory,
+                is_readonly: true,
+                size_bytes: vf.content.len() as i64,
+                created_at: now,
+                updated_at: now,
+            }));
+        }
+
         let row = self.db.get_session_file(session_id, &path).await?;
         Ok(row.map(Self::row_to_session_file))
     }
@@ -283,6 +317,21 @@ impl SessionFileService {
             }));
         }
 
+        // Check virtual mounts first
+        if let Some(registry) = &self.virtual_registry
+            && let Some(vf) = registry.read_file(&session_id, &path)
+        {
+            return Ok(Some(FileStat {
+                path: vf.path.clone(),
+                name: FileInfo::name_from_path(&vf.path),
+                is_directory: vf.is_directory,
+                is_readonly: true,
+                size_bytes: vf.content.len() as i64,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            }));
+        }
+
         let row = self.db.get_session_file(session_id, &path).await?;
         Ok(row.map(|r| FileStat {
             path: r.path.clone(),
@@ -299,8 +348,14 @@ impl SessionFileService {
     pub async fn list_directory(&self, session_id: Uuid, path: &str) -> Result<Vec<FileInfo>> {
         let path = Self::normalize_path(path);
 
+        // Check if directory exists in virtual mounts
+        let virtual_dir_exists = self.virtual_registry.as_ref().is_some_and(|r| {
+            r.read_file(&session_id, &path)
+                .is_some_and(|f| f.is_directory)
+        });
+
         // Verify directory exists (root always exists)
-        if path != "/" {
+        if path != "/" && !virtual_dir_exists {
             let dir = self.db.get_session_file(session_id, &path).await?;
             match dir {
                 Some(d) if !d.is_directory => {
@@ -312,10 +367,34 @@ impl SessionFileService {
         }
 
         let rows = self.db.list_session_files(session_id, &path).await?;
-        Ok(rows
+        let mut entries: Vec<FileInfo> = rows
             .into_iter()
             .map(Self::row_to_file_info_from_info)
-            .collect())
+            .collect();
+
+        // Merge virtual entries (virtual wins on name conflict)
+        if let Some(registry) = &self.virtual_registry {
+            let virtual_entries = registry.list_directory(&session_id, &path);
+            let now = chrono::Utc::now();
+            for vf in virtual_entries {
+                let name = FileInfo::name_from_path(&vf.path);
+                if !entries.iter().any(|e| e.name == name) {
+                    entries.push(FileInfo {
+                        id: uuid::Uuid::nil(),
+                        session_id,
+                        path: vf.path,
+                        name,
+                        is_directory: vf.is_directory,
+                        is_readonly: true,
+                        size_bytes: vf.content.len() as i64,
+                        created_at: now,
+                        updated_at: now,
+                    });
+                }
+            }
+        }
+
+        Ok(entries)
     }
 
     /// List all files recursively
@@ -335,6 +414,13 @@ impl SessionFileService {
         req: UpdateFileInput,
     ) -> Result<Option<SessionFile>> {
         let path = Self::normalize_path(path);
+
+        // Virtual files cannot be modified
+        if let Some(registry) = &self.virtual_registry
+            && registry.is_virtual_path(&session_id, &path)
+        {
+            return Err(anyhow!("Cannot modify readonly file: {}", path));
+        }
 
         // Check if file exists and is not readonly
         if let Some(existing) = self.db.get_session_file(session_id, &path).await? {
@@ -650,6 +736,15 @@ impl SessionFileService {
         let is_readonly = mount.is_readonly();
         let mut stats = MountStats::default();
 
+        // Virtual mounts are registered in-memory, not written to DB
+        if let MountSource::Virtual { tree } = &mount.source {
+            if let Some(registry) = &self.virtual_registry {
+                registry.register(session_id, path, tree.clone(), mount.capability_id.clone());
+                stats.files_created += tree.len();
+            }
+            return Ok(stats);
+        }
+
         self.apply_mount_source(session_id, &path, &mount.source, is_readonly, &mut stats)
             .await?;
 
@@ -684,6 +779,10 @@ impl SessionFileService {
                         self.apply_mount_entry(session_id, &child_path, entry, is_readonly, stats)
                             .await?;
                     }
+                }
+                MountSource::Virtual { .. } => {
+                    // Virtual mounts are handled in apply_single_mount, not here
+                    unreachable!("Virtual mounts should be handled before apply_mount_source");
                 }
             }
             Ok(())

--- a/crates/server/src/services/session_file.rs
+++ b/crates/server/src/services/session_file.rs
@@ -11,8 +11,8 @@ use crate::storage::{
 };
 use anyhow::{Result, anyhow};
 use everruns_core::{
-    FileInfo, FileStat, GrepMatch, GrepResult, MountEntry, MountPoint, MountSource, SessionFile,
-    SessionId,
+    FileInfo, FileStat, GrepMatch, GrepResult, MountAccess, MountEntry, MountPoint, MountSource,
+    SessionFile, SessionId,
 };
 use regex::Regex;
 use std::sync::Arc;
@@ -280,13 +280,18 @@ impl SessionFileService {
             && let Some(vf) = registry.read_file(&session_id, &path)
         {
             let now = chrono::Utc::now();
-            let (content, encoding) = SessionFile::encode_content(&vf.content);
+            let (content, encoding) = if vf.is_directory {
+                (None, "text".to_string())
+            } else {
+                let (c, e) = SessionFile::encode_content(&vf.content);
+                (Some(c), e)
+            };
             return Ok(Some(SessionFile {
                 id: uuid::Uuid::nil(),
                 session_id,
                 path: vf.path.clone(),
                 name: FileInfo::name_from_path(&vf.path),
-                content: Some(content),
+                content,
                 encoding,
                 is_directory: vf.is_directory,
                 is_readonly: true,
@@ -378,21 +383,28 @@ impl SessionFileService {
             let now = chrono::Utc::now();
             for vf in virtual_entries {
                 let name = FileInfo::name_from_path(&vf.path);
-                if !entries.iter().any(|e| e.name == name) {
-                    entries.push(FileInfo {
-                        id: uuid::Uuid::nil(),
-                        session_id,
-                        path: vf.path,
-                        name,
-                        is_directory: vf.is_directory,
-                        is_readonly: true,
-                        size_bytes: vf.content.len() as i64,
-                        created_at: now,
-                        updated_at: now,
-                    });
-                }
+                // Remove any DB entry with the same name so virtual wins
+                entries.retain(|e| e.name != name);
+                entries.push(FileInfo {
+                    id: uuid::Uuid::nil(),
+                    session_id,
+                    path: vf.path,
+                    name,
+                    is_directory: vf.is_directory,
+                    is_readonly: true,
+                    size_bytes: vf.size_bytes,
+                    created_at: now,
+                    updated_at: now,
+                });
             }
         }
+
+        // Sort to match DB ordering: directories first, then by path
+        entries.sort_by(|a, b| {
+            b.is_directory
+                .cmp(&a.is_directory)
+                .then_with(|| a.path.cmp(&b.path))
+        });
 
         Ok(entries)
     }
@@ -738,9 +750,21 @@ impl SessionFileService {
 
         // Virtual mounts are registered in-memory, not written to DB
         if let MountSource::Virtual { tree } = &mount.source {
+            if mount.access == MountAccess::ReadWrite {
+                return Err(anyhow!(
+                    "Virtual mounts are always read-only; mount at '{}' has ReadWrite access",
+                    mount.path
+                ));
+            }
             if let Some(registry) = &self.virtual_registry {
                 registry.register(session_id, path, tree.clone(), mount.capability_id.clone());
                 stats.files_created += tree.len();
+            } else {
+                return Err(anyhow!(
+                    "virtual mount at '{}' for capability '{}' cannot be applied: no virtual registry configured",
+                    mount.path,
+                    mount.capability_id
+                ));
             }
             return Ok(stats);
         }
@@ -781,8 +805,10 @@ impl SessionFileService {
                     }
                 }
                 MountSource::Virtual { .. } => {
-                    // Virtual mounts are handled in apply_single_mount, not here
-                    unreachable!("Virtual mounts should be handled before apply_mount_source");
+                    // Virtual mounts are only supported as top-level mount roots.
+                    return Err(anyhow!(
+                        "Virtual mounts are only supported at the mount root"
+                    ));
                 }
             }
             Ok(())
@@ -1118,5 +1144,137 @@ mod tests {
             .unwrap();
 
         assert!(updated.is_none());
+    }
+
+    // ===== Virtual mount tests =====
+
+    use crate::services::virtual_mount_registry::VirtualMountRegistry;
+    use everruns_core::capability_types::VirtualFileTree;
+
+    fn make_virtual_svc() -> (SessionFileService, Arc<VirtualMountRegistry>, Uuid) {
+        let db = StorageBackend::in_memory();
+        let registry = Arc::new(VirtualMountRegistry::new());
+        let svc = SessionFileService::new(Arc::new(db)).with_virtual_registry(registry.clone());
+        let sid = Uuid::new_v4();
+        (svc, registry, sid)
+    }
+
+    fn sample_tree() -> Arc<VirtualFileTree> {
+        let mut tree = VirtualFileTree::new();
+        tree.insert_text("/docs/readme.md", "# Hello");
+        tree.insert_text("/docs/guide.md", "Guide content");
+        Arc::new(tree)
+    }
+
+    #[tokio::test]
+    async fn virtual_read_file_returns_content() {
+        let (svc, registry, sid) = make_virtual_svc();
+        registry.register(sid, "/docs".into(), sample_tree(), "test_cap".into());
+
+        let file = svc
+            .read_file(sid, "/docs/readme.md")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(file.content.as_deref(), Some("# Hello"));
+        assert!(file.is_readonly);
+        assert!(!file.is_directory);
+    }
+
+    #[tokio::test]
+    async fn virtual_read_directory_returns_none_content() {
+        let (svc, registry, sid) = make_virtual_svc();
+        registry.register(sid, "/docs".into(), sample_tree(), "test_cap".into());
+
+        let dir = svc.read_file(sid, "/docs").await.unwrap().unwrap();
+        assert!(dir.is_directory);
+        assert!(dir.content.is_none());
+    }
+
+    #[tokio::test]
+    async fn virtual_stat_returns_metadata() {
+        let (svc, registry, sid) = make_virtual_svc();
+        registry.register(sid, "/docs".into(), sample_tree(), "test_cap".into());
+
+        let stat = svc.stat(sid, "/docs/readme.md").await.unwrap().unwrap();
+        assert!(!stat.is_directory);
+        assert!(stat.is_readonly);
+        assert!(stat.size_bytes > 0);
+    }
+
+    #[tokio::test]
+    async fn virtual_list_directory_returns_entries() {
+        let (svc, registry, sid) = make_virtual_svc();
+        registry.register(sid, "/docs".into(), sample_tree(), "test_cap".into());
+
+        let entries = svc.list_directory(sid, "/docs").await.unwrap();
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"readme.md"));
+        assert!(names.contains(&"guide.md"));
+    }
+
+    #[tokio::test]
+    async fn virtual_list_directory_sorted_dirs_first() {
+        let (svc, registry, sid) = make_virtual_svc();
+        let mut tree = VirtualFileTree::new();
+        tree.insert_text("/mnt/file.txt", "content");
+        tree.insert_directory("/mnt/subdir");
+        registry.register(sid, "/mnt".into(), Arc::new(tree), "test_cap".into());
+
+        let entries = svc.list_directory(sid, "/mnt").await.unwrap();
+        assert!(entries[0].is_directory, "directories should come first");
+    }
+
+    #[tokio::test]
+    async fn virtual_wins_on_name_conflict() {
+        let (svc, registry, sid) = make_virtual_svc();
+
+        // Create a DB file at /docs/readme.md
+        svc.create_directory(
+            sid,
+            CreateDirectoryInput {
+                path: "/docs".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+        let db_input = CreateFileInput {
+            path: "/docs/readme.md".to_string(),
+            content: Some("DB content".to_string()),
+            encoding: None,
+            is_readonly: Some(false),
+        };
+        svc.create_file(sid, db_input).await.unwrap();
+
+        // Register virtual mount with same path
+        registry.register(sid, "/docs".into(), sample_tree(), "test_cap".into());
+
+        // Virtual should win in listing
+        let entries = svc.list_directory(sid, "/docs").await.unwrap();
+        let readme = entries.iter().find(|e| e.name == "readme.md").unwrap();
+        assert!(readme.is_readonly, "virtual entry should win (readonly)");
+    }
+
+    #[tokio::test]
+    async fn virtual_update_file_rejected() {
+        let (svc, registry, sid) = make_virtual_svc();
+        registry.register(sid, "/docs".into(), sample_tree(), "test_cap".into());
+
+        let err = svc
+            .update_file(
+                sid,
+                "/docs/readme.md",
+                UpdateFileInput {
+                    content: Some("modified".to_string()),
+                    encoding: None,
+                    is_readonly: None,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("readonly"),
+            "Expected readonly error, got: {err}"
+        );
     }
 }

--- a/crates/server/src/services/virtual_mount_registry.rs
+++ b/crates/server/src/services/virtual_mount_registry.rs
@@ -1,0 +1,195 @@
+// Virtual mount registry — per-session registry of virtual file trees.
+//
+// Virtual mounts are registered during apply_capability_mounts() for
+// MountSource::Virtual entries. Content is served from memory without
+// writing rows to session_files. Evicted on session delete.
+
+use everruns_core::capability_types::VirtualFileTree;
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use std::sync::Arc;
+use uuid::Uuid;
+
+/// A registered virtual mount for a session.
+struct RegisteredVirtualMount {
+    mount_path: String,
+    tree: Arc<VirtualFileTree>,
+    #[allow(dead_code)]
+    capability_id: String,
+}
+
+/// Session-scoped registry of virtual mount trees.
+pub struct VirtualMountRegistry {
+    mounts: RwLock<HashMap<Uuid, Vec<RegisteredVirtualMount>>>,
+}
+
+impl VirtualMountRegistry {
+    pub fn new() -> Self {
+        Self {
+            mounts: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Register a virtual mount for a session.
+    pub fn register(
+        &self,
+        session_id: Uuid,
+        mount_path: String,
+        tree: Arc<VirtualFileTree>,
+        capability_id: String,
+    ) {
+        self.mounts
+            .write()
+            .entry(session_id)
+            .or_default()
+            .push(RegisteredVirtualMount {
+                mount_path,
+                tree,
+                capability_id,
+            });
+    }
+
+    /// Remove all virtual mounts for a session.
+    pub fn evict(&self, session_id: &Uuid) {
+        self.mounts.write().remove(session_id);
+    }
+
+    /// Read a file from virtual mounts. Returns content if the path matches any mount.
+    pub fn read_file(&self, session_id: &Uuid, path: &str) -> Option<VirtualFileRead> {
+        let mounts = self.mounts.read();
+        let session_mounts = mounts.get(session_id)?;
+        for mount in session_mounts {
+            if let Some(relative) = strip_mount_prefix(path, &mount.mount_path) {
+                let lookup = if relative.is_empty() {
+                    mount.mount_path.clone()
+                } else {
+                    format!("{}/{relative}", mount.mount_path)
+                };
+                if let Some(file) = mount.tree.get(&lookup) {
+                    return Some(VirtualFileRead {
+                        content: file.content.clone(),
+                        is_directory: file.is_directory,
+                        path: path.to_string(),
+                    });
+                }
+            }
+        }
+        None
+    }
+
+    /// List virtual entries under a directory path.
+    pub fn list_directory(&self, session_id: &Uuid, dir_path: &str) -> Vec<VirtualFileRead> {
+        let mut results = Vec::new();
+        let mounts = self.mounts.read();
+        let Some(session_mounts) = mounts.get(session_id) else {
+            return results;
+        };
+        for mount in session_mounts {
+            if strip_mount_prefix(dir_path, &mount.mount_path).is_some() {
+                for (entry_path, file) in mount.tree.list_directory(dir_path) {
+                    results.push(VirtualFileRead {
+                        content: file.content.clone(),
+                        is_directory: file.is_directory,
+                        path: entry_path,
+                    });
+                }
+            } else if strip_mount_prefix(&mount.mount_path, dir_path).is_some() {
+                // The mount root itself is inside the listed directory
+                if let Some(file) = mount.tree.get(&mount.mount_path) {
+                    results.push(VirtualFileRead {
+                        content: file.content.clone(),
+                        is_directory: file.is_directory,
+                        path: mount.mount_path.clone(),
+                    });
+                }
+            }
+        }
+        results
+    }
+
+    /// Check if a path falls under any virtual mount (for write protection).
+    pub fn is_virtual_path(&self, session_id: &Uuid, path: &str) -> bool {
+        let mounts = self.mounts.read();
+        let Some(session_mounts) = mounts.get(session_id) else {
+            return false;
+        };
+        session_mounts
+            .iter()
+            .any(|m| strip_mount_prefix(path, &m.mount_path).is_some())
+    }
+
+    /// Search virtual files for grep matches.
+    pub fn grep(
+        &self,
+        session_id: &Uuid,
+        pattern: &regex::Regex,
+        path_filter: Option<&str>,
+    ) -> Vec<VirtualGrepMatch> {
+        let mut results = Vec::new();
+        let mounts = self.mounts.read();
+        let Some(session_mounts) = mounts.get(session_id) else {
+            return results;
+        };
+        for mount in session_mounts {
+            for (file_path, file) in mount.tree.all_files() {
+                if let Some(filter) = path_filter {
+                    let filter_prefix = if filter.ends_with('/') {
+                        filter.to_string()
+                    } else {
+                        format!("{filter}/")
+                    };
+                    if !file_path.starts_with(&filter_prefix) && file_path != filter {
+                        continue;
+                    }
+                }
+                let content = match std::str::from_utf8(&file.content) {
+                    Ok(s) => s,
+                    Err(_) => continue,
+                };
+                for (line_num, line) in content.lines().enumerate() {
+                    if pattern.is_match(line) {
+                        results.push(VirtualGrepMatch {
+                            path: file_path.to_string(),
+                            line_number: line_num + 1,
+                            line: line.to_string(),
+                        });
+                    }
+                }
+            }
+        }
+        results
+    }
+}
+
+impl Default for VirtualMountRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Result of reading a virtual file.
+pub struct VirtualFileRead {
+    pub content: Vec<u8>,
+    pub is_directory: bool,
+    pub path: String,
+}
+
+/// A grep match from virtual files.
+pub struct VirtualGrepMatch {
+    pub path: String,
+    pub line_number: usize,
+    pub line: String,
+}
+
+/// Strip the mount prefix from a path. Returns the relative portion.
+/// E.g. strip_mount_prefix("/docs/foo.md", "/docs") -> Some("foo.md")
+/// E.g. strip_mount_prefix("/docs", "/docs") -> Some("")
+fn strip_mount_prefix<'a>(path: &'a str, mount_path: &str) -> Option<&'a str> {
+    if path == mount_path {
+        Some("")
+    } else if let Some(rest) = path.strip_prefix(mount_path) {
+        rest.strip_prefix('/').or(Some(rest))
+    } else {
+        None
+    }
+}

--- a/crates/server/src/services/virtual_mount_registry.rs
+++ b/crates/server/src/services/virtual_mount_registry.rs
@@ -77,8 +77,8 @@ impl VirtualMountRegistry {
         None
     }
 
-    /// List virtual entries under a directory path.
-    pub fn list_directory(&self, session_id: &Uuid, dir_path: &str) -> Vec<VirtualFileRead> {
+    /// List virtual entries under a directory path (metadata only, no content cloned).
+    pub fn list_directory(&self, session_id: &Uuid, dir_path: &str) -> Vec<VirtualFileMeta> {
         let mut results = Vec::new();
         let mounts = self.mounts.read();
         let Some(session_mounts) = mounts.get(session_id) else {
@@ -87,8 +87,8 @@ impl VirtualMountRegistry {
         for mount in session_mounts {
             if strip_mount_prefix(dir_path, &mount.mount_path).is_some() {
                 for (entry_path, file) in mount.tree.list_directory(dir_path) {
-                    results.push(VirtualFileRead {
-                        content: file.content.clone(),
+                    results.push(VirtualFileMeta {
+                        size_bytes: file.content.len() as i64,
                         is_directory: file.is_directory,
                         path: entry_path,
                     });
@@ -96,8 +96,8 @@ impl VirtualMountRegistry {
             } else if strip_mount_prefix(&mount.mount_path, dir_path).is_some() {
                 // The mount root itself is inside the listed directory
                 if let Some(file) = mount.tree.get(&mount.mount_path) {
-                    results.push(VirtualFileRead {
-                        content: file.content.clone(),
+                    results.push(VirtualFileMeta {
+                        size_bytes: file.content.len() as i64,
                         is_directory: file.is_directory,
                         path: mount.mount_path.clone(),
                     });
@@ -174,6 +174,13 @@ pub struct VirtualFileRead {
     pub path: String,
 }
 
+/// Metadata-only result for directory listings (avoids cloning file content).
+pub struct VirtualFileMeta {
+    pub path: String,
+    pub is_directory: bool,
+    pub size_bytes: i64,
+}
+
 /// A grep match from virtual files.
 pub struct VirtualGrepMatch {
     pub path: String,
@@ -182,14 +189,135 @@ pub struct VirtualGrepMatch {
 }
 
 /// Strip the mount prefix from a path. Returns the relative portion.
+/// Only matches on segment boundaries (not arbitrary string prefixes).
 /// E.g. strip_mount_prefix("/docs/foo.md", "/docs") -> Some("foo.md")
 /// E.g. strip_mount_prefix("/docs", "/docs") -> Some("")
+/// E.g. strip_mount_prefix("/docs2", "/docs") -> None
 fn strip_mount_prefix<'a>(path: &'a str, mount_path: &str) -> Option<&'a str> {
     if path == mount_path {
         Some("")
-    } else if let Some(rest) = path.strip_prefix(mount_path) {
-        rest.strip_prefix('/').or(Some(rest))
+    } else if mount_path == "/" {
+        path.strip_prefix('/')
     } else {
-        None
+        let prefix = format!("{mount_path}/");
+        path.strip_prefix(&prefix)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::capability_types::VirtualFileTree;
+
+    #[test]
+    fn strip_mount_prefix_exact_match() {
+        assert_eq!(strip_mount_prefix("/docs", "/docs"), Some(""));
+    }
+
+    #[test]
+    fn strip_mount_prefix_child_path() {
+        assert_eq!(strip_mount_prefix("/docs/foo.md", "/docs"), Some("foo.md"));
+    }
+
+    #[test]
+    fn strip_mount_prefix_no_match_partial_segment() {
+        // "/docs2" should NOT match mount "/docs"
+        assert_eq!(strip_mount_prefix("/docs2", "/docs"), None);
+        assert_eq!(strip_mount_prefix("/docsfoo", "/docs"), None);
+    }
+
+    #[test]
+    fn strip_mount_prefix_root_mount() {
+        assert_eq!(strip_mount_prefix("/foo.md", "/"), Some("foo.md"));
+        assert_eq!(strip_mount_prefix("/", "/"), Some(""));
+    }
+
+    #[test]
+    fn strip_mount_prefix_no_match_different_prefix() {
+        assert_eq!(strip_mount_prefix("/other/foo", "/docs"), None);
+    }
+
+    #[test]
+    fn registry_read_file() {
+        let registry = VirtualMountRegistry::new();
+        let sid = Uuid::new_v4();
+        let mut tree = VirtualFileTree::new();
+        tree.insert_text("/mnt/hello.txt", "world");
+        registry.register(sid, "/mnt".into(), Arc::new(tree), "cap".into());
+
+        let result = registry.read_file(&sid, "/mnt/hello.txt").unwrap();
+        assert_eq!(result.content, b"world");
+        assert!(!result.is_directory);
+    }
+
+    #[test]
+    fn registry_read_file_no_partial_segment_match() {
+        let registry = VirtualMountRegistry::new();
+        let sid = Uuid::new_v4();
+        let mut tree = VirtualFileTree::new();
+        tree.insert_text("/mnt/hello.txt", "world");
+        registry.register(sid, "/mnt".into(), Arc::new(tree), "cap".into());
+
+        // "/mnt2/hello.txt" should NOT match mount at "/mnt"
+        assert!(registry.read_file(&sid, "/mnt2/hello.txt").is_none());
+    }
+
+    #[test]
+    fn registry_is_virtual_path_no_partial_segment_match() {
+        let registry = VirtualMountRegistry::new();
+        let sid = Uuid::new_v4();
+        let mut tree = VirtualFileTree::new();
+        tree.insert_text("/docs/a.md", "content");
+        registry.register(sid, "/docs".into(), Arc::new(tree), "cap".into());
+
+        assert!(registry.is_virtual_path(&sid, "/docs/a.md"));
+        assert!(registry.is_virtual_path(&sid, "/docs"));
+        assert!(!registry.is_virtual_path(&sid, "/docs2"));
+        assert!(!registry.is_virtual_path(&sid, "/docsfoo"));
+    }
+
+    #[test]
+    fn registry_list_directory_returns_metadata() {
+        let registry = VirtualMountRegistry::new();
+        let sid = Uuid::new_v4();
+        let mut tree = VirtualFileTree::new();
+        tree.insert_text("/docs/a.md", "aaa");
+        tree.insert_text("/docs/b.md", "bbb");
+        registry.register(sid, "/docs".into(), Arc::new(tree), "cap".into());
+
+        let entries = registry.list_directory(&sid, "/docs");
+        assert_eq!(entries.len(), 2);
+        // Verify we get metadata, not content
+        for entry in &entries {
+            assert!(entry.size_bytes > 0);
+        }
+    }
+
+    #[test]
+    fn registry_evict_removes_session() {
+        let registry = VirtualMountRegistry::new();
+        let sid = Uuid::new_v4();
+        let mut tree = VirtualFileTree::new();
+        tree.insert_text("/mnt/hello.txt", "world");
+        registry.register(sid, "/mnt".into(), Arc::new(tree), "cap".into());
+
+        assert!(registry.read_file(&sid, "/mnt/hello.txt").is_some());
+        registry.evict(&sid);
+        assert!(registry.read_file(&sid, "/mnt/hello.txt").is_none());
+    }
+
+    #[test]
+    fn registry_grep_matches() {
+        let registry = VirtualMountRegistry::new();
+        let sid = Uuid::new_v4();
+        let mut tree = VirtualFileTree::new();
+        tree.insert_text("/docs/readme.md", "line 1\nfind me\nline 3");
+        registry.register(sid, "/docs".into(), Arc::new(tree), "cap".into());
+
+        let pattern = regex::Regex::new("find me").unwrap();
+        let results = registry.grep(&sid, &pattern, None);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].line_number, 2);
+        assert_eq!(results[0].line, "find me");
     }
 }


### PR DESCRIPTION
## What
Add `MountSource::Virtual` variant and `VirtualMountRegistry` so capabilities can serve files from memory without writing rows to `session_files`. This is the core plumbing for virtual readonly mounts.

## Why
Platform chat sessions will mount docs (~66 files, ~5 MB) that are identical across all sessions — static, compiled into the binary. Writing 66 INSERT per session creation is unnecessary. Virtual mounts eliminate per-session DB cost for static content. Future use cases: starter templates, SDK examples, skill definitions.

Closes EVE-261 (core plumbing — `platform_docs` consumer capability is a follow-up).

## How
**Core types (`crates/core/src/capability_types.rs`):**
- `VirtualFileTree`: path-indexed readonly tree (`HashMap`)
  - `insert_text()`, `get()`, `list_directory()`, `all_files()` (for grep)
  - Auto-creates parent directories on insert
- `MountSource::Virtual { tree: Arc }`: new enum variant

**Registry (`crates/server/src/services/virtual_mount_registry.rs`):**
- `VirtualMountRegistry`: per-session registry using `parking_lot::RwLock`
- `register()`, `evict()`, `read_file()`, `list_directory()`, `is_virtual_path()`, `grep()`
- `VirtualFileMeta`: metadata-only struct for directory listings (avoids cloning content)

**Session file service integration:**
- `read_file()`: virtual-first lookup, fall back to DB
- `stat()`: virtual-first lookup, fall back to DB
- `list_directory()`: merge virtual + DB entries (virtual wins on conflict), sorted dirs-first then by path
- `update_file()`: reject writes to virtual mount paths
- `apply_single_mount()`: registers virtual mounts in-memory instead of writing to DB; rejects ReadWrite access; errors if no registry configured

## Risk
- Low
- No runtime behavior change until a capability uses `MountSource::Virtual`
- Existing inline mount path is completely unchanged
- Follow-up: `platform_docs` capability, grep integration for `DirectWorkerAdapters`/`DbSessionFileStore`

## Security
- Threat categories reviewed: TM-FS, TM-TENANT, TM-DOS
- TM-FS: Paths validated via existing `normalize_path`/`validate_path` before reaching virtual layer. Virtual files hardcoded `is_readonly: true`. Write protection added to `update_file`. `strip_mount_prefix` uses segment-boundary matching (no partial path leaks).
- TM-TENANT: Virtual mounts keyed by session_id (UUID). No cross-session access.
- TM-DOS: Trees built once at startup, shared via `Arc`. Grep iterates bounded static content. Directory listings return metadata-only (`VirtualFileMeta`), avoiding content cloning.
- No new crate dependencies (uses existing `parking_lot`, `regex`).

## Checklist
- [x] Tests added or updated (18 new tests: 7 session file service, 11 virtual mount registry)
- [x] Backward compatibility considered (additive only, no breaking changes)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)