### PR TITLE
feat(container-sandbox): add capability, tools, and crate scaffold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,6 +1570,7 @@ name = "everruns-container-sandbox"
 version = "0.8.10"
 dependencies = [
  "async-trait",
+ "base64",
  "chrono",
  "everruns-core",
  "inventory",
@@ -1940,6 +1941,7 @@ dependencies = [
  "cron",
  "dotenvy",
  "everruns-config",
+ "everruns-container-sandbox",
  "everruns-core",
  "everruns-durable",
  "everruns-integrations-brave-search",
@@ -2030,6 +2032,7 @@ dependencies = [
  "chrono",
  "everruns-anthropic",
  "everruns-config",
+ "everruns-container-sandbox",
  "everruns-core",
  "everruns-durable",
  "everruns-gemini",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,6 +1566,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-container-sandbox"
+version = "0.8.10"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "everruns-core",
+ "inventory",
+ "reqwest 0.13.2",
+ "serde",
+ "serde_json",
+ "tar",
+ "tokio",
+ "tracing",
+ "urlencoding",
+ "wiremock",
+]
+
+[[package]]
 name = "everruns-core"
 version = "0.8.10"
 dependencies = [
@@ -2141,6 +2159,17 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -6222,6 +6251,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8083,6 +8123,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/config",
     "crates/openui",
     "crates/session-sqldb",
+    "crates/container-sandbox",
     "integrations/docker",
     "integrations/daytona",
     "integrations/deno",

--- a/crates/container-sandbox/Cargo.toml
+++ b/crates/container-sandbox/Cargo.toml
@@ -1,0 +1,41 @@
+# Container Sandbox
+# Decision: Core crate (not integration) — self-hosted container execution via Docker Engine REST API.
+# Decision: Uses reqwest for HTTP/TCP Docker host connections. Unix socket support is a future enhancement.
+
+[package]
+name = "everruns-container-sandbox"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Self-hosted container sandbox capability for Everruns via Docker Engine REST API"
+
+[dependencies]
+everruns-core = { path = "../core" }
+inventory.workspace = true
+
+# HTTP client for Docker Engine REST API
+reqwest = { workspace = true }
+
+# Serialization
+serde.workspace = true
+serde_json.workspace = true
+
+# Tar archive encoding/decoding (Docker /archive endpoints)
+tar = "0.4"
+
+# URL encoding for query parameters
+urlencoding = "2"
+
+# Async
+async-trait.workspace = true
+tokio.workspace = true
+chrono.workspace = true
+tracing.workspace = true
+
+[features]
+container-sandbox-live-tests = []
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full", "test-util"] }
+wiremock = "0.6"

--- a/crates/container-sandbox/Cargo.toml
+++ b/crates/container-sandbox/Cargo.toml
@@ -27,6 +27,9 @@ tar = "0.4"
 # URL encoding for query parameters
 urlencoding = "2"
 
+# Base64 encoding for binary file transfers
+base64.workspace = true
+
 # Async
 async-trait.workspace = true
 tokio.workspace = true

--- a/crates/container-sandbox/src/client.rs
+++ b/crates/container-sandbox/src/client.rs
@@ -1,0 +1,787 @@
+//! Docker Engine REST API client.
+//!
+//! Decision: Uses reqwest for HTTP/TCP connections to Docker Engine API v1.47.
+//! Docker host resolution: config → env `CONTAINER_SANDBOX_DOCKER_HOST` → default `http://localhost:2375`.
+//! Unix socket support is a future enhancement (requires hyper unix transport).
+//!
+//! Decision: All methods return `Result<T, String>` for consistency with the Daytona client
+//! pattern and easy mapping to ToolExecutionResult errors.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::io::Read as _;
+use tracing::{debug, warn};
+
+/// Docker Engine API version prefix.
+const API_VERSION: &str = "/v1.47";
+
+/// Default Docker host when no config or env is set.
+const DEFAULT_DOCKER_HOST: &str = "http://localhost:2375";
+
+/// Environment variable for Docker host override.
+const DOCKER_HOST_ENV: &str = "CONTAINER_SANDBOX_DOCKER_HOST";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/// Container creation configuration.
+#[derive(Debug, Clone, Serialize)]
+pub struct ContainerCreateConfig {
+    #[serde(rename = "Image")]
+    pub image: String,
+    #[serde(rename = "Cmd")]
+    pub cmd: Vec<String>,
+    #[serde(rename = "WorkingDir")]
+    pub working_dir: String,
+    #[serde(rename = "Labels")]
+    pub labels: std::collections::HashMap<String, String>,
+    #[serde(rename = "HostConfig")]
+    pub host_config: HostConfig,
+}
+
+/// Container host configuration (resource limits, networking).
+#[derive(Debug, Clone, Serialize)]
+pub struct HostConfig {
+    #[serde(rename = "Runtime", skip_serializing_if = "String::is_empty")]
+    pub runtime: String,
+    #[serde(rename = "NetworkMode")]
+    pub network_mode: String,
+    #[serde(rename = "Memory")]
+    pub memory: i64,
+    #[serde(rename = "NanoCpus")]
+    pub nano_cpus: i64,
+    #[serde(rename = "PidsLimit")]
+    pub pids_limit: i64,
+    #[serde(rename = "Init")]
+    pub init: bool,
+}
+
+/// Response from container create.
+#[derive(Debug, Deserialize)]
+pub struct ContainerCreateResponse {
+    #[serde(rename = "Id")]
+    pub id: String,
+    #[serde(rename = "Warnings", default)]
+    pub warnings: Vec<String>,
+}
+
+/// Container inspect response (subset of fields we need).
+#[derive(Debug, Deserialize)]
+pub struct ContainerInspect {
+    #[serde(rename = "Id")]
+    pub id: String,
+    #[serde(rename = "State")]
+    pub state: ContainerState,
+    #[serde(rename = "Name")]
+    pub name: String,
+}
+
+/// Container state from inspect.
+#[derive(Debug, Deserialize)]
+pub struct ContainerState {
+    #[serde(rename = "Status")]
+    pub status: String,
+    #[serde(rename = "Running")]
+    pub running: bool,
+    #[serde(rename = "ExitCode")]
+    pub exit_code: i64,
+}
+
+/// Container list item.
+#[derive(Debug, Deserialize)]
+pub struct ContainerListItem {
+    #[serde(rename = "Id")]
+    pub id: String,
+    #[serde(rename = "Names")]
+    pub names: Vec<String>,
+    #[serde(rename = "State")]
+    pub state: String,
+    #[serde(rename = "Status")]
+    pub status: String,
+    #[serde(rename = "Labels")]
+    pub labels: std::collections::HashMap<String, String>,
+}
+
+/// Exec create response.
+#[derive(Debug, Deserialize)]
+pub struct ExecCreateResponse {
+    #[serde(rename = "Id")]
+    pub id: String,
+}
+
+/// Exec inspect response.
+#[derive(Debug, Deserialize)]
+pub struct ExecInspect {
+    #[serde(rename = "ExitCode")]
+    pub exit_code: Option<i64>,
+    #[serde(rename = "Running")]
+    pub running: bool,
+}
+
+/// Result of exec start (captured output).
+pub struct ExecOutput {
+    pub stdout: String,
+    pub exit_code: i64,
+}
+
+// ============================================================================
+// DockerClient
+// ============================================================================
+
+pub struct DockerClient {
+    http: reqwest::Client,
+    base_url: String,
+}
+
+impl DockerClient {
+    /// Create a new DockerClient.
+    ///
+    /// Host resolution priority:
+    /// 1. Explicit `docker_host` parameter (from config)
+    /// 2. `CONTAINER_SANDBOX_DOCKER_HOST` env var
+    /// 3. Default: `http://localhost:2375`
+    pub fn new(docker_host: Option<&str>) -> Self {
+        let base_url = docker_host
+            .map(String::from)
+            .or_else(|| std::env::var(DOCKER_HOST_ENV).ok())
+            .unwrap_or_else(|| DEFAULT_DOCKER_HOST.to_string());
+
+        debug!(base_url = %base_url, "DockerClient initialized");
+
+        Self {
+            http: reqwest::Client::new(),
+            base_url,
+        }
+    }
+
+    /// For tests: create with explicit base URL.
+    #[cfg(test)]
+    pub fn with_base_url(base_url: String) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            base_url,
+        }
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{API_VERSION}{path}", self.base_url)
+    }
+
+    // --- Generic request helpers ---
+
+    async fn request(
+        &self,
+        method: reqwest::Method,
+        path: &str,
+        body: Option<Value>,
+    ) -> Result<Value, String> {
+        let url = self.url(path);
+        let mut req = self
+            .http
+            .request(method, &url)
+            .header("Content-Type", "application/json");
+
+        if let Some(b) = body {
+            req = req.json(&b);
+        }
+
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| format!("Docker API connection failed: {e}"))?;
+
+        let status = resp.status();
+        let body_text = resp
+            .text()
+            .await
+            .map_err(|e| format!("Failed to read Docker response: {e}"))?;
+
+        if !status.is_success() {
+            return Err(map_docker_error(status.as_u16(), &body_text));
+        }
+
+        if body_text.is_empty() {
+            return Ok(json!({}));
+        }
+
+        serde_json::from_str(&body_text).map_err(|e| format!("Invalid JSON from Docker: {e}"))
+    }
+
+    async fn request_typed<T: serde::de::DeserializeOwned>(
+        &self,
+        method: reqwest::Method,
+        path: &str,
+        body: Option<Value>,
+    ) -> Result<T, String> {
+        let url = self.url(path);
+        let mut req = self
+            .http
+            .request(method, &url)
+            .header("Content-Type", "application/json");
+
+        if let Some(b) = body {
+            req = req.json(&b);
+        }
+
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| format!("Docker API connection failed: {e}"))?;
+
+        let status = resp.status();
+        let body_text = resp
+            .text()
+            .await
+            .map_err(|e| format!("Failed to read Docker response: {e}"))?;
+
+        if !status.is_success() {
+            return Err(map_docker_error(status.as_u16(), &body_text));
+        }
+
+        serde_json::from_str(&body_text).map_err(|e| format!("Invalid JSON from Docker: {e}"))
+    }
+
+    async fn request_bytes(&self, method: reqwest::Method, path: &str) -> Result<Vec<u8>, String> {
+        let url = self.url(path);
+        let resp = self
+            .http
+            .request(method, &url)
+            .send()
+            .await
+            .map_err(|e| format!("Docker API connection failed: {e}"))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body_text = resp
+                .text()
+                .await
+                .map_err(|e| format!("Failed to read response: {e}"))?;
+            return Err(map_docker_error(status.as_u16(), &body_text));
+        }
+
+        resp.bytes()
+            .await
+            .map(|b| b.to_vec())
+            .map_err(|e| format!("Failed to read bytes: {e}"))
+    }
+
+    async fn request_no_content(
+        &self,
+        method: reqwest::Method,
+        path: &str,
+        body: Option<Value>,
+    ) -> Result<(), String> {
+        let url = self.url(path);
+        let mut req = self
+            .http
+            .request(method, &url)
+            .header("Content-Type", "application/json");
+
+        if let Some(b) = body {
+            req = req.json(&b);
+        }
+
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| format!("Docker API connection failed: {e}"))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body_text = resp
+                .text()
+                .await
+                .map_err(|e| format!("Failed to read response: {e}"))?;
+            return Err(map_docker_error(status.as_u16(), &body_text));
+        }
+
+        Ok(())
+    }
+
+    // ========================================================================
+    // Network operations
+    // ========================================================================
+
+    /// Create an isolated bridge network for a sandbox.
+    pub async fn create_network(
+        &self,
+        name: &str,
+        labels: std::collections::HashMap<String, String>,
+    ) -> Result<String, String> {
+        debug!(name = %name, "Creating Docker network");
+        let body = json!({
+            "Name": name,
+            "Driver": "bridge",
+            "Labels": labels,
+        });
+        let resp: Value = self
+            .request(reqwest::Method::POST, "/networks/create", Some(body))
+            .await?;
+        resp.get("Id")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .ok_or_else(|| "Missing network Id in response".to_string())
+    }
+
+    /// Remove a network by ID.
+    pub async fn remove_network(&self, id: &str) -> Result<(), String> {
+        debug!(id = %id, "Removing Docker network");
+        self.request_no_content(reqwest::Method::DELETE, &format!("/networks/{id}"), None)
+            .await
+    }
+
+    // ========================================================================
+    // Container lifecycle
+    // ========================================================================
+
+    /// Create a container with the given configuration.
+    pub async fn create_container(
+        &self,
+        name: &str,
+        config: &ContainerCreateConfig,
+    ) -> Result<ContainerCreateResponse, String> {
+        debug!(name = %name, image = %config.image, "Creating container");
+        let body =
+            serde_json::to_value(config).map_err(|e| format!("Failed to serialize config: {e}"))?;
+        self.request_typed(
+            reqwest::Method::POST,
+            &format!("/containers/create?name={name}"),
+            Some(body),
+        )
+        .await
+    }
+
+    /// Start a stopped container.
+    pub async fn start_container(&self, id: &str) -> Result<(), String> {
+        debug!(id = %id, "Starting container");
+        self.request_no_content(
+            reqwest::Method::POST,
+            &format!("/containers/{id}/start"),
+            None,
+        )
+        .await
+    }
+
+    /// Gracefully stop a running container.
+    pub async fn stop_container(&self, id: &str, timeout_seconds: u32) -> Result<(), String> {
+        debug!(id = %id, timeout = timeout_seconds, "Stopping container");
+        self.request_no_content(
+            reqwest::Method::POST,
+            &format!("/containers/{id}/stop?t={timeout_seconds}"),
+            None,
+        )
+        .await
+    }
+
+    /// Remove a container (force remove if running).
+    pub async fn remove_container(&self, id: &str) -> Result<(), String> {
+        debug!(id = %id, "Removing container");
+        self.request_no_content(
+            reqwest::Method::DELETE,
+            &format!("/containers/{id}?force=true"),
+            None,
+        )
+        .await
+    }
+
+    /// Inspect a container (get detailed state).
+    pub async fn inspect_container(&self, id: &str) -> Result<ContainerInspect, String> {
+        self.request_typed(
+            reqwest::Method::GET,
+            &format!("/containers/{id}/json"),
+            None,
+        )
+        .await
+    }
+
+    /// List containers matching label filters.
+    pub async fn list_containers(
+        &self,
+        label_filters: &[(&str, &str)],
+    ) -> Result<Vec<ContainerListItem>, String> {
+        let filters: std::collections::HashMap<&str, Vec<String>> =
+            std::collections::HashMap::from([(
+                "label",
+                label_filters
+                    .iter()
+                    .map(|(k, v)| format!("{k}={v}"))
+                    .collect(),
+            )]);
+
+        let filters_json =
+            serde_json::to_string(&filters).map_err(|e| format!("Filter encoding error: {e}"))?;
+
+        self.request_typed(
+            reqwest::Method::GET,
+            &format!(
+                "/containers/json?all=true&filters={}",
+                urlencoding::encode(&filters_json)
+            ),
+            None,
+        )
+        .await
+    }
+
+    // ========================================================================
+    // Exec operations
+    // ========================================================================
+
+    /// Create an exec instance in a container.
+    pub async fn exec_create(
+        &self,
+        container_id: &str,
+        cmd: &[&str],
+        working_dir: Option<&str>,
+    ) -> Result<String, String> {
+        debug!(container_id = %container_id, cmd = ?cmd, "Creating exec instance");
+        let mut body = json!({
+            "AttachStdout": true,
+            "AttachStderr": true,
+            "Cmd": cmd,
+        });
+        if let Some(wd) = working_dir {
+            body["WorkingDir"] = json!(wd);
+        }
+
+        let resp: ExecCreateResponse = self
+            .request_typed(
+                reqwest::Method::POST,
+                &format!("/containers/{container_id}/exec"),
+                Some(body),
+            )
+            .await?;
+        Ok(resp.id)
+    }
+
+    /// Start an exec instance and capture output.
+    ///
+    /// Docker multiplexes stdout/stderr into a single stream with 8-byte headers.
+    /// We demux the stream and combine stdout+stderr into a single string.
+    pub async fn exec_start(&self, exec_id: &str) -> Result<String, String> {
+        debug!(exec_id = %exec_id, "Starting exec");
+        let url = self.url(&format!("/exec/{exec_id}/start"));
+        let resp = self
+            .http
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .json(&json!({"Detach": false, "Tty": false}))
+            .send()
+            .await
+            .map_err(|e| format!("Docker exec start failed: {e}"))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body_text = resp
+                .text()
+                .await
+                .map_err(|e| format!("Failed to read response: {e}"))?;
+            return Err(map_docker_error(status.as_u16(), &body_text));
+        }
+
+        let raw = resp
+            .bytes()
+            .await
+            .map_err(|e| format!("Failed to read exec output: {e}"))?;
+
+        Ok(demux_docker_stream(&raw))
+    }
+
+    /// Get the exit code of a completed exec instance.
+    pub async fn exec_inspect(&self, exec_id: &str) -> Result<ExecInspect, String> {
+        self.request_typed(reqwest::Method::GET, &format!("/exec/{exec_id}/json"), None)
+            .await
+    }
+
+    /// Execute a command and return combined output + exit code.
+    pub async fn exec(
+        &self,
+        container_id: &str,
+        cmd: &[&str],
+        working_dir: Option<&str>,
+    ) -> Result<ExecOutput, String> {
+        let exec_id = self.exec_create(container_id, cmd, working_dir).await?;
+        let stdout = self.exec_start(&exec_id).await?;
+        let inspect = self.exec_inspect(&exec_id).await?;
+        Ok(ExecOutput {
+            stdout,
+            exit_code: inspect.exit_code.unwrap_or(-1),
+        })
+    }
+
+    // ========================================================================
+    // File operations (tar-based archive API)
+    // ========================================================================
+
+    /// Read a file from a container via the archive API.
+    /// Returns the file content as bytes.
+    pub async fn get_archive(&self, container_id: &str, path: &str) -> Result<Vec<u8>, String> {
+        debug!(container_id = %container_id, path = %path, "Reading file from container");
+        let encoded_path = urlencoding::encode(path);
+        let tar_bytes = self
+            .request_bytes(
+                reqwest::Method::GET,
+                &format!("/containers/{container_id}/archive?path={encoded_path}"),
+            )
+            .await?;
+
+        extract_file_from_tar(&tar_bytes)
+    }
+
+    /// Write a file to a container via the archive API.
+    /// Content is wrapped in a tar archive and PUT to the container.
+    pub async fn put_archive(
+        &self,
+        container_id: &str,
+        dir_path: &str,
+        filename: &str,
+        content: &[u8],
+    ) -> Result<(), String> {
+        debug!(container_id = %container_id, dir_path = %dir_path, filename = %filename, "Writing file to container");
+        let tar_bytes = create_tar_with_file(filename, content)?;
+        let encoded_path = urlencoding::encode(dir_path);
+        let url = self.url(&format!(
+            "/containers/{container_id}/archive?path={encoded_path}"
+        ));
+
+        let resp = self
+            .http
+            .put(&url)
+            .header("Content-Type", "application/x-tar")
+            .body(tar_bytes)
+            .send()
+            .await
+            .map_err(|e| format!("Docker archive upload failed: {e}"))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body_text = resp
+                .text()
+                .await
+                .map_err(|e| format!("Failed to read response: {e}"))?;
+            return Err(map_docker_error(status.as_u16(), &body_text));
+        }
+
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Map Docker API HTTP errors to human-readable messages.
+fn map_docker_error(status: u16, body: &str) -> String {
+    // Try to extract Docker's error message from JSON response
+    let detail = serde_json::from_str::<Value>(body)
+        .ok()
+        .and_then(|v| v.get("message").and_then(|m| m.as_str()).map(String::from))
+        .unwrap_or_else(|| body.to_string());
+
+    match status {
+        304 => format!("Container already in requested state: {detail}"),
+        404 => format!("Not found: {detail}"),
+        409 => format!("Conflict (container/network already exists): {detail}"),
+        500 => {
+            if detail.contains("runtime not found") {
+                format!("Container runtime not found. Is sysbox installed? ({detail})")
+            } else {
+                format!("Docker Engine error: {detail}")
+            }
+        }
+        _ => format!("Docker API error (HTTP {status}): {detail}"),
+    }
+}
+
+/// Demultiplex Docker's multiplexed stdout/stderr stream.
+///
+/// Docker exec with `Tty: false` returns a stream where each frame has:
+/// - byte 0: stream type (1 = stdout, 2 = stderr)
+/// - bytes 1-3: reserved (zero)
+/// - bytes 4-7: big-endian payload size
+/// - bytes 8..8+size: payload
+fn demux_docker_stream(raw: &[u8]) -> String {
+    let mut output = String::new();
+    let mut pos = 0;
+
+    while pos + 8 <= raw.len() {
+        // Stream type at byte 0 (we combine stdout+stderr)
+        let size =
+            u32::from_be_bytes([raw[pos + 4], raw[pos + 5], raw[pos + 6], raw[pos + 7]]) as usize;
+        pos += 8;
+
+        if pos + size > raw.len() {
+            warn!(
+                expected = size,
+                available = raw.len() - pos,
+                "Truncated Docker stream frame"
+            );
+            // Append whatever we have
+            output.push_str(&String::from_utf8_lossy(&raw[pos..]));
+            break;
+        }
+
+        output.push_str(&String::from_utf8_lossy(&raw[pos..pos + size]));
+        pos += size;
+    }
+
+    output
+}
+
+/// Extract the first file's content from a tar archive (Docker GET /archive response).
+fn extract_file_from_tar(tar_bytes: &[u8]) -> Result<Vec<u8>, String> {
+    let mut archive = tar::Archive::new(tar_bytes);
+    let mut entries = archive
+        .entries()
+        .map_err(|e| format!("Failed to read tar archive: {e}"))?;
+
+    if let Some(entry_result) = entries.next() {
+        let mut entry = entry_result.map_err(|e| format!("Failed to read tar entry: {e}"))?;
+        let mut content = Vec::new();
+        entry
+            .read_to_end(&mut content)
+            .map_err(|e| format!("Failed to read file from tar: {e}"))?;
+        Ok(content)
+    } else {
+        Err("Empty tar archive — file not found in container".to_string())
+    }
+}
+
+/// Create a tar archive containing a single file.
+fn create_tar_with_file(filename: &str, content: &[u8]) -> Result<Vec<u8>, String> {
+    let mut builder = tar::Builder::new(Vec::new());
+    let mut header = tar::Header::new_gnu();
+    header.set_size(content.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    builder
+        .append_data(&mut header, filename, content)
+        .map_err(|e| format!("Failed to create tar archive: {e}"))?;
+    builder
+        .into_inner()
+        .map_err(|e| format!("Failed to finalize tar archive: {e}"))
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_url_construction() {
+        let client = DockerClient::with_base_url("http://10.0.0.3:2375".to_string());
+        assert_eq!(
+            client.url("/containers/json"),
+            "http://10.0.0.3:2375/v1.47/containers/json"
+        );
+    }
+
+    #[test]
+    fn test_demux_docker_stream_stdout() {
+        // stdout frame: type=1, size=5, payload="hello"
+        let mut frame = vec![1, 0, 0, 0, 0, 0, 0, 5]; // header
+        frame.extend_from_slice(b"hello");
+        assert_eq!(demux_docker_stream(&frame), "hello");
+    }
+
+    #[test]
+    fn test_demux_docker_stream_mixed() {
+        // stdout "hello", stderr " world"
+        let mut frame = vec![1, 0, 0, 0, 0, 0, 0, 5];
+        frame.extend_from_slice(b"hello");
+        frame.extend_from_slice(&[2, 0, 0, 0, 0, 0, 0, 6]);
+        frame.extend_from_slice(b" world");
+        assert_eq!(demux_docker_stream(&frame), "hello world");
+    }
+
+    #[test]
+    fn test_demux_empty_stream() {
+        assert_eq!(demux_docker_stream(&[]), "");
+    }
+
+    #[test]
+    fn test_demux_truncated_frame() {
+        // Frame claims 100 bytes but only 3 available
+        let mut frame = vec![1, 0, 0, 0, 0, 0, 0, 100];
+        frame.extend_from_slice(b"abc");
+        assert_eq!(demux_docker_stream(&frame), "abc");
+    }
+
+    #[test]
+    fn test_create_and_extract_tar() {
+        let content = b"Hello, container!";
+        let tar_bytes = create_tar_with_file("test.txt", content).unwrap();
+        let extracted = extract_file_from_tar(&tar_bytes).unwrap();
+        assert_eq!(extracted, content);
+    }
+
+    #[test]
+    fn test_map_docker_error_not_found() {
+        let msg = map_docker_error(404, r#"{"message":"No such container: abc123"}"#);
+        assert!(msg.contains("Not found"));
+        assert!(msg.contains("No such container"));
+    }
+
+    #[test]
+    fn test_map_docker_error_conflict() {
+        let msg = map_docker_error(409, r#"{"message":"name already in use"}"#);
+        assert!(msg.contains("Conflict"));
+    }
+
+    #[test]
+    fn test_map_docker_error_runtime_not_found() {
+        let msg = map_docker_error(500, r#"{"message":"OCI runtime not found: sysbox-runc"}"#);
+        assert!(msg.contains("runtime not found"));
+        assert!(msg.contains("sysbox"));
+    }
+
+    #[test]
+    fn test_container_create_config_serialization() {
+        let config = ContainerCreateConfig {
+            image: "ubuntu:24.04".to_string(),
+            cmd: vec![
+                "tail".to_string(),
+                "-f".to_string(),
+                "/dev/null".to_string(),
+            ],
+            working_dir: "/workspace".to_string(),
+            labels: std::collections::HashMap::from([(
+                "managed-by".to_string(),
+                "everruns".to_string(),
+            )]),
+            host_config: HostConfig {
+                runtime: String::new(),
+                network_mode: "bridge".to_string(),
+                memory: 2_147_483_648,
+                nano_cpus: 1_000_000_000,
+                pids_limit: 256,
+                init: true,
+            },
+        };
+
+        let json = serde_json::to_value(&config).unwrap();
+        assert_eq!(json["Image"], "ubuntu:24.04");
+        assert_eq!(json["HostConfig"]["Memory"], 2_147_483_648_i64);
+        assert_eq!(json["HostConfig"]["Init"], true);
+        // Empty runtime should not appear in serialized output
+        assert!(json["HostConfig"].get("Runtime").is_none());
+    }
+
+    #[test]
+    fn test_label_filter_encoding() {
+        let filters: std::collections::HashMap<&str, Vec<String>> =
+            std::collections::HashMap::from([(
+                "label",
+                vec![
+                    "managed-by=everruns".to_string(),
+                    "session=abc123".to_string(),
+                ],
+            )]);
+        let json = serde_json::to_string(&filters).unwrap();
+        assert!(json.contains("managed-by=everruns"));
+        assert!(json.contains("session=abc123"));
+    }
+}

--- a/crates/container-sandbox/src/config.rs
+++ b/crates/container-sandbox/src/config.rs
@@ -1,0 +1,131 @@
+//! Container sandbox configuration.
+//!
+//! Decision: Config resolution: explicit config → env vars → defaults.
+//! Decision: All resource limits have safe defaults suitable for development.
+
+use serde::{Deserialize, Serialize};
+
+/// Default Docker image for sandboxes.
+const DEFAULT_IMAGE: &str = "ubuntu:24.04";
+/// Default working directory inside containers.
+const DEFAULT_WORKING_DIR: &str = "/workspace";
+/// Default memory limit (2 GiB).
+const DEFAULT_MEMORY_LIMIT_BYTES: i64 = 2_147_483_648;
+/// Default CPU limit (1 core in nanocpus).
+const DEFAULT_CPU_LIMIT_NANOCPUS: i64 = 1_000_000_000;
+/// Default PID limit.
+const DEFAULT_PIDS_LIMIT: i64 = 256;
+/// Default auto-stop timeout (minutes).
+const DEFAULT_AUTO_STOP_MINUTES: u64 = 10;
+
+/// Configuration for the container sandbox capability.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContainerSandboxConfig {
+    /// Docker Engine host URL (env → config → "http://localhost:2375")
+    #[serde(default)]
+    pub docker_host: Option<String>,
+    /// Container runtime (e.g., "sysbox-runc"). Empty for default runc.
+    #[serde(default)]
+    pub runtime: String,
+    /// Container image.
+    #[serde(default = "default_image")]
+    pub image: String,
+    /// Memory limit in bytes.
+    #[serde(default = "default_memory")]
+    pub memory_limit: i64,
+    /// CPU limit in nanocpus.
+    #[serde(default = "default_cpu")]
+    pub cpu_limit: i64,
+    /// PID limit.
+    #[serde(default = "default_pids")]
+    pub pids_limit: i64,
+    /// Working directory inside the container.
+    #[serde(default = "default_working_dir")]
+    pub working_dir: String,
+    /// Network mode (e.g., "bridge" or a custom network name).
+    #[serde(default = "default_network_mode")]
+    pub network_mode: String,
+    /// Auto-stop timeout in minutes (for lease duration).
+    #[serde(default = "default_auto_stop")]
+    pub auto_stop_minutes: u64,
+}
+
+impl Default for ContainerSandboxConfig {
+    fn default() -> Self {
+        Self {
+            docker_host: None,
+            runtime: String::new(),
+            image: default_image(),
+            memory_limit: default_memory(),
+            cpu_limit: default_cpu(),
+            pids_limit: default_pids(),
+            working_dir: default_working_dir(),
+            network_mode: default_network_mode(),
+            auto_stop_minutes: default_auto_stop(),
+        }
+    }
+}
+
+impl ContainerSandboxConfig {
+    /// Parse config from agent capability config JSON, falling back to defaults.
+    pub fn from_value(config: &serde_json::Value) -> Self {
+        serde_json::from_value(config.clone()).unwrap_or_default()
+    }
+}
+
+fn default_image() -> String {
+    DEFAULT_IMAGE.to_string()
+}
+fn default_memory() -> i64 {
+    DEFAULT_MEMORY_LIMIT_BYTES
+}
+fn default_cpu() -> i64 {
+    DEFAULT_CPU_LIMIT_NANOCPUS
+}
+fn default_pids() -> i64 {
+    DEFAULT_PIDS_LIMIT
+}
+fn default_working_dir() -> String {
+    DEFAULT_WORKING_DIR.to_string()
+}
+fn default_network_mode() -> String {
+    "bridge".to_string()
+}
+fn default_auto_stop() -> u64 {
+    DEFAULT_AUTO_STOP_MINUTES
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_default_config() {
+        let config = ContainerSandboxConfig::default();
+        assert_eq!(config.image, "ubuntu:24.04");
+        assert_eq!(config.working_dir, "/workspace");
+        assert_eq!(config.memory_limit, 2_147_483_648);
+        assert_eq!(config.pids_limit, 256);
+        assert_eq!(config.auto_stop_minutes, 10);
+    }
+
+    #[test]
+    fn test_config_from_value() {
+        let config = ContainerSandboxConfig::from_value(&json!({
+            "image": "node:22",
+            "memory_limit": 4_294_967_296_i64,
+        }));
+        assert_eq!(config.image, "node:22");
+        assert_eq!(config.memory_limit, 4_294_967_296);
+        // Defaults for unspecified fields
+        assert_eq!(config.working_dir, "/workspace");
+        assert_eq!(config.pids_limit, 256);
+    }
+
+    #[test]
+    fn test_config_from_invalid_value() {
+        let config = ContainerSandboxConfig::from_value(&json!("not an object"));
+        assert_eq!(config.image, "ubuntu:24.04"); // falls back to default
+    }
+}

--- a/crates/container-sandbox/src/config.rs
+++ b/crates/container-sandbox/src/config.rs
@@ -21,7 +21,7 @@ const DEFAULT_AUTO_STOP_MINUTES: u64 = 10;
 /// Configuration for the container sandbox capability.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContainerSandboxConfig {
-    /// Docker Engine host URL (env → config → "http://localhost:2375")
+    /// Docker Engine host URL (config → env → "http://localhost:2375")
     #[serde(default)]
     pub docker_host: Option<String>,
     /// Container runtime (e.g., "sysbox-runc"). Empty for default runc.
@@ -43,9 +43,11 @@ pub struct ContainerSandboxConfig {
     #[serde(default = "default_working_dir")]
     pub working_dir: String,
     /// Network mode (e.g., "bridge" or a custom network name).
+    /// TODO: will be wired into container creation in a follow-up.
     #[serde(default = "default_network_mode")]
     pub network_mode: String,
     /// Auto-stop timeout in minutes (for lease duration).
+    /// TODO: will be wired into lease duration calculation in a follow-up.
     #[serde(default = "default_auto_stop")]
     pub auto_stop_minutes: u64,
 }

--- a/crates/container-sandbox/src/lib.rs
+++ b/crates/container-sandbox/src/lib.rs
@@ -1,0 +1,10 @@
+//! Container Sandbox — self-hosted container execution via Docker Engine REST API.
+//!
+//! Decision: Core crate (not integration) because container execution is infrastructure,
+//! not an external service. Same pattern as `crates/session-sqldb/`.
+//!
+//! Decision: Docker Engine REST API directly, no `docker` CLI binary dependency.
+//! Workers can be containerized themselves — talking to the Docker Engine API
+//! over TCP/Unix socket removes the need for Docker-in-Docker.
+
+pub mod client;

--- a/crates/container-sandbox/src/lib.rs
+++ b/crates/container-sandbox/src/lib.rs
@@ -6,5 +6,175 @@
 //! Decision: Docker Engine REST API directly, no `docker` CLI binary dependency.
 //! Workers can be containerized themselves — talking to the Docker Engine API
 //! over TCP/Unix socket removes the need for Docker-in-Docker.
+//!
+//! Decision: One sandbox per session (container name derived from session ID).
+//! Multi-sandbox per session can be added later if needed.
 
 pub mod client;
+pub mod config;
+pub mod state;
+mod tools;
+
+use everruns_core::LEASED_RESOURCES_FEATURE;
+use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin, RiskLevel};
+use everruns_core::tools::Tool;
+use std::sync::LazyLock;
+
+use tools::{
+    SandboxCreateTool, SandboxDownloadTool, SandboxExecTool, SandboxListTool, SandboxManageTool,
+    SandboxReadFileTool, SandboxUploadTool, SandboxWriteFileTool,
+};
+
+// ============================================================================
+// Plugin Registration
+// ============================================================================
+
+inventory::submit! {
+    IntegrationPlugin {
+        experimental_only: false,
+        feature_flag: Some("container_sandbox"),
+        factory: || Box::new(ContainerSandboxCapability),
+    }
+}
+
+// ============================================================================
+// System Prompt
+// ============================================================================
+
+static SYSTEM_PROMPT: LazyLock<String> = LazyLock::new(|| {
+    let mut prompt = String::from(
+        r#"## Container Sandbox
+
+Self-hosted container execution via Docker Engine. Each session gets an isolated
+container with full Linux environment and configurable resource limits.
+
+Lifecycle: sandbox_create → sandbox_exec / sandbox_read_file / sandbox_write_file → sandbox_manage(remove)
+
+Working directory: /workspace (default). Use sandbox_exec for shell commands,
+sandbox_read_file/sandbox_write_file for file I/O, and sandbox_upload/sandbox_download
+for transferring files between session storage and the container.
+
+Always remove sandboxes when done to free Docker resources."#,
+    );
+    prompt.push_str(everruns_core::tool_output_sanitizer::EXEC_OUTPUT_HINT);
+    prompt
+});
+
+// ============================================================================
+// ContainerSandboxCapability
+// ============================================================================
+
+pub struct ContainerSandboxCapability;
+
+#[async_trait::async_trait]
+impl Capability for ContainerSandboxCapability {
+    fn id(&self) -> &str {
+        "container_sandbox"
+    }
+
+    fn name(&self) -> &str {
+        "Container Sandbox"
+    }
+
+    fn description(&self) -> &str {
+        "Run code in self-hosted Docker containers. Create isolated Linux environments \
+         with configurable resource limits, execute commands, and manage files."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn risk_level(&self) -> RiskLevel {
+        RiskLevel::High
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("container")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Execution")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(&SYSTEM_PROMPT)
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(SandboxCreateTool),
+            Box::new(SandboxExecTool),
+            Box::new(SandboxReadFileTool),
+            Box::new(SandboxWriteFileTool),
+            Box::new(SandboxUploadTool),
+            Box::new(SandboxDownloadTool),
+            Box::new(SandboxListTool),
+            Box::new(SandboxManageTool),
+        ]
+    }
+
+    fn dependencies(&self) -> Vec<&'static str> {
+        vec!["session_storage"]
+    }
+
+    fn features(&self) -> Vec<&'static str> {
+        vec![LEASED_RESOURCES_FEATURE]
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_capability_metadata() {
+        let cap = ContainerSandboxCapability;
+        assert_eq!(cap.id(), "container_sandbox");
+        assert_eq!(cap.name(), "Container Sandbox");
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+        assert_eq!(cap.risk_level(), RiskLevel::High);
+        assert_eq!(cap.icon(), Some("container"));
+        assert_eq!(cap.category(), Some("Execution"));
+    }
+
+    #[test]
+    fn test_capability_has_all_tools() {
+        let cap = ContainerSandboxCapability;
+        let tools = cap.tools();
+        assert_eq!(tools.len(), 8);
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(names.contains(&"sandbox_create"));
+        assert!(names.contains(&"sandbox_exec"));
+        assert!(names.contains(&"sandbox_read_file"));
+        assert!(names.contains(&"sandbox_write_file"));
+        assert!(names.contains(&"sandbox_upload"));
+        assert!(names.contains(&"sandbox_download"));
+        assert!(names.contains(&"sandbox_list"));
+        assert!(names.contains(&"sandbox_manage"));
+    }
+
+    #[test]
+    fn test_system_prompt_exists() {
+        let cap = ContainerSandboxCapability;
+        let prompt = cap.system_prompt_addition().unwrap();
+        assert!(prompt.contains("Container Sandbox"));
+        assert!(prompt.contains("/workspace"));
+    }
+
+    #[test]
+    fn test_dependencies() {
+        let cap = ContainerSandboxCapability;
+        assert_eq!(cap.dependencies(), vec!["session_storage"]);
+    }
+
+    #[test]
+    fn test_features() {
+        let cap = ContainerSandboxCapability;
+        assert!(cap.features().contains(&LEASED_RESOURCES_FEATURE));
+    }
+}

--- a/crates/container-sandbox/src/state.rs
+++ b/crates/container-sandbox/src/state.rs
@@ -1,0 +1,237 @@
+//! Sandbox state management — persistence, lease tracking, naming.
+//!
+//! Decision: Sandbox state is stored in session secrets (same pattern as Daytona).
+//! Decision: Container/network names include session UUID for multi-tenant isolation.
+
+use everruns_core::leased_resource::UpsertLeasedResource;
+use everruns_core::tools::ToolExecutionResult;
+use everruns_core::traits::ToolContext;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tracing::error;
+
+/// Secret key prefix for sandbox state.
+const SANDBOX_SECRET_PREFIX: &str = "container_sandbox:";
+
+/// Lease duration for sandbox containers (20 minutes).
+pub const SANDBOX_LEASE_DURATION_SECONDS: u32 = 20 * 60;
+
+/// Sandbox state persisted in session secrets.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SandboxState {
+    pub container_id: String,
+    pub network_id: String,
+    pub container_name: String,
+    pub network_name: String,
+    pub image: String,
+    pub working_dir: String,
+    pub started_at: String,
+}
+
+/// Derive container name from session ID.
+pub fn container_name(session_id: &str) -> String {
+    // Use first 12 chars of session UUID for brevity
+    let short = if session_id.len() > 12 {
+        &session_id[..12]
+    } else {
+        session_id
+    };
+    format!("evr-{short}-sandbox")
+}
+
+/// Derive network name from session ID.
+pub fn network_name(session_id: &str) -> String {
+    let short = if session_id.len() > 12 {
+        &session_id[..12]
+    } else {
+        session_id
+    };
+    format!("sandbox-{short}")
+}
+
+/// Standard labels applied to all containers and networks.
+pub fn sandbox_labels(session_id: &str) -> std::collections::HashMap<String, String> {
+    std::collections::HashMap::from([
+        ("managed-by".to_string(), "everruns".to_string()),
+        ("session".to_string(), session_id.to_string()),
+    ])
+}
+
+/// Save sandbox state to session secrets.
+pub async fn save_sandbox_state(
+    context: &ToolContext,
+    state: &SandboxState,
+) -> Result<(), ToolExecutionResult> {
+    let storage = context
+        .storage_store
+        .as_ref()
+        .ok_or_else(|| ToolExecutionResult::tool_error("Storage not available"))?;
+
+    let json_str = serde_json::to_string(state).map_err(|e| {
+        error!("Failed to serialize sandbox state: {e}");
+        ToolExecutionResult::internal_error_msg(format!("Serialization error: {e}"))
+    })?;
+
+    let key = format!("{SANDBOX_SECRET_PREFIX}{}", state.container_name);
+    storage
+        .set_secret(context.session_id, &key, &json_str)
+        .await
+        .map_err(|e| {
+            error!("Failed to save sandbox state: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to save state: {e}"))
+        })?;
+
+    Ok(())
+}
+
+/// Load sandbox state from session secrets.
+pub async fn get_sandbox_state(context: &ToolContext) -> Result<SandboxState, ToolExecutionResult> {
+    let storage = context
+        .storage_store
+        .as_ref()
+        .ok_or_else(|| ToolExecutionResult::tool_error("Storage not available"))?;
+
+    // Find the sandbox state key by listing secrets with our prefix
+    let session_id = context.session_id.to_string();
+    let name = container_name(&session_id);
+    let key = format!("{SANDBOX_SECRET_PREFIX}{name}");
+
+    let json_str = storage
+        .get_secret(context.session_id, &key)
+        .await
+        .map_err(|e| {
+            error!("Failed to read sandbox state: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to read state: {e}"))
+        })?
+        .ok_or_else(|| {
+            ToolExecutionResult::tool_error(
+                "No sandbox found for this session. Use sandbox_create first.",
+            )
+        })?;
+
+    serde_json::from_str(&json_str).map_err(|e| {
+        error!("Corrupt sandbox state: {e}");
+        ToolExecutionResult::internal_error_msg(format!("Corrupt sandbox state: {e}"))
+    })
+}
+
+/// Delete sandbox state from session secrets.
+pub async fn delete_sandbox_state(
+    context: &ToolContext,
+    container_name: &str,
+) -> Result<(), ToolExecutionResult> {
+    let storage = context
+        .storage_store
+        .as_ref()
+        .ok_or_else(|| ToolExecutionResult::tool_error("Storage not available"))?;
+
+    let key = format!("{SANDBOX_SECRET_PREFIX}{container_name}");
+    storage
+        .delete_secret(context.session_id, &key)
+        .await
+        .map_err(|e| {
+            error!("Failed to delete sandbox state: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to delete state: {e}"))
+        })?;
+
+    Ok(())
+}
+
+/// Refresh or create the leased resource for this sandbox.
+pub async fn touch_sandbox_lease(
+    context: &ToolContext,
+    state: &SandboxState,
+) -> Result<(), ToolExecutionResult> {
+    let Some(store) = context.leased_resource_store.as_ref() else {
+        return Ok(());
+    };
+
+    store
+        .upsert_resource(UpsertLeasedResource {
+            session_id: context.session_id,
+            provider: "container_sandbox".to_string(),
+            resource_type: "container".to_string(),
+            external_id: state.container_id.clone(),
+            display_name: Some(state.container_name.clone()),
+            owner_user_id: None,
+            lease_duration_seconds: SANDBOX_LEASE_DURATION_SECONDS,
+            metadata: json!({
+                "image": state.image,
+                "working_dir": state.working_dir,
+                "started_at": state.started_at,
+            }),
+        })
+        .await
+        .map_err(|e| {
+            error!("Failed to upsert leased resource: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Lease update failed: {e}"))
+        })?;
+
+    Ok(())
+}
+
+/// Release the leased resource for this sandbox.
+pub async fn release_sandbox_lease(
+    context: &ToolContext,
+    container_id: &str,
+) -> Result<(), ToolExecutionResult> {
+    let Some(store) = context.leased_resource_store.as_ref() else {
+        return Ok(());
+    };
+
+    store
+        .release_resource(
+            context.session_id,
+            "container_sandbox",
+            "container",
+            container_id,
+        )
+        .await
+        .map_err(|e| {
+            error!("Failed to release leased resource: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Lease release failed: {e}"))
+        })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_container_name() {
+        let name = container_name("abc123def456-more-stuff");
+        assert_eq!(name, "evr-abc123def456-sandbox");
+    }
+
+    #[test]
+    fn test_network_name() {
+        let name = network_name("abc123def456-more-stuff");
+        assert_eq!(name, "sandbox-abc123def456");
+    }
+
+    #[test]
+    fn test_sandbox_labels() {
+        let labels = sandbox_labels("session-123");
+        assert_eq!(labels.get("managed-by").unwrap(), "everruns");
+        assert_eq!(labels.get("session").unwrap(), "session-123");
+    }
+
+    #[test]
+    fn test_sandbox_state_serialization() {
+        let state = SandboxState {
+            container_id: "abc123".to_string(),
+            network_id: "net456".to_string(),
+            container_name: "evr-abc-sandbox".to_string(),
+            network_name: "sandbox-abc".to_string(),
+            image: "ubuntu:24.04".to_string(),
+            working_dir: "/workspace".to_string(),
+            started_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        let restored: SandboxState = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.container_id, "abc123");
+        assert_eq!(restored.image, "ubuntu:24.04");
+    }
+}

--- a/crates/container-sandbox/src/state.rs
+++ b/crates/container-sandbox/src/state.rs
@@ -156,9 +156,9 @@ pub async fn touch_sandbox_lease(
             owner_user_id: None,
             lease_duration_seconds: SANDBOX_LEASE_DURATION_SECONDS,
             metadata: json!({
-                "image": state.image,
-                "working_dir": state.working_dir,
-                "started_at": state.started_at,
+                "image": &state.image,
+                "working_dir": &state.working_dir,
+                "started_at": &state.started_at,
             }),
         })
         .await

--- a/crates/container-sandbox/src/tools.rs
+++ b/crates/container-sandbox/src/tools.rs
@@ -1,0 +1,814 @@
+//! Tool implementations for container sandbox operations.
+//!
+//! Decision: One sandbox per session (container name derived from session ID).
+//! Decision: All tools require context (requires_context = true).
+//! Decision: Uses tool_output_sanitizer for exec output (same pipeline as Daytona).
+
+use async_trait::async_trait;
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use everruns_core::ToolHints;
+use everruns_core::tool_output_sanitizer::{
+    clean_exec_output, output_verbosity_budget, priority_aware_truncate,
+};
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::ToolContext;
+use serde_json::{Value, json};
+use tracing::{debug, error};
+
+use crate::client::{ContainerCreateConfig, DockerClient, HostConfig};
+use crate::config::ContainerSandboxConfig;
+use crate::state::{
+    SandboxState, container_name, delete_sandbox_state, get_sandbox_state, network_name,
+    release_sandbox_lease, sandbox_labels, save_sandbox_state, touch_sandbox_lease,
+};
+
+/// Helper: extract a required string parameter.
+fn required_str(args: &Value, name: &str) -> Result<String, ToolExecutionResult> {
+    args.get(name)
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .ok_or_else(|| {
+            ToolExecutionResult::tool_error(format!("Missing required parameter: {name}"))
+        })
+}
+
+/// Helper: create a DockerClient from config.
+fn docker_client(config: &ContainerSandboxConfig) -> DockerClient {
+    DockerClient::new(config.docker_host.as_deref())
+}
+
+// ============================================================================
+// sandbox_create
+// ============================================================================
+
+pub struct SandboxCreateTool;
+
+#[async_trait]
+impl Tool for SandboxCreateTool {
+    fn name(&self) -> &str {
+        "sandbox_create"
+    }
+
+    fn description(&self) -> &str {
+        "Create and start a container sandbox for code execution. \
+         One sandbox per session. Returns the sandbox container name."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "string",
+                    "description": "Container image (default: ubuntu:24.04)"
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_long_running(true)
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "Tool requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let config = ContainerSandboxConfig::default();
+        let image = arguments
+            .get("image")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&config.image)
+            .to_string();
+
+        let session_id = context.session_id.to_string();
+        let c_name = container_name(&session_id);
+        let n_name = network_name(&session_id);
+        let labels = sandbox_labels(&session_id);
+        let client = docker_client(&config);
+
+        // Create network
+        let network_id = match client.create_network(&n_name, labels.clone()).await {
+            Ok(id) => id,
+            Err(e) if e.contains("already exists") || e.contains("Conflict") => {
+                // Network exists, that's fine — reuse
+                debug!(name = %n_name, "Network already exists, reusing");
+                n_name.clone()
+            }
+            Err(e) => {
+                return ToolExecutionResult::tool_error(format!("Failed to create network: {e}"));
+            }
+        };
+
+        // Create container
+        let create_config = ContainerCreateConfig {
+            image: image.clone(),
+            cmd: vec![
+                "tail".to_string(),
+                "-f".to_string(),
+                "/dev/null".to_string(),
+            ],
+            working_dir: config.working_dir.clone(),
+            labels,
+            host_config: HostConfig {
+                runtime: config.runtime.clone(),
+                network_mode: n_name.clone(),
+                memory: config.memory_limit,
+                nano_cpus: config.cpu_limit,
+                pids_limit: config.pids_limit,
+                init: true,
+            },
+        };
+
+        let container = match client.create_container(&c_name, &create_config).await {
+            Ok(c) => c,
+            Err(e) => {
+                // Clean up network on failure
+                let _ = client.remove_network(&network_id).await;
+                return ToolExecutionResult::tool_error(format!("Failed to create container: {e}"));
+            }
+        };
+
+        // Start container
+        if let Err(e) = client.start_container(&container.id).await {
+            let _ = client.remove_container(&container.id).await;
+            let _ = client.remove_network(&network_id).await;
+            return ToolExecutionResult::tool_error(format!("Failed to start container: {e}"));
+        }
+
+        let now = chrono::Utc::now().to_rfc3339();
+        let state = SandboxState {
+            container_id: container.id.clone(),
+            network_id: network_id.clone(),
+            container_name: c_name.clone(),
+            network_name: n_name,
+            image: image.clone(),
+            working_dir: config.working_dir.clone(),
+            started_at: now,
+        };
+
+        // Save state and register lease
+        if let Err(e) = save_sandbox_state(context, &state).await {
+            return e;
+        }
+        if let Err(e) = touch_sandbox_lease(context, &state).await {
+            return e;
+        }
+
+        ToolExecutionResult::success(format!(
+            "Sandbox created and running.\n\
+             Container: {c_name}\n\
+             Image: {image}\n\
+             Working directory: {}",
+            config.working_dir
+        ))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// sandbox_exec
+// ============================================================================
+
+pub struct SandboxExecTool;
+
+#[async_trait]
+impl Tool for SandboxExecTool {
+    fn name(&self) -> &str {
+        "sandbox_exec"
+    }
+
+    fn description(&self) -> &str {
+        "Execute a command in the container sandbox. Returns stdout/stderr and exit code."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "Shell command to execute"
+                },
+                "working_dir": {
+                    "type": "string",
+                    "description": "Working directory (default: /workspace)"
+                },
+                "output_mode": everruns_core::tool_output_sanitizer::output_verbosity_schema()
+            },
+            "required": ["command"],
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_long_running(true)
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "Tool requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let command = match required_str(&arguments, "command") {
+            Ok(c) => c,
+            Err(e) => return e,
+        };
+
+        let output_mode = arguments
+            .get("output_mode")
+            .and_then(|v| v.as_str())
+            .unwrap_or("normal");
+
+        let state = match get_sandbox_state(context).await {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let working_dir = arguments
+            .get("working_dir")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&state.working_dir);
+
+        let config = ContainerSandboxConfig::default();
+        let client = docker_client(&config);
+
+        let result = match client
+            .exec(
+                &state.container_id,
+                &["sh", "-c", &command],
+                Some(working_dir),
+            )
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => return ToolExecutionResult::tool_error(format!("Exec failed: {e}")),
+        };
+
+        // Refresh lease on successful exec
+        let _ = touch_sandbox_lease(context, &state).await;
+
+        // Sanitize output
+        let clean_output = clean_exec_output(&result.stdout);
+        let output = if let Some(budget) = output_verbosity_budget(output_mode) {
+            priority_aware_truncate(&clean_output, budget)
+        } else {
+            clean_output
+        };
+
+        let exit_code = result.exit_code;
+        if exit_code == 0 {
+            ToolExecutionResult::success(output)
+        } else {
+            ToolExecutionResult::success(format!("Exit code: {exit_code}\n\n{output}"))
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// sandbox_read_file
+// ============================================================================
+
+pub struct SandboxReadFileTool;
+
+#[async_trait]
+impl Tool for SandboxReadFileTool {
+    fn name(&self) -> &str {
+        "sandbox_read_file"
+    }
+
+    fn description(&self) -> &str {
+        "Read a file from the container sandbox."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute path to the file inside the container"
+                }
+            },
+            "required": ["path"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Tool requires context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let path = match required_str(&arguments, "path") {
+            Ok(p) => p,
+            Err(e) => return e,
+        };
+
+        let state = match get_sandbox_state(context).await {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let config = ContainerSandboxConfig::default();
+        let client = docker_client(&config);
+
+        match client.get_archive(&state.container_id, &path).await {
+            Ok(bytes) => {
+                // Try to return as text, fall back to base64
+                match String::from_utf8(bytes.clone()) {
+                    Ok(text) => ToolExecutionResult::success(text),
+                    Err(_) => ToolExecutionResult::success(format!(
+                        "[Binary file, {} bytes]",
+                        bytes.len()
+                    )),
+                }
+            }
+            Err(e) => ToolExecutionResult::tool_error(format!("Failed to read file: {e}")),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// sandbox_write_file
+// ============================================================================
+
+pub struct SandboxWriteFileTool;
+
+#[async_trait]
+impl Tool for SandboxWriteFileTool {
+    fn name(&self) -> &str {
+        "sandbox_write_file"
+    }
+
+    fn description(&self) -> &str {
+        "Write a file to the container sandbox."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute path for the file inside the container"
+                },
+                "content": {
+                    "type": "string",
+                    "description": "File content to write"
+                }
+            },
+            "required": ["path", "content"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Tool requires context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let path = match required_str(&arguments, "path") {
+            Ok(p) => p,
+            Err(e) => return e,
+        };
+        let content = match required_str(&arguments, "content") {
+            Ok(c) => c,
+            Err(e) => return e,
+        };
+
+        let state = match get_sandbox_state(context).await {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let config = ContainerSandboxConfig::default();
+        let client = docker_client(&config);
+
+        // Split path into directory and filename
+        let (dir, filename) = match path.rsplit_once('/') {
+            Some((d, f)) if !d.is_empty() => (d.to_string(), f.to_string()),
+            _ => ("/".to_string(), path.trim_start_matches('/').to_string()),
+        };
+
+        match client
+            .put_archive(&state.container_id, &dir, &filename, content.as_bytes())
+            .await
+        {
+            Ok(()) => {
+                ToolExecutionResult::success(format!("Written {path} ({} bytes)", content.len()))
+            }
+            Err(e) => ToolExecutionResult::tool_error(format!("Failed to write file: {e}")),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// sandbox_list
+// ============================================================================
+
+pub struct SandboxListTool;
+
+#[async_trait]
+impl Tool for SandboxListTool {
+    fn name(&self) -> &str {
+        "sandbox_list"
+    }
+
+    fn description(&self) -> &str {
+        "List container sandboxes for this session."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Tool requires context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        _arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let session_id = context.session_id.to_string();
+        let config = ContainerSandboxConfig::default();
+        let client = docker_client(&config);
+
+        let filters = [("managed-by", "everruns"), ("session", &session_id)];
+
+        match client.list_containers(&filters).await {
+            Ok(containers) => {
+                if containers.is_empty() {
+                    return ToolExecutionResult::success("No sandboxes found for this session.");
+                }
+                let summary: Vec<String> = containers
+                    .iter()
+                    .map(|c| {
+                        let name = c
+                            .names
+                            .first()
+                            .map(|n| n.trim_start_matches('/'))
+                            .unwrap_or("unknown");
+                        format!("- {} ({}): {}", name, c.state, c.status)
+                    })
+                    .collect();
+                ToolExecutionResult::success(summary.join("\n"))
+            }
+            Err(e) => ToolExecutionResult::tool_error(format!("Failed to list containers: {e}")),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// sandbox_manage
+// ============================================================================
+
+pub struct SandboxManageTool;
+
+#[async_trait]
+impl Tool for SandboxManageTool {
+    fn name(&self) -> &str {
+        "sandbox_manage"
+    }
+
+    fn description(&self) -> &str {
+        "Manage the container sandbox: stop, start, or remove it."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "description": "Action to perform",
+                    "enum": ["stop", "start", "remove"]
+                }
+            },
+            "required": ["action"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Tool requires context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let action = match required_str(&arguments, "action") {
+            Ok(a) => a,
+            Err(e) => return e,
+        };
+
+        let state = match get_sandbox_state(context).await {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let config = ContainerSandboxConfig::default();
+        let client = docker_client(&config);
+
+        match action.as_str() {
+            "stop" => {
+                if let Err(e) = client.stop_container(&state.container_id, 10).await {
+                    return ToolExecutionResult::tool_error(format!("Failed to stop: {e}"));
+                }
+                ToolExecutionResult::success("Sandbox stopped.")
+            }
+            "start" => {
+                if let Err(e) = client.start_container(&state.container_id).await {
+                    return ToolExecutionResult::tool_error(format!("Failed to start: {e}"));
+                }
+                let _ = touch_sandbox_lease(context, &state).await;
+                ToolExecutionResult::success("Sandbox started.")
+            }
+            "remove" => {
+                // Stop, remove container, remove network, clean up state
+                let _ = client.stop_container(&state.container_id, 5).await;
+                if let Err(e) = client.remove_container(&state.container_id).await {
+                    error!("Failed to remove container: {e}");
+                }
+                let _ = client.remove_network(&state.network_id).await;
+                let _ = release_sandbox_lease(context, &state.container_id).await;
+                let _ = delete_sandbox_state(context, &state.container_name).await;
+                ToolExecutionResult::success("Sandbox removed and cleaned up.")
+            }
+            _ => ToolExecutionResult::tool_error("Invalid action. Use: stop, start, or remove"),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// sandbox_upload
+// ============================================================================
+
+pub struct SandboxUploadTool;
+
+#[async_trait]
+impl Tool for SandboxUploadTool {
+    fn name(&self) -> &str {
+        "sandbox_upload"
+    }
+
+    fn description(&self) -> &str {
+        "Upload a file from session storage to the container sandbox."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "session_path": {
+                    "type": "string",
+                    "description": "Path of the file in session storage"
+                },
+                "container_path": {
+                    "type": "string",
+                    "description": "Absolute destination path inside the container"
+                }
+            },
+            "required": ["session_path", "container_path"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Tool requires context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let session_path = match required_str(&arguments, "session_path") {
+            Ok(p) => p,
+            Err(e) => return e,
+        };
+        let container_path = match required_str(&arguments, "container_path") {
+            Ok(p) => p,
+            Err(e) => return e,
+        };
+
+        let state = match get_sandbox_state(context).await {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let file_store = match context.file_store.as_ref() {
+            Some(fs) => fs,
+            None => return ToolExecutionResult::tool_error("File store not available"),
+        };
+
+        // Read file from session VFS
+        let file = match file_store
+            .read_file(context.session_id, &session_path)
+            .await
+        {
+            Ok(Some(f)) => f,
+            Ok(None) => {
+                return ToolExecutionResult::tool_error(format!(
+                    "File not found in session storage: {session_path}"
+                ));
+            }
+            Err(e) => {
+                return ToolExecutionResult::tool_error(format!(
+                    "Failed to read from session storage: {e}"
+                ));
+            }
+        };
+
+        // Decode content (text or base64)
+        let content_str = file.content.unwrap_or_default();
+        let bytes = if file.encoding == "base64" {
+            BASE64.decode(&content_str).unwrap_or_default()
+        } else {
+            content_str.as_bytes().to_vec()
+        };
+
+        let config = ContainerSandboxConfig::default();
+        let client = docker_client(&config);
+
+        let (dir, filename) = match container_path.rsplit_once('/') {
+            Some((d, f)) if !d.is_empty() => (d.to_string(), f.to_string()),
+            _ => (
+                "/".to_string(),
+                container_path.trim_start_matches('/').to_string(),
+            ),
+        };
+
+        match client
+            .put_archive(&state.container_id, &dir, &filename, &bytes)
+            .await
+        {
+            Ok(()) => ToolExecutionResult::success(format!(
+                "Uploaded {session_path} → {container_path} ({} bytes)",
+                bytes.len()
+            )),
+            Err(e) => ToolExecutionResult::tool_error(format!("Upload failed: {e}")),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// sandbox_download
+// ============================================================================
+
+pub struct SandboxDownloadTool;
+
+#[async_trait]
+impl Tool for SandboxDownloadTool {
+    fn name(&self) -> &str {
+        "sandbox_download"
+    }
+
+    fn description(&self) -> &str {
+        "Download a file from the container sandbox to session storage."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "container_path": {
+                    "type": "string",
+                    "description": "Absolute path of the file inside the container"
+                },
+                "session_path": {
+                    "type": "string",
+                    "description": "Destination path in session storage"
+                }
+            },
+            "required": ["container_path", "session_path"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Tool requires context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let container_path = match required_str(&arguments, "container_path") {
+            Ok(p) => p,
+            Err(e) => return e,
+        };
+        let session_path = match required_str(&arguments, "session_path") {
+            Ok(p) => p,
+            Err(e) => return e,
+        };
+
+        let state = match get_sandbox_state(context).await {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let file_store = match context.file_store.as_ref() {
+            Some(fs) => fs,
+            None => return ToolExecutionResult::tool_error("File store not available"),
+        };
+
+        let config = ContainerSandboxConfig::default();
+        let client = docker_client(&config);
+
+        let bytes = match client
+            .get_archive(&state.container_id, &container_path)
+            .await
+        {
+            Ok(b) => b,
+            Err(e) => {
+                return ToolExecutionResult::tool_error(format!("Failed to read file: {e}"));
+            }
+        };
+
+        // Store as text if valid UTF-8, otherwise base64
+        let (content, encoding) = match String::from_utf8(bytes.clone()) {
+            Ok(text) => (text, "text"),
+            Err(_) => (BASE64.encode(&bytes), "base64"),
+        };
+
+        match file_store
+            .write_file(context.session_id, &session_path, &content, encoding)
+            .await
+        {
+            Ok(_) => ToolExecutionResult::success(format!(
+                "Downloaded {container_path} → {session_path} ({} bytes)",
+                bytes.len()
+            )),
+            Err(e) => {
+                ToolExecutionResult::tool_error(format!("Failed to save to session storage: {e}"))
+            }
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}

--- a/crates/container-sandbox/src/tools.rs
+++ b/crates/container-sandbox/src/tools.rs
@@ -97,13 +97,16 @@ impl Tool for SandboxCreateTool {
         let labels = sandbox_labels(&session_id);
         let client = docker_client(&config);
 
-        // Create network
-        let network_id = match client.create_network(&n_name, labels.clone()).await {
-            Ok(id) => id,
+        // Create network (track whether we created it vs reused an existing one)
+        let (network_id, network_created) = match client
+            .create_network(&n_name, labels.clone())
+            .await
+        {
+            Ok(id) => (id, true),
             Err(e) if e.contains("already exists") || e.contains("Conflict") => {
                 // Network exists, that's fine — reuse
                 debug!(name = %n_name, "Network already exists, reusing");
-                n_name.clone()
+                (n_name.clone(), false)
             }
             Err(e) => {
                 return ToolExecutionResult::tool_error(format!("Failed to create network: {e}"));
@@ -133,8 +136,11 @@ impl Tool for SandboxCreateTool {
         let container = match client.create_container(&c_name, &create_config).await {
             Ok(c) => c,
             Err(e) => {
-                // Clean up network on failure
-                let _ = client.remove_network(&network_id).await;
+                // Only remove network if we just created it
+                // TODO: idempotent create (409/name conflict) is a follow-up
+                if network_created {
+                    let _ = client.remove_network(&network_id).await;
+                }
                 return ToolExecutionResult::tool_error(format!("Failed to create container: {e}"));
             }
         };
@@ -142,7 +148,9 @@ impl Tool for SandboxCreateTool {
         // Start container
         if let Err(e) = client.start_container(&container.id).await {
             let _ = client.remove_container(&container.id).await;
-            let _ = client.remove_network(&network_id).await;
+            if network_created {
+                let _ = client.remove_network(&network_id).await;
+            }
             return ToolExecutionResult::tool_error(format!("Failed to start container: {e}"));
         }
 
@@ -207,7 +215,7 @@ impl Tool for SandboxExecTool {
                     "type": "string",
                     "description": "Working directory (default: /workspace)"
                 },
-                "output_mode": everruns_core::tool_output_sanitizer::output_verbosity_schema()
+                "output": everruns_core::tool_output_sanitizer::output_verbosity_schema()
             },
             "required": ["command"],
             "additionalProperties": false
@@ -218,6 +226,7 @@ impl Tool for SandboxExecTool {
         ToolHints::default()
             .with_open_world(true)
             .with_long_running(true)
+            .with_persist_output(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -237,9 +246,9 @@ impl Tool for SandboxExecTool {
         };
 
         let output_mode = arguments
-            .get("output_mode")
+            .get("output")
             .and_then(|v| v.as_str())
-            .unwrap_or("normal");
+            .unwrap_or("concise");
 
         let state = match get_sandbox_state(context).await {
             Ok(s) => s,
@@ -427,6 +436,12 @@ impl Tool for SandboxWriteFileTool {
             Some((d, f)) if !d.is_empty() => (d.to_string(), f.to_string()),
             _ => ("/".to_string(), path.trim_start_matches('/').to_string()),
         };
+
+        if filename.is_empty() {
+            return ToolExecutionResult::tool_error(
+                "Invalid path: filename is empty (trailing slash?)",
+            );
+        }
 
         match client
             .put_archive(&state.container_id, &dir, &filename, content.as_bytes())
@@ -680,7 +695,14 @@ impl Tool for SandboxUploadTool {
         // Decode content (text or base64)
         let content_str = file.content.unwrap_or_default();
         let bytes = if file.encoding == "base64" {
-            BASE64.decode(&content_str).unwrap_or_default()
+            match BASE64.decode(&content_str) {
+                Ok(b) => b,
+                Err(e) => {
+                    return ToolExecutionResult::tool_error(format!(
+                        "Failed to decode base64 content from session file {session_path}: {e}"
+                    ));
+                }
+            }
         } else {
             content_str.as_bytes().to_vec()
         };
@@ -695,6 +717,12 @@ impl Tool for SandboxUploadTool {
                 container_path.trim_start_matches('/').to_string(),
             ),
         };
+
+        if filename.is_empty() {
+            return ToolExecutionResult::tool_error(
+                "Invalid container_path: filename is empty (trailing slash?)",
+            );
+        }
 
         match client
             .put_archive(&state.container_id, &dir, &filename, &bytes)

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -78,6 +78,7 @@ everruns-integrations-deno = { path = "../../integrations/deno" }
 everruns-integrations-browserless = { path = "../../integrations/browserless" }
 everruns-integrations-e2b = { path = "../../integrations/e2b" }
 everruns-integrations-sprites = { path = "../../integrations/sprites" }
+everruns-container-sandbox = { path = "../container-sandbox" }
 everruns-integrations-pi = { path = "../../integrations/pi" }
 everruns-session-sqldb = { path = "../session-sqldb" }
 everruns-worker = { path = "../worker" }  # For AgentRunner trait

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -12,6 +12,7 @@ extern crate everruns_integrations_docker;
 extern crate everruns_integrations_duckduckgo;
 extern crate everruns_integrations_e2b;
 extern crate everruns_integrations_sprites;
+extern crate everruns_container_sandbox;
 
 // API routes and types (shared for OpenAPI generation)
 pub mod api;

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -4,6 +4,7 @@
 // Decision: App builder pattern (ServerAppBuilder) for composable server configurations
 
 // Force-link integration crates so inventory::submit! registrations are included
+extern crate everruns_container_sandbox;
 extern crate everruns_integrations_brave_search;
 extern crate everruns_integrations_browserless;
 extern crate everruns_integrations_daytona;
@@ -12,7 +13,6 @@ extern crate everruns_integrations_docker;
 extern crate everruns_integrations_duckduckgo;
 extern crate everruns_integrations_e2b;
 extern crate everruns_integrations_sprites;
-extern crate everruns_container_sandbox;
 
 // API routes and types (shared for OpenAPI generation)
 pub mod api;

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -24,6 +24,7 @@ everruns-integrations-deno = { path = "../../integrations/deno" }
 everruns-integrations-browserless = { path = "../../integrations/browserless" }
 everruns-integrations-e2b = { path = "../../integrations/e2b" }
 everruns-integrations-sprites = { path = "../../integrations/sprites" }
+everruns-container-sandbox = { path = "../container-sandbox" }
 everruns-integrations-pi = { path = "../../integrations/pi" }
 everruns-openai = { path = "../openai" }
 everruns-anthropic = { path = "../anthropic" }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -1,4 +1,5 @@
 // Force-link integration crates so inventory::submit! registrations are included
+extern crate everruns_container_sandbox;
 extern crate everruns_integrations_brave_search;
 extern crate everruns_integrations_browserless;
 extern crate everruns_integrations_daytona;
@@ -7,7 +8,6 @@ extern crate everruns_integrations_docker;
 extern crate everruns_integrations_duckduckgo;
 extern crate everruns_integrations_e2b;
 extern crate everruns_integrations_sprites;
-extern crate everruns_container_sandbox;
 
 pub mod activities;
 pub mod adapters;

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -7,6 +7,7 @@ extern crate everruns_integrations_docker;
 extern crate everruns_integrations_duckduckgo;
 extern crate everruns_integrations_e2b;
 extern crate everruns_integrations_sprites;
+extern crate everruns_container_sandbox;
 
 pub mod activities;
 pub mod adapters;


### PR DESCRIPTION
## What
Add `ContainerSandboxCapability` with inventory plugin registration and 8 tools for self-hosted container execution via Docker Engine REST API.

## Why
Fills the gap between virtual bash (safe but limited) and cloud sandboxes like Daytona/E2B (powerful but SaaS dependency). Self-hosted Docker containers give full Linux isolation without external service requirements.

## How
- `ContainerSandboxCapability` registered via `inventory::submit!` with `container_sandbox` feature flag
- 8 tools: `sandbox_create`, `sandbox_exec`, `sandbox_read_file`, `sandbox_write_file`, `sandbox_upload`, `sandbox_download`, `sandbox_list`, `sandbox_manage`
- Config module with safe defaults (2 GiB memory, 1 CPU, 256 PIDs, ubuntu:24.04)
- State management via session secrets (same pattern as Daytona)
- Leased resource tracking for automatic cleanup
- Output sanitization via `tool_output_sanitizer` (same pipeline as Daytona)
- Force-linked in server and worker crates for auto-registration
- Risk level: High (admin-gated, same as Daytona/E2B)

## Risk
- Low — new feature behind feature flag `container_sandbox`
- No existing behavior changed
- Force-link adds the crate to server/worker builds but capability only registers when feature flag is enabled

## Security
- Threat categories reviewed: TM-TOOL, TM-TENANT, TM-BASH, TM-FS, TM-DOS
- **TM-TOOL**: All 8 tools require context (`requires_context() = true`), enforced at tool execution layer
- **TM-TENANT**: Container/network names include session ID; all list operations use label filters (`managed-by=everruns`, `session={id}`)
- **TM-BASH**: Commands executed via Docker exec API, not shell subprocess — no host command injection
- **TM-FS**: File I/O via Docker archive API (tar), scoped to container filesystem
- **TM-DOS**: Resource limits enforced via Docker HostConfig (memory, CPU, PIDs). Feature-gated so not available by default.

## Checklist
- [x] Tests added or updated (23 unit tests: capability metadata, tool count, config, state, client)
- [x] Backward compatibility considered (feature-gated, no breaking changes)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Closes EVE-278