### PR TITLE
chore(prompts): adopt Claude 4.7 prompting guidance in capability prompts

### DIFF
--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -457,9 +457,22 @@ impl Capability for FileSystemCapability {
             "to read or write files inside a cloud sandbox, use the sandbox-specific tools ",
             "(e.g. daytona_read_file, e2b_read_file).",
         );
-        // Build the full prompt lazily on first use by appending the shared read-economy hint.
-        static PROMPT: std::sync::LazyLock<String> =
-            std::sync::LazyLock::new(|| format!("{}{}", BASE, READ_ECONOMY_HINT));
+        const INVESTIGATE: &str = "\n\n<investigate_before_answering>\n\
+            Never speculate about code you have not opened. If the user references a specific file, \
+            read it before answering. Investigate and read relevant files before making claims about \
+            the codebase — ground answers in what the files actually contain rather than plausible guesses.\n\
+            </investigate_before_answering>";
+        const PARALLEL: &str = "\n\n<use_parallel_tool_calls>\n\
+            When you intend to call multiple tools and there are no dependencies between the calls, \
+            make all independent tool calls in parallel in the same response. For example, when reading \
+            3 files, issue 3 `read_file` calls in one turn rather than sequentially. If a later call \
+            depends on a value produced by an earlier one, call them sequentially — never use \
+            placeholders or guess missing parameters.\n\
+            </use_parallel_tool_calls>";
+        // Build the full prompt lazily on first use.
+        static PROMPT: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+            format!("{}{}{}{}", BASE, READ_ECONOMY_HINT, INVESTIGATE, PARALLEL)
+        });
         Some(PROMPT.as_str())
     }
 

--- a/crates/core/src/capabilities/infinity_context.rs
+++ b/crates/core/src/capabilities/infinity_context.rs
@@ -66,7 +66,14 @@ const INFINITY_CONTEXT_SYSTEM_PROMPT: &str = r#"## Conversation History
 
 This session may have earlier messages that are not visible in the active prompt.
 If you need information from earlier in the conversation, call `query_history`
-to search or retrieve those messages before answering."#;
+to search or retrieve those messages before answering.
+
+Your context window will be trimmed automatically as it approaches its limit, so
+you can continue working from where you left off. Do not stop tasks early due to
+token budget concerns. As you approach the budget, save any important progress
+or state to persistent storage (files, memory, or external tools) before the
+window refreshes. Complete tasks fully — never artificially cut a task short
+because context is running low."#;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct InfinityContextConfig {

--- a/crates/core/src/capabilities/infinity_context.rs
+++ b/crates/core/src/capabilities/infinity_context.rs
@@ -70,10 +70,10 @@ to search or retrieve those messages before answering.
 
 Your context window will be trimmed automatically as it approaches its limit, so
 you can continue working from where you left off. Do not stop tasks early due to
-token budget concerns. As you approach the budget, save any important progress
-or state to persistent storage (files, memory, or external tools) before the
-window refreshes. Complete tasks fully — never artificially cut a task short
-because context is running low."#;
+token budget concerns. If a persistence tool is available to you (for example
+file system or memory tools), save any important progress or state through it
+before the window refreshes. Complete tasks fully — never artificially cut a
+task short because context is running low."#;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct InfinityContextConfig {

--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -70,10 +70,18 @@ impl Capability for SubagentCapability {
 
 const SUBAGENT_SYSTEM_PROMPT: &str = r#"Delegate tasks to subagents running in their own context window.
 
+When to spawn a subagent:
 - Move noisy/verbose work off the main conversation (test runs, large searches).
-- Run independent tasks in parallel (multiple spawn_subagent calls in one response).
+- Fan out across independent items — spawn multiple subagents in the same response.
+- Isolate an independent workstream that does not need to share state with the main thread.
+
+When NOT to spawn a subagent:
+- Do not spawn a subagent for work you can complete directly in this response (e.g. editing a function you can already see).
+- Do not spawn a subagent for a single sequential step that needs the main context.
+
+Other rules:
 - Subagents cannot spawn other subagents (no nesting).
-- Use `blueprint` parameter to spawn specialist agents with their own tools and model."#;
+- Use the `blueprint` parameter to spawn specialist agents with their own tools and model."#;
 
 // =============================================================================
 // Helper: get platform store from context

--- a/crates/core/src/tool_output_sanitizer.rs
+++ b/crates/core/src/tool_output_sanitizer.rs
@@ -68,7 +68,7 @@ If you need more detail, re-run with `output: \"verbose\"` or read the persisted
 pub const READ_ECONOMY_HINT: &str = "\n\n**File reading economy:** `read_file` returns at most 2000 lines by default.\n\
 - Locate the relevant region first with `grep_files`, then read that section with `read_file` using `offset` and `limit`.\n\
 - Use `list_directory` to understand file structure before reading.\n\
-- When a read is truncated, check `total_lines` to see how much remains and continue from the next offset.";
+- When a read is truncated, check `total_lines` to see how much remains and continue from `lines_shown.end` on the next call.";
 
 /// Strip ANSI escape sequences from text.
 ///

--- a/crates/core/src/tool_output_sanitizer.rs
+++ b/crates/core/src/tool_output_sanitizer.rs
@@ -66,12 +66,9 @@ If you need more detail, re-run with `output: \"verbose\"` or read the persisted
 /// Appended to the FileSystem capability's `system_prompt_addition()` to guide
 /// the LLM toward efficient file reading with offset/limit pagination.
 pub const READ_ECONOMY_HINT: &str = "\n\n**File reading economy:** `read_file` returns at most 2000 lines by default.\n\
-Use `offset` and `limit` to read specific sections of large files.\n\
-- Use `grep_files` to find relevant lines before reading\n\
-- Use `list_directory` for file structure\n\
-- Don't read entire large files when you only need a specific section\n\
-- When a read is truncated, check `total_lines` to see how much remains\n\
-- For files you've already read, use offset to continue from where you left off";
+- Locate the relevant region first with `grep_files`, then read that section with `read_file` using `offset` and `limit`.\n\
+- Use `list_directory` to understand file structure before reading.\n\
+- When a read is truncated, check `total_lines` to see how much remains and continue from the next offset.";
 
 /// Strip ANSI escape sequences from text.
 ///


### PR DESCRIPTION
## What
Align five built-in capability system prompts in `crates/core` with Anthropic's [Claude 4.7 prompting best practices](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices):

1. **`subagents.rs`** — split the prompt into *When to spawn / When NOT to spawn / Other rules*. 4.7 skews toward fewer subagents, but still occasionally over-spawns on simple work; the docs explicitly recommend both-direction steering.
2. **`tool_output_sanitizer.rs::READ_ECONOMY_HINT`** — rewrite the "Don't read entire large files…" bullets as positive task-oriented instructions ("tell the model what to do, not what not to do").
3. **`file_system.rs`** — add `<investigate_before_answering>` block (reduces hallucinations on codebase questions by forcing file reads before claims).
4. **`file_system.rs`** — add `<use_parallel_tool_calls>` block so multi-file reads and grep+read fan-outs reliably parallelize in one turn. Placed on `file_system` (not `subagents`) because it is the most universally loaded fan-out surface.
5. **`infinity_context.rs`** — add persistence/save-state language so agents do not self-truncate near the context budget and save progress before the window refreshes.

## Why
These are the five places in our capability catalog where the 4.7 guidance gives a clear win over what we ship today. Most of the rest of our prompt surface (XML section wrapping, summarization prompt structure, concise phrasing, no "CRITICAL: YOU MUST" language) already matches the doc's recommendations — see `specs/xml-prompt-formatting.md`.

## How
All five changes are edits to existing `&'static str` / `LazyLock<String>` system-prompt constants returned by capability `system_prompt_addition()`. No new tools, no schema changes, no API surface changes, no runtime behavior changes outside the string content the model sees.

## Risk
- **Low.** Prompt-string-only edits. No new crates, no new dependencies, no new endpoints, no migrations.
- What could break: downstream code that asserts exact substrings of these prompts. Checked — existing assertions (`File reading economy`, `offset`, `total_lines`, `/workspace`) are all preserved.

## Security
- **Threat categories reviewed:** `TM-LLM` (prompt construction). No other categories touched.
- **Findings and resolutions:**
  - All added text is static string literals. No user-controllable data flows into any of the new `format!`/`concat!` expressions.
  - No existing safety instruction is weakened or removed. The `<investigate_before_answering>` addition strengthens defensive behavior (anti-hallucination). The `<use_parallel_tool_calls>` instruction is a model nudge — platform-level tool concurrency limits still apply. The infinity-context "don't stop early" instruction does not bypass compaction/budget enforcement, which is enforced outside the prompt.
  - No `THREAT[TM-...]` comments exist in the four touched files; no existing mitigations intersect with this change.
  - No threat-model update needed.

## Validation
- `./scripts/lib/pre-push.sh` — all 7 checks pass (fmt, clippy, lockfile, migrations, author).
- `cargo test -p everruns-core --lib capabilities::` — 607 passed, 0 failed.
- Targeted: `file_system::tests::test_capability_has_system_prompt`, `subagents::tests::capability_basics`, `infinity_context::tests::*` — all green.
- Smoke test skipped with justification: this change only alters the content of `&'static str` prompt constants returned by `system_prompt_addition()`. There is no code-path or data-path change to exercise end-to-end; capability unit tests cover the assembly path.

## Checklist
- [x] Tests added or updated (existing assertions still hold; no new behavior requires new tests)
- [x] Backward compatibility considered (internal code, no external contract)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning) — will track post-push