### PR TITLE
refactor(auth): extract API key CRUD routes from auth_routes()

### DIFF
--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -802,7 +802,14 @@ impl ServerAppBuilder {
             tracing::info!("Evals disabled via feature flag");
         }
 
-        // Auth-specific routes
+        // API key CRUD — auth-provider-agnostic, always mounted
+        api_routes = api_routes.merge(crate::auth::api_key_routes(crate::auth::ApiKeyState {
+            db: db.clone(),
+            auth: auth_state.clone(),
+            resource_limits: crate::server::ResourceLimitsConfig::from_env(),
+        }));
+
+        // Auth-specific routes (login, register, OAuth — provider-dependent)
         if let Some(auth_routes) = auth_backend.auth_routes() {
             api_routes = api_routes.merge(auth_routes);
         }

--- a/crates/server/src/auth/api_key_routes.rs
+++ b/crates/server/src/auth/api_key_routes.rs
@@ -1,0 +1,244 @@
+// API key CRUD routes — auth-provider-agnostic.
+// Decision: Extracted from auth_routes() so all AuthBackend implementations
+// (builtin, PropelAuth, etc.) get API key management without reimplementing it.
+// Follows the same pattern as cli_auth_routes().
+
+use axum::{
+    Json, Router,
+    extract::{FromRef, Path, State},
+    http::{HeaderMap, StatusCode},
+    routing::{delete, get},
+};
+use chrono::{Duration, Utc};
+use everruns_core::DEFAULT_ORG_ID;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use super::api_key::generate_api_key;
+use super::audit;
+use super::middleware::{AuthError, AuthMethod, AuthState, AuthUser, ResolvedOrg};
+use crate::api::common::ListResponse;
+use crate::server::ResourceLimitsConfig;
+use crate::storage::StorageBackend;
+use crate::storage::models::CreateApiKeyRow;
+
+/// State for API key CRUD routes — decoupled from any specific AuthBackend.
+///
+/// Embedders construct this with their own DB/auth and mount via `api_key_routes()`.
+#[derive(Clone)]
+pub struct ApiKeyState {
+    pub db: Arc<StorageBackend>,
+    pub auth: AuthState,
+    pub resource_limits: ResourceLimitsConfig,
+}
+
+/// Enable AuthUser extractor when ApiKeyState is the route state.
+impl FromRef<ApiKeyState> for AuthState {
+    fn from_ref(state: &ApiKeyState) -> Self {
+        state.auth.clone()
+    }
+}
+
+/// API key response (shown only once at creation)
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ApiKeyResponse {
+    pub id: String,
+    pub name: String,
+    pub key: String,
+    pub key_prefix: String,
+    pub scopes: Vec<String>,
+    pub expires_at: Option<String>,
+    pub created_at: String,
+}
+
+/// API key list item (without full key)
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ApiKeyListItem {
+    pub id: String,
+    pub name: String,
+    pub key_prefix: String,
+    pub scopes: Vec<String>,
+    pub expires_at: Option<String>,
+    pub last_used_at: Option<String>,
+    pub created_at: String,
+}
+
+/// Create API key request
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CreateApiKeyRequest {
+    pub name: String,
+    #[serde(default)]
+    pub scopes: Vec<String>,
+    /// Expiration in days (optional)
+    pub expires_in_days: Option<i64>,
+}
+
+/// Create API key CRUD routes
+pub fn api_key_routes(state: ApiKeyState) -> Router {
+    Router::new()
+        .route("/v1/auth/api-keys", get(list_api_keys).post(create_api_key))
+        .route("/v1/auth/api-keys/{key_id}", delete(delete_api_key))
+        .with_state(state)
+}
+
+/// GET /v1/auth/api-keys - List API keys for current user
+async fn list_api_keys(
+    State(state): State<ApiKeyState>,
+    user: AuthUser,
+) -> Result<Json<ListResponse<ApiKeyListItem>>, AuthError> {
+    let keys = state
+        .db
+        .list_api_keys_for_user(user.id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to list API keys: {}", e);
+            AuthError::unauthorized("Failed to list API keys")
+        })?;
+
+    let items: Vec<ApiKeyListItem> = keys
+        .into_iter()
+        .map(|k| {
+            let scopes: Vec<String> = serde_json::from_value(k.scopes).unwrap_or_default();
+            ApiKeyListItem {
+                id: k.id.to_string(),
+                name: k.name,
+                key_prefix: k.key_prefix,
+                scopes,
+                expires_at: k.expires_at.map(|t| t.to_rfc3339()),
+                last_used_at: k.last_used_at.map(|t| t.to_rfc3339()),
+                created_at: k.created_at.to_rfc3339(),
+            }
+        })
+        .collect();
+
+    Ok(Json(ListResponse::new(items)))
+}
+
+/// POST /v1/auth/api-keys - Create a new API key
+///
+/// Organization is derived from the everruns_org cookie (set via /v1/users/me/switch-org).
+/// Cannot be called with API key authentication (must use session auth).
+async fn create_api_key(
+    State(state): State<ApiKeyState>,
+    headers: HeaderMap,
+    user: AuthUser,
+    org: ResolvedOrg,
+    Json(req): Json<CreateApiKeyRequest>,
+) -> Result<(StatusCode, Json<ApiKeyResponse>), AuthError> {
+    // Cannot create API key using API key auth
+    if user.auth_method == AuthMethod::ApiKey {
+        return Err(AuthError::forbidden(
+            "Cannot create API key using API key authentication",
+        ));
+    }
+
+    // Enforce API key limit per user per org
+    let key_count = state
+        .db
+        .count_api_keys_for_user_in_org(user.id, org.org_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to count API keys: {e}");
+            AuthError {
+                error: "Internal server error".to_string(),
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+            }
+        })?;
+    if key_count >= state.resource_limits.max_api_keys_per_user_per_org {
+        return Err(AuthError {
+            error: format!(
+                "API key limit reached (max {})",
+                state.resource_limits.max_api_keys_per_user_per_org
+            ),
+            status: StatusCode::CONFLICT,
+        });
+    }
+
+    let generated = generate_api_key();
+
+    let scopes = if req.scopes.is_empty() {
+        vec!["*".to_string()]
+    } else {
+        req.scopes
+    };
+
+    let expires_at = req
+        .expires_in_days
+        .map(|days| Utc::now() + Duration::days(days));
+
+    let key_row = state
+        .db
+        .create_api_key(CreateApiKeyRow {
+            org_id: org.org_id,
+            user_id: user.id,
+            name: req.name.clone(),
+            key_hash: generated.key_hash.clone(),
+            key_prefix: generated.key_prefix.clone(),
+            scopes: scopes.clone(),
+            expires_at,
+            metadata: serde_json::json!({"source": "web_ui"}),
+        })
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to create API key: {}", e);
+            AuthError::unauthorized("Failed to create API key")
+        })?;
+
+    audit::emit(
+        state.db.clone(),
+        org.org_id,
+        Some(user.id),
+        "auth.api_key.created",
+        audit::client_ip(&headers),
+        serde_json::json!({"key_id": key_row.id.to_string(), "name": req.name}),
+    );
+
+    Ok((
+        StatusCode::CREATED,
+        Json(ApiKeyResponse {
+            id: key_row.id.to_string(),
+            name: key_row.name,
+            key: generated.key, // Full key shown only once!
+            key_prefix: key_row.key_prefix,
+            scopes,
+            expires_at: key_row.expires_at.map(|t| t.to_rfc3339()),
+            created_at: key_row.created_at.to_rfc3339(),
+        }),
+    ))
+}
+
+/// DELETE /v1/auth/api-keys/:key_id - Delete an API key
+async fn delete_api_key(
+    State(state): State<ApiKeyState>,
+    headers: HeaderMap,
+    user: AuthUser,
+    Path(key_id): Path<Uuid>,
+) -> Result<StatusCode, AuthError> {
+    let deleted = state
+        .db
+        .delete_api_key(key_id, user.id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete API key: {}", e);
+            AuthError::unauthorized("Failed to delete API key")
+        })?;
+
+    if deleted {
+        // Notify the auth backend so it can invalidate caches.
+        state.auth.backend.on_api_key_deleted();
+
+        audit::emit(
+            state.db.clone(),
+            DEFAULT_ORG_ID,
+            Some(user.id),
+            "auth.api_key.deleted",
+            audit::client_ip(&headers),
+            serde_json::json!({"key_id": key_id.to_string()}),
+        );
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(AuthError::unauthorized("API key not found"))
+    }
+}

--- a/crates/server/src/auth/backend.rs
+++ b/crates/server/src/auth/backend.rs
@@ -21,9 +21,16 @@ pub trait AuthBackend: Send + Sync + 'static {
     /// Validate an API key and return the authenticated user.
     async fn validate_api_key(&self, key: &str) -> Result<AuthUser, AuthError>;
 
-    /// Return auth-specific HTTP routes (login, register, OAuth callbacks, API key CRUD).
+    /// Return auth-specific HTTP routes (login, register, OAuth callbacks).
     /// Returns `None` if auth is handled externally (e.g., PropelAuth hosted UI).
+    ///
+    /// API key CRUD routes are mounted separately by `ServerAppBuilder` via
+    /// `api_key_routes()` — they are auth-provider-agnostic.
     fn auth_routes(&self) -> Option<Router>;
+
+    /// Called when an API key is deleted, so backends can invalidate caches.
+    /// Default: no-op (backends without caching don't need to override).
+    fn on_api_key_deleted(&self) {}
 
     /// Return root-level public routes that must not be nested under the API prefix.
     ///

--- a/crates/server/src/auth/builtin.rs
+++ b/crates/server/src/auth/builtin.rs
@@ -254,6 +254,10 @@ impl AuthBackend for BuiltinAuthBackend {
         Some(auth_routes.merge(cli_routes))
     }
 
+    fn on_api_key_deleted(&self) {
+        self.invalidate_all_api_key_cache();
+    }
+
     fn public_routes(&self) -> Option<Router> {
         let auth_state =
             super::middleware::AuthState::new(self.config.clone(), Arc::new(self.clone()));

--- a/crates/server/src/auth/mod.rs
+++ b/crates/server/src/auth/mod.rs
@@ -4,6 +4,7 @@
 // Decision: Pluggable auth backend trait for external providers (SaaS)
 
 pub mod api_key;
+pub mod api_key_routes;
 pub mod audit;
 pub mod backend;
 pub mod builtin;
@@ -16,6 +17,7 @@ pub mod oauth;
 pub mod rate_limit;
 pub mod routes;
 
+pub use api_key_routes::{ApiKeyState, api_key_routes};
 pub use backend::AuthBackend;
 pub use builtin::BuiltinAuthBackend;
 pub use cli_auth::CliAuthState;

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -9,7 +9,7 @@ use axum::{
     http::{HeaderMap, Request, StatusCode},
     middleware::{self, Next},
     response::{Redirect, Response},
-    routing::{delete, get, post},
+    routing::{get, post},
 };
 use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use chrono::{Duration, Utc};
@@ -23,11 +23,10 @@ use super::audit;
 use super::rate_limit::extract_client_ip;
 
 use super::{
-    api_key::generate_api_key,
     builtin::{self, BuiltinAuthBackend},
     config::AuthMode,
     jwt::hash_token,
-    middleware::{AuthError, AuthMethod, AuthState, AuthUser, ORG_COOKIE_NAME, ResolvedOrg},
+    middleware::{AuthError, AuthMethod, AuthState, AuthUser, ORG_COOKIE_NAME},
     oauth::{GitHubOAuthService, GoogleOAuthService, OAuthProvider},
 };
 /// Enable AuthUser extractor when BuiltinAuthBackend is the route state.
@@ -38,9 +37,8 @@ impl FromRef<BuiltinAuthBackend> for AuthState {
     }
 }
 
-use crate::api::common::ListResponse;
 use crate::storage::{
-    models::{CreateApiKeyRow, CreateRefreshTokenRow, CreateUserRow},
+    models::{CreateRefreshTokenRow, CreateUserRow},
     password::{hash_password, verify_password},
 };
 
@@ -95,40 +93,6 @@ pub struct UserInfoResponse {
     /// Organizations the user belongs to
     #[serde(skip_serializing_if = "Option::is_none")]
     pub organizations: Option<Vec<OrgMembershipResponse>>,
-}
-
-/// API key response (shown only once at creation)
-#[derive(Debug, Serialize, ToSchema)]
-pub struct ApiKeyResponse {
-    pub id: String,
-    pub name: String,
-    pub key: String,
-    pub key_prefix: String,
-    pub scopes: Vec<String>,
-    pub expires_at: Option<String>,
-    pub created_at: String,
-}
-
-/// API key list item (without full key)
-#[derive(Debug, Serialize, ToSchema)]
-pub struct ApiKeyListItem {
-    pub id: String,
-    pub name: String,
-    pub key_prefix: String,
-    pub scopes: Vec<String>,
-    pub expires_at: Option<String>,
-    pub last_used_at: Option<String>,
-    pub created_at: String,
-}
-
-/// Create API key request
-#[derive(Debug, Deserialize, ToSchema)]
-pub struct CreateApiKeyRequest {
-    pub name: String,
-    #[serde(default)]
-    pub scopes: Vec<String>,
-    /// Expiration in days (optional)
-    pub expires_in_days: Option<i64>,
 }
 
 /// Refresh token request
@@ -226,11 +190,6 @@ pub fn routes(state: BuiltinAuthBackend) -> Router {
         .route("/v1/auth/callback/{provider}", get(oauth_callback))
         // Protected routes
         .route("/v1/auth/me", get(get_current_user))
-        .route(
-            "/v1/auth/api-keys",
-            get(list_api_keys).post(create_api_key_route),
-        )
-        .route("/v1/auth/api-keys/{key_id}", delete(delete_api_key_route))
         // Merge rate-limited routes
         .merge(login_route)
         .merge(register_route)
@@ -836,167 +795,6 @@ pub async fn oauth_callback(
     // Redirect to frontend (different origin in dev)
     let redirect_url = format!("{}/", state.config.frontend_url.trim_end_matches('/'));
     Ok((jar, Redirect::to(&redirect_url)))
-}
-
-/// GET /v1/auth/api-keys - List API keys for current user
-pub async fn list_api_keys(
-    State(state): State<BuiltinAuthBackend>,
-    user: AuthUser,
-) -> Result<Json<ListResponse<ApiKeyListItem>>, AuthError> {
-    let keys = state
-        .db
-        .list_api_keys_for_user(user.id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to list API keys: {}", e);
-            AuthError::unauthorized("Failed to list API keys")
-        })?;
-
-    let items: Vec<ApiKeyListItem> = keys
-        .into_iter()
-        .map(|k| {
-            let scopes: Vec<String> = serde_json::from_value(k.scopes).unwrap_or_default();
-            ApiKeyListItem {
-                id: k.id.to_string(),
-                name: k.name,
-                key_prefix: k.key_prefix,
-                scopes,
-                expires_at: k.expires_at.map(|t| t.to_rfc3339()),
-                last_used_at: k.last_used_at.map(|t| t.to_rfc3339()),
-                created_at: k.created_at.to_rfc3339(),
-            }
-        })
-        .collect();
-
-    Ok(Json(ListResponse::new(items)))
-}
-
-/// POST /v1/auth/api-keys - Create a new API key
-///
-/// Organization is derived from the everruns_org cookie (set via /v1/users/me/switch-org).
-/// Cannot be called with API key authentication (must use session auth).
-pub async fn create_api_key_route(
-    State(state): State<BuiltinAuthBackend>,
-    headers: HeaderMap,
-    user: AuthUser,
-    org: ResolvedOrg,
-    Json(req): Json<CreateApiKeyRequest>,
-) -> Result<(StatusCode, Json<ApiKeyResponse>), AuthError> {
-    // Cannot create API key using API key auth
-    if user.auth_method == AuthMethod::ApiKey {
-        return Err(AuthError::forbidden(
-            "Cannot create API key using API key authentication",
-        ));
-    }
-
-    // Enforce API key limit per user per org
-    let key_count = state
-        .db
-        .count_api_keys_for_user_in_org(user.id, org.org_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to count API keys: {e}");
-            AuthError {
-                error: "Internal server error".to_string(),
-                status: StatusCode::INTERNAL_SERVER_ERROR,
-            }
-        })?;
-    if key_count >= state.resource_limits.max_api_keys_per_user_per_org {
-        return Err(AuthError {
-            error: format!(
-                "API key limit reached (max {})",
-                state.resource_limits.max_api_keys_per_user_per_org
-            ),
-            status: StatusCode::CONFLICT,
-        });
-    }
-
-    let generated = generate_api_key();
-
-    let scopes = if req.scopes.is_empty() {
-        vec!["*".to_string()]
-    } else {
-        req.scopes
-    };
-
-    let expires_at = req
-        .expires_in_days
-        .map(|days| Utc::now() + Duration::days(days));
-
-    let key_row = state
-        .db
-        .create_api_key(CreateApiKeyRow {
-            org_id: org.org_id,
-            user_id: user.id,
-            name: req.name.clone(),
-            key_hash: generated.key_hash.clone(),
-            key_prefix: generated.key_prefix.clone(),
-            scopes: scopes.clone(),
-            expires_at,
-            metadata: serde_json::json!({"source": "web_ui"}),
-        })
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to create API key: {}", e);
-            AuthError::unauthorized("Failed to create API key")
-        })?;
-
-    audit::emit(
-        state.db.clone(),
-        org.org_id,
-        Some(user.id),
-        "auth.api_key.created",
-        audit::client_ip(&headers),
-        serde_json::json!({"key_id": key_row.id.to_string(), "name": req.name}),
-    );
-
-    Ok((
-        StatusCode::CREATED,
-        Json(ApiKeyResponse {
-            id: key_row.id.to_string(),
-            name: key_row.name,
-            key: generated.key, // Full key shown only once!
-            key_prefix: key_row.key_prefix,
-            scopes,
-            expires_at: key_row.expires_at.map(|t| t.to_rfc3339()),
-            created_at: key_row.created_at.to_rfc3339(),
-        }),
-    ))
-}
-
-/// DELETE /v1/auth/api-keys/:key_id - Delete an API key
-pub async fn delete_api_key_route(
-    State(state): State<BuiltinAuthBackend>,
-    headers: HeaderMap,
-    user: AuthUser,
-    Path(key_id): Path<Uuid>,
-) -> Result<StatusCode, AuthError> {
-    let deleted = state
-        .db
-        .delete_api_key(key_id, user.id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to delete API key: {}", e);
-            AuthError::unauthorized("Failed to delete API key")
-        })?;
-
-    if deleted {
-        // Invalidate entire API key auth cache — we don't have the key_hash here,
-        // only the key_id (UUID). Deletion is rare so full invalidation is fine.
-        state.invalidate_all_api_key_cache();
-
-        audit::emit(
-            state.db.clone(),
-            DEFAULT_ORG_ID,
-            Some(user.id),
-            "auth.api_key.deleted",
-            audit::client_ip(&headers),
-            serde_json::json!({"key_id": key_id.to_string()}),
-        );
-        Ok(StatusCode::NO_CONTENT)
-    } else {
-        Err(AuthError::unauthorized("API key not found"))
-    }
 }
 
 /// Helper: Generate token response with cookies


### PR DESCRIPTION
## What
Extract API key CRUD routes (`/v1/auth/api-keys`) from `AuthBackend::auth_routes()` into a standalone `api_key_routes()` function mounted directly by `ServerAppBuilder`.

## Why
`auth_routes()` bundled auth-provider-specific routes (login, OAuth, register) with auth-provider-agnostic routes (API key CRUD). Custom `AuthBackend` implementations (e.g. PropelAuth for SaaS) had to reimplement `auth_routes()` entirely and silently lost API key endpoints — causing the SaaS API Keys page to 404.

## How
- Created `api_key_routes.rs` with `ApiKeyState` struct and `api_key_routes()` function (same pattern as existing `cli_auth_routes()`)
- Moved 3 handlers (`list_api_keys`, `create_api_key`, `delete_api_key`) and 3 types (`ApiKeyResponse`, `ApiKeyListItem`, `CreateApiKeyRequest`) to the new module
- Added `on_api_key_deleted()` to `AuthBackend` trait (default no-op) for cache invalidation; `BuiltinAuthBackend` overrides to clear its moka cache
- `ServerAppBuilder` now mounts `api_key_routes()` unconditionally before provider-specific `auth_routes()`
- Cleaned up unused imports from `routes.rs`

## Risk
- Low
- Pure refactor — same handlers, same paths, same auth checks. Only the state type and mounting location changed.

## Security
- Threat categories reviewed: TM-AUTH, TM-AUTHZ, TM-API, TM-TENANT, TM-DOS
- Auth checks preserved: `AuthUser` extractor still required on all endpoints, `AuthMethod::ApiKey` guard on create, `ResolvedOrg` for org scoping, `resource_limits` for rate limiting
- Cache invalidation preserved via `on_api_key_deleted()` trait method delegating to `invalidate_all_api_key_cache()`
- No new endpoints, no changed authorization logic, no data exposure changes

## Checklist
- [x] Tests added or updated (existing tests pass — no behavioral change)
- [x] Backward compatibility considered (same API surface, no breaking changes)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Closes EVE-272