### PR TITLE
fix(ui): add auth redirect proxy

### DIFF
--- a/apps/ui/src/__tests__/auth-redirect.test.ts
+++ b/apps/ui/src/__tests__/auth-redirect.test.ts
@@ -1,0 +1,19 @@
+import { getLoginRedirectPath } from "@/lib/auth-redirect";
+
+describe("getLoginRedirectPath", () => {
+  it("preserves the current path and query in return_to", () => {
+    expect(getLoginRedirectPath("/settings/providers", new URLSearchParams("tab=models"))).toBe(
+      "/login?return_to=%2Fsettings%2Fproviders%3Ftab%3Dmodels",
+    );
+  });
+
+  it("omits return_to for the default dashboard landing page", () => {
+    expect(getLoginRedirectPath("/dashboard", new URLSearchParams())).toBe("/login");
+  });
+
+  it("preserves dashboard queries because they are not the default landing page", () => {
+    expect(getLoginRedirectPath("/dashboard", new URLSearchParams("tab=recent"))).toBe(
+      "/login?return_to=%2Fdashboard%3Ftab%3Drecent",
+    );
+  });
+});

--- a/apps/ui/src/__tests__/middleware.test.ts
+++ b/apps/ui/src/__tests__/middleware.test.ts
@@ -1,0 +1,52 @@
+/** @jest-environment node */
+
+import { config, proxy } from "@/proxy";
+
+describe("auth proxy", () => {
+  it("redirects protected routes to login when the access token is missing", () => {
+    const request = {
+      cookies: { has: () => false },
+      nextUrl: new URL("http://localhost/settings/providers?tab=models"),
+      url: "http://localhost/settings/providers?tab=models",
+    } as Parameters<typeof proxy>[0];
+
+    const response = proxy(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost/login?return_to=%2Fsettings%2Fproviders%3Ftab%3Dmodels",
+    );
+  });
+
+  it("allows protected routes through when the access token cookie exists", () => {
+    const request = {
+      cookies: { has: (name: string) => name === "access_token" },
+      nextUrl: new URL("http://localhost/settings/providers?tab=models"),
+      url: "http://localhost/settings/providers?tab=models",
+    } as Parameters<typeof proxy>[0];
+
+    const response = proxy(request);
+
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+    expect(response.headers.get("location")).toBeNull();
+  });
+
+  it("protects the main application routes", () => {
+    expect(config.matcher).toEqual([
+      "/agent-identities/:path*",
+      "/agents/:path*",
+      "/apps/:path*",
+      "/capabilities/:path*",
+      "/chat/:path*",
+      "/dashboard/:path*",
+      "/durable/:path*",
+      "/evals/:path*",
+      "/harnesses/:path*",
+      "/mcp-servers/:path*",
+      "/orgs/:path*",
+      "/sessions/:path*",
+      "/settings/:path*",
+      "/skills/:path*",
+    ]);
+  });
+});

--- a/apps/ui/src/app/(main)/layout.tsx
+++ b/apps/ui/src/app/(main)/layout.tsx
@@ -9,6 +9,7 @@ import { CommandPalette } from "@/components/command-palette";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { CommandPaletteContext, useCommandPaletteState } from "@/hooks/use-command-palette";
+import { getLoginRedirectPath } from "@/lib/auth-redirect";
 import { useAuth } from "@/providers/auth-provider";
 import { useOrg } from "@/providers/org-provider";
 import { NotificationsProvider } from "@/providers/notifications-provider";
@@ -55,11 +56,7 @@ function MainLayoutInner({ children }: MainLayoutProps) {
   // Redirect to login if auth is required but user is not authenticated
   useEffect(() => {
     if (!authLoading && !authUnavailable && requiresAuth && !isAuthenticated) {
-      // Preserve current location so login can redirect back
-      const currentUrl = pathname + (searchParams.toString() ? `?${searchParams.toString()}` : "");
-      const returnTo =
-        currentUrl !== "/dashboard" ? `?return_to=${encodeURIComponent(currentUrl)}` : "";
-      router.replace(`/login${returnTo}`);
+      router.replace(getLoginRedirectPath(pathname, searchParams));
     }
   }, [authLoading, authUnavailable, requiresAuth, isAuthenticated, router, pathname, searchParams]);
 

--- a/apps/ui/src/lib/auth-redirect.ts
+++ b/apps/ui/src/lib/auth-redirect.ts
@@ -1,0 +1,27 @@
+// Decision: keep login redirect URL generation in one place so middleware and
+// the client-side auth fallback preserve identical return_to behavior.
+
+type SearchInput = URLSearchParams | string | null | undefined;
+
+function getSearchString(search: SearchInput): string {
+  if (search instanceof URLSearchParams) {
+    return search.toString();
+  }
+
+  if (typeof search === "string") {
+    return search.startsWith("?") ? search.slice(1) : search;
+  }
+
+  return "";
+}
+
+export function getLoginRedirectPath(pathname: string, search: SearchInput): string {
+  const searchString = getSearchString(search);
+  const currentUrl = pathname + (searchString ? `?${searchString}` : "");
+
+  if (currentUrl === "/dashboard") {
+    return "/login";
+  }
+
+  return `/login?return_to=${encodeURIComponent(currentUrl)}`;
+}

--- a/apps/ui/src/proxy.ts
+++ b/apps/ui/src/proxy.ts
@@ -1,0 +1,34 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { getLoginRedirectPath } from "@/lib/auth-redirect";
+
+// Decision: proxy only enforces cookie presence for protected app routes.
+// AuthProvider remains the source of truth for config bootstrap, user loading,
+// token refresh, and auth-unavailable fallback UI.
+export function proxy(request: NextRequest) {
+  if (request.cookies.has("access_token")) {
+    return NextResponse.next();
+  }
+
+  const loginPath = getLoginRedirectPath(request.nextUrl.pathname, request.nextUrl.searchParams);
+  return NextResponse.redirect(new URL(loginPath, request.url));
+}
+
+export const config = {
+  matcher: [
+    "/agent-identities/:path*",
+    "/agents/:path*",
+    "/apps/:path*",
+    "/capabilities/:path*",
+    "/chat/:path*",
+    "/dashboard/:path*",
+    "/durable/:path*",
+    "/evals/:path*",
+    "/harnesses/:path*",
+    "/mcp-servers/:path*",
+    "/orgs/:path*",
+    "/sessions/:path*",
+    "/settings/:path*",
+    "/skills/:path*",
+  ],
+};


### PR DESCRIPTION
## What
Add a protected-route auth redirect proxy for the UI shell and share the login redirect builder with the client fallback.

## Why
Protected routes currently wait for the client layout to bootstrap before redirecting unauthenticated users. This causes an avoidable client-side auth hop for routes that can be rejected immediately from the Next.js edge/runtime layer.

## How
- add `src/proxy.ts` to redirect protected app routes to `/login` when the `access_token` cookie is missing
- share `return_to` URL construction in `src/lib/auth-redirect.ts` so the proxy and `(main)` layout stay aligned
- add focused tests for redirect formatting, protected route matching, and the existing client fallback behavior

## Risk
- Low
- The proxy only checks for presence of the auth cookie on protected UI routes. Auth bootstrap, refresh, and unavailable-state handling remain in `AuthProvider`.

## Security
- Threat categories reviewed: TM-AUTH, TM-WEB
- Findings and resolutions:
  - Reviewed cookie-based route gating to ensure the change does not bypass existing auth bootstrap or leak protected content before redirect.
  - Verified public auth routes remain accessible and protected routes redirect without exposing query data beyond the existing `return_to` contract.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
