### PR TITLE
feat(capabilities): allow capabilities to contribute skills

### DIFF
--- a/crates/core/src/capabilities/attach_skill.rs
+++ b/crates/core/src/capabilities/attach_skill.rs
@@ -86,6 +86,90 @@ pub struct SkillInstructions {
     pub files: Vec<(String, String)>,
 }
 
+/// A skill contributed by a capability in code.
+///
+/// During session startup, contributions are normalized into mount points under
+/// `/.agents/skills/{name}/` so the built-in `SkillsCapability` discovers them
+/// alongside user-uploaded and registry-based skills. This reuses the existing
+/// discovery, prompt listing, and activation path rather than introducing a
+/// parallel skill pipeline.
+#[derive(Debug, Clone)]
+pub struct SkillContribution {
+    /// Skill name — also used as the mount directory name.
+    pub name: String,
+    /// Short description shown in the skill list and prompt.
+    pub description: String,
+    /// SKILL.md body (markdown instructions).
+    pub instructions: String,
+    /// Bundled files mounted alongside SKILL.md (path -> content).
+    pub files: Vec<(String, String)>,
+    /// Whether this skill is user-invocable as a /slash command.
+    pub user_invocable: bool,
+    /// Whether the model is prevented from auto-invoking this skill.
+    pub disable_model_invocation: bool,
+}
+
+impl SkillContribution {
+    /// Create a new skill contribution with default flags
+    /// (`user_invocable = true`, `disable_model_invocation = false`).
+    pub fn new(
+        name: impl Into<String>,
+        description: impl Into<String>,
+        instructions: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            description: description.into(),
+            instructions: instructions.into(),
+            files: Vec::new(),
+            user_invocable: true,
+            disable_model_invocation: false,
+        }
+    }
+
+    /// Attach bundled files that will be mounted alongside SKILL.md.
+    pub fn with_files(mut self, files: Vec<(String, String)>) -> Self {
+        self.files = files;
+        self
+    }
+
+    /// Set whether the skill is user-invocable as a /slash command.
+    pub fn with_user_invocable(mut self, flag: bool) -> Self {
+        self.user_invocable = flag;
+        self
+    }
+
+    /// Set whether the model is prevented from auto-invoking this skill.
+    pub fn with_disable_model_invocation(mut self, flag: bool) -> Self {
+        self.disable_model_invocation = flag;
+        self
+    }
+
+    /// Build a read-only mount at `/.agents/skills/{name}/` containing the
+    /// reconstructed `SKILL.md` and all bundled files. `owner_id` is recorded
+    /// as the mount's owning capability, typically the contributing capability's
+    /// ID.
+    pub fn to_mount(&self, owner_id: &str) -> MountPoint {
+        let skill_md = reconstruct_skill_md(
+            &self.name,
+            &self.description,
+            &self.instructions,
+            self.user_invocable,
+            self.disable_model_invocation,
+        );
+        let mut builder = MountDirectoryBuilder::new();
+        builder = builder.file("SKILL.md", &skill_md);
+        for (path, content) in &self.files {
+            builder = builder.file(path, content);
+        }
+        MountPoint::readonly(
+            format!("{}/{}", SKILLS_DISCOVERY_PATH, self.name),
+            builder.build(),
+            owner_id,
+        )
+    }
+}
+
 /// Attach Skill Virtual Capability.
 ///
 /// Mounts a database-registered skill into `/.agents/skills/{name}/` in the
@@ -256,7 +340,7 @@ impl Capability for AttachSkillCapability {
 ///
 /// <instructions body>
 /// ```
-fn reconstruct_skill_md(
+pub fn reconstruct_skill_md(
     name: &str,
     description: &str,
     instructions: &str,
@@ -592,6 +676,79 @@ mod tests {
 
         let parsed: SkillMeta = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.name, "test-skill");
+    }
+
+    fn inline_file_content<'a>(
+        entries: &'a std::collections::HashMap<String, crate::capability_types::MountEntry>,
+        name: &str,
+    ) -> &'a str {
+        use crate::capability_types::MountSource;
+        match &entries.get(name).expect("entry missing").source {
+            MountSource::InlineFile { content, .. } => content.as_str(),
+            _ => panic!("Expected InlineFile for {name}"),
+        }
+    }
+
+    #[test]
+    fn test_skill_contribution_to_mount_basic() {
+        let contribution = SkillContribution::new(
+            "search-playbook",
+            "Run a structured code search playbook",
+            "# Playbook\n1. Grep for symbol\n2. Read hits\n",
+        );
+
+        let mount = contribution.to_mount("cap:owner");
+
+        assert_eq!(mount.path, "/.agents/skills/search-playbook");
+        assert_eq!(mount.capability_id, "cap:owner");
+        assert!(mount.is_readonly());
+
+        use crate::capability_types::MountSource;
+        match &mount.source {
+            MountSource::InlineDirectory { entries } => {
+                let skill_md = inline_file_content(entries, "SKILL.md");
+                let parsed = crate::skill::parse_skill_md(skill_md).unwrap();
+                assert_eq!(parsed.name, "search-playbook");
+                assert_eq!(parsed.description, "Run a structured code search playbook");
+                assert!(parsed.user_invocable);
+                assert!(!parsed.disable_model_invocation);
+                assert!(parsed.instructions.contains("# Playbook"));
+                assert_eq!(entries.len(), 1);
+            }
+            _ => panic!("Expected InlineDirectory"),
+        }
+    }
+
+    #[test]
+    fn test_skill_contribution_to_mount_with_files_and_flags() {
+        let contribution = SkillContribution::new("ops", "Ops runbook", "# Ops\nRun the thing.")
+            .with_files(vec![
+                (
+                    "scripts/run.sh".to_string(),
+                    "#!/bin/sh\necho hi\n".to_string(),
+                ),
+                ("README.md".to_string(), "# Ops README".to_string()),
+            ])
+            .with_user_invocable(false)
+            .with_disable_model_invocation(true);
+
+        let mount = contribution.to_mount("gpt_image_gen");
+
+        use crate::capability_types::MountSource;
+        match &mount.source {
+            MountSource::InlineDirectory { entries } => {
+                assert_eq!(entries.len(), 3);
+                assert!(entries.contains_key("SKILL.md"));
+                assert!(entries.contains_key("scripts/run.sh"));
+                assert!(entries.contains_key("README.md"));
+
+                let parsed =
+                    crate::skill::parse_skill_md(inline_file_content(entries, "SKILL.md")).unwrap();
+                assert!(!parsed.user_invocable);
+                assert!(parsed.disable_model_invocation);
+            }
+            _ => panic!("Expected InlineDirectory"),
+        }
     }
 
     #[test]

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -117,9 +117,9 @@ pub use agent_instructions::{
     MAX_AGENTS_MD_SIZE, format_agents_md_content,
 };
 pub use attach_skill::{
-    AttachSkillCapability, SKILL_CAPABILITY_PREFIX, SKILLS_DISCOVERY_PATH, SkillInstructions,
-    SkillMeta, SkillSource, discover_skills_from_entries, is_skill_capability,
-    parse_skill_capability_id, skill_capability_id,
+    AttachSkillCapability, SKILL_CAPABILITY_PREFIX, SKILLS_DISCOVERY_PATH, SkillContribution,
+    SkillInstructions, SkillMeta, SkillSource, discover_skills_from_entries, is_skill_capability,
+    parse_skill_capability_id, reconstruct_skill_md, skill_capability_id,
 };
 pub use compaction::{
     COMPACTION_CAPABILITY_ID, CompactionCapability, CompactionConfig, CompactionStep,
@@ -492,6 +492,19 @@ pub trait Capability: Send + Sync {
     ///
     /// By default, returns an empty vector (no blueprints).
     fn agent_blueprints(&self) -> Vec<AgentBlueprint> {
+        vec![]
+    }
+
+    /// Returns skills contributed by this capability in code.
+    ///
+    /// Contributions are normalized during capability collection into read-only
+    /// mount points at `/.agents/skills/{name}/` so the built-in `skills`
+    /// capability discovers them alongside user-uploaded and registry-based
+    /// skills. This keeps discovery, prompt listing, and activation in one
+    /// place rather than adding a parallel skill pipeline.
+    ///
+    /// By default, returns an empty vector (no contributed skills).
+    fn contribute_skills(&self) -> Vec<SkillContribution> {
         vec![]
     }
 }
@@ -1316,6 +1329,13 @@ pub async fn collect_capabilities_with_configs(
 
             // Collect mount points
             mounts.extend(capability.mounts());
+
+            // Normalize capability-contributed skills into mount points under
+            // `/.agents/skills/{name}/`. Discovery/activation stays with the
+            // built-in `skills` capability — see specs/skills-registry.md.
+            for skill in capability.contribute_skills() {
+                mounts.push(skill.to_mount(cap_id));
+            }
 
             // Collect message filter provider
             if let Some(provider) = capability.message_filter_provider() {
@@ -3089,5 +3109,116 @@ mod tests {
                 );
             }
         }
+    }
+
+    // ========================================================================
+    // contribute_skills() collection — EVE-311
+    // ========================================================================
+
+    struct SkillContributingCapability;
+
+    impl Capability for SkillContributingCapability {
+        fn id(&self) -> &str {
+            "contributes_skills"
+        }
+        fn name(&self) -> &str {
+            "Contributes Skills"
+        }
+        fn description(&self) -> &str {
+            "Test capability that contributes skills."
+        }
+        fn contribute_skills(&self) -> Vec<SkillContribution> {
+            vec![
+                SkillContribution::new("alpha-skill", "Alpha skill desc", "# Alpha\nDo alpha.")
+                    .with_files(vec![(
+                        "scripts/a.sh".to_string(),
+                        "#!/bin/sh\necho a\n".to_string(),
+                    )]),
+                SkillContribution::new("beta-skill", "Beta skill desc", "# Beta\nDo beta.")
+                    .with_user_invocable(false),
+            ]
+        }
+    }
+
+    fn skill_md_from_entries(entries: &HashMap<String, MountEntry>) -> &str {
+        match &entries.get("SKILL.md").expect("SKILL.md missing").source {
+            MountSource::InlineFile { content, .. } => content.as_str(),
+            _ => panic!("Expected InlineFile for SKILL.md"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_contribute_skills_normalized_to_mounts() {
+        let mut registry = CapabilityRegistry::new();
+        registry.register(SkillContributingCapability);
+
+        let configs = vec![AgentCapabilityConfig {
+            capability_ref: CapabilityId::new("contributes_skills"),
+            config: serde_json::json!({}),
+        }];
+
+        let collected = collect_capabilities_with_configs(&configs, &registry, &test_ctx()).await;
+
+        let skill_mounts: Vec<_> = collected
+            .mounts
+            .iter()
+            .filter(|m| m.path.starts_with("/.agents/skills/"))
+            .collect();
+        assert_eq!(skill_mounts.len(), 2);
+
+        // Every contributed skill mount is read-only and owned by the contributing
+        // capability so the VFS layer can attribute skill files correctly.
+        for m in &skill_mounts {
+            assert!(m.is_readonly());
+            assert_eq!(m.capability_id, "contributes_skills");
+        }
+
+        let alpha = skill_mounts
+            .iter()
+            .find(|m| m.path == "/.agents/skills/alpha-skill")
+            .expect("alpha-skill mount missing");
+        match &alpha.source {
+            MountSource::InlineDirectory { entries } => {
+                assert!(entries.contains_key("SKILL.md"));
+                assert!(entries.contains_key("scripts/a.sh"));
+                let parsed = crate::skill::parse_skill_md(skill_md_from_entries(entries)).unwrap();
+                assert_eq!(parsed.name, "alpha-skill");
+                assert!(parsed.user_invocable);
+            }
+            _ => panic!("Expected InlineDirectory"),
+        }
+
+        let beta = skill_mounts
+            .iter()
+            .find(|m| m.path == "/.agents/skills/beta-skill")
+            .expect("beta-skill mount missing");
+        match &beta.source {
+            MountSource::InlineDirectory { entries } => {
+                let parsed = crate::skill::parse_skill_md(skill_md_from_entries(entries)).unwrap();
+                assert!(!parsed.user_invocable);
+            }
+            _ => panic!("Expected InlineDirectory"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_contribute_skills_default_empty() {
+        // Registry-resident capability without a contribute_skills override
+        // must not add skill mounts.
+        let mut registry = CapabilityRegistry::new();
+        registry.register(FilterTestCapability { priority: 0 });
+
+        let configs = vec![AgentCapabilityConfig {
+            capability_ref: CapabilityId::new("filter_test"),
+            config: serde_json::json!({}),
+        }];
+
+        let collected = collect_capabilities_with_configs(&configs, &registry, &test_ctx()).await;
+        assert!(
+            collected
+                .mounts
+                .iter()
+                .all(|m| !m.path.starts_with("/.agents/skills/"))
+        );
     }
 }

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -146,6 +146,10 @@ If every piece of information in the prompt is already covered by tool definitio
 
 **Note**: `message_filter_provider()` returns an optional filter that modifies message retrieval. See [Message Filters](#message-filters).
 
+##### Capability-Contributed Skills
+
+Capabilities may ship reusable skills in code via `contribute_skills() -> Vec<SkillContribution>` (default empty). Each `SkillContribution` carries a name, description, SKILL.md body, bundled files, and invocability flags. During capability collection each contribution is normalized into a read-only mount at `/.agents/skills/{name}/` containing a reconstructed `SKILL.md` plus bundled files. The built-in `skills` capability then discovers and serves them through the same VFS scan used for filesystem and registry skills — no parallel pipeline, no special-case prompt injection, and `/slash` invocability + `disable-model-invocation` flags are honored through the same frontmatter. See `specs/skills-registry.md` for the discovery/activation contract and `crates/core/src/capabilities/attach_skill.rs` for `SkillContribution` and the underlying mount construction.
+
 ### Capability Dependencies
 
 Capabilities can declare dependencies on other capabilities. When a capability is selected, its dependencies are automatically resolved and applied.

--- a/specs/skills-registry.md
+++ b/specs/skills-registry.md
@@ -352,6 +352,18 @@ This approach:
 
 **No `bundled_files` in tool result**: The `activate_skill` tool result does not include a separate list of companion file paths. The agent discovers referenced files from relative paths in the SKILL.md instructions (per the [agentskills.io progressive disclosure model](https://agentskills.io/specification)), or via `list_files` on the skill directory. A well-written SKILL.md already references every file the agent needs.
 
+### Capability-Contributed Skills
+
+Beyond user-uploaded (registry) and filesystem skills, any `Capability` can ship skills in code via `contribute_skills() -> Vec<SkillContribution>`. See `specs/capabilities.md` for the trait method and `crates/core/src/capabilities/attach_skill.rs` for `SkillContribution` fields.
+
+Contributed skills flow through the **same** discovery/activation path as other skills:
+
+1. During capability collection, each `SkillContribution` is normalized into a read-only `MountPoint` at `/.agents/skills/{name}/` with a reconstructed `SKILL.md` (frontmatter + body) and every bundled file.
+2. When the built-in `skills` capability is active, its VFS scan finds these mounts alongside `AttachSkillCapability` mounts and filesystem-resident skills.
+3. `list_skills`, `activate_skill`, prompt listing, and `/slash` command visibility all go through the existing path — the frontmatter flags `user-invocable` and `disable-model-invocation` are honored the same way.
+
+The mount's `capability_id` is set to the contributing capability's ID so the VFS layer attributes the mounted files correctly and so users can see which capability a skill came from. There is no separate database row and no parallel prompt-injection path: if a capability wants a skill, it returns a `SkillContribution` and the rest is shared pipeline.
+
 ## Database Schema
 
 ```sql
@@ -571,6 +583,8 @@ Skills can also be discovered from the session filesystem at `/.agents/skills/`.
 | Upload | API endpoints | Write files to VFS |
 | Capability ID | `skill:{uuid}` | `skills` (aggregate) |
 | Best for | Shared/reusable skills | Project-specific skills |
+
+A third source — **capability-contributed skills** — also feeds this pipeline. Any `Capability` can ship skills in code via `contribute_skills()` (see `specs/capabilities.md`); those contributions mount at the same `/.agents/skills/{name}/` path and are served through the same `skills` capability. They are per-session (scoped to the contributing capability's activation) and best for bundling a reusable workflow with the capability that powers it — e.g., a `gpt_image_gen` capability shipping a "prompt an image" skill alongside its tools.
 
 ## Example Skills
 


### PR DESCRIPTION
## What
Adds a `contribute_skills()` trait hook on `Capability` so a capability can ship reusable skills in code. Contributions are normalized during capability collection into read-only mounts at `/.agents/skills/{name}/`; the built-in `skills` capability discovers and activates them through the same VFS-scan pipeline it already uses for filesystem and registry (`skill:{uuid}`) skills.

Closes EVE-311.

## Why
Capabilities already contribute prompts, tools, mounts, and blueprints. Reusable higher-level workflows that should behave exactly like skills had no first-class path — callers had to mint `AttachSkillCapability` by hand or fork the skills pipeline. A `contribute_skills()` hook keeps the skill contract (frontmatter flags, progressive disclosure, VFS bundling) intact while letting any capability ride it.

## How
- Added `SkillContribution` to `crates/core/src/capabilities/attach_skill.rs` (name, description, instructions, bundled files, `user_invocable`, `disable_model_invocation`) plus a `to_mount(owner_id)` helper that reconstructs a parseable `SKILL.md` and builds a read-only `MountPoint` under `/.agents/skills/{name}/`.
- Exposed `reconstruct_skill_md` as `pub` so contributed skills share the exact same frontmatter-reconstruction path used by `AttachSkillCapability`, preserving `user-invocable` / `disable-model-invocation` semantics.
- Added `fn contribute_skills(&self) -> Vec<SkillContribution>` to the `Capability` trait (default empty), mirroring `agent_blueprints()`.
- Wired it into `collect_capabilities_with_configs()` — for every active capability, each contribution is appended to `mounts` with the contributing capability's ID as the mount owner. No changes to `SkillsCapability`, no changes to prompt generation.
- Updated `specs/capabilities.md` and `specs/skills-registry.md` to describe the hook and its shared-pipeline contract.

## Risk
- **Low.** Additive only: new trait method with a default empty implementation, new public type, new mount entries that sit on the existing discovery path. Default behavior for existing capabilities is unchanged — no existing built-in implements `contribute_skills()`.
- **What can break:** If a capability ever contributes a skill whose name collides with another mounted skill (registry, filesystem, or another capability), the `MountPoint` layer will conflict the same way it already does for other mounts. Detection is left to the existing VFS mount plumbing.

## Security
- Threat categories reviewed: TM-AGENT-005 (capability risk surface), TM-DATA (session VFS content).
- Findings and resolutions: Contributed skills mount as read-only at the well-known `/.agents/skills/{name}/` path, identical to registry skills. No new network egress, no new secrets, no new permissions. Content is author-controlled Rust code in-tree; there is no user-supplied path or content flowing through this hook, so there are no new SSRF / path-traversal / injection vectors. Skills themselves do not execute — they provide instructions + files; model-invocation/user-invocable flags round-trip through the existing `parse_skill_md` contract and are honored uniformly.

## Checklist
- [x] Tests added or updated — `test_skill_contribution_to_mount_basic`, `test_skill_contribution_to_mount_with_files_and_flags`, `test_contribute_skills_normalized_to_mounts`, `test_contribute_skills_default_empty` (full `cargo test -p everruns-core --lib`: 1545 passed).
- [x] Backward compatibility considered — default implementation returns `vec![]`; no existing capability or call site changes behavior.
- [x] Security review performed against relevant threat model categories — see Security section above.
- [x] All review comments addressed (code change or written reasoning) — n/a, new PR.