### PR TITLE
feat(observability): add request_id, session_id correlation IDs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ Always make sure you are working on top of latest main from remote.
 - `specs/authentication.md` - Authentication modes and OAuth
 - `specs/integrations.md` - **Integration specs index** (links to specs co-located with their crates)
 - `specs/observability.md` - Observability providers (OpenTelemetry Gen-AI tracing, Braintrust)
+- `specs/correlation-ids.md` - Correlation IDs (request_id, session_id, durable propagation)
 - `specs/prometheus-metrics.md` - Prometheus `/metrics` endpoint and scrape configuration
 - `specs/evals.md` - User-facing behavioral evals for agents (cases, scorers, runs)
 - `specs/encryption.md` - Envelope encryption for sensitive data

--- a/crates/server/src/api/ag_ui.rs
+++ b/crates/server/src/api/ag_ui.rs
@@ -39,7 +39,7 @@ use ag_ui_core::types::{
     tool::ToolCall as AgUiToolCall,
 };
 use axum::{
-    Json, Router,
+    Extension, Json, Router,
     extract::{Path, State},
     http::StatusCode,
     response::sse::{Event as SseEvent, KeepAlive, Sse},
@@ -66,6 +66,7 @@ use crate::api::messages::{
 use crate::api::sessions::CreateSessionRequest;
 use crate::api::sse::SseConnectionTracker;
 use crate::execution_metadata;
+use crate::middleware::RequestId;
 use crate::services::{
     AppService, CreateMessageContext, EventService, MessageService, SessionService,
 };
@@ -115,9 +116,11 @@ pub fn routes(state: AgUiState) -> Router {
 async fn run_agent(
     State(state): State<AgUiState>,
     Path(app_id): Path<String>,
+    req_id: Option<Extension<RequestId>>,
     Json(req): Json<AgUiRunAgentInput>,
 ) -> Result<Sse<impl Stream<Item = Result<SseEvent, Infallible>>>, (StatusCode, Json<ErrorResponse>)>
 {
+    let request_id = req_id.map(|Extension(r)| r.0);
     let app = state
         .app_service
         .get_by_public_id_unscoped(&app_id)
@@ -218,7 +221,7 @@ async fn run_agent(
                     app.public_id,
                     app.agent_identity_id,
                 )),
-                request_id: None,
+                request_id,
             },
             CreateMessageRequest {
                 message: InputMessage {

--- a/crates/server/src/api/ag_ui.rs
+++ b/crates/server/src/api/ag_ui.rs
@@ -218,6 +218,7 @@ async fn run_agent(
                     app.public_id,
                     app.agent_identity_id,
                 )),
+                request_id: None,
             },
             CreateMessageRequest {
                 message: InputMessage {

--- a/crates/server/src/api/mcp_endpoint/handlers.rs
+++ b/crates/server/src/api/mcp_endpoint/handlers.rs
@@ -520,6 +520,7 @@ pub async fn create_message(params: &Value, ctx: &CatalogContext) -> Result<Stri
         agent_id: session.agent_id.map(|id| id.uuid()),
         session_id,
         event_metadata: None,
+        request_id: None,
     };
 
     let req = serde_json::from_value(params.clone()).map_err(err)?;

--- a/crates/server/src/api/messages.rs
+++ b/crates/server/src/api/messages.rs
@@ -227,9 +227,10 @@ pub async fn create_message(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(session_id): Path<String>,
-    Extension(RequestId(request_id)): Extension<RequestId>,
+    req_id: Option<Extension<RequestId>>,
     Json(mut req): Json<CreateMessageRequest>,
 ) -> Result<(StatusCode, Json<Message>), (StatusCode, Json<ErrorResponse>)> {
+    let request_id = req_id.map(|Extension(r)| r.0);
     req.controls = normalize_controls_locale(req.controls)
         .map_err(|err| -> (StatusCode, Json<ErrorResponse>) { err.into() })?;
 
@@ -294,7 +295,7 @@ pub async fn create_message(
                 agent_id: session.agent_id.map(|a| a.uuid()),
                 session_id: session_id.uuid(),
                 event_metadata: None,
-                request_id: Some(request_id),
+                request_id,
             },
             req,
         )

--- a/crates/server/src/api/messages.rs
+++ b/crates/server/src/api/messages.rs
@@ -9,9 +9,10 @@
 // We re-export them here with ToSchema for OpenAPI documentation.
 
 use crate::auth::{AuthState, ResolvedOrg};
+use crate::middleware::RequestId;
 use crate::storage::StorageBackend;
 use axum::{
-    Json, Router,
+    Extension, Json, Router,
     extract::{Path, State},
     http::StatusCode,
     response::IntoResponse,
@@ -226,6 +227,7 @@ pub async fn create_message(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(session_id): Path<String>,
+    Extension(RequestId(request_id)): Extension<RequestId>,
     Json(mut req): Json<CreateMessageRequest>,
 ) -> Result<(StatusCode, Json<Message>), (StatusCode, Json<ErrorResponse>)> {
     req.controls = normalize_controls_locale(req.controls)
@@ -239,6 +241,8 @@ pub async fn create_message(
             }),
         )
     })?;
+
+    tracing::Span::current().record("session_id", session_id.to_string().as_str());
 
     // Get session to retrieve agent_id
     let caller = Caller::from(&org);
@@ -290,6 +294,7 @@ pub async fn create_message(
                 agent_id: session.agent_id.map(|a| a.uuid()),
                 session_id: session_id.uuid(),
                 event_metadata: None,
+                request_id: Some(request_id),
             },
             req,
         )

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -710,6 +710,7 @@ async fn process_slack_message(
                     app.public_id,
                     app.agent_identity_id,
                 )),
+                request_id: None,
             },
             create_msg,
         )
@@ -2865,6 +2866,7 @@ mod tests {
             _harness_id: everruns_core::typed_id::HarnessId,
             _agent_id: Option<everruns_core::typed_id::AgentId>,
             _input_message_id: everruns_core::typed_id::MessageId,
+            _request_id: Option<String>,
         ) -> anyhow::Result<()> {
             Ok(())
         }

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -18,7 +18,7 @@
 // polling in DEV_MODE where EventNotificationBroadcaster is unavailable.
 
 use axum::{
-    Json, Router,
+    Extension, Json, Router,
     body::Bytes,
     extract::{Path, State},
     http::{HeaderMap, StatusCode},
@@ -42,6 +42,7 @@ use tokio::sync::RwLock;
 use crate::api::messages::{CreateMessageRequest, InputContentPart, InputMessage, MessageRole};
 use crate::api::sessions::CreateSessionRequest;
 use crate::execution_metadata;
+use crate::middleware::RequestId;
 use crate::services::{
     AppService, CreateMessageContext, EventService, MessageService, SessionService,
 };
@@ -333,9 +334,11 @@ pub fn routes(state: SlackState) -> Router {
 async fn handle_slack_event(
     State(state): State<SlackState>,
     Path(app_id): Path<String>,
+    req_id: Option<Extension<RequestId>>,
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
+    let request_id = req_id.map(|Extension(r)| r.0);
     // 1. Look up app (unscoped — no org context for webhooks)
     let app = state
         .app_service
@@ -449,8 +452,16 @@ async fn handle_slack_event(
                 let state = state.clone();
                 let app = app.clone();
                 let slack_config = slack_config.clone();
+                let spawned_request_id = request_id.clone();
                 tokio::spawn(async move {
-                    if let Err(e) = process_slack_message(&state, &app, &slack_config, &event).await
+                    if let Err(e) = process_slack_message(
+                        &state,
+                        &app,
+                        &slack_config,
+                        &event,
+                        spawned_request_id,
+                    )
+                    .await
                     {
                         tracing::error!(
                             app_id = %app_id,
@@ -485,6 +496,7 @@ async fn process_slack_message(
     app: &App,
     slack_config: &SlackChannelConfig,
     event: &SlackEvent,
+    request_id: Option<String>,
 ) -> anyhow::Result<()> {
     let org_id = app.org_id;
     let slack_user_id = event.user.clone().unwrap_or_default();
@@ -710,7 +722,7 @@ async fn process_slack_message(
                     app.public_id,
                     app.agent_identity_id,
                 )),
-                request_id: None,
+                request_id,
             },
             create_msg,
         )

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -17,6 +17,8 @@ use crate::server::{ServerConfig, build_router_with_prefix};
 use crate::storage::{EncryptionService, StorageBackend};
 use crate::{api, seed, services};
 
+use crate::middleware::RequestIdLayer;
+use crate::middleware::request_id::RequestId;
 use anyhow::{Context, Result};
 use axum::http::{Method, header};
 use axum::{Json, Router, extract::State, routing::get};
@@ -1010,7 +1012,27 @@ impl ServerAppBuilder {
                 ),
             ));
 
-        let app = app.layer(TraceLayer::new_for_http());
+        let app = app.layer(TraceLayer::new_for_http().make_span_with(
+            |req: &axum::http::Request<_>| {
+                let request_id = req
+                    .extensions()
+                    .get::<RequestId>()
+                    .map(|r| r.0.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                tracing::info_span!(
+                    "http_request",
+                    method = %req.method(),
+                    uri = %req.uri().path(),
+                    request_id = %request_id,
+                    session_id = tracing::field::Empty,
+                )
+            },
+        ));
+
+        // RequestIdLayer must be outer (run first) so TraceLayer can read the ID when
+        // creating the span above. See specs/correlation-ids.md.
+        let app = app.layer(RequestIdLayer);
 
         // HTTP request duration histogram: applied as route_layer so axum's
         // MatchedPath extractor is available for low-cardinality path labels.

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -2050,6 +2050,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
                     session.harness_id,
                     session.agent_id,
                     message_id,
+                    None,
                 )
                 .await
                 .map_err(|e| store_error(format!("Failed to start turn: {e}")))?;

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -3281,6 +3281,7 @@ impl WorkerService for WorkerServiceImpl {
                         harness_id,
                         agent_id,
                         message_id_typed,
+                        None,
                     )
                     .await
                 {

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -17,6 +17,9 @@ extern crate everruns_integrations_sprites;
 // API routes and types (shared for OpenAPI generation)
 pub mod api;
 
+// HTTP middleware (request ID, etc.)
+pub mod middleware;
+
 // Authentication module
 pub mod auth;
 pub use auth::{AuthBackend, BuiltinAuthBackend};

--- a/crates/server/src/middleware/mod.rs
+++ b/crates/server/src/middleware/mod.rs
@@ -1,0 +1,2 @@
+pub mod request_id;
+pub use request_id::{RequestId, RequestIdLayer};

--- a/crates/server/src/middleware/request_id.rs
+++ b/crates/server/src/middleware/request_id.rs
@@ -1,0 +1,75 @@
+// Request ID middleware
+//
+// Extracts X-Request-ID from incoming request or generates a UUID v4.
+// Stores the ID in request extensions for downstream handlers.
+// Echoes the ID in the X-Request-ID response header.
+//
+// Must sit outside (wrap) TraceLayer so the span has the ID when created.
+
+use axum::http::{HeaderName, HeaderValue, Request, Response};
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
+use uuid::Uuid;
+
+pub static REQUEST_ID_HEADER: HeaderName = HeaderName::from_static("x-request-id");
+
+/// Opaque per-request correlation ID stored in request extensions.
+#[derive(Clone, Debug)]
+pub struct RequestId(pub String);
+
+#[derive(Clone, Default)]
+pub struct RequestIdLayer;
+
+impl<S> Layer<S> for RequestIdLayer {
+    type Service = RequestIdService<S>;
+    fn layer(&self, inner: S) -> Self::Service {
+        RequestIdService { inner }
+    }
+}
+
+#[derive(Clone)]
+pub struct RequestIdService<S> {
+    inner: S,
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for RequestIdService<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>> + Send + 'static,
+    S::Future: Send + 'static,
+    ReqBody: Send + 'static,
+    ResBody: Send + 'static,
+{
+    type Response = Response<ResBody>;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Response<ResBody>, S::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+        let request_id = req
+            .headers()
+            .get(&REQUEST_ID_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| Uuid::new_v4().to_string());
+
+        req.extensions_mut().insert(RequestId(request_id.clone()));
+
+        let fut = self.inner.call(req);
+
+        Box::pin(async move {
+            let mut response = fut.await?;
+            if let Ok(val) = HeaderValue::from_str(&request_id) {
+                response
+                    .headers_mut()
+                    .entry(HeaderName::from_static("x-request-id"))
+                    .or_insert(val);
+            }
+            Ok(response)
+        })
+    }
+}

--- a/crates/server/src/middleware/request_id.rs
+++ b/crates/server/src/middleware/request_id.rs
@@ -50,10 +50,12 @@ where
     }
 
     fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+        const MAX_REQUEST_ID_LEN: usize = 256;
         let request_id = req
             .headers()
             .get(&REQUEST_ID_HEADER)
             .and_then(|v| v.to_str().ok())
+            .filter(|s| s.len() <= MAX_REQUEST_ID_LEN)
             .map(|s| s.to_string())
             .unwrap_or_else(|| Uuid::new_v4().to_string());
 
@@ -66,8 +68,7 @@ where
             if let Ok(val) = HeaderValue::from_str(&request_id) {
                 response
                     .headers_mut()
-                    .entry(HeaderName::from_static("x-request-id"))
-                    .or_insert(val);
+                    .insert(REQUEST_ID_HEADER.clone(), val);
             }
             Ok(response)
         })

--- a/crates/server/src/services/eval_runner.rs
+++ b/crates/server/src/services/eval_runner.rs
@@ -451,6 +451,7 @@ async fn send_message_and_wait(
         agent_id: sctx.agent_id,
         session_id: sctx.session_uuid,
         event_metadata: None,
+        request_id: None,
     };
     let msg_req = CreateMessageRequest {
         message: InputMessage {

--- a/crates/server/src/services/message.rs
+++ b/crates/server/src/services/message.rs
@@ -36,6 +36,8 @@ pub struct CreateMessageContext {
     pub agent_id: Option<Uuid>,
     pub session_id: Uuid,
     pub event_metadata: Option<serde_json::Value>,
+    /// HTTP request ID for log correlation. Propagated to durable turn input.
+    pub request_id: Option<String>,
 }
 
 impl MessageService {
@@ -70,6 +72,7 @@ impl MessageService {
             session_id = %ctx.session_id,
             harness_id = %ctx.harness_id,
             agent_id = ?ctx.agent_id,
+            request_id = ?ctx.request_id,
             "Creating user message"
         );
 
@@ -143,6 +146,9 @@ impl MessageService {
         // Start workflow for user message in background (don't block the response)
         // The message is already persisted, so we can return immediately
         let runner = self.runner.clone();
+        let request_id = ctx.request_id.clone();
+        let session_id_str = ctx.session_id.to_string();
+        let message_id_str = message_id.to_string();
         tokio::spawn(async move {
             if let Err(e) = runner
                 .start_run(
@@ -151,19 +157,20 @@ impl MessageService {
                     harness_id_typed,
                     agent_id_typed,
                     message_id_typed,
+                    request_id,
                 )
                 .await
             {
                 tracing::error!(
-                    session_id = %ctx.session_id,
-                    input_message_id = %message_id,
+                    session_id = %session_id_str,
+                    input_message_id = %message_id_str,
                     error = %e,
                     "Failed to start turn workflow"
                 );
             } else {
                 tracing::info!(
-                    session_id = %ctx.session_id,
-                    input_message_id = %message_id,
+                    session_id = %session_id_str,
+                    input_message_id = %message_id_str,
                     "Turn workflow started"
                 );
             }

--- a/crates/server/src/services/message.rs
+++ b/crates/server/src/services/message.rs
@@ -147,6 +147,7 @@ impl MessageService {
         // The message is already persisted, so we can return immediately
         let runner = self.runner.clone();
         let request_id = ctx.request_id.clone();
+        let request_id_str = request_id.as_deref().unwrap_or("").to_string();
         let session_id_str = ctx.session_id.to_string();
         let message_id_str = message_id.to_string();
         tokio::spawn(async move {
@@ -164,6 +165,7 @@ impl MessageService {
                 tracing::error!(
                     session_id = %session_id_str,
                     input_message_id = %message_id_str,
+                    request_id = %request_id_str,
                     error = %e,
                     "Failed to start turn workflow"
                 );
@@ -171,6 +173,7 @@ impl MessageService {
                 tracing::info!(
                     session_id = %session_id_str,
                     input_message_id = %message_id_str,
+                    request_id = %request_id_str,
                     "Turn workflow started"
                 );
             }

--- a/crates/server/src/session_scheduler.rs
+++ b/crates/server/src/session_scheduler.rs
@@ -176,6 +176,7 @@ async fn poll_and_trigger(
                     harness_id,
                     agent_id,
                     message_id_typed,
+                    None,
                 )
                 .await
             {

--- a/crates/worker/src/durable_runner.rs
+++ b/crates/worker/src/durable_runner.rs
@@ -47,6 +47,9 @@ pub struct DurableTurnInput {
     /// Incremented each time a new reason activity is scheduled after act.
     #[serde(default = "default_iteration")]
     pub iteration: u32,
+    /// HTTP request ID that triggered this turn. Propagated for log correlation.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub request_id: Option<String>,
 }
 
 fn default_iteration() -> u32 {
@@ -598,6 +601,7 @@ impl AgentRunner for DurableRunner {
         harness_id: HarnessId,
         agent_id: Option<AgentId>,
         input_message_id: MessageId,
+        request_id: Option<String>,
     ) -> Result<()> {
         info!(
             org_id = org_id,
@@ -605,6 +609,7 @@ impl AgentRunner for DurableRunner {
             harness_id = %harness_id,
             ?agent_id,
             input_message_id = %input_message_id,
+            request_id = ?request_id,
             "Starting durable turn workflow for session"
         );
 
@@ -619,6 +624,7 @@ impl AgentRunner for DurableRunner {
             turn_id: None,
             previous_response_id: None,
             iteration: 1,
+            request_id,
         };
 
         // Create workflow instance
@@ -911,6 +917,7 @@ mod tests {
             turn_id: None,
             previous_response_id: None,
             iteration: 1,
+            request_id: None,
         };
 
         let json = serde_json::to_string(&input).unwrap();
@@ -939,6 +946,7 @@ mod tests {
             turn_id: None,
             previous_response_id: None,
             iteration: 3,
+            request_id: None,
         };
         let mut json_val: serde_json::Value = serde_json::to_value(&input).unwrap();
         // Remove iteration to simulate pre-existing persisted data
@@ -968,6 +976,7 @@ mod tests {
                 harness_id,
                 Some(agent_id),
                 message_id,
+                None,
             )
             .await
             .expect("First start_run should succeed");
@@ -997,6 +1006,7 @@ mod tests {
                 harness_id,
                 Some(agent_id),
                 message_id1,
+                None,
             )
             .await
             .expect("First start_run should succeed");
@@ -1013,6 +1023,7 @@ mod tests {
                 harness_id,
                 Some(agent_id),
                 message_id2,
+                None,
             )
             .await
             .expect("Second start_run should send steering signal");
@@ -1073,6 +1084,7 @@ mod tests {
                 harness_id,
                 Some(agent_id),
                 message_id1,
+                None,
             )
             .await
             .expect("First start_run should succeed");
@@ -1104,6 +1116,7 @@ mod tests {
                 harness_id,
                 Some(agent_id),
                 message_id2,
+                None,
             )
             .await
             .expect("Second start_run should succeed (reset workflow)");
@@ -1136,6 +1149,7 @@ mod tests {
                 harness_id,
                 Some(agent_id),
                 message_id1,
+                None,
             )
             .await
             .expect("First start_run should succeed");
@@ -1164,6 +1178,7 @@ mod tests {
                 harness_id,
                 Some(agent_id),
                 message_id2,
+                None,
             )
             .await
             .expect("Second start_run should reset failed workflow");
@@ -1194,6 +1209,7 @@ mod tests {
                 harness_id,
                 Some(agent_id),
                 message_id,
+                None,
             )
             .await
             .expect("start_run should succeed");
@@ -1209,6 +1225,7 @@ mod tests {
             turn_id: Some(turn_id),
             previous_response_id: Some("resp_abc".to_string()),
             iteration: 3,
+            request_id: None,
         };
         {
             let mut store = runner.store.lock().await;
@@ -1251,7 +1268,14 @@ mod tests {
 
         // Create and complete a workflow without saving turn input in result
         runner
-            .start_run(DEFAULT_ORG_ID, session_id, harness_id, None, message_id)
+            .start_run(
+                DEFAULT_ORG_ID,
+                session_id,
+                harness_id,
+                None,
+                message_id,
+                None,
+            )
             .await
             .expect("start_run should succeed");
 
@@ -1287,7 +1311,14 @@ mod tests {
         let message_id = MessageId::new();
 
         runner
-            .start_run(DEFAULT_ORG_ID, session_id, harness_id, None, message_id)
+            .start_run(
+                DEFAULT_ORG_ID,
+                session_id,
+                harness_id,
+                None,
+                message_id,
+                None,
+            )
             .await
             .expect("start_run should succeed");
 
@@ -1327,6 +1358,7 @@ mod tests {
                 harness_id,
                 Some(agent_id),
                 message_id1,
+                None,
             )
             .await
             .expect("First start_run should succeed");
@@ -1346,6 +1378,7 @@ mod tests {
                 harness_id,
                 Some(agent_id),
                 message_id2,
+                None,
             ),
         )
         .await;
@@ -1378,6 +1411,7 @@ mod tests {
                 HarnessId::new(),
                 Some(AgentId::new()),
                 MessageId::new(),
+                None,
             )
             .await
             .unwrap();
@@ -1391,6 +1425,7 @@ mod tests {
                 HarnessId::new(),
                 Some(AgentId::new()),
                 MessageId::new(),
+                None,
             )
             .await
             .unwrap();
@@ -1419,6 +1454,7 @@ mod tests {
                 HarnessId::new(),
                 Some(AgentId::new()),
                 MessageId::new(),
+                None,
             )
             .await
             .unwrap();
@@ -1452,6 +1488,7 @@ mod tests {
                 harness_id,
                 Some(agent_id),
                 MessageId::new(),
+                None,
             )
             .await
             .expect("First start_run should succeed");
@@ -1466,6 +1503,7 @@ mod tests {
                     harness_id,
                     Some(agent_id),
                     MessageId::new(),
+                    None,
                 )
                 .await
                 .unwrap_or_else(|e| panic!("Message {} should succeed: {}", i + 2, e));
@@ -1496,7 +1534,14 @@ mod tests {
 
         // First message — workflow created, set to Running
         runner
-            .start_run(DEFAULT_ORG_ID, session_id, harness_id, Some(agent_id), msg1)
+            .start_run(
+                DEFAULT_ORG_ID,
+                session_id,
+                harness_id,
+                Some(agent_id),
+                msg1,
+                None,
+            )
             .await
             .expect("First start_run");
 
@@ -1514,11 +1559,25 @@ mod tests {
 
         // Second and third messages — both should send steering signals
         runner
-            .start_run(DEFAULT_ORG_ID, session_id, harness_id, Some(agent_id), msg2)
+            .start_run(
+                DEFAULT_ORG_ID,
+                session_id,
+                harness_id,
+                Some(agent_id),
+                msg2,
+                None,
+            )
             .await
             .expect("Second start_run (steering)");
         runner
-            .start_run(DEFAULT_ORG_ID, session_id, harness_id, Some(agent_id), msg3)
+            .start_run(
+                DEFAULT_ORG_ID,
+                session_id,
+                harness_id,
+                Some(agent_id),
+                msg3,
+                None,
+            )
             .await
             .expect("Third start_run (steering)");
 

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -879,6 +879,7 @@ impl DurableWorker {
                     turn_id: Some(act_task_input.act_input.context.turn_id),
                     previous_response_id,
                     iteration,
+                    request_id: None,
                 };
                 let res = self
                     .execute_act_activity(
@@ -1382,6 +1383,7 @@ impl DurableWorker {
                     turn_id,
                     previous_response_id: None,
                     iteration: 1,
+                    request_id: input.request_id.clone(),
                 };
                 let input_json = serde_json::to_value(&input_with_turn)?;
 
@@ -1491,6 +1493,7 @@ impl DurableWorker {
                         turn_id: input.turn_id,
                         previous_response_id: chained_input.previous_response_id.clone(),
                         iteration: next_iteration,
+                        request_id: input.request_id.clone(),
                     };
                     let continued_json = serde_json::to_value(&continued_input)?;
 

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -38,6 +38,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct ActTaskInput {
     org_id: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    request_id: Option<String>,
     #[serde(flatten)]
     act_input: ActInput,
 }
@@ -879,7 +881,7 @@ impl DurableWorker {
                     turn_id: Some(act_task_input.act_input.context.turn_id),
                     previous_response_id,
                     iteration,
-                    request_id: None,
+                    request_id: act_task_input.request_id.clone(),
                 };
                 let res = self
                     .execute_act_activity(
@@ -1442,6 +1444,7 @@ impl DurableWorker {
 
                     let act_task_input = ActTaskInput {
                         org_id: input.org_id,
+                        request_id: input.request_id.clone(),
                         act_input: ActInput {
                             org_id: Some(input.org_id),
                             context: AtomContext {

--- a/crates/worker/src/runner.rs
+++ b/crates/worker/src/runner.rs
@@ -43,6 +43,7 @@ pub trait AgentRunner: Send + Sync {
         harness_id: HarnessId,
         agent_id: Option<AgentId>,
         input_message_id: MessageId,
+        request_id: Option<String>,
     ) -> Result<()>;
 
     /// Resume a workflow after client-side tool results (e.g. connection_required).

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -447,6 +447,7 @@ where
                 turn_id: Some(act_input.context.turn_id),
                 previous_response_id,
                 iteration,
+                request_id: None,
             };
 
             let res = execute_act_activity(adapters, &act_input).await;
@@ -720,6 +721,7 @@ async fn schedule_next_activity<S: WorkflowEventStore, A: WorkerAdapters + Clone
                 turn_id,
                 previous_response_id: None,
                 iteration: 1,
+                request_id: input.request_id.clone(),
             };
             let input_json = serde_json::to_value(&input_with_turn)?;
 
@@ -843,6 +845,7 @@ async fn schedule_next_activity<S: WorkflowEventStore, A: WorkerAdapters + Clone
                     turn_id: input.turn_id,
                     previous_response_id: response_id,
                     iteration: next_iteration,
+                    request_id: input.request_id.clone(),
                 };
                 let continued_json = serde_json::to_value(&continued_input)?;
                 let activity_id = format!("reason_{}", Uuid::now_v7());

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -435,6 +435,13 @@ where
                 .filter(|&it| it > 0)
                 .unwrap_or(1);
 
+            // Extract request_id propagated from the originating HTTP request
+            let act_request_id = task
+                .input
+                .get("request_id")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+
             // Create DurableTurnInput from ActInput context
             let turn_input = DurableTurnInput {
                 org_id: act_input
@@ -447,7 +454,7 @@ where
                 turn_id: Some(act_input.context.turn_id),
                 previous_response_id,
                 iteration,
-                request_id: None,
+                request_id: act_request_id,
             };
 
             let res = execute_act_activity(adapters, &act_input).await;
@@ -809,6 +816,9 @@ async fn schedule_next_activity<S: WorkflowEventStore, A: WorkerAdapters + Clone
                     act_input_json["previous_response_id"] = serde_json::json!(rid);
                 }
                 act_input_json["iteration"] = serde_json::json!(input.iteration);
+                if let Some(rid) = &input.request_id {
+                    act_input_json["request_id"] = serde_json::json!(rid);
+                }
                 let activity_id = format!("act_{}", Uuid::now_v7());
 
                 let task = TaskDefinition {

--- a/specs/correlation-ids.md
+++ b/specs/correlation-ids.md
@@ -1,0 +1,89 @@
+# Correlation IDs
+
+Everruns attaches three correlation identifiers to every request and propagates them through async execution and observability systems.
+
+## Identifiers
+
+### Request ID (`request_id`)
+
+A per-HTTP-request opaque identifier.
+
+- **Header**: `X-Request-ID` (de facto standard; used by nginx, AWS API Gateway, GCP, Heroku)
+- **Format**: UUID v4 (e.g. `550e8400-e29b-41d4-a716-446655440000`)
+- **Source**: Extracted verbatim from the incoming `X-Request-ID` header if present; generated as UUID v4 otherwise.
+- **Response**: Always echoed back in the `X-Request-ID` response header.
+- **Scope**: Single HTTP request → persists into any async durable run triggered by that request.
+
+Why `X-Request-ID` and not W3C `traceparent`? `traceparent` is the official distributed-tracing standard and Everruns supports it automatically via OpenTelemetry. `X-Request-ID` complements it as a human-readable, stable ID for log search and support workflows — clients can inject their own ID and find all related log lines without understanding OTel trace format.
+
+### Session ID (`session_id`)
+
+The persistent conversation identifier that spans multiple turns.
+
+- **Format**: `sess_{32-hex}` (see `specs/id-schema.md`)
+- **Source**: URL path parameter in session-scoped endpoints.
+- **Scope**: All HTTP handlers and background tasks operating on a session record this on their tracing span.
+
+### Durable Workflow Correlation
+
+The session ID doubles as the durable workflow ID (see `specs/durable-execution-engine.md`). This means a single `session_id` or `request_id` search in logs covers both the HTTP layer and the async worker execution.
+
+---
+
+## Where IDs Appear
+
+### Tracing Spans / Logs
+
+All HTTP request spans include:
+
+| Field | Source |
+|---|---|
+| `request_id` | `X-Request-ID` header or generated UUID |
+| `session_id` | Set by session-scoped handlers via `Span::current().record(...)` |
+
+The `RequestIdLayer` Tower middleware (see `crates/server/src/middleware/request_id.rs`) generates or extracts the request ID and stores it in request extensions. The `TraceLayer` reads it from extensions when creating the per-request span so it is present on every log line emitted within the request.
+
+### Durable Execution
+
+The `request_id` is stored in `DurableTurnInput` and propagated across all durable tasks (reason, act, tool execution) so worker logs carry the originating request ID even when executed asynchronously in a separate worker process.
+
+### OpenTelemetry
+
+`request_id` and `session_id` are span fields on all HTTP spans. OTel exporters include them as span attributes, making them queryable in Jaeger, Honeycomb, Grafana Tempo, and similar backends.
+
+The W3C `traceparent` / `tracestate` headers are handled automatically by the OTel SDK (see `specs/observability.md`) and provide a parallel, standard-format correlation path.
+
+---
+
+## Middleware Stack Position
+
+```
+RequestIdLayer      ← outermost: extracts/generates request_id, stores in extensions, echoes in response
+  TraceLayer        ← reads request_id from extensions, creates span with request_id + session_id fields
+    CORS
+    Security headers
+      Handlers      ← record session_id on span; extract RequestId extension for CreateMessageContext
+```
+
+The `RequestIdLayer` must sit outside `TraceLayer` so the span has the ID when it is created.
+
+---
+
+## Implementation
+
+| Component | File |
+|---|---|
+| `RequestIdLayer` Tower middleware | `crates/server/src/middleware/request_id.rs` |
+| Middleware wiring + custom `TraceLayer` span | `crates/server/src/app_builder.rs` |
+| `request_id` in `CreateMessageContext` | `crates/server/src/services/message.rs` |
+| `request_id` in `AgentRunner::start_run` | `crates/worker/src/runner.rs` |
+| `request_id` in `DurableTurnInput` | `crates/worker/src/durable_runner.rs` |
+| `session_id` span recording | `crates/server/src/api/messages.rs` |
+
+---
+
+## Reverse Proxy Requirements
+
+For `X-Request-ID` to work end-to-end, the reverse proxy must forward it unchanged. See `specs/production-deployment.md` for the full header-forwarding contract.
+
+If the proxy strips or rewrites the header, clients lose the ability to inject their own IDs and the echoed ID in responses will be a server-generated UUID rather than the client-supplied value.

--- a/specs/correlation-ids.md
+++ b/specs/correlation-ids.md
@@ -9,8 +9,8 @@ Everruns attaches three correlation identifiers to every request and propagates 
 A per-HTTP-request opaque identifier.
 
 - **Header**: `X-Request-ID` (de facto standard; used by nginx, AWS API Gateway, GCP, Heroku)
-- **Format**: UUID v4 (e.g. `550e8400-e29b-41d4-a716-446655440000`)
-- **Source**: Extracted verbatim from the incoming `X-Request-ID` header if present; generated as UUID v4 otherwise.
+- **Format**: Opaque client-supplied printable ASCII value when `X-Request-ID` is provided (max 256 chars); otherwise a server-generated UUID v4 (e.g. `550e8400-e29b-41d4-a716-446655440000`). Clients are recommended to send UUID v4 values for interoperability.
+- **Source**: Extracted verbatim from the incoming `X-Request-ID` header if present and valid; generated as UUID v4 otherwise.
 - **Response**: Always echoed back in the `X-Request-ID` response header.
 - **Scope**: Single HTTP request → persists into any async durable run triggered by that request.
 

--- a/specs/observability.md
+++ b/specs/observability.md
@@ -97,6 +97,8 @@ For the complete attribute tables per span type (invoke_agent, chat, execute_too
 
 Spans use the `tracing` crate's native parent-child mechanism. The `OtelEventListener` maintains a `HashMap<String, tracing::Span>` to track active spans. When a child event arrives, the listener looks up the parent span, enters its context, and creates the child span (inheriting the parent). See `crates/core/src/observation/otel.rs` for the full implementation.
 
+HTTP-layer correlation identifiers (`request_id`, `session_id`) are recorded as span fields on every HTTP request span and propagated into durable execution. See [`specs/correlation-ids.md`](./correlation-ids.md) for the full contract.
+
 ### Content Recording
 
 Disabled by default for privacy. Enable with:

--- a/specs/production-deployment.md
+++ b/specs/production-deployment.md
@@ -80,8 +80,10 @@ Do not rewrite `/mcp` under `/api`. Do not rewrite `/.well-known/*` under `/api`
 
 - TLS/HTTPS required for public traffic
 - Disable proxy buffering for SSE responses under `/api/*`
-- Preserve Host and standard forwarding headers
+- Preserve Host and standard forwarding headers, including `X-Request-ID` (pass through unchanged)
 - Keep gRPC worker traffic off the public ingress path
+
+See [`specs/correlation-ids.md`](./correlation-ids.md) for the `X-Request-ID` contract: the server generates a UUID if the header is absent and always echoes it in the response. Stripping or rewriting it breaks client-injected request correlation.
 
 ### Operational Notes
 


### PR DESCRIPTION
## What

Adds three correlation identifiers to every HTTP request and propagates them through async execution and observability systems:

- **`request_id`** — extracted from `X-Request-ID` request header (or generated as UUID v4 if absent), echoed back in `X-Request-ID` response header
- **`session_id`** — recorded on the tracing span by session-scoped handlers
- **Durable propagation** — `request_id` flows through `DurableTurnInput` so worker logs carry the originating HTTP request ID even when executing asynchronously

## Why

Log searches during incidents require correlating the HTTP layer with background durable execution. Without a stable request ID in logs and telemetry spans, tracing a user-visible error back to the worker task that caused it is manual and error-prone.

## How

- **`RequestIdLayer`** Tower middleware (`crates/server/src/middleware/request_id.rs`): extracts/generates the request ID, stores it in request extensions, echoes it in the response header
- **Custom `TraceLayer` span**: reads `RequestId` from extensions at span creation time so all log lines within the request carry `request_id` and have a pre-declared `session_id = Empty` field
- **Middleware ordering**: `RequestIdLayer` is outermost (runs first), then `TraceLayer` reads from extensions
- **`AgentRunner::start_run`** gains `request_id: Option<String>`; `DurableTurnInput` gains the same field with serde default so it propagates through reason/act/tool tasks without breaking existing serialized data
- **`specs/correlation-ids.md`** documents the full contract; cross-references added to `specs/observability.md` and `specs/production-deployment.md`

## Risk

- **Low**
- `X-Request-ID` is a new request/response header; existing clients that don't send it get a server-generated UUID (no behavior change)
- `AgentRunner::start_run` signature change is internal — all call sites updated; worker tests updated
- `DurableTurnInput` gains `request_id` with `#[serde(default)]` — backward compatible with existing persisted workflow state

## Security

- **TM-API** reviewed: `X-Request-ID` header is read via `HeaderValue::to_str()` which only accepts valid printable ASCII (no CRLF, no control chars). Echo path uses `HeaderValue::from_str` which re-validates before writing to the response — header injection is not possible.
- **TM-WEB** reviewed: new `X-Request-ID` response header carries only an opaque UUID or client-supplied validated ASCII string. No sensitive data exposed.
- No auth, authz, SQL, tool execution, or tenant isolation changes.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
