### PR TITLE
fix(docker): harden images against common Dockerfile footguns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directories:
+      - "/crates/server"
+      - "/crates/worker"
+      - "/apps/ui"
+      - "/docker"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "docker"

--- a/apps/ui/.dockerignore
+++ b/apps/ui/.dockerignore
@@ -6,7 +6,10 @@ node_modules
 out
 
 # Development
-.env*.local
+# Exclude all .env* files. A .env / .env.production accidentally placed here
+# would otherwise be copied into the builder layer by `COPY . .` and persist
+# in image history even if later removed (Docker layers are immutable).
+.env*
 *.log
 
 # Testing

--- a/crates/server/Dockerfile
+++ b/crates/server/Dockerfile
@@ -49,7 +49,7 @@ RUN cargo build --release -p everruns-server
 # ============================================================================
 # Stage 4: Runtime - Distroless production image (minimal size and security)
 # ============================================================================
-FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
+FROM gcr.io/distroless/cc-debian12:nonroot@sha256:e2d29aec8061843706b7e484c444f78fafb05bfe47745505252b1769a05d14f1 AS runtime
 
 WORKDIR /app
 

--- a/crates/server/Dockerfile
+++ b/crates/server/Dockerfile
@@ -5,7 +5,7 @@
 # ============================================================================
 FROM rust:1.92-slim AS chef
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     libssl-dev \
     curl \
@@ -49,7 +49,7 @@ RUN cargo build --release -p everruns-server
 # ============================================================================
 # Stage 4: Runtime - Distroless production image (minimal size and security)
 # ============================================================================
-FROM gcr.io/distroless/cc-debian12 AS runtime
+FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
 
 WORKDIR /app
 

--- a/crates/worker/Dockerfile
+++ b/crates/worker/Dockerfile
@@ -5,7 +5,7 @@
 # ============================================================================
 FROM rust:1.92-slim AS chef
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     libssl-dev \
     curl \
@@ -49,7 +49,7 @@ RUN cargo build --release -p everruns-worker
 # ============================================================================
 # Stage 4: Runtime - Distroless production image (minimal size and security)
 # ============================================================================
-FROM gcr.io/distroless/cc-debian12 AS runtime
+FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
 
 WORKDIR /app
 

--- a/crates/worker/Dockerfile
+++ b/crates/worker/Dockerfile
@@ -49,7 +49,7 @@ RUN cargo build --release -p everruns-worker
 # ============================================================================
 # Stage 4: Runtime - Distroless production image (minimal size and security)
 # ============================================================================
-FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
+FROM gcr.io/distroless/cc-debian12:nonroot@sha256:e2d29aec8061843706b7e484c444f78fafb05bfe47745505252b1769a05d14f1 AS runtime
 
 WORKDIR /app
 

--- a/docker/Dockerfile.unified
+++ b/docker/Dockerfile.unified
@@ -14,8 +14,11 @@
 # ============================================================================
 FROM --platform=$BUILDPLATFORM rust:1.92-slim-bookworm AS builder-base
 
-# Install xx for cross-compilation support (pinned — unpinned tag resolves to :latest)
-COPY --from=tonistiigi/xx:1.9.0 / /
+# Install xx for cross-compilation support
+# Pinned by digest so a mutated tag can't slip a compromised toolchain into
+# the build. Dependabot (`.github/dependabot.yml`, docker ecosystem) opens a
+# PR when a newer digest is published for `tonistiigi/xx:1.9.0`.
+COPY --from=tonistiigi/xx:1.9.0@sha256:c64defb9ed5a91eacb37f96ccc3d4cd72521c4bd18d5442905b95e2226b0e707 / /
 
 ARG TARGETPLATFORM
 
@@ -74,7 +77,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARG
 # ============================================================================
 # Stage 3a: Server Runtime image (distroless for minimal size and security)
 # ============================================================================
-FROM gcr.io/distroless/cc-debian12:nonroot AS server
+FROM gcr.io/distroless/cc-debian12:nonroot@sha256:e2d29aec8061843706b7e484c444f78fafb05bfe47745505252b1769a05d14f1 AS server
 
 WORKDIR /app
 
@@ -92,7 +95,7 @@ CMD ["/app/everruns-server"]
 # ============================================================================
 # Stage 3b: Worker Runtime image (distroless for minimal size and security)
 # ============================================================================
-FROM gcr.io/distroless/cc-debian12:nonroot AS worker
+FROM gcr.io/distroless/cc-debian12:nonroot@sha256:e2d29aec8061843706b7e484c444f78fafb05bfe47745505252b1769a05d14f1 AS worker
 
 WORKDIR /app
 

--- a/docker/Dockerfile.unified
+++ b/docker/Dockerfile.unified
@@ -14,18 +14,18 @@
 # ============================================================================
 FROM --platform=$BUILDPLATFORM rust:1.92-slim-bookworm AS builder-base
 
-# Install xx for cross-compilation support
-COPY --from=tonistiigi/xx / /
+# Install xx for cross-compilation support (pinned — unpinned tag resolves to :latest)
+COPY --from=tonistiigi/xx:1.9.0 / /
 
 ARG TARGETPLATFORM
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     clang \
     lld \
     curl \
     libssl-dev \
-    && xx-apt-get install -y \
+    && xx-apt-get install -y --no-install-recommends \
     gcc \
     libc6-dev \
     libssl-dev \
@@ -74,7 +74,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARG
 # ============================================================================
 # Stage 3a: Server Runtime image (distroless for minimal size and security)
 # ============================================================================
-FROM gcr.io/distroless/cc-debian12 AS server
+FROM gcr.io/distroless/cc-debian12:nonroot AS server
 
 WORKDIR /app
 
@@ -92,7 +92,7 @@ CMD ["/app/everruns-server"]
 # ============================================================================
 # Stage 3b: Worker Runtime image (distroless for minimal size and security)
 # ============================================================================
-FROM gcr.io/distroless/cc-debian12 AS worker
+FROM gcr.io/distroless/cc-debian12:nonroot AS worker
 
 WORKDIR /app
 
@@ -126,6 +126,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 
 FROM debian:bookworm-slim AS admin
 
+# Create non-root user. Admin tasks (sqlx migrate, reencrypt-secrets) are
+# user-space DB/crypto operations and don't need root.
+RUN groupadd --system --gid 65532 admin \
+    && useradd --system --uid 65532 --gid admin --shell /bin/bash admin
+
 WORKDIR /app
 
 # Copy CA certificates from build platform stage (no QEMU needed)
@@ -144,6 +149,8 @@ COPY crates/server/migrations /app/migrations
 COPY --chmod=755 docker/admin-entrypoint.sh /app/entrypoint.sh
 
 ENV RUST_LOG=info
+
+USER admin
 
 ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["help"]


### PR DESCRIPTION
## What
Tightens the Docker build surface to close the common classes of Dockerfile mistakes that have caused real breaches (Codecov 2021 — GCP HMAC key pulled from an intermediate Docker layer; Vine 2016 — source/secrets from a publicly pullable image).

Concretely:
- `apps/ui/.dockerignore` — exclude all `.env*` (was only `.env*.local`).
- `docker/Dockerfile.unified` — pin `tonistiigi/xx` to `1.9.0` (was unpinned, resolving to `:latest`).
- `crates/server/Dockerfile`, `crates/worker/Dockerfile`, `docker/Dockerfile.unified` (server + worker stages) — switch runtime base to `gcr.io/distroless/cc-debian12:nonroot` so binaries run as UID 65532.
- `docker/Dockerfile.unified` (admin stage) — create a non-root user and `USER admin` for `sqlx migrate` / `reencrypt-secrets` (both are user-space DB/crypto ops, don't need root).
- Add `--no-install-recommends` to `apt-get install` in builder stages.

## Why
Docker layers are immutable — a `.env` or credential pulled into any builder layer survives in image history even if later `rm`'d. The root `.dockerignore` already excludes `.env*`, but `apps/ui/Dockerfile` builds from `apps/ui/` as context, so only the local dockerignore applies. The previous `.env*.local` pattern would let `.env.production` or `.env` slip through `COPY . .` in `apps/ui/Dockerfile:16` and be baked into a layer where `docker history` recovers it forever. No such file exists today, but `.gitignore` covers `.env*`, so it would never show up in a code review.

The unpinned `tonistiigi/xx` reference is supply-chain risk: it's the cross-compile toolchain injected into the builder, and a compromised `:latest` pushes arbitrary code into the build environment.

Running as root inside distroless is unnecessary — there's no shell or package manager, but any future CVE that escapes the binary gains less with `:nonroot`. Same reasoning for the admin stage.

## How
- One-line `.dockerignore` pattern change + explanatory comment about layer immutability.
- Pin `tonistiigi/xx:1.9.0` (latest stable tag on Docker Hub).
- `:nonroot` tag switch on three runtime stages; distroless provides the user pre-created, no additional setup needed.
- `groupadd`/`useradd` + `USER admin` in admin stage; `WORKDIR /app` default perms (0755 root-owned) allow the non-root user to read+exec the copied binaries and scripts. Entrypoint never writes to `/app`.
- `--no-install-recommends` reduces base-image surface and shaves install size.

## Risk
Low.
- The distroless `:nonroot` image is the same base with a pre-created UID 65532; binaries are copied world-readable/executable by default. Server/worker ports (9000, 9001) don't require `CAP_NET_BIND_SERVICE`.
- Admin non-root: entrypoint only runs `sqlx`, `/app/reencrypt-secrets`, or `/bin/bash` and does not write to `/app`.
- `--no-install-recommends` could theoretically drop a transitive package the build relies on; none of the current installs (`pkg-config`, `libssl-dev`, `curl`, `clang`, `lld`, `gcc`, `libc6-dev`) have meaningful recommends that the build depends on.
- What can break: if a future admin task needs to write under `/app`, it'll need `chown` during COPY or a writable subdir. Not the case today.

Validation: `docker-publish.yml` builds all four targets (server, worker, admin, ui) on every PR — CI is the build proof.

## Security
- **Threat categories reviewed:** no direct `TM-*` category maps to container-image supply-chain, but the change is defense-in-depth for `TM-AUTH-002` (JWT secret in env) and `TM-CRYPTO-001` (KEK in env) — a tightened `.dockerignore` reduces the chance either ever reaches an image layer via an accidentally-committed or locally-dropped `.env*`. Pinning `tonistiigi/xx` reduces supply-chain exposure on the build path.
- **Findings / resolutions:** no new threats introduced; no existing `THREAT[…]` comments touched. All changes are security-positive (reduce attack surface, reduce privilege, reduce supply-chain risk).
- **Threat model update:** not required — this is hardening of existing infrastructure, no new mitigations or categories.

## Checklist
- [x] Tests added or updated — N/A, Dockerfile-only changes; CI docker-publish job validates all four image builds
- [x] Backward compatibility considered — images still expose the same ports, run the same binaries, accept the same env vars; only the effective UID changes
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)