### PR TITLE
feat(container-sandbox): add capability, tools, and crate scaffold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,6 +1569,11 @@ dependencies = [
 name = "everruns-container-sandbox"
 version = "0.8.10"
 dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "everruns-core",
+ "inventory",
  "reqwest 0.13.2",
  "serde",
  "serde_json",
@@ -1936,6 +1941,7 @@ dependencies = [
  "cron",
  "dotenvy",
  "everruns-config",
+ "everruns-container-sandbox",
  "everruns-core",
  "everruns-durable",
  "everruns-integrations-brave-search",
@@ -2026,6 +2032,7 @@ dependencies = [
  "chrono",
  "everruns-anthropic",
  "everruns-config",
+ "everruns-container-sandbox",
  "everruns-core",
  "everruns-durable",
  "everruns-gemini",

--- a/crates/container-sandbox/Cargo.toml
+++ b/crates/container-sandbox/Cargo.toml
@@ -11,6 +11,9 @@ authors.workspace = true
 description = "Self-hosted container sandbox capability for Everruns via Docker Engine REST API"
 
 [dependencies]
+everruns-core = { path = "../core" }
+inventory.workspace = true
+
 # HTTP client for Docker Engine REST API
 reqwest = { workspace = true }
 
@@ -24,8 +27,13 @@ tar = "0.4"
 # URL encoding for query parameters
 urlencoding = "2"
 
+# Base64 encoding for binary file transfers
+base64.workspace = true
+
 # Async
+async-trait.workspace = true
 tokio.workspace = true
+chrono.workspace = true
 tracing.workspace = true
 
 [features]

--- a/crates/container-sandbox/src/config.rs
+++ b/crates/container-sandbox/src/config.rs
@@ -1,0 +1,133 @@
+//! Container sandbox configuration.
+//!
+//! Decision: Config resolution: explicit config → env vars → defaults.
+//! Decision: All resource limits have safe defaults suitable for development.
+
+use serde::{Deserialize, Serialize};
+
+/// Default Docker image for sandboxes.
+const DEFAULT_IMAGE: &str = "ubuntu:24.04";
+/// Default working directory inside containers.
+const DEFAULT_WORKING_DIR: &str = "/workspace";
+/// Default memory limit (2 GiB).
+const DEFAULT_MEMORY_LIMIT_BYTES: i64 = 2_147_483_648;
+/// Default CPU limit (1 core in nanocpus).
+const DEFAULT_CPU_LIMIT_NANOCPUS: i64 = 1_000_000_000;
+/// Default PID limit.
+const DEFAULT_PIDS_LIMIT: i64 = 256;
+/// Default auto-stop timeout (minutes).
+const DEFAULT_AUTO_STOP_MINUTES: u64 = 10;
+
+/// Configuration for the container sandbox capability.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContainerSandboxConfig {
+    /// Docker Engine host URL (config → env → "http://localhost:2375")
+    #[serde(default)]
+    pub docker_host: Option<String>,
+    /// Container runtime (e.g., "sysbox-runc"). Empty for default runc.
+    #[serde(default)]
+    pub runtime: String,
+    /// Container image.
+    #[serde(default = "default_image")]
+    pub image: String,
+    /// Memory limit in bytes.
+    #[serde(default = "default_memory")]
+    pub memory_limit: i64,
+    /// CPU limit in nanocpus.
+    #[serde(default = "default_cpu")]
+    pub cpu_limit: i64,
+    /// PID limit.
+    #[serde(default = "default_pids")]
+    pub pids_limit: i64,
+    /// Working directory inside the container.
+    #[serde(default = "default_working_dir")]
+    pub working_dir: String,
+    /// Network mode (e.g., "bridge" or a custom network name).
+    /// TODO: will be wired into container creation in a follow-up.
+    #[serde(default = "default_network_mode")]
+    pub network_mode: String,
+    /// Auto-stop timeout in minutes (for lease duration).
+    /// TODO: will be wired into lease duration calculation in a follow-up.
+    #[serde(default = "default_auto_stop")]
+    pub auto_stop_minutes: u64,
+}
+
+impl Default for ContainerSandboxConfig {
+    fn default() -> Self {
+        Self {
+            docker_host: None,
+            runtime: String::new(),
+            image: default_image(),
+            memory_limit: default_memory(),
+            cpu_limit: default_cpu(),
+            pids_limit: default_pids(),
+            working_dir: default_working_dir(),
+            network_mode: default_network_mode(),
+            auto_stop_minutes: default_auto_stop(),
+        }
+    }
+}
+
+impl ContainerSandboxConfig {
+    /// Parse config from agent capability config JSON, falling back to defaults.
+    pub fn from_value(config: &serde_json::Value) -> Self {
+        serde_json::from_value(config.clone()).unwrap_or_default()
+    }
+}
+
+fn default_image() -> String {
+    DEFAULT_IMAGE.to_string()
+}
+fn default_memory() -> i64 {
+    DEFAULT_MEMORY_LIMIT_BYTES
+}
+fn default_cpu() -> i64 {
+    DEFAULT_CPU_LIMIT_NANOCPUS
+}
+fn default_pids() -> i64 {
+    DEFAULT_PIDS_LIMIT
+}
+fn default_working_dir() -> String {
+    DEFAULT_WORKING_DIR.to_string()
+}
+fn default_network_mode() -> String {
+    "bridge".to_string()
+}
+fn default_auto_stop() -> u64 {
+    DEFAULT_AUTO_STOP_MINUTES
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_default_config() {
+        let config = ContainerSandboxConfig::default();
+        assert_eq!(config.image, "ubuntu:24.04");
+        assert_eq!(config.working_dir, "/workspace");
+        assert_eq!(config.memory_limit, 2_147_483_648);
+        assert_eq!(config.pids_limit, 256);
+        assert_eq!(config.auto_stop_minutes, 10);
+    }
+
+    #[test]
+    fn test_config_from_value() {
+        let config = ContainerSandboxConfig::from_value(&json!({
+            "image": "node:22",
+            "memory_limit": 4_294_967_296_i64,
+        }));
+        assert_eq!(config.image, "node:22");
+        assert_eq!(config.memory_limit, 4_294_967_296);
+        // Defaults for unspecified fields
+        assert_eq!(config.working_dir, "/workspace");
+        assert_eq!(config.pids_limit, 256);
+    }
+
+    #[test]
+    fn test_config_from_invalid_value() {
+        let config = ContainerSandboxConfig::from_value(&json!("not an object"));
+        assert_eq!(config.image, "ubuntu:24.04"); // falls back to default
+    }
+}

--- a/crates/container-sandbox/src/lib.rs
+++ b/crates/container-sandbox/src/lib.rs
@@ -6,5 +6,175 @@
 //! Decision: Docker Engine REST API directly, no `docker` CLI binary dependency.
 //! Workers can be containerized themselves — talking to the Docker Engine API
 //! over HTTP/TCP removes the need for Docker-in-Docker.
+//!
+//! Decision: One sandbox per session (container name derived from session ID).
+//! Multi-sandbox per session can be added later if needed.
 
 pub mod client;
+pub mod config;
+pub mod state;
+mod tools;
+
+use everruns_core::LEASED_RESOURCES_FEATURE;
+use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin, RiskLevel};
+use everruns_core::tools::Tool;
+use std::sync::LazyLock;
+
+use tools::{
+    SandboxCreateTool, SandboxDownloadTool, SandboxExecTool, SandboxListTool, SandboxManageTool,
+    SandboxReadFileTool, SandboxUploadTool, SandboxWriteFileTool,
+};
+
+// ============================================================================
+// Plugin Registration
+// ============================================================================
+
+inventory::submit! {
+    IntegrationPlugin {
+        experimental_only: false,
+        feature_flag: Some("container_sandbox"),
+        factory: || Box::new(ContainerSandboxCapability),
+    }
+}
+
+// ============================================================================
+// System Prompt
+// ============================================================================
+
+static SYSTEM_PROMPT: LazyLock<String> = LazyLock::new(|| {
+    let mut prompt = String::from(
+        r#"## Container Sandbox
+
+Self-hosted container execution via Docker Engine. Each session gets an isolated
+container with full Linux environment and configurable resource limits.
+
+Lifecycle: sandbox_create → sandbox_exec / sandbox_read_file / sandbox_write_file → sandbox_manage(remove)
+
+Working directory: /workspace (default). Use sandbox_exec for shell commands,
+sandbox_read_file/sandbox_write_file for file I/O, and sandbox_upload/sandbox_download
+for transferring files between session storage and the container.
+
+Always remove sandboxes when done to free Docker resources."#,
+    );
+    prompt.push_str(everruns_core::tool_output_sanitizer::EXEC_OUTPUT_HINT);
+    prompt
+});
+
+// ============================================================================
+// ContainerSandboxCapability
+// ============================================================================
+
+pub struct ContainerSandboxCapability;
+
+#[async_trait::async_trait]
+impl Capability for ContainerSandboxCapability {
+    fn id(&self) -> &str {
+        "container_sandbox"
+    }
+
+    fn name(&self) -> &str {
+        "Container Sandbox"
+    }
+
+    fn description(&self) -> &str {
+        "Run code in self-hosted Docker containers. Create isolated Linux environments \
+         with configurable resource limits, execute commands, and manage files."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn risk_level(&self) -> RiskLevel {
+        RiskLevel::High
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("container")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Execution")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(&SYSTEM_PROMPT)
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(SandboxCreateTool),
+            Box::new(SandboxExecTool),
+            Box::new(SandboxReadFileTool),
+            Box::new(SandboxWriteFileTool),
+            Box::new(SandboxUploadTool),
+            Box::new(SandboxDownloadTool),
+            Box::new(SandboxListTool),
+            Box::new(SandboxManageTool),
+        ]
+    }
+
+    fn dependencies(&self) -> Vec<&'static str> {
+        vec!["session_storage"]
+    }
+
+    fn features(&self) -> Vec<&'static str> {
+        vec![LEASED_RESOURCES_FEATURE]
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_capability_metadata() {
+        let cap = ContainerSandboxCapability;
+        assert_eq!(cap.id(), "container_sandbox");
+        assert_eq!(cap.name(), "Container Sandbox");
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+        assert_eq!(cap.risk_level(), RiskLevel::High);
+        assert_eq!(cap.icon(), Some("container"));
+        assert_eq!(cap.category(), Some("Execution"));
+    }
+
+    #[test]
+    fn test_capability_has_all_tools() {
+        let cap = ContainerSandboxCapability;
+        let tools = cap.tools();
+        assert_eq!(tools.len(), 8);
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(names.contains(&"sandbox_create"));
+        assert!(names.contains(&"sandbox_exec"));
+        assert!(names.contains(&"sandbox_read_file"));
+        assert!(names.contains(&"sandbox_write_file"));
+        assert!(names.contains(&"sandbox_upload"));
+        assert!(names.contains(&"sandbox_download"));
+        assert!(names.contains(&"sandbox_list"));
+        assert!(names.contains(&"sandbox_manage"));
+    }
+
+    #[test]
+    fn test_system_prompt_exists() {
+        let cap = ContainerSandboxCapability;
+        let prompt = cap.system_prompt_addition().unwrap();
+        assert!(prompt.contains("Container Sandbox"));
+        assert!(prompt.contains("/workspace"));
+    }
+
+    #[test]
+    fn test_dependencies() {
+        let cap = ContainerSandboxCapability;
+        assert_eq!(cap.dependencies(), vec!["session_storage"]);
+    }
+
+    #[test]
+    fn test_features() {
+        let cap = ContainerSandboxCapability;
+        assert!(cap.features().contains(&LEASED_RESOURCES_FEATURE));
+    }
+}

--- a/crates/container-sandbox/src/state.rs
+++ b/crates/container-sandbox/src/state.rs
@@ -1,0 +1,237 @@
+//! Sandbox state management — persistence, lease tracking, naming.
+//!
+//! Decision: Sandbox state is stored in session secrets (same pattern as Daytona).
+//! Decision: Container/network names include session UUID for multi-tenant isolation.
+
+use everruns_core::leased_resource::UpsertLeasedResource;
+use everruns_core::tools::ToolExecutionResult;
+use everruns_core::traits::ToolContext;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tracing::error;
+
+/// Secret key prefix for sandbox state.
+const SANDBOX_SECRET_PREFIX: &str = "container_sandbox:";
+
+/// Lease duration for sandbox containers (20 minutes).
+pub const SANDBOX_LEASE_DURATION_SECONDS: u32 = 20 * 60;
+
+/// Sandbox state persisted in session secrets.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SandboxState {
+    pub container_id: String,
+    pub network_id: String,
+    pub container_name: String,
+    pub network_name: String,
+    pub image: String,
+    pub working_dir: String,
+    pub started_at: String,
+}
+
+/// Derive container name from session ID.
+pub fn container_name(session_id: &str) -> String {
+    // Use first 12 chars of session UUID for brevity
+    let short = if session_id.len() > 12 {
+        &session_id[..12]
+    } else {
+        session_id
+    };
+    format!("evr-{short}-sandbox")
+}
+
+/// Derive network name from session ID.
+pub fn network_name(session_id: &str) -> String {
+    let short = if session_id.len() > 12 {
+        &session_id[..12]
+    } else {
+        session_id
+    };
+    format!("sandbox-{short}")
+}
+
+/// Standard labels applied to all containers and networks.
+pub fn sandbox_labels(session_id: &str) -> std::collections::HashMap<String, String> {
+    std::collections::HashMap::from([
+        ("managed-by".to_string(), "everruns".to_string()),
+        ("session".to_string(), session_id.to_string()),
+    ])
+}
+
+/// Save sandbox state to session secrets.
+pub async fn save_sandbox_state(
+    context: &ToolContext,
+    state: &SandboxState,
+) -> Result<(), ToolExecutionResult> {
+    let storage = context
+        .storage_store
+        .as_ref()
+        .ok_or_else(|| ToolExecutionResult::tool_error("Storage not available"))?;
+
+    let json_str = serde_json::to_string(state).map_err(|e| {
+        error!("Failed to serialize sandbox state: {e}");
+        ToolExecutionResult::internal_error_msg(format!("Serialization error: {e}"))
+    })?;
+
+    let key = format!("{SANDBOX_SECRET_PREFIX}{}", state.container_name);
+    storage
+        .set_secret(context.session_id, &key, &json_str)
+        .await
+        .map_err(|e| {
+            error!("Failed to save sandbox state: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to save state: {e}"))
+        })?;
+
+    Ok(())
+}
+
+/// Load sandbox state from session secrets.
+pub async fn get_sandbox_state(context: &ToolContext) -> Result<SandboxState, ToolExecutionResult> {
+    let storage = context
+        .storage_store
+        .as_ref()
+        .ok_or_else(|| ToolExecutionResult::tool_error("Storage not available"))?;
+
+    // Find the sandbox state key by listing secrets with our prefix
+    let session_id = context.session_id.to_string();
+    let name = container_name(&session_id);
+    let key = format!("{SANDBOX_SECRET_PREFIX}{name}");
+
+    let json_str = storage
+        .get_secret(context.session_id, &key)
+        .await
+        .map_err(|e| {
+            error!("Failed to read sandbox state: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to read state: {e}"))
+        })?
+        .ok_or_else(|| {
+            ToolExecutionResult::tool_error(
+                "No sandbox found for this session. Use sandbox_create first.",
+            )
+        })?;
+
+    serde_json::from_str(&json_str).map_err(|e| {
+        error!("Corrupt sandbox state: {e}");
+        ToolExecutionResult::internal_error_msg(format!("Corrupt sandbox state: {e}"))
+    })
+}
+
+/// Delete sandbox state from session secrets.
+pub async fn delete_sandbox_state(
+    context: &ToolContext,
+    container_name: &str,
+) -> Result<(), ToolExecutionResult> {
+    let storage = context
+        .storage_store
+        .as_ref()
+        .ok_or_else(|| ToolExecutionResult::tool_error("Storage not available"))?;
+
+    let key = format!("{SANDBOX_SECRET_PREFIX}{container_name}");
+    storage
+        .delete_secret(context.session_id, &key)
+        .await
+        .map_err(|e| {
+            error!("Failed to delete sandbox state: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Failed to delete state: {e}"))
+        })?;
+
+    Ok(())
+}
+
+/// Refresh or create the leased resource for this sandbox.
+pub async fn touch_sandbox_lease(
+    context: &ToolContext,
+    state: &SandboxState,
+) -> Result<(), ToolExecutionResult> {
+    let Some(store) = context.leased_resource_store.as_ref() else {
+        return Ok(());
+    };
+
+    store
+        .upsert_resource(UpsertLeasedResource {
+            session_id: context.session_id,
+            provider: "container_sandbox".to_string(),
+            resource_type: "container".to_string(),
+            external_id: state.container_id.clone(),
+            display_name: Some(state.container_name.clone()),
+            owner_user_id: None,
+            lease_duration_seconds: SANDBOX_LEASE_DURATION_SECONDS,
+            metadata: json!({
+                "image": &state.image,
+                "working_dir": &state.working_dir,
+                "started_at": &state.started_at,
+            }),
+        })
+        .await
+        .map_err(|e| {
+            error!("Failed to upsert leased resource: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Lease update failed: {e}"))
+        })?;
+
+    Ok(())
+}
+
+/// Release the leased resource for this sandbox.
+pub async fn release_sandbox_lease(
+    context: &ToolContext,
+    container_id: &str,
+) -> Result<(), ToolExecutionResult> {
+    let Some(store) = context.leased_resource_store.as_ref() else {
+        return Ok(());
+    };
+
+    store
+        .release_resource(
+            context.session_id,
+            "container_sandbox",
+            "container",
+            container_id,
+        )
+        .await
+        .map_err(|e| {
+            error!("Failed to release leased resource: {e}");
+            ToolExecutionResult::internal_error_msg(format!("Lease release failed: {e}"))
+        })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_container_name() {
+        let name = container_name("abc123def456-more-stuff");
+        assert_eq!(name, "evr-abc123def456-sandbox");
+    }
+
+    #[test]
+    fn test_network_name() {
+        let name = network_name("abc123def456-more-stuff");
+        assert_eq!(name, "sandbox-abc123def456");
+    }
+
+    #[test]
+    fn test_sandbox_labels() {
+        let labels = sandbox_labels("session-123");
+        assert_eq!(labels.get("managed-by").unwrap(), "everruns");
+        assert_eq!(labels.get("session").unwrap(), "session-123");
+    }
+
+    #[test]
+    fn test_sandbox_state_serialization() {
+        let state = SandboxState {
+            container_id: "abc123".to_string(),
+            network_id: "net456".to_string(),
+            container_name: "evr-abc-sandbox".to_string(),
+            network_name: "sandbox-abc".to_string(),
+            image: "ubuntu:24.04".to_string(),
+            working_dir: "/workspace".to_string(),
+            started_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        let restored: SandboxState = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.container_id, "abc123");
+        assert_eq!(restored.image, "ubuntu:24.04");
+    }
+}

--- a/crates/container-sandbox/src/tools.rs
+++ b/crates/container-sandbox/src/tools.rs
@@ -1,0 +1,842 @@
+//! Tool implementations for container sandbox operations.
+//!
+//! Decision: One sandbox per session (container name derived from session ID).
+//! Decision: All tools require context (requires_context = true).
+//! Decision: Uses tool_output_sanitizer for exec output (same pipeline as Daytona).
+
+use async_trait::async_trait;
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use everruns_core::ToolHints;
+use everruns_core::tool_output_sanitizer::{
+    clean_exec_output, output_verbosity_budget, priority_aware_truncate,
+};
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::ToolContext;
+use serde_json::{Value, json};
+use tracing::{debug, error};
+
+use crate::client::{ContainerCreateConfig, DockerClient, HostConfig};
+use crate::config::ContainerSandboxConfig;
+use crate::state::{
+    SandboxState, container_name, delete_sandbox_state, get_sandbox_state, network_name,
+    release_sandbox_lease, sandbox_labels, save_sandbox_state, touch_sandbox_lease,
+};
+
+/// Helper: extract a required string parameter.
+fn required_str(args: &Value, name: &str) -> Result<String, ToolExecutionResult> {
+    args.get(name)
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .ok_or_else(|| {
+            ToolExecutionResult::tool_error(format!("Missing required parameter: {name}"))
+        })
+}
+
+/// Helper: create a DockerClient from config.
+fn docker_client(config: &ContainerSandboxConfig) -> DockerClient {
+    DockerClient::new(config.docker_host.as_deref())
+}
+
+// ============================================================================
+// sandbox_create
+// ============================================================================
+
+pub struct SandboxCreateTool;
+
+#[async_trait]
+impl Tool for SandboxCreateTool {
+    fn name(&self) -> &str {
+        "sandbox_create"
+    }
+
+    fn description(&self) -> &str {
+        "Create and start a container sandbox for code execution. \
+         One sandbox per session. Returns the sandbox container name."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "string",
+                    "description": "Container image (default: ubuntu:24.04)"
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_long_running(true)
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "Tool requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let config = ContainerSandboxConfig::default();
+        let image = arguments
+            .get("image")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&config.image)
+            .to_string();
+
+        let session_id = context.session_id.to_string();
+        let c_name = container_name(&session_id);
+        let n_name = network_name(&session_id);
+        let labels = sandbox_labels(&session_id);
+        let client = docker_client(&config);
+
+        // Create network (track whether we created it vs reused an existing one)
+        let (network_id, network_created) = match client
+            .create_network(&n_name, labels.clone())
+            .await
+        {
+            Ok(id) => (id, true),
+            Err(e) if e.contains("already exists") || e.contains("Conflict") => {
+                // Network exists, that's fine — reuse
+                debug!(name = %n_name, "Network already exists, reusing");
+                (n_name.clone(), false)
+            }
+            Err(e) => {
+                return ToolExecutionResult::tool_error(format!("Failed to create network: {e}"));
+            }
+        };
+
+        // Create container
+        let create_config = ContainerCreateConfig {
+            image: image.clone(),
+            cmd: vec![
+                "tail".to_string(),
+                "-f".to_string(),
+                "/dev/null".to_string(),
+            ],
+            working_dir: config.working_dir.clone(),
+            labels,
+            host_config: HostConfig {
+                runtime: config.runtime.clone(),
+                network_mode: n_name.clone(),
+                memory: config.memory_limit,
+                nano_cpus: config.cpu_limit,
+                pids_limit: config.pids_limit,
+                init: true,
+            },
+        };
+
+        let container = match client.create_container(&c_name, &create_config).await {
+            Ok(c) => c,
+            Err(e) => {
+                // Only remove network if we just created it
+                // TODO: idempotent create (409/name conflict) is a follow-up
+                if network_created {
+                    let _ = client.remove_network(&network_id).await;
+                }
+                return ToolExecutionResult::tool_error(format!("Failed to create container: {e}"));
+            }
+        };
+
+        // Start container
+        if let Err(e) = client.start_container(&container.id).await {
+            let _ = client.remove_container(&container.id).await;
+            if network_created {
+                let _ = client.remove_network(&network_id).await;
+            }
+            return ToolExecutionResult::tool_error(format!("Failed to start container: {e}"));
+        }
+
+        let now = chrono::Utc::now().to_rfc3339();
+        let state = SandboxState {
+            container_id: container.id.clone(),
+            network_id: network_id.clone(),
+            container_name: c_name.clone(),
+            network_name: n_name,
+            image: image.clone(),
+            working_dir: config.working_dir.clone(),
+            started_at: now,
+        };
+
+        // Save state and register lease
+        if let Err(e) = save_sandbox_state(context, &state).await {
+            return e;
+        }
+        if let Err(e) = touch_sandbox_lease(context, &state).await {
+            return e;
+        }
+
+        ToolExecutionResult::success(format!(
+            "Sandbox created and running.\n\
+             Container: {c_name}\n\
+             Image: {image}\n\
+             Working directory: {}",
+            config.working_dir
+        ))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// sandbox_exec
+// ============================================================================
+
+pub struct SandboxExecTool;
+
+#[async_trait]
+impl Tool for SandboxExecTool {
+    fn name(&self) -> &str {
+        "sandbox_exec"
+    }
+
+    fn description(&self) -> &str {
+        "Execute a command in the container sandbox. Returns stdout/stderr and exit code."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "Shell command to execute"
+                },
+                "working_dir": {
+                    "type": "string",
+                    "description": "Working directory (default: /workspace)"
+                },
+                "output": everruns_core::tool_output_sanitizer::output_verbosity_schema()
+            },
+            "required": ["command"],
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_long_running(true)
+            .with_persist_output(true)
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "Tool requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let command = match required_str(&arguments, "command") {
+            Ok(c) => c,
+            Err(e) => return e,
+        };
+
+        let output_mode = arguments
+            .get("output")
+            .and_then(|v| v.as_str())
+            .unwrap_or("concise");
+
+        let state = match get_sandbox_state(context).await {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let working_dir = arguments
+            .get("working_dir")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&state.working_dir);
+
+        let config = ContainerSandboxConfig::default();
+        let client = docker_client(&config);
+
+        let result = match client
+            .exec(
+                &state.container_id,
+                &["sh", "-c", &command],
+                Some(working_dir),
+            )
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => return ToolExecutionResult::tool_error(format!("Exec failed: {e}")),
+        };
+
+        // Refresh lease on successful exec
+        let _ = touch_sandbox_lease(context, &state).await;
+
+        // Sanitize output
+        let clean_output = clean_exec_output(&result.output);
+        let output = if let Some(budget) = output_verbosity_budget(output_mode) {
+            priority_aware_truncate(&clean_output, budget)
+        } else {
+            clean_output
+        };
+
+        let exit_code = result.exit_code;
+        if exit_code == 0 {
+            ToolExecutionResult::success(output)
+        } else {
+            ToolExecutionResult::success(format!("Exit code: {exit_code}\n\n{output}"))
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// sandbox_read_file
+// ============================================================================
+
+pub struct SandboxReadFileTool;
+
+#[async_trait]
+impl Tool for SandboxReadFileTool {
+    fn name(&self) -> &str {
+        "sandbox_read_file"
+    }
+
+    fn description(&self) -> &str {
+        "Read a file from the container sandbox."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute path to the file inside the container"
+                }
+            },
+            "required": ["path"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Tool requires context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let path = match required_str(&arguments, "path") {
+            Ok(p) => p,
+            Err(e) => return e,
+        };
+
+        let state = match get_sandbox_state(context).await {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let config = ContainerSandboxConfig::default();
+        let client = docker_client(&config);
+
+        match client.get_archive(&state.container_id, &path).await {
+            Ok(bytes) => {
+                // Try to return as text, fall back to base64
+                match String::from_utf8(bytes.clone()) {
+                    Ok(text) => ToolExecutionResult::success(text),
+                    Err(_) => ToolExecutionResult::success(format!(
+                        "[Binary file, {} bytes]",
+                        bytes.len()
+                    )),
+                }
+            }
+            Err(e) => ToolExecutionResult::tool_error(format!("Failed to read file: {e}")),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// sandbox_write_file
+// ============================================================================
+
+pub struct SandboxWriteFileTool;
+
+#[async_trait]
+impl Tool for SandboxWriteFileTool {
+    fn name(&self) -> &str {
+        "sandbox_write_file"
+    }
+
+    fn description(&self) -> &str {
+        "Write a file to the container sandbox."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute path for the file inside the container"
+                },
+                "content": {
+                    "type": "string",
+                    "description": "File content to write"
+                }
+            },
+            "required": ["path", "content"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Tool requires context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let path = match required_str(&arguments, "path") {
+            Ok(p) => p,
+            Err(e) => return e,
+        };
+        let content = match required_str(&arguments, "content") {
+            Ok(c) => c,
+            Err(e) => return e,
+        };
+
+        let state = match get_sandbox_state(context).await {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let config = ContainerSandboxConfig::default();
+        let client = docker_client(&config);
+
+        // Split path into directory and filename
+        let (dir, filename) = match path.rsplit_once('/') {
+            Some((d, f)) if !d.is_empty() => (d.to_string(), f.to_string()),
+            _ => ("/".to_string(), path.trim_start_matches('/').to_string()),
+        };
+
+        if filename.is_empty() {
+            return ToolExecutionResult::tool_error(
+                "Invalid path: filename is empty (trailing slash?)",
+            );
+        }
+
+        match client
+            .put_archive(&state.container_id, &dir, &filename, content.as_bytes())
+            .await
+        {
+            Ok(()) => {
+                ToolExecutionResult::success(format!("Written {path} ({} bytes)", content.len()))
+            }
+            Err(e) => ToolExecutionResult::tool_error(format!("Failed to write file: {e}")),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// sandbox_list
+// ============================================================================
+
+pub struct SandboxListTool;
+
+#[async_trait]
+impl Tool for SandboxListTool {
+    fn name(&self) -> &str {
+        "sandbox_list"
+    }
+
+    fn description(&self) -> &str {
+        "List container sandboxes for this session."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Tool requires context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        _arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let session_id = context.session_id.to_string();
+        let config = ContainerSandboxConfig::default();
+        let client = docker_client(&config);
+
+        let filters = [("managed-by", "everruns"), ("session", &session_id)];
+
+        match client.list_containers(&filters).await {
+            Ok(containers) => {
+                if containers.is_empty() {
+                    return ToolExecutionResult::success("No sandboxes found for this session.");
+                }
+                let summary: Vec<String> = containers
+                    .iter()
+                    .map(|c| {
+                        let name = c
+                            .names
+                            .first()
+                            .map(|n| n.trim_start_matches('/'))
+                            .unwrap_or("unknown");
+                        format!("- {} ({}): {}", name, c.state, c.status)
+                    })
+                    .collect();
+                ToolExecutionResult::success(summary.join("\n"))
+            }
+            Err(e) => ToolExecutionResult::tool_error(format!("Failed to list containers: {e}")),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// sandbox_manage
+// ============================================================================
+
+pub struct SandboxManageTool;
+
+#[async_trait]
+impl Tool for SandboxManageTool {
+    fn name(&self) -> &str {
+        "sandbox_manage"
+    }
+
+    fn description(&self) -> &str {
+        "Manage the container sandbox: stop, start, or remove it."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "description": "Action to perform",
+                    "enum": ["stop", "start", "remove"]
+                }
+            },
+            "required": ["action"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Tool requires context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let action = match required_str(&arguments, "action") {
+            Ok(a) => a,
+            Err(e) => return e,
+        };
+
+        let state = match get_sandbox_state(context).await {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let config = ContainerSandboxConfig::default();
+        let client = docker_client(&config);
+
+        match action.as_str() {
+            "stop" => {
+                if let Err(e) = client.stop_container(&state.container_id, 10).await {
+                    return ToolExecutionResult::tool_error(format!("Failed to stop: {e}"));
+                }
+                ToolExecutionResult::success("Sandbox stopped.")
+            }
+            "start" => {
+                if let Err(e) = client.start_container(&state.container_id).await {
+                    return ToolExecutionResult::tool_error(format!("Failed to start: {e}"));
+                }
+                let _ = touch_sandbox_lease(context, &state).await;
+                ToolExecutionResult::success("Sandbox started.")
+            }
+            "remove" => {
+                // Stop, remove container, remove network, clean up state
+                let _ = client.stop_container(&state.container_id, 5).await;
+                if let Err(e) = client.remove_container(&state.container_id).await {
+                    error!("Failed to remove container: {e}");
+                }
+                let _ = client.remove_network(&state.network_id).await;
+                let _ = release_sandbox_lease(context, &state.container_id).await;
+                let _ = delete_sandbox_state(context, &state.container_name).await;
+                ToolExecutionResult::success("Sandbox removed and cleaned up.")
+            }
+            _ => ToolExecutionResult::tool_error("Invalid action. Use: stop, start, or remove"),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// sandbox_upload
+// ============================================================================
+
+pub struct SandboxUploadTool;
+
+#[async_trait]
+impl Tool for SandboxUploadTool {
+    fn name(&self) -> &str {
+        "sandbox_upload"
+    }
+
+    fn description(&self) -> &str {
+        "Upload a file from session storage to the container sandbox."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "session_path": {
+                    "type": "string",
+                    "description": "Path of the file in session storage"
+                },
+                "container_path": {
+                    "type": "string",
+                    "description": "Absolute destination path inside the container"
+                }
+            },
+            "required": ["session_path", "container_path"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Tool requires context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let session_path = match required_str(&arguments, "session_path") {
+            Ok(p) => p,
+            Err(e) => return e,
+        };
+        let container_path = match required_str(&arguments, "container_path") {
+            Ok(p) => p,
+            Err(e) => return e,
+        };
+
+        let state = match get_sandbox_state(context).await {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let file_store = match context.file_store.as_ref() {
+            Some(fs) => fs,
+            None => return ToolExecutionResult::tool_error("File store not available"),
+        };
+
+        // Read file from session VFS
+        let file = match file_store
+            .read_file(context.session_id, &session_path)
+            .await
+        {
+            Ok(Some(f)) => f,
+            Ok(None) => {
+                return ToolExecutionResult::tool_error(format!(
+                    "File not found in session storage: {session_path}"
+                ));
+            }
+            Err(e) => {
+                return ToolExecutionResult::tool_error(format!(
+                    "Failed to read from session storage: {e}"
+                ));
+            }
+        };
+
+        // Decode content (text or base64)
+        let content_str = file.content.unwrap_or_default();
+        let bytes = if file.encoding == "base64" {
+            match BASE64.decode(&content_str) {
+                Ok(b) => b,
+                Err(e) => {
+                    return ToolExecutionResult::tool_error(format!(
+                        "Failed to decode base64 content from session file {session_path}: {e}"
+                    ));
+                }
+            }
+        } else {
+            content_str.as_bytes().to_vec()
+        };
+
+        let config = ContainerSandboxConfig::default();
+        let client = docker_client(&config);
+
+        let (dir, filename) = match container_path.rsplit_once('/') {
+            Some((d, f)) if !d.is_empty() => (d.to_string(), f.to_string()),
+            _ => (
+                "/".to_string(),
+                container_path.trim_start_matches('/').to_string(),
+            ),
+        };
+
+        if filename.is_empty() {
+            return ToolExecutionResult::tool_error(
+                "Invalid container_path: filename is empty (trailing slash?)",
+            );
+        }
+
+        match client
+            .put_archive(&state.container_id, &dir, &filename, &bytes)
+            .await
+        {
+            Ok(()) => ToolExecutionResult::success(format!(
+                "Uploaded {session_path} → {container_path} ({} bytes)",
+                bytes.len()
+            )),
+            Err(e) => ToolExecutionResult::tool_error(format!("Upload failed: {e}")),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// ============================================================================
+// sandbox_download
+// ============================================================================
+
+pub struct SandboxDownloadTool;
+
+#[async_trait]
+impl Tool for SandboxDownloadTool {
+    fn name(&self) -> &str {
+        "sandbox_download"
+    }
+
+    fn description(&self) -> &str {
+        "Download a file from the container sandbox to session storage."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "container_path": {
+                    "type": "string",
+                    "description": "Absolute path of the file inside the container"
+                },
+                "session_path": {
+                    "type": "string",
+                    "description": "Destination path in session storage"
+                }
+            },
+            "required": ["container_path", "session_path"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("Tool requires context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let container_path = match required_str(&arguments, "container_path") {
+            Ok(p) => p,
+            Err(e) => return e,
+        };
+        let session_path = match required_str(&arguments, "session_path") {
+            Ok(p) => p,
+            Err(e) => return e,
+        };
+
+        let state = match get_sandbox_state(context).await {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+
+        let file_store = match context.file_store.as_ref() {
+            Some(fs) => fs,
+            None => return ToolExecutionResult::tool_error("File store not available"),
+        };
+
+        let config = ContainerSandboxConfig::default();
+        let client = docker_client(&config);
+
+        let bytes = match client
+            .get_archive(&state.container_id, &container_path)
+            .await
+        {
+            Ok(b) => b,
+            Err(e) => {
+                return ToolExecutionResult::tool_error(format!("Failed to read file: {e}"));
+            }
+        };
+
+        // Store as text if valid UTF-8, otherwise base64
+        let (content, encoding) = match String::from_utf8(bytes.clone()) {
+            Ok(text) => (text, "text"),
+            Err(_) => (BASE64.encode(&bytes), "base64"),
+        };
+
+        match file_store
+            .write_file(context.session_id, &session_path, &content, encoding)
+            .await
+        {
+            Ok(_) => ToolExecutionResult::success(format!(
+                "Downloaded {container_path} → {session_path} ({} bytes)",
+                bytes.len()
+            )),
+            Err(e) => {
+                ToolExecutionResult::tool_error(format!("Failed to save to session storage: {e}"))
+            }
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -78,6 +78,7 @@ everruns-integrations-deno = { path = "../../integrations/deno" }
 everruns-integrations-browserless = { path = "../../integrations/browserless" }
 everruns-integrations-e2b = { path = "../../integrations/e2b" }
 everruns-integrations-sprites = { path = "../../integrations/sprites" }
+everruns-container-sandbox = { path = "../container-sandbox" }
 everruns-integrations-pi = { path = "../../integrations/pi" }
 everruns-session-sqldb = { path = "../session-sqldb" }
 everruns-worker = { path = "../worker" }  # For AgentRunner trait

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -4,6 +4,7 @@
 // Decision: App builder pattern (ServerAppBuilder) for composable server configurations
 
 // Force-link integration crates so inventory::submit! registrations are included
+extern crate everruns_container_sandbox;
 extern crate everruns_integrations_brave_search;
 extern crate everruns_integrations_browserless;
 extern crate everruns_integrations_daytona;

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -24,6 +24,7 @@ everruns-integrations-deno = { path = "../../integrations/deno" }
 everruns-integrations-browserless = { path = "../../integrations/browserless" }
 everruns-integrations-e2b = { path = "../../integrations/e2b" }
 everruns-integrations-sprites = { path = "../../integrations/sprites" }
+everruns-container-sandbox = { path = "../container-sandbox" }
 everruns-integrations-pi = { path = "../../integrations/pi" }
 everruns-openai = { path = "../openai" }
 everruns-anthropic = { path = "../anthropic" }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -1,4 +1,5 @@
 // Force-link integration crates so inventory::submit! registrations are included
+extern crate everruns_container_sandbox;
 extern crate everruns_integrations_brave_search;
 extern crate everruns_integrations_browserless;
 extern crate everruns_integrations_daytona;


### PR DESCRIPTION
## What
Add `ContainerSandboxCapability` with inventory plugin registration and 8 tools for self-hosted container execution via Docker Engine REST API.

Supersedes #1277 (rebased cleanly on main after EVE-277 merge).

## Why
Fills the gap between virtual bash (safe but limited) and cloud sandboxes like Daytona/E2B (powerful but SaaS dependency). Self-hosted Docker containers give full Linux isolation without external service requirements.

## How
- `ContainerSandboxCapability` registered via `inventory::submit!` with `container_sandbox` feature flag
- 8 tools: `sandbox_create`, `sandbox_exec`, `sandbox_read_file`, `sandbox_write_file`, `sandbox_upload`, `sandbox_download`, `sandbox_list`, `sandbox_manage`
- Config module with safe defaults (2 GiB memory, 1 CPU, 256 PIDs, ubuntu:24.04)
- State management via session secrets (same pattern as Daytona)
- Leased resource tracking for automatic cleanup
- Output sanitization via `tool_output_sanitizer` (same pipeline as Daytona)
- Force-linked in server and worker crates for auto-registration
- Risk level: High (admin-gated, same as Daytona/E2B)

## Risk
- Low — new feature behind feature flag `container_sandbox`
- No existing behavior changed
- Force-link adds the crate to server/worker builds but capability only registers when feature flag is enabled

## Security
- Threat categories reviewed: TM-TOOL, TM-TENANT, TM-BASH, TM-FS, TM-DOS
- **TM-TOOL**: All 8 tools require context (`requires_context() = true`), enforced at tool execution layer
- **TM-TENANT**: Container/network names include session ID; all list operations use label filters (`managed-by=everruns`, `session={id}`)
- **TM-BASH**: Commands executed via Docker exec API, not shell subprocess — no host command injection
- **TM-FS**: File I/O via Docker archive API (tar), scoped to container filesystem. Filename sanitization rejects `..`, `/`, `\`
- **TM-DOS**: Resource limits enforced via Docker HostConfig (memory, CPU, PIDs). Feature-gated so not available by default.

## Checklist
- [x] Tests added or updated (31 unit tests total: capability metadata, tool count, config, state, client)
- [x] Backward compatibility considered (feature-gated, no breaking changes)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Closes EVE-278