### PR TITLE
chore(release): prepare v0.8.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,10 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - revert(infra): remove sandbox VPS infra (belongs in SaaS repo) ([#1281](https://github.com/everruns/everruns/pull/1281))
 - chore(specs): simplify specs - remove duplication and trim code-mirroring content ([#1285](https://github.com/everruns/everruns/pull/1285))
 
-### Migration Notes
-
-Migration squashed: `012_session_resources.sql` → `012_v0.8.11.sql`. In-place upgrade from 0.8.10 works — the squashed migration applies on top of existing `011_v0.8.10` as a normal incremental migration.
-
 ## [0.8.10] - 2026-04-11
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.8.11] - 2026-04-13
+
+### Highlights
+
+- **Container Sandbox** — Built-in `coding-container` harness with Docker Engine client, capability/tools scaffold, threat model, docs, and full integration parity ([#1276](https://github.com/everruns/everruns/pull/1276), [#1278](https://github.com/everruns/everruns/pull/1278), [#1279](https://github.com/everruns/everruns/pull/1279))
+- **MCP Resources & Multi-Org** — `resources/list` and `resources/read` methods, multi-org OAuth support, direct service call dispatch ([#1259](https://github.com/everruns/everruns/pull/1259), [#1271](https://github.com/everruns/everruns/pull/1271), [#1272](https://github.com/everruns/everruns/pull/1272))
+- **Session Resource Registry** — Generic session-scoped resource tracking for sandboxes, subagents, and background work ([#1274](https://github.com/everruns/everruns/pull/1274))
+- **Auth Hardening** — Scoped API key cache per org, Secure cookie flag, default org harness init ([#1282](https://github.com/everruns/everruns/pull/1282), [#1284](https://github.com/everruns/everruns/pull/1284), [#1275](https://github.com/everruns/everruns/pull/1275))
+
+### What's Changed
+
+- feat(mcp): replace HTTP/router dispatch with direct service calls ([#1272](https://github.com/everruns/everruns/pull/1272))
+- feat(mcp): add multi-org support for OAuth MCP clients ([#1271](https://github.com/everruns/everruns/pull/1271))
+- feat(mcp): implement resources/list and resources/read methods ([#1259](https://github.com/everruns/everruns/pull/1259))
+- feat(container-sandbox): add Docker Engine REST API client ([#1276](https://github.com/everruns/everruns/pull/1276))
+- feat(container-sandbox): add capability, tools, and crate scaffold ([#1278](https://github.com/everruns/everruns/pull/1278))
+- feat(container-sandbox): harness, threat model, docs, and integration parity ([#1279](https://github.com/everruns/everruns/pull/1279))
+- feat(capabilities): mount platform docs in chat via virtual filesystem ([#1273](https://github.com/everruns/everruns/pull/1273))
+- feat(api): session resource registry ([#1274](https://github.com/everruns/everruns/pull/1274))
+- feat(flags): enable notifications feature flag in dev ([#1283](https://github.com/everruns/everruns/pull/1283))
+- fix(auth): ensure default org gets harnesses via init_org ([#1275](https://github.com/everruns/everruns/pull/1275))
+- fix(auth): add missing Secure flag to switch-org cookie ([#1282](https://github.com/everruns/everruns/pull/1282))
+- fix(auth): scope API key query cache per org ([#1284](https://github.com/everruns/everruns/pull/1284))
+- revert(infra): remove sandbox VPS infra (belongs in SaaS repo) ([#1281](https://github.com/everruns/everruns/pull/1281))
+- chore(specs): simplify specs - remove duplication and trim code-mirroring content ([#1285](https://github.com/everruns/everruns/pull/1285))
+
+### Migration Notes
+
+Migration squashed: `012_session_resources.sql` → `012_v0.8.11.sql`. Fresh database required (consistent with all prior squash releases).
+
 ## [0.8.10] - 2026-04-11
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Migration Notes
 
-Migration squashed: `012_session_resources.sql` → `012_v0.8.11.sql`. Fresh database required (consistent with all prior squash releases).
+Migration squashed: `012_session_resources.sql` → `012_v0.8.11.sql`. In-place upgrade from 0.8.10 works — the squashed migration applies on top of existing `011_v0.8.10` as a normal incremental migration.
 
 ## [0.8.10] - 2026-04-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "anyhow",
  "base64",
@@ -1560,14 +1560,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "async-trait",
  "base64",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1672,7 +1672,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1690,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "async-trait",
  "base64",
@@ -1727,7 +1727,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "async-trait",
  "base64",
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "async-trait",
  "base64",
@@ -1781,7 +1781,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1796,7 +1796,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-pi"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1840,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1883,7 +1883,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.8.10"
+version = "0.8.11"
 
 [[package]]
 name = "everruns-sdk"
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2006,7 +2006,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2765,15 +2765,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -4143,9 +4142,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -4181,9 +4180,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
 dependencies = [
  "cc",
  "libc",
@@ -4500,9 +4499,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -5334,9 +5333,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.10"
+version = "0.8.11"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "everruns-ui",
-      "version": "0.8.10",
+      "version": "0.8.11",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@openuidev/react-lang": "^0.1.3",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "private": true,
   "exports": {
     "./providers/*": "./src/providers/*.tsx",

--- a/crates/server/migrations/012_v0.8.11.sql
+++ b/crates/server/migrations/012_v0.8.11.sql
@@ -1,8 +1,11 @@
--- v0.8.11
---
+-- v0.8.11: Session resource registry
+-- Squashed from: 012_session_resources.sql
+
+-- ============================================
 -- 012_session_resources: Session resource registry
 -- Generic, session-scoped registry of active resources (sandboxes, subagents,
 -- browser sessions, etc.). See specs/session-resources.md.
+-- ============================================
 
 CREATE TABLE session_resources (
     id UUID PRIMARY KEY DEFAULT uuidv7(),

--- a/crates/server/migrations/012_v0.8.11.sql
+++ b/crates/server/migrations/012_v0.8.11.sql
@@ -1,5 +1,6 @@
--- Session resource registry
+-- v0.8.11
 --
+-- 012_session_resources: Session resource registry
 -- Generic, session-scoped registry of active resources (sandboxes, subagents,
 -- browser sessions, etc.). See specs/session-resources.md.
 


### PR DESCRIPTION
## What
Prepare v0.8.11 patch release: squash migrations, bump version, update changelog.

## Why
15 commits since v0.8.10 — container sandbox, MCP resources, session resource registry, auth fixes. Time to cut a patch.

## How
- Squash `012_session_resources.sql` → `012_v0.8.11.sql` with version header
- Bump `workspace.package.version` and `apps/ui/package.json` to `0.8.11`
- Regenerate `Cargo.lock` and `package-lock.json`
- Update `CHANGELOG.md` with highlights, full commit list, and migration notes

## Risk
- Low
- Version bump + migration rename only. No runtime behavior change.

## Security
- No security-relevant code changes. This is a release preparation commit (version bump, changelog, migration rename).

## Checklist
- [x] Tests added or updated (N/A — no code changes)
- [x] Backward compatibility considered (squash is breaking by design, documented in migration notes)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)