### PR TITLE
refactor(auth): unify login-page resume contract on return_to

### DIFF
--- a/apps/ui/src/__tests__/auth-redirect.test.ts
+++ b/apps/ui/src/__tests__/auth-redirect.test.ts
@@ -1,4 +1,4 @@
-import { getLoginRedirectPath } from "@/lib/auth-redirect";
+import { getLoginRedirectPath, sanitizeReturnTo } from "@/lib/auth-redirect";
 
 describe("getLoginRedirectPath", () => {
   it("preserves the current path and query in return_to", () => {
@@ -15,5 +15,45 @@ describe("getLoginRedirectPath", () => {
     expect(getLoginRedirectPath("/dashboard", new URLSearchParams("tab=recent"))).toBe(
       "/login?return_to=%2Fdashboard%3Ftab%3Drecent",
     );
+  });
+});
+
+describe("sanitizeReturnTo", () => {
+  it("accepts frontend-relative paths", () => {
+    expect(sanitizeReturnTo("/dashboard")).toBe("/dashboard");
+    expect(sanitizeReturnTo("/settings/providers?tab=models")).toBe(
+      "/settings/providers?tab=models",
+    );
+  });
+
+  it("accepts backend-facing paths used for full-page navigation", () => {
+    expect(sanitizeReturnTo("/oauth/authorize?client_id=x")).toBe("/oauth/authorize?client_id=x");
+    expect(sanitizeReturnTo("/api/v1/auth/cli/callback?state=abc")).toBe(
+      "/api/v1/auth/cli/callback?state=abc",
+    );
+  });
+
+  it("rejects absolute URLs", () => {
+    expect(sanitizeReturnTo("https://evil.com/takeover")).toBeNull();
+    expect(sanitizeReturnTo("http://evil.com/takeover")).toBeNull();
+  });
+
+  it("rejects protocol-relative URLs", () => {
+    expect(sanitizeReturnTo("//evil.com/takeover")).toBeNull();
+  });
+
+  it("rejects backslash-prefixed paths (browser may normalize to //)", () => {
+    expect(sanitizeReturnTo("/\\evil.com")).toBeNull();
+  });
+
+  it("rejects values that don't start with a slash", () => {
+    expect(sanitizeReturnTo("dashboard")).toBeNull();
+    expect(sanitizeReturnTo("evil.com")).toBeNull();
+  });
+
+  it("rejects empty / nullish values", () => {
+    expect(sanitizeReturnTo(null)).toBeNull();
+    expect(sanitizeReturnTo(undefined)).toBeNull();
+    expect(sanitizeReturnTo("")).toBeNull();
   });
 });

--- a/apps/ui/src/app/(auth)/login/page.tsx
+++ b/apps/ui/src/app/(auth)/login/page.tsx
@@ -18,6 +18,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { useAuthConfig, useLogin } from "@/hooks/use-auth";
 import { getOAuthUrl, login } from "@/lib/api/auth";
+import { sanitizeReturnTo } from "@/lib/auth-redirect";
 import { Loader2 } from "lucide-react";
 
 // Session storage key for preserving return_to across OAuth redirects
@@ -39,7 +40,9 @@ export default function LoginPage() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
 
-  const returnTo = searchParams.get("return_to");
+  // Sanitize to a safe relative path — prevents open-redirect into
+  // attacker-controlled origins (see specs/authentication.md).
+  const returnTo = sanitizeReturnTo(searchParams.get("return_to"));
 
   // Redirect to dashboard if auth is not required
   useEffect(() => {
@@ -49,10 +52,11 @@ export default function LoginPage() {
   }, [config, router]);
 
   const getRedirectTarget = (): string => {
-    // Check URL param first, then sessionStorage (for OAuth flow)
-    const target = returnTo || sessionStorage.getItem(RETURN_TO_KEY);
+    // Check URL param first, then sessionStorage (for OAuth flow).
+    // Both are sanitized so a poisoned sessionStorage can't redirect off-origin.
+    const stored = sanitizeReturnTo(sessionStorage.getItem(RETURN_TO_KEY));
     sessionStorage.removeItem(RETURN_TO_KEY);
-    return target || "/dashboard";
+    return returnTo || stored || "/dashboard";
   };
 
   const handleSubmit = async (e: React.FormEvent) => {

--- a/apps/ui/src/app/(auth)/login/page.tsx
+++ b/apps/ui/src/app/(auth)/login/page.tsx
@@ -18,7 +18,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { useAuthConfig, useLogin } from "@/hooks/use-auth";
 import { getOAuthUrl, login } from "@/lib/api/auth";
-import { sanitizeReturnTo } from "@/lib/auth-redirect";
+import { isBackendNavigationPath, sanitizeReturnTo } from "@/lib/auth-redirect";
 import { Loader2 } from "lucide-react";
 
 // Session storage key for preserving return_to across OAuth redirects
@@ -69,7 +69,7 @@ export default function LoginPage() {
       // and navigate immediately — don't go through the mutation's onSuccess
       // which refetches auth state and can trigger React re-renders that
       // race with the navigation.
-      if (target.startsWith("/oauth/") || target.startsWith("/api/")) {
+      if (isBackendNavigationPath(target)) {
         await login({ email, password });
         window.location.assign(target);
         return;

--- a/apps/ui/src/app/(main)/layout.tsx
+++ b/apps/ui/src/app/(main)/layout.tsx
@@ -9,7 +9,7 @@ import { CommandPalette } from "@/components/command-palette";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { CommandPaletteContext, useCommandPaletteState } from "@/hooks/use-command-palette";
-import { getLoginRedirectPath } from "@/lib/auth-redirect";
+import { getLoginRedirectPath, sanitizeReturnTo } from "@/lib/auth-redirect";
 import { useAuth } from "@/providers/auth-provider";
 import { useOrg } from "@/providers/org-provider";
 import { NotificationsProvider } from "@/providers/notifications-provider";
@@ -63,10 +63,11 @@ function MainLayoutInner({ children }: MainLayoutProps) {
   // After OAuth login, check sessionStorage for a pending return_to redirect
   useEffect(() => {
     if (!authLoading && !authUnavailable && isAuthenticated) {
-      const pendingReturnTo = sessionStorage.getItem("everruns_return_to");
+      const pendingReturnTo = sanitizeReturnTo(sessionStorage.getItem("everruns_return_to"));
+      sessionStorage.removeItem("everruns_return_to");
       if (pendingReturnTo) {
-        sessionStorage.removeItem("everruns_return_to");
-        // Backend paths (e.g. /oauth/authorize) need a full page navigation
+        // Backend paths (e.g. /oauth/authorize, /api/v1/auth/cli/callback)
+        // need a full page navigation
         if (pendingReturnTo.startsWith("/oauth/") || pendingReturnTo.startsWith("/api/")) {
           window.location.assign(pendingReturnTo);
         } else {

--- a/apps/ui/src/app/(main)/layout.tsx
+++ b/apps/ui/src/app/(main)/layout.tsx
@@ -9,7 +9,11 @@ import { CommandPalette } from "@/components/command-palette";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { CommandPaletteContext, useCommandPaletteState } from "@/hooks/use-command-palette";
-import { getLoginRedirectPath, sanitizeReturnTo } from "@/lib/auth-redirect";
+import {
+  getLoginRedirectPath,
+  isBackendNavigationPath,
+  sanitizeReturnTo,
+} from "@/lib/auth-redirect";
 import { useAuth } from "@/providers/auth-provider";
 import { useOrg } from "@/providers/org-provider";
 import { NotificationsProvider } from "@/providers/notifications-provider";
@@ -66,9 +70,10 @@ function MainLayoutInner({ children }: MainLayoutProps) {
       const pendingReturnTo = sanitizeReturnTo(sessionStorage.getItem("everruns_return_to"));
       sessionStorage.removeItem("everruns_return_to");
       if (pendingReturnTo) {
-        // Backend paths (e.g. /oauth/authorize, /api/v1/auth/cli/callback)
-        // need a full page navigation
-        if (pendingReturnTo.startsWith("/oauth/") || pendingReturnTo.startsWith("/api/")) {
+        // Backend paths (e.g. /oauth/authorize, /api/v1/auth/cli/callback,
+        // or /v1/... when frontend and backend share an origin) need a
+        // full page navigation so the reverse proxy forwards them.
+        if (isBackendNavigationPath(pendingReturnTo)) {
           window.location.assign(pendingReturnTo);
         } else {
           router.replace(pendingReturnTo);

--- a/apps/ui/src/lib/auth-redirect.ts
+++ b/apps/ui/src/lib/auth-redirect.ts
@@ -43,3 +43,24 @@ export function sanitizeReturnTo(value: string | null | undefined): string | nul
   if (value.startsWith("/\\")) return null;
   return value;
 }
+
+/**
+ * Path prefixes that route to the backend (not Next.js). Navigating to one of
+ * these via `router.push` would render a 404 instead of hitting the backend
+ * handler — they must use full-page navigation (`window.location.assign`) so
+ * the reverse proxy / frontend root forwards to the backend route.
+ *
+ * Includes:
+ * - `/oauth/` — MCP OAuth handlers (mounted at server root)
+ * - `/api/` — backend mounted under the standard `/api` prefix (default layout)
+ * - `/v1/` — backend mounted at the frontend origin root with no API prefix
+ *   (used by `build_cli_callback_path` when `frontend_url == base_url`)
+ *
+ * Keep this in sync with the server's reverse-proxy routing and
+ * `crates/server/src/auth/cli_auth.rs::build_cli_callback_path`.
+ */
+const BACKEND_PATH_PREFIXES = ["/oauth/", "/api/", "/v1/"] as const;
+
+export function isBackendNavigationPath(path: string): boolean {
+  return BACKEND_PATH_PREFIXES.some((prefix) => path.startsWith(prefix));
+}

--- a/apps/ui/src/lib/auth-redirect.ts
+++ b/apps/ui/src/lib/auth-redirect.ts
@@ -1,5 +1,7 @@
 // Decision: keep login redirect URL generation in one place so middleware and
 // the client-side auth fallback preserve identical return_to behavior.
+// `return_to` is the single public login-page contract for auth resume — see
+// specs/authentication.md. Paths must be relative to the frontend origin.
 
 type SearchInput = URLSearchParams | string | null | undefined;
 
@@ -24,4 +26,20 @@ export function getLoginRedirectPath(pathname: string, search: SearchInput): str
   }
 
   return `/login?return_to=${encodeURIComponent(currentUrl)}`;
+}
+
+/**
+ * Validate a `return_to` value is a safe relative path on the frontend origin.
+ *
+ * Rejects absolute URLs, protocol-relative URLs (`//evil.com/...`), and any
+ * value that doesn't start with `/`. Returns the sanitized path or `null` if
+ * invalid. The login page must use this to guard against open-redirect into
+ * attacker-controlled origins.
+ */
+export function sanitizeReturnTo(value: string | null | undefined): string | null {
+  if (!value) return null;
+  if (!value.startsWith("/")) return null;
+  if (value.startsWith("//")) return null;
+  if (value.startsWith("/\\")) return null;
+  return value;
 }

--- a/crates/server/src/auth/cli_auth.rs
+++ b/crates/server/src/auth/cli_auth.rs
@@ -45,11 +45,20 @@ fn generate_random_hex() -> String {
 /// browser can reach the backend through the standard frontend proxy. When
 /// they differ (rare dev setup), no prefix is added and operators must ensure
 /// the backend is reachable from the frontend origin.
+///
+/// The result is always a relative path starting with `/`. We only accept the
+/// stripped remainder when it is empty or starts with `/` — otherwise the strip
+/// landed mid-path-segment (e.g. `frontend_url=https://app` against
+/// `base_url=https://app.example.com/api` would yield `.example.com/api`),
+/// which would produce a `return_to` rejected by the UI sanitizer.
 fn build_cli_callback_path(frontend_url: &str, base_url: &str, auth_state: &str) -> String {
-    let api_path_prefix = base_url
+    let stripped = base_url
         .strip_prefix(frontend_url)
-        .unwrap_or("")
-        .trim_end_matches('/');
+        .map(|s| s.trim_end_matches('/'));
+    let api_path_prefix = match stripped {
+        Some(s) if s.is_empty() || s.starts_with('/') => s,
+        _ => "",
+    };
     format!(
         "{}/v1/auth/cli/callback?state={}",
         api_path_prefix, auth_state
@@ -503,6 +512,16 @@ mod tests {
         // derive. Result is still a relative path (no host leak into return_to).
         let path =
             build_cli_callback_path("http://localhost:9300", "http://localhost:9301", "abcd1234");
+        assert_eq!(path, "/v1/auth/cli/callback?state=abcd1234");
+    }
+
+    #[test]
+    fn test_build_cli_callback_path_strip_lands_mid_segment() {
+        // `frontend_url` is a string-prefix of `base_url` but not a path-prefix
+        // (the strip would land mid-segment). We must fall back to no prefix
+        // rather than emit a `return_to` like ".example.com/api/v1/...".
+        let path =
+            build_cli_callback_path("https://app", "https://app.example.com/api", "abcd1234");
         assert_eq!(path, "/v1/auth/cli/callback?state=abcd1234");
     }
 

--- a/crates/server/src/auth/cli_auth.rs
+++ b/crates/server/src/auth/cli_auth.rs
@@ -36,6 +36,26 @@ fn generate_random_hex() -> String {
     hex::encode(bytes)
 }
 
+/// Build the relative `return_to` path that navigates the browser to the CLI
+/// auth callback endpoint after login.
+///
+/// The CLI callback is mounted on the API (`/v1/auth/cli/callback`). We derive
+/// the API path prefix (e.g. `/api`) by stripping `frontend_url` from
+/// `base_url`. When both live on the same origin with a path prefix, the
+/// browser can reach the backend through the standard frontend proxy. When
+/// they differ (rare dev setup), no prefix is added and operators must ensure
+/// the backend is reachable from the frontend origin.
+fn build_cli_callback_path(frontend_url: &str, base_url: &str, auth_state: &str) -> String {
+    let api_path_prefix = base_url
+        .strip_prefix(frontend_url)
+        .unwrap_or("")
+        .trim_end_matches('/');
+    format!(
+        "{}/v1/auth/cli/callback?state={}",
+        api_path_prefix, auth_state
+    )
+}
+
 // ============================================
 // Request/Response types
 // ============================================
@@ -170,22 +190,26 @@ async fn cli_auth_start(
             AuthError::unauthorized("Failed to start CLI login")
         })?;
 
-    // Build auth URL — points to the server's login page with a redirect back to
-    // the CLI callback endpoint on the server.
-    // base_url already includes any API prefix (e.g. "/api"), so no env lookup needed.
-    let callback_url = format!(
-        "{}/v1/auth/cli/callback?state={}",
-        state.base_url.trim_end_matches('/'),
-        auth_state
-    );
-
-    // Redirect to the frontend login page with a redirect_to parameter
-    // pointing back to our CLI callback. Works for both OSS (built-in login)
-    // and external auth providers (login page handles redirect_to).
-    let auth_url = format!(
-        "{}/login?redirect_to={}",
+    // Build auth URL — points to the server's login page with a `return_to`
+    // pointing back to our CLI callback. `return_to` is the single public
+    // login-page contract for auth resume (see specs/authentication.md).
+    //
+    // We derive a browser-relative path rather than leaking the full backend URL
+    // into `return_to`, because `return_to` is restricted to relative paths on
+    // the frontend origin. The API path prefix is derived by stripping
+    // `frontend_url` from `base_url` (e.g. `/api`) — in the rare case the two
+    // live on different origins (dev without reverse proxy), there is no prefix
+    // and the browser would need the backend mounted under the frontend origin
+    // for CLI login to work.
+    let callback_path = build_cli_callback_path(
         state.frontend_url.trim_end_matches('/'),
-        urlencoding::encode(&callback_url)
+        state.base_url.trim_end_matches('/'),
+        &auth_state,
+    );
+    let auth_url = format!(
+        "{}/login?return_to={}",
+        state.frontend_url.trim_end_matches('/'),
+        urlencoding::encode(&callback_path)
     );
 
     audit::emit(
@@ -449,5 +473,57 @@ mod tests {
     fn test_generate_random_hex_format() {
         let hex = generate_random_hex();
         assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn test_build_cli_callback_path_with_api_prefix() {
+        // Standard production/local layout: base_url = frontend_url + "/api"
+        let path = build_cli_callback_path(
+            "https://app.example.com",
+            "https://app.example.com/api",
+            "abcd1234",
+        );
+        assert_eq!(path, "/api/v1/auth/cli/callback?state=abcd1234");
+    }
+
+    #[test]
+    fn test_build_cli_callback_path_same_origin_no_prefix() {
+        // Backend mounted at the frontend origin root
+        let path = build_cli_callback_path(
+            "https://app.example.com",
+            "https://app.example.com",
+            "abcd1234",
+        );
+        assert_eq!(path, "/v1/auth/cli/callback?state=abcd1234");
+    }
+
+    #[test]
+    fn test_build_cli_callback_path_different_origins() {
+        // Rare dev layout without a reverse proxy — no prefix we can safely
+        // derive. Result is still a relative path (no host leak into return_to).
+        let path =
+            build_cli_callback_path("http://localhost:9300", "http://localhost:9301", "abcd1234");
+        assert_eq!(path, "/v1/auth/cli/callback?state=abcd1234");
+    }
+
+    #[test]
+    fn test_build_cli_callback_path_returns_relative() {
+        // `return_to` must always be a relative path (no absolute URL)
+        let path = build_cli_callback_path(
+            "https://app.example.com",
+            "https://app.example.com/api",
+            "state123",
+        );
+        assert!(path.starts_with('/'), "path must be relative: {}", path);
+        assert!(
+            !path.starts_with("//"),
+            "path must not be protocol-relative: {}",
+            path
+        );
+        assert!(
+            !path.contains("://"),
+            "path must not contain scheme: {}",
+            path
+        );
     }
 }

--- a/crates/server/tests/cli_auth_test.rs
+++ b/crates/server/tests/cli_auth_test.rs
@@ -51,6 +51,34 @@ async fn test_cli_auth_start() {
         auth_url
     );
 
+    // Unified auth resume contract: CLI auth uses `return_to`, the single
+    // public login-page parameter. `redirect_to` must not appear.
+    assert!(
+        auth_url.contains("return_to="),
+        "auth_url must use return_to: {}",
+        auth_url
+    );
+    assert!(
+        !auth_url.contains("redirect_to"),
+        "auth_url must not use legacy redirect_to: {}",
+        auth_url
+    );
+
+    // The return_to value must be a relative path (no scheme leaked) so the
+    // login page stays same-origin.
+    let return_to_start = auth_url.find("return_to=").unwrap() + "return_to=".len();
+    let return_to = &auth_url[return_to_start..];
+    assert!(
+        return_to.starts_with("%2F") || return_to.starts_with('/'),
+        "return_to must be a relative path: {}",
+        return_to
+    );
+    assert!(
+        !return_to.contains("%3A%2F%2F") && !return_to.contains("://"),
+        "return_to must not embed a full URL: {}",
+        return_to
+    );
+
     let state = body["state"].as_str().unwrap();
     assert_eq!(state.len(), 32, "state should be 32 hex chars");
     assert!(

--- a/specs/authentication.md
+++ b/specs/authentication.md
@@ -84,7 +84,10 @@ The login page accepts exactly one public query parameter for auth resume:
 
 - `return_to` is always a **relative path** on the frontend origin (starts with `/`, never `//`, never a scheme). Absolute URLs are rejected.
 - No other resume/redirect parameter is accepted. Historic names like `redirect_to` are not part of the contract and MUST NOT be emitted by any caller.
-- Backend-facing paths (e.g. `/oauth/authorize`, `/api/v1/auth/cli/callback`) are valid `return_to` values — the login page triggers a full-page navigation so the backend route handles the continuation.
+- Backend-facing paths are valid `return_to` values — the login page triggers a full-page navigation so the reverse proxy / frontend root forwards them to the backend route. Concrete prefixes the UI treats as backend-facing:
+  - `/oauth/...` — MCP OAuth handlers mounted at the server root.
+  - `/api/...` — backend mounted under the standard `/api` API prefix (default deployment layout).
+  - `/v1/...` — backend mounted at the frontend origin root with **no** API prefix (used when `frontend_url == base_url`, so the API prefix derived by `build_cli_callback_path` is empty).
 - Workflow-specific continuations (CLI login, OAuth authorize handshakes) MUST NOT leak raw callback URLs into the login-page contract. Instead, they use an opaque server-issued token (e.g. the CLI auth session `state`) encoded in a backend path, and the server resolves that token to complete the workflow.
 
 **Callers that emit `return_to`:**

--- a/specs/authentication.md
+++ b/specs/authentication.md
@@ -54,15 +54,17 @@ Interactive CLI authentication via `everruns login`. Flow:
 
 1. CLI calls `POST /v1/auth/cli/start` with `redirect_port`
 2. Server creates a pending `cli_auth_sessions` row (state + exchange_code, 5-min TTL)
-3. Server returns `auth_url` (login page with redirect to `/v1/auth/cli/callback?state=...`)
+3. Server returns `auth_url` pointing at the login page with `return_to=<api-prefix>/v1/auth/cli/callback?state=...` — the same `return_to` resume parameter used by every other login flow (see [Login Page Contract](#login-page-contract) below)
 4. CLI opens browser and starts one-shot localhost HTTP server
-5. User logs in, server calls `/v1/auth/cli/callback` which associates user and redirects to `localhost:{port}/callback?code=...`
+5. User logs in; the login page navigates to the `return_to` path, which hits `/v1/auth/cli/callback` on the server (through the frontend's standard API proxy). The server looks up the session by `state`, associates the authenticated user, and redirects to `localhost:{port}/callback?code=...`
 6. CLI receives code, redirects browser to `/cli/login-success` (branded success page)
 7. CLI calls `POST /v1/auth/cli/exchange` with code + hostname + os
 8. Server creates API key with metadata, returns key + user + orgs
 9. CLI prompts for org selection (if multiple), stores credentials in the platform config file (`~/.config/everruns/credentials.json` on Linux, `~/Library/Application Support/everruns/credentials.json` on macOS)
 
 Endpoints: `POST /v1/auth/cli/start`, `GET /v1/auth/cli/callback`, `POST /v1/auth/cli/exchange`, `GET /cli/login-success`
+
+The server identifies the CLI session via the opaque `state` token from `cli_auth_sessions`, not via a callback URL embedded in the login-page contract. This keeps the public login-page contract uniform across all auth flows.
 
 See `crates/server/src/auth/cli_auth.rs` for implementation.
 
@@ -71,6 +73,29 @@ See `crates/server/src/auth/cli_auth.rs` for implementation.
 - `access_token` cookie with JWT
 - `refresh_token` cookie (HTTP-only, secure)
 - Suitable for web UI authentication
+
+### Login Page Contract
+
+The login page accepts exactly one public query parameter for auth resume:
+
+- `return_to` — browser-relative path on the frontend origin that the UI navigates to after the user authenticates.
+
+**Rules:**
+
+- `return_to` is always a **relative path** on the frontend origin (starts with `/`, never `//`, never a scheme). Absolute URLs are rejected.
+- No other resume/redirect parameter is accepted. Historic names like `redirect_to` are not part of the contract and MUST NOT be emitted by any caller.
+- Backend-facing paths (e.g. `/oauth/authorize`, `/api/v1/auth/cli/callback`) are valid `return_to` values — the login page triggers a full-page navigation so the backend route handles the continuation.
+- Workflow-specific continuations (CLI login, OAuth authorize handshakes) MUST NOT leak raw callback URLs into the login-page contract. Instead, they use an opaque server-issued token (e.g. the CLI auth session `state`) encoded in a backend path, and the server resolves that token to complete the workflow.
+
+**Callers that emit `return_to`:**
+
+- UI middleware / main layout when redirecting unauthenticated users (via `getLoginRedirectPath`).
+- MCP OAuth `GET /oauth/authorize` when the caller has no session.
+- `POST /v1/auth/cli/start` when building the CLI login URL.
+
+**External auth backends:** External login pages only need to honor `return_to` — no other parameter. There is no need for a separate `redirect_to` path.
+
+Implementations: `apps/ui/src/lib/auth-redirect.ts` (`sanitizeReturnTo`) and `apps/ui/src/app/(auth)/login/page.tsx`.
 
 ### OAuth Providers
 

--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -272,7 +272,7 @@ Works automatically because:
 3. `POST /oauth/token` — validates code + PKCE, creates JWT. Backend not involved.
 4. Token validation — standard JWT validation via `validate_token()`
 
-External backends only need to ensure their login page handles `redirect_to` query parameter (already required for CLI auth).
+External backends only need to ensure their login page honors the shared `return_to` query parameter (see [Login Page Contract](authentication.md#login-page-contract) in the authentication spec). `return_to` is the single public auth-resume parameter across app, MCP OAuth, and CLI flows — there is no separate `redirect_to`.
 
 ## Security
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -584,6 +584,7 @@ Full conversation data (user messages, LLM responses, tool results) is transmitt
 | TM-WEB-005 | Missing security headers | Low | CSP, X-Content-Type-Options: nosniff, Referrer-Policy, Permissions-Policy via tower-http middleware | MITIGATED |
 | TM-WEB-006 | Open redirect in OAuth flow | Medium | OAuth callbacks validated against configured redirect URIs | MITIGATED |
 | TM-WEB-007 | CORS wildcard exposure | Medium | `CORS_ALLOWED_ORIGINS` not set by default; must be explicitly configured | MITIGATED |
+| TM-WEB-008 | Open redirect via login page `return_to` | Medium | `sanitizeReturnTo` (`apps/ui/src/lib/auth-redirect.ts`) restricts `return_to` to relative paths on the frontend origin: must start with `/`, never `//` (protocol-relative), never `/\` (browser-normalized), never an absolute URL. Applied in login page and main layout (sessionStorage consumer). CLI auth start emits only relative `return_to` paths. See `specs/authentication.md` "Login Page Contract". | MITIGATED |
 
 ### Mitigation Details
 


### PR DESCRIPTION
## What

Unify the auth resume contract across OSS so the login page accepts a single public parameter — `return_to` — for every flow (app routes, MCP OAuth, and CLI login). Removes the legacy public `redirect_to` parameter from the CLI auth flow, adds open-redirect protection, and updates specs.

Closes [EVE-313](https://linear.app/everruns/issue/EVE-313/unify-auth-resume-contract-around-return-to-and-remove-public-redirect).

## Why

The login-page contract had drifted:

- App auth and MCP OAuth used `return_to` (browser-relative path).
- CLI auth start emitted `/login?redirect_to=<full server callback URL>`.
- The OSS login page only reads `return_to`, so the CLI flow no longer worked through the OSS page; downstream login pages had to special-case `redirect_to`.
- This drift caused a SaaS MCP OAuth login break on `dev.everruns.com` (legacy `redirect_to` handler vs. correct `return_to` from MCP OAuth).
- Beyond the bug, the prior login page passed `return_to` straight into `router.push` / `window.location.assign`, leaving an open-redirect surface (e.g. `?return_to=https://evil.com`).

## How

- **CLI auth start** (`crates/server/src/auth/cli_auth.rs`) builds `return_to=<api-prefix>/v1/auth/cli/callback?state=...` instead of `redirect_to=<full URL>`. The API path prefix is derived by stripping `frontend_url` from `base_url`, so `return_to` stays a relative path on the frontend origin (no host leaks). The CLI auth session `state` token remains the opaque server-issued continuation key.
- **`sanitizeReturnTo`** (`apps/ui/src/lib/auth-redirect.ts`) — new helper that rejects absolute URLs, protocol-relative URLs (`//evil.com`), backslash-prefixed paths (`/\evil.com`, which some browsers normalize to `//`), and any value that doesn't start with `/`. Applied in both the login page and the main layout's sessionStorage consumer so a poisoned `everruns_return_to` cannot open-redirect either.
- **Spec updates**:
  - `specs/authentication.md`: new "Login Page Contract" section that defines `return_to` as the single public resume parameter; rewrote the CLI login flow description to match.
  - `specs/mcp.md`: replaced the stale "external backends must handle `redirect_to`" line with a link to the unified contract.
  - `specs/threat-model.md`: documented the open-redirect mitigation as `TM-WEB-008`.
- **Tests**:
  - `crates/server/src/auth/cli_auth.rs`: unit tests for `build_cli_callback_path` covering same-origin-with-prefix, same-origin-no-prefix, different-origins, and the "always relative" invariant.
  - `crates/server/tests/cli_auth_test.rs`: assert the CLI auth URL contains `return_to=`, never `redirect_to`, and never embeds a full URL.
  - `apps/ui/src/__tests__/auth-redirect.test.ts`: 7 new cases for `sanitizeReturnTo` (relative paths accepted, absolute / protocol-relative / backslash / non-`/` / empty rejected).

## Risk

- **Low**. The CLI server-side change is the only public-contract shift. The CLI client just opens whatever `auth_url` it gets, so no client release is needed. External login pages that previously had to honor `redirect_to` for CLI auth no longer need that special-case — but there's no breakage because OSS no longer emits `redirect_to`.
- The open-redirect fix is strictly more restrictive than before. Anyone who relied on absolute `return_to` URLs (which would have been a misconfiguration anyway) will get a fallback to `/dashboard`.

## Validation

- `just pre-push` ✅ (formatting, clippy, lockfile, UI lint, migration ordering, commit author).
- `cargo test -p everruns-server --lib auth::cli_auth` ✅ — 6 unit tests pass.
- `jest src/__tests__/auth-redirect.test.ts src/__tests__/main-layout-auth.test.tsx src/__tests__/middleware.test.ts` ✅ — 16 tests pass.
- **Smoke test** (`just start-dev` at `PORT_PREFIX=271`): `POST /api/v1/auth/cli/start` returns
  ```
  auth_url = http://localhost:27100/login?return_to=%2Fapi%2Fv1%2Fauth%2Fcli%2Fcallback%3Fstate%3D...
  ```
  Confirmed: uses `return_to`, value is a relative path, no host or scheme leaked.

## Security

- **Threat categories reviewed**: `TM-AUTH` (CLI auth URL generation), `TM-WEB` (open redirect via `return_to`), `TM-API` (no new endpoints).
- **Findings & resolutions**:
  - **Open redirect via login `return_to` (pre-existing surface)**: the prior login page passed `searchParams.get("return_to")` directly to `router.push` / `window.location.assign`, so `?return_to=https://evil.com` would have redirected the user post-OAuth. Mitigated by `sanitizeReturnTo` in both the login page and the main layout (sessionStorage consumer). Documented as `TM-WEB-008`.
  - **CLI auth URL host leak**: previously `redirect_to` embedded the full backend URL into the public login-page parameter. The new code derives a relative path and asserts (in tests) that no scheme is leaked.
  - **No new endpoints, no new auth logic, no new query parsing.** The CLI auth `state` token (server-generated 16-byte hex, single-use, 5-min TTL) remains the only continuation key.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (no client changes needed; spec note for downstream login pages)
- [x] Security review performed against relevant threat model categories (TM-AUTH, TM-WEB, TM-API; new `TM-WEB-008` documented)
- [x] All review comments addressed (code change or written reasoning)
