### PR TITLE
fix(ci): repair SDK compat, CLI E2E tests and build gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -566,6 +566,7 @@ jobs:
     env:
       DEV_MODE: "true"
       AUTH_MODE: none
+      API_PREFIX: ""
       SECRETS_ENCRYPTION_KEY: kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=
       DEFAULT_OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       DEFAULT_ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -650,6 +651,7 @@ jobs:
     env:
       DEV_MODE: "true"
       AUTH_MODE: none
+      API_PREFIX: ""
       SECRETS_ENCRYPTION_KEY: kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=
       EVERRUNS_API_KEY: sdk-compat-test-key
       EVERRUNS_BASE_URL: http://localhost:9000
@@ -890,8 +892,9 @@ jobs:
     steps:
       - name: Verify all jobs passed
         run: |
-          echo "Job results: ${{ toJson(needs.*.result) }}"
-          if echo "${{ toJson(needs.*.result) }}" | grep -qE '"failure"|"cancelled"'; then
+          results='${{ toJson(needs.*.result) }}'
+          echo "Job results: $results"
+          if echo "$results" | grep -qE '"failure"|"cancelled"'; then
             echo "One or more CI jobs failed or were cancelled"
             exit 1
           fi

--- a/scripts/cli-e2e-test.sh
+++ b/scripts/cli-e2e-test.sh
@@ -46,8 +46,18 @@ detect_api_url() {
 }
 
 API_URL="$(detect_api_url)"
-CLI="./target/debug/everruns"
 SKIP_CHAT="${1:-}"
+
+# Resolve CLI binary: PATH > release build > debug build > build from source
+if command -v everruns >/dev/null 2>&1; then
+  CLI="$(command -v everruns)"
+elif [ -f "./target/release/everruns" ]; then
+  CLI="./target/release/everruns"
+elif [ -f "./target/debug/everruns" ]; then
+  CLI="./target/debug/everruns"
+else
+  CLI="./target/debug/everruns"
+fi
 
 # Colors for output
 RED='\033[0;31m'
@@ -75,9 +85,10 @@ log_fail() {
 }
 
 # Check CLI is built
-if [ ! -f "$CLI" ]; then
+if [ ! -f "$CLI" ] && ! command -v everruns >/dev/null 2>&1; then
   echo "CLI not found at $CLI. Building..."
   cargo build -p everruns-cli
+  CLI="./target/debug/everruns"
 fi
 
 # Verify server is running

--- a/scripts/cli-e2e-test.sh
+++ b/scripts/cli-e2e-test.sh
@@ -110,7 +110,7 @@ echo ""
 # Test: Capabilities
 # ========================================
 log_test "capabilities list"
-CAPS_OUTPUT=$($CLI --api-url "$API_URL" capabilities list --status all --output json 2>&1) || {
+CAPS_OUTPUT=$("$CLI" --api-url "$API_URL" capabilities list --status all --output json 2>&1) || {
   log_fail "capabilities list failed"
   echo "$CAPS_OUTPUT"
   exit 1
@@ -128,7 +128,7 @@ fi
 
 # Create agent
 log_test "agents create"
-AGENT_OUTPUT=$($CLI --api-url "$API_URL" agents create \
+AGENT_OUTPUT=$("$CLI" --api-url "$API_URL" agents create \
   --name "cli-test-agent" \
   --system-prompt "You are a test agent for CLI e2e testing." \
   --description "Test agent created by CLI e2e tests" \
@@ -149,7 +149,7 @@ fi
 
 # List agents
 log_test "agents list"
-LIST_OUTPUT=$($CLI --api-url "$API_URL" agents list --output json 2>&1) || {
+LIST_OUTPUT=$("$CLI" --api-url "$API_URL" agents list --output json 2>&1) || {
   log_fail "agents list failed"
   echo "$LIST_OUTPUT"
 }
@@ -163,7 +163,7 @@ fi
 
 # Get agent (uses prefixed ID directly)
 log_test "agents get"
-GET_OUTPUT=$($CLI --api-url "$API_URL" agents get "$AGENT_ID" --output json 2>&1) || {
+GET_OUTPUT=$("$CLI" --api-url "$API_URL" agents get "$AGENT_ID" --output json 2>&1) || {
   log_fail "agents get failed"
   echo "$GET_OUTPUT"
 }
@@ -199,7 +199,7 @@ fi
 
 # Create session (uses prefixed harness + agent IDs)
 log_test "sessions create"
-SESSION_OUTPUT=$($CLI --api-url "$API_URL" sessions create \
+SESSION_OUTPUT=$("$CLI" --api-url "$API_URL" sessions create \
   --harness "$HARNESS_ID" \
   --agent "$AGENT_ID" \
   --title "CLI E2E Test Session" \
@@ -220,7 +220,7 @@ fi
 
 # List sessions
 log_test "sessions list"
-LIST_SESSIONS_OUTPUT=$($CLI --api-url "$API_URL" sessions list --output json 2>&1) || {
+LIST_SESSIONS_OUTPUT=$("$CLI" --api-url "$API_URL" sessions list --output json 2>&1) || {
   log_fail "sessions list failed"
   echo "$LIST_SESSIONS_OUTPUT"
 }
@@ -234,7 +234,7 @@ fi
 
 # Get session (uses prefixed session ID directly)
 log_test "sessions get"
-GET_SESSION_OUTPUT=$($CLI --api-url "$API_URL" sessions get "$SESSION_ID" --output json 2>&1) || {
+GET_SESSION_OUTPUT=$("$CLI" --api-url "$API_URL" sessions get "$SESSION_ID" --output json 2>&1) || {
   log_fail "sessions get failed"
   echo "$GET_SESSION_OUTPUT"
 }
@@ -255,7 +255,7 @@ log_test "chat (SKIPPED - SDK pagination compatibility with events)"
 # Test: Delete agent (cleanup)
 # ========================================
 log_test "agents delete"
-DELETE_OUTPUT=$($CLI --api-url "$API_URL" agents delete "$AGENT_ID" --output json 2>&1) || {
+DELETE_OUTPUT=$("$CLI" --api-url "$API_URL" agents delete "$AGENT_ID" --output json 2>&1) || {
   log_fail "agents delete failed"
   echo "$DELETE_OUTPUT"
 }
@@ -263,7 +263,7 @@ log_pass "agents delete completed"
 
 # Verify agent is archived or inaccessible after delete
 log_test "agents get (verify archived)"
-if VERIFY_DELETE_OUTPUT=$($CLI --api-url "$API_URL" agents get "$AGENT_ID" --output json 2>&1); then
+if VERIFY_DELETE_OUTPUT=$("$CLI" --api-url "$API_URL" agents get "$AGENT_ID" --output json 2>&1); then
   AGENT_STATUS=$(echo "$VERIFY_DELETE_OUTPUT" | jq -r '.status // empty')
   if [ "$AGENT_STATUS" = "archived" ]; then
     log_pass "agents get returned archived status after delete"


### PR DESCRIPTION
## What

Fix three CI issues that have been silently breaking SDK compat tests, CLI E2E tests, and the build gate since PR #1250.

## Why

PR #1250 restructured routing with `API_PREFIX="/api"` as the default, moving all API routes from `/v1/...` to `/api/v1/...`. The SDK compat and CLI E2E test jobs still start the server expecting routes at `/v1/...`, so every API call returns 404. Additionally, the `ci-success` aggregation gate has a shell quoting bug that prevents it from detecting these failures, allowing PRs to merge despite red tests.

## How

1. **Route mismatch** — Add `API_PREFIX=""` to the `cli-e2e-test` and `sdk-compat-test` job env blocks so the server serves at `/v1/...` as the SDKs expect.
2. **Build gate quoting** — The expression `echo "${{ toJson(needs.*.result) }}"` places JSON double quotes inside a bash double-quoted string, stripping the inner quotes. `grep -qE '"failure"'` never matches. Fix: assign via single-quoted variable (`results='...'`) to preserve the JSON quotes.
3. **CLI binary path** — The E2E script hardcoded `./target/debug/everruns` but CI places the binary on PATH at `./bin/everruns`. Add a PATH-first lookup chain.

Verified locally: started server with `API_PREFIX=""` in DEV_MODE, all 11 CLI E2E tests pass, agent/session CRUD works at `/v1/...`.

## Risk
- Low
- CI-only change. No runtime, API, or data path changes.
- `API_PREFIX=""` restores the pre-#1250 behavior for test jobs only.

## Security
- No security-relevant code changes. All modifications are CI workflow env vars, a GitHub Actions shell quoting fix, and test script path resolution. No new endpoints, auth, input parsing, or data flow.

## Checklist
- [x] Tests added or updated (fixes existing broken tests)
- [x] Backward compatibility considered (CI-only, no runtime impact)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)