### PR TITLE
fix(server): accept stringly-typed flags on MCP catalog list commands

### DIFF
--- a/crates/server/src/domains/agent_identities/commands.rs
+++ b/crates/server/src/domains/agent_identities/commands.rs
@@ -78,7 +78,7 @@ inventory::submit! { CommandDescriptor::of::<CreateAgentIdentity>() }
 #[derive(Debug, Deserialize)]
 pub struct ListAgentIdentities {
     pub search: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_bool_lenient")]
     pub include_archived: bool,
 }
 

--- a/crates/server/src/domains/agents/commands.rs
+++ b/crates/server/src/domains/agents/commands.rs
@@ -229,9 +229,11 @@ inventory::submit! { CommandDescriptor::of::<CreateAgent>() }
 #[derive(Debug, Deserialize)]
 pub struct ListAgents {
     pub search: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_bool_lenient")]
     pub include_archived: bool,
+    #[serde(default, deserialize_with = "deserialize_opt_u32_lenient")]
     pub offset: Option<u32>,
+    #[serde(default, deserialize_with = "deserialize_opt_u32_lenient")]
     pub limit: Option<u32>,
 }
 

--- a/crates/server/src/domains/apps/commands.rs
+++ b/crates/server/src/domains/apps/commands.rs
@@ -162,7 +162,7 @@ inventory::submit! { CommandDescriptor::of::<CreateApp>() }
 #[derive(Debug, Deserialize)]
 pub struct ListApps {
     pub search: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_bool_lenient")]
     pub include_archived: bool,
 }
 

--- a/crates/server/src/domains/capabilities/commands.rs
+++ b/crates/server/src/domains/capabilities/commands.rs
@@ -22,7 +22,9 @@ const MAX_LIMIT: u32 = 200;
 #[derive(Debug, Deserialize)]
 pub struct ListCapabilities {
     pub search: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_opt_u32_lenient")]
     pub offset: Option<u32>,
+    #[serde(default, deserialize_with = "deserialize_opt_u32_lenient")]
     pub limit: Option<u32>,
 }
 
@@ -106,3 +108,29 @@ impl Command for GetCapability {
 }
 
 inventory::submit! { CommandDescriptor::of::<GetCapability>() }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // Regression for EVE-324: bashkit's flag parser emits string values when
+    // the tool schema declares no per-property types (as inventory commands
+    // currently do). Before the lenient deserializer, `--limit 5` deserialized
+    // as `{"limit": "5"}` and failed with "invalid type: string".
+    #[test]
+    fn list_capabilities_accepts_string_numeric_limit() {
+        let cmd: ListCapabilities =
+            serde_json::from_value(json!({ "limit": "5", "offset": "10" })).unwrap();
+        assert_eq!(cmd.limit, Some(5));
+        assert_eq!(cmd.offset, Some(10));
+    }
+
+    #[test]
+    fn list_capabilities_accepts_native_numeric_limit() {
+        let cmd: ListCapabilities =
+            serde_json::from_value(json!({ "limit": 5, "offset": 10 })).unwrap();
+        assert_eq!(cmd.limit, Some(5));
+        assert_eq!(cmd.offset, Some(10));
+    }
+}

--- a/crates/server/src/domains/common.rs
+++ b/crates/server/src/domains/common.rs
@@ -297,3 +297,183 @@ pub fn pagination(offset: Option<u32>, limit: Option<u32>) -> crate::api::common
     let limit = limit.unwrap_or(20).min(100);
     crate::api::common::Pagination::new(offset, limit)
 }
+
+// ============================================================================
+// Lenient deserializers — accept both typed JSON values and stringly-typed
+// values from the MCP CLI bridge (bashkit catalog).
+// ============================================================================
+//
+// Context (EVE-324): inventory-registered commands expose an open JSON schema
+// (`additionalProperties: true`) to bashkit because the request types own
+// their own serde shape. Without per-flag type hints, bashkit's flag parser
+// defaults every value to a string — so `list_capabilities --limit 5` arrives
+// at dispatch as `{"limit": "5"}`. Serde then rejects that string while
+// trying to populate `Option<u32>`, the dispatcher wraps the error as
+// `CommandError::BadRequest`, and the bashkit adapter sanitizes it into the
+// opaque "<cmd>: callback failed" the caller sees.
+//
+// The helpers below sit between the serde field and the raw JSON: they accept
+// the native typed shape (for programmatic callers) and also coerce the
+// string forms bashkit produces. They are intentionally scoped to the input
+// fields that are known to arrive from the flag parser — primarily pagination
+// (`offset`, `limit`) and boolean toggles (`include_archived`).
+/// Accept `Option<u32>` as `null`, an integer, or a numeric string.
+pub fn deserialize_opt_u32_lenient<'de, D>(d: D) -> Result<Option<u32>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Either {
+        Num(u32),
+        Str(String),
+    }
+
+    match Option::<Either>::deserialize(d)? {
+        None => Ok(None),
+        Some(Either::Num(n)) => Ok(Some(n)),
+        Some(Either::Str(s)) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                return Ok(None);
+            }
+            trimmed
+                .parse::<u32>()
+                .map(Some)
+                .map_err(serde::de::Error::custom)
+        }
+    }
+}
+
+/// Accept `bool`, `"true"`/`"false"`/`"1"`/`"0"`/`"yes"`/`"no"` (case-insensitive),
+/// or integer `0`/`1`. Missing keys fall through to serde's default handling.
+pub fn deserialize_bool_lenient<'de, D>(d: D) -> Result<bool, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Either {
+        Bool(bool),
+        Num(i64),
+        Str(String),
+    }
+
+    match Either::deserialize(d)? {
+        Either::Bool(b) => Ok(b),
+        Either::Num(0) => Ok(false),
+        Either::Num(1) => Ok(true),
+        Either::Num(n) => Err(serde::de::Error::custom(format!(
+            "cannot coerce integer {n} to bool (expected 0 or 1)"
+        ))),
+        Either::Str(s) => match s.trim().to_ascii_lowercase().as_str() {
+            "true" | "1" | "yes" | "y" | "on" => Ok(true),
+            "false" | "0" | "no" | "n" | "off" => Ok(false),
+            other => Err(serde::de::Error::custom(format!(
+                "cannot coerce string {other:?} to bool"
+            ))),
+        },
+    }
+}
+
+#[cfg(test)]
+mod lenient_tests {
+    use super::*;
+    use serde::Deserialize;
+    use serde_json::json;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct PageInput {
+        #[serde(default, deserialize_with = "deserialize_opt_u32_lenient")]
+        offset: Option<u32>,
+        #[serde(default, deserialize_with = "deserialize_opt_u32_lenient")]
+        limit: Option<u32>,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct FlagInput {
+        #[serde(default, deserialize_with = "deserialize_bool_lenient")]
+        include_archived: bool,
+    }
+
+    #[test]
+    fn opt_u32_lenient_accepts_integer() {
+        let v: PageInput = serde_json::from_value(json!({"offset": 0, "limit": 5})).unwrap();
+        assert_eq!(
+            v,
+            PageInput {
+                offset: Some(0),
+                limit: Some(5)
+            }
+        );
+    }
+
+    #[test]
+    fn opt_u32_lenient_accepts_numeric_string() {
+        let v: PageInput = serde_json::from_value(json!({"offset": "10", "limit": "20"})).unwrap();
+        assert_eq!(
+            v,
+            PageInput {
+                offset: Some(10),
+                limit: Some(20)
+            }
+        );
+    }
+
+    #[test]
+    fn opt_u32_lenient_accepts_missing_and_null() {
+        let missing: PageInput = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(
+            missing,
+            PageInput {
+                offset: None,
+                limit: None
+            }
+        );
+        let nulled: PageInput =
+            serde_json::from_value(json!({"offset": null, "limit": null})).unwrap();
+        assert_eq!(
+            nulled,
+            PageInput {
+                offset: None,
+                limit: None
+            }
+        );
+    }
+
+    #[test]
+    fn opt_u32_lenient_rejects_non_numeric_string() {
+        let err = serde_json::from_value::<PageInput>(json!({"limit": "abc"})).unwrap_err();
+        assert!(err.to_string().contains("invalid digit"), "got: {err}");
+    }
+
+    #[test]
+    fn bool_lenient_accepts_variants() {
+        for (input, expected) in [
+            (json!(true), true),
+            (json!(false), false),
+            (json!("true"), true),
+            (json!("FALSE"), false),
+            (json!("1"), true),
+            (json!("0"), false),
+            (json!("yes"), true),
+            (json!("no"), false),
+            (json!(1), true),
+            (json!(0), false),
+        ] {
+            let v: FlagInput = serde_json::from_value(json!({"include_archived": input})).unwrap();
+            assert_eq!(v.include_archived, expected, "input: {input}");
+        }
+    }
+
+    #[test]
+    fn bool_lenient_rejects_garbage() {
+        let err =
+            serde_json::from_value::<FlagInput>(json!({"include_archived": "maybe"})).unwrap_err();
+        assert!(err.to_string().contains("coerce string"), "got: {err}");
+    }
+}

--- a/crates/server/src/domains/harnesses/commands.rs
+++ b/crates/server/src/domains/harnesses/commands.rs
@@ -197,7 +197,7 @@ inventory::submit! { CommandDescriptor::of::<CreateHarness>() }
 #[derive(Debug, Deserialize)]
 pub struct ListHarnesses {
     pub search: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_bool_lenient")]
     pub include_archived: bool,
 }
 

--- a/crates/server/src/domains/mcp_servers/commands.rs
+++ b/crates/server/src/domains/mcp_servers/commands.rs
@@ -150,7 +150,7 @@ inventory::submit! { CommandDescriptor::of::<CreateMcpServer>() }
 #[derive(Debug, Deserialize)]
 pub struct ListMcpServers {
     pub search: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_bool_lenient")]
     pub include_archived: bool,
 }
 

--- a/crates/server/src/domains/skills/commands.rs
+++ b/crates/server/src/domains/skills/commands.rs
@@ -107,7 +107,7 @@ inventory::submit! { CommandDescriptor::of::<CreateSkill>() }
 #[derive(Debug, Deserialize)]
 pub struct ListSkills {
     pub search: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_bool_lenient")]
     pub include_archived: bool,
 }
 

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -758,6 +758,55 @@ async fn test_mcp_execute_list_capabilities() {
     );
 }
 
+// Regression for EVE-324: `--limit 5` arrives at the command layer as a string
+// because inventory commands expose an open schema to bashkit. Without lenient
+// deserialization of `Option<u32>`, dispatch fails with an "invalid type: string"
+// error that the bashkit adapter sanitizes to "list_capabilities: callback failed".
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_execute_list_capabilities_with_limit_flag() {
+    let (_server, url) = TestServer::serving().await;
+
+    let resp = mcp_tool_call_http(
+        &url,
+        "execute",
+        json!({ "command": "list_capabilities --limit 5" }),
+    )
+    .await;
+    assert!(
+        !tool_is_error(&resp),
+        "execute list_capabilities --limit 5 failed: {}",
+        tool_text(&resp)
+    );
+
+    let payload = tool_json(&resp);
+    assert_eq!(payload["limit"], 5);
+    assert!(payload["data"].is_array());
+    assert!(payload["data"].as_array().unwrap().len() <= 5);
+}
+
+// Regression for EVE-324: `include_archived` (bool) and `offset`/`limit` (u32)
+// must all survive the bashkit stringly-typed round-trip on list_agents.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_execute_list_agents_with_numeric_and_bool_flags() {
+    let (_server, url) = TestServer::serving().await;
+
+    let resp = mcp_tool_call_http(
+        &url,
+        "execute",
+        json!({ "command": "list_agents --include_archived true --offset 0 --limit 10" }),
+    )
+    .await;
+    assert!(
+        !tool_is_error(&resp),
+        "execute list_agents with flags failed: {}",
+        tool_text(&resp)
+    );
+
+    let payload = tool_json(&resp);
+    assert_eq!(payload["offset"], 0);
+    assert_eq!(payload["limit"], 10);
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mcp_execute_list_mcp_servers() {
     let (_server, url) = TestServer::serving().await;


### PR DESCRIPTION
## What
Add lenient deserializers (`deserialize_opt_u32_lenient`, `deserialize_bool_lenient`) in `crates/server/src/domains/common.rs`, and apply them to numeric/boolean query fields on the MCP-catalog `List*` commands (`list_capabilities`, `list_agents`, `list_agent_identities`, `list_apps`, `list_harnesses`, `list_mcp_servers`, `list_skills`). Numeric-as-string values (`"5"`) and boolean-as-string values (`"true"`) are now accepted alongside native JSON types.

Fixes EVE-324.

## Why
Inventory-registered commands expose an open JSON schema (`additionalProperties: true`) to bashkit because their request types own the serde shape. Without per-flag type hints, bashkit's flag parser (`parse_flags` + `coerce_value`) defaults every value to a string. As a result, `list_capabilities --limit 5` arrived at dispatch as `{"limit": "5"}`. Serde then rejected the string while populating `Option<u32>`, the dispatcher wrapped the error as `CommandError::BadRequest`, and the bashkit adapter sanitized it (`sanitize_errors: true`, THREAT[TM-INF-030]) into the opaque `list_capabilities: callback failed` the caller saw.

Same root cause for `list_agents --include_archived true` and any other `List*` command with numeric or boolean fields.

## How
- Two small serde helpers (untagged-enum style) accept either the native type or the stringly-typed form, reject anything else with a clear error.
- Helpers applied via `#[serde(deserialize_with = ...)]` with `#[serde(default)]` so missing/null behavior is preserved.
- Numeric strings are trimmed; empty string becomes `None`. Boolean strings accept `true/false/yes/no/on/off/1/0` (case-insensitive); integers accept only `0`/`1`.
- 6 unit tests for the helpers themselves, 2 regression tests for `ListCapabilities`, and 2 end-to-end MCP regression tests (`test_mcp_execute_list_capabilities_with_limit_flag`, `test_mcp_execute_list_agents_with_numeric_and_bool_flags`) that go through the full JSON-RPC dispatch.

## Risk
- Low.
- Accepts a strictly wider set of inputs for these fields; cannot break existing callers that send native JSON types.
- Clamp/pagination guards on `limit`/`offset` are unchanged.

## Security
- Threat categories reviewed: TM-API (input parsing on list endpoints), TM-TOOL (MCP dispatch input), TM-DOS (pagination bounds still enforced).
- Findings:
  - No injection surface: parsed values flow into existing typed `u32` / `bool` paths; `.parse::<u32>()` rejects non-numeric input.
  - No auth/policy changes: `AGENT_IDENTITY_VIEW` and friends unchanged; org scoping via `ctx.org_id()` unchanged.
  - No resource-exhaustion change: `.clamp(1, MAX_LIMIT)` on `limit` preserved.
  - No new logging or data exposure.
- No `THREAT` comments added; existing mitigations continue to apply unchanged.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (wider input, no behavior change for existing callers)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)