### PR TITLE
feat(ui): add org setup page shown after org creation

### DIFF
--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { Sidebar } from "@/components/layout/sidebar";
-import type { SidebarConfig, NavigationSection } from "@/components/layout/sidebar";
+import type {
+  SidebarConfig,
+  NavigationSection,
+} from "@/components/layout/sidebar";
 import { Settings, Zap } from "lucide-react";
 
 // Mock next/navigation
@@ -18,9 +21,19 @@ jest.mock("next/navigation", () => ({
 // Mock next/image
 jest.mock("next/image", () => ({
   __esModule: true,
-  default: (props: { src: string; alt: string; width: number; height: number }) => (
+  default: (props: {
+    src: string;
+    alt: string;
+    width: number;
+    height: number;
+  }) => (
     // eslint-disable-next-line nextjs/no-img-element
-    <img src={props.src} alt={props.alt} width={props.width} height={props.height} />
+    <img
+      src={props.src}
+      alt={props.alt}
+      width={props.width}
+      height={props.height}
+    />
   ),
 }));
 
@@ -157,10 +170,18 @@ describe("Sidebar", () => {
       .getAllByRole("link")
       .filter(
         (link) =>
-          link.getAttribute("href") !== "/dashboard" || link.textContent?.includes("Dashboard"),
+          link.getAttribute("href") !== "/dashboard" ||
+          link.textContent?.includes("Dashboard"),
       );
     // Filter to only nav items (Chat, Dashboard, Harnesses, Agents, Capabilities, Settings)
-    const navItems = ["Chat", "Dashboard", "Harnesses", "Agents", "Capabilities", "Settings"];
+    const navItems = [
+      "Chat",
+      "Dashboard",
+      "Harnesses",
+      "Agents",
+      "Capabilities",
+      "Settings",
+    ];
     const foundNavLinks = navLinks.filter((link) =>
       navItems.some((item) => link.textContent?.includes(item)),
     );
@@ -274,10 +295,15 @@ describe("Sidebar with config", () => {
       { items: [{ name: "Home", href: "/home", icon: Settings }] },
     ];
     const extra: NavigationSection[] = [
-      { label: "Extra", items: [{ name: "Extra Item", href: "/extra", icon: Zap }] },
+      {
+        label: "Extra",
+        items: [{ name: "Extra Item", href: "/extra", icon: Zap }],
+      },
     ];
 
-    render(<Sidebar config={{ navigation: customNav, extraSections: extra }} />);
+    render(
+      <Sidebar config={{ navigation: customNav, extraSections: extra }} />,
+    );
 
     expect(screen.getByText("Home")).toBeInTheDocument();
     expect(screen.getByText("Extra")).toBeInTheDocument();
@@ -295,14 +321,18 @@ describe("Sidebar with config", () => {
     render(<Sidebar config={config} />);
 
     // Dialog title should not be in the DOM when custom handler overrides default
-    expect(screen.queryByText("Create a new organisation")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Create a new organisation"),
+    ).not.toBeInTheDocument();
     // The org selector trigger should still render
     expect(screen.getByText("Test Org")).toBeInTheDocument();
   });
 
   it("renders sections without labels (unlabeled sections)", () => {
     const customNav: NavigationSection[] = [
-      { items: [{ name: "Unlabeled Item", href: "/unlabeled", icon: Settings }] },
+      {
+        items: [{ name: "Unlabeled Item", href: "/unlabeled", icon: Settings }],
+      },
     ];
 
     render(<Sidebar config={{ navigation: customNav }} />);
@@ -332,7 +362,9 @@ describe("Sidebar with config", () => {
     mockPathname.mockReturnValue("/custom/child");
     const customNav: NavigationSection[] = [
       {
-        items: [{ name: "Exact Only", href: "/custom", icon: Settings, exact: true }],
+        items: [
+          { name: "Exact Only", href: "/custom", icon: Settings, exact: true },
+        ],
       },
     ];
 
@@ -393,7 +425,7 @@ describe("Create Organisation dialog", () => {
         name: "New Org",
         role: "owner",
       });
-      expect(mockPush).toHaveBeenCalledWith("/dashboard");
+      expect(mockPush).toHaveBeenCalledWith("/orgs/org_new123/setup");
     });
   });
 

--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -1,9 +1,6 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { Sidebar } from "@/components/layout/sidebar";
-import type {
-  SidebarConfig,
-  NavigationSection,
-} from "@/components/layout/sidebar";
+import type { SidebarConfig, NavigationSection } from "@/components/layout/sidebar";
 import { Settings, Zap } from "lucide-react";
 
 // Mock next/navigation
@@ -21,19 +18,9 @@ jest.mock("next/navigation", () => ({
 // Mock next/image
 jest.mock("next/image", () => ({
   __esModule: true,
-  default: (props: {
-    src: string;
-    alt: string;
-    width: number;
-    height: number;
-  }) => (
+  default: (props: { src: string; alt: string; width: number; height: number }) => (
     // eslint-disable-next-line nextjs/no-img-element
-    <img
-      src={props.src}
-      alt={props.alt}
-      width={props.width}
-      height={props.height}
-    />
+    <img src={props.src} alt={props.alt} width={props.width} height={props.height} />
   ),
 }));
 
@@ -170,18 +157,10 @@ describe("Sidebar", () => {
       .getAllByRole("link")
       .filter(
         (link) =>
-          link.getAttribute("href") !== "/dashboard" ||
-          link.textContent?.includes("Dashboard"),
+          link.getAttribute("href") !== "/dashboard" || link.textContent?.includes("Dashboard"),
       );
     // Filter to only nav items (Chat, Dashboard, Harnesses, Agents, Capabilities, Settings)
-    const navItems = [
-      "Chat",
-      "Dashboard",
-      "Harnesses",
-      "Agents",
-      "Capabilities",
-      "Settings",
-    ];
+    const navItems = ["Chat", "Dashboard", "Harnesses", "Agents", "Capabilities", "Settings"];
     const foundNavLinks = navLinks.filter((link) =>
       navItems.some((item) => link.textContent?.includes(item)),
     );
@@ -301,9 +280,7 @@ describe("Sidebar with config", () => {
       },
     ];
 
-    render(
-      <Sidebar config={{ navigation: customNav, extraSections: extra }} />,
-    );
+    render(<Sidebar config={{ navigation: customNav, extraSections: extra }} />);
 
     expect(screen.getByText("Home")).toBeInTheDocument();
     expect(screen.getByText("Extra")).toBeInTheDocument();
@@ -321,9 +298,7 @@ describe("Sidebar with config", () => {
     render(<Sidebar config={config} />);
 
     // Dialog title should not be in the DOM when custom handler overrides default
-    expect(
-      screen.queryByText("Create a new organisation"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Create a new organisation")).not.toBeInTheDocument();
     // The org selector trigger should still render
     expect(screen.getByText("Test Org")).toBeInTheDocument();
   });
@@ -362,9 +337,7 @@ describe("Sidebar with config", () => {
     mockPathname.mockReturnValue("/custom/child");
     const customNav: NavigationSection[] = [
       {
-        items: [
-          { name: "Exact Only", href: "/custom", icon: Settings, exact: true },
-        ],
+        items: [{ name: "Exact Only", href: "/custom", icon: Settings, exact: true }],
       },
     ];
 

--- a/apps/ui/src/app/(main)/orgs/[orgId]/setup/page.tsx
+++ b/apps/ui/src/app/(main)/orgs/[orgId]/setup/page.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+// Org setup page — shown after org creation to confirm provisioning.
+// Extensible: future steps (e.g. LLM key configuration) can be added to SETUP_STEPS.
+
+import { useState, useEffect, useCallback } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { Building2, Check, CircleDot, Loader2, ArrowRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { getOrganization } from "@/lib/api/organizations";
+import { listHarnesses } from "@/lib/api/harnesses";
+import { queryKeys } from "@/lib/query-keys";
+import { useOrg } from "@/providers/org-provider";
+
+interface SetupStep {
+  label: string;
+  description: string;
+  check: (ctx: StepContext) => boolean;
+}
+
+interface StepContext {
+  orgLoaded: boolean;
+  harnessCount: number;
+  defaultHarnessId: string | null;
+  baseHarnessId: string | null;
+}
+
+const SETUP_STEPS: SetupStep[] = [
+  {
+    label: "Organisation created",
+    description: "Your new organisation has been provisioned",
+    check: (ctx) => ctx.orgLoaded,
+  },
+  {
+    label: "Harnesses initialised",
+    description: "Built-in harnesses are ready",
+    check: (ctx) => ctx.harnessCount > 0,
+  },
+  {
+    label: "Default settings configured",
+    description: "Default and base harnesses have been assigned",
+    check: (ctx) => !!ctx.defaultHarnessId && !!ctx.baseHarnessId,
+  },
+];
+
+const STEP_DELAY_MS = 400;
+
+export default function OrgSetupPage() {
+  const { orgId } = useParams<{ orgId: string }>();
+  const router = useRouter();
+  const { setCurrentOrg } = useOrg();
+
+  const {
+    data: org,
+    isLoading: orgLoading,
+    isError: orgError,
+  } = useQuery({
+    queryKey: queryKeys.organizations.detail(orgId),
+    queryFn: () => getOrganization(orgId),
+    staleTime: 30_000,
+    refetchInterval: 5_000,
+  });
+
+  const { data: harnesses = [] } = useQuery({
+    queryKey: queryKeys.harnesses.all,
+    queryFn: () => listHarnesses(),
+    staleTime: 30_000,
+    refetchInterval: 5_000,
+  });
+
+  // Set current org once loaded
+  useEffect(() => {
+    if (org) {
+      setCurrentOrg({ public_id: org.id, name: org.name, role: "owner" });
+    }
+  }, [org, setCurrentOrg]);
+
+  const stepContext: StepContext = {
+    orgLoaded: !!org,
+    harnessCount: harnesses.length,
+    defaultHarnessId: org?.default_harness_id ?? null,
+    baseHarnessId: org?.base_harness_id ?? null,
+  };
+
+  const allReady = SETUP_STEPS.every((s) => s.check(stepContext));
+
+  // Animated step completion — reveal one at a time
+  const [completedCount, setCompletedCount] = useState(0);
+
+  const animateSteps = useCallback(() => {
+    let idx = 0;
+    const tick = () => {
+      idx += 1;
+      setCompletedCount(idx);
+      if (idx < SETUP_STEPS.length) {
+        setTimeout(tick, STEP_DELAY_MS);
+      }
+    };
+    setTimeout(tick, STEP_DELAY_MS);
+  }, []);
+
+  // Trigger animation once all checks pass
+  const [animationStarted, setAnimationStarted] = useState(false);
+  useEffect(() => {
+    if (allReady && !animationStarted) {
+      setAnimationStarted(true);
+      animateSteps();
+    }
+  }, [allReady, animationStarted, animateSteps]);
+
+  const allAnimated = completedCount >= SETUP_STEPS.length;
+
+  // --- Loading skeleton ---
+  if (orgLoading && !org) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center p-4">
+        <Card className="w-full max-w-lg p-8">
+          <div className="flex flex-col items-center gap-4">
+            <Skeleton className="h-12 w-12 rounded-xl" />
+            <Skeleton className="h-6 w-48" />
+            <Skeleton className="h-4 w-64" />
+          </div>
+          <div className="mt-8 space-y-4">
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-12 w-full" />
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
+  // --- Error state ---
+  if (orgError) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center p-4">
+        <Card className="w-full max-w-lg p-8 text-center">
+          <div className="flex flex-col items-center gap-4">
+            <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
+              <Building2 className="h-6 w-6 text-primary" />
+            </div>
+            <h1 className="text-xl font-semibold">Organisation not found</h1>
+            <Button variant="outline" onClick={() => router.push("/dashboard")}>
+              Go to dashboard
+            </Button>
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
+  // --- Setup progress ---
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center p-4">
+      <Card className="w-full max-w-lg p-8">
+        <div className="flex flex-col items-center gap-2 text-center">
+          <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
+            <Building2 className="h-6 w-6 text-primary" />
+          </div>
+          <h1 className="text-xl font-semibold">Setting up {org?.name}</h1>
+          <p className="text-sm text-muted-foreground">
+            Your organisation is being configured with everything you need to
+            get started.
+          </p>
+        </div>
+
+        <div className="mt-8 space-y-4">
+          {SETUP_STEPS.map((step, i) => {
+            const passed = step.check(stepContext);
+            const animated = i < completedCount;
+
+            // Completed and animated
+            if (passed && animated) {
+              return (
+                <div key={step.label} className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground">
+                    <Check className="h-4 w-4" />
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium">{step.label}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {step.description}
+                    </p>
+                  </div>
+                </div>
+              );
+            }
+
+            // In progress (first non-animated step when checks are passing)
+            if (passed && !animated) {
+              return (
+                <div key={step.label} className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 shrink-0 items-center justify-center">
+                    <Loader2 className="h-5 w-5 animate-spin text-primary" />
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium">{step.label}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {step.description}
+                    </p>
+                  </div>
+                </div>
+              );
+            }
+
+            // Pending
+            return (
+              <div
+                key={step.label}
+                className="flex items-center gap-3 opacity-40"
+              >
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center">
+                  <CircleDot className="h-5 w-5 text-muted-foreground/50" />
+                </div>
+                <div>
+                  <p className="text-sm font-medium">{step.label}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {step.description}
+                  </p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div
+          className={`mt-8 transition-opacity duration-500 ${allAnimated ? "opacity-100" : "opacity-0 pointer-events-none"}`}
+        >
+          <Button className="w-full" onClick={() => router.push("/dashboard")}>
+            Go to dashboard
+            <ArrowRight className="ml-2 h-4 w-4" />
+          </Button>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/apps/ui/src/app/(main)/orgs/[orgId]/setup/page.tsx
+++ b/apps/ui/src/app/(main)/orgs/[orgId]/setup/page.tsx
@@ -3,7 +3,7 @@
 // Org setup page — shown after org creation to confirm provisioning.
 // Extensible: future steps (e.g. LLM key configuration) can be added to SETUP_STEPS.
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { Building2, Check, CircleDot, Loader2, ArrowRight } from "lucide-react";
@@ -14,6 +14,7 @@ import { getOrganization } from "@/lib/api/organizations";
 import { listHarnesses } from "@/lib/api/harnesses";
 import { queryKeys } from "@/lib/query-keys";
 import { useOrg } from "@/providers/org-provider";
+import type { ApiError } from "@/lib/api/client";
 
 interface SetupStep {
   label: string;
@@ -51,32 +52,44 @@ const STEP_DELAY_MS = 400;
 export default function OrgSetupPage() {
   const { orgId } = useParams<{ orgId: string }>();
   const router = useRouter();
-  const { setCurrentOrg } = useOrg();
+  const { currentOrg, organizations, setCurrentOrg, isSwitching } = useOrg();
 
   const {
     data: org,
     isLoading: orgLoading,
     isError: orgError,
+    error: orgErrorDetail,
   } = useQuery({
     queryKey: queryKeys.organizations.detail(orgId),
     queryFn: () => getOrganization(orgId),
     staleTime: 30_000,
-    refetchInterval: 5_000,
+    refetchInterval: (query) => {
+      const data = query.state.data;
+      return data?.default_harness_id && data?.base_harness_id ? false : 5_000;
+    },
   });
+
+  // Gate harness query on org cookie being set for the correct org
+  const orgReady = currentOrg?.public_id === orgId && !isSwitching;
 
   const { data: harnesses = [] } = useQuery({
-    queryKey: queryKeys.harnesses.all,
+    queryKey: [...queryKeys.harnesses.all, orgId],
     queryFn: () => listHarnesses(),
+    enabled: orgReady,
     staleTime: 30_000,
-    refetchInterval: 5_000,
+    refetchInterval: (query) => {
+      const data = query.state.data ?? [];
+      return data.length > 0 ? false : 5_000;
+    },
   });
 
-  // Set current org once loaded
+  // Set current org once loaded — derive role from membership list when available
   useEffect(() => {
     if (org) {
-      setCurrentOrg({ public_id: org.id, name: org.name, role: "owner" });
+      const membership = organizations.find((o) => o.public_id === org.id);
+      setCurrentOrg({ public_id: org.id, name: org.name, role: membership?.role ?? "owner" });
     }
-  }, [org, setCurrentOrg]);
+  }, [org, organizations, setCurrentOrg]);
 
   const stepContext: StepContext = {
     orgLoaded: !!org,
@@ -87,8 +100,16 @@ export default function OrgSetupPage() {
 
   const allReady = SETUP_STEPS.every((s) => s.check(stepContext));
 
-  // Animated step completion — reveal one at a time
+  // Animated step completion — reveal one at a time, with cleanup on unmount
   const [completedCount, setCompletedCount] = useState(0);
+  const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  useEffect(() => {
+    const timers = timersRef.current;
+    return () => {
+      for (const id of timers) clearTimeout(id);
+    };
+  }, []);
 
   const animateSteps = useCallback(() => {
     let idx = 0;
@@ -96,10 +117,10 @@ export default function OrgSetupPage() {
       idx += 1;
       setCompletedCount(idx);
       if (idx < SETUP_STEPS.length) {
-        setTimeout(tick, STEP_DELAY_MS);
+        timersRef.current.push(setTimeout(tick, STEP_DELAY_MS));
       }
     };
-    setTimeout(tick, STEP_DELAY_MS);
+    timersRef.current.push(setTimeout(tick, STEP_DELAY_MS));
   }, []);
 
   // Trigger animation once all checks pass
@@ -135,6 +156,7 @@ export default function OrgSetupPage() {
 
   // --- Error state ---
   if (orgError) {
+    const is404 = (orgErrorDetail as ApiError)?.status === 404;
     return (
       <div className="flex min-h-[60vh] items-center justify-center p-4">
         <Card className="w-full max-w-lg p-8 text-center">
@@ -142,7 +164,12 @@ export default function OrgSetupPage() {
             <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
               <Building2 className="h-6 w-6 text-primary" />
             </div>
-            <h1 className="text-xl font-semibold">Organisation not found</h1>
+            <h1 className="text-xl font-semibold">
+              {is404 ? "Organisation not found" : "Failed to load organisation"}
+            </h1>
+            {!is404 && orgErrorDetail?.message && (
+              <p className="text-sm text-muted-foreground">{orgErrorDetail.message}</p>
+            )}
             <Button variant="outline" onClick={() => router.push("/dashboard")}>
               Go to dashboard
             </Button>
@@ -162,8 +189,7 @@ export default function OrgSetupPage() {
           </div>
           <h1 className="text-xl font-semibold">Setting up {org?.name}</h1>
           <p className="text-sm text-muted-foreground">
-            Your organisation is being configured with everything you need to
-            get started.
+            Your organisation is being configured with everything you need to get started.
           </p>
         </div>
 
@@ -181,9 +207,7 @@ export default function OrgSetupPage() {
                   </div>
                   <div>
                     <p className="text-sm font-medium">{step.label}</p>
-                    <p className="text-xs text-muted-foreground">
-                      {step.description}
-                    </p>
+                    <p className="text-xs text-muted-foreground">{step.description}</p>
                   </div>
                 </div>
               );
@@ -198,9 +222,7 @@ export default function OrgSetupPage() {
                   </div>
                   <div>
                     <p className="text-sm font-medium">{step.label}</p>
-                    <p className="text-xs text-muted-foreground">
-                      {step.description}
-                    </p>
+                    <p className="text-xs text-muted-foreground">{step.description}</p>
                   </div>
                 </div>
               );
@@ -208,18 +230,13 @@ export default function OrgSetupPage() {
 
             // Pending
             return (
-              <div
-                key={step.label}
-                className="flex items-center gap-3 opacity-40"
-              >
+              <div key={step.label} className="flex items-center gap-3 opacity-40">
                 <div className="flex h-8 w-8 shrink-0 items-center justify-center">
                   <CircleDot className="h-5 w-5 text-muted-foreground/50" />
                 </div>
                 <div>
                   <p className="text-sm font-medium">{step.label}</p>
-                  <p className="text-xs text-muted-foreground">
-                    {step.description}
-                  </p>
+                  <p className="text-xs text-muted-foreground">{step.description}</p>
                 </div>
               </div>
             );

--- a/apps/ui/src/app/(main)/settings/organisation/page.tsx
+++ b/apps/ui/src/app/(main)/settings/organisation/page.tsx
@@ -58,8 +58,10 @@ export default function OrganisationPage() {
       return;
     }
 
-    const genericHarnessId = harnesses.find((h) => h.name === "Generic")?.id || "";
-    const baseHarnessFallbackId = harnesses.find((h) => h.name === "Base")?.id || "";
+    const genericHarnessId =
+      harnesses.find((h) => h.name === "Generic")?.id || "";
+    const baseHarnessFallbackId =
+      harnesses.find((h) => h.name === "Base")?.id || "";
 
     setName(organization.name);
     setDefaultHarnessId(organization.default_harness_id || genericHarnessId);
@@ -74,7 +76,8 @@ export default function OrganisationPage() {
   };
 
   const handleSave = async () => {
-    if (!hasChanges || !name.trim() || !defaultHarnessId || !baseHarnessId) return;
+    if (!hasChanges || !name.trim() || !defaultHarnessId || !baseHarnessId)
+      return;
 
     await updateOrganization.mutateAsync({
       name: name.trim(),
@@ -85,7 +88,13 @@ export default function OrganisationPage() {
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter" && hasChanges && name.trim() && defaultHarnessId && baseHarnessId) {
+    if (
+      e.key === "Enter" &&
+      hasChanges &&
+      name.trim() &&
+      defaultHarnessId &&
+      baseHarnessId
+    ) {
       handleSave();
     }
   };
@@ -94,11 +103,13 @@ export default function OrganisationPage() {
     e.preventDefault();
     if (!newOrgName.trim()) return;
 
-    const org = await createOrganization.mutateAsync({ name: newOrgName.trim() });
+    const org = await createOrganization.mutateAsync({
+      name: newOrgName.trim(),
+    });
     setCurrentOrg({ public_id: org.id, name: org.name, role: "owner" });
     setNewOrgName("");
     setCreateDialogOpen(false);
-    router.push("/dashboard");
+    router.push(`/orgs/${org.id}/setup`);
   };
 
   if (error) {
@@ -107,11 +118,15 @@ export default function OrganisationPage() {
         <section>
           <div className="mb-4">
             <h2 className="text-xl font-semibold">Organisation</h2>
-            <p className="text-sm text-muted-foreground">Manage organisation settings.</p>
+            <p className="text-sm text-muted-foreground">
+              Manage organisation settings.
+            </p>
           </div>
           <Card className="p-8 text-center">
             <AlertCircle className="h-12 w-12 mx-auto text-destructive mb-4" />
-            <h3 className="text-lg font-medium mb-2">Failed to load organisation</h3>
+            <h3 className="text-lg font-medium mb-2">
+              Failed to load organisation
+            </h3>
             <p className="text-muted-foreground">{error.message}</p>
           </Card>
         </section>
@@ -125,7 +140,9 @@ export default function OrganisationPage() {
       <section>
         <div className="mb-6">
           <h2 className="text-xl font-semibold">Organisation</h2>
-          <p className="text-sm text-muted-foreground">Manage organisation settings.</p>
+          <p className="text-sm text-muted-foreground">
+            Manage organisation settings.
+          </p>
         </div>
 
         {isLoading ? (
@@ -148,8 +165,12 @@ export default function OrganisationPage() {
                 <Building2 className="h-5 w-5 text-primary" />
               </div>
               <div>
-                <h3 className="font-medium">{organization?.name || currentOrg?.name}</h3>
-                <p className="text-sm text-muted-foreground">Organisation settings</p>
+                <h3 className="font-medium">
+                  {organization?.name || currentOrg?.name}
+                </h3>
+                <p className="text-sm text-muted-foreground">
+                  Organisation settings
+                </p>
               </div>
             </div>
 
@@ -177,7 +198,8 @@ export default function OrganisationPage() {
                   placeholder="Select default harness"
                 />
                 <p className="text-xs text-muted-foreground">
-                  Used as the normal starting harness in the UI. New orgs default this to Generic.
+                  Used as the normal starting harness in the UI. New orgs
+                  default this to Generic.
                 </p>
               </div>
 
@@ -192,8 +214,8 @@ export default function OrganisationPage() {
                   placeholder="Select base harness"
                 />
                 <p className="text-xs text-muted-foreground">
-                  Used only when a session starts without an explicit harness. New orgs default this
-                  to Base.
+                  Used only when a session starts without an explicit harness.
+                  New orgs default this to Base.
                 </p>
               </div>
 
@@ -236,7 +258,9 @@ export default function OrganisationPage() {
                     readOnly
                     className="font-mono text-sm bg-muted"
                   />
-                  <CopyButton value={organization?.id || currentOrg?.public_id || ""} />
+                  <CopyButton
+                    value={organization?.id || currentOrg?.public_id || ""}
+                  />
                 </div>
                 <p className="text-xs text-muted-foreground">
                   Use this ID when making API calls scoped to this organisation.
@@ -252,7 +276,9 @@ export default function OrganisationPage() {
         <div className="mb-6 flex items-center justify-between">
           <div>
             <h2 className="text-xl font-semibold">Your Organisations</h2>
-            <p className="text-sm text-muted-foreground">All organisations you are a member of.</p>
+            <p className="text-sm text-muted-foreground">
+              All organisations you are a member of.
+            </p>
           </div>
           <Button onClick={() => setCreateDialogOpen(true)}>
             <Plus className="h-4 w-4 mr-2" />
@@ -269,14 +295,18 @@ export default function OrganisationPage() {
                 className={`p-4 flex items-center justify-between ${isCurrent ? "border-primary/50" : ""}`}
               >
                 <div className="flex items-center gap-3">
-                  <div className={`p-2 rounded-lg ${isCurrent ? "bg-primary/10" : "bg-muted"}`}>
+                  <div
+                    className={`p-2 rounded-lg ${isCurrent ? "bg-primary/10" : "bg-muted"}`}
+                  >
                     <Building2
                       className={`h-4 w-4 ${isCurrent ? "text-primary" : "text-muted-foreground"}`}
                     />
                   </div>
                   <div>
                     <p className="font-medium">{org.name}</p>
-                    <p className="text-xs text-muted-foreground font-mono">{org.public_id}</p>
+                    <p className="text-xs text-muted-foreground font-mono">
+                      {org.public_id}
+                    </p>
                   </div>
                 </div>
                 <div className="flex items-center gap-2">
@@ -286,7 +316,11 @@ export default function OrganisationPage() {
                       Current
                     </span>
                   ) : (
-                    <Button variant="outline" size="sm" onClick={() => setCurrentOrg(org)}>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setCurrentOrg(org)}
+                    >
                       Switch
                     </Button>
                   )}
@@ -303,7 +337,8 @@ export default function OrganisationPage() {
           <DialogHeader>
             <DialogTitle>Create Organisation</DialogTitle>
             <DialogDescription>
-              Create a new organisation. You will be added as a member automatically.
+              Create a new organisation. You will be added as a member
+              automatically.
             </DialogDescription>
           </DialogHeader>
           <form onSubmit={handleCreateOrg} className="space-y-4">
@@ -323,10 +358,17 @@ export default function OrganisationPage() {
               </p>
             )}
             <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => setCreateDialogOpen(false)}>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setCreateDialogOpen(false)}
+              >
                 Cancel
               </Button>
-              <Button type="submit" disabled={createOrganization.isPending || !newOrgName.trim()}>
+              <Button
+                type="submit"
+                disabled={createOrganization.isPending || !newOrgName.trim()}
+              >
                 {createOrganization.isPending ? "Creating..." : "Create"}
               </Button>
             </DialogFooter>

--- a/apps/ui/src/app/(main)/settings/organisation/page.tsx
+++ b/apps/ui/src/app/(main)/settings/organisation/page.tsx
@@ -58,10 +58,8 @@ export default function OrganisationPage() {
       return;
     }
 
-    const genericHarnessId =
-      harnesses.find((h) => h.name === "Generic")?.id || "";
-    const baseHarnessFallbackId =
-      harnesses.find((h) => h.name === "Base")?.id || "";
+    const genericHarnessId = harnesses.find((h) => h.name === "Generic")?.id || "";
+    const baseHarnessFallbackId = harnesses.find((h) => h.name === "Base")?.id || "";
 
     setName(organization.name);
     setDefaultHarnessId(organization.default_harness_id || genericHarnessId);
@@ -76,8 +74,7 @@ export default function OrganisationPage() {
   };
 
   const handleSave = async () => {
-    if (!hasChanges || !name.trim() || !defaultHarnessId || !baseHarnessId)
-      return;
+    if (!hasChanges || !name.trim() || !defaultHarnessId || !baseHarnessId) return;
 
     await updateOrganization.mutateAsync({
       name: name.trim(),
@@ -88,13 +85,7 @@ export default function OrganisationPage() {
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (
-      e.key === "Enter" &&
-      hasChanges &&
-      name.trim() &&
-      defaultHarnessId &&
-      baseHarnessId
-    ) {
+    if (e.key === "Enter" && hasChanges && name.trim() && defaultHarnessId && baseHarnessId) {
       handleSave();
     }
   };
@@ -118,15 +109,11 @@ export default function OrganisationPage() {
         <section>
           <div className="mb-4">
             <h2 className="text-xl font-semibold">Organisation</h2>
-            <p className="text-sm text-muted-foreground">
-              Manage organisation settings.
-            </p>
+            <p className="text-sm text-muted-foreground">Manage organisation settings.</p>
           </div>
           <Card className="p-8 text-center">
             <AlertCircle className="h-12 w-12 mx-auto text-destructive mb-4" />
-            <h3 className="text-lg font-medium mb-2">
-              Failed to load organisation
-            </h3>
+            <h3 className="text-lg font-medium mb-2">Failed to load organisation</h3>
             <p className="text-muted-foreground">{error.message}</p>
           </Card>
         </section>
@@ -140,9 +127,7 @@ export default function OrganisationPage() {
       <section>
         <div className="mb-6">
           <h2 className="text-xl font-semibold">Organisation</h2>
-          <p className="text-sm text-muted-foreground">
-            Manage organisation settings.
-          </p>
+          <p className="text-sm text-muted-foreground">Manage organisation settings.</p>
         </div>
 
         {isLoading ? (
@@ -165,12 +150,8 @@ export default function OrganisationPage() {
                 <Building2 className="h-5 w-5 text-primary" />
               </div>
               <div>
-                <h3 className="font-medium">
-                  {organization?.name || currentOrg?.name}
-                </h3>
-                <p className="text-sm text-muted-foreground">
-                  Organisation settings
-                </p>
+                <h3 className="font-medium">{organization?.name || currentOrg?.name}</h3>
+                <p className="text-sm text-muted-foreground">Organisation settings</p>
               </div>
             </div>
 
@@ -198,8 +179,7 @@ export default function OrganisationPage() {
                   placeholder="Select default harness"
                 />
                 <p className="text-xs text-muted-foreground">
-                  Used as the normal starting harness in the UI. New orgs
-                  default this to Generic.
+                  Used as the normal starting harness in the UI. New orgs default this to Generic.
                 </p>
               </div>
 
@@ -214,8 +194,8 @@ export default function OrganisationPage() {
                   placeholder="Select base harness"
                 />
                 <p className="text-xs text-muted-foreground">
-                  Used only when a session starts without an explicit harness.
-                  New orgs default this to Base.
+                  Used only when a session starts without an explicit harness. New orgs default this
+                  to Base.
                 </p>
               </div>
 
@@ -258,9 +238,7 @@ export default function OrganisationPage() {
                     readOnly
                     className="font-mono text-sm bg-muted"
                   />
-                  <CopyButton
-                    value={organization?.id || currentOrg?.public_id || ""}
-                  />
+                  <CopyButton value={organization?.id || currentOrg?.public_id || ""} />
                 </div>
                 <p className="text-xs text-muted-foreground">
                   Use this ID when making API calls scoped to this organisation.
@@ -276,9 +254,7 @@ export default function OrganisationPage() {
         <div className="mb-6 flex items-center justify-between">
           <div>
             <h2 className="text-xl font-semibold">Your Organisations</h2>
-            <p className="text-sm text-muted-foreground">
-              All organisations you are a member of.
-            </p>
+            <p className="text-sm text-muted-foreground">All organisations you are a member of.</p>
           </div>
           <Button onClick={() => setCreateDialogOpen(true)}>
             <Plus className="h-4 w-4 mr-2" />
@@ -295,18 +271,14 @@ export default function OrganisationPage() {
                 className={`p-4 flex items-center justify-between ${isCurrent ? "border-primary/50" : ""}`}
               >
                 <div className="flex items-center gap-3">
-                  <div
-                    className={`p-2 rounded-lg ${isCurrent ? "bg-primary/10" : "bg-muted"}`}
-                  >
+                  <div className={`p-2 rounded-lg ${isCurrent ? "bg-primary/10" : "bg-muted"}`}>
                     <Building2
                       className={`h-4 w-4 ${isCurrent ? "text-primary" : "text-muted-foreground"}`}
                     />
                   </div>
                   <div>
                     <p className="font-medium">{org.name}</p>
-                    <p className="text-xs text-muted-foreground font-mono">
-                      {org.public_id}
-                    </p>
+                    <p className="text-xs text-muted-foreground font-mono">{org.public_id}</p>
                   </div>
                 </div>
                 <div className="flex items-center gap-2">
@@ -316,11 +288,7 @@ export default function OrganisationPage() {
                       Current
                     </span>
                   ) : (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setCurrentOrg(org)}
-                    >
+                    <Button variant="outline" size="sm" onClick={() => setCurrentOrg(org)}>
                       Switch
                     </Button>
                   )}
@@ -337,8 +305,7 @@ export default function OrganisationPage() {
           <DialogHeader>
             <DialogTitle>Create Organisation</DialogTitle>
             <DialogDescription>
-              Create a new organisation. You will be added as a member
-              automatically.
+              Create a new organisation. You will be added as a member automatically.
             </DialogDescription>
           </DialogHeader>
           <form onSubmit={handleCreateOrg} className="space-y-4">
@@ -358,17 +325,10 @@ export default function OrganisationPage() {
               </p>
             )}
             <DialogFooter>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => setCreateDialogOpen(false)}
-              >
+              <Button type="button" variant="outline" onClick={() => setCreateDialogOpen(false)}>
                 Cancel
               </Button>
-              <Button
-                type="submit"
-                disabled={createOrganization.isPending || !newOrgName.trim()}
-              >
+              <Button type="submit" disabled={createOrganization.isPending || !newOrgName.trim()}>
                 {createOrganization.isPending ? "Creating..." : "Create"}
               </Button>
             </DialogFooter>

--- a/apps/ui/src/components/layout/sidebar-organization-menu.tsx
+++ b/apps/ui/src/components/layout/sidebar-organization-menu.tsx
@@ -52,7 +52,7 @@ function CreateOrganizationDialog({
     setCurrentOrg({ public_id: org.id, name: org.name, role: "owner" });
     setName("");
     onOpenChange(false);
-    router.push("/dashboard");
+    router.push(`/orgs/${org.id}/setup`);
   };
 
   return (
@@ -61,7 +61,8 @@ function CreateOrganizationDialog({
         <DialogHeader>
           <DialogTitle>Create Organisation</DialogTitle>
           <DialogDescription>
-            Create a new organisation. You will be added as a member automatically.
+            Create a new organisation. You will be added as a member
+            automatically.
           </DialogDescription>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
@@ -81,10 +82,17 @@ function CreateOrganizationDialog({
             </p>
           )}
           <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
               Cancel
             </Button>
-            <Button type="submit" disabled={createOrg.isPending || !name.trim()}>
+            <Button
+              type="submit"
+              disabled={createOrg.isPending || !name.trim()}
+            >
               {createOrg.isPending ? "Creating..." : "Create"}
             </Button>
           </DialogFooter>
@@ -153,7 +161,10 @@ export function SidebarOrganizationMenu({
       </div>
 
       {useDefaultCreateOrgDialog && (
-        <CreateOrganizationDialog open={createOrgOpen} onOpenChange={setCreateOrgOpen} />
+        <CreateOrganizationDialog
+          open={createOrgOpen}
+          onOpenChange={setCreateOrgOpen}
+        />
       )}
     </>
   );

--- a/apps/ui/src/components/layout/sidebar-organization-menu.tsx
+++ b/apps/ui/src/components/layout/sidebar-organization-menu.tsx
@@ -61,8 +61,7 @@ function CreateOrganizationDialog({
         <DialogHeader>
           <DialogTitle>Create Organisation</DialogTitle>
           <DialogDescription>
-            Create a new organisation. You will be added as a member
-            automatically.
+            Create a new organisation. You will be added as a member automatically.
           </DialogDescription>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
@@ -82,17 +81,10 @@ function CreateOrganizationDialog({
             </p>
           )}
           <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-            >
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>
-            <Button
-              type="submit"
-              disabled={createOrg.isPending || !name.trim()}
-            >
+            <Button type="submit" disabled={createOrg.isPending || !name.trim()}>
               {createOrg.isPending ? "Creating..." : "Create"}
             </Button>
           </DialogFooter>
@@ -161,10 +153,7 @@ export function SidebarOrganizationMenu({
       </div>
 
       {useDefaultCreateOrgDialog && (
-        <CreateOrganizationDialog
-          open={createOrgOpen}
-          onOpenChange={setCreateOrgOpen}
-        />
+        <CreateOrganizationDialog open={createOrgOpen} onOpenChange={setCreateOrgOpen} />
       )}
     </>
   );


### PR DESCRIPTION
## What
Add org setup page at `/orgs/[orgId]/setup` shown after org creation, replacing the previous redirect to `/dashboard`.

## Why
After creating a new organisation, users had no visual feedback that provisioning (harnesses, default settings) completed successfully. The setup page confirms each provisioning step with animated progress.

## How
- New page `apps/ui/src/app/(main)/orgs/[orgId]/setup/page.tsx` polls org details and harnesses, evaluates three setup steps, animates completion sequentially, then reveals a "Go to dashboard" button
- Updated both org creation entry points (settings page `handleCreateOrg`, sidebar `handleSubmit`) to redirect to `/orgs/${org.id}/setup`
- Updated sidebar test assertion from `/dashboard` to `/orgs/org_new123/setup`
- `SETUP_STEPS` array is extensible for future steps (e.g. LLM key configuration)

## Risk
- Low
- Redirect path change could affect SaaS fork if it overrides the default create dialog — but the `SidebarOrganizationMenu` already supports custom `createOrg` handlers via `orgActions` config

## Security
- Threat categories reviewed: TM-WEB, TM-AUTHZ, TM-TENANT
- `orgId` from URL params flows only through existing API calls (`getOrganization`, `listHarnesses`) — backend validates access. React auto-escapes rendered org name. Hardcoded `role: "owner"` in client-side `setCurrentOrg` matches existing pattern; actual role determined server-side.
- No new API endpoints, no injection vectors, no new dependencies

## Checklist
- [x] Tests added or updated (sidebar test updated to expect `/orgs/org_new123/setup`)
- [x] Backward compatibility considered (SaaS fork custom `createOrg` handlers unaffected)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Closes EVE-275