### PR TITLE
feat(mcp): implement resources/list and resources/read methods

### DIFF
--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -19,10 +19,16 @@ mod handlers;
 
 use crate::auth::middleware::AuthUser;
 use crate::auth::{AuthState, ResolvedOrg};
+<<<<<<< ours
 use crate::services::{
     AgentService, BudgetService, CapabilityService, EventService, McpServerService, MessageService,
     SessionService, SkillService,
 };
+||||||| base
+use crate::services::{EventService, MessageService, SessionService};
+=======
+use crate::services::{CapabilityService, EventService, MessageService, SessionService};
+>>>>>>> theirs
 use crate::storage::StorageBackend;
 use axum::{Json, Router, extract::State, routing::post};
 use bashkit::{ScriptedTool, Tool as ScriptedToolTrait};
@@ -322,16 +328,22 @@ pub struct AppState {
     pub session_service: Arc<SessionService>,
     pub message_service: Arc<MessageService>,
     pub event_service: Arc<EventService>,
+<<<<<<< ours
     pub capability_service: Arc<CapabilityService>,
     pub mcp_server_service: Arc<McpServerService>,
     pub skill_service: Arc<SkillService>,
     pub budget_service: Arc<BudgetService>,
+||||||| base
+=======
+    pub capability_service: Arc<CapabilityService>,
+>>>>>>> theirs
     pub runner: Arc<dyn AgentRunner>,
     pub auth: AuthState,
     pub fallback_base_harness_name: Option<String>,
 }
 
 impl AppState {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         db: Arc<StorageBackend>,
         runner: Arc<dyn AgentRunner>,
@@ -339,7 +351,12 @@ impl AppState {
         platform_definition: &PlatformDefinition,
         notifications_enabled: bool,
         event_delivery: crate::event_delivery::EventDelivery,
+<<<<<<< ours
         encryption: Option<Arc<crate::storage::encryption::EncryptionService>>,
+||||||| base
+=======
+        capability_service: Arc<CapabilityService>,
+>>>>>>> theirs
     ) -> Self {
         Self {
             agent_service: Arc::new(AgentService::new(db.clone())),
@@ -354,6 +371,7 @@ impl AppState {
                 event_delivery.clone(),
             )),
             event_service: Arc::new(EventService::new(db.clone(), event_delivery)),
+<<<<<<< ours
             capability_service: Arc::new(CapabilityService::with_registry(
                 db.clone(),
                 encryption.clone(),
@@ -362,6 +380,10 @@ impl AppState {
             mcp_server_service: Arc::new(McpServerService::new(db.clone(), encryption)),
             skill_service: Arc::new(SkillService::new(db.clone())),
             budget_service: Arc::new(BudgetService::new(db.clone())),
+||||||| base
+=======
+            capability_service,
+>>>>>>> theirs
             db,
             runner,
             auth,
@@ -405,9 +427,17 @@ async fn handle_mcp(
     let response = match req.method.as_str() {
         "initialize" => handle_initialize(req.id),
         "tools/list" => handle_tools_list(req.id),
+<<<<<<< ours
         "tools/call" => {
             handle_tools_call(req.id.clone(), req.params, &auth_user, &org, &state).await
         }
+||||||| base
+        "tools/call" => handle_tools_call(req.id.clone(), req.params, &org, &state, &headers).await,
+=======
+        "tools/call" => handle_tools_call(req.id.clone(), req.params, &org, &state, &headers).await,
+        "resources/list" => handle_resources_list(req.id),
+        "resources/read" => handle_resources_read(req.id, req.params, &org, &state).await,
+>>>>>>> theirs
         "ping" => JsonRpcResponse::success(req.id, json!({})),
         _ => JsonRpcResponse::method_not_found(req.id),
     };
@@ -425,7 +455,8 @@ fn handle_initialize(id: Option<Value>) -> JsonRpcResponse {
         json!({
             "protocolVersion": MCP_PROTOCOL_VERSION,
             "capabilities": {
-                "tools": {}
+                "tools": {},
+                "resources": {}
             },
             "serverInfo": {
                 "name": MCP_SERVER_NAME,
@@ -437,6 +468,171 @@ fn handle_initialize(id: Option<Value>) -> JsonRpcResponse {
 
 fn handle_tools_list(id: Option<Value>) -> JsonRpcResponse {
     JsonRpcResponse::success(id, json!({ "tools": tool_definitions() }))
+}
+
+// ============================================================================
+// Resource handlers (MCP resources capability)
+// ============================================================================
+
+/// Static resource catalog — returned by resources/list.
+fn handle_resources_list(id: Option<Value>) -> JsonRpcResponse {
+    JsonRpcResponse::success(
+        id,
+        json!({
+            "resources": [
+                {
+                    "uri": "everruns://capabilities",
+                    "name": "Capabilities",
+                    "description": "Available capabilities (tools, sandboxes, integrations)",
+                    "mimeType": "application/json"
+                },
+                {
+                    "uri": "everruns://harnesses",
+                    "name": "Harnesses",
+                    "description": "Available harnesses (base environments for sessions)",
+                    "mimeType": "application/json"
+                },
+                {
+                    "uri": "everruns://models",
+                    "name": "LLM Models",
+                    "description": "Available LLM models and providers",
+                    "mimeType": "application/json"
+                },
+                {
+                    "uri": "everruns://agents",
+                    "name": "Agents",
+                    "description": "Agent summaries (id, name, description)",
+                    "mimeType": "application/json"
+                }
+            ]
+        }),
+    )
+}
+
+/// Read a resource by URI — fetches fresh data on each call.
+async fn handle_resources_read(
+    id: Option<Value>,
+    params: Value,
+    org: &ResolvedOrg,
+    state: &AppState,
+) -> JsonRpcResponse {
+    let uri = match params.get("uri").and_then(|v| v.as_str()) {
+        Some(uri) => uri,
+        None => return JsonRpcResponse::invalid_params(id, "Missing 'uri' in params"),
+    };
+
+    let result = match uri {
+        "everruns://capabilities" => read_capabilities(org, state).await,
+        "everruns://harnesses" => read_harnesses(org, state).await,
+        "everruns://models" => read_models(org, state).await,
+        "everruns://agents" => read_agents(org, state).await,
+        _ => Err(format!("Unknown resource URI: {uri}")),
+    };
+
+    match result {
+        Ok(text) => JsonRpcResponse::success(
+            id,
+            json!({
+                "contents": [{
+                    "uri": uri,
+                    "mimeType": "application/json",
+                    "text": text
+                }]
+            }),
+        ),
+        Err(msg) => JsonRpcResponse::error(id, -32602, &msg),
+    }
+}
+
+async fn read_capabilities(org: &ResolvedOrg, state: &AppState) -> Result<String, String> {
+    let capabilities = state
+        .capability_service
+        .list_all(org.org_id)
+        .await
+        .map_err(|e| format!("Failed to list capabilities: {e}"))?;
+
+    let summary: Vec<Value> = capabilities
+        .into_iter()
+        .map(|c| {
+            json!({
+                "id": c.id.as_str(),
+                "name": c.name,
+                "description": c.description,
+                "status": format!("{:?}", c.status),
+            })
+        })
+        .collect();
+
+    serde_json::to_string(&summary).map_err(|e| format!("Serialization error: {e}"))
+}
+
+async fn read_harnesses(org: &ResolvedOrg, state: &AppState) -> Result<String, String> {
+    let harnesses = state
+        .db
+        .list_harnesses(org.org_id, None, false)
+        .await
+        .map_err(|e| format!("Failed to list harnesses: {e}"))?;
+
+    let summary: Vec<Value> = harnesses
+        .into_iter()
+        .map(|h| {
+            json!({
+                "id": h.id.to_string(),
+                "name": h.name,
+                "description": h.description,
+                "status": h.status,
+            })
+        })
+        .collect();
+
+    serde_json::to_string(&summary).map_err(|e| format!("Serialization error: {e}"))
+}
+
+async fn read_models(org: &ResolvedOrg, state: &AppState) -> Result<String, String> {
+    let providers = state
+        .db
+        .list_llm_providers(org.org_id)
+        .await
+        .map_err(|e| format!("Failed to list providers: {e}"))?;
+
+    let summary: Vec<Value> = providers
+        .into_iter()
+        .map(|p| {
+            json!({
+                "id": p.id.to_string(),
+                "name": p.name,
+                "status": p.status,
+            })
+        })
+        .collect();
+
+    serde_json::to_string(&summary).map_err(|e| format!("Serialization error: {e}"))
+}
+
+async fn read_agents(org: &ResolvedOrg, state: &AppState) -> Result<String, String> {
+    let (agents, _total) = state
+        .db
+        .list_agents(
+            org.org_id,
+            None,
+            false,
+            crate::api::common::Pagination::new(0, 100),
+        )
+        .await
+        .map_err(|e| format!("Failed to list agents: {e}"))?;
+
+    let summary: Vec<Value> = agents
+        .into_iter()
+        .map(|a| {
+            json!({
+                "id": a.public_id,
+                "name": a.name,
+                "description": a.description,
+            })
+        })
+        .collect();
+
+    serde_json::to_string(&summary).map_err(|e| format!("Serialization error: {e}"))
 }
 
 async fn handle_tools_call(

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -19,16 +19,10 @@ mod handlers;
 
 use crate::auth::middleware::AuthUser;
 use crate::auth::{AuthState, ResolvedOrg};
-<<<<<<< ours
 use crate::services::{
     AgentService, BudgetService, CapabilityService, EventService, McpServerService, MessageService,
     SessionService, SkillService,
 };
-||||||| base
-use crate::services::{EventService, MessageService, SessionService};
-=======
-use crate::services::{CapabilityService, EventService, MessageService, SessionService};
->>>>>>> theirs
 use crate::storage::StorageBackend;
 use axum::{Json, Router, extract::State, routing::post};
 use bashkit::{ScriptedTool, Tool as ScriptedToolTrait};
@@ -328,15 +322,10 @@ pub struct AppState {
     pub session_service: Arc<SessionService>,
     pub message_service: Arc<MessageService>,
     pub event_service: Arc<EventService>,
-<<<<<<< ours
     pub capability_service: Arc<CapabilityService>,
     pub mcp_server_service: Arc<McpServerService>,
     pub skill_service: Arc<SkillService>,
     pub budget_service: Arc<BudgetService>,
-||||||| base
-=======
-    pub capability_service: Arc<CapabilityService>,
->>>>>>> theirs
     pub runner: Arc<dyn AgentRunner>,
     pub auth: AuthState,
     pub fallback_base_harness_name: Option<String>,
@@ -351,12 +340,8 @@ impl AppState {
         platform_definition: &PlatformDefinition,
         notifications_enabled: bool,
         event_delivery: crate::event_delivery::EventDelivery,
-<<<<<<< ours
         encryption: Option<Arc<crate::storage::encryption::EncryptionService>>,
-||||||| base
-=======
         capability_service: Arc<CapabilityService>,
->>>>>>> theirs
     ) -> Self {
         Self {
             agent_service: Arc::new(AgentService::new(db.clone())),
@@ -371,19 +356,10 @@ impl AppState {
                 event_delivery.clone(),
             )),
             event_service: Arc::new(EventService::new(db.clone(), event_delivery)),
-<<<<<<< ours
-            capability_service: Arc::new(CapabilityService::with_registry(
-                db.clone(),
-                encryption.clone(),
-                platform_definition.capability_registry().clone(),
-            )),
+            capability_service,
             mcp_server_service: Arc::new(McpServerService::new(db.clone(), encryption)),
             skill_service: Arc::new(SkillService::new(db.clone())),
             budget_service: Arc::new(BudgetService::new(db.clone())),
-||||||| base
-=======
-            capability_service,
->>>>>>> theirs
             db,
             runner,
             auth,
@@ -427,17 +403,11 @@ async fn handle_mcp(
     let response = match req.method.as_str() {
         "initialize" => handle_initialize(req.id),
         "tools/list" => handle_tools_list(req.id),
-<<<<<<< ours
         "tools/call" => {
             handle_tools_call(req.id.clone(), req.params, &auth_user, &org, &state).await
         }
-||||||| base
-        "tools/call" => handle_tools_call(req.id.clone(), req.params, &org, &state, &headers).await,
-=======
-        "tools/call" => handle_tools_call(req.id.clone(), req.params, &org, &state, &headers).await,
         "resources/list" => handle_resources_list(req.id),
         "resources/read" => handle_resources_read(req.id, req.params, &org, &state).await,
->>>>>>> theirs
         "ping" => JsonRpcResponse::success(req.id, json!({})),
         _ => JsonRpcResponse::method_not_found(req.id),
     };
@@ -526,7 +496,7 @@ async fn handle_resources_read(
         "everruns://harnesses" => read_harnesses(org, state).await,
         "everruns://models" => read_models(org, state).await,
         "everruns://agents" => read_agents(org, state).await,
-        _ => Err(format!("Unknown resource URI: {uri}")),
+        _ => return JsonRpcResponse::invalid_params(id, format!("Unknown resource URI: {uri}")),
     };
 
     match result {
@@ -540,7 +510,8 @@ async fn handle_resources_read(
                 }]
             }),
         ),
-        Err(msg) => JsonRpcResponse::error(id, -32602, &msg),
+        // -32603 = internal error (service failure, not client error)
+        Err(msg) => JsonRpcResponse::error(id, -32603, &msg),
     }
 }
 
@@ -558,7 +529,7 @@ async fn read_capabilities(org: &ResolvedOrg, state: &AppState) -> Result<String
                 "id": c.id.as_str(),
                 "name": c.name,
                 "description": c.description,
-                "status": format!("{:?}", c.status),
+                "status": c.status,
             })
         })
         .collect();

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -563,7 +563,7 @@ impl ServerAppBuilder {
         };
         let agents_state = api::agents::AppState::new(
             db.clone(),
-            capability_service,
+            capability_service.clone(),
             auth_state.clone(),
             grade,
             platform_definition.clone(),
@@ -692,7 +692,12 @@ impl ServerAppBuilder {
             platform_definition.as_ref(),
             notifications_enabled,
             event_delivery.clone(),
+<<<<<<< ours
             encryption.clone(),
+||||||| base
+=======
+            capability_service.clone(),
+>>>>>>> theirs
         );
 
         let health_state = HealthState {

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -692,12 +692,8 @@ impl ServerAppBuilder {
             platform_definition.as_ref(),
             notifications_enabled,
             event_delivery.clone(),
-<<<<<<< ours
             encryption.clone(),
-||||||| base
-=======
             capability_service.clone(),
->>>>>>> theirs
         );
 
         let health_state = HealthState {

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -252,7 +252,7 @@ impl TestServer {
         );
         let agents_state = api::agents::AppState::new(
             db.clone(),
-            capability_service,
+            capability_service.clone(),
             auth_state.clone(),
             grade,
             platform_definition.clone(),
@@ -338,12 +338,6 @@ impl TestServer {
             feature_flags.notifications,
             everruns_server::EventDelivery::in_memory(),
         );
-        let mcp_capability_service =
-            std::sync::Arc::new(everruns_server::services::CapabilityService::with_registry(
-                db.clone(),
-                encryption.clone(),
-                platform_definition.capability_registry().clone(),
-            ));
         let mcp_endpoint_state = api::mcp_endpoint::AppState::new(
             db.clone(),
             runner.clone(),
@@ -351,12 +345,8 @@ impl TestServer {
             &platform_definition,
             feature_flags.notifications,
             everruns_server::EventDelivery::in_memory(),
-<<<<<<< ours
             None, // No encryption in tests
-||||||| base
-=======
             mcp_capability_service,
->>>>>>> theirs
         );
 
         // Build API routes

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -338,6 +338,12 @@ impl TestServer {
             feature_flags.notifications,
             everruns_server::EventDelivery::in_memory(),
         );
+        let mcp_capability_service =
+            std::sync::Arc::new(everruns_server::services::CapabilityService::with_registry(
+                db.clone(),
+                encryption.clone(),
+                platform_definition.capability_registry().clone(),
+            ));
         let mcp_endpoint_state = api::mcp_endpoint::AppState::new(
             db.clone(),
             runner.clone(),
@@ -345,7 +351,12 @@ impl TestServer {
             &platform_definition,
             feature_flags.notifications,
             everruns_server::EventDelivery::in_memory(),
+<<<<<<< ours
             None, // No encryption in tests
+||||||| base
+=======
+            mcp_capability_service,
+>>>>>>> theirs
         );
 
         // Build API routes

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -346,7 +346,7 @@ impl TestServer {
             feature_flags.notifications,
             everruns_server::EventDelivery::in_memory(),
             None, // No encryption in tests
-            mcp_capability_service,
+            capability_service.clone(),
         );
 
         // Build API routes


### PR DESCRIPTION
## What
Implement MCP `resources/list` and `resources/read` protocol methods, exposing platform metadata as read-only resources with `everruns://` URIs.

## Why
MCP clients that want to seed context (capabilities, harnesses, models, agents) must call `execute` with a command and parse the output. MCP has a native `resources` capability for exactly this — read-only data refreshed on demand.

## How
- Advertise `"resources": {}` in the `initialize` response capabilities
- Add `resources/list` and `resources/read` to the method dispatch in `handle_mcp`
- `resources/list` returns 4 static resources:
  - `everruns://capabilities` — available capabilities (tools, sandboxes, integrations)
  - `everruns://harnesses` — available harnesses (base environments)
  - `everruns://models` — LLM providers
  - `everruns://agents` — agent summaries (id, name, description)
- `resources/read` fetches fresh summary-level data from the service layer on each call (no caching)
- Added `CapabilityService` to MCP endpoint `AppState` for capability listing
- Updated test harness to pass `CapabilityService` to the MCP endpoint state constructor

## Risk
- Low
- New MCP protocol methods — additive, no existing behavior changed
- Resource data is read-only summaries of existing API data

## Security
- Threat categories reviewed: TM-API, TM-TENANT, TM-AUTH
- Resources are scoped to the authenticated user's org via `ResolvedOrg` (same as all other MCP methods)
- No new data exposure — resources return the same data available through existing API endpoints
- Resource URIs are validated via exact match (`everruns://capabilities` etc.), no path traversal risk

## Checklist
- [x] Tests added or updated (test harness updated for new AppState parameter)
- [x] Backward compatibility considered (additive protocol methods, no breaking changes)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Closes EVE-270