### PR TITLE
fix(ui): remove rounded-* class violations across 55 components

### DIFF
--- a/apps/ui/src/app/(auth)/login/page.tsx
+++ b/apps/ui/src/app/(auth)/login/page.tsx
@@ -162,7 +162,7 @@ export default function LoginPage() {
         {hasPasswordAuth && (
           <form onSubmit={handleSubmit} className="space-y-4">
             {error && (
-              <div className="bg-destructive/10 text-destructive text-sm p-3 rounded-md">
+              <div className="bg-destructive/10 text-destructive text-sm p-3">
                 {error}
               </div>
             )}

--- a/apps/ui/src/app/(auth)/login/page.tsx
+++ b/apps/ui/src/app/(auth)/login/page.tsx
@@ -161,11 +161,7 @@ export default function LoginPage() {
         {/* Email/Password Form */}
         {hasPasswordAuth && (
           <form onSubmit={handleSubmit} className="space-y-4">
-            {error && (
-              <div className="bg-destructive/10 text-destructive text-sm p-3">
-                {error}
-              </div>
-            )}
+            {error && <div className="bg-destructive/10 text-destructive text-sm p-3">{error}</div>}
             <div className="space-y-2">
               <Label htmlFor="email">Email</Label>
               <Input

--- a/apps/ui/src/app/(auth)/register/page.tsx
+++ b/apps/ui/src/app/(auth)/register/page.tsx
@@ -97,7 +97,7 @@ export default function RegisterPage() {
       <CardContent>
         <form onSubmit={handleSubmit} className="space-y-4">
           {error && (
-            <div className="bg-destructive/10 text-destructive text-sm p-3 rounded-md">{error}</div>
+            <div className="bg-destructive/10 text-destructive text-sm p-3">{error}</div>
           )}
           <div className="space-y-2">
             <Label htmlFor="name">Name</Label>

--- a/apps/ui/src/app/(auth)/register/page.tsx
+++ b/apps/ui/src/app/(auth)/register/page.tsx
@@ -96,9 +96,7 @@ export default function RegisterPage() {
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit} className="space-y-4">
-          {error && (
-            <div className="bg-destructive/10 text-destructive text-sm p-3">{error}</div>
-          )}
+          {error && <div className="bg-destructive/10 text-destructive text-sm p-3">{error}</div>}
           <div className="space-y-2">
             <Label htmlFor="name">Name</Label>
             <Input

--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -242,7 +242,7 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
                       {hasMoreSessions && (
                         <Link
                           href={`/agents/${agentId}/sessions`}
-                          className="flex items-center justify-center p-3 rounded-md border border-dashed hover:bg-muted transition-colors text-muted-foreground"
+                          className="flex items-center justify-center p-3 border border-dashed hover:bg-muted transition-colors text-muted-foreground"
                         >
                           View all {totalSessions} sessions
                         </Link>
@@ -279,7 +279,7 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
                         return (
                           <div
                             key={capConfig.ref}
-                            className="flex items-center gap-2 p-2 rounded-md border bg-muted/50"
+                            className="flex items-center gap-2 p-2 border bg-muted/50"
                           >
                             <IconComponent className="w-4 h-4" />
                             <div className="flex-1">
@@ -334,7 +334,7 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
                   {agent.usage && (
                     <div>
                       <p className="text-sm font-medium mb-2">Token Usage</p>
-                      <div className="flex items-center gap-2 p-2 rounded-md border bg-muted/50">
+                      <div className="flex items-center gap-2 p-2 border bg-muted/50">
                         <Zap className="w-4 h-4 text-yellow-500" />
                         <div className="flex-1">
                           <p className="text-sm font-medium">

--- a/apps/ui/src/app/(main)/agents/page.tsx
+++ b/apps/ui/src/app/(main)/agents/page.tsx
@@ -102,7 +102,7 @@ export default function AgentsPage() {
       </div>
 
       {importError && (
-        <div className="p-4 bg-red-50 border border-red-200 rounded-md text-red-600 text-sm">
+        <div className="p-4 bg-red-50 border border-red-200 text-red-600 text-sm">
           {importError}
         </div>
       )}

--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -647,7 +647,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                       </a>{" "}
                       to expose your local server:
                     </p>
-                    <div className="bg-muted p-3 rounded-md space-y-1">
+                    <div className="bg-muted p-3 space-y-1">
                       <p className="text-xs font-medium text-muted-foreground">1. Start ngrok:</p>
                       <code className="text-xs block">
                         ngrok http{" "}
@@ -667,7 +667,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                       Paste this URL in your Slack app &rarr; <strong>Event Subscriptions</strong>{" "}
                       &rarr; <strong>Request URL</strong>.
                     </p>
-                    <div className="flex items-center gap-2 bg-muted p-3 rounded-md">
+                    <div className="flex items-center gap-2 bg-muted p-3">
                       <Globe className="w-4 h-4 shrink-0 text-muted-foreground" />
                       <code className="text-sm flex-1 truncate">{webhookUrl}</code>
                       <CopyButton value={webhookUrl} />

--- a/apps/ui/src/app/(main)/capabilities/[capabilityId]/page.tsx
+++ b/apps/ui/src/app/(main)/capabilities/[capabilityId]/page.tsx
@@ -54,7 +54,7 @@ function ToolCard({ tool }: { tool: ToolDefinition }) {
               <Code className="w-4 h-4" />
               Parameters
             </h4>
-            <pre className="text-xs bg-muted p-3 rounded-md overflow-x-auto">
+            <pre className="text-xs bg-muted p-3 overflow-x-auto">
               {JSON.stringify(tool.parameters, null, 2)}
             </pre>
           </div>
@@ -116,7 +116,7 @@ export default function CapabilityDetailPage({
 
       <div className="flex items-start justify-between mb-6">
         <div className="flex items-center gap-4">
-          <div className="p-3 bg-muted rounded-lg">
+          <div className="p-3 bg-muted">
             <IconComponent className="w-6 h-6" />
           </div>
           <div>

--- a/apps/ui/src/app/(main)/durable/page.tsx
+++ b/apps/ui/src/app/(main)/durable/page.tsx
@@ -228,7 +228,7 @@ export default function DurableDashboardPage() {
                   <Link
                     key={schedule.id}
                     href={`/durable/schedules/${schedule.id}`}
-                    className="flex items-center justify-between p-2 rounded-lg bg-muted/50 hover:bg-muted transition-colors"
+                    className="flex items-center justify-between p-2 bg-muted/50 hover:bg-muted transition-colors"
                   >
                     <div className="flex items-center gap-2">
                       {schedule.enabled ? (
@@ -314,7 +314,7 @@ export default function DurableDashboardPage() {
                     {workersData.data.slice(0, 5).map((worker) => (
                       <div
                         key={worker.id}
-                        className="flex items-center justify-between p-2 rounded-lg bg-muted/50"
+                        className="flex items-center justify-between p-2 bg-muted/50"
                       >
                         <div className="flex items-center gap-2">
                           <div
@@ -375,7 +375,7 @@ export default function DurableDashboardPage() {
                     <Link
                       key={workflow.id}
                       href={`/durable/workflows/${workflow.id}`}
-                      className="flex items-center justify-between p-2 rounded-lg bg-muted/50 hover:bg-muted transition-colors"
+                      className="flex items-center justify-between p-2 bg-muted/50 hover:bg-muted transition-colors"
                     >
                       <div className="flex items-center gap-2">
                         <WorkflowStatusIcon status={workflow.status} />
@@ -414,7 +414,7 @@ export default function DurableDashboardPage() {
                   {Object.entries(health.queue_depth_by_type).map(([type, count]) => (
                     <div
                       key={type}
-                      className="flex items-center justify-between p-3 rounded-lg bg-muted/50"
+                      className="flex items-center justify-between p-3 bg-muted/50"
                     >
                       <span className="text-sm font-medium">{type}</span>
                       <Badge variant="outline">{count}</Badge>

--- a/apps/ui/src/app/(main)/durable/page.tsx
+++ b/apps/ui/src/app/(main)/durable/page.tsx
@@ -412,10 +412,7 @@ export default function DurableDashboardPage() {
               <CardContent>
                 <div className="grid gap-2 md:grid-cols-3 lg:grid-cols-4">
                   {Object.entries(health.queue_depth_by_type).map(([type, count]) => (
-                    <div
-                      key={type}
-                      className="flex items-center justify-between p-3 bg-muted/50"
-                    >
+                    <div key={type} className="flex items-center justify-between p-3 bg-muted/50">
                       <span className="text-sm font-medium">{type}</span>
                       <Badge variant="outline">{count}</Badge>
                     </div>

--- a/apps/ui/src/app/(main)/durable/queues/enqueue-dialog.tsx
+++ b/apps/ui/src/app/(main)/durable/queues/enqueue-dialog.tsx
@@ -82,7 +82,7 @@ export function EnqueueDialog({
                 setInputJson(e.target.value);
                 setJsonError(null);
               }}
-              className="flex min-h-[100px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm font-mono ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="flex min-h-[100px] w-full border border-input bg-background px-3 py-2 text-sm font-mono ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               placeholder='{"key": "value"}'
             />
             {jsonError && <p className="text-sm text-destructive">{jsonError}</p>}

--- a/apps/ui/src/app/(main)/durable/queues/page.tsx
+++ b/apps/ui/src/app/(main)/durable/queues/page.tsx
@@ -235,11 +235,11 @@ export default function QueuesPage() {
 
       {/* Tab Navigation */}
       <div className="space-y-6">
-        <div className="flex items-center gap-1 p-1 bg-muted rounded-lg w-fit">
+        <div className="flex items-center gap-1 p-1 bg-muted w-fit">
           <button
             onClick={() => setActiveTab("overview")}
             className={cn(
-              "flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-colors",
+              "flex items-center gap-2 px-3 py-1.5 text-sm font-medium transition-colors",
               activeTab === "overview"
                 ? "bg-background text-foreground shadow-sm"
                 : "text-muted-foreground hover:text-foreground",
@@ -256,7 +256,7 @@ export default function QueuesPage() {
           <button
             onClick={() => setActiveTab("tasks")}
             className={cn(
-              "flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-colors",
+              "flex items-center gap-2 px-3 py-1.5 text-sm font-medium transition-colors",
               activeTab === "tasks"
                 ? "bg-background text-foreground shadow-sm"
                 : "text-muted-foreground hover:text-foreground",
@@ -273,7 +273,7 @@ export default function QueuesPage() {
           <button
             onClick={() => setActiveTab("dlq")}
             className={cn(
-              "flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-colors",
+              "flex items-center gap-2 px-3 py-1.5 text-sm font-medium transition-colors",
               activeTab === "dlq"
                 ? "bg-background text-foreground shadow-sm"
                 : "text-muted-foreground hover:text-foreground",
@@ -340,7 +340,7 @@ export default function QueuesPage() {
                             <Tooltip>
                               <TooltipTrigger className="flex flex-col items-center gap-1 flex-1">
                                 <div
-                                  className="w-full bg-primary/20 rounded-t min-h-[4px]"
+                                  className="w-full bg-primary/20 min-h-[4px]"
                                   style={{ height: `${height}%` }}
                                 />
                                 <span className="text-xs text-muted-foreground">{priority}</span>
@@ -413,7 +413,7 @@ export default function QueuesPage() {
                 {tasksLoading ? (
                   <Skeleton className="h-48" />
                 ) : filteredTasks.length > 0 ? (
-                  <div className="rounded-md border">
+                  <div className="border">
                     <Table>
                       <TableHeader>
                         <TableRow>
@@ -483,7 +483,7 @@ export default function QueuesPage() {
                 {dlqLoading ? (
                   <Skeleton className="h-48" />
                 ) : dlqEntries.length > 0 ? (
-                  <div className="rounded-md border">
+                  <div className="border">
                     <Table>
                       <TableHeader>
                         <TableRow>

--- a/apps/ui/src/app/(main)/durable/schedules/[scheduleId]/page.tsx
+++ b/apps/ui/src/app/(main)/durable/schedules/[scheduleId]/page.tsx
@@ -549,23 +549,23 @@ export default function ScheduleDetailPage() {
               </div>
             ) : stats ? (
               <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
-                <div className="text-center p-4 bg-muted rounded-lg">
+                <div className="text-center p-4 bg-muted">
                   <p className="text-2xl font-bold">{stats.total_executions}</p>
                   <p className="text-sm text-muted-foreground">Total Executions</p>
                 </div>
-                <div className="text-center p-4 bg-muted rounded-lg">
+                <div className="text-center p-4 bg-muted">
                   <p className="text-2xl font-bold text-green-500">{stats.successful_executions}</p>
                   <p className="text-sm text-muted-foreground">Successful</p>
                 </div>
-                <div className="text-center p-4 bg-muted rounded-lg">
+                <div className="text-center p-4 bg-muted">
                   <p className="text-2xl font-bold text-red-500">{stats.failed_executions}</p>
                   <p className="text-sm text-muted-foreground">Failed</p>
                 </div>
-                <div className="text-center p-4 bg-muted rounded-lg">
+                <div className="text-center p-4 bg-muted">
                   <p className="text-2xl font-bold text-yellow-500">{stats.skipped_executions}</p>
                   <p className="text-sm text-muted-foreground">Skipped</p>
                 </div>
-                <div className="text-center p-4 bg-muted rounded-lg">
+                <div className="text-center p-4 bg-muted">
                   <p className="text-2xl font-bold">
                     {stats.avg_duration_ms ? `${stats.avg_duration_ms}ms` : "-"}
                   </p>
@@ -610,7 +610,7 @@ export default function ScheduleDetailPage() {
             {executionsLoading ? (
               <Skeleton className="h-48" />
             ) : executions.length > 0 ? (
-              <div className="rounded-md border">
+              <div className="border">
                 <Table>
                   <TableHeader>
                     <TableRow>

--- a/apps/ui/src/app/(main)/durable/schedules/page.tsx
+++ b/apps/ui/src/app/(main)/durable/schedules/page.tsx
@@ -327,7 +327,7 @@ function CreateScheduleDialog({ onClose }: { onClose: () => void }) {
         </div>
       </div>
       {errorMessage && (
-        <div className="rounded-md bg-destructive/10 border border-destructive/20 p-3">
+        <div className="bg-destructive/10 border border-destructive/20 p-3">
           <p className="text-sm text-destructive">{errorMessage}</p>
         </div>
       )}
@@ -489,7 +489,7 @@ export default function SchedulesPage() {
           </CardHeader>
           <CardContent>
             {filteredSchedules.length > 0 ? (
-              <div className="rounded-md border">
+              <div className="border">
                 <Table>
                   <TableHeader>
                     <TableRow>

--- a/apps/ui/src/app/(main)/durable/workers/page.tsx
+++ b/apps/ui/src/app/(main)/durable/workers/page.tsx
@@ -290,7 +290,7 @@ export default function WorkersPage() {
           </CardHeader>
           <CardContent>
             {workers.length > 0 ? (
-              <div className="rounded-md border">
+              <div className="border">
                 <Table>
                   <TableHeader>
                     <TableRow>

--- a/apps/ui/src/app/(main)/durable/workflows/page.tsx
+++ b/apps/ui/src/app/(main)/durable/workflows/page.tsx
@@ -362,11 +362,11 @@ export default function WorkflowsPage() {
       </div>
       <div className="space-y-6">
         {/* Tab Navigation */}
-        <div className="flex items-center gap-1 p-1 bg-muted rounded-lg w-fit">
+        <div className="flex items-center gap-1 p-1 bg-muted w-fit">
           <button
             onClick={() => setActiveTab("workflows")}
             className={cn(
-              "flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-colors",
+              "flex items-center gap-2 px-3 py-1.5 text-sm font-medium transition-colors",
               activeTab === "workflows"
                 ? "bg-background text-foreground shadow-sm"
                 : "text-muted-foreground hover:text-foreground",
@@ -383,7 +383,7 @@ export default function WorkflowsPage() {
           <button
             onClick={() => setActiveTab("tasks")}
             className={cn(
-              "flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-colors",
+              "flex items-center gap-2 px-3 py-1.5 text-sm font-medium transition-colors",
               activeTab === "tasks"
                 ? "bg-background text-foreground shadow-sm"
                 : "text-muted-foreground hover:text-foreground",
@@ -400,7 +400,7 @@ export default function WorkflowsPage() {
           <button
             onClick={() => setActiveTab("dlq")}
             className={cn(
-              "flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-colors",
+              "flex items-center gap-2 px-3 py-1.5 text-sm font-medium transition-colors",
               activeTab === "dlq"
                 ? "bg-background text-foreground shadow-sm"
                 : "text-muted-foreground hover:text-foreground",
@@ -453,7 +453,7 @@ export default function WorkflowsPage() {
             <Card>
               <CardContent className="pt-6">
                 {filteredWorkflows.length > 0 ? (
-                  <div className="rounded-md border">
+                  <div className="border">
                     <Table>
                       <TableHeader>
                         <TableRow>
@@ -510,7 +510,7 @@ export default function WorkflowsPage() {
               </CardHeader>
               <CardContent>
                 {!tasksLoading && tasks.length > 0 ? (
-                  <div className="rounded-md border">
+                  <div className="border">
                     <Table>
                       <TableHeader>
                         <TableRow>
@@ -564,7 +564,7 @@ export default function WorkflowsPage() {
               </CardHeader>
               <CardContent>
                 {!dlqLoading && dlqEntries.length > 0 ? (
-                  <div className="rounded-md border">
+                  <div className="border">
                     <Table>
                       <TableHeader>
                         <TableRow>

--- a/apps/ui/src/app/(main)/evals/new/page.tsx
+++ b/apps/ui/src/app/(main)/evals/new/page.tsx
@@ -150,7 +150,7 @@ export default function NewEvalPage() {
 
               {/* Session fields (mirrors session creation params) */}
               {targetType === "session" && (
-                <div className="space-y-4 border rounded-lg p-4">
+                <div className="space-y-4 border p-4">
                   <div className="space-y-2">
                     <Label>Harness (optional)</Label>
                     <HarnessSelect
@@ -190,7 +190,7 @@ export default function NewEvalPage() {
 
               {/* App fields */}
               {targetType === "app" && (
-                <div className="space-y-4 border rounded-lg p-4">
+                <div className="space-y-4 border p-4">
                   <div className="space-y-2">
                     <Label>App ID</Label>
                     <Input

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
@@ -204,7 +204,7 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
                         return (
                           <div
                             key={capConfig.ref}
-                            className="flex items-center gap-2 p-2 rounded-md border bg-muted/50"
+                            className="flex items-center gap-2 p-2 border bg-muted/50"
                           >
                             <IconComponent className="w-4 h-4" />
                             <div className="flex-1">

--- a/apps/ui/src/app/(main)/mcp-servers/page.tsx
+++ b/apps/ui/src/app/(main)/mcp-servers/page.tsx
@@ -56,7 +56,7 @@ function McpServerCard({
     <Card>
       <CardHeader className="flex flex-row items-start justify-between space-y-0">
         <div className="flex items-center gap-3">
-          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10">
+          <div className="flex h-9 w-9 items-center justify-center bg-primary/10">
             <Plug className="h-5 w-5 text-primary" />
           </div>
           <div>
@@ -347,7 +347,7 @@ function McpServerCardSkeleton() {
     <Card>
       <CardHeader className="flex flex-row items-start justify-between space-y-0">
         <div className="flex items-center gap-3">
-          <Skeleton className="h-9 w-9 rounded-lg" />
+          <Skeleton className="h-9 w-9" />
           <div className="space-y-2">
             <Skeleton className="h-5 w-32" />
             <Skeleton className="h-4 w-24" />

--- a/apps/ui/src/app/(main)/orgs/[orgId]/setup/page.tsx
+++ b/apps/ui/src/app/(main)/orgs/[orgId]/setup/page.tsx
@@ -140,7 +140,7 @@ export default function OrgSetupPage() {
       <div className="flex min-h-[60vh] items-center justify-center p-4">
         <Card className="w-full max-w-lg p-8">
           <div className="flex flex-col items-center gap-4">
-            <Skeleton className="h-12 w-12 rounded-xl" />
+            <Skeleton className="h-12 w-12" />
             <Skeleton className="h-6 w-48" />
             <Skeleton className="h-4 w-64" />
           </div>
@@ -161,7 +161,7 @@ export default function OrgSetupPage() {
       <div className="flex min-h-[60vh] items-center justify-center p-4">
         <Card className="w-full max-w-lg p-8 text-center">
           <div className="flex flex-col items-center gap-4">
-            <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
+            <div className="flex h-12 w-12 items-center justify-center bg-primary/10">
               <Building2 className="h-6 w-6 text-primary" />
             </div>
             <h1 className="text-xl font-semibold">
@@ -184,7 +184,7 @@ export default function OrgSetupPage() {
     <div className="flex min-h-[60vh] items-center justify-center p-4">
       <Card className="w-full max-w-lg p-8">
         <div className="flex flex-col items-center gap-2 text-center">
-          <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
+          <div className="flex h-12 w-12 items-center justify-center bg-primary/10">
             <Building2 className="h-6 w-6 text-primary" />
           </div>
           <h1 className="text-xl font-semibold">Setting up {org?.name}</h1>

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/events/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/events/page.tsx
@@ -169,7 +169,7 @@ export default function EventsPage() {
           </div>
 
           {/* Events table */}
-          <div className="border rounded-lg">
+          <div className="border">
             <Table>
               <TableHeader>
                 <TableRow>
@@ -274,7 +274,7 @@ export default function EventsPage() {
           if (!open) setSelectedGeneration(null);
         }}
       >
-        <DialogContent className="sm:max-w-4xl max-h-[90vh] flex flex-col overflow-hidden rounded-lg">
+        <DialogContent className="sm:max-w-4xl max-h-[90vh] flex flex-col overflow-hidden">
           <DialogHeader className="shrink-0">
             <DialogTitle>LLM Generation Details</DialogTitle>
           </DialogHeader>

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/files/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/files/page.tsx
@@ -53,7 +53,7 @@ export default function FilesPage() {
 
       {/* Drag overlay */}
       {isDragging && (
-        <div className="absolute inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm border-2 border-dashed border-primary/50 rounded-lg pointer-events-none">
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm border-2 border-dashed border-primary/50 pointer-events-none">
           <div className="flex flex-col items-center gap-3 text-primary">
             <Upload className="size-12" />
             <p className="text-lg font-medium">Drop files to upload</p>
@@ -64,7 +64,7 @@ export default function FilesPage() {
 
       {/* Upload progress toast */}
       {uploads.length > 0 && (
-        <div className="absolute bottom-4 right-4 z-50 w-72 bg-card border rounded-lg shadow-lg p-3 space-y-2">
+        <div className="absolute bottom-4 right-4 z-50 w-72 bg-card border shadow-lg p-3 space-y-2">
           <p className="text-sm font-medium">
             {isUploading ? "Uploading files..." : "Upload complete"}
           </p>

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/storage/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/storage/page.tsx
@@ -85,7 +85,7 @@ export default function StoragePage() {
           ) : (
             <div className="space-y-3">
               {keyValues.map((kv) => (
-                <div key={kv.key} className="border rounded-lg p-3 space-y-2">
+                <div key={kv.key} className="border p-3 space-y-2">
                   <div className="flex items-center justify-between">
                     <Badge variant="outline" className="font-mono">
                       {kv.key}
@@ -124,7 +124,7 @@ export default function StoragePage() {
               {secrets.map((secret) => (
                 <div
                   key={secret.name}
-                  className="border rounded-lg p-3 flex items-center justify-between"
+                  className="border p-3 flex items-center justify-between"
                 >
                   <div className="flex items-center gap-2">
                     <Badge variant="secondary" className="font-mono">

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/storage/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/storage/page.tsx
@@ -122,10 +122,7 @@ export default function StoragePage() {
           ) : (
             <div className="space-y-3">
               {secrets.map((secret) => (
-                <div
-                  key={secret.name}
-                  className="border p-3 flex items-center justify-between"
-                >
+                <div key={secret.name} className="border p-3 flex items-center justify-between">
                   <div className="flex items-center gap-2">
                     <Badge variant="secondary" className="font-mono">
                       {secret.name}

--- a/apps/ui/src/app/(main)/settings/api-keys/page.tsx
+++ b/apps/ui/src/app/(main)/settings/api-keys/page.tsx
@@ -34,7 +34,7 @@ function ApiKeyRow({
   };
 
   return (
-    <div className="flex items-center justify-between p-3 border rounded-lg">
+    <div className="flex items-center justify-between p-3 border">
       <div className="flex items-center gap-3">
         <Key className="h-5 w-5 text-muted-foreground" />
         <div>
@@ -168,7 +168,7 @@ function ShowApiKeyDialog({
           </DialogDescription>
         </DialogHeader>
         <div className="flex items-center gap-2">
-          <div className="bg-muted p-3 rounded-md font-mono text-sm flex-1 min-w-0 max-w-full whitespace-nowrap overflow-x-auto">
+          <div className="bg-muted p-3 font-mono text-sm flex-1 min-w-0 max-w-full whitespace-nowrap overflow-x-auto">
             {apiKey}
           </div>
           <Button

--- a/apps/ui/src/app/(main)/settings/connections/page.tsx
+++ b/apps/ui/src/app/(main)/settings/connections/page.tsx
@@ -63,7 +63,7 @@ function ConnectionRow({
   };
 
   return (
-    <div className="flex items-center justify-between p-4 border rounded-lg">
+    <div className="flex items-center justify-between p-4 border">
       <div className="flex items-center gap-3">
         <ProviderIcon iconName={icon} className="h-5 w-5" />
         <div>
@@ -135,7 +135,7 @@ function AvailableProviderRow({
   };
 
   return (
-    <div className="flex items-center justify-between p-4 border rounded-lg">
+    <div className="flex items-center justify-between p-4 border">
       <div className="flex items-center gap-3">
         <ProviderIcon iconName={provider.icon} className="h-5 w-5" />
         <div>
@@ -198,7 +198,7 @@ export default function ConnectionsPage() {
     <div className="space-y-8">
       {/* Success banner */}
       {successMessage && (
-        <div className="flex items-center gap-2 bg-green-500/10 text-green-700 dark:text-green-400 p-3 rounded-lg text-sm">
+        <div className="flex items-center gap-2 bg-green-500/10 text-green-700 dark:text-green-400 p-3 text-sm">
           <Check className="h-4 w-4" />
           {successMessage}
         </div>
@@ -214,7 +214,7 @@ export default function ConnectionsPage() {
         </div>
 
         {error && (
-          <div className="bg-destructive/10 text-destructive p-4 rounded-lg mb-4">
+          <div className="bg-destructive/10 text-destructive p-4 mb-4">
             Failed to load connections: {error.message}
           </div>
         )}

--- a/apps/ui/src/app/(main)/settings/members/page.tsx
+++ b/apps/ui/src/app/(main)/settings/members/page.tsx
@@ -94,7 +94,7 @@ function MemberCard({
   };
 
   return (
-    <div className="flex items-center justify-between p-4 border rounded-lg">
+    <div className="flex items-center justify-between p-4 border">
       <div className="flex items-center gap-4">
         <Avatar className="h-10 w-10">
           {member.avatar_url && <AvatarImage src={member.avatar_url} alt={member.name} />}
@@ -165,7 +165,7 @@ function MemberCard({
 
 function MemberCardSkeleton() {
   return (
-    <div className="flex items-center justify-between p-4 border rounded-lg">
+    <div className="flex items-center justify-between p-4 border">
       <div className="flex items-center gap-4">
         <Skeleton className="h-10 w-10 rounded-full" />
         <div className="space-y-2">

--- a/apps/ui/src/app/(main)/settings/organisation/page.tsx
+++ b/apps/ui/src/app/(main)/settings/organisation/page.tsx
@@ -146,7 +146,7 @@ export default function OrganisationPage() {
         ) : (
           <Card className="p-6">
             <div className="flex items-center gap-3 mb-6">
-              <div className="p-2 rounded-lg bg-primary/10">
+              <div className="p-2 bg-primary/10">
                 <Building2 className="h-5 w-5 text-primary" />
               </div>
               <div>
@@ -271,7 +271,7 @@ export default function OrganisationPage() {
                 className={`p-4 flex items-center justify-between ${isCurrent ? "border-primary/50" : ""}`}
               >
                 <div className="flex items-center gap-3">
-                  <div className={`p-2 rounded-lg ${isCurrent ? "bg-primary/10" : "bg-muted"}`}>
+                  <div className={`p-2 ${isCurrent ? "bg-primary/10" : "bg-muted"}`}>
                     <Building2
                       className={`h-4 w-4 ${isCurrent ? "text-primary" : "text-muted-foreground"}`}
                     />

--- a/apps/ui/src/app/(main)/settings/providers/model-row.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/model-row.tsx
@@ -45,7 +45,7 @@ export function ModelRow({
   const profile = model.profile;
 
   return (
-    <div className="border rounded-lg overflow-hidden">
+    <div className="border overflow-hidden">
       <div className="flex items-center justify-between p-3">
         <div className="flex items-center gap-3">
           <ProviderIcon

--- a/apps/ui/src/app/(main)/settings/providers/page.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/page.tsx
@@ -131,14 +131,14 @@ export default function ProvidersPage() {
         </div>
 
         {providersError && (
-          <div className="bg-destructive/10 text-destructive p-4 rounded-lg mb-4">
+          <div className="bg-destructive/10 text-destructive p-4 mb-4">
             Failed to load providers: {providersError.message}
           </div>
         )}
 
         {syncMessage && (
           <div
-            className={`p-4 rounded-lg mb-4 ${
+            className={`p-4 mb-4 ${
               syncMessage.type === "success"
                 ? "bg-green-100 text-green-800"
                 : "bg-destructive/10 text-destructive"
@@ -198,7 +198,7 @@ export default function ProvidersPage() {
         </div>
 
         {modelsError && (
-          <div className="bg-destructive/10 text-destructive p-4 rounded-lg mb-4">
+          <div className="bg-destructive/10 text-destructive p-4 mb-4">
             Failed to load models: {modelsError.message}
           </div>
         )}

--- a/apps/ui/src/app/(main)/settings/providers/provider-card.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/provider-card.tsx
@@ -95,7 +95,7 @@ export function ProviderCardSkeleton() {
     <Card>
       <CardHeader className="flex flex-row items-start justify-between space-y-0">
         <div className="flex items-center gap-3">
-          <Skeleton className="h-9 w-9 rounded-lg" />
+          <Skeleton className="h-9 w-9" />
           <div className="space-y-2">
             <Skeleton className="h-5 w-32" />
             <Skeleton className="h-4 w-24" />

--- a/apps/ui/src/app/(main)/skills/page.tsx
+++ b/apps/ui/src/app/(main)/skills/page.tsx
@@ -194,7 +194,7 @@ function UploadSkillDialog({
               type="file"
               accept=".zip"
               onChange={(e) => setFile(e.target.files?.[0] ?? null)}
-              className="block w-full text-sm text-muted-foreground file:mr-4 file:py-2 file:px-4 file:file:border-0 file:text-sm file:font-medium file:bg-primary file:text-primary-foreground hover:file:bg-primary/90"
+              className="block w-full text-sm text-muted-foreground file:mr-4 file:py-2 file:px-4 file:border-0 file:text-sm file:font-medium file:bg-primary file:text-primary-foreground hover:file:bg-primary/90"
             />
             <p className="text-xs text-muted-foreground">Maximum archive size: 10 MB</p>
           </div>

--- a/apps/ui/src/app/(main)/skills/page.tsx
+++ b/apps/ui/src/app/(main)/skills/page.tsx
@@ -46,7 +46,7 @@ function SkillCard({
     <Card>
       <CardHeader className="flex flex-row items-start justify-between space-y-0">
         <div className="flex items-center gap-3">
-          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10">
+          <div className="flex h-9 w-9 items-center justify-center bg-primary/10">
             {skill.source_type === "archive" ? (
               <Archive className="h-5 w-5 text-primary" />
             ) : (
@@ -194,7 +194,7 @@ function UploadSkillDialog({
               type="file"
               accept=".zip"
               onChange={(e) => setFile(e.target.files?.[0] ?? null)}
-              className="block w-full text-sm text-muted-foreground file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-primary file:text-primary-foreground hover:file:bg-primary/90"
+              className="block w-full text-sm text-muted-foreground file:mr-4 file:py-2 file:px-4 file:file:border-0 file:text-sm file:font-medium file:bg-primary file:text-primary-foreground hover:file:bg-primary/90"
             />
             <p className="text-xs text-muted-foreground">Maximum archive size: 10 MB</p>
           </div>
@@ -217,7 +217,7 @@ function SkillCardSkeleton() {
     <Card>
       <CardHeader className="flex flex-row items-start justify-between space-y-0">
         <div className="flex items-center gap-3">
-          <Skeleton className="h-9 w-9 rounded-lg" />
+          <Skeleton className="h-9 w-9" />
           <div className="space-y-2">
             <Skeleton className="h-5 w-32" />
             <Skeleton className="h-4 w-48" />

--- a/apps/ui/src/app/dev/file-previews/page.tsx
+++ b/apps/ui/src/app/dev/file-previews/page.tsx
@@ -45,7 +45,7 @@ function ShowcaseItem({ label, children }: { label: string; children: React.Reac
   return (
     <div className="space-y-2">
       <div className="text-sm font-medium text-muted-foreground">{label}</div>
-      <div className="border rounded-lg overflow-hidden bg-background h-[300px]">{children}</div>
+      <div className="border overflow-hidden bg-background h-[300px]">{children}</div>
     </div>
   );
 }
@@ -454,7 +454,7 @@ export default function DevFilePreviewsPage() {
               </div>
               <div>
                 <div className="font-medium mb-2">Usage</div>
-                <pre className="bg-muted p-4 rounded-md text-xs overflow-x-auto">
+                <pre className="bg-muted p-4 text-xs overflow-x-auto">
                   {`import { FilePreview, canPreview } from "@/components/files";
 
 // Check if preview is available

--- a/apps/ui/src/app/dev/markdown/page.tsx
+++ b/apps/ui/src/app/dev/markdown/page.tsx
@@ -205,10 +205,7 @@ function StreamingDemo() {
         >
           {isStreaming ? "Streaming..." : "Start Streaming Demo"}
         </button>
-        <button
-          onClick={reset}
-          className="px-4 py-2 text-sm font-medium border hover:bg-muted"
-        >
+        <button onClick={reset} className="px-4 py-2 text-sm font-medium border hover:bg-muted">
           Reset
         </button>
       </div>

--- a/apps/ui/src/app/dev/markdown/page.tsx
+++ b/apps/ui/src/app/dev/markdown/page.tsx
@@ -39,7 +39,7 @@ function ShowcaseItem({ label, children }: { label: string; children: React.Reac
   return (
     <div className="space-y-2">
       <div className="text-sm font-medium text-muted-foreground">{label}</div>
-      <div className="border rounded-lg p-4 bg-background">{children}</div>
+      <div className="border p-4 bg-background">{children}</div>
     </div>
   );
 }
@@ -142,7 +142,7 @@ export function Feature({ title, enabled = true }: FeatureProps) {
   const [isActive, setIsActive] = useState(enabled);
 
   return (
-    <div className="p-4 border rounded-lg">
+    <div className="p-4 border">
       <h3 className="text-lg font-medium">{title}</h3>
       <button onClick={() => setIsActive(!isActive)}>
         {isActive ? 'Disable' : 'Enable'}
@@ -201,19 +201,19 @@ function StreamingDemo() {
         <button
           onClick={startStreaming}
           disabled={isStreaming}
-          className="px-4 py-2 text-sm font-medium bg-primary text-primary-foreground rounded-md disabled:opacity-50"
+          className="px-4 py-2 text-sm font-medium bg-primary text-primary-foreground disabled:opacity-50"
         >
           {isStreaming ? "Streaming..." : "Start Streaming Demo"}
         </button>
         <button
           onClick={reset}
-          className="px-4 py-2 text-sm font-medium border rounded-md hover:bg-muted"
+          className="px-4 py-2 text-sm font-medium border hover:bg-muted"
         >
           Reset
         </button>
       </div>
 
-      <div className="border rounded-lg p-4 min-h-[400px] bg-background">
+      <div className="border p-4 min-h-[400px] bg-background">
         {streamedText ? (
           isStreaming ? (
             <StreamingMessage text={streamedText} />
@@ -405,13 +405,13 @@ export default function DevMarkdownPage() {
             description="How to use the StreamdownMessage components"
           >
             <ShowcaseItem label="Import">
-              <pre className="bg-muted p-4 rounded-md text-sm overflow-x-auto">
+              <pre className="bg-muted p-4 text-sm overflow-x-auto">
                 {`import { StreamdownMessage, InlineStreamdownMessage } from "@/components/chat/streamdown-message";`}
               </pre>
             </ShowcaseItem>
 
             <ShowcaseItem label="Streaming Message">
-              <pre className="bg-muted p-4 rounded-md text-sm overflow-x-auto">
+              <pre className="bg-muted p-4 text-sm overflow-x-auto">
                 {`<StreamdownMessage isAnimating={true}>
   {streamingText}
 </StreamdownMessage>`}
@@ -419,7 +419,7 @@ export default function DevMarkdownPage() {
             </ShowcaseItem>
 
             <ShowcaseItem label="Completed Message">
-              <pre className="bg-muted p-4 rounded-md text-sm overflow-x-auto">
+              <pre className="bg-muted p-4 text-sm overflow-x-auto">
                 {`<StreamdownMessage isAnimating={false}>
   {messageContent}
 </StreamdownMessage>`}
@@ -427,7 +427,7 @@ export default function DevMarkdownPage() {
             </ShowcaseItem>
 
             <ShowcaseItem label="Inline for Descriptions">
-              <pre className="bg-muted p-4 rounded-md text-sm overflow-x-auto">
+              <pre className="bg-muted p-4 text-sm overflow-x-auto">
                 {`<InlineStreamdownMessage className="text-muted-foreground">
   {description}
 </InlineStreamdownMessage>`}

--- a/apps/ui/src/app/dev/model-picker/page.tsx
+++ b/apps/ui/src/app/dev/model-picker/page.tsx
@@ -42,7 +42,7 @@ function ShowcaseItem({ label, children }: { label: string; children: React.Reac
   return (
     <div className="space-y-2">
       <div className="text-sm font-medium text-muted-foreground">{label}</div>
-      <div className="border rounded-lg p-4 bg-background">{children}</div>
+      <div className="border p-4 bg-background">{children}</div>
     </div>
   );
 }
@@ -80,7 +80,7 @@ function ModelList() {
             {favoriteModels.map((model) => (
               <div
                 key={model.id}
-                className="flex items-center gap-3 p-2 rounded-md border bg-muted/30"
+                className="flex items-center gap-3 p-2 border bg-muted/30"
               >
                 <ProviderIcon providerType={model.provider_type} size="sm" showBackground={false} />
                 <div className="flex-1">
@@ -106,7 +106,7 @@ function ModelList() {
           <h4 className="text-sm font-medium text-muted-foreground">Other Models</h4>
           <div className="space-y-1">
             {otherModels.map((model) => (
-              <div key={model.id} className="flex items-center gap-3 p-2 rounded-md border">
+              <div key={model.id} className="flex items-center gap-3 p-2 border">
                 <ProviderIcon providerType={model.provider_type} size="sm" showBackground={false} />
                 <div className="flex-1">
                   <div className="font-medium text-sm">{model.display_name}</div>
@@ -222,7 +222,7 @@ export default function DevModelPickerPage() {
               description="How to use the ModelPicker in your components"
             >
               <ShowcaseItem label="Code Example">
-                <pre className="text-sm bg-muted p-4 rounded-md overflow-x-auto">
+                <pre className="text-sm bg-muted p-4 overflow-x-auto">
                   {`import { ModelPicker } from "@/components/models/model-picker";
 
 function MyComponent() {
@@ -240,7 +240,7 @@ function MyComponent() {
               </ShowcaseItem>
 
               <ShowcaseItem label="FavoriteToggle Example">
-                <pre className="text-sm bg-muted p-4 rounded-md overflow-x-auto">
+                <pre className="text-sm bg-muted p-4 overflow-x-auto">
                   {`import { FavoriteToggle } from "@/components/models/model-picker";
 
 function ModelRow({ model }) {

--- a/apps/ui/src/app/dev/model-picker/page.tsx
+++ b/apps/ui/src/app/dev/model-picker/page.tsx
@@ -78,10 +78,7 @@ function ModelList() {
           </h4>
           <div className="space-y-1">
             {favoriteModels.map((model) => (
-              <div
-                key={model.id}
-                className="flex items-center gap-3 p-2 border bg-muted/30"
-              >
+              <div key={model.id} className="flex items-center gap-3 p-2 border bg-muted/30">
                 <ProviderIcon providerType={model.provider_type} size="sm" showBackground={false} />
                 <div className="flex-1">
                   <div className="font-medium text-sm">{model.display_name}</div>

--- a/apps/ui/src/app/dev/session-card/page.tsx
+++ b/apps/ui/src/app/dev/session-card/page.tsx
@@ -39,7 +39,7 @@ function ShowcaseItem({ label, children }: { label: string; children: React.Reac
   return (
     <div className="space-y-2">
       <div className="text-sm font-medium text-muted-foreground">{label}</div>
-      <div className="border rounded-lg p-4 bg-background">{children}</div>
+      <div className="border p-4 bg-background">{children}</div>
     </div>
   );
 }
@@ -287,7 +287,7 @@ export default function DevSessionCardPage() {
                     <SessionCard session={sampleSessions.running} model={sampleModels.anthropic} />
                   </div>
                   <button
-                    className="p-2 rounded-md hover:bg-muted text-muted-foreground hover:text-foreground"
+                    className="p-2 hover:bg-muted text-muted-foreground hover:text-foreground"
                     type="button"
                   >
                     <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/apps/ui/src/app/dev/session-components/page.tsx
+++ b/apps/ui/src/app/dev/session-components/page.tsx
@@ -39,7 +39,7 @@ function ShowcaseItem({ label, children }: { label: string; children: React.Reac
   return (
     <div className="space-y-2">
       <div className="text-sm font-medium text-muted-foreground">{label}</div>
-      <div className="border rounded-lg p-4 bg-background">{children}</div>
+      <div className="border p-4 bg-background">{children}</div>
     </div>
   );
 }
@@ -83,7 +83,7 @@ function TokenUsageCard({ usage, title }: { usage: TokenUsage; title: string }) 
         <CardTitle className="text-sm">{title}</CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="flex items-center gap-2 p-2 rounded-md border bg-muted/50">
+        <div className="flex items-center gap-2 p-2 border bg-muted/50">
           <Zap className="w-4 h-4 text-yellow-500" />
           <div className="flex-1">
             <p className="text-sm font-medium">{formatTokens(totalTokens(usage))} total</p>
@@ -178,7 +178,7 @@ export default function DevSessionComponentsPage() {
               </ShowcaseItem>
 
               <ShowcaseItem label="Session Header with Usage">
-                <div className="border rounded-lg p-4">
+                <div className="border p-4">
                   <div className="flex items-center justify-between">
                     <div>
                       <h2 className="text-lg font-bold">Example Session</h2>
@@ -244,7 +244,7 @@ export default function DevSessionComponentsPage() {
               description="Different configurations of session headers"
             >
               <ShowcaseItem label="Minimal Header">
-                <div className="border rounded-lg p-4">
+                <div className="border p-4">
                   <div className="flex items-center justify-between">
                     <h2 className="text-lg font-semibold">Session #1234</h2>
                     <Badge variant="secondary">pending</Badge>
@@ -253,7 +253,7 @@ export default function DevSessionComponentsPage() {
               </ShowcaseItem>
 
               <ShowcaseItem label="Full Header with All Metadata">
-                <div className="border rounded-lg p-4">
+                <div className="border p-4">
                   <div className="flex items-center justify-between">
                     <div>
                       <h2 className="text-lg font-bold">Production Debug Session</h2>

--- a/apps/ui/src/app/dev/thinking-components/page.tsx
+++ b/apps/ui/src/app/dev/thinking-components/page.tsx
@@ -70,10 +70,10 @@ export default function ThinkingComponentsPage() {
         <p className="text-sm text-muted-foreground">
           Example of how thinking appears in a chat conversation.
         </p>
-        <div className="border rounded-lg p-4 space-y-4 bg-background">
+        <div className="border p-4 space-y-4 bg-background">
           {/* User message */}
           <div className="flex justify-end">
-            <div className="bg-primary text-primary-foreground rounded-lg px-4 py-2 max-w-[80%]">
+            <div className="bg-primary text-primary-foreground px-4 py-2 max-w-[80%]">
               Why is the sky blue?
             </div>
           </div>

--- a/apps/ui/src/app/not-found.tsx
+++ b/apps/ui/src/app/not-found.tsx
@@ -12,7 +12,7 @@ export default function NotFound() {
         <div className="mt-6">
           <Link
             href="/dashboard"
-            className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-6 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 transition-colors"
+            className="inline-flex h-10 items-center justify-center bg-primary px-6 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 transition-colors"
           >
             Back to dashboard
           </Link>

--- a/apps/ui/src/components/agent-identity/identity-connections.tsx
+++ b/apps/ui/src/components/agent-identity/identity-connections.tsx
@@ -53,7 +53,7 @@ function ConnectionRow({
   };
 
   return (
-    <div className="flex items-center justify-between p-4 border rounded-lg">
+    <div className="flex items-center justify-between p-4 border">
       <div className="flex items-center gap-3">
         <ProviderIcon iconName={icon} className="h-5 w-5" />
         <div>
@@ -120,7 +120,7 @@ function AvailableProviderRow({
   if (provider.connection_type !== "api_key") return null;
 
   return (
-    <div className="flex items-center justify-between p-4 border rounded-lg">
+    <div className="flex items-center justify-between p-4 border">
       <div className="flex items-center gap-3">
         <ProviderIcon iconName={provider.icon} className="h-5 w-5" />
         <div>
@@ -161,7 +161,7 @@ export function IdentityConnections({ identityId }: { identityId: string }) {
   return (
     <div className="space-y-4">
       {error && (
-        <div className="bg-destructive/10 text-destructive p-4 rounded-lg">
+        <div className="bg-destructive/10 text-destructive p-4">
           Failed to load connections: {error.message}
         </div>
       )}
@@ -169,7 +169,7 @@ export function IdentityConnections({ identityId }: { identityId: string }) {
       {isLoading ? (
         <Skeleton className="h-[72px] w-full" />
       ) : connections.length === 0 && availableProviders.length === 0 ? (
-        <div className="p-6 text-center border rounded-lg">
+        <div className="p-6 text-center border">
           <LinkIcon className="h-8 w-8 mx-auto text-muted-foreground mb-2" />
           <p className="text-muted-foreground text-sm">No connection providers available.</p>
         </div>

--- a/apps/ui/src/components/agents/agent-preview.tsx
+++ b/apps/ui/src/components/agents/agent-preview.tsx
@@ -95,7 +95,7 @@ export function AgentPreview({ systemPrompt, capabilities, tools = [] }: AgentPr
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <ScrollArea className="h-[400px] rounded-md border p-4 bg-muted/50">
+          <ScrollArea className="h-[400px] border p-4 bg-muted/50">
             <pre className="text-sm whitespace-pre-wrap font-mono">{preview.system_prompt}</pre>
           </ScrollArea>
         </CardContent>
@@ -135,7 +135,7 @@ function ToolCard({ tool }: { tool: ToolDefinition }) {
   const [isExpanded, setIsExpanded] = useState(false);
 
   return (
-    <div className="border rounded-lg p-4 bg-card">
+    <div className="border p-4 bg-card">
       <div className="flex items-start justify-between">
         <div className="space-y-1">
           <h4 className="font-semibold text-sm font-mono">{tool.name}</h4>
@@ -159,7 +159,7 @@ function ToolCard({ tool }: { tool: ToolDefinition }) {
         </button>
         {isExpanded && (
           <ScrollArea className="mt-2 max-h-[200px]">
-            <pre className="text-xs p-2 bg-muted rounded-md overflow-x-auto font-mono">
+            <pre className="text-xs p-2 bg-muted overflow-x-auto font-mono">
               {JSON.stringify(tool.parameters, null, 2)}
             </pre>
           </ScrollArea>

--- a/apps/ui/src/components/agents/capability-dialog.tsx
+++ b/apps/ui/src/components/agents/capability-dialog.tsx
@@ -169,7 +169,7 @@ export function CapabilityDialog({
                             <label
                               key={cap.id}
                               className={cn(
-                                "flex items-start gap-3 p-2 rounded-md cursor-pointer transition-colors",
+                                "flex items-start gap-3 p-2 cursor-pointer transition-colors",
                                 isSelected
                                   ? "bg-primary/10 border border-primary/20"
                                   : "hover:bg-muted/50",

--- a/apps/ui/src/components/agents/selected-capability-list.tsx
+++ b/apps/ui/src/components/agents/selected-capability-list.tsx
@@ -48,7 +48,7 @@ export function SelectedCapabilityList({
 
   if (selected.length === 0) {
     return (
-      <div className="text-sm text-muted-foreground py-4 text-center border rounded-md border-dashed">
+      <div className="text-sm text-muted-foreground py-4 text-center border border-dashed">
         No capabilities selected
       </div>
     );
@@ -72,7 +72,7 @@ export function SelectedCapabilityList({
             open={isSettingsExpanded}
             onOpenChange={() => hasSettings && toggleSettings(capConfig.ref)}
           >
-            <div className="rounded-md border bg-muted/30 group">
+            <div className="border bg-muted/30 group">
               <div className="flex items-center gap-2 p-2">
                 {/* Reorder controls */}
                 <div className="flex flex-col gap-0.5">

--- a/apps/ui/src/components/apps/slack-setup-guidance.tsx
+++ b/apps/ui/src/components/apps/slack-setup-guidance.tsx
@@ -180,7 +180,7 @@ function SetupSteps({
                     </code>{" "}
                     then use the ngrok URL with this path as your Request URL:
                   </p>
-                  <div className="flex items-center gap-2 bg-muted p-2 rounded-md">
+                  <div className="flex items-center gap-2 bg-muted p-2">
                     <code className="text-xs flex-1 truncate">{webhookPath}</code>
                     <button
                       className="shrink-0 hover:text-foreground text-muted-foreground"
@@ -196,7 +196,7 @@ function SetupSteps({
                     In your Slack app settings, go to <strong>Event Subscriptions</strong>, enable
                     events, and paste this Request URL:
                   </p>
-                  <div className="flex items-center gap-2 bg-muted p-2 rounded-md">
+                  <div className="flex items-center gap-2 bg-muted p-2">
                     <code className="text-xs flex-1 truncate">{webhookUrl}</code>
                     <button
                       className="shrink-0 hover:text-foreground text-muted-foreground"

--- a/apps/ui/src/components/chat/chat-message-list.tsx
+++ b/apps/ui/src/components/chat/chat-message-list.tsx
@@ -204,9 +204,9 @@ export const ChatMessageList = memo(function ChatMessageList({
   if (eventsLoading) {
     return (
       <div className="space-y-4">
-        <div className="ml-auto h-20 w-3/4 animate-pulse rounded-md bg-muted" />
-        <div className="h-20 w-3/4 animate-pulse rounded-md bg-muted" />
-        <div className="h-20 w-2/3 animate-pulse rounded-md bg-muted" />
+        <div className="ml-auto h-20 w-3/4 animate-pulse bg-muted" />
+        <div className="h-20 w-3/4 animate-pulse bg-muted" />
+        <div className="h-20 w-2/3 animate-pulse bg-muted" />
       </div>
     );
   }

--- a/apps/ui/src/components/chat/compaction-divider.tsx
+++ b/apps/ui/src/components/chat/compaction-divider.tsx
@@ -28,7 +28,7 @@ export function CompactionDivider({ data }: { data: ContextCompactedData }) {
         <div className="h-px flex-1 bg-border" />
       </button>
       {expanded && (
-        <div className="mx-auto max-w-md rounded-md border bg-muted/50 px-4 py-2 text-xs text-muted-foreground">
+        <div className="mx-auto max-w-md border bg-muted/50 px-4 py-2 text-xs text-muted-foreground">
           <div className="space-y-1">
             <div>
               <span className="font-medium">Saved:</span> {saved} messages in {data.duration_ms}ms

--- a/apps/ui/src/components/chat/openui-renderer.tsx
+++ b/apps/ui/src/components/chat/openui-renderer.tsx
@@ -90,7 +90,7 @@ export function OpenUIBlock({ code, isStreaming = false }: OpenUIBlockProps) {
   );
 
   return (
-    <div className="openui-block my-2 overflow-hidden rounded-lg border border-border bg-card">
+    <div className="openui-block my-2 overflow-hidden border border-border bg-card">
       <OpenUIErrorBoundary fallback={fallback}>
         <Renderer response={code} library={openuiLibrary} isStreaming={isStreaming} />
       </OpenUIErrorBoundary>

--- a/apps/ui/src/components/chat/setup-connection-tool-call.tsx
+++ b/apps/ui/src/components/chat/setup-connection-tool-call.tsx
@@ -128,7 +128,7 @@ export function SetupConnectionToolCall({
 
   return (
     <>
-      <div className="flex items-center gap-3 rounded-lg border border-border bg-muted/50 px-4 py-3">
+      <div className="flex items-center gap-3 border border-border bg-muted/50 px-4 py-3">
         <ProviderIcon iconName={icon} className="h-5 w-5 text-foreground" />
         <div className="flex-1 min-w-0">
           <p className="text-sm font-medium text-foreground">{displayName} connection required</p>

--- a/apps/ui/src/components/durable/metrics-charts.tsx
+++ b/apps/ui/src/components/durable/metrics-charts.tsx
@@ -239,7 +239,7 @@ function ChartTooltip({
 }) {
   if (!active || !payload?.length) return null;
   return (
-    <div className="rounded-lg border bg-background p-2 shadow-sm">
+    <div className="border bg-background p-2 shadow-sm">
       <p className="text-xs text-muted-foreground mb-1">{label}</p>
       {payload.map((entry) => (
         <div key={entry.name} className="flex items-center gap-2 text-xs">

--- a/apps/ui/src/components/files/file-viewer.tsx
+++ b/apps/ui/src/components/files/file-viewer.tsx
@@ -99,11 +99,11 @@ export function FileViewer({ sessionId, file, onClose }: FileViewerProps) {
           </div>
           <div className="flex items-center gap-1 shrink-0">
             {hasPreview && !isEditing && (
-              <div className="flex items-center border rounded-md mr-1">
+              <div className="flex items-center border mr-1">
                 <Button
                   variant={viewMode === "preview" ? "secondary" : "ghost"}
                   size="sm"
-                  className="h-7 px-2 rounded-r-none"
+                  className="h-7 px-2"
                   onClick={() => setViewMode("preview")}
                   title="View"
                 >
@@ -113,7 +113,7 @@ export function FileViewer({ sessionId, file, onClose }: FileViewerProps) {
                 <Button
                   variant={viewMode === "source" ? "secondary" : "ghost"}
                   size="sm"
-                  className="h-7 px-2 rounded-l-none"
+                  className="h-7 px-2"
                   onClick={() => setViewMode("source")}
                   title="Source"
                 >

--- a/apps/ui/src/components/harnesses/harness-preview.tsx
+++ b/apps/ui/src/components/harnesses/harness-preview.tsx
@@ -97,7 +97,7 @@ export function HarnessPreview({
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <ScrollArea className="h-[400px] rounded-md border p-4 bg-muted/50">
+          <ScrollArea className="h-[400px] border p-4 bg-muted/50">
             <pre className="text-sm whitespace-pre-wrap font-mono">{preview.system_prompt}</pre>
           </ScrollArea>
         </CardContent>
@@ -136,7 +136,7 @@ function ToolCard({ tool }: { tool: ToolDefinition }) {
   const [isExpanded, setIsExpanded] = useState(false);
 
   return (
-    <div className="border rounded-lg p-4 bg-card">
+    <div className="border p-4 bg-card">
       <div className="flex items-start justify-between">
         <div className="space-y-1">
           <h4 className="font-semibold text-sm font-mono">{tool.name}</h4>
@@ -159,7 +159,7 @@ function ToolCard({ tool }: { tool: ToolDefinition }) {
         </button>
         {isExpanded && (
           <ScrollArea className="mt-2 max-h-[200px]">
-            <pre className="text-xs p-2 bg-muted rounded-md overflow-x-auto font-mono">
+            <pre className="text-xs p-2 bg-muted overflow-x-auto font-mono">
               {JSON.stringify(tool.parameters, null, 2)}
             </pre>
           </ScrollArea>

--- a/apps/ui/src/components/initial-files-editor.tsx
+++ b/apps/ui/src/components/initial-files-editor.tsx
@@ -114,13 +114,13 @@ export function InitialFilesEditor({
       </div>
 
       {files.length === 0 ? (
-        <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+        <div className="border border-dashed p-4 text-sm text-muted-foreground">
           No starter files configured.
         </div>
       ) : (
         <div className="space-y-3">
           {files.map((file, index) => (
-            <div key={`${file.path}-${index}`} className="rounded-lg border p-4 space-y-3">
+            <div key={`${file.path}-${index}`} className="border p-4 space-y-3">
               <div className="flex items-center justify-between gap-3">
                 <div className="flex items-center gap-2 min-w-0">
                   {file.encoding === "text" ? (

--- a/apps/ui/src/components/llm/llm-history-viewer.tsx
+++ b/apps/ui/src/components/llm/llm-history-viewer.tsx
@@ -44,7 +44,7 @@ function ToolCallContentPart({
   toolCall: { id: string; name: string; arguments: Record<string, unknown> };
 }) {
   return (
-    <div className="border rounded-md p-2 bg-muted/50">
+    <div className="border p-2 bg-muted/50">
       <div className="flex items-center gap-2 mb-1">
         <Wrench className="w-3 h-3 text-muted-foreground" />
         <span className="text-xs font-medium">{toolCall.name}</span>
@@ -89,7 +89,7 @@ function ToolResultContentPart({
   return (
     <div
       className={cn(
-        "border rounded-md p-2",
+        "border p-2",
         error
           ? "bg-red-50 border-red-200 dark:bg-red-950/20 dark:border-red-900"
           : "bg-green-50 border-green-200 dark:bg-green-950/20 dark:border-green-900",
@@ -117,7 +117,7 @@ function ToolResultContentPart({
 
 function ImageContentPart({ imageId, filename }: { imageId?: string; filename?: string }) {
   return (
-    <div className="border rounded-md p-2 bg-muted/50 flex items-center gap-2">
+    <div className="border p-2 bg-muted/50 flex items-center gap-2">
       <FileText className="w-4 h-4 text-muted-foreground" />
       <span className="text-xs">{filename || imageId || "Image"}</span>
     </div>
@@ -180,7 +180,7 @@ function MessageCard({ message, index }: { message: Message; index: number }) {
   const Icon = config.icon;
 
   return (
-    <div className="border rounded-lg p-3 bg-background">
+    <div className="border p-3 bg-background">
       <div className="flex items-center gap-2 mb-2">
         <Icon className="w-4 h-4 text-muted-foreground" />
         <span className="text-sm font-medium">{config.label}</span>
@@ -215,7 +215,7 @@ function OutputSection({ output }: { output: LlmGenerationOutput }) {
       </CardHeader>
       <CardContent className="space-y-3">
         {output.text && (
-          <div className="border rounded-lg p-3 bg-muted/30">
+          <div className="border p-3 bg-muted/30">
             <p className="text-xs font-medium text-muted-foreground mb-1">Text Response</p>
             <p className="text-sm whitespace-pre-wrap">{output.text}</p>
           </div>
@@ -305,7 +305,7 @@ function UsageDisplay({ usage }: { usage: TokenUsage }) {
   const total = usage.input_tokens + usage.output_tokens;
 
   return (
-    <div className="mt-3 p-3 bg-muted/50 rounded-lg">
+    <div className="mt-3 p-3 bg-muted/50">
       <div className="flex items-center gap-2 mb-2">
         <Zap className="w-4 h-4 text-yellow-500" />
         <span className="text-sm font-medium">Token Usage</span>

--- a/apps/ui/src/components/providers/provider-icon.tsx
+++ b/apps/ui/src/components/providers/provider-icon.tsx
@@ -89,7 +89,7 @@ export function ProviderIcon({
 
   if (!IconComponent) {
     return (
-      <div className={cn(showBackground && "bg-primary/10 rounded-lg", container, className)}>
+      <div className={cn(showBackground && "bg-primary/10", container, className)}>
         <Server className="text-primary" style={{ width: iconSize, height: iconSize }} />
       </div>
     );
@@ -97,7 +97,7 @@ export function ProviderIcon({
 
   return (
     <div
-      className={cn(showBackground && "bg-primary/10 rounded-lg", container, className)}
+      className={cn(showBackground && "bg-primary/10", container, className)}
       title={label}
     >
       <IconComponent size={iconSize} />

--- a/apps/ui/src/components/providers/provider-icon.tsx
+++ b/apps/ui/src/components/providers/provider-icon.tsx
@@ -96,10 +96,7 @@ export function ProviderIcon({
   }
 
   return (
-    <div
-      className={cn(showBackground && "bg-primary/10", container, className)}
-      title={label}
-    >
+    <div className={cn(showBackground && "bg-primary/10", container, className)} title={label}>
       <IconComponent size={iconSize} />
     </div>
   );

--- a/apps/ui/src/components/query-state-wrapper.tsx
+++ b/apps/ui/src/components/query-state-wrapper.tsx
@@ -32,7 +32,7 @@ function DefaultLoadingSkeleton({ count = 6 }: { count?: number }) {
 
 function DefaultError({ prefix, message }: { prefix: string; message: string }) {
   return (
-    <div className="rounded-lg bg-destructive/10 p-4 text-destructive">
+    <div className="bg-destructive/10 p-4 text-destructive">
       {prefix}: {message}
     </div>
   );

--- a/apps/ui/src/components/session/session-card.tsx
+++ b/apps/ui/src/components/session/session-card.tsx
@@ -159,7 +159,7 @@ export function SessionCard({
   return (
     <Link
       href={sessionUrl}
-      className="flex items-start justify-between p-3 rounded-md border hover:bg-muted transition-colors group"
+      className="flex items-start justify-between p-3 border hover:bg-muted transition-colors group"
     >
       <div className="flex items-start gap-3 flex-1 min-w-0">
         <div className="flex-shrink-0 mt-0.5">

--- a/apps/ui/src/components/streaming-thinking.tsx
+++ b/apps/ui/src/components/streaming-thinking.tsx
@@ -29,7 +29,7 @@ export function StreamingThinking({
   const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed);
 
   return (
-    <div className={cn("border border-muted-foreground/20 rounded-lg overflow-hidden", className)}>
+    <div className={cn("border border-muted-foreground/20 overflow-hidden", className)}>
       {/* Header - clickable to toggle collapse */}
       <button
         type="button"

--- a/apps/ui/src/components/thinking-indicator.tsx
+++ b/apps/ui/src/components/thinking-indicator.tsx
@@ -27,7 +27,7 @@ export function ThinkingIndicator({ className, model }: ThinkingIndicatorProps) 
         {BAR_DELAYS.map((delay, i) => (
           <span
             key={delay}
-            className={`loading-wave-bar w-[3px] rounded-[1px] loading-wave-bar-${i}`}
+            className={`loading-wave-bar w-[3px] loading-wave-bar-${i}`}
             style={{
               animationDelay: `${delay}ms`,
               animationDuration: "0.7s",

--- a/apps/ui/src/components/trajectory/trajectory-nodes.tsx
+++ b/apps/ui/src/components/trajectory/trajectory-nodes.tsx
@@ -27,14 +27,14 @@ export const TurnGroupNode = memo(function TurnGroupNode({
   const failed = d.failed;
   return (
     <div
-      className={`w-full h-full rounded-xl border-2 ${
+      className={`w-full h-full border-2 ${
         failed
           ? "border-red-300 bg-red-50/50 dark:border-red-700 dark:bg-red-950/30"
           : "border-border bg-muted/20 dark:bg-muted/10"
       }`}
     >
       <div
-        className={`flex items-center gap-2 px-3 py-2 text-xs font-semibold rounded-t-[10px] ${
+        className={`flex items-center gap-2 px-3 py-2 text-xs font-semibold ${
           failed
             ? "text-red-700 bg-red-100/60 dark:text-red-300 dark:bg-red-900/30"
             : "text-foreground/80 bg-muted/40"
@@ -70,7 +70,7 @@ export const UserMessageNode = memo(function UserMessageNode({
 }: NodeProps & { data: UserMessageNodeData }) {
   const d = data as UserMessageNodeData;
   return (
-    <div className="w-[308px] rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 dark:border-blue-800 dark:bg-blue-950">
+    <div className="w-[308px] border border-blue-200 bg-blue-50 px-3 py-2 dark:border-blue-800 dark:bg-blue-950">
       <div className="flex items-center gap-1.5 text-xs font-medium text-blue-700 dark:text-blue-300 mb-0.5">
         <User className="w-3 h-3" />
         User
@@ -93,7 +93,7 @@ export const AgentMessageNode = memo(function AgentMessageNode({
 }: NodeProps & { data: AgentMessageNodeData }) {
   const d = data as AgentMessageNodeData;
   return (
-    <div className="w-[308px] rounded-lg border border-violet-200 bg-violet-50 px-3 py-2 dark:border-violet-800 dark:bg-violet-950">
+    <div className="w-[308px] border border-violet-200 bg-violet-50 px-3 py-2 dark:border-violet-800 dark:bg-violet-950">
       <div className="flex items-center gap-1.5 text-xs font-medium text-violet-700 dark:text-violet-300 mb-0.5">
         <Bot className="w-3 h-3" />
         Agent
@@ -121,7 +121,7 @@ export const ReasoningNode = memo(function ReasoningNode({
 }: NodeProps & { data: ReasoningNodeData }) {
   const d = data as ReasoningNodeData;
   return (
-    <div className="w-[308px] rounded-lg border border-amber-200 bg-amber-50 px-2.5 py-1.5 dark:border-amber-800 dark:bg-amber-950">
+    <div className="w-[308px] border border-amber-200 bg-amber-50 px-2.5 py-1.5 dark:border-amber-800 dark:bg-amber-950">
       <div className="flex items-center gap-2 text-xs">
         <Brain className="w-3 h-3 text-amber-600 dark:text-amber-400 shrink-0" />
         <span className="font-medium text-amber-700 dark:text-amber-300">{d.label}</span>
@@ -151,7 +151,7 @@ export const ToolGroupNode = memo(function ToolGroupNode({
   const hasErrors = d.errorCount > 0;
   return (
     <div
-      className={`w-[308px] rounded-lg border px-2.5 py-2 ${
+      className={`w-[308px] border px-2.5 py-2 ${
         hasErrors
           ? "border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950"
           : "border-emerald-200 bg-emerald-50 dark:border-emerald-800 dark:bg-emerald-950"
@@ -174,7 +174,7 @@ export const ToolGroupNode = memo(function ToolGroupNode({
         {d.tools.map((tool) => (
           <span
             key={tool.id}
-            className={`inline-flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded-md ${
+            className={`inline-flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 ${
               tool.status === "error" || !tool.success
                 ? "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300"
                 : "bg-emerald-100 text-emerald-700 dark:bg-emerald-900 dark:text-emerald-300"


### PR DESCRIPTION
## What
Remove all non-functional `rounded-*` Tailwind class overrides across 55 UI component files (142 line changes). Justified `rounded-full` exceptions (avatars, switches, scroll thumbs, badges, status dots, progress bars) are preserved.

## Why
The Slate Design System mandates sharp corners (0px radius) everywhere. All `--radius` CSS tokens are correctly set to `0px` in `design-system.css`, but 140+ instances of `rounded-md`, `rounded-lg`, `rounded-xl`, `rounded-t-[10px]`, etc. were overriding this at the component level, making the UI softer/rounder than intended.

Closes EVE-290

## How
- Programmatic removal of all `rounded-{sm,md,lg,xl,2xl,t,r,l,b,*-none,*-[N]}` classes
- Preserved all `rounded-full` (functional circles: avatars, badges, status dots, progress bars, toggle switches) and `rounded-[inherit]` (scroll-area)
- Verified with grep that no non-full/inherit rounded classes remain
- UI lint passes (0 errors), Next.js build passes

## Risk
- **Low**
- Since the design system tokens already set all radii to 0px, these classes were already no-ops in most cases. Removing them just eliminates the override, ensuring consistency if tokens change later.

## Security
- No security-relevant code changes — purely cosmetic CSS class removal. No logic, API, auth, data handling, or SQL touched.

## Checklist
- [x] Tests added or updated (no test changes needed — CSS-only)
- [x] Backward compatibility considered (N/A — internal UI)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
