### PR TITLE
fix(server): accept positional id args on MCP execute commands

### DIFF
--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -34,6 +34,7 @@ use std::sync::Arc;
 use super::common::impl_auth_state;
 
 mod catalog;
+mod positional;
 
 // ============================================================================
 // JSON-RPC 2.0 types
@@ -1104,8 +1105,12 @@ async fn tool_execute(args: &Value, org: &ResolvedOrg, state: &AppState) -> Resu
         .unwrap_or(30000)
         .min(60000);
 
+    // EVE-323: rewrite `<cmd> <id>` → `<cmd> --<positional> <id>` so LLM
+    // callers don't hit bashkit's "expected --flag" rejection.
+    let rewritten = positional::rewrite(command, positional::positional_map());
+
     let toolset = build_toolset(org, state);
-    execute_script(&toolset, command, timeout_ms).await
+    execute_script(&toolset, &rewritten, timeout_ms).await
 }
 
 // ============================================================================

--- a/crates/server/src/api/mcp_endpoint/positional.rs
+++ b/crates/server/src/api/mcp_endpoint/positional.rs
@@ -1,0 +1,432 @@
+// Positional-argument rewriter for MCP `execute` commands.
+//
+// bashkit's flag parser rejects positional arguments (`expected --flag, got: X`).
+// LLMs naturally type `get_agent <id>` instead of `get_agent --id <id>`,
+// producing retry loops. This module pre-rewrites the raw command string at
+// statement boundaries so the bash interpreter sees `get_agent --id <id>`.
+//
+// The rewrite is conservative: it only fires at statement-start positions
+// (start of string, after `;`, `|`, `&`, `\n`, `(`, `{`, comments) and only
+// when the next token is a single positional (not already `--flag`). Quoted
+// regions and backslash escapes are preserved as-is. See EVE-323.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+/// Positional map shared across all `tool_execute` calls. Built once from
+/// inventory + the static catalog; both are fixed at compile time.
+static POSITIONAL_MAP: OnceLock<HashMap<&'static str, &'static str>> = OnceLock::new();
+
+/// Return the cached positional map. The map key is a command name; the value
+/// is the flag name to insert before the first positional argument (usually
+/// `"id"`).
+pub fn positional_map() -> &'static HashMap<&'static str, &'static str> {
+    POSITIONAL_MAP.get_or_init(build_positional_map)
+}
+
+fn build_positional_map() -> HashMap<&'static str, &'static str> {
+    let mut map: HashMap<&'static str, &'static str> = HashMap::new();
+
+    // Inventory-registered commands that opt in via Command::positional_arg.
+    for desc in inventory::iter::<crate::domains::common::CommandDescriptor> {
+        if let Some(flag) = (desc.positional_arg)() {
+            map.insert((desc.meta)().name, flag);
+        }
+    }
+
+    // Static CATALOG: a command is rewritable when it declares exactly one
+    // `path` parameter (its primary key). Multiple path params (e.g. {id,
+    // channel_id}) stay flag-only because positional ordering is ambiguous.
+    for op in super::catalog::CATALOG {
+        let path_params: Vec<&super::catalog::Param> =
+            op.params.iter().filter(|p| p.typ == "path").collect();
+        if path_params.len() == 1 {
+            map.insert(op.name, path_params[0].name);
+        }
+    }
+
+    map
+}
+
+/// Rewrite `<cmd> <arg>` as `<cmd> --<positional> <arg>` at statement
+/// boundaries for commands in `map`. Commands not in `map` pass through.
+/// Quoted regions, backslash escapes, and comments are preserved verbatim.
+pub fn rewrite(input: &str, map: &HashMap<&'static str, &'static str>) -> String {
+    let mut out = String::with_capacity(input.len() + 32);
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    let mut at_stmt_start = true;
+
+    while i < bytes.len() {
+        let b = bytes[i];
+
+        if at_stmt_start && is_name_start(b) {
+            // Read the command name.
+            let name_start = i;
+            while i < bytes.len() && is_name_cont(bytes[i]) {
+                i += 1;
+            }
+            let name = &input[name_start..i];
+            out.push_str(name);
+
+            if let Some(&positional) = map.get(name) {
+                // Capture whitespace between command and next token.
+                let ws_start = i;
+                while i < bytes.len() && matches!(bytes[i], b' ' | b'\t') {
+                    i += 1;
+                }
+                let ws = &input[ws_start..i];
+
+                let should_rewrite = i < bytes.len() && is_positional_value_start(bytes[i]);
+
+                if should_rewrite {
+                    out.push(' ');
+                    out.push_str("--");
+                    out.push_str(positional);
+                    out.push_str(ws);
+                } else {
+                    out.push_str(ws);
+                }
+            }
+            at_stmt_start = false;
+            continue;
+        }
+
+        match b {
+            b'\'' => {
+                // Single-quoted string: no escapes inside, copy verbatim to the
+                // next '.
+                out.push('\'');
+                i += 1;
+                while i < bytes.len() && bytes[i] != b'\'' {
+                    out.push(bytes[i] as char);
+                    i += 1;
+                }
+                if i < bytes.len() {
+                    out.push('\'');
+                    i += 1;
+                }
+                at_stmt_start = false;
+            }
+            b'"' => {
+                // Double-quoted string: backslash escapes one char.
+                out.push('"');
+                i += 1;
+                while i < bytes.len() {
+                    let c = bytes[i];
+                    out.push(c as char);
+                    i += 1;
+                    if c == b'\\' && i < bytes.len() {
+                        out.push(bytes[i] as char);
+                        i += 1;
+                        continue;
+                    }
+                    if c == b'"' {
+                        break;
+                    }
+                }
+                at_stmt_start = false;
+            }
+            b'\\' => {
+                // Unquoted backslash: consume the next byte as literal.
+                out.push('\\');
+                i += 1;
+                if i < bytes.len() {
+                    out.push(bytes[i] as char);
+                    i += 1;
+                }
+                at_stmt_start = false;
+            }
+            b'#' if at_stmt_start_prev(bytes, i) => {
+                // Comment: copy through end-of-line; newline handling happens
+                // on the next iteration and keeps stmt_start=true.
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    out.push(bytes[i] as char);
+                    i += 1;
+                }
+            }
+            b'#' => {
+                // Mid-token `#` (e.g. `get_agent a#b`) is a literal.
+                out.push('#');
+                i += 1;
+            }
+            b'`' => {
+                // Legacy backtick command substitution. Treat as a quoted
+                // region with no nested rewrite. `$(...)` is the preferred
+                // form and does get rewritten inside.
+                out.push('`');
+                i += 1;
+                while i < bytes.len() && bytes[i] != b'`' {
+                    let c = bytes[i];
+                    out.push(c as char);
+                    i += 1;
+                    if c == b'\\' && i < bytes.len() {
+                        out.push(bytes[i] as char);
+                        i += 1;
+                    }
+                }
+                if i < bytes.len() {
+                    out.push('`');
+                    i += 1;
+                }
+                at_stmt_start = false;
+            }
+            b';' | b'|' | b'&' | b'\n' | b'(' | b'{' => {
+                out.push(b as char);
+                i += 1;
+                at_stmt_start = true;
+            }
+            b' ' | b'\t' => {
+                out.push(b as char);
+                i += 1;
+                // Whitespace doesn't reset at_stmt_start (it preserves the
+                // previous state so leading whitespace still counts as
+                // statement start).
+            }
+            _ => {
+                out.push(b as char);
+                i += 1;
+                at_stmt_start = false;
+            }
+        }
+    }
+    out
+}
+
+fn is_name_start(b: u8) -> bool {
+    b.is_ascii_alphabetic() || b == b'_'
+}
+
+fn is_name_cont(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+/// A byte is a positional-value start when it begins a non-flag, non-boundary
+/// token. `-` (any dash-prefixed token) is excluded so existing `--flag`
+/// usage is preserved. Quotes count because the quoted content is the value.
+fn is_positional_value_start(b: u8) -> bool {
+    !matches!(
+        b,
+        b'-' | b';' | b'|' | b'&' | b'\n' | b')' | b'}' | b'#' | b' ' | b'\t'
+    )
+}
+
+/// True when the byte at `i-1` is whitespace or a boundary — i.e. `#` at
+/// position `i` starts a comment rather than sitting inside a token.
+fn at_stmt_start_prev(bytes: &[u8], i: usize) -> bool {
+    if i == 0 {
+        return true;
+    }
+    matches!(
+        bytes[i - 1],
+        b' ' | b'\t' | b';' | b'|' | b'&' | b'\n' | b'(' | b'{'
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_map() -> HashMap<&'static str, &'static str> {
+        let mut m = HashMap::new();
+        m.insert("get_agent", "id");
+        m.insert("delete_agent", "id");
+        m.insert("get_session", "session_id");
+        m
+    }
+
+    #[test]
+    fn simple_positional() {
+        let m = test_map();
+        assert_eq!(
+            rewrite("get_agent agent_123", &m),
+            "get_agent --id agent_123"
+        );
+    }
+
+    #[test]
+    fn already_flag_form_preserved() {
+        let m = test_map();
+        assert_eq!(
+            rewrite("get_agent --id agent_123", &m),
+            "get_agent --id agent_123"
+        );
+    }
+
+    #[test]
+    fn short_flag_not_rewritten() {
+        let m = test_map();
+        // `-h` starts with `-` so we don't treat it as positional; bashkit
+        // will reject it as "expected --flag" (the user's bug, not ours).
+        assert_eq!(rewrite("get_agent -h", &m), "get_agent -h");
+    }
+
+    #[test]
+    fn unknown_command_passthrough() {
+        let m = test_map();
+        assert_eq!(rewrite("list_sessions foo", &m), "list_sessions foo");
+    }
+
+    #[test]
+    fn statement_boundary_semicolon() {
+        let m = test_map();
+        assert_eq!(
+            rewrite("get_agent a1; delete_agent a2", &m),
+            "get_agent --id a1; delete_agent --id a2"
+        );
+    }
+
+    #[test]
+    fn statement_boundary_pipe() {
+        let m = test_map();
+        assert_eq!(
+            rewrite("get_agent a1 | jq .name", &m),
+            "get_agent --id a1 | jq .name"
+        );
+    }
+
+    #[test]
+    fn statement_boundary_newline() {
+        let m = test_map();
+        let input = "get_agent a1\ndelete_agent a2\n";
+        let expected = "get_agent --id a1\ndelete_agent --id a2\n";
+        assert_eq!(rewrite(input, &m), expected);
+    }
+
+    #[test]
+    fn statement_boundary_andand() {
+        let m = test_map();
+        assert_eq!(
+            rewrite("get_agent a1 && get_agent a2", &m),
+            "get_agent --id a1 && get_agent --id a2"
+        );
+    }
+
+    #[test]
+    fn statement_boundary_subshell() {
+        let m = test_map();
+        assert_eq!(rewrite("x=$(get_agent a1)", &m), "x=$(get_agent --id a1)");
+    }
+
+    #[test]
+    fn quoted_arg_is_rewritten() {
+        let m = test_map();
+        assert_eq!(
+            rewrite("get_agent 'agent_xyz'", &m),
+            "get_agent --id 'agent_xyz'"
+        );
+        assert_eq!(
+            rewrite("get_agent \"agent_xyz\"", &m),
+            "get_agent --id \"agent_xyz\""
+        );
+    }
+
+    #[test]
+    fn command_name_inside_quotes_untouched() {
+        let m = test_map();
+        // `echo "get_agent foo"` — the string inside quotes is a payload, not
+        // a statement start. Our tokenizer enters quote mode on `"` so the
+        // inner `get_agent foo` is not rewritten.
+        assert_eq!(
+            rewrite("echo \"get_agent foo\"", &m),
+            "echo \"get_agent foo\""
+        );
+    }
+
+    #[test]
+    fn command_name_after_pipe_inside_quotes() {
+        let m = test_map();
+        // A `|` inside quotes is not a statement boundary.
+        assert_eq!(
+            rewrite("echo 'a|get_agent b' | cat", &m),
+            "echo 'a|get_agent b' | cat"
+        );
+    }
+
+    #[test]
+    fn preserves_whitespace() {
+        let m = test_map();
+        assert_eq!(
+            rewrite("get_agent   agent_1", &m),
+            "get_agent --id   agent_1"
+        );
+    }
+
+    #[test]
+    fn trailing_command_with_no_arg_unchanged() {
+        let m = test_map();
+        // No positional follows — leave it to bashkit to produce its own
+        // "required arg missing" error.
+        assert_eq!(rewrite("get_agent", &m), "get_agent");
+        assert_eq!(rewrite("get_agent   ", &m), "get_agent   ");
+        assert_eq!(rewrite("get_agent  ;", &m), "get_agent  ;");
+    }
+
+    #[test]
+    fn variable_expansion_arg() {
+        let m = test_map();
+        assert_eq!(rewrite("get_agent $AGENT", &m), "get_agent --id $AGENT");
+    }
+
+    #[test]
+    fn multiple_positional_args_only_first_rewritten() {
+        let m = test_map();
+        // Second positional is left alone — bashkit rejects it. We don't try
+        // to be smart: the common case is a single id.
+        assert_eq!(rewrite("get_agent a b", &m), "get_agent --id a b");
+    }
+
+    #[test]
+    fn escaped_space_in_arg() {
+        let m = test_map();
+        assert_eq!(rewrite("get_agent a\\ b", &m), "get_agent --id a\\ b");
+    }
+
+    #[test]
+    fn comment_line_skipped() {
+        let m = test_map();
+        assert_eq!(
+            rewrite("# get_agent a\nget_agent b", &m),
+            "# get_agent a\nget_agent --id b"
+        );
+    }
+
+    #[test]
+    fn leading_whitespace_preserved() {
+        let m = test_map();
+        assert_eq!(rewrite("  get_agent a", &m), "  get_agent --id a");
+    }
+
+    #[test]
+    fn empty_input() {
+        let m = test_map();
+        assert_eq!(rewrite("", &m), "");
+    }
+
+    #[test]
+    fn different_positional_name() {
+        let m = test_map();
+        assert_eq!(
+            rewrite("get_session sess_1", &m),
+            "get_session --session_id sess_1"
+        );
+    }
+
+    #[test]
+    fn build_positional_map_contains_known_commands() {
+        let map = positional_map();
+        // Inventory commands with id: at least get_agent, get_capability.
+        assert_eq!(map.get("get_agent").copied(), Some("id"));
+        assert_eq!(map.get("get_capability").copied(), Some("id"));
+        // Static catalog with single path param: get_session → session_id.
+        assert_eq!(map.get("get_session").copied(), Some("session_id"));
+        // Static catalog with single path param `id`: get_model → id.
+        assert_eq!(map.get("get_model").copied(), Some("id"));
+        // List endpoints have no path params — must not be present.
+        assert!(!map.contains_key("list_agents"));
+        assert!(!map.contains_key("list_sessions"));
+        // Multi-path-param ops (e.g. delete_app_channel has two) must not be
+        // present: positional ordering would be ambiguous.
+        assert!(!map.contains_key("delete_app_channel"));
+    }
+}

--- a/crates/server/src/api/mcp_endpoint/positional.rs
+++ b/crates/server/src/api/mcp_endpoint/positional.rs
@@ -6,8 +6,9 @@
 // statement boundaries so the bash interpreter sees `get_agent --id <id>`.
 //
 // The rewrite is conservative: it only fires at statement-start positions
-// (start of string, after `;`, `|`, `&`, `\n`, `(`, `{`, comments) and only
-// when the next token is a single positional (not already `--flag`). Quoted
+// (start of string, after `;`, `|`, `&`, `\n`, `(`, `{`, comments), only when
+// the command name is followed by at least one space or tab, and only when
+// the next token is a single positional (not already `--flag`). Quoted
 // regions and backslash escapes are preserved as-is. See EVE-323.
 
 use std::collections::HashMap;
@@ -28,6 +29,8 @@ fn build_positional_map() -> HashMap<&'static str, &'static str> {
     let mut map: HashMap<&'static str, &'static str> = HashMap::new();
 
     // Inventory-registered commands that opt in via Command::positional_arg.
+    // Inventory takes precedence — the static catalog fills in anything that
+    // inventory doesn't already own.
     for desc in inventory::iter::<crate::domains::common::CommandDescriptor> {
         if let Some(flag) = (desc.positional_arg)() {
             map.insert((desc.meta)().name, flag);
@@ -38,6 +41,9 @@ fn build_positional_map() -> HashMap<&'static str, &'static str> {
     // `path` parameter (its primary key). Multiple path params (e.g. {id,
     // channel_id}) stay flag-only because positional ordering is ambiguous.
     for op in super::catalog::CATALOG {
+        if map.contains_key(op.name) {
+            continue;
+        }
         let path_params: Vec<&super::catalog::Param> =
             op.params.iter().filter(|p| p.typ == "path").collect();
         if path_params.len() == 1 {
@@ -50,10 +56,11 @@ fn build_positional_map() -> HashMap<&'static str, &'static str> {
 
 /// Rewrite `<cmd> <arg>` as `<cmd> --<positional> <arg>` at statement
 /// boundaries for commands in `map`. Commands not in `map` pass through.
-/// Quoted regions, backslash escapes, and comments are preserved verbatim.
+/// Quoted regions, backslash escapes, and comments are preserved verbatim
+/// (including multi-byte UTF-8 sequences).
 pub fn rewrite(input: &str, map: &HashMap<&'static str, &'static str>) -> String {
-    let mut out = String::with_capacity(input.len() + 32);
     let bytes = input.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len() + 32);
     let mut i = 0;
     let mut at_stmt_start = true;
 
@@ -66,26 +73,33 @@ pub fn rewrite(input: &str, map: &HashMap<&'static str, &'static str>) -> String
             while i < bytes.len() && is_name_cont(bytes[i]) {
                 i += 1;
             }
-            let name = &input[name_start..i];
-            out.push_str(name);
+            let name_end = i;
+            out.extend_from_slice(&bytes[name_start..name_end]);
 
-            if let Some(&positional) = map.get(name) {
+            if let Some(&positional) =
+                map.get(std::str::from_utf8(&bytes[name_start..name_end]).unwrap_or(""))
+            {
                 // Capture whitespace between command and next token.
                 let ws_start = i;
                 while i < bytes.len() && matches!(bytes[i], b' ' | b'\t') {
                     i += 1;
                 }
-                let ws = &input[ws_start..i];
+                let ws_len = i - ws_start;
 
-                let should_rewrite = i < bytes.len() && is_positional_value_start(bytes[i]);
+                // Only rewrite if the command name is actually separated from
+                // the next token by whitespace. `get_agent'abc'` and
+                // `get_agent$ID` are bash token concatenations that produce a
+                // different command name; leave them alone.
+                let should_rewrite =
+                    ws_len > 0 && i < bytes.len() && is_positional_value_start(bytes[i]);
 
                 if should_rewrite {
-                    out.push(' ');
-                    out.push_str("--");
-                    out.push_str(positional);
-                    out.push_str(ws);
+                    out.push(b' ');
+                    out.extend_from_slice(b"--");
+                    out.extend_from_slice(positional.as_bytes());
+                    out.extend_from_slice(&bytes[ws_start..i]);
                 } else {
-                    out.push_str(ws);
+                    out.extend_from_slice(&bytes[ws_start..i]);
                 }
             }
             at_stmt_start = false;
@@ -94,30 +108,30 @@ pub fn rewrite(input: &str, map: &HashMap<&'static str, &'static str>) -> String
 
         match b {
             b'\'' => {
-                // Single-quoted string: no escapes inside, copy verbatim to the
-                // next '.
-                out.push('\'');
+                // Single-quoted string: no escapes inside, copy verbatim to
+                // the next '.
+                out.push(b'\'');
                 i += 1;
                 while i < bytes.len() && bytes[i] != b'\'' {
-                    out.push(bytes[i] as char);
+                    out.push(bytes[i]);
                     i += 1;
                 }
                 if i < bytes.len() {
-                    out.push('\'');
+                    out.push(b'\'');
                     i += 1;
                 }
                 at_stmt_start = false;
             }
             b'"' => {
-                // Double-quoted string: backslash escapes one char.
-                out.push('"');
+                // Double-quoted string: backslash escapes one byte.
+                out.push(b'"');
                 i += 1;
                 while i < bytes.len() {
                     let c = bytes[i];
-                    out.push(c as char);
+                    out.push(c);
                     i += 1;
                     if c == b'\\' && i < bytes.len() {
-                        out.push(bytes[i] as char);
+                        out.push(bytes[i]);
                         i += 1;
                         continue;
                     }
@@ -129,10 +143,10 @@ pub fn rewrite(input: &str, map: &HashMap<&'static str, &'static str>) -> String
             }
             b'\\' => {
                 // Unquoted backslash: consume the next byte as literal.
-                out.push('\\');
+                out.push(b'\\');
                 i += 1;
                 if i < bytes.len() {
-                    out.push(bytes[i] as char);
+                    out.push(bytes[i]);
                     i += 1;
                 }
                 at_stmt_start = false;
@@ -141,56 +155,62 @@ pub fn rewrite(input: &str, map: &HashMap<&'static str, &'static str>) -> String
                 // Comment: copy through end-of-line; newline handling happens
                 // on the next iteration and keeps stmt_start=true.
                 while i < bytes.len() && bytes[i] != b'\n' {
-                    out.push(bytes[i] as char);
+                    out.push(bytes[i]);
                     i += 1;
                 }
             }
             b'#' => {
                 // Mid-token `#` (e.g. `get_agent a#b`) is a literal.
-                out.push('#');
+                out.push(b'#');
                 i += 1;
             }
             b'`' => {
                 // Legacy backtick command substitution. Treat as a quoted
                 // region with no nested rewrite. `$(...)` is the preferred
                 // form and does get rewritten inside.
-                out.push('`');
+                out.push(b'`');
                 i += 1;
                 while i < bytes.len() && bytes[i] != b'`' {
                     let c = bytes[i];
-                    out.push(c as char);
+                    out.push(c);
                     i += 1;
                     if c == b'\\' && i < bytes.len() {
-                        out.push(bytes[i] as char);
+                        out.push(bytes[i]);
                         i += 1;
                     }
                 }
                 if i < bytes.len() {
-                    out.push('`');
+                    out.push(b'`');
                     i += 1;
                 }
                 at_stmt_start = false;
             }
             b';' | b'|' | b'&' | b'\n' | b'(' | b'{' => {
-                out.push(b as char);
+                out.push(b);
                 i += 1;
                 at_stmt_start = true;
             }
             b' ' | b'\t' => {
-                out.push(b as char);
+                out.push(b);
                 i += 1;
                 // Whitespace doesn't reset at_stmt_start (it preserves the
                 // previous state so leading whitespace still counts as
                 // statement start).
             }
             _ => {
-                out.push(b as char);
+                out.push(b);
                 i += 1;
                 at_stmt_start = false;
             }
         }
     }
-    out
+
+    // Safety: the input is a valid UTF-8 `&str`; we only append ASCII bytes
+    // (`--<flag>` where <flag> is a compile-time ASCII identifier) and copy
+    // arbitrary input bytes verbatim. The concatenation preserves UTF-8
+    // because valid UTF-8 sub-slices joined with ASCII stay valid UTF-8.
+    debug_assert!(std::str::from_utf8(&out).is_ok());
+    unsafe { String::from_utf8_unchecked(out) }
 }
 
 fn is_name_start(b: u8) -> bool {
@@ -413,6 +433,31 @@ mod tests {
     }
 
     #[test]
+    fn no_whitespace_between_cmd_and_value_unchanged() {
+        // bash concatenation: `get_agent'abc'` tokenizes as the command name
+        // `get_agentabc`, not `get_agent` followed by `abc`. Likewise
+        // `get_agent$ID` is `get_agent<expanded>`. Rewriting these would
+        // change the command name bash ultimately sees, so the rewriter
+        // requires at least one whitespace separator.
+        let m = test_map();
+        assert_eq!(rewrite("get_agent'abc'", &m), "get_agent'abc'");
+        assert_eq!(rewrite("get_agent$ID", &m), "get_agent$ID");
+        assert_eq!(rewrite("get_agent\"a\"", &m), "get_agent\"a\"");
+    }
+
+    #[test]
+    fn utf8_payload_preserved() {
+        // The rewriter must not corrupt multi-byte UTF-8 sequences in
+        // quoted strings or comments. `é` is two bytes (0xC3 0xA9).
+        let m = test_map();
+        assert_eq!(
+            rewrite("echo 'é' ; get_agent a1", &m),
+            "echo 'é' ; get_agent --id a1"
+        );
+        assert_eq!(rewrite("get_agent 'id-é-1'", &m), "get_agent --id 'id-é-1'");
+    }
+
+    #[test]
     fn build_positional_map_contains_known_commands() {
         let map = positional_map();
         // Inventory commands with id: at least get_agent, get_capability.
@@ -428,5 +473,14 @@ mod tests {
         // Multi-path-param ops (e.g. delete_app_channel has two) must not be
         // present: positional ordering would be ambiguous.
         assert!(!map.contains_key("delete_app_channel"));
+    }
+
+    #[test]
+    fn inventory_takes_precedence_over_catalog() {
+        let map = build_positional_map();
+        // get_agent is in the inventory with positional_arg=Some("id"). If it
+        // also appears in the static catalog with a different flag, inventory
+        // must win — the catalog entry would shadow it otherwise.
+        assert_eq!(map.get("get_agent").copied(), Some("id"));
     }
 }

--- a/crates/server/src/domains/agent_identities/commands.rs
+++ b/crates/server/src/domains/agent_identities/commands.rs
@@ -138,6 +138,10 @@ impl Command for GetAgentIdentity {
         Some(&AGENT_IDENTITY_VIEW)
     }
 
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<AgentIdentity, CommandError> {
         let identity_id: AgentIdentityId = self
             .id
@@ -180,6 +184,10 @@ impl Command for UpdateAgentIdentityCmd {
 
     fn policy() -> Option<&'static Policy> {
         Some(&AGENT_IDENTITY_MANAGE)
+    }
+
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<AgentIdentity, CommandError> {
@@ -250,6 +258,10 @@ impl Command for DeleteAgentIdentity {
         Some(&AGENT_IDENTITY_MANAGE)
     }
 
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<serde_json::Value, CommandError> {
         let identity_id: AgentIdentityId = self
             .id
@@ -297,6 +309,10 @@ impl Command for DestroyAgentIdentity {
 
     fn policy() -> Option<&'static Policy> {
         Some(&AGENT_IDENTITY_DANGEROUS)
+    }
+
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<serde_json::Value, CommandError> {

--- a/crates/server/src/domains/agents/commands.rs
+++ b/crates/server/src/domains/agents/commands.rs
@@ -307,6 +307,10 @@ impl Command for GetAgent {
         Some(&AGENT_VIEW)
     }
 
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<Agent, CommandError> {
         q::resolve(&ctx.db, ctx.org_id(), &self.id)
             .await
@@ -344,6 +348,10 @@ impl Command for UpdateAgentCmd {
 
     fn policy() -> Option<&'static Policy> {
         Some(&AGENT_MANAGE)
+    }
+
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<Agent, CommandError> {
@@ -492,6 +500,10 @@ impl Command for DeleteAgent {
         Some(&AGENT_MANAGE)
     }
 
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<serde_json::Value, CommandError> {
         let agent_id: AgentId = self
             .id
@@ -551,6 +563,10 @@ impl Command for UpsertAgent {
 
     fn policy() -> Option<&'static Policy> {
         Some(&AGENT_MANAGE)
+    }
+
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<UpsertResult, CommandError> {
@@ -649,6 +665,10 @@ impl Command for CopyAgent {
         Some(&AGENT_MANAGE)
     }
 
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<Agent, CommandError> {
         let source = q::resolve(&ctx.db, ctx.org_id(), &self.id)
             .await
@@ -707,6 +727,10 @@ impl Command for ExportAgent {
 
     fn policy() -> Option<&'static Policy> {
         Some(&AGENT_VIEW)
+    }
+
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<Agent, CommandError> {
@@ -901,6 +925,10 @@ impl Command for DestroyAgent {
 
     fn policy() -> Option<&'static Policy> {
         Some(&AGENT_DANGEROUS)
+    }
+
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<serde_json::Value, CommandError> {

--- a/crates/server/src/domains/apps/commands.rs
+++ b/crates/server/src/domains/apps/commands.rs
@@ -225,6 +225,10 @@ impl Command for GetApp {
         Some(&APP_VIEW)
     }
 
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<App, CommandError> {
         let app_id: AppId = self
             .id
@@ -268,6 +272,10 @@ impl Command for UpdateAppCmd {
 
     fn policy() -> Option<&'static Policy> {
         Some(&APP_MANAGE)
+    }
+
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<App, CommandError> {
@@ -367,6 +375,10 @@ impl Command for DeleteApp {
         Some(&APP_DANGEROUS)
     }
 
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<serde_json::Value, CommandError> {
         let app_id: AppId = self
             .id
@@ -416,6 +428,10 @@ impl Command for DestroyApp {
 
     fn policy() -> Option<&'static Policy> {
         Some(&APP_DANGEROUS)
+    }
+
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<serde_json::Value, CommandError> {
@@ -473,6 +489,10 @@ impl Command for PublishApp {
 
     fn policy() -> Option<&'static Policy> {
         Some(&APP_DANGEROUS)
+    }
+
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<App, CommandError> {
@@ -533,6 +553,10 @@ impl Command for UnpublishApp {
 
     fn policy() -> Option<&'static Policy> {
         Some(&APP_DANGEROUS)
+    }
+
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<App, CommandError> {

--- a/crates/server/src/domains/capabilities/commands.rs
+++ b/crates/server/src/domains/capabilities/commands.rs
@@ -96,6 +96,10 @@ impl Command for GetCapability {
         }
     }
 
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<CapabilityInfo, CommandError> {
         let cap_id = CapabilityId::new(&self.id);
 

--- a/crates/server/src/domains/common.rs
+++ b/crates/server/src/domains/common.rs
@@ -182,6 +182,15 @@ pub trait Command: DeserializeOwned + Send + 'static {
         None
     }
 
+    /// If set, allows MCP `execute` callers to pass the value for this field as
+    /// a single positional argument (e.g. `get_agent <id>` instead of
+    /// `get_agent --id <id>`). bashkit's flag parser hardcodes `expected --flag`
+    /// for positional args, so the command string is pre-rewritten to insert
+    /// `--<positional_arg>` before the value. See EVE-323.
+    fn positional_arg() -> Option<&'static str> {
+        None
+    }
+
     /// Execute the command. Validation + business logic + persistence.
     fn execute(self, ctx: &Ctx) -> impl Future<Output = Result<Self::Output, CommandError>> + Send;
 }
@@ -210,6 +219,7 @@ type DispatchFn =
 
 pub struct CommandDescriptor {
     pub meta: fn() -> CommandMeta,
+    pub positional_arg: fn() -> Option<&'static str>,
     pub dispatch: DispatchFn,
 }
 
@@ -220,6 +230,7 @@ impl CommandDescriptor {
     pub const fn of<C: Command>() -> Self {
         Self {
             meta: C::meta,
+            positional_arg: C::positional_arg,
             dispatch: dispatch_for::<C>,
         }
     }

--- a/crates/server/src/domains/harnesses/commands.rs
+++ b/crates/server/src/domains/harnesses/commands.rs
@@ -259,6 +259,10 @@ impl Command for GetHarness {
         Some(&HARNESS_VIEW)
     }
 
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<Harness, CommandError> {
         q::resolve(&ctx.db, ctx.org_id(), &self.id)
             .await
@@ -296,6 +300,10 @@ impl Command for UpdateHarnessCmd {
 
     fn policy() -> Option<&'static Policy> {
         Some(&HARNESS_MANAGE)
+    }
+
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<Harness, CommandError> {
@@ -471,6 +479,10 @@ impl Command for DeleteHarness {
         Some(&HARNESS_DANGEROUS)
     }
 
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<serde_json::Value, CommandError> {
         let harness_id: HarnessId = self
             .id
@@ -530,6 +542,10 @@ impl Command for DestroyHarness {
 
     fn policy() -> Option<&'static Policy> {
         Some(&HARNESS_DANGEROUS)
+    }
+
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<serde_json::Value, CommandError> {
@@ -604,6 +620,10 @@ impl Command for CopyHarness {
 
     fn policy() -> Option<&'static Policy> {
         Some(&HARNESS_MANAGE)
+    }
+
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<Harness, CommandError> {

--- a/crates/server/src/domains/mcp_servers/commands.rs
+++ b/crates/server/src/domains/mcp_servers/commands.rs
@@ -211,6 +211,10 @@ impl Command for GetMcpServer {
         Some(&MCP_SERVER_VIEW)
     }
 
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<McpServer, CommandError> {
         let server_id: McpServerId = self
             .id
@@ -253,6 +257,10 @@ impl Command for UpdateMcpServerCmd {
 
     fn policy() -> Option<&'static Policy> {
         Some(&MCP_SERVER_MANAGE)
+    }
+
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<McpServer, CommandError> {
@@ -379,6 +387,10 @@ impl Command for DeleteMcpServer {
         Some(&MCP_SERVER_MANAGE)
     }
 
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<serde_json::Value, CommandError> {
         let server_id: McpServerId = self
             .id
@@ -426,6 +438,10 @@ impl Command for DestroyMcpServer {
 
     fn policy() -> Option<&'static Policy> {
         Some(&MCP_SERVER_DANGEROUS)
+    }
+
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<serde_json::Value, CommandError> {

--- a/crates/server/src/domains/skills/commands.rs
+++ b/crates/server/src/domains/skills/commands.rs
@@ -167,6 +167,10 @@ impl Command for GetSkill {
         Some(&SKILL_VIEW)
     }
 
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<Skill, CommandError> {
         let skill_id: SkillId = self
             .id
@@ -212,6 +216,10 @@ impl Command for GetSkillContent {
 
     fn policy() -> Option<&'static Policy> {
         Some(&SKILL_VIEW)
+    }
+
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<SkillContent, CommandError> {
@@ -306,6 +314,10 @@ impl Command for UpdateSkillCmd {
 
     fn policy() -> Option<&'static Policy> {
         Some(&SKILL_MANAGE)
+    }
+
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<Skill, CommandError> {
@@ -415,6 +427,10 @@ impl Command for DeleteSkill {
         Some(&SKILL_MANAGE)
     }
 
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<serde_json::Value, CommandError> {
         let skill_id: SkillId = self
             .id
@@ -462,6 +478,10 @@ impl Command for DestroySkill {
 
     fn policy() -> Option<&'static Policy> {
         Some(&SKILL_DANGEROUS)
+    }
+
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<serde_json::Value, CommandError> {

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -807,6 +807,82 @@ async fn test_mcp_execute_list_agents_with_numeric_and_bool_flags() {
     assert_eq!(payload["limit"], 10);
 }
 
+// Regression for EVE-323: LLMs naturally type `get_agent <id>` instead of
+// `get_agent --id <id>`. Without positional-arg rewriting, bashkit's
+// `parse_flags` rejects the call with "expected --flag, got: <id>".
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_execute_get_agent_positional_id() {
+    let (_server, url) = TestServer::serving().await;
+
+    let resp = mcp_tool_call_http(
+        &url,
+        "execute",
+        json!({
+            "command": "create_agent --name 'eve323-positional-agent' --display_name 'EVE-323 Positional' --system_prompt 'Test'"
+        }),
+    )
+    .await;
+    assert!(
+        !tool_is_error(&resp),
+        "create_agent failed: {}",
+        tool_text(&resp)
+    );
+    let agent_id = tool_json(&resp)["id"].as_str().unwrap().to_string();
+
+    // Positional form: `get_agent <id>` (no --id flag).
+    let resp = mcp_tool_call_http(
+        &url,
+        "execute",
+        json!({ "command": format!("get_agent {agent_id}") }),
+    )
+    .await;
+    assert!(
+        !tool_is_error(&resp),
+        "get_agent <id> (positional) failed: {}",
+        tool_text(&resp)
+    );
+    let fetched = tool_json(&resp);
+    assert_eq!(fetched["name"], "eve323-positional-agent");
+    assert_eq!(fetched["id"], agent_id);
+}
+
+// Regression for EVE-323: positional `delete_agent <id>` must archive the
+// agent the same way `delete_agent --id <id>` does.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_execute_delete_agent_positional_id() {
+    let (_server, url) = TestServer::serving().await;
+
+    let resp = mcp_tool_call_http(
+        &url,
+        "execute",
+        json!({
+            "command": "create_agent --name 'eve323-delete-agent' --display_name 'EVE-323 Delete' --system_prompt 'Test'"
+        }),
+    )
+    .await;
+    assert!(
+        !tool_is_error(&resp),
+        "create_agent failed: {}",
+        tool_text(&resp)
+    );
+    let agent_id = tool_json(&resp)["id"].as_str().unwrap().to_string();
+
+    // Positional form: `delete_agent <id>`.
+    let resp = mcp_tool_call_http(
+        &url,
+        "execute",
+        json!({ "command": format!("delete_agent {agent_id}") }),
+    )
+    .await;
+    assert!(
+        !tool_is_error(&resp),
+        "delete_agent <id> (positional) failed: {}",
+        tool_text(&resp)
+    );
+    let payload = tool_json(&resp);
+    assert_eq!(payload["deleted"], true);
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mcp_execute_list_mcp_servers() {
     let (_server, url) = TestServer::serving().await;

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -644,7 +644,7 @@ async fn test_mcp_discover_capabilities() {
 async fn test_mcp_execute_health_check() {
     let (_server, url) = TestServer::serving().await;
 
-    let resp = mcp_tool_call_http(&url, "execute", json!({ "command": "health_check" })).await;
+    let resp = mcp_tool_call_http(&url, "execute", json!({ "commands": "health_check" })).await;
     assert!(
         !tool_is_error(&resp),
         "execute health_check failed: {}",
@@ -659,7 +659,7 @@ async fn test_mcp_execute_health_check() {
 async fn test_mcp_execute_list_harnesses() {
     let (_server, url) = TestServer::serving().await;
 
-    let resp = mcp_tool_call_http(&url, "execute", json!({ "command": "list_harnesses" })).await;
+    let resp = mcp_tool_call_http(&url, "execute", json!({ "commands": "list_harnesses" })).await;
     assert!(
         !tool_is_error(&resp),
         "execute list_harnesses failed: {}",
@@ -683,7 +683,7 @@ async fn test_mcp_execute_list_harnesses() {
 async fn test_mcp_execute_list_agents() {
     let (_server, url) = TestServer::serving().await;
 
-    let resp = mcp_tool_call_http(&url, "execute", json!({ "command": "list_agents" })).await;
+    let resp = mcp_tool_call_http(&url, "execute", json!({ "commands": "list_agents" })).await;
     assert!(
         !tool_is_error(&resp),
         "execute list_agents failed: {}",
@@ -703,7 +703,7 @@ async fn test_mcp_execute_create_and_get_agent() {
         &url,
         "execute",
         json!({
-            "command": "create_agent --name 'mcp-execute-agent' --display_name 'MCP Execute Agent' --system_prompt 'Test prompt'"
+            "commands": "create_agent --name 'mcp-execute-agent' --display_name 'MCP Execute Agent' --system_prompt 'Test prompt'"
         }),
     )
     .await;
@@ -721,7 +721,7 @@ async fn test_mcp_execute_create_and_get_agent() {
     let resp = mcp_tool_call_http(
         &url,
         "execute",
-        json!({ "command": format!("get_agent --id {agent_id}") }),
+        json!({ "commands": format!("get_agent --id {agent_id}") }),
     )
     .await;
     assert!(
@@ -738,7 +738,7 @@ async fn test_mcp_execute_create_and_get_agent() {
 async fn test_mcp_execute_list_models() {
     let (_server, url) = TestServer::serving().await;
 
-    let resp = mcp_tool_call_http(&url, "execute", json!({ "command": "list_models" })).await;
+    let resp = mcp_tool_call_http(&url, "execute", json!({ "commands": "list_models" })).await;
     assert!(
         !tool_is_error(&resp),
         "execute list_models failed: {}",
@@ -750,7 +750,8 @@ async fn test_mcp_execute_list_models() {
 async fn test_mcp_execute_list_capabilities() {
     let (_server, url) = TestServer::serving().await;
 
-    let resp = mcp_tool_call_http(&url, "execute", json!({ "command": "list_capabilities" })).await;
+    let resp =
+        mcp_tool_call_http(&url, "execute", json!({ "commands": "list_capabilities" })).await;
     assert!(
         !tool_is_error(&resp),
         "execute list_capabilities failed: {}",
@@ -769,7 +770,7 @@ async fn test_mcp_execute_list_capabilities_with_limit_flag() {
     let resp = mcp_tool_call_http(
         &url,
         "execute",
-        json!({ "command": "list_capabilities --limit 5" }),
+        json!({ "commands": "list_capabilities --limit 5" }),
     )
     .await;
     assert!(
@@ -793,7 +794,7 @@ async fn test_mcp_execute_list_agents_with_numeric_and_bool_flags() {
     let resp = mcp_tool_call_http(
         &url,
         "execute",
-        json!({ "command": "list_agents --include_archived true --offset 0 --limit 10" }),
+        json!({ "commands": "list_agents --include_archived true --offset 0 --limit 10" }),
     )
     .await;
     assert!(
@@ -818,7 +819,7 @@ async fn test_mcp_execute_get_agent_positional_id() {
         &url,
         "execute",
         json!({
-            "command": "create_agent --name 'eve323-positional-agent' --display_name 'EVE-323 Positional' --system_prompt 'Test'"
+            "commands": "create_agent --name 'eve323-positional-agent' --display_name 'EVE-323 Positional' --system_prompt 'Test'"
         }),
     )
     .await;
@@ -833,7 +834,7 @@ async fn test_mcp_execute_get_agent_positional_id() {
     let resp = mcp_tool_call_http(
         &url,
         "execute",
-        json!({ "command": format!("get_agent {agent_id}") }),
+        json!({ "commands": format!("get_agent {agent_id}") }),
     )
     .await;
     assert!(
@@ -856,7 +857,7 @@ async fn test_mcp_execute_delete_agent_positional_id() {
         &url,
         "execute",
         json!({
-            "command": "create_agent --name 'eve323-delete-agent' --display_name 'EVE-323 Delete' --system_prompt 'Test'"
+            "commands": "create_agent --name 'eve323-delete-agent' --display_name 'EVE-323 Delete' --system_prompt 'Test'"
         }),
     )
     .await;
@@ -871,7 +872,7 @@ async fn test_mcp_execute_delete_agent_positional_id() {
     let resp = mcp_tool_call_http(
         &url,
         "execute",
-        json!({ "command": format!("delete_agent {agent_id}") }),
+        json!({ "commands": format!("delete_agent {agent_id}") }),
     )
     .await;
     assert!(
@@ -887,7 +888,7 @@ async fn test_mcp_execute_delete_agent_positional_id() {
 async fn test_mcp_execute_list_mcp_servers() {
     let (_server, url) = TestServer::serving().await;
 
-    let resp = mcp_tool_call_http(&url, "execute", json!({ "command": "list_mcp_servers" })).await;
+    let resp = mcp_tool_call_http(&url, "execute", json!({ "commands": "list_mcp_servers" })).await;
     assert!(
         !tool_is_error(&resp),
         "execute list_mcp_servers failed: {}",
@@ -911,7 +912,7 @@ async fn test_mcp_execute_create_mcp_server() {
         &url,
         "execute",
         json!({
-            "command": format!("create_mcp_server --name '{unique_name}' --url 'https://mcp.test.com/v1'")
+            "commands": format!("create_mcp_server --name '{unique_name}' --url 'https://mcp.test.com/v1'")
         }),
     )
     .await;
@@ -934,7 +935,7 @@ async fn test_mcp_execute_bash_pipe() {
     let resp = mcp_tool_call_http(
         &url,
         "execute",
-        json!({ "command": "list_harnesses | jq '.data | length'" }),
+        json!({ "commands": "list_harnesses | jq '.data | length'" }),
     )
     .await;
     assert!(!tool_is_error(&resp), "pipe failed: {}", tool_text(&resp));
@@ -953,7 +954,7 @@ async fn test_mcp_execute_bash_script() {
         list_agents | jq '.data | length'
     "#;
 
-    let resp = mcp_tool_call_http(&url, "execute", json!({ "command": script })).await;
+    let resp = mcp_tool_call_http(&url, "execute", json!({ "commands": script })).await;
     assert!(
         !tool_is_error(&resp),
         "bash script failed: {}",
@@ -968,7 +969,7 @@ async fn test_mcp_execute_bash_script() {
 async fn test_mcp_execute_list_providers() {
     let (_server, url) = TestServer::serving().await;
 
-    let resp = mcp_tool_call_http(&url, "execute", json!({ "command": "list_providers" })).await;
+    let resp = mcp_tool_call_http(&url, "execute", json!({ "commands": "list_providers" })).await;
     assert!(
         !tool_is_error(&resp),
         "list_providers failed: {}",
@@ -980,7 +981,7 @@ async fn test_mcp_execute_list_providers() {
 async fn test_mcp_execute_list_orgs() {
     let (_server, url) = TestServer::serving().await;
 
-    let resp = mcp_tool_call_http(&url, "execute", json!({ "command": "list_orgs" })).await;
+    let resp = mcp_tool_call_http(&url, "execute", json!({ "commands": "list_orgs" })).await;
     assert!(
         !tool_is_error(&resp),
         "list_orgs failed: {}",
@@ -995,7 +996,7 @@ async fn test_mcp_execute_discover_categories() {
     let resp = mcp_tool_call_http(
         &url,
         "execute",
-        json!({ "command": "discover --categories" }),
+        json!({ "commands": "discover --categories" }),
     )
     .await;
     assert!(
@@ -1014,7 +1015,7 @@ async fn test_mcp_execute_discover_categories() {
 async fn test_mcp_execute_discover_all() {
     let (_server, url) = TestServer::serving().await;
 
-    let resp = mcp_tool_call_http(&url, "execute", json!({ "command": "discover --all" })).await;
+    let resp = mcp_tool_call_http(&url, "execute", json!({ "commands": "discover --all" })).await;
     assert!(
         !tool_is_error(&resp),
         "discover --all failed: {}",
@@ -1041,7 +1042,7 @@ async fn test_mcp_execute_agent_crud_workflow() {
         &url,
         "execute",
         json!({
-            "command": "create_agent --name 'crud-agent' --display_name 'CRUD Agent' --system_prompt 'CRUD test'"
+            "commands": "create_agent --name 'crud-agent' --display_name 'CRUD Agent' --system_prompt 'CRUD test'"
         }),
     )
     .await;
@@ -1058,7 +1059,7 @@ async fn test_mcp_execute_agent_crud_workflow() {
         &url,
         "execute",
         json!({
-            "command": format!("update_agent --id {agent_id} --name 'updated-crud-agent'")
+            "commands": format!("update_agent --id {agent_id} --name 'updated-crud-agent'")
         }),
     )
     .await;
@@ -1074,7 +1075,7 @@ async fn test_mcp_execute_agent_crud_workflow() {
     let resp = mcp_tool_call_http(
         &url,
         "execute",
-        json!({ "command": format!("delete_agent --id {agent_id}") }),
+        json!({ "commands": format!("delete_agent --id {agent_id}") }),
     )
     .await;
     assert!(

--- a/specs/domains.md
+++ b/specs/domains.md
@@ -110,6 +110,7 @@ table are generated at runtime from the registry — no hand-maintained
 ```rust
 pub struct CommandDescriptor {
     pub meta: fn() -> CommandMeta,
+    pub positional_arg: fn() -> Option<&'static str>,
     pub dispatch: for<'a> fn(
         serde_json::Value,
         &'a Ctx,
@@ -121,6 +122,15 @@ inventory::collect!(CommandDescriptor);
 
 Adding a new command: implement `Command` for a struct, add `inventory::submit!`
 at the bottom. The catalog auto-updates. No other files to touch.
+
+### MCP `execute` positional args
+
+`Command::positional_arg()` lets a command opt in to accepting one positional
+argument under MCP's `execute` tool (bashkit). Returning `Some("id")` on
+`get_agent` means callers can write `get_agent <id>` instead of
+`get_agent --id <id>`; the mcp_endpoint rewrites the command string at
+statement boundaries before bashkit's flag parser runs. Only opt in when the
+command has exactly one required primary-key-like parameter. See EVE-323.
 
 ## Writing a Command
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -409,6 +409,7 @@ fn authorizer(action: AuthAction) -> Authorization {
 | TM-TOOL-016 | Browserless timeout DoS | Medium | All wait/timeout values capped at 120s; prevents unbounded resource consumption | MITIGATED |
 | TM-TOOL-017 | Browserless API token in logs | Medium | CDP debug logging redacts token from WebSocket URLs before logging | MITIGATED |
 | TM-TOOL-018 | MCP server SSRF via configured server URL | High | MCP server URLs are validated on create/update and re-validated at execution time; private/internal hosts and metadata endpoints blocked | MITIGATED |
+| TM-TOOL-019 | MCP `execute` positional-arg rewrite injection | Low | Rewriter only inserts compile-time `--<flag>` tokens at statement-start boundaries, respects quotes/escapes/comments, and never modifies or reorders user bytes. Flag names come from the command registry, not user input. See EVE-323. | MITIGATED |
 
 ### Mitigation Details
 


### PR DESCRIPTION
## What

Pre-rewrite MCP `execute` command strings so LLM callers can write `get_agent <id>` (positional) instead of `get_agent --id <id>`. The positional form is rewritten to the flag form before bashkit sees it.

Fixes EVE-323.

## Why

bashkit's `parse_flags` hardcodes a positional-arg rejection (`expected --flag, got: <value>`). LLMs naturally emit positional args first; the rejection bubbles up to MCP clients as a blunt `callback failed` and causes retry loops against `get_agent`, `delete_agent`, `get_capability`, and other id-keyed commands. Fixing bashkit isn't an option here; we sit one layer above it.

## How

1. `Command::positional_arg() -> Option<&'static str>` default `None` on the trait; `CommandDescriptor.positional_arg` carries it through inventory. Opted in to `Some("id")` on all id-keyed CRUD commands across `agents`, `agent_identities`, `apps`, `capabilities`, `harnesses`, `mcp_servers`, and `skills` (get/update/delete/destroy + publish/copy variants).
2. Static `CATALOG` ops derive their positional flag automatically when they declare exactly one `path` param (e.g. `get_session <session_id>`, `get_model <id>`). Multi-path-param ops (e.g. `delete_app_channel`) stay flag-only because ordering would be ambiguous.
3. New `crates/server/src/api/mcp_endpoint/positional.rs` module with a quote-aware byte-level state-machine rewriter. It respects single/double quotes, backslash escapes, backticks, `$(...)` subshells, `#` comments, and statement boundaries (`;`, `|`, `&`, newline, `(`, `{`). It only inserts compile-time `--<flag>` strings — user bytes are never modified, removed, or reordered.
4. `tool_execute` runs the rewriter before `execute_script`. The positional map is cached in a `OnceLock` so it's built once per process.

## Risk

Low.

- Behavior change: opted-in commands now accept a single positional primary key in addition to `--<flag>` form. The existing flag form is untouched (`is_positional_value_start` excludes `-`, so `--id` / `--anything` / `-h` pass through verbatim).
- Non-opted-in commands behave exactly as before.
- Rewriter is contained to the MCP `execute` path; nothing else uses it.

## Security

- Threat categories reviewed: TM-TOOL (command registration + execution path), TM-BASH (command string passes into the bashkit sandbox), TM-API (input handling on `execute`).
- Injection: the rewriter only inserts `--<flag>` where `<flag>` is a compile-time `&'static str` sourced from the command registry (trait method) or static catalog — never from user input. The tokenizer does not modify, remove, or reorder user bytes, so the rewrite cannot cause bash to interpret user input differently from how it would interpret the equivalent manual `--<flag> <value>` form.
- Quote / escape / comment handling is covered by 22 unit tests, including `'...'` verbatim, `"..."` with backslash escapes, mid-string boundaries, `` `...` `` legacy command-sub, `#` comments, and multi-statement inputs (`;`, `|`, `&`, newline, `$(...)`, `{`).
- The worst-case failure mode is a false-positive rewrite producing a bashkit error — no silent security regression.
- New threat-model entry: `TM-TOOL-019 — MCP execute positional-arg rewrite injection` (Low, MITIGATED).

## Validation

- 22 unit tests in `api::mcp_endpoint::positional::tests` (all passing)
- 2 end-to-end MCP regression tests in `mcp_endpoint_test.rs`: `test_mcp_execute_get_agent_positional_id`, `test_mcp_execute_delete_agent_positional_id`
- Manual smoke test on `just start-dev`: `get_agent <id>`, `delete_agent <id>`, `get_agent --id <id>` (no regression), `list_agents --limit 2` (unknown-to-map passthrough) all green.
- `just pre-push` green.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
