### PR TITLE
chore(specs): drop release migration notes

### DIFF
--- a/.claude/commands/prepare-release.md
+++ b/.claude/commands/prepare-release.md
@@ -78,9 +78,10 @@ See `specs/release-process.md` for the full release process specification.
    cd apps/ui && npm install --package-lock-only
    ```
 
-6. **Do not add migration notes**:
-   - Release notes should not include a dedicated migration section
-   - If migration behavior needs engineering discussion, capture it in specs or code comments instead of the user-facing changelog
+6. **Skip migration notes unless necessary**:
+   - Do not add a dedicated migration section by default
+   - Add one only when a release needs user-facing upgrade guidance
+   - If migration behavior only needs engineering discussion, capture it in specs or code comments instead of the changelog
 
 7. **Create commit**:
    ```bash
@@ -122,5 +123,5 @@ See `specs/release-process.md` for the full release process specification.
 - Always preserve the CHANGELOG.md header and versioning policy section
 - The Highlights section is optional but recommended for minor/major releases
 - Include screenshots for UI changes (can be added as links in CHANGELOG.md)
-- Do not add a "Migration Notes" section to release entries
+- Do not add a "Migration Notes" section to release entries unless it is necessary for user-facing upgrade guidance
 - The `chore(release): prepare vX.Y.Z` commit message triggers auto-tagging on merge

--- a/.claude/commands/prepare-release.md
+++ b/.claude/commands/prepare-release.md
@@ -68,6 +68,13 @@ See `specs/release-process.md` for the full release process specification.
 
    - feat: commit message ([#123](https://github.com/everruns/everruns/pull/123)) by [@username](https://github.com/username)
    - fix: commit message ([#124](https://github.com/everruns/everruns/pull/124)) by [@username](https://github.com/username)
+
+   <!-- Optional: keep only when the release needs user-facing upgrade guidance. -->
+   <!--
+   ### Migration Notes
+
+   - Upgrade guidance, if needed.
+   -->
    ```
 
 5. **Update lock files**:
@@ -81,7 +88,7 @@ See `specs/release-process.md` for the full release process specification.
 6. **Skip migration notes unless necessary**:
    - Do not add a dedicated migration section by default
    - Add one only when a release needs user-facing upgrade guidance
-   - If migration behavior only needs engineering discussion, capture it in specs or code comments instead of the changelog
+   - If migration behavior only needs engineering discussion, capture it in the canonical migration locations, for example `crates/server/migrations/` and/or `specs/migrations.md`, instead of the changelog
 
 7. **Create commit**:
    ```bash

--- a/.claude/commands/prepare-release.md
+++ b/.claude/commands/prepare-release.md
@@ -68,10 +68,6 @@ See `specs/release-process.md` for the full release process specification.
 
    - feat: commit message ([#123](https://github.com/everruns/everruns/pull/123)) by [@username](https://github.com/username)
    - fix: commit message ([#124](https://github.com/everruns/everruns/pull/124)) by [@username](https://github.com/username)
-
-   ### Migration Notes
-
-   **X.Y.Z → X.Y.Z:** Migration instructions if needed.
    ```
 
 5. **Update lock files**:
@@ -82,9 +78,9 @@ See `specs/release-process.md` for the full release process specification.
    cd apps/ui && npm install --package-lock-only
    ```
 
-6. **Ask about migrations**:
-   - "Does this release include database schema changes?"
-   - If yes, add migration notes to CHANGELOG.md and remind about fresh DB requirement
+6. **Do not add migration notes**:
+   - Release notes should not include a dedicated migration section
+   - If migration behavior needs engineering discussion, capture it in specs or code comments instead of the user-facing changelog
 
 7. **Create commit**:
    ```bash
@@ -126,4 +122,5 @@ See `specs/release-process.md` for the full release process specification.
 - Always preserve the CHANGELOG.md header and versioning policy section
 - The Highlights section is optional but recommended for minor/major releases
 - Include screenshots for UI changes (can be added as links in CHANGELOG.md)
+- Do not add a "Migration Notes" section to release entries
 - The `chore(release): prepare vX.Y.Z` commit message triggers auto-tagging on merge

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -22,7 +22,8 @@ This specification defines the release process for Everruns. The process is desi
 3. Each version section includes:
    - **Highlights** - Key features (user-written, 5-10 items with PR links)
    - **What's Changed** - List of commits: `- <message> ([#PR](url))`
-   - **Migration Notes** - Breaking changes or upgrade instructions (if needed)
+
+Release notes should not include a dedicated "Migration Notes" section. Releases are expected to preserve normal forward migration from the previous released version; any migration-specific engineering detail belongs in the migration files or migration spec, not the user-facing changelog.
 
 ### Version Updates
 

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -23,7 +23,7 @@ This specification defines the release process for Everruns. The process is desi
    - **Highlights** - Key features (user-written, 5-10 items with PR links)
    - **What's Changed** - List of commits: `- <message> ([#PR](url))`
 
-Release notes should not include a dedicated "Migration Notes" section by default. Add one only when a release truly needs user-facing upgrade guidance; otherwise migration-specific engineering detail belongs in the migration files or migration spec, not the changelog.
+Release notes should not normally include a dedicated "Migration Notes" section. Migration-specific engineering detail belongs in the migration files and migration spec, which remain the source of truth for upgrade and database-migration behavior. If a release has any operator-visible migration caveat, compatibility limitation, or exceptional upgrade requirement, call it out explicitly in the release PR and release notes.
 
 ### Version Updates
 

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -23,7 +23,7 @@ This specification defines the release process for Everruns. The process is desi
    - **Highlights** - Key features (user-written, 5-10 items with PR links)
    - **What's Changed** - List of commits: `- <message> ([#PR](url))`
 
-Release notes should not include a dedicated "Migration Notes" section. Releases are expected to preserve normal forward migration from the previous released version; any migration-specific engineering detail belongs in the migration files or migration spec, not the user-facing changelog.
+Release notes should not include a dedicated "Migration Notes" section by default. Add one only when a release truly needs user-facing upgrade guidance; otherwise migration-specific engineering detail belongs in the migration files or migration spec, not the changelog.
 
 ### Version Updates
 


### PR DESCRIPTION
## What
Remove migration-note guidance from the release contract and release helper.

- update `specs/release-process.md` so release entries no longer include a dedicated "Migration Notes" section
- update `.claude/commands/prepare-release.md` so `/prepare-release` stops asking for and emitting migration-note sections

## Why
We now expect proper forward migrations between released versions, so migration-specific engineering detail should live in migrations/specs rather than the user-facing release notes.

## How
Aligned the durable spec and the agent-facing release helper around the new rule: release notes only need Highlights and What's Changed.

## Risk
- Low
- Docs/process-only change; no runtime behavior changed

## Security
- Threat categories reviewed: No security-relevant code changes
- Findings and resolutions: Specs/helper-only update. No auth, data, execution, or trust-boundary behavior changed.

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)
