### PR TITLE
feat(ui): add zod validation to core forms

### DIFF
--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -26,7 +26,8 @@
         "recharts": "^3.7.0",
         "remark-github-blockquote-alert": "^2.0.1",
         "streamdown": "^2.3.0",
-        "tailwind-merge": "^3.5.0"
+        "tailwind-merge": "^3.5.0",
+        "zod": "^4.1.12"
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
@@ -62,6 +63,16 @@
       "dependencies": {
         "rxjs": "7.8.1",
         "zod": "^3.22.4"
+      }
+    },
+    "node_modules/@ag-ui/core/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2050,15 +2061,6 @@
         "zod": "^4.0.0"
       }
     },
-    "node_modules/@openuidev/lang-core/node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@openuidev/react-headless": {
       "version": "0.7.10",
       "resolved": "https://registry.npmjs.org/@openuidev/react-headless/-/react-headless-0.7.10.tgz",
@@ -2084,15 +2086,6 @@
       },
       "peerDependencies": {
         "react": ">=19.0.0"
-      }
-    },
-    "node_modules/@openuidev/react-lang/node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@openuidev/react-ui": {
@@ -2203,15 +2196,6 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
-      }
-    },
-    "node_modules/@openuidev/react-ui/node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@oxfmt/binding-android-arm-eabi": {
@@ -11792,7 +11776,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -14425,11 +14408,10 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -42,7 +42,8 @@
     "recharts": "^3.7.0",
     "remark-github-blockquote-alert": "^2.0.1",
     "streamdown": "^2.3.0",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/apps/ui/src/__tests__/mcp-servers-page.test.tsx
+++ b/apps/ui/src/__tests__/mcp-servers-page.test.tsx
@@ -150,4 +150,22 @@ describe("McpServersPage", () => {
 
     expect(mockMutateAsync).toHaveBeenCalledWith({ status: "archived" });
   });
+
+  it("shows a validation error for invalid MCP server URLs", async () => {
+    const mockMutateAsync = jest.fn().mockResolvedValue({});
+    mockUseCreateMcpServer.mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    });
+
+    render(<McpServersPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Server" }));
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "atlassian" } });
+    fireEvent.change(screen.getByLabelText("URL"), { target: { value: "not-a-url" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create Server" }));
+
+    expect(await screen.findByText("URL must be a valid absolute URL")).toBeInTheDocument();
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
 });

--- a/apps/ui/src/app/(main)/agent-identities/new/page.tsx
+++ b/apps/ui/src/app/(main)/agent-identities/new/page.tsx
@@ -11,6 +11,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Combobox } from "@/components/ui/combobox";
+import { agentIdentityFormSchema, getFieldErrors, type FieldErrors } from "@/lib/form-validation";
 import { LOCALE_OPTIONS, TIMEZONE_OPTIONS } from "@/lib/locale-data";
 
 export default function NewAgentIdentityPage() {
@@ -20,14 +21,26 @@ export default function NewAgentIdentityPage() {
   const [description, setDescription] = useState("");
   const [locale, setLocale] = useState("");
   const [timezone, setTimezone] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    const identity = await createIdentity.mutateAsync({
+    const parsed = agentIdentityFormSchema.safeParse({
       name,
-      description: description || undefined,
-      locale: locale || undefined,
-      timezone: timezone || undefined,
+      description,
+      locale,
+      timezone,
+    });
+    if (!parsed.success) {
+      setFieldErrors(getFieldErrors(parsed.error));
+      return;
+    }
+
+    const identity = await createIdentity.mutateAsync({
+      name: parsed.data.name,
+      description: parsed.data.description,
+      locale: parsed.data.locale,
+      timezone: parsed.data.timezone,
     });
     router.push(`/agent-identities/${identity.id}`);
   }
@@ -49,16 +62,32 @@ export default function NewAgentIdentityPage() {
           <form onSubmit={handleSubmit} className="space-y-4">
             <div className="space-y-2">
               <Label>Name</Label>
-              <Input value={name} onChange={(e) => setName(e.target.value)} required />
+              <Input
+                value={name}
+                onChange={(e) => {
+                  setName(e.target.value);
+                  setFieldErrors((prev) => ({ ...prev, name: undefined }));
+                }}
+                aria-invalid={!!fieldErrors.name}
+                required
+              />
+              {fieldErrors.name && <p className="text-xs text-destructive">{fieldErrors.name}</p>}
             </div>
             <div className="space-y-2">
               <Label>Description</Label>
               <Textarea
                 value={description}
-                onChange={(e) => setDescription(e.target.value)}
+                onChange={(e) => {
+                  setDescription(e.target.value);
+                  setFieldErrors((prev) => ({ ...prev, description: undefined }));
+                }}
+                aria-invalid={!!fieldErrors.description}
                 placeholder="Describe this identity..."
                 rows={3}
               />
+              {fieldErrors.description && (
+                <p className="text-xs text-destructive">{fieldErrors.description}</p>
+              )}
               <p className="text-xs text-muted-foreground">Supports Markdown</p>
             </div>
             <div className="grid gap-4 md:grid-cols-2">
@@ -67,20 +96,32 @@ export default function NewAgentIdentityPage() {
                 <Combobox
                   options={LOCALE_OPTIONS}
                   value={locale}
-                  onValueChange={setLocale}
+                  onValueChange={(value) => {
+                    setLocale(value);
+                    setFieldErrors((prev) => ({ ...prev, locale: undefined }));
+                  }}
                   placeholder="Select locale..."
                   searchPlaceholder="Search locales..."
                 />
+                {fieldErrors.locale && (
+                  <p className="text-xs text-destructive">{fieldErrors.locale}</p>
+                )}
               </div>
               <div className="space-y-2">
                 <Label>Timezone</Label>
                 <Combobox
                   options={TIMEZONE_OPTIONS}
                   value={timezone}
-                  onValueChange={setTimezone}
+                  onValueChange={(value) => {
+                    setTimezone(value);
+                    setFieldErrors((prev) => ({ ...prev, timezone: undefined }));
+                  }}
                   placeholder="Select timezone..."
                   searchPlaceholder="Search timezones..."
                 />
+                {fieldErrors.timezone && (
+                  <p className="text-xs text-destructive">{fieldErrors.timezone}</p>
+                )}
               </div>
             </div>
             <div className="flex gap-3">

--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -33,6 +33,12 @@ import { AgentPreview } from "@/components/agents/agent-preview";
 import { InitialFilesEditor } from "@/components/initial-files-editor";
 import { ModelPicker } from "@/components/models/model-picker";
 import { ArrowLeft, Save, Trash2, Eye, Edit2, Check, X, Loader2 } from "lucide-react";
+import {
+  agentFormSchema,
+  getFieldErrors,
+  type FieldErrors,
+  parseTagList,
+} from "@/lib/form-validation";
 import type { AgentCapabilityConfig, InitialFile } from "@/lib/api/types";
 import { getDisplayName, isReadOnlyStatus } from "@/lib/entity-lifecycle";
 
@@ -62,6 +68,7 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
   // Tab state
   const [activeTab, setActiveTab] = useState<string>("edit");
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
 
   // Form state - track user changes separately from initial values
   const [formChanges, setFormChanges] = useState<Partial<FormData>>({});
@@ -96,6 +103,7 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
 
   const handleFormChange = useCallback((field: keyof FormData, value: string) => {
     setFormChanges((prev) => ({ ...prev, [field]: value }));
+    setFieldErrors((prev) => ({ ...prev, [field]: undefined }));
   }, []);
 
   // Only check availability when name has been changed from original
@@ -122,13 +130,15 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
   // Submit handler
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    const parsed = agentFormSchema.safeParse(formData);
+    if (!parsed.success) {
+      setFieldErrors(getFieldErrors(parsed.error));
+      return;
+    }
 
     try {
       // Parse tags
-      const tags = formData.tags
-        .split(",")
-        .map((t) => t.trim())
-        .filter((t) => t.length > 0);
+      const tags = parseTagList(parsed.data.tags);
 
       // Get capabilities to save (already full AgentCapabilityConfig format)
       const capabilitiesToSave = localCapabilities ?? initialCapabilities;
@@ -142,12 +152,12 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
       await updateAgent.mutateAsync({
         agentId,
         request: {
-          name: formData.name,
-          display_name: formData.display_name || undefined,
-          description: formData.description || undefined,
-          system_prompt: formData.system_prompt,
+          name: parsed.data.name,
+          display_name: parsed.data.display_name,
+          description: parsed.data.description,
+          system_prompt: parsed.data.system_prompt,
           tags,
-          default_model_id: formData.default_model_id || undefined,
+          default_model_id: parsed.data.default_model_id,
           // Only include capabilities if they changed
           ...(capabilitiesChanged && { capabilities: capabilitiesToSave }),
           ...(initialFilesChanged && { initial_files: initialFilesToSave }),
@@ -257,9 +267,13 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
                         placeholder="customer-support"
                         value={formData.name}
                         onChange={(e) => handleFormChange("name", e.target.value)}
+                        aria-invalid={!!fieldErrors.name}
                         disabled={isSaving || isReadOnly}
                         required
                       />
+                      {fieldErrors.name && (
+                        <p className="text-xs text-destructive">{fieldErrors.name}</p>
+                      )}
                       {nameChanged && formData.name.length >= 2 && (
                         <div className="flex items-center gap-1.5 text-xs">
                           {nameAvailability.isChecking ? (
@@ -349,6 +363,9 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
                         disabled={isSaving || isReadOnly}
                         required
                       />
+                      {fieldErrors.system_prompt && (
+                        <p className="text-xs text-destructive">{fieldErrors.system_prompt}</p>
+                      )}
                       <p className="text-xs text-muted-foreground">
                         Instructions for the AI model (supports Markdown)
                       </p>

--- a/apps/ui/src/app/(main)/agents/new/page.tsx
+++ b/apps/ui/src/app/(main)/agents/new/page.tsx
@@ -14,6 +14,7 @@ import { ArrowLeft, Check, X, Loader2 } from "lucide-react";
 import { ModelPicker } from "@/components/models/model-picker";
 import { CapabilitySelector } from "@/components/agents/capability-selector";
 import { InitialFilesEditor } from "@/components/initial-files-editor";
+import { agentFormSchema, getFieldErrors, type FieldErrors } from "@/lib/form-validation";
 import type { AgentCapabilityConfig, InitialFile } from "@/lib/api/types";
 
 /** Convert a display name to a slug: lowercase, non-alphanumeric → hyphens, deduplicate, trim. */
@@ -45,6 +46,7 @@ export default function NewAgentPage() {
 
   const [selectedCapabilities, setSelectedCapabilities] = useState<AgentCapabilityConfig[]>([]);
   const [initialFiles, setInitialFiles] = useState<InitialFile[]>([]);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
 
   const handleCapabilitiesChange = useCallback((capabilities: AgentCapabilityConfig[]) => {
     setSelectedCapabilities(capabilities);
@@ -57,23 +59,34 @@ export default function NewAgentPage() {
       updates.name = slugify(value);
     }
     setFormData((prev) => ({ ...prev, ...updates }));
+    setFieldErrors((prev) => ({
+      ...prev,
+      display_name: undefined,
+      ...(nameManuallyEdited ? {} : { name: undefined }),
+    }));
   };
 
   const handleNameChange = (value: string) => {
     setNameManuallyEdited(true);
     setFormData((prev) => ({ ...prev, name: value }));
+    setFieldErrors((prev) => ({ ...prev, name: undefined }));
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    const parsed = agentFormSchema.safeParse(formData);
+    if (!parsed.success) {
+      setFieldErrors(getFieldErrors(parsed.error));
+      return;
+    }
 
     try {
       const agent = await createAgent.mutateAsync({
-        name: formData.name,
-        display_name: formData.display_name || undefined,
-        description: formData.description || undefined,
-        system_prompt: formData.system_prompt,
-        default_model_id: formData.default_model_id || undefined,
+        name: parsed.data.name,
+        display_name: parsed.data.display_name,
+        description: parsed.data.description,
+        system_prompt: parsed.data.system_prompt,
+        default_model_id: parsed.data.default_model_id,
         capabilities: selectedCapabilities.length > 0 ? selectedCapabilities : undefined,
         initial_files: initialFiles.length > 0 ? initialFiles : undefined,
       });
@@ -107,8 +120,10 @@ export default function NewAgentPage() {
                 placeholder="customer-support"
                 value={formData.name}
                 onChange={(e) => handleNameChange(e.target.value)}
+                aria-invalid={!!fieldErrors.name}
                 required
               />
+              {fieldErrors.name && <p className="text-xs text-destructive">{fieldErrors.name}</p>}
               {formData.name.length >= 2 && (
                 <div className="flex items-center gap-1.5 text-xs">
                   {nameAvailability.isChecking ? (
@@ -190,9 +205,15 @@ export default function NewAgentPage() {
                 id="system_prompt"
                 placeholder="You are a helpful assistant..."
                 value={formData.system_prompt}
-                onChange={(value) => setFormData({ ...formData, system_prompt: value })}
+                onChange={(value) => {
+                  setFormData({ ...formData, system_prompt: value });
+                  setFieldErrors((prev) => ({ ...prev, system_prompt: undefined }));
+                }}
                 required
               />
+              {fieldErrors.system_prompt && (
+                <p className="text-xs text-destructive">{fieldErrors.system_prompt}</p>
+              )}
               <p className="text-xs text-muted-foreground">
                 Instructions for the AI model (supports Markdown)
               </p>

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
@@ -35,6 +35,12 @@ import { HarnessPreview } from "@/components/harnesses/harness-preview";
 import { InitialFilesEditor } from "@/components/initial-files-editor";
 import { ModelPicker } from "@/components/models/model-picker";
 import { ArrowLeft, Save, Trash2, Eye, Edit2, Check, X, Loader2 } from "lucide-react";
+import {
+  getFieldErrors,
+  harnessFormSchema,
+  type FieldErrors,
+  parseTagList,
+} from "@/lib/form-validation";
 import type { AgentCapabilityConfig, InitialFile } from "@/lib/api/types";
 import { getDisplayName, isReadOnlyStatus } from "@/lib/entity-lifecycle";
 
@@ -64,6 +70,7 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
   const [activeTab, setActiveTab] = useState<string>("edit");
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [formChanges, setFormChanges] = useState<Partial<FormData>>({});
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
 
   const initialFormData = useMemo((): FormData => {
     if (!harness) {
@@ -106,6 +113,7 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
 
   const handleFormChange = useCallback((field: keyof FormData, value: string) => {
     setFormChanges((prev) => ({ ...prev, [field]: value }));
+    setFieldErrors((prev) => ({ ...prev, [field]: undefined }));
   }, []);
 
   const initialCapabilities = useMemo(() => {
@@ -124,12 +132,14 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    const parsed = harnessFormSchema.safeParse(formData);
+    if (!parsed.success) {
+      setFieldErrors(getFieldErrors(parsed.error));
+      return;
+    }
 
     try {
-      const tags = formData.tags
-        .split(",")
-        .map((t) => t.trim())
-        .filter((t) => t.length > 0);
+      const tags = parseTagList(parsed.data.tags);
 
       const capabilitiesToSave = localCapabilities ?? initialCapabilities;
       const capabilitiesChanged =
@@ -141,13 +151,13 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
       await updateHarness.mutateAsync({
         harnessId,
         request: {
-          name: formData.name,
-          display_name: formData.display_name || undefined,
-          description: formData.description || undefined,
-          system_prompt: formData.system_prompt,
-          parent_harness_id: formData.parent_harness_id || null,
+          name: parsed.data.name,
+          display_name: parsed.data.display_name,
+          description: parsed.data.description,
+          system_prompt: parsed.data.system_prompt,
+          parent_harness_id: parsed.data.parent_harness_id || null,
           tags,
-          default_model_id: formData.default_model_id || undefined,
+          default_model_id: parsed.data.default_model_id,
           ...(capabilitiesChanged && { capabilities: capabilitiesToSave }),
           ...(initialFilesChanged && { initial_files: initialFilesToSave }),
         },
@@ -259,9 +269,13 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
                         placeholder="my-harness"
                         value={formData.name}
                         onChange={(e) => handleFormChange("name", e.target.value)}
+                        aria-invalid={!!fieldErrors.name}
                         disabled={isSaving || isReadOnly}
                         required
                       />
+                      {fieldErrors.name && (
+                        <p className="text-xs text-destructive">{fieldErrors.name}</p>
+                      )}
                       {nameChanged && formData.name.length >= 2 && (
                         <div className="flex items-center gap-1.5 text-xs">
                           {nameAvailability.isChecking ? (
@@ -364,6 +378,9 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
                         disabled={isSaving || isReadOnly}
                         required
                       />
+                      {fieldErrors.system_prompt && (
+                        <p className="text-xs text-destructive">{fieldErrors.system_prompt}</p>
+                      )}
                       <p className="text-xs text-muted-foreground">
                         Instructions for the AI model (supports Markdown)
                       </p>

--- a/apps/ui/src/app/(main)/harnesses/new/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/new/page.tsx
@@ -15,6 +15,12 @@ import { ModelPicker } from "@/components/models/model-picker";
 import { CapabilitySelector } from "@/components/agents/capability-selector";
 import { HarnessSelect } from "@/components/harness/harness-select";
 import { InitialFilesEditor } from "@/components/initial-files-editor";
+import {
+  getFieldErrors,
+  harnessFormSchema,
+  type FieldErrors,
+  parseTagList,
+} from "@/lib/form-validation";
 import type { AgentCapabilityConfig, InitialFile } from "@/lib/api/types";
 
 /** Convert a display name to a slug: lowercase, non-alphanumeric → hyphens, deduplicate, trim. */
@@ -53,15 +59,22 @@ export default function NewHarnessPage() {
       updates.name = slugify(value);
     }
     setFormData((prev) => ({ ...prev, ...updates }));
+    setFieldErrors((prev) => ({
+      ...prev,
+      display_name: undefined,
+      ...(nameManuallyEdited ? {} : { name: undefined }),
+    }));
   };
 
   const handleNameChange = (value: string) => {
     setNameManuallyEdited(true);
     setFormData((prev) => ({ ...prev, name: value }));
+    setFieldErrors((prev) => ({ ...prev, name: undefined }));
   };
 
   const [selectedCapabilities, setSelectedCapabilities] = useState<AgentCapabilityConfig[]>([]);
   const [initialFiles, setInitialFiles] = useState<InitialFile[]>([]);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
 
   const handleCapabilitiesChange = useCallback((capabilities: AgentCapabilityConfig[]) => {
     setSelectedCapabilities(capabilities);
@@ -69,20 +82,22 @@ export default function NewHarnessPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    const parsed = harnessFormSchema.safeParse(formData);
+    if (!parsed.success) {
+      setFieldErrors(getFieldErrors(parsed.error));
+      return;
+    }
 
     try {
-      const tags = formData.tags
-        .split(",")
-        .map((t) => t.trim())
-        .filter((t) => t.length > 0);
+      const tags = parseTagList(parsed.data.tags);
 
       const harness = await createHarness.mutateAsync({
-        name: formData.name,
-        display_name: formData.display_name || undefined,
-        description: formData.description || undefined,
-        system_prompt: formData.system_prompt,
-        parent_harness_id: formData.parent_harness_id || undefined,
-        default_model_id: formData.default_model_id || undefined,
+        name: parsed.data.name,
+        display_name: parsed.data.display_name,
+        description: parsed.data.description,
+        system_prompt: parsed.data.system_prompt,
+        parent_harness_id: parsed.data.parent_harness_id,
+        default_model_id: parsed.data.default_model_id,
         tags: tags.length > 0 ? tags : undefined,
         capabilities: selectedCapabilities.length > 0 ? selectedCapabilities : undefined,
         initial_files: initialFiles.length > 0 ? initialFiles : undefined,
@@ -117,8 +132,10 @@ export default function NewHarnessPage() {
                 placeholder="my-harness"
                 value={formData.name}
                 onChange={(e) => handleNameChange(e.target.value)}
+                aria-invalid={!!fieldErrors.name}
                 required
               />
+              {fieldErrors.name && <p className="text-xs text-destructive">{fieldErrors.name}</p>}
               {formData.name.length >= 2 && (
                 <div className="flex items-center gap-1.5 text-xs">
                   {nameAvailability.isChecking ? (
@@ -227,9 +244,15 @@ export default function NewHarnessPage() {
                 id="system_prompt"
                 placeholder="You are a helpful assistant..."
                 value={formData.system_prompt}
-                onChange={(value) => setFormData({ ...formData, system_prompt: value })}
+                onChange={(value) => {
+                  setFormData({ ...formData, system_prompt: value });
+                  setFieldErrors((prev) => ({ ...prev, system_prompt: undefined }));
+                }}
                 required
               />
+              {fieldErrors.system_prompt && (
+                <p className="text-xs text-destructive">{fieldErrors.system_prompt}</p>
+              )}
               <p className="text-xs text-muted-foreground">
                 Instructions for the AI model (supports Markdown)
               </p>

--- a/apps/ui/src/app/(main)/mcp-servers/page.tsx
+++ b/apps/ui/src/app/(main)/mcp-servers/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -140,6 +140,16 @@ function AddMcpServerDialog({
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
 
   const createServer = useCreateMcpServer();
+
+  useEffect(() => {
+    if (!open) return;
+    setName("");
+    setDescription("");
+    setUrl("");
+    setApiKey("");
+    setAuthMode("none");
+    setFieldErrors({});
+  }, [open]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -301,6 +311,12 @@ function SetApiKeyDialog({
   const [apiKey, setApiKey] = useState("");
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
   const updateServer = useUpdateMcpServer(server?.id || "");
+
+  useEffect(() => {
+    if (!open) return;
+    setApiKey("");
+    setFieldErrors({});
+  }, [open]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/apps/ui/src/app/(main)/mcp-servers/page.tsx
+++ b/apps/ui/src/app/(main)/mcp-servers/page.tsx
@@ -33,6 +33,12 @@ import {
 import { usePolicies } from "@/hooks/use-policies";
 import { Plus, Plug, Trash2, Key, Globe } from "lucide-react";
 import type { McpServer, CreateMcpServerRequest, McpServerAuthMode } from "@/lib/api/types";
+import {
+  apiKeySecretSchema,
+  getFieldErrors,
+  mcpServerFormSchema,
+  type FieldErrors,
+} from "@/lib/form-validation";
 import { getEntityNameClassName, getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
 import { ArchiveFilter } from "@/components/archive-filter";
 
@@ -131,18 +137,31 @@ function AddMcpServerDialog({
   const [url, setUrl] = useState("");
   const [apiKey, setApiKey] = useState("");
   const [authMode, setAuthMode] = useState<McpServerAuthMode>("none");
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
 
   const createServer = useCreateMcpServer();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const data: CreateMcpServerRequest = {
+    const parsed = mcpServerFormSchema.safeParse({
       name,
-      description: description || undefined,
+      description,
       url,
-      transport_type: "http",
       auth_mode: authMode,
-      api_key: authMode === "api_key" ? apiKey || undefined : undefined,
+      api_key: apiKey,
+    });
+    if (!parsed.success) {
+      setFieldErrors(getFieldErrors(parsed.error));
+      return;
+    }
+
+    const data: CreateMcpServerRequest = {
+      name: parsed.data.name,
+      description: parsed.data.description,
+      url: parsed.data.url,
+      transport_type: "http",
+      auth_mode: parsed.data.auth_mode,
+      api_key: parsed.data.auth_mode === "api_key" ? parsed.data.api_key : undefined,
     };
     await createServer.mutateAsync(data);
     onOpenChange(false);
@@ -151,6 +170,7 @@ function AddMcpServerDialog({
     setUrl("");
     setApiKey("");
     setAuthMode("none");
+    setFieldErrors({});
   };
 
   return (
@@ -169,38 +189,56 @@ function AddMcpServerDialog({
             <Input
               id="name"
               value={name}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setName(e.target.value)}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                setName(e.target.value);
+                setFieldErrors((prev) => ({ ...prev, name: undefined }));
+              }}
+              aria-invalid={!!fieldErrors.name}
               placeholder="atlassian-mcp-server"
               required
             />
+            {fieldErrors.name && <p className="text-xs text-destructive">{fieldErrors.name}</p>}
           </div>
           <div className="space-y-2">
             <Label htmlFor="description">Description (optional)</Label>
             <Textarea
               id="description"
               value={description}
-              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                setDescription(e.target.value)
-              }
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
+                setDescription(e.target.value);
+                setFieldErrors((prev) => ({ ...prev, description: undefined }));
+              }}
+              aria-invalid={!!fieldErrors.description}
               placeholder="Atlassian MCP Server for Jira and Confluence"
               rows={2}
             />
+            {fieldErrors.description && (
+              <p className="text-xs text-destructive">{fieldErrors.description}</p>
+            )}
           </div>
           <div className="space-y-2">
             <Label htmlFor="url">URL</Label>
             <Input
               id="url"
               value={url}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setUrl(e.target.value)}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                setUrl(e.target.value);
+                setFieldErrors((prev) => ({ ...prev, url: undefined }));
+              }}
+              aria-invalid={!!fieldErrors.url}
               placeholder="https://mcp.atlassian.com/v1/mcp"
               required
             />
+            {fieldErrors.url && <p className="text-xs text-destructive">{fieldErrors.url}</p>}
           </div>
           <div className="space-y-2">
             <Label htmlFor="auth-mode">Authentication</Label>
             <Select
               value={authMode}
-              onValueChange={(value) => setAuthMode(value as McpServerAuthMode)}
+              onValueChange={(value) => {
+                setAuthMode(value as McpServerAuthMode);
+                setFieldErrors((prev) => ({ ...prev, auth_mode: undefined, api_key: undefined }));
+              }}
             >
               <SelectTrigger id="auth-mode">
                 <SelectValue />
@@ -219,10 +257,17 @@ function AddMcpServerDialog({
                 id="api-key"
                 type="password"
                 value={apiKey}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setApiKey(e.target.value)}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  setApiKey(e.target.value);
+                  setFieldErrors((prev) => ({ ...prev, api_key: undefined }));
+                }}
+                aria-invalid={!!fieldErrors.api_key}
                 placeholder="your-api-key"
                 required
               />
+              {fieldErrors.api_key && (
+                <p className="text-xs text-destructive">{fieldErrors.api_key}</p>
+              )}
             </div>
           )}
           <DialogFooter>
@@ -254,14 +299,23 @@ function SetApiKeyDialog({
   onOpenChange: (open: boolean) => void;
 }) {
   const [apiKey, setApiKey] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
   const updateServer = useUpdateMcpServer(server?.id || "");
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!server) return;
-    await updateServer.mutateAsync({ api_key: apiKey });
+
+    const parsed = apiKeySecretSchema.safeParse({ api_key: apiKey });
+    if (!parsed.success) {
+      setFieldErrors(getFieldErrors(parsed.error));
+      return;
+    }
+
+    await updateServer.mutateAsync({ api_key: parsed.data.api_key });
     onOpenChange(false);
     setApiKey("");
+    setFieldErrors({});
   };
 
   return (
@@ -282,10 +336,17 @@ function SetApiKeyDialog({
               id="new-api-key"
               type="password"
               value={apiKey}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setApiKey(e.target.value)}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                setApiKey(e.target.value);
+                setFieldErrors((prev) => ({ ...prev, api_key: undefined }));
+              }}
+              aria-invalid={!!fieldErrors.api_key}
               placeholder="your-api-key"
               required
             />
+            {fieldErrors.api_key && (
+              <p className="text-xs text-destructive">{fieldErrors.api_key}</p>
+            )}
           </div>
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>

--- a/apps/ui/src/components/agent-identity/identity-api-key-dialog.tsx
+++ b/apps/ui/src/components/agent-identity/identity-api-key-dialog.tsx
@@ -17,6 +17,11 @@ import { AlertCircle } from "lucide-react";
 import type { ConnectionProvider } from "@/lib/api/types";
 import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
 import { ProviderIcon } from "@/components/connections/provider-icon";
+import {
+  createConnectionFormSchema,
+  getFieldErrors,
+  type FieldErrors,
+} from "@/lib/form-validation";
 
 interface IdentityApiKeyDialogProps {
   identityId: string;
@@ -33,31 +38,37 @@ export function IdentityApiKeyDialog({
 }: IdentityApiKeyDialogProps) {
   const [formValues, setFormValues] = useState<Record<string, string>>({});
   const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
   const createConnection = useCreateIdentityApiKeyConnection(identityId);
 
   useEffect(() => {
     if (open) {
       setFormValues({});
       setError(null);
+      setFieldErrors({});
     }
   }, [open]);
 
-  if (!provider?.form_schema) return null;
+  const formSchema = provider?.form_schema;
+  if (!provider || !formSchema) return null;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
+    setFieldErrors({});
 
-    const apiKey = formValues["api_key"] ?? "";
-    if (!apiKey.trim()) {
-      setError("API key is required");
+    const parsed = createConnectionFormSchema(formSchema.fields).safeParse(formValues);
+    if (!parsed.success) {
+      setFieldErrors(getFieldErrors(parsed.error));
       return;
     }
 
+    const apiKey = parsed.data["api_key"] as string;
+
     // Collect extra fields (everything except api_key)
     const extraFields: Record<string, string> = {};
-    for (const [key, value] of Object.entries(formValues)) {
-      if (key !== "api_key" && value.trim()) {
+    for (const [key, value] of Object.entries(parsed.data)) {
+      if (key !== "api_key" && typeof value === "string" && value.trim()) {
         extraFields[key] = value;
       }
     }
@@ -89,11 +100,11 @@ export function IdentityApiKeyDialog({
 
         <form onSubmit={handleSubmit}>
           <InlineStreamdownMessage className="text-sm text-muted-foreground mb-4 leading-relaxed">
-            {provider.form_schema.instructions_markdown}
+            {formSchema.instructions_markdown}
           </InlineStreamdownMessage>
 
           <div className="space-y-4 mb-4">
-            {provider.form_schema.fields.map((field) => (
+            {formSchema.fields.map((field) => (
               <div key={field.name} className="space-y-2">
                 <Label htmlFor={field.name}>{field.label}</Label>
                 <Input
@@ -102,14 +113,22 @@ export function IdentityApiKeyDialog({
                   required={field.required}
                   placeholder={field.placeholder}
                   value={formValues[field.name] ?? ""}
-                  onChange={(e) =>
+                  aria-invalid={!!fieldErrors[field.name]}
+                  onChange={(e) => {
                     setFormValues((prev) => ({
                       ...prev,
                       [field.name]: e.target.value,
-                    }))
-                  }
+                    }));
+                    setFieldErrors((prev) => {
+                      if (!prev[field.name]) return prev;
+                      return { ...prev, [field.name]: undefined };
+                    });
+                  }}
                   autoComplete="off"
                 />
+                {fieldErrors[field.name] && (
+                  <p className="text-xs text-destructive">{fieldErrors[field.name]}</p>
+                )}
                 {field.help_text && (
                   <p className="text-xs text-muted-foreground">{field.help_text}</p>
                 )}

--- a/apps/ui/src/components/connections/api-key-dialog.tsx
+++ b/apps/ui/src/components/connections/api-key-dialog.tsx
@@ -21,6 +21,11 @@ import { useCreateApiKeyConnection } from "@/hooks/use-user-connections";
 import { AlertCircle } from "lucide-react";
 import type { ConnectionProvider } from "@/lib/api/types";
 import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
+import {
+  createConnectionFormSchema,
+  getFieldErrors,
+  type FieldErrors,
+} from "@/lib/form-validation";
 import { ProviderIcon } from "./provider-icon";
 
 interface ApiKeyDialogProps {
@@ -34,6 +39,7 @@ interface ApiKeyDialogProps {
 export function ApiKeyDialog({ provider, open, onOpenChange, onConnected }: ApiKeyDialogProps) {
   const [formValues, setFormValues] = useState<Record<string, string>>({});
   const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
   const createConnection = useCreateApiKeyConnection();
 
   // Reset form when dialog opens/closes
@@ -41,25 +47,30 @@ export function ApiKeyDialog({ provider, open, onOpenChange, onConnected }: ApiK
     if (open) {
       setFormValues({});
       setError(null);
+      setFieldErrors({});
     }
   }, [open]);
 
-  if (!provider?.form_schema) return null;
+  const formSchema = provider?.form_schema;
+  if (!provider || !formSchema) return null;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
+    setFieldErrors({});
 
-    const apiKey = formValues["api_key"] ?? "";
-    if (!apiKey.trim()) {
-      setError("API key is required");
+    const parsed = createConnectionFormSchema(formSchema.fields).safeParse(formValues);
+    if (!parsed.success) {
+      setFieldErrors(getFieldErrors(parsed.error));
       return;
     }
 
+    const apiKey = parsed.data["api_key"] as string;
+
     // Collect extra fields (everything except api_key)
     const extraFields: Record<string, string> = {};
-    for (const [key, value] of Object.entries(formValues)) {
-      if (key !== "api_key" && value.trim()) {
+    for (const [key, value] of Object.entries(parsed.data)) {
+      if (key !== "api_key" && typeof value === "string" && value.trim()) {
         extraFields[key] = value;
       }
     }
@@ -93,12 +104,12 @@ export function ApiKeyDialog({ provider, open, onOpenChange, onConnected }: ApiK
         <form onSubmit={handleSubmit}>
           {/* Instructions */}
           <InlineStreamdownMessage className="text-sm text-muted-foreground mb-4 leading-relaxed">
-            {provider.form_schema.instructions_markdown}
+            {formSchema.instructions_markdown}
           </InlineStreamdownMessage>
 
           {/* Form fields */}
           <div className="space-y-4 mb-4">
-            {provider.form_schema.fields.map((field) => (
+            {formSchema.fields.map((field) => (
               <div key={field.name} className="space-y-2">
                 <Label htmlFor={field.name}>{field.label}</Label>
                 <Input
@@ -107,14 +118,22 @@ export function ApiKeyDialog({ provider, open, onOpenChange, onConnected }: ApiK
                   required={field.required}
                   placeholder={field.placeholder}
                   value={formValues[field.name] ?? ""}
-                  onChange={(e) =>
+                  aria-invalid={!!fieldErrors[field.name]}
+                  onChange={(e) => {
                     setFormValues((prev) => ({
                       ...prev,
                       [field.name]: e.target.value,
-                    }))
-                  }
+                    }));
+                    setFieldErrors((prev) => {
+                      if (!prev[field.name]) return prev;
+                      return { ...prev, [field.name]: undefined };
+                    });
+                  }}
                   autoComplete="off"
                 />
+                {fieldErrors[field.name] && (
+                  <p className="text-xs text-destructive">{fieldErrors[field.name]}</p>
+                )}
                 {field.help_text && (
                   <p className="text-xs text-muted-foreground">{field.help_text}</p>
                 )}

--- a/apps/ui/src/lib/__tests__/form-validation.test.ts
+++ b/apps/ui/src/lib/__tests__/form-validation.test.ts
@@ -111,4 +111,18 @@ describe("form validation schemas", () => {
     expect(parsed.error.issues.map((issue) => issue.message)).toContain("Project is required");
     expect(apiKeySecretSchema.parse({ api_key: " secret " }).api_key).toBe("secret");
   });
+
+  it("allows optional provider fields to be omitted entirely", () => {
+    const schema = createConnectionFormSchema([
+      { name: "api_key", label: "API Key", field_type: "password", required: true },
+      { name: "region", label: "Region", field_type: "text", required: false },
+    ]);
+
+    const parsed = schema.parse({ api_key: " secret " });
+
+    expect(parsed).toEqual({
+      api_key: "secret",
+      region: undefined,
+    });
+  });
 });

--- a/apps/ui/src/lib/__tests__/form-validation.test.ts
+++ b/apps/ui/src/lib/__tests__/form-validation.test.ts
@@ -1,0 +1,114 @@
+import {
+  agentFormSchema,
+  agentIdentityFormSchema,
+  apiKeySecretSchema,
+  createConnectionFormSchema,
+  harnessFormSchema,
+  mcpServerFormSchema,
+  parseTagList,
+} from "@/lib/form-validation";
+
+describe("form validation schemas", () => {
+  it("trims and normalizes agent form values", () => {
+    const parsed = agentFormSchema.parse({
+      name: " customer-support ",
+      display_name: " Customer Support ",
+      description: " Handles tickets ",
+      system_prompt: " Be concise ",
+      default_model_id: " gpt-5.4 ",
+    });
+
+    expect(parsed).toEqual({
+      name: "customer-support",
+      display_name: "Customer Support",
+      description: "Handles tickets",
+      system_prompt: "Be concise",
+      default_model_id: "gpt-5.4",
+      tags: "",
+    });
+  });
+
+  it("rejects invalid agent names and missing prompts", () => {
+    const parsed = agentFormSchema.safeParse({
+      name: "Customer Support",
+      display_name: "",
+      description: "",
+      system_prompt: " ",
+      default_model_id: "",
+    });
+
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+
+    const messages = parsed.error.issues.map((issue) => issue.message);
+    expect(messages).toContain("Name must contain only lowercase letters, numbers, and hyphens");
+    expect(messages).toContain("System prompt is required");
+  });
+
+  it("parses harness tags into a clean list", () => {
+    const parsed = harnessFormSchema.parse({
+      name: "ops-harness",
+      display_name: "Ops Harness",
+      description: "",
+      system_prompt: "Do the work",
+      parent_harness_id: "",
+      default_model_id: "",
+      tags: "ops,  alerts , , incident-response ",
+    });
+
+    expect(parseTagList(parsed.tags)).toEqual(["ops", "alerts", "incident-response"]);
+  });
+
+  it("rejects invalid agent identity locale and timezone values", () => {
+    const parsed = agentIdentityFormSchema.safeParse({
+      name: "Ops Bot",
+      description: "",
+      locale: "en-MARS",
+      timezone: "Mars/Olympus_Mons",
+    });
+
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+
+    const messages = parsed.error.issues.map((issue) => issue.message);
+    expect(messages).toContain("Select a valid locale");
+    expect(messages).toContain("Select a valid timezone");
+  });
+
+  it("requires a valid MCP server URL and API key when auth uses api_key", () => {
+    const parsed = mcpServerFormSchema.safeParse({
+      name: "atlassian",
+      description: "",
+      url: "not-a-url",
+      auth_mode: "api_key",
+      api_key: " ",
+    });
+
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+
+    const messages = parsed.error.issues.map((issue) => issue.message);
+    expect(messages).toContain("URL must be a valid absolute URL");
+    expect(messages).toContain("API key is required");
+  });
+
+  it("validates dynamic provider forms from the connection schema", () => {
+    const schema = createConnectionFormSchema([
+      { name: "api_key", label: "API Key", field_type: "password", required: true },
+      { name: "project", label: "Project", field_type: "text", required: true },
+      { name: "region", label: "Region", field_type: "text", required: false },
+    ]);
+
+    const parsed = schema.safeParse({
+      api_key: " secret ",
+      project: " ",
+      region: " us-east-1 ",
+    });
+
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+
+    expect(parsed.error.issues.map((issue) => issue.message)).toContain("Project is required");
+    expect(apiKeySecretSchema.parse({ api_key: " secret " }).api_key).toBe("secret");
+  });
+});

--- a/apps/ui/src/lib/form-validation.ts
+++ b/apps/ui/src/lib/form-validation.ts
@@ -108,7 +108,7 @@ export function createConnectionFormSchema(fields: ConnectionFormField[]) {
   const shape = Object.fromEntries(
     fields.map((field) => [
       field.name,
-      field.required ? requiredString(field.label) : z.preprocess(trimInput, z.string()),
+      field.required ? requiredString(field.label) : optionalString(),
     ]),
   );
 

--- a/apps/ui/src/lib/form-validation.ts
+++ b/apps/ui/src/lib/form-validation.ts
@@ -1,0 +1,116 @@
+import { z } from "zod";
+import type { ConnectionFormField } from "@/lib/api/types";
+import { LOCALE_OPTIONS, TIMEZONE_OPTIONS } from "./locale-data";
+
+export type FieldErrors = Partial<Record<string, string>>;
+
+const VALID_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const localeValues = new Set(LOCALE_OPTIONS.map((option) => option.value));
+const timezoneValues = new Set(TIMEZONE_OPTIONS.map((option) => option.value));
+
+function trimInput(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function requiredString(label: string) {
+  return z.preprocess(trimInput, z.string().min(1, `${label} is required`));
+}
+
+function optionalString() {
+  return z.preprocess(trimInput, z.string()).transform((value) => value || undefined);
+}
+
+function optionalSelection(validValues: Set<string>, label: string) {
+  return z
+    .preprocess(trimInput, z.string())
+    .transform((value) => value || undefined)
+    .refine((value) => !value || validValues.has(value), `Select a valid ${label.toLowerCase()}`);
+}
+
+export function getFieldErrors(error: z.ZodError): FieldErrors {
+  const fieldErrors: FieldErrors = {};
+
+  for (const issue of error.issues) {
+    const field = issue.path[0];
+    if (typeof field === "string" && !fieldErrors[field]) {
+      fieldErrors[field] = issue.message;
+    }
+  }
+
+  return fieldErrors;
+}
+
+export function parseTagList(value: string): string[] {
+  return value
+    .split(",")
+    .map((tag) => tag.trim())
+    .filter((tag) => tag.length > 0);
+}
+
+export const agentFormSchema = z.object({
+  name: requiredString("Name").refine(
+    (value) => VALID_NAME_PATTERN.test(value),
+    "Name must contain only lowercase letters, numbers, and hyphens",
+  ),
+  display_name: optionalString(),
+  description: optionalString(),
+  system_prompt: requiredString("System prompt"),
+  default_model_id: optionalString(),
+  tags: z.preprocess(trimInput, z.string()).optional().default(""),
+});
+
+export const harnessFormSchema = z.object({
+  name: requiredString("Name").refine(
+    (value) => VALID_NAME_PATTERN.test(value),
+    "Name must contain only lowercase letters, numbers, and hyphens",
+  ),
+  display_name: optionalString(),
+  description: optionalString(),
+  system_prompt: requiredString("System prompt"),
+  parent_harness_id: optionalString(),
+  default_model_id: optionalString(),
+  tags: z.preprocess(trimInput, z.string()).optional().default(""),
+});
+
+export const agentIdentityFormSchema = z.object({
+  name: requiredString("Name"),
+  description: optionalString(),
+  locale: optionalSelection(localeValues, "Locale"),
+  timezone: optionalSelection(timezoneValues, "Timezone"),
+});
+
+export const mcpServerFormSchema = z
+  .object({
+    name: requiredString("Name"),
+    description: optionalString(),
+    url: requiredString("URL").refine(
+      (value) => z.url().safeParse(value).success,
+      "URL must be a valid absolute URL",
+    ),
+    auth_mode: z.enum(["none", "api_key", "oauth"]),
+    api_key: optionalString(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.auth_mode === "api_key" && !value.api_key) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["api_key"],
+        message: "API key is required",
+      });
+    }
+  });
+
+export const apiKeySecretSchema = z.object({
+  api_key: requiredString("API key"),
+});
+
+export function createConnectionFormSchema(fields: ConnectionFormField[]) {
+  const shape = Object.fromEntries(
+    fields.map((field) => [
+      field.name,
+      field.required ? requiredString(field.label) : z.preprocess(trimInput, z.string()),
+    ]),
+  );
+
+  return z.object(shape);
+}


### PR DESCRIPTION
## What
Add shared zod-based validation for the main admin form flows in the UI.

- add `apps/ui/src/lib/form-validation.ts` for reusable schemas and field-error extraction
- validate agent and harness create/edit pages before mutations
- validate agent identity creation, MCP server creation/update key dialogs, and API key connection dialogs
- add targeted Jest coverage for the schemas plus MCP dialog validation behavior

## Why
`EVE-292` calls out that form validation is currently scattered across submit handlers and often relies on native `required` checks or ad hoc string guards. That makes richer validation inconsistent and hard to reuse across related forms.

## How
Use zod schemas to normalize input, trim optional fields, and map validation failures into the existing inline UI error patterns without changing API payload shapes. The edit pages reuse the same schemas as create flows, and dynamic connection-provider forms build schemas from the provider field metadata.

## Risk
- Medium
- Client-side validation now rejects some malformed submissions earlier; the main risk is blocking a form that used to submit if the schema is wrong

## Security
- Threat categories reviewed: TM-WEB, TM-DOS
- Findings and resolutions: reviewed the new client-side validation paths for accidental data exposure and unbounded parsing. The change only trims and validates browser input before existing mutations, does not alter auth/session handling, and does not introduce new network or storage behavior. No new threat-model entry was needed.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `cd apps/ui && npm test -- --runInBand form-validation.test.ts mcp-servers-page.test.tsx`
- `cd apps/ui && npm run build`
- `just pre-push`
- manual smoke: authenticated `/agents/new` load and `/mcp-servers` invalid URL flow via `agent-browser`

Fixes EVE-292.
