### PR TITLE
fix(errors): improve user-facing failure messages

### DIFF
--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -111,7 +111,17 @@ fn is_error_placeholder_message(msg: &Message) -> bool {
         return false;
     }
     let text = msg.text().unwrap_or("");
-    ERROR_PLACEHOLDER_MESSAGES.contains(&text)
+    ERROR_PLACEHOLDER_MESSAGES.contains(&text) || is_dynamic_error_placeholder(text)
+}
+
+fn is_dynamic_error_placeholder(text: &str) -> bool {
+    (text.starts_with("Budget exhausted.") && text.ends_with("Increase the budget to continue."))
+        || (text.starts_with("Budget paused.")
+            && text.ends_with("Increase or resume the budget to continue."))
+        || (text.starts_with("Budget paused with ")
+            && text.ends_with("Increase or resume the budget to continue."))
+        || (text.starts_with("Soft limit reached.") && text.ends_with("soft limit."))
+        || (text.starts_with("The model `") && text.ends_with("Please select a different model."))
 }
 
 // ============================================================================

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -1750,6 +1750,147 @@ async fn test_reason_atom_strips_error_placeholder_messages() {
     );
 }
 
+#[tokio::test]
+async fn test_reason_atom_strips_dynamic_error_placeholder_messages() {
+    use everruns_core::memory::InMemoryEventEmitter;
+
+    let (
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever,
+        provider_store,
+        harness_id,
+        agent_id,
+        session_id,
+    ) = setup_test_environment().await;
+
+    message_retriever
+        .seed(
+            session_id.into(),
+            vec![
+                Message::user("Create agents for me"),
+                Message::assistant(
+                    "Budget exhausted. 100.00 tokens spent reached the 100.00 tokens limit. Increase the budget to continue.",
+                ),
+                Message::assistant(
+                    "The model `gpt-99` is not available. It may have been removed, renamed, or your API key may not have access to it. Please select a different model.",
+                ),
+                Message::user("Try again"),
+            ],
+        )
+        .await;
+
+    let driver_registry = create_custom_driver_registry(LlmSimConfig::echo());
+    let event_emitter = InMemoryEventEmitter::new();
+
+    let atom = ReasonAtom::new(
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever.clone(),
+        provider_store,
+        CapabilityRegistry::new(),
+        driver_registry,
+        event_emitter.clone(),
+    );
+
+    let context = create_context(session_id);
+    let input = ReasonInput {
+        context,
+        harness_id,
+        agent_id: Some(agent_id.into()),
+        org_id: 0,
+        mcp_tool_definitions: vec![],
+        previous_response_id: None,
+        iteration: 1,
+    };
+
+    let result = atom
+        .execute(input)
+        .await
+        .expect("ReasonAtom should succeed");
+
+    assert!(result.success);
+    assert!(!result.text.contains("Budget exhausted."));
+    assert!(!result.text.contains("The model `gpt-99` is not available."));
+}
+
+#[tokio::test]
+async fn test_reason_atom_keeps_non_placeholder_messages_that_share_prefixes() {
+    use everruns_core::memory::InMemoryEventEmitter;
+
+    let (
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever,
+        provider_store,
+        harness_id,
+        agent_id,
+        session_id,
+    ) = setup_test_environment().await;
+
+    message_retriever
+        .seed(
+            session_id.into(),
+            vec![
+                Message::user("Summarize the docs"),
+                Message::assistant(
+                    "The model `gpt-4.1` was recommended in the docs because of its context window.",
+                ),
+                Message::user("Repeat the recommendation"),
+            ],
+        )
+        .await;
+
+    let captured_messages = Arc::new(Mutex::new(Vec::new()));
+    let driver_registry = create_conversation_capturing_driver_registry(captured_messages.clone());
+    let event_emitter = InMemoryEventEmitter::new();
+
+    let atom = ReasonAtom::new(
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever.clone(),
+        provider_store,
+        CapabilityRegistry::new(),
+        driver_registry,
+        event_emitter.clone(),
+    );
+
+    let context = create_context(session_id);
+    let input = ReasonInput {
+        context,
+        harness_id,
+        agent_id: Some(agent_id.into()),
+        org_id: 0,
+        mcp_tool_definitions: vec![],
+        previous_response_id: None,
+        iteration: 1,
+    };
+
+    let result = atom
+        .execute(input)
+        .await
+        .expect("ReasonAtom should succeed");
+
+    assert!(result.success);
+
+    let captured = captured_messages.lock().await;
+    let assistant_messages: Vec<String> = captured
+        .iter()
+        .filter(|message| message.role == everruns_core::LlmMessageRole::Assistant)
+        .map(|message| message.content_as_text())
+        .collect();
+    assert!(
+        assistant_messages
+            .iter()
+            .any(|message| message.contains("The model `gpt-4.1` was recommended")),
+        "non-placeholder assistant message should remain in LLM input: {assistant_messages:?}"
+    );
+}
+
 /// A driver that captures the system message sent to the LLM for assertion.
 #[derive(Clone, Debug)]
 struct SystemPromptCapturingDriver {
@@ -1785,6 +1926,48 @@ impl everruns_core::LlmDriver for SystemPromptCapturingDriver {
             ))),
         ])))
     }
+}
+
+#[derive(Clone, Debug)]
+struct ConversationCapturingDriver {
+    captured_messages: Arc<Mutex<Vec<everruns_core::LlmMessage>>>,
+}
+
+#[async_trait]
+impl everruns_core::LlmDriver for ConversationCapturingDriver {
+    async fn chat_completion_stream(
+        &self,
+        messages: Vec<everruns_core::LlmMessage>,
+        config: &everruns_core::LlmCallConfig,
+    ) -> everruns_core::Result<everruns_core::LlmResponseStream> {
+        *self.captured_messages.lock().await = messages;
+
+        Ok(Box::pin(stream::iter(vec![
+            Ok(everruns_core::LlmStreamEvent::TextDelta("ok".to_string())),
+            Ok(everruns_core::LlmStreamEvent::Done(Box::new(
+                everruns_core::LlmCompletionMetadata {
+                    total_tokens: Some(4),
+                    prompt_tokens: Some(2),
+                    completion_tokens: Some(2),
+                    model: Some(config.model.clone()),
+                    finish_reason: Some("stop".to_string()),
+                    ..Default::default()
+                },
+            ))),
+        ])))
+    }
+}
+
+fn create_conversation_capturing_driver_registry(
+    captured_messages: Arc<Mutex<Vec<everruns_core::LlmMessage>>>,
+) -> DriverRegistry {
+    let mut registry = DriverRegistry::new();
+    registry.register(ProviderType::LlmSim, move |_api_key, _base_url| {
+        Box::new(ConversationCapturingDriver {
+            captured_messages: captured_messages.clone(),
+        })
+    });
+    registry
 }
 
 #[tokio::test]

--- a/crates/runtime/src/turn_strategy.rs
+++ b/crates/runtime/src/turn_strategy.rs
@@ -174,7 +174,7 @@ pub async fn plan_next_host_turn<A: RuntimeHostAdapter>(
                     .turn_failed(
                         turn_id,
                         state.input_message_id,
-                        "An error occurred while processing your request.",
+                        &reason_result.text,
                         Some("llm_error"),
                     )
                     .await;

--- a/crates/runtime/tests/runtime_host_test.rs
+++ b/crates/runtime/tests/runtime_host_test.rs
@@ -18,8 +18,8 @@ use everruns_core::traits::{
 };
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
 use everruns_core::{
-    Agent, AgentCapabilityConfig, CapabilityRegistry, Harness, HarnessStatus, InputMessage,
-    Session, SessionStatus, ToolCall, ToolRegistry,
+    Agent, AgentCapabilityConfig, CapabilityRegistry, EventData, Harness, HarnessStatus,
+    InputMessage, Session, SessionStatus, ToolCall, ToolRegistry,
 };
 use everruns_runtime::{
     InMemorySessionFileStore, RuntimeHostAdapter, RuntimeHostTurnContext, RuntimeSessionLifecycle,
@@ -641,6 +641,55 @@ async fn plan_next_host_turn_continues_reason_when_steering_messages_are_pending
         }
         other => panic!("expected ScheduleReason, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn plan_next_host_turn_preserves_reason_failure_message() {
+    let adapter = mock_host();
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    adapter.harness_store.add_harness(harness(harness_id)).await;
+    adapter
+        .session_store
+        .insert(session(session_id, harness_id))
+        .await;
+
+    let input = turn_state(session_id, harness_id);
+    let output = serde_json::to_value(ReasonResult {
+        success: false,
+        text: "Budget exhausted. 100.00 tokens spent reached the 100.00 tokens limit. Increase the budget to continue."
+            .into(),
+        tool_calls: vec![],
+        has_tool_calls: false,
+        tool_definitions: vec![],
+        max_iterations: 8,
+        error: Some("Budget exhausted".into()),
+        usage: None,
+        response_id: None,
+        locale: None,
+        network_access: None,
+    })
+    .unwrap();
+
+    let plan = plan_next_host_turn(&adapter, "reason", &input, &output, 0)
+        .await
+        .unwrap();
+
+    assert!(matches!(plan, RuntimeTurnPlan::Complete { .. }));
+
+    let events = adapter.event_emitter.events().await;
+    let turn_failed = events
+        .into_iter()
+        .find_map(|event| match event.data {
+            EventData::TurnFailed(data) => Some(data),
+            _ => None,
+        })
+        .expect("turn.failed event emitted");
+
+    assert_eq!(
+        turn_failed.error,
+        "Budget exhausted. 100.00 tokens spent reached the 100.00 tokens limit. Increase the budget to continue."
+    );
 }
 
 #[tokio::test]

--- a/crates/server/src/services/budget.rs
+++ b/crates/server/src/services/budget.rs
@@ -270,13 +270,7 @@ impl BudgetService {
         // Rule 1: Hard stop at 0
         if budget.balance <= 0.0 {
             return BudgetAction::Stop {
-                message: format!(
-                    "Budget exhausted. {:.2} {} spent of {:.2} {} limit.",
-                    budget.limit - budget.balance,
-                    budget.currency,
-                    budget.limit,
-                    budget.currency
-                ),
+                message: self.format_exhausted_message(budget),
             };
         }
 
@@ -285,13 +279,7 @@ impl BudgetService {
             && budget.balance <= (budget.limit - soft_limit)
         {
             return BudgetAction::Pause {
-                message: format!(
-                    "Soft limit reached. {:.2} {} spent of {:.2} {} soft limit.",
-                    budget.limit - budget.balance,
-                    budget.currency,
-                    soft_limit,
-                    budget.currency
-                ),
+                message: self.format_paused_message(budget),
             };
         }
 
@@ -353,25 +341,9 @@ impl BudgetService {
         for budget in &all_matching {
             let (action_str, message, priority) =
                 if budget.status == "exhausted" || budget.balance <= 0.0 {
-                    (
-                        "stop",
-                        format!(
-                            "Budget exhausted ({} {})",
-                            budget.currency,
-                            BudgetId::from_uuid(budget.id)
-                        ),
-                        3u8,
-                    )
+                    ("stop", self.format_exhausted_message(budget), 3u8)
                 } else if budget.status == "paused" {
-                    (
-                        "pause",
-                        format!(
-                            "Budget paused ({} {})",
-                            budget.currency,
-                            BudgetId::from_uuid(budget.id)
-                        ),
-                        2u8,
-                    )
+                    ("pause", self.format_paused_message(budget), 2u8)
                 } else {
                     // Active budget — evaluate rules
                     match self.evaluate_rules(budget) {
@@ -395,6 +367,50 @@ impl BudgetService {
         }
 
         most_restrictive
+    }
+
+    fn spent_amount(&self, budget: &BudgetRow) -> f64 {
+        (budget.limit - budget.balance).max(0.0)
+    }
+
+    fn format_exhausted_message(&self, budget: &BudgetRow) -> String {
+        let spent = self.spent_amount(budget);
+        let comparison = if spent > budget.limit {
+            "exceeded"
+        } else {
+            "reached"
+        };
+        format!(
+            "Budget exhausted. {:.2} {} spent {} the {:.2} {} limit. Increase the budget to continue.",
+            spent, budget.currency, comparison, budget.limit, budget.currency
+        )
+    }
+
+    fn format_paused_message(&self, budget: &BudgetRow) -> String {
+        let spent = self.spent_amount(budget);
+        if let Some(soft_limit) = budget.soft_limit {
+            if spent > soft_limit {
+                format!(
+                    "Budget paused. {:.2} {} spent exceeded the {:.2} {} soft limit. Increase or resume the budget to continue.",
+                    spent, budget.currency, soft_limit, budget.currency
+                )
+            } else if spent >= soft_limit {
+                format!(
+                    "Budget paused. {:.2} {} spent reached the {:.2} {} soft limit. Increase or resume the budget to continue.",
+                    spent, budget.currency, soft_limit, budget.currency
+                )
+            } else {
+                format!(
+                    "Budget paused with {:.2} {} spent. Increase or resume the budget to continue.",
+                    spent, budget.currency
+                )
+            }
+        } else {
+            format!(
+                "Budget paused with {:.2} {} spent. Increase or resume the budget to continue.",
+                spent, budget.currency
+            )
+        }
     }
 }
 

--- a/crates/server/src/services/budget_tests.rs
+++ b/crates/server/src/services/budget_tests.rs
@@ -615,6 +615,12 @@ mod tests {
         db.set_budget_status(budget.id, "exhausted").await.unwrap();
         let result = svc.check_budgets_for_session(1, "session_1", None).await;
         assert!(result.should_stop());
+        assert_eq!(
+            result.message.as_deref(),
+            Some(
+                "Budget exhausted. 100.00 tokens spent reached the 100.00 tokens limit. Increase the budget to continue."
+            )
+        );
     }
 
     #[tokio::test]
@@ -627,15 +633,99 @@ mod tests {
                 subject_id: "session_1".into(),
                 currency: "usd".into(),
                 limit: 10.0,
-                soft_limit: None,
+                soft_limit: Some(8.0),
+                period: None,
+                metadata: None,
+            })
+            .await
+            .unwrap();
+        db.create_budget_ledger_entry(CreateBudgetLedgerRow {
+            budget_id: budget.id,
+            amount: 8.0,
+            meter_source: "llm_tokens".into(),
+            ref_type: None,
+            ref_id: None,
+            session_id: None,
+            description: None,
+        })
+        .await
+        .unwrap();
+        db.set_budget_status(budget.id, "paused").await.unwrap();
+        let result = svc.check_budgets_for_session(1, "session_1", None).await;
+        assert!(result.should_pause());
+        assert_eq!(
+            result.message.as_deref(),
+            Some(
+                "Budget paused. 8.00 usd spent reached the 8.00 usd soft limit. Increase or resume the budget to continue."
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_budgets_manually_paused_budget_uses_neutral_message() {
+        let (svc, db) = make_service();
+        let budget = db
+            .create_budget(CreateBudgetRow {
+                org_id: 1,
+                subject_type: "session".into(),
+                subject_id: "session_1".into(),
+                currency: "usd".into(),
+                limit: 10.0,
+                soft_limit: Some(8.0),
                 period: None,
                 metadata: None,
             })
             .await
             .unwrap();
         db.set_budget_status(budget.id, "paused").await.unwrap();
+
         let result = svc.check_budgets_for_session(1, "session_1", None).await;
+
         assert!(result.should_pause());
+        assert_eq!(
+            result.message.as_deref(),
+            Some("Budget paused with 0.00 usd spent. Increase or resume the budget to continue.")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_budgets_paused_budget_above_soft_limit_uses_exceeded_message() {
+        let (svc, db) = make_service();
+        let budget = db
+            .create_budget(CreateBudgetRow {
+                org_id: 1,
+                subject_type: "session".into(),
+                subject_id: "session_1".into(),
+                currency: "usd".into(),
+                limit: 10.0,
+                soft_limit: Some(8.0),
+                period: None,
+                metadata: None,
+            })
+            .await
+            .unwrap();
+        db.create_budget_ledger_entry(CreateBudgetLedgerRow {
+            budget_id: budget.id,
+            amount: 9.0,
+            meter_source: "llm_tokens".into(),
+            ref_type: None,
+            ref_id: None,
+            session_id: None,
+            description: None,
+        })
+        .await
+        .unwrap();
+        db.set_budget_status(budget.id, "paused").await.unwrap();
+
+        let result = svc.check_budgets_for_session(1, "session_1", None).await;
+
+        assert!(result.should_pause());
+        assert_eq!(
+            result.message.as_deref(),
+            Some(
+                "Budget paused. 9.00 usd spent exceeded the 8.00 usd soft limit. Increase or resume the budget to continue."
+            )
+        );
     }
 
     #[tokio::test]

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -27,7 +27,7 @@ use crate::grpc_durable_store::{
     ClaimedTask, GrpcDurableStore, TaskNotificationEvent, TaskNotificationStream, WorkflowStatus,
 };
 use crate::runtime_host::WorkerRuntimeHost;
-use crate::task_error::summarize_task_failure;
+use crate::task_error::{summarize_task_failure, user_facing_failure_message};
 use serde::{Deserialize, Serialize};
 
 // =============================================================================
@@ -698,7 +698,7 @@ impl DurableWorker {
                                     wf_id,
                                     WorkflowStatus::Completed,
                                     None,
-                                    Some(error_msg),
+                                    Some(error_msg.clone()),
                                 )
                                 .await;
                         }
@@ -708,7 +708,7 @@ impl DurableWorker {
                             "reason" | "process_input" | "act"
                         ) {
                             drop(store);
-                            worker.emit_dlq_error_event(&task).await;
+                            worker.emit_dlq_error_event(&task, &error_msg).await;
                         }
                     } else {
                         // Report failure to store (may retry)
@@ -729,7 +729,7 @@ impl DurableWorker {
                                                 wf_id,
                                                 WorkflowStatus::Completed,
                                                 None,
-                                                Some(error_msg),
+                                                Some(error_msg.clone()),
                                             )
                                             .await;
                                     }
@@ -743,7 +743,7 @@ impl DurableWorker {
                                         "reason" | "process_input" | "act"
                                     ) {
                                         drop(store);
-                                        worker.emit_dlq_error_event(&task).await;
+                                        worker.emit_dlq_error_event(&task, &error_msg).await;
                                     }
                                 }
                             }
@@ -1045,7 +1045,7 @@ impl DurableWorker {
     /// prevent duplicate "I encountered an error" messages in the UI. This method
     /// emits one final error event so the user sees exactly one error message,
     /// then emits session.idled + sets session status to idle so the UI unblocks.
-    async fn emit_dlq_error_event(&self, task: &ClaimedTask) {
+    async fn emit_dlq_error_event(&self, task: &ClaimedTask, persisted_error: &str) {
         // Extract session context from the task input. `act` task input is
         // wrapped in `ActTaskInput`, while `reason`/`process_input` use
         // `DurableTurnInput`; both shapes must be handled or act-task DLQs
@@ -1082,9 +1082,7 @@ impl DurableWorker {
             turn_id,
             input_message_id,
         } = ctx;
-        let error_message = Message::assistant(
-            "I encountered an error while processing your request. Please try again later.",
-        );
+        let error_message = Message::assistant(user_facing_failure_message(persisted_error));
         let context = EventContext::turn(turn_id, input_message_id);
 
         if let Err(e) = event_emitter

--- a/crates/worker/src/task_error.rs
+++ b/crates/worker/src/task_error.rs
@@ -55,6 +55,74 @@ pub(crate) fn summarize_task_failure(
     }
 }
 
+pub(crate) fn user_facing_failure_message(error: &str) -> String {
+    let error_chain = error.split("error_chain=").nth(1).unwrap_or(error).trim();
+
+    let normalized = trim_error_chain_prefixes(error_chain);
+    let lower = normalized.to_ascii_lowercase();
+
+    if normalized.starts_with("Budget exhausted.")
+        || normalized.starts_with("Budget paused.")
+        || normalized.starts_with("Soft limit reached.")
+    {
+        return normalized.to_string();
+    }
+
+    if normalized.starts_with("Budget exhausted (") {
+        return "Budget exhausted. Increase the budget to continue.".to_string();
+    }
+
+    if normalized.starts_with("Budget paused (") {
+        return "Budget paused. Increase or resume the budget to continue.".to_string();
+    }
+
+    if normalized.starts_with("Model not available: ") {
+        let model_id = normalized
+            .trim_start_matches("Model not available: ")
+            .trim();
+        return format!(
+            "The model `{}` is not available. It may have been removed, renamed, or your API key may not have access to it. Please select a different model.",
+            model_id
+        );
+    }
+
+    if normalized.starts_with("Request too large:")
+        || lower.contains("context length")
+        || lower.contains("maximum context length")
+    {
+        return "The conversation has become too long for the model to process. Please start a new session or reduce the context size.".to_string();
+    }
+
+    if lower.contains("(429)")
+        || lower.contains("rate limit")
+        || lower.contains("too many requests")
+    {
+        return "Rate limited by the AI provider. Please wait a moment.".to_string();
+    }
+
+    if lower.contains("(401)") || lower.contains("(403)") {
+        return "There is a misconfiguration with the AI provider. Please contact support."
+            .to_string();
+    }
+
+    if ["(500)", "(502)", "(503)", "(504)", "(529)"]
+        .iter()
+        .any(|code| lower.contains(code))
+    {
+        return "The AI provider is experiencing issues. Please try again shortly.".to_string();
+    }
+
+    "I encountered an error while processing your request. Please try again later.".to_string()
+}
+
+fn trim_error_chain_prefixes(error_chain: &str) -> &str {
+    error_chain
+        .trim()
+        .trim_start_matches("InputAtom execution failed: ")
+        .trim_start_matches("ReasonAtom execution failed: ")
+        .trim_start_matches("ActAtom execution failed: ")
+}
+
 fn format_error_chain(error: &Error) -> String {
     let mut messages = Vec::new();
 
@@ -247,6 +315,78 @@ mod tests {
             summary
                 .persisted_message
                 .contains("session_id=session_top_level")
+        );
+    }
+
+    #[test]
+    fn user_facing_failure_message_extracts_budget_copy_from_persisted_error() {
+        let message = user_facing_failure_message(
+            "activity_type=reason | error_chain=ReasonAtom execution failed: Budget exhausted. 100.00 tokens spent reached the 100.00 tokens limit. Increase the budget to continue.",
+        );
+
+        assert_eq!(
+            message,
+            "Budget exhausted. 100.00 tokens spent reached the 100.00 tokens limit. Increase the budget to continue."
+        );
+    }
+
+    #[test]
+    fn user_facing_failure_message_recognizes_rate_limit_errors() {
+        let message = user_facing_failure_message(
+            "activity_type=reason | error_chain=ReasonAtom execution failed: OpenAI API error (429): Rate limit exceeded",
+        );
+
+        assert_eq!(
+            message,
+            "Rate limited by the AI provider. Please wait a moment."
+        );
+    }
+
+    #[test]
+    fn user_facing_failure_message_recognizes_model_unavailable_errors() {
+        let message = user_facing_failure_message(
+            "activity_type=reason | error_chain=ReasonAtom execution failed: Model not available: gpt-99",
+        );
+
+        assert_eq!(
+            message,
+            "The model `gpt-99` is not available. It may have been removed, renamed, or your API key may not have access to it. Please select a different model."
+        );
+    }
+
+    #[test]
+    fn user_facing_failure_message_recognizes_request_too_large_errors() {
+        let message = user_facing_failure_message(
+            "activity_type=reason | error_chain=ReasonAtom execution failed: Request too large: OpenAI API error (429): Request too large for gpt-4o",
+        );
+
+        assert_eq!(
+            message,
+            "The conversation has become too long for the model to process. Please start a new session or reduce the context size."
+        );
+    }
+
+    #[test]
+    fn user_facing_failure_message_recognizes_provider_auth_errors() {
+        let message = user_facing_failure_message(
+            "activity_type=reason | error_chain=ReasonAtom execution failed: OpenAI API error (401): Invalid authentication",
+        );
+
+        assert_eq!(
+            message,
+            "There is a misconfiguration with the AI provider. Please contact support."
+        );
+    }
+
+    #[test]
+    fn user_facing_failure_message_recognizes_provider_5xx_errors() {
+        let message = user_facing_failure_message(
+            "activity_type=reason | error_chain=ReasonAtom execution failed: OpenAI API error (503): Service unavailable",
+        );
+
+        assert_eq!(
+            message,
+            "The AI provider is experiencing issues. Please try again shortly."
         );
     }
 }


### PR DESCRIPTION
## What
Improve user-facing failure messages across budget checks, runtime turn failures, and worker fallback errors.

## Why
Users were seeing generic failures like "unexpected error" when a budget was cut or when sanitized provider/runtime failures should have had clearer guidance.

## How
- format paused/exhausted budget messages as user-facing copy in the budget service
- preserve `ReasonResult.text` when a reason step completes with `success=false`
- recover user-facing fallback messages from persisted worker error chains for DLQ/error-event emission
- treat the new dynamic error strings as placeholders so they do not get fed back into later LLM context
- add focused tests for runtime propagation, budget copy, and worker failure mapping

## Risk
- Medium
- Main risk is surfacing too much internal failure detail. This change keeps the exposed copy constrained to known budget/provider/model/context-length cases and falls back to the generic processing error otherwise.

## Security
- Threat categories reviewed: TM-API, TM-LLM
- Findings and resolutions:
  - Reviewed error-surface changes for internal detail leakage. Budget/model/provider messages remain bounded, human-facing strings; unknown failures still collapse to the generic processing error.
  - No auth, authorization, transport, storage, or secret-handling behavior changed.
  - No new API inputs, routes, or unbounded work were introduced.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `cargo fmt --all --check`
- `cargo test -p everruns-runtime --test runtime_host_test plan_next_host_turn_preserves_reason_failure_message`
- `cargo test -p everruns-server check_budgets_`
- `cargo test -p everruns-worker user_facing_failure_message_`
- `just pre-push`
- Live smoke on `just start-dev --no-watch` via `POST /api/v1/budgets` + `GET /api/v1/sessions/:id/budget-check` for paused/exhausted message paths

## Follow-up
- Long-term localization/structured error metadata tracked in Linear: EVE-329
