### PR TITLE
feat(server): restructure routing and fix MCP OAuth end-to-end

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ Always make sure you are working on top of latest main from remote.
 
 - `specs/concepts.md` - Core entities, relationships, and concept diagram
 - `specs/architecture.md` - System architecture, crate structure, infrastructure
+- `specs/production-deployment.md` - Production deployment aggregation spec and reverse proxy contract
 - `specs/parallel-execution-1m.md` - Scaling to 1M concurrent agents (partitioning, sharding, LLM routing)
 - `specs/embedding.md` - Embedding contract and `PlatformDefinition`
 - `specs/code-organization.md` - Naming conventions, type flow, testing, error handling

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1962,6 +1962,7 @@ dependencies = [
  "serde",
  "serde_html_form",
  "serde_json",
+ "serde_urlencoded",
  "serde_yaml",
  "sha2 0.10.9",
  "sqlx",

--- a/apps/ui/next.config.ts
+++ b/apps/ui/next.config.ts
@@ -1,8 +1,8 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  output: 'standalone',
-  // API routing handled by Caddy reverse proxy (strips /api prefix, forwards to backend)
+  output: "standalone",
+  // API routing handled by Caddy reverse proxy and backend route layout.
   // No Next.js rewrites needed
 };
 

--- a/apps/ui/src/app/(auth)/login/page.tsx
+++ b/apps/ui/src/app/(auth)/login/page.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { useAuthConfig, useLogin } from "@/hooks/use-auth";
-import { getOAuthUrl } from "@/lib/api/auth";
+import { getOAuthUrl, login } from "@/lib/api/auth";
 import { Loader2 } from "lucide-react";
 
 // Session storage key for preserving return_to across OAuth redirects
@@ -60,8 +60,18 @@ export default function LoginPage() {
     setError(null);
 
     try {
+      const target = getRedirectTarget();
+      // For backend redirects (e.g. /oauth/authorize), call login() directly
+      // and navigate immediately — don't go through the mutation's onSuccess
+      // which refetches auth state and can trigger React re-renders that
+      // race with the navigation.
+      if (target.startsWith("/oauth/") || target.startsWith("/api/")) {
+        await login({ email, password });
+        window.location.assign(target);
+        return;
+      }
       await loginMutation.mutateAsync({ email, password });
-      router.push(getRedirectTarget());
+      router.push(target);
     } catch (err) {
       if (err instanceof Error) {
         setError(err.message);

--- a/apps/ui/src/app/(main)/layout.tsx
+++ b/apps/ui/src/app/(main)/layout.tsx
@@ -69,7 +69,12 @@ function MainLayoutInner({ children }: MainLayoutProps) {
       const pendingReturnTo = sessionStorage.getItem("everruns_return_to");
       if (pendingReturnTo) {
         sessionStorage.removeItem("everruns_return_to");
-        router.replace(pendingReturnTo);
+        // Backend paths (e.g. /oauth/authorize) need a full page navigation
+        if (pendingReturnTo.startsWith("/oauth/") || pendingReturnTo.startsWith("/api/")) {
+          window.location.assign(pendingReturnTo);
+        } else {
+          router.replace(pendingReturnTo);
+        }
       }
     }
   }, [authLoading, authUnavailable, isAuthenticated, router]);

--- a/apps/ui/src/components/layout/mcp-connect-button.tsx
+++ b/apps/ui/src/components/layout/mcp-connect-button.tsx
@@ -12,7 +12,11 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 const McpIcon = capabilityIconMap.mcp;
 
@@ -36,7 +40,11 @@ function CopySnippetButton({ value }: { value: string }) {
       className="absolute top-2 right-2 inline-flex h-7 w-7 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
       aria-label={copied ? "Copied" : "Copy to clipboard"}
     >
-      {copied ? <Check className="h-3.5 w-3.5 text-green-500" /> : <Copy className="h-3.5 w-3.5" />}
+      {copied ? (
+        <Check className="h-3.5 w-3.5 text-green-500" />
+      ) : (
+        <Copy className="h-3.5 w-3.5" />
+      )}
     </button>
   );
 }
@@ -48,7 +56,8 @@ export function McpConnectButton() {
     return null;
   }
 
-  const mcpUrl = typeof window !== "undefined" ? `${window.location.origin}/api/mcp` : "/api/mcp";
+  const mcpUrl =
+    typeof window !== "undefined" ? `${window.location.origin}/mcp` : "/mcp";
 
   const configSnippet = JSON.stringify(
     {
@@ -83,7 +92,8 @@ export function McpConnectButton() {
             Connect via MCP
           </DialogTitle>
           <DialogDescription>
-            Use Everruns from Claude Desktop, Cursor, VS Code, or any MCP-compatible client.
+            Use Everruns from Claude Desktop, Cursor, VS Code, or any
+            MCP-compatible client.
           </DialogDescription>
         </DialogHeader>
 
@@ -112,7 +122,8 @@ export function McpConnectButton() {
           </div>
 
           <p className="text-xs text-muted-foreground">
-            Authentication is handled automatically via OAuth when connecting from an MCP client.
+            Authentication is handled automatically via OAuth when connecting
+            from an MCP client.
           </p>
         </div>
       </DialogContent>

--- a/apps/ui/src/components/layout/mcp-connect-button.tsx
+++ b/apps/ui/src/components/layout/mcp-connect-button.tsx
@@ -12,11 +12,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 const McpIcon = capabilityIconMap.mcp;
 
@@ -40,11 +36,7 @@ function CopySnippetButton({ value }: { value: string }) {
       className="absolute top-2 right-2 inline-flex h-7 w-7 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
       aria-label={copied ? "Copied" : "Copy to clipboard"}
     >
-      {copied ? (
-        <Check className="h-3.5 w-3.5 text-green-500" />
-      ) : (
-        <Copy className="h-3.5 w-3.5" />
-      )}
+      {copied ? <Check className="h-3.5 w-3.5 text-green-500" /> : <Copy className="h-3.5 w-3.5" />}
     </button>
   );
 }
@@ -56,8 +48,7 @@ export function McpConnectButton() {
     return null;
   }
 
-  const mcpUrl =
-    typeof window !== "undefined" ? `${window.location.origin}/mcp` : "/mcp";
+  const mcpUrl = typeof window !== "undefined" ? `${window.location.origin}/mcp` : "/mcp";
 
   const configSnippet = JSON.stringify(
     {
@@ -92,8 +83,7 @@ export function McpConnectButton() {
             Connect via MCP
           </DialogTitle>
           <DialogDescription>
-            Use Everruns from Claude Desktop, Cursor, VS Code, or any
-            MCP-compatible client.
+            Use Everruns from Claude Desktop, Cursor, VS Code, or any MCP-compatible client.
           </DialogDescription>
         </DialogHeader>
 
@@ -122,8 +112,7 @@ export function McpConnectButton() {
           </div>
 
           <p className="text-xs text-muted-foreground">
-            Authentication is handled automatically via OAuth when connecting
-            from an MCP client.
+            Authentication is handled automatically via OAuth when connecting from an MCP client.
           </p>
         </div>
       </DialogContent>

--- a/apps/ui/src/lib/api/client.ts
+++ b/apps/ui/src/lib/api/client.ts
@@ -1,6 +1,6 @@
 // API base URL configuration:
 // All API requests (including SSE) use /api prefix.
-// Caddy reverse proxy strips /api and forwards to backend in all environments.
+// The backend serves REST routes under /api directly.
 const API_BASE = "/api";
 
 // Org selection is handled via server-side cookie (everruns_org), set by
@@ -35,7 +35,10 @@ async function tryRefreshToken(): Promise<boolean> {
   }
 }
 
-async function request<T>(endpoint: string, options: RequestInit = {}): Promise<{ data: T }> {
+async function request<T>(
+  endpoint: string,
+  options: RequestInit = {},
+): Promise<{ data: T }> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     ...(options.headers as Record<string, string>),
@@ -124,7 +127,8 @@ export async function throwApiError(response: Response): Promise<never> {
     if (text) {
       try {
         const errorBody = JSON.parse(text);
-        errorMessage = errorBody.error || errorBody.message || JSON.stringify(errorBody);
+        errorMessage =
+          errorBody.error || errorBody.message || JSON.stringify(errorBody);
       } catch {
         // Not JSON — use the raw text as the error message
         errorMessage = text;

--- a/apps/ui/src/lib/api/client.ts
+++ b/apps/ui/src/lib/api/client.ts
@@ -35,10 +35,7 @@ async function tryRefreshToken(): Promise<boolean> {
   }
 }
 
-async function request<T>(
-  endpoint: string,
-  options: RequestInit = {},
-): Promise<{ data: T }> {
+async function request<T>(endpoint: string, options: RequestInit = {}): Promise<{ data: T }> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     ...(options.headers as Record<string, string>),
@@ -127,8 +124,7 @@ export async function throwApiError(response: Response): Promise<never> {
     if (text) {
       try {
         const errorBody = JSON.parse(text);
-        errorMessage =
-          errorBody.error || errorBody.message || JSON.stringify(errorBody);
+        errorMessage = errorBody.error || errorBody.message || JSON.stringify(errorBody);
       } catch {
         // Not JSON — use the raw text as the error message
         errorMessage = text;

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -89,6 +89,7 @@ image.workspace = true  # For image thumbnail generation
 tonic.workspace = true
 prost.workspace = true
 prost-types.workspace = true
+serde_urlencoded = "0.7.1"
 
 [dev-dependencies]
 reqwest = { workspace = true, default-features = false, features = ["json", "stream", "rustls", "blocking", "http2"] }

--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -25,7 +25,7 @@ The API will be available at `http://localhost:9301`
 
 ### 3. Access the API
 
-- **API**: http://localhost:9301/v1/...
+- **API**: http://localhost:9301/api/v1/...
 - **OpenAPI Spec**: http://localhost:9301/api-doc/openapi.json
 
 ## Examples
@@ -155,7 +155,7 @@ Default: `postgres://everruns:everruns@localhost:5432/everruns`
 ### Create an Agent
 
 ```bash
-curl -X POST http://localhost:9301/v1/agents \
+curl -X POST http://localhost:9301/api/v1/agents \
   -H "Content-Type: application/json" \
   -d '{
     "name": "Test Agent",
@@ -166,7 +166,7 @@ curl -X POST http://localhost:9301/v1/agents \
 ### List Agents
 
 ```bash
-curl http://localhost:9301/v1/agents | jq
+curl http://localhost:9301/api/v1/agents | jq
 ```
 
 ## Troubleshooting

--- a/crates/server/specs/user-connections.md
+++ b/crates/server/specs/user-connections.md
@@ -230,7 +230,7 @@ GitHub App installation callback. Receives `installation_id`, verifies it, store
 | `GITHUB_APP_ID` | GitHub App ID (numeric, from App settings page) |
 | `GITHUB_APP_PRIVATE_KEY` | PEM-encoded RSA private key for JWT signing |
 | `GITHUB_APP_SLUG` | App slug for installation URL (default: `everruns`) |
-| `GITHUB_APP_SETUP_URL` | Post-install callback URL (default: `{AUTH_BASE_URL}{API_PREFIX}/v1/user/connections/github/callback`) |
+| `GITHUB_APP_SETUP_URL` | Post-install callback URL (default: `{AUTH_BASE_URL}/v1/user/connections/github/callback`) |
 
 ### GitHub App Setup
 

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -105,7 +105,7 @@ fn tool_definitions() -> Value {
     json!([
         {
             "name": "agent_run",
-            "description": "Create a new session and send the first message to an agent. Returns the session ID and message ID. Use session_get_status to poll for the agent's response, or connect to the SSE stream at /v1/sessions/{session_id}/sse for real-time events.",
+            "description": "Create a new session and send the first message to an agent. Returns the session ID and message ID. Use session_get_status to poll for the agent's response, or connect to the SSE stream at /api/v1/sessions/{session_id}/sse for real-time events.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -546,7 +546,7 @@ async fn tool_agent_run(
         "session_id": session.id.to_string(),
         "message_id": message.id.to_string(),
         "status": session.status.to_string(),
-        "hint": "Use session_get_status to poll for the agent's response, or connect to SSE at /v1/sessions/{session_id}/sse"
+        "hint": "Use session_get_status to poll for the agent's response, or connect to SSE at /api/v1/sessions/{session_id}/sse"
     });
     if let Some(bid) = budget_id {
         result["budget_id"] = json!(bid);

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -315,9 +315,7 @@ async fn handle_mcp(
     let response = match req.method.as_str() {
         "initialize" => handle_initialize(req.id),
         "tools/list" => handle_tools_list(req.id),
-        "tools/call" => {
-            handle_tools_call(req.id.clone(), req.params, &org, &state, &headers).await
-        }
+        "tools/call" => handle_tools_call(req.id.clone(), req.params, &org, &state, &headers).await,
         "ping" => JsonRpcResponse::success(req.id, json!({})),
         _ => JsonRpcResponse::method_not_found(req.id),
     };
@@ -366,11 +364,21 @@ async fn handle_tools_call(
         .cloned()
         .unwrap_or(Value::Object(Default::default()));
 
-    // Extract Bearer token from request to pass to scripted tool HTTP callbacks
+    // Extract Bearer token from request to pass to scripted tool HTTP callbacks.
+    // Parse case-insensitively per RFC 7235, matching extract_auth_user behavior.
     let bearer_token = headers
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.strip_prefix("Bearer "))
+        .and_then(|s| {
+            let (scheme, token) = s.trim().split_once(char::is_whitespace)?;
+            if scheme.eq_ignore_ascii_case("Bearer") {
+                let token = token.trim();
+                if !token.is_empty() {
+                    return Some(token);
+                }
+            }
+            None
+        })
         .unwrap_or("")
         .to_string();
 

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -301,6 +301,7 @@ pub fn routes(state: AppState) -> Router {
 async fn handle_mcp(
     org: ResolvedOrg,
     State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
     Json(req): Json<JsonRpcRequest>,
 ) -> Json<JsonRpcResponse> {
     if req.jsonrpc != "2.0" {
@@ -314,7 +315,9 @@ async fn handle_mcp(
     let response = match req.method.as_str() {
         "initialize" => handle_initialize(req.id),
         "tools/list" => handle_tools_list(req.id),
-        "tools/call" => handle_tools_call(req.id.clone(), req.params, &org, &state).await,
+        "tools/call" => {
+            handle_tools_call(req.id.clone(), req.params, &org, &state, &headers).await
+        }
         "ping" => JsonRpcResponse::success(req.id, json!({})),
         _ => JsonRpcResponse::method_not_found(req.id),
     };
@@ -351,6 +354,7 @@ async fn handle_tools_call(
     params: Value,
     org: &ResolvedOrg,
     state: &AppState,
+    headers: &axum::http::HeaderMap,
 ) -> JsonRpcResponse {
     let tool_name = match params.get("name").and_then(|v| v.as_str()) {
         Some(name) => name,
@@ -362,12 +366,20 @@ async fn handle_tools_call(
         .cloned()
         .unwrap_or(Value::Object(Default::default()));
 
+    // Extract Bearer token from request to pass to scripted tool HTTP callbacks
+    let bearer_token = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+        .unwrap_or("")
+        .to_string();
+
     let result = match tool_name {
         "agent_run" => tool_agent_run(&arguments, org, state).await,
         "session_send_message" => tool_session_send_message(&arguments, org, state).await,
         "session_get_status" => tool_session_get_status(&arguments, org, state).await,
-        "discover" => tool_discover(&arguments, org, state).await,
-        "execute" => tool_execute(&arguments, org, state).await,
+        "discover" => tool_discover(&arguments, org, state, &bearer_token).await,
+        "execute" => tool_execute(&arguments, org, state, &bearer_token).await,
         _ => Err(format!("Unknown tool: {tool_name}")),
     };
 
@@ -721,13 +733,14 @@ async fn tool_discover(
     args: &Value,
     org: &ResolvedOrg,
     state: &AppState,
+    bearer_token: &str,
 ) -> Result<String, String> {
     let query = args
         .get("query")
         .and_then(|v| v.as_str())
         .ok_or("Missing required parameter: query")?;
 
-    let tool = build_scripted_tool(org, state);
+    let tool = build_scripted_tool(org, state, bearer_token);
     let script = format!("discover --search {}", shell_escape(query));
     execute_script(&tool, &script, 10_000).await
 }
@@ -736,7 +749,12 @@ async fn tool_discover(
 // Tier 2: execute — delegates to ScriptedTool
 // ============================================================================
 
-async fn tool_execute(args: &Value, org: &ResolvedOrg, state: &AppState) -> Result<String, String> {
+async fn tool_execute(
+    args: &Value,
+    org: &ResolvedOrg,
+    state: &AppState,
+    bearer_token: &str,
+) -> Result<String, String> {
     let command = args
         .get("command")
         .and_then(|v| v.as_str())
@@ -748,7 +766,7 @@ async fn tool_execute(args: &Value, org: &ResolvedOrg, state: &AppState) -> Resu
         .unwrap_or(30000)
         .min(60000);
 
-    let tool = build_scripted_tool(org, state);
+    let tool = build_scripted_tool(org, state, bearer_token);
     execute_script(&tool, command, timeout_ms).await
 }
 
@@ -757,9 +775,16 @@ async fn tool_execute(args: &Value, org: &ResolvedOrg, state: &AppState) -> Resu
 // ============================================================================
 
 /// Build a ScriptedTool for the given org context.
-fn build_scripted_tool(org: &ResolvedOrg, state: &AppState) -> ScriptedTool {
-    let api_key = format!("org-{}", org.public_id);
-    catalog::build_scripted_tool(&state.api_base_url, &api_key)
+///
+/// Uses the caller's Bearer token for internal API calls so that MCP OAuth
+/// tokens (and API keys) are forwarded to the REST API.
+fn build_scripted_tool(org: &ResolvedOrg, state: &AppState, bearer_token: &str) -> ScriptedTool {
+    let auth_token = if bearer_token.is_empty() {
+        format!("org-{}", org.public_id)
+    } else {
+        bearer_token.to_string()
+    };
+    catalog::build_scripted_tool(&state.api_base_url, &auth_token)
 }
 
 /// Execute a script through a ScriptedTool and return formatted output.

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -837,6 +837,18 @@ impl ServerAppBuilder {
             root_routes = root_routes.merge(public_routes);
         }
 
+        // TM-DOS: Apply the same per-IP rate limiting to root routes (MCP, OAuth)
+        // as to API routes, to prevent brute-force and DoS on unthrottled endpoints.
+        let root_routes = if crate::auth::rate_limit::ApiRateLimiter::is_disabled() {
+            root_routes
+        } else {
+            let root_rate_limiter = crate::auth::rate_limit::ApiRateLimiter::from_env();
+            root_routes.layer(axum::middleware::from_fn(move |req, next| {
+                let limiter = root_rate_limiter.clone();
+                crate::auth::rate_limit::api_rate_limit_middleware(limiter, req, next)
+            }))
+        };
+
         // Main router
         let mut app = Router::new()
             .route("/health", get(health).with_state(health_state))

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -692,7 +692,10 @@ impl ServerAppBuilder {
             } else {
                 addr.to_string()
             };
-            format!("http://{host}")
+            format!(
+                "http://{host}{}",
+                self.config.api_prefix.trim_end_matches('/')
+            )
         });
         let mcp_endpoint_state = api::mcp_endpoint::AppState::new(
             db.clone(),
@@ -799,12 +802,6 @@ impl ServerAppBuilder {
             tracing::info!("Evals disabled via feature flag");
         }
 
-        if feature_flags.mcp_endpoint {
-            api_routes = api_routes.merge(api::mcp_endpoint::routes(mcp_endpoint_state));
-        } else {
-            tracing::info!("MCP endpoint disabled via feature flag");
-        }
-
         // Auth-specific routes
         if let Some(auth_routes) = auth_backend.auth_routes() {
             api_routes = api_routes.merge(auth_routes);
@@ -828,6 +825,18 @@ impl ServerAppBuilder {
             }))
         };
 
+        let mut root_routes = Router::new();
+
+        if feature_flags.mcp_endpoint {
+            root_routes = root_routes.merge(api::mcp_endpoint::routes(mcp_endpoint_state));
+        } else {
+            tracing::info!("MCP endpoint disabled via feature flag");
+        }
+
+        if let Some(public_routes) = auth_backend.public_routes() {
+            root_routes = root_routes.merge(public_routes);
+        }
+
         // Main router
         let mut app = Router::new()
             .route("/health", get(health).with_state(health_state))
@@ -836,6 +845,7 @@ impl ServerAppBuilder {
                 get(|| async { Json(ApiDoc::openapi()) }),
             )
             .merge(api::http_signing_keys::routes(http_signing_keys_state))
+            .merge(root_routes)
             .merge(build_router_with_prefix(
                 api_routes,
                 &self.config.api_prefix,

--- a/crates/server/src/auth/backend.rs
+++ b/crates/server/src/auth/backend.rs
@@ -25,6 +25,14 @@ pub trait AuthBackend: Send + Sync + 'static {
     /// Returns `None` if auth is handled externally (e.g., PropelAuth hosted UI).
     fn auth_routes(&self) -> Option<Router>;
 
+    /// Return root-level public routes that must not be nested under the API prefix.
+    ///
+    /// Used for endpoints like `/.well-known/*` and other browser-facing pages that
+    /// share the backend origin but do not live under `/api`.
+    fn public_routes(&self) -> Option<Router> {
+        None
+    }
+
     /// Return the auth configuration for the `/v1/auth/config` endpoint.
     fn auth_config_response(&self) -> AuthConfigResponse;
 }

--- a/crates/server/src/auth/builtin.rs
+++ b/crates/server/src/auth/builtin.rs
@@ -47,6 +47,17 @@ fn build_api_key_cache() -> Cache<String, AuthUser> {
         .build()
 }
 
+fn root_url_from_api_base(api_base_url: &str) -> String {
+    let trimmed = api_base_url.trim_end_matches('/');
+    if let Ok(api_prefix) = std::env::var("API_PREFIX") {
+        let api_prefix = api_prefix.trim_end_matches('/');
+        if !api_prefix.is_empty() && trimmed.ends_with(api_prefix) {
+            return trimmed[..trimmed.len() - api_prefix.len()].to_string();
+        }
+    }
+    trimmed.strip_suffix("/api").unwrap_or(trimmed).to_string()
+}
+
 impl BuiltinAuthBackend {
     /// Create with in-memory rate limiting (per-instance).
     pub fn new(config: AuthConfig, db: Arc<StorageBackend>) -> Self {
@@ -232,23 +243,46 @@ impl AuthBackend for BuiltinAuthBackend {
         let auth_routes = routes::routes(self.clone());
         let auth_state =
             super::middleware::AuthState::new(self.config.clone(), Arc::new(self.clone()));
-        let api_prefix = std::env::var("API_PREFIX").unwrap_or_default();
-        let base_url = format!("{}{}", self.config.base_url, api_prefix);
+        let api_base_url = self.config.base_url.trim_end_matches('/').to_string();
         let cli_state = super::cli_auth::CliAuthState {
             db: self.db.clone(),
             auth: auth_state.clone(),
             frontend_url: self.config.frontend_url.clone(),
-            base_url: base_url.clone(),
+            base_url: api_base_url.clone(),
         };
-        let cli_routes = super::cli_auth::cli_auth_routes(cli_state);
+        let cli_routes = super::cli_auth::cli_auth_routes(cli_state.clone());
         let mcp_oauth_state = super::mcp_oauth::McpOAuthState {
             db: self.db.clone(),
             auth: auth_state,
             jwt_service: self.jwt_service.clone(),
-            base_url,
+            issuer_url: root_url_from_api_base(&api_base_url),
+            api_base_url,
         };
-        let mcp_oauth_routes = super::mcp_oauth::mcp_oauth_routes(mcp_oauth_state);
+        let mcp_oauth_routes = super::mcp_oauth::mcp_oauth_api_routes(mcp_oauth_state);
         Some(auth_routes.merge(cli_routes).merge(mcp_oauth_routes))
+    }
+
+    fn public_routes(&self) -> Option<Router> {
+        let auth_state =
+            super::middleware::AuthState::new(self.config.clone(), Arc::new(self.clone()));
+        let api_base_url = self.config.base_url.trim_end_matches('/').to_string();
+        let cli_state = super::cli_auth::CliAuthState {
+            db: self.db.clone(),
+            auth: auth_state.clone(),
+            frontend_url: self.config.frontend_url.clone(),
+            base_url: api_base_url.clone(),
+        };
+        let mcp_oauth_state = super::mcp_oauth::McpOAuthState {
+            db: self.db.clone(),
+            auth: auth_state,
+            jwt_service: self.jwt_service.clone(),
+            issuer_url: root_url_from_api_base(&api_base_url),
+            api_base_url,
+        };
+        Some(
+            super::cli_auth::cli_auth_public_routes(cli_state)
+                .merge(super::mcp_oauth::mcp_oauth_public_routes(mcp_oauth_state)),
+        )
     }
 
     fn auth_config_response(&self) -> AuthConfigResponse {

--- a/crates/server/src/auth/builtin.rs
+++ b/crates/server/src/auth/builtin.rs
@@ -246,20 +246,12 @@ impl AuthBackend for BuiltinAuthBackend {
         let api_base_url = self.config.base_url.trim_end_matches('/').to_string();
         let cli_state = super::cli_auth::CliAuthState {
             db: self.db.clone(),
-            auth: auth_state.clone(),
-            frontend_url: self.config.frontend_url.clone(),
-            base_url: api_base_url.clone(),
-        };
-        let cli_routes = super::cli_auth::cli_auth_routes(cli_state.clone());
-        let mcp_oauth_state = super::mcp_oauth::McpOAuthState {
-            db: self.db.clone(),
             auth: auth_state,
-            jwt_service: self.jwt_service.clone(),
-            issuer_url: root_url_from_api_base(&api_base_url),
-            api_base_url,
+            frontend_url: self.config.frontend_url.clone(),
+            base_url: api_base_url,
         };
-        let mcp_oauth_routes = super::mcp_oauth::mcp_oauth_api_routes(mcp_oauth_state);
-        Some(auth_routes.merge(cli_routes).merge(mcp_oauth_routes))
+        let cli_routes = super::cli_auth::cli_auth_routes(cli_state);
+        Some(auth_routes.merge(cli_routes))
     }
 
     fn public_routes(&self) -> Option<Router> {
@@ -277,11 +269,11 @@ impl AuthBackend for BuiltinAuthBackend {
             auth: auth_state,
             jwt_service: self.jwt_service.clone(),
             issuer_url: root_url_from_api_base(&api_base_url),
-            api_base_url,
+            frontend_url: self.config.frontend_url.clone(),
         };
         Some(
             super::cli_auth::cli_auth_public_routes(cli_state)
-                .merge(super::mcp_oauth::mcp_oauth_public_routes(mcp_oauth_state)),
+                .merge(super::mcp_oauth::mcp_oauth_routes(mcp_oauth_state)),
         )
     }
 

--- a/crates/server/src/auth/cli_auth.rs
+++ b/crates/server/src/auth/cli_auth.rs
@@ -128,6 +128,12 @@ pub fn cli_auth_routes(state: CliAuthState) -> Router {
         .route("/v1/auth/cli/start", post(cli_auth_start))
         .route("/v1/auth/cli/callback", get(cli_auth_callback))
         .route("/v1/auth/cli/exchange", post(cli_auth_exchange))
+        .with_state(state)
+}
+
+/// Create root-level CLI auth routes.
+pub fn cli_auth_public_routes(state: CliAuthState) -> Router {
+    Router::new()
         .route("/cli/login-success", get(cli_login_success))
         .with_state(state)
 }

--- a/crates/server/src/auth/config.rs
+++ b/crates/server/src/auth/config.rs
@@ -161,9 +161,6 @@ impl AuthConfig {
         let frontend_url =
             std::env::var("FRONTEND_URL").unwrap_or_else(|_| "http://localhost:9300".to_string());
 
-        // API prefix for constructing OAuth callback URLs
-        let api_prefix = std::env::var("API_PREFIX").unwrap_or_default();
-
         // JWT configuration
         // TM-AUTH-002: Require AUTH_JWT_SECRET when authentication is enabled.
         // In AuthMode::None, generate a random secret (tokens are not validated).
@@ -220,7 +217,7 @@ impl AuthConfig {
                 if !client_id.is_empty() && !client_secret.is_empty() =>
             {
                 let redirect_uri = std::env::var("AUTH_GOOGLE_REDIRECT_URI").unwrap_or_else(|_| {
-                    format!("{}{}/v1/auth/callback/google", base_url, api_prefix)
+                    format!("{}/v1/auth/callback/google", base_url.trim_end_matches('/'))
                 });
                 let allowed_domains = std::env::var("AUTH_GOOGLE_ALLOWED_DOMAINS")
                     .ok()
@@ -246,7 +243,7 @@ impl AuthConfig {
                 if !client_id.is_empty() && !client_secret.is_empty() =>
             {
                 let redirect_uri = std::env::var("AUTH_GITHUB_REDIRECT_URI").unwrap_or_else(|_| {
-                    format!("{}{}/v1/auth/callback/github", base_url, api_prefix)
+                    format!("{}/v1/auth/callback/github", base_url.trim_end_matches('/'))
                 });
                 Some(GitHubOAuthConfig {
                     base: OAuthProviderConfig {
@@ -271,8 +268,8 @@ impl AuthConfig {
                     std::env::var("GITHUB_APP_SLUG").unwrap_or_else(|_| "everruns".to_string());
                 let setup_url = std::env::var("GITHUB_APP_SETUP_URL").unwrap_or_else(|_| {
                     format!(
-                        "{}{}/v1/user/connections/github/callback",
-                        base_url, api_prefix
+                        "{}/v1/user/connections/github/callback",
+                        base_url.trim_end_matches('/')
                     )
                 });
                 Some(GitHubConnectionConfig {

--- a/crates/server/src/auth/mcp_oauth.rs
+++ b/crates/server/src/auth/mcp_oauth.rs
@@ -18,12 +18,13 @@ use crate::storage::models::{
     CreateOAuthAuthorizationCodeRow, CreateOAuthClientRow, CreateOAuthRefreshTokenRow,
 };
 use axum::{
-    Form, Json, Router,
+    Json, Router,
     extract::{FromRef, Query, State},
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Redirect, Response},
     routing::{get, post},
 };
+use axum_extra::extract::CookieJar;
 use chrono::{Duration, Utc};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -65,14 +66,14 @@ fn verify_pkce_s256(verifier: &str, challenge: &str) -> bool {
 // Request/Response types
 // ============================================
 
-/// POST /v1/oauth/register request
+/// POST /oauth/register request
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct OAuthRegisterRequest {
     pub client_name: String,
     pub redirect_uris: Vec<String>,
 }
 
-/// POST /v1/oauth/register response
+/// POST /oauth/register response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct OAuthRegisterResponse {
     pub client_id: String,
@@ -81,7 +82,7 @@ pub struct OAuthRegisterResponse {
     pub redirect_uris: Vec<String>,
 }
 
-/// GET /v1/oauth/authorize query parameters
+/// GET /oauth/authorize query parameters
 #[derive(Debug, Deserialize)]
 pub struct OAuthAuthorizeQuery {
     pub client_id: String,
@@ -92,13 +93,17 @@ pub struct OAuthAuthorizeQuery {
     pub state: String,
     #[serde(default = "default_scope")]
     pub scope: String,
+    /// RFC 9728 resource indicator — ignored but accepted so clients like Cursor
+    /// don't get a deserialization error.
+    #[serde(default)]
+    pub resource: Option<String>,
 }
 
 fn default_scope() -> String {
     "mcp".to_string()
 }
 
-/// POST /v1/oauth/token request (form-encoded per OAuth spec)
+/// POST /oauth/token request (form-encoded per OAuth spec)
 #[derive(Debug, Deserialize)]
 pub struct OAuthTokenRequest {
     pub grant_type: String,
@@ -110,7 +115,7 @@ pub struct OAuthTokenRequest {
     pub refresh_token: Option<String>,
 }
 
-/// POST /v1/oauth/token response
+/// POST /oauth/token response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct OAuthTokenResponse {
     pub access_token: String,
@@ -132,6 +137,14 @@ impl IntoResponse for OAuthErrorResponse {
     fn into_response(self) -> Response {
         (StatusCode::BAD_REQUEST, Json(self)).into_response()
     }
+}
+
+/// Protected resource metadata (RFC 9728 / MCP spec)
+#[derive(Debug, Serialize, ToSchema)]
+pub struct OAuthProtectedResourceMetadata {
+    pub resource: String,
+    pub authorization_servers: Vec<String>,
+    pub bearer_methods_supported: Vec<String>,
 }
 
 /// Authorization server metadata (RFC 8414)
@@ -160,8 +173,8 @@ pub struct McpOAuthState {
     pub jwt_service: Arc<JwtService>,
     /// Public issuer URL without the API prefix (e.g. `https://app.example.com`).
     pub issuer_url: String,
-    /// Full backend API base URL including any path prefix (e.g. `https://app.example.com/api`).
-    pub api_base_url: String,
+    /// Frontend URL for login redirects (e.g. `http://localhost:9300`).
+    pub frontend_url: String,
 }
 
 impl FromRef<McpOAuthState> for AuthState {
@@ -174,54 +187,93 @@ impl FromRef<McpOAuthState> for AuthState {
 // Routes
 // ============================================
 
-/// Create root-level MCP OAuth metadata routes.
-pub fn mcp_oauth_public_routes(state: McpOAuthState) -> Router {
+/// Create root-level MCP OAuth routes (metadata + all OAuth endpoints).
+///
+/// All OAuth routes live at the server root — not under the API prefix —
+/// because the authorize endpoint is browser-facing and the MCP spec
+/// discovers them via `/.well-known/oauth-authorization-server`.
+pub fn mcp_oauth_routes(state: McpOAuthState) -> Router {
     Router::new()
+        .route(
+            "/.well-known/oauth-protected-resource",
+            get(oauth_protected_resource_metadata),
+        )
         .route(
             "/.well-known/oauth-authorization-server",
             get(oauth_server_metadata),
         )
+        .route("/oauth/register", post(oauth_register))
+        .route("/oauth/authorize", get(oauth_authorize))
+        .route("/oauth/token", post(oauth_token))
         .with_state(state)
 }
 
-/// Create MCP OAuth API routes mounted under the API prefix.
-pub fn mcp_oauth_api_routes(state: McpOAuthState) -> Router {
-    Router::new()
-        .route("/v1/oauth/register", post(oauth_register))
-        .route("/v1/oauth/authorize", get(oauth_authorize))
-        .route("/v1/oauth/token", post(oauth_token))
-        .with_state(state)
+// ============================================
+// Helpers
+// ============================================
+
+use super::config::AuthMode;
+
+/// Try to resolve an authenticated user from the cookie jar.
+/// Returns `None` when there is no valid session (no cookie or invalid token).
+/// In `AuthMode::None`, returns the anonymous user.
+async fn try_resolve_user(state: &McpOAuthState, jar: &CookieJar) -> Option<AuthUser> {
+    if state.auth.config.mode == AuthMode::None {
+        return Some(AuthUser::anonymous());
+    }
+    let token = jar.get("access_token")?.value().to_owned();
+    state.auth.backend.validate_token(&token).await.ok()
 }
 
 // ============================================
 // Handlers
 // ============================================
 
+/// GET /.well-known/oauth-protected-resource — Protected resource metadata (RFC 9728)
+///
+/// MCP clients fetch this first to discover which authorization server protects
+/// the resource. Points to the authorization server metadata URL.
+async fn oauth_protected_resource_metadata(
+    State(state): State<McpOAuthState>,
+) -> Json<OAuthProtectedResourceMetadata> {
+    tracing::debug!("MCP OAuth: protected resource metadata requested");
+    let issuer = state.issuer_url.trim_end_matches('/');
+    Json(OAuthProtectedResourceMetadata {
+        resource: format!("{issuer}/mcp"),
+        authorization_servers: vec![issuer.to_string()],
+        bearer_methods_supported: vec!["header".to_string()],
+    })
+}
+
 /// GET /.well-known/oauth-authorization-server — Server metadata
 async fn oauth_server_metadata(State(state): State<McpOAuthState>) -> Json<OAuthServerMetadata> {
+    tracing::debug!("MCP OAuth: authorization server metadata requested");
     let issuer = state.issuer_url.trim_end_matches('/');
-    let api_base = state.api_base_url.trim_end_matches('/');
     Json(OAuthServerMetadata {
         issuer: issuer.to_string(),
-        authorization_endpoint: format!("{api_base}/v1/oauth/authorize"),
-        token_endpoint: format!("{api_base}/v1/oauth/token"),
-        registration_endpoint: format!("{api_base}/v1/oauth/register"),
+        authorization_endpoint: format!("{issuer}/oauth/authorize"),
+        token_endpoint: format!("{issuer}/oauth/token"),
+        registration_endpoint: format!("{issuer}/oauth/register"),
         response_types_supported: vec!["code".to_string()],
         grant_types_supported: vec![
             "authorization_code".to_string(),
             "refresh_token".to_string(),
         ],
         code_challenge_methods_supported: vec!["S256".to_string()],
-        token_endpoint_auth_methods_supported: vec!["client_secret_post".to_string()],
+        token_endpoint_auth_methods_supported: vec![
+            "none".to_string(),
+            "client_secret_post".to_string(),
+        ],
         scopes_supported: vec!["mcp".to_string()],
     })
 }
 
-/// POST /v1/oauth/register — Dynamic Client Registration (RFC 7591)
+/// POST /oauth/register — Dynamic Client Registration (RFC 7591)
 async fn oauth_register(
     State(state): State<McpOAuthState>,
     Json(req): Json<OAuthRegisterRequest>,
 ) -> Result<(StatusCode, Json<OAuthRegisterResponse>), OAuthErrorResponse> {
+    tracing::info!(client_name = %req.client_name, "MCP OAuth: client registration");
     // Validate
     if req.client_name.is_empty() || req.client_name.len() > 255 {
         return Err(OAuthErrorResponse {
@@ -275,13 +327,43 @@ async fn oauth_register(
     ))
 }
 
-/// GET /v1/oauth/authorize — Authorization endpoint (requires authenticated user)
+/// GET /oauth/authorize — Authorization endpoint (requires authenticated user)
+///
+/// If the user has no valid session, redirect to the frontend login page with
+/// `return_to` pointing back here so the browser lands on the authorize flow
+/// after authentication.
 async fn oauth_authorize(
     State(state): State<McpOAuthState>,
     headers: HeaderMap,
-    user: AuthUser,
+    jar: CookieJar,
     Query(query): Query<OAuthAuthorizeQuery>,
 ) -> Result<Response, AuthError> {
+    tracing::debug!(client_id = %query.client_id, "MCP OAuth: authorize request");
+    // Try to resolve user from cookie session (browser flow)
+    let user = match try_resolve_user(&state, &jar).await {
+        Some(u) => u,
+        None => {
+            tracing::debug!("MCP OAuth: no session, redirecting to login");
+            // Build the full authorize URL to redirect back to after login
+            let authorize_url = format!(
+                "/oauth/authorize?response_type={}&client_id={}&redirect_uri={}&code_challenge={}&code_challenge_method={}&state={}&scope={}",
+                urlencoding::encode(&query.response_type),
+                urlencoding::encode(&query.client_id),
+                urlencoding::encode(&query.redirect_uri),
+                urlencoding::encode(&query.code_challenge),
+                urlencoding::encode(&query.code_challenge_method),
+                urlencoding::encode(&query.state),
+                urlencoding::encode(&query.scope),
+            );
+            let frontend = state.frontend_url.trim_end_matches('/');
+            let login_url = format!(
+                "{}/login?return_to={}",
+                frontend,
+                urlencoding::encode(&authorize_url)
+            );
+            return Ok(Redirect::temporary(&login_url).into_response());
+        }
+    };
     let ip = audit::client_ip(&headers);
 
     // Validate response_type
@@ -355,6 +437,7 @@ async fn oauth_authorize(
         serde_json::json!({"client_id": query.client_id}),
     );
 
+    tracing::info!(user_id = %user.id, client_id = %query.client_id, redirect_uri = %query.redirect_uri, "MCP OAuth: auth code issued, redirecting");
     // Redirect to client with code and state
     let redirect_url = format!(
         "{}?code={}&state={}",
@@ -366,22 +449,56 @@ async fn oauth_authorize(
     Ok(Redirect::to(&redirect_url).into_response())
 }
 
-/// POST /v1/oauth/token — Token exchange (authorization_code or refresh_token grant)
+/// POST /oauth/token — Token exchange (authorization_code or refresh_token grant)
+///
+/// Accepts both `application/x-www-form-urlencoded` (per OAuth spec) and
+/// `application/json` (sent by some MCP clients like Cursor).
 async fn oauth_token(
     State(state): State<McpOAuthState>,
     headers: HeaderMap,
-    Form(req): Form<OAuthTokenRequest>,
+    body: axum::body::Bytes,
 ) -> Result<Json<OAuthTokenResponse>, OAuthErrorResponse> {
+    let content_type = headers
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    tracing::debug!(content_type, "MCP OAuth: token request received");
+
+    let req: OAuthTokenRequest = if content_type.contains("application/json") {
+        serde_json::from_slice(&body).map_err(|e| {
+            tracing::warn!(%e, "Failed to parse JSON token request");
+            OAuthErrorResponse {
+                error: "invalid_request".to_string(),
+                error_description: Some(format!("Invalid JSON body: {e}")),
+            }
+        })?
+    } else {
+        serde_urlencoded::from_bytes(&body).map_err(|e| {
+            tracing::warn!(%e, "Failed to parse form token request");
+            OAuthErrorResponse {
+                error: "invalid_request".to_string(),
+                error_description: Some(format!("Invalid form body: {e}")),
+            }
+        })?
+    };
     let ip = audit::client_ip(&headers);
 
-    match req.grant_type.as_str() {
+    tracing::debug!(grant_type = %req.grant_type, "MCP OAuth: processing token grant");
+
+    let result = match req.grant_type.as_str() {
         "authorization_code" => handle_authorization_code_grant(&state, &req, ip).await,
         "refresh_token" => handle_refresh_token_grant(&state, &req, ip).await,
         _ => Err(OAuthErrorResponse {
             error: "unsupported_grant_type".to_string(),
             error_description: Some("Supported: authorization_code, refresh_token".to_string()),
         }),
+    };
+    match &result {
+        Ok(_) => tracing::info!(grant_type = %req.grant_type, "MCP OAuth: token grant succeeded"),
+        Err(e) => tracing::warn!(grant_type = %req.grant_type, error = %e.error, desc = ?e.error_description, "MCP OAuth: token grant failed"),
     }
+    result
 }
 
 async fn handle_authorization_code_grant(
@@ -397,13 +514,6 @@ async fn handle_authorization_code_grant(
         error: "invalid_request".to_string(),
         error_description: Some("client_id is required".to_string()),
     })?;
-    let client_secret = req
-        .client_secret
-        .as_deref()
-        .ok_or_else(|| OAuthErrorResponse {
-            error: "invalid_request".to_string(),
-            error_description: Some("client_secret is required".to_string()),
-        })?;
     let redirect_uri = req
         .redirect_uri
         .as_deref()
@@ -419,7 +529,7 @@ async fn handle_authorization_code_grant(
             error_description: Some("code_verifier is required".to_string()),
         })?;
 
-    // Validate client credentials
+    // Validate client exists
     let client = state
         .db
         .get_oauth_client_by_client_id(client_id)
@@ -433,13 +543,16 @@ async fn handle_authorization_code_grant(
             error_description: Some("Unknown client_id".to_string()),
         })?;
 
-    // Verify client secret
-    let secret_hash = hash_value(client_secret);
-    if secret_hash != client.client_secret_hash {
-        return Err(OAuthErrorResponse {
-            error: "invalid_client".to_string(),
-            error_description: Some("Invalid client_secret".to_string()),
-        });
+    // Verify client secret if provided (confidential client).
+    // Public clients (most MCP clients) rely on PKCE alone.
+    if let Some(client_secret) = req.client_secret.as_deref() {
+        let secret_hash = hash_value(client_secret);
+        if secret_hash != client.client_secret_hash {
+            return Err(OAuthErrorResponse {
+                error: "invalid_client".to_string(),
+                error_description: Some("Invalid client_secret".to_string()),
+            });
+        }
     }
 
     // Look up and consume authorization code
@@ -583,15 +696,7 @@ async fn handle_refresh_token_grant(
         error: "invalid_request".to_string(),
         error_description: Some("client_id is required".to_string()),
     })?;
-    let client_secret = req
-        .client_secret
-        .as_deref()
-        .ok_or_else(|| OAuthErrorResponse {
-            error: "invalid_request".to_string(),
-            error_description: Some("client_secret is required".to_string()),
-        })?;
-
-    // Validate client credentials
+    // Validate client exists
     let client = state
         .db
         .get_oauth_client_by_client_id(client_id)
@@ -605,12 +710,15 @@ async fn handle_refresh_token_grant(
             error_description: Some("Unknown client_id".to_string()),
         })?;
 
-    let secret_hash = hash_value(client_secret);
-    if secret_hash != client.client_secret_hash {
-        return Err(OAuthErrorResponse {
-            error: "invalid_client".to_string(),
-            error_description: Some("Invalid client_secret".to_string()),
-        });
+    // Verify client secret if provided (confidential client).
+    if let Some(client_secret) = req.client_secret.as_deref() {
+        let secret_hash = hash_value(client_secret);
+        if secret_hash != client.client_secret_hash {
+            return Err(OAuthErrorResponse {
+                error: "invalid_client".to_string(),
+                error_description: Some("Invalid client_secret".to_string()),
+            });
+        }
     }
 
     // Look up refresh token

--- a/crates/server/src/auth/mcp_oauth.rs
+++ b/crates/server/src/auth/mcp_oauth.rs
@@ -10,6 +10,7 @@
 
 use super::{
     audit,
+    config::AuthMode,
     jwt::JwtService,
     middleware::{AuthError, AuthState, AuthUser},
 };
@@ -212,8 +213,6 @@ pub fn mcp_oauth_routes(state: McpOAuthState) -> Router {
 // Helpers
 // ============================================
 
-use super::config::AuthMode;
-
 /// Try to resolve an authenticated user from the cookie jar.
 /// Returns `None` when there is no valid session (no cookie or invalid token).
 /// In `AuthMode::None`, returns the anonymous user.
@@ -334,6 +333,7 @@ async fn oauth_register(
 /// after authentication.
 async fn oauth_authorize(
     State(state): State<McpOAuthState>,
+    original_uri: axum::extract::OriginalUri,
     headers: HeaderMap,
     jar: CookieJar,
     Query(query): Query<OAuthAuthorizeQuery>,
@@ -344,22 +344,17 @@ async fn oauth_authorize(
         Some(u) => u,
         None => {
             tracing::debug!("MCP OAuth: no session, redirecting to login");
-            // Build the full authorize URL to redirect back to after login
-            let authorize_url = format!(
-                "/oauth/authorize?response_type={}&client_id={}&redirect_uri={}&code_challenge={}&code_challenge_method={}&state={}&scope={}",
-                urlencoding::encode(&query.response_type),
-                urlencoding::encode(&query.client_id),
-                urlencoding::encode(&query.redirect_uri),
-                urlencoding::encode(&query.code_challenge),
-                urlencoding::encode(&query.code_challenge_method),
-                urlencoding::encode(&query.state),
-                urlencoding::encode(&query.scope),
-            );
+            // Preserve the full original URI (including `resource` and any other
+            // query params) so nothing is lost across the login redirect.
+            let authorize_path = original_uri
+                .path_and_query()
+                .map(|pq| pq.as_str())
+                .unwrap_or("/oauth/authorize");
             let frontend = state.frontend_url.trim_end_matches('/');
             let login_url = format!(
                 "{}/login?return_to={}",
                 frontend,
-                urlencoding::encode(&authorize_url)
+                urlencoding::encode(authorize_path)
             );
             return Ok(Redirect::temporary(&login_url).into_response());
         }
@@ -496,7 +491,9 @@ async fn oauth_token(
     };
     match &result {
         Ok(_) => tracing::info!(grant_type = %req.grant_type, "MCP OAuth: token grant succeeded"),
-        Err(e) => tracing::warn!(grant_type = %req.grant_type, error = %e.error, desc = ?e.error_description, "MCP OAuth: token grant failed"),
+        Err(e) => {
+            tracing::warn!(grant_type = %req.grant_type, error = %e.error, desc = ?e.error_description, "MCP OAuth: token grant failed")
+        }
     }
     result
 }

--- a/crates/server/src/auth/mcp_oauth.rs
+++ b/crates/server/src/auth/mcp_oauth.rs
@@ -158,8 +158,10 @@ pub struct McpOAuthState {
     pub db: Arc<StorageBackend>,
     pub auth: AuthState,
     pub jwt_service: Arc<JwtService>,
-    /// Full backend base URL including any path prefix (e.g. `https://app.example.com/api`).
-    pub base_url: String,
+    /// Public issuer URL without the API prefix (e.g. `https://app.example.com`).
+    pub issuer_url: String,
+    /// Full backend API base URL including any path prefix (e.g. `https://app.example.com/api`).
+    pub api_base_url: String,
 }
 
 impl FromRef<McpOAuthState> for AuthState {
@@ -172,13 +174,19 @@ impl FromRef<McpOAuthState> for AuthState {
 // Routes
 // ============================================
 
-/// Create MCP OAuth routes
-pub fn mcp_oauth_routes(state: McpOAuthState) -> Router {
+/// Create root-level MCP OAuth metadata routes.
+pub fn mcp_oauth_public_routes(state: McpOAuthState) -> Router {
     Router::new()
         .route(
             "/.well-known/oauth-authorization-server",
             get(oauth_server_metadata),
         )
+        .with_state(state)
+}
+
+/// Create MCP OAuth API routes mounted under the API prefix.
+pub fn mcp_oauth_api_routes(state: McpOAuthState) -> Router {
+    Router::new()
         .route("/v1/oauth/register", post(oauth_register))
         .route("/v1/oauth/authorize", get(oauth_authorize))
         .route("/v1/oauth/token", post(oauth_token))
@@ -191,12 +199,13 @@ pub fn mcp_oauth_routes(state: McpOAuthState) -> Router {
 
 /// GET /.well-known/oauth-authorization-server — Server metadata
 async fn oauth_server_metadata(State(state): State<McpOAuthState>) -> Json<OAuthServerMetadata> {
-    let base = state.base_url.trim_end_matches('/');
+    let issuer = state.issuer_url.trim_end_matches('/');
+    let api_base = state.api_base_url.trim_end_matches('/');
     Json(OAuthServerMetadata {
-        issuer: base.to_string(),
-        authorization_endpoint: format!("{base}/v1/oauth/authorize"),
-        token_endpoint: format!("{base}/v1/oauth/token"),
-        registration_endpoint: format!("{base}/v1/oauth/register"),
+        issuer: issuer.to_string(),
+        authorization_endpoint: format!("{api_base}/v1/oauth/authorize"),
+        token_endpoint: format!("{api_base}/v1/oauth/token"),
+        registration_endpoint: format!("{api_base}/v1/oauth/register"),
         response_types_supported: vec!["code".to_string()],
         grant_types_supported: vec![
             "authorization_code".to_string(),

--- a/crates/server/src/auth/middleware.rs
+++ b/crates/server/src/auth/middleware.rs
@@ -531,14 +531,25 @@ where
                 // Cookie is set via POST /v1/users/me/switch-org
                 // Cookies work automatically with SSE (EventSource) unlike headers
                 let jar = CookieJar::from_headers(&parts.headers);
-                let org_public_id = jar
-                    .get(ORG_COOKIE_NAME)
-                    .map(|c| c.value().to_string())
-                    .ok_or_else(|| {
-                        AuthError::unauthorized(
-                            "Missing organization cookie. Call POST /v1/users/me/switch-org first.",
-                        )
-                    })?;
+                let cookie_org = jar.get(ORG_COOKIE_NAME).map(|c| c.value().to_string());
+
+                // When no org cookie is present (e.g. MCP OAuth Bearer tokens),
+                // fall back to the user's first organization.
+                if cookie_org.is_none() {
+                    let org = user
+                        .organizations
+                        .first()
+                        .ok_or_else(|| AuthError::unauthorized("No organization available"))?;
+                    return Ok(ResolvedOrg {
+                        org_id: org.org_id,
+                        public_id: org.public_id.clone(),
+                        name: org.name.clone(),
+                        user_id: Some(user.id),
+                        role: org.role,
+                    });
+                }
+
+                let org_public_id = cookie_org.unwrap();
                 let org_public_id = org_public_id.as_str();
 
                 // Validate format

--- a/crates/server/src/auth/middleware.rs
+++ b/crates/server/src/auth/middleware.rs
@@ -528,7 +528,7 @@ where
             }
             AuthMethod::Jwt => {
                 // Session auth: get org from everruns_org cookie
-                // Cookie is set via POST /v1/users/me/switch-org
+                // Cookie is set via the switch-org endpoint.
                 // Cookies work automatically with SSE (EventSource) unlike headers
                 let jar = CookieJar::from_headers(&parts.headers);
                 let cookie_org = jar.get(ORG_COOKIE_NAME).map(|c| c.value().to_string());

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -6,6 +6,8 @@ use axum::Router;
 use axum::http::HeaderValue;
 use everruns_config::{env_bool, env_list, env_or, env_string};
 
+pub const DEFAULT_API_PREFIX: &str = "/api";
+
 /// Configurable resource limits for orgs, members, API keys.
 ///
 /// Defaults are sane for self-hosted. SaaS overrides per plan.
@@ -55,7 +57,8 @@ impl ServerConfig {
         Self {
             dev_mode: env_bool("DEV_MODE", false),
             no_migrations: false,
-            api_prefix: std::env::var("API_PREFIX").unwrap_or_default(),
+            api_prefix: std::env::var("API_PREFIX")
+                .unwrap_or_else(|_| DEFAULT_API_PREFIX.to_string()),
             cors_origins: env_list::<String>("CORS_ALLOWED_ORIGINS")
                 .into_iter()
                 .filter_map(|s| s.parse::<HeaderValue>().ok())

--- a/crates/server/tests/cli_auth_test.rs
+++ b/crates/server/tests/cli_auth_test.rs
@@ -11,7 +11,8 @@
 
 use serde_json::{Value, json};
 
-const API_BASE_URL: &str = "http://localhost:9000";
+const SERVER_BASE_URL: &str = "http://localhost:9000";
+const API_BASE_URL: &str = "http://localhost:9000/api";
 
 #[tokio::test]
 async fn test_cli_auth_start() {
@@ -63,7 +64,7 @@ async fn test_cli_login_success_page() {
     let client = reqwest::Client::new();
 
     let resp = match client
-        .get(format!("{}/cli/login-success", API_BASE_URL))
+        .get(format!("{}/cli/login-success", SERVER_BASE_URL))
         .send()
         .await
     {

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -1019,39 +1019,6 @@ async fn register_oauth_client(server: &TestServer) -> (String, String) {
     (client_id, client_secret)
 }
 
-/// Helper: complete the authorize flow and return an authorization code.
-/// Works in auth=none mode where the anonymous user is automatically resolved.
-async fn get_auth_code(server: &TestServer, client_id: &str) -> String {
-    let resp = server
-        .request_raw(
-            axum::http::Method::GET,
-            &format!(
-                "/oauth/authorize?response_type=code&client_id={}&redirect_uri={}&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256&state=teststate&scope=mcp",
-                urlencoding::encode(client_id),
-                urlencoding::encode("http://localhost:9999/callback"),
-            ),
-            vec![],
-            vec![],
-        )
-        .await;
-    // Should be a redirect (302/307) to the callback URL with code param
-    assert!(
-        resp.status().is_redirection(),
-        "Expected redirect, got {}. Body: {}",
-        resp.status(),
-        resp.text()
-    );
-    let location = resp.text();
-    // Parse the code from the redirect location
-    // The response body for tower oneshot won't have Location header easily,
-    // but we can check from the body/status. Let's use request_raw more carefully.
-    // Actually, with our test harness, we need to extract from the Location header.
-    // The TestResponse doesn't expose headers, so let's parse the redirect URL
-    // from a known pattern. Since it's a redirect, we use a different approach.
-    // For simplicity, we'll use the token endpoint tests that don't need the code.
-    location
-}
-
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_oauth_token_json_invalid_grant_type() {
     let server = TestServer::new().await;

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -996,3 +996,174 @@ async fn test_mcp_full_flow_agent_run_then_status() {
         "Expected more events after send_message (before={first_event_count}, after={second_event_count})"
     );
 }
+
+// ============================================================================
+// MCP OAuth token endpoint tests
+// ============================================================================
+
+/// Helper: register an OAuth client and return client_id + client_secret.
+async fn register_oauth_client(server: &TestServer) -> (String, String) {
+    let resp: Value = server
+        .post(
+            "/oauth/register",
+            json!({
+                "client_name": "test-client",
+                "redirect_uris": ["http://localhost:9999/callback"]
+            }),
+        )
+        .await
+        .assert_success()
+        .json();
+    let client_id = resp["client_id"].as_str().unwrap().to_string();
+    let client_secret = resp["client_secret"].as_str().unwrap().to_string();
+    (client_id, client_secret)
+}
+
+/// Helper: complete the authorize flow and return an authorization code.
+/// Works in auth=none mode where the anonymous user is automatically resolved.
+async fn get_auth_code(server: &TestServer, client_id: &str) -> String {
+    let resp = server
+        .request_raw(
+            axum::http::Method::GET,
+            &format!(
+                "/oauth/authorize?response_type=code&client_id={}&redirect_uri={}&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256&state=teststate&scope=mcp",
+                urlencoding::encode(client_id),
+                urlencoding::encode("http://localhost:9999/callback"),
+            ),
+            vec![],
+            vec![],
+        )
+        .await;
+    // Should be a redirect (302/307) to the callback URL with code param
+    assert!(
+        resp.status().is_redirection(),
+        "Expected redirect, got {}. Body: {}",
+        resp.status(),
+        resp.text()
+    );
+    let location = resp.text();
+    // Parse the code from the redirect location
+    // The response body for tower oneshot won't have Location header easily,
+    // but we can check from the body/status. Let's use request_raw more carefully.
+    // Actually, with our test harness, we need to extract from the Location header.
+    // The TestResponse doesn't expose headers, so let's parse the redirect URL
+    // from a known pattern. Since it's a redirect, we use a different approach.
+    // For simplicity, we'll use the token endpoint tests that don't need the code.
+    location
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_oauth_token_json_invalid_grant_type() {
+    let server = TestServer::new().await;
+    let resp = server
+        .request_raw(
+            axum::http::Method::POST,
+            "/oauth/token",
+            vec![("content-type", "application/json")],
+            serde_json::to_vec(&json!({
+                "grant_type": "invalid_type",
+                "client_id": "nonexistent"
+            }))
+            .unwrap(),
+        )
+        .await;
+    assert_eq!(resp.status(), axum::http::StatusCode::BAD_REQUEST);
+    let body: Value = resp.json();
+    assert_eq!(body["error"], "unsupported_grant_type");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_oauth_token_form_encoded_invalid_grant_type() {
+    let server = TestServer::new().await;
+    let resp = server
+        .request_raw(
+            axum::http::Method::POST,
+            "/oauth/token",
+            vec![("content-type", "application/x-www-form-urlencoded")],
+            b"grant_type=invalid_type&client_id=nonexistent".to_vec(),
+        )
+        .await;
+    assert_eq!(resp.status(), axum::http::StatusCode::BAD_REQUEST);
+    let body: Value = resp.json();
+    assert_eq!(body["error"], "unsupported_grant_type");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_oauth_token_json_missing_code() {
+    let server = TestServer::new().await;
+    let (client_id, _) = register_oauth_client(&server).await;
+    let resp = server
+        .request_raw(
+            axum::http::Method::POST,
+            "/oauth/token",
+            vec![("content-type", "application/json")],
+            serde_json::to_vec(&json!({
+                "grant_type": "authorization_code",
+                "client_id": client_id
+            }))
+            .unwrap(),
+        )
+        .await;
+    assert_eq!(resp.status(), axum::http::StatusCode::BAD_REQUEST);
+    let body: Value = resp.json();
+    assert_eq!(body["error"], "invalid_request");
+    assert!(
+        body["error_description"]
+            .as_str()
+            .unwrap_or("")
+            .contains("code"),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_oauth_token_invalid_content_type_falls_back_to_form() {
+    let server = TestServer::new().await;
+    // With a random content-type, it should try form parsing and fail gracefully
+    let resp = server
+        .request_raw(
+            axum::http::Method::POST,
+            "/oauth/token",
+            vec![("content-type", "text/plain")],
+            b"this is not valid form data at all {{{".to_vec(),
+        )
+        .await;
+    assert_eq!(resp.status(), axum::http::StatusCode::BAD_REQUEST);
+    let body: Value = resp.json();
+    assert_eq!(body["error"], "invalid_request");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_oauth_register_and_metadata() {
+    let server = TestServer::new().await;
+    // Test dynamic client registration
+    let (client_id, client_secret) = register_oauth_client(&server).await;
+    assert!(!client_id.is_empty());
+    assert!(!client_secret.is_empty());
+
+    // Test server metadata endpoint
+    let metadata: Value = server
+        .get("/.well-known/oauth-authorization-server")
+        .await
+        .assert_success()
+        .json();
+    assert!(
+        metadata["authorization_endpoint"]
+            .as_str()
+            .unwrap()
+            .ends_with("/oauth/authorize")
+    );
+    assert!(
+        metadata["token_endpoint"]
+            .as_str()
+            .unwrap()
+            .ends_with("/oauth/token")
+    );
+
+    // Test protected resource metadata endpoint
+    let resource: Value = server
+        .get("/.well-known/oauth-protected-resource")
+        .await
+        .assert_success()
+        .json();
+    assert!(resource["resource"].as_str().unwrap().ends_with("/mcp"));
+}

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -386,15 +386,6 @@ impl TestServer {
                     frontend_url: auth_config.frontend_url.clone(),
                     base_url: auth_config.base_url.clone(),
                 },
-            ))
-            .merge(auth::mcp_oauth::mcp_oauth_api_routes(
-                auth::mcp_oauth::McpOAuthState {
-                    db: db.clone(),
-                    auth: auth_state.clone(),
-                    jwt_service: auth_backend.jwt_service.clone(),
-                    issuer_url: auth_config.frontend_url.clone(),
-                    api_base_url: auth_config.base_url.clone(),
-                },
             ));
 
         if let Some(notifications_state) = notifications_state {
@@ -411,13 +402,13 @@ impl TestServer {
                     base_url: auth_config.base_url.clone(),
                 },
             ))
-            .merge(auth::mcp_oauth::mcp_oauth_public_routes(
+            .merge(auth::mcp_oauth::mcp_oauth_routes(
                 auth::mcp_oauth::McpOAuthState {
                     db: db.clone(),
                     auth: auth_state.clone(),
                     jwt_service: auth_backend.jwt_service.clone(),
                     issuer_url: auth_config.frontend_url.clone(),
-                    api_base_url: auth_config.base_url.clone(),
+                    frontend_url: auth_config.frontend_url.clone(),
                 },
             ));
 

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -64,12 +64,12 @@ pub struct TestServer {
 impl TestServer {
     /// Create a new test server with PostgreSQL backend
     pub async fn new() -> Self {
-        Self::with_mode_and_url(TestMode::Postgres, "http://127.0.0.1:0".to_string()).await
+        Self::with_mode_and_url(TestMode::Postgres, "http://127.0.0.1:0/api".to_string()).await
     }
 
     /// Create a new test server in dev mode (in-memory storage)
     pub async fn in_memory() -> Self {
-        Self::with_mode_and_url(TestMode::InMemory, "http://127.0.0.1:0".to_string()).await
+        Self::with_mode_and_url(TestMode::InMemory, "http://127.0.0.1:0/api".to_string()).await
     }
 
     /// Create a test server backed by a real TCP listener.
@@ -85,7 +85,7 @@ impl TestServer {
         let addr = listener.local_addr().unwrap();
         let base_url = format!("http://{addr}");
 
-        let server = Self::with_mode_and_url(TestMode::Postgres, base_url.clone()).await;
+        let server = Self::with_mode_and_url(TestMode::Postgres, format!("{base_url}/api")).await;
         let router = server.router.clone();
 
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
@@ -107,6 +107,14 @@ impl TestServer {
         std::mem::forget((shutdown_tx, handle));
 
         (server, base_url)
+    }
+
+    fn normalize_uri(uri: &str) -> String {
+        if uri.starts_with("/v1/") {
+            format!("/api{uri}")
+        } else {
+            uri.to_string()
+        }
     }
 
     async fn with_mode_and_url(mode: TestMode, api_base_url: String) -> Self {
@@ -152,7 +160,14 @@ impl TestServer {
         ));
 
         // Create auth config and backend (no auth for tests)
-        let auth_config = auth::AuthConfig::default(); // mode: None is the default
+        let auth_config = auth::AuthConfig {
+            base_url: api_base_url.clone(),
+            frontend_url: api_base_url
+                .trim_end_matches("/api")
+                .trim_end_matches('/')
+                .to_string(),
+            ..auth::AuthConfig::default()
+        };
         let auth_backend = auth::BuiltinAuthBackend::new(auth_config.clone(), db.clone());
         let auth_state = auth::AuthState::new(auth_config.clone(), Arc::new(auth_backend.clone()));
 
@@ -363,12 +378,48 @@ impl TestServer {
             .merge(api::feature_flags::routes(feature_flags_state))
             .merge(api::user_connections::routes(user_connections_state))
             .merge(api::slack_events::routes(slack_state))
-            .merge(api::mcp_endpoint::routes(mcp_endpoint_state))
-            .merge(auth::routes(auth_backend));
+            .merge(auth::routes(auth_backend.clone()))
+            .merge(auth::cli_auth::cli_auth_routes(
+                auth::cli_auth::CliAuthState {
+                    db: db.clone(),
+                    auth: auth_state.clone(),
+                    frontend_url: auth_config.frontend_url.clone(),
+                    base_url: auth_config.base_url.clone(),
+                },
+            ))
+            .merge(auth::mcp_oauth::mcp_oauth_api_routes(
+                auth::mcp_oauth::McpOAuthState {
+                    db: db.clone(),
+                    auth: auth_state.clone(),
+                    jwt_service: auth_backend.jwt_service.clone(),
+                    issuer_url: auth_config.frontend_url.clone(),
+                    api_base_url: auth_config.base_url.clone(),
+                },
+            ));
 
         if let Some(notifications_state) = notifications_state {
             api_routes = api_routes.merge(api::notifications::routes(notifications_state));
         }
+
+        let root_routes = Router::new()
+            .merge(api::mcp_endpoint::routes(mcp_endpoint_state))
+            .merge(auth::cli_auth::cli_auth_public_routes(
+                auth::cli_auth::CliAuthState {
+                    db: db.clone(),
+                    auth: auth_state.clone(),
+                    frontend_url: auth_config.frontend_url.clone(),
+                    base_url: auth_config.base_url.clone(),
+                },
+            ))
+            .merge(auth::mcp_oauth::mcp_oauth_public_routes(
+                auth::mcp_oauth::McpOAuthState {
+                    db: db.clone(),
+                    auth: auth_state.clone(),
+                    jwt_service: auth_backend.jwt_service.clone(),
+                    issuer_url: auth_config.frontend_url.clone(),
+                    api_base_url: auth_config.base_url.clone(),
+                },
+            ));
 
         // Build main router with health endpoint
         let router = Router::new()
@@ -376,7 +427,8 @@ impl TestServer {
                 "/health",
                 get(|| async { axum::Json(serde_json::json!({"status": "ok"})) }),
             )
-            .merge(api_routes);
+            .merge(root_routes)
+            .nest("/api", api_routes);
 
         Self { router, db, pool }
     }
@@ -414,7 +466,8 @@ impl TestServer {
         headers: Vec<(&str, &str)>,
         body: Vec<u8>,
     ) -> TestResponse {
-        let mut builder = Request::builder().method(method).uri(uri);
+        let normalized_uri = Self::normalize_uri(uri);
+        let mut builder = Request::builder().method(method).uri(&normalized_uri);
         for (key, value) in headers {
             builder = builder.header(key, value);
         }
@@ -450,9 +503,10 @@ impl TestServer {
         uri: &str,
         body: Option<T>,
     ) -> TestResponse {
+        let normalized_uri = Self::normalize_uri(uri);
         let request_builder = Request::builder()
             .method(method)
-            .uri(uri)
+            .uri(&normalized_uri)
             .header("content-type", "application/json");
 
         let request = if let Some(body) = body {

--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -19,7 +19,8 @@ use everruns_core::llm_models::LlmProvider;
 use everruns_core::{Agent, LlmModel, Session, SessionFile};
 use serde_json::{Value, json};
 
-const API_BASE_URL: &str = "http://localhost:9000";
+const SERVER_BASE_URL: &str = "http://localhost:9000";
+const API_BASE_URL: &str = "http://localhost:9000/api";
 // Note: With AUTH_MODE=none, org is derived from the anonymous user's default org.
 // No cookie or header needed for integration tests.
 
@@ -222,7 +223,7 @@ async fn test_health_endpoint() {
 
     println!("Testing health endpoint...");
     let response = client
-        .get(format!("{}/health", API_BASE_URL))
+        .get(format!("{}/health", SERVER_BASE_URL))
         .send()
         .await
         .expect("Failed to call health endpoint");
@@ -239,7 +240,7 @@ async fn test_openapi_spec() {
 
     println!("Testing OpenAPI spec endpoint...");
     let response = client
-        .get(format!("{}/api-doc/openapi.json", API_BASE_URL))
+        .get(format!("{}/api-doc/openapi.json", SERVER_BASE_URL))
         .send()
         .await
         .expect("Failed to get OpenAPI spec");

--- a/docs/getting-started/docker-compose.md
+++ b/docs/getting-started/docker-compose.md
@@ -69,6 +69,7 @@ This starts:
 |---------|-----|
 | **Web UI** | http://localhost:9300 |
 | **API** | http://localhost:9300/api/... |
+| **OAuth** | http://localhost:9300/oauth/... |
 | **MCP** | http://localhost:9300/mcp |
 | **OAuth Metadata** | http://localhost:9300/.well-known/oauth-authorization-server |
 | **Health Check** | http://localhost:9300/health |

--- a/docs/getting-started/docker-compose.md
+++ b/docs/getting-started/docker-compose.md
@@ -69,6 +69,8 @@ This starts:
 |---------|-----|
 | **Web UI** | http://localhost:9300 |
 | **API** | http://localhost:9300/api/... |
+| **MCP** | http://localhost:9300/mcp |
+| **OAuth Metadata** | http://localhost:9300/.well-known/oauth-authorization-server |
 | **Health Check** | http://localhost:9300/health |
 
 ## Configuration

--- a/docs/sre/environment-variables.md
+++ b/docs/sre/environment-variables.md
@@ -73,12 +73,12 @@ DEPLOYMENT_GRADE=prod ./target/debug/everruns-server
 
 ## API_PREFIX
 
-Optional prefix for all API routes.
+Path prefix for REST API routes.
 
 | Property | Value |
 |----------|-------|
 | **Required** | No |
-| **Default** | Empty (no prefix) |
+| **Default** | `/api` |
 
 **Example:**
 
@@ -88,10 +88,10 @@ API_PREFIX=/api
 ```
 
 **Notes:**
-- `/health` and `/api-doc/openapi.json` are not affected by this prefix
-- All API routes including auth (`/v1/auth/*`) are affected by this prefix
-- OAuth callback URLs automatically include this prefix when using defaults
-- Use when running behind a reverse proxy or API gateway that expects a path prefix
+- `/health`, `/api-doc/openapi.json`, `/mcp`, and `/.well-known/*` stay at the server root
+- REST API routes including auth (`/v1/auth/*`) are mounted under this prefix
+- OAuth callback URLs use `AUTH_BASE_URL`, which should already include the API prefix
+- Override only if you need a non-`/api` REST prefix behind a reverse proxy or gateway
 
 ## CORS_ALLOWED_ORIGINS
 
@@ -113,7 +113,7 @@ CORS_ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com
 ```
 
 **Notes:**
-- Not needed for local development (Caddy reverse proxy handles `/api/*` requests)
+- Not needed for local development (Caddy reverse proxy keeps UI and backend on one origin)
 - Not needed in production if using a reverse proxy on the same domain
 - If set, credentials are allowed (`Access-Control-Allow-Credentials: true`)
 - Wildcard (`*`) is not supported when using credentials
@@ -229,17 +229,18 @@ DEFAULT_GEMINI_API_KEY=AIza...
 
 ## UI API Proxy Architecture
 
-The UI makes all API requests (including SSE) to `/api/*` paths. Caddy reverse proxy strips `/api` and forwards to the backend.
+The UI makes all REST API requests (including SSE) to `/api/*` paths. The backend serves those routes under `/api` directly. Root-level backend routes like `/mcp` and `/.well-known/*` bypass the UI and are proxied straight to the backend.
 
 **Local Development:**
-- Caddy on `:9300` routes `/api/*` to backend at `:9301` (strips `/api` prefix)
-- Example: `/api/v1/agents` → `http://localhost:9301/v1/agents`
+- Caddy on `:9300` routes `/api/*`, `/mcp`, and `/.well-known/*` to backend at `:9301`
+- Example: `/api/v1/agents` → `http://localhost:9301/api/v1/agents`
+- Example: `/mcp` → `http://localhost:9301/mcp`
+- Example: `/.well-known/oauth-authorization-server` → `http://localhost:9301/.well-known/oauth-authorization-server`
 - SSE streaming works via `flush_interval -1` in Caddy config
 - No CORS needed (same-origin through Caddy)
 
 **Production:**
-- Configure your reverse proxy (nginx, Caddy, etc.) to route `/api/*` to the API server
-- Strip the `/api` prefix when forwarding
+- Configure your reverse proxy (nginx, Caddy, etc.) to route `/api/*`, `/mcp`, and `/.well-known/*` to the API server
 - Disable response buffering for SSE endpoints
 - Example Caddy config: see `local/Caddyfile`
 

--- a/docs/sre/environment-variables.md
+++ b/docs/sre/environment-variables.md
@@ -229,18 +229,19 @@ DEFAULT_GEMINI_API_KEY=AIza...
 
 ## UI API Proxy Architecture
 
-The UI makes all REST API requests (including SSE) to `/api/*` paths. The backend serves those routes under `/api` directly. Root-level backend routes like `/mcp` and `/.well-known/*` bypass the UI and are proxied straight to the backend.
+The UI makes all REST API requests (including SSE) to `/api/*` paths. The backend serves those routes under `/api` directly. Root-level backend routes like `/oauth/*`, `/mcp`, and `/.well-known/*` bypass the UI and are proxied straight to the backend.
 
 **Local Development:**
-- Caddy on `:9300` routes `/api/*`, `/mcp`, and `/.well-known/*` to backend at `:9301`
+- Caddy on `:9300` routes `/api/*`, `/oauth/*`, `/mcp`, and `/.well-known/*` to backend at `:9301`
 - Example: `/api/v1/agents` → `http://localhost:9301/api/v1/agents`
+- Example: `/oauth/authorize?...` → `http://localhost:9301/oauth/authorize?...`
 - Example: `/mcp` → `http://localhost:9301/mcp`
 - Example: `/.well-known/oauth-authorization-server` → `http://localhost:9301/.well-known/oauth-authorization-server`
 - SSE streaming works via `flush_interval -1` in Caddy config
 - No CORS needed (same-origin through Caddy)
 
 **Production:**
-- Configure your reverse proxy (nginx, Caddy, etc.) to route `/api/*`, `/mcp`, and `/.well-known/*` to the API server
+- Configure your reverse proxy (nginx, Caddy, etc.) to route `/api/*`, `/oauth/*`, `/mcp`, and `/.well-known/*` to the API server
 - Disable response buffering for SSE endpoints
 - Example Caddy config: see `local/Caddyfile`
 

--- a/docs/sre/environment-variables.md
+++ b/docs/sre/environment-variables.md
@@ -88,7 +88,7 @@ API_PREFIX=/api
 ```
 
 **Notes:**
-- `/health`, `/api-doc/openapi.json`, `/mcp`, and `/.well-known/*` stay at the server root
+- `/health`, `/api-doc/openapi.json`, `/mcp`, `/.well-known/*`, `/oauth/*`, and `/cli/login-success` stay at the server root
 - REST API routes including auth (`/v1/auth/*`) are mounted under this prefix
 - OAuth callback URLs use `AUTH_BASE_URL`, which should already include the API prefix
 - Override only if you need a non-`/api` REST prefix behind a reverse proxy or gateway

--- a/docs/sre/runbooks/authentication.md
+++ b/docs/sre/runbooks/authentication.md
@@ -171,8 +171,8 @@ DELETE FROM refresh_tokens WHERE user_id = 'user-uuid-here';
 ### OAuth Redirect Fails
 
 - Verify `AUTH_BASE_URL` matches the OAuth app configuration
-- Check that redirect URI in provider matches `{AUTH_BASE_URL}{API_PREFIX}/v1/auth/callback/{provider}`
-- If using `API_PREFIX`, ensure it's included in OAuth provider redirect URI configuration
+- Check that redirect URI in provider matches `{AUTH_BASE_URL}/v1/auth/callback/{provider}`
+- Ensure `AUTH_BASE_URL` already includes your REST API prefix (default: `/api`)
 - Ensure client ID and secret are correct
 
 ### Password Login Returns Unauthorized

--- a/examples/docker-compose-full.yaml
+++ b/examples/docker-compose-full.yaml
@@ -220,7 +220,9 @@ configs:
   caddyfile:
     content: |
       # Reverse proxy routes:
-      #   /api/*     -> API (strips prefix)
+      #   /api/*     -> API
+      #   /mcp       -> API
+      #   /.well-known/* -> API
       #   /api-doc/* -> API
       #   /health    -> API
       #   /*         -> UI
@@ -229,11 +231,17 @@ configs:
       # Server handles 5-min connection cycling with disconnecting events;
       # SDK reconnects transparently (no retry budget cost).
       :9300 {
-        handle_path /api/* {
+        handle /api/* {
           reverse_proxy server:9301 {
             # Disable response buffering for SSE streaming
             flush_interval -1
           }
+        }
+        handle /mcp {
+          reverse_proxy server:9301
+        }
+        handle /.well-known/* {
+          reverse_proxy server:9301
         }
         handle /api-doc/* {
           reverse_proxy server:9301

--- a/examples/docker-compose-full.yaml
+++ b/examples/docker-compose-full.yaml
@@ -221,6 +221,7 @@ configs:
     content: |
       # Reverse proxy routes:
       #   /api/*     -> API
+      #   /oauth/*   -> API
       #   /mcp       -> API
       #   /.well-known/* -> API
       #   /api-doc/* -> API
@@ -236,6 +237,9 @@ configs:
             # Disable response buffering for SSE streaming
             flush_interval -1
           }
+        }
+        handle /oauth/* {
+          reverse_proxy server:9301
         }
         handle /mcp {
           reverse_proxy server:9301

--- a/local/Caddyfile
+++ b/local/Caddyfile
@@ -13,6 +13,7 @@
 #
 # Routes:
 #   /api/*     -> API server at :API_PORT
+#   /oauth/*   -> API server at :API_PORT
 #   /mcp       -> API server at :API_PORT
 #   /.well-known/* -> API server at :API_PORT
 #   /api-doc/* -> API server at :API_PORT
@@ -29,6 +30,9 @@
 			# Disable response buffering for SSE streaming
 			flush_interval -1
 		}
+	}
+	handle /oauth/* {
+		reverse_proxy localhost:{$API_PORT:9301}
 	}
 	handle /mcp {
 		reverse_proxy localhost:{$API_PORT:9301}

--- a/local/Caddyfile
+++ b/local/Caddyfile
@@ -12,7 +12,9 @@
 #   API_PORT=9301 UI_PORT=9305 PROXY_PORT=9300 CADDY_ADMIN_PORT=2019
 #
 # Routes:
-#   /api/*     -> API server at :API_PORT (strips /api prefix)
+#   /api/*     -> API server at :API_PORT
+#   /mcp       -> API server at :API_PORT
+#   /.well-known/* -> API server at :API_PORT
 #   /api-doc/* -> API server at :API_PORT
 #   /health    -> API server at :API_PORT
 #   /*         -> UI dev server at :UI_PORT
@@ -22,11 +24,17 @@
 #   - Server handles its own 5-min connection cycling with disconnecting events
 #   - SDK reconnects transparently on disconnecting events (no retry budget cost)
 :{$PROXY_PORT:9300} {
-	handle_path /api/* {
+	handle /api/* {
 		reverse_proxy localhost:{$API_PORT:9301} {
 			# Disable response buffering for SSE streaming
 			flush_interval -1
 		}
+	}
+	handle /mcp {
+		reverse_proxy localhost:{$API_PORT:9301}
+	}
+	handle /.well-known/* {
+		reverse_proxy localhost:{$API_PORT:9301}
 	}
 	handle /api-doc/* {
 		reverse_proxy localhost:{$API_PORT:9301}

--- a/scripts/repro-sse-caddy.sh
+++ b/scripts/repro-sse-caddy.sh
@@ -82,7 +82,7 @@ start_caddy_proxy() {
 admin :${CADDY_ADMIN_PORT}
 
 :${PROXY_PORT} {
-    handle_path /api/* {
+    handle /api/* {
         reverse_proxy localhost:${API_PORT} {
             flush_interval -1
             transport http {
@@ -102,7 +102,7 @@ EOF
 admin :${CADDY_ADMIN_PORT}
 
 :${PROXY_PORT} {
-    handle_path /api/* {
+    handle /api/* {
         reverse_proxy localhost:${API_PORT} {
             flush_interval -1
         }

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -8,9 +8,10 @@ This document defines the HTTP API endpoints for Everruns v0.2.0 (M2).
 
 ### Routing Layout
 
-The backend exposes three top-level route groups:
+The backend exposes four top-level route groups:
 
 - `/api/*` — REST API routes, including auth and SSE
+- `/oauth/*` — MCP OAuth 2.1 endpoints (authorize, token, register)
 - `/mcp` — MCP JSON-RPC endpoint
 - `/.well-known/*` — public metadata and discovery endpoints
 
@@ -28,6 +29,7 @@ REST endpoints are mounted under `/api`, so the public REST base URL is `/api/v1
 Production and local reverse proxies must preserve this route split:
 
 - forward `/api/*` to the backend unchanged
+- forward `/oauth/*` to the backend unchanged
 - forward `/mcp` to the backend unchanged
 - forward `/.well-known/*` to the backend unchanged
 - forward all other browser routes to the UI

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -6,9 +6,33 @@ This document defines the HTTP API endpoints for Everruns v0.2.0 (M2).
 
 ## Requirements
 
+### Routing Layout
+
+The backend exposes three top-level route groups:
+
+- `/api/*` — REST API routes, including auth and SSE
+- `/mcp` — MCP JSON-RPC endpoint
+- `/.well-known/*` — public metadata and discovery endpoints
+
+Operational endpoints stay at the server root:
+
+- `/health`
+- `/api-doc/openapi.json`
+
 ### Base URL
 
-All endpoints are prefixed with `/v1/`.
+REST endpoints are mounted under `/api`, so the public REST base URL is `/api/v1/`.
+
+### Reverse Proxy Contract
+
+Production and local reverse proxies must preserve this route split:
+
+- forward `/api/*` to the backend unchanged
+- forward `/mcp` to the backend unchanged
+- forward `/.well-known/*` to the backend unchanged
+- forward all other browser routes to the UI
+
+SSE responses under `/api/*` must disable proxy buffering.
 
 ### Health
 
@@ -24,21 +48,28 @@ All endpoints are prefixed with `/v1/`.
 
 Exposes Everruns as an MCP server. Tier 1 tools (`agent_run`, `session_send_message`, `session_get_status`) handle the agent conversation loop via direct service calls. Tier 2 tools (`discover`, `execute`) are backed by a bashkit `ScriptedTool` with all API operations registered as builtins — run `discover --categories` to list them, or call them directly in bash scripts via `execute`. See `crates/server/src/api/mcp_endpoint/mod.rs` for implementation.
 
+### Well-Known Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/.well-known/oauth-authorization-server` | MCP OAuth authorization server metadata |
+| GET | `/.well-known/http-message-signatures-directory` | Bot auth signing key directory |
+
 ### Authentication
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/v1/auth/config` | Get authentication configuration |
-| POST | `/v1/auth/login` | Login with email/password |
-| POST | `/v1/auth/register` | Register new user |
-| POST | `/v1/auth/refresh` | Refresh access token |
-| POST | `/v1/auth/logout` | Logout (clear cookies) |
-| GET | `/v1/auth/oauth/{provider}` | Redirect to OAuth provider |
-| GET | `/v1/auth/callback/{provider}` | OAuth callback |
-| GET | `/v1/auth/me` | Get current user info |
-| GET | `/v1/auth/api-keys` | List user's API keys |
-| POST | `/v1/auth/api-keys` | Create API key |
-| DELETE | `/v1/auth/api-keys/{key_id}` | Delete API key |
+| GET | `/api/v1/auth/config` | Get authentication configuration |
+| POST | `/api/v1/auth/login` | Login with email/password |
+| POST | `/api/v1/auth/register` | Register new user |
+| POST | `/api/v1/auth/refresh` | Refresh access token |
+| POST | `/api/v1/auth/logout` | Logout (clear cookies) |
+| GET | `/api/v1/auth/oauth/{provider}` | Redirect to OAuth provider |
+| GET | `/api/v1/auth/callback/{provider}` | OAuth callback |
+| GET | `/api/v1/auth/me` | Get current user info |
+| GET | `/api/v1/auth/api-keys` | List user's API keys |
+| POST | `/api/v1/auth/api-keys` | Create API key |
+| DELETE | `/api/v1/auth/api-keys/{key_id}` | Delete API key |
 
 See [authentication.md](authentication.md) for full authentication specification.
 

--- a/specs/authentication.md
+++ b/specs/authentication.md
@@ -106,7 +106,7 @@ Account linking by email is supported (same email = same account).
 | `AUTH_GITHUB_REDIRECT_URI` | GitHub OAuth redirect URI | `{base_url}{api_prefix}/v1/auth/callback/github` |
 | `GITHUB_CONNECTION_CLIENT_ID` | GitHub OAuth App client ID (for connections, NOT login) | - |
 | `GITHUB_CONNECTION_CLIENT_SECRET` | GitHub OAuth App client secret (for connections) | - |
-| `GITHUB_CONNECTION_REDIRECT_URI` | Callback URL for connections OAuth | `{AUTH_BASE_URL}{API_PREFIX}/v1/user/connections/github/callback` |
+| `GITHUB_CONNECTION_REDIRECT_URI` | Callback URL for connections OAuth | `{AUTH_BASE_URL}/v1/user/connections/github/callback` |
 | `CORS_ALLOWED_ORIGINS` | Comma-separated allowed CORS origins (only if cross-origin) | Not set |
 
 ### Database Schema

--- a/specs/authentication.md
+++ b/specs/authentication.md
@@ -99,11 +99,11 @@ Account linking by email is supported (same email = same account).
 | `AUTH_DISABLE_SIGNUP` | Disable user registration | `false` |
 | `AUTH_GOOGLE_CLIENT_ID` | Google OAuth client ID | - |
 | `AUTH_GOOGLE_CLIENT_SECRET` | Google OAuth client secret | - |
-| `AUTH_GOOGLE_REDIRECT_URI` | Google OAuth redirect URI | `{base_url}{api_prefix}/v1/auth/callback/google` |
+| `AUTH_GOOGLE_REDIRECT_URI` | Google OAuth redirect URI | `{AUTH_BASE_URL}/v1/auth/callback/google` |
 | `AUTH_GOOGLE_ALLOWED_DOMAINS` | Comma-separated allowed email domains | - |
 | `AUTH_GITHUB_CLIENT_ID` | GitHub OAuth client ID | - |
 | `AUTH_GITHUB_CLIENT_SECRET` | GitHub OAuth client secret | - |
-| `AUTH_GITHUB_REDIRECT_URI` | GitHub OAuth redirect URI | `{base_url}{api_prefix}/v1/auth/callback/github` |
+| `AUTH_GITHUB_REDIRECT_URI` | GitHub OAuth redirect URI | `{AUTH_BASE_URL}/v1/auth/callback/github` |
 | `GITHUB_CONNECTION_CLIENT_ID` | GitHub OAuth App client ID (for connections, NOT login) | - |
 | `GITHUB_CONNECTION_CLIENT_SECRET` | GitHub OAuth App client secret (for connections) | - |
 | `GITHUB_CONNECTION_REDIRECT_URI` | Callback URL for connections OAuth | `{AUTH_BASE_URL}/v1/user/connections/github/callback` |

--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -7,7 +7,8 @@ Everruns exposes an MCP server endpoint (`/mcp`) so external MCP clients — Cla
 Routing is intentionally split:
 
 - REST API lives under `/api/*`
-- MCP lives at `/mcp`
+- MCP OAuth lives at `/oauth/*` (authorize, token, register)
+- MCP JSON-RPC lives at `/mcp`
 - OAuth discovery metadata lives at `/.well-known/oauth-authorization-server`
 
 Everruns also acts as an **MCP client** (connecting to remote MCP servers). That side is covered in [`specs/mcp-servers.md`](mcp-servers.md).
@@ -67,14 +68,15 @@ External MCP clients authenticate via OAuth 2.1 with mandatory PKCE (S256). The 
 MCP Client → GET {issuer}/.well-known/oauth-authorization-server
            ← Server metadata (endpoints, PKCE support)
 
-MCP Client → POST /api/v1/oauth/register
+MCP Client → POST /oauth/register
            ← client_id, client_secret (dynamic registration)
 
-MCP Client → GET /api/v1/oauth/authorize?client_id=...&code_challenge=...&state=...&redirect_uri=...
-           → AuthUser extractor requires authenticated session (returns 401 if not)
+MCP Client → GET /oauth/authorize?client_id=...&code_challenge=...&state=...&redirect_uri=...
+           → Not authenticated → 302 redirect to frontend login with return_to
+           → Authenticated → issue authorization code
            ← Redirect to redirect_uri with ?code=...&state=...
 
-MCP Client → POST /api/v1/oauth/token (grant_type=authorization_code, code=..., code_verifier=...)
+MCP Client → POST /oauth/token (grant_type=authorization_code, code=..., code_verifier=...)
            ← { access_token, token_type, expires_in, refresh_token }
 
 MCP Client → POST /mcp (with Authorization: Bearer <access_token>)
@@ -87,15 +89,15 @@ MCP Client → POST /mcp (with Authorization: Bearer <access_token>)
 
 OAuth 2.0 Authorization Server Metadata (RFC 8414). No auth required.
 
-The `issuer` is the backend root URL (e.g. `https://app.example.com`). OAuth API endpoints still live under `/api/v1/...`.
+The `issuer` is the backend root URL (e.g. `https://app.example.com`). OAuth endpoints live at the server root alongside `/mcp`.
 
 **Response:**
 ```json
 {
   "issuer": "https://app.example.com",
-  "authorization_endpoint": "https://app.example.com/api/v1/oauth/authorize",
-  "token_endpoint": "https://app.example.com/api/v1/oauth/token",
-  "registration_endpoint": "https://app.example.com/api/v1/oauth/register",
+  "authorization_endpoint": "https://app.example.com/oauth/authorize",
+  "token_endpoint": "https://app.example.com/oauth/token",
+  "registration_endpoint": "https://app.example.com/oauth/register",
   "response_types_supported": ["code"],
   "grant_types_supported": ["authorization_code", "refresh_token"],
   "code_challenge_methods_supported": ["S256"],
@@ -104,7 +106,7 @@ The `issuer` is the backend root URL (e.g. `https://app.example.com`). OAuth API
 }
 ```
 
-#### POST /api/v1/oauth/register
+#### POST /oauth/register
 
 Dynamic Client Registration (RFC 7591). No auth required.
 
@@ -126,9 +128,9 @@ Dynamic Client Registration (RFC 7591). No auth required.
 }
 ```
 
-#### GET /api/v1/oauth/authorize
+#### GET /oauth/authorize
 
-Authorization endpoint. **Requires authenticated user** (via `AuthUser` extractor).
+Authorization endpoint. Redirects to login when no session cookie is present.
 
 **Query Parameters:**
 - `client_id` (required)
@@ -140,14 +142,15 @@ Authorization endpoint. **Requires authenticated user** (via `AuthUser` extracto
 - `scope=mcp` (optional, defaults to `mcp`)
 
 **Flow:**
-1. `AuthUser` extractor fires — delegates to configured auth backend
-2. Not authenticated → returns `401 Unauthorized` (login redirect, if desired, must be handled by the frontend/client)
-3. Authenticated → validate client_id, redirect_uri, generate authorization code
-4. Redirect to `redirect_uri?code=...&state=...` (no consent UI — code is issued immediately)
+1. Check for valid session cookie
+2. Not authenticated → 302 redirect to `{FRONTEND_URL}/login?return_to=/oauth/authorize?...`
+3. User logs in → browser navigates back to `/oauth/authorize?...` (now with cookie)
+4. Authenticated → validate client_id, redirect_uri, generate authorization code
+5. Redirect to `redirect_uri?code=...&state=...` (no consent UI — code is issued immediately)
 
 Authorization codes: random 32-byte hex, 5-minute TTL, one-time use, stored with PKCE challenge.
 
-#### POST /api/v1/oauth/token
+#### POST /oauth/token
 
 Token exchange. No cookie/session auth — uses client credentials.
 
@@ -264,9 +267,9 @@ The well-known endpoint is also merged — the API prefix is handled by construc
 ### External Auth Backend (PropelAuth)
 
 Works automatically because:
-1. `POST /v1/oauth/register` — no auth needed, backend not involved
-2. `GET /v1/oauth/authorize` — uses `AuthUser` extractor, which delegates to any backend
-3. `POST /v1/oauth/token` — validates code + PKCE, creates JWT. Backend not involved.
+1. `POST /oauth/register` — no auth needed, backend not involved
+2. `GET /oauth/authorize` — resolves user from cookie, redirects to login if needed
+3. `POST /oauth/token` — validates code + PKCE, creates JWT. Backend not involved.
 4. Token validation — standard JWT validation via `validate_token()`
 
 External backends only need to ensure their login page handles `redirect_to` query parameter (already required for CLI auth).

--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -4,6 +4,12 @@
 
 Everruns exposes an MCP server endpoint (`/mcp`) so external MCP clients — Claude Desktop, Cursor, VS Code, etc. — can interact with Everruns agents and tools over the [Model Context Protocol](https://spec.modelcontextprotocol.io). Authentication uses the same mechanisms as other API routes (`ResolvedOrg` extractor — API keys, JWT/cookie sessions), including OAuth 2.1-issued JWTs with mandatory PKCE for MCP client registration flows.
 
+Routing is intentionally split:
+
+- REST API lives under `/api/*`
+- MCP lives at `/mcp`
+- OAuth discovery metadata lives at `/.well-known/oauth-authorization-server`
+
 Everruns also acts as an **MCP client** (connecting to remote MCP servers). That side is covered in [`specs/mcp-servers.md`](mcp-servers.md).
 
 ## Protocol
@@ -61,14 +67,14 @@ External MCP clients authenticate via OAuth 2.1 with mandatory PKCE (S256). The 
 MCP Client → GET {issuer}/.well-known/oauth-authorization-server
            ← Server metadata (endpoints, PKCE support)
 
-MCP Client → POST /v1/oauth/register
+MCP Client → POST /api/v1/oauth/register
            ← client_id, client_secret (dynamic registration)
 
-MCP Client → GET /v1/oauth/authorize?client_id=...&code_challenge=...&state=...&redirect_uri=...
+MCP Client → GET /api/v1/oauth/authorize?client_id=...&code_challenge=...&state=...&redirect_uri=...
            → AuthUser extractor requires authenticated session (returns 401 if not)
            ← Redirect to redirect_uri with ?code=...&state=...
 
-MCP Client → POST /v1/oauth/token (grant_type=authorization_code, code=..., code_verifier=...)
+MCP Client → POST /api/v1/oauth/token (grant_type=authorization_code, code=..., code_verifier=...)
            ← { access_token, token_type, expires_in, refresh_token }
 
 MCP Client → POST /mcp (with Authorization: Bearer <access_token>)
@@ -81,12 +87,12 @@ MCP Client → POST /mcp (with Authorization: Bearer <access_token>)
 
 OAuth 2.0 Authorization Server Metadata (RFC 8414). No auth required.
 
-The `issuer` is the backend `base_url` (e.g. `https://app.example.com/api`). All endpoint URLs are constructed from this base.
+The `issuer` is the backend root URL (e.g. `https://app.example.com`). OAuth API endpoints still live under `/api/v1/...`.
 
 **Response:**
 ```json
 {
-  "issuer": "https://app.example.com/api",
+  "issuer": "https://app.example.com",
   "authorization_endpoint": "https://app.example.com/api/v1/oauth/authorize",
   "token_endpoint": "https://app.example.com/api/v1/oauth/token",
   "registration_endpoint": "https://app.example.com/api/v1/oauth/register",
@@ -98,7 +104,7 @@ The `issuer` is the backend `base_url` (e.g. `https://app.example.com/api`). All
 }
 ```
 
-#### POST /v1/oauth/register
+#### POST /api/v1/oauth/register
 
 Dynamic Client Registration (RFC 7591). No auth required.
 
@@ -120,7 +126,7 @@ Dynamic Client Registration (RFC 7591). No auth required.
 }
 ```
 
-#### GET /v1/oauth/authorize
+#### GET /api/v1/oauth/authorize
 
 Authorization endpoint. **Requires authenticated user** (via `AuthUser` extractor).
 
@@ -141,7 +147,7 @@ Authorization endpoint. **Requires authenticated user** (via `AuthUser` extracto
 
 Authorization codes: random 32-byte hex, 5-minute TTL, one-time use, stored with PKCE challenge.
 
-#### POST /v1/oauth/token
+#### POST /api/v1/oauth/token
 
 Token exchange. No cookie/session auth — uses client credentials.
 

--- a/specs/production-deployment.md
+++ b/specs/production-deployment.md
@@ -86,9 +86,10 @@ Do not rewrite `/mcp` under `/api`. Do not rewrite `/.well-known/*` under `/api`
 ### Operational Notes
 
 - REST API base URL should stay under `/api`
+- MCP OAuth endpoints stay at root: `/oauth/*`
 - MCP endpoint stays at root: `/mcp`
 - OAuth discovery metadata stays at root: `/.well-known/oauth-authorization-server`
-- If the UI is deployed separately, it still must target the same public `/api` base and root-level `/mcp`
+- If the UI is deployed separately, it still must target the same public `/api` base and root-level `/oauth/*`, `/mcp`
 
 Canonical references:
 - [`specs/apis.md`](./apis.md)

--- a/specs/production-deployment.md
+++ b/specs/production-deployment.md
@@ -1,0 +1,141 @@
+# Production Deployment Specification
+
+## Abstract
+
+This specification is the aggregation point for Everruns production deployment. It does not restate subsystem specs. It defines the minimum production shape, the required reverse proxy contract, and the canonical references operators should follow for the details.
+
+## Design Goals
+
+Production deployment guidance should:
+
+1. Give operators one place to orient quickly.
+2. Keep deployment-critical contracts explicit.
+3. Point to the real source-of-truth docs instead of duplicating them.
+4. Make routing, security, and operational boundaries hard to misread.
+
+## Ownership Boundary
+
+- This spec owns the high-level production deployment contract.
+- Subsystem specs own their own detailed behavior.
+- SRE docs and runbooks own step-by-step operational procedures.
+
+## Baseline Production Topology
+
+Production deployment consists of these roles:
+
+- Reverse proxy / ingress
+- Server (control plane)
+- Worker pool
+- PostgreSQL
+- Optional Valkey
+- Optional NATS
+- Optional UI
+
+The server is the only public backend HTTP surface. Workers communicate with the control plane over gRPC only.
+
+See:
+- [`specs/architecture.md`](./architecture.md)
+- [`docs/getting-started/architecture.md`](../docs/getting-started/architecture.md)
+- [`docs/getting-started/docker-compose.md`](../docs/getting-started/docker-compose.md)
+
+## Required Deployment Decisions
+
+Every production deployment must make explicit decisions for:
+
+- ingress / reverse proxy
+- TLS termination
+- database connectivity and TLS mode
+- auth mode
+- worker authentication
+- secrets encryption keys
+- observability and metrics exposure
+- whether Valkey and NATS are enabled
+
+See:
+- [`docs/sre/environment-variables.md`](../docs/sre/environment-variables.md)
+- [`specs/authentication.md`](./authentication.md)
+- [`specs/encryption.md`](./encryption.md)
+- [`specs/prometheus-metrics.md`](./prometheus-metrics.md)
+- [`specs/otel-observability.md`](./otel-observability.md)
+- [`specs/threat-model.md`](./threat-model.md)
+
+## Production Reverse Proxy Setup
+
+The reverse proxy is mandatory in production unless an equivalent platform ingress enforces the same routing contract.
+
+### Route Contract
+
+The proxy must preserve these public route groups:
+
+- `/api/*` -> backend unchanged
+- `/mcp` -> backend unchanged
+- `/.well-known/*` -> backend unchanged
+- `/health` -> backend
+- `/api-doc/openapi.json` -> backend when exposed
+- all other browser routes -> UI
+
+Do not rewrite `/mcp` under `/api`. Do not rewrite `/.well-known/*` under `/api`.
+
+### Transport Requirements
+
+- TLS/HTTPS required for public traffic
+- Disable proxy buffering for SSE responses under `/api/*`
+- Preserve Host and standard forwarding headers
+- Keep gRPC worker traffic off the public ingress path
+
+### Operational Notes
+
+- REST API base URL should stay under `/api`
+- MCP endpoint stays at root: `/mcp`
+- OAuth discovery metadata stays at root: `/.well-known/oauth-authorization-server`
+- If the UI is deployed separately, it still must target the same public `/api` base and root-level `/mcp`
+
+Canonical references:
+- [`specs/apis.md`](./apis.md)
+- [`specs/mcp.md`](./mcp.md)
+- [`docs/sre/environment-variables.md`](../docs/sre/environment-variables.md)
+
+Concrete config examples:
+- [`local/Caddyfile`](../local/Caddyfile)
+- [`examples/docker-compose-full.yaml`](../examples/docker-compose-full.yaml)
+
+## Security Minimums
+
+Production deployments must satisfy these minimums:
+
+- HTTPS enabled for public traffic
+- `AUTH_JWT_SECRET` configured
+- `WORKER_GRPC_AUTH_TOKEN` configured
+- secrets encryption key configured
+- explicit CORS policy when UI and API origins differ
+- private network or equivalent isolation for PostgreSQL, worker gRPC, Valkey, and NATS
+
+See:
+- [`specs/threat-model.md`](./threat-model.md)
+- [`specs/authentication.md`](./authentication.md)
+- [`specs/encryption.md`](./encryption.md)
+
+## Operations And Upgrades
+
+For production operations, use the runbooks rather than this spec:
+
+- authentication setup: [`docs/sre/runbooks/authentication.md`](../docs/sre/runbooks/authentication.md)
+- durable mode setup: [`docs/sre/runbooks/durable-mode-setup.md`](../docs/sre/runbooks/durable-mode-setup.md)
+- encryption key rotation: [`docs/sre/runbooks/encryption-key-rotation.md`](../docs/sre/runbooks/encryption-key-rotation.md)
+- admin tasks and migrations: [`docs/sre/admin-container.md`](../docs/sre/admin-container.md)
+
+Release and rollout references:
+- [`specs/release-process.md`](./release-process.md)
+- [`specs/shipping.md`](./shipping.md)
+- [`specs/maintenance.md`](./maintenance.md)
+
+## Non-Goals
+
+This spec does not define:
+
+- exact Kubernetes manifests
+- exact Docker Compose commands
+- cloud-vendor-specific load balancer configuration
+- step-by-step migration or incident procedures
+
+Those belong in operator docs, runbooks, or deployment-specific repositories.


### PR DESCRIPTION
## What
Restructure server routing so MCP (`/mcp`) and MCP OAuth (`/oauth/*`, `/.well-known/*`) endpoints live at the server root, while REST API stays under `/api`. Fix MCP OAuth flow to work end-to-end with Cursor and other MCP clients. Forward caller's Bearer token to scripted tool internal API calls.

## Why
MCP clients (Cursor, etc.) discover OAuth endpoints via `/.well-known/oauth-authorization-server` at the server root. Having them under `/api/v1/oauth/*` broke discovery. The authorize endpoint also returned 401 JSON instead of redirecting unauthenticated users to login.

## How
- Move MCP + OAuth routes to `root_routes` merged at server root (not nested under `API_PREFIX`)
- Add RFC 9728 `/.well-known/oauth-protected-resource` endpoint
- Authorize endpoint redirects to login page when unauthenticated (cookie-based session check)
- Accept both JSON and form-encoded token requests (`client_secret` optional for PKCE clients)
- Forward inbound Bearer token through scripted tool HTTP callbacks
- Apply per-IP rate limiting to root routes (same as API routes)
- Parse Bearer token case-insensitively per RFC 7235
- Preserve full original URI across login redirect (including `resource` param)

## Risk
- Medium
- Routing change affects all API consumers — mitigated by `API_PREFIX` defaulting to `/api` and Caddy configs updated
- OAuth flow changes — mitigated by PKCE remaining mandatory, client_secret validation still enforced when provided

## Security
- Threat categories reviewed: TM-DOS, TM-AUTH, TM-API, TM-LLM, TM-WEB
- **TM-DOS**: Root routes now rate-limited identically to API routes (was unthrottled — fixed)
- **TM-AUTH**: Bearer parsing made case-insensitive per RFC 7235; PKCE S256 mandatory; client_secret optional but validated when present; org fallback only for authenticated users
- **TM-API**: Route paths changed but all validation (client, code, PKCE, redirect_uri) preserved
- **TM-LLM**: Bearer token forwarded to scripted tools uses caller's own auth level — no escalation
- **TM-WEB**: `window.location.assign` only used for known backend OAuth paths

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)