### PR TITLE
feat(setup): add LLM provider configuration to org setup page

### DIFF
--- a/apps/ui/src/app/(main)/orgs/[orgId]/setup/page.tsx
+++ b/apps/ui/src/app/(main)/orgs/[orgId]/setup/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 // Org setup page — shown after org creation to confirm provisioning.
-// Extensible: future steps (e.g. LLM key configuration) can be added to SETUP_STEPS.
+// Includes inline LLM provider setup (provider type + API key) as the final step.
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
@@ -9,12 +9,16 @@ import { useQuery } from "@tanstack/react-query";
 import { Building2, Check, CircleDot, Loader2, ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { getOrganization } from "@/lib/api/organizations";
 import { listHarnesses } from "@/lib/api/harnesses";
+import { useCreateLlmProvider, useLlmProviders } from "@/hooks/use-llm-providers";
+import { ProviderIcon } from "@/components/providers/provider-icon";
 import { queryKeys } from "@/lib/query-keys";
 import { useOrg } from "@/providers/org-provider";
 import type { ApiError } from "@/lib/api/client";
+import type { LlmProviderType } from "@/lib/api/types";
 
 interface SetupStep {
   label: string;
@@ -45,9 +49,34 @@ const SETUP_STEPS: SetupStep[] = [
     description: "Default and base harnesses have been assigned",
     check: (ctx) => !!ctx.defaultHarnessId && !!ctx.baseHarnessId,
   },
+  {
+    label: "LLM provider configured",
+    description: "API provider and credentials set up",
+    // Always shows as part of the animated sequence — actual config happens inline
+    check: () => true,
+  },
 ];
 
 const STEP_DELAY_MS = 400;
+
+const PROVIDER_OPTIONS: { type: LlmProviderType; label: string }[] = [
+  { type: "openai", label: "OpenAI" },
+  { type: "anthropic", label: "Anthropic" },
+];
+
+function getProviderName(providerType: LlmProviderType): string {
+  switch (providerType) {
+    case "openai":
+    case "openai_completions":
+      return "OpenAI";
+    case "anthropic":
+      return "Anthropic";
+    case "gemini":
+      return "Gemini";
+    default:
+      return providerType;
+  }
+}
 
 export default function OrgSetupPage() {
   const { orgId } = useParams<{ orgId: string }>();
@@ -82,6 +111,10 @@ export default function OrgSetupPage() {
       return data.length > 0 ? false : 5_000;
     },
   });
+
+  // Check if a provider already exists (skip the form if so)
+  const { data: providers = [] } = useLlmProviders();
+  const hasProvider = providers.length > 0;
 
   // Set current org once loaded — derive role from membership list when available
   useEffect(() => {
@@ -134,6 +167,30 @@ export default function OrgSetupPage() {
 
   const allAnimated = completedCount >= SETUP_STEPS.length;
 
+  // --- LLM provider form state ---
+  const [selectedProvider, setSelectedProvider] = useState<LlmProviderType>("openai");
+  const [apiKey, setApiKey] = useState("");
+  const createProvider = useCreateLlmProvider();
+  const [providerError, setProviderError] = useState<string | null>(null);
+
+  const handleContinue = async () => {
+    if (!apiKey.trim()) {
+      setProviderError("Please enter an API key");
+      return;
+    }
+    setProviderError(null);
+    try {
+      await createProvider.mutateAsync({
+        name: getProviderName(selectedProvider),
+        provider_type: selectedProvider,
+        api_key: apiKey,
+      });
+      router.push("/dashboard");
+    } catch {
+      setProviderError("Failed to configure provider. Please try again.");
+    }
+  };
+
   // --- Loading skeleton ---
   if (orgLoading && !org) {
     return (
@@ -145,6 +202,7 @@ export default function OrgSetupPage() {
             <Skeleton className="h-4 w-64" />
           </div>
           <div className="mt-8 space-y-4">
+            <Skeleton className="h-12 w-full" />
             <Skeleton className="h-12 w-full" />
             <Skeleton className="h-12 w-full" />
             <Skeleton className="h-12 w-full" />
@@ -243,13 +301,102 @@ export default function OrgSetupPage() {
           })}
         </div>
 
+        {/* LLM Provider selection — shown after step animation completes */}
         <div
           className={`mt-8 transition-opacity duration-500 ${allAnimated ? "opacity-100" : "opacity-0 pointer-events-none"}`}
         >
-          <Button className="w-full" onClick={() => router.push("/dashboard")}>
-            Go to dashboard
-            <ArrowRight className="ml-2 h-4 w-4" />
-          </Button>
+          {hasProvider ? (
+            /* Provider already configured — go straight to dashboard */
+            <Button className="w-full" onClick={() => router.push("/dashboard")}>
+              Continue
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Button>
+          ) : (
+            <div className="space-y-6">
+              {/* Provider type selector */}
+              <div>
+                <h2 className="text-sm font-semibold mb-3">Select your LLM provider</h2>
+                <div className="grid grid-cols-2 gap-3">
+                  {PROVIDER_OPTIONS.map((opt) => {
+                    const isSelected = selectedProvider === opt.type;
+                    return (
+                      <button
+                        key={opt.type}
+                        type="button"
+                        onClick={() => {
+                          setSelectedProvider(opt.type);
+                          setProviderError(null);
+                        }}
+                        className={`relative flex flex-col items-center gap-2 border-2 p-4 transition-colors ${
+                          isSelected
+                            ? "border-primary bg-primary/5"
+                            : "border-border hover:border-primary/40"
+                        }`}
+                      >
+                        <ProviderIcon providerType={opt.type} size="lg" />
+                        <span className="text-sm font-medium">{opt.label}</span>
+                        {/* Radio indicator */}
+                        <div
+                          className={`h-4 w-4 rounded-full border-2 transition-colors ${
+                            isSelected ? "border-primary" : "border-muted-foreground/40"
+                          }`}
+                        >
+                          {isSelected && (
+                            <div className="m-[2px] h-2 w-2 rounded-full bg-primary" />
+                          )}
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+
+                {/* Skip link */}
+                <div className="mt-3 text-center">
+                  <button
+                    type="button"
+                    onClick={() => router.push("/dashboard")}
+                    className="text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground transition-colors"
+                  >
+                    Skip for now
+                  </button>
+                </div>
+              </div>
+
+              {/* API Key input */}
+              <div>
+                <label htmlFor="setup-api-key" className="text-sm font-semibold">
+                  API Key
+                </label>
+                <Input
+                  id="setup-api-key"
+                  type="password"
+                  className="mt-1.5"
+                  value={apiKey}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    setApiKey(e.target.value);
+                    setProviderError(null);
+                  }}
+                  placeholder={`Enter your ${getProviderName(selectedProvider)} API key`}
+                />
+                <p className="mt-1.5 text-xs text-muted-foreground">
+                  Your API key will be stored securely and encrypted
+                </p>
+                {providerError && (
+                  <p className="mt-1.5 text-xs text-destructive">{providerError}</p>
+                )}
+              </div>
+
+              {/* Continue button */}
+              <Button
+                className="w-full"
+                onClick={handleContinue}
+                disabled={createProvider.isPending}
+              >
+                {createProvider.isPending ? "Configuring..." : "Continue"}
+                {!createProvider.isPending && <ArrowRight className="ml-2 h-4 w-4" />}
+              </Button>
+            </div>
+          )}
         </div>
       </Card>
     </div>


### PR DESCRIPTION
## What
Add a 4th "LLM provider configured" step to the org setup page, with an inline provider selection form (OpenAI/Anthropic) and API key input so new orgs can wire up their first provider during onboarding.

## Why
A freshly provisioned organisation has no LLM provider configured, so agents can't actually run until the user navigates to `/settings/providers` and sets one up. Bundling this into the setup flow matches the design and removes the dead-end that an empty provider list creates right after org creation.

## How
- Extend `SETUP_STEPS` with a `"LLM provider configured"` step that animates in sequence with the existing three provisioning checks.
- Once all steps finish animating, reveal a form with two card-style radio options (OpenAI, Anthropic), a password-masked API Key input, a "Skip for now" link, and a "Continue" primary action.
- "Continue" calls the existing `useCreateLlmProvider` mutation (which uses the existing encrypted `/v1/llm-providers` endpoint) with the selected provider type and API key, then routes to `/dashboard`.
- If a provider already exists for the org (e.g. returning to setup after configuring), the form is replaced by a plain "Continue" button straight to the dashboard.
- Follows the Slate Design System (no `rounded-*` overrides, sharp corners).

## Risk
- Low
- UI-only; uses the existing provider CRUD API with the same encryption and permission policies as the settings page. Skip link preserves the previous "go to dashboard" escape hatch.

## Security
- Threat categories reviewed: **TM-LLM**, **TM-WEB**.
- API key is sent to the existing `POST /v1/llm-providers` endpoint which encrypts at rest via `EncryptionService` (EVE-69, SSRF prevention on base URLs). No new backend surface, no new permissions, no new logging of secrets.
- Input uses `type="password"` to mask the key in the DOM; errors shown to the user are generic ("Failed to configure provider…") and don't echo request details.
- No `dangerouslySetInnerHTML`, no new external fetches, no new cookies or auth changes.
- No new threats introduced; existing `OrgLlmProvidersManage` policy continues to gate provider creation on the backend. No updates to `specs/threat-model.md` needed.

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `just pre-push` — all 7 checks pass
- `npm run lint` (oxlint) — 0 errors (4 pre-existing warnings in unrelated files)
- `npm run format:check` — clean
- `npx tsc --noEmit` — no errors in the modified file (pre-existing test-file errors only)
- `npm run build` — compiled successfully; `/orgs/[orgId]/setup` route included