### PR TITLE
fix(ui): move sidebar notifications into account menu

### DIFF
--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -54,6 +54,7 @@ jest.mock("@/hooks/use-organizations", () => ({
 
 jest.mock("@/components/layout/mcp-connect-button", () => ({
   McpConnectButton: () => <button type="button" aria-label="Connect via MCP" />,
+  McpConnectDialog: () => null,
   McpConnectMenuItem: () => <div>Connect via MCP</div>,
 }));
 

--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { Sidebar } from "@/components/layout/sidebar";
 import type { SidebarConfig, NavigationSection } from "@/components/layout/sidebar";
 import { Settings, Zap } from "lucide-react";
@@ -25,17 +25,9 @@ jest.mock("next/image", () => ({
 }));
 
 // Mock auth provider
+const mockUseAuth = jest.fn();
 jest.mock("@/providers/auth-provider", () => ({
-  useAuth: () => ({
-    user: null,
-    requiresAuth: false,
-    isAuthenticated: true,
-    config: { mode: "none" },
-    isLoading: false,
-    logout: jest.fn(),
-    logoutPending: false,
-    createOrganization: undefined,
-  }),
+  useAuth: () => mockUseAuth(),
 }));
 
 // Mock org provider
@@ -60,11 +52,23 @@ jest.mock("@/hooks/use-organizations", () => ({
   }),
 }));
 
+jest.mock("@/components/layout/mcp-connect-button", () => ({
+  McpConnectButton: () => <button type="button" aria-label="Connect via MCP" />,
+  McpConnectMenuItem: () => <div>Connect via MCP</div>,
+}));
+
+jest.mock("@/components/layout/notification-bell", () => ({
+  NotificationBell: () => <button type="button" aria-label="Notifications" />,
+  NotificationIndicator: () => <span aria-label="Unread notifications" />,
+  NotificationMenuSub: () => <div>Notifications</div>,
+}));
+
 // Mock feature flags provider
 jest.mock("@/providers/feature-flags-provider", () => ({
   useFeatureFlags: () => ({
     global_chat: true,
     apps: true,
+    notifications: true,
     mcp_endpoint: true,
   }),
 }));
@@ -83,6 +87,16 @@ describe("Sidebar", () => {
   beforeEach(() => {
     mockPathname.mockReturnValue("/dashboard");
     mockPush.mockClear();
+    mockUseAuth.mockReturnValue({
+      user: null,
+      requiresAuth: false,
+      isAuthenticated: true,
+      config: { mode: "none" },
+      isLoading: false,
+      logout: jest.fn(),
+      logoutPending: false,
+      createOrganization: undefined,
+    });
   });
 
   it("renders the Everruns logo and title", () => {
@@ -90,6 +104,43 @@ describe("Sidebar", () => {
 
     expect(screen.getByText("Everruns")).toBeInTheDocument();
     expect(screen.getByAltText("Everruns")).toBeInTheDocument();
+  });
+
+  it("keeps search row focused on search only", () => {
+    render(<Sidebar />);
+
+    const brandRow = screen.getByAltText("Everruns").closest("a")?.parentElement;
+    const searchRow = screen.getByRole("search", { name: "Sidebar search" });
+
+    expect(brandRow).not.toBeNull();
+    expect(within(searchRow).getByRole("button", { name: /search/i })).toBeInTheDocument();
+    expect(within(brandRow!).queryByLabelText("Connect via MCP")).not.toBeInTheDocument();
+    expect(within(brandRow!).queryByLabelText("Notifications")).not.toBeInTheDocument();
+    expect(within(searchRow).queryByLabelText("Connect via MCP")).not.toBeInTheDocument();
+    expect(within(searchRow).queryByLabelText("Notifications")).not.toBeInTheDocument();
+  });
+
+  it("renders notifications as an account-row indicator and MCP in the profile menu", () => {
+    mockUseAuth.mockReturnValue({
+      user: { name: "Test User", email: "test@example.com", avatar_url: null },
+      requiresAuth: true,
+      isAuthenticated: true,
+      config: { mode: "password" },
+      isLoading: false,
+      logout: jest.fn(),
+      logoutPending: false,
+      createOrganization: undefined,
+    });
+
+    render(<Sidebar />);
+
+    const footer = screen.getByRole("contentinfo", { name: "Sidebar footer" });
+    expect(within(footer).getByRole("button", { name: /test user/i })).toBeInTheDocument();
+    expect(within(footer).getByLabelText("Unread notifications")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /test user/i }));
+    expect(screen.getByText("Notifications")).toBeInTheDocument();
+    expect(screen.getByText("Connect via MCP")).toBeInTheDocument();
   });
 
   it("renders all navigation items", () => {

--- a/apps/ui/src/components/layout/mcp-connect-button.tsx
+++ b/apps/ui/src/components/layout/mcp-connect-button.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Check, Copy } from "lucide-react";
 import { capabilityIconMap } from "@/lib/capability-icons";
 import { useFeatureFlags } from "@/providers/feature-flags-provider";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import {
   Dialog,
   DialogContent,
@@ -15,6 +16,25 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 const McpIcon = capabilityIconMap.mcp;
+
+function useMcpConfig() {
+  const featureFlags = useFeatureFlags();
+  const enabled = featureFlags.mcp_endpoint;
+  const mcpUrl = typeof window !== "undefined" ? `${window.location.origin}/mcp` : "/mcp";
+  const configSnippet = JSON.stringify(
+    {
+      mcpServers: {
+        everruns: {
+          url: mcpUrl,
+        },
+      },
+    },
+    null,
+    2,
+  );
+
+  return { enabled, mcpUrl, configSnippet };
+}
 
 function CopySnippetButton({ value }: { value: string }) {
   const [copied, setCopied] = useState(false);
@@ -41,26 +61,61 @@ function CopySnippetButton({ value }: { value: string }) {
   );
 }
 
-export function McpConnectButton() {
-  const featureFlags = useFeatureFlags();
+function McpConnectDialogContent({
+  mcpUrl,
+  configSnippet,
+}: {
+  mcpUrl: string;
+  configSnippet: string;
+}) {
+  return (
+    <DialogContent className="sm:max-w-md">
+      <DialogHeader>
+        <DialogTitle className="flex items-center gap-2">
+          <McpIcon className="h-5 w-5" />
+          Connect via MCP
+        </DialogTitle>
+        <DialogDescription>
+          Use Everruns from Claude Desktop, Cursor, VS Code, or any MCP-compatible client.
+        </DialogDescription>
+      </DialogHeader>
 
-  if (!featureFlags.mcp_endpoint) {
+      <div className="space-y-4">
+        <div>
+          <p className="mb-1.5 text-sm font-medium">MCP Server URL</p>
+          <div className="relative">
+            <code className="block overflow-x-auto border bg-muted px-3 py-2 pr-9 text-sm">
+              {mcpUrl}
+            </code>
+            <CopySnippetButton value={mcpUrl} />
+          </div>
+        </div>
+
+        <div>
+          <p className="mb-1.5 text-sm font-medium">Quick Setup</p>
+          <p className="mb-2 text-sm text-muted-foreground">Add this to your MCP client config:</p>
+          <div className="relative">
+            <pre className="overflow-x-auto border bg-muted px-3 py-2 pr-9 font-mono text-sm">
+              {configSnippet}
+            </pre>
+            <CopySnippetButton value={configSnippet} />
+          </div>
+        </div>
+
+        <p className="text-xs text-muted-foreground">
+          Authentication is handled automatically via OAuth when connecting from an MCP client.
+        </p>
+      </div>
+    </DialogContent>
+  );
+}
+
+export function McpConnectButton() {
+  const { enabled, mcpUrl, configSnippet } = useMcpConfig();
+
+  if (!enabled) {
     return null;
   }
-
-  const mcpUrl = typeof window !== "undefined" ? `${window.location.origin}/mcp` : "/mcp";
-
-  const configSnippet = JSON.stringify(
-    {
-      mcpServers: {
-        everruns: {
-          url: mcpUrl,
-        },
-      },
-    },
-    null,
-    2,
-  );
 
   return (
     <Dialog>
@@ -76,46 +131,31 @@ export function McpConnectButton() {
         <TooltipContent>Connect via MCP</TooltipContent>
       </Tooltip>
 
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <McpIcon className="h-5 w-5" />
-            Connect via MCP
-          </DialogTitle>
-          <DialogDescription>
-            Use Everruns from Claude Desktop, Cursor, VS Code, or any MCP-compatible client.
-          </DialogDescription>
-        </DialogHeader>
+      <McpConnectDialogContent mcpUrl={mcpUrl} configSnippet={configSnippet} />
+    </Dialog>
+  );
+}
 
-        <div className="space-y-4">
-          <div>
-            <p className="mb-1.5 text-sm font-medium">MCP Server URL</p>
-            <div className="relative">
-              <code className="block overflow-x-auto border bg-muted px-3 py-2 pr-9 text-sm">
-                {mcpUrl}
-              </code>
-              <CopySnippetButton value={mcpUrl} />
-            </div>
-          </div>
+export function McpConnectMenuItem() {
+  const { enabled, mcpUrl, configSnippet } = useMcpConfig();
+  const [open, setOpen] = useState(false);
 
-          <div>
-            <p className="mb-1.5 text-sm font-medium">Quick Setup</p>
-            <p className="mb-2 text-sm text-muted-foreground">
-              Add this to your MCP client config:
-            </p>
-            <div className="relative">
-              <pre className="overflow-x-auto border bg-muted px-3 py-2 pr-9 font-mono text-sm">
-                {configSnippet}
-              </pre>
-              <CopySnippetButton value={configSnippet} />
-            </div>
-          </div>
+  if (!enabled) {
+    return null;
+  }
 
-          <p className="text-xs text-muted-foreground">
-            Authentication is handled automatically via OAuth when connecting from an MCP client.
-          </p>
-        </div>
-      </DialogContent>
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DropdownMenuItem
+        onSelect={(event) => {
+          event.preventDefault();
+          setOpen(true);
+        }}
+      >
+        <McpIcon className="icon-sharp mr-2 h-4 w-4" />
+        Connect via MCP
+      </DropdownMenuItem>
+      <McpConnectDialogContent mcpUrl={mcpUrl} configSnippet={configSnippet} />
     </Dialog>
   );
 }

--- a/apps/ui/src/components/layout/mcp-connect-button.tsx
+++ b/apps/ui/src/components/layout/mcp-connect-button.tsx
@@ -110,6 +110,26 @@ function McpConnectDialogContent({
   );
 }
 
+export function McpConnectDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { enabled, mcpUrl, configSnippet } = useMcpConfig();
+
+  if (!enabled) {
+    return null;
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <McpConnectDialogContent mcpUrl={mcpUrl} configSnippet={configSnippet} />
+    </Dialog>
+  );
+}
+
 export function McpConnectButton() {
   const { enabled, mcpUrl, configSnippet } = useMcpConfig();
 
@@ -136,26 +156,22 @@ export function McpConnectButton() {
   );
 }
 
-export function McpConnectMenuItem() {
-  const { enabled, mcpUrl, configSnippet } = useMcpConfig();
-  const [open, setOpen] = useState(false);
+export function McpConnectMenuItem({ onSelect }: { onSelect: () => void }) {
+  const { enabled } = useMcpConfig();
 
   if (!enabled) {
     return null;
   }
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DropdownMenuItem
-        onSelect={(event) => {
-          event.preventDefault();
-          setOpen(true);
-        }}
-      >
-        <McpIcon className="icon-sharp mr-2 h-4 w-4" />
-        Connect via MCP
-      </DropdownMenuItem>
-      <McpConnectDialogContent mcpUrl={mcpUrl} configSnippet={configSnippet} />
-    </Dialog>
+    <DropdownMenuItem
+      onClick={() => {
+        // Let the menu close and restore focus before opening the dialog.
+        window.setTimeout(onSelect, 0);
+      }}
+    >
+      <McpIcon className="icon-sharp mr-2 h-4 w-4" />
+      Connect via MCP
+    </DropdownMenuItem>
   );
 }

--- a/apps/ui/src/components/layout/notification-bell.tsx
+++ b/apps/ui/src/components/layout/notification-bell.tsx
@@ -2,7 +2,10 @@
 
 import { useRouter } from "next/navigation";
 import { Bell } from "lucide-react";
-import { useNotificationsContext } from "@/providers/notifications-provider";
+import {
+  useNotificationsContext,
+  useOptionalNotificationsContext,
+} from "@/providers/notifications-provider";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -11,6 +14,9 @@ import {
   DropdownMenuLabel,
   DropdownMenuPositioner,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
@@ -24,10 +30,82 @@ function formatNotificationTime(timestamp: string): string {
   }).format(new Date(timestamp));
 }
 
-export function NotificationBell() {
+function NotificationMenuContent() {
   const router = useRouter();
-  const { notifications, unviewedCount, isEnabled, openNotification, markViewed } =
-    useNotificationsContext();
+  const { notifications, isEnabled, openNotification, markViewed } = useNotificationsContext();
+
+  if (!isEnabled) {
+    return null;
+  }
+
+  return (
+    <>
+      <DropdownMenuGroup>
+        <DropdownMenuLabel>Notifications</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {notifications.length === 0 ? (
+          <div className="px-3 py-6 text-sm text-muted-foreground">No notifications</div>
+        ) : (
+          notifications.map((notification) => (
+            <DropdownMenuItem
+              key={notification.id}
+              className="block px-3 py-3"
+              onClick={() => openNotification(notification)}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p
+                    className={cn(
+                      "truncate text-sm",
+                      notification.viewed_at ? "text-muted-foreground" : "font-medium",
+                    )}
+                  >
+                    {notification.title}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">{notification.body}</p>
+                  <p className="mt-2 text-[11px] text-muted-foreground">
+                    {formatNotificationTime(notification.created_at)}
+                  </p>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  {notification.occurrence_count > 1 && (
+                    <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground">
+                      x{notification.occurrence_count}
+                    </span>
+                  )}
+                  {!notification.viewed_at && (
+                    <button
+                      type="button"
+                      className="rounded px-2 py-1 text-[10px] text-muted-foreground hover:bg-muted hover:text-foreground"
+                      onClick={(event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        void markViewed(notification.id);
+                      }}
+                    >
+                      View
+                    </button>
+                  )}
+                </div>
+              </div>
+            </DropdownMenuItem>
+          ))
+        )}
+      </DropdownMenuGroup>
+      {notifications.some((notification) => notification.href) && (
+        <>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onClick={() => router.push("/sessions")}>
+            Open sessions
+          </DropdownMenuItem>
+        </>
+      )}
+    </>
+  );
+}
+
+export function NotificationBell() {
+  const { unviewedCount, isEnabled } = useNotificationsContext();
 
   if (!isEnabled) {
     return null;
@@ -51,68 +129,44 @@ export function NotificationBell() {
       </DropdownMenuTrigger>
       <DropdownMenuPositioner side="bottom" align="end">
         <DropdownMenuContent className="w-[22rem]">
-          <DropdownMenuGroup>
-            <DropdownMenuLabel>Notifications</DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            {notifications.length === 0 ? (
-              <div className="px-3 py-6 text-sm text-muted-foreground">No notifications</div>
-            ) : (
-              notifications.map((notification) => (
-                <DropdownMenuItem
-                  key={notification.id}
-                  className="block px-3 py-3"
-                  onClick={() => openNotification(notification)}
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0">
-                      <p
-                        className={cn(
-                          "truncate text-sm",
-                          notification.viewed_at ? "text-muted-foreground" : "font-medium",
-                        )}
-                      >
-                        {notification.title}
-                      </p>
-                      <p className="mt-1 text-xs text-muted-foreground">{notification.body}</p>
-                      <p className="mt-2 text-[11px] text-muted-foreground">
-                        {formatNotificationTime(notification.created_at)}
-                      </p>
-                    </div>
-                    <div className="flex shrink-0 items-center gap-2">
-                      {notification.occurrence_count > 1 && (
-                        <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground">
-                          x{notification.occurrence_count}
-                        </span>
-                      )}
-                      {!notification.viewed_at && (
-                        <button
-                          type="button"
-                          className="rounded px-2 py-1 text-[10px] text-muted-foreground hover:bg-muted hover:text-foreground"
-                          onClick={(event) => {
-                            event.preventDefault();
-                            event.stopPropagation();
-                            void markViewed(notification.id);
-                          }}
-                        >
-                          View
-                        </button>
-                      )}
-                    </div>
-                  </div>
-                </DropdownMenuItem>
-              ))
-            )}
-          </DropdownMenuGroup>
-          {notifications.some((notification) => notification.href) && (
-            <>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={() => router.push("/sessions")}>
-                Open sessions
-              </DropdownMenuItem>
-            </>
-          )}
+          <NotificationMenuContent />
         </DropdownMenuContent>
       </DropdownMenuPositioner>
     </DropdownMenu>
+  );
+}
+
+export function NotificationIndicator() {
+  const context = useOptionalNotificationsContext();
+
+  if (!context?.isEnabled || context.unviewedCount === 0) {
+    return null;
+  }
+
+  return <span aria-label="Unread notifications" className="h-2.5 w-2.5 rounded-full bg-primary" />;
+}
+
+export function NotificationMenuSub() {
+  const context = useOptionalNotificationsContext();
+
+  if (!context?.isEnabled) {
+    return null;
+  }
+
+  return (
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger>
+        <Bell className="icon-sharp mr-2 h-4 w-4" />
+        Notifications
+        {context.unviewedCount > 0 && (
+          <span className="ml-auto rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-medium leading-none text-primary-foreground">
+            {context.unviewedCount > 9 ? "9+" : context.unviewedCount}
+          </span>
+        )}
+      </DropdownMenuSubTrigger>
+      <DropdownMenuSubContent className="w-[22rem]">
+        <NotificationMenuContent />
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
   );
 }

--- a/apps/ui/src/components/layout/notification-bell.tsx
+++ b/apps/ui/src/components/layout/notification-bell.tsx
@@ -143,7 +143,14 @@ export function NotificationIndicator() {
     return null;
   }
 
-  return <span aria-label="Unread notifications" className="h-2.5 w-2.5 rounded-full bg-primary" />;
+  return (
+    <>
+      <span aria-hidden="true" className="h-2.5 w-2.5 rounded-full bg-primary" />
+      <span className="sr-only">
+        {context.unviewedCount} unread notification{context.unviewedCount === 1 ? "" : "s"}
+      </span>
+    </>
+  );
 }
 
 export function NotificationMenuSub() {

--- a/apps/ui/src/components/layout/sidebar-user-menu.tsx
+++ b/apps/ui/src/components/layout/sidebar-user-menu.tsx
@@ -7,6 +7,8 @@
 
 import { useRouter } from "next/navigation";
 import { ChevronUp, Key, LogOut, User } from "lucide-react";
+import { McpConnectMenuItem } from "@/components/layout/mcp-connect-button";
+import { NotificationIndicator, NotificationMenuSub } from "@/components/layout/notification-bell";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   DropdownMenu,
@@ -67,12 +69,14 @@ export function SidebarUserMenu({
           <p className="truncate font-semibold leading-5">{user.name || user.email}</p>
           {user.name && <p className="truncate text-[11px] text-muted-foreground">{user.email}</p>}
         </div>
+        <NotificationIndicator />
         <ChevronUp className="icon-sharp h-4 w-4 text-muted-foreground" />
       </DropdownMenuTrigger>
       <DropdownMenuPositioner side="top" align="start">
         <DropdownMenuContent className="w-56">
           <DropdownMenuGroup>
             <DropdownMenuLabel>My Account</DropdownMenuLabel>
+            <NotificationMenuSub />
             <DropdownMenuItem onClick={() => router.push("/settings")}>
               <User className="icon-sharp mr-2 h-4 w-4" />
               Profile
@@ -81,6 +85,7 @@ export function SidebarUserMenu({
               <Key className="icon-sharp mr-2 h-4 w-4" />
               API Keys
             </DropdownMenuItem>
+            <McpConnectMenuItem />
           </DropdownMenuGroup>
           <DropdownMenuSeparator />
           <DropdownMenuItem variant="destructive" onClick={handleLogout} disabled={logoutPending}>

--- a/apps/ui/src/components/layout/sidebar-user-menu.tsx
+++ b/apps/ui/src/components/layout/sidebar-user-menu.tsx
@@ -5,9 +5,10 @@
  */
 "use client";
 
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { ChevronUp, Key, LogOut, User } from "lucide-react";
-import { McpConnectMenuItem } from "@/components/layout/mcp-connect-button";
+import { McpConnectDialog, McpConnectMenuItem } from "@/components/layout/mcp-connect-button";
 import { NotificationIndicator, NotificationMenuSub } from "@/components/layout/notification-bell";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
@@ -46,6 +47,7 @@ export function SidebarUserMenu({
   version: string;
 }) {
   const router = useRouter();
+  const [mcpDialogOpen, setMcpDialogOpen] = useState(false);
 
   const handleLogout = async () => {
     await logout();
@@ -57,43 +59,48 @@ export function SidebarUserMenu({
   }
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger className="flex w-full items-center gap-2.5 border border-transparent px-2.5 py-1.5 text-[13px] transition-colors hover:border-border hover:bg-card">
-        <Avatar className="h-7 w-7">
-          {user.avatar_url && <AvatarImage src={user.avatar_url} alt={user.name || user.email} />}
-          <AvatarFallback>
-            {user.name ? getInitials(user.name) : <User className="h-4 w-4" />}
-          </AvatarFallback>
-        </Avatar>
-        <div className="flex-1 text-left">
-          <p className="truncate font-semibold leading-5">{user.name || user.email}</p>
-          {user.name && <p className="truncate text-[11px] text-muted-foreground">{user.email}</p>}
-        </div>
-        <NotificationIndicator />
-        <ChevronUp className="icon-sharp h-4 w-4 text-muted-foreground" />
-      </DropdownMenuTrigger>
-      <DropdownMenuPositioner side="top" align="start">
-        <DropdownMenuContent className="w-56">
-          <DropdownMenuGroup>
-            <DropdownMenuLabel>My Account</DropdownMenuLabel>
-            <NotificationMenuSub />
-            <DropdownMenuItem onClick={() => router.push("/settings")}>
-              <User className="icon-sharp mr-2 h-4 w-4" />
-              Profile
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger className="flex w-full items-center gap-2.5 border border-transparent px-2.5 py-1.5 text-[13px] transition-colors hover:border-border hover:bg-card">
+          <Avatar className="h-7 w-7">
+            {user.avatar_url && <AvatarImage src={user.avatar_url} alt={user.name || user.email} />}
+            <AvatarFallback>
+              {user.name ? getInitials(user.name) : <User className="h-4 w-4" />}
+            </AvatarFallback>
+          </Avatar>
+          <div className="flex-1 text-left">
+            <p className="truncate font-semibold leading-5">{user.name || user.email}</p>
+            {user.name && (
+              <p className="truncate text-[11px] text-muted-foreground">{user.email}</p>
+            )}
+          </div>
+          <NotificationIndicator />
+          <ChevronUp className="icon-sharp h-4 w-4 text-muted-foreground" />
+        </DropdownMenuTrigger>
+        <DropdownMenuPositioner side="top" align="start">
+          <DropdownMenuContent className="w-56">
+            <DropdownMenuGroup>
+              <DropdownMenuLabel>My Account</DropdownMenuLabel>
+              <NotificationMenuSub />
+              <DropdownMenuItem onClick={() => router.push("/settings")}>
+                <User className="icon-sharp mr-2 h-4 w-4" />
+                Profile
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => router.push("/settings/api-keys")}>
+                <Key className="icon-sharp mr-2 h-4 w-4" />
+                API Keys
+              </DropdownMenuItem>
+              <McpConnectMenuItem onSelect={() => setMcpDialogOpen(true)} />
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem variant="destructive" onClick={handleLogout} disabled={logoutPending}>
+              <LogOut className="icon-sharp mr-2 h-4 w-4" />
+              {logoutPending ? "Signing out..." : "Sign out"}
             </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => router.push("/settings/api-keys")}>
-              <Key className="icon-sharp mr-2 h-4 w-4" />
-              API Keys
-            </DropdownMenuItem>
-            <McpConnectMenuItem />
-          </DropdownMenuGroup>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem variant="destructive" onClick={handleLogout} disabled={logoutPending}>
-            <LogOut className="icon-sharp mr-2 h-4 w-4" />
-            {logoutPending ? "Signing out..." : "Sign out"}
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenuPositioner>
-    </DropdownMenu>
+          </DropdownMenuContent>
+        </DropdownMenuPositioner>
+      </DropdownMenu>
+      <McpConnectDialog open={mcpDialogOpen} onOpenChange={setMcpDialogOpen} />
+    </>
   );
 }

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -38,8 +38,6 @@ import {
   Cog,
 } from "lucide-react";
 import { capabilityIconMap } from "@/lib/capability-icons";
-import { McpConnectButton } from "@/components/layout/mcp-connect-button";
-import { NotificationBell } from "@/components/layout/notification-bell";
 import { useCommandPalette } from "@/hooks/use-command-palette";
 import { useLlmProviders } from "@/hooks/use-llm-providers";
 import { useAuth } from "@/providers/auth-provider";
@@ -164,10 +162,6 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
           <Image src="/logo.svg" alt="Everruns" width={28} height={28} />
           <span className="text-base font-semibold tracking-[-0.02em]">Everruns</span>
         </Link>
-        <div className="flex items-center gap-1">
-          <McpConnectButton />
-          {featureFlags.notifications && <NotificationBell />}
-        </div>
       </div>
 
       <SidebarOrganizationMenu
@@ -175,7 +169,7 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
         useDefaultCreateOrgDialog={useDefaultCreateOrgDialog}
       />
 
-      <div className="px-2.5 py-2">
+      <div role="search" aria-label="Sidebar search" className="px-2.5 py-2">
         <button
           type="button"
           onClick={() => openCommandPalette(true)}
@@ -191,7 +185,11 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
 
       <SidebarNavigation sections={allSections} pathname={pathname} featureFlags={featureFlags} />
 
-      <div className="border-t border-border/70 p-2.5">
+      <div
+        role="contentinfo"
+        aria-label="Sidebar footer"
+        className="border-t border-border/70 p-2.5"
+      >
         <SidebarUserMenu
           requiresAuth={requiresAuth}
           user={user ?? null}

--- a/apps/ui/src/providers/notifications-provider.tsx
+++ b/apps/ui/src/providers/notifications-provider.tsx
@@ -383,3 +383,7 @@ export function useNotificationsContext() {
   }
   return context;
 }
+
+export function useOptionalNotificationsContext() {
+  return useContext(NotificationsContext);
+}


### PR DESCRIPTION
## What
Move sidebar notifications into the account control and move MCP access into the account menu.

## Why
The previous placements kept creating awkward extra rows in the left rail. Notifications and MCP were both utility actions competing with the brand and search areas, which made the sidebar feel visually broken.

## How
- keep the header focused on brand + org switcher + search
- show unread notifications as a small indicator on the account row
- expose notifications from an account-menu submenu
- expose MCP from an account-menu item that opens the existing MCP dialog
- update sidebar tests to lock in the new layout and menu behavior

## Risk
- Low
- Could regress sidebar menu behavior or notification discoverability if the account-menu wiring is wrong

## Security
- Threat categories reviewed: TM-WEB
- Findings and resolutions:
  - Reviewed the UI-only change for auth/session exposure, navigation leaks, and unsafe rendering paths
  - No new security-relevant surface was introduced; this is a presentational/layout change on existing authenticated UI controls

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `npm test -- --runTestsByPath src/__tests__/sidebar.test.tsx`
- `just pre-push`
- Local visual smoke via sidebar preview renders during implementation to verify the closed-state footer/menu layout after rebasing onto latest `origin/main`
