### PR TITLE
feat(mcp): simplify execute tool output to plain text

### DIFF
--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -831,7 +831,12 @@ async fn execute_script(
                 } else {
                     format!("{}\n{}", response.stdout, response.stderr)
                 };
-                Err(combined.trim().to_string())
+                let trimmed = combined.trim();
+                if trimmed.is_empty() {
+                    Err(format!("Command failed with exit code {}", response.exit_code))
+                } else {
+                    Err(trimmed.to_string())
+                }
             }
         }
         Err(_) => Err(format!("Command timed out after {timeout_ms}ms")),

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -821,18 +821,17 @@ async fn execute_script(
 
     match result {
         Ok(response) => {
-            let output = serde_json::to_string_pretty(&json!({
-                "stdout": response.stdout,
-                "stderr": response.stderr,
-                "exit_code": response.exit_code,
-                "success": response.exit_code == 0
-            }))
-            .unwrap();
-
             if response.exit_code == 0 {
-                Ok(output)
+                Ok(response.stdout)
             } else {
-                Err(output)
+                let combined = if response.stderr.is_empty() {
+                    response.stdout
+                } else if response.stdout.is_empty() {
+                    response.stderr
+                } else {
+                    format!("{}\n{}", response.stdout, response.stderr)
+                };
+                Err(combined.trim().to_string())
             }
         }
         Err(_) => Err(format!("Command timed out after {timeout_ms}ms")),

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -833,7 +833,10 @@ async fn execute_script(
                 };
                 let trimmed = combined.trim();
                 if trimmed.is_empty() {
-                    Err(format!("Command failed with exit code {}", response.exit_code))
+                    Err(format!(
+                        "Command failed with exit code {}",
+                        response.exit_code
+                    ))
                 } else {
                     Err(trimmed.to_string())
                 }

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -821,10 +821,7 @@ async fn test_mcp_execute_discover_categories() {
     let text = tool_text(&resp);
     assert!(text.contains("agents"), "Should list agents category");
     assert!(text.contains("sessions"), "Should list sessions category");
-    assert!(
-        text.contains("harnesses"),
-        "Should list harnesses category"
-    );
+    assert!(text.contains("harnesses"), "Should list harnesses category");
 }
 
 // ============================================================================

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -591,13 +591,7 @@ async fn test_mcp_execute_health_check() {
     );
 
     let result = tool_json(&resp);
-    assert!(
-        result["success"].as_bool().unwrap(),
-        "health_check should succeed"
-    );
-    let stdout: Value = serde_json::from_str(result["stdout"].as_str().unwrap())
-        .expect("stdout should be valid JSON");
-    assert_eq!(stdout["status"], "ok");
+    assert_eq!(result["status"], "ok");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -612,10 +606,7 @@ async fn test_mcp_execute_list_harnesses() {
     );
 
     let result = tool_json(&resp);
-    assert!(result["success"].as_bool().unwrap());
-    let stdout: Value = serde_json::from_str(result["stdout"].as_str().unwrap())
-        .expect("stdout should be valid JSON");
-    let harnesses = stdout["data"].as_array().expect("Expected harnesses array");
+    let harnesses = result["data"].as_array().expect("Expected harnesses array");
     assert!(!harnesses.is_empty(), "Should have seed harnesses");
 
     // Verify seed harnesses exist (Base and Generic are always seeded)
@@ -639,7 +630,7 @@ async fn test_mcp_execute_list_agents() {
     );
 
     let result = tool_json(&resp);
-    assert!(result["success"].as_bool().unwrap());
+    assert!(result["data"].is_array());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -661,9 +652,7 @@ async fn test_mcp_execute_create_and_get_agent() {
         tool_text(&resp)
     );
 
-    let result = tool_json(&resp);
-    assert!(result["success"].as_bool().unwrap());
-    let created: Value = serde_json::from_str(result["stdout"].as_str().unwrap()).unwrap();
+    let created = tool_json(&resp);
     let agent_id = created["id"].as_str().unwrap();
     assert!(agent_id.starts_with("agent_"));
 
@@ -680,8 +669,7 @@ async fn test_mcp_execute_create_and_get_agent() {
         tool_text(&resp)
     );
 
-    let result = tool_json(&resp);
-    let fetched: Value = serde_json::from_str(result["stdout"].as_str().unwrap()).unwrap();
+    let fetched = tool_json(&resp);
     assert_eq!(fetched["name"], "mcp-execute-agent");
 }
 
@@ -695,9 +683,6 @@ async fn test_mcp_execute_list_models() {
         "execute list_models failed: {}",
         tool_text(&resp)
     );
-
-    let result = tool_json(&resp);
-    assert!(result["success"].as_bool().unwrap());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -710,9 +695,6 @@ async fn test_mcp_execute_list_capabilities() {
         "execute list_capabilities failed: {}",
         tool_text(&resp)
     );
-
-    let result = tool_json(&resp);
-    assert!(result["success"].as_bool().unwrap());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -725,9 +707,6 @@ async fn test_mcp_execute_list_mcp_servers() {
         "execute list_mcp_servers failed: {}",
         tool_text(&resp)
     );
-
-    let result = tool_json(&resp);
-    assert!(result["success"].as_bool().unwrap());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -756,9 +735,7 @@ async fn test_mcp_execute_create_mcp_server() {
         tool_text(&resp)
     );
 
-    let result = tool_json(&resp);
-    assert!(result["success"].as_bool().unwrap());
-    let created: Value = serde_json::from_str(result["stdout"].as_str().unwrap()).unwrap();
+    let created = tool_json(&resp);
     assert_eq!(created["name"], unique_name);
     assert!(created["id"].as_str().unwrap().starts_with("mcp_"));
 }
@@ -776,9 +753,7 @@ async fn test_mcp_execute_bash_pipe() {
     .await;
     assert!(!tool_is_error(&resp), "pipe failed: {}", tool_text(&resp));
 
-    let result = tool_json(&resp);
-    assert!(result["success"].as_bool().unwrap());
-    let count: i64 = result["stdout"].as_str().unwrap().trim().parse().unwrap();
+    let count: i64 = tool_text(&resp).trim().parse().unwrap();
     assert!(count >= 2, "Should have at least 2 harnesses, got {count}");
 }
 
@@ -799,9 +774,7 @@ async fn test_mcp_execute_bash_script() {
         tool_text(&resp)
     );
 
-    let result = tool_json(&resp);
-    assert!(result["success"].as_bool().unwrap());
-    let count: i64 = result["stdout"].as_str().unwrap().trim().parse().unwrap();
+    let count: i64 = tool_text(&resp).trim().parse().unwrap();
     assert!(count >= 1, "Should have at least 1 agent after creation");
 }
 
@@ -815,9 +788,6 @@ async fn test_mcp_execute_list_providers() {
         "list_providers failed: {}",
         tool_text(&resp)
     );
-
-    let result = tool_json(&resp);
-    assert!(result["success"].as_bool().unwrap());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -830,9 +800,6 @@ async fn test_mcp_execute_list_orgs() {
         "list_orgs failed: {}",
         tool_text(&resp)
     );
-
-    let result = tool_json(&resp);
-    assert!(result["success"].as_bool().unwrap());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -851,13 +818,11 @@ async fn test_mcp_execute_discover_categories() {
         tool_text(&resp)
     );
 
-    let result = tool_json(&resp);
-    assert!(result["success"].as_bool().unwrap());
-    let stdout = result["stdout"].as_str().unwrap();
-    assert!(stdout.contains("agents"), "Should list agents category");
-    assert!(stdout.contains("sessions"), "Should list sessions category");
+    let text = tool_text(&resp);
+    assert!(text.contains("agents"), "Should list agents category");
+    assert!(text.contains("sessions"), "Should list sessions category");
     assert!(
-        stdout.contains("harnesses"),
+        text.contains("harnesses"),
         "Should list harnesses category"
     );
 }
@@ -884,9 +849,7 @@ async fn test_mcp_execute_agent_crud_workflow() {
         "create_agent failed: {}",
         tool_text(&resp)
     );
-    let result = tool_json(&resp);
-    assert!(result["success"].as_bool().unwrap(), "create failed");
-    let created: Value = serde_json::from_str(result["stdout"].as_str().unwrap()).unwrap();
+    let created = tool_json(&resp);
     let agent_id = created["id"].as_str().unwrap().to_string();
 
     // Update
@@ -903,9 +866,7 @@ async fn test_mcp_execute_agent_crud_workflow() {
         "update_agent failed: {}",
         tool_text(&resp)
     );
-    let result = tool_json(&resp);
-    assert!(result["success"].as_bool().unwrap(), "update failed");
-    let updated: Value = serde_json::from_str(result["stdout"].as_str().unwrap()).unwrap();
+    let updated = tool_json(&resp);
     assert_eq!(updated["name"], "updated-crud-agent");
 
     // Delete (archive)
@@ -915,8 +876,11 @@ async fn test_mcp_execute_agent_crud_workflow() {
         json!({ "command": format!("delete_agent --id {agent_id}") }),
     )
     .await;
-    let result = tool_json(&resp);
-    assert!(result["success"].as_bool().unwrap(), "delete failed");
+    assert!(
+        !tool_is_error(&resp),
+        "delete_agent failed: {}",
+        tool_text(&resp)
+    );
 }
 
 // ============================================================================


### PR DESCRIPTION
## What
Simplify the `execute` and `discover` tool output from a JSON envelope (`{stdout, stderr, exit_code, success}`) to plain text content.

## Why
MCP consumers (LLMs) don't need the bash-style structured output. The JSON wrapper wastes tokens and adds parsing friction. The MCP protocol already has `isError` to distinguish success from failure — double-wrapping is redundant.

Closes EVE-266

## How
- On success (exit_code == 0): return `stdout` directly as plain text
- On failure (exit_code != 0): return combined `stdout + stderr` (trimmed) as error text; MCP layer sets `isError: true`
- Applies to both `execute` and `discover` tools (both use `execute_script`)

## Risk
- Low
- MCP consumers that parsed the JSON envelope will see plain text instead — this is a breaking change for any client that depends on the `{stdout, stderr, exit_code}` structure, but the issue explicitly calls for this simplification

## Security
- Threat categories reviewed: TM-TOOL (tool output surface)
- No security-relevant code changes — output format change only, no new input parsing or auth changes

## Checklist
- [x] Tests added or updated (no tests needed — output format simplification)
- [x] Backward compatibility considered (intentional breaking change per issue spec)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)