### PR TITLE
docs: rename Capabilities tab to Built-ins, add harness pages

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -203,7 +203,7 @@ export default defineConfig({
             },
           ],
           {
-            exclude: ["/", "/api/**"],
+            exclude: ["/", "/api/**", "/proposals/**"],
           },
         ),
         apiSidebarFix(),

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -127,10 +127,14 @@ export default defineConfig({
               ],
             },
             {
-              label: "Capabilities",
-              link: "/capabilities/",
+              label: "Built-ins",
+              link: "/built-ins/",
               icon: "puzzle",
               items: [
+                {
+                  label: "Harnesses",
+                  autogenerate: { directory: "built-ins/harnesses" },
+                },
                 {
                   label: "Capabilities",
                   autogenerate: { directory: "capabilities" },

--- a/docs/built-ins/harnesses/base.md
+++ b/docs/built-ins/harnesses/base.md
@@ -1,0 +1,42 @@
+---
+title: Base Harness
+description: An empty harness with no capabilities for full control over session configuration.
+---
+
+The **Base** harness is a blank-slate starting point with no bundled capabilities.
+
+## When to Use
+
+- Full control over which tools and behaviors are available
+- Testing individual capabilities in isolation
+- Minimal-overhead sessions where no default tools are needed
+
+## Configuration
+
+| Property | Value |
+|----------|-------|
+| **Type** | `base` |
+| **Capabilities** | None |
+| **System Prompt** | "You are a helpful assistant." |
+| **Default Model** | None (inherits from agent or organization) |
+
+## Usage
+
+Assign the Base harness when creating an agent or session:
+
+```bash
+curl -X POST http://localhost:9300/api/v1/agents \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Minimal Agent",
+    "harness_id": "<base-harness-id>",
+    "capabilities": ["web_fetch"]
+  }'
+```
+
+The agent's own capabilities are added on top of the empty harness. In this example, only `web_fetch` would be available.
+
+## See Also
+
+- [Generic Harness](/built-ins/harnesses/generic/) — recommended default with core capabilities
+- [Harnesses feature guide](/features/harnesses/) — harness selection and API management

--- a/docs/built-ins/harnesses/generic.md
+++ b/docs/built-ins/harnesses/generic.md
@@ -3,7 +3,7 @@ title: Generic Harness
 description: The recommended default harness bundling core capabilities for general-purpose agent sessions.
 ---
 
-The **Generic** harness is the recommended default for most use cases. It bundles 11 core capabilities that cover file operations, command execution, web access, memory, and context management.
+The **Generic** harness is the recommended default for most use cases. It bundles 12 core capabilities that cover file operations, command execution, web access, memory, budgeting, and context management.
 
 ## When to Use
 
@@ -34,6 +34,7 @@ The **Generic** harness is the recommended default for most use cases. It bundle
 | [Infinity Context](/capabilities/infinity-context/) | Trims older messages from the live prompt while exposing earlier history via `query_history` |
 | [OpenAI Tool Search](/capabilities/openai-tool-search/) | Defers tool schema loading on supported models to reduce prompt size |
 | [Context Compaction](/advanced/compaction/) | Auto-compacts context at 85% budget via cascading strategies |
+| [Budgeting](/capabilities/budgeting/) | Token budget enforcement with configurable meters and rules |
 | Tool Output Persistence | Persists full tool output to `/.outputs/` before truncation for lossless retrieval |
 
 Infinity Context and Context Compaction work together to keep long sessions unbounded. See [Context Compaction](/advanced/compaction/#generic-harness-defaults) for details.

--- a/docs/built-ins/harnesses/generic.md
+++ b/docs/built-ins/harnesses/generic.md
@@ -1,0 +1,45 @@
+---
+title: Generic Harness
+description: The recommended default harness bundling core capabilities for general-purpose agent sessions.
+---
+
+The **Generic** harness is the recommended default for most use cases. It bundles 11 core capabilities that cover file operations, command execution, web access, memory, and context management.
+
+## When to Use
+
+- General-purpose assistants
+- Coding and scripting tasks
+- Research workflows
+- Any session where you want a solid set of defaults
+
+## Configuration
+
+| Property | Value |
+|----------|-------|
+| **Type** | `generic` |
+| **System Prompt** | "You are a helpful assistant." |
+| **Default Model** | None (inherits from agent or organization) |
+
+## Bundled Capabilities
+
+| Capability | What it provides |
+|------------|-----------------|
+| [File System](/capabilities/file-system/) | Read, write, list, grep, and delete files in the session workspace (`/workspace`) |
+| [Virtual Bash](/capabilities/virtual-bash/) | Sandboxed bash shell for running commands, scripts, and text processing |
+| [Web Fetch](/capabilities/web-fetch/) | Fetch web content with file download support |
+| [Storage](/capabilities/session-storage/) | Key/value store for general data and encrypted secret storage |
+| [Session](/capabilities/session/) | Access session metadata and manage session title |
+| [AGENTS.md](/capabilities/agent-instructions/) | Reads AGENTS.md from workspace and injects project-level instructions |
+| [Agent Skills](/capabilities/agent-skills/) | Discover and activate skills from `/.agents/skills/` |
+| [Infinity Context](/capabilities/infinity-context/) | Trims older messages from the live prompt while exposing earlier history via `query_history` |
+| [OpenAI Tool Search](/capabilities/openai-tool-search/) | Defers tool schema loading on supported models to reduce prompt size |
+| [Context Compaction](/advanced/compaction/) | Auto-compacts context at 85% budget via cascading strategies |
+| Tool Output Persistence | Persists full tool output to `/.outputs/` before truncation for lossless retrieval |
+
+Infinity Context and Context Compaction work together to keep long sessions unbounded. See [Context Compaction](/advanced/compaction/#generic-harness-defaults) for details.
+
+## See Also
+
+- [Base Harness](/built-ins/harnesses/base/) — empty harness for full control
+- [Platform Chat Harness](/built-ins/harnesses/platform-chat/) — extends Generic with platform management
+- [Harnesses feature guide](/features/harnesses/) — harness selection and API management

--- a/docs/built-ins/harnesses/platform-chat.md
+++ b/docs/built-ins/harnesses/platform-chat.md
@@ -1,0 +1,34 @@
+---
+title: Platform Chat Harness
+description: Extends the Generic harness with platform management capabilities for the global chat interface.
+---
+
+The **Platform Chat** harness extends the [Generic harness](/built-ins/harnesses/generic/) with platform management capabilities. It powers the global chat interface where users interact with agents that can manage the Everruns platform itself.
+
+## When to Use
+
+- Global chat interface sessions
+- Agents that need to manage platform resources (agents, harnesses, providers)
+- Administrative assistants that interact with the Everruns API
+
+## Configuration
+
+| Property | Value |
+|----------|-------|
+| **Type** | `platform-chat` |
+| **System Prompt** | Extended prompt with platform management instructions |
+| **Default Model** | None (inherits from agent or organization) |
+
+## Bundled Capabilities
+
+All [Generic harness capabilities](/built-ins/harnesses/generic/#bundled-capabilities) plus:
+
+| Capability | What it provides |
+|------------|-----------------|
+| [Platform Management](/capabilities/platform-management/) | Tools to list and manage agents, harnesses, providers, and other platform resources |
+
+## See Also
+
+- [Generic Harness](/built-ins/harnesses/generic/) — the base this harness extends
+- [Platform Management capability](/capabilities/platform-management/) — the additional capability
+- [Harnesses feature guide](/features/harnesses/) — harness selection and API management

--- a/docs/built-ins/index.md
+++ b/docs/built-ins/index.md
@@ -12,7 +12,7 @@ A harness defines the base environment for sessions — system prompt, default m
 | Harness | Description | Capabilities |
 |---------|-------------|-------------|
 | [Base](/built-ins/harnesses/base/) | Empty harness, full control | None |
-| [Generic](/built-ins/harnesses/generic/) | Recommended default with core tools | 11 bundled |
+| [Generic](/built-ins/harnesses/generic/) | Recommended default with core tools | 12 bundled |
 | [Platform Chat](/built-ins/harnesses/platform-chat/) | Extends Generic for global chat | Generic + Platform Management |
 
 See the [Harnesses feature guide](/features/harnesses/) for harness selection, API management, and the prompt stack model.

--- a/docs/built-ins/index.md
+++ b/docs/built-ins/index.md
@@ -1,0 +1,24 @@
+---
+title: Built-ins Overview
+description: Built-in harness types and capabilities that ship with Everruns. Harnesses define session environments; capabilities add tools and behaviors.
+---
+
+Everruns ships with built-in **harness types** and **capabilities** that provide the foundation for agent sessions.
+
+## Harnesses
+
+A harness defines the base environment for sessions — system prompt, default model, and bundled capabilities. Every session is assigned a harness.
+
+| Harness | Description | Capabilities |
+|---------|-------------|-------------|
+| [Base](/built-ins/harnesses/base/) | Empty harness, full control | None |
+| [Generic](/built-ins/harnesses/generic/) | Recommended default with core tools | 11 bundled |
+| [Platform Chat](/built-ins/harnesses/platform-chat/) | Extends Generic for global chat | Generic + Platform Management |
+
+See the [Harnesses feature guide](/features/harnesses/) for harness selection, API management, and the prompt stack model.
+
+## Capabilities
+
+Capabilities are modular units that extend what an agent can do. Each can contribute tools, system prompt additions, and UI features.
+
+Browse the full [Capabilities reference](/capabilities/) for the complete list organized by category.


### PR DESCRIPTION
## What
Restructure the docs sidebar: rename the "Capabilities" tab to "Built-ins" and add dedicated pages for each built-in harness type (Base, Generic, Platform Chat).

## Why
The flat "Capabilities" tab only covered capability pages. The new "Built-ins" section provides a broader home for both harness types and capabilities, giving users a clearer picture of what ships with Everruns out of the box.

Closes EVE-298

## How
- Renamed sidebar tab from "Capabilities" to "Built-ins" in `astro.config.mjs`
- Added "Harnesses" sub-section with autogenerate from `built-ins/harnesses/`
- Kept "Capabilities" as a sub-section (existing pages unchanged)
- Created 4 new pages:
  - `built-ins/index.md` — overview linking to harnesses and capabilities
  - `built-ins/harnesses/base.md` — Base harness (empty, no capabilities)
  - `built-ins/harnesses/generic.md` — Generic harness (11 bundled capabilities)
  - `built-ins/harnesses/platform-chat.md` — Platform Chat harness (Generic + platform management)

## Risk
- **Low** — docs-only change, no runtime code affected
- Existing capability page URLs remain unchanged

## Security
- No security-relevant code changes — purely documentation restructuring

## Checklist
- [x] Tests added or updated (N/A — docs only)
- [x] Backward compatibility considered (existing URLs unchanged)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
