### PR TITLE
fix(ui): reuse settings warning notice

### DIFF
--- a/apps/ui/src/__tests__/notice.test.tsx
+++ b/apps/ui/src/__tests__/notice.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { ShieldAlert } from "lucide-react";
+
+import { Notice, NoticeDescription, NoticeTitle } from "@/components/ui/notice";
+
+describe("Notice", () => {
+  it("renders a warning notice with shared structure", () => {
+    render(
+      <Notice
+        variant="warning"
+        icon={<ShieldAlert className="h-5 w-5" data-testid="notice-icon" aria-hidden="true" />}
+      >
+        <NoticeTitle>Full account access</NoticeTitle>
+        <NoticeDescription>Treat API keys like passwords.</NoticeDescription>
+      </Notice>,
+    );
+
+    const notice = screen.getByText("Full account access").closest('[data-slot="notice"]');
+
+    expect(notice).toHaveAttribute("data-variant", "warning");
+    expect(screen.getByTestId("notice-icon")).toBeInTheDocument();
+    expect(screen.getByText("Treat API keys like passwords.")).toHaveAttribute(
+      "data-slot",
+      "notice-description",
+    );
+  });
+});

--- a/apps/ui/src/__tests__/settings-api-keys.test.tsx
+++ b/apps/ui/src/__tests__/settings-api-keys.test.tsx
@@ -84,6 +84,19 @@ describe("ApiKeysPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders the account access warning as a reusable notice", () => {
+    render(<ApiKeysPage />, { wrapper });
+
+    const notice = screen.getByText("Full account access").closest('[data-slot="notice"]');
+
+    expect(notice).toHaveAttribute("data-variant", "warning");
+    expect(
+      screen.getByText(
+        /API keys grant access to all organizations and resources available to your account\./,
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("renders API key rows with correct data", () => {
     render(<ApiKeysPage />, { wrapper });
 

--- a/apps/ui/src/app/(main)/settings/api-keys/page.tsx
+++ b/apps/ui/src/app/(main)/settings/api-keys/page.tsx
@@ -16,6 +16,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Notice, NoticeDescription, NoticeTitle } from "@/components/ui/notice";
 import { useApiKeys, useCreateApiKey, useDeleteApiKey } from "@/hooks/use-auth";
 import { useAuth } from "@/providers/auth-provider";
 import { Plus, Key, Trash2, Copy, Check, Clock, ShieldAlert } from "lucide-react";
@@ -250,16 +251,17 @@ export default function ApiKeysPage() {
           </Button>
         </div>
 
-        <div className="flex items-start gap-3 p-3 mb-4 rounded-lg border border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-950/30">
-          <ShieldAlert className="h-5 w-5 text-amber-600 dark:text-amber-500 mt-0.5 shrink-0" />
-          <div className="text-sm">
-            <p className="font-medium text-amber-800 dark:text-amber-400">Full account access</p>
-            <p className="text-amber-700 dark:text-amber-500/80 mt-0.5">
-              API keys grant access to all organizations and resources available to your account.
-              Treat them like passwords &mdash; do not share or commit them to source control.
-            </p>
-          </div>
-        </div>
+        <Notice
+          variant="warning"
+          icon={<ShieldAlert className="h-5 w-5 shrink-0" aria-hidden="true" />}
+          className="mb-4"
+        >
+          <NoticeTitle>Full account access</NoticeTitle>
+          <NoticeDescription>
+            API keys grant access to all organizations and resources available to your account.
+            Treat them like passwords &mdash; do not share or commit them to source control.
+          </NoticeDescription>
+        </Notice>
 
         <QueryStateWrapper
           isLoading={apiKeysLoading}

--- a/apps/ui/src/components/ui/notice.tsx
+++ b/apps/ui/src/components/ui/notice.tsx
@@ -56,7 +56,7 @@ function useNoticeContext() {
   return React.useContext(NoticeContext);
 }
 
-type NoticeProps = Omit<React.ComponentProps<"div">, "title"> &
+type NoticeProps = React.ComponentProps<"div"> &
   Omit<VariantProps<typeof noticeVariants>, "hasIcon"> & {
     icon?: React.ReactNode;
   };

--- a/apps/ui/src/components/ui/notice.tsx
+++ b/apps/ui/src/components/ui/notice.tsx
@@ -1,0 +1,127 @@
+/**
+ * Decisions:
+ * - Notices are a composable primitive so pages can reuse one chrome for info, warning, success, and destructive messaging.
+ * - Variants change the accent treatment, while the body text stays readable against the shared card/background tokens.
+ */
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const noticeVariants = cva(
+  "border bg-card/90 px-4 py-3 shadow-[inset_0_1px_0_hsl(var(--background)/0.92)]",
+  {
+    variants: {
+      variant: {
+        info: "border-l-[3px] border-l-primary",
+        warning: "border-l-[3px] border-l-accent",
+        success: "border-l-[3px] border-l-emerald-600 dark:border-l-emerald-500",
+        destructive: "border-l-[3px] border-l-destructive",
+      },
+      hasIcon: {
+        true: "grid grid-cols-[auto_1fr] items-start gap-3",
+        false: "block",
+      },
+    },
+    defaultVariants: {
+      variant: "info",
+      hasIcon: false,
+    },
+  },
+);
+
+const noticeIconVariants = cva("mt-0.5 text-muted-foreground", {
+  variants: {
+    variant: {
+      info: "text-primary",
+      warning: "text-accent-foreground",
+      success: "text-emerald-700 dark:text-emerald-400",
+      destructive: "text-destructive",
+    },
+  },
+  defaultVariants: {
+    variant: "info",
+  },
+});
+
+type NoticeVariant = NonNullable<VariantProps<typeof noticeVariants>["variant"]>;
+
+type NoticeContextValue = {
+  variant: NoticeVariant;
+};
+
+const NoticeContext = React.createContext<NoticeContextValue | null>(null);
+
+function useNoticeContext() {
+  return React.useContext(NoticeContext);
+}
+
+type NoticeProps = Omit<React.ComponentProps<"div">, "title"> &
+  Omit<VariantProps<typeof noticeVariants>, "hasIcon"> & {
+    icon?: React.ReactNode;
+  };
+
+const Notice = React.forwardRef<HTMLDivElement, NoticeProps>(
+  ({ className, variant, icon, children, ...props }, ref) => {
+    const resolvedVariant: NoticeVariant = variant ?? "info";
+    const hasIcon = Boolean(icon);
+
+    return (
+      <NoticeContext.Provider value={{ variant: resolvedVariant }}>
+        <div
+          ref={ref}
+          data-slot="notice"
+          data-variant={resolvedVariant}
+          className={cn(noticeVariants({ variant: resolvedVariant, hasIcon }), className)}
+          {...props}
+        >
+          {hasIcon ? (
+            <div
+              data-slot="notice-icon"
+              className={noticeIconVariants({ variant: resolvedVariant })}
+            >
+              {icon}
+            </div>
+          ) : null}
+          <div className="min-w-0 space-y-1">{children}</div>
+        </div>
+      </NoticeContext.Provider>
+    );
+  },
+);
+Notice.displayName = "Notice";
+
+const noticeTitleVariants = cva("font-medium leading-none text-foreground");
+
+const NoticeTitle = React.forwardRef<HTMLParagraphElement, React.ComponentProps<"p">>(
+  ({ className, ...props }, ref) => (
+    <p
+      ref={ref}
+      data-slot="notice-title"
+      className={cn(noticeTitleVariants(), className)}
+      {...props}
+    />
+  ),
+);
+NoticeTitle.displayName = "NoticeTitle";
+
+const noticeDescriptionVariants = cva("text-sm leading-6 text-muted-foreground");
+
+const NoticeDescription = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(
+  ({ className, ...props }, ref) => {
+    const context = useNoticeContext();
+
+    return (
+      <div
+        ref={ref}
+        data-slot="notice-description"
+        data-variant={context?.variant}
+        className={cn(noticeDescriptionVariants(), className)}
+        {...props}
+      />
+    );
+  },
+);
+NoticeDescription.displayName = "NoticeDescription";
+
+export { Notice, NoticeDescription, NoticeTitle };


### PR DESCRIPTION
## What
Add a reusable notice component and switch the API keys warning panel to use it.

## Why
The API keys warning rendered as a muddy page-specific amber block that looked out of place. We want a cleaner, reusable notice pattern for warning/info messaging.

## How
- Add a shared `Notice` UI primitive with composable title/description slots and variants.
- Replace the inline API keys warning markup with `Notice` + `ShieldAlert`.
- Add tests for the shared primitive and the API keys page warning.

## Risk
- Low
- Scoped to UI presentation for the API keys settings page and a new shared component.

## Security
- Threat categories reviewed: TM-WEB
- Findings and resolutions: Reviewed the new shared notice rendering for unsafe HTML injection, auth boundary changes, and unintended data exposure. This change only rearranges static React content and styling; no new input surface, auth logic, or sensitive data handling was introduced.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
