### PR TITLE
fix(worker): preserve inner act activity failures

### DIFF
--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -27,6 +27,7 @@ use crate::grpc_adapters::{GrpcClient, GrpcEventEmitter, load_turn_context};
 use crate::grpc_durable_store::{
     ClaimedTask, GrpcDurableStore, TaskNotificationEvent, TaskNotificationStream, WorkflowStatus,
 };
+use crate::task_error::summarize_task_failure;
 use serde::{Deserialize, Serialize};
 
 // =============================================================================
@@ -593,14 +594,27 @@ impl DurableWorker {
                 let result = worker.execute_task(&task).await;
 
                 if let Err(e) = result {
+                    let failure = summarize_task_failure(
+                        task.id,
+                        task.workflow_id,
+                        &task.activity_type,
+                        task.attempt,
+                        None,
+                        &task.input,
+                        &e,
+                    );
                     error!(
                         task_id = %task.id,
+                        workflow_id = ?task.workflow_id,
                         activity_type = %task.activity_type,
-                        error = %e,
+                        attempt = task.attempt,
+                        session_id = ?failure.session_id,
+                        tool_identifiers = ?failure.tool_identifiers,
+                        error_chain = %failure.error_chain,
                         "Task execution failed"
                     );
 
-                    let error_msg = e.to_string();
+                    let error_msg = failure.persisted_message;
                     let force_dlq = is_non_retryable_task_error(&error_msg);
 
                     if force_dlq {
@@ -1671,6 +1685,7 @@ impl DurableWorker {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_config_default() {
@@ -1699,5 +1714,25 @@ mod tests {
         assert!(!is_non_retryable_task_error(
             "LLM provider temporarily unavailable (circuit breaker open)"
         ));
+    }
+
+    #[test]
+    fn test_is_non_retryable_task_error_with_formatted_task_failure() {
+        let task_id = Uuid::parse_str("019d97fa-c961-7272-a2f8-fef2220f0ec1").unwrap();
+        let workflow_id = Some(Uuid::parse_str("019d9861-b17a-71d3-b929-eb0e7ae2dc55").unwrap());
+        let input = json!({
+            "act_input": {
+                "context": {
+                    "session_id": "session_019d97fa3d8f736195d605c1ace8b83c"
+                }
+            }
+        });
+        let error = anyhow::anyhow!("Message store error: User message not found: msg_abc123")
+            .context("ActAtom execution failed");
+
+        let failure =
+            summarize_task_failure(task_id, workflow_id, "act", 1, Some(3), &input, &error);
+
+        assert!(is_non_retryable_task_error(&failure.persisted_message));
     }
 }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -23,6 +23,7 @@ pub mod platform;
 pub mod runner;
 pub mod runtime_host;
 pub mod session_lifecycle;
+pub mod task_error;
 pub mod unified_worker;
 pub mod worker_adapters;
 

--- a/crates/worker/src/task_error.rs
+++ b/crates/worker/src/task_error.rs
@@ -77,12 +77,18 @@ fn format_error_chain(error: &Error) -> String {
 }
 
 fn extract_session_id(input: &Value) -> Option<String> {
-    session_context(input).and_then(|context| {
-        context
-            .get("session_id")
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned)
-    })
+    input
+        .get("session_id")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            session_context(input).and_then(|context| {
+                context
+                    .get("session_id")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned)
+            })
+        })
 }
 
 fn extract_tool_identifiers(input: &Value) -> Vec<String> {
@@ -220,6 +226,27 @@ mod tests {
             summary
                 .persisted_message
                 .contains("error_chain=outer: inner")
+        );
+    }
+
+    #[test]
+    fn summarize_task_failure_reads_top_level_durable_turn_session_id() {
+        let input = json!({
+            "session_id": "session_top_level",
+            "context": {
+                "session_id": "session_nested"
+            }
+        });
+        let error = anyhow::anyhow!("inner");
+
+        let summary =
+            summarize_task_failure(Uuid::nil(), None, "reason", 1, Some(2), &input, &error);
+
+        assert_eq!(summary.session_id.as_deref(), Some("session_top_level"));
+        assert!(
+            summary
+                .persisted_message
+                .contains("session_id=session_top_level")
         );
     }
 }

--- a/crates/worker/src/task_error.rs
+++ b/crates/worker/src/task_error.rs
@@ -1,0 +1,225 @@
+// Task failure formatting helpers
+// Decision: Persist a single human-readable failure string that keeps both
+// task metadata and the full anyhow error chain for durable task surfaces.
+
+use anyhow::Error;
+use serde_json::Value;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TaskFailureSummary {
+    pub(crate) session_id: Option<String>,
+    pub(crate) tool_identifiers: Vec<String>,
+    pub(crate) error_chain: String,
+    pub(crate) persisted_message: String,
+}
+
+pub(crate) fn summarize_task_failure(
+    task_id: Uuid,
+    workflow_id: Option<Uuid>,
+    activity_type: &str,
+    attempt: u32,
+    max_attempts: Option<u32>,
+    input: &Value,
+    error: &Error,
+) -> TaskFailureSummary {
+    let session_id = extract_session_id(input);
+    let tool_identifiers = extract_tool_identifiers(input);
+    let error_chain = format_error_chain(error);
+
+    let mut metadata = vec![
+        format!("activity_type={activity_type}"),
+        format!("task_id={task_id}"),
+    ];
+    if let Some(workflow_id) = workflow_id {
+        metadata.push(format!("workflow_id={workflow_id}"));
+    }
+    if let Some(session_id) = session_id.as_deref() {
+        metadata.push(format!("session_id={session_id}"));
+    }
+    let attempt_value = max_attempts
+        .map(|max_attempts| format!("{attempt}/{max_attempts}"))
+        .unwrap_or_else(|| attempt.to_string());
+    metadata.push(format!("attempt={attempt_value}"));
+    if !tool_identifiers.is_empty() {
+        metadata.push(format!("tools={}", tool_identifiers.join(",")));
+    }
+
+    let persisted_message = format!("{} | error_chain={error_chain}", metadata.join(" "));
+
+    TaskFailureSummary {
+        session_id,
+        tool_identifiers,
+        error_chain,
+        persisted_message,
+    }
+}
+
+fn format_error_chain(error: &Error) -> String {
+    let mut messages = Vec::new();
+
+    for cause in error.chain() {
+        let message = cause.to_string();
+        if message.is_empty() {
+            continue;
+        }
+        if messages.last().is_some_and(|last| last == &message) {
+            continue;
+        }
+        messages.push(message);
+    }
+
+    if messages.is_empty() {
+        error.to_string()
+    } else {
+        messages.join(": ")
+    }
+}
+
+fn extract_session_id(input: &Value) -> Option<String> {
+    session_context(input).and_then(|context| {
+        context
+            .get("session_id")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+    })
+}
+
+fn extract_tool_identifiers(input: &Value) -> Vec<String> {
+    let tool_calls = input
+        .get("tool_calls")
+        .or_else(|| {
+            input
+                .get("act_input")
+                .and_then(|value| value.get("tool_calls"))
+        })
+        .and_then(Value::as_array);
+
+    let mut identifiers = tool_calls
+        .into_iter()
+        .flatten()
+        .filter_map(|tool_call| {
+            let name = tool_call.get("name").and_then(Value::as_str);
+            let id = tool_call.get("id").and_then(Value::as_str);
+
+            match (id, name) {
+                (Some(id), Some(name)) => Some(format!("{id}:{name}")),
+                (None, Some(name)) => Some(name.to_string()),
+                (Some(id), None) => Some(id.to_string()),
+                (None, None) => None,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    const MAX_TOOL_IDENTIFIERS: usize = 5;
+    if identifiers.len() > MAX_TOOL_IDENTIFIERS {
+        let remaining = identifiers.len() - MAX_TOOL_IDENTIFIERS;
+        identifiers.truncate(MAX_TOOL_IDENTIFIERS);
+        identifiers.push(format!("+{remaining} more"));
+    }
+
+    identifiers
+}
+
+fn session_context(input: &Value) -> Option<&Value> {
+    input.get("context").or_else(|| {
+        input
+            .get("act_input")
+            .and_then(|value| value.get("context"))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn summarize_task_failure_preserves_anyhow_chain_and_act_metadata() {
+        let task_id = Uuid::parse_str("019d9861-c0f7-7ab1-967e-ddacc25f0690").unwrap();
+        let workflow_id = Some(Uuid::parse_str("019d9861-b17a-71d3-b929-eb0e7ae2dc55").unwrap());
+        let input = json!({
+            "org_id": 1,
+            "act_input": {
+                "context": {
+                    "session_id": "session_019d9861b17a71d3b929eb0e7ae2dc55",
+                    "turn_id": "turn_123",
+                    "input_message_id": "msg_123"
+                },
+                "tool_calls": [
+                    {"id": "call_1", "name": "web.search"},
+                    {"id": "call_2", "name": "linear.fetch"}
+                ]
+            }
+        });
+        let error = anyhow::anyhow!("tool call 1 failed").context("ActAtom execution failed");
+
+        let summary =
+            summarize_task_failure(task_id, workflow_id, "act", 2, Some(5), &input, &error);
+
+        assert_eq!(
+            summary.error_chain,
+            "ActAtom execution failed: tool call 1 failed"
+        );
+        assert_eq!(
+            summary.session_id.as_deref(),
+            Some("session_019d9861b17a71d3b929eb0e7ae2dc55")
+        );
+        assert_eq!(
+            summary.tool_identifiers,
+            vec!["call_1:web.search", "call_2:linear.fetch"]
+        );
+        assert!(summary.persisted_message.contains("activity_type=act"));
+        assert!(
+            summary
+                .persisted_message
+                .contains(&format!("task_id={task_id}"))
+        );
+        assert!(
+            summary
+                .persisted_message
+                .contains("workflow_id=019d9861-b17a-71d3-b929-eb0e7ae2dc55")
+        );
+        assert!(
+            summary
+                .persisted_message
+                .contains("session_id=session_019d9861b17a71d3b929eb0e7ae2dc55")
+        );
+        assert!(summary.persisted_message.contains("attempt=2/5"));
+        assert!(
+            summary
+                .persisted_message
+                .contains("tools=call_1:web.search,call_2:linear.fetch")
+        );
+        assert!(
+            summary
+                .persisted_message
+                .contains("error_chain=ActAtom execution failed: tool call 1 failed")
+        );
+    }
+
+    #[test]
+    fn summarize_task_failure_reads_unwrapped_act_input_shape() {
+        let task_id = Uuid::nil();
+        let input = json!({
+            "context": {
+                "session_id": "session_123"
+            },
+            "tool_calls": [
+                {"name": "commentary"}
+            ]
+        });
+        let error = anyhow::anyhow!("inner").context("outer");
+
+        let summary = summarize_task_failure(task_id, None, "act", 1, Some(3), &input, &error);
+
+        assert_eq!(summary.session_id.as_deref(), Some("session_123"));
+        assert_eq!(summary.tool_identifiers, vec!["commentary"]);
+        assert!(summary.persisted_message.contains("attempt=1/3"));
+        assert!(
+            summary
+                .persisted_message
+                .contains("error_chain=outer: inner")
+        );
+    }
+}

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -31,6 +31,7 @@ use uuid::Uuid;
 
 use crate::durable_runner::DurableTurnInput;
 use crate::runtime_host::WorkerRuntimeHost;
+use crate::task_error::summarize_task_failure;
 use crate::worker_adapters::WorkerAdapters;
 
 // Re-export atom types
@@ -322,14 +323,28 @@ where
                 let result = execute_task(&store, &adapters, &worker_id, &task).await;
 
                 if let Err(e) = result {
+                    let failure = summarize_task_failure(
+                        task.id,
+                        task.workflow_id,
+                        &task.activity_type,
+                        task.attempt,
+                        Some(task.max_attempts),
+                        &task.input,
+                        &e,
+                    );
                     error!(
                         task_id = %task.id,
+                        workflow_id = ?task.workflow_id,
                         activity_type = %task.activity_type,
-                        error = %e,
+                        attempt = task.attempt,
+                        max_attempts = task.max_attempts,
+                        session_id = ?failure.session_id,
+                        tool_identifiers = ?failure.tool_identifiers,
+                        error_chain = %failure.error_chain,
                         "Task execution failed"
                     );
 
-                    let _ = store.fail_task(task.id, &e.to_string()).await;
+                    let _ = store.fail_task(task.id, &failure.persisted_message).await;
                 }
 
                 in_flight.fetch_sub(1, Ordering::SeqCst);
@@ -563,11 +578,20 @@ where
         }
         Err(e) => {
             let will_retry = task.attempt < task.max_attempts;
+            let failure = summarize_task_failure(
+                task.id,
+                task.workflow_id,
+                &task.activity_type,
+                task.attempt,
+                Some(task.max_attempts),
+                &task.input,
+                &e,
+            );
             record_activity_failed(
                 store.as_ref(),
                 task.workflow_id,
                 task.activity_id.clone(),
-                e.to_string(),
+                failure.persisted_message,
                 will_retry,
             )
             .await;


### PR DESCRIPTION
## What
Preserve the full act-activity failure chain in worker logs, durable task `last_error`, and workflow failure messages.

## Why
`act_activity` wrapped failures with `ActAtom execution failed`, but downstream worker persistence/logging flattened the error to the outer message. That dropped the inner cause right where we need it for diagnosis.

## How
- add a worker-local task failure formatter that keeps the full `anyhow` chain
- include task metadata in persisted failure text: activity type, task id, workflow id, session id, attempt, and tool identifiers when present
- use that formatter in both the durable gRPC worker and the in-process unified worker
- add regression coverage for wrapped act failures and non-retryable detection against the formatted error text

## Risk
- Low
- Limited to worker error formatting and logging paths; does not change execution flow or retry policy

## Security
- Threat categories reviewed: No security-relevant code changes; this is internal error/log formatting in worker failure handling only.
- Findings and resolutions: No new security findings.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

## Validation
- `cargo test -p everruns-worker summarize_task_failure`
- `cargo test -p everruns-worker test_is_non_retryable_task_error_with_formatted_task_failure`
- `just pre-push`
- `cargo test -p everruns-worker --lib` *(fails on existing unrelated test: `leased_resource_cleanup::tests::e2b_cleanup_rejects_blank_env_key`)*

Fixes EVE-307.
