### PR TITLE
feat(api): add url and view_url fields to all resource API responses

### DIFF
--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -21,7 +21,7 @@ use everruns_core::{
 
 use super::common::{
     ApiOptionExt, ApiPolicyResultExt, ApiResult, ErrorResponse, PaginatedResponse, Pagination,
-    impl_auth_state,
+    UrlBuilder, WithUrls, impl_auth_state,
 };
 use super::validation::{
     validate_agent_name_format, validate_create_agent_input, validate_import_file_size,
@@ -433,7 +433,7 @@ pub(crate) fn require_admin_for_high_risk(
     path = "/v1/agents",
     request_body = CreateAgentRequest,
     responses(
-        (status = 201, description = "Agent created successfully", body = Agent),
+        (status = 201, description = "Agent created successfully", body = WithUrls<Agent>),
         (status = 400, description = "Input exceeds allowed limits", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
@@ -443,7 +443,7 @@ pub async fn create_agent(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Json(req): Json<CreateAgentRequest>,
-) -> Result<(StatusCode, Json<Agent>), (StatusCode, Json<ErrorResponse>)> {
+) -> Result<(StatusCode, Json<WithUrls<Agent>>), (StatusCode, Json<ErrorResponse>)> {
     // Validate slug name format
     validate_agent_name_format(&req.name)?;
 
@@ -477,7 +477,8 @@ pub async fn create_agent(
         }
     };
 
-    Ok((StatusCode::CREATED, Json(agent)))
+    let builder = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok((StatusCode::CREATED, Json(builder.wrap(agent))))
 }
 
 /// GET /v1/agents - List all active agents
@@ -486,7 +487,7 @@ pub async fn create_agent(
     path = "/v1/agents",
     params(ListAgentsQuery),
     responses(
-        (status = 200, description = "Paginated list of agents", body = PaginatedResponse<Agent>),
+        (status = 200, description = "Paginated list of agents", body = PaginatedResponse<WithUrls<Agent>>),
         (status = 500, description = "Internal server error")
     ),
     tag = "agents"
@@ -495,7 +496,7 @@ pub async fn list_agents(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListAgentsQuery>,
-) -> ApiResult<PaginatedResponse<Agent>> {
+) -> ApiResult<PaginatedResponse<WithUrls<Agent>>> {
     let offset = query.offset.unwrap_or(0);
     let limit = query.limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT);
     let pagination = Pagination::new(offset, limit);
@@ -512,7 +513,10 @@ pub async fn list_agents(
         .await
         .map_policy_or_internal("list agents")?;
 
-    Ok(Json(PaginatedResponse::new(agents, total, offset, limit)))
+    let builder = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(
+        PaginatedResponse::new(agents, total, offset, limit).with_urls(&builder),
+    ))
 }
 
 /// GET /v1/agents/{agent_id} - Get agent by ID or name
@@ -526,7 +530,7 @@ pub async fn list_agents(
         ("agent_id" = String, Path, description = "Agent ID (prefixed) or name")
     ),
     responses(
-        (status = 200, description = "Agent found", body = Agent),
+        (status = 200, description = "Agent found", body = WithUrls<Agent>),
         (status = 400, description = "Invalid agent ID"),
         (status = 404, description = "Agent not found"),
         (status = 500, description = "Internal server error")
@@ -537,8 +541,9 @@ pub async fn get_agent(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(agent_id_or_name): Path<String>,
-) -> ApiResult<Agent> {
+) -> ApiResult<WithUrls<Agent>> {
     let caller = Caller::from(&org);
+    let builder = UrlBuilder::from_auth_config(&state.auth.config);
 
     // Try parsing as a prefixed ID first; fall back to name lookup.
     if let Ok(agent_id) = agent_id_or_name.parse::<AgentId>() {
@@ -548,7 +553,7 @@ pub async fn get_agent(
             .await
             .map_policy_or_internal("get agent")?
             .ok_or_not_found_json("Agent")?;
-        return Ok(Json(agent));
+        return Ok(Json(builder.wrap(agent)));
     }
 
     let agent = state
@@ -558,7 +563,7 @@ pub async fn get_agent(
         .map_policy_or_internal("get agent by name")?
         .ok_or_not_found_json("Agent")?;
 
-    Ok(Json(agent))
+    Ok(Json(builder.wrap(agent)))
 }
 
 /// PATCH /v1/agents/{agent_id} - Update agent
@@ -570,7 +575,7 @@ pub async fn get_agent(
     ),
     request_body = UpdateAgentRequest,
     responses(
-        (status = 200, description = "Agent updated successfully", body = Agent),
+        (status = 200, description = "Agent updated successfully", body = WithUrls<Agent>),
         (status = 400, description = "Invalid agent ID or input exceeds allowed limits", body = ErrorResponse),
         (status = 404, description = "Agent not found", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
@@ -582,7 +587,7 @@ pub async fn update_agent(
     State(state): State<AppState>,
     Path(agent_id): Path<String>,
     Json(req): Json<UpdateAgentRequest>,
-) -> ApiResult<Agent> {
+) -> ApiResult<WithUrls<Agent>> {
     let agent_id: AgentId = agent_id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -619,7 +624,8 @@ pub async fn update_agent(
         .map_policy_or_internal("update agent")?
         .ok_or_not_found_json("Agent")?;
 
-    Ok(Json(agent))
+    let builder = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(builder.wrap(agent)))
 }
 
 /// DELETE /v1/agents/{agent_id} - Archive agent
@@ -714,7 +720,7 @@ pub async fn destroy_agent(
         ("agent_id" = String, Path, description = "Source agent ID to copy")
     ),
     responses(
-        (status = 201, description = "Agent copied successfully", body = Agent),
+        (status = 201, description = "Agent copied successfully", body = WithUrls<Agent>),
         (status = 400, description = "Invalid agent ID", body = ErrorResponse),
         (status = 404, description = "Source agent not found", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
@@ -725,7 +731,7 @@ pub async fn copy_agent(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(agent_id): Path<String>,
-) -> Result<(StatusCode, Json<Agent>), (StatusCode, Json<ErrorResponse>)> {
+) -> Result<(StatusCode, Json<WithUrls<Agent>>), (StatusCode, Json<ErrorResponse>)> {
     let agent_id: AgentId = agent_id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -743,7 +749,8 @@ pub async fn copy_agent(
         .map_policy_or_internal("copy agent")?
         .ok_or_not_found_json("Agent")?;
 
-    Ok((StatusCode::CREATED, Json(agent)))
+    let builder = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok((StatusCode::CREATED, Json(builder.wrap(agent))))
 }
 
 /// PUT /v1/agents/{agent_id} - Create or update agent (upsert)
@@ -759,8 +766,8 @@ pub async fn copy_agent(
     ),
     request_body = CreateAgentRequest,
     responses(
-        (status = 200, description = "Agent updated", body = Agent),
-        (status = 201, description = "Agent created", body = Agent),
+        (status = 200, description = "Agent updated", body = WithUrls<Agent>),
+        (status = 201, description = "Agent created", body = WithUrls<Agent>),
         (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
@@ -771,7 +778,7 @@ pub async fn upsert_agent(
     State(state): State<AppState>,
     Path(agent_id_or_name): Path<String>,
     Json(req): Json<CreateAgentRequest>,
-) -> Result<(StatusCode, Json<Agent>), (StatusCode, Json<ErrorResponse>)> {
+) -> Result<(StatusCode, Json<WithUrls<Agent>>), (StatusCode, Json<ErrorResponse>)> {
     // Validate name format
     validate_agent_name_format(&req.name)?;
 
@@ -820,7 +827,8 @@ pub async fn upsert_agent(
         StatusCode::OK
     };
 
-    Ok((status, Json(agent)))
+    let builder = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok((status, Json(builder.wrap(agent))))
 }
 
 /// GET /v1/agents/{agent_id}/export - Export agent in Markdown format with YAML front matter
@@ -904,8 +912,8 @@ pub struct ImportAgentQuery {
     params(ImportAgentQuery),
     request_body(content = String, content_type = "text/plain"),
     responses(
-        (status = 200, description = "Agent updated via import", body = Agent),
-        (status = 201, description = "Agent imported successfully", body = Agent),
+        (status = 200, description = "Agent updated via import", body = WithUrls<Agent>),
+        (status = 201, description = "Agent imported successfully", body = WithUrls<Agent>),
         (status = 400, description = "Invalid format or input exceeds limits", body = ErrorResponse),
         (status = 404, description = "Example not found", body = ErrorResponse),
         (status = 403, description = "High-risk capabilities require admin role", body = ErrorResponse),
@@ -918,7 +926,7 @@ pub async fn import_agent(
     State(state): State<AppState>,
     Query(query): Query<ImportAgentQuery>,
     body: String,
-) -> Result<(StatusCode, Json<Agent>), (StatusCode, Json<ErrorResponse>)> {
+) -> Result<(StatusCode, Json<WithUrls<Agent>>), (StatusCode, Json<ErrorResponse>)> {
     // Branch: import from built-in example
     if let Some(name) = query.from_example {
         return import_from_example(org, &state, &name).await;
@@ -933,7 +941,7 @@ async fn import_from_example(
     org: ResolvedOrg,
     state: &AppState,
     name: &str,
-) -> Result<(StatusCode, Json<Agent>), (StatusCode, Json<ErrorResponse>)> {
+) -> Result<(StatusCode, Json<WithUrls<Agent>>), (StatusCode, Json<ErrorResponse>)> {
     use crate::seed::SEED_AGENTS;
 
     let seed = SEED_AGENTS
@@ -1032,7 +1040,8 @@ async fn import_from_example(
         .await
         .map_policy_or_internal("import agent from example")?;
 
-    Ok((StatusCode::CREATED, Json(agent)))
+    let builder = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok((StatusCode::CREATED, Json(builder.wrap(agent))))
 }
 
 /// Import an agent from a file body (Markdown/YAML/JSON).
@@ -1040,7 +1049,7 @@ async fn import_from_file(
     org: ResolvedOrg,
     state: &AppState,
     body: String,
-) -> Result<(StatusCode, Json<Agent>), (StatusCode, Json<ErrorResponse>)> {
+) -> Result<(StatusCode, Json<WithUrls<Agent>>), (StatusCode, Json<ErrorResponse>)> {
     // Validate import file size (last-resort protection against abuse)
     validate_import_file_size(body.len())?;
 
@@ -1121,6 +1130,8 @@ async fn import_from_file(
 
     let caller = Caller::from(&org);
 
+    let builder = UrlBuilder::from_auth_config(&state.auth.config);
+
     // If the file has an ID, upsert (create or update). Otherwise, always create.
     if let Some(ref id) = client_id {
         let (agent, was_created) = state
@@ -1135,7 +1146,7 @@ async fn import_from_file(
             StatusCode::OK
         };
 
-        Ok((status, Json(agent)))
+        Ok((status, Json(builder.wrap(agent))))
     } else {
         let agent = state
             .service
@@ -1146,7 +1157,7 @@ async fn import_from_file(
                 ErrorResponse::internal_error()
             })?;
 
-        Ok((StatusCode::CREATED, Json(agent)))
+        Ok((StatusCode::CREATED, Json(builder.wrap(agent))))
     }
 }
 

--- a/crates/server/src/api/apps.rs
+++ b/crates/server/src/api/apps.rs
@@ -17,7 +17,7 @@ use everruns_core::{
 };
 
 use super::common::{
-    ApiOptionExt, ApiPolicyResultExt, ApiResult, ErrorResponse, ListResponse,
+    ApiOptionExt, ApiPolicyResultExt, ApiResult, ErrorResponse, ListResponse, UrlBuilder, WithUrls,
     deserialize_nullable_update_field, impl_auth_state,
 };
 use everruns_durable::UpdateField;
@@ -187,7 +187,7 @@ pub async fn app_config(
     path = "/v1/apps",
     request_body = CreateAppRequest,
     responses(
-        (status = 201, description = "App created successfully", body = App),
+        (status = 201, description = "App created successfully", body = WithUrls<App>),
         (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
@@ -197,7 +197,7 @@ pub async fn create_app(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Json(req): Json<CreateAppRequest>,
-) -> Result<(StatusCode, Json<App>), (StatusCode, Json<ErrorResponse>)> {
+) -> Result<(StatusCode, Json<WithUrls<App>>), (StatusCode, Json<ErrorResponse>)> {
     let caller = Caller::from(&org);
     let app = state
         .service
@@ -205,7 +205,8 @@ pub async fn create_app(
         .await
         .map_policy_or_internal("create app")?;
 
-    Ok((StatusCode::CREATED, Json(app)))
+    let builder = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok((StatusCode::CREATED, Json(builder.wrap(app))))
 }
 
 /// GET /v1/apps - List all non-archived apps
@@ -213,7 +214,7 @@ pub async fn create_app(
     get,
     path = "/v1/apps",
     responses(
-        (status = 200, description = "List of apps", body = ListResponse<App>),
+        (status = 200, description = "List of apps", body = ListResponse<WithUrls<App>>),
         (status = 500, description = "Internal server error")
     ),
     params(ListAppsQuery),
@@ -223,7 +224,7 @@ pub async fn list_apps(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListAppsQuery>,
-) -> ApiResult<ListResponse<App>> {
+) -> ApiResult<ListResponse<WithUrls<App>>> {
     let caller = Caller::from(&org);
     let apps = state
         .service
@@ -235,7 +236,8 @@ pub async fn list_apps(
         .await
         .map_policy_or_internal("list apps")?;
 
-    Ok(Json(ListResponse::new(apps)))
+    let builder = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(ListResponse::new(apps).with_urls(&builder)))
 }
 
 /// GET /v1/apps/{app_id} - Get app by ID
@@ -244,7 +246,7 @@ pub async fn list_apps(
     path = "/v1/apps/{app_id}",
     params(("app_id" = String, Path, description = "App ID")),
     responses(
-        (status = 200, description = "App found", body = App),
+        (status = 200, description = "App found", body = WithUrls<App>),
         (status = 400, description = "Invalid app ID"),
         (status = 404, description = "App not found"),
         (status = 500, description = "Internal server error")
@@ -255,7 +257,7 @@ pub async fn get_app(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(app_id): Path<String>,
-) -> ApiResult<App> {
+) -> ApiResult<WithUrls<App>> {
     let app_id: AppId = app_id.parse().map_err(|e| {
         ErrorResponse::new(format!("Invalid app ID: {}", e)).into_response(StatusCode::BAD_REQUEST)
     })?;
@@ -268,7 +270,8 @@ pub async fn get_app(
         .map_policy_or_internal("get app")?
         .ok_or_not_found_json("App")?;
 
-    Ok(Json(app))
+    let builder = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(builder.wrap(app)))
 }
 
 /// PATCH /v1/apps/{app_id} - Update app
@@ -278,7 +281,7 @@ pub async fn get_app(
     params(("app_id" = String, Path, description = "App ID")),
     request_body = UpdateAppRequest,
     responses(
-        (status = 200, description = "App updated successfully", body = App),
+        (status = 200, description = "App updated successfully", body = WithUrls<App>),
         (status = 400, description = "Invalid app ID or input", body = ErrorResponse),
         (status = 404, description = "App not found", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
@@ -290,7 +293,7 @@ pub async fn update_app(
     State(state): State<AppState>,
     Path(app_id): Path<String>,
     Json(req): Json<UpdateAppRequest>,
-) -> ApiResult<App> {
+) -> ApiResult<WithUrls<App>> {
     let app_id: AppId = app_id.parse().map_err(|e| {
         ErrorResponse::new(format!("Invalid app ID: {}", e)).into_response(StatusCode::BAD_REQUEST)
     })?;
@@ -303,7 +306,8 @@ pub async fn update_app(
         .map_policy_or_internal("update app")?
         .ok_or_not_found_json("App")?;
 
-    Ok(Json(app))
+    let builder = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(builder.wrap(app)))
 }
 
 /// DELETE /v1/apps/{app_id} - Archive app
@@ -371,7 +375,7 @@ pub async fn destroy_app(
     path = "/v1/apps/{app_id}/publish",
     params(("app_id" = String, Path, description = "App ID")),
     responses(
-        (status = 200, description = "App published", body = App),
+        (status = 200, description = "App published", body = WithUrls<App>),
         (status = 400, description = "Invalid app ID"),
         (status = 404, description = "App not found"),
         (status = 500, description = "Internal server error")
@@ -382,7 +386,7 @@ pub async fn publish_app(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(app_id): Path<String>,
-) -> ApiResult<App> {
+) -> ApiResult<WithUrls<App>> {
     let app_id: AppId = app_id.parse().map_err(|e| {
         ErrorResponse::new(format!("Invalid app ID: {}", e)).into_response(StatusCode::BAD_REQUEST)
     })?;
@@ -395,7 +399,8 @@ pub async fn publish_app(
         .map_policy_or_internal("publish app")?
         .ok_or_not_found_json("App")?;
 
-    Ok(Json(app))
+    let builder = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(builder.wrap(app)))
 }
 
 /// POST /v1/apps/{app_id}/unpublish - Unpublish app (stop accepting requests)
@@ -404,7 +409,7 @@ pub async fn publish_app(
     path = "/v1/apps/{app_id}/unpublish",
     params(("app_id" = String, Path, description = "App ID")),
     responses(
-        (status = 200, description = "App unpublished", body = App),
+        (status = 200, description = "App unpublished", body = WithUrls<App>),
         (status = 400, description = "Invalid app ID"),
         (status = 404, description = "App not found"),
         (status = 500, description = "Internal server error")
@@ -415,7 +420,7 @@ pub async fn unpublish_app(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(app_id): Path<String>,
-) -> ApiResult<App> {
+) -> ApiResult<WithUrls<App>> {
     let app_id: AppId = app_id.parse().map_err(|e| {
         ErrorResponse::new(format!("Invalid app ID: {}", e)).into_response(StatusCode::BAD_REQUEST)
     })?;
@@ -428,7 +433,8 @@ pub async fn unpublish_app(
         .map_policy_or_internal("unpublish app")?
         .ok_or_not_found_json("App")?;
 
-    Ok(Json(app))
+    let builder = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(builder.wrap(app)))
 }
 
 // ============================================

--- a/crates/server/src/api/budgets.rs
+++ b/crates/server/src/api/budgets.rs
@@ -17,7 +17,7 @@ use serde::Deserialize;
 use std::sync::Arc;
 use utoipa::{IntoParams, ToSchema};
 
-use super::common::{ErrorResponse, impl_auth_state};
+use super::common::{ErrorResponse, UrlBuilder, WithUrls, impl_auth_state};
 
 type ApiError = (StatusCode, Json<ErrorResponse>);
 
@@ -159,7 +159,7 @@ async fn create_budget(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Json(req): Json<CreateBudgetRequest>,
-) -> Result<(StatusCode, Json<Budget>), ApiError> {
+) -> Result<(StatusCode, Json<WithUrls<Budget>>), ApiError> {
     if !["session", "agent", "user", "org"].contains(&req.subject_type.as_str()) {
         return Err(err(StatusCode::BAD_REQUEST, "Invalid subject_type"));
     }
@@ -185,9 +185,10 @@ async fn create_budget(
         metadata: req.metadata,
     };
     let row = state.db.create_budget(input).await.map_err(internal)?;
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
     Ok((
         StatusCode::CREATED,
-        Json(BudgetService::row_to_budget(&row)),
+        Json(urls.wrap(BudgetService::row_to_budget(&row))),
     ))
 }
 
@@ -195,7 +196,7 @@ async fn get_budget(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(budget_id): Path<String>,
-) -> Result<Json<Budget>, ApiError> {
+) -> Result<Json<WithUrls<Budget>>, ApiError> {
     let id = parse_budget_id(&budget_id)?;
     let row = state
         .db
@@ -203,14 +204,15 @@ async fn get_budget(
         .await
         .map_err(internal)?
         .ok_or_else(|| not_found("Budget"))?;
-    Ok(Json(BudgetService::row_to_budget(&row)))
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(urls.wrap(BudgetService::row_to_budget(&row))))
 }
 
 async fn list_budgets(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListBudgetsQuery>,
-) -> Result<Json<Vec<Budget>>, ApiError> {
+) -> Result<Json<Vec<WithUrls<Budget>>>, ApiError> {
     let rows = state
         .db
         .list_budgets(
@@ -220,9 +222,9 @@ async fn list_budgets(
         )
         .await
         .map_err(internal)?;
-    Ok(Json(
-        rows.iter().map(BudgetService::row_to_budget).collect(),
-    ))
+    let budgets: Vec<Budget> = rows.iter().map(BudgetService::row_to_budget).collect();
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(urls.wrap_vec(budgets)))
 }
 
 async fn update_budget(
@@ -230,7 +232,7 @@ async fn update_budget(
     State(state): State<AppState>,
     Path(budget_id): Path<String>,
     Json(req): Json<UpdateBudgetRequest>,
-) -> Result<Json<Budget>, ApiError> {
+) -> Result<Json<WithUrls<Budget>>, ApiError> {
     let id = parse_budget_id(&budget_id)?;
     let input = UpdateBudgetRow {
         limit: req.limit,
@@ -244,7 +246,8 @@ async fn update_budget(
         .await
         .map_err(internal)?
         .ok_or_else(|| not_found("Budget"))?;
-    Ok(Json(BudgetService::row_to_budget(&row)))
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(urls.wrap(BudgetService::row_to_budget(&row))))
 }
 
 async fn delete_budget(
@@ -270,7 +273,7 @@ async fn top_up(
     State(state): State<AppState>,
     Path(budget_id): Path<String>,
     Json(req): Json<TopUpRequest>,
-) -> Result<Json<Budget>, ApiError> {
+) -> Result<Json<WithUrls<Budget>>, ApiError> {
     if req.amount <= 0.0 {
         return Err(err(StatusCode::BAD_REQUEST, "Amount must be positive"));
     }
@@ -309,7 +312,8 @@ async fn top_up(
         .await
         .map_err(internal)?
         .unwrap();
-    Ok(Json(BudgetService::row_to_budget(&row)))
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(urls.wrap(BudgetService::row_to_budget(&row))))
 }
 
 async fn list_ledger(
@@ -370,15 +374,15 @@ async fn list_session_budgets(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(session_id): Path<String>,
-) -> Result<Json<Vec<Budget>>, ApiError> {
+) -> Result<Json<Vec<WithUrls<Budget>>>, ApiError> {
     let rows = state
         .db
         .list_budgets(org.org_id, Some("session"), Some(&session_id))
         .await
         .map_err(internal)?;
-    Ok(Json(
-        rows.iter().map(BudgetService::row_to_budget).collect(),
-    ))
+    let budgets: Vec<Budget> = rows.iter().map(BudgetService::row_to_budget).collect();
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(urls.wrap_vec(budgets)))
 }
 
 async fn check_session_budgets(

--- a/crates/server/src/api/capabilities.rs
+++ b/crates/server/src/api/capabilities.rs
@@ -17,7 +17,7 @@ use axum::{
 use everruns_core::{CapabilityId, CapabilityInfo};
 use serde::Deserialize;
 
-use super::common::{PaginatedResponse, impl_auth_state};
+use super::common::{PaginatedResponse, UrlBuilder, WithUrls, impl_auth_state};
 use std::sync::Arc;
 
 use crate::services::CapabilityService;
@@ -66,7 +66,7 @@ pub struct ListCapabilitiesQuery {
         ("limit" = Option<u32>, Query, description = "Page size (default: 20, max: 100)"),
     ),
     responses(
-        (status = 200, description = "Paginated list of capabilities", body = PaginatedResponse<CapabilityInfo>),
+        (status = 200, description = "Paginated list of capabilities", body = PaginatedResponse<WithUrls<CapabilityInfo>>),
     ),
     tag = "capabilities"
 )]
@@ -74,7 +74,7 @@ pub async fn list_capabilities(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListCapabilitiesQuery>,
-) -> Result<Json<PaginatedResponse<CapabilityInfo>>, StatusCode> {
+) -> Result<Json<PaginatedResponse<WithUrls<CapabilityInfo>>>, StatusCode> {
     let mut capabilities = state.service.list_all(org.org_id).await.map_err(|e| {
         tracing::error!("Failed to list capabilities: {}", e);
         StatusCode::INTERNAL_SERVER_ERROR
@@ -95,7 +95,10 @@ pub async fn list_capabilities(
         .take(limit as usize)
         .collect();
 
-    Ok(Json(PaginatedResponse::new(data, total, offset, limit)))
+    let builder = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(
+        PaginatedResponse::new(data, total, offset, limit).with_urls(&builder),
+    ))
 }
 
 /// GET /v1/capabilities/{capability_id} - Get a specific capability
@@ -106,7 +109,7 @@ pub async fn list_capabilities(
         ("capability_id" = String, Path, description = "Capability ID")
     ),
     responses(
-        (status = 200, description = "Capability found", body = CapabilityInfo),
+        (status = 200, description = "Capability found", body = WithUrls<CapabilityInfo>),
         (status = 404, description = "Capability not found"),
     ),
     tag = "capabilities"
@@ -115,7 +118,7 @@ pub async fn get_capability(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(capability_id): Path<String>,
-) -> Result<Json<CapabilityInfo>, StatusCode> {
+) -> Result<Json<WithUrls<CapabilityInfo>>, StatusCode> {
     let cap_id = CapabilityId::new(&capability_id);
 
     let capability = state
@@ -128,5 +131,6 @@ pub async fn get_capability(
         })?
         .ok_or(StatusCode::NOT_FOUND)?;
 
-    Ok(Json(capability))
+    let builder = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(builder.wrap(capability)))
 }

--- a/crates/server/src/api/common.rs
+++ b/crates/server/src/api/common.rs
@@ -336,6 +336,158 @@ impl Pagination {
     }
 }
 
+// ============================================================================
+// Resource URL enrichment
+// ============================================================================
+
+/// Builds absolute `url` (API) and `view_url` (UI) for resources.
+#[derive(Debug, Clone)]
+pub struct UrlBuilder {
+    api_base: String,
+    ui_base: String,
+}
+
+impl UrlBuilder {
+    pub fn new(api_base: &str, ui_base: &str) -> Self {
+        Self {
+            api_base: api_base.trim_end_matches('/').to_string(),
+            ui_base: ui_base.trim_end_matches('/').to_string(),
+        }
+    }
+
+    /// Create from an `AuthConfig`.
+    pub fn from_auth_config(config: &crate::auth::config::AuthConfig) -> Self {
+        Self::new(&config.base_url, &config.frontend_url)
+    }
+
+    /// Wrap a single resource with `url` and `view_url`.
+    pub fn wrap<T: ResourceUrlable + Serialize>(&self, item: T) -> WithUrls<T> {
+        let id = item.resource_id();
+        let api_path = T::api_path();
+        let ui_path = T::ui_path();
+        WithUrls {
+            url: format!("{}/{}/{}", self.api_base, api_path, id),
+            view_url: format!("{}/{}/{}", self.ui_base, ui_path, id),
+            inner: item,
+        }
+    }
+
+    /// Wrap a vec of resources.
+    pub fn wrap_vec<T: ResourceUrlable + Serialize>(&self, items: Vec<T>) -> Vec<WithUrls<T>> {
+        items.into_iter().map(|item| self.wrap(item)).collect()
+    }
+}
+
+/// Trait for resources that can have `url` and `view_url` generated.
+pub trait ResourceUrlable {
+    /// API path segment (e.g. `"v1/agents"`).
+    fn api_path() -> &'static str;
+    /// UI path segment (e.g. `"agents"`).
+    fn ui_path() -> &'static str;
+    /// The resource's public ID as a string.
+    fn resource_id(&self) -> String;
+}
+
+/// Wrapper that adds `url` and `view_url` to a serialized resource.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct WithUrls<T: Serialize> {
+    /// Full API endpoint URL for this resource.
+    pub url: String,
+    /// Full UI URL for viewing this resource.
+    pub view_url: String,
+    /// The resource itself (fields are flattened into the parent object).
+    #[serde(flatten)]
+    pub inner: T,
+}
+
+impl<T: ResourceUrlable + Serialize> PaginatedResponse<T> {
+    /// Map all items through `UrlBuilder::wrap`.
+    pub fn with_urls(self, builder: &UrlBuilder) -> PaginatedResponse<WithUrls<T>> {
+        PaginatedResponse {
+            data: builder.wrap_vec(self.data),
+            total: self.total,
+            offset: self.offset,
+            limit: self.limit,
+        }
+    }
+}
+
+impl<T: ResourceUrlable + Serialize> ListResponse<T> {
+    /// Map all items through `UrlBuilder::wrap`.
+    pub fn with_urls(self, builder: &UrlBuilder) -> ListResponse<WithUrls<T>> {
+        ListResponse {
+            data: builder.wrap_vec(self.data),
+        }
+    }
+}
+
+// ── ResourceUrlable implementations ──────────────────────────────────────────
+
+macro_rules! impl_resource_urlable {
+    ($ty:ty, $api:expr, $ui:expr, $id_field:ident) => {
+        impl ResourceUrlable for $ty {
+            fn api_path() -> &'static str {
+                $api
+            }
+            fn ui_path() -> &'static str {
+                $ui
+            }
+            fn resource_id(&self) -> String {
+                self.$id_field.to_string()
+            }
+        }
+    };
+}
+
+impl_resource_urlable!(everruns_core::Agent, "v1/agents", "agents", public_id);
+impl_resource_urlable!(everruns_core::Session, "v1/sessions", "sessions", id);
+impl_resource_urlable!(everruns_core::Harness, "v1/harnesses", "harnesses", id);
+impl_resource_urlable!(everruns_core::Skill, "v1/skills", "skills", id);
+impl_resource_urlable!(everruns_core::budget::Budget, "v1/budgets", "budgets", id);
+impl_resource_urlable!(
+    everruns_core::McpServer,
+    "v1/mcp-servers",
+    "mcp-servers",
+    id
+);
+impl_resource_urlable!(everruns_core::App, "v1/apps", "apps", public_id);
+impl_resource_urlable!(
+    everruns_core::llm_models::LlmProvider,
+    "v1/llm-providers",
+    "llm-providers",
+    id
+);
+impl_resource_urlable!(
+    everruns_core::llm_models::LlmModel,
+    "v1/llm-models",
+    "llm-models",
+    id
+);
+impl_resource_urlable!(
+    everruns_core::LlmModelWithProvider,
+    "v1/llm-models",
+    "llm-models",
+    id
+);
+impl_resource_urlable!(
+    everruns_core::session_schedule::SessionSchedule,
+    "v1/schedules",
+    "durable/schedules",
+    id
+);
+
+impl ResourceUrlable for everruns_core::CapabilityInfo {
+    fn api_path() -> &'static str {
+        "v1/capabilities"
+    }
+    fn ui_path() -> &'static str {
+        "capabilities"
+    }
+    fn resource_id(&self) -> String {
+        self.id.to_string()
+    }
+}
+
 /// Verify that a session belongs to the caller's organization.
 ///
 /// Returns Ok(()) if the session exists under org_id, or a 404 (StatusCode only)

--- a/crates/server/src/api/common.rs
+++ b/crates/server/src/api/common.rs
@@ -360,13 +360,13 @@ impl UrlBuilder {
         Self::new(&config.base_url, &config.frontend_url)
     }
 
-    /// Wrap a single resource with `url` and `view_url`.
+    /// Wrap a single resource with `self_url` and `view_url`.
     pub fn wrap<T: ResourceUrlable + Serialize>(&self, item: T) -> WithUrls<T> {
         let id = item.resource_id();
         let api_path = T::api_path();
         let ui_path = T::ui_path();
         WithUrls {
-            url: format!("{}/{}/{}", self.api_base, api_path, id),
+            self_url: format!("{}/{}/{}", self.api_base, api_path, id),
             view_url: format!("{}/{}/{}", self.ui_base, ui_path, id),
             inner: item,
         }
@@ -388,11 +388,14 @@ pub trait ResourceUrlable {
     fn resource_id(&self) -> String;
 }
 
-/// Wrapper that adds `url` and `view_url` to a serialized resource.
+/// Wrapper that adds `self_url` and `view_url` to a serialized resource.
+///
+/// Uses `self_url` (not `url`) for the API link to avoid collision with
+/// resources that already have a `url` field (e.g. McpServer).
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct WithUrls<T: Serialize> {
     /// Full API endpoint URL for this resource.
-    pub url: String,
+    pub self_url: String,
     /// Full UI URL for viewing this resource.
     pub view_url: String,
     /// The resource itself (fields are flattened into the parent object).
@@ -469,12 +472,17 @@ impl_resource_urlable!(
     "llm-models",
     id
 );
-impl_resource_urlable!(
-    everruns_core::session_schedule::SessionSchedule,
-    "v1/schedules",
-    "durable/schedules",
-    id
-);
+impl ResourceUrlable for everruns_core::session_schedule::SessionSchedule {
+    fn api_path() -> &'static str {
+        "v1/sessions"
+    }
+    fn ui_path() -> &'static str {
+        "sessions"
+    }
+    fn resource_id(&self) -> String {
+        format!("{}/schedules/{}", self.session_id, self.id)
+    }
+}
 
 impl ResourceUrlable for everruns_core::CapabilityInfo {
     fn api_path() -> &'static str {

--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -20,7 +20,8 @@ use everruns_core::{
 };
 
 use super::common::{
-    ApiOptionExt, ApiPolicyResultExt, ApiResult, ErrorResponse, ListResponse, impl_auth_state,
+    ApiOptionExt, ApiPolicyResultExt, ApiResult, ErrorResponse, ListResponse, UrlBuilder, WithUrls,
+    impl_auth_state,
 };
 use super::validation::{
     validate_create_agent_input, validate_harness_name_strict, validate_update_agent_input,
@@ -275,7 +276,7 @@ pub async fn check_harness_name(
     path = "/v1/harnesses",
     request_body = CreateHarnessRequest,
     responses(
-        (status = 201, description = "Harness created", body = Harness),
+        (status = 201, description = "Harness created", body = WithUrls<Harness>),
         (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 403, description = "Forbidden", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
@@ -286,7 +287,7 @@ pub async fn create_harness(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Json(req): Json<CreateHarnessRequest>,
-) -> Result<(StatusCode, Json<Harness>), (StatusCode, Json<ErrorResponse>)> {
+) -> Result<(StatusCode, Json<WithUrls<Harness>>), (StatusCode, Json<ErrorResponse>)> {
     validate_harness_name_strict(&req.name)?;
     // Reuse agent validation for display_name and other fields
     validate_create_agent_input(
@@ -305,7 +306,8 @@ pub async fn create_harness(
         .await
         .map_policy_or_internal("create harness")?;
 
-    Ok((StatusCode::CREATED, Json(harness)))
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok((StatusCode::CREATED, Json(urls.wrap(harness))))
 }
 
 /// GET /v1/harnesses
@@ -313,7 +315,7 @@ pub async fn create_harness(
     get,
     path = "/v1/harnesses",
     responses(
-        (status = 200, description = "List of harnesses", body = ListResponse<Harness>),
+        (status = 200, description = "List of harnesses", body = ListResponse<WithUrls<Harness>>),
         (status = 403, description = "Forbidden"),
         (status = 500, description = "Internal server error")
     ),
@@ -324,7 +326,7 @@ pub async fn list_harnesses(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListHarnessesQuery>,
-) -> ApiResult<ListResponse<Harness>> {
+) -> ApiResult<ListResponse<WithUrls<Harness>>> {
     let caller = Caller::from(&org);
     let harnesses = state
         .service
@@ -336,7 +338,8 @@ pub async fn list_harnesses(
         .await
         .map_policy_or_internal("list harnesses")?;
 
-    Ok(Json(ListResponse::new(harnesses)))
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(ListResponse::new(harnesses).with_urls(&urls)))
 }
 
 /// GET /v1/harnesses/{harness_id}
@@ -351,7 +354,7 @@ pub async fn list_harnesses(
         ("harness_id" = String, Path, description = "Harness ID (prefixed) or name")
     ),
     responses(
-        (status = 200, description = "Harness found", body = Harness),
+        (status = 200, description = "Harness found", body = WithUrls<Harness>),
         (status = 403, description = "Forbidden"),
         (status = 404, description = "Harness not found"),
         (status = 500, description = "Internal server error")
@@ -362,8 +365,9 @@ pub async fn get_harness(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(harness_id_or_name): Path<String>,
-) -> ApiResult<Harness> {
+) -> ApiResult<WithUrls<Harness>> {
     let caller = Caller::from(&org);
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
 
     // Try parsing as a prefixed ID first; fall back to name lookup.
     if let Ok(harness_id) = harness_id_or_name.parse::<HarnessId>() {
@@ -373,7 +377,7 @@ pub async fn get_harness(
             .await
             .map_policy_or_internal("get harness")?
             .ok_or_not_found_json("Harness")?;
-        return Ok(Json(harness));
+        return Ok(Json(urls.wrap(harness)));
     }
 
     let harness = state
@@ -383,7 +387,7 @@ pub async fn get_harness(
         .map_policy_or_internal("get harness by name")?
         .ok_or_not_found_json("Harness")?;
 
-    Ok(Json(harness))
+    Ok(Json(urls.wrap(harness)))
 }
 
 /// PATCH /v1/harnesses/{harness_id}
@@ -395,7 +399,7 @@ pub async fn get_harness(
     ),
     request_body = UpdateHarnessRequest,
     responses(
-        (status = 200, description = "Harness updated", body = Harness),
+        (status = 200, description = "Harness updated", body = WithUrls<Harness>),
         (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 403, description = "Forbidden", body = ErrorResponse),
         (status = 404, description = "Harness not found", body = ErrorResponse),
@@ -408,7 +412,7 @@ pub async fn update_harness(
     State(state): State<AppState>,
     Path(harness_id): Path<String>,
     Json(req): Json<UpdateHarnessRequest>,
-) -> ApiResult<Harness> {
+) -> ApiResult<WithUrls<Harness>> {
     let harness_id: HarnessId = harness_id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -438,7 +442,8 @@ pub async fn update_harness(
         .map_policy_or_internal("update harness")?
         .ok_or_not_found_json("Harness")?;
 
-    Ok(Json(harness))
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(urls.wrap(harness)))
 }
 
 /// DELETE /v1/harnesses/{harness_id}
@@ -534,7 +539,7 @@ pub async fn destroy_harness(
         ("harness_id" = String, Path, description = "Source harness ID to copy")
     ),
     responses(
-        (status = 201, description = "Harness copied successfully", body = Harness),
+        (status = 201, description = "Harness copied successfully", body = WithUrls<Harness>),
         (status = 400, description = "Invalid harness ID", body = ErrorResponse),
         (status = 403, description = "Forbidden", body = ErrorResponse),
         (status = 404, description = "Source harness not found", body = ErrorResponse),
@@ -546,7 +551,7 @@ pub async fn copy_harness(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(harness_id): Path<String>,
-) -> Result<(StatusCode, Json<Harness>), (StatusCode, Json<ErrorResponse>)> {
+) -> Result<(StatusCode, Json<WithUrls<Harness>>), (StatusCode, Json<ErrorResponse>)> {
     let harness_id: HarnessId = harness_id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -564,7 +569,8 @@ pub async fn copy_harness(
         .map_policy_or_internal("copy harness")?
         .ok_or_not_found_json("Harness")?;
 
-    Ok((StatusCode::CREATED, Json(harness)))
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok((StatusCode::CREATED, Json(urls.wrap(harness))))
 }
 
 /// POST /v1/harnesses/preview

--- a/crates/server/src/api/llm_models.rs
+++ b/crates/server/src/api/llm_models.rs
@@ -2,7 +2,8 @@
 // Routes: /v1/llm-providers/:provider_id/models/... and /v1/llm-models/...
 
 use crate::api::common::{
-    ApiOptionExt, ApiPolicyResultExt, ApiResult, ErrorResponse, ListResponse, impl_auth_state,
+    ApiOptionExt, ApiPolicyResultExt, ApiResult, ErrorResponse, ListResponse, UrlBuilder, WithUrls,
+    impl_auth_state,
 };
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::services::llm_model::{LLM_MODEL_MANAGE, LLM_MODEL_VIEW};
@@ -127,7 +128,7 @@ pub struct UpdateLlmModelRequest {
     ),
     request_body = CreateLlmModelRequest,
     responses(
-        (status = 201, description = "Model created", body = LlmModel),
+        (status = 201, description = "Model created", body = WithUrls<LlmModel>),
         (status = 400, description = "Invalid provider ID"),
         (status = 404, description = "Provider not found"),
         (status = 500, description = "Internal error")
@@ -139,7 +140,7 @@ pub async fn create_model(
     State(state): State<AppState>,
     Path(provider_id): Path<String>,
     Json(req): Json<CreateLlmModelRequest>,
-) -> Result<(StatusCode, Json<LlmModel>), (StatusCode, Json<ErrorResponse>)> {
+) -> Result<(StatusCode, Json<WithUrls<LlmModel>>), (StatusCode, Json<ErrorResponse>)> {
     let provider_id: ProviderId = provider_id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -156,7 +157,8 @@ pub async fn create_model(
         .await
         .map_policy_or_internal("create LLM model")?;
 
-    Ok((StatusCode::CREATED, Json(model)))
+    let builder = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok((StatusCode::CREATED, Json(builder.wrap(model))))
 }
 
 /// List models for a specific provider
@@ -167,7 +169,7 @@ pub async fn create_model(
         ("provider_id" = String, Path, description = "Provider ID (prefixed, e.g., prov_...)")
     ),
     responses(
-        (status = 200, description = "List of models", body = ListResponse<LlmModel>),
+        (status = 200, description = "List of models", body = ListResponse<WithUrls<LlmModel>>),
         (status = 400, description = "Invalid provider ID")
     ),
     tag = "llm-models"
@@ -176,7 +178,7 @@ pub async fn list_provider_models(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(provider_id): Path<String>,
-) -> ApiResult<ListResponse<LlmModel>> {
+) -> ApiResult<ListResponse<WithUrls<LlmModel>>> {
     let provider_id: ProviderId = provider_id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -193,7 +195,8 @@ pub async fn list_provider_models(
         .await
         .map_policy_or_internal("list LLM models for provider")?;
 
-    Ok(Json(ListResponse::new(models)))
+    let builder = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(ListResponse::new(models).with_urls(&builder)))
 }
 
 /// List all models across all providers
@@ -204,7 +207,7 @@ pub async fn list_provider_models(
         ListModelsQuery
     ),
     responses(
-        (status = 200, description = "List of all models", body = ListResponse<LlmModelWithProvider>)
+        (status = 200, description = "List of all models", body = ListResponse<WithUrls<LlmModelWithProvider>>)
     ),
     tag = "llm-models"
 )]
@@ -212,7 +215,7 @@ pub async fn list_all_models(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListModelsQuery>,
-) -> ApiResult<ListResponse<LlmModelWithProvider>> {
+) -> ApiResult<ListResponse<WithUrls<LlmModelWithProvider>>> {
     let caller = Caller::from(&org);
     let models = state
         .service
@@ -225,7 +228,8 @@ pub async fn list_all_models(
         .await
         .map_policy_or_internal("list all LLM models")?;
 
-    Ok(Json(ListResponse::new(models)))
+    let builder = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(ListResponse::new(models).with_urls(&builder)))
 }
 
 /// Get a specific model with provider info and profile
@@ -236,7 +240,7 @@ pub async fn list_all_models(
         ("id" = String, Path, description = "Model ID (prefixed, e.g., mod_...)")
     ),
     responses(
-        (status = 200, description = "Model found", body = LlmModelWithProvider),
+        (status = 200, description = "Model found", body = WithUrls<LlmModelWithProvider>),
         (status = 400, description = "Invalid model ID"),
         (status = 404, description = "Model not found")
     ),
@@ -246,7 +250,7 @@ pub async fn get_model(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(id): Path<String>,
-) -> ApiResult<LlmModelWithProvider> {
+) -> ApiResult<WithUrls<LlmModelWithProvider>> {
     let model_id: ModelId = id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -264,7 +268,8 @@ pub async fn get_model(
         .map_policy_or_internal("get LLM model")?
         .ok_or_not_found_json("Model")?;
 
-    Ok(Json(model))
+    let builder = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(builder.wrap(model)))
 }
 
 /// Update a model
@@ -276,7 +281,7 @@ pub async fn get_model(
     ),
     request_body = UpdateLlmModelRequest,
     responses(
-        (status = 200, description = "Model updated", body = LlmModel),
+        (status = 200, description = "Model updated", body = WithUrls<LlmModel>),
         (status = 400, description = "Invalid model ID"),
         (status = 404, description = "Model not found")
     ),
@@ -287,7 +292,7 @@ pub async fn update_model(
     State(state): State<AppState>,
     Path(id): Path<String>,
     Json(req): Json<UpdateLlmModelRequest>,
-) -> ApiResult<LlmModel> {
+) -> ApiResult<WithUrls<LlmModel>> {
     let model_id: ModelId = id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -305,7 +310,8 @@ pub async fn update_model(
         .map_policy_or_internal("update LLM model")?
         .ok_or_not_found_json("Model")?;
 
-    Ok(Json(model))
+    let builder = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(builder.wrap(model)))
 }
 
 /// Delete a model

--- a/crates/server/src/api/llm_providers.rs
+++ b/crates/server/src/api/llm_providers.rs
@@ -22,7 +22,8 @@ use std::sync::Arc;
 use utoipa::ToSchema;
 
 use super::common::{
-    ApiOptionExt, ApiPolicyResultExt, ApiResult, ErrorResponse, ListResponse, impl_auth_state,
+    ApiOptionExt, ApiPolicyResultExt, ApiResult, ErrorResponse, ListResponse, UrlBuilder, WithUrls,
+    impl_auth_state,
 };
 
 #[derive(Clone)]
@@ -120,7 +121,7 @@ pub struct UpdateLlmProviderRequest {
     path = "/v1/llm-providers",
     request_body = CreateLlmProviderRequest,
     responses(
-        (status = 201, description = "Provider created", body = LlmProvider),
+        (status = 201, description = "Provider created", body = WithUrls<LlmProvider>),
         (status = 400, description = "Invalid request"),
         (status = 500, description = "Internal error")
     ),
@@ -130,7 +131,7 @@ pub async fn create_provider(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Json(req): Json<CreateLlmProviderRequest>,
-) -> Result<(StatusCode, Json<LlmProvider>), (StatusCode, Json<ErrorResponse>)> {
+) -> Result<(StatusCode, Json<WithUrls<LlmProvider>>), (StatusCode, Json<ErrorResponse>)> {
     let caller = Caller::from(&org);
     let provider = state
         .service
@@ -138,7 +139,8 @@ pub async fn create_provider(
         .await
         .map_policy_or_internal("create LLM provider")?;
 
-    Ok((StatusCode::CREATED, Json(provider)))
+    let builder = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok((StatusCode::CREATED, Json(builder.wrap(provider))))
 }
 
 /// List all LLM providers
@@ -146,14 +148,14 @@ pub async fn create_provider(
     get,
     path = "/v1/llm-providers",
     responses(
-        (status = 200, description = "List of providers", body = ListResponse<LlmProvider>)
+        (status = 200, description = "List of providers", body = ListResponse<WithUrls<LlmProvider>>)
     ),
     tag = "llm-providers"
 )]
 pub async fn list_providers(
     org: ResolvedOrg,
     State(state): State<AppState>,
-) -> ApiResult<ListResponse<LlmProvider>> {
+) -> ApiResult<ListResponse<WithUrls<LlmProvider>>> {
     let caller = Caller::from(&org);
     let providers = state
         .service
@@ -161,7 +163,8 @@ pub async fn list_providers(
         .await
         .map_policy_or_internal("list LLM providers")?;
 
-    Ok(Json(ListResponse::new(providers)))
+    let builder = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(ListResponse::new(providers).with_urls(&builder)))
 }
 
 /// Get a specific LLM provider
@@ -172,7 +175,7 @@ pub async fn list_providers(
         ("id" = String, Path, description = "Provider ID (prefixed, e.g., prov_...)")
     ),
     responses(
-        (status = 200, description = "Provider found", body = LlmProvider),
+        (status = 200, description = "Provider found", body = WithUrls<LlmProvider>),
         (status = 400, description = "Invalid provider ID"),
         (status = 404, description = "Provider not found")
     ),
@@ -182,7 +185,7 @@ pub async fn get_provider(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(id): Path<String>,
-) -> ApiResult<LlmProvider> {
+) -> ApiResult<WithUrls<LlmProvider>> {
     let provider_id: ProviderId = id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -200,7 +203,8 @@ pub async fn get_provider(
         .map_policy_or_internal("get LLM provider")?
         .ok_or_not_found_json("Provider")?;
 
-    Ok(Json(provider))
+    let builder = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(builder.wrap(provider)))
 }
 
 /// Update an LLM provider
@@ -212,7 +216,7 @@ pub async fn get_provider(
     ),
     request_body = UpdateLlmProviderRequest,
     responses(
-        (status = 200, description = "Provider updated", body = LlmProvider),
+        (status = 200, description = "Provider updated", body = WithUrls<LlmProvider>),
         (status = 400, description = "Invalid provider ID"),
         (status = 404, description = "Provider not found")
     ),
@@ -223,7 +227,7 @@ pub async fn update_provider(
     State(state): State<AppState>,
     Path(id): Path<String>,
     Json(req): Json<UpdateLlmProviderRequest>,
-) -> ApiResult<LlmProvider> {
+) -> ApiResult<WithUrls<LlmProvider>> {
     let provider_id: ProviderId = id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -241,7 +245,8 @@ pub async fn update_provider(
         .map_policy_or_internal("update LLM provider")?
         .ok_or_not_found_json("Provider")?;
 
-    Ok(Json(provider))
+    let builder = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(builder.wrap(provider)))
 }
 
 /// Delete an LLM provider

--- a/crates/server/src/api/mcp_servers.rs
+++ b/crates/server/src/api/mcp_servers.rs
@@ -20,7 +20,8 @@ use everruns_core::{
 };
 
 use super::common::{
-    ApiOptionExt, ApiPolicyResultExt, ApiResult, ErrorResponse, ListResponse, impl_auth_state,
+    ApiOptionExt, ApiPolicyResultExt, ApiResult, ErrorResponse, ListResponse, UrlBuilder, WithUrls,
+    impl_auth_state,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -182,7 +183,7 @@ pub async fn mcp_server_config(
     path = "/v1/mcp-servers",
     request_body = CreateMcpServerRequest,
     responses(
-        (status = 201, description = "MCP server created successfully", body = McpServer),
+        (status = 201, description = "MCP server created successfully", body = WithUrls<McpServer>),
         (status = 400, description = "Invalid input or duplicate name", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
@@ -192,7 +193,7 @@ pub async fn create_mcp_server(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Json(req): Json<CreateMcpServerRequest>,
-) -> Result<(StatusCode, Json<McpServer>), (StatusCode, Json<ErrorResponse>)> {
+) -> Result<(StatusCode, Json<WithUrls<McpServer>>), (StatusCode, Json<ErrorResponse>)> {
     // Validate name is not empty
     if req.name.trim().is_empty() {
         return Err(
@@ -218,7 +219,8 @@ pub async fn create_mcp_server(
         .await
         .map_policy_or_internal("create MCP server")?;
 
-    Ok((StatusCode::CREATED, Json(server)))
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok((StatusCode::CREATED, Json(urls.wrap(server))))
 }
 
 /// GET /v1/mcp-servers - List all MCP servers
@@ -226,7 +228,7 @@ pub async fn create_mcp_server(
     get,
     path = "/v1/mcp-servers",
     responses(
-        (status = 200, description = "List of MCP servers", body = ListResponse<McpServer>),
+        (status = 200, description = "List of MCP servers", body = ListResponse<WithUrls<McpServer>>),
         (status = 500, description = "Internal server error")
     ),
     params(ListMcpServersQuery),
@@ -236,7 +238,7 @@ pub async fn list_mcp_servers(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListMcpServersQuery>,
-) -> ApiResult<ListResponse<McpServer>> {
+) -> ApiResult<ListResponse<WithUrls<McpServer>>> {
     let caller = Caller::from(&org);
     let servers = state
         .service
@@ -248,7 +250,8 @@ pub async fn list_mcp_servers(
         .await
         .map_policy_or_internal("list MCP servers")?;
 
-    Ok(Json(ListResponse::new(servers)))
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(ListResponse::new(servers).with_urls(&urls)))
 }
 
 /// GET /v1/mcp-servers/{server_id} - Get MCP server by ID
@@ -259,7 +262,7 @@ pub async fn list_mcp_servers(
         ("server_id" = String, Path, description = "MCP server ID (prefixed, e.g., mcp_...)")
     ),
     responses(
-        (status = 200, description = "MCP server found", body = McpServer),
+        (status = 200, description = "MCP server found", body = WithUrls<McpServer>),
         (status = 400, description = "Invalid server ID"),
         (status = 404, description = "MCP server not found"),
         (status = 500, description = "Internal server error")
@@ -270,7 +273,7 @@ pub async fn get_mcp_server(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(server_id): Path<String>,
-) -> ApiResult<McpServer> {
+) -> ApiResult<WithUrls<McpServer>> {
     let server_id: McpServerId = server_id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -288,7 +291,8 @@ pub async fn get_mcp_server(
         .map_policy_or_internal("get MCP server")?
         .ok_or_not_found_json("MCP server")?;
 
-    Ok(Json(server))
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(urls.wrap(server)))
 }
 
 /// PATCH /v1/mcp-servers/{server_id} - Update MCP server
@@ -300,7 +304,7 @@ pub async fn get_mcp_server(
     ),
     request_body = UpdateMcpServerRequest,
     responses(
-        (status = 200, description = "MCP server updated successfully", body = McpServer),
+        (status = 200, description = "MCP server updated successfully", body = WithUrls<McpServer>),
         (status = 400, description = "Invalid server ID or input", body = ErrorResponse),
         (status = 404, description = "MCP server not found", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
@@ -312,7 +316,7 @@ pub async fn update_mcp_server(
     State(state): State<AppState>,
     Path(server_id): Path<String>,
     Json(req): Json<UpdateMcpServerRequest>,
-) -> ApiResult<McpServer> {
+) -> ApiResult<WithUrls<McpServer>> {
     let server_id: McpServerId = server_id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -352,7 +356,8 @@ pub async fn update_mcp_server(
         .map_policy_or_internal("update MCP server")?
         .ok_or_not_found_json("MCP server")?;
 
-    Ok(Json(server))
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(urls.wrap(server)))
 }
 
 /// DELETE /v1/mcp-servers/{server_id} - Delete MCP server

--- a/crates/server/src/api/session_schedules.rs
+++ b/crates/server/src/api/session_schedules.rs
@@ -12,7 +12,9 @@ use axum::{
 use everruns_core::session_schedule::SessionSchedule;
 use everruns_core::typed_id::{ScheduleId, SessionId};
 
-use super::common::{ApiOptionExt, ApiResult, ApiResultExt, ErrorResponse, impl_auth_state};
+use super::common::{
+    ApiOptionExt, ApiResult, ApiResultExt, ErrorResponse, UrlBuilder, WithUrls, impl_auth_state,
+};
 use serde::Deserialize;
 use std::sync::Arc;
 use utoipa::ToSchema;
@@ -77,7 +79,7 @@ pub fn routes(state: AppState) -> Router {
     get,
     path = "/v1/sessions/{session_id}/schedules",
     responses(
-        (status = 200, description = "List of schedules", body = Vec<SessionSchedule>),
+        (status = 200, description = "List of schedules", body = [WithUrls<SessionSchedule>]),
     ),
     tag = "session-schedules"
 )]
@@ -85,14 +87,15 @@ pub async fn list_schedules(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(session_id): Path<SessionId>,
-) -> ApiResult<Vec<SessionSchedule>> {
+) -> ApiResult<Vec<WithUrls<SessionSchedule>>> {
     let schedules = state
         .schedule_service
         .list(org.org_id, session_id)
         .await
         .log_internal_error_json("list schedules")?;
 
-    Ok(Json(schedules))
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(urls.wrap_vec(schedules)))
 }
 
 /// Get a specific schedule.
@@ -100,7 +103,7 @@ pub async fn list_schedules(
     get,
     path = "/v1/sessions/{session_id}/schedules/{schedule_id}",
     responses(
-        (status = 200, description = "Schedule details", body = SessionSchedule),
+        (status = 200, description = "Schedule details", body = WithUrls<SessionSchedule>),
         (status = 404, description = "Schedule not found"),
     ),
     tag = "session-schedules"
@@ -109,12 +112,13 @@ pub async fn get_schedule(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path((session_id, schedule_id)): Path<(SessionId, ScheduleId)>,
-) -> ApiResult<SessionSchedule> {
+) -> ApiResult<WithUrls<SessionSchedule>> {
     let schedule =
         get_schedule_in_session(&state, org.org_id, session_id, schedule_id, "get schedule")
             .await?;
 
-    Ok(Json(schedule))
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(urls.wrap(schedule)))
 }
 
 /// Update a schedule (enable/disable).
@@ -123,7 +127,7 @@ pub async fn get_schedule(
     path = "/v1/sessions/{session_id}/schedules/{schedule_id}",
     request_body = UpdateScheduleRequest,
     responses(
-        (status = 200, description = "Updated schedule", body = SessionSchedule),
+        (status = 200, description = "Updated schedule", body = WithUrls<SessionSchedule>),
         (status = 404, description = "Schedule not found"),
     ),
     tag = "session-schedules"
@@ -133,7 +137,7 @@ pub async fn update_schedule(
     State(state): State<AppState>,
     Path((session_id, schedule_id)): Path<(SessionId, ScheduleId)>,
     Json(req): Json<UpdateScheduleRequest>,
-) -> ApiResult<SessionSchedule> {
+) -> ApiResult<WithUrls<SessionSchedule>> {
     let enabled = req.enabled.unwrap_or(true);
     get_schedule_in_session(
         &state,
@@ -151,7 +155,8 @@ pub async fn update_schedule(
         .log_internal_error_json("update schedule")?
         .ok_or_not_found_json("Schedule")?;
 
-    Ok(Json(schedule))
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(urls.wrap(schedule)))
 }
 
 /// Delete a schedule.
@@ -201,7 +206,7 @@ pub async fn delete_schedule(
     post,
     path = "/v1/sessions/{session_id}/schedules/{schedule_id}/trigger",
     responses(
-        (status = 200, description = "Schedule triggered", body = SessionSchedule),
+        (status = 200, description = "Schedule triggered", body = WithUrls<SessionSchedule>),
         (status = 404, description = "Schedule not found"),
     ),
     tag = "session-schedules"
@@ -210,7 +215,7 @@ pub async fn trigger_schedule(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path((session_id, schedule_id)): Path<(SessionId, ScheduleId)>,
-) -> ApiResult<SessionSchedule> {
+) -> ApiResult<WithUrls<SessionSchedule>> {
     get_schedule_in_session(
         &state,
         org.org_id,
@@ -227,7 +232,8 @@ pub async fn trigger_schedule(
         .log_internal_error_json("trigger schedule")?
         .ok_or_not_found_json("Schedule")?;
 
-    Ok(Json(schedule))
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(urls.wrap(schedule)))
 }
 
 async fn get_schedule_in_session(

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -26,7 +26,7 @@ use everruns_worker::AgentRunner;
 
 use super::common::{
     ApiOptionExt, ApiPolicyResultExt, ApiResult, ApiResultExt, ErrorResponse, PaginatedResponse,
-    Pagination, deserialize_nullable_update_field, impl_auth_state,
+    Pagination, UrlBuilder, WithUrls, deserialize_nullable_update_field, impl_auth_state,
 };
 use super::validation::{self, normalize_locale};
 use everruns_durable::UpdateField;
@@ -298,7 +298,7 @@ pub async fn session_config(
     path = "/v1/sessions",
     request_body = CreateSessionRequest,
     responses(
-        (status = 201, description = "Session created successfully", body = Session),
+        (status = 201, description = "Session created successfully", body = WithUrls<Session>),
         (status = 404, description = "Harness, Agent, or Model not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -308,7 +308,7 @@ pub async fn create_session(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Json(mut req): Json<CreateSessionRequest>,
-) -> Result<(StatusCode, Json<Session>), (StatusCode, Json<ErrorResponse>)> {
+) -> Result<(StatusCode, Json<WithUrls<Session>>), (StatusCode, Json<ErrorResponse>)> {
     req.locale = normalize_locale(req.locale)
         .map_err(|err| -> (StatusCode, Json<ErrorResponse>) { err.into() })?;
 
@@ -415,6 +415,7 @@ pub async fn create_session(
             .map_err(|err| -> (StatusCode, Json<ErrorResponse>) { err.into() })?;
     }
 
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
     let caller = Caller::from(&org);
     let session = state
         .session_service
@@ -428,7 +429,7 @@ pub async fn create_session(
         .await
         .map_policy_or_internal("create session")?;
 
-    Ok((StatusCode::CREATED, Json(session)))
+    Ok((StatusCode::CREATED, Json(urls.wrap(session))))
 }
 
 async fn resolve_session_harness_id(
@@ -470,7 +471,7 @@ async fn resolve_session_harness_id(
     path = "/v1/sessions/chat",
     request_body = Option<GetOrCreateChatSessionRequest>,
     responses(
-        (status = 200, description = "Chat session returned", body = Session),
+        (status = 200, description = "Chat session returned", body = WithUrls<Session>),
         (status = 401, description = "Authentication required"),
         (status = 500, description = "Internal server error")
     ),
@@ -480,7 +481,7 @@ pub async fn get_or_create_chat_session(
     org: ResolvedOrg,
     State(state): State<AppState>,
     payload: Option<Json<GetOrCreateChatSessionRequest>>,
-) -> ApiResult<Session> {
+) -> ApiResult<WithUrls<Session>> {
     let locale = normalize_locale(payload.and_then(|Json(body)| body.locale))
         .map_err(|err| -> (StatusCode, Json<ErrorResponse>) { err.into() })?;
 
@@ -497,6 +498,7 @@ pub async fn get_or_create_chat_session(
             .await
             .log_internal_error_json("resolve chat harness")?;
 
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
     let caller = Caller::from(&org);
     let session = state
         .session_service
@@ -513,7 +515,7 @@ pub async fn get_or_create_chat_session(
         .await
         .map_policy_or_internal("get or create chat session")?;
 
-    Ok(Json(session))
+    Ok(Json(urls.wrap(session)))
 }
 
 async fn resolve_named_built_in_harness_id(
@@ -537,7 +539,7 @@ async fn resolve_named_built_in_harness_id(
     path = "/v1/sessions",
     params(ListSessionsQuery),
     responses(
-        (status = 200, description = "Paginated list of sessions", body = PaginatedResponse<Session>),
+        (status = 200, description = "Paginated list of sessions", body = PaginatedResponse<WithUrls<Session>>),
         (status = 500, description = "Internal server error")
     ),
     tag = "sessions"
@@ -546,10 +548,11 @@ pub async fn list_sessions(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListSessionsQuery>,
-) -> ApiResult<PaginatedResponse<Session>> {
+) -> ApiResult<PaginatedResponse<WithUrls<Session>>> {
     let offset = query.offset.unwrap_or(0);
     let limit = query.limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT);
     let pagination = Pagination::new(offset, limit);
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
 
     // Resolve agent public_id to internal UUID if filtering by agent.
     // If agent_id is provided but not found, return empty results rather than
@@ -583,7 +586,9 @@ pub async fn list_sessions(
         .await
         .map_policy_or_internal("list sessions")?;
 
-    Ok(Json(PaginatedResponse::new(sessions, total, offset, limit)))
+    Ok(Json(
+        PaginatedResponse::new(sessions, total, offset, limit).with_urls(&urls),
+    ))
 }
 
 /// GET /v1/sessions/stats - Get session counts by status
@@ -624,7 +629,7 @@ pub async fn get_session_stats(
         ("session_id" = String, Path, description = "Session ID (prefixed, e.g., session_...)")
     ),
     responses(
-        (status = 200, description = "Session found", body = Session),
+        (status = 200, description = "Session found", body = WithUrls<Session>),
         (status = 400, description = "Invalid session ID"),
         (status = 404, description = "Session not found"),
         (status = 500, description = "Internal server error")
@@ -635,7 +640,7 @@ pub async fn get_session(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(session_id): Path<String>,
-) -> ApiResult<Session> {
+) -> ApiResult<WithUrls<Session>> {
     let session_id: SessionId = session_id.parse().map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -645,6 +650,7 @@ pub async fn get_session(
         )
     })?;
 
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
     let caller = Caller::from(&org);
     let session = state
         .session_service
@@ -660,7 +666,7 @@ pub async fn get_session(
             )
         })?;
 
-    Ok(Json(session))
+    Ok(Json(urls.wrap(session)))
 }
 
 /// PATCH /v1/sessions/{session_id} - Update session
@@ -672,7 +678,7 @@ pub async fn get_session(
     ),
     request_body = UpdateSessionRequest,
     responses(
-        (status = 200, description = "Session updated successfully", body = Session),
+        (status = 200, description = "Session updated successfully", body = WithUrls<Session>),
         (status = 400, description = "Invalid session ID"),
         (status = 404, description = "Session not found"),
         (status = 500, description = "Internal server error")
@@ -684,7 +690,7 @@ pub async fn update_session(
     State(state): State<AppState>,
     Path(session_id): Path<String>,
     Json(mut req): Json<UpdateSessionRequest>,
-) -> ApiResult<Session> {
+) -> ApiResult<WithUrls<Session>> {
     req.locale = normalize_locale(req.locale)
         .map_err(|err| -> (StatusCode, Json<ErrorResponse>) { err.into() })?;
 
@@ -697,6 +703,7 @@ pub async fn update_session(
         )
     })?;
 
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
     let caller = Caller::from(&org);
     let session = state
         .session_service
@@ -712,7 +719,7 @@ pub async fn update_session(
             )
         })?;
 
-    Ok(Json(session))
+    Ok(Json(urls.wrap(session)))
 }
 
 /// DELETE /v1/sessions/{session_id} - Delete session

--- a/crates/server/src/api/skills.rs
+++ b/crates/server/src/api/skills.rs
@@ -5,7 +5,8 @@
 // Supports both SKILL.md text upload and ZIP archive upload.
 
 use crate::api::common::{
-    ApiOptionExt, ApiPolicyResultExt, ApiResult, ErrorResponse, ListResponse, impl_auth_state,
+    ApiOptionExt, ApiPolicyResultExt, ApiResult, ErrorResponse, ListResponse, UrlBuilder, WithUrls,
+    impl_auth_state,
 };
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::services::SkillService;
@@ -153,7 +154,7 @@ pub fn routes(state: AppState) -> Router {
     path = "/v1/skills",
     request_body = CreateSkillRequest,
     responses(
-        (status = 201, description = "Skill created", body = Skill),
+        (status = 201, description = "Skill created", body = WithUrls<Skill>),
         (status = 409, description = "Duplicate skill name", body = ErrorResponse),
         (status = 422, description = "Invalid SKILL.md", body = ErrorResponse),
     ),
@@ -163,7 +164,7 @@ pub async fn create_skill(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Json(req): Json<CreateSkillRequest>,
-) -> Result<(StatusCode, Json<Skill>), (StatusCode, Json<ErrorResponse>)> {
+) -> Result<(StatusCode, Json<WithUrls<Skill>>), (StatusCode, Json<ErrorResponse>)> {
     let caller = Caller::from(&org);
     let skill = state.service.create(&caller, req).await.map_err(|e| {
         let msg = e.to_string();
@@ -177,7 +178,8 @@ pub async fn create_skill(
         }
     })?;
 
-    Ok((StatusCode::CREATED, Json(skill)))
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok((StatusCode::CREATED, Json(urls.wrap(skill))))
 }
 
 /// POST /v1/skills/upload - Create skill from ZIP archive
@@ -185,7 +187,7 @@ pub async fn create_skill(
     post,
     path = "/v1/skills/upload",
     responses(
-        (status = 201, description = "Skill created from archive", body = Skill),
+        (status = 201, description = "Skill created from archive", body = WithUrls<Skill>),
         (status = 409, description = "Duplicate skill name", body = ErrorResponse),
         (status = 413, description = "Archive too large", body = ErrorResponse),
         (status = 422, description = "Invalid archive or SKILL.md", body = ErrorResponse),
@@ -196,7 +198,7 @@ pub async fn upload_skill(
     org: ResolvedOrg,
     State(state): State<AppState>,
     mut multipart: Multipart,
-) -> Result<(StatusCode, Json<Skill>), (StatusCode, Json<ErrorResponse>)> {
+) -> Result<(StatusCode, Json<WithUrls<Skill>>), (StatusCode, Json<ErrorResponse>)> {
     let mut file_data: Option<Vec<u8>> = None;
 
     while let Some(field) = multipart.next_field().await.map_err(|e| {
@@ -240,7 +242,8 @@ pub async fn upload_skill(
             }
         })?;
 
-    Ok((StatusCode::CREATED, Json(skill)))
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok((StatusCode::CREATED, Json(urls.wrap(skill))))
 }
 
 /// GET /v1/skills - List all skills
@@ -248,7 +251,7 @@ pub async fn upload_skill(
     get,
     path = "/v1/skills",
     responses(
-        (status = 200, description = "List of skills", body = ListResponse<Skill>),
+        (status = 200, description = "List of skills", body = ListResponse<WithUrls<Skill>>),
     ),
     params(ListSkillsQuery),
     tag = "skills"
@@ -257,7 +260,7 @@ pub async fn list_skills(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListSkillsQuery>,
-) -> ApiResult<ListResponse<Skill>> {
+) -> ApiResult<ListResponse<WithUrls<Skill>>> {
     let caller = Caller::from(&org);
     let skills = state
         .service
@@ -269,7 +272,8 @@ pub async fn list_skills(
         .await
         .map_policy_or_internal("list skills")?;
 
-    Ok(Json(ListResponse::new(skills)))
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(ListResponse::new(skills).with_urls(&urls)))
 }
 
 /// GET /v1/skills/{skill_id} - Get skill by ID
@@ -280,7 +284,7 @@ pub async fn list_skills(
         ("skill_id" = String, Path, description = "Skill ID (prefixed, e.g., skill_...)")
     ),
     responses(
-        (status = 200, description = "Skill found", body = Skill),
+        (status = 200, description = "Skill found", body = WithUrls<Skill>),
         (status = 404, description = "Skill not found"),
     ),
     tag = "skills"
@@ -289,7 +293,7 @@ pub async fn get_skill(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(skill_id): Path<String>,
-) -> ApiResult<Skill> {
+) -> ApiResult<WithUrls<Skill>> {
     let skill_id: SkillId = skill_id.parse().map_err(|e| {
         ErrorResponse::new(format!("Invalid skill ID: {e}")).into_response(StatusCode::BAD_REQUEST)
     })?;
@@ -302,7 +306,8 @@ pub async fn get_skill(
         .map_policy_or_internal("get skill")?
         .ok_or_not_found_json("Skill")?;
 
-    Ok(Json(skill))
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(urls.wrap(skill)))
 }
 
 /// GET /v1/skills/{skill_id}/content - Get full skill content
@@ -344,7 +349,7 @@ pub async fn get_skill_content(
     path = "/v1/skills/{skill_id}",
     request_body = UpdateSkillRequest,
     responses(
-        (status = 200, description = "Skill updated", body = Skill),
+        (status = 200, description = "Skill updated", body = WithUrls<Skill>),
         (status = 404, description = "Skill not found"),
         (status = 409, description = "Duplicate skill name", body = ErrorResponse),
         (status = 422, description = "Invalid SKILL.md", body = ErrorResponse),
@@ -356,7 +361,7 @@ pub async fn update_skill(
     State(state): State<AppState>,
     Path(skill_id): Path<String>,
     Json(req): Json<UpdateSkillRequest>,
-) -> ApiResult<Skill> {
+) -> ApiResult<WithUrls<Skill>> {
     let skill_id: SkillId = skill_id.parse().map_err(|e| {
         ErrorResponse::new(format!("Invalid skill ID: {e}")).into_response(StatusCode::BAD_REQUEST)
     })?;
@@ -379,7 +384,8 @@ pub async fn update_skill(
         })?
         .ok_or_else(|| ErrorResponse::not_found("Skill"))?;
 
-    Ok(Json(skill))
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok(Json(urls.wrap(skill)))
 }
 
 /// DELETE /v1/skills/{skill_id} - Delete skill

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -9252,11 +9252,11 @@
                 {
                   "type": "object",
                   "required": [
-                    "url",
+                    "self_url",
                     "view_url"
                   ],
                   "properties": {
-                    "url": {
+                    "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
                     },
@@ -9267,7 +9267,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+              "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
             },
             "description": "Array of items returned by the list operation."
           }
@@ -9348,11 +9348,11 @@
                 {
                   "type": "object",
                   "required": [
-                    "url",
+                    "self_url",
                     "view_url"
                   ],
                   "properties": {
-                    "url": {
+                    "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
                     },
@@ -9363,7 +9363,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+              "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
             },
             "description": "Array of items returned by the list operation."
           }
@@ -9463,11 +9463,11 @@
                 {
                   "type": "object",
                   "required": [
-                    "url",
+                    "self_url",
                     "view_url"
                   ],
                   "properties": {
-                    "url": {
+                    "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
                     },
@@ -9478,7 +9478,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+              "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
             },
             "description": "Array of items returned by the list operation."
           }
@@ -9552,11 +9552,11 @@
                 {
                   "type": "object",
                   "required": [
-                    "url",
+                    "self_url",
                     "view_url"
                   ],
                   "properties": {
-                    "url": {
+                    "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
                     },
@@ -9567,7 +9567,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+              "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
             },
             "description": "Array of items returned by the list operation."
           }
@@ -9685,11 +9685,11 @@
                 {
                   "type": "object",
                   "required": [
-                    "url",
+                    "self_url",
                     "view_url"
                   ],
                   "properties": {
-                    "url": {
+                    "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
                     },
@@ -9700,7 +9700,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+              "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
             },
             "description": "Array of items returned by the list operation."
           }
@@ -9812,11 +9812,11 @@
                 {
                   "type": "object",
                   "required": [
-                    "url",
+                    "self_url",
                     "view_url"
                   ],
                   "properties": {
-                    "url": {
+                    "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
                     },
@@ -9827,7 +9827,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+              "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
             },
             "description": "Array of items returned by the list operation."
           }
@@ -11482,11 +11482,11 @@
                 {
                   "type": "object",
                   "required": [
-                    "url",
+                    "self_url",
                     "view_url"
                   ],
                   "properties": {
-                    "url": {
+                    "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
                     },
@@ -11497,7 +11497,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+              "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
             },
             "description": "Array of items returned by the list operation."
           },
@@ -11620,11 +11620,11 @@
                 {
                   "type": "object",
                   "required": [
-                    "url",
+                    "self_url",
                     "view_url"
                   ],
                   "properties": {
-                    "url": {
+                    "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
                     },
@@ -11635,7 +11635,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+              "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
             },
             "description": "Array of items returned by the list operation."
           },
@@ -11928,11 +11928,11 @@
                 {
                   "type": "object",
                   "required": [
-                    "url",
+                    "self_url",
                     "view_url"
                   ],
                   "properties": {
-                    "url": {
+                    "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
                     },
@@ -11943,7 +11943,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+              "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
             },
             "description": "Array of items returned by the list operation."
           },
@@ -14846,11 +14846,11 @@
           {
             "type": "object",
             "required": [
-              "url",
+              "self_url",
               "view_url"
             ],
             "properties": {
-              "url": {
+              "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
               },
@@ -14861,7 +14861,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+        "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
       },
       "WithUrls_CapabilityInfo": {
         "allOf": [
@@ -14950,11 +14950,11 @@
           {
             "type": "object",
             "required": [
-              "url",
+              "self_url",
               "view_url"
             ],
             "properties": {
-              "url": {
+              "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
               },
@@ -14965,7 +14965,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+        "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
       },
       "WithUrls_Harness": {
         "allOf": [
@@ -15095,11 +15095,11 @@
           {
             "type": "object",
             "required": [
-              "url",
+              "self_url",
               "view_url"
             ],
             "properties": {
-              "url": {
+              "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
               },
@@ -15110,7 +15110,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+        "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
       },
       "WithUrls_LlmModel": {
         "allOf": [
@@ -15178,11 +15178,11 @@
           {
             "type": "object",
             "required": [
-              "url",
+              "self_url",
               "view_url"
             ],
             "properties": {
-              "url": {
+              "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
               },
@@ -15193,7 +15193,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+        "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
       },
       "WithUrls_LlmModelWithProvider": {
         "allOf": [
@@ -15280,11 +15280,11 @@
           {
             "type": "object",
             "required": [
-              "url",
+              "self_url",
               "view_url"
             ],
             "properties": {
-              "url": {
+              "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
               },
@@ -15295,7 +15295,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+        "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
       },
       "WithUrls_LlmProvider": {
         "allOf": [
@@ -15356,11 +15356,11 @@
           {
             "type": "object",
             "required": [
-              "url",
+              "self_url",
               "view_url"
             ],
             "properties": {
-              "url": {
+              "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
               },
@@ -15371,7 +15371,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+        "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
       },
       "WithUrls_McpServer": {
         "allOf": [
@@ -15476,11 +15476,11 @@
           {
             "type": "object",
             "required": [
-              "url",
+              "self_url",
               "view_url"
             ],
             "properties": {
-              "url": {
+              "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
               },
@@ -15491,7 +15491,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+        "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
       },
       "WithUrls_Session": {
         "allOf": [
@@ -15750,11 +15750,11 @@
           {
             "type": "object",
             "required": [
-              "url",
+              "self_url",
               "view_url"
             ],
             "properties": {
-              "url": {
+              "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
               },
@@ -15765,7 +15765,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+        "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
       },
       "WithUrls_Skill": {
         "allOf": [
@@ -15864,11 +15864,11 @@
           {
             "type": "object",
             "required": [
-              "url",
+              "self_url",
               "view_url"
             ],
             "properties": {
-              "url": {
+              "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
               },
@@ -15879,7 +15879,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+        "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
       }
     }
   },

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -86,7 +86,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PaginatedResponse_Agent"
+                  "$ref": "#/components/schemas/PaginatedResponse_WithUrls_Agent"
                 }
               }
             }
@@ -118,7 +118,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Agent"
+                  "$ref": "#/components/schemas/WithUrls_Agent"
                 }
               }
             }
@@ -181,7 +181,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Agent"
+                  "$ref": "#/components/schemas/WithUrls_Agent"
                 }
               }
             }
@@ -191,7 +191,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Agent"
+                  "$ref": "#/components/schemas/WithUrls_Agent"
                 }
               }
             }
@@ -306,7 +306,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Agent"
+                  "$ref": "#/components/schemas/WithUrls_Agent"
                 }
               }
             }
@@ -356,7 +356,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Agent"
+                  "$ref": "#/components/schemas/WithUrls_Agent"
                 }
               }
             }
@@ -366,7 +366,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Agent"
+                  "$ref": "#/components/schemas/WithUrls_Agent"
                 }
               }
             }
@@ -458,7 +458,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Agent"
+                  "$ref": "#/components/schemas/WithUrls_Agent"
                 }
               }
             }
@@ -521,7 +521,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Agent"
+                  "$ref": "#/components/schemas/WithUrls_Agent"
                 }
               }
             }
@@ -642,7 +642,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PaginatedResponse_CapabilityInfo"
+                  "$ref": "#/components/schemas/PaginatedResponse_WithUrls_CapabilityInfo"
                 }
               }
             }
@@ -674,7 +674,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CapabilityInfo"
+                  "$ref": "#/components/schemas/WithUrls_CapabilityInfo"
                 }
               }
             }
@@ -1406,7 +1406,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponse_Harness"
+                  "$ref": "#/components/schemas/ListResponse_WithUrls_Harness"
                 }
               }
             }
@@ -1441,7 +1441,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Harness"
+                  "$ref": "#/components/schemas/WithUrls_Harness"
                 }
               }
             }
@@ -1567,7 +1567,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Harness"
+                  "$ref": "#/components/schemas/WithUrls_Harness"
                 }
               }
             }
@@ -1651,7 +1651,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Harness"
+                  "$ref": "#/components/schemas/WithUrls_Harness"
                 }
               }
             }
@@ -1724,7 +1724,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Harness"
+                  "$ref": "#/components/schemas/WithUrls_Harness"
                 }
               }
             }
@@ -2023,7 +2023,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponse_LlmModelWithProvider"
+                  "$ref": "#/components/schemas/ListResponse_WithUrls_LlmModelWithProvider"
                 }
               }
             }
@@ -2055,7 +2055,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/LlmModelWithProvider"
+                  "$ref": "#/components/schemas/WithUrls_LlmModelWithProvider"
                 }
               }
             }
@@ -2130,7 +2130,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/LlmModel"
+                  "$ref": "#/components/schemas/WithUrls_LlmModel"
                 }
               }
             }
@@ -2157,7 +2157,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponse_LlmProvider"
+                  "$ref": "#/components/schemas/ListResponse_WithUrls_LlmProvider"
                 }
               }
             }
@@ -2186,7 +2186,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/LlmProvider"
+                  "$ref": "#/components/schemas/WithUrls_LlmProvider"
                 }
               }
             }
@@ -2224,7 +2224,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/LlmProvider"
+                  "$ref": "#/components/schemas/WithUrls_LlmProvider"
                 }
               }
             }
@@ -2299,7 +2299,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/LlmProvider"
+                  "$ref": "#/components/schemas/WithUrls_LlmProvider"
                 }
               }
             }
@@ -2379,7 +2379,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponse_LlmModel"
+                  "$ref": "#/components/schemas/ListResponse_WithUrls_LlmModel"
                 }
               }
             }
@@ -2422,7 +2422,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/LlmModel"
+                  "$ref": "#/components/schemas/WithUrls_LlmModel"
                 }
               }
             }
@@ -2478,7 +2478,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponse_McpServer"
+                  "$ref": "#/components/schemas/ListResponse_WithUrls_McpServer"
                 }
               }
             }
@@ -2510,7 +2510,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/McpServer"
+                  "$ref": "#/components/schemas/WithUrls_McpServer"
                 }
               }
             }
@@ -2562,7 +2562,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/McpServer"
+                  "$ref": "#/components/schemas/WithUrls_McpServer"
                 }
               }
             }
@@ -2643,7 +2643,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/McpServer"
+                  "$ref": "#/components/schemas/WithUrls_McpServer"
                 }
               }
             }
@@ -2936,7 +2936,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PaginatedResponse_Session"
+                  "$ref": "#/components/schemas/PaginatedResponse_WithUrls_Session"
                 }
               }
             }
@@ -2968,7 +2968,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Session"
+                  "$ref": "#/components/schemas/WithUrls_Session"
                 }
               }
             }
@@ -3012,7 +3012,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Session"
+                  "$ref": "#/components/schemas/WithUrls_Session"
                 }
               }
             }
@@ -3050,7 +3050,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Session"
+                  "$ref": "#/components/schemas/WithUrls_Session"
                 }
               }
             }
@@ -3131,7 +3131,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Session"
+                  "$ref": "#/components/schemas/WithUrls_Session"
                 }
               }
             }
@@ -4782,7 +4782,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponse_Skill"
+                  "$ref": "#/components/schemas/ListResponse_WithUrls_Skill"
                 }
               }
             }
@@ -4811,7 +4811,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Skill"
+                  "$ref": "#/components/schemas/WithUrls_Skill"
                 }
               }
             }
@@ -4852,7 +4852,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Skill"
+                  "$ref": "#/components/schemas/WithUrls_Skill"
                 }
               }
             }
@@ -4945,7 +4945,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Skill"
+                  "$ref": "#/components/schemas/WithUrls_Skill"
                 }
               }
             }
@@ -5013,7 +5013,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Skill"
+                  "$ref": "#/components/schemas/WithUrls_Skill"
                 }
               }
             }
@@ -8654,240 +8654,6 @@
           }
         }
       },
-      "ListResponse_LlmModel": {
-        "type": "object",
-        "description": "Response wrapper for list endpoints.\nAll list endpoints return responses wrapped in a `data` field.",
-        "required": [
-          "data"
-        ],
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "description": "LLM Model entity",
-              "required": [
-                "id",
-                "provider_id",
-                "model_id",
-                "display_name",
-                "capabilities",
-                "is_favorite",
-                "installed",
-                "status",
-                "source",
-                "created_at",
-                "updated_at"
-              ],
-              "properties": {
-                "capabilities": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "created_at": {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                "display_name": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "string",
-                  "example": "model_01933b5a00007000800000000000001"
-                },
-                "installed": {
-                  "type": "boolean",
-                  "description": "Whether this model is installed (available in UI model pickers).\nAll models are available via API regardless of this flag."
-                },
-                "is_favorite": {
-                  "type": "boolean"
-                },
-                "model_id": {
-                  "type": "string"
-                },
-                "provider_id": {
-                  "type": "string",
-                  "example": "provider_01933b5a00007000800000000000001"
-                },
-                "source": {
-                  "$ref": "#/components/schemas/LlmModelSource",
-                  "description": "How the model was added to the system"
-                },
-                "status": {
-                  "$ref": "#/components/schemas/LlmModelStatus"
-                },
-                "updated_at": {
-                  "type": "string",
-                  "format": "date-time"
-                }
-              }
-            },
-            "description": "Array of items returned by the list operation."
-          }
-        }
-      },
-      "ListResponse_LlmModelWithProvider": {
-        "type": "object",
-        "description": "Response wrapper for list endpoints.\nAll list endpoints return responses wrapped in a `data` field.",
-        "required": [
-          "data"
-        ],
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "description": "LLM Model with provider info",
-              "required": [
-                "id",
-                "provider_id",
-                "model_id",
-                "display_name",
-                "capabilities",
-                "is_favorite",
-                "installed",
-                "status",
-                "source",
-                "created_at",
-                "updated_at",
-                "provider_name",
-                "provider_type"
-              ],
-              "properties": {
-                "capabilities": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "created_at": {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                "display_name": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "string",
-                  "example": "model_01933b5a00007000800000000000001"
-                },
-                "installed": {
-                  "type": "boolean",
-                  "description": "Whether this model is installed (available in UI model pickers)"
-                },
-                "is_favorite": {
-                  "type": "boolean"
-                },
-                "model_id": {
-                  "type": "string"
-                },
-                "profile": {
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "$ref": "#/components/schemas/LlmModelProfile",
-                      "description": "Readonly profile with model capabilities (not persisted to database)"
-                    }
-                  ]
-                },
-                "provider_id": {
-                  "type": "string",
-                  "example": "provider_01933b5a00007000800000000000001"
-                },
-                "provider_name": {
-                  "type": "string"
-                },
-                "provider_type": {
-                  "$ref": "#/components/schemas/LlmProviderType"
-                },
-                "source": {
-                  "$ref": "#/components/schemas/LlmModelSource",
-                  "description": "How the model was added to the system"
-                },
-                "status": {
-                  "$ref": "#/components/schemas/LlmModelStatus"
-                },
-                "updated_at": {
-                  "type": "string",
-                  "format": "date-time"
-                }
-              }
-            },
-            "description": "Array of items returned by the list operation."
-          }
-        }
-      },
-      "ListResponse_LlmProvider": {
-        "type": "object",
-        "description": "Response wrapper for list endpoints.\nAll list endpoints return responses wrapped in a `data` field.",
-        "required": [
-          "data"
-        ],
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "description": "LLM Provider entity (API keys never exposed)\nNote: This is the entity struct, separate from the LlmProvider trait in llm.rs",
-              "required": [
-                "id",
-                "name",
-                "provider_type",
-                "api_key_set",
-                "status",
-                "created_at",
-                "updated_at"
-              ],
-              "properties": {
-                "api_key_set": {
-                  "type": "boolean",
-                  "description": "Whether an API key is configured (key is never returned)"
-                },
-                "base_url": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "created_at": {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                "id": {
-                  "type": "string",
-                  "example": "provider_01933b5a00007000800000000000001"
-                },
-                "last_synced_at": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "format": "date-time",
-                  "description": "When models were last synced from provider API"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "provider_type": {
-                  "$ref": "#/components/schemas/LlmProviderType"
-                },
-                "status": {
-                  "$ref": "#/components/schemas/LlmProviderStatus"
-                },
-                "updated_at": {
-                  "type": "string",
-                  "format": "date-time"
-                }
-              }
-            },
-            "description": "Array of items returned by the list operation."
-          }
-        }
-      },
       "ListResponse_McpServer": {
         "type": "object",
         "description": "Response wrapper for list endpoints.\nAll list endpoints return responses wrapped in a `data` field.",
@@ -9344,6 +9110,724 @@
                   }
                 }
               }
+            },
+            "description": "Array of items returned by the list operation."
+          }
+        }
+      },
+      "ListResponse_WithUrls_Harness": {
+        "type": "object",
+        "description": "Response wrapper for list endpoints.\nAll list endpoints return responses wrapped in a `data` field.",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "type": "object",
+                  "description": "Harness configuration for sessions.\nA harness defines the base behavior and capabilities that apply to all sessions.",
+                  "required": [
+                    "id",
+                    "name",
+                    "system_prompt",
+                    "status",
+                    "created_at",
+                    "updated_at"
+                  ],
+                  "properties": {
+                    "archived_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time",
+                      "description": "Timestamp when the harness was archived."
+                    },
+                    "capabilities": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AgentCapabilityConfig"
+                      },
+                      "description": "Capabilities enabled for this harness with per-harness configuration."
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "Timestamp when the harness was created."
+                    },
+                    "default_model_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Default LLM model ID for this harness.\nLowest priority in chain: controls > session > agent > harness.",
+                      "example": "model_01933b5a00007000800000000000001"
+                    },
+                    "deleted_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time",
+                      "description": "Timestamp when the harness was deleted."
+                    },
+                    "description": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Human-readable description of what the harness does."
+                    },
+                    "display_name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Human-readable display name shown in UI."
+                    },
+                    "id": {
+                      "type": "string",
+                      "description": "Unique identifier for the harness (format: harness_{32-hex}).",
+                      "example": "harness_01933b5a00007000800000000000001"
+                    },
+                    "initial_files": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/InitialFile"
+                      },
+                      "description": "Starter files copied into each new session for this harness."
+                    },
+                    "is_built_in": {
+                      "type": "boolean",
+                      "description": "Whether this harness is built-in (system-managed, readonly).\nBuilt-in harnesses are provisioned during org initialization and\ncannot be modified or deleted via the API. Users can copy them."
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Name, unique per org (e.g. \"generic\")."
+                    },
+                    "network_access": {
+                      "oneOf": [
+                        {
+                          "type": "null"
+                        },
+                        {
+                          "$ref": "#/components/schemas/NetworkAccessList",
+                          "description": "Network access list controlling which hosts/URLs sessions can reach.\nMerged with agent and session layers (allowed: intersect, blocked: union)."
+                        }
+                      ]
+                    },
+                    "parent_harness_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Optional parent harness that this harness inherits from.",
+                      "example": "harness_01933b5a000070008000000000000602"
+                    },
+                    "status": {
+                      "$ref": "#/components/schemas/HarnessStatus",
+                      "description": "Current lifecycle status of the harness."
+                    },
+                    "system_prompt": {
+                      "type": "string",
+                      "description": "System prompt that defines the harness's base behavior.\nForms the foundation of the prompt stack."
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Tags for organizing and filtering harnesses."
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "Timestamp when the harness was last updated."
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "url",
+                    "view_url"
+                  ],
+                  "properties": {
+                    "url": {
+                      "type": "string",
+                      "description": "Full API endpoint URL for this resource."
+                    },
+                    "view_url": {
+                      "type": "string",
+                      "description": "Full UI URL for viewing this resource."
+                    }
+                  }
+                }
+              ],
+              "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+            },
+            "description": "Array of items returned by the list operation."
+          }
+        }
+      },
+      "ListResponse_WithUrls_LlmModel": {
+        "type": "object",
+        "description": "Response wrapper for list endpoints.\nAll list endpoints return responses wrapped in a `data` field.",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "type": "object",
+                  "description": "LLM Model entity",
+                  "required": [
+                    "id",
+                    "provider_id",
+                    "model_id",
+                    "display_name",
+                    "capabilities",
+                    "is_favorite",
+                    "installed",
+                    "status",
+                    "source",
+                    "created_at",
+                    "updated_at"
+                  ],
+                  "properties": {
+                    "capabilities": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "display_name": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string",
+                      "example": "model_01933b5a00007000800000000000001"
+                    },
+                    "installed": {
+                      "type": "boolean",
+                      "description": "Whether this model is installed (available in UI model pickers).\nAll models are available via API regardless of this flag."
+                    },
+                    "is_favorite": {
+                      "type": "boolean"
+                    },
+                    "model_id": {
+                      "type": "string"
+                    },
+                    "provider_id": {
+                      "type": "string",
+                      "example": "provider_01933b5a00007000800000000000001"
+                    },
+                    "source": {
+                      "$ref": "#/components/schemas/LlmModelSource",
+                      "description": "How the model was added to the system"
+                    },
+                    "status": {
+                      "$ref": "#/components/schemas/LlmModelStatus"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "url",
+                    "view_url"
+                  ],
+                  "properties": {
+                    "url": {
+                      "type": "string",
+                      "description": "Full API endpoint URL for this resource."
+                    },
+                    "view_url": {
+                      "type": "string",
+                      "description": "Full UI URL for viewing this resource."
+                    }
+                  }
+                }
+              ],
+              "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+            },
+            "description": "Array of items returned by the list operation."
+          }
+        }
+      },
+      "ListResponse_WithUrls_LlmModelWithProvider": {
+        "type": "object",
+        "description": "Response wrapper for list endpoints.\nAll list endpoints return responses wrapped in a `data` field.",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "type": "object",
+                  "description": "LLM Model with provider info",
+                  "required": [
+                    "id",
+                    "provider_id",
+                    "model_id",
+                    "display_name",
+                    "capabilities",
+                    "is_favorite",
+                    "installed",
+                    "status",
+                    "source",
+                    "created_at",
+                    "updated_at",
+                    "provider_name",
+                    "provider_type"
+                  ],
+                  "properties": {
+                    "capabilities": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "display_name": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string",
+                      "example": "model_01933b5a00007000800000000000001"
+                    },
+                    "installed": {
+                      "type": "boolean",
+                      "description": "Whether this model is installed (available in UI model pickers)"
+                    },
+                    "is_favorite": {
+                      "type": "boolean"
+                    },
+                    "model_id": {
+                      "type": "string"
+                    },
+                    "profile": {
+                      "oneOf": [
+                        {
+                          "type": "null"
+                        },
+                        {
+                          "$ref": "#/components/schemas/LlmModelProfile",
+                          "description": "Readonly profile with model capabilities (not persisted to database)"
+                        }
+                      ]
+                    },
+                    "provider_id": {
+                      "type": "string",
+                      "example": "provider_01933b5a00007000800000000000001"
+                    },
+                    "provider_name": {
+                      "type": "string"
+                    },
+                    "provider_type": {
+                      "$ref": "#/components/schemas/LlmProviderType"
+                    },
+                    "source": {
+                      "$ref": "#/components/schemas/LlmModelSource",
+                      "description": "How the model was added to the system"
+                    },
+                    "status": {
+                      "$ref": "#/components/schemas/LlmModelStatus"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "url",
+                    "view_url"
+                  ],
+                  "properties": {
+                    "url": {
+                      "type": "string",
+                      "description": "Full API endpoint URL for this resource."
+                    },
+                    "view_url": {
+                      "type": "string",
+                      "description": "Full UI URL for viewing this resource."
+                    }
+                  }
+                }
+              ],
+              "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+            },
+            "description": "Array of items returned by the list operation."
+          }
+        }
+      },
+      "ListResponse_WithUrls_LlmProvider": {
+        "type": "object",
+        "description": "Response wrapper for list endpoints.\nAll list endpoints return responses wrapped in a `data` field.",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "type": "object",
+                  "description": "LLM Provider entity (API keys never exposed)\nNote: This is the entity struct, separate from the LlmProvider trait in llm.rs",
+                  "required": [
+                    "id",
+                    "name",
+                    "provider_type",
+                    "api_key_set",
+                    "status",
+                    "created_at",
+                    "updated_at"
+                  ],
+                  "properties": {
+                    "api_key_set": {
+                      "type": "boolean",
+                      "description": "Whether an API key is configured (key is never returned)"
+                    },
+                    "base_url": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "id": {
+                      "type": "string",
+                      "example": "provider_01933b5a00007000800000000000001"
+                    },
+                    "last_synced_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time",
+                      "description": "When models were last synced from provider API"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "provider_type": {
+                      "$ref": "#/components/schemas/LlmProviderType"
+                    },
+                    "status": {
+                      "$ref": "#/components/schemas/LlmProviderStatus"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "url",
+                    "view_url"
+                  ],
+                  "properties": {
+                    "url": {
+                      "type": "string",
+                      "description": "Full API endpoint URL for this resource."
+                    },
+                    "view_url": {
+                      "type": "string",
+                      "description": "Full UI URL for viewing this resource."
+                    }
+                  }
+                }
+              ],
+              "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+            },
+            "description": "Array of items returned by the list operation."
+          }
+        }
+      },
+      "ListResponse_WithUrls_McpServer": {
+        "type": "object",
+        "description": "Response wrapper for list endpoints.\nAll list endpoints return responses wrapped in a `data` field.",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "type": "object",
+                  "description": "MCP Server configuration.\nRepresents a remote MCP server that can provide tools and resources.",
+                  "required": [
+                    "id",
+                    "name",
+                    "url",
+                    "transport_type",
+                    "status",
+                    "api_key_set",
+                    "created_at",
+                    "updated_at"
+                  ],
+                  "properties": {
+                    "api_key_set": {
+                      "type": "boolean",
+                      "description": "Whether an API key has been configured."
+                    },
+                    "archived_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time",
+                      "description": "Timestamp when the MCP server was archived."
+                    },
+                    "auth_mode": {
+                      "$ref": "#/components/schemas/McpServerAuthMode",
+                      "description": "Authentication mode for this MCP server."
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "Timestamp when the MCP server was created."
+                    },
+                    "deleted_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time",
+                      "description": "Timestamp when the MCP server was deleted."
+                    },
+                    "description": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Human-readable description of the MCP server.",
+                      "example": "Atlassian MCP Server for Jira and Confluence"
+                    },
+                    "headers": {
+                      "type": "object",
+                      "description": "Additional HTTP headers for authentication.\nKeys are header names, values are header values.",
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "id": {
+                      "type": "string",
+                      "description": "Unique identifier for the MCP server.",
+                      "example": "mcp_01933b5a00007000800000000000001"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Display name of the MCP server.",
+                      "example": "atlassian-mcp-server"
+                    },
+                    "oauth_provider_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Stable provider id used for user-scoped OAuth connections."
+                    },
+                    "status": {
+                      "$ref": "#/components/schemas/McpServerStatus",
+                      "description": "Current lifecycle status of the MCP server."
+                    },
+                    "transport_type": {
+                      "$ref": "#/components/schemas/McpServerTransportType",
+                      "description": "Transport type (currently only HTTP supported)."
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "Timestamp when the MCP server was last updated."
+                    },
+                    "url": {
+                      "type": "string",
+                      "description": "URL of the MCP server endpoint.",
+                      "example": "https://mcp.atlassian.com/v1/mcp"
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "url",
+                    "view_url"
+                  ],
+                  "properties": {
+                    "url": {
+                      "type": "string",
+                      "description": "Full API endpoint URL for this resource."
+                    },
+                    "view_url": {
+                      "type": "string",
+                      "description": "Full UI URL for viewing this resource."
+                    }
+                  }
+                }
+              ],
+              "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+            },
+            "description": "Array of items returned by the list operation."
+          }
+        }
+      },
+      "ListResponse_WithUrls_Skill": {
+        "type": "object",
+        "description": "Response wrapper for list endpoints.\nAll list endpoints return responses wrapped in a `data` field.",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "type": "object",
+                  "description": "Skill entity (API response type)",
+                  "required": [
+                    "id",
+                    "name",
+                    "description",
+                    "source_type",
+                    "status",
+                    "version",
+                    "created_at",
+                    "updated_at"
+                  ],
+                  "properties": {
+                    "allowed_tools": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "archived_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time"
+                    },
+                    "compatibility": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "deleted_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time"
+                    },
+                    "description": {
+                      "type": "string",
+                      "example": "Extract text and tables from PDF files."
+                    },
+                    "disable_model_invocation": {
+                      "type": "boolean",
+                      "description": "Whether the model is prevented from auto-invoking this skill"
+                    },
+                    "id": {
+                      "type": "string",
+                      "example": "skill_01933b5a00007000800000000000001"
+                    },
+                    "license": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": {},
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "example": "pdf-processing"
+                    },
+                    "source_type": {
+                      "$ref": "#/components/schemas/SkillSourceType"
+                    },
+                    "status": {
+                      "$ref": "#/components/schemas/SkillStatus"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "user_invocable": {
+                      "type": "boolean",
+                      "description": "Whether this skill appears as a /slash command for users"
+                    },
+                    "version": {
+                      "type": "string"
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "url",
+                    "view_url"
+                  ],
+                  "properties": {
+                    "url": {
+                      "type": "string",
+                      "description": "Full API endpoint URL for this resource."
+                    },
+                    "view_url": {
+                      "type": "string",
+                      "description": "Full UI URL for viewing this resource."
+                    }
+                  }
+                }
+              ],
+              "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
             },
             "description": "Array of items returned by the list operation."
           }
@@ -10558,293 +11042,6 @@
           }
         }
       },
-      "PaginatedResponse_Agent": {
-        "type": "object",
-        "description": "Response wrapper for paginated list endpoints.\nIncludes pagination metadata along with the data array.",
-        "required": [
-          "data",
-          "total",
-          "offset",
-          "limit"
-        ],
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "description": "Agent configuration for agentic loop.\nAn agent defines the behavior and capabilities of an AI assistant.",
-              "required": [
-                "id",
-                "name",
-                "system_prompt",
-                "status",
-                "created_at",
-                "updated_at"
-              ],
-              "properties": {
-                "archived_at": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "format": "date-time",
-                  "description": "Timestamp when the agent was archived."
-                },
-                "capabilities": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AgentCapabilityConfig"
-                  },
-                  "description": "Capabilities enabled for this agent with per-agent configuration.\nCapabilities add tools and system prompt modifications."
-                },
-                "created_at": {
-                  "type": "string",
-                  "format": "date-time",
-                  "description": "Timestamp when the agent was created."
-                },
-                "default_model_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Default LLM model ID for this agent.\nCan be overridden at the session level.",
-                  "example": "model_01933b5a00007000800000000000001"
-                },
-                "deleted_at": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "format": "date-time",
-                  "description": "Timestamp when the agent was deleted."
-                },
-                "description": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Human-readable description of what the agent does."
-                },
-                "display_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Human-readable display name shown in UI (e.g. \"Customer Support Agent\").\nFalls back to `name` when absent."
-                },
-                "id": {
-                  "type": "string",
-                  "description": "External identifier (agent_<32-hex>). Shown as \"id\" in API.\nClient-supplied or auto-generated.",
-                  "example": "agent_01933b5a000070008000000000000001"
-                },
-                "initial_files": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/InitialFile"
-                  },
-                  "description": "Starter files copied into each new session for this agent."
-                },
-                "max_iterations": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Maximum number of LLM iterations per turn for this agent.",
-                  "minimum": 0
-                },
-                "name": {
-                  "type": "string",
-                  "description": "Name, unique per org (e.g. \"customer-support\")."
-                },
-                "network_access": {
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "$ref": "#/components/schemas/NetworkAccessList",
-                      "description": "Network access list controlling which hosts/URLs agent sessions can reach.\nMerged with harness and session layers (allowed: intersect, blocked: union)."
-                    }
-                  ]
-                },
-                "status": {
-                  "$ref": "#/components/schemas/AgentStatus",
-                  "description": "Current lifecycle status of the agent."
-                },
-                "system_prompt": {
-                  "type": "string",
-                  "description": "System prompt that defines the agent's behavior.\nSent as the first message in every conversation."
-                },
-                "tags": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Tags for organizing and filtering agents."
-                },
-                "tools": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ToolDefinition"
-                  },
-                  "description": "Client-side tools registered for this agent.\nThese tools are executed by the client, not the server."
-                },
-                "updated_at": {
-                  "type": "string",
-                  "format": "date-time",
-                  "description": "Timestamp when the agent was last updated."
-                },
-                "usage": {
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "$ref": "#/components/schemas/TokenUsage",
-                      "description": "Cumulative token usage across all sessions for this agent."
-                    }
-                  ]
-                }
-              }
-            },
-            "description": "Array of items returned by the list operation."
-          },
-          "limit": {
-            "type": "integer",
-            "format": "int32",
-            "description": "Maximum number of items per page.",
-            "minimum": 0
-          },
-          "offset": {
-            "type": "integer",
-            "format": "int32",
-            "description": "Current offset (starting position).",
-            "minimum": 0
-          },
-          "total": {
-            "type": "integer",
-            "format": "int32",
-            "description": "Total number of items matching the query (across all pages).",
-            "minimum": 0
-          }
-        }
-      },
-      "PaginatedResponse_CapabilityInfo": {
-        "type": "object",
-        "description": "Response wrapper for paginated list endpoints.\nIncludes pagination metadata along with the data array.",
-        "required": [
-          "data",
-          "total",
-          "offset",
-          "limit"
-        ],
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "description": "Public capability information (without internal details)\nThis is what gets returned from the API\nNamed CapabilityInfo to distinguish from the Capability trait",
-              "required": [
-                "id",
-                "name",
-                "description",
-                "status"
-              ],
-              "properties": {
-                "category": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Category for grouping in UI"
-                },
-                "dependencies": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "IDs of capabilities that this capability depends on.\nWhen this capability is selected, its dependencies are automatically included."
-                },
-                "description": {
-                  "type": "string",
-                  "description": "Description of what this capability provides"
-                },
-                "features": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "UI feature strings this capability contributes to.\nMultiple capabilities can contribute the same feature."
-                },
-                "icon": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Icon name (for UI rendering)"
-                },
-                "id": {
-                  "type": "string",
-                  "description": "Unique capability identifier"
-                },
-                "is_mcp": {
-                  "type": "boolean",
-                  "description": "Whether this is an MCP server capability (for UI badge)"
-                },
-                "is_skill": {
-                  "type": "boolean",
-                  "description": "Whether this is an Agent Skill capability (for UI badge)"
-                },
-                "name": {
-                  "type": "string",
-                  "description": "Display name"
-                },
-                "risk_level": {
-                  "$ref": "#/components/schemas/RiskLevel",
-                  "description": "TM-AGENT-005: Risk level. High-risk capabilities require admin approval."
-                },
-                "status": {
-                  "type": "string",
-                  "description": "Current status"
-                },
-                "system_prompt": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "System prompt addition contributed by this capability"
-                },
-                "tool_definitions": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
-                  },
-                  "description": "Tool definitions provided by this capability"
-                }
-              }
-            },
-            "description": "Array of items returned by the list operation."
-          },
-          "limit": {
-            "type": "integer",
-            "format": "int32",
-            "description": "Maximum number of items per page.",
-            "minimum": 0
-          },
-          "offset": {
-            "type": "integer",
-            "format": "int32",
-            "description": "Current offset (starting position).",
-            "minimum": 0
-          },
-          "total": {
-            "type": "integer",
-            "format": "int32",
-            "description": "Total number of items matching the query (across all pages).",
-            "minimum": 0
-          }
-        }
-      },
       "PaginatedResponse_Session": {
         "type": "object",
         "description": "Response wrapper for paginated list endpoints.\nIncludes pagination metadata along with the data array.",
@@ -11108,6 +11305,645 @@
                   ]
                 }
               }
+            },
+            "description": "Array of items returned by the list operation."
+          },
+          "limit": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Maximum number of items per page.",
+            "minimum": 0
+          },
+          "offset": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Current offset (starting position).",
+            "minimum": 0
+          },
+          "total": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Total number of items matching the query (across all pages).",
+            "minimum": 0
+          }
+        }
+      },
+      "PaginatedResponse_WithUrls_Agent": {
+        "type": "object",
+        "description": "Response wrapper for paginated list endpoints.\nIncludes pagination metadata along with the data array.",
+        "required": [
+          "data",
+          "total",
+          "offset",
+          "limit"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "type": "object",
+                  "description": "Agent configuration for agentic loop.\nAn agent defines the behavior and capabilities of an AI assistant.",
+                  "required": [
+                    "id",
+                    "name",
+                    "system_prompt",
+                    "status",
+                    "created_at",
+                    "updated_at"
+                  ],
+                  "properties": {
+                    "archived_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time",
+                      "description": "Timestamp when the agent was archived."
+                    },
+                    "capabilities": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AgentCapabilityConfig"
+                      },
+                      "description": "Capabilities enabled for this agent with per-agent configuration.\nCapabilities add tools and system prompt modifications."
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "Timestamp when the agent was created."
+                    },
+                    "default_model_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Default LLM model ID for this agent.\nCan be overridden at the session level.",
+                      "example": "model_01933b5a00007000800000000000001"
+                    },
+                    "deleted_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time",
+                      "description": "Timestamp when the agent was deleted."
+                    },
+                    "description": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Human-readable description of what the agent does."
+                    },
+                    "display_name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Human-readable display name shown in UI (e.g. \"Customer Support Agent\").\nFalls back to `name` when absent."
+                    },
+                    "id": {
+                      "type": "string",
+                      "description": "External identifier (agent_<32-hex>). Shown as \"id\" in API.\nClient-supplied or auto-generated.",
+                      "example": "agent_01933b5a000070008000000000000001"
+                    },
+                    "initial_files": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/InitialFile"
+                      },
+                      "description": "Starter files copied into each new session for this agent."
+                    },
+                    "max_iterations": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "description": "Maximum number of LLM iterations per turn for this agent.",
+                      "minimum": 0
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Name, unique per org (e.g. \"customer-support\")."
+                    },
+                    "network_access": {
+                      "oneOf": [
+                        {
+                          "type": "null"
+                        },
+                        {
+                          "$ref": "#/components/schemas/NetworkAccessList",
+                          "description": "Network access list controlling which hosts/URLs agent sessions can reach.\nMerged with harness and session layers (allowed: intersect, blocked: union)."
+                        }
+                      ]
+                    },
+                    "status": {
+                      "$ref": "#/components/schemas/AgentStatus",
+                      "description": "Current lifecycle status of the agent."
+                    },
+                    "system_prompt": {
+                      "type": "string",
+                      "description": "System prompt that defines the agent's behavior.\nSent as the first message in every conversation."
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Tags for organizing and filtering agents."
+                    },
+                    "tools": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ToolDefinition"
+                      },
+                      "description": "Client-side tools registered for this agent.\nThese tools are executed by the client, not the server."
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "Timestamp when the agent was last updated."
+                    },
+                    "usage": {
+                      "oneOf": [
+                        {
+                          "type": "null"
+                        },
+                        {
+                          "$ref": "#/components/schemas/TokenUsage",
+                          "description": "Cumulative token usage across all sessions for this agent."
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "url",
+                    "view_url"
+                  ],
+                  "properties": {
+                    "url": {
+                      "type": "string",
+                      "description": "Full API endpoint URL for this resource."
+                    },
+                    "view_url": {
+                      "type": "string",
+                      "description": "Full UI URL for viewing this resource."
+                    }
+                  }
+                }
+              ],
+              "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+            },
+            "description": "Array of items returned by the list operation."
+          },
+          "limit": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Maximum number of items per page.",
+            "minimum": 0
+          },
+          "offset": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Current offset (starting position).",
+            "minimum": 0
+          },
+          "total": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Total number of items matching the query (across all pages).",
+            "minimum": 0
+          }
+        }
+      },
+      "PaginatedResponse_WithUrls_CapabilityInfo": {
+        "type": "object",
+        "description": "Response wrapper for paginated list endpoints.\nIncludes pagination metadata along with the data array.",
+        "required": [
+          "data",
+          "total",
+          "offset",
+          "limit"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "type": "object",
+                  "description": "Public capability information (without internal details)\nThis is what gets returned from the API\nNamed CapabilityInfo to distinguish from the Capability trait",
+                  "required": [
+                    "id",
+                    "name",
+                    "description",
+                    "status"
+                  ],
+                  "properties": {
+                    "category": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Category for grouping in UI"
+                    },
+                    "dependencies": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "IDs of capabilities that this capability depends on.\nWhen this capability is selected, its dependencies are automatically included."
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Description of what this capability provides"
+                    },
+                    "features": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "UI feature strings this capability contributes to.\nMultiple capabilities can contribute the same feature."
+                    },
+                    "icon": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Icon name (for UI rendering)"
+                    },
+                    "id": {
+                      "type": "string",
+                      "description": "Unique capability identifier"
+                    },
+                    "is_mcp": {
+                      "type": "boolean",
+                      "description": "Whether this is an MCP server capability (for UI badge)"
+                    },
+                    "is_skill": {
+                      "type": "boolean",
+                      "description": "Whether this is an Agent Skill capability (for UI badge)"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Display name"
+                    },
+                    "risk_level": {
+                      "$ref": "#/components/schemas/RiskLevel",
+                      "description": "TM-AGENT-005: Risk level. High-risk capabilities require admin approval."
+                    },
+                    "status": {
+                      "type": "string",
+                      "description": "Current status"
+                    },
+                    "system_prompt": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "System prompt addition contributed by this capability"
+                    },
+                    "tool_definitions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      },
+                      "description": "Tool definitions provided by this capability"
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "url",
+                    "view_url"
+                  ],
+                  "properties": {
+                    "url": {
+                      "type": "string",
+                      "description": "Full API endpoint URL for this resource."
+                    },
+                    "view_url": {
+                      "type": "string",
+                      "description": "Full UI URL for viewing this resource."
+                    }
+                  }
+                }
+              ],
+              "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+            },
+            "description": "Array of items returned by the list operation."
+          },
+          "limit": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Maximum number of items per page.",
+            "minimum": 0
+          },
+          "offset": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Current offset (starting position).",
+            "minimum": 0
+          },
+          "total": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Total number of items matching the query (across all pages).",
+            "minimum": 0
+          }
+        }
+      },
+      "PaginatedResponse_WithUrls_Session": {
+        "type": "object",
+        "description": "Response wrapper for paginated list endpoints.\nIncludes pagination metadata along with the data array.",
+        "required": [
+          "data",
+          "total",
+          "offset",
+          "limit"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "type": "object",
+                  "description": "Session - instance of agentic loop execution.\nA session represents a single conversation with an agent.",
+                  "required": [
+                    "id",
+                    "organization_id",
+                    "harness_id",
+                    "status",
+                    "created_at",
+                    "updated_at"
+                  ],
+                  "properties": {
+                    "active_schedule_count": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "format": "int32",
+                      "description": "Number of active (enabled) schedules for this session.\nPopulated when the session is fetched for API responses.",
+                      "minimum": 0
+                    },
+                    "agent_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "ID of the agent working in this session (format: agent_{32-hex}). Optional.",
+                      "example": "agent_01933b5a00007000800000000000001"
+                    },
+                    "agent_identity_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Optional resident agent identity for unattended/background execution.",
+                      "example": "identity_01933b5a00007000800000000000001"
+                    },
+                    "blueprint_config": {
+                      "description": "Validated config passed by host at blueprint spawn time."
+                    },
+                    "blueprint_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Blueprint ID. When set, reason_activity and act_activity build RuntimeAgent\nfrom the blueprint definition instead of from harness_id/agent_id."
+                    },
+                    "capabilities": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AgentCapabilityConfig"
+                      },
+                      "description": "Session-level capabilities (additive to agent capabilities).\nApplied after agent capabilities when building RuntimeAgent."
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "Timestamp when the session was created."
+                    },
+                    "features": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Aggregated UI features from all active capabilities (harness + agent + session).\nComputed at read time from the capability registry.\nKnown features: \"file_system\", \"schedules\", \"secrets\", \"key_value\",\n\"sql_database\", \"leased_resources\"."
+                    },
+                    "finished_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time",
+                      "description": "Timestamp when the session finished (completed or failed)."
+                    },
+                    "harness_id": {
+                      "type": "string",
+                      "description": "ID of the harness for this session (format: harness_{32-hex}).",
+                      "example": "harness_01933b5a00007000800000000000001"
+                    },
+                    "hints": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "description": "Session-level client hints — arbitrary key-value pairs declared by the\nclient at session creation time. These are defaults for every turn;\nper-message `controls.hints` override these key-by-key (shallow merge).\n\nExamples: `{\"setup_connection\": true, \"rich_media\": true}`",
+                      "additionalProperties": {},
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "id": {
+                      "type": "string",
+                      "description": "Unique identifier for the session (format: session_{32-hex}).",
+                      "example": "session_01933b5a00007000800000000000001"
+                    },
+                    "initial_files": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/InitialFile"
+                      },
+                      "description": "Session-level initial files (additive to agent initial_files).\nFiles with matching paths override agent/harness files; new paths are appended."
+                    },
+                    "is_pinned": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ],
+                      "description": "Whether this session is pinned by the current user.\nOnly populated when the request has an authenticated user context."
+                    },
+                    "locale": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Locale for localized agent behavior and formatting (BCP 47, e.g. `uk-UA`)."
+                    },
+                    "max_iterations": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "description": "Maximum number of LLM iterations per turn for this session.",
+                      "minimum": 0
+                    },
+                    "model_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "LLM model ID to use for this session (format: model_{32-hex}).\nOverrides the agent's default model if set.",
+                      "example": "model_01933b5a00007000800000000000001"
+                    },
+                    "network_access": {
+                      "oneOf": [
+                        {
+                          "type": "null"
+                        },
+                        {
+                          "$ref": "#/components/schemas/NetworkAccessList",
+                          "description": "Network access list controlling which hosts/URLs this session can reach.\nMerged with harness and agent layers (allowed: intersect, blocked: union)."
+                        }
+                      ]
+                    },
+                    "organization_id": {
+                      "type": "string",
+                      "description": "Organization this session belongs to (format: org_{32-hex}).",
+                      "example": "org_00000000000000000000000000000001"
+                    },
+                    "output_preview": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Preview text from the last assistant response (truncated)."
+                    },
+                    "parent_session_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Parent session that spawned this subagent. NULL for top-level sessions."
+                    },
+                    "preview": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Preview text from the first user message (truncated)."
+                    },
+                    "started_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time",
+                      "description": "Timestamp when the session started executing."
+                    },
+                    "status": {
+                      "$ref": "#/components/schemas/SessionStatus",
+                      "description": "Current execution status of the session."
+                    },
+                    "subagent_name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Human-readable subagent name (\"Test Runner\"), unique per parent."
+                    },
+                    "subagent_status": {
+                      "oneOf": [
+                        {
+                          "type": "null"
+                        },
+                        {
+                          "$ref": "#/components/schemas/SubagentStatus",
+                          "description": "Subagent lifecycle status: spawning, running, completed, failed, cancelled."
+                        }
+                      ]
+                    },
+                    "subagent_task": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Original task description given to this subagent."
+                    },
+                    "system_prompt": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Session-level system prompt override.\nPrepended to the agent's system prompt when building RuntimeAgent."
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Tags for organizing and filtering sessions."
+                    },
+                    "title": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Human-readable title for the session."
+                    },
+                    "tools": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ToolDefinition"
+                      },
+                      "description": "Client-side tools for this session (additive to agent tools)."
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "Timestamp when the session was last updated."
+                    },
+                    "usage": {
+                      "oneOf": [
+                        {
+                          "type": "null"
+                        },
+                        {
+                          "$ref": "#/components/schemas/TokenUsage",
+                          "description": "Cumulative token usage for all LLM calls in this session."
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "url",
+                    "view_url"
+                  ],
+                  "properties": {
+                    "url": {
+                      "type": "string",
+                      "description": "Full API endpoint URL for this resource."
+                    },
+                    "view_url": {
+                      "type": "string",
+                      "description": "Full UI URL for viewing this resource."
+                    }
+                  }
+                }
+              ],
+              "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
             },
             "description": "Array of items returned by the list operation."
           },
@@ -13867,6 +14703,1183 @@
             "description": "SKILL.md content to validate"
           }
         }
+      },
+      "WithUrls_Agent": {
+        "allOf": [
+          {
+            "type": "object",
+            "description": "Agent configuration for agentic loop.\nAn agent defines the behavior and capabilities of an AI assistant.",
+            "required": [
+              "id",
+              "name",
+              "system_prompt",
+              "status",
+              "created_at",
+              "updated_at"
+            ],
+            "properties": {
+              "archived_at": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time",
+                "description": "Timestamp when the agent was archived."
+              },
+              "capabilities": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AgentCapabilityConfig"
+                },
+                "description": "Capabilities enabled for this agent with per-agent configuration.\nCapabilities add tools and system prompt modifications."
+              },
+              "created_at": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Timestamp when the agent was created."
+              },
+              "default_model_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Default LLM model ID for this agent.\nCan be overridden at the session level.",
+                "example": "model_01933b5a00007000800000000000001"
+              },
+              "deleted_at": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time",
+                "description": "Timestamp when the agent was deleted."
+              },
+              "description": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Human-readable description of what the agent does."
+              },
+              "display_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Human-readable display name shown in UI (e.g. \"Customer Support Agent\").\nFalls back to `name` when absent."
+              },
+              "id": {
+                "type": "string",
+                "description": "External identifier (agent_<32-hex>). Shown as \"id\" in API.\nClient-supplied or auto-generated.",
+                "example": "agent_01933b5a000070008000000000000001"
+              },
+              "initial_files": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/InitialFile"
+                },
+                "description": "Starter files copied into each new session for this agent."
+              },
+              "max_iterations": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Maximum number of LLM iterations per turn for this agent.",
+                "minimum": 0
+              },
+              "name": {
+                "type": "string",
+                "description": "Name, unique per org (e.g. \"customer-support\")."
+              },
+              "network_access": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/NetworkAccessList",
+                    "description": "Network access list controlling which hosts/URLs agent sessions can reach.\nMerged with harness and session layers (allowed: intersect, blocked: union)."
+                  }
+                ]
+              },
+              "status": {
+                "$ref": "#/components/schemas/AgentStatus",
+                "description": "Current lifecycle status of the agent."
+              },
+              "system_prompt": {
+                "type": "string",
+                "description": "System prompt that defines the agent's behavior.\nSent as the first message in every conversation."
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Tags for organizing and filtering agents."
+              },
+              "tools": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ToolDefinition"
+                },
+                "description": "Client-side tools registered for this agent.\nThese tools are executed by the client, not the server."
+              },
+              "updated_at": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Timestamp when the agent was last updated."
+              },
+              "usage": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/TokenUsage",
+                    "description": "Cumulative token usage across all sessions for this agent."
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "url",
+              "view_url"
+            ],
+            "properties": {
+              "url": {
+                "type": "string",
+                "description": "Full API endpoint URL for this resource."
+              },
+              "view_url": {
+                "type": "string",
+                "description": "Full UI URL for viewing this resource."
+              }
+            }
+          }
+        ],
+        "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+      },
+      "WithUrls_CapabilityInfo": {
+        "allOf": [
+          {
+            "type": "object",
+            "description": "Public capability information (without internal details)\nThis is what gets returned from the API\nNamed CapabilityInfo to distinguish from the Capability trait",
+            "required": [
+              "id",
+              "name",
+              "description",
+              "status"
+            ],
+            "properties": {
+              "category": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Category for grouping in UI"
+              },
+              "dependencies": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "IDs of capabilities that this capability depends on.\nWhen this capability is selected, its dependencies are automatically included."
+              },
+              "description": {
+                "type": "string",
+                "description": "Description of what this capability provides"
+              },
+              "features": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "UI feature strings this capability contributes to.\nMultiple capabilities can contribute the same feature."
+              },
+              "icon": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Icon name (for UI rendering)"
+              },
+              "id": {
+                "type": "string",
+                "description": "Unique capability identifier"
+              },
+              "is_mcp": {
+                "type": "boolean",
+                "description": "Whether this is an MCP server capability (for UI badge)"
+              },
+              "is_skill": {
+                "type": "boolean",
+                "description": "Whether this is an Agent Skill capability (for UI badge)"
+              },
+              "name": {
+                "type": "string",
+                "description": "Display name"
+              },
+              "risk_level": {
+                "$ref": "#/components/schemas/RiskLevel",
+                "description": "TM-AGENT-005: Risk level. High-risk capabilities require admin approval."
+              },
+              "status": {
+                "type": "string",
+                "description": "Current status"
+              },
+              "system_prompt": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "System prompt addition contributed by this capability"
+              },
+              "tool_definitions": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                },
+                "description": "Tool definitions provided by this capability"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "url",
+              "view_url"
+            ],
+            "properties": {
+              "url": {
+                "type": "string",
+                "description": "Full API endpoint URL for this resource."
+              },
+              "view_url": {
+                "type": "string",
+                "description": "Full UI URL for viewing this resource."
+              }
+            }
+          }
+        ],
+        "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+      },
+      "WithUrls_Harness": {
+        "allOf": [
+          {
+            "type": "object",
+            "description": "Harness configuration for sessions.\nA harness defines the base behavior and capabilities that apply to all sessions.",
+            "required": [
+              "id",
+              "name",
+              "system_prompt",
+              "status",
+              "created_at",
+              "updated_at"
+            ],
+            "properties": {
+              "archived_at": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time",
+                "description": "Timestamp when the harness was archived."
+              },
+              "capabilities": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AgentCapabilityConfig"
+                },
+                "description": "Capabilities enabled for this harness with per-harness configuration."
+              },
+              "created_at": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Timestamp when the harness was created."
+              },
+              "default_model_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Default LLM model ID for this harness.\nLowest priority in chain: controls > session > agent > harness.",
+                "example": "model_01933b5a00007000800000000000001"
+              },
+              "deleted_at": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time",
+                "description": "Timestamp when the harness was deleted."
+              },
+              "description": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Human-readable description of what the harness does."
+              },
+              "display_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Human-readable display name shown in UI."
+              },
+              "id": {
+                "type": "string",
+                "description": "Unique identifier for the harness (format: harness_{32-hex}).",
+                "example": "harness_01933b5a00007000800000000000001"
+              },
+              "initial_files": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/InitialFile"
+                },
+                "description": "Starter files copied into each new session for this harness."
+              },
+              "is_built_in": {
+                "type": "boolean",
+                "description": "Whether this harness is built-in (system-managed, readonly).\nBuilt-in harnesses are provisioned during org initialization and\ncannot be modified or deleted via the API. Users can copy them."
+              },
+              "name": {
+                "type": "string",
+                "description": "Name, unique per org (e.g. \"generic\")."
+              },
+              "network_access": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/NetworkAccessList",
+                    "description": "Network access list controlling which hosts/URLs sessions can reach.\nMerged with agent and session layers (allowed: intersect, blocked: union)."
+                  }
+                ]
+              },
+              "parent_harness_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Optional parent harness that this harness inherits from.",
+                "example": "harness_01933b5a000070008000000000000602"
+              },
+              "status": {
+                "$ref": "#/components/schemas/HarnessStatus",
+                "description": "Current lifecycle status of the harness."
+              },
+              "system_prompt": {
+                "type": "string",
+                "description": "System prompt that defines the harness's base behavior.\nForms the foundation of the prompt stack."
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Tags for organizing and filtering harnesses."
+              },
+              "updated_at": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Timestamp when the harness was last updated."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "url",
+              "view_url"
+            ],
+            "properties": {
+              "url": {
+                "type": "string",
+                "description": "Full API endpoint URL for this resource."
+              },
+              "view_url": {
+                "type": "string",
+                "description": "Full UI URL for viewing this resource."
+              }
+            }
+          }
+        ],
+        "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+      },
+      "WithUrls_LlmModel": {
+        "allOf": [
+          {
+            "type": "object",
+            "description": "LLM Model entity",
+            "required": [
+              "id",
+              "provider_id",
+              "model_id",
+              "display_name",
+              "capabilities",
+              "is_favorite",
+              "installed",
+              "status",
+              "source",
+              "created_at",
+              "updated_at"
+            ],
+            "properties": {
+              "capabilities": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "created_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "display_name": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string",
+                "example": "model_01933b5a00007000800000000000001"
+              },
+              "installed": {
+                "type": "boolean",
+                "description": "Whether this model is installed (available in UI model pickers).\nAll models are available via API regardless of this flag."
+              },
+              "is_favorite": {
+                "type": "boolean"
+              },
+              "model_id": {
+                "type": "string"
+              },
+              "provider_id": {
+                "type": "string",
+                "example": "provider_01933b5a00007000800000000000001"
+              },
+              "source": {
+                "$ref": "#/components/schemas/LlmModelSource",
+                "description": "How the model was added to the system"
+              },
+              "status": {
+                "$ref": "#/components/schemas/LlmModelStatus"
+              },
+              "updated_at": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "url",
+              "view_url"
+            ],
+            "properties": {
+              "url": {
+                "type": "string",
+                "description": "Full API endpoint URL for this resource."
+              },
+              "view_url": {
+                "type": "string",
+                "description": "Full UI URL for viewing this resource."
+              }
+            }
+          }
+        ],
+        "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+      },
+      "WithUrls_LlmModelWithProvider": {
+        "allOf": [
+          {
+            "type": "object",
+            "description": "LLM Model with provider info",
+            "required": [
+              "id",
+              "provider_id",
+              "model_id",
+              "display_name",
+              "capabilities",
+              "is_favorite",
+              "installed",
+              "status",
+              "source",
+              "created_at",
+              "updated_at",
+              "provider_name",
+              "provider_type"
+            ],
+            "properties": {
+              "capabilities": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "created_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "display_name": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string",
+                "example": "model_01933b5a00007000800000000000001"
+              },
+              "installed": {
+                "type": "boolean",
+                "description": "Whether this model is installed (available in UI model pickers)"
+              },
+              "is_favorite": {
+                "type": "boolean"
+              },
+              "model_id": {
+                "type": "string"
+              },
+              "profile": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LlmModelProfile",
+                    "description": "Readonly profile with model capabilities (not persisted to database)"
+                  }
+                ]
+              },
+              "provider_id": {
+                "type": "string",
+                "example": "provider_01933b5a00007000800000000000001"
+              },
+              "provider_name": {
+                "type": "string"
+              },
+              "provider_type": {
+                "$ref": "#/components/schemas/LlmProviderType"
+              },
+              "source": {
+                "$ref": "#/components/schemas/LlmModelSource",
+                "description": "How the model was added to the system"
+              },
+              "status": {
+                "$ref": "#/components/schemas/LlmModelStatus"
+              },
+              "updated_at": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "url",
+              "view_url"
+            ],
+            "properties": {
+              "url": {
+                "type": "string",
+                "description": "Full API endpoint URL for this resource."
+              },
+              "view_url": {
+                "type": "string",
+                "description": "Full UI URL for viewing this resource."
+              }
+            }
+          }
+        ],
+        "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+      },
+      "WithUrls_LlmProvider": {
+        "allOf": [
+          {
+            "type": "object",
+            "description": "LLM Provider entity (API keys never exposed)\nNote: This is the entity struct, separate from the LlmProvider trait in llm.rs",
+            "required": [
+              "id",
+              "name",
+              "provider_type",
+              "api_key_set",
+              "status",
+              "created_at",
+              "updated_at"
+            ],
+            "properties": {
+              "api_key_set": {
+                "type": "boolean",
+                "description": "Whether an API key is configured (key is never returned)"
+              },
+              "base_url": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "created_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "id": {
+                "type": "string",
+                "example": "provider_01933b5a00007000800000000000001"
+              },
+              "last_synced_at": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time",
+                "description": "When models were last synced from provider API"
+              },
+              "name": {
+                "type": "string"
+              },
+              "provider_type": {
+                "$ref": "#/components/schemas/LlmProviderType"
+              },
+              "status": {
+                "$ref": "#/components/schemas/LlmProviderStatus"
+              },
+              "updated_at": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "url",
+              "view_url"
+            ],
+            "properties": {
+              "url": {
+                "type": "string",
+                "description": "Full API endpoint URL for this resource."
+              },
+              "view_url": {
+                "type": "string",
+                "description": "Full UI URL for viewing this resource."
+              }
+            }
+          }
+        ],
+        "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+      },
+      "WithUrls_McpServer": {
+        "allOf": [
+          {
+            "type": "object",
+            "description": "MCP Server configuration.\nRepresents a remote MCP server that can provide tools and resources.",
+            "required": [
+              "id",
+              "name",
+              "url",
+              "transport_type",
+              "status",
+              "api_key_set",
+              "created_at",
+              "updated_at"
+            ],
+            "properties": {
+              "api_key_set": {
+                "type": "boolean",
+                "description": "Whether an API key has been configured."
+              },
+              "archived_at": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time",
+                "description": "Timestamp when the MCP server was archived."
+              },
+              "auth_mode": {
+                "$ref": "#/components/schemas/McpServerAuthMode",
+                "description": "Authentication mode for this MCP server."
+              },
+              "created_at": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Timestamp when the MCP server was created."
+              },
+              "deleted_at": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time",
+                "description": "Timestamp when the MCP server was deleted."
+              },
+              "description": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Human-readable description of the MCP server.",
+                "example": "Atlassian MCP Server for Jira and Confluence"
+              },
+              "headers": {
+                "type": "object",
+                "description": "Additional HTTP headers for authentication.\nKeys are header names, values are header values.",
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "id": {
+                "type": "string",
+                "description": "Unique identifier for the MCP server.",
+                "example": "mcp_01933b5a00007000800000000000001"
+              },
+              "name": {
+                "type": "string",
+                "description": "Display name of the MCP server.",
+                "example": "atlassian-mcp-server"
+              },
+              "oauth_provider_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Stable provider id used for user-scoped OAuth connections."
+              },
+              "status": {
+                "$ref": "#/components/schemas/McpServerStatus",
+                "description": "Current lifecycle status of the MCP server."
+              },
+              "transport_type": {
+                "$ref": "#/components/schemas/McpServerTransportType",
+                "description": "Transport type (currently only HTTP supported)."
+              },
+              "updated_at": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Timestamp when the MCP server was last updated."
+              },
+              "url": {
+                "type": "string",
+                "description": "URL of the MCP server endpoint.",
+                "example": "https://mcp.atlassian.com/v1/mcp"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "url",
+              "view_url"
+            ],
+            "properties": {
+              "url": {
+                "type": "string",
+                "description": "Full API endpoint URL for this resource."
+              },
+              "view_url": {
+                "type": "string",
+                "description": "Full UI URL for viewing this resource."
+              }
+            }
+          }
+        ],
+        "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+      },
+      "WithUrls_Session": {
+        "allOf": [
+          {
+            "type": "object",
+            "description": "Session - instance of agentic loop execution.\nA session represents a single conversation with an agent.",
+            "required": [
+              "id",
+              "organization_id",
+              "harness_id",
+              "status",
+              "created_at",
+              "updated_at"
+            ],
+            "properties": {
+              "active_schedule_count": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "int32",
+                "description": "Number of active (enabled) schedules for this session.\nPopulated when the session is fetched for API responses.",
+                "minimum": 0
+              },
+              "agent_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "ID of the agent working in this session (format: agent_{32-hex}). Optional.",
+                "example": "agent_01933b5a00007000800000000000001"
+              },
+              "agent_identity_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Optional resident agent identity for unattended/background execution.",
+                "example": "identity_01933b5a00007000800000000000001"
+              },
+              "blueprint_config": {
+                "description": "Validated config passed by host at blueprint spawn time."
+              },
+              "blueprint_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Blueprint ID. When set, reason_activity and act_activity build RuntimeAgent\nfrom the blueprint definition instead of from harness_id/agent_id."
+              },
+              "capabilities": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AgentCapabilityConfig"
+                },
+                "description": "Session-level capabilities (additive to agent capabilities).\nApplied after agent capabilities when building RuntimeAgent."
+              },
+              "created_at": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Timestamp when the session was created."
+              },
+              "features": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Aggregated UI features from all active capabilities (harness + agent + session).\nComputed at read time from the capability registry.\nKnown features: \"file_system\", \"schedules\", \"secrets\", \"key_value\",\n\"sql_database\", \"leased_resources\"."
+              },
+              "finished_at": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time",
+                "description": "Timestamp when the session finished (completed or failed)."
+              },
+              "harness_id": {
+                "type": "string",
+                "description": "ID of the harness for this session (format: harness_{32-hex}).",
+                "example": "harness_01933b5a00007000800000000000001"
+              },
+              "hints": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Session-level client hints — arbitrary key-value pairs declared by the\nclient at session creation time. These are defaults for every turn;\nper-message `controls.hints` override these key-by-key (shallow merge).\n\nExamples: `{\"setup_connection\": true, \"rich_media\": true}`",
+                "additionalProperties": {},
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "id": {
+                "type": "string",
+                "description": "Unique identifier for the session (format: session_{32-hex}).",
+                "example": "session_01933b5a00007000800000000000001"
+              },
+              "initial_files": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/InitialFile"
+                },
+                "description": "Session-level initial files (additive to agent initial_files).\nFiles with matching paths override agent/harness files; new paths are appended."
+              },
+              "is_pinned": {
+                "type": [
+                  "boolean",
+                  "null"
+                ],
+                "description": "Whether this session is pinned by the current user.\nOnly populated when the request has an authenticated user context."
+              },
+              "locale": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Locale for localized agent behavior and formatting (BCP 47, e.g. `uk-UA`)."
+              },
+              "max_iterations": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Maximum number of LLM iterations per turn for this session.",
+                "minimum": 0
+              },
+              "model_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "LLM model ID to use for this session (format: model_{32-hex}).\nOverrides the agent's default model if set.",
+                "example": "model_01933b5a00007000800000000000001"
+              },
+              "network_access": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/NetworkAccessList",
+                    "description": "Network access list controlling which hosts/URLs this session can reach.\nMerged with harness and agent layers (allowed: intersect, blocked: union)."
+                  }
+                ]
+              },
+              "organization_id": {
+                "type": "string",
+                "description": "Organization this session belongs to (format: org_{32-hex}).",
+                "example": "org_00000000000000000000000000000001"
+              },
+              "output_preview": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Preview text from the last assistant response (truncated)."
+              },
+              "parent_session_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Parent session that spawned this subagent. NULL for top-level sessions."
+              },
+              "preview": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Preview text from the first user message (truncated)."
+              },
+              "started_at": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time",
+                "description": "Timestamp when the session started executing."
+              },
+              "status": {
+                "$ref": "#/components/schemas/SessionStatus",
+                "description": "Current execution status of the session."
+              },
+              "subagent_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Human-readable subagent name (\"Test Runner\"), unique per parent."
+              },
+              "subagent_status": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/SubagentStatus",
+                    "description": "Subagent lifecycle status: spawning, running, completed, failed, cancelled."
+                  }
+                ]
+              },
+              "subagent_task": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Original task description given to this subagent."
+              },
+              "system_prompt": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Session-level system prompt override.\nPrepended to the agent's system prompt when building RuntimeAgent."
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Tags for organizing and filtering sessions."
+              },
+              "title": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Human-readable title for the session."
+              },
+              "tools": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ToolDefinition"
+                },
+                "description": "Client-side tools for this session (additive to agent tools)."
+              },
+              "updated_at": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Timestamp when the session was last updated."
+              },
+              "usage": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/TokenUsage",
+                    "description": "Cumulative token usage for all LLM calls in this session."
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "url",
+              "view_url"
+            ],
+            "properties": {
+              "url": {
+                "type": "string",
+                "description": "Full API endpoint URL for this resource."
+              },
+              "view_url": {
+                "type": "string",
+                "description": "Full UI URL for viewing this resource."
+              }
+            }
+          }
+        ],
+        "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
+      },
+      "WithUrls_Skill": {
+        "allOf": [
+          {
+            "type": "object",
+            "description": "Skill entity (API response type)",
+            "required": [
+              "id",
+              "name",
+              "description",
+              "source_type",
+              "status",
+              "version",
+              "created_at",
+              "updated_at"
+            ],
+            "properties": {
+              "allowed_tools": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "archived_at": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time"
+              },
+              "compatibility": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "created_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "deleted_at": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date-time"
+              },
+              "description": {
+                "type": "string",
+                "example": "Extract text and tables from PDF files."
+              },
+              "disable_model_invocation": {
+                "type": "boolean",
+                "description": "Whether the model is prevented from auto-invoking this skill"
+              },
+              "id": {
+                "type": "string",
+                "example": "skill_01933b5a00007000800000000000001"
+              },
+              "license": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "metadata": {
+                "type": "object",
+                "additionalProperties": {},
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "name": {
+                "type": "string",
+                "example": "pdf-processing"
+              },
+              "source_type": {
+                "$ref": "#/components/schemas/SkillSourceType"
+              },
+              "status": {
+                "$ref": "#/components/schemas/SkillStatus"
+              },
+              "updated_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "user_invocable": {
+                "type": "boolean",
+                "description": "Whether this skill appears as a /slash command for users"
+              },
+              "version": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "url",
+              "view_url"
+            ],
+            "properties": {
+              "url": {
+                "type": "string",
+                "description": "Full API endpoint URL for this resource."
+              },
+              "view_url": {
+                "type": "string",
+                "description": "Full UI URL for viewing this resource."
+              }
+            }
+          }
+        ],
+        "description": "Wrapper that adds `url` and `view_url` to a serialized resource."
       }
     }
   },


### PR DESCRIPTION
## What
Add `url` (API endpoint) and `view_url` (UI link) fields to all resource API responses. LLMs and MCP consumers can now provide clickable links and follow up with API calls without constructing URLs themselves.

## Why
Resource API responses lacked direct links. Consumers had to know the URL schema to construct links, which is fragile and prevents LLMs from offering clickable references.

## How
- Add `UrlBuilder` utility in `api/common.rs` that constructs absolute URLs from `AuthConfig` (base_url + frontend_url)
- Add `ResourceUrlable` trait with `api_path()`, `ui_path()`, and `resource_id()` methods
- Add `WithUrls<T>` wrapper struct that uses `#[serde(flatten)]` to inject `url` and `view_url` into any serializable resource
- Add `.with_urls()` helpers on `PaginatedResponse` and `ListResponse`
- Implement `ResourceUrlable` for all resource types: Agent, Session, Harness, Skill, Budget, McpServer, App, LlmProvider, LlmModel, LlmModelWithProvider, SessionSchedule, CapabilityInfo
- Update all GET/list/create/update handlers across 12 API modules
- Regenerate OpenAPI spec

## Risk
- Low-Medium
- Response shapes change (additive — new fields only), but no backward compat needed per project policy
- All existing tests pass (42/42 MCP tests, 1 pre-existing failure on main)

## Security
- Threat categories reviewed: TM-API, TM-TENANT, TM-AUTH
- `url` and `view_url` are constructed from server-side config (`base_url`, `frontend_url`), not user input — no injection risk
- URLs use the resource's own public ID, which is already present in the response — no new data exposure
- No auth/authz changes; URL construction is purely presentational
- Org-scoped resources remain org-scoped; URLs don't bypass access control

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Closes EVE-267