### PR TITLE
feat(monitors): add scheduled monitor support

### DIFF
--- a/apps/ui/e2e/message-components.spec.ts
+++ b/apps/ui/e2e/message-components.spec.ts
@@ -71,6 +71,10 @@ test.describe("Tool Activity Page", () => {
     ).toBeVisible();
     await expect(page.getByText("/ship")).toBeVisible();
     await expect(page.getByText("Pick File")).toBeVisible();
+    await expect(page.getByText("Created")).toBeVisible();
+    await expect(page.getByText("Deleted")).toBeVisible();
+    await expect(page.getByText("Every 10m")).toBeVisible();
+    await expect(page.getByText("Watch PR 1319").first()).toBeVisible();
   });
 });
 

--- a/apps/ui/src/__tests__/schedule-display.test.ts
+++ b/apps/ui/src/__tests__/schedule-display.test.ts
@@ -1,0 +1,47 @@
+import {
+  formatScheduleCadence,
+  formatScheduledDateTime,
+  getScheduleDisplayTitle,
+} from "@/lib/schedule-display";
+
+describe("schedule-display", () => {
+  it("formats recurring minute intervals compactly", () => {
+    expect(formatScheduleCadence({ cronExpression: "*/10 * * * *" })).toBe("Every 10m");
+  });
+
+  it("formats daily schedules with a readable time", () => {
+    expect(formatScheduleCadence({ cronExpression: "0 9 * * *" })).toBe("Daily 9:00 AM");
+  });
+
+  it("formats weekday schedules with a readable prefix", () => {
+    expect(formatScheduleCadence({ cronExpression: "30 14 * * 1-5" })).toBe("Weekdays 2:30 PM");
+  });
+
+  it("formats one-shot schedules using the provided timezone", () => {
+    expect(
+      formatScheduleCadence({
+        scheduledAt: "2026-04-16T15:30:00Z",
+        timezone: "UTC",
+      }),
+    ).toBe("At Apr 16, 3:30 PM UTC");
+  });
+
+  it("formats absolute schedule timestamps", () => {
+    expect(formatScheduledDateTime("2026-04-16T15:30:00Z", "UTC")).toBe("Apr 16, 3:30 PM UTC");
+  });
+
+  it("extracts background monitor titles from synthetic schedule descriptions", () => {
+    expect(
+      getScheduleDisplayTitle(`This scheduled monitor fired. Start the background run now.
+
+Use \`spawn_background\` with:
+- tool: \`github\`
+- title: \`Watch PR 1319\`
+- signal_on_completion: true
+- args:
+\`\`\`json
+{}
+\`\`\``),
+    ).toBe("Watch PR 1319");
+  });
+});

--- a/apps/ui/src/__tests__/schedule-display.test.ts
+++ b/apps/ui/src/__tests__/schedule-display.test.ts
@@ -32,16 +32,12 @@ describe("schedule-display", () => {
 
   it("extracts background monitor titles from synthetic schedule descriptions", () => {
     expect(
-      getScheduleDisplayTitle(`This scheduled monitor fired. Start the background run now.
+      getScheduleDisplayTitle(`Monitor: Watch PR 1319
 
-Use \`spawn_background\` with:
-- tool: \`github\`
-- title: \`Watch PR 1319\`
-- signal_on_completion: true
-- args:
-\`\`\`json
-{}
-\`\`\``),
+This scheduled monitor fired. Start the background run now.
+
+spawn_background payload:
+{"tool":"github","title":"Watch PR 1319","signal_on_completion":true,"args":{}}`),
     ).toBe("Watch PR 1319");
   });
 });

--- a/apps/ui/src/__tests__/tool-activity-utils.test.ts
+++ b/apps/ui/src/__tests__/tool-activity-utils.test.ts
@@ -1,0 +1,73 @@
+import { getToolActivitySummaryChip } from "@/components/chat/tool-activity-utils";
+import type { ToolCompletedData } from "@/lib/api/types";
+import type { ToolCallContent } from "@/components/chat/tool-call-utils";
+
+function textResult(text: string): ToolCompletedData {
+  return {
+    tool_call_id: "tool-1",
+    tool_name: "spawn_background",
+    success: true,
+    status: "success",
+    result: [{ type: "text", text }],
+  };
+}
+
+describe("getToolActivitySummaryChip", () => {
+  it("renders scheduled monitor creation with a compact cadence", () => {
+    const toolCall: ToolCallContent = {
+      id: "tool-1",
+      name: "spawn_background",
+      arguments: {},
+    };
+
+    const summary = getToolActivitySummaryChip(
+      toolCall,
+      textResult(
+        JSON.stringify({
+          status: "scheduled",
+          title: "Watch PR 1319",
+          cron_expression: "*/10 * * * *",
+          timezone: "America/Chicago",
+        }),
+      ),
+    );
+
+    expect(summary).toEqual({
+      status: "Created",
+      title: "Watch PR 1319",
+      schedule: "Every 10m",
+    });
+  });
+
+  it("renders cancelled monitor chips with the extracted monitor title", () => {
+    const toolCall: ToolCallContent = {
+      id: "tool-2",
+      name: "cancel_schedule",
+      arguments: {},
+    };
+
+    const summary = getToolActivitySummaryChip(
+      toolCall,
+      textResult(
+        JSON.stringify({
+          cancelled: true,
+          description: `This scheduled monitor fired. Start the background run now.
+
+Use \`spawn_background\` with:
+- tool: \`github\`
+- title: \`Watch PR 1319\`
+- signal_on_completion: true
+- args:
+\`\`\`json
+{}
+\`\`\``,
+        }),
+      ),
+    );
+
+    expect(summary).toEqual({
+      status: "Deleted",
+      title: "Watch PR 1319",
+    });
+  });
+});

--- a/apps/ui/src/__tests__/tool-activity-utils.test.ts
+++ b/apps/ui/src/__tests__/tool-activity-utils.test.ts
@@ -2,10 +2,10 @@ import { getToolActivitySummaryChip } from "@/components/chat/tool-activity-util
 import type { ToolCompletedData } from "@/lib/api/types";
 import type { ToolCallContent } from "@/components/chat/tool-call-utils";
 
-function textResult(text: string): ToolCompletedData {
+function textResult(toolName: string, text: string): ToolCompletedData {
   return {
     tool_call_id: "tool-1",
-    tool_name: "spawn_background",
+    tool_name: toolName,
     success: true,
     status: "success",
     result: [{ type: "text", text }],
@@ -23,6 +23,7 @@ describe("getToolActivitySummaryChip", () => {
     const summary = getToolActivitySummaryChip(
       toolCall,
       textResult(
+        "spawn_background",
         JSON.stringify({
           status: "scheduled",
           title: "Watch PR 1319",
@@ -49,18 +50,15 @@ describe("getToolActivitySummaryChip", () => {
     const summary = getToolActivitySummaryChip(
       toolCall,
       textResult(
+        "cancel_schedule",
         JSON.stringify({
           cancelled: true,
-          description: `This scheduled monitor fired. Start the background run now.
+          description: `Monitor: Watch PR 1319
 
-Use \`spawn_background\` with:
-- tool: \`github\`
-- title: \`Watch PR 1319\`
-- signal_on_completion: true
-- args:
-\`\`\`json
-{}
-\`\`\``,
+This scheduled monitor fired. Start the background run now.
+
+spawn_background payload:
+{"tool":"github","title":"Watch PR 1319","signal_on_completion":true,"args":{}}`,
         }),
       ),
     );

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/schedules/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/schedules/page.tsx
@@ -23,6 +23,11 @@ import {
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Clock, CalendarClock, Repeat, Play, Pause, Trash2, Zap, AlertCircle } from "lucide-react";
 import { formatRelativeTime } from "@/lib/formatting";
+import {
+  formatScheduleCadence,
+  formatScheduledDateTime,
+  getScheduleDisplayTitle,
+} from "@/lib/schedule-display";
 import type { SessionSchedule } from "@/lib/api/types";
 
 function ScheduleCard({ schedule, sessionId }: { schedule: SessionSchedule; sessionId: string }) {
@@ -32,6 +37,12 @@ function ScheduleCard({ schedule, sessionId }: { schedule: SessionSchedule; sess
   const triggerMutation = useTriggerSessionSchedule();
 
   const isRecurring = schedule.schedule_type === "recurring";
+  const scheduleTitle = getScheduleDisplayTitle(schedule.description);
+  const scheduleLabel = formatScheduleCadence({
+    cronExpression: schedule.cron_expression,
+    scheduledAt: schedule.scheduled_at,
+    timezone: schedule.timezone,
+  });
 
   const handleToggle = () => {
     updateMutation.mutate({
@@ -61,7 +72,7 @@ function ScheduleCard({ schedule, sessionId }: { schedule: SessionSchedule; sess
               ) : (
                 <CalendarClock className="h-4 w-4 text-muted-foreground" />
               )}
-              <CardTitle className="text-base">{schedule.description}</CardTitle>
+              <CardTitle className="text-base">{scheduleTitle}</CardTitle>
             </div>
             <div className="flex items-center gap-1">
               <Badge variant={schedule.enabled ? "default" : "secondary"}>
@@ -70,10 +81,15 @@ function ScheduleCard({ schedule, sessionId }: { schedule: SessionSchedule; sess
               <Badge variant="outline">{isRecurring ? "Recurring" : "One-shot"}</Badge>
             </div>
           </div>
-          {schedule.cron_expression && (
-            <CardDescription className="font-mono text-xs">
-              cron: {schedule.cron_expression}
-            </CardDescription>
+          {(scheduleLabel || schedule.cron_expression) && (
+            <div className="space-y-1">
+              {scheduleLabel && <CardDescription>{scheduleLabel}</CardDescription>}
+              {schedule.cron_expression && (
+                <div className="font-mono text-[11px] text-muted-foreground">
+                  cron: {schedule.cron_expression}
+                </div>
+              )}
+            </div>
           )}
         </CardHeader>
         <CardContent>
@@ -83,7 +99,7 @@ function ScheduleCard({ schedule, sessionId }: { schedule: SessionSchedule; sess
                 <div className="flex items-center gap-1">
                   <Clock className="h-3 w-3" />
                   <span>
-                    Next: {new Date(schedule.next_trigger_at).toLocaleString()} (
+                    Next: {formatScheduledDateTime(schedule.next_trigger_at, schedule.timezone)} (
                     {formatRelativeTime(schedule.next_trigger_at)})
                   </span>
                 </div>

--- a/apps/ui/src/app/dev/tool-activity/page.tsx
+++ b/apps/ui/src/app/dev/tool-activity/page.tsx
@@ -145,6 +145,81 @@ const clientToolCalls: ToolCallContent[] = [
   },
 ];
 
+const monitorToolCalls: ToolCallContent[] = [
+  {
+    id: "tool-monitor-create",
+    name: "spawn_background",
+    arguments: {
+      tool: "github_watch_pr",
+      title: "Watch PR 1319",
+      schedule: {
+        cron_expression: "*/10 * * * *",
+        timezone: "America/Chicago",
+      },
+    },
+  },
+  {
+    id: "tool-monitor-delete",
+    name: "cancel_schedule",
+    arguments: {
+      schedule_id: "sched_0195monitor",
+    },
+  },
+];
+
+const monitorToolResults = new Map<string, ToolCompletedData>([
+  [
+    "tool-monitor-create",
+    {
+      tool_call_id: "tool-monitor-create",
+      tool_name: "spawn_background",
+      success: true,
+      status: "success",
+      result: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            created: true,
+            status: "scheduled",
+            title: "Watch PR 1319",
+            cron_expression: "*/10 * * * *",
+            timezone: "America/Chicago",
+          }),
+        },
+      ],
+      duration_ms: 84,
+    },
+  ],
+  [
+    "tool-monitor-delete",
+    {
+      tool_call_id: "tool-monitor-delete",
+      tool_name: "cancel_schedule",
+      success: true,
+      status: "success",
+      result: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            cancelled: true,
+            description: `This scheduled monitor fired. Start the background run now.
+
+Use \`spawn_background\` with:
+- tool: \`github_watch_pr\`
+- title: \`Watch PR 1319\`
+- signal_on_completion: true
+- args:
+\`\`\`json
+{"pull_request":1319}
+\`\`\``,
+          }),
+        },
+      ],
+      duration_ms: 41,
+    },
+  ],
+]);
+
 const planTodos = [
   {
     content: "Update schema for rock collection domain",
@@ -324,6 +399,21 @@ export default function ToolActivityDevPage() {
                       toolResultsMap={completedToolResults}
                     />
                     <TodoListRenderer arguments={{ todos: planTodos }} isExecuting />
+                  </div>
+                </div>
+
+                <div className={chatSurfaceStyles.agentMessageRow}>
+                  <div className={chatSurfaceStyles.agentIcon}>
+                    <Bot className="h-3.5 w-3.5" />
+                  </div>
+                  <div className="flex-1 space-y-3">
+                    <p className={chatSurfaceStyles.agentMessage}>
+                      I set a monitor for the PR and removed it after merge.
+                    </p>
+                    <ToolActivityGroup
+                      toolCalls={monitorToolCalls}
+                      toolResultsMap={monitorToolResults}
+                    />
                   </div>
                 </div>
 

--- a/apps/ui/src/app/dev/tool-activity/page.tsx
+++ b/apps/ui/src/app/dev/tool-activity/page.tsx
@@ -202,16 +202,12 @@ const monitorToolResults = new Map<string, ToolCompletedData>([
           type: "text",
           text: JSON.stringify({
             cancelled: true,
-            description: `This scheduled monitor fired. Start the background run now.
+            description: `Monitor: Watch PR 1319
 
-Use \`spawn_background\` with:
-- tool: \`github_watch_pr\`
-- title: \`Watch PR 1319\`
-- signal_on_completion: true
-- args:
-\`\`\`json
-{"pull_request":1319}
-\`\`\``,
+This scheduled monitor fired. Start the background run now.
+
+spawn_background payload:
+{"tool":"github_watch_pr","title":"Watch PR 1319","signal_on_completion":true,"args":{"pull_request":1319}}`,
           }),
         },
       ],

--- a/apps/ui/src/components/chat/tool-activity-row.tsx
+++ b/apps/ui/src/components/chat/tool-activity-row.tsx
@@ -6,11 +6,15 @@
 "use client";
 
 import { useState } from "react";
-import { AlertCircle, Check, Loader2, MonitorSmartphone } from "lucide-react";
+import { AlertCircle, CalendarClock, Check, Loader2, MonitorSmartphone } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { ToolCompletedData } from "@/lib/api/types";
 import type { ToolCallContent } from "./tool-call-utils";
-import { formatResultDetails, getToolLabel } from "./tool-activity-utils";
+import {
+  formatResultDetails,
+  getToolActivitySummaryChip,
+  getToolLabel,
+} from "./tool-activity-utils";
 import { getFullText } from "./tool-call-utils";
 import { useLocale } from "@/providers/locale-provider";
 
@@ -36,6 +40,7 @@ export function ToolActivityRow({
   const hasToolError = Boolean(toolResult?.error);
   const isComplete = Boolean(toolResult);
   const isRunning = !isComplete && !hasToolError;
+  const summaryChip = isComplete ? getToolActivitySummaryChip(toolCall, toolResult) : null;
 
   return (
     <div
@@ -59,15 +64,30 @@ export function ToolActivityRow({
             {mode === "client" && (
               <MonitorSmartphone className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-primary/75" />
             )}
-            <span className="truncate text-sm text-foreground">
-              {getToolLabel(toolCall, locale)}
-            </span>
+            {summaryChip ? (
+              <div className="inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-[8px] border border-border/70 bg-background px-2.5 py-1 text-[13px] shadow-[inset_0_1px_0_hsl(var(--background)/0.92)]">
+                <CalendarClock className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+                <span className="shrink-0 text-muted-foreground">{summaryChip.status}</span>
+                <span className="shrink-0 text-muted-foreground/60">·</span>
+                <span className="truncate text-primary">{summaryChip.title}</span>
+                {summaryChip.schedule && (
+                  <>
+                    <span className="shrink-0 text-muted-foreground/60">·</span>
+                    <span className="shrink-0 text-muted-foreground">{summaryChip.schedule}</span>
+                  </>
+                )}
+              </div>
+            ) : (
+              <span className="truncate text-sm text-foreground">
+                {getToolLabel(toolCall, locale)}
+              </span>
+            )}
             {isRunning && (
               <span className="animate-tool-pulse text-[10px] uppercase tracking-[0.18em] text-accent-foreground/70">
                 {progressMessage ?? (mode === "client" ? t("waiting") : t("running"))}
               </span>
             )}
-            {!isRunning && hasOutput && (
+            {!isRunning && hasOutput && !summaryChip && (
               <button
                 type="button"
                 onClick={() => setIsExpanded((current) => !current)}

--- a/apps/ui/src/components/chat/tool-activity-utils.ts
+++ b/apps/ui/src/components/chat/tool-activity-utils.ts
@@ -7,6 +7,7 @@
 
 import type { ToolCompletedData } from "@/lib/api/types";
 import { isRecord } from "@/lib/api/types";
+import { formatScheduleCadence, getScheduleDisplayTitle } from "@/lib/schedule-display";
 import { basename } from "@/lib/path-utils";
 import {
   getToolCategory,
@@ -205,6 +206,12 @@ function parseStructuredText(text: string): unknown | null {
   }
 }
 
+export interface ToolActivitySummaryChip {
+  status: string;
+  title: string;
+  schedule?: string;
+}
+
 function maskSensitiveFields(toolName: string, value: unknown): unknown {
   if (toolName !== "secret_store" || !isRecord(value)) return value;
   if (!("value" in value) || value.value == null) return value;
@@ -252,6 +259,60 @@ function summarizeStructuredResult(toolCall: ToolCallContent, parsed: unknown): 
     .join(" · ");
 
   return preview.length > 120 ? `${preview.slice(0, 120)}...` : preview;
+}
+
+function scheduleLabelFromRecord(record: Record<string, unknown>): string | undefined {
+  const cronExpression =
+    typeof record.cron_expression === "string" ? record.cron_expression : undefined;
+  const scheduledAt = typeof record.scheduled_at === "string" ? record.scheduled_at : undefined;
+  const timezone = typeof record.timezone === "string" ? record.timezone : undefined;
+  return formatScheduleCadence({ cronExpression, scheduledAt, timezone }) ?? undefined;
+}
+
+export function getToolActivitySummaryChip(
+  toolCall: ToolCallContent,
+  toolResult?: ToolCompletedData,
+): ToolActivitySummaryChip | null {
+  const fullText = getFullText(toolResult?.result);
+  const parsed = parseStructuredText(fullText);
+  if (!isRecord(parsed)) return null;
+
+  if (toolCall.name === "spawn_background" && parsed.status === "scheduled") {
+    const title = typeof parsed.title === "string" ? parsed.title : null;
+    if (!title) return null;
+    return {
+      status: "Created",
+      title,
+      schedule: scheduleLabelFromRecord(parsed),
+    };
+  }
+
+  if (toolCall.name === "create_schedule" && parsed.created === true) {
+    const title =
+      typeof parsed.title === "string"
+        ? parsed.title
+        : typeof parsed.description === "string"
+          ? getScheduleDisplayTitle(parsed.description)
+          : null;
+    if (!title) return null;
+    return {
+      status: "Created",
+      title,
+      schedule: scheduleLabelFromRecord(parsed),
+    };
+  }
+
+  if (toolCall.name === "cancel_schedule" && parsed.cancelled === true) {
+    const title =
+      typeof parsed.description === "string" ? getScheduleDisplayTitle(parsed.description) : null;
+    if (!title) return null;
+    return {
+      status: "Deleted",
+      title,
+    };
+  }
+
+  return null;
 }
 
 /** Fields filtered from human-friendly details view (noise for the user). */

--- a/apps/ui/src/lib/schedule-display.ts
+++ b/apps/ui/src/lib/schedule-display.ts
@@ -1,0 +1,127 @@
+/**
+ * Schedule display helpers shared by chat activity rows and schedule pages.
+ *
+ * Decisions:
+ * - Favor compact labels for common recurring patterns because schedule chips need to fit inline.
+ * - Keep the parser deliberately narrow to the 5-field session-schedule cron shape we support today.
+ * - Fall back to raw cron for patterns we do not recognize instead of guessing incorrectly.
+ */
+
+const WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const BACKGROUND_MONITOR_TITLE_LINE = /^- title: `([^`]+)`$/m;
+const BACKGROUND_MONITOR_HEADER = /^Monitor: (.+)$/m;
+
+function formatClockTime(hour: number, minute: number): string {
+  return new Intl.DateTimeFormat("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+    timeZone: "UTC",
+  }).format(new Date(Date.UTC(2026, 0, 1, hour, minute)));
+}
+
+function formatWeekdays(value: string): string | null {
+  if (value === "*") return null;
+  if (value === "1-5") return "Weekdays";
+  if (value === "0,6" || value === "6,0") return "Weekends";
+
+  const parts = value.split(",");
+  const labels = parts
+    .map((part) => {
+      const day = Number(part);
+      return Number.isInteger(day) && day >= 0 && day <= 6 ? WEEKDAY_LABELS[day] : null;
+    })
+    .filter((label): label is string => Boolean(label));
+
+  if (labels.length !== parts.length || labels.length === 0) return null;
+  return labels.join(", ");
+}
+
+export function formatScheduleCadence(input: {
+  cronExpression?: string;
+  scheduledAt?: string;
+  timezone?: string;
+}): string | null {
+  const cronExpression = input.cronExpression?.trim();
+  if (cronExpression) {
+    const fields = cronExpression.split(/\s+/);
+    if (fields.length !== 5) return cronExpression;
+
+    const [minute, hour, dayOfMonth, month, dayOfWeek] = fields;
+
+    if (minute === "*" && hour === "*" && dayOfMonth === "*" && month === "*" && dayOfWeek === "*")
+      return "Every minute";
+
+    const everyMinutes = minute.match(/^\*\/(\d+)$/);
+    if (everyMinutes && hour === "*" && dayOfMonth === "*" && month === "*" && dayOfWeek === "*") {
+      const interval = Number(everyMinutes[1]);
+      return interval === 1 ? "Every minute" : `Every ${interval}m`;
+    }
+
+    if (minute === "0" && hour === "*" && dayOfMonth === "*" && month === "*" && dayOfWeek === "*")
+      return "Hourly";
+
+    const everyHours = hour.match(/^\*\/(\d+)$/);
+    if (
+      everyHours &&
+      /^\d+$/.test(minute) &&
+      dayOfMonth === "*" &&
+      month === "*" &&
+      dayOfWeek === "*"
+    ) {
+      const interval = Number(everyHours[1]);
+      return `Every ${interval}h`;
+    }
+
+    if (
+      /^\d+$/.test(minute) &&
+      /^\d+$/.test(hour) &&
+      dayOfMonth === "*" &&
+      month === "*" &&
+      dayOfWeek === "*"
+    ) {
+      return `Daily ${formatClockTime(Number(hour), Number(minute))}`;
+    }
+
+    const weekdayLabel = formatWeekdays(dayOfWeek);
+    if (
+      weekdayLabel &&
+      /^\d+$/.test(minute) &&
+      /^\d+$/.test(hour) &&
+      dayOfMonth === "*" &&
+      month === "*"
+    ) {
+      return `${weekdayLabel} ${formatClockTime(Number(hour), Number(minute))}`;
+    }
+
+    return cronExpression;
+  }
+
+  if (input.scheduledAt) {
+    return `At ${formatScheduledDateTime(input.scheduledAt, input.timezone)}`;
+  }
+
+  return null;
+}
+
+export function formatScheduledDateTime(dateString: string, timezone = "UTC"): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: timezone,
+    timeZoneName: "short",
+  }).format(new Date(dateString));
+}
+
+export function getScheduleDisplayTitle(description: string): string {
+  const trimmed = description.trim();
+  const monitorHeader = trimmed.match(BACKGROUND_MONITOR_HEADER)?.[1]?.trim();
+  if (monitorHeader) return monitorHeader;
+
+  const monitorTitle = trimmed.match(BACKGROUND_MONITOR_TITLE_LINE)?.[1]?.trim();
+  if (monitorTitle) return monitorTitle;
+
+  return trimmed;
+}

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -21,6 +21,7 @@ use crate::background::{
     BackgroundEventSink, BackgroundExecutableTool, BackgroundOutcome, BackgroundProgress,
 };
 use crate::session_resource::{RegisterSessionResource, SessionResourceStatus};
+use crate::session_schedule::MAX_ACTIVE_SCHEDULES_PER_SESSION;
 use crate::tool_types::{
     BuiltinTool, DeferrablePolicy, ToolCall, ToolDefinition, ToolHints, ToolPolicy, ToolResult,
 };
@@ -758,6 +759,76 @@ impl Tool for EchoTool {
 /// Spawn a background-capable tool and return immediately with a run handle.
 pub struct SpawnBackgroundTool;
 
+#[derive(Debug, Clone)]
+struct BackgroundScheduleRequest {
+    cron_expression: Option<String>,
+    scheduled_at: Option<chrono::DateTime<chrono::Utc>>,
+    timezone: String,
+}
+
+fn parse_background_schedule(
+    arguments: &Value,
+) -> std::result::Result<Option<BackgroundScheduleRequest>, String> {
+    let Some(schedule) = arguments.get("schedule") else {
+        return Ok(None);
+    };
+    let Some(schedule) = schedule.as_object() else {
+        return Err("schedule must be an object".to_string());
+    };
+
+    let cron_expression = schedule
+        .get("cron_expression")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string);
+    let scheduled_at = schedule
+        .get("scheduled_at")
+        .and_then(Value::as_str)
+        .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
+        .map(|dt| dt.with_timezone(&chrono::Utc));
+
+    if cron_expression.is_none() && scheduled_at.is_none() {
+        return Err(
+            "schedule must include either cron_expression (recurring) or scheduled_at (one-shot)"
+                .to_string(),
+        );
+    }
+
+    let timezone = schedule
+        .get("timezone")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("UTC")
+        .to_string();
+
+    Ok(Some(BackgroundScheduleRequest {
+        cron_expression,
+        scheduled_at,
+        timezone,
+    }))
+}
+
+fn build_background_schedule_description(
+    tool_name: &str,
+    tool_args: &Value,
+    title: &str,
+    signal_on_completion: bool,
+) -> String {
+    let args_json =
+        serde_json::to_string_pretty(tool_args).unwrap_or_else(|_| tool_args.to_string());
+
+    format!(
+        "This scheduled monitor fired. Start the background run now.\n\n\
+Use `spawn_background` with:\n\
+- tool: `{tool_name}`\n\
+- title: `{title}`\n\
+- signal_on_completion: {signal_on_completion}\n\
+- args:\n```json\n{args_json}\n```"
+    )
+}
+
 #[async_trait]
 impl Tool for SpawnBackgroundTool {
     fn name(&self) -> &str {
@@ -787,6 +858,25 @@ impl Tool for SpawnBackgroundTool {
                 "title": {
                     "type": "string",
                     "description": "Optional human-readable label for the background run"
+                },
+                "schedule": {
+                    "type": "object",
+                    "description": "Optional session schedule. When provided, this creates a scheduled monitor instead of starting the run immediately.",
+                    "properties": {
+                        "cron_expression": {
+                            "type": "string",
+                            "description": "Standard 5-field cron expression for recurring runs (e.g. '*/10 * * * *' for every 10 minutes)"
+                        },
+                        "scheduled_at": {
+                            "type": "string",
+                            "description": "ISO 8601 datetime for a one-shot run (e.g. '2026-04-16T15:30:00Z')"
+                        },
+                        "timezone": {
+                            "type": "string",
+                            "description": "IANA timezone for the schedule. Default: UTC"
+                        }
+                    },
+                    "additionalProperties": false
                 },
                 "signal_on_completion": {
                     "type": "boolean",
@@ -826,6 +916,10 @@ impl Tool for SpawnBackgroundTool {
             .get("signal_on_completion")
             .and_then(|v| v.as_bool())
             .unwrap_or(true);
+        let schedule_request = match parse_background_schedule(&arguments) {
+            Ok(schedule) => schedule,
+            Err(message) => return ToolExecutionResult::tool_error(message),
+        };
 
         let Some(tool_registry) = &context.tool_registry else {
             return ToolExecutionResult::tool_error(
@@ -851,18 +945,6 @@ impl Tool for SpawnBackgroundTool {
                 "Tool declared background support but has no background executor: {tool_name}"
             ));
         }
-        let Some(resource_registry) = &context.session_resource_registry else {
-            return ToolExecutionResult::tool_error(
-                "Session resource registry not available in this context",
-            );
-        };
-        if context.file_store.is_none() {
-            return ToolExecutionResult::tool_error(
-                "Session file store not available in this context. spawn_background requires artifact persistence.",
-            );
-        }
-
-        let run_id = format!("bg_{}", uuid::Uuid::now_v7().simple());
         let title = arguments
             .get("title")
             .and_then(|v| v.as_str())
@@ -875,6 +957,73 @@ impl Tool for SpawnBackgroundTool {
                     .unwrap_or_else(|| format!("Background {tool_name}"))
             });
 
+        if let Some(schedule_request) = schedule_request {
+            let Some(schedule_store) = &context.schedule_store else {
+                return ToolExecutionResult::tool_error(
+                    "Schedule store not available in this context. Scheduled monitors require session schedules.",
+                );
+            };
+
+            match schedule_store
+                .count_active_schedules(context.session_id)
+                .await
+            {
+                Ok(count) if count >= MAX_ACTIVE_SCHEDULES_PER_SESSION => {
+                    return ToolExecutionResult::tool_error(format!(
+                        "Maximum {MAX_ACTIVE_SCHEDULES_PER_SESSION} active schedules per session. Cancel an existing schedule first."
+                    ));
+                }
+                Err(err) => return ToolExecutionResult::internal_error(err),
+                _ => {}
+            }
+
+            let description = build_background_schedule_description(
+                tool_name,
+                &tool_args,
+                &title,
+                signal_on_completion,
+            );
+
+            return match schedule_store
+                .create_schedule(
+                    context.session_id,
+                    description,
+                    schedule_request.cron_expression.clone(),
+                    schedule_request.scheduled_at,
+                    schedule_request.timezone.clone(),
+                )
+                .await
+            {
+                Ok(schedule) => ToolExecutionResult::success(json!({
+                    "created": true,
+                    "status": "scheduled",
+                    "title": title,
+                    "tool": tool_name,
+                    "signal_on_completion": signal_on_completion,
+                    "schedule_id": schedule.id.to_string(),
+                    "schedule_type": schedule.schedule_type,
+                    "cron_expression": schedule.cron_expression,
+                    "scheduled_at": schedule.scheduled_at,
+                    "timezone": schedule.timezone,
+                    "next_trigger_at": schedule.next_trigger_at,
+                    "enabled": schedule.enabled
+                })),
+                Err(err) => ToolExecutionResult::internal_error(err),
+            };
+        }
+
+        let Some(resource_registry) = &context.session_resource_registry else {
+            return ToolExecutionResult::tool_error(
+                "Session resource registry not available in this context",
+            );
+        };
+        if context.file_store.is_none() {
+            return ToolExecutionResult::tool_error(
+                "Session file store not available in this context. spawn_background requires artifact persistence.",
+            );
+        }
+
+        let run_id = format!("bg_{}", uuid::Uuid::now_v7().simple());
         let artifact_dir = format!("/.background/{run_id}");
         let log_path = format!("{artifact_dir}/output.log");
         let result_path = format!("{artifact_dir}/result.json");
@@ -1277,7 +1426,7 @@ mod tests {
     use crate::platform_store::PlatformStore;
     use crate::session_file::{FileInfo, FileStat, SessionFile};
     use crate::session_resource::{SessionResourceEntry, SessionResourceFilter};
-    use crate::traits::{SessionFileStore, SessionResourceRegistry};
+    use crate::traits::{SessionFileStore, SessionResourceRegistry, SessionScheduleStore};
     use crate::typed_id::{HarnessId, SessionId};
     use crate::{AgentId, KeyInfo, PlatformMessage, SecretInfo};
     use async_trait::async_trait;
@@ -1726,6 +1875,81 @@ mod tests {
 
     #[derive(Default)]
     struct NoopStorageStore;
+
+    #[derive(Default)]
+    struct TestScheduleStore {
+        schedules: Mutex<Vec<crate::session_schedule::SessionSchedule>>,
+    }
+
+    #[async_trait]
+    impl crate::traits::SessionScheduleStore for TestScheduleStore {
+        async fn create_schedule(
+            &self,
+            session_id: SessionId,
+            description: String,
+            cron_expression: Option<String>,
+            scheduled_at: Option<chrono::DateTime<chrono::Utc>>,
+            timezone: String,
+        ) -> crate::Result<crate::session_schedule::SessionSchedule> {
+            let schedule = crate::session_schedule::SessionSchedule {
+                id: crate::typed_id::ScheduleId::new(),
+                session_id,
+                description,
+                cron_expression: cron_expression.clone(),
+                scheduled_at,
+                timezone,
+                enabled: true,
+                schedule_type: crate::session_schedule::SessionSchedule::derive_type(
+                    &cron_expression,
+                ),
+                next_trigger_at: Some(chrono::Utc::now() + chrono::Duration::minutes(10)),
+                last_triggered_at: None,
+                trigger_count: 0,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            };
+            self.schedules.lock().unwrap().push(schedule.clone());
+            Ok(schedule)
+        }
+
+        async fn cancel_schedule(
+            &self,
+            _session_id: SessionId,
+            schedule_id: crate::ScheduleId,
+        ) -> crate::Result<crate::session_schedule::SessionSchedule> {
+            let mut schedules = self.schedules.lock().unwrap();
+            let schedule = schedules
+                .iter_mut()
+                .find(|schedule| schedule.id == schedule_id)
+                .ok_or_else(|| crate::AgentLoopError::tool("Schedule not found".to_string()))?;
+            schedule.enabled = false;
+            Ok(schedule.clone())
+        }
+
+        async fn list_schedules(
+            &self,
+            session_id: SessionId,
+        ) -> crate::Result<Vec<crate::session_schedule::SessionSchedule>> {
+            Ok(self
+                .schedules
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|schedule| schedule.session_id == session_id)
+                .cloned()
+                .collect())
+        }
+
+        async fn count_active_schedules(&self, session_id: SessionId) -> crate::Result<u32> {
+            Ok(self
+                .schedules
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|schedule| schedule.session_id == session_id && schedule.enabled)
+                .count() as u32)
+        }
+    }
 
     #[async_trait]
     impl crate::traits::SessionStorageStore for NoopStorageStore {
@@ -2207,5 +2431,62 @@ mod tests {
             panic!("spawn_background should reject missing file store");
         };
         assert!(message.contains("Session file store not available"));
+    }
+
+    #[tokio::test]
+    async fn test_spawn_background_can_create_scheduled_monitor() {
+        let session_id = SessionId::new();
+        let schedule_store = Arc::new(TestScheduleStore::default());
+        let storage_store = Arc::new(NoopStorageStore);
+        let tool_registry = ToolRegistry::builder()
+            .tool(SpawnBackgroundTool)
+            .tool(TestBackgroundTool)
+            .build();
+
+        let context = ToolContext::with_storage_store(session_id, storage_store)
+            .with_tool_registry(Arc::new(tool_registry))
+            .with_schedule_store(schedule_store.clone());
+
+        let result = SpawnBackgroundTool
+            .execute_with_context(
+                json!({
+                    "tool": "test_background",
+                    "title": "Watch PR 1319",
+                    "args": { "summary": "Background complete" },
+                    "schedule": {
+                        "cron_expression": "*/10 * * * *",
+                        "timezone": "America/Chicago"
+                    }
+                }),
+                &context,
+            )
+            .await;
+
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("spawn_background should create a schedule: {result:?}");
+        };
+
+        assert_eq!(value["status"], "scheduled");
+        assert_eq!(value["title"], "Watch PR 1319");
+        assert_eq!(value["cron_expression"], "*/10 * * * *");
+        assert_eq!(value["timezone"], "America/Chicago");
+
+        let schedules = schedule_store.list_schedules(session_id).await.unwrap();
+        assert_eq!(schedules.len(), 1);
+        assert_eq!(
+            schedules[0].cron_expression.as_deref(),
+            Some("*/10 * * * *")
+        );
+        assert!(
+            schedules[0]
+                .description
+                .contains("This scheduled monitor fired.")
+        );
+        assert!(schedules[0].description.contains("Watch PR 1319"));
+        assert!(
+            schedules[0]
+                .description
+                .contains("\"summary\": \"Background complete\"")
+        );
     }
 }

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -782,17 +782,36 @@ fn parse_background_schedule(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToString::to_string);
-    let scheduled_at = schedule
-        .get("scheduled_at")
-        .and_then(Value::as_str)
-        .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
-        .map(|dt| dt.with_timezone(&chrono::Utc));
+    let scheduled_at = match schedule.get("scheduled_at").and_then(Value::as_str) {
+        Some(value) => {
+            let value = value.trim();
+            if value.is_empty() {
+                None
+            } else {
+                Some(
+                    chrono::DateTime::parse_from_rfc3339(value)
+                        .map_err(|_| "scheduled_at must be RFC3339".to_string())?
+                        .with_timezone(&chrono::Utc),
+                )
+            }
+        }
+        None => None,
+    };
 
-    if cron_expression.is_none() && scheduled_at.is_none() {
-        return Err(
-            "schedule must include either cron_expression (recurring) or scheduled_at (one-shot)"
-                .to_string(),
-        );
+    match (cron_expression.is_some(), scheduled_at.is_some()) {
+        (false, false) => {
+            return Err(
+                "schedule must include exactly one of cron_expression (recurring) or scheduled_at (one-shot)"
+                    .to_string(),
+            );
+        }
+        (true, true) => {
+            return Err(
+                "schedule must not include both cron_expression and scheduled_at; provide exactly one"
+                    .to_string(),
+            );
+        }
+        _ => {}
     }
 
     let timezone = schedule
@@ -816,16 +835,19 @@ fn build_background_schedule_description(
     title: &str,
     signal_on_completion: bool,
 ) -> String {
-    let args_json =
-        serde_json::to_string_pretty(tool_args).unwrap_or_else(|_| tool_args.to_string());
+    let payload = json!({
+        "tool": tool_name,
+        "title": title,
+        "signal_on_completion": signal_on_completion,
+        "args": tool_args,
+    });
+    let payload_json =
+        serde_json::to_string_pretty(&payload).unwrap_or_else(|_| payload.to_string());
 
     format!(
-        "This scheduled monitor fired. Start the background run now.\n\n\
-Use `spawn_background` with:\n\
-- tool: `{tool_name}`\n\
-- title: `{title}`\n\
-- signal_on_completion: {signal_on_completion}\n\
-- args:\n```json\n{args_json}\n```"
+        "Monitor: {title}\n\n\
+This scheduled monitor fired. Start the background run now.\n\n\
+spawn_background payload:\n{payload_json}"
     )
 }
 
@@ -2477,16 +2499,72 @@ mod tests {
             schedules[0].cron_expression.as_deref(),
             Some("*/10 * * * *")
         );
-        assert!(
-            schedules[0]
-                .description
-                .contains("This scheduled monitor fired.")
-        );
-        assert!(schedules[0].description.contains("Watch PR 1319"));
+        assert!(schedules[0].description.contains("Monitor: Watch PR 1319"));
         assert!(
             schedules[0]
                 .description
                 .contains("\"summary\": \"Background complete\"")
         );
+    }
+
+    #[tokio::test]
+    async fn test_spawn_background_rejects_invalid_scheduled_at() {
+        let session_id = SessionId::new();
+        let storage_store = Arc::new(NoopStorageStore);
+        let tool_registry = ToolRegistry::builder()
+            .tool(SpawnBackgroundTool)
+            .tool(TestBackgroundTool)
+            .build();
+        let context = ToolContext::with_storage_store(session_id, storage_store)
+            .with_tool_registry(Arc::new(tool_registry));
+
+        let result = SpawnBackgroundTool
+            .execute_with_context(
+                json!({
+                    "tool": "test_background",
+                    "args": {},
+                    "schedule": {
+                        "scheduled_at": "tomorrow at noon"
+                    }
+                }),
+                &context,
+            )
+            .await;
+
+        let ToolExecutionResult::ToolError(message) = result else {
+            panic!("spawn_background should reject invalid scheduled_at");
+        };
+        assert!(message.contains("scheduled_at must be RFC3339"));
+    }
+
+    #[tokio::test]
+    async fn test_spawn_background_rejects_ambiguous_schedule_shape() {
+        let session_id = SessionId::new();
+        let storage_store = Arc::new(NoopStorageStore);
+        let tool_registry = ToolRegistry::builder()
+            .tool(SpawnBackgroundTool)
+            .tool(TestBackgroundTool)
+            .build();
+        let context = ToolContext::with_storage_store(session_id, storage_store)
+            .with_tool_registry(Arc::new(tool_registry));
+
+        let result = SpawnBackgroundTool
+            .execute_with_context(
+                json!({
+                    "tool": "test_background",
+                    "args": {},
+                    "schedule": {
+                        "cron_expression": "*/10 * * * *",
+                        "scheduled_at": "2026-04-16T15:30:00Z"
+                    }
+                }),
+                &context,
+            )
+            .await;
+
+        let ToolExecutionResult::ToolError(message) = result else {
+            panic!("spawn_background should reject ambiguous schedule shape");
+        };
+        assert!(message.contains("must not include both cron_expression and scheduled_at"));
     }
 }

--- a/crates/server/src/harnesses/generic.rs
+++ b/crates/server/src/harnesses/generic.rs
@@ -6,7 +6,7 @@ pub fn definition() -> BuiltInHarnessDefinition {
     BuiltInHarnessDefinition::new(
         "generic",
         "Generic",
-        "General-purpose harness with file system, bash, web fetch, secrets, session management, long-context support, context compaction, budgeting, tool output persistence, and agent skills. Recommended default for most use cases.",
+        "General-purpose harness with file system, bash, web fetch, secrets, session management, session schedules, long-context support, context compaction, budgeting, tool output persistence, and agent skills. Recommended default for most use cases.",
         SYSTEM_PROMPT,
     )
     .with_seed_id(crate::org_init::GENERIC_HARNESS_ID)
@@ -21,6 +21,7 @@ pub fn definition() -> BuiltInHarnessDefinition {
         ),
         BuiltInCapabilityDefinition::new("session_storage"),
         BuiltInCapabilityDefinition::new("session"),
+        BuiltInCapabilityDefinition::new("session_schedule"),
         BuiltInCapabilityDefinition::new("agent_instructions"),
         BuiltInCapabilityDefinition::new("skills"),
         BuiltInCapabilityDefinition::new("infinity_context"),

--- a/crates/server/src/harnesses/platform_chat.rs
+++ b/crates/server/src/harnesses/platform_chat.rs
@@ -43,11 +43,11 @@ When asked to \"run an agent\" or \"run X with agent Y\", follow these steps:
 3. Wait for the turn to complete (use `session_read_response`)
 4. Retrieve and relay the results (use `session_read_messages`)
 
-When creating sessions, the `harness_id` parameter is optional. If not specified, it defaults to the built-in Generic harness which includes file system, bash, storage, context compaction, and other standard capabilities.
+When creating sessions, the `harness_id` parameter is optional. If not specified, it defaults to the built-in Generic harness which includes file system, bash, storage, schedules, context compaction, and other standard capabilities.
 
 ## Harness creation
 
-Avoid creating new harnesses unless the user explicitly needs a custom one. For most tasks, use the built-in \"Generic\" harness (find it via `read_harnesses`) which already includes file system, bash, storage, long-context support, context compaction, session, agent instructions, and skills capabilities.
+Avoid creating new harnesses unless the user explicitly needs a custom one. For most tasks, use the built-in \"Generic\" harness (find it via `read_harnesses`) which already includes file system, bash, storage, schedules, long-context support, context compaction, session, agent instructions, and skills capabilities.
 
 ## Confirmation guidelines
 

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -2257,12 +2257,13 @@ mod tests {
             .expect("Generic harness should exist");
 
         let cap_ids: Vec<&str> = generic.capabilities.iter().map(|c| c.id.as_str()).collect();
-        assert_eq!(cap_ids.len(), 12);
+        assert_eq!(cap_ids.len(), 13);
         assert!(cap_ids.contains(&"session_file_system"));
         assert!(cap_ids.contains(&"virtual_bash"));
         assert!(cap_ids.contains(&"web_fetch"));
         assert!(cap_ids.contains(&"session_storage"));
         assert!(cap_ids.contains(&"session"));
+        assert!(cap_ids.contains(&"session_schedule"));
         assert!(cap_ids.contains(&"agent_instructions"));
         assert!(cap_ids.contains(&"skills"));
         assert!(cap_ids.contains(&"infinity_context"));

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -1535,8 +1535,8 @@ async fn test_get_generic_harness() {
         .collect();
     assert_eq!(
         cap_ids.len(),
-        12,
-        "Generic harness should have 12 capabilities"
+        13,
+        "Generic harness should have 13 capabilities"
     );
     assert!(
         cap_ids.contains(&"session_file_system"),
@@ -1554,6 +1554,10 @@ async fn test_get_generic_harness() {
     assert!(
         cap_ids.contains(&"session"),
         "Should have session capability"
+    );
+    assert!(
+        cap_ids.contains(&"session_schedule"),
+        "Should have session schedules"
     );
     assert!(
         cap_ids.contains(&"agent_instructions"),
@@ -1904,8 +1908,8 @@ async fn test_copy_seed_generic_harness() {
     // Generic harness capabilities should be preserved on copy
     assert_eq!(
         copied.capabilities.len(),
-        12,
-        "Copied harness should have same 12 capabilities"
+        13,
+        "Copied harness should have same 13 capabilities"
     );
 }
 

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -122,7 +122,7 @@ Background eligibility rules:
 - `spawn_background` must run with a worker-side `ToolContext` that includes the current `ToolRegistry`.
 
 Contract:
-- Input: `{ "tool": "...", "args": { ... }, "title"?: "...", "signal_on_completion"?: true }`
+- Input: `{ "tool": "...", "args": { ... }, "title"?: "...", "signal_on_completion"?: true, "schedule"?: { "cron_expression"?: "...", "scheduled_at"?: "...", "timezone"?: "..." } }`
 - Immediate result: `run_id`, `resource_id`, target `tool`, and artifact paths under `/.background/{run_id}/`
 - Execution happens in a detached worker task
 - Progress flows through `BackgroundEventSink`, which supports:
@@ -137,6 +137,11 @@ Artifacts and visibility:
   - `/.background/{run_id}/output.log`
   - `/.background/{run_id}/result.json`
 - On completion or failure, the worker may send a synthetic session message summarizing the result and artifact paths.
+
+Scheduled monitors:
+- When `schedule` is provided, `spawn_background` does not start the tool immediately.
+- Instead it creates a session schedule using the existing session-scheduling infrastructure.
+- When that schedule fires, the session receives a synthetic user message instructing the agent to start the requested background run with the original `tool`, `args`, `title`, and `signal_on_completion` values.
 
 V1 limitation:
 - Background runs are best-effort and worker-local. They are started with `tokio::spawn` inside the worker process and are not yet durable across worker restarts.

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -123,7 +123,8 @@ Background eligibility rules:
 
 Contract:
 - Input: `{ "tool": "...", "args": { ... }, "title"?: "...", "signal_on_completion"?: true, "schedule"?: { "cron_expression"?: "...", "scheduled_at"?: "...", "timezone"?: "..." } }`
-- Immediate result: `run_id`, `resource_id`, target `tool`, and artifact paths under `/.background/{run_id}/`
+- Immediate result without `schedule`: `run_id`, `resource_id`, target `tool`, and artifact paths under `/.background/{run_id}/`
+- Immediate result with `schedule`: `schedule_id`, schedule cadence fields (`cron_expression` or `scheduled_at`, `timezone`, `next_trigger_at`), `enabled`, and `status = "scheduled"`
 - Execution happens in a detached worker task
 - Progress flows through `BackgroundEventSink`, which supports:
   - one-line status updates


### PR DESCRIPTION
## What
Add scheduled monitor support to spawn_background, expose scheduling in the Generic harness, and render compact monitor creation/deletion summaries in the UI.

## Why
Monitors need a durable schedule path and the chat/schedules UI needs to show the result in the compact, human-readable form from the product examples.

## How
- extend spawn_background with an optional schedule payload backed by session schedules
- add session_schedule to the Generic harness and document the contract
- add compact schedule/title formatters plus created/deleted monitor chips in chat and the schedules page
- add focused UI tests and a dev preview for the new monitor rows

## Risk
- Medium
- Could affect background-tool scheduling, session schedule rendering, and chat activity summaries if the new schedule/result parsing is wrong

## Security
- Threat categories reviewed: TM-TOOL, TM-WEB, TM-DOS
- Findings and resolutions:
- TM-TOOL: scheduled monitors reuse the existing session schedule store and keep background-tool eligibility checks in place; no new tool target bypass was added.
- TM-WEB: new UI formatters only derive display text from structured schedule fields or the stored monitor title line; no unsafe HTML rendering was introduced.
- TM-DOS: scheduled monitor creation still enforces MAX_ACTIVE_SCHEDULES_PER_SESSION, so the new path preserves the existing per-session cap.
- No new threat-model entry required; the change extends existing mitigations rather than introducing a new trust boundary.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
