### PR TITLE
fix(auth): ensure default org gets harnesses via init_org

### DIFF
--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -394,6 +394,12 @@ pub async fn register(
             // Continue anyway - user is created, they just might not have org membership
         });
 
+    // Ensure default org has built-in harnesses (safety net — background seed task
+    // may not have completed yet or may have failed silently).
+    if let Err(e) = crate::org_init::initialize_org_harnesses(&state.db, DEFAULT_ORG_ID).await {
+        tracing::warn!(error = %e, "Failed to ensure default org harnesses (non-fatal)");
+    }
+
     let organizations = builtin::fetch_user_organizations(&state.db, user.id)
         .await
         .unwrap_or_default();
@@ -762,6 +768,12 @@ pub async fn oauth_callback(
                 // Continue anyway
             });
 
+        // Ensure default org has built-in harnesses (safety net — background seed task
+        // may not have completed yet or may have failed silently).
+        if let Err(e) = crate::org_init::initialize_org_harnesses(&state.db, DEFAULT_ORG_ID).await {
+            tracing::warn!(error = %e, "Failed to ensure default org harnesses (non-fatal)");
+        }
+
         created_user
     };
 
@@ -926,6 +938,12 @@ async fn get_or_create_admin_user(
                 tracing::error!("Failed to add admin user to default org: {}", e);
                 // Continue anyway
             });
+
+        // Ensure default org has built-in harnesses (safety net — background seed task
+        // may not have completed yet or may have failed silently).
+        if let Err(e) = crate::org_init::initialize_org_harnesses(&state.db, DEFAULT_ORG_ID).await {
+            tracing::warn!(error = %e, "Failed to ensure default org harnesses (non-fatal)");
+        }
 
         created_user
     };

--- a/crates/server/src/org_init.rs
+++ b/crates/server/src/org_init.rs
@@ -707,6 +707,54 @@ mod tests {
         assert!(!result3.has_changes());
     }
 
+    /// Verify that calling initialize_org_harnesses on a fresh default org
+    /// (without full seed_all) creates harnesses and sets org settings.
+    /// This simulates the safety-net path in auth registration handlers.
+    #[tokio::test]
+    async fn test_initialize_without_prior_seed() {
+        let db = make_db();
+        // Only create the org row — skip full seeding (models, providers, etc.)
+        seed_default_org(&db).await;
+
+        // Before init, no harnesses exist
+        let before = db
+            .list_harnesses(DEFAULT_ORG_ID, None, false)
+            .await
+            .unwrap();
+        assert!(before.is_empty());
+
+        // Initialize harnesses (same call the registration handlers make)
+        let result = initialize_org_harnesses(&db, DEFAULT_ORG_ID).await.unwrap();
+        assert!(result.created > 0, "should create built-in harnesses");
+
+        // Harnesses exist
+        let after = db
+            .list_harnesses(DEFAULT_ORG_ID, None, false)
+            .await
+            .unwrap();
+        assert_eq!(after.len(), harnesses().len());
+
+        // Org settings have default and base harness IDs
+        let settings = db
+            .get_organization_settings(DEFAULT_ORG_ID)
+            .await
+            .unwrap()
+            .expect("org settings should exist");
+        assert!(
+            settings.default_harness_id.is_some(),
+            "default_harness_id should be set"
+        );
+        assert!(
+            settings.base_harness_id.is_some(),
+            "base_harness_id should be set"
+        );
+
+        // Second call is idempotent
+        let result2 = initialize_org_harnesses(&db, DEFAULT_ORG_ID).await.unwrap();
+        assert_eq!(result2.created, 0, "should be idempotent");
+        assert_eq!(result2.unchanged, harnesses().len());
+    }
+
     async fn seed_default_org(db: &StorageBackend) {
         use crate::storage::models::CreateOrganizationRow;
         use everruns_core::DEFAULT_ORG_PUBLIC_ID;

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -297,6 +297,9 @@ async fn seed_admin_user(
     db.ensure_membership(user_id, DEFAULT_ORG_ID, "owner")
         .await?;
 
+    // Ensure default org has built-in harnesses (same safety net as registration handlers)
+    org_init::initialize_org_harnesses(db, DEFAULT_ORG_ID).await?;
+
     Ok(result)
 }
 

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -235,6 +235,9 @@ async fn seed_anonymous_user(db: &StorageBackend) -> anyhow::Result<SeedResult> 
     db.ensure_membership(ANONYMOUS_USER_ID, DEFAULT_ORG_ID, "owner")
         .await?;
 
+    // Ensure default org has built-in harnesses (same safety net as registration handlers)
+    org_init::initialize_org_harnesses(db, DEFAULT_ORG_ID).await?;
+
     Ok(result)
 }
 
@@ -1896,10 +1899,10 @@ pub fn spawn_seed_task_with_platform_definition(
                     );
                 }
 
-                // After seed succeeds, reconcile harnesses for non-default orgs.
-                // This runs here (not as a separate task) so ordering is deterministic:
-                // the default org and its harnesses are guaranteed to exist.
-                reconcile_non_default_org_harnesses(&db, &platform_definition).await;
+                // After seed succeeds, reconcile built-in harnesses for ALL orgs.
+                // Runs inside the seed task (not a separate task) so the default
+                // org row is guaranteed to exist before harness init runs.
+                reconcile_org_harnesses(&db, &platform_definition).await;
             }
             Err(e) => {
                 tracing::warn!(
@@ -1911,17 +1914,14 @@ pub fn spawn_seed_task_with_platform_definition(
     });
 }
 
-/// Reconcile built-in harnesses for every non-default org.
+/// Reconcile built-in harnesses for every organization (including the default org).
 ///
-/// Called after seeding completes (inside the seed task) so the default org and
-/// its harnesses are guaranteed to exist. Each org is reconciled independently;
-/// a single failure is logged but does not prevent other orgs from updating.
-async fn reconcile_non_default_org_harnesses(
-    db: &StorageBackend,
-    platform_definition: &PlatformDefinition,
-) {
+/// Called after seeding completes (inside the seed task) so the default org row
+/// is guaranteed to exist. Each org is reconciled independently; a single failure
+/// is logged but does not prevent other orgs from updating.
+async fn reconcile_org_harnesses(db: &StorageBackend, platform_definition: &PlatformDefinition) {
     let harnesses = platform_definition.built_in_harnesses();
-    let mut orgs = match db.list_organizations().await {
+    let orgs = match db.list_organizations().await {
         Ok(orgs) => orgs,
         Err(e) => {
             tracing::warn!(error = %e, "Harness reconciliation: failed to list orgs (non-fatal)");
@@ -1929,11 +1929,8 @@ async fn reconcile_non_default_org_harnesses(
         }
     };
 
-    // Skip the default org — already handled synchronously during seed.
-    orgs.retain(|o| o.org_id != everruns_core::DEFAULT_ORG_ID);
-
     if orgs.is_empty() {
-        tracing::debug!("No non-default orgs to reconcile harnesses for");
+        tracing::debug!("No orgs to reconcile harnesses for");
         return;
     }
 
@@ -2031,8 +2028,9 @@ async fn run_seed_with_retry(
 }
 
 /// Run all seeders in order
-/// Order: organization → users → providers → models → mcp_servers → harnesses
-/// Organization must be seeded first (all resources have org_id FK)
+/// Order: organization → users → providers → models → mcp_servers
+/// Organization must be seeded first (all resources have org_id FK).
+/// Harnesses are initialized by reconcile_org_harnesses (post-seed).
 /// Note: Agents are NOT seeded; they live as examples and are adopted on demand.
 pub async fn seed_all(
     db: &StorageBackend,
@@ -2126,24 +2124,10 @@ pub async fn seed_all_with_platform_definition(
     );
     result.merge(mcp_result);
 
-    // Initialize built-in harnesses for the default org (fast, O(1)).
-    // Multi-org reconciliation runs as a separate background task
-    // (spawn_harness_reconciliation_task) so it does not block startup.
-    let harness_result = org_init::initialize_org_harnesses_with_definitions(
-        db,
-        DEFAULT_ORG_ID,
-        platform_definition.built_in_harnesses(),
-    )
-    .await?;
-    tracing::debug!(
-        created = harness_result.created,
-        updated = harness_result.updated,
-        unchanged = harness_result.unchanged,
-        "Default org built-in harnesses seeded"
-    );
-    result.created += harness_result.created;
-    result.updated += harness_result.updated;
-    result.unchanged += harness_result.unchanged;
+    // Built-in harnesses are initialized for ALL orgs (including the default org)
+    // by reconcile_org_harnesses() which runs after seed_all completes.
+    // Auth registration handlers also call initialize_org_harnesses as a safety
+    // net, so harnesses are always present before a user interacts with an org.
 
     // Seed agents are available as examples (GET /v1/agent-examples) and adopted
     // on demand via POST /v1/agent-examples/{slug}/use. No automatic seeding —
@@ -2419,6 +2403,11 @@ mod tests {
         assert!(result.created > 0, "first run should create items");
         assert_eq!(result.updated, 0, "first run should not update anything");
 
+        // Harnesses are created by reconcile_org_harnesses (post-seed), not seed_all.
+        // Simulate the full startup flow.
+        let pd = crate::platform::oss_platform_definition_for_grade(DeploymentGrade::Dev);
+        reconcile_org_harnesses(&db, &pd).await;
+
         let settings = db
             .get_organization_settings(DEFAULT_ORG_ID)
             .await
@@ -2579,11 +2568,13 @@ mod tests {
     // --- Harness upsert ---
 
     #[tokio::test]
-    async fn test_harness_seed_detects_description_change() {
+    async fn test_harness_reconcile_detects_description_change() {
         let db = make_db();
         let _ = seed_all(&db, DeploymentGrade::Dev, &SeedAuthContext::default())
             .await
             .unwrap();
+        let pd = crate::platform::oss_platform_definition_for_grade(DeploymentGrade::Dev);
+        reconcile_org_harnesses(&db, &pd).await;
 
         // Mutate harness description via public API
         let built_in_harnesses = built_in_harnesses();
@@ -2606,7 +2597,8 @@ mod tests {
         .await
         .unwrap();
 
-        let result = seed_all(&db, DeploymentGrade::Dev, &SeedAuthContext::default())
+        // Reconciliation should detect the stale description and update it
+        let result = org_init::initialize_org_harnesses(&db, DEFAULT_ORG_ID)
             .await
             .unwrap();
         assert!(
@@ -2667,11 +2659,11 @@ mod tests {
     // --- Multi-org harness reconciliation ---
 
     #[tokio::test]
-    async fn test_reconcile_non_default_org_harnesses() {
+    async fn test_reconcile_org_harnesses() {
         use crate::storage::models::CreateOrganizationRow;
 
         let db = make_db();
-        // Seed default org first (creates harnesses for DEFAULT_ORG_ID).
+        // Seed creates the org but no longer initialises harnesses inline.
         seed_all(&db, DeploymentGrade::Dev, &SeedAuthContext::default())
             .await
             .unwrap();
@@ -2696,25 +2688,24 @@ mod tests {
             "second org should start with no harnesses"
         );
 
-        // Run reconciliation.
+        // Run reconciliation (covers ALL orgs, including default).
         let pd = crate::platform::oss_platform_definition_for_grade(DeploymentGrade::Dev);
-        reconcile_non_default_org_harnesses(&db, &pd).await;
+        reconcile_org_harnesses(&db, &pd).await;
 
-        // After reconciliation, second org should have the built-in harnesses.
-        let after = db
-            .list_harnesses(second_org.org_id, None, false)
-            .await
-            .unwrap();
-        assert!(
-            !after.is_empty(),
-            "second org should have harnesses after reconciliation"
-        );
-
-        // Default org harness count should match.
+        // After reconciliation, both orgs should have the built-in harnesses.
         let default_harnesses = db
             .list_harnesses(DEFAULT_ORG_ID, None, false)
             .await
             .unwrap();
-        assert_eq!(after.len(), default_harnesses.len());
+        assert!(
+            !default_harnesses.is_empty(),
+            "default org should have harnesses after reconciliation"
+        );
+
+        let second_harnesses = db
+            .list_harnesses(second_org.org_id, None, false)
+            .await
+            .unwrap();
+        assert_eq!(second_harnesses.len(), default_harnesses.len());
     }
 }

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -205,7 +205,10 @@ async fn seed_default_organization(db: &StorageBackend) -> anyhow::Result<SeedRe
 /// Seed anonymous user for auth=none mode.
 /// Uses ANONYMOUS_USER_ID so all code paths (org membership, API keys, etc.)
 /// work without special-casing a nil/missing user.
-async fn seed_anonymous_user(db: &StorageBackend) -> anyhow::Result<SeedResult> {
+async fn seed_anonymous_user(
+    db: &StorageBackend,
+    harness_definitions: &[everruns_core::BuiltInHarnessDefinition],
+) -> anyhow::Result<SeedResult> {
     let mut result = SeedResult::default();
 
     let input = CreateUserRow {
@@ -236,7 +239,8 @@ async fn seed_anonymous_user(db: &StorageBackend) -> anyhow::Result<SeedResult> 
         .await?;
 
     // Ensure default org has built-in harnesses (same safety net as registration handlers)
-    org_init::initialize_org_harnesses(db, DEFAULT_ORG_ID).await?;
+    org_init::initialize_org_harnesses_with_definitions(db, DEFAULT_ORG_ID, harness_definitions)
+        .await?;
 
     Ok(result)
 }
@@ -253,6 +257,7 @@ const ADMIN_USER_ID: Uuid = Uuid::from_u128(0x00000000_0000_0000_0000_0000000000
 async fn seed_admin_user(
     db: &StorageBackend,
     admin_config: &AdminConfig,
+    harness_definitions: &[everruns_core::BuiltInHarnessDefinition],
 ) -> anyhow::Result<SeedResult> {
     let mut result = SeedResult::default();
 
@@ -298,7 +303,8 @@ async fn seed_admin_user(
         .await?;
 
     // Ensure default org has built-in harnesses (same safety net as registration handlers)
-    org_init::initialize_org_harnesses(db, DEFAULT_ORG_ID).await?;
+    org_init::initialize_org_harnesses_with_definitions(db, DEFAULT_ORG_ID, harness_definitions)
+        .await?;
 
     Ok(result)
 }
@@ -2031,9 +2037,10 @@ async fn run_seed_with_retry(
 }
 
 /// Run all seeders in order
-/// Order: organization → users → providers → models → mcp_servers
+/// Order: organization → users (+ default-org harnesses) → providers → models → mcp_servers
 /// Organization must be seeded first (all resources have org_id FK).
-/// Harnesses are initialized by reconcile_org_harnesses (post-seed).
+/// Default-org harnesses are initialized inline by seed_anonymous_user / seed_admin_user.
+/// Multi-org harness reconciliation runs post-seed via reconcile_org_harnesses.
 /// Note: Agents are NOT seeded; they live as examples and are adopted on demand.
 pub async fn seed_all(
     db: &StorageBackend,
@@ -2064,7 +2071,7 @@ pub async fn seed_all_with_platform_definition(
     result.merge(org_result);
 
     // Seed anonymous user (for auth=none mode, depends on default org)
-    let anon_result = seed_anonymous_user(db).await?;
+    let anon_result = seed_anonymous_user(db, platform_definition.built_in_harnesses()).await?;
     tracing::debug!(
         created = anon_result.created,
         updated = anon_result.updated,
@@ -2077,7 +2084,8 @@ pub async fn seed_all_with_platform_definition(
     if auth_ctx.mode == AuthMode::Admin
         && let Some(admin_config) = &auth_ctx.admin
     {
-        let admin_result = seed_admin_user(db, admin_config).await?;
+        let admin_result =
+            seed_admin_user(db, admin_config, platform_definition.built_in_harnesses()).await?;
         tracing::debug!(
             created = admin_result.created,
             updated = admin_result.updated,
@@ -2127,10 +2135,10 @@ pub async fn seed_all_with_platform_definition(
     );
     result.merge(mcp_result);
 
-    // Built-in harnesses are initialized for ALL orgs (including the default org)
-    // by reconcile_org_harnesses() which runs after seed_all completes.
-    // Auth registration handlers also call initialize_org_harnesses as a safety
-    // net, so harnesses are always present before a user interacts with an org.
+    // Default-org harnesses were initialized above by seed_anonymous_user / seed_admin_user.
+    // Multi-org reconciliation (reconcile_org_harnesses) runs post-seed to cover
+    // all orgs. Auth registration handlers also call initialize_org_harnesses as
+    // a safety net for the race between seed task and first user registration.
 
     // Seed agents are available as examples (GET /v1/agent-examples) and adopted
     // on demand via POST /v1/agent-examples/{slug}/use. No automatic seeding —
@@ -2406,8 +2414,8 @@ mod tests {
         assert!(result.created > 0, "first run should create items");
         assert_eq!(result.updated, 0, "first run should not update anything");
 
-        // Harnesses are created by reconcile_org_harnesses (post-seed), not seed_all.
-        // Simulate the full startup flow.
+        // seed_all creates default-org harnesses via seed_anonymous_user.
+        // Run reconciliation too, matching the full startup flow.
         let pd = crate::platform::oss_platform_definition_for_grade(DeploymentGrade::Dev);
         reconcile_org_harnesses(&db, &pd).await;
 


### PR DESCRIPTION
## What
Ensure the default organization gets built-in harnesses through `init_org` on every user-creation path, instead of relying solely on the background seed task.

## Why
The default org's harnesses were only created by a background seed task (500ms delay after startup). If a user registered before seeding completed, or if seeding failed silently, the org had no harnesses. Unlike user-created orgs (which call `initialize_org_harnesses` synchronously), the default org had no safety net.

## How
1. **Add `init_org` to every user-creation path** — `register()`, `oauth_callback()`, `get_or_create_admin_user()`, `seed_anonymous_user()`, and `seed_admin_user()` now all call `initialize_org_harnesses`. The call is idempotent (no-op when harnesses exist).

2. **Remove redundant default-org harness init from `seed_all`** — `seed_all` no longer special-cases the default org for harness creation. Instead, `seed_anonymous_user` (which runs in all auth modes) handles it.

3. **Reconciliation covers all orgs** — `reconcile_org_harnesses` (post-seed) no longer skips the default org, so all orgs go through the same path.

**Harness init coverage by auth mode:**

| Mode | Primary init_org | Safety-net init_org |
|---|---|---|
| `none` | `seed_anonymous_user` | `reconcile_org_harnesses` |
| `admin` | `seed_anonymous_user` | `seed_admin_user`, `get_or_create_admin_user` |
| `full` | `seed_anonymous_user` | `register()`, `oauth_callback()` |

## Risk
- Low
- `initialize_org_harnesses` is idempotent — extra calls are fast no-ops (a few DB reads). No behavioral change when seeding succeeds normally.

## Security
- Threat categories reviewed: TM-AUTH, TM-TENANT
- `initialize_org_harnesses` is always called with the hardcoded `DEFAULT_ORG_ID` in auth handlers — cannot be directed at arbitrary orgs. Reconciliation iterates `list_organizations()` (internal DB call). No new inputs, no auth bypass, no data exposure.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
