### PR TITLE
feat(ui): add profile menu extension point

### DIFF
--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { Sidebar } from "@/components/layout/sidebar";
 import type { SidebarConfig, NavigationSection } from "@/components/layout/sidebar";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { Settings, Zap } from "lucide-react";
 
 // Mock next/navigation
@@ -370,6 +371,37 @@ describe("Sidebar with config", () => {
     expect(screen.queryByText("Create a new organisation")).not.toBeInTheDocument();
     // The org selector trigger should still render
     expect(screen.getByText("Test Org")).toBeInTheDocument();
+  });
+
+  it("appends custom profile menu items when config.profileMenu.items is provided", () => {
+    mockUseAuth.mockReturnValue({
+      user: { name: "Test User", email: "test@example.com", avatar_url: null },
+      requiresAuth: true,
+      isAuthenticated: true,
+      config: { mode: "password" },
+      isLoading: false,
+      logout: jest.fn(),
+      logoutPending: false,
+      createOrganization: undefined,
+    });
+
+    const config: Partial<SidebarConfig> = {
+      profileMenu: {
+        items: ({ navigate }) => (
+          <DropdownMenuItem onClick={() => navigate("/billing")}>Billing</DropdownMenuItem>
+        ),
+      },
+    };
+
+    render(<Sidebar config={config} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /test user/i }));
+
+    const billingItem = screen.getByText("Billing");
+    expect(billingItem).toBeInTheDocument();
+
+    fireEvent.click(billingItem);
+    expect(mockPush).toHaveBeenCalledWith("/billing");
   });
 
   it("renders sections without labels (unlabeled sections)", () => {

--- a/apps/ui/src/components/layout/sidebar-user-menu.tsx
+++ b/apps/ui/src/components/layout/sidebar-user-menu.tsx
@@ -2,6 +2,7 @@
  * Decisions:
  * - User footer owns auth-only actions; anonymous mode stays a simple version label.
  * - Route pushes happen inside menu actions so parent layout does not coordinate menu details.
+ * - Forks can append profile menu items via a render prop instead of replacing this component.
  */
 "use client";
 
@@ -22,6 +23,17 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
+export type SidebarUserMenuUser = {
+  name?: string | null;
+  email: string;
+  avatar_url?: string | null;
+};
+
+export type SidebarUserMenuItemsRenderer = (context: {
+  user: SidebarUserMenuUser;
+  navigate: (href: string) => void;
+}) => React.ReactNode;
+
 function getInitials(name: string): string {
   if (!name.trim()) return "";
   return name
@@ -38,20 +50,23 @@ export function SidebarUserMenu({
   user,
   logout,
   logoutPending,
+  renderExtraItems,
   version,
 }: {
   requiresAuth: boolean;
-  user: { name?: string | null; email: string; avatar_url?: string | null } | null;
+  user: SidebarUserMenuUser | null;
   logout: () => Promise<void>;
   logoutPending: boolean;
+  renderExtraItems?: SidebarUserMenuItemsRenderer;
   version: string;
 }) {
   const router = useRouter();
   const [mcpDialogOpen, setMcpDialogOpen] = useState(false);
+  const navigate = (href: string) => router.push(href);
 
   const handleLogout = async () => {
     await logout();
-    router.push("/login");
+    navigate("/login");
   };
 
   if (!requiresAuth || !user) {
@@ -82,15 +97,16 @@ export function SidebarUserMenu({
             <DropdownMenuGroup>
               <DropdownMenuLabel>My Account</DropdownMenuLabel>
               <NotificationMenuSub />
-              <DropdownMenuItem onClick={() => router.push("/settings")}>
+              <DropdownMenuItem onClick={() => navigate("/settings")}>
                 <User className="icon-sharp mr-2 h-4 w-4" />
                 Profile
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => router.push("/settings/api-keys")}>
+              <DropdownMenuItem onClick={() => navigate("/settings/api-keys")}>
                 <Key className="icon-sharp mr-2 h-4 w-4" />
                 API Keys
               </DropdownMenuItem>
               <McpConnectMenuItem onSelect={() => setMcpDialogOpen(true)} />
+              {renderExtraItems?.({ user, navigate })}
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
             <DropdownMenuItem variant="destructive" onClick={handleLogout} disabled={logoutPending}>

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -10,6 +10,7 @@
  * - navigation: replace the default navigation sections entirely
  * - orgActions.createOrg: override "Create Organisation" click handler
  * - extraSections: append additional sections (billing, usage, etc.)
+ * - profileMenu.items: append items inside the authenticated profile menu
  */
 "use client";
 
@@ -46,6 +47,7 @@ import type { FeatureFlags } from "@/lib/api/types";
 import { SidebarNavigation } from "./sidebar-navigation";
 import { SidebarOrganizationMenu } from "./sidebar-organization-menu";
 import { SidebarUserMenu } from "./sidebar-user-menu";
+import type { SidebarUserMenuItemsRenderer } from "./sidebar-user-menu";
 
 const { version } = packageJson;
 
@@ -72,6 +74,9 @@ export interface SidebarConfig {
     createOrg?: () => void;
   };
   extraSections?: NavigationSection[];
+  profileMenu?: {
+    items?: SidebarUserMenuItemsRenderer;
+  };
 }
 
 export const defaultTopNavigation: NavigationItem[] = [
@@ -195,6 +200,7 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
           user={user ?? null}
           logout={logout}
           logoutPending={logoutPending}
+          renderExtraItems={config?.profileMenu?.items}
           version={version}
         />
       </div>


### PR DESCRIPTION
## What
Add a sidebar extension point so forks can append authenticated profile-menu items without copying the built-in user menu.

## Why
Forks already have sidebar hooks for navigation and org actions, but profile-menu customization still required replacing the whole component.

## How
Extend `SidebarConfig` with `profileMenu.items`, thread that renderer into `SidebarUserMenu`, and expose `user` plus a shared `navigate()` helper so custom menu items can reuse the built-in routing behavior. Add a sidebar test that injects a custom menu item and verifies the navigation callback fires.

## Risk
- Low
- Could break the authenticated sidebar menu if the new render hook changed menu structure or routing behavior

## Security
- Threat categories reviewed: TM-WEB
- Findings and resolutions: Reviewed the new render hook for XSS and unsafe navigation paths. The change does not introduce raw HTML, new trust boundaries, or cross-origin behavior; it only renders fork-supplied React nodes inside the existing authenticated menu and reuses `router.push` for local navigation.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
