### PR TITLE
feat(infra): add sandbox VPS infrastructure (Terraform, cloud-init, compose)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,10 @@ build/
 
 # Tools
 .sqlx.envrc
+
+# Terraform
+**/.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfvars
+!*.tfvars.example

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -1,0 +1,100 @@
+# Everruns Dev Deployment — Docker Compose
+#
+# SaaS dev environment running on Hetzner control plane VPS.
+# Secrets injected via Doppler: `doppler run -- docker compose -f docker-compose.dev.yml up -d`
+#
+# Requires:
+#   - PostgreSQL running on the host or as a managed service
+#   - Doppler project "everruns", config "dev"
+#   - Sandbox VPS reachable at 10.0.0.3 (private network)
+
+services:
+  # ==========================================================================
+  # Server (Control Plane) - HTTP API + gRPC server
+  # ==========================================================================
+  server:
+    image: ghcr.io/everruns/everruns-server:${EVERRUNS_TAG:-latest}
+    environment:
+      - DATABASE_URL
+      - VALKEY_URL
+      - NATS_URL
+      - SECRETS_ENCRYPTION_KEY
+      - DEFAULT_OPENAI_API_KEY
+      - DEFAULT_ANTHROPIC_API_KEY
+      - DEFAULT_GEMINI_API_KEY
+      - WORKER_GRPC_AUTH_TOKEN
+      - OTEL_EXPORTER_OTLP_ENDPOINT
+      - ADDR=0.0.0.0:9301
+      - RUST_LOG=info
+    ports:
+      - "9301:9301"
+      - "9001:9001"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "/app/everruns-server", "--version"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  # ==========================================================================
+  # Worker
+  # ==========================================================================
+  worker:
+    image: ghcr.io/everruns/everruns-worker:${EVERRUNS_TAG:-latest}
+    environment:
+      - WORKER_GRPC_ADDRESS=server:9001
+      - WORKER_GRPC_AUTH_TOKEN
+      - OTEL_EXPORTER_OTLP_ENDPOINT
+      - RUST_LOG=info
+      # Container sandbox (sandbox VPS via private network)
+      - CONTAINER_SANDBOX_DOCKER_HOST
+      - CONTAINER_SANDBOX_RUNTIME
+      - CONTAINER_SANDBOX_MAX_PER_ORG
+      - CONTAINER_SANDBOX_MEMORY_LIMIT
+      - CONTAINER_SANDBOX_CPU_LIMIT
+      - CONTAINER_SANDBOX_DEFAULT_IMAGE
+    depends_on:
+      server:
+        condition: service_started
+    restart: unless-stopped
+
+  # ==========================================================================
+  # UI (Next.js dashboard)
+  # ==========================================================================
+  ui:
+    image: ghcr.io/everruns/everruns-ui:${EVERRUNS_TAG:-latest}
+    environment:
+      PORT: "9305"
+      HOSTNAME: 0.0.0.0
+    depends_on:
+      server:
+        condition: service_started
+    restart: unless-stopped
+
+  # ==========================================================================
+  # Caddy Reverse Proxy
+  # ==========================================================================
+  caddy:
+    image: caddy:2-alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - caddy_data:/data
+      - caddy_config:/config
+    configs:
+      - source: caddyfile
+        target: /etc/caddy/Caddyfile
+    depends_on:
+      - server
+      - ui
+    restart: unless-stopped
+
+configs:
+  caddyfile:
+    file: ./Caddyfile.dev
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/infra/terraform/cloud-init-sandbox.yaml
+++ b/infra/terraform/cloud-init-sandbox.yaml
@@ -1,0 +1,39 @@
+#cloud-config
+# Sandbox VPS: Docker + Sysbox + socket proxy. No server, no UI, no secrets.
+
+package_update: true
+packages:
+  - curl
+  - iptables
+
+runcmd:
+  # Install Docker
+  - curl -fsSL https://get.docker.com | sh
+  - systemctl enable --now docker
+
+  # Install Sysbox
+  - wget -q https://downloads.nestybox.com/sysbox/releases/v0.7.0/sysbox-ce_0.7.0-0.linux_amd64.deb
+  - apt-get install -y ./sysbox-ce_0.7.0-0.linux_amd64.deb
+  - systemctl enable --now sysbox
+  - rm sysbox-ce_0.7.0-0.linux_amd64.deb
+
+  # Verify Sysbox registered with Docker
+  - docker info --format '{{.Runtimes}}' | grep -q sysbox-runc
+
+  # Login to GHCR (for pulling sandbox base images if needed)
+  - echo "${ghcr_token}" | docker login ghcr.io -u "${ghcr_username}" --password-stdin
+
+  # Pre-pull default sandbox image
+  - docker pull ubuntu:24.04
+
+  # Start socket proxy (listens on private network only)
+  - |
+    docker run -d --name docker-proxy --restart unless-stopped \
+      -e CONTAINERS=1 -e POST=1 -e IMAGES=1 -e NETWORKS=1 -e EXEC=1 \
+      -v /var/run/docker.sock:/var/run/docker.sock:ro \
+      -p 10.0.0.3:2375:2375 \
+      tecnativa/docker-socket-proxy
+
+  # Block docker-proxy from public interface (defense-in-depth)
+  - iptables -A INPUT -p tcp --dport 2375 -s 10.0.0.0/24 -j ACCEPT
+  - iptables -A INPUT -p tcp --dport 2375 -j DROP

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,139 @@
+# Everruns Dev Infrastructure — Hetzner Cloud
+#
+# Resources:
+#   - Control plane VPS (server + workers + UI + DB)
+#   - Private network (10.0.0.0/16) for internal communication
+#   - Sandbox VPS (Docker + Sysbox for agent container execution)
+#
+# Usage:
+#   terraform init
+#   terraform plan
+#   terraform apply
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "~> 1.49"
+    }
+  }
+}
+
+provider "hcloud" {
+  token = var.hcloud_token
+}
+
+# ==========================================================================
+# SSH Key
+# ==========================================================================
+
+resource "hcloud_ssh_key" "deploy" {
+  name       = "everruns-dev-deploy"
+  public_key = var.ssh_public_key
+}
+
+# ==========================================================================
+# Firewall — Control Plane (HTTP, HTTPS, SSH)
+# ==========================================================================
+
+resource "hcloud_firewall" "control_plane" {
+  name = "everruns-dev-control-plane"
+
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
+    port       = "22"
+    source_ips = ["0.0.0.0/0", "::/0"]
+  }
+
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
+    port       = "80"
+    source_ips = ["0.0.0.0/0", "::/0"]
+  }
+
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
+    port       = "443"
+    source_ips = ["0.0.0.0/0", "::/0"]
+  }
+}
+
+# ==========================================================================
+# Firewall — Sandbox (SSH only, no public services)
+# ==========================================================================
+
+resource "hcloud_firewall" "sandbox" {
+  name = "everruns-dev-sandbox"
+
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
+    port       = "22"
+    source_ips = ["0.0.0.0/0", "::/0"]
+  }
+  # No 80/443 — Docker API (2375) only via private network
+}
+
+# ==========================================================================
+# Private Network (control plane <-> sandbox communication)
+# ==========================================================================
+
+resource "hcloud_network" "internal" {
+  name     = "everruns-dev-internal"
+  ip_range = "10.0.0.0/16"
+}
+
+resource "hcloud_network_subnet" "internal" {
+  network_id   = hcloud_network.internal.id
+  type         = "cloud"
+  network_zone = "us-east"
+  ip_range     = "10.0.0.0/24"
+}
+
+# ==========================================================================
+# Control Plane VPS
+# ==========================================================================
+
+resource "hcloud_server" "dev" {
+  name         = "everruns-dev"
+  server_type  = var.server_type
+  location     = var.server_location
+  image        = "ubuntu-24.04"
+  ssh_keys     = [hcloud_ssh_key.deploy.id]
+  firewall_ids = [hcloud_firewall.control_plane.id]
+
+  user_data = var.control_plane_user_data
+
+  network {
+    network_id = hcloud_network.internal.id
+    ip         = "10.0.0.2"
+  }
+}
+
+# ==========================================================================
+# Sandbox VPS (Docker + Sysbox for agent container execution)
+# ==========================================================================
+
+resource "hcloud_server" "sandbox" {
+  name         = "everruns-dev-sandbox"
+  server_type  = var.sandbox_server_type
+  location     = var.server_location
+  image        = "ubuntu-24.04"
+  ssh_keys     = [hcloud_ssh_key.deploy.id]
+  firewall_ids = [hcloud_firewall.sandbox.id]
+
+  user_data = templatefile("${path.module}/cloud-init-sandbox.yaml", {
+    ghcr_token    = var.ghcr_token
+    ghcr_username = var.ghcr_username
+  })
+
+  network {
+    network_id = hcloud_network.internal.id
+    ip         = "10.0.0.3"
+  }
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,21 @@
+# Everruns Dev Infrastructure — Outputs
+
+output "control_plane_ip" {
+  value       = hcloud_server.dev.ipv4_address
+  description = "Control plane public IPv4 address"
+}
+
+output "control_plane_private_ip" {
+  value       = "10.0.0.2"
+  description = "Control plane private network IP"
+}
+
+output "sandbox_ip" {
+  value       = hcloud_server.sandbox.ipv4_address
+  description = "Sandbox VPS public IPv4 address"
+}
+
+output "sandbox_private_ip" {
+  value       = "10.0.0.3"
+  description = "Sandbox VPS private network IP"
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,47 @@
+# Everruns Dev Infrastructure — Variables
+
+variable "hcloud_token" {
+  description = "Hetzner Cloud API token"
+  type        = string
+  sensitive   = true
+}
+
+variable "ssh_public_key" {
+  description = "SSH public key for deploy access"
+  type        = string
+}
+
+variable "server_type" {
+  description = "Hetzner server type for control plane VPS"
+  type        = string
+  default     = "cpx31" # 4 vCPU, 8 GB
+}
+
+variable "sandbox_server_type" {
+  description = "Hetzner server type for sandbox VPS"
+  type        = string
+  default     = "cpx31" # 4 vCPU, 8 GB. Upgrade to cpx41 for more headroom.
+}
+
+variable "server_location" {
+  description = "Hetzner datacenter location"
+  type        = string
+  default     = "ash" # Ashburn, US East
+}
+
+variable "control_plane_user_data" {
+  description = "Cloud-init user data for the control plane VPS"
+  type        = string
+  default     = ""
+}
+
+variable "ghcr_token" {
+  description = "GitHub Container Registry token for sandbox image pulls"
+  type        = string
+  sensitive   = true
+}
+
+variable "ghcr_username" {
+  description = "GitHub Container Registry username"
+  type        = string
+}


### PR DESCRIPTION
## What

Add Hetzner Cloud infrastructure for the dedicated sandbox VPS used by the `container_sandbox` capability. Three new file groups:

1. **Terraform** (`infra/terraform/`) — Private network (10.0.0.0/16), control plane VPS (10.0.0.2), sandbox VPS (10.0.0.3), firewalls, SSH key
2. **Cloud-init** (`infra/terraform/cloud-init-sandbox.yaml`) — First-boot provisioning: Docker Engine, Sysbox 0.7.0 runtime, tecnativa/docker-socket-proxy bound to private network only, iptables defense-in-depth
3. **Docker Compose** (`infra/docker-compose.dev.yml`) — SaaS dev deployment with `CONTAINER_SANDBOX_*` env pass-through from Doppler to worker containers

Also adds Terraform-related patterns to `.gitignore` (`.terraform/`, `*.tfstate`, `*.tfvars`).

## Why

The OSS `container_sandbox` capability (EVE-276) is runtime-agnostic — it talks Docker Engine REST API. The SaaS deployment needs a dedicated sandbox VPS with Sysbox for VM-like multi-tenant isolation, separate from the control plane. This is the infrastructure layer for EVE-281.

## How

- Terraform manages Hetzner resources: private network, subnet, two firewalls (control plane: SSH+HTTP+HTTPS; sandbox: SSH-only), two VPS instances connected via private network
- Cloud-init provisions the sandbox VPS on first boot with Docker, Sysbox, GHCR login, and a socket proxy listening only on the private interface
- Docker-compose passes sandbox env vars from Doppler through to worker containers

## Risk

- **Low** — New infrastructure files only. No existing code modified. No runtime behavior changes.
- Terraform and cloud-init are not applied automatically; they require manual `terraform apply` and VPS provisioning.

## Security

- Threat categories reviewed: **TM-BASH** (cloud-init runs shell commands), network isolation
- Findings and resolutions:
  - Docker API (port 2375) bound to private network IP only (10.0.0.3), not 0.0.0.0
  - iptables defense-in-depth rules block port 2375 from public interface even if firewall is misconfigured
  - Sandbox firewall allows only SSH (port 22) — no public HTTP/HTTPS
  - Sensitive Terraform variables (`hcloud_token`, `ghcr_token`) marked `sensitive = true`
  - `.gitignore` updated to exclude `*.tfstate`, `*.tfvars`, `.terraform/` — prevents accidental secret commits
  - Docker-compose uses env pass-through (not hardcoded values) — secrets stay in Doppler

## Checklist

- [x] Tests added or updated — N/A (infrastructure config, no testable runtime code)
- [x] Backward compatibility considered — New files only, no breaking changes
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Closes EVE-282, EVE-283, EVE-284