### PR TITLE
fix(ui): tighten app density

### DIFF
--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -149,6 +149,23 @@ describe("Sidebar", () => {
     expect(screen.getByText(/^Everruns v\d+\.\d+\.\d+$/)).toBeInTheDocument();
   });
 
+  it("uses the compact sidebar shell treatment", () => {
+    const { container } = render(<Sidebar />);
+
+    expect(container.firstChild).toHaveClass("w-60");
+
+    const searchButton = screen.getByRole("button", { name: /search/i });
+    expect(searchButton).toHaveClass("gap-2");
+    expect(searchButton).toHaveClass("px-2.5");
+    expect(searchButton).toHaveClass("py-1.5");
+    expect(searchButton).toHaveClass("text-[13px]");
+
+    const dashboardLink = screen.getByRole("link", { name: "Dashboard" });
+    expect(dashboardLink).toHaveClass("gap-2.5");
+    expect(dashboardLink).toHaveClass("py-1.5");
+    expect(dashboardLink).toHaveClass("text-[13px]");
+  });
+
   it("has exactly 6 navigation items", () => {
     render(<Sidebar />);
 

--- a/apps/ui/src/app/design-system.css
+++ b/apps/ui/src/app/design-system.css
@@ -107,6 +107,7 @@
   }
   body {
     @apply bg-background text-foreground;
+    letter-spacing: -0.01em;
   }
 }
 

--- a/apps/ui/src/components/chat/chat-message-list.tsx
+++ b/apps/ui/src/components/chat/chat-message-list.tsx
@@ -226,9 +226,9 @@ export const ChatMessageList = memo(function ChatMessageList({
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       {loadingOlderEvents && hasMoreEvents && (
-        <div className="flex items-center justify-center py-3">
+        <div className="flex items-center justify-center py-2.5">
           <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
           <span className="ml-2 text-xs text-muted-foreground">{t("loading_older_messages")}</span>
         </div>

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -181,7 +181,7 @@ export function ChatPanel() {
         ref={scrollContainerRef}
         onScroll={handleScrollUp}
         className={cn(
-          "relative flex-1 overflow-y-auto bg-background bg-brand-dots px-4 py-5 sm:px-6",
+          "relative flex-1 overflow-y-auto bg-background bg-brand-dots px-3 py-4 sm:px-4",
           !eventsLoading && chatEvents.length === 0 && "flex flex-col justify-end",
         )}
       >
@@ -200,10 +200,10 @@ export function ChatPanel() {
         />
 
         {(isThinking || streamingText) && (
-          <div className="mt-6 flex justify-start">
+          <div className="mt-4 flex justify-start">
             <div className={chatSurfaceStyles.agentMessageRow}>
               <div className={chatSurfaceStyles.agentIcon}>
-                <Bot className="h-3.5 w-3.5" />
+                <Bot className="h-3 w-3" />
               </div>
               <div className={chatSurfaceStyles.agentMessage}>
                 {streamingIteration && streamingIteration > 1 && (

--- a/apps/ui/src/components/chat/chat-surface.ts
+++ b/apps/ui/src/components/chat/chat-surface.ts
@@ -5,25 +5,25 @@
 
 export const chatSurfaceStyles = {
   emptyStateCard:
-    "animate-chat-surface-in mx-auto mb-8 w-full max-w-md border border-border/70 bg-card/90 px-8 py-8 text-center shadow-[inset_0_1px_0_hsl(var(--background)/0.92)]",
+    "animate-chat-surface-in mx-auto mb-6 w-full max-w-md border border-border/70 bg-card/90 px-6 py-6 text-center shadow-[inset_0_1px_0_hsl(var(--background)/0.92)]",
   userMessage:
-    "animate-chat-row-in max-w-[min(78%,42rem)] border-r border-r-accent/75 bg-[hsl(var(--accent)/0.09)] px-4 py-3.5 text-sm text-foreground shadow-[inset_0_1px_0_hsl(var(--background)/0.92)]",
-  agentMessageRow: "flex w-full items-start gap-3 pr-2",
+    "animate-chat-row-in max-w-[min(78%,42rem)] border-r border-r-accent/75 bg-[hsl(var(--accent)/0.09)] px-3 py-2.5 text-[13px] leading-5 text-foreground shadow-[inset_0_1px_0_hsl(var(--background)/0.92)]",
+  agentMessageRow: "flex w-full items-start gap-2.5 pr-2",
   agentIcon:
-    "mt-1 flex h-6 w-6 flex-shrink-0 items-center justify-center border border-border/70 bg-primary text-primary-foreground shadow-[inset_0_1px_0_hsl(var(--background)/0.12)]",
+    "mt-0.5 flex h-[22px] w-[22px] flex-shrink-0 items-center justify-center border border-border/70 bg-primary text-primary-foreground shadow-[inset_0_1px_0_hsl(var(--background)/0.12)]",
   agentMessage:
-    "animate-chat-row-in flex-1 space-y-2 border-l border-l-primary/65 bg-card/90 px-4 py-3.5 shadow-[inset_0_1px_0_hsl(var(--background)/0.92)]",
-  composerSection: "bg-background/55 px-4 pb-4 pt-3 backdrop-blur-[1px] sm:px-5",
+    "animate-chat-row-in flex-1 space-y-1.5 border-l border-l-primary/65 bg-card/90 px-3 py-2.5 shadow-[inset_0_1px_0_hsl(var(--background)/0.92)]",
+  composerSection: "bg-background/55 px-3 pb-3 pt-2.5 backdrop-blur-[1px] sm:px-4",
   composerInputShell:
     "relative overflow-hidden border border-border/70 bg-background/95 shadow-[0_1px_0_hsl(var(--background)/0.88)] transition-[background-color,border-color,box-shadow] duration-200 focus-within:border-primary/30 focus-within:ring-1 focus-within:ring-primary/10",
   composerControlChip:
-    "flex h-9 items-center gap-2 border border-border/70 bg-card/85 px-2.5 text-sm shadow-[inset_0_1px_0_hsl(var(--background)/0.92)]",
-  composerIconButton: "h-9 w-9 border-border/70 bg-card/85 shadow-none hover:bg-muted/40",
+    "flex h-8 items-center gap-1.5 border border-border/70 bg-card/85 px-2 text-[13px] shadow-[inset_0_1px_0_hsl(var(--background)/0.92)]",
+  composerIconButton: "h-8 w-8 border-border/70 bg-card/85 shadow-none hover:bg-muted/40",
   composerDangerButton:
-    "h-9 w-9 border border-destructive/30 bg-destructive/[0.08] text-destructive shadow-none hover:bg-destructive/[0.14]",
-  composerSubmitButton: "h-9 w-9 shadow-[inset_0_1px_0_hsl(var(--primary-foreground)/0.1)]",
+    "h-8 w-8 border border-destructive/30 bg-destructive/[0.08] text-destructive shadow-none hover:bg-destructive/[0.14]",
+  composerSubmitButton: "h-8 w-8 shadow-[inset_0_1px_0_hsl(var(--primary-foreground)/0.1)]",
   composerTextarea:
-    "min-h-[96px] max-h-[220px] w-full resize-none border-0 bg-transparent px-4 py-3.5 text-sm shadow-none focus-visible:ring-0",
+    "min-h-[84px] max-h-[200px] w-full resize-none border-0 bg-transparent px-3 py-2.5 text-[13px] leading-5 shadow-none focus-visible:ring-0",
   floatingNotice:
-    "sticky bottom-3 left-1/2 z-10 mx-auto flex -translate-x-1/2 items-center gap-1.5 border border-border/70 bg-card/90 px-3 py-1.5 text-xs font-medium text-foreground shadow-md transition-colors hover:bg-accent/10",
+    "sticky bottom-3 left-1/2 z-10 mx-auto flex -translate-x-1/2 items-center gap-1.5 border border-border/70 bg-card/90 px-2.5 py-1 text-[11px] font-medium text-foreground shadow-md transition-colors hover:bg-accent/10",
 } as const;

--- a/apps/ui/src/components/layout/main-layout.tsx
+++ b/apps/ui/src/components/layout/main-layout.tsx
@@ -10,7 +10,7 @@ export function MainLayout({ children }: MainLayoutProps) {
   return (
     <div className="flex h-screen">
       <Sidebar />
-      <main className="flex-1 overflow-auto bg-background">{children}</main>
+      <main className="flex-1 overflow-auto bg-background text-[15px]">{children}</main>
     </div>
   );
 }

--- a/apps/ui/src/components/layout/sidebar-navigation.tsx
+++ b/apps/ui/src/components/layout/sidebar-navigation.tsx
@@ -35,13 +35,13 @@ function NavLink({
     <Link
       href={item.href}
       className={cn(
-        "flex items-center gap-3 border-l-2 px-3 py-2.5 text-sm font-medium transition-colors",
+        "flex items-center gap-2.5 border-l-2 px-3 py-1.5 text-[13px] font-semibold leading-5 transition-colors",
         isActive
           ? "border-l-primary bg-card text-foreground"
-          : "border-l-transparent text-muted-foreground hover:border-l-border hover:bg-card hover:text-foreground",
+          : "border-l-transparent text-muted-foreground hover:border-l-border hover:bg-card/80 hover:text-foreground",
       )}
     >
-      <item.icon className="icon-sharp h-[18px] w-[18px] shrink-0 stroke-[2.15]" />
+      <item.icon className="icon-sharp h-4 w-4 shrink-0 stroke-[2.15]" />
       {item.name}
       {item.warningTooltip && <WarningBadge tooltip={item.warningTooltip} />}
       {item.experimental && !item.warningTooltip && <ExperimentalBadge />}
@@ -67,13 +67,13 @@ function NavSection({
 
   return (
     <>
-      {!isFirst && <div className="my-3 border-t" />}
+      {!isFirst && <div className="my-2 border-t" />}
       {section.label &&
         (isCollapsible ? (
           <button
             type="button"
             onClick={() => setCollapsed((value) => !value)}
-            className="flex w-full items-center justify-between px-3 py-1 text-[10px] font-medium uppercase tracking-[0.22em] text-muted-foreground transition-colors hover:text-foreground"
+            className="flex w-full items-center justify-between px-3 py-0.5 text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground transition-colors hover:text-foreground"
           >
             {section.label}
             {collapsed ? (
@@ -83,7 +83,7 @@ function NavSection({
             )}
           </button>
         ) : (
-          <p className="px-3 py-1 text-[10px] font-medium uppercase tracking-[0.22em] text-muted-foreground">
+          <p className="px-3 py-0.5 text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
             {section.label}
           </p>
         ))}
@@ -107,7 +107,7 @@ export function SidebarNavigation({
   let visibleIndex = 0;
 
   return (
-    <nav className="flex-1 min-h-0 overflow-y-auto space-y-1 bg-background py-4">
+    <nav className="flex-1 min-h-0 overflow-y-auto space-y-0.5 bg-background py-2.5">
       {sections.map((section, index) => {
         if (section.devOnly && !isDev) return null;
         const isFirst = visibleIndex === 0;

--- a/apps/ui/src/components/layout/sidebar-organization-menu.tsx
+++ b/apps/ui/src/components/layout/sidebar-organization-menu.tsx
@@ -116,11 +116,11 @@ export function SidebarOrganizationMenu({
 
   return (
     <>
-      <div className="border-b px-3 py-2">
+      <div className="border-b border-border/70 px-2.5 py-2">
         <DropdownMenu>
-          <DropdownMenuTrigger className="flex w-full items-center gap-2 border border-transparent px-3 py-2 text-sm transition-colors hover:border-border hover:bg-card">
+          <DropdownMenuTrigger className="flex w-full items-center gap-1.5 border border-transparent px-2.5 py-1.5 text-[13px] transition-colors hover:border-border hover:bg-card">
             <Building2 className="icon-sharp h-4 w-4 text-muted-foreground" />
-            <span className="flex-1 truncate text-left font-medium">
+            <span className="flex-1 truncate text-left font-semibold leading-5">
               {currentOrg?.name ?? "Select Organization"}
             </span>
             <ChevronDown className="icon-sharp h-4 w-4 text-muted-foreground" />

--- a/apps/ui/src/components/layout/sidebar-user-menu.tsx
+++ b/apps/ui/src/components/layout/sidebar-user-menu.tsx
@@ -51,21 +51,21 @@ export function SidebarUserMenu({
   };
 
   if (!requiresAuth || !user) {
-    return <p className="px-3 text-xs text-muted-foreground">Everruns v{version}</p>;
+    return <p className="px-2.5 text-[11px] text-muted-foreground">Everruns v{version}</p>;
   }
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger className="flex w-full items-center gap-3 border border-transparent px-3 py-2 text-sm transition-colors hover:border-border hover:bg-card">
-        <Avatar className="h-8 w-8">
+      <DropdownMenuTrigger className="flex w-full items-center gap-2.5 border border-transparent px-2.5 py-1.5 text-[13px] transition-colors hover:border-border hover:bg-card">
+        <Avatar className="h-7 w-7">
           {user.avatar_url && <AvatarImage src={user.avatar_url} alt={user.name || user.email} />}
           <AvatarFallback>
             {user.name ? getInitials(user.name) : <User className="h-4 w-4" />}
           </AvatarFallback>
         </Avatar>
         <div className="flex-1 text-left">
-          <p className="truncate font-medium">{user.name || user.email}</p>
-          {user.name && <p className="truncate text-xs text-muted-foreground">{user.email}</p>}
+          <p className="truncate font-semibold leading-5">{user.name || user.email}</p>
+          {user.name && <p className="truncate text-[11px] text-muted-foreground">{user.email}</p>}
         </div>
         <ChevronUp className="icon-sharp h-4 w-4 text-muted-foreground" />
       </DropdownMenuTrigger>

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -158,11 +158,11 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
   const useDefaultCreateOrgDialog = !config?.orgActions?.createOrg && !createOrgOverride;
 
   return (
-    <div className="flex h-full w-64 flex-col border-r bg-background">
-      <div className="flex h-16 items-center justify-between border-b bg-card px-6">
+    <div className="flex h-full w-60 flex-col border-r border-border/70 bg-background">
+      <div className="flex h-14 items-center justify-between border-b border-border/70 bg-card px-4">
         <Link href="/dashboard" className="flex items-center gap-2">
-          <Image src="/logo.svg" alt="Everruns" width={32} height={32} />
-          <span className="text-xl font-bold">Everruns</span>
+          <Image src="/logo.svg" alt="Everruns" width={28} height={28} />
+          <span className="text-base font-semibold tracking-[-0.02em]">Everruns</span>
         </Link>
         <div className="flex items-center gap-1">
           <McpConnectButton />
@@ -175,23 +175,23 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
         useDefaultCreateOrgDialog={useDefaultCreateOrgDialog}
       />
 
-      <div className="px-3 py-2">
+      <div className="px-2.5 py-2">
         <button
           type="button"
           onClick={() => openCommandPalette(true)}
-          className="flex w-full items-center gap-3 border border-input bg-transparent px-3 py-2 text-sm text-muted-foreground transition-colors hover:border-border hover:bg-card hover:text-foreground"
+          className="flex w-full items-center gap-2 border border-input bg-transparent px-2.5 py-1.5 text-[13px] font-medium text-muted-foreground transition-colors hover:border-border hover:bg-card hover:text-foreground"
         >
-          <Search className="h-4 w-4 shrink-0" />
+          <Search className="h-3.5 w-3.5 shrink-0" />
           <span className="flex-1 text-left">Search...</span>
-          <kbd className="hidden h-5 items-center gap-0.5 border bg-muted px-1.5 font-mono text-[10px] font-medium sm:inline-flex">
-            <span className="text-xs">⌘</span>K
+          <kbd className="hidden h-4 items-center gap-0.5 border bg-muted px-1.5 font-mono text-[10px] font-medium sm:inline-flex">
+            <span className="text-[11px]">⌘</span>K
           </kbd>
         </button>
       </div>
 
       <SidebarNavigation sections={allSections} pathname={pathname} featureFlags={featureFlags} />
 
-      <div className="border-t p-3">
+      <div className="border-t border-border/70 p-2.5">
         <SidebarUserMenu
           requiresAuth={requiresAuth}
           user={user ?? null}

--- a/apps/ui/src/components/ui/badge.tsx
+++ b/apps/ui/src/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center justify-center border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  "inline-flex items-center justify-center border px-1.5 py-0.5 text-[11px] font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
   {
     variants: {
       variant: {

--- a/apps/ui/src/components/ui/button.tsx
+++ b/apps/ui/src/components/ui/button.tsx
@@ -19,12 +19,12 @@ const buttonVariants = cva(
         accent: "bg-accent text-primary font-medium shadow-xs hover:bg-accent/90",
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 px-6 has-[>svg]:px-4",
-        icon: "size-9",
-        "icon-sm": "size-8",
-        "icon-lg": "size-10",
+        default: "h-8 px-3.5 py-1.5 has-[>svg]:px-2.5",
+        sm: "h-7 gap-1.5 px-2.5 has-[>svg]:px-2",
+        lg: "h-9 px-5 has-[>svg]:px-3.5",
+        icon: "size-8",
+        "icon-sm": "size-7",
+        "icon-lg": "size-9",
       },
     },
     defaultVariants: {

--- a/apps/ui/src/components/ui/card.tsx
+++ b/apps/ui/src/components/ui/card.tsx
@@ -6,7 +6,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card"
-      className={cn("bg-card text-card-foreground flex flex-col gap-6 border py-6", className)}
+      className={cn("bg-card text-card-foreground flex flex-col gap-4 border py-4", className)}
       {...props}
     />
   );
@@ -17,7 +17,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-header"
       className={cn(
-        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-4 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-4",
         className,
       )}
       {...props}
@@ -56,14 +56,14 @@ function CardAction({ className, ...props }: React.ComponentProps<"div">) {
 }
 
 function CardContent({ className, ...props }: React.ComponentProps<"div">) {
-  return <div data-slot="card-content" className={cn("px-6", className)} {...props} />;
+  return <div data-slot="card-content" className={cn("px-4", className)} {...props} />;
 }
 
 function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-footer"
-      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      className={cn("flex items-center px-4 [.border-t]:pt-4", className)}
       {...props}
     />
   );

--- a/apps/ui/src/components/ui/dropdown-menu.tsx
+++ b/apps/ui/src/components/ui/dropdown-menu.tsx
@@ -65,7 +65,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-muted focus:text-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-muted focus:text-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 px-2 py-1 text-[13px] outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -83,7 +83,7 @@ function DropdownMenuCheckboxItem({
     <MenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-muted focus:text-foreground relative flex cursor-default items-center gap-2 py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-muted focus:text-foreground relative flex cursor-default items-center gap-2 py-1 pr-2 pl-8 text-[13px] outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       checked={checked}
@@ -134,7 +134,10 @@ function DropdownMenuLabel({
     <MenuPrimitive.GroupLabel
       data-slot="dropdown-menu-label"
       data-inset={inset}
-      className={cn("px-2 py-1.5 text-sm font-medium data-[inset]:pl-8", className)}
+      className={cn(
+        "px-2 py-1 text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground data-[inset]:pl-8",
+        className,
+      )}
       {...props}
     />
   );
@@ -177,7 +180,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-muted focus:text-foreground data-[open]:bg-muted data-[open]:text-foreground flex cursor-default items-center gap-2 px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground",
+        "focus:bg-muted focus:text-foreground data-[open]:bg-muted data-[open]:text-foreground flex cursor-default items-center gap-2 px-2 py-1 text-[13px] outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground",
         className,
       )}
       {...props}

--- a/apps/ui/src/components/ui/input.tsx
+++ b/apps/ui/src/components/ui/input.tsx
@@ -13,7 +13,7 @@ function Input({
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-8 w-full min-w-0 border bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-[13px]",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className,

--- a/apps/ui/src/components/ui/select.tsx
+++ b/apps/ui/src/components/ui/select.tsx
@@ -97,7 +97,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit appearance-none items-center justify-between gap-2 border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit appearance-none items-center justify-between gap-2 border bg-transparent px-2.5 py-1.5 text-[13px] whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-8 data-[size=sm]:h-7 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -145,7 +145,10 @@ function SelectLabel({ className, ...props }: SelectPrimitive.GroupLabel.Props) 
   return (
     <SelectPrimitive.GroupLabel
       data-slot="select-label"
-      className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+      className={cn(
+        "text-muted-foreground px-2 py-1 text-[11px] uppercase tracking-[0.14em]",
+        className,
+      )}
       {...props}
     />
   );
@@ -156,7 +159,7 @@ function SelectItem({ className, children, ...props }: SelectPrimitive.Item.Prop
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-muted focus:text-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-muted focus:text-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 py-1 pr-8 pl-2 text-[13px] outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className,
       )}
       {...props}

--- a/apps/ui/src/components/ui/table.tsx
+++ b/apps/ui/src/components/ui/table.tsx
@@ -9,7 +9,7 @@ function Table({ className, ...props }: React.ComponentProps<"table">) {
     <div data-slot="table-container" className="relative w-full overflow-x-auto">
       <table
         data-slot="table"
-        className={cn("w-full caption-bottom text-sm", className)}
+        className={cn("w-full caption-bottom text-[13px]", className)}
         {...props}
       />
     </div>
@@ -58,7 +58,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "text-foreground h-8 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className,
       )}
       {...props}
@@ -71,7 +71,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
     <td
       data-slot="table-cell"
       className={cn(
-        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "p-1.5 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className,
       )}
       {...props}

--- a/apps/ui/src/components/ui/tabs.tsx
+++ b/apps/ui/src/components/ui/tabs.tsx
@@ -42,7 +42,7 @@ function TabsList({ children, className }: TabsListProps) {
   return (
     <div
       className={cn(
-        "inline-flex h-10 items-center justify-center bg-muted p-1 text-muted-foreground",
+        "inline-flex h-8 items-center justify-center bg-muted p-0.5 text-muted-foreground",
         className,
       )}
     >
@@ -69,7 +69,7 @@ function TabsTrigger({ value, children, className, disabled }: TabsTriggerProps)
       aria-selected={isSelected}
       disabled={disabled}
       className={cn(
-        "inline-flex items-center justify-center whitespace-nowrap px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+        "inline-flex items-center justify-center whitespace-nowrap px-2.5 py-1 text-[13px] font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
         isSelected ? "bg-background text-foreground shadow-sm" : "hover:bg-background/50",
         className,
       )}

--- a/apps/ui/src/components/ui/textarea.tsx
+++ b/apps/ui/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-14 w-full border bg-transparent px-2.5 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-[13px]",
         className,
       )}
       {...props}


### PR DESCRIPTION
## What
Tighten the UI density across the shared shell and primitives.

## Why
The current sidebar and main app chrome spend too much space on row height, card padding, and control sizing, which makes the product feel less information-dense than the target desktop workflow.

## How
- tighten sidebar width, header/footer spacing, nav row height, and search/org/user menu chrome
- compact shared chat spacing in the transcript and composer shell
- reduce padding/heights in shared UI primitives (`Card`, `Button`, `Input`, `Select`, `Textarea`, `Tabs`, `Badge`, `Table`, dropdown menu)
- add a sidebar regression test that pins the compact shell treatment

## Risk
- Low
- This is a UI-only density pass. The main risk is visual regression from shared primitive sizing changes across pages.

## Security
- Threat categories reviewed: TM-WEB
- Findings and resolutions:
  - Reviewed the diff for new rendering sinks, auth flows, client-side data exposure, and unbounded UI behavior.
  - No security-relevant code changes. The patch only adjusts presentational classes and a regression test; it does not introduce new trust boundaries, input handling, or network/data paths.

## Validation
- `pnpm --dir apps/ui format:check`
- `pnpm --dir apps/ui lint` (passes; only pre-existing warnings in unrelated files)
- `pnpm --dir apps/ui test -- --runInBand src/__tests__/sidebar.test.tsx src/__tests__/chat-panel.test.tsx`
- `pnpm --dir apps/ui build`
- `PORT_PREFIX=159 just start-dev --no-watch`
- `agent-browser --session ship-smoke open http://localhost:15900/dev/tool-activity`
- `curl -I http://localhost:15900/dev/tool-activity`
- `just pre-push`

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
