### PR TITLE
feat(flags): enable notifications feature flag in dev

### DIFF
--- a/crates/core/src/feature_flags.rs
+++ b/crates/core/src/feature_flags.rs
@@ -22,7 +22,7 @@ pub struct FeatureFlags {
     pub global_chat: bool,
     /// Apps (agent deployment to distribution channels). Experimental.
     pub apps: bool,
-    /// In-app notifications (bell, toasts, notification SSE). Standard.
+    /// In-app notifications (bell, toasts, notification SSE). Experimental.
     pub notifications: bool,
     /// MCP endpoint (POST /mcp — Everruns as an MCP server). Experimental.
     pub mcp_endpoint: bool,
@@ -36,7 +36,7 @@ impl FeatureFlags {
         Self {
             global_chat: experimental_flag("FEATURE_GLOBAL_CHAT", grade),
             apps: experimental_flag("FEATURE_APPS", grade),
-            notifications: standard_flag("FEATURE_NOTIFICATIONS", false),
+            notifications: experimental_flag("FEATURE_NOTIFICATIONS", grade),
             mcp_endpoint: experimental_flag("FEATURE_MCP_ENDPOINT", grade),
             evals: experimental_flag("FEATURE_EVALS", grade),
         }
@@ -224,15 +224,23 @@ mod tests {
     }
 
     #[test]
-    fn test_standard_notifications_flag_defaults_off() {
+    fn test_notifications_enabled_in_dev() {
         let _lock = lock_env();
         unsafe { std::env::remove_var("FEATURE_NOTIFICATIONS") };
         let flags = FeatureFlags::from_env(&DeploymentGrade::Dev);
+        assert!(flags.notifications);
+    }
+
+    #[test]
+    fn test_notifications_disabled_in_prod() {
+        let _lock = lock_env();
+        unsafe { std::env::remove_var("FEATURE_NOTIFICATIONS") };
+        let flags = FeatureFlags::from_env(&DeploymentGrade::Prod);
         assert!(!flags.notifications);
     }
 
     #[test]
-    fn test_standard_notifications_flag_respects_env_override() {
+    fn test_notifications_respects_env_override() {
         let _lock = lock_env();
         unsafe { std::env::set_var("FEATURE_NOTIFICATIONS", "true") };
         let flags = FeatureFlags::from_env(&DeploymentGrade::Prod);


### PR DESCRIPTION
## What
Change the `notifications` feature flag from `standard_flag` (default off) to `experimental_flag` so it auto-enables in `DeploymentGrade::Dev`.

## Why
Notifications feature should be available in dev mode for development and testing, consistent with other experimental features (global_chat, apps, evals, mcp_endpoint).

## How
- Changed `standard_flag("FEATURE_NOTIFICATIONS", false)` → `experimental_flag("FEATURE_NOTIFICATIONS", grade)` in `FeatureFlags::from_env`
- Updated doc comment from "Standard" to "Experimental"
- Updated tests: replaced two standard-flag tests with three experimental-flag tests (enabled in dev, disabled in prod, env override)

## Risk
- Low
- Notifications UI/backend gated behind this flag will now appear in dev mode. No prod impact — experimental flags default off in prod.

## Security
- No security-relevant code changes. This is a flag default change scoped to dev mode only. No new endpoints, auth changes, or trust boundary modifications. Prod behavior unchanged unless `FEATURE_NOTIFICATIONS=true` is explicitly set.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)