### PR TITLE
fix(core): advertise bash help in virtual bash

### DIFF
--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -117,7 +117,8 @@ impl Capability for VirtualBashCapability {
 
 > [!TIP]
 > Use standard Unix commands like `ls`, `cat`, `grep`, `echo`, and shell features
-> like pipes, redirections, and command substitution."#
+> like pipes, redirections, and command substitution. Builtin commands support
+> `<command> --help`, and many also support `<command> --version`."#
     }
 
     fn status(&self) -> CapabilityStatus {
@@ -1125,6 +1126,17 @@ mod tests {
         assert_eq!(cap.status(), CapabilityStatus::Available);
         assert_eq!(cap.icon(), Some("terminal"));
         assert_eq!(cap.category(), Some("Execution"));
+        let description = cap.description();
+        assert!(
+            description.contains("`<command> --help`"),
+            "description should advertise builtin help, got: {}",
+            description
+        );
+        assert!(
+            description.contains("`<command> --version`"),
+            "description should advertise builtin version support, got: {}",
+            description
+        );
     }
 
     #[test]

--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -117,7 +117,7 @@ impl Capability for VirtualBashCapability {
 
 > [!TIP]
 > Use standard Unix commands like `ls`, `cat`, `grep`, `echo`, and shell features
-> like pipes, redirections, and command substitution. Builtin commands support
+> like pipes, redirections, and command substitution. Built-in commands support
 > `<command> --help`, and many also support `<command> --version`."#
     }
 
@@ -1129,12 +1129,12 @@ mod tests {
         let description = cap.description();
         assert!(
             description.contains("`<command> --help`"),
-            "description should advertise builtin help, got: {}",
+            "description should advertise built-in help, got: {}",
             description
         );
         assert!(
             description.contains("`<command> --version`"),
-            "description should advertise builtin version support, got: {}",
+            "description should advertise built-in version support, got: {}",
             description
         );
     }


### PR DESCRIPTION
## What
Add bash capability guidance that surfaces builtin `--help` and `--version` support, and lock that copy with a focused metadata test.

## Why
The feature already exists through bashkit, but it was not discoverable from Everruns virtual bash capability text.

## How
Updated `VirtualBashCapability::description()` in `crates/core/src/capabilities/virtual_bash.rs` and extended the existing metadata test to assert the new guidance stays present.

## Risk
- Low
- Static capability copy and test only; no execution-path or schema changes

## Security
- Threat categories reviewed: No security-relevant code changes; this is static capability guidance text plus a metadata test.
- Findings and resolutions: None.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)
