### PR TITLE
chore(cli): adopt everruns-sdk 0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1962,9 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "everruns-sdk"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f131ee2ead4a76973f479ab37deac47bb98793034fd6c2ed28e4f9909bccc610"
+checksum = "7ce73a256198a98da88496d6dfdccabc6b969008ac5c931d9b1578a0c7631f75"
 dependencies = [
  "async-stream",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ tokio-tungstenite = { version = "0.26", features = ["rustls-tls-native-roots"] }
 futures-util = "0.3"
 
 # Everruns SDK
-everruns-sdk = "0.1.7"
+everruns-sdk = "0.1.8"
 
 # gRPC (tonic)
 tonic = { version = "0.14", features = ["tls-ring"] }

--- a/crates/cli/src/commands/sessions.rs
+++ b/crates/cli/src/commands/sessions.rs
@@ -75,8 +75,6 @@ pub enum SessionsCommand {
 pub async fn run(
     command: SessionsCommand,
     client: &Everruns,
-    api_url: &str,
-    api_key: &str,
     output: OutputFormat,
     quiet: bool,
 ) -> Result<()> {
@@ -92,8 +90,6 @@ pub async fn run(
         } => {
             create(
                 client,
-                api_url,
-                api_key,
                 output,
                 quiet,
                 harness,
@@ -112,15 +108,13 @@ pub async fn run(
         SessionsCommand::Export {
             session,
             output: file_path,
-        } => export(api_url, api_key, output, quiet, session, file_path).await,
+        } => export(client, output, quiet, session, file_path).await,
     }
 }
 
 #[allow(clippy::too_many_arguments)]
 async fn create(
     client: &Everruns,
-    api_url: &str,
-    api_key: &str,
     output: OutputFormat,
     quiet: bool,
     harness: Option<String>,
@@ -134,21 +128,13 @@ async fn create(
     let secrets = parse_secrets(&raw_secrets)?;
     let budget_specs = parse_budget_limits(&raw_budget_limits, &raw_budget_soft_limits)?;
 
-    // Resolve harness: if it looks like a prefixed ID (harness_ + 32 hex chars),
-    // use it directly. Otherwise resolve via the server's GET /v1/harnesses/{id_or_name}
-    // endpoint (which handles both IDs and names).
-    let harness_id = match harness {
-        Some(h) if h.starts_with("harness_") && h.len() == 40 => Some(h),
-        Some(name) => {
-            let resolved = resolve_harness_name(api_url, api_key, &name).await?;
-            Some(resolved)
-        }
-        None => None,
-    };
-
     let mut req = CreateSessionRequest::new();
-    if let Some(h) = harness_id {
-        req = req.harness_id(h);
+    if let Some(h) = harness {
+        req = if h.starts_with("harness_") && h.len() == 40 {
+            req.harness_id(h)
+        } else {
+            req.harness_name(h)
+        };
     }
     if let Some(a) = agent_id {
         req = req.agent_id(a);
@@ -595,31 +581,18 @@ fn truncate_str(s: &str, max: usize) -> String {
     }
 }
 
-// TODO: Replace direct HTTP with everruns-sdk once export is supported.
-// Tracking issue: https://github.com/everruns/everruns/issues/1180
 async fn export(
-    api_url: &str,
-    api_key: &str,
+    client: &Everruns,
     output: OutputFormat,
     quiet: bool,
     session_id: String,
     file_path: Option<String>,
 ) -> Result<()> {
-    let http = reqwest::Client::new();
-    let resp = http
-        .get(format!("{}/v1/sessions/{}/export", api_url, session_id))
-        .header("Authorization", format!("Bearer {}", api_key))
-        .send()
+    let body = client
+        .sessions()
+        .export(&session_id)
         .await
-        .context("Failed to request session export")?;
-
-    let status = resp.status();
-    if !status.is_success() {
-        let body = resp.text().await.unwrap_or_default();
-        anyhow::bail!("Export failed ({}): {}", status, body);
-    }
-
-    let body = resp.text().await.context("Failed to read export body")?;
+        .context("Failed to export session")?;
 
     if let Some(path) = file_path {
         std::fs::write(&path, &body).with_context(|| format!("Failed to write to {}", path))?;
@@ -632,33 +605,6 @@ async fn export(
     }
 
     Ok(())
-}
-
-/// Resolve a harness name to its ID via the GET /v1/harnesses/{name} endpoint.
-/// Harness names are `[a-z0-9-]` only, so no percent-encoding is needed for path
-/// segments. We strip trailing slashes from the base URL to avoid double slashes.
-async fn resolve_harness_name(api_url: &str, api_key: &str, name: &str) -> Result<String> {
-    let base = api_url.trim_end_matches('/');
-    let http = reqwest::Client::new();
-    let resp = http
-        .get(format!("{base}/v1/harnesses/{name}"))
-        .header("Authorization", format!("Bearer {}", api_key))
-        .send()
-        .await
-        .context("Failed to resolve harness name")?;
-
-    let status = resp.status();
-    if !status.is_success() {
-        let body = resp.text().await.unwrap_or_default();
-        anyhow::bail!("Harness '{name}' not found ({status}): {body}");
-    }
-
-    let harness: serde_json::Value = resp.json().await.context("Invalid harness response")?;
-    harness
-        .get("id")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
-        .context(format!("Harness '{name}' response missing id field"))
 }
 
 fn capitalize_first(s: &str) -> String {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -199,15 +199,7 @@ async fn main() -> anyhow::Result<()> {
             commands::capabilities::run(&client, output_format, &status).await
         }
         Commands::Sessions { command } => {
-            commands::sessions::run(
-                command,
-                &client,
-                &api_url,
-                &api_key,
-                output_format,
-                cli.quiet,
-            )
-            .await
+            commands::sessions::run(command, &client, output_format, cli.quiet).await
         }
         Commands::Files { command } => {
             commands::files::run(command, &api_url, &api_key, output_format, cli.quiet).await

--- a/crates/core/src/message_filter.rs
+++ b/crates/core/src/message_filter.rs
@@ -404,7 +404,7 @@ impl MessageQuery {
         }
 
         // Sort index injections by index (descending) to avoid index shifts affecting later insertions
-        index_injections.sort_by(|a, b| b.0.cmp(&a.0));
+        index_injections.sort_by_key(|entry| std::cmp::Reverse(entry.0));
 
         for (idx, is_before, msg) in index_injections {
             let insert_idx = if is_before {

--- a/crates/core/src/permissions.rs
+++ b/crates/core/src/permissions.rs
@@ -596,11 +596,9 @@ pub fn check_skill_permission(rules: &[SkillPermissionRule], skill_name: &str) -
                 best_specificity = Some(spec);
                 best_allowed = is_allow;
             }
-            Some(best) if spec == best => {
+            Some(best) if spec == best && !is_allow => {
                 // Same specificity: deny wins
-                if !is_allow {
-                    best_allowed = false;
-                }
+                best_allowed = false;
             }
             _ => {} // lower specificity, ignore
         }

--- a/crates/durable/benches/cold_start_latency.rs
+++ b/crates/durable/benches/cold_start_latency.rs
@@ -218,11 +218,9 @@ fn parse_args() -> CliOptions {
     while i < args.len() {
         match args[i].as_str() {
             "--save" => opts.save_checkpoint = true,
-            "--moniker" => {
-                if i + 1 < args.len() {
-                    opts.moniker = Some(args[i + 1].clone());
-                    i += 1;
-                }
+            "--moniker" if i + 1 < args.len() => {
+                opts.moniker = Some(args[i + 1].clone());
+                i += 1;
             }
             _ => {}
         }

--- a/crates/durable/benches/concurrent_workers.rs
+++ b/crates/durable/benches/concurrent_workers.rs
@@ -292,11 +292,9 @@ fn parse_args() -> CliOptions {
     while i < args.len() {
         match args[i].as_str() {
             "--save" => opts.save_checkpoint = true,
-            "--moniker" => {
-                if i + 1 < args.len() {
-                    opts.moniker = Some(args[i + 1].clone());
-                    i += 1;
-                }
+            "--moniker" if i + 1 < args.len() => {
+                opts.moniker = Some(args[i + 1].clone());
+                i += 1;
             }
             _ => {}
         }

--- a/crates/durable/benches/db_cold_start_latency.rs
+++ b/crates/durable/benches/db_cold_start_latency.rs
@@ -446,11 +446,9 @@ fn parse_args() -> CliOptions {
     while i < args.len() {
         match args[i].as_str() {
             "--save" => opts.save_checkpoint = true,
-            "--moniker" => {
-                if i + 1 < args.len() {
-                    opts.moniker = Some(args[i + 1].clone());
-                    i += 1;
-                }
+            "--moniker" if i + 1 < args.len() => {
+                opts.moniker = Some(args[i + 1].clone());
+                i += 1;
             }
             _ => {}
         }

--- a/crates/durable/benches/db_concurrent_workers.rs
+++ b/crates/durable/benches/db_concurrent_workers.rs
@@ -350,11 +350,9 @@ fn parse_args() -> CliOptions {
     while i < args.len() {
         match args[i].as_str() {
             "--save" => opts.save_checkpoint = true,
-            "--moniker" => {
-                if i + 1 < args.len() {
-                    opts.moniker = Some(args[i + 1].clone());
-                    i += 1;
-                }
+            "--moniker" if i + 1 < args.len() => {
+                opts.moniker = Some(args[i + 1].clone());
+                i += 1;
             }
             _ => {}
         }

--- a/crates/durable/benches/db_workflow_throughput.rs
+++ b/crates/durable/benches/db_workflow_throughput.rs
@@ -424,11 +424,9 @@ fn parse_args() -> CliOptions {
     while i < args.len() {
         match args[i].as_str() {
             "--save" => opts.save_checkpoint = true,
-            "--moniker" => {
-                if i + 1 < args.len() {
-                    opts.moniker = Some(args[i + 1].clone());
-                    i += 1;
-                }
+            "--moniker" if i + 1 < args.len() => {
+                opts.moniker = Some(args[i + 1].clone());
+                i += 1;
             }
             _ => {}
         }

--- a/crates/durable/benches/workflow_throughput.rs
+++ b/crates/durable/benches/workflow_throughput.rs
@@ -368,11 +368,9 @@ fn parse_args() -> CliOptions {
     while i < args.len() {
         match args[i].as_str() {
             "--save" => opts.save_checkpoint = true,
-            "--moniker" => {
-                if i + 1 < args.len() {
-                    opts.moniker = Some(args[i + 1].clone());
-                    i += 1;
-                }
+            "--moniker" if i + 1 < args.len() => {
+                opts.moniker = Some(args[i + 1].clone());
+                i += 1;
             }
             _ => {}
         }

--- a/crates/durable/src/bench/checkpoint.rs
+++ b/crates/durable/src/bench/checkpoint.rs
@@ -273,7 +273,7 @@ impl CheckpointStore {
         }
 
         // Sort by timestamp (newest first)
-        checkpoints.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        checkpoints.sort_by_key(|checkpoint| std::cmp::Reverse(checkpoint.timestamp));
 
         Ok(checkpoints)
     }
@@ -315,7 +315,7 @@ impl CheckpointStore {
         let mut deleted = 0;
         for (_, mut checkpoints) in groups {
             // Sort by timestamp (newest first)
-            checkpoints.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+            checkpoints.sort_by_key(|checkpoint| std::cmp::Reverse(checkpoint.timestamp));
 
             // Delete all but the most recent N
             for checkpoint in checkpoints.into_iter().skip(keep_per_combo) {

--- a/crates/durable/src/bench/metrics.rs
+++ b/crates/durable/src/bench/metrics.rs
@@ -182,11 +182,11 @@ impl LatencyHistogramSnapshot {
 
         LatencySummary {
             count: self.count,
-            mean: if self.count == 0 {
-                Duration::ZERO
-            } else {
-                Duration::from_micros(self.sum_micros / self.count)
-            },
+            mean: self
+                .sum_micros
+                .checked_div(self.count)
+                .map(Duration::from_micros)
+                .unwrap_or(Duration::ZERO),
             min: if self.min_micros == u64::MAX {
                 Duration::ZERO
             } else {

--- a/crates/durable/src/persistence/memory.rs
+++ b/crates/durable/src/persistence/memory.rs
@@ -865,7 +865,7 @@ impl WorkflowEventStore for InMemoryWorkflowEventStore {
             .cloned()
             .collect();
 
-        entries.sort_by(|a, b| b.dead_at.cmp(&a.dead_at));
+        entries.sort_by_key(|entry| std::cmp::Reverse(entry.dead_at));
 
         let start = pagination.offset as usize;
         let end = (pagination.offset + pagination.limit) as usize;
@@ -1080,7 +1080,7 @@ impl WorkflowEventStore for InMemoryWorkflowEventStore {
             })
             .cloned()
             .collect();
-        result.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+        result.sort_by_key(|worker| std::cmp::Reverse(worker.started_at));
         Ok(result)
     }
 
@@ -1215,7 +1215,7 @@ impl WorkflowEventStore for InMemoryWorkflowEventStore {
                 continued_as_new_id: w.continued_as_new_id,
             })
             .collect();
-        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        result.sort_by_key(|workflow| std::cmp::Reverse(workflow.created_at));
 
         let start = pagination.offset as usize;
         let end = (pagination.offset + pagination.limit) as usize;
@@ -1271,7 +1271,7 @@ impl WorkflowEventStore for InMemoryWorkflowEventStore {
             })
             .collect();
         // Sort by created_at ascending (oldest first) to show execution order
-        result.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        result.sort_by_key(|task| task.created_at);
 
         let start = pagination.offset as usize;
         let end = (pagination.offset + pagination.limit) as usize;
@@ -1340,7 +1340,7 @@ impl WorkflowEventStore for InMemoryWorkflowEventStore {
             })
             .map(|s| s.row.clone())
             .collect();
-        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        result.sort_by_key(|schedule| std::cmp::Reverse(schedule.created_at));
 
         let start = pagination.offset as usize;
         let end = (pagination.offset + pagination.limit) as usize;
@@ -1436,7 +1436,7 @@ impl WorkflowEventStore for InMemoryWorkflowEventStore {
                     && s.row.claimed_by.is_none()
             })
             .collect();
-        candidates.sort_by(|a, b| a.1.row.next_trigger_at.cmp(&b.1.row.next_trigger_at));
+        candidates.sort_by_key(|entry| entry.1.row.next_trigger_at);
 
         let mut claimed = Vec::new();
         for (_, state) in candidates {
@@ -1600,7 +1600,7 @@ impl WorkflowEventStore for InMemoryWorkflowEventStore {
             })
             .map(|e| e.row.clone())
             .collect();
-        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        result.sort_by_key(|execution| std::cmp::Reverse(execution.created_at));
 
         let start = pagination.offset as usize;
         let end = (pagination.offset + pagination.limit) as usize;

--- a/crates/server/benches/load_test.rs
+++ b/crates/server/benches/load_test.rs
@@ -428,7 +428,7 @@ impl CheckpointStore {
         }
 
         // Sort by timestamp (newest first)
-        checkpoints.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        checkpoints.sort_by_key(|checkpoint| std::cmp::Reverse(checkpoint.timestamp));
         checkpoints.truncate(limit);
 
         Ok(checkpoints)

--- a/crates/server/src/api/ag_ui.rs
+++ b/crates/server/src/api/ag_ui.rs
@@ -635,17 +635,17 @@ fn translate_event(state: &mut AgUiStreamState, event: &everruns_core::Event) {
                 state.finished = true;
             }
         }
-        "reason.thinking.started" => {
-            if parse_event_data::<ReasonThinkingStartedData>(event).is_ok() {
-                state
-                    .queue
-                    .push_back(AgUiEvent::ThinkingStart(AgUiThinkingStartEvent {
-                        base: agui_base_event(),
-                        title: None,
-                    }));
-                state.thinking_started = true;
-                state.thinking_text_started = false;
-            }
+        "reason.thinking.started"
+            if parse_event_data::<ReasonThinkingStartedData>(event).is_ok() =>
+        {
+            state
+                .queue
+                .push_back(AgUiEvent::ThinkingStart(AgUiThinkingStartEvent {
+                    base: agui_base_event(),
+                    title: None,
+                }));
+            state.thinking_started = true;
+            state.thinking_text_started = false;
         }
         "reason.thinking.delta" => {
             if let Ok(data) = parse_event_data::<ReasonThinkingDeltaData>(event) {
@@ -665,25 +665,25 @@ fn translate_event(state: &mut AgUiStreamState, event: &everruns_core::Event) {
                 ));
             }
         }
-        "reason.thinking.completed" => {
-            if parse_event_data::<ReasonThinkingCompletedData>(event).is_ok() {
-                if state.thinking_text_started {
-                    state.queue.push_back(AgUiEvent::ThinkingTextMessageEnd(
-                        AgUiThinkingTextMessageEndEvent {
-                            base: agui_base_event(),
-                        },
-                    ));
-                }
-                if state.thinking_started {
-                    state
-                        .queue
-                        .push_back(AgUiEvent::ThinkingEnd(AgUiThinkingEndEvent {
-                            base: agui_base_event(),
-                        }));
-                }
-                state.thinking_started = false;
-                state.thinking_text_started = false;
+        "reason.thinking.completed"
+            if parse_event_data::<ReasonThinkingCompletedData>(event).is_ok() =>
+        {
+            if state.thinking_text_started {
+                state.queue.push_back(AgUiEvent::ThinkingTextMessageEnd(
+                    AgUiThinkingTextMessageEndEvent {
+                        base: agui_base_event(),
+                    },
+                ));
             }
+            if state.thinking_started {
+                state
+                    .queue
+                    .push_back(AgUiEvent::ThinkingEnd(AgUiThinkingEndEvent {
+                        base: agui_base_event(),
+                    }));
+            }
+            state.thinking_started = false;
+            state.thinking_text_started = false;
         }
         "tool.started" => {
             if let Ok(data) = parse_event_data::<ToolStartedData>(event) {
@@ -744,18 +744,16 @@ fn translate_event(state: &mut AgUiStreamState, event: &everruns_core::Event) {
                     }));
             }
         }
-        "turn.completed" | "session.idled" => {
-            if !state.finished {
-                state
-                    .queue
-                    .push_back(AgUiEvent::RunFinished(AgUiRunFinishedEvent {
-                        base: agui_base_event(),
-                        thread_id: state.thread_id.clone(),
-                        run_id: state.run_id.clone(),
-                        result: None,
-                    }));
-                state.finished = true;
-            }
+        "turn.completed" | "session.idled" if !state.finished => {
+            state
+                .queue
+                .push_back(AgUiEvent::RunFinished(AgUiRunFinishedEvent {
+                    base: agui_base_event(),
+                    thread_id: state.thread_id.clone(),
+                    run_id: state.run_id.clone(),
+                    result: None,
+                }));
+            state.finished = true;
         }
         "turn.failed" | "turn.cancelled" => {
             let event_data = serde_json::to_value(&event.data).unwrap_or_default();

--- a/crates/server/src/storage/memory/agent_identities.rs
+++ b/crates/server/src/storage/memory/agent_identities.rs
@@ -72,7 +72,7 @@ impl InMemoryDatabase {
             })
             .cloned()
             .collect();
-        rows.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        rows.sort_by_key(|row| std::cmp::Reverse(row.created_at));
         Ok(rows)
     }
 

--- a/crates/server/src/storage/memory/agents.rs
+++ b/crates/server/src/storage/memory/agents.rs
@@ -163,7 +163,7 @@ impl InMemoryDatabase {
             })
             .cloned()
             .collect();
-        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        result.sort_by_key(|agent| std::cmp::Reverse(agent.created_at));
 
         let total = result.len() as u32;
         let offset = pagination.offset as usize;

--- a/crates/server/src/storage/memory/app_channels.rs
+++ b/crates/server/src/storage/memory/app_channels.rs
@@ -39,7 +39,7 @@ impl InMemoryDatabase {
             .filter(|ch| ch.app_id == app_id)
             .cloned()
             .collect();
-        result.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        result.sort_by_key(|channel| channel.created_at);
         Ok(result)
     }
 

--- a/crates/server/src/storage/memory/apps.rs
+++ b/crates/server/src/storage/memory/apps.rs
@@ -77,7 +77,7 @@ impl InMemoryDatabase {
             })
             .cloned()
             .collect();
-        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        result.sort_by_key(|app| std::cmp::Reverse(app.created_at));
         Ok(result)
     }
 

--- a/crates/server/src/storage/memory/audit_logs.rs
+++ b/crates/server/src/storage/memory/audit_logs.rs
@@ -46,7 +46,7 @@ impl InMemoryDatabase {
             })
             .cloned()
             .collect();
-        filtered.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        filtered.sort_by_key(|entry| std::cmp::Reverse(entry.created_at));
         filtered.truncate(query.limit as usize);
         Ok(filtered)
     }

--- a/crates/server/src/storage/memory/auth.rs
+++ b/crates/server/src/storage/memory/auth.rs
@@ -51,7 +51,7 @@ impl InMemoryDatabase {
             .filter(|k| k.user_id == user_id)
             .cloned()
             .collect();
-        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        result.sort_by_key(|provider| std::cmp::Reverse(provider.created_at));
         Ok(result)
     }
 

--- a/crates/server/src/storage/memory/budgets.rs
+++ b/crates/server/src/storage/memory/budgets.rs
@@ -55,7 +55,7 @@ impl InMemoryDatabase {
             })
             .cloned()
             .collect();
-        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        result.sort_by_key(|budget| std::cmp::Reverse(budget.created_at));
         result.truncate(200);
         Ok(result)
     }
@@ -185,7 +185,7 @@ impl InMemoryDatabase {
             .filter(|e| e.budget_id == budget_id)
             .cloned()
             .collect();
-        entries.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        entries.sort_by_key(|entry| std::cmp::Reverse(entry.created_at));
         let result = entries
             .into_iter()
             .skip(offset as usize)

--- a/crates/server/src/storage/memory/evals.rs
+++ b/crates/server/src/storage/memory/evals.rs
@@ -67,7 +67,7 @@ impl InMemoryDatabase {
             })
             .cloned()
             .collect();
-        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        result.sort_by_key(|evaluation| std::cmp::Reverse(evaluation.created_at));
         Ok(result)
     }
 
@@ -276,7 +276,7 @@ impl InMemoryDatabase {
             .filter(|r| r.eval_id == eval_id)
             .cloned()
             .collect();
-        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        result.sort_by_key(|run| std::cmp::Reverse(run.created_at));
         Ok(result)
     }
 
@@ -321,7 +321,7 @@ impl InMemoryDatabase {
         let runs = self.eval_runs.read();
         let mut matching: Vec<&EvalRunRow> =
             runs.values().filter(|r| r.eval_id == eval_id).collect();
-        matching.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        matching.sort_by_key(|run| std::cmp::Reverse(run.created_at));
         Ok(matching.first().cloned().cloned())
     }
 
@@ -367,7 +367,7 @@ impl InMemoryDatabase {
             .filter(|r| r.eval_run_id == eval_run_id)
             .cloned()
             .collect();
-        result.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        result.sort_by_key(|event| event.created_at);
         Ok(result)
     }
 

--- a/crates/server/src/storage/memory/harnesses.rs
+++ b/crates/server/src/storage/memory/harnesses.rs
@@ -146,7 +146,7 @@ impl InMemoryDatabase {
             })
             .cloned()
             .collect();
-        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        result.sort_by_key(|harness| std::cmp::Reverse(harness.created_at));
         Ok(result)
     }
 
@@ -223,7 +223,7 @@ impl InMemoryDatabase {
             })
             .cloned()
             .collect();
-        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        result.sort_by_key(|invocation| std::cmp::Reverse(invocation.created_at));
         Ok(result)
     }
 

--- a/crates/server/src/storage/memory/mcp_servers.rs
+++ b/crates/server/src/storage/memory/mcp_servers.rs
@@ -184,7 +184,7 @@ impl InMemoryDatabase {
             })
             .cloned()
             .collect();
-        servers.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        servers.sort_by_key(|server| std::cmp::Reverse(server.created_at));
         Ok(servers)
     }
 

--- a/crates/server/src/storage/memory/organizations.rs
+++ b/crates/server/src/storage/memory/organizations.rs
@@ -134,7 +134,7 @@ impl InMemoryDatabase {
     pub async fn list_organizations(&self) -> Result<Vec<OrganizationRow>> {
         let orgs = self.organizations.read();
         let mut result: Vec<_> = orgs.values().cloned().collect();
-        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        result.sort_by_key(|organization| std::cmp::Reverse(organization.created_at));
         Ok(result)
     }
 
@@ -199,7 +199,7 @@ impl InMemoryDatabase {
             .filter(|m| m.org_id == org_id)
             .cloned()
             .collect();
-        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        result.sort_by_key(|invitation| std::cmp::Reverse(invitation.created_at));
         Ok(result)
     }
 
@@ -225,7 +225,7 @@ impl InMemoryDatabase {
                     })
             })
             .collect();
-        result.sort_by(|a, b| a.joined_at.cmp(&b.joined_at));
+        result.sort_by_key(|membership| membership.joined_at);
         Ok(result)
     }
 

--- a/crates/server/src/storage/memory/schedules.rs
+++ b/crates/server/src/storage/memory/schedules.rs
@@ -63,7 +63,7 @@ impl InMemoryDatabase {
             .filter(|r| r.org_id == org_id && r.session_id == session_id)
             .cloned()
             .collect();
-        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        result.sort_by_key(|schedule| std::cmp::Reverse(schedule.created_at));
         Ok(result)
     }
 
@@ -128,7 +128,7 @@ impl InMemoryDatabase {
             .filter(|r| r.enabled && r.next_trigger_at.is_some_and(|t| t <= now))
             .cloned()
             .collect();
-        due.sort_by(|a, b| a.next_trigger_at.cmp(&b.next_trigger_at));
+        due.sort_by_key(|schedule| schedule.next_trigger_at);
         due.truncate(limit as usize);
         Ok(due)
     }
@@ -232,7 +232,7 @@ impl InMemoryDatabase {
             .filter(|row| row.session_id == Some(session_id))
             .cloned()
             .collect();
-        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        result.sort_by_key(|execution| std::cmp::Reverse(execution.created_at));
         Ok(result)
     }
 

--- a/crates/server/src/storage/memory/session_resources.rs
+++ b/crates/server/src/storage/memory/session_resources.rs
@@ -82,7 +82,7 @@ impl InMemoryDatabase {
             })
             .cloned()
             .collect();
-        result.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        result.sort_by_key(|resource| resource.created_at);
         Ok(result)
     }
 

--- a/crates/server/src/storage/memory/sessions.rs
+++ b/crates/server/src/storage/memory/sessions.rs
@@ -99,7 +99,7 @@ impl InMemoryDatabase {
             .filter(|s| matches_search_tokens(search, &[s.title.as_deref().unwrap_or("")]))
             .cloned()
             .collect();
-        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        result.sort_by_key(|session| std::cmp::Reverse(session.created_at));
 
         let total = result.len() as u32;
         let offset = pagination.offset as usize;
@@ -122,7 +122,7 @@ impl InMemoryDatabase {
             .filter(|s| s.parent_session_id == Some(parent_session_id))
             .cloned()
             .collect();
-        result.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        result.sort_by_key(|message| message.created_at);
         Ok(result)
     }
 
@@ -175,7 +175,7 @@ impl InMemoryDatabase {
             .filter(|s| s.org_id == org_id && tags.iter().all(|tag| s.tags.contains(tag)))
             .cloned()
             .collect();
-        result.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        result.sort_by_key(|session| session.created_at);
         Ok(result.into_iter().next())
     }
 
@@ -301,7 +301,7 @@ impl InMemoryDatabase {
             .filter(|((uid, _), (oid, _))| *uid == user_id && *oid == org_id)
             .map(|((_, sid), (_, pinned_at))| (*sid, *pinned_at))
             .collect();
-        entries.sort_by(|a, b| b.1.cmp(&a.1)); // Most recently pinned first
+        entries.sort_by_key(|entry| std::cmp::Reverse(entry.1)); // Most recently pinned first
         Ok(entries.into_iter().map(|(sid, _)| sid).collect())
     }
 }

--- a/crates/server/src/storage/memory/skills.rs
+++ b/crates/server/src/storage/memory/skills.rs
@@ -93,7 +93,7 @@ impl InMemoryDatabase {
                 created_at: img.created_at,
             })
             .collect();
-        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        result.sort_by_key(|skill| std::cmp::Reverse(skill.created_at));
         let result = result
             .into_iter()
             .skip(offset as usize)
@@ -184,7 +184,7 @@ impl InMemoryDatabase {
             .filter(|s| matches_search_tokens(search, &[&s.name, &s.description]))
             .cloned()
             .collect();
-        skills.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        skills.sort_by_key(|skill| std::cmp::Reverse(skill.created_at));
         Ok(skills)
     }
 

--- a/crates/server/src/storage/memory/users.rs
+++ b/crates/server/src/storage/memory/users.rs
@@ -130,7 +130,7 @@ impl InMemoryDatabase {
             }
             _ => users.values().cloned().collect(),
         };
-        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        result.sort_by_key(|user| std::cmp::Reverse(user.created_at));
         Ok(result)
     }
 
@@ -251,7 +251,7 @@ impl InMemoryDatabase {
             })
             .cloned()
             .collect();
-        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        result.sort_by_key(|invitation| std::cmp::Reverse(invitation.created_at));
         Ok(result)
     }
 }

--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -4694,17 +4694,13 @@ async fn test_anthropic_extended_thinking() {
                             thinking_content.len()
                         );
                     }
-                    "message.agent" => {
-                        // Check if message has thinking field
-                        if event["data"]["message"]["thinking"].is_string() {
-                            message_agent_with_thinking = true;
-                            let thinking =
-                                event["data"]["message"]["thinking"].as_str().unwrap_or("");
-                            println!(
-                                "  Found message.agent with thinking field ({} chars)",
-                                thinking.len()
-                            );
-                        }
+                    "message.agent" if event["data"]["message"]["thinking"].is_string() => {
+                        message_agent_with_thinking = true;
+                        let thinking = event["data"]["message"]["thinking"].as_str().unwrap_or("");
+                        println!(
+                            "  Found message.agent with thinking field ({} chars)",
+                            thinking.len()
+                        );
                     }
                     _ => {}
                 }


### PR DESCRIPTION
## What
Bump `everruns-sdk` from `0.1.7` to `0.1.8` and adopt the new Rust SDK session APIs in the CLI.

## Why
The latest SDK release added session export JSONL support and native `harness_name` support for session creation. The CLI was still carrying raw HTTP fallback code for session export and manual harness-name resolution.

Related Linear:
- EVE-238 — update CLI session export to use SDK once export support ships
- EVE-232 / EVE-233 were already satisfied by earlier SDK additions and remain unaffected

## How
- bumped the workspace SDK dependency and lockfile to `everruns-sdk 0.1.8`
- switched `sessions export` to `client.sessions().export(...)`
- switched `sessions create --harness <name>` to use SDK-native `harness_name`
- removed the obsolete raw HTTP helpers and extra plumbing from the sessions command path

## Risk
- Low
- Touches CLI-only behavior. Main risk is SDK compatibility regression in session creation/export, covered by local CLI tests and smoke testing.

## Security
- Threat categories reviewed: No security-relevant code changes beyond dependency risk in a CLI-only SDK bump; reviewed dependency/update risk and request-path changes
- Findings and resolutions:
  - Dependency risk: limited to `everruns-sdk 0.1.8`; adopted for its new typed session APIs and validated locally
  - Request handling: reduced raw HTTP usage in the CLI by routing session export and harness-name session creation through the typed SDK

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `cargo test -p everruns-cli`
- `cargo clippy -p everruns-cli -- -D warnings`
- `just pre-push`
- Smoke test against `just start-dev --no-watch`:
  - create session with `--harness generic` using the current branch CLI binary
  - export that session through the SDK-backed CLI path and verify JSONL output
