### PR TITLE
feat(core): add background tool execution

### DIFF
--- a/apps/ui/src/app/(main)/sessions/[sessionId]/resources/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/resources/page.tsx
@@ -43,7 +43,8 @@ function ResourceCard({ resource }: { resource: SessionResourceEntry }) {
   const statusText =
     typeof resource.metadata?.status_text === "string" ? resource.metadata.status_text : null;
   const summary = typeof resource.metadata?.summary === "string" ? resource.metadata.summary : null;
-  const logPath = typeof resource.metadata?.log_path === "string" ? resource.metadata.log_path : null;
+  const logPath =
+    typeof resource.metadata?.log_path === "string" ? resource.metadata.log_path : null;
   const resultPath =
     typeof resource.metadata?.result_path === "string" ? resource.metadata.result_path : null;
   const outputTail =

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/resources/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/resources/page.tsx
@@ -40,6 +40,23 @@ function statusIcon(status: string) {
 }
 
 function ResourceCard({ resource }: { resource: SessionResourceEntry }) {
+  const statusText =
+    typeof resource.metadata?.status_text === "string" ? resource.metadata.status_text : null;
+  const summary = typeof resource.metadata?.summary === "string" ? resource.metadata.summary : null;
+  const logPath = typeof resource.metadata?.log_path === "string" ? resource.metadata.log_path : null;
+  const resultPath =
+    typeof resource.metadata?.result_path === "string" ? resource.metadata.result_path : null;
+  const outputTail =
+    typeof resource.metadata?.output_tail === "string" ? resource.metadata.output_tail : null;
+  const progress =
+    resource.metadata?.progress && typeof resource.metadata.progress === "object"
+      ? (resource.metadata.progress as Record<string, unknown>)
+      : null;
+  const progressLine =
+    progress && (progress.current !== undefined || progress.total !== undefined)
+      ? `${progress.label ? `${progress.label}: ` : ""}${progress.current ?? "?"}/${progress.total ?? "?"}${typeof progress.unit === "string" ? ` ${progress.unit}` : ""}`
+      : null;
+
   return (
     <Card>
       <CardHeader className="pb-3">
@@ -60,7 +77,17 @@ function ResourceCard({ resource }: { resource: SessionResourceEntry }) {
         <div className="grid gap-1">
           <div>Registered: {formatRelativeTime(resource.created_at)}</div>
           <div className="truncate">ID: {resource.resource_id}</div>
+          {statusText ? <div>Status: {statusText}</div> : null}
+          {progressLine ? <div>Progress: {progressLine}</div> : null}
+          {summary ? <div className="text-foreground">Summary: {summary}</div> : null}
+          {logPath ? <div className="truncate">Log: {logPath}</div> : null}
+          {resultPath ? <div className="truncate">Result: {resultPath}</div> : null}
         </div>
+        {outputTail ? (
+          <pre className="overflow-x-auto whitespace-pre-wrap rounded border border-border/70 bg-card px-3 py-2 text-xs text-foreground">
+            {outputTail}
+          </pre>
+        ) : null}
       </CardContent>
     </Card>
   );

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -177,7 +177,7 @@ where
     /// Optional capability registry for blueprint lookups in subagent tools
     capability_registry: Option<crate::capabilities::CapabilityRegistry>,
     /// Optional built-in tool registry for meta-tools that delegate to sibling tools.
-    tool_registry: Option<crate::tools::ToolRegistry>,
+    tool_registry: Option<Arc<crate::tools::ToolRegistry>>,
     /// Optional memory store backend for persistent cross-session memory.
     memory_store: Option<Arc<dyn crate::memory_store::MemoryStoreBackend>>,
     /// Optional org ID for org-scoped operations.
@@ -370,7 +370,7 @@ where
     }
 
     /// Set the active built-in tool registry for meta-tools like `spawn_background`.
-    pub fn with_tool_registry(mut self, registry: crate::tools::ToolRegistry) -> Self {
+    pub fn with_tool_registry(mut self, registry: Arc<crate::tools::ToolRegistry>) -> Self {
         self.tool_registry = Some(registry);
         self
     }

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -176,6 +176,8 @@ where
     session_resource_registry: Option<Arc<dyn crate::traits::SessionResourceRegistry>>,
     /// Optional capability registry for blueprint lookups in subagent tools
     capability_registry: Option<crate::capabilities::CapabilityRegistry>,
+    /// Optional built-in tool registry for meta-tools that delegate to sibling tools.
+    tool_registry: Option<crate::tools::ToolRegistry>,
     /// Optional memory store backend for persistent cross-session memory.
     memory_store: Option<Arc<dyn crate::memory_store::MemoryStoreBackend>>,
     /// Optional org ID for org-scoped operations.
@@ -217,6 +219,7 @@ where
             leased_resource_store: None,
             session_resource_registry: None,
             capability_registry: None,
+            tool_registry: None,
             memory_store: None,
             org_id: None,
             network_access: None,
@@ -248,6 +251,7 @@ where
             leased_resource_store: None,
             session_resource_registry: None,
             capability_registry: None,
+            tool_registry: None,
             memory_store: None,
             org_id: None,
             network_access: None,
@@ -362,6 +366,12 @@ where
         registry: crate::capabilities::CapabilityRegistry,
     ) -> Self {
         self.capability_registry = Some(registry);
+        self
+    }
+
+    /// Set the active built-in tool registry for meta-tools like `spawn_background`.
+    pub fn with_tool_registry(mut self, registry: crate::tools::ToolRegistry) -> Self {
+        self.tool_registry = Some(registry);
         self
     }
 
@@ -826,6 +836,9 @@ where
         }
         if let Some(ref registry) = self.capability_registry {
             tool_context.capability_registry = Some(registry.clone());
+        }
+        if let Some(ref registry) = self.tool_registry {
+            tool_context.tool_registry = Some(registry.clone());
         }
         if let Some(ref store) = self.memory_store {
             tool_context.memory_store = Some(store.clone());

--- a/crates/core/src/background.rs
+++ b/crates/core/src/background.rs
@@ -1,0 +1,52 @@
+// Background tool execution contracts.
+//
+// Decision: foreground tool execution remains the default. Tools opt into
+// detached execution with the `supports_background` hint plus a native
+// `BackgroundExecutableTool` implementation.
+
+use crate::error::Result;
+use crate::tools::ToolExecutionResult;
+use crate::traits::ToolContext;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::sync::Arc;
+
+/// Structured progress reported by background tools.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BackgroundProgress {
+    pub current: Option<u64>,
+    pub total: Option<u64>,
+    pub unit: Option<String>,
+    pub label: Option<String>,
+}
+
+/// Final result from a completed background tool.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackgroundOutcome {
+    pub summary: String,
+    pub result: Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw_output: Option<String>,
+}
+
+/// Sink for background status, output, and progress updates.
+#[async_trait]
+pub trait BackgroundEventSink: Send + Sync {
+    async fn status(&self, message: &str) -> Result<()>;
+
+    async fn output(&self, stream: &str, delta: &str) -> Result<()>;
+
+    async fn progress(&self, progress: BackgroundProgress) -> Result<()>;
+}
+
+/// Trait implemented by tools that natively support detached execution.
+#[async_trait]
+pub trait BackgroundExecutableTool: Send + Sync {
+    async fn execute_background(
+        &self,
+        arguments: Value,
+        context: ToolContext,
+        sink: Arc<dyn BackgroundEventSink>,
+    ) -> std::result::Result<BackgroundOutcome, ToolExecutionResult>;
+}

--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -14,6 +14,9 @@
 //!   single-query indexed search instead of per-file linear scan
 
 use super::{Capability, CapabilityStatus};
+use crate::background::{
+    BackgroundEventSink, BackgroundExecutableTool, BackgroundOutcome, BackgroundProgress,
+};
 use crate::session_file::SessionFile;
 use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
@@ -181,6 +184,7 @@ impl Tool for BashTool {
             .with_long_running(true)
             .with_open_world(true)
             .with_persist_output(true)
+            .with_supports_background(true)
     }
 
     async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
@@ -399,6 +403,181 @@ impl Tool for BashTool {
 
     fn requires_context(&self) -> bool {
         true
+    }
+
+    fn as_background_executable(&self) -> Option<&dyn BackgroundExecutableTool> {
+        Some(self)
+    }
+}
+
+#[async_trait]
+impl BackgroundExecutableTool for BashTool {
+    async fn execute_background(
+        &self,
+        arguments: Value,
+        context: ToolContext,
+        sink: Arc<dyn BackgroundEventSink>,
+    ) -> Result<BackgroundOutcome, ToolExecutionResult> {
+        let command = match arguments.get("commands").and_then(|v| v.as_str()) {
+            Some(c) => c,
+            None => {
+                return Err(ToolExecutionResult::tool_error(
+                    "Missing required parameter: commands",
+                ));
+            }
+        };
+
+        let working_dir = arguments
+            .get("working_dir")
+            .and_then(|v| v.as_str())
+            .unwrap_or("/workspace");
+
+        let timeout_ms = arguments
+            .get("timeout_ms")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(30000)
+            .min(60000);
+
+        let output_mode = arguments
+            .get("output")
+            .and_then(|v| v.as_str())
+            .unwrap_or("concise");
+
+        let file_store = match &context.file_store {
+            Some(store) => store.clone(),
+            None => {
+                return Err(ToolExecutionResult::tool_error(
+                    "File system not available in this context",
+                ));
+            }
+        };
+
+        let session_fs = Arc::new(SessionFileSystemAdapter::new(
+            context.session_id,
+            file_store,
+        ));
+        let locale = context.locale.as_deref().unwrap_or("en-US");
+
+        let mut bash = Bash::builder()
+            .fs(session_fs)
+            .cwd(working_dir)
+            .username("everruns")
+            .hostname("everruns")
+            .env("HOME", "/home/agent")
+            .env("SHELL", "/bin/bash")
+            .env("PATH", "/usr/local/bin:/usr/bin:/bin")
+            .env("WORKSPACE", "/workspace")
+            .env("LANG", locale)
+            .limits(execution_limits())
+            .max_memory(10 * 1024 * 1024)
+            .trace_mode(TraceMode::Redacted)
+            .build();
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<(String, String)>();
+        let (partial_tx, partial_rx) = tokio::sync::mpsc::channel::<(String, String)>(128);
+        let sink_for_output = sink.clone();
+        let output_callback: OutputCallback =
+            Box::new(move |stdout_chunk: &str, stderr_chunk: &str| {
+                let _ = tx.send((stdout_chunk.to_string(), stderr_chunk.to_string()));
+                let _ = partial_tx.try_send((stdout_chunk.to_string(), stderr_chunk.to_string()));
+            });
+
+        let emit_task = tokio::spawn(async move {
+            while let Some((stdout_chunk, stderr_chunk)) = rx.recv().await {
+                if !stdout_chunk.is_empty() {
+                    let _ = sink_for_output.output("stdout", &stdout_chunk).await;
+                }
+                if !stderr_chunk.is_empty() {
+                    let _ = sink_for_output.output("stderr", &stderr_chunk).await;
+                }
+            }
+        });
+
+        let _ = sink.status("Running bash command").await;
+        let cancel_token = bash.cancellation_token();
+        let exec_start = std::time::Instant::now();
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(timeout_ms),
+            bash.exec_streaming(command, output_callback),
+        )
+        .await;
+        let exec_duration = exec_start.elapsed();
+        let _ = emit_task.await;
+
+        match result {
+            Ok(Ok(output)) => {
+                use crate::tool_output_sanitizer::{
+                    clean_exec_output, output_verbosity_budget, priority_aware_truncate,
+                };
+
+                let clean_stdout = clean_exec_output(&output.stdout);
+                let clean_stderr = clean_exec_output(&output.stderr);
+                let (stdout, stderr) = if let Some(budget) = output_verbosity_budget(output_mode) {
+                    (
+                        priority_aware_truncate(&clean_stdout, budget),
+                        priority_aware_truncate(&clean_stderr, budget.min(4096)),
+                    )
+                } else {
+                    (clean_stdout.clone(), clean_stderr.clone())
+                };
+                let mut raw = clean_stdout;
+                if !clean_stderr.is_empty() {
+                    raw.push_str("\n--- stderr ---\n");
+                    raw.push_str(&clean_stderr);
+                }
+                let _ = sink
+                    .progress(BackgroundProgress {
+                        current: Some(exec_duration.as_millis() as u64),
+                        total: None,
+                        unit: Some("ms".to_string()),
+                        label: Some("runtime".to_string()),
+                    })
+                    .await;
+                Ok(BackgroundOutcome {
+                    summary: format!(
+                        "Bash command exited with code {} after {} ms",
+                        output.exit_code,
+                        exec_duration.as_millis()
+                    ),
+                    result: json!({
+                        "stdout": stdout,
+                        "stderr": stderr,
+                        "exit_code": output.exit_code,
+                        "success": output.exit_code == 0
+                    }),
+                    raw_output: Some(raw),
+                })
+            }
+            Ok(Err(e)) => Err(ToolExecutionResult::tool_error(format!(
+                "Bash execution error: {}",
+                e
+            ))),
+            Err(_) => {
+                cancel_token.store(true, std::sync::atomic::Ordering::Relaxed);
+
+                let partial = collect_partial_output(partial_rx);
+                if partial.is_empty() {
+                    Err(ToolExecutionResult::tool_error(format!(
+                        "Command timed out after {}ms",
+                        timeout_ms
+                    )))
+                } else {
+                    use crate::tool_output_sanitizer::{
+                        clean_exec_output, output_verbosity_budget, priority_aware_truncate,
+                    };
+                    let clean = clean_exec_output(&partial);
+                    let truncated = if let Some(budget) = output_verbosity_budget(output_mode) {
+                        priority_aware_truncate(&clean, budget)
+                    } else {
+                        clean.clone()
+                    };
+                    Err(ToolExecutionResult::tool_error(format!(
+                        "Command timed out after {}ms. Partial output:\n{}",
+                        timeout_ms, truncated
+                    )))
+                }
+            }
+        }
     }
 }
 

--- a/crates/core/src/in_memory_loop.rs
+++ b/crates/core/src/in_memory_loop.rs
@@ -474,7 +474,8 @@ impl InMemoryAgenticLoopBuilder {
             driver_registry,
             event_emitter.clone(),
         );
-        let act_atom = ActAtom::new(tool_registry.clone(), event_emitter.clone());
+        let act_atom = ActAtom::new(tool_registry.clone(), event_emitter.clone())
+            .with_tool_registry(tool_registry.clone());
 
         Ok(InMemoryAgenticLoop {
             harness_id,

--- a/crates/core/src/in_memory_loop.rs
+++ b/crates/core/src/in_memory_loop.rs
@@ -475,7 +475,7 @@ impl InMemoryAgenticLoopBuilder {
             event_emitter.clone(),
         );
         let act_atom = ActAtom::new(tool_registry.clone(), event_emitter.clone())
-            .with_tool_registry(tool_registry.clone());
+            .with_tool_registry(Arc::new(tool_registry.clone()));
 
         Ok(InMemoryAgenticLoop {
             harness_id,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -45,6 +45,7 @@ pub mod typed_id;
 pub mod audit;
 
 // Budget types (budgets, ledger, rules, actions)
+pub mod background;
 pub mod budget;
 
 // Domain entity types
@@ -163,6 +164,9 @@ pub use channel::{
 pub use platform_store::{PlatformMessage, PlatformStore};
 
 // Event listener re-exports
+pub use background::{
+    BackgroundEventSink, BackgroundExecutableTool, BackgroundOutcome, BackgroundProgress,
+};
 pub use event_listeners::{CompositeEventListener, EventListener, NoopEventListener};
 
 // LLM driver types re-exports
@@ -189,8 +193,8 @@ pub use openresponses_protocol::{
 
 // Tool abstraction re-exports
 pub use tools::{
-    EchoTool, FailingTool, Tool, ToolExecutionResult, ToolInternalError, ToolRegistry,
-    ToolRegistryBuilder, ToolResultImage,
+    EchoTool, FailingTool, SpawnBackgroundTool, Tool, ToolExecutionResult, ToolInternalError,
+    ToolRegistry, ToolRegistryBuilder, ToolResultImage,
 };
 
 // Capability re-exports

--- a/crates/core/src/tool_types.rs
+++ b/crates/core/src/tool_types.rs
@@ -246,6 +246,12 @@ pub struct ToolHints {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub long_running: Option<bool>,
 
+    /// Tool supports detached background execution via `spawn_background`.
+    /// When true, the tool may be executed asynchronously outside the current
+    /// foreground tool call and report status back later.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supports_background: Option<bool>,
+
     /// Tool output should be persisted to session VFS before truncation.
     /// When set, the `tool_output_persistence` capability (EVE-222, EVE-245) writes
     /// stdout to `/.outputs/{tool_call_id}.stdout` and stderr to
@@ -301,6 +307,12 @@ impl ToolHints {
     /// Builder: set long_running hint.
     pub fn with_long_running(mut self, value: bool) -> Self {
         self.long_running = Some(value);
+        self
+    }
+
+    /// Builder: set supports_background hint.
+    pub fn with_supports_background(mut self, value: bool) -> Self {
+        self.supports_background = Some(value);
         self
     }
 

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -12,11 +12,15 @@
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::error;
 
+use crate::background::{
+    BackgroundEventSink, BackgroundExecutableTool, BackgroundOutcome, BackgroundProgress,
+};
+use crate::session_resource::{RegisterSessionResource, SessionResourceStatus};
 use crate::tool_types::{
     BuiltinTool, DeferrablePolicy, ToolCall, ToolDefinition, ToolHints, ToolPolicy, ToolResult,
 };
@@ -423,6 +427,12 @@ pub trait Tool: Send + Sync {
         ToolHints::default()
     }
 
+    /// Returns native background execution support when this tool opts into
+    /// detached execution via `hints().supports_background`.
+    fn as_background_executable(&self) -> Option<&dyn BackgroundExecutableTool> {
+        None
+    }
+
     /// Convert this tool to a ToolDefinition for the agent config.
     ///
     /// This is used by ToolRegistry to generate tool definitions
@@ -502,6 +512,7 @@ impl ToolRegistry {
         ToolRegistry::builder()
             .tool(GetCurrentTimeTool)
             .tool(EchoTool)
+            .tool(SpawnBackgroundTool)
             .tool(ReportProgressTool)
             // TestMath capability tools
             .tool(AddTool)
@@ -744,6 +755,414 @@ impl Tool for EchoTool {
     }
 }
 
+/// Spawn a background-capable tool and return immediately with a run handle.
+pub struct SpawnBackgroundTool;
+
+#[async_trait]
+impl Tool for SpawnBackgroundTool {
+    fn name(&self) -> &str {
+        "spawn_background"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Spawn Background")
+    }
+
+    fn description(&self) -> &str {
+        "Run a background-capable built-in tool asynchronously. Returns immediately and signals the session when the background run completes."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "tool": {
+                    "type": "string",
+                    "description": "Name of the built-in tool to execute in the background"
+                },
+                "args": {
+                    "type": "object",
+                    "description": "Arguments to pass to the target tool"
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Optional human-readable label for the background run"
+                },
+                "signal_on_completion": {
+                    "type": "boolean",
+                    "description": "Send a synthetic user message back to the session when the run completes",
+                    "default": true
+                }
+            },
+            "required": ["tool", "args"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "spawn_background requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let tool_name = match arguments.get("tool").and_then(|v| v.as_str()) {
+            Some(name) if !name.trim().is_empty() => name.trim(),
+            _ => return ToolExecutionResult::tool_error("Missing required parameter: tool"),
+        };
+        let tool_args = match arguments.get("args") {
+            Some(args) if args.is_object() => args.clone(),
+            _ => {
+                return ToolExecutionResult::tool_error(
+                    "Missing required parameter: args (object expected)",
+                );
+            }
+        };
+        let signal_on_completion = arguments
+            .get("signal_on_completion")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+
+        let Some(tool_registry) = &context.tool_registry else {
+            return ToolExecutionResult::tool_error(
+                "Tool registry not available in this context. spawn_background requires worker-side tool execution.",
+            );
+        };
+
+        let Some(tool) = tool_registry.get(tool_name).cloned() else {
+            return ToolExecutionResult::tool_error(format!("Unknown tool: {tool_name}"));
+        };
+        if tool_name == self.name() {
+            return ToolExecutionResult::tool_error(
+                "spawn_background cannot target itself recursively",
+            );
+        }
+        if tool.hints().supports_background != Some(true) {
+            return ToolExecutionResult::tool_error(format!(
+                "Tool does not support background execution: {tool_name}"
+            ));
+        }
+        if tool.as_background_executable().is_none() {
+            return ToolExecutionResult::tool_error(format!(
+                "Tool declared background support but has no background executor: {tool_name}"
+            ));
+        }
+        let Some(resource_registry) = &context.session_resource_registry else {
+            return ToolExecutionResult::tool_error(
+                "Session resource registry not available in this context",
+            );
+        };
+
+        let run_id = format!("bg_{}", uuid::Uuid::now_v7().simple());
+        let title = arguments
+            .get("title")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| {
+                tool.display_name()
+                    .map(ToString::to_string)
+                    .unwrap_or_else(|| format!("Background {tool_name}"))
+            });
+
+        let artifact_dir = format!("/.background/{run_id}");
+        let log_path = format!("{artifact_dir}/output.log");
+        let result_path = format!("{artifact_dir}/result.json");
+        let metadata = json!({
+            "tool": tool_name,
+            "status_text": "Queued",
+            "signal_on_completion": signal_on_completion,
+            "artifact_dir": artifact_dir,
+            "log_path": log_path,
+            "result_path": result_path,
+        });
+
+        if let Err(e) = resource_registry
+            .register(RegisterSessionResource {
+                session_id: context.session_id,
+                resource_id: run_id.clone(),
+                kind: "background_run".to_string(),
+                display_name: title.clone(),
+                status: SessionResourceStatus::Active,
+                metadata,
+            })
+            .await
+        {
+            return ToolExecutionResult::internal_error_msg(format!(
+                "Failed to register background run: {e}"
+            ));
+        }
+
+        let background_context = context.clone().with_tool_registry(tool_registry.clone());
+        let sink = Arc::new(SessionBackgroundSink::new(
+            background_context.clone(),
+            run_id.clone(),
+            title.clone(),
+            tool_name.to_string(),
+            log_path.clone(),
+            result_path.clone(),
+            signal_on_completion,
+        ));
+        let run_id_for_task = run_id.clone();
+        let tool_for_task = tool.clone();
+        let tool_name_for_task = tool_name.to_string();
+
+        tokio::spawn(async move {
+            let _ = sink.status("Starting").await;
+            let outcome = match tool_for_task.as_background_executable() {
+                Some(background_tool) => {
+                    background_tool
+                        .execute_background(tool_args, background_context, sink.clone())
+                        .await
+                }
+                None => Err(ToolExecutionResult::tool_error(format!(
+                    "Tool declared background support but has no background executor: {}",
+                    tool_name_for_task
+                ))),
+            };
+
+            if let Err(err) = sink.finalize(outcome).await {
+                tracing::warn!(
+                    run_id = run_id_for_task,
+                    error = %err,
+                    "Background run finalization failed"
+                );
+            }
+        });
+
+        ToolExecutionResult::success(json!({
+            "run_id": run_id,
+            "resource_id": run_id,
+            "title": title,
+            "tool": tool_name,
+            "status": "running",
+            "signal_on_completion": signal_on_completion,
+            "artifact_dir": artifact_dir,
+            "log_path": log_path,
+            "result_path": result_path
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Default)]
+struct SessionBackgroundState {
+    status_text: String,
+    progress: Option<BackgroundProgress>,
+    output_tail: String,
+}
+
+struct SessionBackgroundSink {
+    context: ToolContext,
+    run_id: String,
+    display_name: String,
+    tool_name: String,
+    log_path: String,
+    result_path: String,
+    signal_on_completion: bool,
+    state: tokio::sync::Mutex<SessionBackgroundState>,
+}
+
+impl SessionBackgroundSink {
+    fn new(
+        context: ToolContext,
+        run_id: String,
+        display_name: String,
+        tool_name: String,
+        log_path: String,
+        result_path: String,
+        signal_on_completion: bool,
+    ) -> Self {
+        Self {
+            context,
+            run_id,
+            display_name,
+            tool_name,
+            log_path,
+            result_path,
+            signal_on_completion,
+            state: tokio::sync::Mutex::new(SessionBackgroundState {
+                status_text: "Queued".to_string(),
+                ..Default::default()
+            }),
+        }
+    }
+
+    async fn finalize(
+        &self,
+        outcome: std::result::Result<BackgroundOutcome, ToolExecutionResult>,
+    ) -> Result<()> {
+        match outcome {
+            Ok(outcome) => {
+                if let Some(raw_output) = &outcome.raw_output {
+                    self.write_text_file(&self.log_path, raw_output).await?;
+                }
+                let result_json = serde_json::to_string_pretty(&outcome.result)
+                    .unwrap_or_else(|_| outcome.result.to_string());
+                self.write_text_file(&self.result_path, &result_json)
+                    .await?;
+
+                let mut state = self.state.lock().await;
+                state.status_text = "Completed".to_string();
+                drop(state);
+                self.update_resource(SessionResourceStatus::Completed, Some(&outcome.summary))
+                    .await?;
+                if self.signal_on_completion {
+                    self.signal_session("completed", &outcome.summary).await?;
+                }
+            }
+            Err(err) => {
+                let message = match err {
+                    ToolExecutionResult::ToolError(msg) => msg,
+                    ToolExecutionResult::InternalError(inner) => inner.message,
+                    ToolExecutionResult::ConnectionRequired { provider } => {
+                        format!("Background tool requires connection setup: {provider}")
+                    }
+                    ToolExecutionResult::Success(_)
+                    | ToolExecutionResult::SuccessWithImages { .. } => {
+                        "Background run ended unexpectedly".to_string()
+                    }
+                };
+                let mut state = self.state.lock().await;
+                state.status_text = "Failed".to_string();
+                drop(state);
+                self.update_resource(SessionResourceStatus::Failed, Some(&message))
+                    .await?;
+                if self.signal_on_completion {
+                    self.signal_session("failed", &message).await?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn signal_session(&self, status: &str, summary: &str) -> Result<()> {
+        let Some(platform_store) = &self.context.platform_store else {
+            return Ok(());
+        };
+        let message = format!(
+            "Background run {status}.\n- run_id: {}\n- title: {}\n- tool: {}\n- summary: {}\n- result_path: {}\n- log_path: {}",
+            self.run_id,
+            self.display_name,
+            self.tool_name,
+            summary,
+            self.result_path,
+            self.log_path
+        );
+        platform_store
+            .send_message(self.context.session_id, &message)
+            .await
+    }
+
+    async fn update_resource(
+        &self,
+        status: SessionResourceStatus,
+        summary: Option<&str>,
+    ) -> Result<()> {
+        let Some(registry) = &self.context.session_resource_registry else {
+            return Ok(());
+        };
+        let state = self.state.lock().await;
+        registry
+            .register(RegisterSessionResource {
+                session_id: self.context.session_id,
+                resource_id: self.run_id.clone(),
+                kind: "background_run".to_string(),
+                display_name: self.display_name.clone(),
+                status,
+                metadata: json!({
+                    "tool": self.tool_name,
+                    "status_text": state.status_text,
+                    "progress": state.progress,
+                    "output_tail": state.output_tail,
+                    "log_path": self.log_path,
+                    "result_path": self.result_path,
+                    "summary": summary,
+                    "signal_on_completion": self.signal_on_completion,
+                }),
+            })
+            .await?;
+        Ok(())
+    }
+
+    async fn write_text_file(&self, path: &str, content: &str) -> Result<()> {
+        let Some(file_store) = &self.context.file_store else {
+            return Ok(());
+        };
+
+        ensure_directory(file_store.as_ref(), self.context.session_id, "/.background").await?;
+        let run_dir = format!("/.background/{}", self.run_id);
+        ensure_directory(file_store.as_ref(), self.context.session_id, &run_dir).await?;
+        file_store
+            .write_file(self.context.session_id, path, content, "text")
+            .await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl BackgroundEventSink for SessionBackgroundSink {
+    async fn status(&self, message: &str) -> Result<()> {
+        let mut state = self.state.lock().await;
+        state.status_text = message.to_string();
+        drop(state);
+        self.update_resource(SessionResourceStatus::Active, None)
+            .await
+    }
+
+    async fn output(&self, stream: &str, delta: &str) -> Result<()> {
+        let mut state = self.state.lock().await;
+        if !delta.is_empty() {
+            let prefix = format!("[{stream}] ");
+            state.output_tail.push_str(&prefix);
+            state.output_tail.push_str(delta);
+            if state.output_tail.chars().count() > 2048 {
+                state.output_tail = state
+                    .output_tail
+                    .chars()
+                    .rev()
+                    .take(2048)
+                    .collect::<Vec<_>>()
+                    .into_iter()
+                    .rev()
+                    .collect();
+            }
+        }
+        drop(state);
+        self.update_resource(SessionResourceStatus::Active, None)
+            .await
+    }
+
+    async fn progress(&self, progress: BackgroundProgress) -> Result<()> {
+        let mut state = self.state.lock().await;
+        state.progress = Some(progress);
+        drop(state);
+        self.update_resource(SessionResourceStatus::Active, None)
+            .await
+    }
+}
+
+async fn ensure_directory(
+    file_store: &dyn crate::traits::SessionFileStore,
+    session_id: crate::SessionId,
+    path: &str,
+) -> Result<()> {
+    if file_store.stat_file(session_id, path).await?.is_some() {
+        return Ok(());
+    }
+    let _ = file_store.create_directory(session_id, path).await?;
+    Ok(())
+}
+
 /// A tool that always fails (useful for testing error handling)
 pub struct FailingTool {
     error_message: String,
@@ -819,6 +1238,449 @@ impl Tool for FailingTool {
 mod tests {
     use super::*;
     use crate::capabilities::GetCurrentTimeTool;
+    use crate::platform_store::PlatformStore;
+    use crate::session_file::{FileInfo, FileStat, SessionFile};
+    use crate::session_resource::{SessionResourceEntry, SessionResourceFilter};
+    use crate::traits::{SessionFileStore, SessionResourceRegistry};
+    use crate::typed_id::{HarnessId, SessionId};
+    use crate::{AgentId, KeyInfo, PlatformMessage, SecretInfo};
+    use async_trait::async_trait;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct TestBackgroundTool;
+
+    #[async_trait]
+    impl BackgroundExecutableTool for TestBackgroundTool {
+        async fn execute_background(
+            &self,
+            arguments: Value,
+            _context: ToolContext,
+            sink: Arc<dyn BackgroundEventSink>,
+        ) -> std::result::Result<BackgroundOutcome, ToolExecutionResult> {
+            sink.status("Waiting for test result")
+                .await
+                .map_err(ToolExecutionResult::internal_error)?;
+            sink.output("stdout", "hello from background")
+                .await
+                .map_err(ToolExecutionResult::internal_error)?;
+            sink.progress(BackgroundProgress {
+                current: Some(1),
+                total: Some(1),
+                unit: Some("step".to_string()),
+                label: Some("done".to_string()),
+            })
+            .await
+            .map_err(ToolExecutionResult::internal_error)?;
+
+            Ok(BackgroundOutcome {
+                summary: arguments["summary"].as_str().unwrap_or("done").to_string(),
+                result: json!({"ok": true}),
+                raw_output: Some("hello from background".to_string()),
+            })
+        }
+    }
+
+    #[async_trait]
+    impl Tool for TestBackgroundTool {
+        fn name(&self) -> &str {
+            "test_background"
+        }
+
+        fn display_name(&self) -> Option<&str> {
+            Some("Test Background")
+        }
+
+        fn description(&self) -> &str {
+            "test tool"
+        }
+
+        fn parameters_schema(&self) -> Value {
+            json!({
+                "type": "object",
+                "properties": {
+                    "summary": { "type": "string" }
+                }
+            })
+        }
+
+        async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+            ToolExecutionResult::tool_error("foreground unsupported")
+        }
+
+        fn hints(&self) -> ToolHints {
+            ToolHints::default().with_supports_background(true)
+        }
+
+        fn as_background_executable(&self) -> Option<&dyn BackgroundExecutableTool> {
+            Some(self)
+        }
+    }
+
+    #[derive(Default)]
+    struct TestSessionResourceRegistry {
+        entries: Mutex<HashMap<String, SessionResourceEntry>>,
+    }
+
+    #[async_trait]
+    impl crate::traits::SessionResourceRegistry for TestSessionResourceRegistry {
+        async fn register(
+            &self,
+            entry: RegisterSessionResource,
+        ) -> crate::Result<SessionResourceEntry> {
+            let stored = SessionResourceEntry {
+                resource_id: entry.resource_id.clone(),
+                session_id: entry.session_id,
+                kind: entry.kind,
+                display_name: entry.display_name,
+                status: entry.status,
+                metadata: entry.metadata,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            };
+            self.entries
+                .lock()
+                .unwrap()
+                .insert(entry.resource_id, stored.clone());
+            Ok(stored)
+        }
+
+        async fn update_status(
+            &self,
+            _session_id: SessionId,
+            resource_id: &str,
+            status: SessionResourceStatus,
+        ) -> crate::Result<Option<SessionResourceEntry>> {
+            let mut entries = self.entries.lock().unwrap();
+            if let Some(entry) = entries.get_mut(resource_id) {
+                entry.status = status;
+                entry.updated_at = chrono::Utc::now();
+                return Ok(Some(entry.clone()));
+            }
+            Ok(None)
+        }
+
+        async fn get(
+            &self,
+            _session_id: SessionId,
+            resource_id: &str,
+        ) -> crate::Result<Option<SessionResourceEntry>> {
+            Ok(self.entries.lock().unwrap().get(resource_id).cloned())
+        }
+
+        async fn list(
+            &self,
+            _session_id: SessionId,
+            _filter: Option<&SessionResourceFilter>,
+        ) -> crate::Result<Vec<SessionResourceEntry>> {
+            Ok(self.entries.lock().unwrap().values().cloned().collect())
+        }
+
+        async fn deregister(
+            &self,
+            _session_id: SessionId,
+            resource_id: &str,
+        ) -> crate::Result<bool> {
+            Ok(self.entries.lock().unwrap().remove(resource_id).is_some())
+        }
+    }
+
+    #[derive(Default)]
+    struct TestFileStore {
+        files: Mutex<HashMap<String, SessionFile>>,
+    }
+
+    #[async_trait]
+    impl crate::traits::SessionFileStore for TestFileStore {
+        async fn read_file(
+            &self,
+            _session_id: SessionId,
+            path: &str,
+        ) -> crate::Result<Option<SessionFile>> {
+            Ok(self.files.lock().unwrap().get(path).cloned())
+        }
+
+        async fn write_file(
+            &self,
+            session_id: SessionId,
+            path: &str,
+            content: &str,
+            encoding: &str,
+        ) -> crate::Result<SessionFile> {
+            let now = chrono::Utc::now();
+            let file = SessionFile {
+                id: uuid::Uuid::now_v7(),
+                session_id: session_id.uuid(),
+                path: path.to_string(),
+                name: FileInfo::name_from_path(path),
+                content: Some(content.to_string()),
+                encoding: encoding.to_string(),
+                is_directory: false,
+                is_readonly: false,
+                size_bytes: content.len() as i64,
+                created_at: now,
+                updated_at: now,
+            };
+            self.files
+                .lock()
+                .unwrap()
+                .insert(path.to_string(), file.clone());
+            Ok(file)
+        }
+
+        async fn delete_file(
+            &self,
+            _session_id: SessionId,
+            _path: &str,
+            _recursive: bool,
+        ) -> crate::Result<bool> {
+            Ok(false)
+        }
+
+        async fn list_directory(
+            &self,
+            _session_id: SessionId,
+            _path: &str,
+        ) -> crate::Result<Vec<FileInfo>> {
+            Ok(Vec::new())
+        }
+
+        async fn stat_file(
+            &self,
+            _session_id: SessionId,
+            path: &str,
+        ) -> crate::Result<Option<FileStat>> {
+            let file = self.files.lock().unwrap().get(path).cloned();
+            Ok(file.map(|entry| FileStat {
+                path: entry.path,
+                name: entry.name,
+                is_directory: entry.is_directory,
+                is_readonly: entry.is_readonly,
+                size_bytes: entry.size_bytes,
+                created_at: entry.created_at,
+                updated_at: entry.updated_at,
+            }))
+        }
+
+        async fn grep_files(
+            &self,
+            _session_id: SessionId,
+            _pattern: &str,
+            _path_pattern: Option<&str>,
+        ) -> crate::Result<Vec<crate::session_file::GrepMatch>> {
+            Ok(Vec::new())
+        }
+
+        async fn create_directory(
+            &self,
+            session_id: SessionId,
+            path: &str,
+        ) -> crate::Result<FileInfo> {
+            let now = chrono::Utc::now();
+            let id = uuid::Uuid::now_v7();
+            let dir = SessionFile {
+                id,
+                session_id: session_id.uuid(),
+                path: path.to_string(),
+                name: FileInfo::name_from_path(path),
+                content: None,
+                encoding: "text".to_string(),
+                is_directory: true,
+                is_readonly: false,
+                size_bytes: 0,
+                created_at: now,
+                updated_at: now,
+            };
+            self.files.lock().unwrap().insert(path.to_string(), dir);
+            Ok(FileInfo {
+                id,
+                session_id: session_id.uuid(),
+                path: path.to_string(),
+                name: FileInfo::name_from_path(path),
+                is_directory: true,
+                is_readonly: false,
+                size_bytes: 0,
+                created_at: now,
+                updated_at: now,
+            })
+        }
+    }
+
+    #[derive(Default)]
+    struct TestPlatformStore {
+        sent_messages: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl PlatformStore for TestPlatformStore {
+        async fn list_harnesses(&self) -> crate::Result<Vec<crate::Harness>> {
+            Ok(Vec::new())
+        }
+        async fn get_harness(&self, _id: HarnessId) -> crate::Result<Option<crate::Harness>> {
+            Ok(None)
+        }
+        async fn create_harness(
+            &self,
+            _name: &str,
+            _display_name: Option<&str>,
+            _description: Option<&str>,
+            _system_prompt: &str,
+            _parent_harness_id: Option<HarnessId>,
+            _capabilities: &[String],
+        ) -> crate::Result<crate::Harness> {
+            unreachable!()
+        }
+        async fn update_harness(
+            &self,
+            _id: HarnessId,
+            _name: Option<&str>,
+            _display_name: Option<&str>,
+            _description: Option<&str>,
+            _system_prompt: Option<&str>,
+            _parent_harness_id: Option<Option<HarnessId>>,
+        ) -> crate::Result<crate::Harness> {
+            unreachable!()
+        }
+        async fn delete_harness(&self, _id: HarnessId) -> crate::Result<()> {
+            Ok(())
+        }
+        async fn copy_harness(
+            &self,
+            _id: HarnessId,
+            _new_name: Option<&str>,
+        ) -> crate::Result<crate::Harness> {
+            unreachable!()
+        }
+        async fn list_agents(&self) -> crate::Result<Vec<crate::Agent>> {
+            Ok(Vec::new())
+        }
+        async fn get_agent_by_id(&self, _id: AgentId) -> crate::Result<Option<crate::Agent>> {
+            Ok(None)
+        }
+        async fn create_agent(
+            &self,
+            _name: &str,
+            _display_name: Option<&str>,
+            _description: Option<&str>,
+            _system_prompt: &str,
+            _capabilities: &[String],
+        ) -> crate::Result<crate::Agent> {
+            unreachable!()
+        }
+        async fn update_agent(
+            &self,
+            _id: AgentId,
+            _name: Option<&str>,
+            _display_name: Option<&str>,
+            _description: Option<&str>,
+            _system_prompt: Option<&str>,
+        ) -> crate::Result<crate::Agent> {
+            unreachable!()
+        }
+        async fn delete_agent(&self, _id: AgentId) -> crate::Result<()> {
+            Ok(())
+        }
+        async fn list_sessions(
+            &self,
+            _limit: Option<usize>,
+            _agent_id: Option<AgentId>,
+        ) -> crate::Result<Vec<crate::Session>> {
+            Ok(Vec::new())
+        }
+        async fn create_session(
+            &self,
+            _harness_id: HarnessId,
+            _agent_id: Option<AgentId>,
+            _title: Option<&str>,
+            _locale: Option<&str>,
+            _blueprint_id: Option<&str>,
+            _blueprint_config: Option<&serde_json::Value>,
+        ) -> crate::Result<crate::Session> {
+            unreachable!()
+        }
+        async fn get_session_by_id(&self, _id: SessionId) -> crate::Result<Option<crate::Session>> {
+            Ok(None)
+        }
+        async fn delete_session(&self, _id: SessionId) -> crate::Result<()> {
+            Ok(())
+        }
+        async fn send_message(&self, _session_id: SessionId, content: &str) -> crate::Result<()> {
+            self.sent_messages.lock().unwrap().push(content.to_string());
+            Ok(())
+        }
+        async fn get_messages(
+            &self,
+            _session_id: SessionId,
+            _limit: Option<usize>,
+        ) -> crate::Result<Vec<PlatformMessage>> {
+            Ok(Vec::new())
+        }
+        async fn wait_for_idle(
+            &self,
+            _session_id: SessionId,
+            _timeout_secs: Option<u64>,
+        ) -> crate::Result<String> {
+            Ok("idle".to_string())
+        }
+        async fn list_capabilities(
+            &self,
+            _search: Option<&str>,
+        ) -> crate::Result<Vec<crate::CapabilityInfo>> {
+            Ok(Vec::new())
+        }
+        fn base_url(&self) -> &str {
+            "http://localhost:9300"
+        }
+    }
+
+    #[derive(Default)]
+    struct NoopStorageStore;
+
+    #[async_trait]
+    impl crate::traits::SessionStorageStore for NoopStorageStore {
+        async fn set_value(
+            &self,
+            _session_id: SessionId,
+            _key: &str,
+            _value: &str,
+        ) -> crate::Result<()> {
+            Ok(())
+        }
+        async fn get_value(
+            &self,
+            _session_id: SessionId,
+            _key: &str,
+        ) -> crate::Result<Option<String>> {
+            Ok(None)
+        }
+        async fn delete_value(&self, _session_id: SessionId, _key: &str) -> crate::Result<bool> {
+            Ok(false)
+        }
+        async fn list_keys(&self, _session_id: SessionId) -> crate::Result<Vec<KeyInfo>> {
+            Ok(Vec::new())
+        }
+        async fn set_secret(
+            &self,
+            _session_id: SessionId,
+            _name: &str,
+            _value: &str,
+        ) -> crate::Result<()> {
+            Ok(())
+        }
+        async fn get_secret(
+            &self,
+            _session_id: SessionId,
+            _name: &str,
+        ) -> crate::Result<Option<String>> {
+            Ok(None)
+        }
+        async fn delete_secret(&self, _session_id: SessionId, _name: &str) -> crate::Result<bool> {
+            Ok(false)
+        }
+        async fn list_secrets(&self, _session_id: SessionId) -> crate::Result<Vec<SecretInfo>> {
+            Ok(Vec::new())
+        }
+    }
 
     #[tokio::test]
     async fn test_echo_tool() {
@@ -994,6 +1856,10 @@ mod tests {
         );
         assert!(registry.has("echo"), "should have echo");
         assert!(
+            registry.has("spawn_background"),
+            "should have spawn_background"
+        );
+        assert!(
             registry.has("report_progress"),
             "should have report_progress"
         );
@@ -1024,7 +1890,7 @@ mod tests {
         assert!(registry.has("web_fetch"), "should have web_fetch");
 
         // Total count
-        assert_eq!(registry.len(), 18, "should have 18 default tools");
+        assert_eq!(registry.len(), 19, "should have 19 default tools");
     }
 
     #[tokio::test]
@@ -1080,6 +1946,74 @@ mod tests {
         assert!(
             !registry.has("kv_store"),
             "kv_store must not be in defaults — it comes from session_storage capability"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_spawn_background_executes_and_signals_session() {
+        let session_id = SessionId::new();
+        let resource_registry = Arc::new(TestSessionResourceRegistry::default());
+        let file_store = Arc::new(TestFileStore::default());
+        let platform_store = Arc::new(TestPlatformStore::default());
+        let storage_store = Arc::new(NoopStorageStore);
+        let tool_registry = ToolRegistry::builder()
+            .tool(SpawnBackgroundTool)
+            .tool(TestBackgroundTool)
+            .build();
+
+        let context = ToolContext::with_stores(session_id, file_store.clone(), storage_store)
+            .with_tool_registry(tool_registry)
+            .with_platform_store(platform_store.clone())
+            .with_session_resource_registry(resource_registry.clone());
+
+        let tool = SpawnBackgroundTool;
+        let result = tool
+            .execute_with_context(
+                json!({
+                    "tool": "test_background",
+                    "args": { "summary": "Background complete" }
+                }),
+                &context,
+            )
+            .await;
+
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("spawn_background should succeed");
+        };
+        let run_id = value["run_id"].as_str().unwrap().to_string();
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let entry = resource_registry
+                    .get(session_id, &run_id)
+                    .await
+                    .unwrap()
+                    .expect("resource exists");
+                if entry.status == SessionResourceStatus::Completed {
+                    break entry;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("background run should complete");
+
+        let messages = platform_store.sent_messages.lock().unwrap().clone();
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0].contains("Background run completed"));
+        assert!(messages[0].contains(&run_id));
+
+        let log_file = file_store
+            .read_file(session_id, &format!("/.background/{run_id}/output.log"))
+            .await
+            .unwrap()
+            .expect("log file");
+        assert!(
+            log_file
+                .content
+                .as_deref()
+                .unwrap_or_default()
+                .contains("hello from background")
         );
     }
 }

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -856,6 +856,11 @@ impl Tool for SpawnBackgroundTool {
                 "Session resource registry not available in this context",
             );
         };
+        if context.file_store.is_none() {
+            return ToolExecutionResult::tool_error(
+                "Session file store not available in this context. spawn_background requires artifact persistence.",
+            );
+        }
 
         let run_id = format!("bg_{}", uuid::Uuid::now_v7().simple());
         let title = arguments
@@ -958,6 +963,7 @@ struct SessionBackgroundState {
     status_text: String,
     progress: Option<BackgroundProgress>,
     output_tail: String,
+    output_log: String,
 }
 
 struct SessionBackgroundSink {
@@ -1002,9 +1008,12 @@ impl SessionBackgroundSink {
     ) -> Result<()> {
         match outcome {
             Ok(outcome) => {
-                if let Some(raw_output) = &outcome.raw_output {
-                    self.write_text_file(&self.log_path, raw_output).await?;
-                }
+                let output_log = if let Some(raw_output) = &outcome.raw_output {
+                    raw_output.clone()
+                } else {
+                    self.state.lock().await.output_log.clone()
+                };
+                self.write_text_file(&self.log_path, &output_log).await?;
                 let result_json = serde_json::to_string_pretty(&outcome.result)
                     .unwrap_or_else(|_| outcome.result.to_string());
                 self.write_text_file(&self.result_path, &result_json)
@@ -1031,6 +1040,20 @@ impl SessionBackgroundSink {
                         "Background run ended unexpectedly".to_string()
                     }
                 };
+                let output_log = self.state.lock().await.output_log.clone();
+                self.write_text_file(&self.log_path, &output_log).await?;
+                let error_json = serde_json::to_string_pretty(&json!({
+                    "status": "failed",
+                    "error": &message,
+                }))
+                .unwrap_or_else(|_| {
+                    json!({
+                        "status": "failed",
+                        "error": &message,
+                    })
+                    .to_string()
+                });
+                self.write_text_file(&self.result_path, &error_json).await?;
                 let mut state = self.state.lock().await;
                 state.status_text = "Failed".to_string();
                 drop(state);
@@ -1072,6 +1095,10 @@ impl SessionBackgroundSink {
             return Ok(());
         };
         let state = self.state.lock().await;
+        let status_text = state.status_text.clone();
+        let progress = state.progress.clone();
+        let output_tail = state.output_tail.clone();
+        drop(state);
         registry
             .register(RegisterSessionResource {
                 session_id: self.context.session_id,
@@ -1081,9 +1108,9 @@ impl SessionBackgroundSink {
                 status,
                 metadata: json!({
                     "tool": self.tool_name,
-                    "status_text": state.status_text,
-                    "progress": state.progress,
-                    "output_tail": state.output_tail,
+                    "status_text": status_text,
+                    "progress": progress,
+                    "output_tail": output_tail,
                     "log_path": self.log_path,
                     "result_path": self.result_path,
                     "summary": summary,
@@ -1095,9 +1122,13 @@ impl SessionBackgroundSink {
     }
 
     async fn write_text_file(&self, path: &str, content: &str) -> Result<()> {
-        let Some(file_store) = &self.context.file_store else {
-            return Ok(());
-        };
+        let file_store = self.context.file_store.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "background run {} cannot persist artifact {} because no session file store is configured",
+                self.run_id,
+                path
+            )
+        })?;
 
         ensure_directory(file_store.as_ref(), self.context.session_id, "/.background").await?;
         let run_dir = format!("/.background/{}", self.run_id);
@@ -1125,6 +1156,8 @@ impl BackgroundEventSink for SessionBackgroundSink {
             let prefix = format!("[{stream}] ");
             state.output_tail.push_str(&prefix);
             state.output_tail.push_str(delta);
+            state.output_log.push_str(&prefix);
+            state.output_log.push_str(delta);
             if state.output_tail.chars().count() > 2048 {
                 state.output_tail = state
                     .output_tail
@@ -1156,8 +1189,11 @@ async fn ensure_directory(
     session_id: crate::SessionId,
     path: &str,
 ) -> Result<()> {
-    if file_store.stat_file(session_id, path).await?.is_some() {
-        return Ok(());
+    if let Some(entry) = file_store.stat_file(session_id, path).await? {
+        if entry.is_directory {
+            return Ok(());
+        }
+        return Err(anyhow::anyhow!("path exists but is not a directory: {path}").into());
     }
     let _ = file_store.create_directory(session_id, path).await?;
     Ok(())
@@ -1276,7 +1312,7 @@ mod tests {
             Ok(BackgroundOutcome {
                 summary: arguments["summary"].as_str().unwrap_or("done").to_string(),
                 result: json!({"ok": true}),
-                raw_output: Some("hello from background".to_string()),
+                raw_output: None,
             })
         }
     }
@@ -1301,6 +1337,61 @@ mod tests {
                 "properties": {
                     "summary": { "type": "string" }
                 }
+            })
+        }
+
+        async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+            ToolExecutionResult::tool_error("foreground unsupported")
+        }
+
+        fn hints(&self) -> ToolHints {
+            ToolHints::default().with_supports_background(true)
+        }
+
+        fn as_background_executable(&self) -> Option<&dyn BackgroundExecutableTool> {
+            Some(self)
+        }
+    }
+
+    #[derive(Default)]
+    struct TestFailingBackgroundTool;
+
+    #[async_trait]
+    impl BackgroundExecutableTool for TestFailingBackgroundTool {
+        async fn execute_background(
+            &self,
+            _arguments: Value,
+            _context: ToolContext,
+            sink: Arc<dyn BackgroundEventSink>,
+        ) -> std::result::Result<BackgroundOutcome, ToolExecutionResult> {
+            sink.status("Running failing test")
+                .await
+                .map_err(ToolExecutionResult::internal_error)?;
+            sink.output("stderr", "background failed")
+                .await
+                .map_err(ToolExecutionResult::internal_error)?;
+            Err(ToolExecutionResult::tool_error("boom"))
+        }
+    }
+
+    #[async_trait]
+    impl Tool for TestFailingBackgroundTool {
+        fn name(&self) -> &str {
+            "test_background_fail"
+        }
+
+        fn display_name(&self) -> Option<&str> {
+            Some("Test Background Fail")
+        }
+
+        fn description(&self) -> &str {
+            "failing background test tool"
+        }
+
+        fn parameters_schema(&self) -> Value {
+            json!({
+                "type": "object",
+                "properties": {}
             })
         }
 
@@ -1962,7 +2053,7 @@ mod tests {
             .build();
 
         let context = ToolContext::with_stores(session_id, file_store.clone(), storage_store)
-            .with_tool_registry(tool_registry)
+            .with_tool_registry(Arc::new(tool_registry))
             .with_platform_store(platform_store.clone())
             .with_session_resource_registry(resource_registry.clone());
 
@@ -2015,5 +2106,106 @@ mod tests {
                 .unwrap_or_default()
                 .contains("hello from background")
         );
+    }
+
+    #[tokio::test]
+    async fn test_spawn_background_persists_failure_artifacts() {
+        let session_id = SessionId::new();
+        let resource_registry = Arc::new(TestSessionResourceRegistry::default());
+        let file_store = Arc::new(TestFileStore::default());
+        let storage_store = Arc::new(NoopStorageStore);
+        let tool_registry = ToolRegistry::builder()
+            .tool(SpawnBackgroundTool)
+            .tool(TestFailingBackgroundTool)
+            .build();
+
+        let context = ToolContext::with_stores(session_id, file_store.clone(), storage_store)
+            .with_tool_registry(Arc::new(tool_registry))
+            .with_session_resource_registry(resource_registry.clone());
+
+        let result = SpawnBackgroundTool
+            .execute_with_context(
+                json!({
+                    "tool": "test_background_fail",
+                    "args": {}
+                }),
+                &context,
+            )
+            .await;
+
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("spawn_background should succeed");
+        };
+        let run_id = value["run_id"].as_str().unwrap().to_string();
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let entry = resource_registry
+                    .get(session_id, &run_id)
+                    .await
+                    .unwrap()
+                    .expect("resource exists");
+                if entry.status == SessionResourceStatus::Failed {
+                    break entry;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("background run should fail");
+
+        let log_file = file_store
+            .read_file(session_id, &format!("/.background/{run_id}/output.log"))
+            .await
+            .unwrap()
+            .expect("log file");
+        assert!(
+            log_file
+                .content
+                .as_deref()
+                .unwrap_or_default()
+                .contains("background failed")
+        );
+
+        let result_file = file_store
+            .read_file(session_id, &format!("/.background/{run_id}/result.json"))
+            .await
+            .unwrap()
+            .expect("result file");
+        let result_json: Value =
+            serde_json::from_str(result_file.content.as_deref().unwrap_or_default())
+                .expect("valid json");
+        assert_eq!(result_json["status"], "failed");
+        assert_eq!(result_json["error"], "boom");
+    }
+
+    #[tokio::test]
+    async fn test_spawn_background_requires_file_store() {
+        let session_id = SessionId::new();
+        let resource_registry = Arc::new(TestSessionResourceRegistry::default());
+        let storage_store = Arc::new(NoopStorageStore);
+        let tool_registry = ToolRegistry::builder()
+            .tool(SpawnBackgroundTool)
+            .tool(TestBackgroundTool)
+            .build();
+
+        let context = ToolContext::with_storage_store(session_id, storage_store)
+            .with_tool_registry(Arc::new(tool_registry))
+            .with_session_resource_registry(resource_registry);
+
+        let result = SpawnBackgroundTool
+            .execute_with_context(
+                json!({
+                    "tool": "test_background",
+                    "args": {}
+                }),
+                &context,
+            )
+            .await;
+
+        let ToolExecutionResult::ToolError(message) = result else {
+            panic!("spawn_background should reject missing file store");
+        };
+        assert!(message.contains("Session file store not available"));
     }
 }

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -602,6 +602,10 @@ pub struct ToolContext {
     /// Optional capability registry for blueprint lookups.
     pub capability_registry: Option<crate::capabilities::CapabilityRegistry>,
 
+    /// Optional registry of active built-in tools for meta-tools such as
+    /// `spawn_background` that need to inspect or delegate to sibling tools.
+    pub tool_registry: Option<crate::tools::ToolRegistry>,
+
     /// Optional memory store backend for persistent cross-session memory.
     pub memory_store: Option<Arc<dyn crate::memory_store::MemoryStoreBackend>>,
 
@@ -642,6 +646,7 @@ impl ToolContext {
             event_context: None,
             tool_call_id: None,
             capability_registry: None,
+            tool_registry: None,
             memory_store: None,
             org_id: None,
             network_access: None,
@@ -670,6 +675,7 @@ impl ToolContext {
             event_context: None,
             tool_call_id: None,
             capability_registry: None,
+            tool_registry: None,
             memory_store: None,
             org_id: None,
             network_access: None,
@@ -701,6 +707,7 @@ impl ToolContext {
             event_context: None,
             tool_call_id: None,
             capability_registry: None,
+            tool_registry: None,
             memory_store: None,
             org_id: None,
             network_access: None,
@@ -733,6 +740,7 @@ impl ToolContext {
             event_context: None,
             tool_call_id: None,
             capability_registry: None,
+            tool_registry: None,
             memory_store: None,
             org_id: None,
             network_access: None,
@@ -822,6 +830,12 @@ impl ToolContext {
     /// Set org ID for org-scoped operations.
     pub fn with_org_id(mut self, org_id: crate::typed_id::OrgId) -> Self {
         self.org_id = Some(org_id);
+        self
+    }
+
+    /// Set the active built-in tool registry on this context.
+    pub fn with_tool_registry(mut self, registry: crate::tools::ToolRegistry) -> Self {
+        self.tool_registry = Some(registry);
         self
     }
 
@@ -918,6 +932,7 @@ impl std::fmt::Debug for ToolContext {
                 &self.leased_resource_store.is_some(),
             )
             .field("event_emitter", &self.event_emitter.is_some())
+            .field("tool_registry", &self.tool_registry.is_some())
             .field("memory_store", &self.memory_store.is_some())
             .field("org_id", &self.org_id)
             .finish()

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -604,7 +604,7 @@ pub struct ToolContext {
 
     /// Optional registry of active built-in tools for meta-tools such as
     /// `spawn_background` that need to inspect or delegate to sibling tools.
-    pub tool_registry: Option<crate::tools::ToolRegistry>,
+    pub tool_registry: Option<Arc<crate::tools::ToolRegistry>>,
 
     /// Optional memory store backend for persistent cross-session memory.
     pub memory_store: Option<Arc<dyn crate::memory_store::MemoryStoreBackend>>,
@@ -834,7 +834,7 @@ impl ToolContext {
     }
 
     /// Set the active built-in tool registry on this context.
-    pub fn with_tool_registry(mut self, registry: crate::tools::ToolRegistry) -> Self {
+    pub fn with_tool_registry(mut self, registry: Arc<crate::tools::ToolRegistry>) -> Self {
         self.tool_registry = Some(registry);
         self
     }

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -656,7 +656,7 @@ pub async fn execute_act_activity<A: RuntimeHostAdapter>(
             input.blueprint_id.as_deref(),
         )
         .await?;
-    let builtin_tool_registry = tool_registry.clone();
+    let builtin_tool_registry = Arc::new(tool_registry.clone());
 
     let mut atom = ActAtom::with_file_store(
         tool_registry,

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -648,21 +648,25 @@ pub async fn execute_act_activity<A: RuntimeHostAdapter>(
         });
     }
 
+    let tool_registry = adapter
+        .build_tool_registry(
+            org_id,
+            input.harness_id,
+            input.agent_id,
+            input.blueprint_id.as_deref(),
+        )
+        .await?;
+    let builtin_tool_registry = tool_registry.clone();
+
     let mut atom = ActAtom::with_file_store(
-        adapter
-            .build_tool_registry(
-                org_id,
-                input.harness_id,
-                input.agent_id,
-                input.blueprint_id.as_deref(),
-            )
-            .await?,
+        tool_registry,
         HostEventEmitter(adapter.event_emitter()),
         adapter.file_store(),
     )
     .with_session_store(adapter.session_store(org_id))
     .with_session_mutator(adapter.session_mutator(org_id))
     .with_agent_store(adapter.agent_store(org_id))
+    .with_tool_registry(builtin_tool_registry)
     .with_org_id(
         org_public_id_from_internal(org_id)
             .parse()

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -459,7 +459,7 @@ impl InProcessRuntime {
             DynEventEmitter(Arc::new(self.event_emitter.clone())),
             Arc::new(DynFileStore(self.file_store.clone())),
         )
-        .with_tool_registry(tool_registry.clone())
+        .with_tool_registry(Arc::new(tool_registry.clone()))
         .with_storage_store(self.storage_store.clone())
         .with_session_store(Arc::new(DynSessionStore(self.session_store.clone())))
         .with_session_mutator(Arc::new(DynSessionStore(self.session_store.clone())))

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -459,6 +459,7 @@ impl InProcessRuntime {
             DynEventEmitter(Arc::new(self.event_emitter.clone())),
             Arc::new(DynFileStore(self.file_store.clone())),
         )
+        .with_tool_registry(tool_registry.clone())
         .with_storage_store(self.storage_store.clone())
         .with_session_store(Arc::new(DynSessionStore(self.session_store.clone())))
         .with_session_mutator(Arc::new(DynSessionStore(self.session_store.clone())))

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -13801,6 +13801,13 @@
               "null"
             ],
             "description": "Tool requires API keys, credentials, or other secrets to function.\nUseful for UI to show connection prompts and for LLMs to anticipate\nauthentication failures."
+          },
+          "supports_background": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Tool supports detached background execution via `spawn_background`.\nWhen true, the tool may be executed asynchronously outside the current\nforeground tool call and report status back later."
           }
         }
       },

--- a/specs/session-resources.md
+++ b/specs/session-resources.md
@@ -42,6 +42,7 @@ rather than duplicate.
 | Sandbox (Daytona, E2B, Deno) | `LeasedResourceStore.upsert_resource` | `sandbox`         | Leased resource public ID  |
 | Browser (Browserless)        | `LeasedResourceStore.upsert_resource` | `browser_session` | Leased resource public ID  |
 | Subagents                    | `spawn_subagent` tool                 | `subagent`        | Child session public ID    |
+| Background tool runs         | `spawn_background` tool              | `background_run`  | Generated background run ID |
 | Sprites                      | `LeasedResourceStore.upsert_resource` | `sprite`          | Leased resource public ID  |
 | *(future)*                   | Direct `registry.register()`          | *(any string)*    | Caller-defined             |
 
@@ -58,6 +59,27 @@ In-memory: `HashMap<SessionId, HashMap<String, SessionResourceEntry>>`.
 Agents query via the registry through `ToolContext.session_resource_registry`.
 Capabilities or tools can call `registry.list()` to answer "what is running?".
 Infrastructure cleanup workers scan the registry to find stale resources.
+
+### Background runs
+
+Background tool runs are session resources, not leased resources.
+
+Properties:
+- They are registered immediately when `spawn_background` accepts the run.
+- They remain visible while active and are updated in-place as status, output tail, or progress changes.
+- Metadata may include:
+  - `tool`
+  - `status_text`
+  - `progress`
+  - `output_tail`
+  - `log_path`
+  - `result_path`
+  - `summary`
+- Final logs and result payloads live in the session VFS under `/.background/{run_id}/`.
+
+V1 limitation:
+- The registry gives visibility only. It does not make background runs durable or restartable.
+- If a worker dies, the registry entry may remain until cleanup logic or a later reconciliation marks it failed.
 
 ### API
 

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -58,6 +58,7 @@ Follows the [MCP tool annotations](https://spec.modelcontextprotocol.io) convent
 | `requires_secrets` | Needs API keys or credentials | Assume no secrets needed |
 | `long_running` | May take significant time (> ~5s typical) | Assume fast |
 | `persist_output` | Tool requests full output be persisted to VFS before truncation when supported | Assume no persistence |
+| `supports_background` | Tool can be executed through `spawn_background` and stream status/output/progress updates | Assume foreground-only |
 | `narration_noun` | Entity noun for operation-based narration (e.g. `"agent"`, `"harness"`) | Generic "Ran {display_name}" fallback |
 
 ### Narration Formatting
@@ -110,6 +111,36 @@ All exec tools accept an `output` parameter controlling how much output is retur
 Default is `concise`. Budgets apply to stdout; stderr is capped at `min(budget, 4096)` to keep error output proportional. Full output is always persisted to `/.outputs/` via `tool_output_persistence` — stdout to `/.outputs/{tool_call_id}.stdout`, stderr to `.stderr` — and readable with `read_file`. See `crates/core/src/tool_output_sanitizer.rs` for budget constants and `output_verbosity_budget()`.
 
 This is the tool's responsibility — each tool calls the helpers before constructing `ToolExecutionResult`. See `crates/core/src/tool_output_sanitizer.rs` for the primitives.
+
+### Background Tool Execution
+
+`spawn_background` is a built-in meta-tool that schedules another built-in tool to run asynchronously and returns immediately with a run handle. It is generic: the caller passes `tool` plus `args`; the target tool determines whether background execution is supported.
+
+Background eligibility rules:
+- The target tool must set `ToolHints.supports_background = Some(true)`.
+- The target tool must implement `BackgroundExecutableTool`.
+- `spawn_background` must run with a worker-side `ToolContext` that includes the current `ToolRegistry`.
+
+Contract:
+- Input: `{ "tool": "...", "args": { ... }, "title"?: "...", "signal_on_completion"?: true }`
+- Immediate result: `run_id`, `resource_id`, target `tool`, and artifact paths under `/.background/{run_id}/`
+- Execution happens in a detached worker task
+- Progress flows through `BackgroundEventSink`, which supports:
+  - one-line status updates
+  - streamed output deltas
+  - optional structured progress (`current`, `total`, `unit`, `label`)
+
+Artifacts and visibility:
+- Each run is registered in the session resource registry as `kind = "background_run"`.
+- Live metadata includes status text, output tail, and optional progress.
+- Final artifacts are persisted to session VFS:
+  - `/.background/{run_id}/output.log`
+  - `/.background/{run_id}/result.json`
+- On completion or failure, the worker may send a synthetic session message summarizing the result and artifact paths.
+
+V1 limitation:
+- Background runs are best-effort and worker-local. They are started with `tokio::spawn` inside the worker process and are not yet durable across worker restarts.
+- This is intentional for the first iteration; durable resumption can be layered later without changing the tool contract.
 
 ### PostToolExecHook (per-tool hooks)
 


### PR DESCRIPTION
## What
Add generic background tool execution through a new built-in `spawn_background` meta-tool.

## Why
We need a first implementation of monitors/background work that can run a long-lived tool asynchronously, surface live status in session resources, and signal the main session when the work completes.

## How
- add `ToolHints.supports_background` plus a `BackgroundExecutableTool` contract
- add `spawn_background` to register `background_run` resources, run the target tool in a detached worker task, persist final artifacts to `/.background/{run_id}/`, and optionally signal the session on completion
- make `virtual_bash` the first background-capable tool and thread the built-in tool registry through worker/runtime contexts so meta-tools can delegate safely
- show background metadata on the session resources page and document the V1 best-effort/non-durable behavior in specs

## Risk
- Medium
- Background runs are worker-local in V1, so a worker restart can strand an in-flight run or leave stale resource state until reconciliation

## Security
- Threat categories reviewed: TM-TOOL, TM-BASH, TM-FS, TM-AGENT, TM-DOS
- Findings and resolutions:
  - `spawn_background` only targets registered built-in tools and rejects tools without explicit `supports_background` opt-in plus `BackgroundExecutableTool` implementation
  - background bash execution stays inside existing bashkit/VFS/resource-limit boundaries
  - run artifacts are written to session-scoped VFS paths and surfaced through session resources rather than host paths or secret-bearing metadata

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
