### PR TITLE
fix(worker): preserve ActInput.org_id through durable act-task roundtrip

### DIFF
--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -34,15 +34,28 @@ use serde::{Deserialize, Serialize};
 // Act Task Input Wrapper
 // =============================================================================
 
-/// Wrapper for act task input that includes org_id
-/// This keeps org_id (infrastructure concern) out of core types
+/// Wrapper for act task input.
+///
+/// `org_id` is carried on the flattened `ActInput` itself. Duplicating it as
+/// an explicit outer field collides with the flattened key during
+/// deserialization and drops the inner value (EVE-325), so the wrapper only
+/// adds fields not already present on `ActInput`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct ActTaskInput {
-    org_id: i64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     request_id: Option<String>,
     #[serde(flatten)]
     act_input: ActInput,
+}
+
+impl ActTaskInput {
+    /// Returns the org_id carried by the inner `ActInput`, erroring if it is
+    /// missing. Used by all act-task dequeue paths.
+    fn require_org_id(&self) -> Result<i64> {
+        self.act_input
+            .org_id
+            .ok_or_else(|| anyhow::anyhow!("ActTaskInput.act_input.org_id must be set"))
+    }
 }
 
 // =============================================================================
@@ -94,7 +107,7 @@ fn extract_task_session_context(
             let act_task_input: ActTaskInput = serde_json::from_value(input.clone())
                 .with_context(|| format!("parse ActTaskInput for activity '{activity_type}'"))?;
             Ok(TaskSessionContext {
-                org_id: act_task_input.org_id,
+                org_id: act_task_input.act_input.org_id.unwrap_or(0),
                 session_id: act_task_input.act_input.context.session_id,
                 turn_id: act_task_input.act_input.context.turn_id,
                 input_message_id: act_task_input.act_input.context.input_message_id,
@@ -789,7 +802,7 @@ impl DurableWorker {
                             serde_json::from_value::<ActTaskInput>(task.input.clone())
                         {
                             (
-                                act_input.org_id,
+                                act_input.act_input.org_id.unwrap_or(0),
                                 act_input.act_input.context.session_id,
                                 act_input.act_input.context.input_message_id,
                             )
@@ -891,6 +904,7 @@ impl DurableWorker {
                 // Act activity uses ActTaskInput wrapper to include org_id
                 let act_task_input: ActTaskInput = serde_json::from_value(task.input.clone())
                     .map_err(|e| anyhow::anyhow!("Failed to parse ActTaskInput: {}", e))?;
+                let org_id = act_task_input.require_org_id()?;
                 // Create DurableTurnInput from ActInput context for scheduling next activity
                 // Include turn_id from act_input context for trace correlation
                 // Extract previous_response_id injected by reason→act scheduling
@@ -908,7 +922,7 @@ impl DurableWorker {
                     .filter(|&it| it > 0)
                     .unwrap_or(1);
                 let turn_input = DurableTurnInput {
-                    org_id: act_task_input.org_id,
+                    org_id,
                     session_id: act_task_input.act_input.context.session_id,
                     harness_id: act_task_input.act_input.harness_id,
                     agent_id: act_task_input.act_input.agent_id,
@@ -919,11 +933,7 @@ impl DurableWorker {
                     request_id: act_task_input.request_id.clone(),
                 };
                 let res = self
-                    .execute_act_activity(
-                        grpc_client.clone(),
-                        act_task_input.org_id,
-                        act_task_input.act_input,
-                    )
+                    .execute_act_activity(grpc_client.clone(), org_id, act_task_input.act_input)
                     .await;
                 (res, Some(turn_input))
             }
@@ -1426,11 +1436,12 @@ impl DurableWorker {
 }
 
 fn serialize_act_plan_for_durable_worker(plan: &RuntimeActPlan) -> Result<serde_json::Value> {
+    if plan.input.org_id.is_none() {
+        return Err(anyhow::anyhow!(
+            "ActInput.org_id must be set for durable worker scheduling"
+        ));
+    }
     let mut input_json = serde_json::to_value(ActTaskInput {
-        org_id: plan
-            .input
-            .org_id
-            .expect("ActInput.org_id must be set for durable worker scheduling"),
         request_id: plan.request_id.clone(),
         act_input: plan.input.clone(),
     })?;
@@ -1531,7 +1542,6 @@ mod tests {
         let input_message_id = MessageId::new();
         let turn_id = TurnId::new();
         let act_task_input = ActTaskInput {
-            org_id: 7,
             request_id: Some("req_123".to_string()),
             act_input: ActInput {
                 org_id: Some(7),
@@ -1577,5 +1587,40 @@ mod tests {
             chain.contains("ActTaskInput"),
             "expected wrapping context in error chain: {chain}"
         );
+    }
+
+    /// Regression for EVE-325: ensure the inner `ActInput.org_id` survives a
+    /// serde round-trip through `ActTaskInput`. Previously the outer
+    /// `ActTaskInput.org_id` and flattened `ActInput.org_id` collided on the
+    /// same JSON key and deserialization dropped the inner value, causing
+    /// every tool call in the durable worker path to fail with
+    /// "ActInput.org_id must be set for runtime host execution".
+    #[test]
+    fn act_task_input_roundtrip_preserves_inner_org_id() {
+        use everruns_core::atoms::{ActInput, AtomContext};
+        use everruns_core::typed_id::ExecId;
+
+        let input = ActTaskInput {
+            request_id: None,
+            act_input: ActInput {
+                org_id: Some(7),
+                context: AtomContext {
+                    session_id: SessionId::new(),
+                    turn_id: TurnId::new(),
+                    input_message_id: MessageId::new(),
+                    exec_id: ExecId::new(),
+                },
+                harness_id: HarnessId::new(),
+                agent_id: None,
+                tool_calls: vec![],
+                tool_definitions: vec![],
+                locale: None,
+                blueprint_id: None,
+                network_access: None,
+            },
+        };
+        let json = serde_json::to_value(&input).unwrap();
+        let decoded: ActTaskInput = serde_json::from_value(json).unwrap();
+        assert_eq!(decoded.act_input.org_id, Some(7));
     }
 }

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -50,13 +50,22 @@ struct ActTaskInput {
 
 impl ActTaskInput {
     /// Returns the org_id carried by the inner `ActInput`, erroring if it is
-    /// missing. Used by all act-task dequeue paths.
+    /// missing. Used by paths that require a present org_id to execute (the
+    /// main `execute_task` act branch); some failure-emission paths
+    /// intentionally tolerate a missing value and fall back to 0 so they can
+    /// still surface an error event to the session.
     fn require_org_id(&self) -> Result<i64> {
         self.act_input
             .org_id
-            .ok_or_else(|| anyhow::anyhow!("ActTaskInput.act_input.org_id must be set"))
+            .ok_or_else(|| anyhow::anyhow!(MISSING_ACT_ORG_ID_ERROR))
     }
 }
+
+/// Error substring marking a missing `org_id` on an act task. Persisted into
+/// the task failure message so `is_non_retryable_task_error` can short-circuit
+/// the retry loop and DLQ the task immediately instead of burning attempts on
+/// a deterministic configuration failure.
+const MISSING_ACT_ORG_ID_ERROR: &str = "ActTaskInput.act_input.org_id must be set";
 
 // =============================================================================
 // Task Session Context Extraction
@@ -566,6 +575,7 @@ fn is_non_retryable_task_error(error: &str) -> bool {
     let lower = error.to_ascii_lowercase();
     lower.contains("user message not found")
         || (lower.contains("inputatom execution failed") && lower.contains("not found"))
+        || lower.contains(&MISSING_ACT_ORG_ID_ERROR.to_ascii_lowercase())
 }
 
 impl DurableWorker {
@@ -901,7 +911,8 @@ impl DurableWorker {
                 (res, Some(turn_input))
             }
             "act" => {
-                // Act activity uses ActTaskInput wrapper to include org_id
+                // Act activity uses ActTaskInput; org_id is read from the
+                // flattened ActInput payload via require_org_id().
                 let act_task_input: ActTaskInput = serde_json::from_value(task.input.clone())
                     .map_err(|e| anyhow::anyhow!("Failed to parse ActTaskInput: {}", e))?;
                 let org_id = act_task_input.require_org_id()?;
@@ -1473,6 +1484,13 @@ mod tests {
         ));
         assert!(is_non_retryable_task_error(
             "InputAtom execution failed: Message store error: User message not found: msg_xyz"
+        ));
+    }
+
+    #[test]
+    fn test_is_non_retryable_task_error_detects_missing_act_org_id() {
+        assert!(is_non_retryable_task_error(
+            "ActAtom execution failed: ActTaskInput.act_input.org_id must be set"
         ));
     }
 


### PR DESCRIPTION
## What

Remove the duplicate outer `org_id: i64` from `ActTaskInput` in `crates/worker/src/durable_worker.rs`. The inner `ActInput.org_id` is now the single source of truth. Adds an `act_task_input_roundtrip_preserves_inner_org_id` regression test.

Fixes EVE-325.

## Why

`ActTaskInput` wrapped `ActInput` with `#[serde(flatten)]` but also declared its own explicit `org_id: i64`. Both serialize to the same JSON key `org_id`, and on deserialize the outer field claimed the value first — leaving `ActInput.org_id` as `None`.

Every durable-worker act task then hit `ActInput.org_id must be set for runtime host execution` in `runtime::host::execute_act_activity`, failed non-retryably 5x into the DLQ, and surfaced to the user as *"I encountered an error while processing your request."* This reproduced deterministically on `dev.everruns.com` today for every tool-calling turn (session `session_019d9cf75ebc750a97fabd439bb61fe3`, org_id=38, both `gpt-5.4` and `gpt-4o-mini`).

The in-process `unified_worker` path was unaffected because it deserializes `ActInput` directly, which is why local dev tests did not catch the issue.

## How

Fix option A from the issue:

- Drop the outer `org_id: i64` field from `ActTaskInput`. The wrapper now only adds fields not already present on `ActInput` (just `request_id`).
- All dequeue sites (`extract_task_session_context`, workflow-cancellation context extraction, `execute_task` act branch) read `org_id` from `act_task_input.act_input.org_id`.
- Add `ActTaskInput::require_org_id` for the primary dispatch path so a missing org_id produces a clear error instead of silently using 0.
- Replace the old `.expect()` in `serialize_act_plan_for_durable_worker` with a proper `Result::Err` since the outer field no longer exists.

## Risk

- Low.
- Internal refactor of a wrapper that existed only inside the worker crate. No API, no schema migration, no config changes.
- Behavior on error-path extractors (DLQ emit, cancellation) is equivalent: previous code fell back to `org_id=0` when the `ActTaskInput` parse failed; the new code falls back to `org_id=0` when the inner `org_id` is missing.
- Primary dispatch path now surfaces a missing `org_id` as an explicit runtime error (previously impossible because `i64` was required).

## Security

- Threat categories reviewed: **TM-TENANT** (org_id is the tenant scoping value), **TM-TOOL** (act-task is the tool-execution dispatch path).
- Findings: the pre-fix bug silently dropped the tenant id on the durable path, forcing `execute_act_activity` to fail with a tenant-missing error; the fix restores correct tenant propagation end-to-end on that path. No new inputs, no new trust boundaries, no new dependencies.
- `unwrap_or(0)` only appears in pre-existing failure/cancellation extraction paths whose prior behavior already fell back to `0`. The main dispatch path now uses `require_org_id` which returns `Err` on missing values.

## Validation

- `cargo test -p everruns-worker --lib durable_worker` → 9 passed, including the new `act_task_input_roundtrip_preserves_inner_org_id` regression that fails against the old struct layout.
- `just pre-push` → all checks green (fmt, clippy, Cargo.lock, migrations, commit attribution).
- Distributed durable-worker end-to-end smoke (requires PG + Valkey + NATS + configured LLM) was not re-run locally; the unit regression reproduces the exact flatten-collision the production logs showed and verifies the fix.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (internal wrapper, no external consumers — persisted in-flight tasks continue to deserialize correctly because the JSON key was the same; only the post-deserialize consumer path changed)
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)
