### PR TITLE
feat(session): include usage in get_session_info

### DIFF
--- a/crates/core/src/capabilities/session.rs
+++ b/crates/core/src/capabilities/session.rs
@@ -2,9 +2,10 @@
 //!
 //! Provides session metadata tools:
 //! - `write_session_title`: update session title
-//! - `get_session_info`: return session id, title, and agent name (if any)
+//! - `get_session_info`: return session id, title, agent name, and cumulative usage
 
 use super::{Capability, CapabilityStatus};
+use crate::events::TokenUsage;
 use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
@@ -132,7 +133,7 @@ impl Tool for GetSessionInfoTool {
     }
 
     fn description(&self) -> &str {
-        "Get current session metadata: id, title, and agent name (if assigned)."
+        "Get current session metadata: id, title, locale, agent name, and cumulative token usage."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -187,8 +188,19 @@ impl Tool for GetSessionInfoTool {
             "title": session.title,
             "locale": session.locale,
             "agent_name": agent_name,
+            "usage": session.usage.as_ref().map(usage_json),
         }))
     }
+}
+
+fn usage_json(usage: &TokenUsage) -> Value {
+    json!({
+        "input_tokens": usage.input_tokens,
+        "output_tokens": usage.output_tokens,
+        "cache_read_tokens": usage.cache_read_tokens,
+        "cache_creation_tokens": usage.cache_creation_tokens,
+        "total_tokens": usage.total_tokens(),
+    })
 }
 
 #[cfg(test)]
@@ -346,6 +358,32 @@ mod tests {
             ToolExecutionResult::Success(value) => {
                 assert_eq!(value["title"], "Old title");
                 assert_eq!(value["agent_name"], "Research Agent");
+                assert!(value["usage"].is_null());
+            }
+            _ => panic!("expected success"),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_session_info_returns_cumulative_usage() {
+        let mut session = build_session(None);
+        session.usage = Some(TokenUsage::with_cache(120, 45, Some(30), Some(10)));
+        let session_id = session.id;
+
+        let context = ToolContext::new(session_id).with_session_store(Arc::new(MockSessionStore {
+            session: Arc::new(Mutex::new(Some(session))),
+        }));
+
+        let tool = GetSessionInfoTool;
+        let result = tool.execute_with_context(json!({}), &context).await;
+
+        match result {
+            ToolExecutionResult::Success(value) => {
+                assert_eq!(value["usage"]["input_tokens"], 120);
+                assert_eq!(value["usage"]["output_tokens"], 45);
+                assert_eq!(value["usage"]["cache_read_tokens"], 30);
+                assert_eq!(value["usage"]["cache_creation_tokens"], 10);
+                assert_eq!(value["usage"]["total_tokens"], 165);
             }
             _ => panic!("expected success"),
         }


### PR DESCRIPTION
## What
Add cumulative session token usage to the `get_session_info` tool response.

## Why
Agents can already read session metadata, but they could not inspect cumulative usage from the same tool. Exposing usage here gives agents a simple read-only path for self-managed budget awareness.

## How
Return the existing `Session.usage` payload from `get_session_info`, normalize it into a stable JSON object, and include a derived `total_tokens` field. Add focused tests for both null and populated usage responses.

## Risk
- Low
- The change is additive to a read-only tool response. Existing callers that ignore unknown fields continue to work.

## Security
- Threat categories reviewed: TM-TOOL, TM-DOS
- Findings and resolutions:
  - Reviewed the new response field for tool-surface risk. The tool remains read-only and session-scoped; no new write path, privilege boundary, or external input parsing was introduced.
  - Reviewed resource-exhaustion risk. The added payload is a fixed-size summary derived from existing session metadata, so it does not introduce unbounded output or iteration.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)