### PR TITLE
feat(models): add Claude Opus 4.7

### DIFF
--- a/apps/ui/src/app/dev/thinking-animations/page.tsx
+++ b/apps/ui/src/app/dev/thinking-animations/page.tsx
@@ -68,7 +68,7 @@ export default function ThinkingAnimationsPage() {
         <div className="space-y-3">
           <h2 className="text-sm font-medium text-foreground">With model name</h2>
           <div className="flex items-center justify-center h-16 border border-dashed border-border bg-background">
-            <ThinkingIndicator model="claude-opus-4-6" />
+            <ThinkingIndicator model="claude-opus-4-7" />
           </div>
         </div>
       </div>

--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -1244,6 +1244,9 @@ impl AnthropicModelInfo {
             if image_input {
                 input_mods.push(Modality::Image);
             }
+            if pdf_input {
+                input_mods.push(Modality::Pdf);
+            }
             Some(LlmModelModalities {
                 input: input_mods,
                 output: vec![Modality::Text],
@@ -1407,6 +1410,7 @@ impl AnthropicModelInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use everruns_core::llm_models::Modality;
 
     // These tests verify that empty text blocks are filtered out to avoid
     // Anthropic API error: "text content blocks must be non-empty"
@@ -1878,8 +1882,8 @@ mod tests {
     #[test]
     fn test_to_discovered_profile_with_capabilities() {
         let info = AnthropicModelInfo {
-            id: "claude-opus-4-6-20260205".into(),
-            display_name: "Claude Opus 4.6".into(),
+            id: "claude-opus-4-7-20260416".into(),
+            display_name: "Claude Opus 4.7".into(),
             created_at: None,
             max_input_tokens: Some(1_000_000),
             max_tokens: Some(128_000),
@@ -1906,9 +1910,15 @@ mod tests {
         };
 
         let profile = info.to_discovered_profile();
+        assert_eq!(profile.name, "Claude Opus 4.7");
+        assert_eq!(profile.family, "claude-opus-4-7");
         assert!(profile.attachment); // image + PDF
         assert!(profile.reasoning);
         assert!(profile.structured_output);
+        assert_eq!(
+            profile.modalities.as_ref().map(|m| m.input.clone()),
+            Some(vec![Modality::Text, Modality::Image, Modality::Pdf])
+        );
         assert!(profile.reasoning_effort.is_some());
         let effort = profile.reasoning_effort.unwrap();
         assert_eq!(effort.values.len(), 4); // low, medium, high, max

--- a/crates/core/src/llm_model_profiles.rs
+++ b/crates/core/src/llm_model_profiles.rs
@@ -118,7 +118,8 @@ fn reasoning_effort_anthropic_extended_thinking() -> ReasoningEffortConfig {
     }
 }
 
-/// Adaptive thinking config for Claude 4.6+ models (Opus 4.6, Sonnet 4.6)
+/// Adaptive thinking config for recent Claude reasoning models
+/// (Opus 4.7, Opus 4.6, Sonnet 4.6)
 /// Uses thinking.type="adaptive" with effort parameter instead of budget_tokens
 /// Default: high, supports: low, medium, high, max (mapped to xhigh)
 fn reasoning_effort_anthropic_adaptive_thinking() -> ReasoningEffortConfig {
@@ -1375,7 +1376,42 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
     let base_id = normalize_anthropic_model_id(model_id);
 
     match base_id {
-        // Claude 4.6 series (newest)
+        // Claude 4.7 series (newest)
+        "claude-opus-4-7" => Some(LlmModelProfile {
+            name: "Claude Opus 4.7".into(),
+            family: "claude-opus-4-7".into(),
+            description: None,
+            release_date: Some("2026-04-16".into()),
+            last_updated: Some("2026-04-16".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: true,
+            knowledge: Some("2026-01-01".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 5.00,
+                output: 25.00,
+                cache_read: Some(0.50),
+                cost_tiers: vec![],
+            }),
+            limits: Some(LlmModelLimits {
+                context: 1_000_000,
+                input: None,
+                output: 128_000,
+                max_media: None,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image, Modality::Pdf],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: Some(reasoning_effort_anthropic_adaptive_thinking()),
+            tool_search: false,
+            supports_phases: false,
+        }),
+
+        // Claude 4.6 series
         "claude-opus-4-6" => Some(LlmModelProfile {
             name: "Claude Opus 4.6".into(),
             family: "claude-opus-4-6".into(),
@@ -2193,7 +2229,8 @@ fn normalize_model_id(model_id: &str) -> &str {
 fn normalize_anthropic_model_id(model_id: &str) -> &str {
     // Known base model patterns (order matters - more specific first)
     let patterns = [
-        // Claude 4.6
+        // Claude 4.7 / 4.6
+        "claude-opus-4-7",
         "claude-opus-4-6",
         "claude-sonnet-4-6",
         // Claude 4.5 series
@@ -2703,24 +2740,32 @@ mod tests {
         assert_eq!(effort.default, ReasoningEffort::Medium);
     }
 
-    // Claude 4.6 model tests
+    // Claude 4.7 / 4.6 model tests
 
     #[test]
-    fn test_claude_opus_46_profile() {
-        let profile = get_model_profile(&LlmProviderType::Anthropic, "claude-opus-4-6").unwrap();
-        assert_eq!(profile.name, "Claude Opus 4.6");
-        assert_eq!(profile.family, "claude-opus-4-6");
+    fn test_claude_opus_47_profile() {
+        let profile = get_model_profile(&LlmProviderType::Anthropic, "claude-opus-4-7").unwrap();
+        assert_eq!(profile.name, "Claude Opus 4.7");
+        assert_eq!(profile.family, "claude-opus-4-7");
         assert!(profile.reasoning);
         assert!(profile.tool_call);
+        assert!(profile.temperature);
         assert!(profile.structured_output);
 
         let limits = profile.limits.unwrap();
         assert_eq!(limits.context, 1_000_000);
         assert_eq!(limits.output, 128_000);
+        assert_eq!(limits.max_media, None);
 
         let cost = profile.cost.unwrap();
         assert!((cost.input - 5.00).abs() < f64::EPSILON);
         assert!((cost.output - 25.00).abs() < f64::EPSILON);
+
+        let modalities = profile.modalities.unwrap();
+        assert_eq!(
+            modalities.input,
+            vec![Modality::Text, Modality::Image, Modality::Pdf]
+        );
 
         // Adaptive thinking: default high, supports low/medium/high/max(xhigh)
         let effort = profile.reasoning_effort.unwrap();
@@ -2732,6 +2777,33 @@ mod tests {
                 .iter()
                 .any(|v| v.value == ReasoningEffort::Xhigh)
         );
+    }
+
+    #[test]
+    fn test_claude_opus_46_profile() {
+        let profile = get_model_profile(&LlmProviderType::Anthropic, "claude-opus-4-6").unwrap();
+        assert_eq!(profile.name, "Claude Opus 4.6");
+        assert_eq!(profile.family, "claude-opus-4-6");
+        assert!(profile.reasoning);
+        assert!(profile.tool_call);
+        assert!(profile.temperature);
+        assert!(profile.structured_output);
+
+        let limits = profile.limits.unwrap();
+        assert_eq!(limits.context, 1_000_000);
+        assert_eq!(limits.output, 128_000);
+        assert_eq!(limits.max_media, Some(600));
+
+        let cost = profile.cost.unwrap();
+        assert!((cost.input - 5.00).abs() < f64::EPSILON);
+        assert!((cost.output - 25.00).abs() < f64::EPSILON);
+
+        let modalities = profile.modalities.unwrap();
+        assert_eq!(modalities.input, vec![Modality::Text, Modality::Image]);
+
+        let effort = profile.reasoning_effort.unwrap();
+        assert_eq!(effort.default, ReasoningEffort::High);
+        assert_eq!(effort.values.len(), 4);
     }
 
     #[test]
@@ -2761,6 +2833,13 @@ mod tests {
                 .iter()
                 .any(|v| v.value == ReasoningEffort::Xhigh)
         );
+    }
+
+    #[test]
+    fn test_claude_opus_47_versioned() {
+        let profile =
+            get_model_profile(&LlmProviderType::Anthropic, "claude-opus-4-7-20260416").unwrap();
+        assert_eq!(profile.name, "Claude Opus 4.7");
     }
 
     #[test]
@@ -2857,7 +2936,15 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_claude_46_model_ids() {
+    fn test_normalize_claude_47_and_46_model_ids() {
+        assert_eq!(
+            normalize_anthropic_model_id("claude-opus-4-7"),
+            "claude-opus-4-7"
+        );
+        assert_eq!(
+            normalize_anthropic_model_id("claude-opus-4-7-20260416"),
+            "claude-opus-4-7"
+        );
         assert_eq!(
             normalize_anthropic_model_id("claude-opus-4-6"),
             "claude-opus-4-6"

--- a/crates/core/tests/agent_run_with_thinking.rs
+++ b/crates/core/tests/agent_run_with_thinking.rs
@@ -27,6 +27,7 @@ use everruns_core::message_retriever::InputMessage;
 // ============================================================================
 
 #[rstest]
+#[case::anthropic_opus(ANTHROPIC_OPUS)]
 #[case::anthropic_sonnet(ANTHROPIC_SONNET)]
 #[case::openai_gpt52(OPENAI_GPT52)]
 #[case::openai_gpt54(OPENAI_GPT54)]
@@ -106,6 +107,7 @@ async fn test_extended_thinking(#[case] config: ProviderModelConfig) {
 // ============================================================================
 
 #[rstest]
+#[case::anthropic_opus(ANTHROPIC_OPUS)]
 #[case::anthropic_sonnet(ANTHROPIC_SONNET)]
 #[case::openai_gpt52(OPENAI_GPT52)]
 #[case::openai_gpt54(OPENAI_GPT54)]

--- a/crates/core/tests/llm_test_matrix/mod.rs
+++ b/crates/core/tests/llm_test_matrix/mod.rs
@@ -78,6 +78,12 @@ pub const ANTHROPIC_HAIKU: ProviderModelConfig = ProviderModelConfig::new(
     "ANTHROPIC_API_KEY",
 );
 
+pub const ANTHROPIC_OPUS: ProviderModelConfig = ProviderModelConfig::new(
+    LlmProviderType::Anthropic,
+    "claude-opus-4-7-20260416",
+    "ANTHROPIC_API_KEY",
+);
+
 pub const ANTHROPIC_SONNET: ProviderModelConfig = ProviderModelConfig::new(
     LlmProviderType::Anthropic,
     "claude-sonnet-4-20250514",

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -114,7 +114,7 @@ mod seed_ids {
     pub const O1_PREVIEW: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000021e);
 
     // Anthropic Models (0x300-0x3FF)
-    pub const CLAUDE_OPUS_4_6: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000309);
+    pub const CLAUDE_OPUS_4_7: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000309);
     pub const CLAUDE_SONNET_4_6: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000030a);
     pub const CLAUDE_HAIKU_4_6: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_00000000030b);
     pub const CLAUDE_OPUS_4_5: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000301);
@@ -1599,12 +1599,12 @@ const SEED_MODELS: &[SeedModel] = &[
         enabled: false,
         is_favorite: false,
     },
-    // Anthropic Claude 4.6 series
+    // Anthropic Claude 4.7 / 4.6 series
     SeedModel {
-        id: seed_ids::CLAUDE_OPUS_4_6,
+        id: seed_ids::CLAUDE_OPUS_4_7,
         provider_id: seed_ids::ANTHROPIC_PROVIDER,
-        model_id: "claude-opus-4-6",
-        display_name: "Claude Opus 4.6",
+        model_id: "claude-opus-4-7",
+        display_name: "Claude Opus 4.7",
         enabled: true,     // Enabled by default
         is_favorite: true, // Favorite model
     },


### PR DESCRIPTION
## What
Add a hardcoded Anthropic profile for Claude Opus 4.7, replace the seeded favorite Opus entry from 4.6 to 4.7, and include Opus 4.7 in the Anthropic thinking test matrix.

## Why
Claude Opus 4.7 is now published on models.dev and should be available in the product anywhere the repo currently treats Opus 4.6 as the preferred seeded/favorite Opus model.

## How
- added `claude-opus-4-7` to hardcoded Anthropic model profiles using the current models.dev metadata
- updated normalization/tests for versioned Opus 4.7 IDs
- switched the seeded favorite Anthropic Opus model to `claude-opus-4-7`
- added Opus 4.7 to the Anthropic thinking test matrix
- updated the Anthropic discovered-profile unit test and the dev UI sample string

## Risk
- Low
- Main risk is stale or mismatched model metadata causing wrong capabilities/costs in model selection and profile responses

## Security
- Threat categories reviewed: TM-LLM, TM-DOS
- Findings and resolutions:
  - Reviewed LLM profile and seed changes for accidental API key handling, prompt/tool surface expansion, and incorrect capability exposure. No new trust boundary or secret-handling path was introduced.
  - Reviewed the new limits/capabilities for unbounded resource changes. The profile remains declarative metadata only; no new execution path or unbounded loop was added.
  - No threat-model update needed because this change does not introduce a new threat or materially change an existing mitigation.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `cargo test -p everruns-anthropic test_to_discovered_profile_with_capabilities`
- `cargo test -p everruns-core test_claude_opus_47_profile`
- `cargo test -p everruns-core test_claude_opus_47_versioned`
- `cargo test -p everruns-core test_normalize_claude_47_and_46_model_ids`
- `cargo check -p everruns-server --lib`
- `just pre-push`
- smoke tested `PORT_PREFIX=489 just start-dev --no-watch` and verified via `GET /api/v1/llm-models` that `claude-opus-4-7` is enabled, favorited, and returns the expected profile payload
- UI lint/format checks were skipped by `just pre-push` in this worktree because `apps/ui/node_modules` is not installed locally
