### PR TITLE
feat(runtime): share host orchestration with worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2091,6 +2091,7 @@ dependencies = [
  "everruns-integrations-sprites",
  "everruns-internal-protocol",
  "everruns-openai",
+ "everruns-runtime",
  "futures",
  "hex",
  "prost-types",

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -1,0 +1,707 @@
+// Shared host orchestration for embedded and durable execution hosts.
+// Decision: everruns-runtime owns worker-facing turn phase execution so
+// durable/server-backed hosts reuse the same input/reason/act wiring.
+
+use async_trait::async_trait;
+use everruns_core::atoms::{
+    ActAtom, ActInput, ActResult, Atom, InputAtom, InputAtomInput, InputAtomResult, ReasonAtom,
+    ReasonInput, ReasonResult,
+};
+use everruns_core::events::{
+    EventContext, EventRequest, OutputMessageCompletedData, SessionActivatedData, SessionIdledData,
+    TurnCompletedData, TurnFailedData, TurnStartedData,
+};
+use everruns_core::message::Message;
+use everruns_core::message_retriever::MessageRetriever;
+use everruns_core::platform_store::PlatformStore;
+use everruns_core::session::SessionStatus;
+use everruns_core::traits::{
+    AgentStore, BudgetChecker, EventEmitter, HarnessStore, ImageResolver, LeasedResourceStore,
+    LlmProviderStore, ModelWithProvider, SessionFileStore, SessionMutator, SessionResourceRegistry,
+    SessionScheduleStore, SessionSqlDbStoreRef, SessionStorageStore, SessionStore,
+    UserConnectionResolver,
+};
+use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
+use everruns_core::{
+    Agent, CapabilityRegistry, DependencyBlocker, DriverRegistry, Harness, Session, TokenUsage,
+    ToolDefinition, ToolRegistry,
+};
+use std::sync::Arc;
+
+#[derive(Clone)]
+struct HostAgentStore(Arc<dyn AgentStore>);
+
+#[async_trait]
+impl AgentStore for HostAgentStore {
+    async fn get_agent(&self, agent_id: AgentId) -> everruns_core::error::Result<Option<Agent>> {
+        self.0.get_agent(agent_id).await
+    }
+}
+
+#[derive(Clone)]
+struct HostHarnessStore(Arc<dyn HarnessStore>);
+
+#[async_trait]
+impl HarnessStore for HostHarnessStore {
+    async fn get_harness_chain(
+        &self,
+        harness_id: HarnessId,
+    ) -> everruns_core::error::Result<Vec<Harness>> {
+        self.0.get_harness_chain(harness_id).await
+    }
+}
+
+#[derive(Clone)]
+struct HostSessionStore(Arc<dyn SessionStore>);
+
+#[async_trait]
+impl SessionStore for HostSessionStore {
+    async fn get_session(
+        &self,
+        session_id: SessionId,
+    ) -> everruns_core::error::Result<Option<Session>> {
+        self.0.get_session(session_id).await
+    }
+}
+
+#[derive(Clone)]
+struct HostMessageStore(Arc<dyn MessageRetriever>);
+
+#[async_trait]
+impl MessageRetriever for HostMessageStore {
+    async fn get(
+        &self,
+        session_id: SessionId,
+        message_id: MessageId,
+    ) -> everruns_core::error::Result<Option<Message>> {
+        self.0.get(session_id, message_id).await
+    }
+
+    async fn load(&self, session_id: SessionId) -> everruns_core::error::Result<Vec<Message>> {
+        self.0.load(session_id).await
+    }
+
+    async fn load_filtered(
+        &self,
+        query: everruns_core::message_filter::MessageQuery,
+    ) -> everruns_core::error::Result<Vec<Message>> {
+        self.0.load_filtered(query).await
+    }
+
+    async fn load_page(
+        &self,
+        session_id: SessionId,
+        offset: usize,
+        limit: usize,
+    ) -> everruns_core::error::Result<Vec<Message>> {
+        self.0.load_page(session_id, offset, limit).await
+    }
+
+    async fn count(&self, session_id: SessionId) -> everruns_core::error::Result<usize> {
+        self.0.count(session_id).await
+    }
+}
+
+#[derive(Clone)]
+struct HostProviderStore(Arc<dyn LlmProviderStore>);
+
+#[async_trait]
+impl LlmProviderStore for HostProviderStore {
+    async fn get_model_with_provider(
+        &self,
+        model_id: everruns_core::typed_id::ModelId,
+    ) -> everruns_core::error::Result<Option<ModelWithProvider>> {
+        self.0.get_model_with_provider(model_id).await
+    }
+
+    async fn get_default_model(&self) -> everruns_core::error::Result<Option<ModelWithProvider>> {
+        self.0.get_default_model().await
+    }
+}
+
+#[derive(Clone)]
+struct HostEventEmitter(Arc<dyn EventEmitter>);
+
+#[async_trait]
+impl EventEmitter for HostEventEmitter {
+    async fn emit(
+        &self,
+        request: EventRequest,
+    ) -> everruns_core::error::Result<everruns_core::events::Event> {
+        self.0.emit(request).await
+    }
+}
+
+/// Turn context loaded in one batched call for runtime host execution.
+#[derive(Debug, Clone)]
+pub struct RuntimeHostTurnContext {
+    pub agent: Option<Agent>,
+    pub session: Session,
+    pub messages: Vec<Message>,
+    pub model: Option<ModelWithProvider>,
+    pub mcp_tool_definitions: Vec<ToolDefinition>,
+}
+
+/// Public adapter contract for server-backed or durable runtime hosts.
+///
+/// `everruns-runtime` owns the phase execution (`input -> reason -> act`).
+/// Host crates implement this trait to provide their own persistence,
+/// session-lifecycle plumbing, and tool registry construction.
+///
+/// The durable scheduler still lives outside this crate. Hosts use this trait
+/// to delegate individual turn phases to `everruns-runtime`, while keeping
+/// queueing, retries, and workflow resumption in their own layer.
+#[async_trait]
+pub trait RuntimeHostAdapter: Send + Sync + Clone + 'static {
+    async fn get_agent(
+        &self,
+        org_id: i64,
+        agent_id: AgentId,
+    ) -> everruns_core::error::Result<Option<Agent>>;
+
+    async fn get_harness(
+        &self,
+        org_id: i64,
+        harness_id: HarnessId,
+    ) -> everruns_core::error::Result<Option<Harness>>;
+
+    async fn set_session_status(
+        &self,
+        org_id: i64,
+        session_id: SessionId,
+        status: SessionStatus,
+    ) -> everruns_core::error::Result<Session>;
+
+    async fn load_turn_context(
+        &self,
+        org_id: i64,
+        session_id: SessionId,
+    ) -> everruns_core::error::Result<RuntimeHostTurnContext>;
+
+    fn capability_registry(&self) -> CapabilityRegistry;
+
+    fn driver_registry(&self) -> DriverRegistry;
+
+    async fn build_tool_registry_for_agent(
+        &self,
+        org_id: i64,
+        agent_id: AgentId,
+    ) -> everruns_core::error::Result<ToolRegistry>;
+
+    async fn build_tool_registry_for_harness(
+        &self,
+        org_id: i64,
+        harness_id: HarnessId,
+    ) -> everruns_core::error::Result<ToolRegistry>;
+
+    fn harness_store(&self, org_id: i64) -> Arc<dyn HarnessStore>;
+
+    fn agent_store(&self, org_id: i64) -> Arc<dyn AgentStore>;
+
+    fn session_store(&self, org_id: i64) -> Arc<dyn SessionStore>;
+
+    fn session_mutator(&self, org_id: i64) -> Arc<dyn SessionMutator>;
+
+    fn provider_store(&self, org_id: i64) -> Arc<dyn LlmProviderStore>;
+
+    fn message_store(&self) -> Arc<dyn MessageRetriever>;
+
+    fn event_emitter(&self) -> Arc<dyn EventEmitter>;
+
+    fn file_store(&self) -> Arc<dyn SessionFileStore>;
+
+    fn image_resolver(&self, _org_id: i64) -> Option<Arc<dyn ImageResolver>> {
+        None
+    }
+
+    fn storage_store(&self) -> Option<Arc<dyn SessionStorageStore>> {
+        None
+    }
+
+    fn memory_store(&self) -> Option<Arc<dyn everruns_core::MemoryStoreBackend>> {
+        None
+    }
+
+    fn connection_resolver(&self) -> Option<Arc<dyn UserConnectionResolver>> {
+        None
+    }
+
+    fn sqldb_store(&self) -> Option<SessionSqlDbStoreRef> {
+        None
+    }
+
+    fn leased_resource_store(&self) -> Option<Arc<dyn LeasedResourceStore>> {
+        None
+    }
+
+    fn session_resource_registry(&self) -> Option<Arc<dyn SessionResourceRegistry>> {
+        None
+    }
+
+    fn schedule_store(&self, _org_id: i64) -> Option<Arc<dyn SessionScheduleStore>> {
+        None
+    }
+
+    fn platform_store(&self, _org_id: i64) -> Option<Arc<dyn PlatformStore>> {
+        None
+    }
+
+    fn budget_checker(
+        &self,
+        _org_id: i64,
+        _agent_id: Option<AgentId>,
+    ) -> Option<Arc<dyn BudgetChecker>> {
+        None
+    }
+
+    async fn build_tool_registry(
+        &self,
+        org_id: i64,
+        harness_id: HarnessId,
+        agent_id: Option<AgentId>,
+        blueprint_id: Option<&str>,
+    ) -> everruns_core::error::Result<ToolRegistry> {
+        if let Some(blueprint_id) = blueprint_id {
+            let mut registry = ToolRegistry::with_defaults();
+            let capability_registry = self.capability_registry();
+            let blueprint = capability_registry.blueprint(blueprint_id).ok_or_else(|| {
+                everruns_core::error::AgentLoopError::config(format!(
+                    "Blueprint \"{blueprint_id}\" not found in registry"
+                ))
+            })?;
+            for tool in blueprint.tools {
+                registry.register_boxed(tool);
+            }
+            return Ok(registry);
+        }
+
+        match agent_id {
+            Some(agent_id) => self.build_tool_registry_for_agent(org_id, agent_id).await,
+            None => {
+                self.build_tool_registry_for_harness(org_id, harness_id)
+                    .await
+            }
+        }
+    }
+
+    async fn post_tool_hooks(
+        &self,
+        org_id: i64,
+        harness_id: HarnessId,
+        agent_id: Option<AgentId>,
+        blueprint_id: Option<&str>,
+    ) -> everruns_core::error::Result<Vec<Arc<dyn everruns_core::PostToolExecHook>>> {
+        if blueprint_id.is_some() {
+            return Ok(Vec::new());
+        }
+
+        let capability_registry = self.capability_registry();
+        let capability_configs = match agent_id {
+            Some(agent_id) => self
+                .get_agent(org_id, agent_id)
+                .await?
+                .map(|agent| agent.capabilities)
+                .unwrap_or_default(),
+            None => self
+                .get_harness(org_id, harness_id)
+                .await?
+                .map(|harness| harness.capabilities)
+                .unwrap_or_default(),
+        };
+
+        Ok(capability_configs
+            .iter()
+            .flat_map(|config| {
+                capability_registry
+                    .get(config.capability_id())
+                    .map(|capability| capability.post_tool_exec_hooks())
+                    .unwrap_or_default()
+            })
+            .collect())
+    }
+}
+
+/// Shared lifecycle helper for runtime-backed hosts.
+pub struct RuntimeSessionLifecycle<A: RuntimeHostAdapter> {
+    adapter: A,
+    org_id: i64,
+    session_id: SessionId,
+}
+
+impl<A: RuntimeHostAdapter> RuntimeSessionLifecycle<A> {
+    pub fn new(adapter: A, org_id: i64, session_id: SessionId) -> Self {
+        Self {
+            adapter,
+            org_id,
+            session_id,
+        }
+    }
+
+    pub async fn turn_started(&self, turn_id: TurnId, input_message_id: MessageId) {
+        let input_content = self
+            .adapter
+            .message_store()
+            .get(self.session_id, input_message_id)
+            .await
+            .ok()
+            .flatten()
+            .map(|message| message.content_to_llm_string());
+
+        let _ = self
+            .adapter
+            .set_session_status(self.org_id, self.session_id, SessionStatus::Active)
+            .await;
+
+        let _ = self
+            .adapter
+            .event_emitter()
+            .emit(EventRequest::new(
+                self.session_id,
+                EventContext::turn(turn_id, input_message_id),
+                SessionActivatedData {
+                    turn_id,
+                    input_message_id,
+                },
+            ))
+            .await;
+
+        let _ = self
+            .adapter
+            .event_emitter()
+            .emit(EventRequest::new(
+                self.session_id,
+                EventContext::turn(turn_id, input_message_id),
+                TurnStartedData {
+                    turn_id,
+                    input_message_id,
+                    input_content,
+                },
+            ))
+            .await;
+    }
+
+    pub async fn emit_turn_completed(
+        &self,
+        turn_id: TurnId,
+        input_message_id: MessageId,
+        iterations: u32,
+        usage: Option<TokenUsage>,
+        input_content: Option<String>,
+    ) {
+        let _ = self
+            .adapter
+            .event_emitter()
+            .emit(EventRequest::new(
+                self.session_id,
+                EventContext::turn(turn_id, input_message_id),
+                TurnCompletedData {
+                    turn_id,
+                    iterations,
+                    duration_ms: None,
+                    usage,
+                    input_content,
+                },
+            ))
+            .await;
+    }
+
+    pub async fn emit_session_idled(
+        &self,
+        turn_id: TurnId,
+        input_message_id: MessageId,
+        iterations: Option<u32>,
+        usage: Option<TokenUsage>,
+    ) {
+        let _ = self
+            .adapter
+            .set_session_status(self.org_id, self.session_id, SessionStatus::Idle)
+            .await;
+
+        let _ = self
+            .adapter
+            .event_emitter()
+            .emit(EventRequest::new(
+                self.session_id,
+                EventContext::turn(turn_id, input_message_id),
+                SessionIdledData {
+                    turn_id,
+                    iterations,
+                    usage,
+                },
+            ))
+            .await;
+    }
+
+    pub async fn turn_completed(
+        &self,
+        turn_id: TurnId,
+        input_message_id: MessageId,
+        iterations: u32,
+        usage: Option<TokenUsage>,
+        input_content: Option<String>,
+    ) {
+        self.emit_turn_completed(
+            turn_id,
+            input_message_id,
+            iterations,
+            usage.clone(),
+            input_content,
+        )
+        .await;
+        self.emit_session_idled(turn_id, input_message_id, Some(iterations), usage)
+            .await;
+    }
+
+    pub async fn turn_failed(
+        &self,
+        turn_id: TurnId,
+        input_message_id: MessageId,
+        error: &str,
+        error_code: Option<&str>,
+    ) {
+        let _ = self
+            .adapter
+            .set_session_status(self.org_id, self.session_id, SessionStatus::Idle)
+            .await;
+
+        let _ = self
+            .adapter
+            .event_emitter()
+            .emit(EventRequest::new(
+                self.session_id,
+                EventContext::turn(turn_id, input_message_id),
+                TurnFailedData {
+                    turn_id,
+                    error: error.to_string(),
+                    error_code: error_code.map(str::to_string),
+                },
+            ))
+            .await;
+
+        let _ = self
+            .adapter
+            .event_emitter()
+            .emit(EventRequest::new(
+                self.session_id,
+                EventContext::turn(turn_id, input_message_id),
+                SessionIdledData {
+                    turn_id,
+                    iterations: None,
+                    usage: None,
+                },
+            ))
+            .await;
+    }
+
+    pub async fn waiting_for_tool_results(&self) {
+        let _ = self
+            .adapter
+            .set_session_status(
+                self.org_id,
+                self.session_id,
+                SessionStatus::WaitingForToolResults,
+            )
+            .await;
+    }
+
+    pub async fn dependency_blocked(
+        &self,
+        turn_id: TurnId,
+        input_message_id: MessageId,
+        blocker: DependencyBlocker,
+    ) {
+        let _ = self
+            .adapter
+            .event_emitter()
+            .emit(EventRequest::new(
+                self.session_id,
+                EventContext::turn(turn_id, input_message_id),
+                OutputMessageCompletedData::new(Message::assistant(blocker.message())),
+            ))
+            .await;
+
+        self.turn_failed(
+            turn_id,
+            input_message_id,
+            blocker.message(),
+            Some(blocker.error_code()),
+        )
+        .await;
+    }
+}
+
+pub async fn detect_dependency_blocker<A: RuntimeHostAdapter>(
+    adapter: &A,
+    org_id: i64,
+    harness_id: HarnessId,
+    agent_id: Option<AgentId>,
+) -> everruns_core::error::Result<Option<DependencyBlocker>> {
+    let harness_store = adapter.harness_store(org_id);
+    let agent_store = adapter.agent_store(org_id);
+    everruns_core::detect_dependency_blocker(
+        harness_store.as_ref(),
+        agent_store.as_ref(),
+        harness_id,
+        agent_id,
+    )
+    .await
+}
+
+pub async fn execute_input_activity<A: RuntimeHostAdapter>(
+    adapter: &A,
+    org_id: i64,
+    input: InputAtomInput,
+) -> everruns_core::error::Result<InputAtomResult> {
+    RuntimeSessionLifecycle::new(adapter.clone(), org_id, input.context.session_id)
+        .turn_started(input.context.turn_id, input.context.input_message_id)
+        .await;
+
+    let atom = InputAtom::new(HostMessageStore(adapter.message_store()));
+    atom.execute(input).await
+}
+
+pub async fn execute_reason_activity<A: RuntimeHostAdapter>(
+    adapter: &A,
+    org_id: i64,
+    input: ReasonInput,
+) -> everruns_core::error::Result<ReasonResult> {
+    if let Some(blocker) =
+        detect_dependency_blocker(adapter, org_id, input.harness_id, input.agent_id).await?
+    {
+        RuntimeSessionLifecycle::new(adapter.clone(), org_id, input.context.session_id)
+            .dependency_blocked(
+                input.context.turn_id,
+                input.context.input_message_id,
+                blocker,
+            )
+            .await;
+        return Ok(ReasonResult {
+            success: false,
+            text: blocker.message().to_string(),
+            tool_calls: vec![],
+            has_tool_calls: false,
+            tool_definitions: vec![],
+            max_iterations: everruns_core::runtime_agent::default_max_iterations(),
+            error: Some("dependency_unavailable".to_string()),
+            usage: None,
+            response_id: None,
+            locale: None,
+            network_access: None,
+        });
+    }
+
+    let turn_context = adapter
+        .load_turn_context(org_id, input.context.session_id)
+        .await?;
+
+    let mut atom = ReasonAtom::new(
+        HostHarnessStore(adapter.harness_store(org_id)),
+        HostAgentStore(adapter.agent_store(org_id)),
+        HostSessionStore(adapter.session_store(org_id)),
+        HostMessageStore(adapter.message_store()),
+        HostProviderStore(adapter.provider_store(org_id)),
+        adapter.capability_registry(),
+        adapter.driver_registry(),
+        HostEventEmitter(adapter.event_emitter()),
+    )
+    .with_file_store(adapter.file_store());
+    if let Some(image_resolver) = adapter.image_resolver(org_id) {
+        atom = atom.with_image_resolver(image_resolver);
+    }
+
+    atom.execute(ReasonInput {
+        mcp_tool_definitions: turn_context.mcp_tool_definitions,
+        ..input
+    })
+    .await
+}
+
+pub async fn execute_act_activity<A: RuntimeHostAdapter>(
+    adapter: &A,
+    input: ActInput,
+) -> everruns_core::error::Result<ActResult> {
+    let org_id = input.org_id.ok_or_else(|| {
+        everruns_core::error::AgentLoopError::config(
+            "ActInput.org_id must be set for runtime host execution",
+        )
+    })?;
+
+    if let Some(blocker) =
+        detect_dependency_blocker(adapter, org_id, input.harness_id, input.agent_id).await?
+    {
+        RuntimeSessionLifecycle::new(adapter.clone(), org_id, input.context.session_id)
+            .dependency_blocked(
+                input.context.turn_id,
+                input.context.input_message_id,
+                blocker,
+            )
+            .await;
+        return Ok(ActResult {
+            results: vec![],
+            completed: true,
+            success_count: 0,
+            error_count: 1,
+            waiting_for_tool_results: false,
+            blocked: true,
+            client_tool_calls: vec![],
+            client_tool_definitions: vec![],
+        });
+    }
+
+    let mut atom = ActAtom::with_file_store(
+        adapter
+            .build_tool_registry(
+                org_id,
+                input.harness_id,
+                input.agent_id,
+                input.blueprint_id.as_deref(),
+            )
+            .await?,
+        HostEventEmitter(adapter.event_emitter()),
+        adapter.file_store(),
+    )
+    .with_session_store(adapter.session_store(org_id))
+    .with_session_mutator(adapter.session_mutator(org_id))
+    .with_agent_store(adapter.agent_store(org_id))
+    .with_capability_registry(adapter.capability_registry())
+    .with_post_tool_hooks(
+        adapter
+            .post_tool_hooks(
+                org_id,
+                input.harness_id,
+                input.agent_id,
+                input.blueprint_id.as_deref(),
+            )
+            .await?,
+    );
+
+    if let Some(storage_store) = adapter.storage_store() {
+        atom = atom.with_storage_store(storage_store);
+    }
+    if let Some(memory_store) = adapter.memory_store() {
+        atom = atom.with_memory_store(memory_store);
+    }
+    if let Some(connection_resolver) = adapter.connection_resolver() {
+        atom = atom.with_connection_resolver(connection_resolver);
+    }
+    if let Some(sqldb_store) = adapter.sqldb_store() {
+        atom = atom.with_sqldb_store(sqldb_store);
+    }
+    if let Some(leased_resource_store) = adapter.leased_resource_store() {
+        atom = atom.with_leased_resource_store(leased_resource_store);
+    }
+    if let Some(registry) = adapter.session_resource_registry() {
+        atom = atom.with_session_resource_registry(registry);
+    }
+    if let Some(schedule_store) = adapter.schedule_store(org_id) {
+        atom = atom.with_schedule_store(schedule_store);
+    }
+    if let Some(platform_store) = adapter.platform_store(org_id) {
+        atom = atom.with_platform_store(platform_store);
+    }
+    if let Some(budget_checker) = adapter.budget_checker(org_id, input.agent_id) {
+        atom = atom.with_budget_checker(budget_checker);
+    }
+
+    atom.execute(input).await
+}

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -24,9 +24,10 @@ use everruns_core::traits::{
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
 use everruns_core::{
     Agent, CapabilityRegistry, DependencyBlocker, DriverRegistry, Harness, Session, TokenUsage,
-    ToolDefinition, ToolRegistry,
+    ToolDefinition, ToolRegistry, org_public_id_from_internal,
 };
 use std::sync::Arc;
+use tracing::warn;
 
 #[derive(Clone)]
 struct HostAgentStore(Arc<dyn AgentStore>);
@@ -337,6 +338,35 @@ impl<A: RuntimeHostAdapter> RuntimeSessionLifecycle<A> {
         }
     }
 
+    async fn set_session_status(&self, status: SessionStatus, action: &'static str) {
+        if let Err(error) = self
+            .adapter
+            .set_session_status(self.org_id, self.session_id, status)
+            .await
+        {
+            warn!(
+                session_id = %self.session_id,
+                org_id = self.org_id,
+                action,
+                %error,
+                "runtime host lifecycle status update failed"
+            );
+        }
+    }
+
+    async fn emit_event(&self, request: EventRequest) {
+        let event_type = request.event_type.clone();
+        if let Err(error) = self.adapter.event_emitter().emit(request).await {
+            warn!(
+                session_id = %self.session_id,
+                org_id = self.org_id,
+                event_type,
+                %error,
+                "runtime host lifecycle event emission failed"
+            );
+        }
+    }
+
     pub async fn turn_started(&self, turn_id: TurnId, input_message_id: MessageId) {
         let input_content = self
             .adapter
@@ -347,37 +377,29 @@ impl<A: RuntimeHostAdapter> RuntimeSessionLifecycle<A> {
             .flatten()
             .map(|message| message.content_to_llm_string());
 
-        let _ = self
-            .adapter
-            .set_session_status(self.org_id, self.session_id, SessionStatus::Active)
+        self.set_session_status(SessionStatus::Active, "turn_started")
             .await;
 
-        let _ = self
-            .adapter
-            .event_emitter()
-            .emit(EventRequest::new(
-                self.session_id,
-                EventContext::turn(turn_id, input_message_id),
-                SessionActivatedData {
-                    turn_id,
-                    input_message_id,
-                },
-            ))
-            .await;
+        self.emit_event(EventRequest::new(
+            self.session_id,
+            EventContext::turn(turn_id, input_message_id),
+            SessionActivatedData {
+                turn_id,
+                input_message_id,
+            },
+        ))
+        .await;
 
-        let _ = self
-            .adapter
-            .event_emitter()
-            .emit(EventRequest::new(
-                self.session_id,
-                EventContext::turn(turn_id, input_message_id),
-                TurnStartedData {
-                    turn_id,
-                    input_message_id,
-                    input_content,
-                },
-            ))
-            .await;
+        self.emit_event(EventRequest::new(
+            self.session_id,
+            EventContext::turn(turn_id, input_message_id),
+            TurnStartedData {
+                turn_id,
+                input_message_id,
+                input_content,
+            },
+        ))
+        .await;
     }
 
     pub async fn emit_turn_completed(
@@ -388,21 +410,18 @@ impl<A: RuntimeHostAdapter> RuntimeSessionLifecycle<A> {
         usage: Option<TokenUsage>,
         input_content: Option<String>,
     ) {
-        let _ = self
-            .adapter
-            .event_emitter()
-            .emit(EventRequest::new(
-                self.session_id,
-                EventContext::turn(turn_id, input_message_id),
-                TurnCompletedData {
-                    turn_id,
-                    iterations,
-                    duration_ms: None,
-                    usage,
-                    input_content,
-                },
-            ))
-            .await;
+        self.emit_event(EventRequest::new(
+            self.session_id,
+            EventContext::turn(turn_id, input_message_id),
+            TurnCompletedData {
+                turn_id,
+                iterations,
+                duration_ms: None,
+                usage,
+                input_content,
+            },
+        ))
+        .await;
     }
 
     pub async fn emit_session_idled(
@@ -412,24 +431,19 @@ impl<A: RuntimeHostAdapter> RuntimeSessionLifecycle<A> {
         iterations: Option<u32>,
         usage: Option<TokenUsage>,
     ) {
-        let _ = self
-            .adapter
-            .set_session_status(self.org_id, self.session_id, SessionStatus::Idle)
+        self.set_session_status(SessionStatus::Idle, "emit_session_idled")
             .await;
 
-        let _ = self
-            .adapter
-            .event_emitter()
-            .emit(EventRequest::new(
-                self.session_id,
-                EventContext::turn(turn_id, input_message_id),
-                SessionIdledData {
-                    turn_id,
-                    iterations,
-                    usage,
-                },
-            ))
-            .await;
+        self.emit_event(EventRequest::new(
+            self.session_id,
+            EventContext::turn(turn_id, input_message_id),
+            SessionIdledData {
+                turn_id,
+                iterations,
+                usage,
+            },
+        ))
+        .await;
     }
 
     pub async fn turn_completed(
@@ -459,49 +473,38 @@ impl<A: RuntimeHostAdapter> RuntimeSessionLifecycle<A> {
         error: &str,
         error_code: Option<&str>,
     ) {
-        let _ = self
-            .adapter
-            .set_session_status(self.org_id, self.session_id, SessionStatus::Idle)
+        self.set_session_status(SessionStatus::Idle, "turn_failed")
             .await;
 
-        let _ = self
-            .adapter
-            .event_emitter()
-            .emit(EventRequest::new(
-                self.session_id,
-                EventContext::turn(turn_id, input_message_id),
-                TurnFailedData {
-                    turn_id,
-                    error: error.to_string(),
-                    error_code: error_code.map(str::to_string),
-                },
-            ))
-            .await;
+        self.emit_event(EventRequest::new(
+            self.session_id,
+            EventContext::turn(turn_id, input_message_id),
+            TurnFailedData {
+                turn_id,
+                error: error.to_string(),
+                error_code: error_code.map(str::to_string),
+            },
+        ))
+        .await;
 
-        let _ = self
-            .adapter
-            .event_emitter()
-            .emit(EventRequest::new(
-                self.session_id,
-                EventContext::turn(turn_id, input_message_id),
-                SessionIdledData {
-                    turn_id,
-                    iterations: None,
-                    usage: None,
-                },
-            ))
-            .await;
+        self.emit_event(EventRequest::new(
+            self.session_id,
+            EventContext::turn(turn_id, input_message_id),
+            SessionIdledData {
+                turn_id,
+                iterations: None,
+                usage: None,
+            },
+        ))
+        .await;
     }
 
     pub async fn waiting_for_tool_results(&self) {
-        let _ = self
-            .adapter
-            .set_session_status(
-                self.org_id,
-                self.session_id,
-                SessionStatus::WaitingForToolResults,
-            )
-            .await;
+        self.set_session_status(
+            SessionStatus::WaitingForToolResults,
+            "waiting_for_tool_results",
+        )
+        .await;
     }
 
     pub async fn dependency_blocked(
@@ -510,15 +513,12 @@ impl<A: RuntimeHostAdapter> RuntimeSessionLifecycle<A> {
         input_message_id: MessageId,
         blocker: DependencyBlocker,
     ) {
-        let _ = self
-            .adapter
-            .event_emitter()
-            .emit(EventRequest::new(
-                self.session_id,
-                EventContext::turn(turn_id, input_message_id),
-                OutputMessageCompletedData::new(Message::assistant(blocker.message())),
-            ))
-            .await;
+        self.emit_event(EventRequest::new(
+            self.session_id,
+            EventContext::turn(turn_id, input_message_id),
+            OutputMessageCompletedData::new(Message::assistant(blocker.message())),
+        ))
+        .await;
 
         self.turn_failed(
             turn_id,
@@ -663,6 +663,11 @@ pub async fn execute_act_activity<A: RuntimeHostAdapter>(
     .with_session_store(adapter.session_store(org_id))
     .with_session_mutator(adapter.session_mutator(org_id))
     .with_agent_store(adapter.agent_store(org_id))
+    .with_org_id(
+        org_public_id_from_internal(org_id)
+            .parse()
+            .expect("internal org id converts to valid public org id"),
+    )
     .with_capability_registry(adapter.capability_registry())
     .with_post_tool_hooks(
         adapter

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -11,6 +11,7 @@
 //! - seed harnesses, agents, sessions, and workspace files directly in code
 //! - replace the default in-memory stores with custom runtime backends
 //! - inspect the assembled turn context before or after executing a turn
+//! - reuse runtime-owned host phase execution from durable or server-backed hosts
 //!
 //! For a runnable example, see:
 //!
@@ -133,6 +134,7 @@
 //! ```
 
 mod backends;
+mod host;
 mod in_memory;
 mod runtime;
 
@@ -141,5 +143,9 @@ pub use backends::{
     RuntimeHarnessStore, RuntimeMessageStore, RuntimeProviderStore, RuntimeSessionStore,
 };
 pub use everruns_core::AssembledTurnContext;
+pub use host::{
+    RuntimeHostAdapter, RuntimeHostTurnContext, RuntimeSessionLifecycle, detect_dependency_blocker,
+    execute_act_activity, execute_input_activity, execute_reason_activity,
+};
 pub use in_memory::{InMemorySessionFileStore, InMemorySessionStorageStore, InMemorySessionStore};
 pub use runtime::{InProcessRuntime, InProcessRuntimeBuilder, TurnResult};

--- a/crates/runtime/tests/runtime_host_test.rs
+++ b/crates/runtime/tests/runtime_host_test.rs
@@ -3,13 +3,14 @@ use chrono::Utc;
 use everruns_core::MessageRetriever;
 use everruns_core::atoms::{ActInput, AtomContext, InputAtomInput};
 use everruns_core::capabilities::{
-    SystemPromptContext, TestMathCapability, collect_capabilities_with_configs,
+    MemoryCapability, SystemPromptContext, TestMathCapability, collect_capabilities_with_configs,
 };
 use everruns_core::llm_driver_registry::DriverRegistry;
 use everruns_core::memory::{
     InMemoryAgentStore, InMemoryEventEmitter, InMemoryHarnessStore, InMemoryLlmProviderStore,
-    InMemoryMessageRetriever,
+    InMemoryMemoryStore, InMemoryMessageRetriever,
 };
+use everruns_core::memory_store::MemoryStoreBackend;
 use everruns_core::traits::{
     AgentStore, EventEmitter, HarnessStore, LlmProviderStore, SessionFileStore, SessionMutator,
     SessionStore,
@@ -82,6 +83,7 @@ struct MockHostAdapter {
     provider_store: Arc<InMemoryLlmProviderStore>,
     event_emitter: Arc<InMemoryEventEmitter>,
     file_store: Arc<InMemorySessionFileStore>,
+    memory_store: Option<Arc<dyn MemoryStoreBackend>>,
 }
 
 #[async_trait]
@@ -211,6 +213,10 @@ impl RuntimeHostAdapter for MockHostAdapter {
     fn file_store(&self) -> Arc<dyn SessionFileStore> {
         self.file_store.clone()
     }
+
+    fn memory_store(&self) -> Option<Arc<dyn MemoryStoreBackend>> {
+        self.memory_store.clone()
+    }
 }
 
 async fn build_registry(
@@ -301,6 +307,7 @@ fn mock_host() -> MockHostAdapter {
         provider_store: Arc::new(InMemoryLlmProviderStore::new()),
         event_emitter: Arc::new(InMemoryEventEmitter::new()),
         file_store: Arc::new(InMemorySessionFileStore::new()),
+        memory_store: None,
     }
 }
 
@@ -399,6 +406,79 @@ async fn act_activity_executes_capability_tools_from_harness_registry() {
     assert_eq!(result.success_count, 1);
     assert_eq!(result.error_count, 0);
     assert_eq!(result.results.len(), 1);
+}
+
+#[tokio::test]
+async fn act_activity_passes_public_org_id_to_memory_tools() {
+    let mut adapter = mock_host();
+    adapter.capability_registry.register(MemoryCapability);
+    let memory_store = Arc::new(InMemoryMemoryStore::new());
+    adapter.memory_store = Some(memory_store.clone());
+
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    let input_message_id = MessageId::from_uuid(Uuid::now_v7());
+    adapter
+        .harness_store
+        .add_harness(Harness {
+            capabilities: vec![AgentCapabilityConfig::new("memory")],
+            ..harness(harness_id)
+        })
+        .await;
+    adapter
+        .session_store
+        .insert(session(session_id, harness_id))
+        .await;
+
+    let result = execute_act_activity(
+        &adapter,
+        ActInput {
+            org_id: Some(42),
+            context: AtomContext::new(
+                session_id,
+                TurnId::from_uuid(Uuid::now_v7()),
+                input_message_id,
+            ),
+            harness_id,
+            agent_id: None,
+            tool_calls: vec![ToolCall {
+                id: "call_remember".into(),
+                name: "remember".into(),
+                arguments: serde_json::json!({
+                    "content": "Runtime host should pass org id to memory tools",
+                    "kind": "fact",
+                    "importance": 6,
+                    "tags": ["runtime"]
+                }),
+            }],
+            tool_definitions: build_registry(
+                &adapter.capability_registry,
+                session_id,
+                &[AgentCapabilityConfig::new("memory")],
+            )
+            .await
+            .unwrap()
+            .tool_definitions(),
+            locale: None,
+            blueprint_id: None,
+            network_access: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.success_count, 1);
+    assert_eq!(result.error_count, 0);
+
+    let store = memory_store
+        .get_or_create_default_store(
+            everruns_core::org_public_id_from_internal(42)
+                .parse()
+                .expect("valid public org id"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(memory_store.count_active(store.id).await.unwrap(), 1);
 }
 
 #[tokio::test]

--- a/crates/runtime/tests/runtime_host_test.rs
+++ b/crates/runtime/tests/runtime_host_test.rs
@@ -1,0 +1,426 @@
+use async_trait::async_trait;
+use chrono::Utc;
+use everruns_core::MessageRetriever;
+use everruns_core::atoms::{ActInput, AtomContext, InputAtomInput};
+use everruns_core::capabilities::{
+    SystemPromptContext, TestMathCapability, collect_capabilities_with_configs,
+};
+use everruns_core::llm_driver_registry::DriverRegistry;
+use everruns_core::memory::{
+    InMemoryAgentStore, InMemoryEventEmitter, InMemoryHarnessStore, InMemoryLlmProviderStore,
+    InMemoryMessageRetriever,
+};
+use everruns_core::traits::{
+    AgentStore, EventEmitter, HarnessStore, LlmProviderStore, SessionFileStore, SessionMutator,
+    SessionStore,
+};
+use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
+use everruns_core::{
+    Agent, AgentCapabilityConfig, CapabilityRegistry, Harness, HarnessStatus, InputMessage,
+    Session, SessionStatus, ToolCall, ToolRegistry,
+};
+use everruns_runtime::{
+    InMemorySessionFileStore, RuntimeHostAdapter, RuntimeHostTurnContext, RuntimeSessionLifecycle,
+    execute_act_activity, execute_input_activity,
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+#[derive(Clone, Default)]
+struct TestSessionStore {
+    sessions: Arc<RwLock<HashMap<SessionId, Session>>>,
+}
+
+impl TestSessionStore {
+    async fn insert(&self, session: Session) {
+        self.sessions.write().await.insert(session.id, session);
+    }
+
+    async fn set_status(&self, session_id: SessionId, status: SessionStatus) -> Session {
+        let mut sessions = self.sessions.write().await;
+        let session = sessions.get_mut(&session_id).expect("session exists");
+        session.status = status;
+        session.updated_at = Utc::now();
+        session.clone()
+    }
+}
+
+#[async_trait]
+impl SessionStore for TestSessionStore {
+    async fn get_session(
+        &self,
+        session_id: SessionId,
+    ) -> everruns_core::error::Result<Option<Session>> {
+        Ok(self.sessions.read().await.get(&session_id).cloned())
+    }
+}
+
+#[async_trait]
+impl SessionMutator for TestSessionStore {
+    async fn update_session_title(
+        &self,
+        session_id: SessionId,
+        title: String,
+    ) -> everruns_core::error::Result<Session> {
+        let mut sessions = self.sessions.write().await;
+        let session = sessions.get_mut(&session_id).expect("session exists");
+        session.title = Some(title);
+        Ok(session.clone())
+    }
+}
+
+#[derive(Clone)]
+struct MockHostAdapter {
+    capability_registry: CapabilityRegistry,
+    driver_registry: DriverRegistry,
+    harness_store: Arc<InMemoryHarnessStore>,
+    agent_store: Arc<InMemoryAgentStore>,
+    session_store: Arc<TestSessionStore>,
+    message_store: Arc<InMemoryMessageRetriever>,
+    provider_store: Arc<InMemoryLlmProviderStore>,
+    event_emitter: Arc<InMemoryEventEmitter>,
+    file_store: Arc<InMemorySessionFileStore>,
+}
+
+#[async_trait]
+impl RuntimeHostAdapter for MockHostAdapter {
+    async fn get_agent(
+        &self,
+        _org_id: i64,
+        agent_id: AgentId,
+    ) -> everruns_core::error::Result<Option<Agent>> {
+        self.agent_store.get_agent(agent_id).await
+    }
+
+    async fn get_harness(
+        &self,
+        _org_id: i64,
+        harness_id: HarnessId,
+    ) -> everruns_core::error::Result<Option<Harness>> {
+        Ok(self
+            .harness_store
+            .get_harness_chain(harness_id)
+            .await?
+            .into_iter()
+            .last())
+    }
+
+    async fn set_session_status(
+        &self,
+        _org_id: i64,
+        session_id: SessionId,
+        status: SessionStatus,
+    ) -> everruns_core::error::Result<Session> {
+        Ok(self.session_store.set_status(session_id, status).await)
+    }
+
+    async fn load_turn_context(
+        &self,
+        _org_id: i64,
+        session_id: SessionId,
+    ) -> everruns_core::error::Result<RuntimeHostTurnContext> {
+        Ok(RuntimeHostTurnContext {
+            agent: None,
+            session: self
+                .session_store
+                .get_session(session_id)
+                .await?
+                .expect("session exists"),
+            messages: self.message_store.load(session_id).await?,
+            model: None,
+            mcp_tool_definitions: vec![],
+        })
+    }
+
+    fn capability_registry(&self) -> CapabilityRegistry {
+        self.capability_registry.clone()
+    }
+
+    fn driver_registry(&self) -> DriverRegistry {
+        self.driver_registry.clone()
+    }
+
+    async fn build_tool_registry_for_agent(
+        &self,
+        _org_id: i64,
+        agent_id: AgentId,
+    ) -> everruns_core::error::Result<ToolRegistry> {
+        let agent = self
+            .agent_store
+            .get_agent(agent_id)
+            .await?
+            .expect("agent exists");
+        build_registry(
+            &self.capability_registry,
+            SessionId::new(),
+            &agent.capabilities,
+        )
+        .await
+    }
+
+    async fn build_tool_registry_for_harness(
+        &self,
+        _org_id: i64,
+        harness_id: HarnessId,
+    ) -> everruns_core::error::Result<ToolRegistry> {
+        let harness = self
+            .harness_store
+            .get_harness_chain(harness_id)
+            .await?
+            .into_iter()
+            .last()
+            .expect("harness exists");
+        build_registry(
+            &self.capability_registry,
+            SessionId::new(),
+            &harness.capabilities,
+        )
+        .await
+    }
+
+    fn harness_store(&self, _org_id: i64) -> Arc<dyn HarnessStore> {
+        self.harness_store.clone()
+    }
+
+    fn agent_store(&self, _org_id: i64) -> Arc<dyn AgentStore> {
+        self.agent_store.clone()
+    }
+
+    fn session_store(&self, _org_id: i64) -> Arc<dyn SessionStore> {
+        self.session_store.clone()
+    }
+
+    fn session_mutator(&self, _org_id: i64) -> Arc<dyn SessionMutator> {
+        self.session_store.clone()
+    }
+
+    fn provider_store(&self, _org_id: i64) -> Arc<dyn LlmProviderStore> {
+        self.provider_store.clone()
+    }
+
+    fn message_store(&self) -> Arc<dyn everruns_core::MessageRetriever> {
+        self.message_store.clone()
+    }
+
+    fn event_emitter(&self) -> Arc<dyn EventEmitter> {
+        self.event_emitter.clone()
+    }
+
+    fn file_store(&self) -> Arc<dyn SessionFileStore> {
+        self.file_store.clone()
+    }
+}
+
+async fn build_registry(
+    capability_registry: &CapabilityRegistry,
+    session_id: SessionId,
+    capabilities: &[AgentCapabilityConfig],
+) -> everruns_core::error::Result<ToolRegistry> {
+    let ctx = SystemPromptContext::without_file_store(session_id);
+    let collected =
+        collect_capabilities_with_configs(capabilities, capability_registry, &ctx).await;
+    let mut registry = ToolRegistry::with_defaults();
+    for tool in collected.tools {
+        registry.register_boxed(tool);
+    }
+    Ok(registry)
+}
+
+fn harness(harness_id: HarnessId) -> Harness {
+    Harness {
+        id: harness_id,
+        name: "math".into(),
+        display_name: Some("Math".into()),
+        description: None,
+        system_prompt: "You are a math harness.".into(),
+        parent_harness_id: None,
+        default_model_id: None,
+        tags: vec![],
+        capabilities: vec![AgentCapabilityConfig::new("test_math")],
+        initial_files: vec![],
+        network_access: None,
+        is_built_in: false,
+        status: HarnessStatus::Active,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        archived_at: None,
+        deleted_at: None,
+    }
+}
+
+fn session(session_id: SessionId, harness_id: HarnessId) -> Session {
+    Session {
+        id: session_id,
+        organization_id: everruns_core::DEFAULT_ORG_PUBLIC_ID.to_string(),
+        harness_id,
+        agent_id: None,
+        agent_identity_id: None,
+        title: Some("Runtime Host".into()),
+        locale: None,
+        preview: None,
+        output_preview: None,
+        tags: vec![],
+        model_id: None,
+        capabilities: vec![],
+        tools: vec![],
+        system_prompt: None,
+        initial_files: vec![],
+        hints: None,
+        network_access: None,
+        max_iterations: None,
+        status: SessionStatus::Started,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        started_at: None,
+        finished_at: None,
+        usage: None,
+        is_pinned: None,
+        active_schedule_count: None,
+        features: vec![],
+        parent_session_id: None,
+        subagent_name: None,
+        subagent_task: None,
+        subagent_status: None,
+        blueprint_id: None,
+        blueprint_config: None,
+    }
+}
+
+fn mock_host() -> MockHostAdapter {
+    let mut capability_registry = CapabilityRegistry::new();
+    capability_registry.register(TestMathCapability);
+    MockHostAdapter {
+        capability_registry,
+        driver_registry: DriverRegistry::new(),
+        harness_store: Arc::new(InMemoryHarnessStore::new()),
+        agent_store: Arc::new(InMemoryAgentStore::new()),
+        session_store: Arc::new(TestSessionStore::default()),
+        message_store: Arc::new(InMemoryMessageRetriever::new()),
+        provider_store: Arc::new(InMemoryLlmProviderStore::new()),
+        event_emitter: Arc::new(InMemoryEventEmitter::new()),
+        file_store: Arc::new(InMemorySessionFileStore::new()),
+    }
+}
+
+#[tokio::test]
+async fn input_activity_emits_lifecycle_events_and_marks_session_active() {
+    let adapter = mock_host();
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    adapter.harness_store.add_harness(harness(harness_id)).await;
+    adapter
+        .session_store
+        .insert(session(session_id, harness_id))
+        .await;
+
+    let input_message = adapter
+        .message_store
+        .add(session_id, InputMessage::user("hello"))
+        .await
+        .unwrap();
+    let turn_id = TurnId::from_uuid(Uuid::now_v7());
+
+    execute_input_activity(
+        &adapter,
+        1,
+        InputAtomInput {
+            context: AtomContext::new(session_id, turn_id, input_message.id),
+        },
+    )
+    .await
+    .unwrap();
+
+    let session = adapter
+        .session_store
+        .get_session(session_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(session.status, SessionStatus::Active);
+
+    let event_types: Vec<_> = adapter
+        .event_emitter
+        .events()
+        .await
+        .into_iter()
+        .map(|event| event.data.event_type().to_string())
+        .collect();
+    assert!(event_types.contains(&"session.activated".to_string()));
+    assert!(event_types.contains(&"turn.started".to_string()));
+}
+
+#[tokio::test]
+async fn act_activity_executes_capability_tools_from_harness_registry() {
+    let adapter = mock_host();
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    let input_message_id = MessageId::from_uuid(Uuid::now_v7());
+    adapter.harness_store.add_harness(harness(harness_id)).await;
+    adapter
+        .session_store
+        .insert(session(session_id, harness_id))
+        .await;
+    let tool_definitions = build_registry(
+        &adapter.capability_registry,
+        session_id,
+        &[AgentCapabilityConfig::new("test_math")],
+    )
+    .await
+    .unwrap()
+    .tool_definitions();
+
+    let result = execute_act_activity(
+        &adapter,
+        ActInput {
+            org_id: Some(1),
+            context: AtomContext::new(
+                session_id,
+                TurnId::from_uuid(Uuid::now_v7()),
+                input_message_id,
+            ),
+            harness_id,
+            agent_id: None,
+            tool_calls: vec![ToolCall {
+                id: "call_mul".into(),
+                name: "multiply".into(),
+                arguments: serde_json::json!({"a": 6, "b": 7}),
+            }],
+            tool_definitions,
+            locale: None,
+            blueprint_id: None,
+            network_access: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.success_count, 1);
+    assert_eq!(result.error_count, 0);
+    assert_eq!(result.results.len(), 1);
+}
+
+#[tokio::test]
+async fn lifecycle_helper_sets_waiting_for_tool_results_status() {
+    let adapter = mock_host();
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    adapter.harness_store.add_harness(harness(harness_id)).await;
+    adapter
+        .session_store
+        .insert(session(session_id, harness_id))
+        .await;
+
+    RuntimeSessionLifecycle::new(adapter.clone(), 1, session_id)
+        .waiting_for_tool_results()
+        .await;
+
+    let session = adapter
+        .session_store
+        .get_session(session_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(session.status, SessionStatus::WaitingForToolResults);
+}

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -30,6 +30,7 @@ everruns-openai = { path = "../openai" }
 everruns-anthropic = { path = "../anthropic" }
 everruns-gemini = { path = "../gemini" }
 everruns-internal-protocol = { path = "../internal-protocol" }
+everruns-runtime = { path = "../runtime" }
 # Note: Workers don't need direct DB access - all DB operations go through gRPC
 # The durable module is used for control-plane direct DB mode (avoids circular gRPC dependency)
 everruns-durable = { path = "../durable" }

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -13,100 +13,21 @@
 // Atoms emit events via EventEmitter for observability.
 
 use anyhow::{Context, Result};
-use everruns_core::ToolRegistry;
-use everruns_core::atoms::{ActAtom, Atom, InputAtom, ReasonAtom};
-use everruns_core::capabilities::{SystemPromptContext, collect_capabilities, is_mcp_capability};
-use everruns_core::traits::{AgentStore, SessionStore};
-use everruns_core::{Message, PlatformDefinition};
-use std::sync::Arc;
-
-use crate::grpc_adapters::{
-    GrpcAgentStore, GrpcBudgetChecker, GrpcClient, GrpcConnectionResolver, GrpcEventEmitter,
-    GrpcHarnessStore, GrpcImageResolver, GrpcLeasedResourceStore, GrpcLlmProviderStore,
-    GrpcMessageRetriever, GrpcPlatformStore, GrpcScheduleStore, GrpcSessionFileStore,
-    GrpcSessionMutator, GrpcSessionResourceRegistry, GrpcSessionSqlDbStore,
-    GrpcSessionStorageStore, GrpcSessionStore,
+use everruns_core::PlatformDefinition;
+use everruns_runtime::{
+    execute_act_activity as runtime_execute_act_activity,
+    execute_input_activity as runtime_execute_input_activity,
+    execute_reason_activity as runtime_execute_reason_activity,
 };
+
+use crate::grpc_adapters::GrpcClient;
+use crate::grpc_worker_adapters::GrpcWorkerAdapters;
+use crate::runtime_host::WorkerRuntimeHost;
 
 // Re-export atom types for activity callers
 pub use everruns_core::atoms::{
     ActInput, ActResult, InputAtomInput, InputAtomResult, ReasonInput, ReasonResult, ToolCallResult,
 };
-
-/// Thin wrapper: detect dependency blockers using core's shared logic with gRPC adapters.
-async fn detect_dependency_blocker(
-    grpc_client: &GrpcClient,
-    org_id: i64,
-    harness_id: everruns_core::HarnessId,
-    agent_id: Option<everruns_core::AgentId>,
-) -> Result<Option<everruns_core::DependencyBlocker>> {
-    let harness_store = GrpcHarnessStore::new(grpc_client.clone(), org_id);
-    let agent_store = GrpcAgentStore::new(grpc_client.clone(), org_id);
-    everruns_core::detect_dependency_blocker(&harness_store, &agent_store, harness_id, agent_id)
-        .await
-        .map_err(anyhow::Error::new)
-}
-
-/// Emit dependency-blocked events (output message + turn.failed + session.idled, set idle).
-async fn emit_dependency_blocked_events(
-    grpc_client: &GrpcClient,
-    org_id: i64,
-    context: &everruns_core::atoms::AtomContext,
-    blocker: everruns_core::DependencyBlocker,
-) {
-    use everruns_core::events::{
-        EventContext, EventRequest, OutputMessageCompletedData, SessionIdledData, TurnFailedData,
-    };
-    use everruns_core::traits::EventEmitter;
-
-    let session_id = context.session_id;
-    let turn_id = context.turn_id;
-    let input_message_id = context.input_message_id;
-    let message = blocker.message();
-    let event_emitter = GrpcEventEmitter::new(grpc_client.clone());
-
-    let output_event = EventRequest::new(
-        session_id,
-        EventContext::turn(turn_id, input_message_id),
-        OutputMessageCompletedData::new(Message::assistant(message)),
-    );
-    if let Err(e) = event_emitter.emit(output_event).await {
-        tracing::warn!(error = %e, "Failed to emit dependency blocked message");
-    }
-
-    if let Err(e) = grpc_client
-        .set_session_status(org_id, session_id, "idle")
-        .await
-    {
-        tracing::warn!(error = %e, "Failed to set session status to idle");
-    }
-
-    let failed_event = EventRequest::new(
-        session_id,
-        EventContext::turn(turn_id, input_message_id),
-        TurnFailedData {
-            turn_id,
-            error: message.to_string(),
-            error_code: Some(blocker.error_code().to_string()),
-        },
-    );
-    if let Err(e) = event_emitter.emit(failed_event).await {
-        tracing::warn!(error = %e, "Failed to emit dependency turn.failed");
-    }
-
-    let idled_event = EventRequest::new(
-        session_id,
-        EventContext::turn(turn_id, input_message_id),
-        SessionIdledData {
-            turn_id,
-            iterations: None,
-            usage: None,
-        },
-    );
-    if let Err(e) = event_emitter.emit(idled_event).await {
-        tracing::warn!(error = %e, "Failed to emit dependency session.idled");
-    }
-}
 
 // ============================================================================
 // Activity Implementations
@@ -124,12 +45,6 @@ pub async fn input_activity(
     org_id: i64,
     input: InputAtomInput,
 ) -> Result<InputAtomResult> {
-    use everruns_core::MessageRetriever;
-    use everruns_core::events::{
-        EventContext, EventRequest, SessionActivatedData, TurnStartedData,
-    };
-    use everruns_core::traits::EventEmitter;
-
     tracing::info!(
         org_id = org_id,
         session_id = %input.context.session_id,
@@ -138,66 +53,13 @@ pub async fn input_activity(
         "Executing input_activity"
     );
 
-    // Set session status to "active" - turn is starting
-    if let Err(e) = grpc_client
-        .set_session_status(org_id, input.context.session_id, "active")
-        .await
-    {
-        tracing::warn!(error = %e, "Failed to set session status to active");
-    }
-
-    // Create message retriever early to fetch input content for observability
-    let message_retriever = GrpcMessageRetriever::new(grpc_client.clone());
-
-    // Fetch input message content for turn.started event (for Braintrust observability)
-    let input_content = match message_retriever
-        .get(input.context.session_id, input.context.input_message_id)
-        .await
-    {
-        Ok(Some(msg)) => Some(msg.content_to_llm_string()),
-        Ok(None) => {
-            tracing::warn!("Input message not found for turn.started event");
-            None
-        }
-        Err(e) => {
-            tracing::warn!(error = %e, "Failed to fetch input message for turn.started event");
-            None
-        }
-    };
-
-    // Emit session.activated event
-    let event_emitter = GrpcEventEmitter::new(grpc_client.clone());
-    let activated_event = EventRequest::new(
-        input.context.session_id,
-        EventContext::turn(input.context.turn_id, input.context.input_message_id),
-        SessionActivatedData {
-            turn_id: input.context.turn_id,
-            input_message_id: input.context.input_message_id,
-        },
-    );
-    if let Err(e) = event_emitter.emit(activated_event).await {
-        tracing::warn!(error = %e, "Failed to emit session.activated event");
-    }
-
-    // Emit turn.started event with input content for observability
-    let turn_started_event = EventRequest::new(
-        input.context.session_id,
-        EventContext::turn(input.context.turn_id, input.context.input_message_id),
-        TurnStartedData {
-            turn_id: input.context.turn_id,
-            input_message_id: input.context.input_message_id,
-            input_content,
-        },
-    );
-    if let Err(e) = event_emitter.emit(turn_started_event).await {
-        tracing::warn!(error = %e, "Failed to emit turn.started event");
-    }
-
-    let atom = InputAtom::new(message_retriever);
-
-    atom.execute(input)
-        .await
-        .context("InputAtom execution failed")
+    runtime_execute_input_activity(
+        &WorkerRuntimeHost::new(GrpcWorkerAdapters::from_client(grpc_client)),
+        org_id,
+        input,
+    )
+    .await
+    .context("InputAtom execution failed")
 }
 
 /// Call the LLM model for reasoning using ReasonAtom
@@ -227,58 +89,16 @@ pub async fn reason_activity(
         "Executing reason_activity"
     );
 
-    if let Some(blocker) =
-        detect_dependency_blocker(&grpc_client, org_id, input.harness_id, input.agent_id).await?
-    {
-        emit_dependency_blocked_events(&grpc_client, org_id, &input.context, blocker).await;
-        return Ok(ReasonResult {
-            success: false,
-            text: blocker.message().to_string(),
-            tool_calls: vec![],
-            has_tool_calls: false,
-            tool_definitions: vec![],
-            max_iterations: everruns_core::runtime_agent::default_max_iterations(),
-            error: Some("dependency_unavailable".to_string()),
-            usage: None,
-            response_id: None,
-            locale: None,
-            network_access: None,
-        });
-    }
-
-    // Create atom dependencies using gRPC adapters
-    let harness_store = GrpcHarnessStore::new(grpc_client.clone(), org_id);
-    let agent_store = GrpcAgentStore::new(grpc_client.clone(), org_id);
-    let session_store = GrpcSessionStore::new(grpc_client.clone(), org_id);
-    let message_retriever = GrpcMessageRetriever::new(grpc_client.clone());
-    let provider_store = GrpcLlmProviderStore::new(grpc_client.clone(), org_id);
-    let capability_registry = platform_definition.capability_registry().clone();
-    let driver_registry = platform_definition.driver_registry().clone();
-    let event_emitter = GrpcEventEmitter::new(grpc_client.clone());
-
-    // Create image resolver for multimodal image support
-    let image_resolver = Arc::new(GrpcImageResolver::new(grpc_client.clone(), org_id));
-
-    // Create file store for AGENTS.md reading (agent_instructions capability)
-    let file_store = Arc::new(GrpcSessionFileStore::new(grpc_client.clone()));
-
-    let atom = ReasonAtom::new(
-        harness_store,
-        agent_store,
-        session_store,
-        message_retriever,
-        provider_store,
-        capability_registry,
-        driver_registry,
-        event_emitter,
+    let result = runtime_execute_reason_activity(
+        &WorkerRuntimeHost::new(GrpcWorkerAdapters::from_client_with_platform_definition(
+            grpc_client,
+            platform_definition.clone(),
+        )),
+        org_id,
+        input,
     )
-    .with_image_resolver(image_resolver)
-    .with_file_store(file_store);
-
-    let result = atom
-        .execute(input)
-        .await
-        .context("ReasonAtom execution failed")?;
+    .await
+    .context("ReasonAtom execution failed")?;
 
     // Turn lifecycle events (turn.completed, turn.failed, session.idled) are NOT
     // emitted here. They are deferred to the workflow scheduler which checks for
@@ -314,171 +134,15 @@ pub async fn act_activity(
         "Executing act_activity"
     );
 
-    if let Some(blocker) =
-        detect_dependency_blocker(&grpc_client, org_id, input.harness_id, input.agent_id).await?
-    {
-        emit_dependency_blocked_events(&grpc_client, org_id, &input.context, blocker).await;
-        return Ok(ActResult {
-            results: vec![],
-            completed: true,
-            success_count: 0,
-            error_count: 1,
-            waiting_for_tool_results: false,
-            blocked: true,
-            client_tool_calls: vec![],
-            client_tool_definitions: vec![],
-        });
-    }
-
-    // Create tool registry with default built-in tools
-    let mut builtin_executor = ToolRegistry::with_defaults();
-
-    // Resolve blueprint_id: prefer ActInput field, fall back to session lookup
-    let blueprint_id = if input.blueprint_id.is_some() {
-        input.blueprint_id.clone()
-    } else {
-        let session_store = GrpcSessionStore::new(grpc_client.clone(), org_id);
-        match session_store.get_session(input.context.session_id).await {
-            Ok(Some(session)) => session.blueprint_id.clone(),
-            _ => None,
-        }
-    };
-
-    // Load tools: blueprint tools for blueprint sessions, capability tools otherwise.
-    if let Some(ref blueprint_id) = blueprint_id {
-        // Blueprint path: load tools from the blueprint definition
-        let capability_registry = platform_definition.capability_registry().clone();
-        let blueprint = capability_registry
-            .blueprint(blueprint_id)
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "Blueprint \"{}\" not found in registry. Session has blueprint_id but no matching blueprint.",
-                    blueprint_id
-                )
-            })?;
-        for tool in blueprint.tools {
-            builtin_executor.register_boxed(tool);
-        }
-        tracing::debug!(
-            blueprint_id = blueprint_id,
-            "Registered blueprint tools for act_activity"
-        );
-    } else {
-        // Standard path: load capabilities from agent or harness.
-        // When agent_id is present, use agent capabilities.
-        // When agent_id is absent, fall back to harness capabilities so that
-        // harness-provided tools (e.g. bash) are still registered.
-        let cap_ids: Vec<String> = if let Some(agent_id) = input.agent_id {
-            let agent_store = GrpcAgentStore::new(grpc_client.clone(), org_id);
-            if let Ok(Some(agent)) = agent_store.get_agent(agent_id).await {
-                agent
-                    .capabilities
-                    .iter()
-                    .map(|c| c.capability_id().to_string())
-                    .filter(|id| !is_mcp_capability(id))
-                    .collect()
-            } else {
-                vec![]
-            }
-        } else {
-            let harness_store = GrpcHarnessStore::new(grpc_client.clone(), org_id);
-            let chain = everruns_core::traits::HarnessStore::get_harness_chain(
-                &harness_store,
-                input.harness_id,
-            )
-            .await
-            .unwrap_or_default();
-            // Fold harness chain into effective overlay to get merged capabilities
-            let overlay = everruns_core::AgentConfigOverlay::fold(
-                chain.iter().map(everruns_core::AgentConfigOverlay::from),
-            );
-            overlay
-                .capabilities
-                .iter()
-                .map(|c| c.capability_id().to_string())
-                .filter(|id| !is_mcp_capability(id))
-                .collect()
-        };
-
-        if !cap_ids.is_empty() {
-            let capability_registry = platform_definition.capability_registry().clone();
-            let ctx = SystemPromptContext::without_file_store(input.context.session_id);
-            let collected = collect_capabilities(&cap_ids, &capability_registry, &ctx).await;
-            for tool in collected.tools {
-                builtin_executor.register_boxed(tool);
-            }
-            tracing::debug!(
-                capability_count = cap_ids.len(),
-                tool_count = collected.tool_definitions.len(),
-                "Registered capability tools for act_activity"
-            );
-        }
-    }
-
-    // Create composite tool executor that handles both built-in and MCP tools
-    let mcp_executor = Arc::new(crate::mcp_executor::McpToolExecutor::new(
-        grpc_client.clone(),
-        org_id,
-    ));
-    let tool_executor =
-        crate::mcp_executor::CompositeToolExecutor::new(builtin_executor, mcp_executor);
-
-    let event_emitter = GrpcEventEmitter::new(grpc_client.clone());
-    let file_store = Arc::new(GrpcSessionFileStore::new(grpc_client.clone()));
-    let storage_store: Arc<dyn everruns_core::traits::SessionStorageStore> =
-        Arc::new(GrpcSessionStorageStore::new(grpc_client.clone()));
-    let connection_resolver: Arc<dyn everruns_core::traits::UserConnectionResolver> =
-        Arc::new(GrpcConnectionResolver::new(grpc_client.clone()));
-    let session_store: Arc<dyn everruns_core::traits::SessionStore> =
-        Arc::new(GrpcSessionStore::new(grpc_client.clone(), org_id));
-    let session_mutator: Arc<dyn everruns_core::traits::SessionMutator> =
-        Arc::new(GrpcSessionMutator::new(grpc_client.clone(), org_id));
-    let agent_store: Arc<dyn everruns_core::traits::AgentStore> =
-        Arc::new(GrpcAgentStore::new(grpc_client.clone(), org_id));
-    let sqldb_store: everruns_core::traits::SessionSqlDbStoreRef =
-        Arc::new(GrpcSessionSqlDbStore::new(grpc_client.clone()));
-    let leased_resource_store: Arc<dyn everruns_core::traits::LeasedResourceStore> =
-        Arc::new(GrpcLeasedResourceStore::new(grpc_client.clone()));
-    let session_resource_registry: Arc<dyn everruns_core::traits::SessionResourceRegistry> =
-        Arc::new(GrpcSessionResourceRegistry::new(grpc_client.clone()));
-    let schedule_store: Arc<dyn everruns_core::traits::SessionScheduleStore> =
-        Arc::new(GrpcScheduleStore::new(grpc_client.clone(), org_id));
-    let platform_store: Arc<dyn everruns_core::platform_store::PlatformStore> =
-        Arc::new(GrpcPlatformStore::new(grpc_client.clone(), org_id));
-    let budget_checker: Arc<dyn everruns_core::traits::BudgetChecker> = Arc::new(
-        GrpcBudgetChecker::new(grpc_client, org_id)
-            .with_agent_id(input.agent_id.map(|id| id.to_string())),
-    );
-
-    let atom = ActAtom::with_file_store(tool_executor, event_emitter, file_store)
-        .with_storage_store(storage_store)
-        .with_connection_resolver(connection_resolver)
-        .with_session_store(session_store)
-        .with_session_mutator(session_mutator)
-        .with_agent_store(agent_store)
-        .with_sqldb_store(sqldb_store)
-        .with_leased_resource_store(leased_resource_store)
-        .with_session_resource_registry(session_resource_registry)
-        .with_schedule_store(schedule_store)
-        .with_platform_store(platform_store)
-        .with_budget_checker(budget_checker)
-        .with_capability_registry(platform_definition.capability_registry().clone())
-        // Collect post-tool hooks from all capabilities. Hooks self-gate on tool hints
-        // (e.g. persist_output), so this is safe even though it uses the full registry
-        // rather than only session-active capabilities. A future refinement could pass
-        // only hooks from the active capability set.
-        .with_post_tool_hooks(
-            platform_definition
-                .capability_registry()
-                .list()
-                .iter()
-                .flat_map(|c| c.post_tool_exec_hooks())
-                .collect(),
-        );
-
-    atom.execute(input)
-        .await
-        .context("ActAtom execution failed")
+    runtime_execute_act_activity(
+        &WorkerRuntimeHost::new(GrpcWorkerAdapters::from_client_with_platform_definition(
+            grpc_client,
+            platform_definition.clone(),
+        )),
+        input,
+    )
+    .await
+    .context("ActAtom execution failed")
 }
 
 // ============================================================================

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -23,9 +23,9 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::grpc_adapters::{
-    GrpcAgentStore, GrpcClient, GrpcEventEmitter, GrpcHarnessStore, GrpcImageResolver,
-    GrpcLeasedResourceStore, GrpcLlmProviderStore, GrpcMessageRetriever, GrpcSessionFileStore,
-    GrpcSessionSqlDbStore, GrpcSessionStorageStore, GrpcSessionStore,
+    GrpcAgentStore, GrpcBudgetChecker, GrpcClient, GrpcEventEmitter, GrpcHarnessStore,
+    GrpcImageResolver, GrpcLeasedResourceStore, GrpcLlmProviderStore, GrpcMessageRetriever,
+    GrpcSessionFileStore, GrpcSessionSqlDbStore, GrpcSessionStorageStore, GrpcSessionStore,
 };
 use crate::mcp_executor::McpServerInfo;
 use crate::worker_adapters::{TurnContext, WorkerAdapters};
@@ -407,6 +407,17 @@ impl WorkerAdapters for GrpcWorkerAdapters {
         Arc::new(crate::grpc_adapters::GrpcScheduleStore::new(
             self.client.clone(),
             org_id,
+        ))
+    }
+
+    fn budget_checker(
+        &self,
+        org_id: i64,
+        agent_id: Option<AgentId>,
+    ) -> Option<Arc<dyn everruns_core::traits::BudgetChecker>> {
+        Some(Arc::new(
+            GrpcBudgetChecker::new(self.client.clone(), org_id)
+                .with_agent_id(agent_id.map(|id| id.to_string())),
         ))
     }
 

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -21,6 +21,7 @@ pub mod leased_resource_cleanup;
 pub mod mcp_executor;
 pub mod platform;
 pub mod runner;
+pub mod runtime_host;
 pub mod session_lifecycle;
 pub mod unified_worker;
 pub mod worker_adapters;
@@ -49,6 +50,7 @@ pub use grpc_adapters::{
 
 // Re-export task worker types
 pub use grpc_worker_adapters::GrpcWorkerAdapters;
+pub use runtime_host::WorkerRuntimeHost;
 pub use unified_worker::{TaskWorker, TaskWorkerConfig};
 pub use worker_adapters::{
     AdapterAgentStore, AdapterEventEmitter, AdapterLlmProviderStore, AdapterMessageRetriever,

--- a/crates/worker/src/runtime_host.rs
+++ b/crates/worker/src/runtime_host.rs
@@ -1,0 +1,198 @@
+// Runtime-host adapter bridge for durable/server-backed workers.
+// Decision: everruns-worker exposes first-party adapters from WorkerAdapters to
+// the public everruns-runtime host contract.
+
+use async_trait::async_trait;
+use everruns_core::error::Result;
+use everruns_core::traits::{
+    AgentStore, EventEmitter, HarnessStore, ImageResolver, LlmProviderStore, SessionFileStore,
+    SessionMutator, SessionStore,
+};
+use everruns_core::typed_id::{AgentId, HarnessId, SessionId};
+use everruns_core::{Agent, CapabilityRegistry, DriverRegistry, Harness, Session, SessionStatus};
+use everruns_runtime::{RuntimeHostAdapter, RuntimeHostTurnContext};
+use std::sync::Arc;
+
+use crate::worker_adapters::{
+    AdapterAgentStore, AdapterEventEmitter, AdapterHarnessStore, AdapterImageResolver,
+    AdapterLlmProviderStore, AdapterMessageRetriever, AdapterSessionFileStore,
+    AdapterSessionMutator, AdapterSessionStore, WorkerAdapters,
+};
+
+/// First-party adapter from worker backends into `everruns-runtime` host execution.
+///
+/// This is the bridge that lets durable workers execute the shared runtime
+/// host phases without depending on in-process-only stores.
+///
+/// ```ignore
+/// use everruns_runtime::execute_reason_activity;
+/// use everruns_worker::{GrpcWorkerAdapters, WorkerRuntimeHost};
+///
+/// let adapters = GrpcWorkerAdapters::connect("127.0.0.1:9001").await?;
+/// let host = WorkerRuntimeHost::new(adapters);
+/// let result = execute_reason_activity(&host, org_id, reason_input).await?;
+/// # Ok::<(), everruns_core::AgentLoopError>(())
+/// ```
+#[derive(Clone)]
+pub struct WorkerRuntimeHost<A: WorkerAdapters> {
+    adapters: A,
+}
+
+impl<A: WorkerAdapters> WorkerRuntimeHost<A> {
+    pub fn new(adapters: A) -> Self {
+        Self { adapters }
+    }
+}
+
+#[async_trait]
+impl<A: WorkerAdapters> RuntimeHostAdapter for WorkerRuntimeHost<A> {
+    async fn get_agent(&self, org_id: i64, agent_id: AgentId) -> Result<Option<Agent>> {
+        self.adapters.get_agent(org_id, agent_id.uuid()).await
+    }
+
+    async fn get_harness(&self, org_id: i64, harness_id: HarnessId) -> Result<Option<Harness>> {
+        self.adapters.get_harness(org_id, harness_id.uuid()).await
+    }
+
+    async fn set_session_status(
+        &self,
+        org_id: i64,
+        session_id: SessionId,
+        status: SessionStatus,
+    ) -> Result<Session> {
+        self.adapters
+            .set_session_status(org_id, session_id.uuid(), &status.to_string())
+            .await
+    }
+
+    async fn load_turn_context(
+        &self,
+        org_id: i64,
+        session_id: SessionId,
+    ) -> Result<RuntimeHostTurnContext> {
+        let context = self
+            .adapters
+            .load_turn_context(org_id, session_id.uuid())
+            .await?;
+        Ok(RuntimeHostTurnContext {
+            agent: context.agent,
+            session: context.session,
+            messages: context.messages,
+            model: context.model,
+            mcp_tool_definitions: context.mcp_tool_definitions,
+        })
+    }
+
+    fn capability_registry(&self) -> CapabilityRegistry {
+        self.adapters.capability_registry()
+    }
+
+    fn driver_registry(&self) -> DriverRegistry {
+        self.adapters.driver_registry()
+    }
+
+    async fn build_tool_registry_for_agent(
+        &self,
+        org_id: i64,
+        agent_id: AgentId,
+    ) -> Result<everruns_core::ToolRegistry> {
+        self.adapters
+            .build_tool_registry(org_id, agent_id.uuid())
+            .await
+    }
+
+    async fn build_tool_registry_for_harness(
+        &self,
+        org_id: i64,
+        harness_id: HarnessId,
+    ) -> Result<everruns_core::ToolRegistry> {
+        self.adapters
+            .build_tool_registry_for_harness(org_id, harness_id.uuid())
+            .await
+    }
+
+    fn harness_store(&self, org_id: i64) -> Arc<dyn HarnessStore> {
+        Arc::new(AdapterHarnessStore::new(self.adapters.clone(), org_id))
+    }
+
+    fn agent_store(&self, org_id: i64) -> Arc<dyn AgentStore> {
+        Arc::new(AdapterAgentStore::new(self.adapters.clone(), org_id))
+    }
+
+    fn session_store(&self, org_id: i64) -> Arc<dyn SessionStore> {
+        Arc::new(AdapterSessionStore::new(self.adapters.clone(), org_id))
+    }
+
+    fn session_mutator(&self, org_id: i64) -> Arc<dyn SessionMutator> {
+        Arc::new(AdapterSessionMutator::new(self.adapters.clone(), org_id))
+    }
+
+    fn provider_store(&self, org_id: i64) -> Arc<dyn LlmProviderStore> {
+        Arc::new(AdapterLlmProviderStore::new(self.adapters.clone(), org_id))
+    }
+
+    fn message_store(&self) -> Arc<dyn everruns_core::MessageRetriever> {
+        Arc::new(AdapterMessageRetriever::new(self.adapters.clone()))
+    }
+
+    fn event_emitter(&self) -> Arc<dyn EventEmitter> {
+        Arc::new(AdapterEventEmitter::new(self.adapters.clone()))
+    }
+
+    fn file_store(&self) -> Arc<dyn SessionFileStore> {
+        Arc::new(AdapterSessionFileStore::new(self.adapters.clone()))
+    }
+
+    fn image_resolver(&self, org_id: i64) -> Option<Arc<dyn ImageResolver>> {
+        Some(Arc::new(AdapterImageResolver::new(
+            self.adapters.clone(),
+            org_id,
+        )))
+    }
+
+    fn storage_store(&self) -> Option<Arc<dyn everruns_core::traits::SessionStorageStore>> {
+        Some(self.adapters.storage_store())
+    }
+
+    fn connection_resolver(
+        &self,
+    ) -> Option<Arc<dyn everruns_core::traits::UserConnectionResolver>> {
+        Some(self.adapters.connection_resolver())
+    }
+
+    fn sqldb_store(&self) -> Option<everruns_core::traits::SessionSqlDbStoreRef> {
+        Some(self.adapters.sqldb_store())
+    }
+
+    fn leased_resource_store(&self) -> Option<Arc<dyn everruns_core::traits::LeasedResourceStore>> {
+        Some(self.adapters.leased_resource_store())
+    }
+
+    fn session_resource_registry(
+        &self,
+    ) -> Option<Arc<dyn everruns_core::traits::SessionResourceRegistry>> {
+        self.adapters.session_resource_registry()
+    }
+
+    fn schedule_store(
+        &self,
+        org_id: i64,
+    ) -> Option<Arc<dyn everruns_core::traits::SessionScheduleStore>> {
+        Some(self.adapters.schedule_store(org_id))
+    }
+
+    fn platform_store(
+        &self,
+        org_id: i64,
+    ) -> Option<Arc<dyn everruns_core::platform_store::PlatformStore>> {
+        Some(self.adapters.platform_store(org_id))
+    }
+
+    fn budget_checker(
+        &self,
+        org_id: i64,
+        agent_id: Option<AgentId>,
+    ) -> Option<Arc<dyn everruns_core::traits::BudgetChecker>> {
+        self.adapters.budget_checker(org_id, agent_id)
+    }
+}

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -10,12 +10,17 @@
 
 use anyhow::Result;
 use everruns_core::ActInput;
-use everruns_core::atoms::{ActAtom, Atom, AtomContext, InputAtom, ReasonAtom};
+use everruns_core::atoms::AtomContext;
 use everruns_core::typed_id::{ExecId, TurnId};
 use everruns_durable::{
     ActivityOptions, ClaimedTask, WorkerInfo, WorkflowEvent, WorkflowEventStore, WorkflowStatus,
     append_event, record_activity_completed, record_activity_failed, record_activity_started,
     record_workflow_completed,
+};
+use everruns_runtime::{
+    RuntimeSessionLifecycle, execute_act_activity as runtime_execute_act_activity,
+    execute_input_activity as runtime_execute_input_activity,
+    execute_reason_activity as runtime_execute_reason_activity,
 };
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -25,12 +30,8 @@ use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crate::durable_runner::DurableTurnInput;
-use crate::session_lifecycle::SessionLifecycle;
-use crate::worker_adapters::{
-    AdapterAgentStore, AdapterEventEmitter, AdapterHarnessStore, AdapterImageResolver,
-    AdapterLlmProviderStore, AdapterMessageRetriever, AdapterSessionFileStore,
-    AdapterSessionMutator, AdapterSessionStore, WorkerAdapters,
-};
+use crate::runtime_host::WorkerRuntimeHost;
+use crate::worker_adapters::WorkerAdapters;
 
 // Re-export atom types
 pub use everruns_core::atoms::{InputAtomInput, ReasonInput, ReasonResult};
@@ -345,26 +346,6 @@ pub struct ShutdownHandle {
     tx: watch::Sender<bool>,
 }
 
-/// Helper: detect dependency blockers using shared core logic.
-async fn detect_dependency_blocker<A: WorkerAdapters>(
-    adapters: &A,
-    org_id: i64,
-    harness_id: everruns_core::HarnessId,
-    agent_id: Option<everruns_core::AgentId>,
-) -> Result<Option<everruns_core::DependencyBlocker>> {
-    let harness_store = AdapterHarnessStore::new(adapters.clone(), org_id);
-    let agent_store = AdapterAgentStore::new(adapters.clone(), org_id);
-    Ok(
-        everruns_core::detect_dependency_blocker(
-            &harness_store,
-            &agent_store,
-            harness_id,
-            agent_id,
-        )
-        .await?,
-    )
-}
-
 impl ShutdownHandle {
     /// Trigger shutdown of the worker
     pub fn shutdown(&self) {
@@ -544,8 +525,8 @@ where
                                 };
 
                             if hint_enabled {
-                                let lifecycle = SessionLifecycle::new(
-                                    adapters.clone(),
+                                let lifecycle = RuntimeSessionLifecycle::new(
+                                    WorkerRuntimeHost::new(adapters.clone()),
                                     ti.org_id,
                                     ti.session_id,
                                 );
@@ -620,20 +601,15 @@ async fn execute_input_activity<A: WorkerAdapters>(
         exec_id: ExecId::new(),
     };
 
-    // Turn starting: set active, emit session.activated + turn.started
-    let lifecycle = SessionLifecycle::new(adapters.clone(), input.org_id, input.session_id);
-    lifecycle
-        .turn_started(context.turn_id, input.input_message_id, None)
-        .await;
-
-    // Execute InputAtom
-    let message_retriever = AdapterMessageRetriever::new(adapters.clone());
-    let atom = InputAtom::new(message_retriever);
-
     let atom_input = everruns_core::InputAtomInput {
         context: context.clone(),
     };
-    let result = atom.execute(atom_input).await?;
+    let result = runtime_execute_input_activity(
+        &WorkerRuntimeHost::new(adapters.clone()),
+        input.org_id,
+        atom_input,
+    )
+    .await?;
 
     // Include turn_id in output for propagation
     let mut output = serde_json::to_value(&result)?;
@@ -666,71 +642,22 @@ async fn execute_reason_activity<A: WorkerAdapters>(
         exec_id: ExecId::new(),
     };
 
-    let session_id = input.session_id;
-    let input_message_id = input.input_message_id;
-
-    let lifecycle = SessionLifecycle::new(adapters.clone(), input.org_id, session_id);
-
-    if let Some(blocker) =
-        detect_dependency_blocker(adapters, input.org_id, input.harness_id, input.agent_id).await?
-    {
-        lifecycle
-            .dependency_blocked(turn_id, input_message_id, blocker)
-            .await;
-        return Ok(serde_json::to_value(everruns_core::ReasonResult {
-            success: false,
-            text: blocker.message().to_string(),
-            tool_calls: vec![],
-            has_tool_calls: false,
-            tool_definitions: vec![],
-            max_iterations: everruns_core::runtime_agent::default_max_iterations(),
-            error: Some("dependency_unavailable".to_string()),
-            usage: None,
-            response_id: None,
-            locale: None,
-            network_access: None,
-        })?);
-    }
-
-    // Load turn context (batch call for efficiency)
-    let turn_context = adapters
-        .load_turn_context(input.org_id, session_id.uuid())
-        .await?;
-
-    // Create atom dependencies
-    let harness_store = AdapterHarnessStore::new(adapters.clone(), input.org_id);
-    let agent_store = AdapterAgentStore::new(adapters.clone(), input.org_id);
-    let session_store = AdapterSessionStore::new(adapters.clone(), input.org_id);
-    let message_retriever = AdapterMessageRetriever::new(adapters.clone());
-    let provider_store = AdapterLlmProviderStore::new(adapters.clone(), input.org_id);
-    let capability_registry = adapters.capability_registry();
-    let driver_registry = adapters.driver_registry();
-    let event_emitter = AdapterEventEmitter::new(adapters.clone());
-    let image_resolver = Arc::new(AdapterImageResolver::new(adapters.clone(), input.org_id));
-
-    let atom = ReasonAtom::new(
-        harness_store,
-        agent_store,
-        session_store,
-        message_retriever,
-        provider_store,
-        capability_registry,
-        driver_registry,
-        event_emitter,
-    )
-    .with_image_resolver(image_resolver);
-
     let reason_input = everruns_core::ReasonInput {
         context: context.clone(),
         harness_id: input.harness_id,
         agent_id: input.agent_id,
         org_id: input.org_id,
-        mcp_tool_definitions: turn_context.mcp_tool_definitions,
+        mcp_tool_definitions: vec![],
         previous_response_id: input.previous_response_id.clone(),
         iteration: input.iteration,
     };
 
-    let result = atom.execute(reason_input).await?;
+    let result = runtime_execute_reason_activity(
+        &WorkerRuntimeHost::new(adapters.clone()),
+        input.org_id,
+        reason_input,
+    )
+    .await?;
 
     // Turn lifecycle events (turn.completed, turn.failed, session.idled) are NOT
     // emitted here. They are deferred to the workflow scheduler which checks for
@@ -753,70 +680,9 @@ async fn execute_act_activity<A: WorkerAdapters>(
     );
 
     // Extract org_id early — must be set by callers for proper tenant isolation.
-    let org_id = input
-        .org_id
-        .expect("ActInput.org_id must be set for act activities");
-
-    if let Some(blocker) =
-        detect_dependency_blocker(adapters, org_id, input.harness_id, input.agent_id).await?
-    {
-        let lifecycle = SessionLifecycle::new(adapters.clone(), org_id, input.context.session_id);
-        lifecycle
-            .dependency_blocked(
-                input.context.turn_id,
-                input.context.input_message_id,
-                blocker,
-            )
-            .await;
-        let output = serde_json::to_value(everruns_core::ActResult {
-            results: vec![],
-            completed: true,
-            success_count: 0,
-            error_count: 1,
-            waiting_for_tool_results: false,
-            blocked: true,
-            client_tool_calls: vec![],
-            client_tool_definitions: vec![],
-        })?;
-        return Ok(output);
-    }
-
-    // Build tool registry with defaults and capability tools.
-    // When agent_id is present, use agent capabilities.
-    // When agent_id is absent, fall back to harness capabilities so that
-    // harness-provided tools (e.g. bash) are still registered.
-    let tool_registry = if let Some(agent_id) = input.agent_id {
-        adapters
-            .build_tool_registry(org_id, agent_id.uuid())
-            .await?
-    } else {
-        adapters
-            .build_tool_registry_for_harness(org_id, input.harness_id.uuid())
-            .await?
-    };
-
-    let event_emitter = AdapterEventEmitter::new(adapters.clone());
-    let file_store = Arc::new(AdapterSessionFileStore::new(adapters.clone()));
-    let session_store = Arc::new(AdapterSessionStore::new(adapters.clone(), org_id));
-    let session_mutator = Arc::new(AdapterSessionMutator::new(adapters.clone(), org_id));
-    let agent_store = Arc::new(AdapterAgentStore::new(adapters.clone(), org_id));
-
-    let mut atom = ActAtom::with_file_store(tool_registry, event_emitter, file_store)
-        .with_session_store(session_store)
-        .with_session_mutator(session_mutator)
-        .with_agent_store(agent_store);
-    atom = atom
-        .with_sqldb_store(adapters.sqldb_store())
-        .with_storage_store(adapters.storage_store())
-        .with_connection_resolver(adapters.connection_resolver())
-        .with_leased_resource_store(adapters.leased_resource_store())
-        .with_schedule_store(adapters.schedule_store(org_id))
-        .with_platform_store(adapters.platform_store(org_id));
-    if let Some(registry) = adapters.session_resource_registry() {
-        atom = atom.with_session_resource_registry(registry);
-    }
-
-    let result = atom.execute(input.clone()).await?;
+    let result =
+        runtime_execute_act_activity(&WorkerRuntimeHost::new(adapters.clone()), input.clone())
+            .await?;
 
     Ok(serde_json::to_value(&result)?)
 }
@@ -1008,8 +874,11 @@ async fn schedule_next_activity<S: WorkflowEventStore, A: WorkerAdapters + Clone
             } else {
                 // Turn truly complete. Emit turn event + session.idled + mark done.
                 let turn_id = input.turn_id.unwrap_or_default();
-                let lifecycle =
-                    SessionLifecycle::new(adapters.clone(), input.org_id, input.session_id);
+                let lifecycle = RuntimeSessionLifecycle::new(
+                    WorkerRuntimeHost::new(adapters.clone()),
+                    input.org_id,
+                    input.session_id,
+                );
 
                 if reason_result.success {
                     lifecycle

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -16,7 +16,9 @@ use everruns_core::error::Result;
 use everruns_core::events::{Event, EventRequest};
 use everruns_core::leased_resource::LeasedResource;
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
-use everruns_core::traits::{ImageResolver, LeasedResourceStore, ModelWithProvider, ResolvedImage};
+use everruns_core::traits::{
+    BudgetChecker, ImageResolver, LeasedResourceStore, ModelWithProvider, ResolvedImage,
+};
 use everruns_core::typed_id::{
     AgentId, HarnessId, LeasedResourceId, MessageId, ModelId, SessionId,
 };
@@ -289,6 +291,19 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
     /// Get the session schedule store for scheduling tools.
     /// Takes org_id so the store is scoped to the current session's organization.
     fn schedule_store(&self, org_id: i64) -> Arc<dyn everruns_core::traits::SessionScheduleStore>;
+
+    /// Get the budget checker for the current turn, if available.
+    ///
+    /// gRPC workers provide this through the control-plane API. Direct dev-mode
+    /// workers may return `None` until they are wired to the server budget
+    /// service.
+    fn budget_checker(
+        &self,
+        _org_id: i64,
+        _agent_id: Option<AgentId>,
+    ) -> Option<Arc<dyn BudgetChecker>> {
+        None
+    }
 
     /// Claim due leased resources for cleanup work.
     ///

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -68,7 +68,7 @@ Events are classified as **ephemeral** or **durable**:
    - `server/` → `everruns-server` - **Control plane**: HTTP API (axum) + gRPC server (tonic), SSE streaming, database layer
    - `worker/` → `everruns-worker` - TaskWorker, WorkerAdapters, activities, gRPC adapters, durable task execution
    - `core/` → `everruns-core` - Core agent abstractions (traits, atoms, tools, events, capabilities, LLM drivers, shared types)
-   - `runtime/` → `everruns-runtime` - Public in-process runtime for embedded execution without durable engine/server
+   - `runtime/` → `everruns-runtime` - Public in-process runtime plus reusable host-phase execution for embedded and durable/server-backed execution
    - `internal-protocol/` → `everruns-internal-protocol` - gRPC protocol for worker ↔ server
    - `durable/` → `everruns-durable` - PostgreSQL-backed durable execution engine
    - `openai/` → `everruns-openai` - OpenAI LLM provider implementation
@@ -162,6 +162,11 @@ process should use `everruns-runtime`.
 - in-memory session/filesystem/storage/message backends
 - turn execution via the shared core `TurnStateMachine`
 - direct seeding of harnesses, agents, sessions, and files
+- runtime-owned host phase execution (`execute_input_activity`, `execute_reason_activity`, `execute_act_activity`)
+
+`everruns-worker` provides the first-party adapter bridge from worker backends
+into that host contract via `WorkerRuntimeHost`, so both the in-process worker
+and external durable worker reuse the same runtime-owned atom wiring.
 
 See [specs/runtime.md](runtime.md) for the public embedded runtime contract.
 
@@ -238,6 +243,7 @@ Workers communicate with the control-plane via gRPC instead of direct database a
    - `GrpcMessageRetriever` - Implements `MessageRetriever` trait via gRPC
    - `GrpcAgentStore` - Implements `AgentStore` trait via gRPC
    - `GrpcSessionStore` - Implements `SessionStore` trait via gRPC
+   - `WorkerRuntimeHost` - Bridges worker adapters into `everruns-runtime` host execution
    - `GrpcLlmProviderStore` - Implements `LlmProviderStore` trait via gRPC
    - `GrpcSessionFileStore` - Implements `SessionFileStore` trait via gRPC
    - `GrpcEventEmitter` - Implements `EventEmitter` trait via gRPC

--- a/specs/runtime.md
+++ b/specs/runtime.md
@@ -2,12 +2,15 @@
 
 ## Abstract
 
-`everruns-runtime` is the public in-process execution crate for Everruns.
+`everruns-runtime` is the public execution crate for Everruns.
 
-It lets embedders run sessions inside their own process, without the durable
-execution engine, gRPC worker boundary, or control-plane server. The crate uses
-the same core atoms and capability resolution path as the worker so embedded
-execution stays behaviorally aligned with the main runtime.
+It lets embedders run sessions inside their own process without the durable
+execution engine, gRPC worker boundary, or control-plane server. It also owns
+the reusable host-phase execution contract that durable/server-backed workers
+use for `input -> reason -> act`.
+
+The crate uses the same core atoms and capability resolution path as the worker
+so embedded execution stays behaviorally aligned with the main runtime.
 
 ## Goals
 
@@ -19,6 +22,8 @@ execution stays behaviorally aligned with the main runtime.
    server internals.
 5. Preserve the core turn contract (`input -> reason -> act`) and event/message
    shapes used elsewhere in the system.
+6. Provide a supported host adapter contract so durable/server-backed execution
+   can reuse runtime-owned phase orchestration.
 
 ## Position in the Stack
 
@@ -27,9 +32,10 @@ execution stays behaviorally aligned with the main runtime.
 - `everruns-core` owns atoms, traits, capabilities, event types, and shared
   domain/runtime types.
 - `everruns-runtime` owns embedder-facing orchestration, in-memory stores, turn
-  execution, and runtime seeding helpers.
+  execution, runtime seeding helpers, and reusable host-phase execution.
 - `everruns-server` and `everruns-worker` remain control-plane and durable
-  execution hosts. They do not define the public in-process contract.
+  execution hosts. They use runtime-owned host execution but still own queueing,
+  retries, workflows, and process boundaries.
 
 ## Public Contract
 
@@ -61,6 +67,21 @@ The builder must allow an embedder to:
 - `read_file(session_id, path)` to inspect the in-memory workspace
 - `events()` to inspect emitted runtime events
 
+### Host execution responsibilities
+
+`everruns-runtime` must also expose a reusable host contract for durable or
+server-backed execution:
+
+- `RuntimeHostAdapter`
+- `RuntimeSessionLifecycle`
+- `execute_input_activity(...)`
+- `execute_reason_activity(...)`
+- `execute_act_activity(...)`
+
+These APIs own phase-local orchestration, atom wiring, dependency blocker
+handling, and lifecycle event emission for the host runtime. Durable scheduling
+and workflow management remain outside this contract.
+
 ## Execution Semantics
 
 `everruns-runtime` must execute the shared `TurnStateMachine` from `everruns-core`.
@@ -78,6 +99,9 @@ Required behavior:
 6. Persist assistant messages and tool-result messages from emitted events so
    subsequent turns see the same history shape as the durable/server-backed
    runtime.
+7. Durable/server-backed workers must execute their per-phase host logic
+   through `everruns-runtime` instead of maintaining a separate copy of atom
+   wiring in the worker crate.
 
 ## Shared Context Assembly
 
@@ -144,8 +168,10 @@ embedded runtime needs for:
 This keeps `everruns-core` storage traits read-oriented where they already were,
 while making custom embedded backends a supported public path.
 
-This first public contract still does not require full production-ready
-persistence adapters in-tree. It only defines the supported extension seam.
+`everruns-runtime` owns the public extension seam for embedder-supplied
+backends. `everruns-worker` ships the first-party durable/server-backed host
+adapter (`WorkerRuntimeHost`) that bridges worker storage/adapters into the
+runtime host contract.
 
 ## Context and Capabilities
 
@@ -176,25 +202,26 @@ configuration error.
 
 ## Non-goals
 
-This spec does not require:
+This spec does not require runtime to own:
 
 - durable workflows
 - cross-process task recovery
-- gRPC adapters
-- database-backed persistence
+- task queues or workflow schedulers
 - server route composition
-- full parity with every server-owned integration backend
 
-Those remain separate concerns.
+Those remain separate concerns outside the runtime host-phase contract.
 
 ## Source Index
 
 - `crates/runtime/src/lib.rs`
 - `crates/runtime/src/runtime.rs`
+- `crates/runtime/src/host.rs`
 - `crates/runtime/src/in_memory.rs`
 - `crates/runtime/examples/in_process_runtime.rs`
 - `crates/runtime/examples/inspect_context.rs`
 - `crates/runtime/tests/in_process_runtime_test.rs`
+- `crates/runtime/tests/runtime_host_test.rs`
+- `crates/worker/src/runtime_host.rs`
 - `crates/core/src/runtime_context.rs`
 - `crates/core/src/turn.rs`
 - `crates/core/src/platform_definition.rs`


### PR DESCRIPTION
## What
Move worker turn-phase execution onto `everruns-runtime` host orchestration.

## Why
The earlier runtime extraction still had two gaps:
- first-party durable/server-backed adapters were not shipped
- server/worker still wired `InputAtom`/`ReasonAtom`/`ActAtom` themselves instead of executing through the runtime crate

That left the public runtime contract incomplete and kept behavior drift risk in the worker host path.

## How
- added `crates/runtime/src/host.rs` with the public `RuntimeHostAdapter` contract, `RuntimeSessionLifecycle`, and shared `execute_input_activity`, `execute_reason_activity`, and `execute_act_activity` helpers
- added `WorkerRuntimeHost` in `everruns-worker` as the first-party adapter bridge from `WorkerAdapters` into the runtime host contract
- switched both worker execution paths to runtime-owned host execution:
  - gRPC activity wrappers now delegate to runtime helpers
  - `TaskWorker` now delegates to runtime helpers and runtime lifecycle handling
- filled the missing runtime-host surface for gRPC budget checks
- added runtime host tests and updated runtime/architecture specs to document the new contract and the remaining boundary: durable scheduling still stays outside `everruns-runtime`

## Risk
- Medium
- This changes the worker host path for input/reason/act execution. Regressions would show up as missing lifecycle events, broken tool registry construction, or store wiring mismatches in dev/prod worker execution.

## Security
- Threat categories reviewed: TM-TOOL, TM-LLM, TM-TENANT, TM-DOS
- Findings and resolutions:
  - Reviewed org-scoped store/budget/tool wiring to ensure runtime helpers continue to receive the same tenant-scoped adapters as before.
  - Reviewed tool registry construction and dependency blocker handling to ensure the worker still gates unavailable dependencies before tool or model execution.
  - No new auth, external input parsing, or secret-handling surface was introduced; this is an orchestration refactor over existing trusted paths.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `cargo test -p everruns-runtime -p everruns-worker`
- `cargo clippy -p everruns-runtime -p everruns-worker --all-targets --all-features -- -D warnings`
- `just pre-push`
- DEV smoke:
  - `PORT_PREFIX=279 just start-dev --no-watch`
  - authenticated against `/api/v1/auth/login`
  - created LlmSim provider/model, agent, session, and message via `http://127.0.0.1:27901/api`
  - observed `roles: ["user", "agent"]` and agent reply `"Hello! I'm a simulated LLM response."`
