### PR TITLE
feat(apps): add AG-UI app channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ag-ui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cfd1ace43da05cf4dc0ffeb6d55dc16003df69b9c6959f1ac1262611137c2e2"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,7 +142,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -141,7 +153,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1363,7 +1375,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1488,7 +1500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1972,6 +1984,7 @@ name = "everruns-server"
 version = "0.8.12"
 dependencies = [
  "aes-gcm",
+ "ag-ui-core",
  "anyhow",
  "argon2",
  "async-nats",
@@ -2881,7 +2894,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2901,7 +2914,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3943,7 +3956,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4713,7 +4726,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4751,7 +4764,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5282,7 +5295,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5363,7 +5376,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5832,7 +5845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6241,7 +6254,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7482,7 +7495,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -30,6 +30,7 @@
         "zod": "^4.1.12"
       },
       "devDependencies": {
+        "@ag-ui/core": "^0.0.45",
         "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4.2.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -59,7 +60,6 @@
       "version": "0.0.45",
       "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.45.tgz",
       "integrity": "sha512-Ccsarxb23TChONOWXDbNBqp1fIbOSMht8g7w6AsSYBTtdOwZ7h7AkjNkr3LSdVv+RbT30JMdSLtieJE0YepNPg==",
-      "peer": true,
       "dependencies": {
         "rxjs": "7.8.1",
         "zod": "^3.22.4"
@@ -70,7 +70,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -12769,7 +12768,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -46,6 +46,7 @@
     "zod": "^4.1.12"
   },
   "devDependencies": {
+    "@ag-ui/core": "^0.0.45",
     "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4.2.0",
     "@testing-library/jest-dom": "^6.6.3",

--- a/apps/ui/src/__tests__/ag-ui-contract.test.ts
+++ b/apps/ui/src/__tests__/ag-ui-contract.test.ts
@@ -1,0 +1,72 @@
+import { EventSchemas, RunAgentInputSchema } from "@ag-ui/core";
+
+describe("AG-UI contract fixtures", () => {
+  const threadId = "00000000-0000-0000-0000-000000000001";
+  const runId = "00000000-0000-0000-0000-000000000002";
+  const messageId = "00000000-0000-0000-0000-000000000003";
+
+  it("validates a canonical run request", () => {
+    const payload = {
+      threadId,
+      runId,
+      state: {},
+      messages: [
+        {
+          id: "00000000-0000-0000-0000-000000000004",
+          role: "user",
+          content: "Hello",
+        },
+      ],
+      tools: [],
+      context: [],
+      forwardedProps: {},
+    };
+
+    expect(() => RunAgentInputSchema.parse(payload)).not.toThrow();
+  });
+
+  it("validates representative AG-UI events we emit", () => {
+    const events = [
+      { type: "RUN_STARTED", threadId, runId },
+      {
+        type: "MESSAGES_SNAPSHOT",
+        messages: [
+          {
+            id: "00000000-0000-0000-0000-000000000010",
+            role: "assistant",
+            content: "Snapshot message",
+          },
+        ],
+      },
+      { type: "THINKING_START" },
+      { type: "THINKING_TEXT_MESSAGE_START" },
+      { type: "THINKING_TEXT_MESSAGE_CONTENT", delta: "planning" },
+      { type: "THINKING_TEXT_MESSAGE_END" },
+      { type: "THINKING_END" },
+      { type: "TEXT_MESSAGE_START", messageId, role: "assistant" },
+      { type: "TEXT_MESSAGE_CONTENT", messageId, delta: "Hello" },
+      { type: "TEXT_MESSAGE_END", messageId },
+      {
+        type: "TOOL_CALL_START",
+        toolCallId: "call_12345678",
+        toolCallName: "search",
+        parentMessageId: messageId,
+      },
+      { type: "TOOL_CALL_ARGS", toolCallId: "call_12345678", delta: '{"q":"hi"}' },
+      { type: "TOOL_CALL_END", toolCallId: "call_12345678" },
+      {
+        type: "TOOL_CALL_RESULT",
+        messageId,
+        toolCallId: "call_12345678",
+        content: "done",
+        role: "tool",
+      },
+      { type: "RUN_FINISHED", threadId, runId },
+      { type: "RUN_ERROR", message: "Run failed" },
+    ];
+
+    for (const event of events) {
+      expect(() => EventSchemas.parse(event)).not.toThrow();
+    }
+  });
+});

--- a/apps/ui/src/__tests__/ag-ui-setup-guidance.test.tsx
+++ b/apps/ui/src/__tests__/ag-ui-setup-guidance.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { AgUiSetupGuidance } from "@/components/apps/ag-ui-setup-guidance";
+
+describe("AgUiSetupGuidance", () => {
+  it("renders the endpoint and anonymous status", () => {
+    render(
+      <AgUiSetupGuidance
+        endpointUrl="https://example.com/api/v1/apps/app-123/ag-ui"
+        isPublished={true}
+        anonymousEnabled={true}
+      />,
+    );
+
+    expect(screen.getByText("Anonymous")).toBeInTheDocument();
+    expect(screen.getByText("Ready for AG-UI clients")).toBeInTheDocument();
+    expect(screen.getByText("https://example.com/api/v1/apps/app-123/ag-ui")).toBeInTheDocument();
+    expect(screen.getByText("Responses stream back as AG-UI SSE events.")).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -49,9 +49,12 @@ import {
 } from "@/components/ui/dialog";
 import { ArrowLeft, Globe, GlobeLock, Trash2, Pencil, Check, X, Rocket, Plus } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
+import { AgUiSetupGuidance } from "@/components/apps/ag-ui-setup-guidance";
 import { SlackSetupGuidance } from "@/components/apps/slack-setup-guidance";
 import type {
+  AgUiChannelConfig,
   AppChannel,
+  ChannelType,
   SessionStrategy,
   SlackChannelConfig,
   SlackReplyMode,
@@ -83,6 +86,8 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
   const [editingChannelId, setEditingChannelId] = useState<string | null>(null);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showAddChannel, setShowAddChannel] = useState(false);
+  const [editingChannelType, setEditingChannelType] = useState<ChannelType>("slack");
+  const [addChannelType, setAddChannelType] = useState<ChannelType>("slack");
 
   // Basic info edit state
   const [editName, setEditName] = useState("");
@@ -112,7 +117,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
       config,
     }: {
       channelId: string;
-      config: SlackChannelConfig;
+      config: SlackChannelConfig | AgUiChannelConfig;
     }) => {
       return apiUpdateChannel(appId, channelId, { channel_config: config });
     },
@@ -120,9 +125,15 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
   });
 
   const addChannelMutation = useMutation({
-    mutationFn: async (config: SlackChannelConfig) => {
+    mutationFn: async ({
+      channelType,
+      config,
+    }: {
+      channelType: ChannelType;
+      config: SlackChannelConfig | AgUiChannelConfig;
+    }) => {
       return apiAddChannel(appId, {
-        channel_type: "slack",
+        channel_type: channelType,
         channel_config: config,
       });
     },
@@ -150,11 +161,21 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
   );
   const slackConfig = slackChannel?.channel_config as SlackChannelConfig | undefined;
   const hasSlackConfig = slackConfig?.signing_secret && slackConfig?.bot_token;
+  const agUiChannel = app?.channels?.find(
+    (ch: AppChannel) => ch.channel_type === "ag_ui" && ch.enabled,
+  );
+  const agUiConfig = agUiChannel?.channel_config as AgUiChannelConfig | undefined;
+  const hasAgUiConfig = agUiConfig?.anonymous ?? !!agUiChannel;
+  const canPublishApp = !!hasSlackConfig || hasAgUiConfig;
 
   const webhookUrl =
     typeof window !== "undefined"
       ? `${window.location.origin}/api/v1/apps/${appId}/slack/events`
       : `/api/v1/apps/${appId}/slack/events`;
+  const agUiEndpointUrl =
+    typeof window !== "undefined"
+      ? `${window.location.origin}/api/v1/apps/${appId}/ag-ui`
+      : `/api/v1/apps/${appId}/ag-ui`;
 
   const isLocalhost =
     typeof window !== "undefined" &&
@@ -199,17 +220,21 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
   };
 
   const startEditChannel = (channel: AppChannel) => {
-    const config = channel.channel_config as SlackChannelConfig;
-    setEditSigningSecret(config?.signing_secret ?? "");
-    setEditBotToken(config?.bot_token ?? "");
-    setEditChannelIdField(config?.channel_id ?? "");
-    setEditTeamId(config?.team_id ?? "");
-    setEditSessionStrategy(config?.session_strategy ?? "per_thread");
-    setEditReplyMode(config?.reply_mode ?? "all_messages");
+    setEditingChannelType(channel.channel_type);
+    if (channel.channel_type === "slack") {
+      const config = channel.channel_config as SlackChannelConfig;
+      setEditSigningSecret(config?.signing_secret ?? "");
+      setEditBotToken(config?.bot_token ?? "");
+      setEditChannelIdField(config?.channel_id ?? "");
+      setEditTeamId(config?.team_id ?? "");
+      setEditSessionStrategy(config?.session_strategy ?? "per_thread");
+      setEditReplyMode(config?.reply_mode ?? "all_messages");
+    }
     setEditingChannelId(channel.id);
   };
 
   const startAddChannel = () => {
+    setAddChannelType("slack");
     setEditSigningSecret("");
     setEditBotToken("");
     setEditChannelIdField("");
@@ -221,31 +246,38 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
 
   const saveChannel = async () => {
     if (!editingChannelId) return;
-    const channelConfig: SlackChannelConfig = {
-      signing_secret: editSigningSecret,
-      bot_token: editBotToken,
-      session_strategy: editSessionStrategy,
-      reply_mode: editReplyMode,
-      ...(editChannelIdField ? { channel_id: editChannelIdField } : {}),
-      ...(editTeamId ? { team_id: editTeamId } : {}),
-    };
     await updateChannelMutation.mutateAsync({
       channelId: editingChannelId,
-      config: channelConfig,
+      config:
+        editingChannelType === "ag_ui"
+          ? { anonymous: true }
+          : {
+              signing_secret: editSigningSecret,
+              bot_token: editBotToken,
+              session_strategy: editSessionStrategy,
+              reply_mode: editReplyMode,
+              ...(editChannelIdField ? { channel_id: editChannelIdField } : {}),
+              ...(editTeamId ? { team_id: editTeamId } : {}),
+            },
     });
     setEditingChannelId(null);
   };
 
   const saveNewChannel = async () => {
-    const channelConfig: SlackChannelConfig = {
-      signing_secret: editSigningSecret,
-      bot_token: editBotToken,
-      session_strategy: editSessionStrategy,
-      reply_mode: editReplyMode,
-      ...(editChannelIdField ? { channel_id: editChannelIdField } : {}),
-      ...(editTeamId ? { team_id: editTeamId } : {}),
-    };
-    await addChannelMutation.mutateAsync(channelConfig);
+    await addChannelMutation.mutateAsync({
+      channelType: addChannelType,
+      config:
+        addChannelType === "ag_ui"
+          ? { anonymous: true }
+          : {
+              signing_secret: editSigningSecret,
+              bot_token: editBotToken,
+              session_strategy: editSessionStrategy,
+              reply_mode: editReplyMode,
+              ...(editChannelIdField ? { channel_id: editChannelIdField } : {}),
+              ...(editTeamId ? { team_id: editTeamId } : {}),
+            },
+    });
   };
 
   const handleDelete = async () => {
@@ -283,132 +315,204 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
     );
   }
 
-  const renderChannelForm = (isSaving: boolean, formId: string = "default") => (
-    <div className="space-y-4">
-      <div>
-        <Label htmlFor={`signing_secret_${formId}`}>Signing Secret</Label>
-        <Input
-          id={`signing_secret_${formId}`}
-          type="password"
-          value={editSigningSecret}
-          onChange={(e) => setEditSigningSecret(e.target.value)}
-          placeholder="Your Slack app's signing secret"
-          required
-        />
-        <p className="text-xs text-muted-foreground mt-1">
-          Found in your Slack app &rarr; Settings &rarr; Basic Information &rarr; App Credentials
-        </p>
+  const renderChannelForm = (isSaving: boolean, formId: string = "default") => {
+    const formChannelType = editingChannelId ? editingChannelType : addChannelType;
+
+    return (
+      <div className="space-y-4">
+        {!editingChannelId && (
+          <div>
+            <Label htmlFor={`channel_type_${formId}`}>Channel Type</Label>
+            <Select
+              value={addChannelType}
+              onValueChange={(v) => setAddChannelType(v as ChannelType)}
+            >
+              <SelectTrigger id={`channel_type_${formId}`}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="slack">Slack</SelectItem>
+                <SelectItem value="ag_ui">AG-UI</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+
+        {formChannelType === "ag_ui" ? (
+          <div className="space-y-4">
+            <div className="rounded-md border p-3 text-sm text-muted-foreground">
+              AG-UI requests are accepted anonymously for now. Publish the app, then point an AG-UI
+              client at the endpoint shown on this page.
+            </div>
+            <div className="flex gap-2 pt-2">
+              <Button
+                size="sm"
+                onClick={editingChannelId ? saveChannel : saveNewChannel}
+                disabled={isSaving}
+              >
+                <Check className="w-3 h-3 mr-1" />
+                {isSaving ? "Saving..." : "Save"}
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setEditingChannelId(null);
+                  setShowAddChannel(false);
+                }}
+              >
+                <X className="w-3 h-3 mr-1" />
+                Cancel
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <div>
+              <Label htmlFor={`signing_secret_${formId}`}>Signing Secret</Label>
+              <Input
+                id={`signing_secret_${formId}`}
+                type="password"
+                value={editSigningSecret}
+                onChange={(e) => setEditSigningSecret(e.target.value)}
+                placeholder="Your Slack app's signing secret"
+                required
+              />
+              <p className="text-xs text-muted-foreground mt-1">
+                Found in your Slack app &rarr; Settings &rarr; Basic Information &rarr; App
+                Credentials
+              </p>
+            </div>
+
+            <div>
+              <Label htmlFor={`bot_token_${formId}`}>Bot User OAuth Token</Label>
+              <Input
+                id={`bot_token_${formId}`}
+                type="password"
+                value={editBotToken}
+                onChange={(e) => setEditBotToken(e.target.value)}
+                placeholder="xoxb-..."
+                required
+              />
+              <p className="text-xs text-muted-foreground mt-1">
+                Found in your Slack app &rarr; OAuth &amp; Permissions &rarr; Bot User OAuth Token
+              </p>
+            </div>
+
+            <Separator />
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label htmlFor={`team_id_${formId}`}>Workspace ID (optional)</Label>
+                <Input
+                  id={`team_id_${formId}`}
+                  value={editTeamId}
+                  onChange={(e) => setEditTeamId(e.target.value)}
+                  placeholder="T0123456789"
+                />
+              </div>
+
+              <div>
+                <Label htmlFor={`channel_id_${formId}`}>Channel ID (optional)</Label>
+                <Input
+                  id={`channel_id_${formId}`}
+                  value={editChannelIdField}
+                  onChange={(e) => setEditChannelIdField(e.target.value)}
+                  placeholder="C0123456789"
+                />
+              </div>
+            </div>
+
+            <div>
+              <Label htmlFor={`session_strategy_${formId}`}>Session Strategy</Label>
+              <Select
+                value={editSessionStrategy}
+                onValueChange={(v) => setEditSessionStrategy(v as SessionStrategy)}
+              >
+                <SelectTrigger>
+                  <SelectValue>
+                    {
+                      {
+                        per_thread: "Per Thread (default)",
+                        per_channel: "Per Channel",
+                        per_user: "Per User",
+                      }[editSessionStrategy]
+                    }
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="per_thread">Per Thread (default)</SelectItem>
+                  <SelectItem value="per_channel">Per Channel</SelectItem>
+                  <SelectItem value="per_user">Per User</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div>
+              <Label htmlFor={`reply_mode_${formId}`}>Reply Mode</Label>
+              <Select
+                value={editReplyMode}
+                onValueChange={(v) => setEditReplyMode(v as SlackReplyMode)}
+              >
+                <SelectTrigger>
+                  <SelectValue>
+                    {
+                      {
+                        all_messages: "All Assistant Messages",
+                        report_progress_only: "Report Progress Only",
+                      }[editReplyMode]
+                    }
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all_messages">All Assistant Messages</SelectItem>
+                  <SelectItem value="report_progress_only">Report Progress Only</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="flex gap-2 pt-2">
+              <Button
+                size="sm"
+                onClick={editingChannelId ? saveChannel : saveNewChannel}
+                disabled={isSaving || !editSigningSecret || !editBotToken}
+              >
+                <Check className="w-3 h-3 mr-1" />
+                {isSaving ? "Saving..." : "Save"}
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setEditingChannelId(null);
+                  setShowAddChannel(false);
+                }}
+              >
+                <X className="w-3 h-3 mr-1" />
+                Cancel
+              </Button>
+            </div>
+          </>
+        )}
       </div>
-
-      <div>
-        <Label htmlFor={`bot_token_${formId}`}>Bot User OAuth Token</Label>
-        <Input
-          id={`bot_token_${formId}`}
-          type="password"
-          value={editBotToken}
-          onChange={(e) => setEditBotToken(e.target.value)}
-          placeholder="xoxb-..."
-          required
-        />
-        <p className="text-xs text-muted-foreground mt-1">
-          Found in your Slack app &rarr; OAuth &amp; Permissions &rarr; Bot User OAuth Token
-        </p>
-      </div>
-
-      <Separator />
-
-      <div className="grid grid-cols-2 gap-4">
-        <div>
-          <Label htmlFor={`team_id_${formId}`}>Workspace ID (optional)</Label>
-          <Input
-            id={`team_id_${formId}`}
-            value={editTeamId}
-            onChange={(e) => setEditTeamId(e.target.value)}
-            placeholder="T0123456789"
-          />
-        </div>
-
-        <div>
-          <Label htmlFor={`channel_id_${formId}`}>Channel ID (optional)</Label>
-          <Input
-            id={`channel_id_${formId}`}
-            value={editChannelIdField}
-            onChange={(e) => setEditChannelIdField(e.target.value)}
-            placeholder="C0123456789"
-          />
-        </div>
-      </div>
-
-      <div>
-        <Label htmlFor={`session_strategy_${formId}`}>Session Strategy</Label>
-        <Select
-          value={editSessionStrategy}
-          onValueChange={(v) => setEditSessionStrategy(v as SessionStrategy)}
-        >
-          <SelectTrigger>
-            <SelectValue>
-              {
-                {
-                  per_thread: "Per Thread (default)",
-                  per_channel: "Per Channel",
-                  per_user: "Per User",
-                }[editSessionStrategy]
-              }
-            </SelectValue>
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="per_thread">Per Thread (default)</SelectItem>
-            <SelectItem value="per_channel">Per Channel</SelectItem>
-            <SelectItem value="per_user">Per User</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-
-      <div>
-        <Label htmlFor={`reply_mode_${formId}`}>Reply Mode</Label>
-        <Select value={editReplyMode} onValueChange={(v) => setEditReplyMode(v as SlackReplyMode)}>
-          <SelectTrigger>
-            <SelectValue>
-              {
-                {
-                  all_messages: "All Assistant Messages",
-                  report_progress_only: "Report Progress Only",
-                }[editReplyMode]
-              }
-            </SelectValue>
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all_messages">All Assistant Messages</SelectItem>
-            <SelectItem value="report_progress_only">Report Progress Only</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-
-      <div className="flex gap-2 pt-2">
-        <Button
-          size="sm"
-          onClick={editingChannelId ? saveChannel : saveNewChannel}
-          disabled={isSaving || !editSigningSecret || !editBotToken}
-        >
-          <Check className="w-3 h-3 mr-1" />
-          {isSaving ? "Saving..." : "Save"}
-        </Button>
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={() => {
-            setEditingChannelId(null);
-            setShowAddChannel(false);
-          }}
-        >
-          <X className="w-3 h-3 mr-1" />
-          Cancel
-        </Button>
-      </div>
-    </div>
-  );
+    );
+  };
 
   const renderChannelDisplay = (channel: AppChannel) => {
+    if (channel.channel_type === "ag_ui") {
+      const config = channel.channel_config as AgUiChannelConfig;
+      return (
+        <div key={channel.id} className="space-y-4">
+          <AgUiSetupGuidance
+            endpointUrl={agUiEndpointUrl}
+            isPublished={isPublished}
+            anonymousEnabled={config?.anonymous ?? true}
+            onConfigure={() => startEditChannel(channel)}
+          />
+        </div>
+      );
+    }
+
     const config = channel.channel_config as SlackChannelConfig;
     const chHasConfig = config?.signing_secret && config?.bot_token;
     const chWebhookVerified = !!config?.webhook_verified_at;
@@ -531,7 +635,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
             <Button
               variant="default"
               onClick={() => publishApp.mutate(app.id)}
-              disabled={publishApp.isPending || !hasSlackConfig || isReadOnly}
+              disabled={publishApp.isPending || !canPublishApp || isReadOnly}
             >
               <Globe className="w-4 h-4 mr-2" />
               {publishApp.isPending ? "Publishing..." : "Publish"}
@@ -579,7 +683,8 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                     <>
                       <Button variant="outline" size="sm" onClick={() => startEditChannel(channel)}>
                         <Pencil className="w-3 h-3 mr-1" />
-                        {(channel.channel_config as SlackChannelConfig)?.signing_secret
+                        {channel.channel_type === "slack" &&
+                        (channel.channel_config as SlackChannelConfig)?.signing_secret
                           ? "Edit"
                           : "Configure"}
                       </Button>
@@ -617,7 +722,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
           {showAddChannel && (
             <Card>
               <CardHeader>
-                <CardTitle>Add Slack Channel</CardTitle>
+                <CardTitle>Add Channel</CardTitle>
               </CardHeader>
               <CardContent>{renderChannelForm(addChannelMutation.isPending, "new")}</CardContent>
             </Card>

--- a/apps/ui/src/app/(main)/apps/new/page.tsx
+++ b/apps/ui/src/app/(main)/apps/new/page.tsx
@@ -7,11 +7,19 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { AgentSelect } from "@/components/agent/agent-select";
 import { AgentIdentitySelect } from "@/components/agent-identity/agent-identity-select";
 import { HarnessSelect } from "@/components/harness/harness-select";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
+import type { ChannelType } from "@/lib/api/types";
 
 export default function NewAppPage() {
   const router = useRouter();
@@ -22,6 +30,7 @@ export default function NewAppPage() {
   const [agentId, setAgentId] = useState("");
   const [harnessId, setHarnessId] = useState("");
   const [agentIdentityId, setAgentIdentityId] = useState("");
+  const [channelType, setChannelType] = useState<ChannelType>("slack");
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -33,10 +42,11 @@ export default function NewAppPage() {
         agent_id: agentId,
         agent_identity_id: agentIdentityId || undefined,
         harness_id: harnessId,
-        channel_type: "slack",
+        channel_type: channelType,
+        channel_config: channelType === "ag_ui" ? { anonymous: true } : undefined,
       });
 
-      // Redirect to detail page where user can create the Slack app
+      // Redirect to the detail page for channel-specific setup.
       router.push(`/apps/${app.id}`);
     } catch (error) {
       console.error("Failed to create app:", error);
@@ -96,9 +106,26 @@ export default function NewAppPage() {
               </div>
             </div>
 
+            <div className="space-y-2">
+              <Label htmlFor="channel_type">Channel</Label>
+              <Select
+                value={channelType}
+                onValueChange={(value) => setChannelType(value as ChannelType)}
+              >
+                <SelectTrigger id="channel_type">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="slack">Slack</SelectItem>
+                  <SelectItem value="ag_ui">AG-UI</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
             <p className="text-sm text-muted-foreground">
-              After creating the app, you&apos;ll be able to generate a Slack App manifest and
-              create the Slack bot on the detail page.
+              {channelType === "slack"
+                ? "After creating the app, you'll be able to generate a Slack App manifest and create the Slack bot on the detail page."
+                : "After creating the app, publish it and point your AG-UI client at the channel endpoint on the detail page."}
             </p>
 
             <div className="flex gap-4">

--- a/apps/ui/src/app/(main)/apps/page.tsx
+++ b/apps/ui/src/app/(main)/apps/page.tsx
@@ -61,10 +61,15 @@ function AppCard({ app }: { app: App }) {
   const unpublishApp = useUnpublishApp();
   const isPublished = app.status === "published";
   const isArchived = app.status === "archived";
-  const webhookUrl =
+  const primaryChannel = app.channels.find((channel) => channel.enabled) ?? app.channels[0];
+  const primaryUrl =
     typeof window !== "undefined"
-      ? `${window.location.origin}/api/v1/apps/${app.id}/slack/events`
-      : `/api/v1/apps/${app.id}/slack/events`;
+      ? primaryChannel?.channel_type === "ag_ui"
+        ? `${window.location.origin}/api/v1/apps/${app.id}/ag-ui`
+        : `${window.location.origin}/api/v1/apps/${app.id}/slack/events`
+      : primaryChannel?.channel_type === "ag_ui"
+        ? `/api/v1/apps/${app.id}/ag-ui`
+        : `/api/v1/apps/${app.id}/slack/events`;
 
   return (
     <Link href={`/apps/${app.id}`}>
@@ -84,21 +89,23 @@ function AppCard({ app }: { app: App }) {
         <CardContent className="space-y-3">
           {app.description && <p className="text-sm text-muted-foreground">{app.description}</p>}
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <Badge variant="outline" className="text-xs">
-              Slack
-            </Badge>
+            {app.channels.map((channel) => (
+              <Badge key={channel.id} variant="outline" className="text-xs uppercase">
+                {channel.channel_type === "ag_ui" ? "AG-UI" : "Slack"}
+              </Badge>
+            ))}
           </div>
 
-          {isPublished && (
+          {isPublished && primaryUrl && (
             <div className="flex items-center gap-1 text-xs text-muted-foreground bg-muted p-2 rounded">
               <Globe className="w-3 h-3 shrink-0" />
-              <span className="truncate font-mono">{webhookUrl}</span>
+              <span className="truncate font-mono">{primaryUrl}</span>
               <button
                 className="shrink-0 ml-1 hover:text-foreground"
                 onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
-                  navigator.clipboard.writeText(webhookUrl);
+                  navigator.clipboard.writeText(primaryUrl);
                 }}
               >
                 <Copy className="w-3 h-3" />
@@ -149,8 +156,8 @@ function EmptyState() {
       <Rocket className="w-12 h-12 text-muted-foreground mb-4" />
       <h3 className="text-lg font-semibold mb-2">No Apps Yet</h3>
       <p className="text-muted-foreground mb-4 max-w-md">
-        Apps deploy your agents to channels like Slack. Create an app to connect an agent to a Slack
-        workspace.
+        Apps deploy your agents to channels like Slack and AG-UI. Create an app to connect an agent
+        to the interface you need.
       </p>
       <Link href="/apps/new">
         <Button variant="accent">

--- a/apps/ui/src/components/apps/ag-ui-setup-guidance.tsx
+++ b/apps/ui/src/components/apps/ag-ui-setup-guidance.tsx
@@ -1,0 +1,53 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { CopyButton } from "@/components/ui/copy-button";
+import { Globe } from "lucide-react";
+
+interface AgUiSetupGuidanceProps {
+  endpointUrl: string;
+  isPublished: boolean;
+  anonymousEnabled: boolean;
+  onConfigure?: () => void;
+}
+
+export function AgUiSetupGuidance({
+  endpointUrl,
+  isPublished,
+  anonymousEnabled,
+  onConfigure,
+}: AgUiSetupGuidanceProps) {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Badge variant={anonymousEnabled ? "default" : "secondary"}>
+          {anonymousEnabled ? "Anonymous" : "Restricted"}
+        </Badge>
+        <span className="text-sm text-muted-foreground">
+          {isPublished ? "Ready for AG-UI clients" : "Publish the app to accept requests"}
+        </span>
+      </div>
+
+      <div>
+        <p className="text-sm font-medium">Endpoint</p>
+        <div className="mt-2 flex items-center gap-2 bg-muted p-3">
+          <Globe className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <code className="flex-1 truncate text-sm">{endpointUrl}</code>
+          <CopyButton value={endpointUrl} />
+        </div>
+      </div>
+
+      <div className="space-y-1 text-sm text-muted-foreground">
+        <p>Send AG-UI `RunAgentInput` JSON to this endpoint.</p>
+        <p>Responses stream back as AG-UI SSE events.</p>
+      </div>
+
+      {onConfigure && (
+        <div className="pt-1">
+          <Button size="sm" variant="outline" onClick={onConfigure}>
+            Configure
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/lib/api/types/app-types.ts
+++ b/apps/ui/src/lib/api/types/app-types.ts
@@ -1,7 +1,7 @@
 // App types (deployable agent+harness bundles with multi-channel support)
 
 export type AppStatus = "draft" | "published" | "archived" | "deleted";
-export type ChannelType = "slack";
+export type ChannelType = "slack" | "ag_ui";
 export type SessionStrategy = "per_thread" | "per_channel" | "per_user";
 export type SlackReplyMode = "all_messages" | "report_progress_only";
 
@@ -16,10 +16,14 @@ export interface SlackChannelConfig {
   first_message_received_at?: string | null;
 }
 
+export interface AgUiChannelConfig {
+  anonymous?: boolean;
+}
+
 export interface AppChannel {
   id: string;
   channel_type: ChannelType;
-  channel_config: SlackChannelConfig | Record<string, unknown>;
+  channel_config: SlackChannelConfig | AgUiChannelConfig | Record<string, unknown>;
   enabled: boolean;
   created_at: string;
   updated_at: string;
@@ -48,7 +52,7 @@ export interface CreateAppRequest {
   agent_id: string;
   agent_identity_id?: string;
   channel_type: ChannelType;
-  channel_config?: SlackChannelConfig | Record<string, unknown>;
+  channel_config?: SlackChannelConfig | AgUiChannelConfig | Record<string, unknown>;
 }
 
 export interface UpdateAppRequest {
@@ -62,12 +66,12 @@ export interface UpdateAppRequest {
 
 export interface AddChannelRequest {
   channel_type: ChannelType;
-  channel_config?: SlackChannelConfig | Record<string, unknown>;
+  channel_config?: SlackChannelConfig | AgUiChannelConfig | Record<string, unknown>;
   enabled?: boolean;
 }
 
 export interface UpdateChannelRequest {
   channel_type?: ChannelType;
-  channel_config?: SlackChannelConfig | Record<string, unknown>;
+  channel_config?: SlackChannelConfig | AgUiChannelConfig | Record<string, unknown>;
   enabled?: boolean;
 }

--- a/crates/core/src/app.rs
+++ b/crates/core/src/app.rs
@@ -4,12 +4,11 @@
 // - public_id: AppId (external, API-facing, client-supplied or auto-generated)
 // - internal_id: Uuid (internal PK, used for FK references, never exposed in API)
 //
-// An App binds a Harness + Agent to a distribution channel (Slack, etc.)
+// An App binds a Harness + Agent to a distribution channel (Slack, AG-UI, etc.)
 // with a publish/unpublish lifecycle.
 //
-// Design Decision: Slack ingestion is app-scoped (POST /v1/apps/{app_id}/slack/events)
-// because the App defines the agent, harness, signing secret, and session strategy.
-// Webhooks are unauthenticated — security comes from Slack signing secret verification.
+// Design Decision: Channel ingress is app-scoped because the App defines the
+// agent, harness, identity, and channel-specific configuration.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -63,12 +62,15 @@ impl From<&str> for AppStatus {
 #[serde(rename_all = "lowercase")]
 pub enum ChannelType {
     Slack,
+    #[serde(rename = "ag_ui")]
+    AgUi,
 }
 
 impl std::fmt::Display for ChannelType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ChannelType::Slack => write!(f, "slack"),
+            ChannelType::AgUi => write!(f, "ag_ui"),
         }
     }
 }
@@ -77,6 +79,7 @@ impl ChannelType {
     pub fn from_str_opt(s: &str) -> Option<Self> {
         match s {
             "slack" => Some(ChannelType::Slack),
+            "ag_ui" => Some(ChannelType::AgUi),
             _ => None,
         }
     }
@@ -171,6 +174,15 @@ impl AppChannel {
         }
         serde_json::from_value(self.channel_config.clone()).ok()
     }
+
+    /// Parse channel_config as AgUiChannelConfig. Returns None if not an AG-UI
+    /// channel or if the config is invalid.
+    pub fn ag_ui_config(&self) -> Option<AgUiChannelConfig> {
+        if self.channel_type != ChannelType::AgUi {
+            return None;
+        }
+        serde_json::from_value(self.channel_config.clone()).ok()
+    }
 }
 
 impl App {
@@ -179,6 +191,13 @@ impl App {
         self.channels
             .iter()
             .find(|ch| ch.channel_type == ChannelType::Slack && ch.enabled)
+    }
+
+    /// Find the first enabled AG-UI channel on this app.
+    pub fn ag_ui_channel(&self) -> Option<&AppChannel> {
+        self.channels
+            .iter()
+            .find(|ch| ch.channel_type == ChannelType::AgUi && ch.enabled)
     }
 
     /// Find a channel by its public ID.
@@ -286,6 +305,18 @@ pub struct SlackChannelConfig {
     pub first_message_received_at: Option<DateTime<Utc>>,
 }
 
+/// Typed AG-UI channel configuration.
+///
+/// Parsed from the `channel_config` JSON field on App.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct AgUiChannelConfig {
+    /// Whether anonymous access is allowed for this endpoint.
+    /// Enabled by default for the initial AG-UI rollout.
+    #[serde(default = "default_true")]
+    pub anonymous: bool,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -319,11 +350,13 @@ mod tests {
     #[test]
     fn test_channel_type_display() {
         assert_eq!(ChannelType::Slack.to_string(), "slack");
+        assert_eq!(ChannelType::AgUi.to_string(), "ag_ui");
     }
 
     #[test]
     fn test_channel_type_from_str_opt() {
         assert_eq!(ChannelType::from_str_opt("slack"), Some(ChannelType::Slack));
+        assert_eq!(ChannelType::from_str_opt("ag_ui"), Some(ChannelType::AgUi));
         assert_eq!(ChannelType::from_str_opt("unknown"), None);
         assert_eq!(ChannelType::from_str_opt(""), None);
     }
@@ -334,6 +367,11 @@ mod tests {
         assert_eq!(json, r#""slack""#);
         let parsed: ChannelType = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, ChannelType::Slack);
+
+        let json = serde_json::to_string(&ChannelType::AgUi).unwrap();
+        assert_eq!(json, r#""ag_ui""#);
+        let parsed: ChannelType = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, ChannelType::AgUi);
     }
 
     #[test]
@@ -432,6 +470,20 @@ mod tests {
         assert!(serde_json::from_str::<SlackChannelConfig>(json).is_err());
     }
 
+    #[test]
+    fn test_ag_ui_channel_config_defaults_to_anonymous() {
+        let config: AgUiChannelConfig = serde_json::from_str("{}").unwrap();
+        assert!(config.anonymous);
+    }
+
+    #[test]
+    fn test_ag_ui_channel_config_roundtrip() {
+        let config = AgUiChannelConfig { anonymous: true };
+        let json = serde_json::to_string(&config).unwrap();
+        let parsed: AgUiChannelConfig = serde_json::from_str(&json).unwrap();
+        assert!(parsed.anonymous);
+    }
+
     fn test_app(channels: Vec<AppChannel>) -> App {
         App {
             public_id: AppId::from_uuid(Uuid::nil()),
@@ -494,6 +546,20 @@ mod tests {
     fn test_app_slack_channel_none_when_empty() {
         let app = test_app(vec![]);
         assert!(app.slack_channel().is_none());
+    }
+
+    #[test]
+    fn test_app_channel_ag_ui_config_valid() {
+        let ch = test_channel(ChannelType::AgUi, serde_json::json!({"anonymous": true}));
+        let config = ch.ag_ui_config().unwrap();
+        assert!(config.anonymous);
+    }
+
+    #[test]
+    fn test_app_ag_ui_channel_lookup() {
+        let ch = test_channel(ChannelType::AgUi, serde_json::json!({"anonymous": true}));
+        let app = test_app(vec![ch]);
+        assert!(app.ag_ui_channel().is_some());
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -263,7 +263,8 @@ pub use agent::{
 };
 pub use agent_identity::{AgentIdentity, AgentIdentityStatus};
 pub use app::{
-    App, AppChannel, AppStatus, ChannelType, SessionStrategy, SlackChannelConfig, SlackReplyMode,
+    AgUiChannelConfig, App, AppChannel, AppStatus, ChannelType, SessionStrategy,
+    SlackChannelConfig, SlackReplyMode,
 };
 pub use capability_dto::{AgentCapability, CapabilityInfo};
 pub use events::{

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -91,6 +91,7 @@ tonic.workspace = true
 prost.workspace = true
 prost-types.workspace = true
 serde_urlencoded = "0.7.1"
+ag-ui-core = "0.1.0"
 
 [dev-dependencies]
 reqwest = { workspace = true, default-features = false, features = ["json", "stream", "rustls", "blocking", "http2"] }

--- a/crates/server/migrations/014_ag_ui_app_channel.sql
+++ b/crates/server/migrations/014_ag_ui_app_channel.sql
@@ -1,0 +1,17 @@
+----------------------------------------------------------------------
+-- 014: AG-UI app channel
+----------------------------------------------------------------------
+
+ALTER TABLE apps
+    DROP CONSTRAINT IF EXISTS apps_channel_type_check;
+
+ALTER TABLE apps
+    ADD CONSTRAINT apps_channel_type_check
+    CHECK (channel_type IN ('slack', 'ag_ui'));
+
+ALTER TABLE app_channels
+    DROP CONSTRAINT IF EXISTS app_channels_channel_type_check;
+
+ALTER TABLE app_channels
+    ADD CONSTRAINT app_channels_channel_type_check
+    CHECK (channel_type IN ('slack', 'ag_ui'));

--- a/crates/server/src/api/ag_ui.rs
+++ b/crates/server/src/api/ag_ui.rs
@@ -64,6 +64,7 @@ use crate::api::messages::{
     CreateMessageRequest, InputContentPart, InputMessage, MessageRole as ApiMessageRole,
 };
 use crate::api::sessions::CreateSessionRequest;
+use crate::api::sse::SseConnectionTracker;
 use crate::execution_metadata;
 use crate::services::{
     AppService, CreateMessageContext, EventService, MessageService, SessionService,
@@ -77,6 +78,7 @@ pub struct AgUiState {
     pub session_service: Arc<SessionService>,
     pub message_service: Arc<MessageService>,
     pub event_service: Arc<EventService>,
+    pub sse_tracker: Arc<SseConnectionTracker>,
 }
 
 impl AgUiState {
@@ -86,6 +88,7 @@ impl AgUiState {
         runner: Arc<dyn everruns_worker::AgentRunner>,
         notifications_enabled: bool,
         event_delivery: crate::event_delivery::EventDelivery,
+        sse_tracker: Arc<SseConnectionTracker>,
     ) -> Self {
         Self {
             app_service: Arc::new(AppService::new(db.clone(), encryption)),
@@ -97,6 +100,7 @@ impl AgUiState {
                 event_delivery.clone(),
             )),
             event_service: Arc::new(EventService::new(db.clone(), event_delivery)),
+            sse_tracker,
             db,
         }
     }
@@ -164,6 +168,22 @@ async fn run_agent(
     let session = find_or_create_session(&state, &app, &routing_tags, &thread_tag, &req)
         .await
         .map_err(internal_error)?;
+
+    // THREAT[TM-DOS-010]: Anonymous AG-UI streams must still respect server-wide
+    // SSE connection limits.
+    // Mitigation: Reuse the shared SSE tracker for per-org and per-session limits
+    // before opening the stream.
+    let sse_guard = state
+        .sse_tracker
+        .try_acquire(app.org_id, session.session.id.uuid())
+        .map_err(|rejection| {
+            (
+                StatusCode::TOO_MANY_REQUESTS,
+                Json(ErrorResponse {
+                    error: rejection.to_string(),
+                }),
+            )
+        })?;
 
     // Seed prior history only on first use of the thread so a new AG-UI client can
     // carry conversation context into the durable session without triggering old runs.
@@ -303,7 +323,10 @@ async fn run_agent(
         }
     });
 
-    let stream = initial_stream.chain(translated_stream);
+    let stream = initial_stream.chain(translated_stream).map(move |event| {
+        let _guard = &sse_guard;
+        event
+    });
 
     Ok(Sse::new(stream).keep_alive(
         KeepAlive::new()
@@ -518,6 +541,23 @@ fn content_part_to_string(part: &ContentPart) -> String {
     }
 }
 
+fn ensure_assistant_message_id(
+    state: &mut AgUiStreamState,
+    event: &everruns_core::Event,
+) -> AgUiMessageId {
+    state
+        .assistant_message_id
+        .get_or_insert_with(|| {
+            event
+                .context
+                .turn_id
+                .as_ref()
+                .map(|id| AgUiMessageId::from(id.uuid()))
+                .unwrap_or_else(AgUiMessageId::random)
+        })
+        .clone()
+}
+
 struct AgUiStreamState {
     subscription: Box<crate::event_delivery::EventSubscription>,
     session_id: Uuid,
@@ -538,10 +578,7 @@ fn translate_event(state: &mut AgUiStreamState, event: &everruns_core::Event) {
     match event.event_type.as_str() {
         "output.message.delta" => {
             if let Ok(data) = parse_event_data::<OutputMessageDeltaData>(event) {
-                let message_id = state
-                    .assistant_message_id
-                    .get_or_insert_with(|| AgUiMessageId::from(data.turn_id.uuid()))
-                    .clone();
+                let message_id = ensure_assistant_message_id(state, event);
                 if !state.assistant_content_started {
                     state
                         .queue
@@ -560,10 +597,7 @@ fn translate_event(state: &mut AgUiStreamState, event: &everruns_core::Event) {
         }
         "output.message.completed" => {
             if let Ok(data) = parse_event_data::<OutputMessageCompletedData>(event) {
-                let message_id = state
-                    .assistant_message_id
-                    .clone()
-                    .unwrap_or_else(|| AgUiMessageId::from(data.message.id.uuid()));
+                let message_id = ensure_assistant_message_id(state, event);
                 if !state.assistant_content_started {
                     state
                         .queue
@@ -653,6 +687,7 @@ fn translate_event(state: &mut AgUiStreamState, event: &everruns_core::Event) {
         }
         "tool.started" => {
             if let Ok(data) = parse_event_data::<ToolStartedData>(event) {
+                let message_id = ensure_assistant_message_id(state, event);
                 let tool_call_id = state
                     .tool_call_ids
                     .entry(data.tool_call.id.clone())
@@ -664,7 +699,7 @@ fn translate_event(state: &mut AgUiStreamState, event: &everruns_core::Event) {
                         base: agui_base_event(),
                         tool_call_id: tool_call_id.clone(),
                         tool_call_name: data.tool_call.name,
-                        parent_message_id: state.assistant_message_id.clone(),
+                        parent_message_id: Some(message_id),
                     }));
                 state
                     .queue
@@ -684,6 +719,7 @@ fn translate_event(state: &mut AgUiStreamState, event: &everruns_core::Event) {
         }
         "tool.completed" => {
             if let Ok(data) = parse_event_data::<ToolCompletedData>(event) {
+                let message_id = ensure_assistant_message_id(state, event);
                 let tool_call_id = state
                     .tool_call_ids
                     .remove(&data.tool_call_id)
@@ -692,10 +728,7 @@ fn translate_event(state: &mut AgUiStreamState, event: &everruns_core::Event) {
                     .queue
                     .push_back(AgUiEvent::ToolCallResult(AgUiToolCallResultEvent {
                         base: agui_base_event(),
-                        message_id: state
-                            .assistant_message_id
-                            .clone()
-                            .unwrap_or_else(AgUiMessageId::random),
+                        message_id,
                         tool_call_id,
                         content: data
                             .result
@@ -819,7 +852,7 @@ mod tests {
     use ag_ui_core::event::EventType as AgUiEventType;
     use everruns_core::{
         Event, EventContext, Message, MessageId, OutputMessageCompletedData,
-        OutputMessageDeltaData, SessionId, TurnId,
+        OutputMessageDeltaData, SessionId, ToolCall, ToolCompletedData, ToolStartedData, TurnId,
     };
 
     async fn test_stream_state() -> AgUiStreamState {
@@ -918,5 +951,82 @@ mod tests {
             _ => unreachable!(),
         }
         assert!(state.finished);
+    }
+
+    #[tokio::test]
+    async fn test_tool_first_run_reuses_assistant_message_id() {
+        let mut state = test_stream_state().await;
+        let turn_id = TurnId::new();
+        let input_message_id = MessageId::parse(&state.input_message_id).unwrap();
+        let context = EventContext::turn(turn_id, input_message_id);
+        let session_id = SessionId::from_uuid(state.session_id);
+
+        let tool_started = Event::new(
+            session_id,
+            context.clone(),
+            ToolStartedData {
+                tool_call: ToolCall {
+                    id: "call_1".to_string(),
+                    name: "web_search".to_string(),
+                    arguments: serde_json::json!({"q": "hello"}),
+                },
+                display_name: None,
+                narration: None,
+            },
+        );
+        translate_event(&mut state, &tool_started);
+
+        let tool_completed = Event::new(
+            session_id,
+            context.clone(),
+            ToolCompletedData {
+                tool_call_id: "call_1".to_string(),
+                tool_name: "web_search".to_string(),
+                display_name: None,
+                success: true,
+                status: "success".to_string(),
+                result: Some(vec![ContentPart::text("result")]),
+                error: None,
+                duration_ms: Some(10),
+                narration: None,
+            },
+        );
+        translate_event(&mut state, &tool_completed);
+
+        let output_completed = Event::new(
+            session_id,
+            context,
+            OutputMessageCompletedData::new(Message::assistant("Hello after tool")),
+        );
+        translate_event(&mut state, &output_completed);
+
+        let expected_message_id = AgUiMessageId::from(turn_id.uuid());
+
+        let tool_call_id = match &state.queue[0] {
+            AgUiEvent::ToolCallStart(event) => {
+                assert_eq!(event.parent_message_id, Some(expected_message_id.clone()));
+                event.tool_call_id.clone()
+            }
+            _ => panic!("expected tool start event"),
+        };
+        match &state.queue[1] {
+            AgUiEvent::ToolCallArgs(_) => {}
+            _ => panic!("expected tool args event"),
+        }
+        match &state.queue[2] {
+            AgUiEvent::ToolCallEnd(event) => assert_eq!(event.tool_call_id, tool_call_id),
+            _ => panic!("expected tool end event"),
+        }
+        match &state.queue[3] {
+            AgUiEvent::ToolCallResult(event) => {
+                assert_eq!(event.message_id, expected_message_id.clone());
+                assert_eq!(event.tool_call_id, tool_call_id);
+            }
+            _ => panic!("expected tool result event"),
+        }
+        match &state.queue[4] {
+            AgUiEvent::TextMessageStart(event) => assert_eq!(event.message_id, expected_message_id),
+            _ => panic!("expected text start event"),
+        }
     }
 }

--- a/crates/server/src/api/ag_ui.rs
+++ b/crates/server/src/api/ag_ui.rs
@@ -1,0 +1,922 @@
+// AG-UI app channel — anonymous, app-scoped streaming endpoint
+//
+// Design Decision: AG-UI ingress is app-scoped (POST /v1/apps/{app_id}/ag-ui)
+// so the App controls the agent, harness, identity, and publication lifecycle.
+//
+// Design Decision: The endpoint is anonymous for the initial rollout. Requests
+// are accepted without API auth when the app is published and an enabled AG-UI
+// channel is present.
+//
+// Design Decision: The AG-UI stream is translated from Everruns session events
+// instead of bypassing the durable runtime. This keeps app-channel behavior
+// aligned with normal sessions and preserves streaming parity.
+
+use std::collections::{HashMap, VecDeque};
+use std::convert::Infallible;
+use std::sync::Arc;
+
+use ag_ui_core::event::{
+    BaseEvent as AgUiBaseEvent, Event as AgUiEvent,
+    MessagesSnapshotEvent as AgUiMessagesSnapshotEvent, RunErrorEvent as AgUiRunErrorEvent,
+    RunFinishedEvent as AgUiRunFinishedEvent, RunStartedEvent as AgUiRunStartedEvent,
+    TextMessageContentEvent as AgUiTextMessageContentEvent,
+    TextMessageEndEvent as AgUiTextMessageEndEvent,
+    TextMessageStartEvent as AgUiTextMessageStartEvent, ThinkingEndEvent as AgUiThinkingEndEvent,
+    ThinkingStartEvent as AgUiThinkingStartEvent,
+    ThinkingTextMessageContentEvent as AgUiThinkingTextMessageContentEvent,
+    ThinkingTextMessageEndEvent as AgUiThinkingTextMessageEndEvent,
+    ThinkingTextMessageStartEvent as AgUiThinkingTextMessageStartEvent,
+    ToolCallArgsEvent as AgUiToolCallArgsEvent, ToolCallEndEvent as AgUiToolCallEndEvent,
+    ToolCallResultEvent as AgUiToolCallResultEvent, ToolCallStartEvent as AgUiToolCallStartEvent,
+};
+use ag_ui_core::types::{
+    ids::{
+        MessageId as AgUiMessageId, RunId as AgUiRunId, ThreadId as AgUiThreadId,
+        ToolCallId as AgUiToolCallId,
+    },
+    input::RunAgentInput as AgUiRunAgentInput,
+    message::{Message as AgUiMessage, Role as AgUiRole},
+    tool::ToolCall as AgUiToolCall,
+};
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    http::StatusCode,
+    response::sse::{Event as SseEvent, KeepAlive, Sse},
+    routing::post,
+};
+use everruns_core::events::{
+    OutputMessageCompletedData, OutputMessageDeltaData, ReasonThinkingCompletedData,
+    ReasonThinkingDeltaData, ReasonThinkingStartedData, ToolCompletedData, ToolStartedData,
+};
+use everruns_core::message_retriever::InputMessage as StoredInputMessage;
+use everruns_core::{App, AppStatus, Caller, ContentPart, ExternalActor, MessageRole};
+use futures::{
+    StreamExt,
+    stream::{self, Stream},
+};
+use serde::Deserialize;
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::api::common::ErrorResponse;
+use crate::api::messages::{
+    CreateMessageRequest, InputContentPart, InputMessage, MessageRole as ApiMessageRole,
+};
+use crate::api::sessions::CreateSessionRequest;
+use crate::execution_metadata;
+use crate::services::{
+    AppService, CreateMessageContext, EventService, MessageService, SessionService,
+};
+use crate::storage::{DbMessageRetriever, StorageBackend};
+
+#[derive(Clone)]
+pub struct AgUiState {
+    pub db: Arc<StorageBackend>,
+    pub app_service: Arc<AppService>,
+    pub session_service: Arc<SessionService>,
+    pub message_service: Arc<MessageService>,
+    pub event_service: Arc<EventService>,
+}
+
+impl AgUiState {
+    pub fn new(
+        db: Arc<StorageBackend>,
+        encryption: Option<Arc<crate::storage::EncryptionService>>,
+        runner: Arc<dyn everruns_worker::AgentRunner>,
+        notifications_enabled: bool,
+        event_delivery: crate::event_delivery::EventDelivery,
+    ) -> Self {
+        Self {
+            app_service: Arc::new(AppService::new(db.clone(), encryption)),
+            session_service: Arc::new(SessionService::new(db.clone())),
+            message_service: Arc::new(MessageService::new(
+                db.clone(),
+                runner,
+                notifications_enabled,
+                event_delivery.clone(),
+            )),
+            event_service: Arc::new(EventService::new(db.clone(), event_delivery)),
+            db,
+        }
+    }
+}
+
+pub fn routes(state: AgUiState) -> Router {
+    Router::new()
+        .route("/v1/apps/{app_id}/ag-ui", post(run_agent))
+        .with_state(state)
+}
+
+async fn run_agent(
+    State(state): State<AgUiState>,
+    Path(app_id): Path<String>,
+    Json(req): Json<AgUiRunAgentInput>,
+) -> Result<Sse<impl Stream<Item = Result<SseEvent, Infallible>>>, (StatusCode, Json<ErrorResponse>)>
+{
+    let app = state
+        .app_service
+        .get_by_public_id_unscoped(&app_id)
+        .await
+        .map_err(internal_error)?
+        .ok_or_else(not_found)?;
+
+    // THREAT[TM-AUTHZ-005]: Anonymous AG-UI requests must not reach draft or
+    // private app configurations.
+    // Mitigation: Require a published app, an enabled AG-UI channel, and
+    // `anonymous=true` before accepting unauthenticated traffic.
+    if app.status != AppStatus::Published {
+        return Err(forbidden("App is not published"));
+    }
+
+    let channel = app
+        .ag_ui_channel()
+        .ok_or_else(|| bad_request("App does not have an enabled AG-UI channel"))?;
+    let channel_config = channel
+        .ag_ui_config()
+        .ok_or_else(|| bad_request("Invalid AG-UI channel configuration"))?;
+    if !channel_config.anonymous {
+        return Err(forbidden("Anonymous AG-UI access is disabled"));
+    }
+
+    let trigger_message = req
+        .messages
+        .last()
+        .ok_or_else(|| bad_request("messages must contain at least one user message"))?;
+    let (trigger_content, trigger_name) = match trigger_message {
+        AgUiMessage::User { content, name, .. } => (content.clone(), name.clone()),
+        _ => return Err(bad_request("the final AG-UI message must have role=user")),
+    };
+
+    let thread_id = req.thread_id.clone();
+    let run_id = req.run_id.clone();
+    let thread_tag = thread_id.to_string();
+    let run_tag = run_id.to_string();
+
+    // THREAT[TM-TENANT-009]: Reusing the same AG-UI thread ID across apps must
+    // not merge tenants or app sessions.
+    // Mitigation: Scope the session lookup tags by both app public ID and
+    // thread ID so thread collisions stay isolated per app.
+    let routing_tags = vec![
+        format!("ag_ui:app:{}", app.public_id),
+        format!("ag_ui:thread:{}", thread_tag),
+    ];
+    let session = find_or_create_session(&state, &app, &routing_tags, &thread_tag, &req)
+        .await
+        .map_err(internal_error)?;
+
+    // Seed prior history only on first use of the thread so a new AG-UI client can
+    // carry conversation context into the durable session without triggering old runs.
+    if session.is_new {
+        seed_history(
+            &state,
+            session.session.id.uuid(),
+            &req.messages[..req.messages.len() - 1],
+        )
+        .await
+        .map_err(internal_error)?;
+    }
+
+    let subscription = state
+        .event_service
+        .event_delivery()
+        .clone()
+        .subscribe(session.session.id.uuid())
+        .await
+        .map_err(internal_error)?;
+
+    let message = state
+        .message_service
+        .create(
+            CreateMessageContext {
+                org_id: app.org_id,
+                user_id: None,
+                harness_id: app.harness_id.uuid(),
+                agent_id: Some(app.agent_id.uuid()),
+                session_id: session.session.id.uuid(),
+                event_metadata: Some(execution_metadata::app_message_metadata(
+                    app.public_id,
+                    app.agent_identity_id,
+                )),
+            },
+            CreateMessageRequest {
+                message: InputMessage {
+                    role: ApiMessageRole::User,
+                    content: vec![InputContentPart::text(trigger_content)],
+                },
+                controls: None,
+                metadata: Some(
+                    [
+                        ("ag_ui_thread_id".to_string(), Value::String(thread_tag)),
+                        ("ag_ui_run_id".to_string(), Value::String(run_tag)),
+                    ]
+                    .into_iter()
+                    .collect(),
+                ),
+                tags: None,
+                external_actor: build_external_actor(trigger_name.as_ref()),
+            },
+        )
+        .await
+        .map_err(internal_error)?;
+
+    let snapshot_messages = state
+        .message_service
+        .list(session.session.id.uuid())
+        .await
+        .map_err(internal_error)?;
+
+    let initial_events = vec![
+        AgUiEvent::RunStarted(AgUiRunStartedEvent {
+            base: agui_base_event(),
+            thread_id: req.thread_id.clone(),
+            run_id: req.run_id.clone(),
+        }),
+        AgUiEvent::MessagesSnapshot(AgUiMessagesSnapshotEvent {
+            base: agui_base_event(),
+            messages: snapshot_messages
+                .iter()
+                .map(to_ag_ui_message)
+                .collect::<Vec<_>>(),
+        }),
+    ];
+
+    let stream_state = AgUiStreamState {
+        subscription: Box::new(subscription),
+        session_id: session.session.id.uuid(),
+        input_message_id: message.id.to_string(),
+        thread_id,
+        run_id,
+        queue: VecDeque::new(),
+        assistant_message_id: None,
+        assistant_content_started: false,
+        assistant_emitted_delta: false,
+        thinking_started: false,
+        thinking_text_started: false,
+        tool_call_ids: HashMap::new(),
+        finished: false,
+    };
+
+    let initial_stream = stream::iter(initial_events.into_iter().map(|event| Ok(agui_sse(&event))));
+    let translated_stream = stream::unfold(stream_state, |mut state| async move {
+        loop {
+            if let Some(event) = state.queue.pop_front() {
+                if state.finished && state.queue.is_empty() {
+                    let done_state = state;
+                    return Some((Ok(agui_sse(&event)), done_state));
+                }
+                return Some((Ok(agui_sse(&event)), state));
+            }
+
+            if state.finished {
+                return None;
+            }
+
+            let Some(event) = state.subscription.recv().await else {
+                state
+                    .queue
+                    .push_back(AgUiEvent::RunError(AgUiRunErrorEvent {
+                        base: agui_base_event(),
+                        message: "Event stream closed before the run finished".to_string(),
+                        code: Some("stream_closed".to_string()),
+                    }));
+                state.finished = true;
+                continue;
+            };
+
+            if event.session_id.uuid() != state.session_id {
+                continue;
+            }
+
+            if event
+                .context
+                .input_message_id
+                .as_ref()
+                .map(|id| id.to_string())
+                .as_deref()
+                != Some(state.input_message_id.as_str())
+            {
+                continue;
+            }
+
+            translate_event(&mut state, &event);
+        }
+    });
+
+    let stream = initial_stream.chain(translated_stream);
+
+    Ok(Sse::new(stream).keep_alive(
+        KeepAlive::new()
+            .interval(std::time::Duration::from_secs(15))
+            .text("keepalive"),
+    ))
+}
+
+struct SessionResolution {
+    session: everruns_core::Session,
+    is_new: bool,
+}
+
+async fn find_or_create_session(
+    state: &AgUiState,
+    app: &App,
+    routing_tags: &[String],
+    thread_id: &str,
+    req: &AgUiRunAgentInput,
+) -> anyhow::Result<SessionResolution> {
+    let org_row = state
+        .db
+        .get_organization(app.org_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("Organization not found for app"))?;
+    let org_public_id = org_row.public_id;
+
+    match state
+        .db
+        .find_session_by_tags(app.org_id, routing_tags)
+        .await?
+    {
+        Some(row) => Ok(SessionResolution {
+            session: SessionService::row_to_session(row, &org_public_id),
+            is_new: false,
+        }),
+        None => {
+            let title = format!("AG-UI thread {}", thread_id);
+            let session = state
+                .session_service
+                .create(
+                    &Caller::internal(app.org_id),
+                    app.harness_id.uuid(),
+                    Some(app.agent_id.uuid()),
+                    Some(app.agent_id),
+                    CreateSessionRequest {
+                        harness_id: Some(app.harness_id),
+                        harness_name: None,
+                        agent_id: Some(app.agent_id),
+                        agent_identity_id: app.agent_identity_id,
+                        title: Some(title),
+                        locale: None,
+                        tags: routing_tags.to_vec(),
+                        model_id: None,
+                        capabilities: vec![],
+                        tools: vec![],
+                        system_prompt: None,
+                        initial_files: vec![],
+                        hints: None,
+                        network_access: None,
+                        max_iterations: None,
+                    },
+                )
+                .await?;
+
+            tracing::info!(
+                app_id = %app.public_id,
+                session_id = %session.id,
+                message_count = req.messages.len(),
+                "Created AG-UI app session"
+            );
+
+            Ok(SessionResolution {
+                session,
+                is_new: true,
+            })
+        }
+    }
+}
+
+async fn seed_history(
+    state: &AgUiState,
+    session_id: Uuid,
+    messages: &[AgUiMessage],
+) -> anyhow::Result<()> {
+    if messages.is_empty() {
+        return Ok(());
+    }
+
+    let retriever = DbMessageRetriever::new(state.db.clone());
+    for message in messages {
+        if let Some(stored) = to_stored_history_message(message) {
+            retriever.add(session_id, stored).await?;
+        }
+    }
+    Ok(())
+}
+
+fn to_stored_history_message(message: &AgUiMessage) -> Option<StoredInputMessage> {
+    let (role, content, name) = match message {
+        AgUiMessage::User { content, name, .. } => {
+            (MessageRole::User, content.clone(), name.clone())
+        }
+        AgUiMessage::Assistant {
+            content,
+            name,
+            tool_calls,
+            ..
+        } => (
+            MessageRole::Agent,
+            content
+                .clone()
+                .or_else(|| {
+                    tool_calls
+                        .as_ref()
+                        .map(|calls| format_agui_tool_calls(calls))
+                })
+                .unwrap_or_default(),
+            name.clone(),
+        ),
+        AgUiMessage::Tool {
+            content,
+            error,
+            tool_call_id,
+            ..
+        } => (
+            MessageRole::Agent,
+            match error {
+                Some(error) => format!("[Tool {} error: {}]\n{}", &**tool_call_id, error, content),
+                None => format!("[Tool {} result]\n{}", &**tool_call_id, content),
+            },
+            None,
+        ),
+        AgUiMessage::System { content, name, .. }
+        | AgUiMessage::Developer { content, name, .. } => {
+            (MessageRole::System, content.clone(), name.clone())
+        }
+    };
+
+    let mut stored = StoredInputMessage {
+        role,
+        content: vec![ContentPart::text(content)],
+        controls: None,
+        metadata: None,
+        tags: vec![],
+    };
+    if let Some(name) = name {
+        stored.metadata = Some(
+            [("ag_ui_name".to_string(), Value::String(name))]
+                .into_iter()
+                .collect(),
+        );
+    }
+    Some(stored)
+}
+
+fn build_external_actor(name: Option<&String>) -> Option<ExternalActor> {
+    name.map(|name| ExternalActor {
+        actor_id: name.clone(),
+        actor_name: Some(name.clone()),
+        source: "ag_ui".to_string(),
+        metadata: None,
+    })
+}
+
+fn to_ag_ui_message(message: &crate::api::messages::Message) -> AgUiMessage {
+    let id = AgUiMessageId::from(message.id.uuid());
+    let content = message
+        .content
+        .iter()
+        .map(content_part_to_string)
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    match message.role {
+        ApiMessageRole::User => AgUiMessage::User {
+            id,
+            content,
+            name: None,
+        },
+        ApiMessageRole::Agent => AgUiMessage::Assistant {
+            id,
+            content: (!content.is_empty()).then_some(content),
+            name: None,
+            tool_calls: None,
+        },
+    }
+}
+
+fn content_part_to_string(part: &ContentPart) -> String {
+    match part {
+        ContentPart::Text(text) => text.text.clone(),
+        ContentPart::Image(image) => image.url.clone().unwrap_or_else(|| "[Image]".to_string()),
+        ContentPart::ImageFile(image) => format!(
+            "[Image file: {}]",
+            image.filename.as_deref().unwrap_or("unnamed")
+        ),
+        ContentPart::ToolCall(tool_call) => format!(
+            "[Tool call: {} {}]",
+            tool_call.name,
+            serde_json::to_string(&tool_call.arguments).unwrap_or_else(|_| "{}".to_string())
+        ),
+        ContentPart::ToolResult(tool_result) => format!(
+            "[Tool result {}: {}]",
+            tool_result.tool_call_id,
+            tool_result
+                .result
+                .clone()
+                .unwrap_or_else(|| Value::String(tool_result.error.clone().unwrap_or_default()))
+        ),
+    }
+}
+
+struct AgUiStreamState {
+    subscription: Box<crate::event_delivery::EventSubscription>,
+    session_id: Uuid,
+    input_message_id: String,
+    thread_id: AgUiThreadId,
+    run_id: AgUiRunId,
+    queue: VecDeque<AgUiEvent>,
+    assistant_message_id: Option<AgUiMessageId>,
+    assistant_content_started: bool,
+    assistant_emitted_delta: bool,
+    thinking_started: bool,
+    thinking_text_started: bool,
+    tool_call_ids: HashMap<String, AgUiToolCallId>,
+    finished: bool,
+}
+
+fn translate_event(state: &mut AgUiStreamState, event: &everruns_core::Event) {
+    match event.event_type.as_str() {
+        "output.message.delta" => {
+            if let Ok(data) = parse_event_data::<OutputMessageDeltaData>(event) {
+                let message_id = state
+                    .assistant_message_id
+                    .get_or_insert_with(|| AgUiMessageId::from(data.turn_id.uuid()))
+                    .clone();
+                if !state.assistant_content_started {
+                    state
+                        .queue
+                        .push_back(AgUiEvent::TextMessageStart(AgUiTextMessageStartEvent {
+                            base: agui_base_event(),
+                            message_id: message_id.clone(),
+                            role: AgUiRole::Assistant,
+                        }));
+                    state.assistant_content_started = true;
+                }
+                state.queue.push_back(AgUiEvent::TextMessageContent(
+                    AgUiTextMessageContentEvent::new(message_id, data.delta).unwrap(),
+                ));
+                state.assistant_emitted_delta = true;
+            }
+        }
+        "output.message.completed" => {
+            if let Ok(data) = parse_event_data::<OutputMessageCompletedData>(event) {
+                let message_id = state
+                    .assistant_message_id
+                    .clone()
+                    .unwrap_or_else(|| AgUiMessageId::from(data.message.id.uuid()));
+                if !state.assistant_content_started {
+                    state
+                        .queue
+                        .push_back(AgUiEvent::TextMessageStart(AgUiTextMessageStartEvent {
+                            base: agui_base_event(),
+                            message_id: message_id.clone(),
+                            role: AgUiRole::Assistant,
+                        }));
+                }
+                if !state.assistant_emitted_delta {
+                    let text = data.message.content_to_llm_string();
+                    if !text.is_empty() {
+                        state.queue.push_back(AgUiEvent::TextMessageContent(
+                            AgUiTextMessageContentEvent::new(message_id.clone(), text).unwrap(),
+                        ));
+                    }
+                }
+                state
+                    .queue
+                    .push_back(AgUiEvent::TextMessageEnd(AgUiTextMessageEndEvent {
+                        base: agui_base_event(),
+                        message_id: message_id.clone(),
+                    }));
+                state
+                    .queue
+                    .push_back(AgUiEvent::RunFinished(AgUiRunFinishedEvent {
+                        base: agui_base_event(),
+                        thread_id: state.thread_id.clone(),
+                        run_id: state.run_id.clone(),
+                        result: None,
+                    }));
+                state.assistant_message_id = Some(message_id);
+                state.assistant_content_started = false;
+                state.assistant_emitted_delta = false;
+                state.finished = true;
+            }
+        }
+        "reason.thinking.started" => {
+            if parse_event_data::<ReasonThinkingStartedData>(event).is_ok() {
+                state
+                    .queue
+                    .push_back(AgUiEvent::ThinkingStart(AgUiThinkingStartEvent {
+                        base: agui_base_event(),
+                        title: None,
+                    }));
+                state.thinking_started = true;
+                state.thinking_text_started = false;
+            }
+        }
+        "reason.thinking.delta" => {
+            if let Ok(data) = parse_event_data::<ReasonThinkingDeltaData>(event) {
+                if !state.thinking_text_started {
+                    state.queue.push_back(AgUiEvent::ThinkingTextMessageStart(
+                        AgUiThinkingTextMessageStartEvent {
+                            base: agui_base_event(),
+                        },
+                    ));
+                    state.thinking_text_started = true;
+                }
+                state.queue.push_back(AgUiEvent::ThinkingTextMessageContent(
+                    AgUiThinkingTextMessageContentEvent {
+                        base: agui_base_event(),
+                        delta: data.delta,
+                    },
+                ));
+            }
+        }
+        "reason.thinking.completed" => {
+            if parse_event_data::<ReasonThinkingCompletedData>(event).is_ok() {
+                if state.thinking_text_started {
+                    state.queue.push_back(AgUiEvent::ThinkingTextMessageEnd(
+                        AgUiThinkingTextMessageEndEvent {
+                            base: agui_base_event(),
+                        },
+                    ));
+                }
+                if state.thinking_started {
+                    state
+                        .queue
+                        .push_back(AgUiEvent::ThinkingEnd(AgUiThinkingEndEvent {
+                            base: agui_base_event(),
+                        }));
+                }
+                state.thinking_started = false;
+                state.thinking_text_started = false;
+            }
+        }
+        "tool.started" => {
+            if let Ok(data) = parse_event_data::<ToolStartedData>(event) {
+                let tool_call_id = state
+                    .tool_call_ids
+                    .entry(data.tool_call.id.clone())
+                    .or_insert_with(AgUiToolCallId::random)
+                    .clone();
+                state
+                    .queue
+                    .push_back(AgUiEvent::ToolCallStart(AgUiToolCallStartEvent {
+                        base: agui_base_event(),
+                        tool_call_id: tool_call_id.clone(),
+                        tool_call_name: data.tool_call.name,
+                        parent_message_id: state.assistant_message_id.clone(),
+                    }));
+                state
+                    .queue
+                    .push_back(AgUiEvent::ToolCallArgs(AgUiToolCallArgsEvent {
+                        base: agui_base_event(),
+                        tool_call_id: tool_call_id.clone(),
+                        delta: serde_json::to_string(&data.tool_call.arguments)
+                            .unwrap_or_else(|_| "{}".to_string()),
+                    }));
+                state
+                    .queue
+                    .push_back(AgUiEvent::ToolCallEnd(AgUiToolCallEndEvent {
+                        base: agui_base_event(),
+                        tool_call_id,
+                    }));
+            }
+        }
+        "tool.completed" => {
+            if let Ok(data) = parse_event_data::<ToolCompletedData>(event) {
+                let tool_call_id = state
+                    .tool_call_ids
+                    .remove(&data.tool_call_id)
+                    .unwrap_or_else(AgUiToolCallId::random);
+                state
+                    .queue
+                    .push_back(AgUiEvent::ToolCallResult(AgUiToolCallResultEvent {
+                        base: agui_base_event(),
+                        message_id: state
+                            .assistant_message_id
+                            .clone()
+                            .unwrap_or_else(AgUiMessageId::random),
+                        tool_call_id,
+                        content: data
+                            .result
+                            .map(|parts| {
+                                parts
+                                    .iter()
+                                    .map(content_part_to_string)
+                                    .collect::<Vec<_>>()
+                                    .join("\n")
+                            })
+                            .unwrap_or_else(|| data.error.unwrap_or(data.status)),
+                        role: AgUiRole::Tool,
+                    }));
+            }
+        }
+        "turn.completed" | "session.idled" => {
+            if !state.finished {
+                state
+                    .queue
+                    .push_back(AgUiEvent::RunFinished(AgUiRunFinishedEvent {
+                        base: agui_base_event(),
+                        thread_id: state.thread_id.clone(),
+                        run_id: state.run_id.clone(),
+                        result: None,
+                    }));
+                state.finished = true;
+            }
+        }
+        "turn.failed" | "turn.cancelled" => {
+            let event_data = serde_json::to_value(&event.data).unwrap_or_default();
+            let message = event_data
+                .get("error")
+                .and_then(Value::as_str)
+                .or_else(|| event_data.get("message").and_then(Value::as_str))
+                .unwrap_or("Run failed");
+            if !state.finished {
+                state
+                    .queue
+                    .push_back(AgUiEvent::RunError(AgUiRunErrorEvent {
+                        base: agui_base_event(),
+                        message: message.to_string(),
+                        code: None,
+                    }));
+                state.finished = true;
+            }
+        }
+        _ => {}
+    }
+}
+
+fn agui_base_event() -> AgUiBaseEvent {
+    AgUiBaseEvent {
+        timestamp: None,
+        raw_event: None,
+    }
+}
+
+fn agui_sse(event: &AgUiEvent) -> SseEvent {
+    SseEvent::default().data(serde_json::to_string(event).unwrap_or_else(|_| "{}".to_string()))
+}
+
+fn format_agui_tool_calls(tool_calls: &[AgUiToolCall]) -> String {
+    tool_calls
+        .iter()
+        .map(|tool_call| {
+            format!(
+                "[Tool call: {} {}]",
+                tool_call.function.name, tool_call.function.arguments
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn parse_event_data<T: for<'de> Deserialize<'de>>(
+    event: &everruns_core::Event,
+) -> Result<T, serde_json::Error> {
+    serde_json::from_value(serde_json::to_value(&event.data)?)
+}
+
+fn internal_error(err: anyhow::Error) -> (StatusCode, Json<ErrorResponse>) {
+    tracing::error!(error = %err, "AG-UI route failed");
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse {
+            error: "Internal server error".to_string(),
+        }),
+    )
+}
+
+fn bad_request(message: &str) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ErrorResponse {
+            error: message.to_string(),
+        }),
+    )
+}
+
+fn forbidden(message: &str) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::FORBIDDEN,
+        Json(ErrorResponse {
+            error: message.to_string(),
+        }),
+    )
+}
+
+fn not_found() -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::NOT_FOUND,
+        Json(ErrorResponse {
+            error: "App not found".to_string(),
+        }),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ag_ui_core::event::EventType as AgUiEventType;
+    use everruns_core::{
+        Event, EventContext, Message, MessageId, OutputMessageCompletedData,
+        OutputMessageDeltaData, SessionId, TurnId,
+    };
+
+    async fn test_stream_state() -> AgUiStreamState {
+        let session_id = SessionId::new();
+        let delivery = crate::event_delivery::EventDelivery::in_memory();
+        let subscription = delivery.subscribe(session_id.uuid()).await.unwrap();
+        AgUiStreamState {
+            subscription: Box::new(subscription),
+            session_id: session_id.uuid(),
+            input_message_id: MessageId::new().to_string(),
+            thread_id: AgUiThreadId::random(),
+            run_id: AgUiRunId::random(),
+            queue: VecDeque::new(),
+            assistant_message_id: None,
+            assistant_content_started: false,
+            assistant_emitted_delta: false,
+            thinking_started: false,
+            thinking_text_started: false,
+            tool_call_ids: HashMap::new(),
+            finished: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_translate_output_completion_to_ag_ui_run_finished() {
+        let mut state = test_stream_state().await;
+        let turn_id = TurnId::new();
+        let input_message_id = MessageId::parse(&state.input_message_id).unwrap();
+        let event = Event::new(
+            SessionId::from_uuid(state.session_id),
+            EventContext::turn(turn_id, input_message_id),
+            OutputMessageCompletedData::new(Message::assistant("Hello from AG-UI")),
+        );
+
+        translate_event(&mut state, &event);
+
+        let event_types: Vec<AgUiEventType> =
+            state.queue.iter().map(AgUiEvent::event_type).collect();
+        assert_eq!(
+            event_types,
+            vec![
+                AgUiEventType::TextMessageStart,
+                AgUiEventType::TextMessageContent,
+                AgUiEventType::TextMessageEnd,
+                AgUiEventType::RunFinished,
+            ]
+        );
+        assert!(state.finished);
+    }
+
+    #[tokio::test]
+    async fn test_translate_streaming_delta_does_not_duplicate_final_content() {
+        let mut state = test_stream_state().await;
+        let turn_id = TurnId::new();
+        let input_message_id = MessageId::parse(&state.input_message_id).unwrap();
+        let context = EventContext::turn(turn_id, input_message_id);
+        let session_id = SessionId::from_uuid(state.session_id);
+
+        let delta_event = Event::new(
+            session_id,
+            context.clone(),
+            OutputMessageDeltaData {
+                turn_id,
+                delta: "Hello".to_string(),
+                accumulated: "Hello".to_string(),
+            },
+        );
+        translate_event(&mut state, &delta_event);
+
+        let completed_event = Event::new(
+            session_id,
+            context,
+            OutputMessageCompletedData::new(Message::assistant("Hello from AG-UI")),
+        );
+        translate_event(&mut state, &completed_event);
+
+        let event_types: Vec<AgUiEventType> =
+            state.queue.iter().map(AgUiEvent::event_type).collect();
+        assert_eq!(
+            event_types,
+            vec![
+                AgUiEventType::TextMessageStart,
+                AgUiEventType::TextMessageContent,
+                AgUiEventType::TextMessageEnd,
+                AgUiEventType::RunFinished,
+            ]
+        );
+        let content_events: Vec<&AgUiEvent> = state
+            .queue
+            .iter()
+            .filter(|event| matches!(event, AgUiEvent::TextMessageContent(_)))
+            .collect();
+        assert_eq!(content_events.len(), 1);
+        match content_events[0] {
+            AgUiEvent::TextMessageContent(event) => assert_eq!(event.delta, "Hello"),
+            _ => unreachable!(),
+        }
+        assert!(state.finished);
+    }
+}

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -3,6 +3,7 @@
 // This module contains all HTTP route handlers for the public API.
 // Each submodule handles a specific resource type with its own AppState.
 
+pub mod ag_ui;
 pub mod agent_examples;
 pub mod agent_identities;
 pub mod agent_identity_connections;

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -675,6 +675,13 @@ impl ServerAppBuilder {
             notifications_enabled,
             event_delivery.clone(),
         );
+        let ag_ui_state = api::ag_ui::AgUiState::new(
+            db.clone(),
+            encryption.clone(),
+            runner.clone(),
+            notifications_enabled,
+            event_delivery.clone(),
+        );
         let session_files_state = api::session_files::AppState::new(
             db.clone(),
             event_service.clone(),
@@ -852,6 +859,7 @@ impl ServerAppBuilder {
             .merge(api::audit_logs::routes(audit_logs_state))
             .merge(api::commands::routes(commands_state))
             .merge(api::slack_events::routes(slack_state))
+            .merge(api::ag_ui::routes(ag_ui_state))
             .merge(api::feature_flags::routes(feature_flags_state))
             .merge(api::budgets::routes(api::budgets::AppState::new(
                 db.clone(),

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -591,7 +591,7 @@ impl ServerAppBuilder {
         let notifications_state = notification_service.as_ref().map(|notification_service| {
             api::notifications::AppState {
                 notification_service: notification_service.clone(),
-                sse_tracker,
+                sse_tracker: sse_tracker.clone(),
                 notification_broadcaster,
                 auth: auth_state.clone(),
             }
@@ -681,6 +681,7 @@ impl ServerAppBuilder {
             runner.clone(),
             notifications_enabled,
             event_delivery.clone(),
+            sse_tracker.clone(),
         );
         let session_files_state = api::session_files::AppState::new(
             db.clone(),

--- a/crates/server/tests/ag_ui_integration_test.rs
+++ b/crates/server/tests/ag_ui_integration_test.rs
@@ -1,0 +1,218 @@
+//! AG-UI app channel integration tests.
+//!
+//! These tests cover the app-scoped AG-UI endpoint at the route boundary:
+//! - published app gating
+//! - request validation for the AG-UI contract
+
+mod test_harness;
+
+use axum::http::{Method, StatusCode};
+use serde_json::{Value, json};
+use test_harness::TestServer;
+
+use everruns_core::App;
+
+/// Seed harness ID (BASE_HARNESS)
+const SEED_BASE_HARNESS_ID: &str = "harness_01933b5a000070008000000000000601";
+
+fn unique_id(prefix: &str) -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis();
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{prefix}_{now}_{seq}")
+}
+
+fn unique_slug(prefix: &str) -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis();
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{prefix}-{now}-{seq}")
+}
+
+fn raw_uuid() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+async fn create_llmsim_agent(server: &TestServer) -> String {
+    let provider: Value = server
+        .post(
+            "/v1/llm-providers",
+            json!({
+                "name": unique_id("AG-UI Test Provider"),
+                "provider_type": "llmsim"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let model: Value = server
+        .post(
+            &format!(
+                "/v1/llm-providers/{}/models",
+                provider["id"].as_str().unwrap()
+            ),
+            json!({
+                "model_id": unique_id("llmsim-streaming"),
+                "display_name": unique_id("AG-UI Streaming Model")
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let agent: Value = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": unique_slug("ag-ui-test-agent"),
+                "display_name": unique_id("AG-UI Test Agent"),
+                "system_prompt": "You are a brief test agent.",
+                "default_model_id": model["id"]
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    agent["id"].as_str().unwrap().to_string()
+}
+
+async fn create_published_ag_ui_app(server: &TestServer) -> App {
+    let agent_id = create_llmsim_agent(server).await;
+
+    let app: App = server
+        .post(
+            "/v1/apps",
+            json!({
+                "name": unique_id("AG-UI App"),
+                "harness_id": SEED_BASE_HARNESS_ID,
+                "agent_id": agent_id,
+                "channel_type": "ag_ui",
+                "channel_config": {
+                    "anonymous": true
+                }
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    server
+        .post(&format!("/v1/apps/{}/publish", app.public_id), json!({}))
+        .await
+        .assert_success();
+
+    server
+        .get(&format!("/v1/apps/{}", app.public_id))
+        .await
+        .assert_success()
+        .json()
+}
+
+async fn send_ag_ui_run(
+    server: &TestServer,
+    app_id: impl std::fmt::Display,
+    payload: &Value,
+) -> test_harness::TestResponse {
+    server
+        .request_raw(
+            Method::POST,
+            &format!("/v1/apps/{}/ag-ui", app_id),
+            vec![
+                ("content-type", "application/json"),
+                ("accept", "text/event-stream"),
+            ],
+            serde_json::to_vec(payload).unwrap(),
+        )
+        .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ag_ui_rejects_missing_messages() {
+    let server = TestServer::in_memory().await;
+    let app = create_published_ag_ui_app(&server).await;
+
+    let payload = json!({
+        "threadId": raw_uuid(),
+        "runId": raw_uuid(),
+        "state": {},
+        "messages": []
+        ,
+        "tools": [],
+        "context": [],
+        "forwardedProps": {}
+    });
+
+    send_ag_ui_run(&server, &app.public_id, &payload)
+        .await
+        .assert_status(StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ag_ui_rejects_non_user_final_message() {
+    let server = TestServer::in_memory().await;
+    let app = create_published_ag_ui_app(&server).await;
+    let payload = json!({
+        "threadId": raw_uuid(),
+        "runId": raw_uuid(),
+        "state": {},
+        "messages": [
+            {
+                "id": raw_uuid(),
+                "role": "assistant",
+                "content": "I should not be accepted as the trigger message"
+            }
+        ],
+        "tools": [],
+        "context": [],
+        "forwardedProps": {}
+    });
+
+    send_ag_ui_run(&server, &app.public_id, &payload)
+        .await
+        .assert_status(StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ag_ui_unpublished_app_rejected() {
+    let server = TestServer::in_memory().await;
+    let agent_id = create_llmsim_agent(&server).await;
+
+    let app: App = server
+        .post(
+            "/v1/apps",
+            json!({
+                "name": unique_id("Draft AG-UI App"),
+                "harness_id": SEED_BASE_HARNESS_ID,
+                "agent_id": agent_id,
+                "channel_type": "ag_ui",
+                "channel_config": { "anonymous": true }
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let payload = json!({
+        "threadId": raw_uuid(),
+        "runId": raw_uuid(),
+        "state": {},
+        "messages": [{ "id": raw_uuid(), "role": "user", "content": "Hello" }],
+        "tools": [],
+        "context": [],
+        "forwardedProps": {}
+    });
+
+    send_ag_ui_run(&server, &app.public_id, &payload)
+        .await
+        .assert_status(StatusCode::FORBIDDEN);
+}

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -336,7 +336,14 @@ impl TestServer {
             runner.clone(),
             None, // No delivery dispatcher in tests
             feature_flags.notifications,
-            everruns_server::EventDelivery::in_memory(),
+            event_delivery.clone(),
+        );
+        let ag_ui_state = api::ag_ui::AgUiState::new(
+            db.clone(),
+            None, // No encryption in tests
+            runner.clone(),
+            feature_flags.notifications,
+            event_delivery.clone(),
         );
         let mcp_endpoint_state = api::mcp_endpoint::AppState::new(
             db.clone(),
@@ -344,7 +351,7 @@ impl TestServer {
             auth_state.clone(),
             &platform_definition,
             feature_flags.notifications,
-            everruns_server::EventDelivery::in_memory(),
+            event_delivery.clone(),
             None, // No encryption in tests
             capability_service.clone(),
         );
@@ -378,6 +385,7 @@ impl TestServer {
             .merge(api::session_schedules::routes(session_schedules_state))
             .merge(api::feature_flags::routes(feature_flags_state))
             .merge(api::user_connections::routes(user_connections_state))
+            .merge(api::ag_ui::routes(ag_ui_state))
             .merge(api::slack_events::routes(slack_state))
             .merge(auth::routes(auth_backend.clone()))
             .merge(auth::cli_auth::cli_auth_routes(

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -298,7 +298,7 @@ impl TestServer {
         let notifications_state = if feature_flags.notifications {
             Some(api::notifications::AppState {
                 notification_service: Arc::new(services::NotificationService::new(db.clone())),
-                sse_tracker,
+                sse_tracker: sse_tracker.clone(),
                 notification_broadcaster: None,
                 auth: auth_state.clone(),
             })
@@ -344,6 +344,7 @@ impl TestServer {
             runner.clone(),
             feature_flags.notifications,
             event_delivery.clone(),
+            sse_tracker.clone(),
         );
         let mcp_endpoint_state = api::mcp_endpoint::AppState::new(
             db.clone(),

--- a/specs/apps.md
+++ b/specs/apps.md
@@ -2,7 +2,7 @@
 
 ## Abstract
 
-An App is a deployable unit that binds a Harness and Agent to a distribution channel (Slack, WhatsApp, web widget, etc.). It provides a publish/unpublish lifecycle that controls whether the app actively accepts incoming requests from its configured channel.
+An App is a deployable unit that binds a Harness and Agent to a distribution channel (Slack, AG-UI, WhatsApp, web widget, etc.). It provides a publish/unpublish lifecycle that controls whether the app actively accepts incoming requests from its configured channel.
 
 ## Concepts
 
@@ -28,7 +28,7 @@ A distribution channel attached to an App. Each channel has its own type, config
 
 ### Channel Types
 
-Initially: `slack`. Future: `whatsapp`, `web_widget`, `api_endpoint`, `discord`, etc.
+Current: `slack`, `ag_ui`. Future: `whatsapp`, `web_widget`, `api_endpoint`, `discord`, etc.
 
 Channel config is stored as JSONB and validated at the application layer per channel type.
 
@@ -42,6 +42,21 @@ Channel config is stored as JSONB and validated at the application layer per cha
   "reply_mode": "all_messages"
 }
 ```
+
+**AG-UI channel config example:**
+```json
+{
+  "anonymous": true
+}
+```
+
+AG-UI uses an app-scoped anonymous ingress for the initial rollout:
+
+- Endpoint: `POST /v1/apps/{app_id}/ag-ui`
+- Requests use AG-UI `RunAgentInput` JSON
+- Responses stream back as AG-UI SSE events translated from the durable runtime
+- Anonymous access is currently required when the channel is enabled
+- Session routing is per `threadId`, with sessions tagged by app and thread
 
 ### Session Strategy
 

--- a/specs/dismissed-options.md
+++ b/specs/dismissed-options.md
@@ -4,20 +4,20 @@ This document records technical options that were considered but dismissed for s
 
 ## AG-UI Protocol
 
-**Status**: Dismissed (may revisit)
+**Status**: Revisited and implemented for Apps
 
 **What it was**: AG-UI is a protocol for streaming agent UI events, designed for compatibility with CopilotKit and other agent UI frameworks. See https://docs.ag-ui.com for the specification.
 
 **Why considered**: AG-UI provided a standardized event format for streaming agent execution events (RunStarted, TextMessageContent, ToolCallStart, etc.) to UI clients via SSE. This would enable compatibility with the CopilotKit ecosystem and other AG-UI-compatible clients.
 
-**Why dismissed**: The current implementation priorities shifted away from CopilotKit compatibility. The system uses a custom PostgreSQL-backed durable execution engine for orchestration, which provides sufficient visibility into workflow execution state without a separate event streaming layer.
+**Original reason it was dismissed**: The implementation priorities shifted away from CopilotKit compatibility. The system uses a custom PostgreSQL-backed durable execution engine for orchestration, which provides sufficient visibility into workflow execution state without a separate event streaming layer.
 
-**What we use instead**: PostgreSQL-backed durable execution state for tracking execution progress. Session status transitions (pending → running → pending) reflect workflow state changes. Real-time streaming can be revisited when there's a concrete need.
+**What changed**: Apps now support AG-UI as a first-class channel with anonymous ingress and SSE streaming translated from durable runtime events. See `specs/apps.md` for the active contract.
 
-**May revisit when**:
-- There is renewed interest in CopilotKit integration
-- Real-time SSE streaming becomes a requirement
-- The AG-UI protocol matures and provides clear benefits
+**Remaining constraints**:
+- Initial rollout is app-scoped and anonymous only
+- The runtime remains the source of truth; AG-UI events are translated from internal events
+- Follow-up work may add authenticated or scoped access controls
 
 ## Temporal Workflow Engine
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -802,6 +802,7 @@ When a bash script calls `bash` or `sh` or uses `eval`, bashkit re-invokes its o
 | TM-DOS-007 | Nested JSON depth in API input | Medium | Input validation rejects deeply nested structures | MITIGATED |
 | TM-DOS-008 | ReDoS via file grep endpoint | Medium | `POST /v1/sessions/:id/fs/_/grep` accepts user regex with no complexity limits | **OPEN** |
 | TM-DOS-009 | Valkey unauthenticated access | Medium | Valkey listens on localhost:6379 by default; no AUTH configured in local/example compose | **CALLER RISK** |
+| TM-DOS-010 | AG-UI SSE connection exhaustion | Medium | AG-UI app streams reuse the shared `SseConnectionTracker`, enforcing the same global/per-org/per-session limits as other SSE endpoints | MITIGATED |
 | TM-DOS-010 | Rate limit bypass via Valkey failure | Low | Fail-open design: if Valkey is down, requests are allowed without rate limiting | **ACCEPTED** |
 
 ### Mitigation Details

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -179,6 +179,7 @@ Re-encryption CLI tool implemented at `crates/server/src/bin/reencrypt_secrets.r
 | TM-TENANT-006 | Session inherits wrong org | Medium | Sessions scoped via agent FK; agent scoped to org; query joins enforce chain | MITIGATED |
 | TM-TENANT-007 | Durable tasks cross-org | Medium | gRPC `GetTurnContext` validates org_id in request matches record in DB | MITIGATED |
 | TM-TENANT-008 | User listing cross-org | High | `GET /v1/users` returns all system users without org filtering; uses `AuthUser` not `ResolvedOrg` | **OPEN** |
+| TM-TENANT-009 | AG-UI thread ID collision crosses app session boundaries | High | AG-UI session routing tags include both `ag_ui:app:{app_id}` and `ag_ui:thread:{thread_id}` so a shared thread UUID cannot attach to another app's session | MITIGATED |
 
 ### Mitigation Details
 
@@ -214,6 +215,7 @@ ApiError::Forbidden("No access")         // ✗ Reveals resource exists
 | TM-AUTHZ-002 | Policy bypass via internal Caller | Medium | `Caller::internal()` bypasses policies with Owner role; only used in gRPC service (worker ↔ server), not HTTP-accessible | MITIGATED |
 | TM-AUTHZ-003 | Policy error reveals permission names | Low | 403 response includes policy ID and required permission; acceptable for debugging, no internal state leaked | **ACCEPTED** |
 | TM-AUTHZ-004 | Missing policy on service method | Medium | Compile-time enforcement via `#[policy]` macro; code review required to ensure coverage | MITIGATED |
+| TM-AUTHZ-005 | Anonymous app channel reaches draft or disabled app config | High | Public AG-UI ingress requires `AppStatus::Published`, an enabled `ag_ui` channel, and `anonymous=true`; otherwise returns 403/400 before session creation | MITIGATED |
 
 ### Mitigation Details
 


### PR DESCRIPTION
## What
Add AG-UI as a first-class app channel with anonymous ingress, streaming translation, conformance coverage, and app management UI.

## Why
Apps already supported Slack, but AG-UI clients needed the same app-scoped deployment model and a documented endpoint they could talk to directly.

## How
- add `ag_ui` channel types/config in core app models and DB constraints
- add `POST /v1/apps/{app_id}/ag-ui` with anonymous published-app gating and AG-UI SSE event translation backed by the normal runtime
- add app management UI and setup guidance for the canonical endpoint
- add server route coverage plus UI contract tests against `@ag-ui/core` schemas
- document the endpoint and security posture in specs and threat model

## Risk
- Medium
- Public anonymous ingress for published AG-UI apps could expose draft/private apps or cross-app thread reuse if gating or routing tags were wrong

## Security
- Threat categories reviewed: TM-AUTHZ, TM-TENANT, TM-DOS, TM-LLM
- Findings and resolutions:
  - TM-AUTHZ-005: block anonymous traffic unless the app is published and the enabled AG-UI channel has `anonymous=true`
  - TM-TENANT-009: scope AG-UI session routing by both app id and thread id so a reused thread UUID cannot attach to another app session
  - TM-DOS: anonymous SSE ingress still relies on existing API rate limiting and normal runtime bounds; no new unbounded server-side buffering introduced
  - TM-LLM: AG-UI requests still execute through the standard session/message pipeline, so existing message/tool controls remain in force

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `cargo test -p everruns-core app::tests:: -- --nocapture`
- `cargo test -p everruns-server ag_ui -- --nocapture`
- `npm test -- --runInBand src/__tests__/ag-ui-setup-guidance.test.tsx src/__tests__/ag-ui-contract.test.ts`
- `just pre-push`
- live smoke: published AG-UI app on local `start-all`, then `POST /api/v1/apps/{app_id}/ag-ui` emitted `RUN_STARTED`, `MESSAGES_SNAPSHOT`, `TEXT_MESSAGE_*`, `RUN_FINISHED`
