### PR TITLE
feat(mcp): improve discover tool with fuzzy search, clean output, and --all flag

### DIFF
--- a/crates/server/src/api/mcp_endpoint/catalog.rs
+++ b/crates/server/src/api/mcp_endpoint/catalog.rs
@@ -6,6 +6,7 @@
 
 use bashkit::{ScriptedTool, ToolArgs, ToolDef};
 use serde_json::json;
+use std::collections::BTreeMap;
 
 /// A single API operation in the catalog.
 pub struct Operation {
@@ -1261,3 +1262,110 @@ pub static CATALOG: &[Operation] = &[
         params: &[],
     },
 ];
+
+// ============================================================================
+// Discover — fuzzy search and catalog listing
+// ============================================================================
+
+/// Return all tools grouped by category.
+pub fn discover_all() -> String {
+    let mut by_category: BTreeMap<&str, Vec<&Operation>> = BTreeMap::new();
+    for op in CATALOG {
+        by_category.entry(op.category).or_default().push(op);
+    }
+
+    let mut out = String::new();
+    for (cat, ops) in &by_category {
+        out.push_str(&format!("## {}\n", cat));
+        for op in ops {
+            out.push_str(&format!("  {} — {}\n", op.name, op.description));
+        }
+        out.push('\n');
+    }
+    out.truncate(out.trim_end().len());
+    out
+}
+
+/// Fuzzy-search the catalog by tokenizing the query and matching against
+/// name (split on `_`), description, and category.
+///
+/// Returns results sorted by match score (descending), formatted as plain text.
+pub fn discover_search(query: &str) -> String {
+    let tokens: Vec<String> = query
+        .split_whitespace()
+        .map(|t| t.to_ascii_lowercase())
+        .filter(|t| !t.is_empty())
+        .collect();
+
+    if tokens.is_empty() {
+        return discover_all();
+    }
+
+    let mut scored: Vec<(usize, &Operation)> = CATALOG
+        .iter()
+        .filter_map(|op| {
+            let score = match_score(op, &tokens);
+            if score > 0 { Some((score, op)) } else { None }
+        })
+        .collect();
+
+    scored.sort_by(|a, b| b.0.cmp(&a.0));
+
+    if scored.is_empty() {
+        return format!("No operations found matching '{}'.", query);
+    }
+
+    // Group by category if >5 results, otherwise flat list.
+    if scored.len() > 5 {
+        let mut by_category: BTreeMap<&str, Vec<&Operation>> = BTreeMap::new();
+        for (_, op) in &scored {
+            by_category.entry(op.category).or_default().push(op);
+        }
+        let mut out = String::new();
+        for (cat, ops) in &by_category {
+            out.push_str(&format!("## {}\n", cat));
+            for op in ops {
+                out.push_str(&format!("  {} — {}\n", op.name, op.description));
+            }
+            out.push('\n');
+        }
+        out.truncate(out.trim_end().len());
+        out
+    } else {
+        let mut out = String::new();
+        for (_, op) in &scored {
+            out.push_str(&format!("{} — {}\n", op.name, op.description));
+            if !op.params.is_empty() {
+                let param_names: Vec<&str> = op.params.iter().map(|p| p.name).collect();
+                out.push_str(&format!("  params: {}\n", param_names.join(", ")));
+            }
+        }
+        out.truncate(out.trim_end().len());
+        out
+    }
+}
+
+/// Score an operation against search tokens. Higher = better match.
+fn match_score(op: &Operation, tokens: &[String]) -> usize {
+    let name_parts: Vec<String> = op.name.split('_').map(|s| s.to_ascii_lowercase()).collect();
+    let desc_lower = op.description.to_ascii_lowercase();
+    let cat_lower = op.category.to_ascii_lowercase();
+
+    let mut score = 0;
+    for token in tokens {
+        // Exact name-part match (e.g. "create" matches "create_agent")
+        if name_parts.iter().any(|p| p == token) {
+            score += 3;
+        // Prefix match on name parts (e.g. "sess" matches "sessions")
+        } else if name_parts.iter().any(|p| p.starts_with(token.as_str())) {
+            score += 2;
+        // Category match
+        } else if cat_lower == *token || cat_lower.starts_with(token.as_str()) {
+            score += 2;
+        // Substring in description
+        } else if desc_lower.contains(token.as_str()) {
+            score += 1;
+        }
+    }
+    score
+}

--- a/crates/server/src/api/mcp_endpoint/catalog.rs
+++ b/crates/server/src/api/mcp_endpoint/catalog.rs
@@ -1289,10 +1289,11 @@ pub fn discover_all() -> String {
 /// Fuzzy-search the catalog by tokenizing the query and matching against
 /// name (split on `_`), description, and category.
 ///
-/// Returns results sorted by match score (descending), formatted as plain text.
+/// Results are sorted by score descending; when >5 results they are grouped
+/// by category (alphabetical), losing strict global score order.
 pub fn discover_search(query: &str) -> String {
     let tokens: Vec<String> = query
-        .split_whitespace()
+        .split(|c: char| c.is_whitespace() || c == '-' || c == '_')
         .map(|t| t.to_ascii_lowercase())
         .filter(|t| !t.is_empty())
         .collect();
@@ -1360,7 +1361,7 @@ fn match_score(op: &Operation, tokens: &[String]) -> usize {
         } else if name_parts.iter().any(|p| p.starts_with(token.as_str())) {
             score += 2;
         // Category match
-        } else if cat_lower == *token || cat_lower.starts_with(token.as_str()) {
+        } else if cat_lower == token.as_str() || cat_lower.starts_with(token.as_str()) {
             score += 2;
         // Substring in description
         } else if desc_lower.contains(token.as_str()) {

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -188,7 +188,7 @@ fn tool_definitions() -> Value {
                 "Search the Everruns API catalog to find available operations. ",
                 "Returns matching operations with description and parameters.\n\n",
                 "Available resource types: agents, sessions, harnesses, capabilities, models, ",
-                "providers, mcp-servers, skills, budgets, schedules, files, events, messages, ",
+                "providers, mcp servers, skills, budgets, schedules, files, events, messages, ",
                 "images, organizations, users, databases, storage.\n\n",
                 "Example queries: 'create agent', 'list sessions', 'capabilities', 'mcp'\n\n",
                 "Use `all: true` to list every operation grouped by category.\n\n",
@@ -741,7 +741,7 @@ async fn tool_session_get_status(
 }
 
 // ============================================================================
-// Tier 2: discover — delegates to ScriptedTool's built-in `discover` command
+// Tier 2: discover — searches catalog directly via catalog::discover_all/search
 // ============================================================================
 
 async fn tool_discover(args: &Value) -> Result<String, String> {

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -186,8 +186,12 @@ fn tool_definitions() -> Value {
             "name": "discover",
             "description": concat!(
                 "Search the Everruns API catalog to find available operations. ",
-                "Returns matching API operations with their description, parameters, and usage.\n\n",
-                "Example queries: 'list agents', 'create session', 'events', 'mcp servers', 'models'\n\n",
+                "Returns matching operations with description and parameters.\n\n",
+                "Available resource types: agents, sessions, harnesses, capabilities, models, ",
+                "providers, mcp-servers, skills, budgets, schedules, files, events, messages, ",
+                "images, organizations, users, databases, storage.\n\n",
+                "Example queries: 'create agent', 'list sessions', 'capabilities', 'mcp'\n\n",
+                "Use `all: true` to list every operation grouped by category.\n\n",
                 "The discovered operations are available as bash builtins in the 'execute' tool."
             ),
             "inputSchema": {
@@ -195,10 +199,13 @@ fn tool_definitions() -> Value {
                 "properties": {
                     "query": {
                         "type": "string",
-                        "description": "Search query to find API operations (e.g., 'list agents', 'session events', 'mcp')."
+                        "description": "Search query to find API operations (e.g., 'create agent', 'sessions', 'mcp'). Supports natural language — tokens are matched against names, descriptions, and categories."
+                    },
+                    "all": {
+                        "type": "boolean",
+                        "description": "List all available operations grouped by category. When true, query is ignored."
                     }
-                },
-                "required": ["query"]
+                }
             }
         },
         {
@@ -386,7 +393,7 @@ async fn handle_tools_call(
         "agent_run" => tool_agent_run(&arguments, org, state).await,
         "session_send_message" => tool_session_send_message(&arguments, org, state).await,
         "session_get_status" => tool_session_get_status(&arguments, org, state).await,
-        "discover" => tool_discover(&arguments, org, state, &bearer_token).await,
+        "discover" => tool_discover(&arguments).await,
         "execute" => tool_execute(&arguments, org, state, &bearer_token).await,
         _ => Err(format!("Unknown tool: {tool_name}")),
     };
@@ -737,20 +744,20 @@ async fn tool_session_get_status(
 // Tier 2: discover — delegates to ScriptedTool's built-in `discover` command
 // ============================================================================
 
-async fn tool_discover(
-    args: &Value,
-    org: &ResolvedOrg,
-    state: &AppState,
-    bearer_token: &str,
-) -> Result<String, String> {
-    let query = args
-        .get("query")
-        .and_then(|v| v.as_str())
-        .ok_or("Missing required parameter: query")?;
+async fn tool_discover(args: &Value) -> Result<String, String> {
+    let show_all = args.get("all").and_then(|v| v.as_bool()).unwrap_or(false);
 
-    let tool = build_scripted_tool(org, state, bearer_token);
-    let script = format!("discover --search {}", shell_escape(query));
-    execute_script(&tool, &script, 10_000).await
+    if show_all {
+        return Ok(catalog::discover_all());
+    }
+
+    let query = args.get("query").and_then(|v| v.as_str()).unwrap_or("");
+
+    if query.is_empty() {
+        return Err("Provide a 'query' to search or set 'all: true' to list everything.".into());
+    }
+
+    Ok(catalog::discover_search(query))
 }
 
 // ============================================================================
@@ -767,6 +774,13 @@ async fn tool_execute(
         .get("command")
         .and_then(|v| v.as_str())
         .ok_or("Missing required parameter: command")?;
+
+    // Normalize `discover --all` to bashkit's `discover --categories`.
+    let command = if command.trim() == "discover --all" {
+        "discover --categories"
+    } else {
+        command
+    };
 
     let timeout_ms = args
         .get("timeout_ms")
@@ -826,17 +840,6 @@ async fn execute_script(
             }
         }
         Err(_) => Err(format!("Command timed out after {timeout_ms}ms")),
-    }
-}
-
-/// Simple shell escaping for a single argument.
-fn shell_escape(s: &str) -> String {
-    if s.chars()
-        .all(|c| c.is_alphanumeric() || c == '_' || c == '-' || c == '.')
-    {
-        s.to_string()
-    } else {
-        format!("'{}'", s.replace('\'', "'\\''"))
     }
 }
 

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -575,6 +575,61 @@ async fn test_mcp_discover_missing_query() {
     assert!(tool_is_error(&resp), "Expected error for missing query");
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_discover_all() {
+    let server = TestServer::new().await;
+    let resp = mcp_tool_call(&server, "discover", json!({ "all": true })).await;
+
+    assert!(
+        !tool_is_error(&resp),
+        "discover --all failed: {}",
+        tool_text(&resp)
+    );
+    let text = tool_text(&resp);
+    assert!(text.contains("agents"), "Should list agents category");
+    assert!(text.contains("sessions"), "Should list sessions category");
+    assert!(text.contains("create_agent"), "Should include create_agent");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_discover_fuzzy_search() {
+    let server = TestServer::new().await;
+    // "create agent" should match "create_agent" via token matching
+    let resp = mcp_tool_call(&server, "discover", json!({ "query": "create agent" })).await;
+
+    assert!(
+        !tool_is_error(&resp),
+        "discover fuzzy search failed: {}",
+        tool_text(&resp)
+    );
+    let text = tool_text(&resp);
+    assert!(
+        text.contains("create_agent"),
+        "fuzzy search 'create agent' should find create_agent, got: {text}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_discover_capabilities() {
+    let server = TestServer::new().await;
+    let resp = mcp_tool_call(&server, "discover", json!({ "query": "capabilities" })).await;
+
+    assert!(
+        !tool_is_error(&resp),
+        "discover capabilities failed: {}",
+        tool_text(&resp)
+    );
+    let text = tool_text(&resp);
+    assert!(
+        text.contains("list_capabilities"),
+        "Should find list_capabilities, got: {text}"
+    );
+    assert!(
+        text.contains("get_capability"),
+        "Should find get_capability, got: {text}"
+    );
+}
+
 // ============================================================================
 // Tier 2: execute — requires a real TCP server for HTTP callbacks
 // ============================================================================

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -586,8 +586,14 @@ async fn test_mcp_discover_all() {
         tool_text(&resp)
     );
     let text = tool_text(&resp);
-    assert!(text.contains("agents"), "Should list agents category");
-    assert!(text.contains("sessions"), "Should list sessions category");
+    assert!(
+        text.contains("## agents"),
+        "Should list agents category heading"
+    );
+    assert!(
+        text.contains("## sessions"),
+        "Should list sessions category heading"
+    );
     assert!(text.contains("create_agent"), "Should include create_agent");
 }
 
@@ -915,6 +921,24 @@ async fn test_mcp_execute_discover_categories() {
         stdout.contains("harnesses"),
         "Should list harnesses category"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_execute_discover_all() {
+    let (_server, url) = TestServer::serving().await;
+
+    let resp = mcp_tool_call_http(&url, "execute", json!({ "command": "discover --all" })).await;
+    assert!(
+        !tool_is_error(&resp),
+        "discover --all failed: {}",
+        tool_text(&resp)
+    );
+
+    let result = tool_json(&resp);
+    assert!(result["success"].as_bool().unwrap());
+    let stdout = result["stdout"].as_str().unwrap();
+    assert!(stdout.contains("agents"), "Should list agents category");
+    assert!(stdout.contains("sessions"), "Should list sessions category");
 }
 
 // ============================================================================


### PR DESCRIPTION
## What
Improve the MCP `discover` tool with relaxed fuzzy search, clean plain-text output (no `{stdout, stderr, exit_code}` wrapping), and a new `all` parameter to list the full catalog grouped by category.

## Why
The previous implementation delegated to bashkit's built-in `discover --search`, which had strict matching (e.g. "create agent" wouldn't find `create_agent`), returned bash-shaped output, had no way to list everything, and didn't mention available entity types in its description.

## How
- Implement token-based fuzzy search directly in the server crate against the static CATALOG, matching tokens against operation names (split on `_`), descriptions, and categories
- Score results by match quality (exact name-part > prefix > category > description substring)
- Add `all: boolean` parameter that returns the full catalog grouped by category
- Update tool description to list all available resource types
- Return plain text output directly instead of JSON-wrapping through bashkit
- Normalize `discover --all` to `discover --categories` in the `execute` tool context for consistency
- Remove now-unused `shell_escape` helper

## Risk
- Low
- The discover tool is read-only metadata; no data mutation or auth changes

## Security
- Threat categories reviewed: TM-TOOL, TM-API, TM-DOS
- The change removes a shell-execution path (bashkit `discover --search`) and replaces it with direct Rust iteration over a static array — strictly reduces attack surface
- No user input flows into shell commands anymore
- The `discover --all` normalization in `tool_execute` is a hardcoded string comparison, not injectable
- Catalog is static/fixed-size, so no unbounded allocation risk

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Closes EVE-269