### PR TITLE
chore(release): prepare v0.8.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Migration Notes
 
-**0.8.11 → 0.8.12:** Migrations squashed into `013_v0.8.12.sql`. Fresh database required.
+**0.8.11 → 0.8.12:** Released `0.8.11` databases migrate forward normally with `013_v0.8.12.sql`. Fresh database required only if you already applied the unreleased `013_rename_installed_to_enabled.sql` and `014_api_keys_user_scoped.sql` migrations from `main`.
 
 ## [0.8.11] - 2026-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.8.12] - 2026-04-14
+
+### Highlights
+
+- **API Keys Are Personal** - API keys are now user-scoped instead of org-scoped, which aligns key auth with session auth and removes org binding drift ([#1293](https://github.com/everruns/everruns/pull/1293))
+- **Form Validation Tightening** - Core UI forms now use Zod validation, catching invalid input earlier and making client-side errors more consistent ([#1294](https://github.com/everruns/everruns/pull/1294))
+- **Auth + MCP Cleanup** - Auth redirect proxying and MCP endpoint simplification reduce auth friction and remove duplicated endpoint logic ([#1295](https://github.com/everruns/everruns/pull/1295), [#1289](https://github.com/everruns/everruns/pull/1289))
+
+### What's Changed
+
+- chore(deps): bump bashkit to v0.1.18 ([#1296](https://github.com/everruns/everruns/pull/1296))
+- fix(ui): add auth redirect proxy ([#1295](https://github.com/everruns/everruns/pull/1295))
+- feat(ui): add zod validation to core forms ([#1294](https://github.com/everruns/everruns/pull/1294))
+- refactor(auth): make API keys user-scoped instead of org-scoped ([#1293](https://github.com/everruns/everruns/pull/1293))
+- refactor(mcp): simplify MCP endpoint, remove duplication ([#1289](https://github.com/everruns/everruns/pull/1289))
+- docs: rename Capabilities tab to Built-ins, add harness pages ([#1292](https://github.com/everruns/everruns/pull/1292))
+- feat(models): rename installed to enabled for LLM model visibility ([#1291](https://github.com/everruns/everruns/pull/1291))
+- fix(ui): remove rounded-* class violations across 55 components ([#1290](https://github.com/everruns/everruns/pull/1290))
+- fix(rate-limit): raise default API rate limit from 120 to 1200 req/min ([#1288](https://github.com/everruns/everruns/pull/1288))
+- ci: reduce CI waste and improve cache sharing ([#1287](https://github.com/everruns/everruns/pull/1287))
+
+### Migration Notes
+
+**0.8.11 → 0.8.12:** Migrations squashed into `013_v0.8.12.sql`. Fresh database required.
+
 ## [0.8.11] - 2026-04-13
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "anyhow",
  "base64",
@@ -1590,14 +1590,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "async-trait",
  "base64",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1667,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1720,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1736,7 +1736,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "async-trait",
  "base64",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "async-trait",
  "base64",
@@ -1796,7 +1796,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "async-trait",
  "base64",
@@ -1811,7 +1811,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-pi"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1870,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1886,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -1903,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.8.11"
+version = "0.8.12"
 
 [[package]]
 name = "everruns-sdk"
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2036,7 +2036,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2055,7 +2055,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.11"
+version = "0.8.12"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "everruns-ui",
-      "version": "0.8.11",
+      "version": "0.8.12",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@openuidev/react-lang": "^0.1.3",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "private": true,
   "exports": {
     "./providers/*": "./src/providers/*.tsx",

--- a/crates/server/migrations/013_rename_installed_to_enabled.sql
+++ b/crates/server/migrations/013_rename_installed_to_enabled.sql
@@ -1,9 +1,0 @@
--- Rename installed -> enabled on llm_models
--- The "installed" terminology implied downloading a binary; "enabled" better
--- describes the visibility toggle semantics.
-
-ALTER TABLE llm_models RENAME COLUMN installed TO enabled;
-
--- Recreate the partial index with the new column name
-DROP INDEX IF EXISTS idx_llm_models_installed;
-CREATE INDEX IF NOT EXISTS idx_llm_models_enabled ON llm_models(enabled) WHERE enabled = TRUE;

--- a/crates/server/migrations/013_v0.8.12.sql
+++ b/crates/server/migrations/013_v0.8.12.sql
@@ -1,0 +1,23 @@
+-- v0.8.12: model visibility + personal API keys
+-- Squashed from: 013_rename_installed_to_enabled.sql + 014_api_keys_user_scoped.sql
+
+-- ============================================
+-- 013_rename_installed_to_enabled: Rename installed -> enabled on llm_models
+-- The "installed" terminology implied downloading a binary; "enabled" better
+-- describes the visibility toggle semantics.
+-- ============================================
+
+ALTER TABLE llm_models RENAME COLUMN installed TO enabled;
+
+-- Recreate the partial index with the new column name
+DROP INDEX IF EXISTS idx_llm_models_installed;
+CREATE INDEX IF NOT EXISTS idx_llm_models_enabled ON llm_models(enabled) WHERE enabled = TRUE;
+
+-- ============================================
+-- 014_api_keys_user_scoped: API keys become user-scoped
+-- Organization context is now resolved per-request via cookie/header, the same
+-- way as session auth.
+-- ============================================
+
+DROP INDEX IF EXISTS idx_api_keys_org_id;
+ALTER TABLE api_keys DROP COLUMN org_id;

--- a/crates/server/migrations/014_api_keys_user_scoped.sql
+++ b/crates/server/migrations/014_api_keys_user_scoped.sql
@@ -1,9 +1,0 @@
--- API keys: user-scoped (remove org binding)
---
--- API keys become personal, user-scoped tokens. Organization context is now
--- resolved per-request via cookie/header, same as session (JWT) auth.
--- This aligns API key auth with session auth: both produce the same AuthUser
--- shape and use the same org resolution mechanism.
-
-DROP INDEX IF EXISTS idx_api_keys_org_id;
-ALTER TABLE api_keys DROP COLUMN org_id;


### PR DESCRIPTION
## What
Prepare the `v0.8.12` patch release.

- squash the post-`v0.8.11` database migrations into `013_v0.8.12.sql`
- bump workspace and UI package versions to `0.8.12`
- add the `0.8.12` changelog section and refresh lockfiles

## Why
The next patch release needs a release-prep commit on top of `main` so the merge can trigger the automated tag, GitHub Release, Docker publish, CLI binaries, and Homebrew update workflows.

## How
- replaced `013_rename_installed_to_enabled.sql` and `014_api_keys_user_scoped.sql` with a single release migration
- updated release metadata in `Cargo.toml`, `apps/ui/package.json`, lockfiles, and `CHANGELOG.md`
- validated with isolated startup smoke test and `just pre-push`

## Risk
- Medium
- Fresh database required for the squashed migration path in `0.8.12`
- Release automation depends on the release commit/changelog remaining intact through squash merge

## Security
- Threat categories reviewed: TM-SQL
- Findings and resolutions: Reviewed the migration squash for schema safety and drift. No new trust boundary or runtime auth path was introduced; the change preserves the existing DDL semantics and documents the fresh-database requirement in the changelog.

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)
