### PR TITLE
ci: reduce CI waste and improve cache sharing

### DIFF
--- a/.github/workflows/brave-search-integration.yml
+++ b/.github/workflows/brave-search-integration.yml
@@ -38,17 +38,13 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "brave-search-integration"
+          shared-key: "integration"
+
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@v3
 
       - name: Fetch Brave Search API key from Doppler
         run: |
-          if [ -z "$DOPPLER_TOKEN" ]; then
-            echo "::error::DOPPLER_TOKEN secret is not set"
-            exit 1
-          fi
-          if ! command -v doppler &>/dev/null; then
-            curl -sLf --retry 3 https://cli.doppler.com/install.sh | sudo sh >/dev/null 2>&1
-          fi
           echo "BRAVE_SEARCH_API_KEY=$(doppler secrets get BRAVE_SEARCH_API_KEY --plain)" >> "$GITHUB_ENV"
 
       - name: Run integration tests

--- a/.github/workflows/brave-search-integration.yml
+++ b/.github/workflows/brave-search-integration.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "integration"
+          shared-key: "debug"
 
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,16 +296,20 @@ jobs:
         with:
           shared-key: "test"
 
-      - name: Cache sqlx-cli
+      - name: Cache cargo binaries
         uses: actions/cache@v4
         with:
-          path: ~/.cargo/bin/sqlx
-          key: ${{ runner.os }}-sqlx-cli-0.8
+          path: |
+            ~/.cargo/bin/cargo-binstall
+            ~/.cargo/bin/sqlx
+          key: ${{ runner.os }}-cargo-bins-sqlx-0.8
 
       - name: Install sqlx-cli
         run: |
           if [ ! -f ~/.cargo/bin/sqlx ]; then
-            curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+            if [ ! -f ~/.cargo/bin/cargo-binstall ]; then
+              curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+            fi
             cargo binstall sqlx-cli --no-confirm --version '~0.8'
           fi
 
@@ -423,16 +427,20 @@ jobs:
         with:
           shared-key: "test"
 
-      - name: Cache sqlx-cli
+      - name: Cache cargo binaries
         uses: actions/cache@v4
         with:
-          path: ~/.cargo/bin/sqlx
-          key: ${{ runner.os }}-sqlx-cli-0.8
+          path: |
+            ~/.cargo/bin/cargo-binstall
+            ~/.cargo/bin/sqlx
+          key: ${{ runner.os }}-cargo-bins-sqlx-0.8
 
       - name: Install sqlx-cli
         run: |
           if [ ! -f ~/.cargo/bin/sqlx ]; then
-            curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+            if [ ! -f ~/.cargo/bin/cargo-binstall ]; then
+              curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+            fi
             cargo binstall sqlx-cli --no-confirm --version '~0.8'
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,8 @@ jobs:
       - name: Install sqlx-cli
         run: |
           if [ ! -f ~/.cargo/bin/sqlx ]; then
-            cargo install sqlx-cli --no-default-features --features postgres
+            curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+            cargo binstall sqlx-cli --no-confirm --version '~0.8'
           fi
 
       - name: Run migrations
@@ -431,7 +432,8 @@ jobs:
       - name: Install sqlx-cli
         run: |
           if [ ! -f ~/.cargo/bin/sqlx ]; then
-            cargo install sqlx-cli --no-default-features --features postgres
+            curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+            cargo binstall sqlx-cli --no-confirm --version '~0.8'
           fi
 
       - name: Run migrations

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,35 +166,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check for Doppler token
-        id: check-key
-        run: |
-          if [ -z "$DOPPLER_TOKEN" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "⏭️ DOPPLER_TOKEN not configured, skipping live tests"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Install Doppler CLI
-        if: steps.check-key.outputs.skip != 'true'
         uses: dopplerhq/cli-action@v3
 
       - name: Install Rust toolchain
-        if: steps.check-key.outputs.skip != 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust
-        if: steps.check-key.outputs.skip != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "test"
 
       - name: Run Daytona live integration tests
-        if: steps.check-key.outputs.skip != 'true'
         run: doppler run -- cargo test -p everruns-integrations-daytona --features daytona-live-tests --test live_api_test -- --test-threads=1
 
-  # Live Browserless API tests — only when integrations/browserless/** changes and secret exists
+  # Live Browserless API tests — only when integrations/browserless/** changes
   browserless-live-test:
     name: Browserless Live API Tests
     runs-on: ubuntu-latest
@@ -205,35 +191,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check for Doppler token
-        id: check-key
-        run: |
-          if [ -z "$DOPPLER_TOKEN" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "⏭️ DOPPLER_TOKEN not configured, skipping live tests"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Install Doppler CLI
-        if: steps.check-key.outputs.skip != 'true'
         uses: dopplerhq/cli-action@v3
 
       - name: Install Rust toolchain
-        if: steps.check-key.outputs.skip != 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust
-        if: steps.check-key.outputs.skip != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "test"
 
       - name: Run Browserless live integration tests
-        if: steps.check-key.outputs.skip != 'true'
         run: doppler run -- cargo test -p everruns-integrations-browserless --features browserless-live-tests --test live_api -- --test-threads=1
 
-  # Live E2B API tests — only when integrations/e2b/** changes and secret exists
+  # Live E2B API tests — only when integrations/e2b/** changes
   e2b-live-test:
     name: E2B Live API Tests
     runs-on: ubuntu-latest
@@ -244,35 +216,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check for Doppler token
-        id: check-key
-        run: |
-          if [ -z "$DOPPLER_TOKEN" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "⏭️ DOPPLER_TOKEN not configured, skipping live tests"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Install Doppler CLI
-        if: steps.check-key.outputs.skip != 'true'
         uses: dopplerhq/cli-action@v3
 
       - name: Install Rust toolchain
-        if: steps.check-key.outputs.skip != 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust
-        if: steps.check-key.outputs.skip != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "test"
 
       - name: Run E2B live integration tests
-        if: steps.check-key.outputs.skip != 'true'
         run: doppler run -- cargo test -p everruns-integrations-e2b --features e2b-live-tests --test live_api_test -- --test-threads=1
 
-  # Live Deno API tests — only when integrations/deno/** changes and secret exists
+  # Live Deno API tests — only when integrations/deno/** changes
   deno-live-test:
     name: Deno Live API Tests
     runs-on: ubuntu-latest
@@ -283,32 +241,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check for Doppler token
-        id: check-key
-        run: |
-          if [ -z "$DOPPLER_TOKEN" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "⏭️ DOPPLER_TOKEN not configured, skipping live tests"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Install Doppler CLI
-        if: steps.check-key.outputs.skip != 'true'
         uses: dopplerhq/cli-action@v3
 
       - name: Install Rust toolchain
-        if: steps.check-key.outputs.skip != 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust
-        if: steps.check-key.outputs.skip != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "test"
 
       - name: Run Deno live integration tests
-        if: steps.check-key.outputs.skip != 'true'
         run: doppler run -- cargo test -p everruns-integrations-deno --features deno-live-tests --test live_api_test -- --test-threads=1
 
   # Integration tests requiring PostgreSQL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "clippy"
+          shared-key: "debug"
 
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
@@ -144,7 +144,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "test"
+          shared-key: "debug"
 
       - name: Run pure unit tests
         run: |
@@ -175,7 +175,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "test"
+          shared-key: "debug"
 
       - name: Run Daytona live integration tests
         run: doppler run -- cargo test -p everruns-integrations-daytona --features daytona-live-tests --test live_api_test -- --test-threads=1
@@ -200,7 +200,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "test"
+          shared-key: "debug"
 
       - name: Run Browserless live integration tests
         run: doppler run -- cargo test -p everruns-integrations-browserless --features browserless-live-tests --test live_api -- --test-threads=1
@@ -225,7 +225,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "test"
+          shared-key: "debug"
 
       - name: Run E2B live integration tests
         run: doppler run -- cargo test -p everruns-integrations-e2b --features e2b-live-tests --test live_api_test -- --test-threads=1
@@ -250,7 +250,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "test"
+          shared-key: "debug"
 
       - name: Run Deno live integration tests
         run: doppler run -- cargo test -p everruns-integrations-deno --features deno-live-tests --test live_api_test -- --test-threads=1
@@ -294,7 +294,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "test"
+          shared-key: "debug"
 
       - name: Cache cargo binaries
         uses: actions/cache@v4
@@ -425,7 +425,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "test"
+          shared-key: "debug"
 
       - name: Cache cargo binaries
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,7 +308,7 @@ jobs:
         run: |
           if [ ! -f ~/.cargo/bin/sqlx ]; then
             if [ ! -f ~/.cargo/bin/cargo-binstall ]; then
-              curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+              curl -L --proto '=https' --tlsv1.2 -sSf --retry 3 https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
             fi
             cargo binstall sqlx-cli --no-confirm --version '~0.8'
           fi
@@ -439,7 +439,7 @@ jobs:
         run: |
           if [ ! -f ~/.cargo/bin/sqlx ]; then
             if [ ! -f ~/.cargo/bin/cargo-binstall ]; then
-              curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+              curl -L --proto '=https' --tlsv1.2 -sSf --retry 3 https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
             fi
             cargo binstall sqlx-cli --no-confirm --version '~0.8'
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,6 @@ jobs:
               - '.github/workflows/ci.yml'
             docs:
               - 'apps/docs/**'
-              - '.github/workflows/ci.yml'
             docker:
               - 'docker/**'
               - 'crates/**'

--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "cli-${{ matrix.target }}"
+          shared-key: "cli"
 
       - name: Build CLI binary
         run: cargo build --release --target ${{ matrix.target }} -p everruns-cli

--- a/.github/workflows/container-sandbox-integration.yml
+++ b/.github/workflows/container-sandbox-integration.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "integration"
+          shared-key: "debug"
 
       - name: Run unit tests
         run: cargo test -p everruns-container-sandbox
@@ -62,7 +62,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "integration"
+          shared-key: "debug"
 
       - name: Run live integration tests
         run: cargo test -p everruns-container-sandbox --features container-sandbox-live-tests --test live_api_test -- --test-threads=1

--- a/.github/workflows/container-sandbox-integration.yml
+++ b/.github/workflows/container-sandbox-integration.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "container-sandbox-integration"
+          shared-key: "integration"
 
       - name: Run unit tests
         run: cargo test -p everruns-container-sandbox
@@ -62,7 +62,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "container-sandbox-integration"
+          shared-key: "integration"
 
       - name: Run live integration tests
         run: cargo test -p everruns-container-sandbox --features container-sandbox-live-tests --test live_api_test -- --test-threads=1

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened]
 
 permissions:
   contents: read

--- a/.github/workflows/duckduckgo-integration.yml
+++ b/.github/workflows/duckduckgo-integration.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "integration"
+          shared-key: "debug"
 
       - name: Run integration tests
         run: cargo test -p everruns-integrations-duckduckgo --features integration

--- a/.github/workflows/duckduckgo-integration.yml
+++ b/.github/workflows/duckduckgo-integration.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "duckduckgo-integration"
+          shared-key: "integration"
 
       - name: Run integration tests
         run: cargo test -p everruns-integrations-duckduckgo --features integration

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -3,8 +3,22 @@ name: License Check
 on:
   push:
     branches: [main]
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/**'
+      - 'integrations/**'
+      - 'deny.toml'
+      - '.github/workflows/licenses.yml'
   pull_request:
     branches: [main]
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/**'
+      - 'integrations/**'
+      - 'deny.toml'
+      - '.github/workflows/licenses.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/server-worker-binaries.yml
+++ b/.github/workflows/server-worker-binaries.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "${{ matrix.binary }}-${{ matrix.target }}"
+          shared-key: "server-worker-${{ matrix.target }}"
 
       - name: Build binary
         run: cargo build --release --target ${{ matrix.target }} -p ${{ matrix.package }} --bin ${{ matrix.binary }}

--- a/.github/workflows/sprites-integration.yml
+++ b/.github/workflows/sprites-integration.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "sprites-integration"
+          shared-key: "integration"
 
       - name: Run unit tests
         run: cargo test -p everruns-integrations-sprites
@@ -62,7 +62,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "sprites-integration"
+          shared-key: "integration"
 
       - name: Run Sprites live integration tests
         run: doppler run -- cargo test -p everruns-integrations-sprites --features sprites-live-tests --test live_api_test -- --test-threads=1

--- a/.github/workflows/sprites-integration.yml
+++ b/.github/workflows/sprites-integration.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "integration"
+          shared-key: "debug"
 
       - name: Run unit tests
         run: cargo test -p everruns-integrations-sprites
@@ -62,7 +62,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "integration"
+          shared-key: "debug"
 
       - name: Run Sprites live integration tests
         run: doppler run -- cargo test -p everruns-integrations-sprites --features sprites-live-tests --test live_api_test -- --test-threads=1

--- a/docs/proposals/parallel-execution-1m.md
+++ b/docs/proposals/parallel-execution-1m.md
@@ -1,3 +1,7 @@
+---
+title: Parallel Agent Execution at 1M Scale
+---
+
 # Parallel Agent Execution at 1M Scale
 
 ## Abstract

--- a/docs/proposals/subagent-architecture-analysis.md
+++ b/docs/proposals/subagent-architecture-analysis.md
@@ -1,3 +1,7 @@
+---
+title: Subagent Architecture Analysis
+---
+
 # Subagent Architecture Analysis
 
 Analysis of how top coding agents implement subagents/child agents, compared to everruns' current architecture, with recommendations.


### PR DESCRIPTION
## What
Reduce unnecessary CI runner minutes across all GitHub Actions workflows by improving cache sharing, removing redundant steps, and adding path filters.

## Why
Several workflows had isolated Rust caches that compiled nearly identical dependencies independently, Docker images built on every PR commit (expensive Rust cross-compilation), and defensive token checks that wasted runner allocation time when tokens are always present.

## How
- **Docker builds**: Remove `synchronize` from PR trigger so images only build on PR open/reopen, not every pushed commit
- **Unified Rust cache**: Merge `"clippy"`, `"test"`, and `"integration"` cache keys into a single `"debug"` key across all debug-profile jobs (ci.yml + 4 integration workflows)
- **Remove Doppler token checks**: Tokens are always present in CI; missing token should fail loudly rather than silently skipping
- **License check path filters**: Skip license check on docs/UI-only changes
- **Brave-search Doppler install**: Replace manual `curl` install with standard `dopplerhq/cli-action@v3`
- **Binary install for sqlx-cli**: Switch from `cargo install` (compiles from source, ~3 min) to `cargo binstall` (pre-built binary, ~5s) on cache miss; cache both `cargo-binstall` and `sqlx` binaries
- **Binary workflow cache sharing**: Server + worker share cache by target; CLI shares cache across targets on same runner

## Risk
- Low
- Cache key rename means first CI run after merge will have cold caches (one-time ~5 min penalty, then all subsequent runs benefit)
- Removing Doppler token checks means missing token will fail the job instead of skipping — this is the desired behavior

## Security
- No security-relevant code changes. All changes are CI workflow YAML configuration (cache keys, triggers, path filters, tool installation). No runtime code, no secrets handling changes, no auth/authz changes.

## Checklist
- [x] Tests added or updated — CI-only changes; CI itself validates the workflows
- [x] Backward compatibility considered — N/A (internal CI config)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
