### PR TITLE
feat(runtime): add embedded in-process runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ Always make sure you are working on top of latest main from remote.
 - `specs/architecture.md` - System architecture, crate structure, infrastructure
 - `specs/production-deployment.md` - Production deployment aggregation spec and reverse proxy contract
 - `specs/embedding.md` - Embedding contract and `PlatformDefinition`
+- `specs/runtime.md` - Public in-process runtime contract for embedded execution
 - `specs/code-organization.md` - Developer conventions: formatting, testing, error handling, UI patterns
 - `specs/migrations.md` - Database migration naming, squashing, ordering, and conflict resolution
 - `specs/models.md` - Data models (Agent, Session, Message, etc.)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1935,6 +1935,19 @@ name = "everruns-openui"
 version = "0.8.12"
 
 [[package]]
+name = "everruns-runtime"
+version = "0.8.12"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "everruns-core",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "everruns-sdk"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/server",
     "crates/worker",
     "crates/core",
+    "crates/runtime",
     "crates/macros",
     "crates/openai",
     "crates/anthropic",

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -1,0 +1,24 @@
+# Public in-process runtime.
+# Decision: first public runtime is in-memory by default so embedders can run
+# harnesses in-process without the durable engine or control-plane services.
+
+[package]
+name = "everruns-runtime"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Public in-process runtime for embedding Everruns harnesses"
+
+[dependencies]
+async-trait.workspace = true
+chrono.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["sync"] }
+tracing.workspace = true
+uuid.workspace = true
+
+everruns-core = { path = "../core" }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/runtime/examples/in_process_runtime.rs
+++ b/crates/runtime/examples/in_process_runtime.rs
@@ -1,0 +1,126 @@
+use chrono::Utc;
+use everruns_core::capabilities::TestMathCapability;
+use everruns_core::llm_driver_registry::DriverRegistry;
+use everruns_core::llmsim_driver::LlmSimConfig;
+use everruns_core::{
+    Agent, AgentCapabilityConfig, AgentStatus, CapabilityRegistry, Harness, HarnessStatus,
+    LlmProviderType, ModelWithProvider, PlatformDefinition, Session, SessionStatus,
+};
+use everruns_runtime::InProcessRuntimeBuilder;
+use uuid::Uuid;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut capabilities = CapabilityRegistry::new();
+    capabilities.register(TestMathCapability);
+
+    let platform = PlatformDefinition::new(capabilities, DriverRegistry::new());
+
+    let harness_id = "harness_00000000000000000000000000000010".parse()?;
+    let agent_id = "agent_00000000000000000000000000000010".parse()?;
+    let session_id = "session_00000000000000000000000000000010".parse()?;
+
+    let runtime = InProcessRuntimeBuilder::new()
+        .platform_definition(platform)
+        .llm_sim(
+            LlmSimConfig::fixed("Let me calculate that.").with_tool_call_sequence(vec![
+                vec![everruns_core::ToolCall {
+                    id: "call_mul_1".into(),
+                    name: "multiply".into(),
+                    arguments: serde_json::json!({"a": 6, "b": 7}),
+                }],
+                vec![],
+            ]),
+        )
+        .default_model(ModelWithProvider {
+            model: "llmsim-model".into(),
+            provider_type: LlmProviderType::LlmSim,
+            api_key: Some("fake-key".into()),
+            base_url: None,
+        })
+        .harness(Harness {
+            id: harness_id,
+            name: "math".into(),
+            display_name: Some("Math".into()),
+            description: Some("Minimal embedded harness".into()),
+            system_prompt: "You are a math assistant.".into(),
+            parent_harness_id: None,
+            default_model_id: None,
+            tags: vec![],
+            capabilities: vec![AgentCapabilityConfig::new("test_math")],
+            initial_files: vec![],
+            network_access: None,
+            is_built_in: false,
+            status: HarnessStatus::Active,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            archived_at: None,
+            deleted_at: None,
+        })
+        .agent(Agent {
+            public_id: agent_id,
+            internal_id: Uuid::nil(),
+            name: "math-agent".into(),
+            display_name: Some("Math Agent".into()),
+            description: None,
+            system_prompt: "Use tools when they help.".into(),
+            default_model_id: None,
+            tags: vec![],
+            capabilities: vec![],
+            initial_files: vec![],
+            network_access: None,
+            max_iterations: Some(8),
+            tools: vec![],
+            status: AgentStatus::Active,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            archived_at: None,
+            deleted_at: None,
+            usage: None,
+        })
+        .session(Session {
+            id: session_id,
+            organization_id: everruns_core::DEFAULT_ORG_PUBLIC_ID.to_string(),
+            harness_id,
+            agent_id: Some(agent_id),
+            agent_identity_id: None,
+            title: Some("Embedded Math Session".into()),
+            locale: None,
+            preview: None,
+            output_preview: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: vec![],
+            tools: vec![],
+            system_prompt: None,
+            initial_files: vec![],
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            status: SessionStatus::Started,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            started_at: None,
+            finished_at: None,
+            usage: None,
+            is_pinned: None,
+            active_schedule_count: None,
+            features: vec![],
+            parent_session_id: None,
+            subagent_name: None,
+            subagent_task: None,
+            subagent_status: None,
+            blueprint_id: None,
+            blueprint_config: None,
+        })
+        .build()
+        .await?;
+
+    let result = runtime.run_text_turn(session_id, "What is 6 * 7?").await?;
+
+    println!("success: {}", result.success);
+    println!("iterations: {}", result.iterations);
+    println!("response: {}", result.response);
+
+    Ok(())
+}

--- a/crates/runtime/src/backends.rs
+++ b/crates/runtime/src/backends.rs
@@ -1,0 +1,351 @@
+// Public backend contract for the embedded runtime.
+// Decision: runtime extends core's read-only traits with the minimal write
+// operations needed for seeding and message persistence.
+
+use crate::in_memory::{InMemorySessionFileStore, InMemorySessionStore};
+use async_trait::async_trait;
+use everruns_core::agent::Agent;
+use everruns_core::error::Result;
+use everruns_core::events::{Event, EventRequest};
+use everruns_core::harness::Harness;
+use everruns_core::memory::{
+    InMemoryAgentStore, InMemoryEventEmitter, InMemoryHarnessStore, InMemoryLlmProviderStore,
+    InMemoryMessageRetriever,
+};
+use everruns_core::memory_store::MemoryStoreBackend;
+use everruns_core::message::Message;
+use everruns_core::message_retriever::{InputMessage, MessageRetriever};
+use everruns_core::session::Session;
+use everruns_core::session_file::{InitialFile, SessionFile};
+use everruns_core::traits::{
+    AgentStore, EventEmitter, HarnessStore, LlmProviderStore, ModelWithProvider, SessionFileStore,
+    SessionMutator, SessionStorageStore, SessionStore,
+};
+use everruns_core::typed_id::{AgentId, HarnessId, MessageId, ModelId, SessionId};
+use std::sync::Arc;
+
+/// Agent store contract for runtime seeding and lookup.
+#[async_trait]
+pub trait RuntimeAgentStore: AgentStore + Send + Sync {
+    /// Insert or replace an agent definition.
+    async fn add_agent(&self, agent: Agent) -> Result<()>;
+}
+
+/// Harness store contract for runtime seeding and lookup.
+#[async_trait]
+pub trait RuntimeHarnessStore: HarnessStore + Send + Sync {
+    /// Insert or replace a harness definition.
+    async fn add_harness(&self, harness: Harness) -> Result<()>;
+}
+
+/// Session store contract for runtime seeding, lookup, and mutation.
+#[async_trait]
+pub trait RuntimeSessionStore: SessionStore + SessionMutator + Send + Sync {
+    /// Insert or replace a session definition.
+    async fn add_session(&self, session: Session) -> Result<()>;
+}
+
+/// Message store contract for runtime persistence and lookup.
+#[async_trait]
+pub trait RuntimeMessageStore: MessageRetriever + Send + Sync {
+    /// Store a new input message and return the generated message record.
+    async fn add_input_message(
+        &self,
+        session_id: SessionId,
+        input: InputMessage,
+    ) -> Result<Message>;
+
+    /// Persist an existing message record.
+    async fn store_message(&self, session_id: SessionId, message: Message) -> Result<()>;
+}
+
+/// Filesystem contract for runtime seeding and lookup.
+#[async_trait]
+pub trait RuntimeFileStore: SessionFileStore + Send + Sync {
+    /// Seed a starter file into a session workspace.
+    async fn seed_initial_file(&self, session_id: SessionId, file: &InitialFile) -> Result<()>;
+}
+
+/// Provider store contract for runtime lookup and default-model configuration.
+#[async_trait]
+pub trait RuntimeProviderStore: LlmProviderStore + Send + Sync {
+    /// Set the runtime default model.
+    async fn set_default_model(&self, model: ModelWithProvider) -> Result<()>;
+}
+
+/// Optional event collector for embedders that want to inspect emitted events.
+#[async_trait]
+pub trait RuntimeEventCollector: Send + Sync {
+    /// Return all collected events.
+    async fn events(&self) -> Vec<Event>;
+}
+
+/// Backend bundle supplied to the embedded runtime.
+///
+/// Use this when you want the public runtime orchestration but your own store
+/// implementations instead of the built-in in-memory ones.
+#[derive(Clone)]
+pub struct RuntimeBackends {
+    /// Harness definitions available to the runtime.
+    pub harness_store: Arc<dyn RuntimeHarnessStore>,
+    /// Agent definitions available to the runtime.
+    pub agent_store: Arc<dyn RuntimeAgentStore>,
+    /// Session records and mutable session metadata.
+    pub session_store: Arc<dyn RuntimeSessionStore>,
+    /// Conversation message persistence and retrieval.
+    pub message_store: Arc<dyn RuntimeMessageStore>,
+    /// Model/provider resolution and default-model configuration.
+    pub provider_store: Arc<dyn RuntimeProviderStore>,
+    /// Event sink used during turn execution.
+    pub event_emitter: Arc<dyn EventEmitter>,
+    /// Optional collector for `InProcessRuntime::events()`.
+    pub event_collector: Option<Arc<dyn RuntimeEventCollector>>,
+    /// Session filesystem backend.
+    pub file_store: Arc<dyn RuntimeFileStore>,
+    /// Session key/value + secret storage backend.
+    pub storage_store: Arc<dyn SessionStorageStore>,
+    /// Persistent cross-session memory backend.
+    pub memory_store: Arc<dyn MemoryStoreBackend>,
+}
+
+#[derive(Clone)]
+pub(crate) struct DynAgentStore(pub Arc<dyn RuntimeAgentStore>);
+
+#[async_trait]
+impl AgentStore for DynAgentStore {
+    async fn get_agent(&self, agent_id: AgentId) -> Result<Option<Agent>> {
+        self.0.get_agent(agent_id).await
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct DynHarnessStore(pub Arc<dyn RuntimeHarnessStore>);
+
+#[async_trait]
+impl HarnessStore for DynHarnessStore {
+    async fn get_harness_chain(&self, harness_id: HarnessId) -> Result<Vec<Harness>> {
+        self.0.get_harness_chain(harness_id).await
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct DynSessionStore(pub Arc<dyn RuntimeSessionStore>);
+
+#[async_trait]
+impl SessionStore for DynSessionStore {
+    async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>> {
+        self.0.get_session(session_id).await
+    }
+}
+
+#[async_trait]
+impl SessionMutator for DynSessionStore {
+    async fn update_session_title(&self, session_id: SessionId, title: String) -> Result<Session> {
+        self.0.update_session_title(session_id, title).await
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct DynMessageStore(pub Arc<dyn RuntimeMessageStore>);
+
+#[async_trait]
+impl MessageRetriever for DynMessageStore {
+    async fn get(&self, session_id: SessionId, message_id: MessageId) -> Result<Option<Message>> {
+        self.0.get(session_id, message_id).await
+    }
+
+    async fn load(&self, session_id: SessionId) -> Result<Vec<Message>> {
+        self.0.load(session_id).await
+    }
+
+    async fn load_filtered(
+        &self,
+        query: everruns_core::message_filter::MessageQuery,
+    ) -> Result<Vec<Message>> {
+        self.0.load_filtered(query).await
+    }
+
+    async fn load_page(
+        &self,
+        session_id: SessionId,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<Message>> {
+        self.0.load_page(session_id, offset, limit).await
+    }
+
+    async fn count(&self, session_id: SessionId) -> Result<usize> {
+        self.0.count(session_id).await
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct DynFileStore(pub Arc<dyn RuntimeFileStore>);
+
+#[async_trait]
+impl SessionFileStore for DynFileStore {
+    async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>> {
+        self.0.read_file(session_id, path).await
+    }
+
+    async fn write_file(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        content: &str,
+        encoding: &str,
+    ) -> Result<SessionFile> {
+        self.0.write_file(session_id, path, content, encoding).await
+    }
+
+    async fn delete_file(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        recursive: bool,
+    ) -> Result<bool> {
+        self.0.delete_file(session_id, path, recursive).await
+    }
+
+    async fn list_directory(
+        &self,
+        session_id: SessionId,
+        path: &str,
+    ) -> Result<Vec<everruns_core::session_file::FileInfo>> {
+        self.0.list_directory(session_id, path).await
+    }
+
+    async fn stat_file(
+        &self,
+        session_id: SessionId,
+        path: &str,
+    ) -> Result<Option<everruns_core::session_file::FileStat>> {
+        self.0.stat_file(session_id, path).await
+    }
+
+    async fn grep_files(
+        &self,
+        session_id: SessionId,
+        pattern: &str,
+        path_pattern: Option<&str>,
+    ) -> Result<Vec<everruns_core::session_file::GrepMatch>> {
+        self.0.grep_files(session_id, pattern, path_pattern).await
+    }
+
+    async fn create_directory(
+        &self,
+        session_id: SessionId,
+        path: &str,
+    ) -> Result<everruns_core::session_file::FileInfo> {
+        self.0.create_directory(session_id, path).await
+    }
+
+    async fn write_file_if_content_matches(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        expected_content: &str,
+        expected_encoding: &str,
+        content: &str,
+        encoding: &str,
+    ) -> Result<Option<SessionFile>> {
+        self.0
+            .write_file_if_content_matches(
+                session_id,
+                path,
+                expected_content,
+                expected_encoding,
+                content,
+                encoding,
+            )
+            .await
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct DynProviderStore(pub Arc<dyn RuntimeProviderStore>);
+
+#[async_trait]
+impl LlmProviderStore for DynProviderStore {
+    async fn get_model_with_provider(
+        &self,
+        model_id: ModelId,
+    ) -> Result<Option<ModelWithProvider>> {
+        self.0.get_model_with_provider(model_id).await
+    }
+
+    async fn get_default_model(&self) -> Result<Option<ModelWithProvider>> {
+        self.0.get_default_model().await
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct DynEventEmitter(pub Arc<dyn EventEmitter>);
+
+#[async_trait]
+impl EventEmitter for DynEventEmitter {
+    async fn emit(&self, request: EventRequest) -> Result<Event> {
+        self.0.emit(request).await
+    }
+}
+
+#[async_trait]
+impl RuntimeAgentStore for InMemoryAgentStore {
+    async fn add_agent(&self, agent: Agent) -> Result<()> {
+        InMemoryAgentStore::add_agent(self, agent).await;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl RuntimeHarnessStore for InMemoryHarnessStore {
+    async fn add_harness(&self, harness: Harness) -> Result<()> {
+        InMemoryHarnessStore::add_harness(self, harness).await;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl RuntimeSessionStore for InMemorySessionStore {
+    async fn add_session(&self, session: Session) -> Result<()> {
+        InMemorySessionStore::add_session(self, session).await;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl RuntimeMessageStore for InMemoryMessageRetriever {
+    async fn add_input_message(
+        &self,
+        session_id: SessionId,
+        input: InputMessage,
+    ) -> Result<Message> {
+        self.add(session_id, input).await
+    }
+
+    async fn store_message(&self, session_id: SessionId, message: Message) -> Result<()> {
+        self.store(session_id, message).await
+    }
+}
+
+#[async_trait]
+impl RuntimeFileStore for InMemorySessionFileStore {
+    async fn seed_initial_file(&self, session_id: SessionId, file: &InitialFile) -> Result<()> {
+        InMemorySessionFileStore::seed_initial_file(self, session_id, file).await
+    }
+}
+
+#[async_trait]
+impl RuntimeProviderStore for InMemoryLlmProviderStore {
+    async fn set_default_model(&self, model: ModelWithProvider) -> Result<()> {
+        InMemoryLlmProviderStore::set_default_model(self, model).await;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl RuntimeEventCollector for InMemoryEventEmitter {
+    async fn events(&self) -> Vec<Event> {
+        InMemoryEventEmitter::events(self).await
+    }
+}

--- a/crates/runtime/src/in_memory.rs
+++ b/crates/runtime/src/in_memory.rs
@@ -1,0 +1,570 @@
+// In-memory runtime stores.
+// Decision: runtime ships batteries-included in-memory stores for public
+// embedding so common capabilities work without depending on server internals.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use everruns_core::error::{AgentLoopError, Result};
+use everruns_core::session::Session;
+use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, InitialFile, SessionFile};
+use everruns_core::traits::{
+    KeyInfo, SecretInfo, SessionFileStore, SessionMutator, SessionStorageStore, SessionStore,
+};
+use everruns_core::typed_id::SessionId;
+use std::collections::{BTreeSet, HashMap};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+/// In-memory `SessionStore` + `SessionMutator` for embedded runtimes.
+///
+/// This is the default session backend used by [`crate::InProcessRuntime`].
+#[derive(Debug, Default, Clone)]
+pub struct InMemorySessionStore {
+    sessions: Arc<RwLock<HashMap<SessionId, Session>>>,
+}
+
+impl InMemorySessionStore {
+    /// Create an empty in-memory session store.
+    pub fn new() -> Self {
+        Self {
+            sessions: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Insert or replace a session in the store.
+    pub async fn add_session(&self, session: Session) {
+        self.sessions.write().await.insert(session.id, session);
+    }
+}
+
+#[async_trait]
+impl SessionStore for InMemorySessionStore {
+    async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>> {
+        Ok(self.sessions.read().await.get(&session_id).cloned())
+    }
+}
+
+#[async_trait]
+impl SessionMutator for InMemorySessionStore {
+    async fn update_session_title(&self, session_id: SessionId, title: String) -> Result<Session> {
+        let mut sessions = self.sessions.write().await;
+        let session = sessions
+            .get_mut(&session_id)
+            .ok_or_else(|| AgentLoopError::store(format!("session not found: {session_id}")))?;
+        session.title = Some(title);
+        session.updated_at = Utc::now();
+        Ok(session.clone())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct FileEntry {
+    file: SessionFile,
+}
+
+/// In-memory implementation of the session virtual filesystem.
+///
+/// Paths accept either canonical session paths (`/notes.txt`) or `/workspace`
+/// prefixed paths (`/workspace/notes.txt`).
+#[derive(Debug, Default, Clone)]
+pub struct InMemorySessionFileStore {
+    files: Arc<RwLock<HashMap<(SessionId, String), FileEntry>>>,
+}
+
+impl InMemorySessionFileStore {
+    /// Create an empty in-memory file store.
+    pub fn new() -> Self {
+        Self {
+            files: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Seed a file into a session workspace.
+    pub async fn seed_initial_file(&self, session_id: SessionId, file: &InitialFile) -> Result<()> {
+        let path = normalize_path(&file.path);
+        self.ensure_parent_directories(session_id, &path).await?;
+        self.upsert_file(
+            session_id,
+            &path,
+            &file.content,
+            &file.encoding,
+            file.is_readonly,
+        )
+        .await
+        .map(|_| ())
+    }
+
+    async fn ensure_parent_directories(&self, session_id: SessionId, path: &str) -> Result<()> {
+        let mut current = String::new();
+        for segment in path.trim_start_matches('/').split('/').collect::<Vec<_>>() {
+            if segment.is_empty() {
+                continue;
+            }
+            current.push('/');
+            current.push_str(segment);
+            let is_leaf = current == path;
+            if is_leaf {
+                break;
+            }
+            self.insert_directory_if_missing(session_id, &current)
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn insert_directory_if_missing(&self, session_id: SessionId, path: &str) -> Result<()> {
+        let path = normalize_path(path);
+        if path == "/" {
+            return Ok(());
+        }
+
+        let mut files = self.files.write().await;
+        files
+            .entry((session_id, path.clone()))
+            .or_insert_with(|| FileEntry {
+                file: SessionFile {
+                    id: Uuid::now_v7(),
+                    session_id: session_id.uuid(),
+                    path: path.clone(),
+                    name: FileInfo::name_from_path(&path),
+                    content: None,
+                    encoding: "text".to_string(),
+                    is_directory: true,
+                    is_readonly: false,
+                    size_bytes: 0,
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                },
+            });
+        Ok(())
+    }
+
+    async fn upsert_file(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        content: &str,
+        encoding: &str,
+        is_readonly: bool,
+    ) -> Result<SessionFile> {
+        let now = Utc::now();
+        let normalized = normalize_path(path);
+        let mut files = self.files.write().await;
+        let key = (session_id, normalized.clone());
+
+        let file = files
+            .entry(key)
+            .and_modify(|entry| {
+                entry.file.content = Some(content.to_string());
+                entry.file.encoding = encoding.to_string();
+                entry.file.is_directory = false;
+                entry.file.is_readonly = is_readonly;
+                entry.file.size_bytes = content.len() as i64;
+                entry.file.updated_at = now;
+            })
+            .or_insert_with(|| FileEntry {
+                file: SessionFile {
+                    id: Uuid::now_v7(),
+                    session_id: session_id.uuid(),
+                    path: normalized.clone(),
+                    name: FileInfo::name_from_path(&normalized),
+                    content: Some(content.to_string()),
+                    encoding: encoding.to_string(),
+                    is_directory: false,
+                    is_readonly,
+                    size_bytes: content.len() as i64,
+                    created_at: now,
+                    updated_at: now,
+                },
+            })
+            .file
+            .clone();
+
+        Ok(file)
+    }
+
+    /// Read a text file from the workspace, returning `None` when absent.
+    pub async fn read_text(&self, session_id: SessionId, path: &str) -> Option<String> {
+        self.read_file(session_id, path)
+            .await
+            .ok()
+            .flatten()
+            .and_then(|file| file.content)
+    }
+}
+
+#[async_trait]
+impl SessionFileStore for InMemorySessionFileStore {
+    async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>> {
+        let normalized = normalize_path(path);
+        if normalized == "/" {
+            return Ok(Some(root_directory(session_id)));
+        }
+
+        Ok(self
+            .files
+            .read()
+            .await
+            .get(&(session_id, normalized))
+            .map(|entry| entry.file.clone()))
+    }
+
+    async fn write_file(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        content: &str,
+        encoding: &str,
+    ) -> Result<SessionFile> {
+        let normalized = normalize_path(path);
+        self.ensure_parent_directories(session_id, &normalized)
+            .await?;
+
+        if let Some(existing) = self.read_file(session_id, &normalized).await?
+            && existing.is_readonly
+        {
+            return Err(AgentLoopError::tool(format!(
+                "file is read-only: {}",
+                normalized
+            )));
+        }
+
+        self.upsert_file(session_id, &normalized, content, encoding, false)
+            .await
+    }
+
+    async fn delete_file(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        recursive: bool,
+    ) -> Result<bool> {
+        let normalized = normalize_path(path);
+        if normalized == "/" {
+            return Ok(false);
+        }
+
+        let mut files = self.files.write().await;
+        let key = (session_id, normalized.clone());
+        let Some(existing) = files.get(&key).cloned() else {
+            return Ok(false);
+        };
+
+        if existing.file.is_readonly {
+            return Ok(false);
+        }
+
+        if existing.file.is_directory {
+            let prefix = format!("{normalized}/");
+            let has_children = files
+                .keys()
+                .any(|(sid, candidate)| *sid == session_id && candidate.starts_with(&prefix));
+            if has_children && !recursive {
+                return Ok(false);
+            }
+            files.retain(|(sid, candidate), _| {
+                !(*sid == session_id
+                    && (candidate == &normalized || candidate.starts_with(&prefix)))
+            });
+            return Ok(true);
+        }
+
+        Ok(files.remove(&key).is_some())
+    }
+
+    async fn list_directory(&self, session_id: SessionId, path: &str) -> Result<Vec<FileInfo>> {
+        let normalized = normalize_path(path);
+        if normalized != "/" {
+            let Some(dir) = self.read_file(session_id, &normalized).await? else {
+                return Ok(vec![]);
+            };
+            if !dir.is_directory {
+                return Ok(vec![]);
+            }
+        }
+
+        let files = self.files.read().await;
+        let mut infos = Vec::new();
+        let mut seen = BTreeSet::new();
+
+        for ((sid, candidate), entry) in files.iter() {
+            if *sid != session_id {
+                continue;
+            }
+            if FileInfo::parent_path(candidate).as_deref() != Some(normalized.as_str()) {
+                continue;
+            }
+            if seen.insert(candidate.clone()) {
+                infos.push(file_info(&entry.file));
+            }
+        }
+
+        infos.sort_by(|a, b| a.path.cmp(&b.path));
+        Ok(infos)
+    }
+
+    async fn stat_file(&self, session_id: SessionId, path: &str) -> Result<Option<FileStat>> {
+        let normalized = normalize_path(path);
+        if normalized == "/" {
+            let root = root_directory(session_id);
+            return Ok(Some(FileStat {
+                path: root.path,
+                name: root.name,
+                is_directory: true,
+                is_readonly: false,
+                size_bytes: 0,
+                created_at: root.created_at,
+                updated_at: root.updated_at,
+            }));
+        }
+
+        Ok(self
+            .files
+            .read()
+            .await
+            .get(&(session_id, normalized))
+            .map(|entry| FileStat {
+                path: entry.file.path.clone(),
+                name: entry.file.name.clone(),
+                is_directory: entry.file.is_directory,
+                is_readonly: entry.file.is_readonly,
+                size_bytes: entry.file.size_bytes,
+                created_at: entry.file.created_at,
+                updated_at: entry.file.updated_at,
+            }))
+    }
+
+    async fn grep_files(
+        &self,
+        session_id: SessionId,
+        pattern: &str,
+        path_pattern: Option<&str>,
+    ) -> Result<Vec<GrepMatch>> {
+        let files = self.files.read().await;
+        let mut matches = Vec::new();
+
+        for ((sid, path), entry) in files.iter() {
+            if *sid != session_id || entry.file.is_directory || entry.file.encoding != "text" {
+                continue;
+            }
+            if let Some(path_pattern) = path_pattern
+                && !path.contains(path_pattern)
+            {
+                continue;
+            }
+
+            let Some(content) = &entry.file.content else {
+                continue;
+            };
+
+            for (idx, line) in content.lines().enumerate() {
+                if line.contains(pattern) {
+                    matches.push(GrepMatch {
+                        path: path.clone(),
+                        line_number: idx + 1,
+                        line: line.to_string(),
+                    });
+                }
+            }
+        }
+
+        Ok(matches)
+    }
+
+    async fn create_directory(&self, session_id: SessionId, path: &str) -> Result<FileInfo> {
+        let normalized = normalize_path(path);
+        self.ensure_parent_directories(session_id, &normalized)
+            .await?;
+        self.insert_directory_if_missing(session_id, &normalized)
+            .await?;
+        let file = self
+            .read_file(session_id, &normalized)
+            .await?
+            .ok_or_else(|| AgentLoopError::store(format!("directory not found: {normalized}")))?;
+        Ok(file_info(&file))
+    }
+}
+
+/// In-memory implementation of session key/value and secret storage.
+#[derive(Debug, Default, Clone)]
+pub struct InMemorySessionStorageStore {
+    values: Arc<RwLock<HashMap<(SessionId, String), StorageValue>>>,
+    secrets: Arc<RwLock<HashMap<(SessionId, String), StorageValue>>>,
+}
+
+#[derive(Debug, Clone)]
+struct StorageValue {
+    value: String,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+impl InMemorySessionStorageStore {
+    /// Create an empty in-memory storage store.
+    pub fn new() -> Self {
+        Self {
+            values: Arc::new(RwLock::new(HashMap::new())),
+            secrets: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+}
+
+#[async_trait]
+impl SessionStorageStore for InMemorySessionStorageStore {
+    async fn set_value(&self, session_id: SessionId, key: &str, value: &str) -> Result<()> {
+        upsert_storage(&self.values, session_id, key, value).await;
+        Ok(())
+    }
+
+    async fn get_value(&self, session_id: SessionId, key: &str) -> Result<Option<String>> {
+        Ok(self
+            .values
+            .read()
+            .await
+            .get(&(session_id, key.to_string()))
+            .map(|value| value.value.clone()))
+    }
+
+    async fn delete_value(&self, session_id: SessionId, key: &str) -> Result<bool> {
+        Ok(self
+            .values
+            .write()
+            .await
+            .remove(&(session_id, key.to_string()))
+            .is_some())
+    }
+
+    async fn list_keys(&self, session_id: SessionId) -> Result<Vec<KeyInfo>> {
+        Ok(list_storage(&self.values, session_id)
+            .await
+            .into_iter()
+            .map(|(key, value)| KeyInfo {
+                key,
+                created_at: value.created_at,
+                updated_at: value.updated_at,
+            })
+            .collect())
+    }
+
+    async fn set_secret(&self, session_id: SessionId, name: &str, value: &str) -> Result<()> {
+        upsert_storage(&self.secrets, session_id, name, value).await;
+        Ok(())
+    }
+
+    async fn get_secret(&self, session_id: SessionId, name: &str) -> Result<Option<String>> {
+        Ok(self
+            .secrets
+            .read()
+            .await
+            .get(&(session_id, name.to_string()))
+            .map(|value| value.value.clone()))
+    }
+
+    async fn delete_secret(&self, session_id: SessionId, name: &str) -> Result<bool> {
+        Ok(self
+            .secrets
+            .write()
+            .await
+            .remove(&(session_id, name.to_string()))
+            .is_some())
+    }
+
+    async fn list_secrets(&self, session_id: SessionId) -> Result<Vec<SecretInfo>> {
+        Ok(list_storage(&self.secrets, session_id)
+            .await
+            .into_iter()
+            .map(|(name, value)| SecretInfo {
+                name,
+                created_at: value.created_at,
+                updated_at: value.updated_at,
+            })
+            .collect())
+    }
+}
+
+async fn upsert_storage(
+    map: &Arc<RwLock<HashMap<(SessionId, String), StorageValue>>>,
+    session_id: SessionId,
+    key: &str,
+    value: &str,
+) {
+    let mut map = map.write().await;
+    let now = Utc::now();
+    map.entry((session_id, key.to_string()))
+        .and_modify(|stored| {
+            stored.value = value.to_string();
+            stored.updated_at = now;
+        })
+        .or_insert_with(|| StorageValue {
+            value: value.to_string(),
+            created_at: now,
+            updated_at: now,
+        });
+}
+
+async fn list_storage(
+    map: &Arc<RwLock<HashMap<(SessionId, String), StorageValue>>>,
+    session_id: SessionId,
+) -> Vec<(String, StorageValue)> {
+    let mut values: Vec<_> = map
+        .read()
+        .await
+        .iter()
+        .filter(|((sid, _), _)| *sid == session_id)
+        .map(|((_, key), value)| (key.clone(), value.clone()))
+        .collect();
+    values.sort_by(|a, b| a.0.cmp(&b.0));
+    values
+}
+
+fn normalize_path(path: &str) -> String {
+    if path == "/" || path.is_empty() {
+        return "/".to_string();
+    }
+    let mut normalized = if let Some(stripped) = path.strip_prefix("/workspace/") {
+        format!("/{}", stripped)
+    } else if path == "/workspace" {
+        "/".to_string()
+    } else if path.starts_with('/') {
+        path.to_string()
+    } else {
+        format!("/{}", path)
+    };
+
+    while normalized.len() > 1 && normalized.ends_with('/') {
+        normalized.pop();
+    }
+    normalized
+}
+
+fn root_directory(session_id: SessionId) -> SessionFile {
+    let now = Utc::now();
+    SessionFile {
+        id: Uuid::nil(),
+        session_id: session_id.uuid(),
+        path: "/".to_string(),
+        name: "/".to_string(),
+        content: None,
+        encoding: "text".to_string(),
+        is_directory: true,
+        is_readonly: false,
+        size_bytes: 0,
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+fn file_info(file: &SessionFile) -> FileInfo {
+    FileInfo {
+        id: file.id,
+        session_id: file.session_id,
+        path: file.path.clone(),
+        name: file.name.clone(),
+        is_directory: file.is_directory,
+        is_readonly: file.is_readonly,
+        size_bytes: file.size_bytes,
+        created_at: file.created_at,
+        updated_at: file.updated_at,
+    }
+}

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1,0 +1,142 @@
+//! Public in-process runtime for embedding Everruns.
+//!
+//! The runtime crate exposes an in-memory execution surface that runs the same
+//! core atoms (`input`, `reason`, `act`) used elsewhere in the system, but
+//! without the durable engine, gRPC worker boundary, or control-plane server.
+//!
+//! This is the intended public entrypoint for embedders who want to:
+//!
+//! - run sessions in their own process
+//! - provide their own platform definition (capabilities, drivers, harnesses)
+//! - seed harnesses, agents, sessions, and workspace files directly in code
+//! - replace the default in-memory stores with custom runtime backends
+//!
+//! For a runnable example, see:
+//!
+//! ```text
+//! cargo run -p everruns-runtime --example in_process_runtime
+//! ```
+//!
+//! # Example
+//!
+//! ```ignore
+//! use everruns_core::{
+//!     Agent, AgentCapabilityConfig, AgentStatus, CapabilityRegistry, DriverRegistry, Harness,
+//!     HarnessStatus, InputMessage, LlmProviderType, ModelWithProvider, PlatformDefinition,
+//!     Session, SessionStatus,
+//! };
+//! use everruns_core::capabilities::TestMathCapability;
+//! use everruns_runtime::InProcessRuntimeBuilder;
+//!
+//! let mut capabilities = CapabilityRegistry::new();
+//! capabilities.register(TestMathCapability);
+//!
+//! let platform = PlatformDefinition::new(capabilities, DriverRegistry::new());
+//!
+//! let runtime = InProcessRuntimeBuilder::new()
+//!     .platform_definition(platform)
+//!     .harness(Harness {
+//!         id: "harness_00000000000000000000000000000010".parse().unwrap(),
+//!         name: "math".into(),
+//!         display_name: Some("Math".into()),
+//!         description: Some("Minimal in-process harness".into()),
+//!         system_prompt: "You are a calculator.".into(),
+//!         parent_harness_id: None,
+//!         default_model_id: None,
+//!         tags: vec![],
+//!         capabilities: vec![AgentCapabilityConfig::new("test_math")],
+//!         initial_files: vec![],
+//!         network_access: None,
+//!         is_built_in: false,
+//!         status: HarnessStatus::Active,
+//!         created_at: chrono::Utc::now(),
+//!         updated_at: chrono::Utc::now(),
+//!         archived_at: None,
+//!         deleted_at: None,
+//!     })
+//!     .agent(Agent {
+//!         public_id: "agent_00000000000000000000000000000010".parse().unwrap(),
+//!         internal_id: uuid::Uuid::nil(),
+//!         name: "math-agent".into(),
+//!         display_name: Some("Math Agent".into()),
+//!         description: None,
+//!         system_prompt: "Use tools when needed.".into(),
+//!         default_model_id: None,
+//!         tags: vec![],
+//!         capabilities: vec![],
+//!         initial_files: vec![],
+//!         network_access: None,
+//!         max_iterations: Some(8),
+//!         tools: vec![],
+//!         status: AgentStatus::Active,
+//!         created_at: chrono::Utc::now(),
+//!         updated_at: chrono::Utc::now(),
+//!         archived_at: None,
+//!         deleted_at: None,
+//!         usage: None,
+//!     })
+//!     .session(Session {
+//!         id: "session_00000000000000000000000000000010".parse().unwrap(),
+//!         organization_id: everruns_core::DEFAULT_ORG_PUBLIC_ID.to_string(),
+//!         harness_id: "harness_00000000000000000000000000000010".parse().unwrap(),
+//!         agent_id: Some("agent_00000000000000000000000000000010".parse().unwrap()),
+//!         agent_identity_id: None,
+//!         title: Some("Math Session".into()),
+//!         locale: None,
+//!         preview: None,
+//!         output_preview: None,
+//!         tags: vec![],
+//!         model_id: None,
+//!         capabilities: vec![],
+//!         tools: vec![],
+//!         system_prompt: None,
+//!         initial_files: vec![],
+//!         hints: None,
+//!         network_access: None,
+//!         max_iterations: None,
+//!         status: SessionStatus::Started,
+//!         created_at: chrono::Utc::now(),
+//!         updated_at: chrono::Utc::now(),
+//!         started_at: None,
+//!         finished_at: None,
+//!         usage: None,
+//!         is_pinned: None,
+//!         active_schedule_count: None,
+//!         features: vec![],
+//!         parent_session_id: None,
+//!         subagent_name: None,
+//!         subagent_task: None,
+//!         subagent_status: None,
+//!         blueprint_id: None,
+//!         blueprint_config: None,
+//!     })
+//!     .llm_sim(everruns_core::llmsim_driver::LlmSimConfig::fixed("4"))
+//!     .default_model(ModelWithProvider {
+//!         model: "llmsim-model".into(),
+//!         provider_type: LlmProviderType::LlmSim,
+//!         api_key: Some("fake-key".into()),
+//!         base_url: None,
+//!     })
+//!     .build()
+//!     .await?;
+//!
+//! let result = runtime
+//!     .run_turn(
+//!         "session_00000000000000000000000000000010".parse().unwrap(),
+//!         InputMessage::user("What is 2 + 2?"),
+//!     )
+//!     .await?;
+//! assert!(result.success);
+//! # Ok::<(), everruns_core::AgentLoopError>(())
+//! ```
+
+mod backends;
+mod in_memory;
+mod runtime;
+
+pub use backends::{
+    RuntimeAgentStore, RuntimeBackends, RuntimeEventCollector, RuntimeFileStore,
+    RuntimeHarnessStore, RuntimeMessageStore, RuntimeProviderStore, RuntimeSessionStore,
+};
+pub use in_memory::{InMemorySessionFileStore, InMemorySessionStorageStore, InMemorySessionStore};
+pub use runtime::{InProcessRuntime, InProcessRuntimeBuilder, TurnResult};

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -423,8 +423,15 @@ impl InProcessRuntime {
         let capability_registry = self.platform_definition.capability_registry().clone();
         let driver_registry = self.platform_definition.driver_registry().clone();
         let resolved_configs =
-            resolve_capability_configs(&overlay.capabilities, &capability_registry)
-                .unwrap_or_else(|_| overlay.capabilities.clone());
+            resolve_capability_configs(&overlay.capabilities, &capability_registry).unwrap_or_else(
+                |error| {
+                    tracing::warn!(
+                        error = ?error,
+                        "failed to resolve capability configs; falling back to overlay capabilities"
+                    );
+                    overlay.capabilities.clone()
+                },
+            );
         let system_prompt_ctx = SystemPromptContext {
             session_id,
             locale: session.locale.clone(),
@@ -447,8 +454,10 @@ impl InProcessRuntime {
             .collect::<Vec<_>>();
 
         let tool_registry = build_tool_registry(collected.tools);
-        let synthetic_agent_id = session.agent_id.unwrap_or_else(AgentId::new);
-        let org_id = 1;
+        let synthetic_agent_id = session
+            .agent_id
+            .unwrap_or_else(|| AgentId::from_uuid(session.id.uuid()));
+        let org_id = 0;
         let org_public_id = session
             .organization_id
             .parse::<OrgId>()
@@ -625,7 +634,7 @@ impl PersistingEventEmitter {
 impl EventEmitter for PersistingEventEmitter {
     async fn emit(&self, request: EventRequest) -> Result<Event> {
         let event = self.inner.emit(request.clone()).await?;
-        if let Some(message) = message_from_event(&request.data) {
+        if let Some(message) = message_from_event(&event.data) {
             self.message_store
                 .store_message(request.session_id, message)
                 .await?;

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -1,0 +1,734 @@
+// In-process runtime builder and runner.
+// Decision: the public runtime is in-memory today, but uses the same core atoms
+// and capability resolution path as the durable worker so behavior stays close.
+
+use crate::backends::{
+    DynAgentStore, DynEventEmitter, DynFileStore, DynHarnessStore, DynMessageStore,
+    DynProviderStore, DynSessionStore, RuntimeAgentStore, RuntimeBackends, RuntimeEventCollector,
+    RuntimeFileStore, RuntimeHarnessStore, RuntimeMessageStore, RuntimeProviderStore,
+    RuntimeSessionStore,
+};
+use crate::in_memory::{
+    InMemorySessionFileStore, InMemorySessionStorageStore, InMemorySessionStore,
+};
+use async_trait::async_trait;
+use everruns_core::agent::Agent;
+use everruns_core::atoms::{
+    ActAtom, ActInput, Atom, AtomContext, InputAtom, InputAtomInput, ReasonAtom, ReasonInput,
+};
+use everruns_core::capabilities::{
+    Capability, CapabilityRegistry, SystemPromptContext, collect_capabilities_with_configs,
+    resolve_capability_configs,
+};
+use everruns_core::config_layer::AgentConfigOverlay;
+use everruns_core::error::{AgentLoopError, Result};
+use everruns_core::events::{
+    Event, EventContext, EventData, EventRequest, InputMessageData, OutputMessageCompletedData,
+    ToolCompletedData,
+};
+use everruns_core::harness::Harness;
+use everruns_core::llm_driver_registry::{DriverRegistry, ProviderType};
+use everruns_core::llm_models::LlmProviderType;
+use everruns_core::llmsim_driver::{LlmSimConfig, LlmSimDriver};
+use everruns_core::memory::{
+    InMemoryAgentStore, InMemoryEventEmitter, InMemoryHarnessStore, InMemoryLlmProviderStore,
+    InMemoryMemoryStore, InMemoryMessageRetriever,
+};
+use everruns_core::message::{ContentPart, Message};
+use everruns_core::platform_definition::PlatformDefinition;
+use everruns_core::runtime_agent::default_max_iterations;
+use everruns_core::session::Session;
+use everruns_core::session_file::{InitialFile, SessionFile};
+use everruns_core::tools::{ToolRegistry, ToolResultImage};
+use everruns_core::traits::{EventEmitter, ModelWithProvider, SessionStorageStore};
+use everruns_core::turn::{TurnAction, TurnContext, TurnOutcome, TurnStateMachine};
+use everruns_core::typed_id::{AgentId, OrgId, SessionId};
+use everruns_core::{InputMessage, MemoryStoreBackend};
+use std::sync::Arc;
+
+#[derive(Debug, Clone)]
+pub struct TurnResult {
+    /// Final text response produced by the turn.
+    pub response: String,
+    /// Number of reason iterations executed.
+    pub iterations: usize,
+    /// Total number of tool calls executed during the turn.
+    pub tool_calls_count: usize,
+    /// Whether the turn completed without an unrecoverable failure.
+    pub success: bool,
+    /// Failure message when `success` is false.
+    pub error: Option<String>,
+    /// Turn identifier used to correlate emitted events.
+    pub turn_id: everruns_core::typed_id::TurnId,
+}
+
+impl TurnResult {
+    fn from_outcome(outcome: TurnOutcome, turn_id: everruns_core::typed_id::TurnId) -> Self {
+        match outcome {
+            TurnOutcome::Success {
+                response,
+                iterations,
+                tool_calls_count,
+            } => Self {
+                response,
+                iterations,
+                tool_calls_count,
+                success: true,
+                error: None,
+                turn_id,
+            },
+            TurnOutcome::Failed { error, iterations } => Self {
+                response: String::new(),
+                iterations,
+                tool_calls_count: 0,
+                success: false,
+                error: Some(error),
+                turn_id,
+            },
+            TurnOutcome::MaxIterationsReached {
+                response,
+                iterations,
+                tool_calls_count,
+            } => Self {
+                response,
+                iterations,
+                tool_calls_count,
+                success: true,
+                error: None,
+                turn_id,
+            },
+        }
+    }
+}
+
+/// Builder for the public in-process runtime.
+///
+/// The builder owns a standalone runtime bundle:
+/// - `PlatformDefinition` for capabilities and drivers
+/// - in-memory stores for sessions, files, storage, memory, and messages
+/// - seeded harness/agent/session entities
+///
+/// `build()` returns an [`InProcessRuntime`] that can execute turns in-process
+/// without the durable engine or the control-plane server.
+pub struct InProcessRuntimeBuilder {
+    platform_definition: PlatformDefinition,
+    llm_sim_config: Option<LlmSimConfig>,
+    default_model: Option<ModelWithProvider>,
+    backends: Option<RuntimeBackends>,
+    harnesses: Vec<Harness>,
+    agents: Vec<Agent>,
+    sessions: Vec<Session>,
+    seeded_files: Vec<(SessionId, InitialFile)>,
+}
+
+impl Default for InProcessRuntimeBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InProcessRuntimeBuilder {
+    /// Create a builder with built-in capabilities and no implicit LLM driver.
+    ///
+    /// Embedders must either:
+    /// - call [`Self::llm_sim`] for deterministic local examples/tests, or
+    /// - register their own driver(s) on the platform definition and set a
+    ///   default model via [`Self::default_model`].
+    pub fn new() -> Self {
+        Self {
+            platform_definition: PlatformDefinition::new(
+                CapabilityRegistry::with_builtins(),
+                DriverRegistry::new(),
+            ),
+            llm_sim_config: None,
+            default_model: None,
+            backends: None,
+            harnesses: Vec::new(),
+            agents: Vec::new(),
+            sessions: Vec::new(),
+            seeded_files: Vec::new(),
+        }
+    }
+
+    /// Replace the platform definition used by the runtime.
+    pub fn platform_definition(mut self, platform_definition: PlatformDefinition) -> Self {
+        self.platform_definition = platform_definition;
+        self
+    }
+
+    /// Register an additional capability on the runtime platform.
+    pub fn capability<C: Capability + 'static>(mut self, capability: C) -> Self {
+        self.platform_definition
+            .capability_registry_mut()
+            .register(capability);
+        self
+    }
+
+    /// Replace the platform driver registry.
+    pub fn driver_registry(mut self, driver_registry: DriverRegistry) -> Self {
+        *self.platform_definition.driver_registry_mut() = driver_registry;
+        self
+    }
+
+    /// Register the built-in `llmsim` driver for deterministic local execution.
+    pub fn llm_sim(mut self, config: LlmSimConfig) -> Self {
+        self.llm_sim_config = Some(config);
+        self
+    }
+
+    /// Set the runtime default model used when sessions/agents do not override it.
+    pub fn default_model(mut self, model: ModelWithProvider) -> Self {
+        self.default_model = Some(model);
+        self
+    }
+
+    /// Supply a custom backend bundle instead of the built-in in-memory stores.
+    pub fn backends(mut self, backends: RuntimeBackends) -> Self {
+        self.backends = Some(backends);
+        self
+    }
+
+    /// Seed a harness into the runtime store.
+    pub fn harness(mut self, harness: Harness) -> Self {
+        self.harnesses.push(harness);
+        self
+    }
+
+    /// Seed an agent into the runtime store.
+    pub fn agent(mut self, agent: Agent) -> Self {
+        self.agents.push(agent);
+        self
+    }
+
+    /// Seed a session into the runtime store.
+    pub fn session(mut self, session: Session) -> Self {
+        self.sessions.push(session);
+        self
+    }
+
+    /// Seed an additional text file directly into a session workspace.
+    ///
+    /// This is applied after harness/agent/session `initial_files` are merged.
+    pub fn seed_text_file(
+        mut self,
+        session_id: SessionId,
+        path: impl Into<String>,
+        content: impl Into<String>,
+    ) -> Self {
+        self.seeded_files.push((
+            session_id,
+            InitialFile {
+                path: path.into(),
+                content: content.into(),
+                encoding: "text".to_string(),
+                is_readonly: false,
+            },
+        ));
+        self
+    }
+
+    /// Build the in-process runtime.
+    ///
+    /// Returns a configuration error when no default model is available after
+    /// applying explicit configuration and any requested `llmsim` setup.
+    pub async fn build(mut self) -> Result<InProcessRuntime> {
+        let backends = self
+            .backends
+            .take()
+            .unwrap_or_else(default_in_memory_backends);
+
+        if let Some(config) = self.llm_sim_config.take() {
+            let driver = LlmSimDriver::new(config);
+            self.platform_definition
+                .driver_registry_mut()
+                .register(ProviderType::LlmSim, move |_api_key, _base_url| {
+                    Box::new(driver.clone())
+                });
+
+            if self.default_model.is_none() {
+                self.default_model = Some(ModelWithProvider {
+                    model: "llmsim-model".to_string(),
+                    provider_type: LlmProviderType::LlmSim,
+                    api_key: Some("fake-key".to_string()),
+                    base_url: None,
+                });
+            }
+        }
+
+        let default_model = self.default_model.ok_or_else(|| {
+            AgentLoopError::config(
+                "in-process runtime requires a default model; call \
+                 InProcessRuntimeBuilder::default_model(...) or \
+                 InProcessRuntimeBuilder::llm_sim(...)",
+            )
+        })?;
+
+        backends
+            .provider_store
+            .set_default_model(default_model)
+            .await?;
+
+        for harness in &self.harnesses {
+            backends.harness_store.add_harness(harness.clone()).await?;
+        }
+        for agent in &self.agents {
+            backends.agent_store.add_agent(agent.clone()).await?;
+        }
+        for session in &self.sessions {
+            backends.session_store.add_session(session.clone()).await?;
+        }
+
+        for session in &self.sessions {
+            seed_runtime_initial_files(
+                backends.harness_store.as_ref(),
+                backends.agent_store.as_ref(),
+                backends.file_store.as_ref(),
+                session,
+            )
+            .await?;
+        }
+
+        for (session_id, file) in &self.seeded_files {
+            backends
+                .file_store
+                .seed_initial_file(*session_id, file)
+                .await?;
+        }
+
+        let event_emitter = PersistingEventEmitter::new(
+            backends.event_emitter.clone(),
+            backends.message_store.clone(),
+        );
+
+        Ok(InProcessRuntime {
+            platform_definition: Arc::new(self.platform_definition),
+            harness_store: backends.harness_store,
+            agent_store: backends.agent_store,
+            session_store: backends.session_store,
+            message_store: backends.message_store,
+            provider_store: backends.provider_store,
+            event_emitter,
+            raw_event_emitter: backends.event_emitter,
+            event_collector: backends.event_collector,
+            file_store: backends.file_store,
+            storage_store: backends.storage_store,
+            memory_store: backends.memory_store,
+        })
+    }
+}
+
+fn default_in_memory_backends() -> RuntimeBackends {
+    let harness_store: Arc<dyn RuntimeHarnessStore> = Arc::new(InMemoryHarnessStore::new());
+    let agent_store: Arc<dyn RuntimeAgentStore> = Arc::new(InMemoryAgentStore::new());
+    let session_store: Arc<dyn RuntimeSessionStore> = Arc::new(InMemorySessionStore::new());
+    let message_store: Arc<dyn RuntimeMessageStore> = Arc::new(InMemoryMessageRetriever::new());
+    let file_store: Arc<dyn RuntimeFileStore> = Arc::new(InMemorySessionFileStore::new());
+    let storage_store: Arc<dyn SessionStorageStore> = Arc::new(InMemorySessionStorageStore::new());
+    let memory_store: Arc<dyn MemoryStoreBackend> = Arc::new(InMemoryMemoryStore::new());
+    let provider_store: Arc<dyn RuntimeProviderStore> = Arc::new(InMemoryLlmProviderStore::new());
+    let event_emitter_impl = InMemoryEventEmitter::new();
+    let event_emitter: Arc<dyn EventEmitter> = Arc::new(event_emitter_impl.clone());
+    let event_collector: Arc<dyn RuntimeEventCollector> = Arc::new(event_emitter_impl);
+
+    RuntimeBackends {
+        harness_store,
+        agent_store,
+        session_store,
+        message_store,
+        provider_store,
+        event_emitter,
+        event_collector: Some(event_collector),
+        file_store,
+        storage_store,
+        memory_store,
+    }
+}
+
+#[derive(Clone)]
+/// Public in-process runtime backed by either in-memory or custom stores.
+///
+/// This runtime is intended for embedders who want to execute Everruns
+/// harnesses inside their own process while controlling capabilities,
+/// harness definitions, and driver registrations directly in Rust.
+pub struct InProcessRuntime {
+    platform_definition: Arc<PlatformDefinition>,
+    harness_store: Arc<dyn RuntimeHarnessStore>,
+    agent_store: Arc<dyn RuntimeAgentStore>,
+    session_store: Arc<dyn RuntimeSessionStore>,
+    message_store: Arc<dyn RuntimeMessageStore>,
+    provider_store: Arc<dyn RuntimeProviderStore>,
+    event_emitter: PersistingEventEmitter,
+    raw_event_emitter: Arc<dyn EventEmitter>,
+    event_collector: Option<Arc<dyn RuntimeEventCollector>>,
+    file_store: Arc<dyn RuntimeFileStore>,
+    storage_store: Arc<dyn SessionStorageStore>,
+    memory_store: Arc<dyn MemoryStoreBackend>,
+}
+
+impl InProcessRuntime {
+    /// Create a builder for the in-process runtime.
+    pub fn builder() -> InProcessRuntimeBuilder {
+        InProcessRuntimeBuilder::new()
+    }
+
+    /// Execute one turn for an existing session.
+    ///
+    /// The input message is stored in the runtime history, an `input.message`
+    /// event is emitted, and the turn then executes the shared core
+    /// `input -> reason -> act` state machine.
+    pub async fn run_turn(
+        &self,
+        session_id: SessionId,
+        input: impl Into<InputMessage>,
+    ) -> Result<TurnResult> {
+        let session = self
+            .session_store
+            .get_session(session_id)
+            .await?
+            .ok_or_else(|| AgentLoopError::store(format!("session not found: {session_id}")))?;
+
+        let input_message = self
+            .message_store
+            .add_input_message(session_id, input.into())
+            .await?;
+        self.raw_event_emitter
+            .emit(EventRequest::new(
+                session_id,
+                EventContext::empty(),
+                InputMessageData::new(input_message.clone()),
+            ))
+            .await?;
+        let harness_chain = self
+            .harness_store
+            .get_harness_chain(session.harness_id)
+            .await?;
+        if harness_chain.is_empty() {
+            return Err(AgentLoopError::store(format!(
+                "harness not found: {}",
+                session.harness_id
+            )));
+        }
+
+        let agent = match session.agent_id {
+            Some(agent_id) => self
+                .agent_store
+                .get_agent(agent_id)
+                .await?
+                .ok_or_else(|| AgentLoopError::store(format!("agent not found: {agent_id}")))
+                .map(Some)?,
+            None => None,
+        };
+
+        let overlay = effective_overlay(&harness_chain, agent.as_ref(), &session);
+        let capability_registry = self.platform_definition.capability_registry().clone();
+        let driver_registry = self.platform_definition.driver_registry().clone();
+        let resolved_configs =
+            resolve_capability_configs(&overlay.capabilities, &capability_registry)
+                .unwrap_or_else(|_| overlay.capabilities.clone());
+        let system_prompt_ctx = SystemPromptContext {
+            session_id,
+            locale: session.locale.clone(),
+            file_store: Some(Arc::new(DynFileStore(self.file_store.clone()))),
+        };
+        let collected = collect_capabilities_with_configs(
+            &resolved_configs,
+            &capability_registry,
+            &system_prompt_ctx,
+        )
+        .await;
+        let post_tool_hooks = resolved_configs
+            .iter()
+            .flat_map(|config| {
+                capability_registry
+                    .get(config.capability_id())
+                    .map(|capability| capability.post_tool_exec_hooks())
+                    .unwrap_or_default()
+            })
+            .collect::<Vec<_>>();
+
+        let tool_registry = build_tool_registry(collected.tools);
+        let synthetic_agent_id = session.agent_id.unwrap_or_else(AgentId::new);
+        let org_id = 1;
+        let org_public_id = session
+            .organization_id
+            .parse::<OrgId>()
+            .unwrap_or_else(|_| {
+                everruns_core::DEFAULT_ORG_PUBLIC_ID
+                    .parse()
+                    .expect("valid org id")
+            });
+
+        let input_atom = InputAtom::new(DynMessageStore(self.message_store.clone()));
+        let reason_atom = ReasonAtom::new(
+            DynHarnessStore(self.harness_store.clone()),
+            DynAgentStore(self.agent_store.clone()),
+            DynSessionStore(self.session_store.clone()),
+            DynMessageStore(self.message_store.clone()),
+            DynProviderStore(self.provider_store.clone()),
+            capability_registry.clone(),
+            driver_registry,
+            DynEventEmitter(Arc::new(self.event_emitter.clone())),
+        )
+        .with_file_store(Arc::new(DynFileStore(self.file_store.clone())));
+
+        let act_atom = ActAtom::with_file_store(
+            tool_registry.clone(),
+            DynEventEmitter(Arc::new(self.event_emitter.clone())),
+            Arc::new(DynFileStore(self.file_store.clone())),
+        )
+        .with_storage_store(self.storage_store.clone())
+        .with_session_store(Arc::new(DynSessionStore(self.session_store.clone())))
+        .with_session_mutator(Arc::new(DynSessionStore(self.session_store.clone())))
+        .with_memory_store(self.memory_store.clone())
+        .with_org_id(org_public_id)
+        .with_capability_registry(capability_registry)
+        .with_post_tool_hooks(post_tool_hooks);
+
+        let mut previous_response_id: Option<String> = None;
+        let mut last_reason_result: Option<everruns_core::ReasonResult> = None;
+        let max_iterations = overlay
+            .max_iterations
+            .unwrap_or_else(default_max_iterations);
+        let mut state_machine = TurnStateMachine::new(
+            TurnContext::new(session_id, input_message.id, synthetic_agent_id, org_id),
+            max_iterations,
+        );
+
+        loop {
+            match state_machine.next_action() {
+                TurnAction::ExecuteInput => {
+                    let base_context = AtomContext::new(
+                        state_machine.context().session_id,
+                        state_machine.context().turn_id,
+                        state_machine.context().input_message_id,
+                    );
+                    input_atom
+                        .execute(InputAtomInput {
+                            context: base_context,
+                        })
+                        .await?;
+                    state_machine.on_input_completed();
+                }
+                TurnAction::ExecuteReason => {
+                    let base_context = AtomContext::new(
+                        state_machine.context().session_id,
+                        state_machine.context().turn_id,
+                        state_machine.context().input_message_id,
+                    );
+                    let reason_result = reason_atom
+                        .execute(ReasonInput {
+                            context: base_context.next_exec(),
+                            harness_id: session.harness_id,
+                            agent_id: session.agent_id,
+                            org_id,
+                            mcp_tool_definitions: vec![],
+                            previous_response_id: previous_response_id.take(),
+                            iteration: state_machine.current_iteration() as u32 + 1,
+                        })
+                        .await?;
+
+                    let tool_call_count = reason_result.tool_calls.len();
+                    previous_response_id = reason_result.response_id.clone();
+                    state_machine.on_reason_completed(
+                        reason_result.text.clone(),
+                        reason_result.has_tool_calls,
+                        tool_call_count,
+                        reason_result.success,
+                        reason_result.error.clone(),
+                        false,
+                    );
+                    if reason_result.has_tool_calls {
+                        last_reason_result = Some(reason_result);
+                    }
+                }
+                TurnAction::ExecuteAct => {
+                    let reason_result = last_reason_result
+                        .take()
+                        .expect("ExecuteAct requires a prior ReasonResult");
+                    let base_context = AtomContext::new(
+                        state_machine.context().session_id,
+                        state_machine.context().turn_id,
+                        state_machine.context().input_message_id,
+                    );
+                    act_atom
+                        .execute(ActInput {
+                            org_id: Some(org_id),
+                            context: base_context.next_exec(),
+                            harness_id: session.harness_id,
+                            agent_id: session.agent_id,
+                            tool_calls: reason_result.tool_calls,
+                            tool_definitions: reason_result.tool_definitions,
+                            locale: reason_result.locale,
+                            blueprint_id: None,
+                            network_access: reason_result.network_access,
+                        })
+                        .await?;
+                    state_machine.on_act_completed();
+                }
+                TurnAction::Complete(outcome) => {
+                    return Ok(TurnResult::from_outcome(
+                        outcome,
+                        state_machine.context().turn_id,
+                    ));
+                }
+            }
+        }
+    }
+
+    pub async fn run_text_turn(
+        &self,
+        session_id: SessionId,
+        text: impl Into<String>,
+    ) -> Result<TurnResult> {
+        self.run_turn(session_id, InputMessage::user(text)).await
+    }
+
+    /// Load the current message history for a session.
+    pub async fn messages(&self, session_id: SessionId) -> Result<Vec<Message>> {
+        self.message_store.load(session_id).await
+    }
+
+    /// Read a file from the in-memory session filesystem.
+    pub async fn read_file(
+        &self,
+        session_id: SessionId,
+        path: &str,
+    ) -> Result<Option<SessionFile>> {
+        self.file_store.read_file(session_id, path).await
+    }
+
+    /// Return all emitted events when the backend exposes an event collector.
+    pub async fn events(&self) -> Result<Vec<Event>> {
+        let collector = self.event_collector.as_ref().ok_or_else(|| {
+            AgentLoopError::config("events are not available for this runtime backend")
+        })?;
+        Ok(collector.events().await)
+    }
+}
+
+#[derive(Clone)]
+struct PersistingEventEmitter {
+    inner: Arc<dyn EventEmitter>,
+    message_store: Arc<dyn RuntimeMessageStore>,
+}
+
+impl PersistingEventEmitter {
+    fn new(inner: Arc<dyn EventEmitter>, message_store: Arc<dyn RuntimeMessageStore>) -> Self {
+        Self {
+            inner,
+            message_store,
+        }
+    }
+}
+
+#[async_trait]
+impl EventEmitter for PersistingEventEmitter {
+    async fn emit(&self, request: EventRequest) -> Result<Event> {
+        let event = self.inner.emit(request.clone()).await?;
+        if let Some(message) = message_from_event(&request.data) {
+            self.message_store
+                .store_message(request.session_id, message)
+                .await?;
+        }
+        Ok(event)
+    }
+}
+
+fn effective_overlay(
+    harness_chain: &[Harness],
+    agent: Option<&Agent>,
+    session: &Session,
+) -> AgentConfigOverlay {
+    let harness_layers = harness_chain.iter().map(AgentConfigOverlay::from);
+    let agent_layers = agent.into_iter().map(AgentConfigOverlay::from);
+    AgentConfigOverlay::fold(
+        harness_layers
+            .chain(agent_layers)
+            .chain([AgentConfigOverlay::from(session)]),
+    )
+}
+
+async fn seed_runtime_initial_files(
+    harness_store: &dyn RuntimeHarnessStore,
+    agent_store: &dyn RuntimeAgentStore,
+    file_store: &dyn RuntimeFileStore,
+    session: &Session,
+) -> Result<()> {
+    let harness_chain = harness_store.get_harness_chain(session.harness_id).await?;
+    if harness_chain.is_empty() {
+        return Err(AgentLoopError::store(format!(
+            "harness not found while seeding files: {}",
+            session.harness_id
+        )));
+    }
+    let agent = match session.agent_id {
+        Some(agent_id) => Some(
+            agent_store
+                .get_agent(agent_id)
+                .await?
+                .ok_or_else(|| AgentLoopError::store(format!("agent not found: {agent_id}")))?,
+        ),
+        None => None,
+    };
+    let overlay = effective_overlay(&harness_chain, agent.as_ref(), session);
+    for file in &overlay.initial_files {
+        file_store.seed_initial_file(session.id, file).await?;
+    }
+    Ok(())
+}
+
+fn build_tool_registry(tools: Vec<Box<dyn everruns_core::tools::Tool>>) -> ToolRegistry {
+    let mut registry = ToolRegistry::with_defaults();
+    for tool in tools {
+        registry.register_boxed(tool);
+    }
+    registry
+}
+
+fn message_from_event(data: &EventData) -> Option<Message> {
+    match data {
+        EventData::InputMessage(data) => Some(data.message.clone()),
+        EventData::OutputMessageCompleted(OutputMessageCompletedData { message, .. }) => {
+            Some(message.clone())
+        }
+        EventData::ToolCompleted(data) => Some(tool_completed_to_message(data.clone())),
+        _ => None,
+    }
+}
+
+fn tool_completed_to_message(data: ToolCompletedData) -> Message {
+    let mut images: Vec<ToolResultImage> = Vec::new();
+    let result = data.result.map(|parts| {
+        for part in &parts {
+            if let ContentPart::Image(img) = part
+                && let (Some(base64), Some(media_type)) = (&img.base64, &img.media_type)
+            {
+                images.push(ToolResultImage {
+                    base64: base64.clone(),
+                    media_type: media_type.clone(),
+                });
+            }
+        }
+
+        let text_parts: Vec<&ContentPart> = parts
+            .iter()
+            .filter(|part| matches!(part, ContentPart::Text(_)))
+            .collect();
+        if text_parts.len() == 1
+            && let ContentPart::Text(text) = text_parts[0]
+        {
+            return serde_json::Value::String(text.text.clone());
+        }
+        if !text_parts.is_empty() {
+            serde_json::to_value(&text_parts).unwrap_or_default()
+        } else {
+            serde_json::Value::Null
+        }
+    });
+
+    if images.is_empty() {
+        Message::tool_result(&data.tool_call_id, result, data.error)
+    } else {
+        Message::tool_result_with_images(&data.tool_call_id, result, images)
+    }
+}

--- a/crates/runtime/tests/in_process_runtime_test.rs
+++ b/crates/runtime/tests/in_process_runtime_test.rs
@@ -1,0 +1,306 @@
+use chrono::Utc;
+use everruns_core::capabilities::TestMathCapability;
+use everruns_core::llm_driver_registry::DriverRegistry;
+use everruns_core::llmsim_driver::LlmSimConfig;
+use everruns_core::memory::{
+    InMemoryAgentStore, InMemoryEventEmitter, InMemoryHarnessStore, InMemoryLlmProviderStore,
+    InMemoryMemoryStore, InMemoryMessageRetriever,
+};
+use everruns_core::{
+    Agent, AgentCapabilityConfig, AgentStatus, CapabilityRegistry, Harness, HarnessStatus,
+    LlmProviderType, MessageRole, ModelWithProvider, PlatformDefinition, Session, SessionStatus,
+    ToolCall,
+};
+use everruns_runtime::{
+    InMemorySessionFileStore, InMemorySessionStorageStore, InMemorySessionStore,
+    InProcessRuntimeBuilder, RuntimeBackends,
+};
+use std::sync::Arc;
+use uuid::Uuid;
+
+fn minimal_platform() -> PlatformDefinition {
+    let mut capabilities = CapabilityRegistry::new();
+    capabilities.register(TestMathCapability);
+    PlatformDefinition::new(capabilities, DriverRegistry::new())
+}
+
+fn harness(harness_id: everruns_core::HarnessId) -> Harness {
+    Harness {
+        id: harness_id,
+        name: "math".into(),
+        display_name: Some("Math".into()),
+        description: None,
+        system_prompt: "You are a math assistant.".into(),
+        parent_harness_id: None,
+        default_model_id: None,
+        tags: vec![],
+        capabilities: vec![AgentCapabilityConfig::new("test_math")],
+        initial_files: vec![],
+        network_access: None,
+        is_built_in: false,
+        status: HarnessStatus::Active,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        archived_at: None,
+        deleted_at: None,
+    }
+}
+
+fn agent(agent_id: everruns_core::AgentId) -> Agent {
+    Agent {
+        public_id: agent_id,
+        internal_id: Uuid::nil(),
+        name: "math-agent".into(),
+        display_name: Some("Math Agent".into()),
+        description: None,
+        system_prompt: "Use tools when needed.".into(),
+        default_model_id: None,
+        tags: vec![],
+        capabilities: vec![],
+        initial_files: vec![],
+        network_access: None,
+        max_iterations: Some(8),
+        tools: vec![],
+        status: AgentStatus::Active,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        archived_at: None,
+        deleted_at: None,
+        usage: None,
+    }
+}
+
+fn session(
+    session_id: everruns_core::SessionId,
+    harness_id: everruns_core::HarnessId,
+    agent_id: Option<everruns_core::AgentId>,
+) -> Session {
+    Session {
+        id: session_id,
+        organization_id: everruns_core::DEFAULT_ORG_PUBLIC_ID.to_string(),
+        harness_id,
+        agent_id,
+        agent_identity_id: None,
+        title: Some("Embedded Session".into()),
+        locale: None,
+        preview: None,
+        output_preview: None,
+        tags: vec![],
+        model_id: None,
+        capabilities: vec![],
+        tools: vec![],
+        system_prompt: None,
+        initial_files: vec![],
+        hints: None,
+        network_access: None,
+        max_iterations: None,
+        status: SessionStatus::Started,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        started_at: None,
+        finished_at: None,
+        usage: None,
+        is_pinned: None,
+        active_schedule_count: None,
+        features: vec![],
+        parent_session_id: None,
+        subagent_name: None,
+        subagent_task: None,
+        subagent_status: None,
+        blueprint_id: None,
+        blueprint_config: None,
+    }
+}
+
+#[tokio::test]
+async fn runtime_executes_tool_loop_and_persists_messages() {
+    let harness_id = "harness_00000000000000000000000000000021".parse().unwrap();
+    let agent_id = "agent_00000000000000000000000000000021".parse().unwrap();
+    let session_id = "session_00000000000000000000000000000021".parse().unwrap();
+
+    let runtime = InProcessRuntimeBuilder::new()
+        .platform_definition(minimal_platform())
+        .llm_sim(
+            LlmSimConfig::fixed("Let me calculate that.").with_tool_call_sequence(vec![
+                vec![ToolCall {
+                    id: "call_mul_1".into(),
+                    name: "multiply".into(),
+                    arguments: serde_json::json!({"a": 6, "b": 7}),
+                }],
+                vec![],
+            ]),
+        )
+        .default_model(ModelWithProvider {
+            model: "llmsim-model".into(),
+            provider_type: LlmProviderType::LlmSim,
+            api_key: Some("fake-key".into()),
+            base_url: None,
+        })
+        .harness(harness(harness_id))
+        .agent(agent(agent_id))
+        .session(session(session_id, harness_id, Some(agent_id)))
+        .build()
+        .await
+        .unwrap();
+
+    let result = runtime
+        .run_text_turn(session_id, "What is 6 * 7?")
+        .await
+        .unwrap();
+    assert!(result.success);
+
+    let messages = runtime.messages(session_id).await.unwrap();
+    assert_eq!(
+        messages.len(),
+        4,
+        "user + assistant(tool call) + tool result + assistant"
+    );
+    assert_eq!(messages[0].role, MessageRole::User);
+    assert!(
+        messages[1].has_tool_calls(),
+        "assistant tool call must be persisted"
+    );
+    assert_eq!(messages[2].role, MessageRole::ToolResult);
+    assert_eq!(messages[2].tool_call_id(), Some("call_mul_1"));
+    assert_eq!(messages[3].role, MessageRole::Agent);
+
+    let event_types: Vec<_> = runtime
+        .events()
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|event| event.data.event_type().to_string())
+        .collect();
+    assert!(
+        event_types
+            .iter()
+            .any(|event_type| event_type == "input.message"),
+        "run_turn should emit the same input event shape as the API path",
+    );
+    assert!(
+        event_types
+            .iter()
+            .any(|event_type| event_type == "tool.completed"),
+        "tool execution events must be captured for embedders",
+    );
+}
+
+#[tokio::test]
+async fn runtime_seeds_initial_files_from_harness_chain() {
+    let harness_id = "harness_00000000000000000000000000000031".parse().unwrap();
+    let agent_id = "agent_00000000000000000000000000000031".parse().unwrap();
+    let session_id = "session_00000000000000000000000000000031".parse().unwrap();
+
+    let mut math_harness = harness(harness_id);
+    math_harness
+        .initial_files
+        .push(everruns_core::session_file::InitialFile {
+            path: "/workspace/notes.txt".into(),
+            content: "hello embedded runtime".into(),
+            encoding: "text".into(),
+            is_readonly: true,
+        });
+
+    let runtime = InProcessRuntimeBuilder::new()
+        .platform_definition(minimal_platform())
+        .llm_sim(LlmSimConfig::fixed("No-op"))
+        .default_model(ModelWithProvider {
+            model: "llmsim-model".into(),
+            provider_type: LlmProviderType::LlmSim,
+            api_key: Some("fake-key".into()),
+            base_url: None,
+        })
+        .harness(math_harness)
+        .agent(agent(agent_id))
+        .session(session(session_id, harness_id, Some(agent_id)))
+        .build()
+        .await
+        .unwrap();
+
+    let file = runtime
+        .read_file(session_id, "/workspace/notes.txt")
+        .await
+        .unwrap()
+        .expect("seeded file");
+
+    assert_eq!(file.content.as_deref(), Some("hello embedded runtime"));
+    assert!(file.is_readonly);
+}
+
+#[tokio::test]
+async fn runtime_runs_session_without_agent_entity() {
+    let harness_id = "harness_00000000000000000000000000000041".parse().unwrap();
+    let session_id = "session_00000000000000000000000000000041".parse().unwrap();
+
+    let runtime = InProcessRuntimeBuilder::new()
+        .platform_definition(minimal_platform())
+        .llm_sim(LlmSimConfig::fixed("Harness-only runtime works"))
+        .default_model(ModelWithProvider {
+            model: "llmsim-model".into(),
+            provider_type: LlmProviderType::LlmSim,
+            api_key: Some("fake-key".into()),
+            base_url: None,
+        })
+        .harness(harness(harness_id))
+        .session(session(session_id, harness_id, None))
+        .build()
+        .await
+        .unwrap();
+
+    let result = runtime
+        .run_text_turn(session_id, "Say hello from the harness")
+        .await
+        .unwrap();
+
+    assert!(result.success);
+    assert_eq!(result.response, "Harness-only runtime works");
+
+    let messages = runtime.messages(session_id).await.unwrap();
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[0].role, MessageRole::User);
+    assert_eq!(messages[1].role, MessageRole::Agent);
+}
+
+#[tokio::test]
+async fn runtime_accepts_explicit_backend_bundle() {
+    let harness_id = "harness_00000000000000000000000000000051".parse().unwrap();
+    let agent_id = "agent_00000000000000000000000000000051".parse().unwrap();
+    let session_id = "session_00000000000000000000000000000051".parse().unwrap();
+
+    let event_emitter = InMemoryEventEmitter::new();
+    let runtime = InProcessRuntimeBuilder::new()
+        .platform_definition(minimal_platform())
+        .backends(RuntimeBackends {
+            harness_store: Arc::new(InMemoryHarnessStore::new()),
+            agent_store: Arc::new(InMemoryAgentStore::new()),
+            session_store: Arc::new(InMemorySessionStore::new()),
+            message_store: Arc::new(InMemoryMessageRetriever::new()),
+            provider_store: Arc::new(InMemoryLlmProviderStore::new()),
+            event_emitter: Arc::new(event_emitter.clone()),
+            event_collector: Some(Arc::new(event_emitter)),
+            file_store: Arc::new(InMemorySessionFileStore::new()),
+            storage_store: Arc::new(InMemorySessionStorageStore::new()),
+            memory_store: Arc::new(InMemoryMemoryStore::new()),
+        })
+        .llm_sim(LlmSimConfig::fixed("Custom backend bundle works"))
+        .default_model(ModelWithProvider {
+            model: "llmsim-model".into(),
+            provider_type: LlmProviderType::LlmSim,
+            api_key: Some("fake-key".into()),
+            base_url: None,
+        })
+        .harness(harness(harness_id))
+        .agent(agent(agent_id))
+        .session(session(session_id, harness_id, Some(agent_id)))
+        .build()
+        .await
+        .unwrap();
+
+    let result = runtime
+        .run_text_turn(session_id, "Use the explicit backend bundle")
+        .await
+        .unwrap();
+
+    assert!(result.success);
+    assert_eq!(result.response, "Custom backend bundle works");
+}

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -68,6 +68,7 @@ Events are classified as **ephemeral** or **durable**:
    - `server/` → `everruns-server` - **Control plane**: HTTP API (axum) + gRPC server (tonic), SSE streaming, database layer
    - `worker/` → `everruns-worker` - TaskWorker, WorkerAdapters, activities, gRPC adapters, durable task execution
    - `core/` → `everruns-core` - Core agent abstractions (traits, atoms, tools, events, capabilities, LLM drivers, shared types)
+   - `runtime/` → `everruns-runtime` - Public in-process runtime for embedded execution without durable engine/server
    - `internal-protocol/` → `everruns-internal-protocol` - gRPC protocol for worker ↔ server
    - `durable/` → `everruns-durable` - PostgreSQL-backed durable execution engine
    - `openai/` → `everruns-openai` - OpenAI LLM provider implementation
@@ -92,6 +93,7 @@ everruns/
 │   ├── server/           # Control plane: HTTP API + gRPC server + storage
 │   ├── worker/           # Durable worker with gRPC client
 │   ├── core/             # Shared abstractions and types
+│   ├── runtime/          # Public in-process embedded runtime
 │   ├── internal-protocol/# gRPC protocol definitions
 │   ├── durable/          # Durable execution engine
 │   ├── openai/           # OpenAI provider
@@ -113,12 +115,14 @@ everruns/
 ```mermaid
 graph TD
     core[core]
+    runtime[runtime]
     openai[openai]
     anthropic[anthropic]
     protocol[internal-protocol]
     worker[worker]
     server["server (control plane)"]
 
+    core --> runtime
     core --> openai
     core --> anthropic
     core --> protocol
@@ -146,6 +150,20 @@ The server and worker builders both accept an explicit `PlatformDefinition`. If 
 - `everruns_worker::default_platform_definition()`
 
 This keeps the existing OSS runtime as the default while allowing embedders to remove integrations, add custom capabilities, replace harness templates, or register different LLM drivers without forking Everruns internals.
+
+### Embedded Runtime
+
+Embedders who want to execute Everruns harnesses directly inside their own
+process should use `everruns-runtime`.
+
+`everruns-runtime` provides:
+
+- `InProcessRuntimeBuilder`
+- in-memory session/filesystem/storage/message backends
+- turn execution via the shared core `TurnStateMachine`
+- direct seeding of harnesses, agents, sessions, and files
+
+See [specs/runtime.md](runtime.md) for the public embedded runtime contract.
 
 ### Integration Plugin Force-Linking
 

--- a/specs/embedding.md
+++ b/specs/embedding.md
@@ -9,9 +9,10 @@ This spec defines the contract for embedding. See `crates/core/src/platform_defi
 ## Goals
 
 1. Let downstream Rust services start from `ServerAppBuilder` and `WorkerAppBuilder` instead of forking Everruns binaries.
-2. Let embedders add or remove built-in runtime components without patching internal call sites.
-3. Keep server startup, worker execution, org initialization, and seeding consistent by reading from the same definition.
-4. Preserve the existing OSS experience through default presets.
+2. Let downstream Rust services run Everruns harnesses directly in-process through `everruns-runtime`.
+3. Let embedders add or remove built-in runtime components without patching internal call sites.
+4. Keep server startup, worker execution, org initialization, and seeding consistent by reading from the same definition.
+5. Preserve the existing OSS experience through default presets.
 
 ## PlatformDefinition
 
@@ -23,6 +24,17 @@ This spec defines the contract for embedding. See `crates/core/src/platform_defi
 - Built-in harness templates
 
 The type lives in `everruns-core` so any binary can construct or mutate it without depending on `everruns-server`.
+
+## In-process Runtime
+
+Embedders that want to execute harnesses in their own process, without the
+durable engine or control-plane server, should use `everruns-runtime`.
+
+`everruns-runtime` consumes the same `PlatformDefinition` type and uses the
+shared core atoms and turn state machine. This keeps embedded execution aligned
+with the worker/runtime behavior while exposing a simpler embedder-facing API.
+
+See [specs/runtime.md](runtime.md) for the public embedded runtime contract.
 
 ### Built-in Harness Templates
 

--- a/specs/runtime.md
+++ b/specs/runtime.md
@@ -1,0 +1,173 @@
+# Runtime Specification
+
+## Abstract
+
+`everruns-runtime` is the public in-process execution crate for Everruns.
+
+It lets embedders run sessions inside their own process, without the durable
+execution engine, gRPC worker boundary, or control-plane server. The crate uses
+the same core atoms and capability resolution path as the worker so embedded
+execution stays behaviorally aligned with the main runtime.
+
+## Goals
+
+1. Provide a supported public crate for in-process execution.
+2. Let embedders supply their own `PlatformDefinition` with custom capabilities,
+   LLM drivers, and built-in harness templates.
+3. Run without PostgreSQL, NATS, or the durable engine.
+4. Ship batteries-included in-memory stores so common harnesses work without
+   server internals.
+5. Preserve the core turn contract (`input -> reason -> act`) and event/message
+   shapes used elsewhere in the system.
+
+## Position in the Stack
+
+`everruns-runtime` sits above `everruns-core` and below any host application.
+
+- `everruns-core` owns atoms, traits, capabilities, event types, and shared
+  domain/runtime types.
+- `everruns-runtime` owns embedder-facing orchestration, in-memory stores, turn
+  execution, and runtime seeding helpers.
+- `everruns-server` and `everruns-worker` remain control-plane and durable
+  execution hosts. They do not define the public in-process contract.
+
+## Public Contract
+
+The public entrypoint is `InProcessRuntimeBuilder` in
+`crates/runtime/src/runtime.rs`.
+
+### Builder responsibilities
+
+The builder must allow an embedder to:
+
+- Replace the `PlatformDefinition`
+- Register extra capabilities
+- Register or replace LLM drivers
+- Seed harnesses, agents, and sessions
+- Seed workspace files
+- Configure a default model
+- Optionally register `llmsim` for deterministic local examples and tests
+- Swap the default in-memory stores for custom backends via `RuntimeBackends`
+
+### Runtime responsibilities
+
+`InProcessRuntime` must expose:
+
+- `run_turn(session_id, input)` for one turn of execution
+- `run_text_turn(session_id, text)` convenience helper
+- `messages(session_id)` to inspect conversation history
+- `read_file(session_id, path)` to inspect the in-memory workspace
+- `events()` to inspect emitted runtime events
+
+## Execution Semantics
+
+`everruns-runtime` must execute the shared `TurnStateMachine` from `everruns-core`.
+
+Required behavior:
+
+1. Store the input message in runtime message history before `InputAtom` runs.
+2. Emit `input.message` when a turn starts.
+3. Resolve effective configuration by folding harness chain, agent, and session
+   overlays via `AgentConfigOverlay`.
+4. Resolve active capabilities from the effective overlay, not from the full
+   platform registry.
+5. Execute the same `ReasonAtom` and `ActAtom` implementations used by other
+   runtime hosts.
+6. Persist assistant messages and tool-result messages from emitted events so
+   subsequent turns see the same history shape as the durable/server-backed
+   runtime.
+
+## In-Memory Stores
+
+`everruns-runtime` ships reference in-memory stores for public embedding:
+
+- Session store
+- Session virtual filesystem store
+- Session key/value + secret store
+- Message retriever
+- Harness store
+- Agent store
+- Provider store
+- Memory store
+- Event emitter
+
+These stores are intended to make embedded execution usable out of the box.
+
+## Custom Backends
+
+Embedders that need persistence across process restarts may supply their own
+backend bundle through `RuntimeBackends`.
+
+`everruns-runtime` owns a small set of extension traits for this:
+
+- `RuntimeHarnessStore`
+- `RuntimeAgentStore`
+- `RuntimeSessionStore`
+- `RuntimeMessageStore`
+- `RuntimeFileStore`
+- `RuntimeProviderStore`
+- optional `RuntimeEventCollector`
+
+These extend the corresponding core traits with the minimal write operations the
+embedded runtime needs for:
+
+- seeding harnesses, agents, sessions, and initial files
+- storing input messages
+- persisting assistant and tool-result messages from emitted events
+- configuring the runtime default model
+
+This keeps `everruns-core` storage traits read-oriented where they already were,
+while making custom embedded backends a supported public path.
+
+This first public contract still does not require full production-ready
+persistence adapters in-tree. It only defines the supported extension seam.
+
+## Context and Capabilities
+
+Capabilities continue to live in `everruns-core`.
+
+`everruns-runtime` must provide the supporting stores those capabilities expect
+through `ToolContext`, including:
+
+- filesystem access
+- session storage
+- session metadata access/mutation
+- memory store access
+- message retrieval for context-management capabilities
+
+This means capabilities such as filesystem tools, persistent memory, and
+infinity context can run in-process as long as the runtime wires the necessary
+backends.
+
+## Model Resolution
+
+The runtime requires a default model. It may come from:
+
+- explicit `InProcessRuntimeBuilder::default_model(...)`
+- helper configuration like `InProcessRuntimeBuilder::llm_sim(...)`
+
+If no default model is available at build time, `build()` must fail with a
+configuration error.
+
+## Non-goals
+
+This spec does not require:
+
+- durable workflows
+- cross-process task recovery
+- gRPC adapters
+- database-backed persistence
+- server route composition
+- full parity with every server-owned integration backend
+
+Those remain separate concerns.
+
+## Source Index
+
+- `crates/runtime/src/lib.rs`
+- `crates/runtime/src/runtime.rs`
+- `crates/runtime/src/in_memory.rs`
+- `crates/runtime/examples/in_process_runtime.rs`
+- `crates/runtime/tests/in_process_runtime_test.rs`
+- `crates/core/src/turn.rs`
+- `crates/core/src/platform_definition.rs`


### PR DESCRIPTION
## What
Add a new public `everruns-runtime` crate for embedded in-process execution.

This ships:
- `InProcessRuntimeBuilder` and `InProcessRuntime`
- public in-memory session/filesystem/storage backends
- a supported custom-backend seam via `RuntimeBackends` and runtime-owned store extension traits
- rustdocs, example, tests, and runtime spec updates

## Why
We want embedders to run Everruns harnesses in their own process without the durable engine, gRPC worker boundary, or control-plane server, while still using the shared core atoms/capability path.

## How
Build the new crate on top of `everruns-core`:
- execute turns through `TurnStateMachine`, `ReasonAtom`, and `ActAtom`
- seed harness/agent/session/file state into runtime-owned backends
- persist assistant/tool-result messages from emitted events so history shape matches the main runtime
- require explicit default-model configuration instead of silently widening the provider surface
- document the public contract in `specs/runtime.md` and link it from architecture/embedding docs

## Risk
- Medium
- New public crate and backend contract for embedded execution. Main risks are message persistence drift, capability context wiring drift, and file/store behavior differences between default in-memory backends and future custom backends.

## Security
- Threat categories reviewed: TM-TOOL, TM-LLM, TM-FS, TM-DOS
- Findings and resolutions:
  - Prevented duplicate message persistence by emitting `input.message` through the raw emitter while persisting assistant/tool-result messages through the runtime wrapper.
  - Removed implicit `llmsim` registration from the default builder path so embedders do not get hidden provider surface unless they opt in.
  - Kept filesystem behavior behind `SessionFileStore`/`RuntimeFileStore` and preserved readonly enforcement in the built-in backend.
  - No new external auth, tenant, network, or API trust boundary was introduced; no threat-model entry changes were required.

## Validation
- `cargo test -p everruns-runtime`
- `cargo clippy -p everruns-runtime -- -D warnings`
- `cargo check -p everruns-runtime --example in_process_runtime`
- `cargo run -p everruns-runtime --example in_process_runtime`
- `just pre-push`

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
