### PR TITLE
feat(ui): abstract SSE transport for downstream auth

### DIFF
--- a/apps/ui/src/hooks/use-durable.ts
+++ b/apps/ui/src/hooks/use-durable.ts
@@ -4,6 +4,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createReconnectTracker } from "@/lib/sse-reconnect";
+import { createEventStream, type EventStreamLike } from "@/lib/event-stream";
 import {
   getDurableHealth,
   listWorkers,
@@ -73,7 +74,7 @@ interface WorkflowSnapshot {
  */
 export function useDurableSSE(options?: { enabled?: boolean }) {
   const queryClient = useQueryClient();
-  const eventSourceRef = useRef<EventSource | null>(null);
+  const eventSourceRef = useRef<EventStreamLike | null>(null);
   const reconnectRef = useRef(createReconnectTracker());
   const [isConnected, setIsConnected] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -99,7 +100,7 @@ export function useDurableSSE(options?: { enabled?: boolean }) {
       cleanup();
 
       const sseUrl = getDurableSseUrl();
-      const eventSource = new EventSource(sseUrl, { withCredentials: true });
+      const eventSource = createEventStream(sseUrl, { withCredentials: true });
       eventSourceRef.current = eventSource;
 
       eventSource.addEventListener("connected", () => {
@@ -200,7 +201,7 @@ export function useDurableSSE(options?: { enabled?: boolean }) {
  */
 export function useWorkflowSSE(workflowId: string | undefined, options?: { enabled?: boolean }) {
   const queryClient = useQueryClient();
-  const eventSourceRef = useRef<EventSource | null>(null);
+  const eventSourceRef = useRef<EventStreamLike | null>(null);
   const reconnectRef = useRef(createReconnectTracker());
   const [isConnected, setIsConnected] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -232,7 +233,7 @@ export function useWorkflowSSE(workflowId: string | undefined, options?: { enabl
       cleanup();
 
       const sseUrl = getWorkflowSseUrl(workflowId);
-      const eventSource = new EventSource(sseUrl, { withCredentials: true });
+      const eventSource = createEventStream(sseUrl, { withCredentials: true });
       eventSourceRef.current = eventSource;
 
       eventSource.addEventListener("connected", () => {

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -26,6 +26,7 @@ import type {
 import { useOrg } from "@/providers/org-provider";
 import { useLocale } from "@/providers/locale-provider";
 import { createReconnectTracker } from "@/lib/sse-reconnect";
+import { createEventStream, type EventStreamLike } from "@/lib/event-stream";
 
 /**
  * Fetch paginated sessions for an organization.
@@ -254,7 +255,7 @@ export function useEvents(sessionId: string | undefined, options?: { enabled?: b
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const [isReconnecting, setIsReconnecting] = useState(false);
-  const eventSourceRef = useRef<EventSource | null>(null);
+  const eventSourceRef = useRef<EventStreamLike | null>(null);
   const lastEventIdRef = useRef<string | null>(null);
   const reconnectRef = useRef(createReconnectTracker());
   const isEnabled = options?.enabled !== false;
@@ -414,7 +415,7 @@ export function useEvents(sessionId: string | undefined, options?: { enabled?: b
       cleanup();
 
       const sseUrl = getSseUrl(sessionId, lastEventIdRef.current ?? undefined);
-      const eventSource = new EventSource(sseUrl, { withCredentials: true });
+      const eventSource = createEventStream(sseUrl, { withCredentials: true });
       eventSourceRef.current = eventSource;
 
       eventSource.addEventListener("connected", () => {

--- a/apps/ui/src/lib/__tests__/event-stream.test.ts
+++ b/apps/ui/src/lib/__tests__/event-stream.test.ts
@@ -1,0 +1,117 @@
+import {
+  createEventStream,
+  getEventStreamFactory,
+  setEventStreamFactory,
+  type EventStreamFactory,
+  type EventStreamLike,
+} from "@/lib/event-stream";
+
+describe("event-stream factory", () => {
+  let originalFactory: EventStreamFactory;
+
+  beforeEach(() => {
+    originalFactory = getEventStreamFactory();
+  });
+
+  afterEach(() => {
+    setEventStreamFactory(originalFactory);
+  });
+
+  it("default factory uses native EventSource with withCredentials=true", () => {
+    const calls: Array<{ url: string; init: EventSourceInit | undefined }> = [];
+    const originalEventSource = globalThis.EventSource;
+    globalThis.EventSource = function (
+      this: EventSource,
+      url: string | URL,
+      init?: EventSourceInit,
+    ) {
+      calls.push({ url: String(url), init });
+      return {
+        addEventListener: () => {},
+        close: () => {},
+        onopen: null,
+        onerror: null,
+      } as unknown as EventSource;
+    } as unknown as typeof EventSource;
+
+    try {
+      createEventStream("/api/events");
+      expect(calls).toHaveLength(1);
+      expect(calls[0].url).toBe("/api/events");
+      expect(calls[0].init).toEqual({ withCredentials: true });
+    } finally {
+      globalThis.EventSource = originalEventSource;
+    }
+  });
+
+  it("default factory forwards withCredentials=false", () => {
+    const calls: Array<{ url: string; init: EventSourceInit | undefined }> = [];
+    const originalEventSource = globalThis.EventSource;
+    globalThis.EventSource = function (
+      this: EventSource,
+      url: string | URL,
+      init?: EventSourceInit,
+    ) {
+      calls.push({ url: String(url), init });
+      return {
+        addEventListener: () => {},
+        close: () => {},
+        onopen: null,
+        onerror: null,
+      } as unknown as EventSource;
+    } as unknown as typeof EventSource;
+
+    try {
+      createEventStream("/api/events", { withCredentials: false });
+      expect(calls[0].init).toEqual({ withCredentials: false });
+    } finally {
+      globalThis.EventSource = originalEventSource;
+    }
+  });
+
+  it("setEventStreamFactory swaps the active factory", () => {
+    const fakeStream: EventStreamLike = {
+      addEventListener: () => {},
+      close: () => {},
+      onopen: null,
+      onerror: null,
+    };
+    const customCalls: Array<string> = [];
+    setEventStreamFactory((url) => {
+      customCalls.push(url);
+      return fakeStream;
+    });
+
+    const result = createEventStream("/api/notifications/sse?since=abc");
+    expect(result).toBe(fakeStream);
+    expect(customCalls).toEqual(["/api/notifications/sse?since=abc"]);
+  });
+
+  it("setEventStreamFactory(null) restores the default", () => {
+    const custom: EventStreamFactory = () =>
+      ({
+        addEventListener: () => {},
+        close: () => {},
+        onopen: null,
+        onerror: null,
+      }) as EventStreamLike;
+    setEventStreamFactory(custom);
+    expect(getEventStreamFactory()).toBe(custom);
+
+    setEventStreamFactory(null);
+    expect(getEventStreamFactory()).not.toBe(custom);
+  });
+
+  it("setEventStreamFactory returns the previous factory", () => {
+    const custom: EventStreamFactory = () =>
+      ({
+        addEventListener: () => {},
+        close: () => {},
+        onopen: null,
+        onerror: null,
+      }) as EventStreamLike;
+    const previous = setEventStreamFactory(custom);
+    const restored = setEventStreamFactory(previous);
+    expect(restored).toBe(custom);
+  });
+});

--- a/apps/ui/src/lib/event-stream.ts
+++ b/apps/ui/src/lib/event-stream.ts
@@ -1,0 +1,61 @@
+// Pluggable SSE transport for UI live streams.
+//
+// OSS UI opens live streams via native `EventSource`, which authenticates
+// through cookies. Downstream embedders (e.g. SaaS with bearer tokens) may
+// need an alternate transport since native `EventSource` cannot set request
+// headers. Previously, downstreams had to patch `window.EventSource`
+// globally. This module provides a narrow factory that downstreams can
+// override in one place without forking the hooks/providers.
+//
+// Default behavior (OSS) is unchanged: native `EventSource` with
+// `withCredentials: true` + cookies.
+
+export interface EventStreamLike {
+  addEventListener(type: string, listener: (event: MessageEvent) => void): void;
+  removeEventListener?(type: string, listener: (event: MessageEvent) => void): void;
+  close(): void;
+  onopen: ((ev: unknown) => unknown) | null;
+  onerror: ((ev: unknown) => unknown) | null;
+}
+
+export interface EventStreamOptions {
+  /** Send credentials (cookies) with the request. Default: true. */
+  withCredentials?: boolean;
+}
+
+export type EventStreamFactory = (url: string, options?: EventStreamOptions) => EventStreamLike;
+
+const defaultFactory: EventStreamFactory = (url, options) =>
+  new EventSource(url, {
+    withCredentials: options?.withCredentials ?? true,
+  }) as unknown as EventStreamLike;
+
+let activeFactory: EventStreamFactory = defaultFactory;
+
+/**
+ * Override the global SSE transport factory. Call with `null` to restore the
+ * default (native `EventSource`). Intended for downstream embedders that need
+ * header-based auth or custom reconnect behavior.
+ *
+ * Returns the previous factory so callers can restore it if needed (useful in
+ * tests).
+ */
+export function setEventStreamFactory(factory: EventStreamFactory | null): EventStreamFactory {
+  const previous = activeFactory;
+  activeFactory = factory ?? defaultFactory;
+  return previous;
+}
+
+/** Return the currently active factory (primarily for tests). */
+export function getEventStreamFactory(): EventStreamFactory {
+  return activeFactory;
+}
+
+/**
+ * Open an SSE stream using the currently active factory. Prefer this over
+ * constructing `EventSource` directly so downstream embedders can inject a
+ * custom authenticated transport.
+ */
+export function createEventStream(url: string, options?: EventStreamOptions): EventStreamLike {
+  return activeFactory(url, options);
+}

--- a/apps/ui/src/providers/notifications-provider.tsx
+++ b/apps/ui/src/providers/notifications-provider.tsx
@@ -25,6 +25,7 @@ import { useFeatureFlag } from "@/providers/feature-flags-provider";
 import { useNotifications } from "@/hooks/use-notifications";
 import { markNotificationViewed, getNotificationsSseUrl } from "@/lib/api/notifications";
 import { createReconnectTracker } from "@/lib/sse-reconnect";
+import { createEventStream, type EventStreamLike } from "@/lib/event-stream";
 import {
   getActiveNotificationTarget,
   getNotificationTargetKey,
@@ -115,7 +116,7 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
   const [isFocused, setIsFocused] = useState(true);
   const reconnectRef = useRef(createReconnectTracker());
   const lastUpdatedAtRef = useRef<string | undefined>(undefined);
-  const eventSourceRef = useRef<EventSource | null>(null);
+  const eventSourceRef = useRef<EventStreamLike | null>(null);
   const autoViewingIdsRef = useRef<Set<string>>(new Set());
   const toastIdsRef = useRef<Set<string>>(new Set());
   const activeTargetKey = useMemo(() => getActiveNotificationTarget(pathname), [pathname]);
@@ -216,7 +217,7 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
     const connect = () => {
       if (cancelled) return;
       eventSourceRef.current?.close();
-      const eventSource = new EventSource(getNotificationsSseUrl(lastUpdatedAtRef.current), {
+      const eventSource = createEventStream(getNotificationsSseUrl(lastUpdatedAtRef.current), {
         withCredentials: true,
       });
       eventSourceRef.current = eventSource;


### PR DESCRIPTION
## What
Introduce a pluggable SSE transport factory so downstream embedders can inject an authenticated stream implementation without forking the OSS hooks/providers or patching `window.EventSource` globally.

- New module `apps/ui/src/lib/event-stream.ts` exposing `createEventStream(url, options)` plus `setEventStreamFactory(...)` for overrides and `getEventStreamFactory()` for tests.
- Routed the three existing SSE callsites through the factory:
  - `apps/ui/src/hooks/use-sessions.ts`
  - `apps/ui/src/providers/notifications-provider.tsx`
  - `apps/ui/src/hooks/use-durable.ts` (both `useDurableSSE` and `useWorkflowSSE`)
- Added jest coverage: `apps/ui/src/lib/__tests__/event-stream.test.ts` covers default behaviour, `withCredentials` forwarding, override, reset-to-default, and previous-factory return.

## Why
Native `EventSource` cannot set request headers, so downstreams using bearer-token auth previously had to patch `window.EventSource` globally. This exposes a single, narrow seam for injecting a header-capable transport while leaving OSS behaviour unchanged.

Fixes EVE-308.

## How
`createEventStream()` delegates to a module-level factory. The default factory wraps the native `EventSource` (`withCredentials: true` unless overridden). Downstreams call `setEventStreamFactory(custom)` once (e.g. in an app-shell bootstrap) to swap in a wrapped transport. Hooks use the shared `EventStreamLike` type, which intentionally mirrors the minimal surface the existing callsites already rely on (`addEventListener`, `close`, `onopen`, `onerror`).

## Risk
- **Low.** OSS default continues to use the native `EventSource` with the same `withCredentials: true` option. Types for existing refs moved from `EventSource` to the structurally-compatible `EventStreamLike`; no runtime semantics change.

## Security
- Threat categories reviewed: **TM-WEB** (frontend transport). No authentication, authorization, or data exposure changes. Default factory preserves cookie-based auth; override hook is opt-in and the responsibility of the downstream embedder. No new persistent state, no new request path.
- Findings and resolutions: none.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (default factory is drop-in)
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)