### PR TITLE
fix(auth): scope API key query cache per org

### DIFF
--- a/apps/ui/src/hooks/use-auth.ts
+++ b/apps/ui/src/hooks/use-auth.ts
@@ -11,6 +11,7 @@ import {
   deleteApiKey,
 } from "@/lib/api/auth";
 import { updateProfile } from "@/lib/api/users";
+import { useOrg } from "@/providers/org-provider";
 import { ORG_STORAGE_KEY } from "@/lib/constants";
 import type {
   LoginRequest,
@@ -24,7 +25,7 @@ export const authKeys = {
   all: ["auth"] as const,
   config: () => [...authKeys.all, "config"] as const,
   user: () => [...authKeys.all, "user"] as const,
-  apiKeys: () => [...authKeys.all, "api-keys"] as const,
+  apiKeys: (org?: string) => [...authKeys.all, "api-keys", org] as const,
 };
 
 /**
@@ -105,14 +106,23 @@ export function useLogout() {
 }
 
 /**
- * Hook to list API keys
+ * Hook to list API keys (scoped per org to avoid stale cache after org switch)
  */
 export function useApiKeys() {
-  return useQuery({
-    queryKey: authKeys.apiKeys(),
+  const { currentOrg, isLoading: orgLoading } = useOrg();
+  const org = currentOrg?.public_id;
+
+  const query = useQuery({
+    queryKey: authKeys.apiKeys(org),
     queryFn: listApiKeys,
+    enabled: !!org,
     retry: false,
   });
+
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
 }
 
 /**
@@ -120,11 +130,13 @@ export function useApiKeys() {
  */
 export function useCreateApiKey() {
   const queryClient = useQueryClient();
+  const { currentOrg } = useOrg();
+  const org = currentOrg?.public_id;
 
   return useMutation({
     mutationFn: (request: CreateApiKeyRequest) => createApiKey(request),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: authKeys.apiKeys() });
+      queryClient.invalidateQueries({ queryKey: authKeys.apiKeys(org) });
     },
   });
 }
@@ -134,11 +146,13 @@ export function useCreateApiKey() {
  */
 export function useDeleteApiKey() {
   const queryClient = useQueryClient();
+  const { currentOrg } = useOrg();
+  const org = currentOrg?.public_id;
 
   return useMutation({
     mutationFn: (keyId: string) => deleteApiKey(keyId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: authKeys.apiKeys() });
+      queryClient.invalidateQueries({ queryKey: authKeys.apiKeys(org) });
     },
   });
 }

--- a/apps/ui/src/hooks/use-auth.ts
+++ b/apps/ui/src/hooks/use-auth.ts
@@ -25,7 +25,8 @@ export const authKeys = {
   all: ["auth"] as const,
   config: () => [...authKeys.all, "config"] as const,
   user: () => [...authKeys.all, "user"] as const,
-  apiKeys: (org?: string) => [...authKeys.all, "api-keys", org] as const,
+  apiKeys: (org?: string) =>
+    org ? ([...authKeys.all, "api-keys", org] as const) : ([...authKeys.all, "api-keys"] as const),
 };
 
 /**


### PR DESCRIPTION
## What
Add org to the React Query cache key for API keys so the cache is scoped per org, matching all other org-scoped hooks.

## Why
After switching orgs, the API keys page showed keys from the **previous** org because `useApiKeys()` used a static query key `["auth", "api-keys"]` that never changed across orgs. All other org-scoped hooks (agents, harnesses, etc.) use `useOrgScopedQuery()` which appends `org` to the key — API keys was the only hook that didn't follow this pattern.

## How
- `authKeys.apiKeys()` now accepts an optional `org` parameter → key becomes `["auth", "api-keys", org]`
- `useApiKeys()` uses `useOrg()` to get the current org and includes it in the query key, with `enabled: !!org` to prevent fetching before org is resolved
- `useCreateApiKey()` and `useDeleteApiKey()` invalidate the org-scoped key so mutations refresh the correct cache entry

Follows the same pattern as `useOrgScopedQuery` in `create-crud-hooks.ts`.

## Risk
- Low
- Cache key shape change means existing cached data (from before the fix) won't match the new key — this is intentional and correct (forces a fresh fetch)

## Security
- Threat categories reviewed: TM-TENANT, TM-WEB
- This fix **improves** tenant isolation: previously, cached API key data from org A was visible in the UI after switching to org B. The actual API calls were always correctly scoped server-side via the org cookie — this was a client-side cache leak only. No new trust boundaries, injection vectors, or data exposure introduced.

## Checklist
- [x] Tests added or updated (existing 20 tests pass — hooks are mocked in component tests, query key tests use `authKeys.apiKeys()` which still works with optional arg)
- [x] Backward compatibility considered (N/A — internal UI code, no external API change)
- [x] Security review performed against relevant threat model categories

Closes EVE-288