### PR TITLE
fix(auth): add missing Secure flag to switch-org cookie

### DIFF
--- a/crates/server/src/api/users.rs
+++ b/crates/server/src/api/users.rs
@@ -317,7 +317,8 @@ pub async fn switch_org(
     // Build the org cookie
     let org_cookie = Cookie::build((ORG_COOKIE_NAME, req.org_id.clone()))
         .path("/")
-        .http_only(true)
+        .http_only(false) // Allow JS to read for UI state
+        .secure(true)
         .same_site(SameSite::Lax)
         .build();
 

--- a/crates/server/tests/org_lifecycle_test.rs
+++ b/crates/server/tests/org_lifecycle_test.rs
@@ -302,10 +302,10 @@ async fn test_switch_org_cookie_has_secure_flag() {
         .assert_status(StatusCode::OK);
 
     let set_cookie_values: Vec<&str> = resp
-        .headers
+        .headers()
         .get_all(SET_COOKIE)
         .iter()
-        .map(|v| v.to_str().unwrap())
+        .map(|v| v.to_str().expect("Set-Cookie header must be valid ASCII/UTF-8"))
         .collect();
 
     let org_cookie = set_cookie_values

--- a/crates/server/tests/org_lifecycle_test.rs
+++ b/crates/server/tests/org_lifecycle_test.rs
@@ -12,6 +12,7 @@
 mod test_harness;
 
 use axum::http::StatusCode;
+use axum::http::header::SET_COOKIE;
 use serde_json::{Value, json};
 use test_harness::TestServer;
 
@@ -276,4 +277,44 @@ async fn test_get_created_org_by_id() {
         .json();
     assert_eq!(fetched["name"], "Get By ID");
     assert_eq!(fetched["id"], org_id);
+}
+
+// ============================================
+// Bug regression: switch-org cookie must have Secure flag
+// ============================================
+
+#[tokio::test]
+async fn test_switch_org_cookie_has_secure_flag() {
+    let server = TestServer::in_memory().await;
+
+    // Create a new org to switch to
+    let created: Value = server
+        .post("/v1/orgs", json!({"name": "Secure Cookie Test"}))
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    let new_org_id = created["id"].as_str().expect("org id");
+
+    // Switch to new org and inspect Set-Cookie header
+    let resp = server
+        .post("/v1/users/me/switch-org", json!({"org_id": new_org_id}))
+        .await
+        .assert_status(StatusCode::OK);
+
+    let set_cookie_values: Vec<&str> = resp
+        .headers
+        .get_all(SET_COOKIE)
+        .iter()
+        .map(|v| v.to_str().unwrap())
+        .collect();
+
+    let org_cookie = set_cookie_values
+        .iter()
+        .find(|c| c.contains("everruns_org="))
+        .expect("everruns_org cookie must be set");
+
+    assert!(
+        org_cookie.contains("Secure"),
+        "everruns_org cookie must have Secure flag, got: {org_cookie}"
+    );
 }

--- a/crates/server/tests/org_lifecycle_test.rs
+++ b/crates/server/tests/org_lifecycle_test.rs
@@ -305,7 +305,10 @@ async fn test_switch_org_cookie_has_secure_flag() {
         .headers()
         .get_all(SET_COOKIE)
         .iter()
-        .map(|v| v.to_str().expect("Set-Cookie header must be valid ASCII/UTF-8"))
+        .map(|v| {
+            v.to_str()
+                .expect("Set-Cookie header must be valid ASCII/UTF-8")
+        })
         .collect();
 
     let org_cookie = set_cookie_values

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use axum::{
     Router,
     body::Body,
-    http::{Method, Request, StatusCode, header::HeaderMap},
+    http::{HeaderMap, Method, Request, StatusCode},
     routing::get,
 };
 use http_body_util::BodyExt;
@@ -548,7 +548,7 @@ pub enum TestMode {
 /// Response from a test request
 pub struct TestResponse {
     status: StatusCode,
-    pub headers: HeaderMap,
+    headers: HeaderMap,
     body: Vec<u8>,
 }
 
@@ -556,6 +556,11 @@ impl TestResponse {
     /// Get the status code
     pub fn status(&self) -> StatusCode {
         self.status
+    }
+
+    /// Get the response headers
+    pub fn headers(&self) -> &HeaderMap {
+        &self.headers
     }
 
     /// Get the body as a string

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use axum::{
     Router,
     body::Body,
-    http::{Method, Request, StatusCode},
+    http::{Method, Request, StatusCode, header::HeaderMap},
     routing::get,
 };
 use http_body_util::BodyExt;
@@ -475,6 +475,7 @@ impl TestServer {
             .expect("Request failed");
 
         let status = response.status();
+        let headers = response.headers().clone();
         let body_bytes = response
             .into_body()
             .collect()
@@ -484,6 +485,7 @@ impl TestServer {
 
         TestResponse {
             status,
+            headers,
             body: body_bytes.to_vec(),
         }
     }
@@ -520,6 +522,7 @@ impl TestServer {
             .expect("Request failed");
 
         let status = response.status();
+        let headers = response.headers().clone();
         let body_bytes = response
             .into_body()
             .collect()
@@ -529,6 +532,7 @@ impl TestServer {
 
         TestResponse {
             status,
+            headers,
             body: body_bytes.to_vec(),
         }
     }
@@ -544,6 +548,7 @@ pub enum TestMode {
 /// Response from a test request
 pub struct TestResponse {
     status: StatusCode,
+    pub headers: HeaderMap,
     body: Vec<u8>,
 }
 


### PR DESCRIPTION
## What
Add missing `secure(true)` to the `everruns_org` cookie in `switch_org()` and align `http_only(false)` to match the other two call sites (login and `/v1/auth/me`).

## Why
On HTTPS, browsers silently reject a non-Secure `Set-Cookie` that would overwrite a Secure cookie (RFC 6265bis §5.5). Because login sets the cookie with `Secure` but `switch_org` did not, **org switching never took effect in production** — the cookie stayed at the login-time org. This caused API keys, sessions, and all org-scoped operations to silently bind to the wrong org after switching.

## How
One-line addition of `.secure(true)` plus aligning `.http_only(false)` in `crates/server/src/api/users.rs:318`. Added a regression test that inspects the `Set-Cookie` header for the `Secure` flag. Extended `TestResponse` to capture response headers.

## Risk
- **Low** — cookie attribute change only, no logic change.
- Breakage: none expected. The cookie now matches the flags used by the two other call sites that set the same cookie.

## Security
- Threat categories reviewed: **TM-AUTH**, **TM-WEB**
- This change **fixes** a security issue: a missing `Secure` flag allowed the org cookie to be sent over plaintext HTTP and prevented HTTPS cookie overwrite. The fix aligns `switch_org` with the existing secure cookie pattern used in login and `/v1/auth/me`.
- No new threat surface introduced.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Closes EVE-287