### PR TITLE
feat(runtime): add durable-agnostic host planning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1954,6 +1954,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "everruns-core",
+ "serde",
  "serde_json",
  "tokio",
  "tracing",

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -13,6 +13,7 @@ description = "Public in-process runtime for embedding Everruns harnesses"
 [dependencies]
 async-trait.workspace = true
 chrono.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 tracing.workspace = true

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -145,13 +145,14 @@ pub struct RuntimeHostTurnContext {
 
 /// Public adapter contract for server-backed or durable runtime hosts.
 ///
-/// `everruns-runtime` owns the phase execution (`input -> reason -> act`).
-/// Host crates implement this trait to provide their own persistence,
-/// session-lifecycle plumbing, and tool registry construction.
+/// `everruns-runtime` owns shared host orchestration for both embedded and
+/// durable execution. That includes phase execution (`input -> reason -> act`),
+/// lifecycle emission, and the generic turn-strategy decisions used by durable
+/// or custom hosts.
 ///
-/// The durable scheduler still lives outside this crate. Hosts use this trait
-/// to delegate individual turn phases to `everruns-runtime`, while keeping
-/// queueing, retries, and workflow resumption in their own layer.
+/// Host crates implement this trait to provide persistence, session-lifecycle
+/// plumbing, event delivery, and their own orchestration backend. The durable
+/// engine itself remains outside this crate.
 #[async_trait]
 pub trait RuntimeHostAdapter: Send + Sync + Clone + 'static {
     async fn get_agent(

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -12,6 +12,7 @@
 //! - replace the default in-memory stores with custom runtime backends
 //! - inspect the assembled turn context before or after executing a turn
 //! - reuse runtime-owned host phase execution from durable or server-backed hosts
+//! - map `plan_next_host_turn(...)` onto their own queue, retry, or in-memory host
 //!
 //! For a runnable example, see:
 //!
@@ -137,6 +138,7 @@ mod backends;
 mod host;
 mod in_memory;
 mod runtime;
+mod turn_strategy;
 
 pub use backends::{
     RuntimeAgentStore, RuntimeBackends, RuntimeEventCollector, RuntimeFileStore,
@@ -149,3 +151,4 @@ pub use host::{
 };
 pub use in_memory::{InMemorySessionFileStore, InMemorySessionStorageStore, InMemorySessionStore};
 pub use runtime::{InProcessRuntime, InProcessRuntimeBuilder, TurnResult};
+pub use turn_strategy::{RuntimeActPlan, RuntimeTurnPlan, RuntimeTurnState, plan_next_host_turn};

--- a/crates/runtime/src/turn_strategy.rs
+++ b/crates/runtime/src/turn_strategy.rs
@@ -1,0 +1,245 @@
+// Shared turn-strategy planning for embedded, durable, and custom hosts.
+// Decision: everruns-runtime stays durable-agnostic and returns generic next-step plans.
+
+use crate::{RuntimeHostAdapter, RuntimeSessionLifecycle};
+use everruns_core::atoms::{ActInput, AtomContext};
+use everruns_core::error::{AgentLoopError, Result};
+use everruns_core::typed_id::{AgentId, ExecId, HarnessId, MessageId, SessionId, TurnId};
+use everruns_core::{Controls, ReasonResult};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info};
+
+/// Host-owned state carried across turn phases.
+///
+/// Durable hosts can persist this between activities; in-memory hosts can hold
+/// it directly in memory. The type itself is runtime-level and has no durable
+/// engine coupling.
+///
+/// Hosts are expected to serialize this however they want. `everruns-runtime`
+/// only defines the fields required to resume the next semantic step.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuntimeTurnState {
+    pub org_id: i64,
+    pub session_id: SessionId,
+    pub harness_id: HarnessId,
+    pub agent_id: Option<AgentId>,
+    pub input_message_id: MessageId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<TurnId>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub previous_response_id: Option<String>,
+    #[serde(default = "default_iteration")]
+    pub iteration: u32,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub request_id: Option<String>,
+}
+
+fn default_iteration() -> u32 {
+    1
+}
+
+/// Runtime-owned act scheduling payload.
+///
+/// Hosts enqueue or execute this immediately using their own worker model.
+#[derive(Debug, Clone)]
+pub struct RuntimeActPlan {
+    pub input: ActInput,
+    pub previous_response_id: Option<String>,
+    pub iteration: u32,
+    pub request_id: Option<String>,
+}
+
+/// Generic next-step decision for a host turn.
+///
+/// This intentionally stops at the semantic boundary:
+/// - runtime decides what should happen next
+/// - the host decides how to persist, enqueue, retry, or resume it
+#[derive(Debug, Clone)]
+pub enum RuntimeTurnPlan {
+    ScheduleReason(RuntimeTurnState),
+    ScheduleAct(RuntimeActPlan),
+    Complete { error: Option<String> },
+    WaitForToolResults { resume: RuntimeTurnState },
+}
+
+/// Determine the next host step after an activity finishes.
+///
+/// The host provides:
+/// - `completed_activity`: which phase just finished
+/// - `state`: host-carried turn state
+/// - `output`: serialized activity output
+/// - `pending_user_message_count`: number of queued steering messages already consumed by the host
+///
+/// Runtime owns the semantic decision. Hosts translate the returned plan into
+/// their own queueing / persistence model.
+///
+/// Typical host mapping:
+/// - `ScheduleReason` => enqueue or invoke a reason phase with the returned state
+/// - `ScheduleAct` => enqueue or invoke an act phase with the returned payload
+/// - `WaitForToolResults` => persist the resume state until external tool input arrives
+/// - `Complete` => mark the host-owned workflow/session turn complete
+pub async fn plan_next_host_turn<A: RuntimeHostAdapter>(
+    adapter: &A,
+    completed_activity: &str,
+    state: &RuntimeTurnState,
+    output: &serde_json::Value,
+    pending_user_message_count: usize,
+) -> Result<RuntimeTurnPlan> {
+    match completed_activity {
+        "process_input" => {
+            let turn_id: Option<TurnId> = output
+                .get("turn_id")
+                .and_then(|value| value.as_str())
+                .and_then(|value| value.parse().ok());
+            let next = RuntimeTurnState {
+                turn_id,
+                previous_response_id: None,
+                iteration: 1,
+                ..state.clone()
+            };
+            debug!(session_id = %state.session_id, turn_id = ?turn_id, "planned reason step");
+            Ok(RuntimeTurnPlan::ScheduleReason(next))
+        }
+        "reason" => {
+            let reason_result: ReasonResult = serde_json::from_value(output.clone())
+                .map_err(|error| AgentLoopError::Internal(error.into()))?;
+            let response_id = reason_result.response_id.clone();
+
+            if reason_result.has_tool_calls && reason_result.success {
+                let plan = RuntimeActPlan {
+                    input: ActInput {
+                        org_id: Some(state.org_id),
+                        context: AtomContext {
+                            session_id: state.session_id,
+                            turn_id: state.turn_id.unwrap_or_default(),
+                            input_message_id: state.input_message_id,
+                            exec_id: ExecId::new(),
+                        },
+                        harness_id: state.harness_id,
+                        agent_id: state.agent_id,
+                        tool_calls: reason_result.tool_calls,
+                        tool_definitions: reason_result.tool_definitions,
+                        locale: reason_result.locale,
+                        blueprint_id: None,
+                        network_access: reason_result.network_access,
+                    },
+                    previous_response_id: response_id,
+                    iteration: state.iteration,
+                    request_id: state.request_id.clone(),
+                };
+                return Ok(RuntimeTurnPlan::ScheduleAct(plan));
+            }
+
+            if reason_result.success && pending_user_message_count > 0 {
+                if pending_user_message_count > 1 {
+                    info!(
+                        session_id = %state.session_id,
+                        pending_user_message_count,
+                        "multiple steering messages arrived during turn"
+                    );
+                }
+
+                let next = RuntimeTurnState {
+                    previous_response_id: response_id,
+                    iteration: state.iteration.saturating_add(1),
+                    ..state.clone()
+                };
+                return Ok(RuntimeTurnPlan::ScheduleReason(next));
+            }
+
+            let lifecycle =
+                RuntimeSessionLifecycle::new(adapter.clone(), state.org_id, state.session_id);
+            let turn_id = state.turn_id.unwrap_or_default();
+
+            if reason_result.success {
+                lifecycle
+                    .emit_turn_completed(
+                        turn_id,
+                        state.input_message_id,
+                        state.iteration,
+                        reason_result.usage.clone(),
+                        None,
+                    )
+                    .await;
+                lifecycle
+                    .emit_session_idled(
+                        turn_id,
+                        state.input_message_id,
+                        Some(state.iteration),
+                        reason_result.usage.clone(),
+                    )
+                    .await;
+            } else {
+                lifecycle
+                    .turn_failed(
+                        turn_id,
+                        state.input_message_id,
+                        "An error occurred while processing your request.",
+                        Some("llm_error"),
+                    )
+                    .await;
+            }
+
+            Ok(RuntimeTurnPlan::Complete {
+                error: reason_result.error,
+            })
+        }
+        "act" => {
+            if output
+                .get("blocked")
+                .and_then(|value| value.as_bool())
+                .unwrap_or(false)
+            {
+                return Ok(RuntimeTurnPlan::Complete { error: None });
+            }
+
+            let waiting_for_tool_results = output
+                .get("waiting_for_tool_results")
+                .and_then(|value| value.as_bool())
+                .unwrap_or(false);
+            let should_pause_for_tool_results = waiting_for_tool_results
+                && setup_connection_hint_enabled(adapter, state.org_id, state.session_id).await;
+
+            let next = RuntimeTurnState {
+                iteration: state.iteration.saturating_add(1),
+                ..state.clone()
+            };
+
+            if should_pause_for_tool_results {
+                let lifecycle =
+                    RuntimeSessionLifecycle::new(adapter.clone(), state.org_id, state.session_id);
+                lifecycle.waiting_for_tool_results().await;
+                return Ok(RuntimeTurnPlan::WaitForToolResults { resume: next });
+            }
+
+            if waiting_for_tool_results {
+                info!(
+                    session_id = %state.session_id,
+                    "setup_connection hint absent, continuing turn instead of pausing"
+                );
+            }
+
+            Ok(RuntimeTurnPlan::ScheduleReason(next))
+        }
+        other => Err(AgentLoopError::config(format!(
+            "Unknown activity type completed: {other}"
+        ))),
+    }
+}
+
+async fn setup_connection_hint_enabled<A: RuntimeHostAdapter>(
+    adapter: &A,
+    org_id: i64,
+    session_id: SessionId,
+) -> bool {
+    match adapter.session_store(org_id).get_session(session_id).await {
+        Ok(Some(session)) => {
+            let hints = Controls::resolve_hints(session.hints.as_ref(), None);
+            hints
+                .get("setup_connection")
+                .and_then(|value| value.as_bool())
+                .unwrap_or(false)
+        }
+        _ => false,
+    }
+}

--- a/crates/runtime/tests/runtime_host_test.rs
+++ b/crates/runtime/tests/runtime_host_test.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use chrono::Utc;
 use everruns_core::MessageRetriever;
+use everruns_core::atoms::ReasonResult;
 use everruns_core::atoms::{ActInput, AtomContext, InputAtomInput};
 use everruns_core::capabilities::{
     MemoryCapability, SystemPromptContext, TestMathCapability, collect_capabilities_with_configs,
@@ -22,7 +23,8 @@ use everruns_core::{
 };
 use everruns_runtime::{
     InMemorySessionFileStore, RuntimeHostAdapter, RuntimeHostTurnContext, RuntimeSessionLifecycle,
-    execute_act_activity, execute_input_activity,
+    RuntimeTurnPlan, RuntimeTurnState, execute_act_activity, execute_input_activity,
+    plan_next_host_turn,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -294,6 +296,20 @@ fn session(session_id: SessionId, harness_id: HarnessId) -> Session {
     }
 }
 
+fn turn_state(session_id: SessionId, harness_id: HarnessId) -> RuntimeTurnState {
+    RuntimeTurnState {
+        org_id: 1,
+        session_id,
+        harness_id,
+        agent_id: None,
+        input_message_id: MessageId::from_uuid(Uuid::now_v7()),
+        turn_id: Some(TurnId::from_uuid(Uuid::now_v7())),
+        previous_response_id: None,
+        iteration: 1,
+        request_id: None,
+    }
+}
+
 fn mock_host() -> MockHostAdapter {
     let mut capability_registry = CapabilityRegistry::new();
     capability_registry.register(TestMathCapability);
@@ -503,4 +519,164 @@ async fn lifecycle_helper_sets_waiting_for_tool_results_status() {
         .unwrap()
         .unwrap();
     assert_eq!(session.status, SessionStatus::WaitingForToolResults);
+}
+
+#[tokio::test]
+async fn plan_next_host_turn_schedules_reason_after_process_input() {
+    let adapter = mock_host();
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    adapter.harness_store.add_harness(harness(harness_id)).await;
+    adapter
+        .session_store
+        .insert(session(session_id, harness_id))
+        .await;
+
+    let input = turn_state(session_id, harness_id);
+    let turn_id = TurnId::from_uuid(Uuid::now_v7());
+    let output = serde_json::json!({ "turn_id": turn_id.to_string() });
+
+    let plan = plan_next_host_turn(&adapter, "process_input", &input, &output, 0)
+        .await
+        .unwrap();
+
+    match plan {
+        RuntimeTurnPlan::ScheduleReason(next) => {
+            assert_eq!(next.session_id, session_id);
+            assert_eq!(next.harness_id, harness_id);
+            assert_eq!(next.turn_id, Some(turn_id));
+            assert_eq!(next.iteration, 1);
+            assert_eq!(next.previous_response_id, None);
+        }
+        other => panic!("expected ScheduleReason, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn plan_next_host_turn_schedules_act_after_reason_tool_calls() {
+    let adapter = mock_host();
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    adapter.harness_store.add_harness(harness(harness_id)).await;
+    adapter
+        .session_store
+        .insert(session(session_id, harness_id))
+        .await;
+
+    let input = turn_state(session_id, harness_id);
+    let output = serde_json::to_value(ReasonResult {
+        success: true,
+        text: "Calling a tool".into(),
+        tool_calls: vec![ToolCall {
+            id: "call_mul".into(),
+            name: "multiply".into(),
+            arguments: serde_json::json!({ "a": 6, "b": 7 }),
+        }],
+        has_tool_calls: true,
+        tool_definitions: vec![],
+        max_iterations: 8,
+        error: None,
+        usage: None,
+        response_id: Some("resp_123".into()),
+        locale: Some("en-US".into()),
+        network_access: None,
+    })
+    .unwrap();
+
+    let plan = plan_next_host_turn(&adapter, "reason", &input, &output, 0)
+        .await
+        .unwrap();
+
+    match plan {
+        RuntimeTurnPlan::ScheduleAct(plan) => {
+            assert_eq!(plan.input.context.session_id, session_id);
+            assert_eq!(plan.input.context.turn_id, input.turn_id.unwrap());
+            assert_eq!(plan.input.harness_id, harness_id);
+            assert_eq!(plan.iteration, 1);
+            assert_eq!(plan.previous_response_id.as_deref(), Some("resp_123"));
+            assert_eq!(plan.input.tool_calls.len(), 1);
+        }
+        other => panic!("expected ScheduleAct, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn plan_next_host_turn_continues_reason_when_steering_messages_are_pending() {
+    let adapter = mock_host();
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    adapter.harness_store.add_harness(harness(harness_id)).await;
+    adapter
+        .session_store
+        .insert(session(session_id, harness_id))
+        .await;
+
+    let input = turn_state(session_id, harness_id);
+    let output = serde_json::to_value(ReasonResult {
+        success: true,
+        text: "Continuing".into(),
+        tool_calls: vec![],
+        has_tool_calls: false,
+        tool_definitions: vec![],
+        max_iterations: 8,
+        error: None,
+        usage: None,
+        response_id: Some("resp_steer".into()),
+        locale: None,
+        network_access: None,
+    })
+    .unwrap();
+
+    let plan = plan_next_host_turn(&adapter, "reason", &input, &output, 2)
+        .await
+        .unwrap();
+
+    match plan {
+        RuntimeTurnPlan::ScheduleReason(next) => {
+            assert_eq!(next.iteration, 2);
+            assert_eq!(next.previous_response_id.as_deref(), Some("resp_steer"));
+            assert_eq!(next.turn_id, input.turn_id);
+        }
+        other => panic!("expected ScheduleReason, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn plan_next_host_turn_waits_for_tool_results_when_session_hint_requests_it() {
+    let adapter = mock_host();
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    adapter.harness_store.add_harness(harness(harness_id)).await;
+
+    let mut host_session = session(session_id, harness_id);
+    host_session.hints = Some(std::collections::HashMap::from([(
+        "setup_connection".to_string(),
+        serde_json::json!(true),
+    )]));
+    adapter.session_store.insert(host_session).await;
+
+    let input = turn_state(session_id, harness_id);
+    let output = serde_json::json!({
+        "waiting_for_tool_results": true,
+        "blocked": false
+    });
+
+    let plan = plan_next_host_turn(&adapter, "act", &input, &output, 0)
+        .await
+        .unwrap();
+
+    match plan {
+        RuntimeTurnPlan::WaitForToolResults { resume } => {
+            assert_eq!(resume.iteration, 2);
+            assert_eq!(resume.turn_id, input.turn_id);
+            let session = adapter
+                .session_store
+                .get_session(session_id)
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(session.status, SessionStatus::WaitingForToolResults);
+        }
+        other => panic!("expected WaitForToolResults, got {other:?}"),
+    }
 }

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -1288,6 +1288,7 @@ impl ServerAppBuilder {
                     platform_definition.driver_registry().clone(),
                     sqldb_store.clone(),
                 )
+                .with_budget_service(budget_service.clone())
                 .with_virtual_registry(virtual_registry.clone())
                 .with_storage_store(session_storage_store)
                 .with_runner(runner.clone());

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -7,6 +7,7 @@
 // but with direct access to the storage backend and services.
 
 use async_trait::async_trait;
+use everruns_core::budget::{BudgetSummary, BudgetToolResponse};
 use everruns_core::capabilities::{
     AgentCapabilityConfig, CapabilityRegistry, SystemPromptContext, collect_capabilities,
     is_mcp_capability,
@@ -14,7 +15,7 @@ use everruns_core::capabilities::{
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::events::{Event, EventRequest};
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
-use everruns_core::traits::{ModelWithProvider, ResolvedImage};
+use everruns_core::traits::{BudgetChecker, ModelWithProvider, ResolvedImage};
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId};
 use everruns_core::{
     Agent, AgentStatus, Caller, ContentPart, DriverRegistry, EventData, Harness, HarnessStatus,
@@ -28,7 +29,7 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::org_init::BASE_HARNESS_ID;
-use crate::services::{EventService, LlmResolverService, McpServerService};
+use crate::services::{BudgetService, EventService, LlmResolverService, McpServerService};
 use crate::storage::StorageBackend;
 use crate::storage::models::{AgentCapabilityRow, AgentRow, UpdateSession};
 
@@ -49,6 +50,104 @@ fn name_from_path(path: &str) -> String {
         .to_string()
 }
 
+struct DirectBudgetChecker {
+    db: Arc<StorageBackend>,
+    budget_service: Arc<BudgetService>,
+    org_id: i64,
+    agent_id: Option<String>,
+}
+
+#[async_trait]
+impl BudgetChecker for DirectBudgetChecker {
+    async fn check_budgets(&self, session_id: &str) -> Result<BudgetToolResponse> {
+        let session_budgets = self
+            .db
+            .list_budgets(self.org_id, Some("session"), Some(session_id))
+            .await
+            .map_err(|e| store_error(format!("Failed to list session budgets: {e}")))?;
+
+        let mut all_budgets = session_budgets;
+        if let Some(agent_id) = self.agent_id.as_deref() {
+            match self
+                .db
+                .list_budgets(self.org_id, Some("agent"), Some(agent_id))
+                .await
+            {
+                Ok(agent_budgets) => all_budgets.extend(agent_budgets),
+                Err(error) => {
+                    tracing::error!(agent_id, error = %error, "Failed to list agent budgets");
+                }
+            }
+        }
+
+        if all_budgets.is_empty() {
+            return Ok(BudgetToolResponse {
+                status: "no_budgets".to_string(),
+                budgets: vec![],
+                hint: Some(
+                    "No budgets are configured for this session. You can proceed without budget constraints.".to_string(),
+                ),
+            });
+        }
+
+        let check = self
+            .budget_service
+            .check_budgets_for_session(self.org_id, session_id, self.agent_id.as_deref())
+            .await;
+
+        let budgets = all_budgets
+            .into_iter()
+            .map(|budget| {
+                let percent_remaining = if budget.limit > 0.0 {
+                    (budget.balance / budget.limit * 100.0).clamp(0.0, 100.0)
+                } else {
+                    100.0
+                };
+
+                BudgetSummary {
+                    currency: budget.currency,
+                    limit: budget.limit,
+                    balance: budget.balance,
+                    soft_limit: budget.soft_limit,
+                    percent_remaining: (percent_remaining * 10.0).round() / 10.0,
+                    status: budget.status,
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let status = match check.action.as_str() {
+            "stop" => "exhausted",
+            "pause" => "paused",
+            "warn" => "warning",
+            _ => "active",
+        }
+        .to_string();
+
+        let hint = if status == "active" {
+            let min_pct = budgets
+                .iter()
+                .map(|budget| budget.percent_remaining)
+                .min_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+                .unwrap_or(100.0);
+            if min_pct < 50.0 {
+                Some(format!(
+                    "{min_pct}% of budget remaining. Consider prioritizing task completion."
+                ))
+            } else {
+                Some(format!("{min_pct}% of budget remaining."))
+            }
+        } else {
+            check.message.clone()
+        };
+
+        Ok(BudgetToolResponse {
+            status,
+            budgets,
+            hint,
+        })
+    }
+}
+
 // =============================================================================
 // DirectWorkerAdapters Implementation
 // =============================================================================
@@ -58,6 +157,7 @@ fn name_from_path(path: &str) -> String {
 pub struct DirectWorkerAdapters {
     db: Arc<StorageBackend>,
     event_service: Arc<EventService>,
+    budget_service: Option<Arc<BudgetService>>,
     llm_resolver: Arc<LlmResolverService>,
     mcp_server_service: Arc<McpServerService>,
     capability_registry: CapabilityRegistry,
@@ -83,6 +183,7 @@ impl DirectWorkerAdapters {
         Self {
             db,
             event_service,
+            budget_service: None,
             llm_resolver,
             mcp_server_service,
             capability_registry,
@@ -98,6 +199,12 @@ impl DirectWorkerAdapters {
     /// Set the agent runner for platform management tools (send_message, etc.)
     pub fn with_runner(mut self, runner: Arc<dyn everruns_worker::AgentRunner>) -> Self {
         self.runner = Some(runner);
+        self
+    }
+
+    /// Set the budget service for in-process budget tool parity.
+    pub fn with_budget_service(mut self, service: Arc<BudgetService>) -> Self {
+        self.budget_service = Some(service);
         self
     }
 
@@ -1058,6 +1165,21 @@ impl WorkerAdapters for DirectWorkerAdapters {
             self.db.clone(),
             org_id,
         ))
+    }
+
+    fn budget_checker(
+        &self,
+        org_id: i64,
+        agent_id: Option<AgentId>,
+    ) -> Option<Arc<dyn BudgetChecker>> {
+        self.budget_service.as_ref().map(|budget_service| {
+            Arc::new(DirectBudgetChecker {
+                db: self.db.clone(),
+                budget_service: budget_service.clone(),
+                org_id,
+                agent_id: agent_id.map(|id| id.to_string()),
+            }) as Arc<dyn BudgetChecker>
+        })
     }
 
     fn platform_store(&self, org_id: i64) -> Arc<dyn everruns_core::platform_store::PlatformStore> {
@@ -2567,6 +2689,39 @@ mod tests {
             driver_registry,
             sqldb_store,
         )
+    }
+
+    fn test_adapters_with_budget_service() -> DirectWorkerAdapters {
+        let adapters = test_adapters();
+        let budget_service = Arc::new(crate::services::BudgetService::new(adapters.db.clone()));
+        adapters.with_budget_service(budget_service)
+    }
+
+    #[tokio::test]
+    async fn budget_checker_is_absent_without_service() {
+        let adapters = test_adapters();
+        assert!(
+            adapters
+                .budget_checker(everruns_core::DEFAULT_ORG_ID, None)
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn budget_checker_returns_no_budgets_without_rows() {
+        let adapters = test_adapters_with_budget_service();
+        let checker = adapters
+            .budget_checker(everruns_core::DEFAULT_ORG_ID, None)
+            .expect("budget checker should be wired");
+
+        let response = checker
+            .check_budgets("session_test_budget")
+            .await
+            .expect("budget check should succeed");
+
+        assert_eq!(response.status, "no_budgets");
+        assert!(response.budgets.is_empty());
+        assert!(response.hint.is_some());
     }
 
     /// Seed an MCP server with an optional encrypted API key. Returns server UUID.

--- a/crates/worker/src/durable_runner.rs
+++ b/crates/worker/src/durable_runner.rs
@@ -1,75 +1,31 @@
-// Durable execution engine runner
-// Decision: Use custom PostgreSQL-backed durable engine for workflow orchestration
-// Decision: AgentRunner interface for clean abstraction
-// Decision: Workers communicate with control-plane via gRPC (no direct DB access)
-// Decision: Control-plane uses direct database access (PostgresWorkflowEventStore)
+// Durable execution engine runner adapters.
+// Decision: everruns-worker owns durable orchestration and maps runtime turn state onto the durable engine.
+// Decision: everruns-runtime remains durable-agnostic and only exports generic turn strategy/state.
 
 use anyhow::Result;
 use async_trait::async_trait;
-use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
-use serde::{Deserialize, Serialize};
+use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId};
+use everruns_durable::{
+    InMemoryWorkflowEventStore, PostgresWorkflowEventStore, WorkflowEvent, WorkflowEventStore,
+    WorkflowSignal, WorkflowStatus,
+};
+pub use everruns_runtime::RuntimeTurnState as DurableTurnInput;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::info;
 use uuid::Uuid;
 
-use crate::grpc_durable_store::{GrpcDurableStore, WorkflowStatus};
+use crate::grpc_durable_store::{GrpcDurableStore, WorkflowStatus as GrpcWorkflowStatus};
 use crate::runner::AgentRunner;
-use everruns_durable::{
-    ActivityOptions, InMemoryWorkflowEventStore, PostgresWorkflowEventStore, WorkflowEvent,
-    WorkflowEventStore,
-};
 
-// =============================================================================
-// TurnWorkflow Input/Output
-// =============================================================================
-
-/// Input for the turn workflow
-///
-/// The turn_id is created by the input activity and propagated to subsequent
-/// activities (reason, act) to ensure all events share the same turn context
-/// for proper trace correlation in observability tools like Braintrust.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DurableTurnInput {
-    pub org_id: i64,
-    pub session_id: SessionId,
-    pub harness_id: HarnessId,
-    pub agent_id: Option<AgentId>,
-    pub input_message_id: MessageId,
-    /// Turn ID for trace correlation. Created by input activity, propagated to reason/act.
-    /// Uses typed TurnId for type safety and consistent prefixed format.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub turn_id: Option<TurnId>,
-    /// Previous LLM response ID for stateful continuation across reason iterations.
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub previous_response_id: Option<String>,
-    /// Current iteration number within this turn (1-based).
-    /// Incremented each time a new reason activity is scheduled after act.
-    #[serde(default = "default_iteration")]
-    pub iteration: u32,
-    /// HTTP request ID that triggered this turn. Propagated for log correlation.
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub request_id: Option<String>,
-}
-
-fn default_iteration() -> u32 {
-    1
-}
-
-/// Output from the turn workflow
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Output metadata for durable turns.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DurableTurnOutput {
     pub session_id: SessionId,
     pub success: bool,
     pub error: Option<String>,
 }
 
-// =============================================================================
-// DurableStoreBackend Trait
-// =============================================================================
-
-/// Backend trait for durable store operations
-/// Allows switching between gRPC (for workers) and direct DB (for control-plane)
 #[async_trait]
 pub trait DurableStoreBackend: Send + Sync {
     async fn get_workflow_status(
@@ -102,10 +58,8 @@ pub trait DurableStoreBackend: Send + Sync {
 
     async fn count_active_workflows(&mut self) -> Result<usize>;
 
-    /// Cancel all pending (unclaimed) tasks for a workflow.
     async fn cancel_pending_tasks(&mut self, workflow_id: Uuid) -> Result<u64>;
 
-    /// Append workflow events (for event sourcing)
     async fn append_events(
         &mut self,
         workflow_id: Uuid,
@@ -113,30 +67,52 @@ pub trait DurableStoreBackend: Send + Sync {
         events: Vec<WorkflowEvent>,
     ) -> Result<i32>;
 
-    /// Atomically try to claim a workflow for a new turn.
-    /// Transitions the workflow from terminal/pending → Running.
-    /// Returns Ok(true) if claimed, Ok(false) if workflow is Running (active turn).
-    /// This provides database-level atomicity for horizontal scaling.
     async fn try_claim_workflow_for_new_turn(&mut self, workflow_id: Uuid) -> Result<bool>;
 
-    /// Send a signal to a running workflow (e.g. user_message steering signal).
-    async fn send_signal(
-        &mut self,
-        workflow_id: Uuid,
-        signal: everruns_durable::WorkflowSignal,
-    ) -> Result<()>;
+    async fn send_signal(&mut self, workflow_id: Uuid, signal: WorkflowSignal) -> Result<()>;
 
-    /// Get and consume all pending signals for a workflow.
-    /// Returns the signals and marks them as processed atomically.
-    async fn get_and_consume_signals(
-        &mut self,
-        workflow_id: Uuid,
-    ) -> Result<Vec<everruns_durable::WorkflowSignal>>;
+    async fn get_and_consume_signals(&mut self, workflow_id: Uuid) -> Result<Vec<WorkflowSignal>>;
 }
 
-// =============================================================================
-// GrpcDurableStore Backend Implementation
-// =============================================================================
+/// Direct database store for control-plane use.
+pub struct DirectDurableStore {
+    store: PostgresWorkflowEventStore,
+}
+
+impl DirectDurableStore {
+    pub fn new(pool: sqlx::PgPool) -> Self {
+        Self {
+            store: PostgresWorkflowEventStore::new(pool),
+        }
+    }
+}
+
+/// In-memory store for dev mode (no PostgreSQL required).
+pub struct InMemoryDurableStore {
+    store: Arc<InMemoryWorkflowEventStore>,
+}
+
+impl InMemoryDurableStore {
+    pub fn new() -> Self {
+        Self {
+            store: Arc::new(InMemoryWorkflowEventStore::new()),
+        }
+    }
+
+    pub fn from_shared(store: Arc<InMemoryWorkflowEventStore>) -> Self {
+        Self { store }
+    }
+
+    pub fn store(&self) -> Arc<InMemoryWorkflowEventStore> {
+        Arc::clone(&self.store)
+    }
+}
+
+impl Default for InMemoryDurableStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[async_trait]
 impl DurableStoreBackend for GrpcDurableStore {
@@ -144,7 +120,9 @@ impl DurableStoreBackend for GrpcDurableStore {
         &mut self,
         workflow_id: Uuid,
     ) -> Result<(WorkflowStatus, Option<serde_json::Value>, Option<String>)> {
-        GrpcDurableStore::get_workflow_status(self, workflow_id).await
+        let (status, output, error) =
+            GrpcDurableStore::get_workflow_status(self, workflow_id).await?;
+        Ok((grpc_to_runtime_status(status), output, error))
     }
 
     async fn create_workflow(
@@ -163,7 +141,14 @@ impl DurableStoreBackend for GrpcDurableStore {
         output: Option<serde_json::Value>,
         error: Option<String>,
     ) -> Result<()> {
-        GrpcDurableStore::update_workflow_status(self, workflow_id, status, output, error).await
+        GrpcDurableStore::update_workflow_status(
+            self,
+            workflow_id,
+            runtime_to_grpc_status(status),
+            output,
+            error,
+        )
+        .await
     }
 
     async fn enqueue_task(
@@ -180,14 +165,7 @@ impl DurableStoreBackend for GrpcDurableStore {
         GrpcDurableStore::count_active_workflows(self).await
     }
 
-    async fn try_claim_workflow_for_new_turn(&mut self, _workflow_id: Uuid) -> Result<bool> {
-        // gRPC workers don't call start_run — only the control-plane does.
-        Ok(false)
-    }
-
     async fn cancel_pending_tasks(&mut self, _workflow_id: Uuid) -> Result<u64> {
-        // gRPC workers don't call start_run — only the control-plane does.
-        // If this is ever needed, add a CancelPendingTasks gRPC method.
         Ok(0)
     }
 
@@ -197,41 +175,19 @@ impl DurableStoreBackend for GrpcDurableStore {
         _expected_sequence: i32,
         _events: Vec<WorkflowEvent>,
     ) -> Result<i32> {
-        // gRPC mode doesn't support append_events directly yet
-        // Events are appended by the control-plane
         Ok(0)
     }
 
-    async fn send_signal(
-        &mut self,
-        workflow_id: Uuid,
-        signal: everruns_durable::WorkflowSignal,
-    ) -> Result<()> {
+    async fn try_claim_workflow_for_new_turn(&mut self, _workflow_id: Uuid) -> Result<bool> {
+        Ok(false)
+    }
+
+    async fn send_signal(&mut self, workflow_id: Uuid, signal: WorkflowSignal) -> Result<()> {
         GrpcDurableStore::send_signal(self, workflow_id, signal).await
     }
 
-    async fn get_and_consume_signals(
-        &mut self,
-        workflow_id: Uuid,
-    ) -> Result<Vec<everruns_durable::WorkflowSignal>> {
+    async fn get_and_consume_signals(&mut self, workflow_id: Uuid) -> Result<Vec<WorkflowSignal>> {
         GrpcDurableStore::get_and_consume_signals(self, workflow_id).await
-    }
-}
-
-// =============================================================================
-// DirectDurableStore - wraps PostgresWorkflowEventStore for control-plane use
-// =============================================================================
-
-/// Direct database store for control-plane use
-pub struct DirectDurableStore {
-    store: PostgresWorkflowEventStore,
-}
-
-impl DirectDurableStore {
-    pub fn new(pool: sqlx::PgPool) -> Self {
-        Self {
-            store: PostgresWorkflowEventStore::new(pool),
-        }
     }
 }
 
@@ -243,9 +199,9 @@ impl DurableStoreBackend for DirectDurableStore {
     ) -> Result<(WorkflowStatus, Option<serde_json::Value>, Option<String>)> {
         let info = self.store.get_workflow_info(workflow_id).await?;
         Ok((
-            durable_to_local_status(info.status),
+            info.status,
             info.result,
-            info.error.map(|e| format!("{:?}", e)),
+            info.error.map(|error| format!("{error:?}")),
         ))
     }
 
@@ -268,10 +224,13 @@ impl DurableStoreBackend for DirectDurableStore {
         output: Option<serde_json::Value>,
         error: Option<String>,
     ) -> Result<()> {
-        let durable_status = local_to_durable_status(status);
-        let durable_error = error.map(everruns_durable::WorkflowError::new);
         self.store
-            .update_workflow_status(workflow_id, durable_status, output, durable_error)
+            .update_workflow_status(
+                workflow_id,
+                status,
+                output,
+                error.map(everruns_durable::WorkflowError::new),
+            )
             .await?;
         Ok(())
     }
@@ -283,28 +242,23 @@ impl DurableStoreBackend for DirectDurableStore {
         activity_type: String,
         input: serde_json::Value,
     ) -> Result<Uuid> {
-        let task = everruns_durable::TaskDefinition {
-            workflow_id: Some(workflow_id),
-            activity_id,
-            activity_type,
-            input,
-            options: everruns_durable::ActivityOptions::default(),
-        };
-        self.store.enqueue_task(task).await.map_err(Into::into)
+        self.store
+            .enqueue_task(everruns_durable::TaskDefinition {
+                workflow_id: Some(workflow_id),
+                activity_id,
+                activity_type,
+                input,
+                options: Default::default(),
+            })
+            .await
+            .map_err(Into::into)
     }
 
     async fn count_active_workflows(&mut self) -> Result<usize> {
         self.store
             .count_active_workflows()
             .await
-            .map(|c| c as usize)
-            .map_err(Into::into)
-    }
-
-    async fn try_claim_workflow_for_new_turn(&mut self, workflow_id: Uuid) -> Result<bool> {
-        self.store
-            .try_claim_workflow_for_new_turn(workflow_id)
-            .await
+            .map(|count| count as usize)
             .map_err(Into::into)
     }
 
@@ -327,57 +281,25 @@ impl DurableStoreBackend for DirectDurableStore {
             .map_err(Into::into)
     }
 
-    async fn send_signal(
-        &mut self,
-        workflow_id: Uuid,
-        signal: everruns_durable::WorkflowSignal,
-    ) -> Result<()> {
+    async fn try_claim_workflow_for_new_turn(&mut self, workflow_id: Uuid) -> Result<bool> {
+        self.store
+            .try_claim_workflow_for_new_turn(workflow_id)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn send_signal(&mut self, workflow_id: Uuid, signal: WorkflowSignal) -> Result<()> {
         self.store
             .send_signal(workflow_id, signal)
             .await
             .map_err(Into::into)
     }
 
-    async fn get_and_consume_signals(
-        &mut self,
-        workflow_id: Uuid,
-    ) -> Result<Vec<everruns_durable::WorkflowSignal>> {
-        let signals = self.store.consume_pending_signals(workflow_id).await?;
-        Ok(signals)
-    }
-}
-
-// =============================================================================
-// InMemoryDurableStore - wraps InMemoryWorkflowEventStore for dev mode
-// =============================================================================
-
-/// In-memory store for dev mode (no PostgreSQL required)
-pub struct InMemoryDurableStore {
-    store: Arc<InMemoryWorkflowEventStore>,
-}
-
-impl InMemoryDurableStore {
-    pub fn new() -> Self {
-        Self {
-            store: Arc::new(InMemoryWorkflowEventStore::new()),
-        }
-    }
-
-    /// Create from an existing shared store
-    /// Used for DEV_MODE where the store is shared between runner and in-process worker
-    pub fn from_shared(store: Arc<InMemoryWorkflowEventStore>) -> Self {
-        Self { store }
-    }
-
-    /// Get a reference to the underlying store (for sharing between components)
-    pub fn store(&self) -> Arc<InMemoryWorkflowEventStore> {
-        Arc::clone(&self.store)
-    }
-}
-
-impl Default for InMemoryDurableStore {
-    fn default() -> Self {
-        Self::new()
+    async fn get_and_consume_signals(&mut self, workflow_id: Uuid) -> Result<Vec<WorkflowSignal>> {
+        self.store
+            .consume_pending_signals(workflow_id)
+            .await
+            .map_err(Into::into)
     }
 }
 
@@ -389,9 +311,9 @@ impl DurableStoreBackend for InMemoryDurableStore {
     ) -> Result<(WorkflowStatus, Option<serde_json::Value>, Option<String>)> {
         let info = self.store.get_workflow_info(workflow_id).await?;
         Ok((
-            durable_to_local_status(info.status),
+            info.status,
             info.result,
-            info.error.map(|e| format!("{:?}", e)),
+            info.error.map(|error| format!("{error:?}")),
         ))
     }
 
@@ -414,10 +336,13 @@ impl DurableStoreBackend for InMemoryDurableStore {
         output: Option<serde_json::Value>,
         error: Option<String>,
     ) -> Result<()> {
-        let durable_status = local_to_durable_status(status);
-        let durable_error = error.map(everruns_durable::WorkflowError::new);
         self.store
-            .update_workflow_status(workflow_id, durable_status, output, durable_error)
+            .update_workflow_status(
+                workflow_id,
+                status,
+                output,
+                error.map(everruns_durable::WorkflowError::new),
+            )
             .await?;
         Ok(())
     }
@@ -429,26 +354,20 @@ impl DurableStoreBackend for InMemoryDurableStore {
         activity_type: String,
         input: serde_json::Value,
     ) -> Result<Uuid> {
-        let task = everruns_durable::TaskDefinition {
-            workflow_id: Some(workflow_id),
-            activity_id,
-            activity_type,
-            input,
-            options: everruns_durable::ActivityOptions::default(),
-        };
-        self.store.enqueue_task(task).await.map_err(Into::into)
+        self.store
+            .enqueue_task(everruns_durable::TaskDefinition {
+                workflow_id: Some(workflow_id),
+                activity_id,
+                activity_type,
+                input,
+                options: Default::default(),
+            })
+            .await
+            .map_err(Into::into)
     }
 
     async fn count_active_workflows(&mut self) -> Result<usize> {
-        // In-memory store doesn't have count_active_workflows, return workflow count
         Ok(self.store.workflow_count())
-    }
-
-    async fn try_claim_workflow_for_new_turn(&mut self, workflow_id: Uuid) -> Result<bool> {
-        self.store
-            .try_claim_workflow_for_new_turn(workflow_id)
-            .await
-            .map_err(Into::into)
     }
 
     async fn cancel_pending_tasks(&mut self, workflow_id: Uuid) -> Result<u64> {
@@ -470,130 +389,81 @@ impl DurableStoreBackend for InMemoryDurableStore {
             .map_err(Into::into)
     }
 
-    async fn send_signal(
-        &mut self,
-        workflow_id: Uuid,
-        signal: everruns_durable::WorkflowSignal,
-    ) -> Result<()> {
+    async fn try_claim_workflow_for_new_turn(&mut self, workflow_id: Uuid) -> Result<bool> {
+        self.store
+            .try_claim_workflow_for_new_turn(workflow_id)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn send_signal(&mut self, workflow_id: Uuid, signal: WorkflowSignal) -> Result<()> {
         self.store
             .send_signal(workflow_id, signal)
             .await
             .map_err(Into::into)
     }
 
-    async fn get_and_consume_signals(
-        &mut self,
-        workflow_id: Uuid,
-    ) -> Result<Vec<everruns_durable::WorkflowSignal>> {
-        let signals = self.store.consume_pending_signals(workflow_id).await?;
-        Ok(signals)
+    async fn get_and_consume_signals(&mut self, workflow_id: Uuid) -> Result<Vec<WorkflowSignal>> {
+        self.store
+            .consume_pending_signals(workflow_id)
+            .await
+            .map_err(Into::into)
     }
 }
 
-fn durable_to_local_status(s: everruns_durable::WorkflowStatus) -> WorkflowStatus {
-    match s {
-        everruns_durable::WorkflowStatus::Pending => WorkflowStatus::Pending,
-        everruns_durable::WorkflowStatus::Running => WorkflowStatus::Running,
-        everruns_durable::WorkflowStatus::Completed => WorkflowStatus::Completed,
-        everruns_durable::WorkflowStatus::Failed => WorkflowStatus::Failed,
-        everruns_durable::WorkflowStatus::Cancelled => WorkflowStatus::Cancelled,
-        everruns_durable::WorkflowStatus::ContinuedAsNew => WorkflowStatus::ContinuedAsNew,
-    }
-}
-
-fn local_to_durable_status(s: WorkflowStatus) -> everruns_durable::WorkflowStatus {
-    match s {
-        WorkflowStatus::Pending => everruns_durable::WorkflowStatus::Pending,
-        WorkflowStatus::Running => everruns_durable::WorkflowStatus::Running,
-        WorkflowStatus::Completed => everruns_durable::WorkflowStatus::Completed,
-        WorkflowStatus::Failed => everruns_durable::WorkflowStatus::Failed,
-        WorkflowStatus::Cancelled => everruns_durable::WorkflowStatus::Cancelled,
-        WorkflowStatus::ContinuedAsNew => everruns_durable::WorkflowStatus::ContinuedAsNew,
-    }
-}
-
-// =============================================================================
-// DurableRunner Implementation
-// =============================================================================
-
-/// Durable execution engine based runner
+/// Durable execution engine based runner.
 ///
-/// This runner uses the custom durable engine backed by PostgreSQL
-/// for workflow orchestration.
-/// - Workers communicate with the control-plane via gRPC
-/// - Control-plane uses direct database access
+/// This runner maps runtime turn state onto the durable engine.
 pub struct DurableRunner {
     store: Arc<Mutex<dyn DurableStoreBackend>>,
 }
 
 impl DurableRunner {
-    /// Create a new durable runner connected to control-plane gRPC
-    /// Used by workers that connect to the control-plane
     pub async fn new(grpc_address: &str) -> Result<Self> {
         info!(
             grpc_address = %grpc_address,
-            "Initializing Durable execution engine runner (gRPC mode)"
+            "Initializing durable runner (gRPC mode)"
         );
 
         let store = GrpcDurableStore::connect(grpc_address).await?;
-
-        info!("Durable runner initialized");
-
         Ok(Self {
             store: Arc::new(Mutex::new(store)),
         })
     }
 
-    /// Create a new durable runner with direct database access
-    /// Used by the control-plane which has direct database access
     pub fn new_with_pool(pool: sqlx::PgPool) -> Self {
-        info!("Initializing Durable execution engine runner (direct DB mode)");
-
+        info!("Initializing durable runner (direct DB mode)");
         let store = DirectDurableStore::new(pool);
-
         Self {
             store: Arc::new(Mutex::new(store)),
         }
     }
 
-    /// Create a new durable runner with in-memory storage
-    /// Used by the control-plane in dev mode (no PostgreSQL required)
     pub fn new_in_memory() -> Self {
-        info!("Initializing Durable execution engine runner (in-memory dev mode)");
-
+        info!("Initializing durable runner (in-memory dev mode)");
         let store = InMemoryDurableStore::new();
-
         Self {
             store: Arc::new(Mutex::new(store)),
         }
     }
 
-    /// Create a new durable runner with a shared in-memory store
-    /// Used by the control-plane in DEV_MODE where the store is shared
-    /// between the runner and in-process worker
     pub fn new_with_shared_store(shared_store: Arc<InMemoryWorkflowEventStore>) -> Self {
-        info!("Initializing Durable execution engine runner (shared in-memory dev mode)");
-
+        info!("Initializing durable runner (shared in-memory dev mode)");
         let store = InMemoryDurableStore::from_shared(shared_store);
-
         Self {
             store: Arc::new(Mutex::new(store)),
         }
     }
 
-    /// Create from WORKER_GRPC_ADDRESS environment variable (defaults to 127.0.0.1:9001)
-    /// Used by workers
     pub async fn from_env() -> Result<Self> {
         let grpc_address =
             std::env::var("WORKER_GRPC_ADDRESS").unwrap_or_else(|_| "127.0.0.1:9001".to_string());
-
         Self::new(&grpc_address).await
     }
 }
 
 #[async_trait]
 impl AgentRunner for DurableRunner {
-    /// Start a turn workflow for the given session
     async fn start_run(
         &self,
         org_id: i64,
@@ -604,17 +474,14 @@ impl AgentRunner for DurableRunner {
         request_id: Option<String>,
     ) -> Result<()> {
         info!(
-            org_id = org_id,
+            org_id,
             session_id = %session_id,
             harness_id = %harness_id,
             ?agent_id,
             input_message_id = %input_message_id,
-            request_id = ?request_id,
-            "Starting durable turn workflow for session"
+            "starting durable turn workflow"
         );
 
-        // Build workflow input
-        // turn_id is None at workflow start - will be created by input activity
         let input = DurableTurnInput {
             org_id,
             session_id,
@@ -626,215 +493,142 @@ impl AgentRunner for DurableRunner {
             iteration: 1,
             request_id,
         };
-
-        // Create workflow instance
-        // Use session_id as workflow_id for consistency
         let workflow_id = session_id.uuid();
         let input_json = serde_json::to_value(&input)?;
-
-        // Atomically try to claim the workflow for a new turn.
-        //
-        // try_claim_workflow_for_new_turn uses SELECT FOR UPDATE (Postgres) to
-        // atomically transition terminal/pending → Running AND cancel stale tasks.
-        // This is safe under horizontal scaling — only one replica wins the claim.
-        //
-        // If the workflow is Running (active turn), the claim fails and we send
-        // a steering signal instead of starting a concurrent turn.
         let mut store = self.store.lock().await;
 
-        let claim_result = store.try_claim_workflow_for_new_turn(workflow_id).await;
-
-        match claim_result {
+        match store.try_claim_workflow_for_new_turn(workflow_id).await {
             Ok(true) => {
-                // Claimed successfully — workflow is now Running.
-                // Enqueue process_input task for the new turn.
-                info!(
-                    session_id = %session_id,
-                    workflow_id = %workflow_id,
-                    "Claimed existing workflow for new turn"
-                );
-
-                let activity_id = format!("input_{}", Uuid::now_v7());
-                if let Err(e) = store
+                if let Err(error) = store
                     .enqueue_task(
                         workflow_id,
-                        activity_id,
+                        format!("input_{}", Uuid::now_v7()),
                         "process_input".to_string(),
                         input_json,
                     )
                     .await
                 {
-                    // Rollback: set workflow back to Completed so future claims can succeed.
                     let _ = store
                         .update_workflow_status(workflow_id, WorkflowStatus::Completed, None, None)
                         .await;
-                    return Err(anyhow::anyhow!("Failed to enqueue task: {}", e));
+                    return Err(anyhow::anyhow!("Failed to enqueue task: {error}"));
                 }
             }
             Ok(false) => {
-                // Workflow is Running — a turn is active.
-                // Send a steering signal so the running turn picks up this message.
-                // The message is already stored in the events table.
-                info!(
-                    session_id = %session_id,
-                    workflow_id = %workflow_id,
-                    input_message_id = %input_message_id,
-                    "Turn already running — sending steering signal instead of starting concurrent turn"
-                );
-                let signal = everruns_durable::WorkflowSignal::new(
+                let signal = WorkflowSignal::new(
                     everruns_durable::signal_types::USER_MESSAGE,
                     serde_json::json!({
                         "input_message_id": input_message_id.to_string(),
                         "org_id": org_id,
                         "harness_id": harness_id.to_string(),
-                        "agent_id": agent_id.map(|a| a.to_string()),
+                        "agent_id": agent_id.map(|id| id.to_string()),
                     }),
                 );
-                if let Err(e) = store.send_signal(workflow_id, signal).await {
+                if let Err(error) = store.send_signal(workflow_id, signal).await {
                     tracing::warn!(
-                        error = %e,
                         session_id = %session_id,
-                        "Failed to send steering signal — message is still stored"
+                        %error,
+                        "failed to send steering signal"
                     );
                 }
                 return Ok(());
             }
-            Err(e) => {
-                let err_str = e.to_string();
-                if err_str.contains("not found") || err_str.contains("NOT_FOUND") {
-                    // Workflow doesn't exist yet — create a new one.
-                    info!(
-                        session_id = %session_id,
-                        workflow_id = %workflow_id,
-                        "Creating new workflow for session"
-                    );
-
-                    store
-                        .create_workflow(workflow_id, "turn_workflow", input_json.clone())
-                        .await
-                        .map_err(|e| anyhow::anyhow!("Failed to create workflow: {}", e))?;
-
-                    let activity_id = format!("input_{}", Uuid::now_v7());
-
-                    // Append WorkflowStarted event
-                    let started_event = WorkflowEvent::WorkflowStarted {
-                        input: input_json.clone(),
-                    };
-                    let sequence = store
-                        .append_events(workflow_id, 0, vec![started_event])
-                        .await
-                        .map_err(|e| {
-                            anyhow::anyhow!("Failed to append WorkflowStarted event: {}", e)
-                        })?;
-
-                    // Enqueue task
-                    store
-                        .enqueue_task(
-                            workflow_id,
-                            activity_id.clone(),
-                            "process_input".to_string(),
-                            input_json.clone(),
-                        )
-                        .await
-                        .map_err(|e| anyhow::anyhow!("Failed to enqueue task: {}", e))?;
-
-                    // Set to Running only after task is enqueued, so a failure above
-                    // leaves the workflow in Pending (not stuck in Running with no task).
-                    store
-                        .update_workflow_status(workflow_id, WorkflowStatus::Running, None, None)
-                        .await
-                        .map_err(|e| {
-                            anyhow::anyhow!("Failed to set new workflow to Running: {}", e)
-                        })?;
-
-                    // Append ActivityScheduled event
-                    let scheduled_event = WorkflowEvent::ActivityScheduled {
-                        activity_id,
-                        activity_type: "process_input".to_string(),
-                        input: input_json,
-                        options: ActivityOptions::default(),
-                    };
-                    let _ = store
-                        .append_events(workflow_id, sequence, vec![scheduled_event])
-                        .await
-                        .map_err(|e| {
-                            anyhow::anyhow!("Failed to append ActivityScheduled event: {}", e)
-                        })?;
-                } else {
-                    return Err(anyhow::anyhow!("Failed to check workflow status: {}", e));
+            Err(error) => {
+                let err = error.to_string();
+                if !err.contains("not found") && !err.contains("NOT_FOUND") {
+                    return Err(anyhow::anyhow!("Failed to check workflow status: {error}"));
                 }
+
+                store
+                    .create_workflow(workflow_id, "turn_workflow", input_json.clone())
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to create workflow: {e}"))?;
+
+                let activity_id = format!("input_{}", Uuid::now_v7());
+                let sequence = store
+                    .append_events(
+                        workflow_id,
+                        0,
+                        vec![WorkflowEvent::WorkflowStarted {
+                            input: input_json.clone(),
+                        }],
+                    )
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to append WorkflowStarted event: {e}"))?;
+
+                store
+                    .enqueue_task(
+                        workflow_id,
+                        activity_id.clone(),
+                        "process_input".to_string(),
+                        input_json.clone(),
+                    )
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to enqueue task: {e}"))?;
+
+                store
+                    .update_workflow_status(workflow_id, WorkflowStatus::Running, None, None)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to set new workflow to Running: {e}"))?;
+
+                let _ = store
+                    .append_events(
+                        workflow_id,
+                        sequence,
+                        vec![WorkflowEvent::ActivityScheduled {
+                            activity_id,
+                            activity_type: "process_input".to_string(),
+                            input: input_json,
+                            options: everruns_durable::ActivityOptions::default(),
+                        }],
+                    )
+                    .await
+                    .map_err(|e| {
+                        anyhow::anyhow!("Failed to append ActivityScheduled event: {e}")
+                    })?;
             }
         }
-
-        info!(
-            session_id = %session_id,
-            workflow_id = %workflow_id,
-            "Durable workflow created and input task enqueued (status: Running)"
-        );
 
         Ok(())
     }
 
     async fn resume_after_tool_results(&self, session_id: SessionId) -> Result<()> {
         let workflow_id = session_id.uuid();
-
-        info!(
-            session_id = %session_id,
-            workflow_id = %workflow_id,
-            "Resuming workflow after client tool results"
-        );
-
         let mut store = self.store.lock().await;
 
-        // Retrieve saved DurableTurnInput from the workflow result.
-        // schedule_next_activity stores it when completing due to connection_required.
         let (status, result_json, _) = store
             .get_workflow_status(workflow_id)
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to get workflow status: {}", e))?;
-
-        // Only resume workflows that completed normally (i.e. due to
-        // connection_required). Failed/Cancelled/ContinuedAsNew workflows
-        // should not be resumed via this path.
+            .map_err(|e| anyhow::anyhow!("Failed to get workflow status: {e}"))?;
         if status != WorkflowStatus::Completed {
             return Err(anyhow::anyhow!(
-                "Cannot resume: workflow {} is not in Completed status (status: {:?})",
-                workflow_id,
-                status
+                "Cannot resume: workflow {workflow_id} is not in Completed status (status: {status:?})"
             ));
         }
 
-        let turn_input: DurableTurnInput = result_json
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "Cannot resume: workflow {} has no saved turn input in result",
-                    workflow_id
-                )
-            })
-            .and_then(|v| {
-                serde_json::from_value(v)
-                    .map_err(|e| anyhow::anyhow!("Failed to parse saved turn input: {}", e))
-            })?;
+        let saved_value = result_json.ok_or_else(|| {
+            anyhow::anyhow!(
+                "Cannot resume: workflow {workflow_id} has no saved turn input in result"
+            )
+        })?;
+        let turn_input: DurableTurnInput = serde_json::from_value(saved_value)
+            .map_err(|e| anyhow::anyhow!("Failed to parse saved turn input: {e}"))?;
 
-        // Reset workflow to Pending and enqueue a reason activity directly
-        // (skipping process_input / InputAtom — there is no new user message).
         let input_json = serde_json::to_value(&turn_input)?;
         store
             .update_workflow_status(workflow_id, WorkflowStatus::Pending, None, None)
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to reset workflow status: {}", e))?;
+            .map_err(|e| anyhow::anyhow!("Failed to reset workflow status: {e}"))?;
 
-        if let Err(e) = store
+        if let Err(error) = store
             .enqueue_task(
                 workflow_id,
                 format!("reason_{}", Uuid::now_v7()),
                 "reason".to_string(),
-                input_json.clone(),
+                input_json,
             )
             .await
         {
-            // Enqueue failed — restore workflow to Completed with saved input
-            // so a subsequent resume attempt can still succeed.
             let _ = store
                 .update_workflow_status(
                     workflow_id,
@@ -843,27 +637,15 @@ impl AgentRunner for DurableRunner {
                     None,
                 )
                 .await;
-            return Err(anyhow::anyhow!("Failed to enqueue reason task: {}", e));
+            return Err(anyhow::anyhow!("Failed to enqueue reason task: {error}"));
         }
-
-        info!(
-            session_id = %session_id,
-            workflow_id = %workflow_id,
-            turn_id = ?turn_input.turn_id,
-            iteration = turn_input.iteration,
-            "Workflow resumed — reason activity enqueued (skipped InputAtom)"
-        );
 
         Ok(())
     }
 
     async fn cancel_run(&self, session_id: SessionId) -> Result<()> {
-        info!(session_id = %session_id, "Cancelling durable workflow");
-
         let workflow_id = session_id.uuid();
         let mut store = self.store.lock().await;
-
-        // Update workflow status to cancelled
         store
             .update_workflow_status(
                 workflow_id,
@@ -872,21 +654,12 @@ impl AgentRunner for DurableRunner {
                 Some("User requested cancellation".to_string()),
             )
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to cancel workflow: {}", e))?;
-
-        info!(
-            session_id = %session_id,
-            workflow_id = %workflow_id,
-            "Workflow cancelled"
-        );
-
-        Ok(())
+            .map_err(|e| anyhow::anyhow!("Failed to cancel workflow: {e}"))
     }
 
     async fn is_running(&self, session_id: SessionId) -> bool {
         let workflow_id = session_id.uuid();
         let mut store = self.store.lock().await;
-
         match store.get_workflow_status(workflow_id).await {
             Ok((status, _, _)) => !status.is_terminal(),
             Err(_) => false,
@@ -899,706 +672,146 @@ impl AgentRunner for DurableRunner {
     }
 }
 
+fn grpc_to_runtime_status(status: GrpcWorkflowStatus) -> WorkflowStatus {
+    match status {
+        GrpcWorkflowStatus::Pending => WorkflowStatus::Pending,
+        GrpcWorkflowStatus::Running => WorkflowStatus::Running,
+        GrpcWorkflowStatus::Completed => WorkflowStatus::Completed,
+        GrpcWorkflowStatus::Failed => WorkflowStatus::Failed,
+        GrpcWorkflowStatus::Cancelled => WorkflowStatus::Cancelled,
+        GrpcWorkflowStatus::ContinuedAsNew => WorkflowStatus::ContinuedAsNew,
+    }
+}
+
+fn runtime_to_grpc_status(status: WorkflowStatus) -> GrpcWorkflowStatus {
+    match status {
+        WorkflowStatus::Pending => GrpcWorkflowStatus::Pending,
+        WorkflowStatus::Running => GrpcWorkflowStatus::Running,
+        WorkflowStatus::Completed => GrpcWorkflowStatus::Completed,
+        WorkflowStatus::Failed => GrpcWorkflowStatus::Failed,
+        WorkflowStatus::Cancelled => GrpcWorkflowStatus::Cancelled,
+        WorkflowStatus::ContinuedAsNew => GrpcWorkflowStatus::ContinuedAsNew,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId};
 
-    #[test]
-    fn test_durable_turn_input_serialization() {
-        use everruns_core::DEFAULT_ORG_ID;
-
-        let input = DurableTurnInput {
-            org_id: DEFAULT_ORG_ID,
-            session_id: SessionId::new(),
-            harness_id: HarnessId::new(),
-            agent_id: Some(AgentId::new()),
-            input_message_id: MessageId::new(),
-            turn_id: None,
-            previous_response_id: None,
-            iteration: 1,
-            request_id: None,
-        };
-
-        let json = serde_json::to_string(&input).unwrap();
-        let parsed: DurableTurnInput = serde_json::from_str(&json).unwrap();
-
-        assert_eq!(input.org_id, parsed.org_id);
-        assert_eq!(input.session_id, parsed.session_id);
-        assert_eq!(input.agent_id, parsed.agent_id);
-        assert_eq!(input.input_message_id, parsed.input_message_id);
-        assert_eq!(input.turn_id, parsed.turn_id);
-        assert_eq!(input.iteration, parsed.iteration);
-    }
-
-    /// Test that iteration defaults to 1 when missing from JSON (backward compat)
-    #[test]
-    fn test_durable_turn_input_iteration_default() {
-        use everruns_core::DEFAULT_ORG_ID;
-
-        // Build a valid input and serialize it
-        let input = DurableTurnInput {
-            org_id: DEFAULT_ORG_ID,
-            session_id: SessionId::new(),
-            harness_id: HarnessId::new(),
-            agent_id: None,
-            input_message_id: MessageId::new(),
-            turn_id: None,
-            previous_response_id: None,
-            iteration: 3,
-            request_id: None,
-        };
-        let mut json_val: serde_json::Value = serde_json::to_value(&input).unwrap();
-        // Remove iteration to simulate pre-existing persisted data
-        json_val.as_object_mut().unwrap().remove("iteration");
-
-        let parsed: DurableTurnInput = serde_json::from_value(json_val).unwrap();
-        assert_eq!(parsed.iteration, 1); // defaults to 1
-    }
-
-    /// Test that start_run works for a new session (first message)
     #[tokio::test]
-    async fn test_start_run_creates_new_workflow() {
-        use everruns_core::DEFAULT_ORG_ID;
-
-        let runner = DurableRunner::new_in_memory();
-
+    async fn start_run_creates_new_workflow_and_input_task() {
+        let shared = Arc::new(InMemoryWorkflowEventStore::new());
+        let runner = DurableRunner::new_with_shared_store(shared.clone());
         let session_id = SessionId::new();
         let harness_id = HarnessId::new();
-        let agent_id = AgentId::new();
         let message_id = MessageId::new();
 
-        // First call should create a new workflow
         runner
-            .start_run(
-                DEFAULT_ORG_ID,
-                session_id,
-                harness_id,
-                Some(agent_id),
-                message_id,
-                None,
-            )
+            .start_run(1, session_id, harness_id, None, message_id, None)
             .await
-            .expect("First start_run should succeed");
+            .expect("start_run should create workflow");
 
-        // Workflow should be running
-        assert!(runner.is_running(session_id).await);
+        let info = shared
+            .get_workflow_info(session_id.uuid())
+            .await
+            .expect("workflow info should exist");
+        assert_eq!(info.status, WorkflowStatus::Running);
+
+        let claimed = shared
+            .claim_task("worker-1", &["process_input".to_string()], 10)
+            .await
+            .expect("task should be claimable");
+        assert_eq!(claimed.len(), 1);
+        assert_eq!(claimed[0].activity_type, "process_input");
     }
 
-    /// Test that start_run waits for the prior workflow to finish before reusing it.
     #[tokio::test]
-    async fn test_start_run_sends_steering_signal_when_running() {
-        use everruns_core::DEFAULT_ORG_ID;
+    async fn start_run_steers_running_workflow() {
+        let shared = Arc::new(InMemoryWorkflowEventStore::new());
+        let workflow_id = Uuid::now_v7();
+        shared
+            .create_workflow(workflow_id, "turn_workflow", serde_json::json!({}), None)
+            .await
+            .expect("create workflow");
+        shared
+            .update_workflow_status(workflow_id, WorkflowStatus::Running, None, None)
+            .await
+            .expect("mark running");
 
-        let runner = DurableRunner::new_in_memory();
-
-        let session_id = SessionId::new();
+        let runner = DurableRunner::new_with_shared_store(shared.clone());
+        let session_id = SessionId::from_uuid(workflow_id);
         let harness_id = HarnessId::new();
-        let agent_id = AgentId::new();
-        let message_id1 = MessageId::new();
-        let message_id2 = MessageId::new();
+        let message_id = MessageId::new();
 
-        // First message — creates workflow, sets Running
         runner
-            .start_run(
-                DEFAULT_ORG_ID,
-                session_id,
-                harness_id,
-                Some(agent_id),
-                message_id1,
-                None,
-            )
+            .start_run(1, session_id, harness_id, None, message_id, None)
             .await
-            .expect("First start_run should succeed");
+            .expect("start_run should send steering signal");
 
-        assert!(runner.is_running(session_id).await);
-
-        // Second message while Running — should send steering signal and return
-        // immediately (no blocking, no concurrent turn).
-        let start = std::time::Instant::now();
-        runner
-            .start_run(
-                DEFAULT_ORG_ID,
-                session_id,
-                harness_id,
-                Some(agent_id),
-                message_id2,
-                None,
-            )
+        let signals = shared
+            .consume_pending_signals(workflow_id)
             .await
-            .expect("Second start_run should send steering signal");
-
-        assert!(
-            start.elapsed() < std::time::Duration::from_millis(100),
-            "Steering signal path should be instant, took {:?}",
-            start.elapsed()
-        );
-
-        // Workflow should still be running (no concurrent turn started)
-        assert!(
-            runner.is_running(session_id).await,
-            "Workflow should still be running — no concurrent turn"
-        );
-
-        // Verify a steering signal was stored
-        let mut store = runner.store.lock().await;
-        let signals = store
-            .get_and_consume_signals(session_id.uuid())
-            .await
-            .expect("Should get signals");
-        assert_eq!(signals.len(), 1, "Should have exactly 1 steering signal");
+            .expect("signals should load");
+        assert_eq!(signals.len(), 1);
         assert_eq!(
             signals[0].signal_type,
             everruns_durable::signal_types::USER_MESSAGE
         );
-        let signal_msg_id = signals[0]
-            .payload
-            .get("input_message_id")
-            .and_then(|v| v.as_str())
-            .unwrap();
-        assert_eq!(signal_msg_id, message_id2.to_string());
     }
 
-    /// Test that start_run resets a completed workflow for a second message
-    ///
-    /// This is the key test for the second message bug fix:
-    /// When a workflow is completed and a new message arrives, the workflow
-    /// should be reset to pending so it can process the new message.
     #[tokio::test]
-    async fn test_start_run_resets_completed_workflow() {
-        use everruns_core::DEFAULT_ORG_ID;
-
-        let runner = DurableRunner::new_in_memory();
-
+    async fn resume_after_tool_results_enqueues_reason() {
+        let shared = Arc::new(InMemoryWorkflowEventStore::new());
         let session_id = SessionId::new();
-        let harness_id = HarnessId::new();
-        let agent_id = AgentId::new();
-        let message_id1 = MessageId::new();
-        let message_id2 = MessageId::new();
-
-        // First message - creates workflow
-        runner
-            .start_run(
-                DEFAULT_ORG_ID,
-                session_id,
-                harness_id,
-                Some(agent_id),
-                message_id1,
-                None,
-            )
-            .await
-            .expect("First start_run should succeed");
-
-        assert!(runner.is_running(session_id).await);
-
-        // Simulate workflow completion by updating status to Completed
-        {
-            let mut store = runner.store.lock().await;
-            store
-                .update_workflow_status(session_id.uuid(), WorkflowStatus::Completed, None, None)
-                .await
-                .expect("Should update workflow status");
-        }
-
-        // Workflow should now be terminal (not running)
-        assert!(
-            !runner.is_running(session_id).await,
-            "Workflow should be completed"
-        );
-
-        // Second message - should reset and create new turn
-        // This is the bug fix - previously this would fail because it tried
-        // to create a workflow with the same ID
-        runner
-            .start_run(
-                DEFAULT_ORG_ID,
-                session_id,
-                harness_id,
-                Some(agent_id),
-                message_id2,
-                None,
-            )
-            .await
-            .expect("Second start_run should succeed (reset workflow)");
-
-        // Workflow should be running again (reset to pending, new task enqueued)
-        assert!(
-            runner.is_running(session_id).await,
-            "Workflow should be running again after reset"
-        );
-    }
-
-    /// Test that start_run resets a failed workflow for retry
-    #[tokio::test]
-    async fn test_start_run_resets_failed_workflow() {
-        use everruns_core::DEFAULT_ORG_ID;
-
-        let runner = DurableRunner::new_in_memory();
-
-        let session_id = SessionId::new();
-        let harness_id = HarnessId::new();
-        let agent_id = AgentId::new();
-        let message_id1 = MessageId::new();
-        let message_id2 = MessageId::new();
-
-        // First message
-        runner
-            .start_run(
-                DEFAULT_ORG_ID,
-                session_id,
-                harness_id,
-                Some(agent_id),
-                message_id1,
-                None,
-            )
-            .await
-            .expect("First start_run should succeed");
-
-        // Simulate workflow failure
-        {
-            let mut store = runner.store.lock().await;
-            store
-                .update_workflow_status(
-                    session_id.uuid(),
-                    WorkflowStatus::Failed,
-                    None,
-                    Some("Test error".to_string()),
-                )
-                .await
-                .expect("Should update workflow status");
-        }
-
-        assert!(!runner.is_running(session_id).await);
-
-        // Second message - should reset failed workflow
-        runner
-            .start_run(
-                DEFAULT_ORG_ID,
-                session_id,
-                harness_id,
-                Some(agent_id),
-                message_id2,
-                None,
-            )
-            .await
-            .expect("Second start_run should reset failed workflow");
-
-        assert!(runner.is_running(session_id).await);
-    }
-
-    /// Test that resume_after_tool_results enqueues a reason activity directly
-    /// (skipping InputAtom) using the saved DurableTurnInput from the workflow result.
-    #[tokio::test]
-    async fn test_resume_after_tool_results_skips_input_atom() {
-        use everruns_core::DEFAULT_ORG_ID;
-        use everruns_core::typed_id::TurnId;
-
-        let runner = DurableRunner::new_in_memory();
-
-        let session_id = SessionId::new();
-        let harness_id = HarnessId::new();
-        let agent_id = AgentId::new();
-        let message_id = MessageId::new();
-        let turn_id = TurnId::new();
-
-        // Create a workflow via start_run (simulates the initial user message)
-        runner
-            .start_run(
-                DEFAULT_ORG_ID,
-                session_id,
-                harness_id,
-                Some(agent_id),
-                message_id,
-                None,
-            )
-            .await
-            .expect("start_run should succeed");
-
-        // Simulate the workflow completing with connection_required:
-        // save a DurableTurnInput as the workflow result (as schedule_next_activity does).
         let saved_input = DurableTurnInput {
-            org_id: DEFAULT_ORG_ID,
+            org_id: 1,
             session_id,
-            harness_id,
-            agent_id: Some(agent_id),
-            input_message_id: message_id,
-            turn_id: Some(turn_id),
-            previous_response_id: Some("resp_abc".to_string()),
+            harness_id: HarnessId::new(),
+            agent_id: Some(AgentId::new()),
+            input_message_id: MessageId::new(),
+            turn_id: None,
+            previous_response_id: Some("resp_123".to_string()),
             iteration: 3,
             request_id: None,
         };
-        {
-            let mut store = runner.store.lock().await;
-            store
-                .update_workflow_status(
-                    session_id.uuid(),
-                    WorkflowStatus::Completed,
-                    Some(serde_json::to_value(&saved_input).unwrap()),
-                    None,
-                )
-                .await
-                .expect("Should complete workflow with saved input");
-        }
+        shared
+            .create_workflow(
+                session_id.uuid(),
+                "turn_workflow",
+                serde_json::to_value(&saved_input).expect("serialize input"),
+                None,
+            )
+            .await
+            .expect("create workflow");
+        shared
+            .update_workflow_status(
+                session_id.uuid(),
+                WorkflowStatus::Completed,
+                Some(serde_json::to_value(&saved_input).expect("serialize result")),
+                None,
+            )
+            .await
+            .expect("mark completed");
 
-        assert!(!runner.is_running(session_id).await, "Should be completed");
-
-        // Resume after tool results — should enqueue reason directly
+        let runner = DurableRunner::new_with_shared_store(shared.clone());
         runner
             .resume_after_tool_results(session_id)
             .await
-            .expect("resume_after_tool_results should succeed");
+            .expect("resume should enqueue reason");
 
-        // Workflow should be running again (reset to Pending with reason task)
-        assert!(
-            runner.is_running(session_id).await,
-            "Workflow should be running after resume"
-        );
-    }
-
-    /// Test that resume_after_tool_results fails when workflow has no saved turn input
-    #[tokio::test]
-    async fn test_resume_after_tool_results_no_saved_input() {
-        use everruns_core::DEFAULT_ORG_ID;
-
-        let runner = DurableRunner::new_in_memory();
-
-        let session_id = SessionId::new();
-        let harness_id = HarnessId::new();
-        let message_id = MessageId::new();
-
-        // Create and complete a workflow without saving turn input in result
-        runner
-            .start_run(
-                DEFAULT_ORG_ID,
-                session_id,
-                harness_id,
-                None,
-                message_id,
-                None,
-            )
-            .await
-            .expect("start_run should succeed");
-
-        {
-            let mut store = runner.store.lock().await;
-            store
-                .update_workflow_status(session_id.uuid(), WorkflowStatus::Completed, None, None)
-                .await
-                .expect("Should complete workflow");
-        }
-
-        // Should fail because no saved turn input
-        let err = runner
-            .resume_after_tool_results(session_id)
-            .await
-            .unwrap_err();
-        assert!(
-            err.to_string().contains("no saved turn input"),
-            "Error should mention missing turn input, got: {}",
-            err
-        );
-    }
-
-    /// Test that resume_after_tool_results fails on a still-running workflow
-    #[tokio::test]
-    async fn test_resume_after_tool_results_rejects_running_workflow() {
-        use everruns_core::DEFAULT_ORG_ID;
-
-        let runner = DurableRunner::new_in_memory();
-
-        let session_id = SessionId::new();
-        let harness_id = HarnessId::new();
-        let message_id = MessageId::new();
-
-        runner
-            .start_run(
-                DEFAULT_ORG_ID,
-                session_id,
-                harness_id,
-                None,
-                message_id,
-                None,
-            )
-            .await
-            .expect("start_run should succeed");
-
-        assert!(runner.is_running(session_id).await);
-
-        // Should fail because workflow is still running
-        let err = runner
-            .resume_after_tool_results(session_id)
-            .await
-            .unwrap_err();
-        assert!(
-            err.to_string().contains("not in Completed status"),
-            "Error should reject non-Completed workflow, got: {}",
-            err
-        );
-    }
-
-    /// Test that a Pending workflow does NOT cause a 10s wait — the new turn
-    /// takes over immediately (EVE-168).
-    #[tokio::test]
-    async fn test_start_run_takes_over_pending_workflow_immediately() {
-        use everruns_core::DEFAULT_ORG_ID;
-
-        let runner = DurableRunner::new_in_memory();
-
-        let session_id = SessionId::new();
-        let harness_id = HarnessId::new();
-        let agent_id = AgentId::new();
-        let message_id1 = MessageId::new();
-        let message_id2 = MessageId::new();
-
-        // First message — creates workflow (status becomes Pending)
-        runner
-            .start_run(
-                DEFAULT_ORG_ID,
-                session_id,
-                harness_id,
-                Some(agent_id),
-                message_id1,
-                None,
-            )
-            .await
-            .expect("First start_run should succeed");
-
-        // Workflow is Pending (no worker has claimed it).
-        // Don't transition to Running — leave it Pending to reproduce
-        // the exact scenario from EVE-168.
-
-        // Second message while workflow is still Pending — must complete
-        // within 1s (not 10s). Using timeout so a regression fails fast
-        // instead of blocking CI for 10s.
-        let result = tokio::time::timeout(
-            std::time::Duration::from_secs(1),
-            runner.start_run(
-                DEFAULT_ORG_ID,
-                session_id,
-                harness_id,
-                Some(agent_id),
-                message_id2,
-                None,
-            ),
-        )
-        .await;
-
-        let inner = result
-            .expect("Second start_run should complete within 1s (Pending takeover, not 10s wait)");
-        inner.expect("Second start_run should succeed");
-
-        assert!(
-            runner.is_running(session_id).await,
-            "Workflow should be active (non-terminal) after takeover"
-        );
-    }
-
-    /// Regression guard: a Running workflow blocks and waits (polling at 100ms),
-    /// whereas a Pending workflow returns instantly. This test asserts the Running
-    /// path takes measurable time (>200ms) while the Pending path (<50ms) doesn't.
-    /// The contrast is the regression signal for EVE-168.
-    #[tokio::test]
-    async fn test_running_sends_signal_completed_gets_claimed() {
-        use everruns_core::DEFAULT_ORG_ID;
-
-        // --- Running path: steering signal is instant ---
-        let runner = DurableRunner::new_in_memory();
-        let sid = SessionId::new();
-        runner
-            .start_run(
-                DEFAULT_ORG_ID,
-                sid,
-                HarnessId::new(),
-                Some(AgentId::new()),
-                MessageId::new(),
-                None,
-            )
-            .await
-            .unwrap();
-        // Workflow is now Running
-
-        let t0 = std::time::Instant::now();
-        runner
-            .start_run(
-                DEFAULT_ORG_ID,
-                sid,
-                HarnessId::new(),
-                Some(AgentId::new()),
-                MessageId::new(),
-                None,
-            )
-            .await
-            .unwrap();
-        let running_dur = t0.elapsed();
-
-        assert!(
-            running_dur < std::time::Duration::from_millis(50),
-            "Steering signal path should be instant, took {:?}",
-            running_dur
-        );
-
-        // --- Completed path: new turn gets claimed ---
-        {
-            let mut store = runner.store.lock().await;
-            store
-                .update_workflow_status(sid.uuid(), WorkflowStatus::Completed, None, None)
-                .await
-                .unwrap();
-        }
-
-        let t1 = std::time::Instant::now();
-        runner
-            .start_run(
-                DEFAULT_ORG_ID,
-                sid,
-                HarnessId::new(),
-                Some(AgentId::new()),
-                MessageId::new(),
-                None,
-            )
-            .await
-            .unwrap();
-        let completed_dur = t1.elapsed();
-
-        assert!(
-            completed_dur < std::time::Duration::from_millis(50),
-            "Completed takeover should be instant, took {:?}",
-            completed_dur
-        );
-        assert!(runner.is_running(sid).await);
-    }
-
-    /// Test that three rapid messages while workflow stays Pending all succeed
-    /// instantly — no cumulative delay (EVE-168).
-    #[tokio::test]
-    async fn test_multiple_rapid_messages_while_pending() {
-        use everruns_core::DEFAULT_ORG_ID;
-
-        let runner = DurableRunner::new_in_memory();
-
-        let session_id = SessionId::new();
-        let harness_id = HarnessId::new();
-        let agent_id = AgentId::new();
-
-        // First message — creates workflow (Pending)
-        runner
-            .start_run(
-                DEFAULT_ORG_ID,
-                session_id,
-                harness_id,
-                Some(agent_id),
-                MessageId::new(),
-                None,
-            )
-            .await
-            .expect("First start_run should succeed");
-
-        // Send two more messages rapidly while Running — should send steering signals
-        let start = std::time::Instant::now();
-        for i in 0..2 {
-            runner
-                .start_run(
-                    DEFAULT_ORG_ID,
-                    session_id,
-                    harness_id,
-                    Some(agent_id),
-                    MessageId::new(),
-                    None,
-                )
-                .await
-                .unwrap_or_else(|e| panic!("Message {} should succeed: {}", i + 2, e));
-        }
-
-        assert!(
-            start.elapsed() < std::time::Duration::from_secs(1),
-            "Steering signal sends should be instant — took {:?}",
-            start.elapsed(),
-        );
-        assert!(runner.is_running(session_id).await);
-    }
-
-    /// Test that start_run sets workflow to Running and subsequent calls
-    /// send steering signals rather than creating concurrent turns.
-    #[tokio::test]
-    async fn test_start_run_sets_running_prevents_concurrent_turns() {
-        use everruns_core::DEFAULT_ORG_ID;
-
-        let runner = DurableRunner::new_in_memory();
-
-        let session_id = SessionId::new();
-        let harness_id = HarnessId::new();
-        let agent_id = AgentId::new();
-        let msg1 = MessageId::new();
-        let msg2 = MessageId::new();
-        let msg3 = MessageId::new();
-
-        // First message — workflow created, set to Running
-        runner
-            .start_run(
-                DEFAULT_ORG_ID,
-                session_id,
-                harness_id,
-                Some(agent_id),
-                msg1,
-                None,
-            )
-            .await
-            .expect("First start_run");
-
-        let mut store = runner.store.lock().await;
-        let (status, _, _) = store
-            .get_workflow_status(session_id.uuid())
-            .await
-            .expect("Should get status");
         assert_eq!(
-            status,
-            WorkflowStatus::Running,
-            "First start_run should set workflow to Running"
+            shared
+                .get_workflow_status(session_id.uuid())
+                .await
+                .expect("status should load"),
+            WorkflowStatus::Pending
         );
-        drop(store);
 
-        // Second and third messages — both should send steering signals
-        runner
-            .start_run(
-                DEFAULT_ORG_ID,
-                session_id,
-                harness_id,
-                Some(agent_id),
-                msg2,
-                None,
-            )
+        let claimed = shared
+            .claim_task("worker-1", &["reason".to_string()], 10)
             .await
-            .expect("Second start_run (steering)");
-        runner
-            .start_run(
-                DEFAULT_ORG_ID,
-                session_id,
-                harness_id,
-                Some(agent_id),
-                msg3,
-                None,
-            )
-            .await
-            .expect("Third start_run (steering)");
-
-        // Workflow should still be Running
-        let mut store = runner.store.lock().await;
-        let (status, _, _) = store
-            .get_workflow_status(session_id.uuid())
-            .await
-            .expect("Should get status");
-        assert_eq!(status, WorkflowStatus::Running);
-
-        // Should have 2 pending signals (msg2 and msg3)
-        let signals = store
-            .get_and_consume_signals(session_id.uuid())
-            .await
-            .expect("Should get signals");
-        assert_eq!(
-            signals.len(),
-            2,
-            "Should have 2 steering signals, got {}",
-            signals.len()
-        );
+            .expect("reason task should be claimable");
+        assert_eq!(claimed.len(), 1);
+        assert_eq!(claimed[0].activity_type, "reason");
     }
 }

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -5,12 +5,12 @@
 use anyhow::Result;
 use everruns_core::atoms::AtomContext;
 use everruns_core::events::{
-    EventContext, EventRequest, OutputMessageCompletedData, SessionIdledData, TurnCompletedData,
-    TurnFailedData,
+    EventContext, EventRequest, OutputMessageCompletedData, SessionIdledData,
 };
 use everruns_core::traits::EventEmitter;
 use everruns_core::typed_id::{ExecId, MessageId, SessionId, TurnId};
 use everruns_core::{Message, PlatformDefinition};
+use everruns_runtime::{RuntimeActPlan, RuntimeTurnPlan, plan_next_host_turn};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
@@ -19,14 +19,14 @@ use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crate::activities::{
-    ActInput, InputAtomInput, ReasonInput, ReasonResult, act_activity, input_activity,
-    reason_activity,
+    ActInput, InputAtomInput, ReasonInput, act_activity, input_activity, reason_activity,
 };
 use crate::durable_runner::DurableTurnInput;
 use crate::grpc_adapters::{GrpcClient, GrpcEventEmitter, load_turn_context};
 use crate::grpc_durable_store::{
     ClaimedTask, GrpcDurableStore, TaskNotificationEvent, TaskNotificationStream, WorkflowStatus,
 };
+use crate::runtime_host::WorkerRuntimeHost;
 use crate::task_error::summarize_task_failure;
 use serde::{Deserialize, Serialize};
 
@@ -164,53 +164,6 @@ async fn emit_cancellation_events(
     }
 
     info!(session_id = %session_id, "Cancellation events emitted");
-}
-
-/// Emit session.idled event and set session status to idle.
-///
-/// Called by the workflow scheduler (not by activities) so that session-level
-/// status is only set to idle after checking for pending steering signals.
-/// This prevents the idle→active flicker when a queued user message triggers
-/// a consecutive turn.
-async fn emit_session_idled(
-    grpc_address: &str,
-    org_id: i64,
-    session_id: SessionId,
-    turn_id: TurnId,
-    input_message_id: MessageId,
-    iterations: Option<u32>,
-    usage: Option<everruns_core::TokenUsage>,
-) {
-    let grpc_client = match GrpcClient::connect(grpc_address).await {
-        Ok(client) => client,
-        Err(e) => {
-            warn!(error = %e, "Failed to connect to gRPC for session.idled");
-            return;
-        }
-    };
-
-    // Set session status to idle
-    if let Err(e) = grpc_client
-        .set_session_status(org_id, session_id, "idle")
-        .await
-    {
-        warn!(session_id = %session_id, error = %e, "Failed to set session status to idle");
-    }
-
-    // Emit session.idled event
-    let event_emitter = GrpcEventEmitter::new(grpc_client);
-    let idled_event = EventRequest::new(
-        session_id,
-        EventContext::turn(turn_id, input_message_id),
-        SessionIdledData {
-            turn_id,
-            iterations,
-            usage,
-        },
-    );
-    if let Err(e) = event_emitter.emit(idled_event).await {
-        warn!(session_id = %session_id, error = %e, "Failed to emit session.idled event");
-    }
 }
 
 // =============================================================================
@@ -918,10 +871,17 @@ impl DurableWorker {
                 let turn_input: DurableTurnInput = serde_json::from_value(task.input.clone())
                     .map_err(|e| anyhow::anyhow!("Failed to parse task input: {}", e))?;
                 let res = match task.activity_type.as_str() {
-                    "process_input" => self.execute_input_activity(grpc_client, &turn_input).await,
-                    "reason" => {
-                        self.execute_reason_activity(grpc_client, &turn_input, self.store.clone())
+                    "process_input" => {
+                        self.execute_input_activity(grpc_client.clone(), &turn_input)
                             .await
+                    }
+                    "reason" => {
+                        self.execute_reason_activity(
+                            grpc_client.clone(),
+                            &turn_input,
+                            self.store.clone(),
+                        )
+                        .await
                     }
                     _ => unreachable!(),
                 };
@@ -960,7 +920,7 @@ impl DurableWorker {
                 };
                 let res = self
                     .execute_act_activity(
-                        grpc_client,
+                        grpc_client.clone(),
                         act_task_input.org_id,
                         act_task_input.act_input,
                     )
@@ -1014,69 +974,12 @@ impl DurableWorker {
                             "Task completed successfully"
                         );
 
-                        // After act activity: if ActAtom signaled waiting_for_tool_results
-                        // (connection setup, client-side tools), check the setup_connection
-                        // client hint before pausing. When the hint is true, set the session
-                        // status so the client can handle the tool calls. When absent, skip
-                        // the pause — the LLM will see the tool errors and inform the user.
-                        if task.activity_type == "act"
-                            && let Some(ref ti) = turn_input_opt
-                        {
-                            let waiting = output
-                                .get("waiting_for_tool_results")
-                                .and_then(|v| v.as_bool())
-                                .unwrap_or(false);
-                            if waiting {
-                                // Check the setup_connection hint before pausing
-                                let hint_enabled = {
-                                    use everruns_core::traits::SessionStore;
-                                    let grpc_client =
-                                        GrpcClient::connect(&self.grpc_address).await?;
-                                    let session_store = crate::grpc_adapters::GrpcSessionStore::new(
-                                        grpc_client.clone(),
-                                        ti.org_id,
-                                    );
-                                    match session_store.get_session(ti.session_id).await {
-                                        Ok(Some(session)) => {
-                                            let hints = everruns_core::Controls::resolve_hints(
-                                                session.hints.as_ref(),
-                                                None,
-                                            );
-                                            hints
-                                                .get("setup_connection")
-                                                .and_then(|v| v.as_bool())
-                                                .unwrap_or(false)
-                                        }
-                                        _ => false,
-                                    }
-                                };
-
-                                if hint_enabled {
-                                    let grpc_client =
-                                        GrpcClient::connect(&self.grpc_address).await?;
-                                    if let Err(e) = grpc_client
-                                        .set_session_status(
-                                            ti.org_id,
-                                            ti.session_id,
-                                            "waiting_for_tool_results",
-                                        )
-                                        .await
-                                    {
-                                        warn!(error = %e, "Failed to set session status to waiting_for_tool_results");
-                                    }
-                                } else {
-                                    info!(
-                                        "setup_connection hint absent; skipping wait for tool results"
-                                    );
-                                }
-                            }
-                        }
-
                         // Only schedule next activity if we successfully completed the task
                         // and it has a parent workflow. Standalone tasks have no next activity.
                         if let (Some(turn_input), Some(wf_id)) = (turn_input_opt, task.workflow_id)
                         {
                             self.schedule_next_activity(
+                                grpc_client,
                                 wf_id,
                                 &task.activity_type,
                                 &turn_input,
@@ -1414,13 +1317,12 @@ impl DurableWorker {
     /// Schedule the next activity based on current activity completion
     async fn schedule_next_activity(
         &self,
+        grpc_client: GrpcClient,
         workflow_id: Uuid,
         completed_activity: &str,
         input: &DurableTurnInput,
         output: &serde_json::Value,
     ) -> Result<()> {
-        // Clone input so we can update previous_response_id for chaining
-        let mut chained_input = input.clone();
         let mut store = self.store.lock().await;
 
         // Check if workflow is cancelled before scheduling next activity
@@ -1448,312 +1350,95 @@ impl DurableWorker {
             return Ok(());
         }
 
-        match completed_activity {
-            "process_input" => {
-                // Extract turn_id from output (set by execute_input_activity)
-                // TurnId is serialized as prefixed string "turn_abc123"
-                let turn_id: Option<TurnId> = output
-                    .get("turn_id")
-                    .and_then(|v| v.as_str())
-                    .and_then(|s| s.parse().ok());
+        let adapters =
+            crate::grpc_worker_adapters::GrpcWorkerAdapters::from_client_with_platform_definition(
+                grpc_client,
+                self.platform_definition.as_ref().clone(),
+            );
+        let host = WorkerRuntimeHost::new(adapters);
+        let pending_user_message_count = if completed_activity == "reason" {
+            store
+                .get_and_consume_signals(workflow_id)
+                .await
+                .map_err(|error| anyhow::anyhow!("Failed to consume workflow signals: {}", error))?
+                .into_iter()
+                .filter(|signal| signal.signal_type == everruns_durable::signal_types::USER_MESSAGE)
+                .count()
+        } else {
+            0
+        };
 
-                // Create input with turn_id for subsequent activities
-                let input_with_turn = DurableTurnInput {
-                    org_id: input.org_id,
-                    session_id: input.session_id,
-                    harness_id: input.harness_id,
-                    agent_id: input.agent_id,
-                    input_message_id: input.input_message_id,
-                    turn_id,
-                    previous_response_id: None,
-                    iteration: 1,
-                    request_id: input.request_id.clone(),
-                };
-                let input_json = serde_json::to_value(&input_with_turn)?;
-
-                // After input processing, schedule reason activity
+        match plan_next_host_turn(
+            &host,
+            completed_activity,
+            input,
+            output,
+            pending_user_message_count,
+        )
+        .await?
+        {
+            RuntimeTurnPlan::ScheduleReason(next) => {
                 store
                     .enqueue_task(
                         workflow_id,
                         format!("reason_{}", Uuid::now_v7()),
                         "reason".to_string(),
+                        serde_json::to_value(&next)?,
+                    )
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to enqueue reason task: {}", e))?;
+            }
+            RuntimeTurnPlan::ScheduleAct(plan) => {
+                let input_json = serialize_act_plan_for_durable_worker(&plan)?;
+                store
+                    .enqueue_task(
+                        workflow_id,
+                        format!("act_{}", Uuid::now_v7()),
+                        "act".to_string(),
                         input_json,
                     )
                     .await
-                    .map_err(|e| anyhow::anyhow!("Failed to enqueue reason task: {}", e))?;
-
-                debug!(workflow_id = %workflow_id, turn_id = ?turn_id, "Scheduled reason activity");
+                    .map_err(|e| anyhow::anyhow!("Failed to enqueue act task: {}", e))?;
             }
-            "reason" => {
-                let reason_result: ReasonResult = serde_json::from_value(output.clone())
-                    .map_err(|e| anyhow::anyhow!("Failed to parse ReasonResult: {}", e))?;
-
-                // Carry response_id forward for next reason iteration
-                chained_input.previous_response_id = reason_result.response_id.clone();
-
-                // Check for pending user messages (steering signals) only when
-                // the turn would otherwise complete (no tool calls, success).
-                let has_pending_user_messages = if !reason_result.has_tool_calls
-                    && reason_result.success
-                {
-                    let signals = match store.get_and_consume_signals(workflow_id).await {
-                        Ok(s) => s,
-                        Err(e) => {
-                            warn!(workflow_id = %workflow_id, error = %e,
-                                "Failed to consume steering signals; treating as no pending messages");
-                            vec![]
-                        }
-                    };
-                    let count = signals
-                        .iter()
-                        .filter(|s| s.signal_type == everruns_durable::signal_types::USER_MESSAGE)
-                        .count();
-                    if count > 1 {
-                        info!(
-                            workflow_id = %workflow_id,
-                            queued_count = count,
-                            "Multiple user messages arrived during turn"
-                        );
-                    }
-                    count > 0
-                } else {
-                    false
-                };
-
-                if reason_result.has_tool_calls && reason_result.success {
-                    let tool_count = reason_result.tool_calls.len();
-                    let turn_id = input.turn_id.unwrap_or_default();
-
-                    let act_task_input = ActTaskInput {
-                        org_id: input.org_id,
-                        request_id: input.request_id.clone(),
-                        act_input: ActInput {
-                            org_id: Some(input.org_id),
-                            context: AtomContext {
-                                session_id: input.session_id,
-                                turn_id,
-                                input_message_id: input.input_message_id,
-                                exec_id: ExecId::new(),
-                            },
-                            harness_id: input.harness_id,
-                            agent_id: input.agent_id,
-                            tool_calls: reason_result.tool_calls,
-                            tool_definitions: reason_result.tool_definitions,
-                            locale: reason_result.locale,
-                            blueprint_id: None,
-                            network_access: reason_result.network_access,
-                        },
-                    };
-                    let mut act_input_json = serde_json::to_value(&act_task_input)?;
-                    if let Some(rid) = &chained_input.previous_response_id {
-                        act_input_json["previous_response_id"] = serde_json::json!(rid);
-                    }
-                    act_input_json["iteration"] = serde_json::json!(input.iteration);
-
-                    store
-                        .enqueue_task(
-                            workflow_id,
-                            format!("act_{}", Uuid::now_v7()),
-                            "act".to_string(),
-                            act_input_json,
-                        )
-                        .await
-                        .map_err(|e| anyhow::anyhow!("Failed to enqueue act task: {}", e))?;
-
-                    debug!(
-                        workflow_id = %workflow_id,
-                        tool_count = tool_count,
-                        "Scheduled act activity for tool execution"
-                    );
-                } else if has_pending_user_messages {
-                    // User message(s) arrived during this turn. Continue the same
-                    // turn — the message retriever re-queries the DB on next reason.
-                    let next_iteration = input.iteration.saturating_add(1);
-                    let continued_input = DurableTurnInput {
-                        org_id: input.org_id,
-                        session_id: input.session_id,
-                        harness_id: input.harness_id,
-                        agent_id: input.agent_id,
-                        input_message_id: input.input_message_id,
-                        turn_id: input.turn_id,
-                        previous_response_id: chained_input.previous_response_id.clone(),
-                        iteration: next_iteration,
-                        request_id: input.request_id.clone(),
-                    };
-                    let continued_json = serde_json::to_value(&continued_input)?;
-
-                    store
-                        .enqueue_task(
-                            workflow_id,
-                            format!("reason_{}", Uuid::now_v7()),
-                            "reason".to_string(),
-                            continued_json,
-                        )
-                        .await
-                        .map_err(|e| {
-                            anyhow::anyhow!("Failed to enqueue steered reason iteration: {}", e)
-                        })?;
-
-                    info!(
-                        workflow_id = %workflow_id,
-                        iteration = next_iteration,
-                        "Steering: continuing turn with new reason iteration"
-                    );
-                } else {
-                    // Turn truly complete. Emit turn event + session.idled + mark done.
-                    let turn_id = input.turn_id.unwrap_or_default();
-                    let grpc_address = self.grpc_address.clone();
-                    let org_id = input.org_id;
-                    let session_id = input.session_id;
-                    let input_message_id = input.input_message_id;
-                    let iteration = input.iteration;
-                    let usage = reason_result.usage.clone();
-
-                    store
-                        .update_workflow_status(
-                            workflow_id,
-                            WorkflowStatus::Completed,
-                            None,
-                            reason_result.error.clone(),
-                        )
-                        .await
-                        .map_err(|e| anyhow::anyhow!("Failed to update workflow status: {}", e))?;
-
-                    drop(store);
-
-                    // Emit turn.completed or turn.failed + session.idled via gRPC
-                    let grpc_client = GrpcClient::connect(&grpc_address).await;
-                    if let Ok(client) = grpc_client {
-                        let event_emitter = GrpcEventEmitter::new(client.clone());
-                        let ctx = EventContext::turn(turn_id, input_message_id);
-
-                        if reason_result.success {
-                            let _ = event_emitter
-                                .emit(EventRequest::new(
-                                    session_id,
-                                    ctx,
-                                    TurnCompletedData {
-                                        turn_id,
-                                        iterations: iteration,
-                                        duration_ms: None,
-                                        usage: usage.clone(),
-                                        input_content: None,
-                                    },
-                                ))
-                                .await;
-                        } else {
-                            let _ = event_emitter
-                                .emit(EventRequest::new(
-                                    session_id,
-                                    ctx,
-                                    TurnFailedData {
-                                        turn_id,
-                                        error: "An error occurred while processing your request."
-                                            .to_string(),
-                                        error_code: Some("llm_error".to_string()),
-                                    },
-                                ))
-                                .await;
-                        }
-                    }
-
-                    emit_session_idled(
-                        &grpc_address,
-                        org_id,
-                        session_id,
-                        turn_id,
-                        input_message_id,
-                        Some(iteration),
-                        usage,
-                    )
-                    .await;
-
-                    info!(workflow_id = %workflow_id, "Workflow completed");
-                    return Ok(());
-                }
-            }
-            "act" => {
-                let blocked = output
-                    .get("blocked")
-                    .and_then(|value| value.as_bool())
-                    .unwrap_or(false);
-                if blocked {
-                    store
-                        .update_workflow_status(workflow_id, WorkflowStatus::Completed, None, None)
-                        .await
-                        .map_err(|e| anyhow::anyhow!("Failed to update workflow status: {}", e))?;
-
-                    info!(workflow_id = %workflow_id, "Workflow completed after dependency block");
-                    return Ok(());
-                }
-
-                // Check if act needs external input (connection setup, client-side tools).
-                // ActAtom sets waiting_for_tool_results via hooks; worker just checks the flag.
-                let waiting = output
-                    .get("waiting_for_tool_results")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(false);
-
-                if waiting {
-                    // Complete workflow and persist the current DurableTurnInput so
-                    // the tool-results endpoint can resume with correct turn_id,
-                    // iteration, and previous_response_id (instead of creating a
-                    // phantom MessageId that InputAtom cannot find).
-                    let resumed_input = DurableTurnInput {
-                        iteration: chained_input.iteration.saturating_add(1),
-                        ..chained_input.clone()
-                    };
-                    let result_json = serde_json::to_value(&resumed_input)
-                        .map_err(|e| {
-                            anyhow::anyhow!(
-                                "Failed to serialize DurableTurnInput for connection_required resume: {}",
-                                e
-                            )
-                        })?;
-                    store
-                        .update_workflow_status(
-                            workflow_id,
-                            WorkflowStatus::Completed,
-                            Some(result_json),
-                            None,
-                        )
-                        .await
-                        .map_err(|e| anyhow::anyhow!("Failed to update workflow status: {}", e))?;
-
-                    info!(
-                        workflow_id = %workflow_id,
-                        "Workflow completed — waiting for user to set up connection"
-                    );
-                    return Ok(());
-                }
-
-                // After action, schedule another reason activity (continue the loop)
-                // Use chained_input which carries previous_response_id from last reason
-                // Increment iteration count for the next reason step
-                chained_input.iteration = chained_input.iteration.saturating_add(1);
-                let chained_json = serde_json::to_value(&chained_input)?;
+            RuntimeTurnPlan::Complete { error } => {
                 store
-                    .enqueue_task(
+                    .update_workflow_status(workflow_id, WorkflowStatus::Completed, None, error)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to update workflow status: {}", e))?;
+            }
+            RuntimeTurnPlan::WaitForToolResults { resume } => {
+                store
+                    .update_workflow_status(
                         workflow_id,
-                        format!("reason_{}", Uuid::now_v7()),
-                        "reason".to_string(),
-                        chained_json,
+                        WorkflowStatus::Completed,
+                        Some(serde_json::to_value(&resume)?),
+                        None,
                     )
                     .await
-                    .map_err(|e| anyhow::anyhow!("Failed to enqueue reason task: {}", e))?;
-
-                debug!(workflow_id = %workflow_id, "Scheduled reason activity after act");
-            }
-            _ => {
-                warn!(
-                    activity = completed_activity,
-                    "Unknown activity type completed"
-                );
+                    .map_err(|e| {
+                        anyhow::anyhow!("Failed to persist wait-for-tools state: {}", e)
+                    })?;
             }
         }
 
         Ok(())
     }
+}
+
+fn serialize_act_plan_for_durable_worker(plan: &RuntimeActPlan) -> Result<serde_json::Value> {
+    let mut input_json = serde_json::to_value(ActTaskInput {
+        org_id: plan
+            .input
+            .org_id
+            .expect("ActInput.org_id must be set for durable worker scheduling"),
+        request_id: plan.request_id.clone(),
+        act_input: plan.input.clone(),
+    })?;
+    if let Some(response_id) = &plan.previous_response_id {
+        input_json["previous_response_id"] = serde_json::json!(response_id);
+    }
+    input_json["iteration"] = serde_json::json!(plan.iteration);
+    Ok(input_json)
 }
 
 #[cfg(test)]
@@ -1825,6 +1510,7 @@ mod tests {
             turn_id: Some(turn_id),
             previous_response_id: None,
             iteration: 1,
+            request_id: None,
         };
         let value = serde_json::to_value(&turn_input).unwrap();
 
@@ -1846,6 +1532,7 @@ mod tests {
         let turn_id = TurnId::new();
         let act_task_input = ActTaskInput {
             org_id: 7,
+            request_id: Some("req_123".to_string()),
             act_input: ActInput {
                 org_id: Some(7),
                 context: AtomContext {

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -13,14 +13,13 @@ use everruns_core::ActInput;
 use everruns_core::atoms::AtomContext;
 use everruns_core::typed_id::{ExecId, TurnId};
 use everruns_durable::{
-    ActivityOptions, ClaimedTask, WorkerInfo, WorkflowEvent, WorkflowEventStore, WorkflowStatus,
-    append_event, record_activity_completed, record_activity_failed, record_activity_started,
-    record_workflow_completed,
+    ClaimedTask, WorkerInfo, WorkflowEventStore, WorkflowStatus, record_activity_completed,
+    record_activity_failed, record_activity_started,
 };
 use everruns_runtime::{
-    RuntimeSessionLifecycle, execute_act_activity as runtime_execute_act_activity,
+    RuntimeActPlan, RuntimeTurnPlan, execute_act_activity as runtime_execute_act_activity,
     execute_input_activity as runtime_execute_input_activity,
-    execute_reason_activity as runtime_execute_reason_activity,
+    execute_reason_activity as runtime_execute_reason_activity, plan_next_host_turn,
 };
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -450,7 +449,6 @@ where
                 .filter(|&it| it > 0)
                 .unwrap_or(1);
 
-            // Extract request_id propagated from the originating HTTP request
             let act_request_id = task
                 .input
                 .get("request_id")
@@ -516,51 +514,6 @@ where
                         activity_type = %task.activity_type,
                         "Task completed successfully"
                     );
-
-                    // After act activity: if ActAtom signaled waiting_for_tool_results
-                    // (connection setup, client-side tools), check the setup_connection
-                    // client hint before pausing. When the hint is true, set the session
-                    // status so the client can handle the tool calls. When absent, skip
-                    // the pause — the LLM will see the tool errors and inform the user.
-                    if task.activity_type == "act"
-                        && let Some(ref ti) = turn_input_opt
-                    {
-                        let act_result: Option<everruns_core::ActResult> =
-                            serde_json::from_value(output.clone()).ok();
-                        let waiting = act_result
-                            .as_ref()
-                            .is_some_and(|r| r.waiting_for_tool_results);
-                        if waiting {
-                            // Check the setup_connection hint before pausing
-                            let hint_enabled =
-                                match adapters.get_session(ti.org_id, ti.session_id.uuid()).await {
-                                    Ok(Some(session)) => {
-                                        let hints = everruns_core::Controls::resolve_hints(
-                                            session.hints.as_ref(),
-                                            None,
-                                        );
-                                        hints
-                                            .get("setup_connection")
-                                            .and_then(|v| v.as_bool())
-                                            .unwrap_or(false)
-                                    }
-                                    _ => false,
-                                };
-
-                            if hint_enabled {
-                                let lifecycle = RuntimeSessionLifecycle::new(
-                                    WorkerRuntimeHost::new(adapters.clone()),
-                                    ti.org_id,
-                                    ti.session_id,
-                                );
-                                lifecycle.waiting_for_tool_results().await;
-                            } else {
-                                info!(
-                                    "setup_connection hint absent; skipping wait for tool results"
-                                );
-                            }
-                        }
-                    }
 
                     // Schedule next activity if needed (only for workflow-bound tasks)
                     if let (Some(turn_input), Some(wf_id)) = (turn_input_opt, task.workflow_id) {
@@ -732,300 +685,135 @@ async fn schedule_next_activity<S: WorkflowEventStore, A: WorkerAdapters + Clone
     input: &DurableTurnInput,
     output: &serde_json::Value,
 ) -> Result<()> {
-    use everruns_durable::TaskDefinition;
+    let pending_user_message_count = if completed_activity == "reason" {
+        store
+            .consume_pending_signals(workflow_id)
+            .await
+            .map_err(|error| anyhow::anyhow!("Failed to consume workflow signals: {}", error))?
+            .into_iter()
+            .filter(|signal| signal.signal_type == everruns_durable::signal_types::USER_MESSAGE)
+            .count()
+    } else {
+        0
+    };
 
-    match completed_activity {
-        "process_input" => {
-            // Extract turn_id from output
-            let turn_id: Option<TurnId> = output
-                .get("turn_id")
-                .and_then(|v| v.as_str())
-                .and_then(|s| s.parse().ok());
-
-            // Create input with turn_id for subsequent activities
-            let input_with_turn = DurableTurnInput {
-                org_id: input.org_id,
-                session_id: input.session_id,
-                harness_id: input.harness_id,
-                agent_id: input.agent_id,
-                input_message_id: input.input_message_id,
-                turn_id,
-                previous_response_id: None,
-                iteration: 1,
-                request_id: input.request_id.clone(),
-            };
-            let input_json = serde_json::to_value(&input_with_turn)?;
-
-            // Schedule reason activity
-            let activity_id = format!("reason_{}", Uuid::now_v7());
-            let task = TaskDefinition {
-                workflow_id: Some(workflow_id),
-                activity_id: activity_id.clone(),
-                activity_type: "reason".to_string(),
-                input: input_json.clone(),
-                options: Default::default(),
-            };
+    match plan_next_host_turn(
+        &WorkerRuntimeHost::new(adapters.clone()),
+        completed_activity,
+        input,
+        output,
+        pending_user_message_count,
+    )
+    .await?
+    {
+        RuntimeTurnPlan::ScheduleReason(next) => {
+            enqueue_reason_task(store, workflow_id, &next).await?;
+        }
+        RuntimeTurnPlan::ScheduleAct(plan) => {
+            enqueue_act_task(store, workflow_id, &plan).await?;
+        }
+        RuntimeTurnPlan::Complete { error } => {
+            everruns_durable::record_workflow_completed(
+                store.as_ref(),
+                workflow_id,
+                output.clone(),
+            )
+            .await;
             store
-                .enqueue_task(task)
+                .update_workflow_status(
+                    workflow_id,
+                    WorkflowStatus::Completed,
+                    None,
+                    error.map(everruns_durable::WorkflowError::new),
+                )
                 .await
-                .map_err(|e| anyhow::anyhow!("Failed to enqueue reason task: {}", e))?;
-
-            // Record ActivityScheduled event
-            let scheduled_event = WorkflowEvent::ActivityScheduled {
-                activity_id,
-                activity_type: "reason".to_string(),
-                input: input_json,
-                options: ActivityOptions::default(),
-            };
-            let _ = append_event(store.as_ref(), workflow_id, scheduled_event).await;
-
-            debug!(workflow_id = %workflow_id, turn_id = ?turn_id, "Scheduled reason activity");
+                .map_err(|e| anyhow::anyhow!("Failed to update workflow status: {}", e))?;
         }
-        "reason" => {
-            let reason_result: everruns_core::ReasonResult = serde_json::from_value(output.clone())
-                .map_err(|e| anyhow::anyhow!("Failed to parse ReasonResult: {}", e))?;
-
-            let response_id = reason_result.response_id.clone();
-
-            // Check for pending user messages (steering signals) only when
-            // the turn would otherwise complete (no tool calls, success).
-            let has_pending_user_messages = if !reason_result.has_tool_calls
-                && reason_result.success
-            {
-                let signals = match store.consume_pending_signals(workflow_id).await {
-                    Ok(s) => s,
-                    Err(e) => {
-                        warn!(workflow_id = %workflow_id, error = ?e,
-                                "Failed to consume steering signals; treating as no pending messages");
-                        Vec::new()
-                    }
-                };
-                let count = signals
-                    .iter()
-                    .filter(|s| s.signal_type == everruns_durable::signal_types::USER_MESSAGE)
-                    .count();
-                if count > 1 {
-                    info!(
-                        workflow_id = %workflow_id,
-                        queued_count = count,
-                        "Multiple user messages arrived during turn"
-                    );
-                }
-                count > 0
-            } else {
-                false
-            };
-
-            if reason_result.has_tool_calls && reason_result.success {
-                let turn_id = input.turn_id.unwrap_or_default();
-
-                let act_input = ActInput {
-                    org_id: Some(input.org_id),
-                    context: AtomContext {
-                        session_id: input.session_id,
-                        turn_id,
-                        input_message_id: input.input_message_id,
-                        exec_id: ExecId::new(),
-                    },
-                    harness_id: input.harness_id,
-                    agent_id: input.agent_id,
-                    tool_calls: reason_result.tool_calls,
-                    tool_definitions: reason_result.tool_definitions,
-                    locale: reason_result.locale,
-                    blueprint_id: None,
-                    network_access: reason_result.network_access,
-                };
-                let mut act_input_json = serde_json::to_value(&act_input)?;
-                if let Some(rid) = &response_id {
-                    act_input_json["previous_response_id"] = serde_json::json!(rid);
-                }
-                act_input_json["iteration"] = serde_json::json!(input.iteration);
-                if let Some(rid) = &input.request_id {
-                    act_input_json["request_id"] = serde_json::json!(rid);
-                }
-                let activity_id = format!("act_{}", Uuid::now_v7());
-
-                let task = TaskDefinition {
-                    workflow_id: Some(workflow_id),
-                    activity_id: activity_id.clone(),
-                    activity_type: "act".to_string(),
-                    input: act_input_json.clone(),
-                    options: Default::default(),
-                };
-                store
-                    .enqueue_task(task)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Failed to enqueue act task: {}", e))?;
-
-                let scheduled_event = WorkflowEvent::ActivityScheduled {
-                    activity_id,
-                    activity_type: "act".to_string(),
-                    input: act_input_json,
-                    options: ActivityOptions::default(),
-                };
-                let _ = append_event(store.as_ref(), workflow_id, scheduled_event).await;
-
-                debug!(workflow_id = %workflow_id, "Scheduled act activity");
-            } else if has_pending_user_messages {
-                // User message(s) arrived during this turn. Continue the same
-                // turn — the message retriever re-queries the DB on next reason.
-                let next_iteration = input.iteration.saturating_add(1);
-                let continued_input = DurableTurnInput {
-                    org_id: input.org_id,
-                    session_id: input.session_id,
-                    harness_id: input.harness_id,
-                    agent_id: input.agent_id,
-                    input_message_id: input.input_message_id,
-                    turn_id: input.turn_id,
-                    previous_response_id: response_id,
-                    iteration: next_iteration,
-                    request_id: input.request_id.clone(),
-                };
-                let continued_json = serde_json::to_value(&continued_input)?;
-                let activity_id = format!("reason_{}", Uuid::now_v7());
-
-                let task = TaskDefinition {
-                    workflow_id: Some(workflow_id),
-                    activity_id: activity_id.clone(),
-                    activity_type: "reason".to_string(),
-                    input: continued_json.clone(),
-                    options: Default::default(),
-                };
-                store.enqueue_task(task).await.map_err(|e| {
-                    anyhow::anyhow!("Failed to enqueue steered reason iteration: {}", e)
-                })?;
-
-                let scheduled_event = WorkflowEvent::ActivityScheduled {
-                    activity_id,
-                    activity_type: "reason".to_string(),
-                    input: continued_json,
-                    options: ActivityOptions::default(),
-                };
-                let _ = append_event(store.as_ref(), workflow_id, scheduled_event).await;
-
-                info!(
-                    workflow_id = %workflow_id,
-                    iteration = next_iteration,
-                    "Steering: continuing turn with new reason iteration"
-                );
-            } else {
-                // Turn truly complete. Emit turn event + session.idled + mark done.
-                let turn_id = input.turn_id.unwrap_or_default();
-                let lifecycle = RuntimeSessionLifecycle::new(
-                    WorkerRuntimeHost::new(adapters.clone()),
-                    input.org_id,
-                    input.session_id,
-                );
-
-                if reason_result.success {
-                    lifecycle
-                        .emit_turn_completed(
-                            turn_id,
-                            input.input_message_id,
-                            input.iteration,
-                            reason_result.usage.clone(),
-                            None,
-                        )
-                        .await;
-                    lifecycle
-                        .emit_session_idled(
-                            turn_id,
-                            input.input_message_id,
-                            Some(input.iteration),
-                            reason_result.usage.clone(),
-                        )
-                        .await;
-                } else {
-                    lifecycle
-                        .turn_failed(
-                            turn_id,
-                            input.input_message_id,
-                            "An error occurred while processing your request.",
-                            Some("llm_error"),
-                        )
-                        .await;
-                }
-
-                record_workflow_completed(store.as_ref(), workflow_id, output.clone()).await;
-                store
-                    .update_workflow_status(workflow_id, WorkflowStatus::Completed, None, None)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Failed to update workflow status: {}", e))?;
-
-                info!(workflow_id = %workflow_id, "Workflow completed");
-            }
-        }
-        "act" => {
-            let blocked = output
-                .get("blocked")
-                .and_then(|value| value.as_bool())
-                .unwrap_or(false);
-            if blocked {
-                record_workflow_completed(store.as_ref(), workflow_id, output.clone()).await;
-                store
-                    .update_workflow_status(workflow_id, WorkflowStatus::Completed, None, None)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Failed to update workflow status: {}", e))?;
-                info!(workflow_id = %workflow_id, "Workflow completed after dependency block");
-                return Ok(());
-            }
-            // Check if act needs external input (connection setup, client-side tools).
-            // ActAtom sets waiting_for_tool_results via hooks; worker just checks the flag.
-            let waiting = output
-                .get("waiting_for_tool_results")
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false);
-
-            if waiting {
-                // Complete workflow — it will be resumed by tool-results endpoint
-                record_workflow_completed(store.as_ref(), workflow_id, output.clone()).await;
-                store
-                    .update_workflow_status(workflow_id, WorkflowStatus::Completed, None, None)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Failed to update workflow status: {}", e))?;
-
-                info!(
-                    workflow_id = %workflow_id,
-                    "Workflow completed — waiting for tool results"
-                );
-            } else {
-                // Normal flow: schedule another reason activity
-                // Increment iteration count for the next reason step
-                let mut next_input = input.clone();
-                next_input.iteration = next_input.iteration.saturating_add(1);
-                let input_json = serde_json::to_value(&next_input)?;
-                let activity_id = format!("reason_{}", Uuid::now_v7());
-                let task = TaskDefinition {
-                    workflow_id: Some(workflow_id),
-                    activity_id: activity_id.clone(),
-                    activity_type: "reason".to_string(),
-                    input: input_json.clone(),
-                    options: Default::default(),
-                };
-                store
-                    .enqueue_task(task)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Failed to enqueue reason task: {}", e))?;
-
-                let scheduled_event = WorkflowEvent::ActivityScheduled {
-                    activity_id,
-                    activity_type: "reason".to_string(),
-                    input: input_json,
-                    options: ActivityOptions::default(),
-                };
-                let _ = append_event(store.as_ref(), workflow_id, scheduled_event).await;
-
-                debug!(workflow_id = %workflow_id, turn_id = ?input.turn_id, "Scheduled reason activity after act");
-            }
-        }
-        _ => {
-            warn!(
-                activity = completed_activity,
-                "Unknown activity type completed"
-            );
+        RuntimeTurnPlan::WaitForToolResults { resume } => {
+            everruns_durable::record_workflow_completed(
+                store.as_ref(),
+                workflow_id,
+                output.clone(),
+            )
+            .await;
+            store
+                .update_workflow_status(
+                    workflow_id,
+                    WorkflowStatus::Completed,
+                    Some(serde_json::to_value(&resume)?),
+                    None,
+                )
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to persist wait-for-tools state: {}", e))?;
         }
     }
 
+    Ok(())
+}
+
+async fn enqueue_reason_task<S: WorkflowEventStore>(
+    store: &Arc<S>,
+    workflow_id: Uuid,
+    input: &DurableTurnInput,
+) -> Result<()> {
+    let activity_id = format!("reason_{}", Uuid::now_v7());
+    let input_json = serde_json::to_value(input)?;
+    let task = everruns_durable::TaskDefinition {
+        workflow_id: Some(workflow_id),
+        activity_id: activity_id.clone(),
+        activity_type: "reason".to_string(),
+        input: input_json.clone(),
+        options: Default::default(),
+    };
+    store
+        .enqueue_task(task)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to enqueue reason task: {}", e))?;
+
+    let scheduled_event = everruns_durable::WorkflowEvent::ActivityScheduled {
+        activity_id,
+        activity_type: "reason".to_string(),
+        input: input_json,
+        options: everruns_durable::ActivityOptions::default(),
+    };
+    let _ = everruns_durable::append_event(store.as_ref(), workflow_id, scheduled_event).await;
+    Ok(())
+}
+
+async fn enqueue_act_task<S: WorkflowEventStore>(
+    store: &Arc<S>,
+    workflow_id: Uuid,
+    plan: &RuntimeActPlan,
+) -> Result<()> {
+    let mut act_input_json = serde_json::to_value(&plan.input)?;
+    if let Some(response_id) = &plan.previous_response_id {
+        act_input_json["previous_response_id"] = serde_json::json!(response_id);
+    }
+    act_input_json["iteration"] = serde_json::json!(plan.iteration);
+    if let Some(request_id) = &plan.request_id {
+        act_input_json["request_id"] = serde_json::json!(request_id);
+    }
+
+    let activity_id = format!("act_{}", Uuid::now_v7());
+    let task = everruns_durable::TaskDefinition {
+        workflow_id: Some(workflow_id),
+        activity_id: activity_id.clone(),
+        activity_type: "act".to_string(),
+        input: act_input_json.clone(),
+        options: Default::default(),
+    };
+    store
+        .enqueue_task(task)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to enqueue act task: {}", e))?;
+
+    let scheduled_event = everruns_durable::WorkflowEvent::ActivityScheduled {
+        activity_id,
+        activity_type: "act".to_string(),
+        input: act_input_json,
+        options: everruns_durable::ActivityOptions::default(),
+    };
+    let _ = everruns_durable::append_event(store.as_ref(), workflow_id, scheduled_event).await;
     Ok(())
 }
 

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -344,7 +344,7 @@ The `TaskWorker` provides a unified worker implementation that works with both i
    - `sqldb_store()` — optional with default `None` until gRPC support added (EVE-44)
 
 2. **Implementations**:
-   - `DirectWorkerAdapters` - Direct storage access (in-process workers)
+   - `DirectWorkerAdapters` - Direct storage access (in-process workers), including budget-check parity for runtime tools
    - `GrpcWorkerAdapters` - gRPC access (external workers)
 
 3. **Deployment Modes**:
@@ -358,6 +358,7 @@ The `TaskWorker` provides a unified worker implementation that works with both i
 
 **Benefits of Unified Architecture**:
 - Single codebase for activity implementations (input, reason, act)
+- `everruns-runtime` owns the shared turn-strategy planner, so in-process and gRPC-backed workers use the same reason/act continuation and tool-results pause/resume policy without coupling runtime to the durable engine
 - Shared task scheduling logic
 - Easy to test with mock adapters
 - Consistent behavior across deployment modes

--- a/specs/runtime.md
+++ b/specs/runtime.md
@@ -32,10 +32,12 @@ so embedded execution stays behaviorally aligned with the main runtime.
 - `everruns-core` owns atoms, traits, capabilities, event types, and shared
   domain/runtime types.
 - `everruns-runtime` owns embedder-facing orchestration, in-memory stores, turn
-  execution, runtime seeding helpers, and reusable host-phase execution.
+  execution, runtime seeding helpers, reusable host-phase execution, and shared
+  turn-strategy planning.
 - `everruns-server` and `everruns-worker` remain control-plane and durable
-  execution hosts. They use runtime-owned host execution but still own queueing,
-  retries, workflows, and process boundaries.
+  execution hosts. They use runtime-owned host execution and turn-strategy
+  planning, while still owning the durable engine implementation, worker
+  polling, retries, and process boundaries.
 
 ## Public Contract
 
@@ -79,8 +81,19 @@ server-backed execution:
 - `execute_act_activity(...)`
 
 These APIs own phase-local orchestration, atom wiring, dependency blocker
-handling, and lifecycle event emission for the host runtime. Durable scheduling
-and workflow management remain outside this contract.
+handling, lifecycle event emission, and generic turn-strategy planning for
+server-backed hosts.
+
+Host planning APIs:
+
+- `RuntimeTurnState`
+- `RuntimeActPlan`
+- `RuntimeTurnPlan`
+- `plan_next_host_turn(...)`
+
+The planner contract is intentionally durable-agnostic. Runtime decides the
+next semantic step; the host owns queueing, retries, scheduling, persistence,
+and workflow resumption.
 
 ## Execution Semantics
 
@@ -102,6 +115,9 @@ Required behavior:
 7. Durable/server-backed workers must execute their per-phase host logic
    through `everruns-runtime` instead of maintaining a separate copy of atom
    wiring in the worker crate.
+8. Durable/server-backed workers must use runtime-owned turn-strategy planning
+   for `process_input -> reason -> act`, steering continuation,
+   dependency-blocked completion, and `waiting_for_tool_results` pause/resume.
 
 ## Shared Context Assembly
 
@@ -204,12 +220,13 @@ configuration error.
 
 This spec does not require runtime to own:
 
-- durable workflows
-- cross-process task recovery
-- task queues or workflow schedulers
+- durable workflow persistence schemas
+- durable runners or queue/store contracts
+- worker registration, polling, and heartbeat transport
+- scheduler daemons for cron/due-time task discovery
 - server route composition
 
-Those remain separate concerns outside the runtime host-phase contract.
+Those remain separate concerns outside the runtime host orchestration contract.
 
 ## Source Index
 


### PR DESCRIPTION
## What
Keep `everruns-runtime` durable-agnostic while extracting the shared host turn planner and wiring both worker paths to use it.

This removes the runtime-side durable runner/store abstraction from the earlier version of the branch, restores durable ownership to worker/server hosts, and keeps the direct in-process adapter budget-checker parity work.

## Why
The previous version moved too much into `everruns-runtime`:
- runtime depended on `everruns-durable`
- runtime exposed durable-specific runner/store concepts
- the boundary implied runtime owned queueing and persistence policy

That is not the intended embedding contract. Runtime should stay generic enough to run in memory, inside the durable engine, or inside any custom host. Durable scheduling, retries, queue ownership, and workflow resumption should remain host responsibilities.

## How
- remove `crates/runtime/src/durable.rs` and the `everruns-durable` dependency from `everruns-runtime`
- add durable-agnostic host planning APIs: `RuntimeTurnState`, `RuntimeActPlan`, `RuntimeTurnPlan`, `plan_next_host_turn(...)`
- keep runtime ownership at the semantic layer: `process_input -> reason -> act`, lifecycle emission, steering continuation, dependency-blocked completion, and tool-result pause/resume decisions
- map that planner back into durable queueing in both `TaskWorker` and `DurableWorker`
- restore worker-local durable backend ownership for start/resume/cancel orchestration
- add runtime-level tests for the planner contract and keep direct adapter budget-checker parity/tests
- tighten rustdoc/spec wording so embedders see the intended host boundary clearly
- fail fast if workflow signal consumption fails instead of silently dropping steering continuation

## Risk
- Medium
- This changes the boundary between runtime and durable hosts; regressions would affect both gRPC-backed and direct worker scheduling.

## Security
- Threat categories reviewed: TM-DURABLE, TM-CLIENT
- Findings and resolutions:
  - Reviewed host/runtime boundary to ensure runtime does not introduce new durable queue bypass or persistence paths.
  - Reviewed `waiting_for_tool_results` handling so only hosts persist resume state and runtime only returns the semantic plan.
  - Reviewed signal-consumption handling so store failures no longer look like “no steering messages,” which could otherwise hide user intent during a turn.

## Validation
- `cargo check -p everruns-runtime -p everruns-worker -p everruns-server`
- `cargo test -p everruns-runtime --test runtime_host_test --jobs 1`
- `cargo test -p everruns-worker durable_runner::tests --lib --jobs 1`
- `cargo test -p everruns-server budget_checker --lib --jobs 1`
- `cargo clippy -p everruns-runtime -p everruns-worker -p everruns-server --lib --tests -- -D warnings`
- `just pre-push`

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
