### PR TITLE
feat(cli): add agent.toml support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -141,7 +141,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1363,7 +1363,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1488,7 +1488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1585,6 +1585,7 @@ dependencies = [
  "sha2 0.10.9",
  "tempfile",
  "tokio",
+ "toml",
  "webbrowser",
 ]
 
@@ -2882,7 +2883,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2902,7 +2903,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3944,7 +3945,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4550,7 +4551,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -4714,7 +4715,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4752,7 +4753,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5283,7 +5284,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5364,7 +5365,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5607,6 +5608,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5833,7 +5843,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6242,7 +6252,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6586,6 +6596,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6596,12 +6627,26 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.1",
 ]
@@ -6614,6 +6659,12 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.1",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -7483,7 +7534,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7959,6 +8010,15 @@ name = "winnow"
 version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -31,6 +31,7 @@ futures.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
+toml = "0.8"
 
 # Error handling
 anyhow.workspace = true

--- a/crates/cli/src/commands/agents.rs
+++ b/crates/cli/src/commands/agents.rs
@@ -1,9 +1,9 @@
 // Agent management commands
 //
-// Design Decision: When --file is provided, send raw content to the server's
-// import API (POST /v1/agents/import) which handles YAML/JSON/Markdown parsing.
-// --initial-files-dir injects files from a local directory into the payload
-// before sending, so the server receives them as initial_files.
+// Design Decision: Most file formats are forwarded to the server import API
+// unchanged, but TOML is normalized client-side into JSON because the server
+// import endpoint only parses Markdown/YAML/JSON today. The CLI also parses any
+// agent file locally when it needs to inject initial_files.
 
 use crate::output::{OutputFormat, print_field, print_table_header, print_table_row};
 use anyhow::{Context, Result};
@@ -12,11 +12,13 @@ use everruns_sdk::{CreateAgentRequest, Everruns};
 use serde::Deserialize;
 use std::path::Path;
 
+const DEFAULT_AGENT_FILE_NAME: &str = "agent.toml";
+
 #[derive(Subcommand)]
 pub enum AgentsCommand {
     /// Create a new agent (upserts if id: is present in frontmatter)
     Create {
-        /// YAML/JSON/Markdown file with agent definition (sent to server for parsing)
+        /// TOML/YAML/JSON/Markdown file with agent definition
         #[arg(short, long)]
         file: Option<String>,
 
@@ -54,7 +56,7 @@ pub enum AgentsCommand {
         /// Agent ID (e.g. agent_xxx). If omitted, uses id from file frontmatter.
         agent_id: Option<String>,
 
-        /// YAML/JSON/Markdown file with agent definition (sent to server for parsing)
+        /// TOML/YAML/JSON/Markdown file with agent definition
         #[arg(short, long)]
         file: Option<String>,
 
@@ -129,6 +131,12 @@ pub async fn run(
             model,
             tag,
         } => {
+            let use_default_file = name.is_none()
+                && system_prompt.is_none()
+                && description.is_none()
+                && model.is_none()
+                && tag.is_empty();
+            let file = resolve_agent_file(file, use_default_file);
             if let Some(path) = file {
                 if name.is_some()
                     || system_prompt.is_some()
@@ -176,6 +184,13 @@ pub async fn run(
             model,
             tag,
         } => {
+            let use_default_file = agent_id.is_none()
+                && name.is_none()
+                && system_prompt.is_none()
+                && description.is_none()
+                && model.is_none()
+                && tag.is_empty();
+            let file = resolve_agent_file(file, use_default_file);
             if let Some(path) = file {
                 if agent_id.is_some()
                     || name.is_some()
@@ -223,7 +238,7 @@ pub async fn run(
 }
 
 /// Import agent from file via server import API.
-/// Server handles YAML/JSON/Markdown parsing.
+/// The CLI normalizes TOML into JSON before calling the server import API.
 /// When initial_files_dir is provided, files are globbed and injected into the
 /// payload as initial_files before sending.
 async fn import_from_file(
@@ -235,6 +250,7 @@ async fn import_from_file(
     output: OutputFormat,
     quiet: bool,
 ) -> Result<()> {
+    let file_path = Path::new(path);
     let content =
         std::fs::read_to_string(path).with_context(|| format!("Failed to read file: {}", path))?;
 
@@ -245,20 +261,28 @@ async fn import_from_file(
         .map(|p| p.to_path_buf())
         .unwrap_or_else(|| std::path::PathBuf::from("."));
 
-    // If --initial-files-dir is provided, parse the agent file, inject the files,
-    // and send as JSON so the server receives initial_files in the payload.
-    // Also parse when initial_files contains glob patterns (strings) in frontmatter.
-    let (body, content_type) = if let Some(dir) = initial_files_dir {
-        let files = glob_initial_files(dir, writable)?;
-        let mut agent: serde_json::Value =
-            parse_agent_file_as_json(&content).context("Failed to parse agent file")?;
-        agent["initial_files"] = serde_json::to_value(&files)?;
-        (serde_json::to_string(&agent)?, "application/json")
-    } else if has_initial_files_globs(&content) {
-        let mut agent: serde_json::Value =
-            parse_agent_file_as_json(&content).context("Failed to parse agent file")?;
-        let files = expand_initial_files_globs(&agent, &file_dir, writable)?;
-        agent["initial_files"] = serde_json::to_value(&files)?;
+    // Parse once when possible so TOML conversion and initial_files inspection
+    // don't duplicate work before we build the request body.
+    let parsed_agent = parse_agent_file_as_json(file_path, &content).ok();
+    let has_glob_initial_files = parsed_agent.as_ref().is_some_and(initial_files_has_globs);
+    let should_send_json =
+        initial_files_dir.is_some() || has_glob_initial_files || is_toml_agent_file(file_path);
+
+    let (body, content_type) = if should_send_json {
+        let mut agent = if let Some(agent) = parsed_agent {
+            agent
+        } else {
+            parse_agent_file_as_json(file_path, &content).context("Failed to parse agent file")?
+        };
+
+        if let Some(dir) = initial_files_dir {
+            let files = glob_initial_files(dir, writable)?;
+            agent["initial_files"] = serde_json::to_value(&files)?;
+        } else if has_glob_initial_files {
+            let files = expand_initial_files_globs(&agent, &file_dir, writable)?;
+            agent["initial_files"] = serde_json::to_value(&files)?;
+        }
+
         (serde_json::to_string(&agent)?, "application/json")
     } else {
         (content, "text/plain")
@@ -305,6 +329,16 @@ async fn import_from_file(
     }
 
     Ok(())
+}
+
+fn resolve_agent_file(file: Option<String>, use_default: bool) -> Option<String> {
+    file.or_else(|| {
+        if use_default && Path::new(DEFAULT_AGENT_FILE_NAME).is_file() {
+            Some(DEFAULT_AGENT_FILE_NAME.to_string())
+        } else {
+            None
+        }
+    })
 }
 
 /// Represents a file to be uploaded as an initial file for an agent.
@@ -417,15 +451,17 @@ fn glob_initial_files(dir: &str, writable: bool) -> Result<Vec<CollectedFile>> {
 
 /// Quick check whether parsed initial_files contains glob patterns (strings)
 /// rather than fully-specified InitialFile objects.
-fn has_initial_files_globs(content: &str) -> bool {
-    // Fast-path: parse just enough to detect string entries in initial_files.
-    let Ok(agent) = parse_agent_file_as_json(content) else {
-        return false;
-    };
+fn initial_files_has_globs(agent: &serde_json::Value) -> bool {
     let Some(arr) = agent.get("initial_files").and_then(|v| v.as_array()) else {
         return false;
     };
     arr.iter().any(|v| v.is_string())
+}
+
+fn is_toml_agent_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("toml"))
 }
 
 /// Check if a path component is a hidden/dot entry that should be skipped.
@@ -655,10 +691,10 @@ fn collect_single_file(
     Ok(())
 }
 
-/// Parse agent file content (Markdown/YAML/JSON) into a JSON Value.
+/// Parse agent file content (Markdown/TOML/YAML/JSON) into a JSON Value.
 /// This is minimal parsing to allow injecting initial_files before sending
 /// to the server import API.
-fn parse_agent_file_as_json(content: &str) -> Result<serde_json::Value> {
+fn parse_agent_file_as_json(path: &Path, content: &str) -> Result<serde_json::Value> {
     let content = content.trim();
 
     // Markdown with front matter: require `---` delimiters on their own lines
@@ -708,6 +744,15 @@ fn parse_agent_file_as_json(content: &str) -> Result<serde_json::Value> {
     // JSON
     if content.starts_with('{') {
         return serde_json::from_str(content).context("Failed to parse JSON");
+    }
+
+    if is_toml_agent_file(path) {
+        let val: toml::Value = toml::from_str(content).context("Failed to parse TOML")?;
+        let val = serde_json::to_value(val).context("Failed to convert TOML to JSON")?;
+        if !val.is_object() {
+            anyhow::bail!("Agent file must be a TOML object");
+        }
+        return Ok(val);
     }
 
     // YAML
@@ -904,7 +949,7 @@ mod tests {
     #[test]
     fn test_parse_agent_file_json() {
         let content = r#"{"name":"test","system_prompt":"hello"}"#;
-        let val = parse_agent_file_as_json(content).unwrap();
+        let val = parse_agent_file_as_json(Path::new("agent.json"), content).unwrap();
         assert_eq!(val["name"], "test");
         assert_eq!(val["system_prompt"], "hello");
     }
@@ -912,7 +957,15 @@ mod tests {
     #[test]
     fn test_parse_agent_file_yaml() {
         let content = "name: test\nsystem_prompt: hello\n";
-        let val = parse_agent_file_as_json(content).unwrap();
+        let val = parse_agent_file_as_json(Path::new("agent.yaml"), content).unwrap();
+        assert_eq!(val["name"], "test");
+        assert_eq!(val["system_prompt"], "hello");
+    }
+
+    #[test]
+    fn test_parse_agent_file_toml() {
+        let content = "name = \"test\"\nsystem_prompt = \"hello\"\n";
+        let val = parse_agent_file_as_json(Path::new("agent.toml"), content).unwrap();
         assert_eq!(val["name"], "test");
         assert_eq!(val["system_prompt"], "hello");
     }
@@ -920,7 +973,7 @@ mod tests {
     #[test]
     fn test_parse_agent_file_markdown() {
         let content = "---\nname: test\n---\nHello world";
-        let val = parse_agent_file_as_json(content).unwrap();
+        let val = parse_agent_file_as_json(Path::new("agent.md"), content).unwrap();
         assert_eq!(val["name"], "test");
         assert_eq!(val["system_prompt"], "Hello world");
     }
@@ -928,7 +981,7 @@ mod tests {
     #[test]
     fn test_parse_agent_file_markdown_with_system_prompt() {
         let content = "---\nname: test\nsystem_prompt: from frontmatter\n---\nBody text";
-        let val = parse_agent_file_as_json(content).unwrap();
+        let val = parse_agent_file_as_json(Path::new("agent.md"), content).unwrap();
         assert_eq!(val["name"], "test");
         // Frontmatter system_prompt takes precedence
         assert_eq!(val["system_prompt"], "from frontmatter");
@@ -1022,25 +1075,35 @@ mod tests {
     #[test]
     fn test_parse_agent_file_non_object_errors() {
         let content = "just a string";
-        let result = parse_agent_file_as_json(content);
+        let result = parse_agent_file_as_json(Path::new("agent.yaml"), content);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_has_initial_files_globs_with_strings() {
         let content = "---\nname: test\ninitial_files:\n  - .\n  - .agents/*\n---\nPrompt";
-        assert!(has_initial_files_globs(content));
+        let agent = parse_agent_file_as_json(Path::new("agent.md"), content).unwrap();
+        assert!(initial_files_has_globs(&agent));
     }
 
     #[test]
     fn test_has_initial_files_globs_without_strings() {
         // No initial_files at all
         let content = "---\nname: test\n---\nPrompt";
-        assert!(!has_initial_files_globs(content));
+        let agent = parse_agent_file_as_json(Path::new("agent.md"), content).unwrap();
+        assert!(!initial_files_has_globs(&agent));
 
         // initial_files with objects (already expanded)
         let content = r#"{"name":"test","initial_files":[{"path":"/workspace/f.txt","content":"x","encoding":"text","is_readonly":false}]}"#;
-        assert!(!has_initial_files_globs(content));
+        let agent = parse_agent_file_as_json(Path::new("agent.json"), content).unwrap();
+        assert!(!initial_files_has_globs(&agent));
+    }
+
+    #[test]
+    fn test_has_initial_files_globs_toml() {
+        let content = "name = \"test\"\ninitial_files = [\".\", \".agents/*\"]\n";
+        let agent = parse_agent_file_as_json(Path::new("agent.toml"), content).unwrap();
+        assert!(initial_files_has_globs(&agent));
     }
 
     #[test]

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -68,6 +68,12 @@ everruns agents create \
   --system-prompt "You are a helpful assistant." \
   --tag production
 
+# From default TOML file in the current directory
+everruns agents create
+
+# From TOML file
+everruns agents create -f agent.toml
+
 # From YAML file
 everruns agents create -f agent.yaml
 
@@ -76,6 +82,26 @@ everruns agents create -f agent.json
 
 # From Markdown with front matter
 everruns agents create -f agent.md
+```
+
+If `./agent.toml` exists and you do not pass inline creation flags, `everruns agents create` will use it automatically. `everruns agents update` also uses it in file-based mode, but passing an explicit positional `<id>` disables implicit `agent.toml` selection.
+
+**TOML file format** (`agent.toml`):
+
+```toml
+name = "research-assistant"
+description = "Helps with research tasks"
+system_prompt = """
+You are a helpful research assistant.
+Always cite your sources.
+"""
+tags = ["research", "assistant"]
+
+[[capabilities]]
+ref = "current_time"
+
+[[capabilities]]
+ref = "web_fetch"
 ```
 
 **YAML file format** (`agent.yaml`):
@@ -290,7 +316,7 @@ Suppress non-essential output:
 
 ```bash
 # Only output the created agent ID
-everruns agents create -f agent.yaml --quiet
+everruns agents create -f agent.toml --quiet
 # Output: agt_550e8400e29b41d4a716446655440000
 ```
 

--- a/specs/cli.md
+++ b/specs/cli.md
@@ -49,11 +49,11 @@ Organization management.
 
 ### `everruns agents`
 
-Agent CRUD. Create from YAML/JSON/Markdown files or CLI flags.
+Agent CRUD. Create from TOML/YAML/JSON/Markdown files or CLI flags.
 
-- `create --file <path> [--initial-files-dir <dir>] [--writable]` — send file to server import API (server handles parsing); upserts when `id:` present in frontmatter. `--initial-files-dir` recursively collects non-hidden text files from the directory and injects them as read-only `initial_files`. `--writable` makes collected files writable. Alternatively, `initial_files` can be specified directly in frontmatter as a list of relative paths — each entry is resolved relative to the agent file's parent directory, directories are walked recursively, and files are collected with the same security rules as `--initial-files-dir`.
+- `create --file <path> [--initial-files-dir <dir>] [--writable]` — send file to server import API; the CLI normalizes TOML to JSON and otherwise forwards the file as-is. Upserts when `id:` is present in the definition. If `--file` is omitted and `./agent.toml` exists, the CLI uses it automatically unless inline creation flags are present. `--initial-files-dir` recursively collects non-hidden text files from the directory and injects them as read-only `initial_files`. `--writable` makes collected files writable. Alternatively, `initial_files` can be specified directly in the definition as a list of relative paths — each entry is resolved relative to the agent file's parent directory, directories are walked recursively, and files are collected with the same security rules as `--initial-files-dir`.
 - `create --name <n> --system-prompt <s> [--description <d>] [--model <m>] [--tag <t>]` — create from CLI flags
-- `update --file <path> [--initial-files-dir <dir>] [--writable]` — send file to server import API; requires `id:` in file frontmatter for upsert. `--initial-files-dir` and frontmatter `initial_files` work the same as in create.
+- `update --file <path> [--initial-files-dir <dir>] [--writable]` — send file to server import API; TOML is normalized client-side, and `./agent.toml` is used automatically when `--file` is omitted, no inline update flags are present, and no positional `<id>` is provided. Requires `id:` in the definition for upsert. `--initial-files-dir` and definition `initial_files` work the same as in create.
 - `update <id> --name <n> --system-prompt <s> [--description <d>] [--model <m>] [--tag <t>]` — update from CLI flags
 - `list`
 - `get <id>`


### PR DESCRIPTION
## What
Add TOML support for CLI agent definitions and treat `agent.toml` as the implicit file for `everruns agents create` and `everruns agents update` when inline flags are not provided.

## Why
The CLI only accepted YAML/JSON/Markdown agent definitions, which made TOML-based agent configs unusable and forced users to pass an explicit file path even when following a conventional `agent.toml` layout.

## How
Normalize TOML agent files to JSON client-side before calling the existing import API, extend the local parser used for `initial_files` expansion to understand TOML, add tests for TOML parsing/glob detection, and update the CLI docs/spec to document `agent.toml` as the default file.

## Risk
- Low
- Scope is limited to CLI-side agent file loading and docs. Server import behavior is unchanged.

## Security
- Threat categories reviewed: TM-FS, TM-DOS, dependency risk
- Findings and resolutions:
  - Reviewed the new implicit file lookup path. It only resolves the fixed local filename `agent.toml` in the current working directory and keeps the existing guarded `initial_files` collection rules intact.
  - Reviewed TOML parsing at the CLI trust boundary. Parsed TOML is converted to JSON and sent through the same import path as existing formats; no server-side trust boundary or auth surface changed.
  - Reviewed the new `toml` dependency. It is used only for local CLI config parsing.
  - No security findings requiring code or threat-model changes.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)
