### PR TITLE
feat(evals): collect eval run artifacts

### DIFF
--- a/apps/ui/src/lib/api/types/eval-types.ts
+++ b/apps/ui/src/lib/api/types/eval-types.ts
@@ -60,6 +60,7 @@ export interface EvalCase {
   target?: EvalTarget;
   tags: string[];
   conversation: EvalInputMessage[];
+  artifacts?: ArtifactSpec[];
   scorers: Scorer[];
   max_turns?: number;
   timeout_seconds?: number;
@@ -70,6 +71,11 @@ export interface EvalCase {
 
 export interface EvalInputMessage {
   content: string;
+}
+
+export interface ArtifactSpec {
+  name: string;
+  path: string;
 }
 
 export type Scorer =
@@ -112,6 +118,7 @@ export interface EvalCaseResult {
   input_tokens?: number;
   output_tokens?: number;
   error_message?: string;
+  artifacts?: Record<string, string>;
   created_at: string;
   updated_at: string;
 }
@@ -139,6 +146,7 @@ export interface CreateEvalCaseRequest {
   target?: EvalTarget;
   tags?: string[];
   conversation: EvalInputMessage[];
+  artifacts?: ArtifactSpec[];
   scorers: Scorer[];
   max_turns?: number;
   timeout_seconds?: number;

--- a/crates/core/src/eval.rs
+++ b/crates/core/src/eval.rs
@@ -13,6 +13,7 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use uuid::Uuid;
 
 use crate::typed_id::{
@@ -21,6 +22,16 @@ use crate::typed_id::{
 
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
+
+/// Named session file to collect after an eval case completes.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct ArtifactSpec {
+    /// Export key for this artifact (for example `patch` or `log`).
+    pub name: String,
+    /// Absolute path in the session filesystem.
+    pub path: String,
+}
 
 // ============================================
 // Eval Target
@@ -396,6 +407,9 @@ pub struct EvalCase {
     /// Scorers run after post messages complete (not after conversation).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub post: Option<Vec<EvalInputMessage>>,
+    /// Session files to collect after scoring completes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifacts: Option<Vec<ArtifactSpec>>,
     /// Scoring rules.
     pub scorers: Vec<Scorer>,
     /// Max agent turns (default: 10).
@@ -493,6 +507,9 @@ pub struct EvalCaseResult {
     /// Error message if errored.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error_message: Option<String>,
+    /// Collected session file contents keyed by artifact name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifacts: Option<BTreeMap<String, String>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -724,5 +741,30 @@ mod tests {
         assert!(json.get("target").is_some());
         assert!(json.get("description").is_none());
         assert!(json.get("model_override").is_none());
+    }
+
+    #[test]
+    fn test_eval_case_artifacts_serde_roundtrip() {
+        let json = serde_json::json!({
+            "id": "evalcase_01933b5a000070008000000000000001",
+            "name": "case",
+            "conversation": [{"content": "hello"}],
+            "artifacts": [{"name": "patch", "path": "/workspace/fix.patch"}],
+            "scorers": [{"type": "contains", "text": "done", "weight": 1.0}],
+            "tags": [],
+            "position": 0,
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z"
+        });
+
+        let case: EvalCase = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(
+            case.artifacts,
+            Some(vec![ArtifactSpec {
+                name: "patch".to_string(),
+                path: "/workspace/fix.patch".to_string(),
+            }])
+        );
+        assert_eq!(serde_json::to_value(case).unwrap(), json);
     }
 }

--- a/crates/server/migrations/017_eval_artifacts.sql
+++ b/crates/server/migrations/017_eval_artifacts.sql
@@ -1,0 +1,7 @@
+-- Add artifact specs to eval cases and collected artifact payloads to eval case results.
+
+ALTER TABLE eval_cases
+    ADD COLUMN artifacts JSONB;
+
+ALTER TABLE eval_case_results
+    ADD COLUMN artifacts JSONB;

--- a/crates/server/src/api/evals.rs
+++ b/crates/server/src/api/evals.rs
@@ -1,11 +1,15 @@
 // Eval API routes
 // See specs/evals.md
 
+use axum::body::{Body, Bytes};
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
+use axum::response::IntoResponse;
 use axum::routing::{get, patch, post};
 use axum::{Json, Router};
+use futures::stream;
 use serde::Deserialize;
+use serde_json::{Map, Value};
 
 use everruns_core::eval::*;
 use everruns_core::typed_id::{EvalCaseId, EvalId, EvalResultId, EvalRunId};
@@ -18,6 +22,7 @@ use crate::services::EvalService;
 use crate::services::eval_runner::EvalRunContext;
 use crate::storage::StorageBackend;
 use everruns_core::Caller;
+use std::io;
 use std::sync::Arc;
 
 use utoipa::{IntoParams, ToSchema};
@@ -98,6 +103,9 @@ pub struct CreateEvalCaseRequest {
     /// Verification messages sent after conversation completes and session idles.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub post: Option<Vec<EvalInputMessage>>,
+    /// Session files to capture after scoring completes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifacts: Option<Vec<ArtifactSpec>>,
     pub scorers: Vec<Scorer>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_turns: Option<u32>,
@@ -124,6 +132,9 @@ pub struct UpdateEvalCaseRequest {
     /// Verification messages sent after conversation completes.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub post: Option<Vec<EvalInputMessage>>,
+    /// Session files to capture after scoring completes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifacts: Option<Vec<ArtifactSpec>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scorers: Option<Vec<Scorer>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -217,6 +228,10 @@ pub fn routes(state: AppState) -> Router {
         // Runs
         .route("/v1/evals/{eval_id}/runs", post(create_run).get(list_runs))
         .route("/v1/evals/{eval_id}/runs/{run_id}", get(get_run))
+        .route(
+            "/v1/evals/{eval_id}/runs/{run_id}/artifacts",
+            get(export_run_artifacts),
+        )
         .route("/v1/evals/{eval_id}/runs/{run_id}/cancel", post(cancel_run))
         .route(
             "/v1/evals/{eval_id}/runs/{run_id}/results/{result_id}/scores",
@@ -489,6 +504,46 @@ async fn get_run(
     Ok(Json(run))
 }
 
+async fn export_run_artifacts(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path((eval_id, run_id)): Path<(String, String)>,
+) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+    let eval_id: EvalId = eval_id.parse().map_err(|e| {
+        ErrorResponse::new(format!("Invalid eval ID: {e}")).into_response(StatusCode::BAD_REQUEST)
+    })?;
+    let run_id: EvalRunId = run_id.parse().map_err(|e| {
+        ErrorResponse::new(format!("Invalid run ID: {e}")).into_response(StatusCode::BAD_REQUEST)
+    })?;
+    let caller = Caller::from(&org);
+    let run = state
+        .service
+        .get_run(&caller, &eval_id.to_string(), &run_id.to_string())
+        .await
+        .map_policy_or_internal("export eval run artifacts")?
+        .ok_or_not_found_json("EvalRun")?;
+    let body = Body::from_stream(stream::iter(run.results.into_iter().map(|result| {
+        serde_json::to_vec(&run_artifact_export_value(&result))
+            .map(|mut line| {
+                line.push(b'\n');
+                Bytes::from(line)
+            })
+            .map_err(|error| {
+                tracing::error!("Failed to serialize eval artifact export: {}", error);
+                io::Error::other(error)
+            })
+    })));
+
+    Ok((
+        StatusCode::OK,
+        [(
+            axum::http::header::CONTENT_TYPE,
+            "application/x-ndjson".to_string(),
+        )],
+        body,
+    ))
+}
+
 async fn cancel_run(
     org: ResolvedOrg,
     State(state): State<AppState>,
@@ -560,4 +615,110 @@ async fn bulk_update_run_scores(
         .await
         .map_policy_or_internal("bulk update eval result scores")?;
     Ok(Json(ListResponse::new(results)))
+}
+
+fn run_artifact_export_value(result: &EvalCaseResult) -> Value {
+    let mut export = Map::new();
+    export.insert(
+        "instance_id".to_string(),
+        Value::String(
+            result
+                .case_name
+                .clone()
+                .unwrap_or_else(|| result.eval_case_id.to_string()),
+        ),
+    );
+
+    if let Some(artifacts) = &result.artifacts {
+        for (name, content) in artifacts {
+            let key = if name == "patch" {
+                "model_patch"
+            } else {
+                name.as_str()
+            };
+            if export.contains_key(key) {
+                tracing::warn!(
+                    eval_case_id = %result.eval_case_id,
+                    artifact_name = %name,
+                    export_key = %key,
+                    "Skipping colliding eval artifact export field"
+                );
+                continue;
+            }
+            export.insert(key.to_string(), Value::String(content.clone()));
+        }
+    }
+
+    Value::Object(export)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use uuid::Uuid;
+
+    #[test]
+    fn run_artifact_export_maps_patch_to_model_patch() {
+        let result = EvalCaseResult {
+            public_id: everruns_core::typed_id::EvalResultId::from_uuid(Uuid::now_v7()),
+            internal_id: Uuid::nil(),
+            eval_case_id: EvalCaseId::from_uuid(Uuid::now_v7()),
+            case_name: Some("astropy__astropy-12907".to_string()),
+            session_id: None,
+            target: None,
+            target_snapshot: None,
+            status: CaseResultStatus::Passed,
+            scores: None,
+            metadata: None,
+            turns: None,
+            latency_ms: None,
+            input_tokens: None,
+            output_tokens: None,
+            error_message: None,
+            artifacts: Some(BTreeMap::from([
+                ("patch".to_string(), "diff --git a/file b/file".to_string()),
+                ("log".to_string(), "done".to_string()),
+            ])),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+
+        let value = run_artifact_export_value(&result);
+        assert_eq!(value["instance_id"], "astropy__astropy-12907");
+        assert_eq!(value["model_patch"], "diff --git a/file b/file");
+        assert_eq!(value["log"], "done");
+        assert!(value.get("patch").is_none());
+    }
+
+    #[test]
+    fn run_artifact_export_preserves_existing_model_patch() {
+        let result = EvalCaseResult {
+            public_id: everruns_core::typed_id::EvalResultId::from_uuid(Uuid::now_v7()),
+            internal_id: Uuid::nil(),
+            eval_case_id: EvalCaseId::from_uuid(Uuid::now_v7()),
+            case_name: Some("collision-case".to_string()),
+            session_id: None,
+            target: None,
+            target_snapshot: None,
+            status: CaseResultStatus::Passed,
+            scores: None,
+            metadata: None,
+            turns: None,
+            latency_ms: None,
+            input_tokens: None,
+            output_tokens: None,
+            error_message: None,
+            artifacts: Some(BTreeMap::from([
+                ("model_patch".to_string(), "kept".to_string()),
+                ("patch".to_string(), "ignored".to_string()),
+            ])),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+
+        let value = run_artifact_export_value(&result);
+        assert_eq!(value["model_patch"], "kept");
+        assert!(value.get("patch").is_none());
+    }
 }

--- a/crates/server/src/services/eval.rs
+++ b/crates/server/src/services/eval.rs
@@ -19,7 +19,7 @@ use everruns_core::eval::*;
 use everruns_core::typed_id::{EvalCaseId, EvalId, EvalResultId, EvalRunId, SessionId};
 use everruns_core::{Caller, Permission, Policy, Rule};
 use everruns_macros::policy;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -199,6 +199,11 @@ impl EvalService {
         let target_json = req.target.as_ref().map(serde_json::to_value).transpose()?;
 
         let post_json = req.post.as_ref().map(serde_json::to_value).transpose()?;
+        let artifacts_json = req
+            .artifacts
+            .as_ref()
+            .map(serde_json::to_value)
+            .transpose()?;
 
         let input = CreateEvalCaseRow {
             public_id: case_public_id.to_string(),
@@ -208,6 +213,7 @@ impl EvalService {
             tags: req.tags.unwrap_or_default(),
             conversation: serde_json::to_value(&req.conversation)?,
             post: post_json,
+            artifacts: artifacts_json,
             scorers: serde_json::to_value(&req.scorers)?,
             max_turns: req.max_turns.map(|v| v as i32),
             timeout_seconds: req.timeout_seconds.map(|v| v as i32),
@@ -275,6 +281,7 @@ impl EvalService {
         let target_json = req.target.as_ref().map(serde_json::to_value).transpose()?;
 
         let post_json = req.post.map(serde_json::to_value).transpose()?;
+        let artifacts_json = req.artifacts.map(serde_json::to_value).transpose()?;
 
         let input = UpdateEvalCaseRow {
             name: req.name,
@@ -283,6 +290,7 @@ impl EvalService {
             tags: req.tags,
             conversation: req.conversation.map(serde_json::to_value).transpose()?,
             post: post_json,
+            artifacts: artifacts_json,
             scorers: req.scorers.map(serde_json::to_value).transpose()?,
             max_turns: req.max_turns.map(|v| v as i32),
             timeout_seconds: req.timeout_seconds.map(|v| v as i32),
@@ -390,6 +398,7 @@ impl EvalService {
                 eval_case_id: case.id,
                 target: Some(resolved_json.clone()),
                 target_snapshot: Some(resolved_json),
+                artifacts: None,
             };
             self.db.create_eval_case_result(result_input).await?;
         }
@@ -756,6 +765,7 @@ fn case_row_to_case(row: crate::storage::models::EvalCaseRow) -> EvalCase {
         tags: row.tags,
         conversation: serde_json::from_value(row.conversation).unwrap_or_default(),
         post: row.post.and_then(|v| serde_json::from_value(v).ok()),
+        artifacts: row.artifacts.and_then(|v| serde_json::from_value(v).ok()),
         scorers: serde_json::from_value(row.scorers).unwrap_or_default(),
         max_turns: row.max_turns.map(|v| v as u32),
         timeout_seconds: row.timeout_seconds.map(|v| v as u32),
@@ -807,6 +817,10 @@ fn result_row_to_result(
         .target_snapshot
         .as_ref()
         .and_then(|v| serde_json::from_value(v.clone()).ok());
+    let artifacts: Option<BTreeMap<String, String>> = row
+        .artifacts
+        .as_ref()
+        .and_then(|v| serde_json::from_value(v.clone()).ok());
 
     EvalCaseResult {
         public_id: row
@@ -827,6 +841,7 @@ fn result_row_to_result(
         input_tokens: row.input_tokens.map(|v| v as u64),
         output_tokens: row.output_tokens.map(|v| v as u64),
         error_message: row.error_message,
+        artifacts,
         created_at: row.created_at,
         updated_at: row.updated_at,
     }

--- a/crates/server/src/services/eval_runner.rs
+++ b/crates/server/src/services/eval_runner.rs
@@ -17,6 +17,7 @@ use anyhow::Result;
 use everruns_core::eval::*;
 use everruns_core::events::{TURN_COMPLETED, TURN_FAILED};
 use everruns_core::typed_id::SessionId;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::Semaphore;
@@ -231,6 +232,8 @@ async fn execute_case_inner(
     let conversation: Vec<EvalInputMessage> = serde_json::from_value(case_row.conversation)?;
     let post: Option<Vec<EvalInputMessage>> =
         case_row.post.map(serde_json::from_value).transpose()?;
+    let artifact_specs: Option<Vec<ArtifactSpec>> =
+        case_row.artifacts.map(serde_json::from_value).transpose()?;
     let scorers: Vec<Scorer> = serde_json::from_value(case_row.scorers)?;
     let timeout_secs = case_row.timeout_seconds.map(|v| v as u64).unwrap_or(120);
     let case_deadline = Instant::now()
@@ -399,6 +402,7 @@ async fn execute_case_inner(
     } else {
         0.0
     };
+    let artifacts = collect_case_artifacts(&ctx.db, session_uuid, artifact_specs.as_deref()).await;
 
     let status = if all_passed { "passed" } else { "failed" };
 
@@ -412,6 +416,7 @@ async fn execute_case_inner(
                 latency_ms: None, // Set by caller
                 input_tokens: Some(input_tokens as i64),
                 output_tokens: Some(output_tokens as i64),
+                artifacts: artifacts.map(serde_json::to_value).transpose()?,
                 ..Default::default()
             },
         )
@@ -425,6 +430,50 @@ async fn execute_case_inner(
         input_tokens,
         output_tokens,
     })
+}
+
+async fn collect_case_artifacts(
+    db: &StorageBackend,
+    session_uuid: Uuid,
+    specs: Option<&[ArtifactSpec]>,
+) -> Option<BTreeMap<String, String>> {
+    let mut artifacts = BTreeMap::new();
+
+    for spec in specs.unwrap_or(&[]) {
+        match db.get_session_file(session_uuid, &spec.path).await {
+            Ok(Some(file)) if !file.is_directory => {
+                let content = file
+                    .content
+                    .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+                    .unwrap_or_default();
+                artifacts.insert(spec.name.clone(), content);
+            }
+            Ok(Some(_)) => {
+                tracing::warn!(
+                    session_id = %session_uuid,
+                    path = %spec.path,
+                    "Skipping directory artifact path"
+                );
+            }
+            Ok(None) => {
+                tracing::warn!(
+                    session_id = %session_uuid,
+                    path = %spec.path,
+                    "Configured eval artifact not found"
+                );
+            }
+            Err(error) => {
+                tracing::warn!(
+                    session_id = %session_uuid,
+                    path = %spec.path,
+                    error = %error,
+                    "Failed to read eval artifact"
+                );
+            }
+        }
+    }
+
+    (!artifacts.is_empty()).then_some(artifacts)
 }
 
 struct SessionCtx {
@@ -724,5 +773,52 @@ async fn run_single_scorer(
                 },
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{CreateSessionFileRow, StorageBackend};
+
+    #[tokio::test]
+    async fn collect_case_artifacts_reads_named_files() {
+        let db = StorageBackend::in_memory();
+        let session_uuid = Uuid::now_v7();
+
+        db.create_session_file(CreateSessionFileRow {
+            session_id: SessionId::from_uuid(session_uuid),
+            path: "/workspace/fix.patch".to_string(),
+            content: Some(b"diff --git a/file b/file\n".to_vec()),
+            is_directory: false,
+            is_readonly: false,
+        })
+        .await
+        .unwrap();
+
+        let artifacts = collect_case_artifacts(
+            &db,
+            session_uuid,
+            Some(&[
+                ArtifactSpec {
+                    name: "patch".to_string(),
+                    path: "/workspace/fix.patch".to_string(),
+                },
+                ArtifactSpec {
+                    name: "missing".to_string(),
+                    path: "/workspace/missing.txt".to_string(),
+                },
+            ]),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            artifacts,
+            BTreeMap::from([(
+                "patch".to_string(),
+                "diff --git a/file b/file\n".to_string()
+            )])
+        );
     }
 }

--- a/crates/server/src/storage/memory/evals.rs
+++ b/crates/server/src/storage/memory/evals.rs
@@ -141,6 +141,7 @@ impl InMemoryDatabase {
             tags: input.tags,
             conversation: input.conversation,
             post: input.post,
+            artifacts: input.artifacts,
             scorers: input.scorers,
             max_turns: input.max_turns,
             timeout_seconds: input.timeout_seconds,
@@ -210,6 +211,9 @@ impl InMemoryDatabase {
         }
         if let Some(post) = input.post {
             case.post = Some(post);
+        }
+        if let Some(artifacts) = input.artifacts {
+            case.artifacts = Some(artifacts);
         }
         if let Some(scorers) = input.scorers {
             case.scorers = scorers;
@@ -351,6 +355,7 @@ impl InMemoryDatabase {
             input_tokens: None,
             output_tokens: None,
             error_message: None,
+            artifacts: input.artifacts,
             created_at: now,
             updated_at: now,
         };
@@ -413,6 +418,9 @@ impl InMemoryDatabase {
         }
         if let Some(error_message) = input.error_message {
             result.error_message = Some(error_message);
+        }
+        if let Some(artifacts) = input.artifacts {
+            result.artifacts = Some(artifacts);
         }
         result.updated_at = Self::now();
         Ok(Some(result.clone()))

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -1628,6 +1628,7 @@ pub struct EvalCaseRow {
     pub tags: Vec<String>,
     pub conversation: serde_json::Value,
     pub post: Option<serde_json::Value>,
+    pub artifacts: Option<serde_json::Value>,
     pub scorers: serde_json::Value,
     pub max_turns: Option<i32>,
     pub timeout_seconds: Option<i32>,
@@ -1646,6 +1647,7 @@ pub struct CreateEvalCaseRow {
     pub tags: Vec<String>,
     pub conversation: serde_json::Value,
     pub post: Option<serde_json::Value>,
+    pub artifacts: Option<serde_json::Value>,
     pub scorers: serde_json::Value,
     pub max_turns: Option<i32>,
     pub timeout_seconds: Option<i32>,
@@ -1661,6 +1663,7 @@ pub struct UpdateEvalCaseRow {
     pub tags: Option<Vec<String>>,
     pub conversation: Option<serde_json::Value>,
     pub post: Option<serde_json::Value>,
+    pub artifacts: Option<serde_json::Value>,
     pub scorers: Option<serde_json::Value>,
     pub max_turns: Option<i32>,
     pub timeout_seconds: Option<i32>,
@@ -1715,6 +1718,7 @@ pub struct EvalCaseResultRow {
     pub input_tokens: Option<i64>,
     pub output_tokens: Option<i64>,
     pub error_message: Option<String>,
+    pub artifacts: Option<serde_json::Value>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -1727,6 +1731,7 @@ pub struct CreateEvalCaseResultRow {
     pub eval_case_id: Uuid,
     pub target: Option<serde_json::Value>,
     pub target_snapshot: Option<serde_json::Value>,
+    pub artifacts: Option<serde_json::Value>,
 }
 
 /// Input for updating an eval case result
@@ -1743,6 +1748,7 @@ pub struct UpdateEvalCaseResultRow {
     pub input_tokens: Option<i64>,
     pub output_tokens: Option<i64>,
     pub error_message: Option<String>,
+    pub artifacts: Option<serde_json::Value>,
 }
 
 // ============================================================================

--- a/crates/server/src/storage/repositories/evals.rs
+++ b/crates/server/src/storage/repositories/evals.rs
@@ -141,9 +141,9 @@ impl Database {
     ) -> Result<EvalCaseRow> {
         let row = sqlx::query_as::<_, EvalCaseRow>(
             r#"
-            INSERT INTO eval_cases (eval_id, public_id, name, description, target, tags, conversation, post, scorers, max_turns, timeout_seconds, position)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
-            RETURNING id, eval_id, public_id, name, description, target, tags, conversation, post, scorers,
+            INSERT INTO eval_cases (eval_id, public_id, name, description, target, tags, conversation, post, artifacts, scorers, max_turns, timeout_seconds, position)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+            RETURNING id, eval_id, public_id, name, description, target, tags, conversation, post, artifacts, scorers,
                       max_turns, timeout_seconds, position, created_at, updated_at
             "#,
         )
@@ -155,6 +155,7 @@ impl Database {
         .bind(&input.tags)
         .bind(&input.conversation)
         .bind(&input.post)
+        .bind(&input.artifacts)
         .bind(&input.scorers)
         .bind(input.max_turns)
         .bind(input.timeout_seconds)
@@ -167,7 +168,7 @@ impl Database {
     pub async fn list_eval_cases(&self, eval_id: Uuid) -> Result<Vec<EvalCaseRow>> {
         let rows = sqlx::query_as::<_, EvalCaseRow>(
             r#"
-            SELECT id, eval_id, public_id, name, description, target, tags, conversation, post, scorers,
+            SELECT id, eval_id, public_id, name, description, target, tags, conversation, post, artifacts, scorers,
                    max_turns, timeout_seconds, position, created_at, updated_at
             FROM eval_cases
             WHERE eval_id = $1
@@ -183,7 +184,7 @@ impl Database {
     pub async fn get_eval_case(&self, id: Uuid) -> Result<Option<EvalCaseRow>> {
         let row = sqlx::query_as::<_, EvalCaseRow>(
             r#"
-            SELECT id, eval_id, public_id, name, description, target, tags, conversation, post, scorers,
+            SELECT id, eval_id, public_id, name, description, target, tags, conversation, post, artifacts, scorers,
                    max_turns, timeout_seconds, position, created_at, updated_at
             FROM eval_cases
             WHERE id = $1
@@ -202,7 +203,7 @@ impl Database {
     ) -> Result<Option<EvalCaseRow>> {
         let row = sqlx::query_as::<_, EvalCaseRow>(
             r#"
-            SELECT id, eval_id, public_id, name, description, target, tags, conversation, post, scorers,
+            SELECT id, eval_id, public_id, name, description, target, tags, conversation, post, artifacts, scorers,
                    max_turns, timeout_seconds, position, created_at, updated_at
             FROM eval_cases
             WHERE eval_id = $1 AND public_id = $2
@@ -230,13 +231,14 @@ impl Database {
                 tags = COALESCE($5, tags),
                 conversation = COALESCE($6, conversation),
                 post = COALESCE($7, post),
-                scorers = COALESCE($8, scorers),
-                max_turns = COALESCE($9, max_turns),
-                timeout_seconds = COALESCE($10, timeout_seconds),
-                position = COALESCE($11, position),
+                artifacts = COALESCE($8, artifacts),
+                scorers = COALESCE($9, scorers),
+                max_turns = COALESCE($10, max_turns),
+                timeout_seconds = COALESCE($11, timeout_seconds),
+                position = COALESCE($12, position),
                 updated_at = NOW()
             WHERE id = $1
-            RETURNING id, eval_id, public_id, name, description, target, tags, conversation, post, scorers,
+            RETURNING id, eval_id, public_id, name, description, target, tags, conversation, post, artifacts, scorers,
                       max_turns, timeout_seconds, position, created_at, updated_at
             "#,
         )
@@ -247,6 +249,7 @@ impl Database {
         .bind(&input.tags)
         .bind(&input.conversation)
         .bind(&input.post)
+        .bind(&input.artifacts)
         .bind(&input.scorers)
         .bind(input.max_turns)
         .bind(input.timeout_seconds)
@@ -401,10 +404,10 @@ impl Database {
     ) -> Result<EvalCaseResultRow> {
         let row = sqlx::query_as::<_, EvalCaseResultRow>(
             r#"
-            INSERT INTO eval_case_results (eval_run_id, eval_case_id, public_id, target, target_snapshot)
-            VALUES ($1, $2, $3, $4, $5)
+            INSERT INTO eval_case_results (eval_run_id, eval_case_id, public_id, target, target_snapshot, artifacts)
+            VALUES ($1, $2, $3, $4, $5, $6)
             RETURNING id, eval_run_id, eval_case_id, public_id, session_id, target, target_snapshot,
-                      status, scores, metadata, turns, latency_ms, input_tokens, output_tokens, error_message,
+                      status, scores, metadata, turns, latency_ms, input_tokens, output_tokens, error_message, artifacts,
                       created_at, updated_at
             "#,
         )
@@ -413,6 +416,7 @@ impl Database {
         .bind(&input.public_id)
         .bind(&input.target)
         .bind(&input.target_snapshot)
+        .bind(&input.artifacts)
         .fetch_one(&self.pool)
         .await?;
         Ok(row)
@@ -427,7 +431,7 @@ impl Database {
             SELECT ecr.id, ecr.eval_run_id, ecr.eval_case_id, ecr.public_id, ecr.session_id,
                    ecr.target, ecr.target_snapshot,
                    ecr.status, ecr.scores, ecr.metadata, ecr.turns, ecr.latency_ms,
-                   ecr.input_tokens, ecr.output_tokens, ecr.error_message,
+                   ecr.input_tokens, ecr.output_tokens, ecr.error_message, ecr.artifacts,
                    ecr.created_at, ecr.updated_at
             FROM eval_case_results ecr
             WHERE ecr.eval_run_id = $1
@@ -460,10 +464,11 @@ impl Database {
                 input_tokens = COALESCE($10, input_tokens),
                 output_tokens = COALESCE($11, output_tokens),
                 error_message = COALESCE($12, error_message),
+                artifacts = COALESCE($13, artifacts),
                 updated_at = NOW()
             WHERE id = $1
             RETURNING id, eval_run_id, eval_case_id, public_id, session_id, target, target_snapshot,
-                      status, scores, metadata, turns, latency_ms, input_tokens, output_tokens, error_message,
+                      status, scores, metadata, turns, latency_ms, input_tokens, output_tokens, error_message, artifacts,
                       created_at, updated_at
             "#,
         )
@@ -479,6 +484,7 @@ impl Database {
         .bind(input.input_tokens)
         .bind(input.output_tokens)
         .bind(&input.error_message)
+        .bind(&input.artifacts)
         .fetch_optional(&self.pool)
         .await?;
         Ok(row)

--- a/crates/server/tests/evals_integration_test.rs
+++ b/crates/server/tests/evals_integration_test.rs
@@ -357,6 +357,7 @@ async fn seed_completed_run(server: &TestServer) -> SeededRun {
             eval_case_id: case_one_row.id,
             target: Some(target.clone()),
             target_snapshot: Some(target.clone()),
+            artifacts: None,
         })
         .await
         .expect("create result one");
@@ -371,6 +372,7 @@ async fn seed_completed_run(server: &TestServer) -> SeededRun {
                 "type": "session",
                 "harness_id": TEST_HARNESS_ID
             })),
+            artifacts: None,
         })
         .await
         .expect("create result two");

--- a/specs/evals.md
+++ b/specs/evals.md
@@ -45,12 +45,13 @@ Top-level entity. Contains cases that define expected behaviors.
 
 ### EvalCase
 
-A single test within an eval. Defines input messages, scoring criteria, and execution bounds.
+A single test within an eval. Defines input messages, scoring criteria, execution bounds, and optional artifact collection.
 
 - Each case has a `description` explaining what behavior it measures (self-documenting)
 - Optional `target` (EvalTarget) — per-case override
 - `conversation`: one or more input messages sent sequentially (multi-turn support)
 - `post`: optional verification messages sent after conversation completes and session idles, before scoring (e.g. running test scripts for SWE-bench)
+- `artifacts`: optional named session-file reads captured after post messages and scoring complete
 - `scorers`: list of scoring rules applied after execution completes
 - `max_turns`: optional bound on agent turns (default: 10)
 - `timeout_seconds`: per-case timeout (default: 120)
@@ -76,6 +77,7 @@ The outcome of a single case within a run.
 - `target_snapshot`: identical frozen copy for immutability (both set at run creation, both equal initially; `target_snapshot` must never be overwritten)
 - Contains per-scorer scores with pass/fail, value (0.0–1.0), and reason
 - Optional `metadata` records external scorer provenance for deferred write-back (scorer name, version, timestamps, raw output, reviewer notes)
+- Stores collected artifact contents keyed by the case's artifact names
 - Captures efficiency metrics: turn count, latency, token usage
 
 ### Scorer
@@ -134,6 +136,7 @@ See `crates/core/src/eval.rs` for full field definitions.
 | `tags` | Vec\<String\> | Tags for subset runs |
 | `conversation` | Vec\<InputMessage\> | Input messages (sequential) |
 | `post` | Option\<Vec\<InputMessage\>\> | Post-conversation verification messages (sent after session idles, before scoring) |
+| `artifacts` | Option\<Vec\<ArtifactSpec\>\> | Named session files to collect after the case finishes |
 | `scorers` | Vec\<Scorer\> | Scoring rules (JSONB) |
 | `max_turns` | Option\<u32\> | Turn limit (default: 10) |
 | `timeout_seconds` | Option\<u32\> | Timeout (default: 120) |
@@ -185,8 +188,9 @@ See `crates/core/src/eval.rs` for full field definitions.
 | `target` | EvalTarget | Resolved target at execution time (JSONB, always concrete) |
 | `target_snapshot` | EvalTarget | Frozen copy of resolved target (JSONB, immutable) |
 | `status` | CaseResultStatus | `pending`, `running`, `passed`, `failed`, `errored`, `timeout` |
-| `scores` | Option\<Vec\<Score\>\> | Per-scorer results (JSONB, scorer order preserved) |
+| `scores` | Option\<JSON\> | Per-scorer results (JSONB) |
 | `metadata` | Option\<JSON\> | External scorer provenance and audit details (JSONB) |
+| `artifacts` | Option\<Map\<String, String\>\> | Collected session file contents (JSONB) |
 | `turns` | Option\<u32\> | Turn count |
 | `latency_ms` | Option\<u64\> | Execution time |
 | `tokens` | Option\<TokenUsage\> | Token usage |
@@ -242,6 +246,7 @@ All endpoints under `/v1/evals`. See `crates/server/src/api/evals.rs`.
 | `POST` | `/v1/evals/{eval_id}/runs` | Trigger run (body: optional `model_override`, `filter_tags`) |
 | `GET` | `/v1/evals/{eval_id}/runs` | List runs with summaries |
 | `GET` | `/v1/evals/{eval_id}/runs/{run_id}` | Get run with case results |
+| `GET` | `/v1/evals/{eval_id}/runs/{run_id}/artifacts` | Export run artifacts as NDJSON (`instance_id` plus artifact fields, with `patch` exported as `model_patch`) |
 | `POST` | `/v1/evals/{eval_id}/runs/{run_id}/cancel` | Cancel running eval |
 | `PATCH` | `/v1/evals/{eval_id}/runs/{run_id}/results/{result_id}/scores` | Write external scores back to a completed result |
 | `PATCH` | `/v1/evals/{eval_id}/runs/{run_id}/scores` | Bulk write external scores back to a completed run |
@@ -269,7 +274,8 @@ POST /v1/evals/{eval_id}/runs
   │    5. Fetch session events (tool.completed, turn.completed)
   │    6. Fetch final assistant messages
   │    7. Run scorers → produce Score per scorer
-  │    8. Update CaseResult (status, scores, turns, latency, tokens)
+  │    8. Collect configured session files into CaseResult.artifacts
+  │    9. Update CaseResult (status, scores, artifacts, turns, latency, tokens)
   │
   ├─ Aggregate results → RunSummary
   ├─ Update EvalRun (status: completed, summary)


### PR DESCRIPTION
## What
- Add artifact specs to eval cases and persist collected artifacts on eval case results.
- Add an NDJSON export endpoint for eval run artifacts, including SWE-bench-compatible `model_patch` output.

## Why
EVE-327 needs eval runs to expose session filesystem artifacts so external scorers can consume agent-produced files after the run completes.

## How
- Add `ArtifactSpec` plus `artifacts` fields to the eval domain, storage models, repositories, and migration set.
- Collect configured session files after scoring in the eval runner and store them on `EvalCaseResult`.
- Export run artifacts from `/v1/evals/{eval_id}/runs/{run_id}/artifacts` as NDJSON, mapping `patch` to `model_patch`.
- Keep UI eval types and the eval spec aligned with the server contract.
- Validation: `just pre-push`; `cargo test -p everruns-core test_eval_case_artifacts_serde_roundtrip -- --nocapture`; `cargo test -p everruns-server --lib run_artifact_export_maps_patch_to_model_patch`; `cargo test -p everruns-server collect_case_artifacts_reads_named_files`; live smoke via `PORT_PREFIX=509 just start-all --no-watch --no-ui` plus create eval/case/run and verify artifact export endpoint output.

## Risk
- Medium
- Touches eval persistence, result serialization, and a new export endpoint.

## Security
- Threat categories reviewed: TM-API, TM-FS, TM-DOS
- Findings and resolutions:
- Export stays behind existing eval run authorization and org scoping.
- Artifact collection reads only explicitly configured session-file paths from the case session filesystem.
- No new unbounded query paths were added; export iterates the runs existing case results.
- No threat-model updates required.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Fixes EVE-327
