### PR TITLE
chore(release): prepare v0.8.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.8.13] - 2026-04-15
+
+### Highlights
+
+- **Embedded Runtime** - Everruns can now run embedded in-process with shared turn context and shared host orchestration, which closes the gap between local runtime and worker execution ([#1304](https://github.com/everruns/everruns/pull/1304), [#1306](https://github.com/everruns/everruns/pull/1306), [#1309](https://github.com/everruns/everruns/pull/1309))
+- **Managed Session Sandboxes** - Session sandboxes now have an explicit managed lifecycle, which gives runtime-owned sandbox resources the same durability model as other session resources ([#1305](https://github.com/everruns/everruns/pull/1305))
+- **UI Flow Tightening** - List pages now hydrate on the server and the shell chrome got smaller cleanup passes around density, warnings, and notifications ([#1299](https://github.com/everruns/everruns/pull/1299), [#1300](https://github.com/everruns/everruns/pull/1300), [#1302](https://github.com/everruns/everruns/pull/1302), [#1303](https://github.com/everruns/everruns/pull/1303))
+
+### What's Changed
+
+- feat(runtime): share host orchestration with worker ([#1309](https://github.com/everruns/everruns/pull/1309))
+- feat(runtime): expose shared turn context ([#1306](https://github.com/everruns/everruns/pull/1306))
+- feat(session): add managed session sandbox lifecycle ([#1305](https://github.com/everruns/everruns/pull/1305))
+- feat(runtime): add embedded in-process runtime ([#1304](https://github.com/everruns/everruns/pull/1304))
+- fix(ui): move sidebar notifications into account menu ([#1303](https://github.com/everruns/everruns/pull/1303))
+- fix(core): advertise bash help in virtual bash ([#1301](https://github.com/everruns/everruns/pull/1301))
+- fix(ui): tighten app density ([#1302](https://github.com/everruns/everruns/pull/1302))
+- fix(ui): reuse settings warning notice ([#1300](https://github.com/everruns/everruns/pull/1300))
+- chore(specs): drop release migration notes ([#1298](https://github.com/everruns/everruns/pull/1298))
+- feat(ui): hydrate list pages on the server ([#1299](https://github.com/everruns/everruns/pull/1299))
+
 ## [0.8.12] - 2026-04-14
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "anyhow",
  "base64",
@@ -1590,14 +1590,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "async-trait",
  "base64",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1667,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1720,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1736,7 +1736,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "async-trait",
  "base64",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "async-trait",
  "base64",
@@ -1796,7 +1796,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "async-trait",
  "base64",
@@ -1811,7 +1811,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-pi"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1870,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1886,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -1903,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1932,11 +1932,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.8.12"
+version = "0.8.13"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1969,7 +1969,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2068,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.12"
+version = "0.8.13"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "everruns-ui",
-      "version": "0.8.12",
+      "version": "0.8.13",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@openuidev/react-lang": "^0.1.3",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "private": true,
   "exports": {
     "./providers/*": "./src/providers/*.tsx",


### PR DESCRIPTION
## What
Prepare the `0.8.13` patch release by updating workspace/UI versions, syncing lockfiles, and drafting the changelog from changes merged after `v0.8.12`.

## Why
Cut the next patch release from current `main` so the embedded runtime, managed session sandbox lifecycle, and recent UI fixes ship as an official tagged release.

## How
- bump release version to `0.8.13` in Rust workspace metadata and UI package metadata
- update `Cargo.lock` local package versions and refresh `apps/ui/package-lock.json`
- add the `0.8.13` changelog entry with highlights and commit links

## Risk
- Low
- Release metadata only; the main failure modes are incomplete release notes or inconsistent version metadata/lockfiles

## Security
- Threat categories reviewed: No security-relevant code changes
- Findings and resolutions: Release-only metadata update (`CHANGELOG.md`, package versions, lockfiles). No runtime, API, auth, persistence, or infrastructure behavior changed.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

## Validation
- `just pre-push`
- Skipped smoke test: release metadata only, no runtime behavior change
