### PR TITLE
feat(llm): add Azure OpenAI provider

### DIFF
--- a/apps/ui/src/__tests__/provider-icon.test.tsx
+++ b/apps/ui/src/__tests__/provider-icon.test.tsx
@@ -3,7 +3,13 @@ import { ProviderIcon, getProviderLabel } from "@/components/providers/provider-
 import type { LlmProviderType } from "@/lib/api/types";
 
 describe("ProviderIcon", () => {
-  const providerTypes: LlmProviderType[] = ["openai", "openai_completions", "anthropic", "gemini"];
+  const providerTypes: LlmProviderType[] = [
+    "openai",
+    "azure_openai",
+    "openai_completions",
+    "anthropic",
+    "gemini",
+  ];
 
   it.each(providerTypes)("renders inline SVG for %s provider", (providerType) => {
     const { container } = render(<ProviderIcon providerType={providerType} />);
@@ -79,6 +85,10 @@ describe("ProviderIcon", () => {
 describe("getProviderLabel", () => {
   it("returns correct label for openai", () => {
     expect(getProviderLabel("openai")).toBe("OpenAI (Responses)");
+  });
+
+  it("returns correct label for azure openai", () => {
+    expect(getProviderLabel("azure_openai")).toBe("Azure OpenAI");
   });
 
   it("returns correct label for anthropic", () => {

--- a/apps/ui/src/app/(main)/orgs/[orgId]/setup/page.tsx
+++ b/apps/ui/src/app/(main)/orgs/[orgId]/setup/page.tsx
@@ -61,6 +61,7 @@ const STEP_DELAY_MS = 400;
 
 const PROVIDER_OPTIONS: { type: LlmProviderType; label: string }[] = [
   { type: "openai", label: "OpenAI" },
+  { type: "azure_openai", label: "Azure OpenAI" },
   { type: "anthropic", label: "Anthropic" },
 ];
 
@@ -69,6 +70,8 @@ function getProviderName(providerType: LlmProviderType): string {
     case "openai":
     case "openai_completions":
       return "OpenAI";
+    case "azure_openai":
+      return "Azure OpenAI";
     case "anthropic":
       return "Anthropic";
     case "gemini":

--- a/apps/ui/src/app/(main)/settings/providers/provider-dialogs.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/provider-dialogs.tsx
@@ -28,6 +28,7 @@ import type {
 
 const PROVIDER_TYPES: { value: LlmProviderType; label: string }[] = [
   { value: "openai", label: "OpenAI (Responses API)" },
+  { value: "azure_openai", label: "Azure OpenAI" },
   { value: "openai_completions", label: "OpenAI (Completions API)" },
   { value: "anthropic", label: "Anthropic" },
   { value: "gemini", label: "Google Gemini" },
@@ -39,10 +40,29 @@ function getApiKeyPlaceholder(providerType: LlmProviderType): string {
     case "openai":
     case "openai_completions":
       return "sk-...";
+    case "azure_openai":
+      return "Azure OpenAI resource key";
     case "anthropic":
       return "sk-ant-api03-...";
     default:
       return "your-api-key";
+  }
+}
+
+function getBaseUrlPlaceholder(providerType: LlmProviderType): string {
+  switch (providerType) {
+    case "azure_openai":
+      return "https://your-resource.openai.azure.com/openai/v1";
+    case "openai":
+      return "https://api.openai.com/v1";
+    case "openai_completions":
+      return "https://api.openai.com/v1/chat/completions";
+    case "anthropic":
+      return "https://api.anthropic.com/v1/messages";
+    case "gemini":
+      return "https://generativelanguage.googleapis.com";
+    default:
+      return "https://api.example.com";
   }
 }
 
@@ -126,8 +146,15 @@ export function AddProviderDialog({
               id="base-url"
               value={baseUrl}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => setBaseUrl(e.target.value)}
-              placeholder="https://api.openai.com/v1"
+              placeholder={getBaseUrlPlaceholder(providerType)}
+              required={providerType === "azure_openai"}
             />
+            {providerType === "azure_openai" ? (
+              <p className="text-sm text-muted-foreground">
+                Use your Azure OpenAI `.../openai/v1` endpoint on `openai.azure.com` or
+                `services.ai.azure.com`.
+              </p>
+            ) : null}
           </div>
           <div className="space-y-2">
             <Label htmlFor="api-key">API Key (optional)</Label>
@@ -143,7 +170,14 @@ export function AddProviderDialog({
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>
-            <Button type="submit" disabled={createProvider.isPending || !name}>
+            <Button
+              type="submit"
+              disabled={
+                createProvider.isPending ||
+                !name ||
+                (providerType === "azure_openai" && !baseUrl.trim())
+              }
+            >
               {createProvider.isPending ? "Creating..." : "Create Provider"}
             </Button>
           </DialogFooter>

--- a/apps/ui/src/components/providers/provider-icon.tsx
+++ b/apps/ui/src/components/providers/provider-icon.tsx
@@ -50,8 +50,26 @@ function GeminiIcon({ size }: { size: number }) {
   );
 }
 
+function AzureOpenAiIcon({ size }: { size: number }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+    >
+      <path
+        d="M13.05 4.24L6.56 18.05L2 18.22L7.68 7.32L13.05 4.24ZM14.15 5.56L16.65 10.25L12.38 18.04L22 18.25L14.15 5.56Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
 const PROVIDER_ICON_COMPONENTS: Record<LlmProviderType, React.ComponentType<{ size: number }>> = {
   openai: OpenAiIcon,
+  azure_openai: AzureOpenAiIcon,
   openai_completions: OpenAiIcon,
   anthropic: AnthropicIcon,
   gemini: GeminiIcon,
@@ -59,6 +77,7 @@ const PROVIDER_ICON_COMPONENTS: Record<LlmProviderType, React.ComponentType<{ si
 
 const PROVIDER_LABELS: Record<LlmProviderType, string> = {
   openai: "OpenAI (Responses)",
+  azure_openai: "Azure OpenAI",
   openai_completions: "OpenAI (Completions)",
   anthropic: "Anthropic",
   gemini: "Google Gemini",

--- a/apps/ui/src/lib/api/types/llm-types.ts
+++ b/apps/ui/src/lib/api/types/llm-types.ts
@@ -4,7 +4,12 @@
 // LLM Provider types
 // ============================================
 
-export type LlmProviderType = "openai" | "openai_completions" | "anthropic" | "gemini";
+export type LlmProviderType =
+  | "openai"
+  | "azure_openai"
+  | "openai_completions"
+  | "anthropic"
+  | "gemini";
 
 export type LlmProviderStatus = "active" | "disabled";
 export type LlmModelStatus = "active" | "disabled";

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -1695,6 +1695,7 @@ impl ReasonAtom {
     ) -> Result<crate::llm_driver_registry::BoxedLlmDriver> {
         let provider_type = match model.provider_type {
             crate::llm_models::LlmProviderType::Openai => ProviderType::OpenAI,
+            crate::llm_models::LlmProviderType::AzureOpenai => ProviderType::AzureOpenAI,
             crate::llm_models::LlmProviderType::OpenaiCompletions => {
                 ProviderType::OpenAICompletions
             }

--- a/crates/core/src/llm_driver_registry.rs
+++ b/crates/core/src/llm_driver_registry.rs
@@ -776,6 +776,8 @@ pub enum ProviderType {
     /// OpenAI using Open Responses API (<https://www.openresponses.org/>)
     /// This is the recommended API for new projects.
     OpenAI,
+    /// Azure OpenAI using the Azure-hosted OpenAI v1 API.
+    AzureOpenAI,
     /// OpenAI using Chat Completions API (for backward compatibility)
     /// Use this if you need the legacy /v1/chat/completions endpoint.
     OpenAICompletions,
@@ -792,6 +794,7 @@ impl std::str::FromStr for ProviderType {
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "openai" => Ok(ProviderType::OpenAI),
+            "azure_openai" => Ok(ProviderType::AzureOpenAI),
             "openai_completions" => Ok(ProviderType::OpenAICompletions),
             "anthropic" => Ok(ProviderType::Anthropic),
             "gemini" => Ok(ProviderType::Gemini),
@@ -805,6 +808,7 @@ impl std::fmt::Display for ProviderType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ProviderType::OpenAI => write!(f, "openai"),
+            ProviderType::AzureOpenAI => write!(f, "azure_openai"),
             ProviderType::OpenAICompletions => write!(f, "openai_completions"),
             ProviderType::Anthropic => write!(f, "anthropic"),
             ProviderType::Gemini => write!(f, "gemini"),
@@ -1053,6 +1057,10 @@ mod tests {
             ProviderType::OpenAICompletions
         );
         assert_eq!(
+            "azure_openai".parse::<ProviderType>().unwrap(),
+            ProviderType::AzureOpenAI
+        );
+        assert_eq!(
             "anthropic".parse::<ProviderType>().unwrap(),
             ProviderType::Anthropic
         );
@@ -1060,8 +1068,7 @@ mod tests {
             "gemini".parse::<ProviderType>().unwrap(),
             ProviderType::Gemini
         );
-        // Azure, Ollama and Custom are no longer supported
-        assert!("azure_openai".parse::<ProviderType>().is_err());
+        // Ollama and Custom are no longer supported
         assert!("ollama".parse::<ProviderType>().is_err());
         assert!("custom".parse::<ProviderType>().is_err());
     }
@@ -1069,6 +1076,7 @@ mod tests {
     #[test]
     fn test_provider_type_display() {
         assert_eq!(ProviderType::OpenAI.to_string(), "openai");
+        assert_eq!(ProviderType::AzureOpenAI.to_string(), "azure_openai");
         assert_eq!(
             ProviderType::OpenAICompletions.to_string(),
             "openai_completions"

--- a/crates/core/src/llm_model_profiles.rs
+++ b/crates/core/src/llm_model_profiles.rs
@@ -141,9 +141,9 @@ pub fn get_model_profile(
     model_id: &str,
 ) -> Option<LlmModelProfile> {
     match provider_type {
-        LlmProviderType::Openai | LlmProviderType::OpenaiCompletions => {
-            get_openai_profile(model_id)
-        }
+        LlmProviderType::Openai
+        | LlmProviderType::AzureOpenai
+        | LlmProviderType::OpenaiCompletions => get_openai_profile(model_id),
         LlmProviderType::Anthropic => get_anthropic_profile(model_id),
         LlmProviderType::Gemini => get_gemini_profile(model_id),
         LlmProviderType::LlmSim => get_llmsim_profile(model_id),
@@ -2377,6 +2377,13 @@ mod tests {
     #[test]
     fn test_openai_completions_uses_openai_profiles() {
         let profile = get_model_profile(&LlmProviderType::OpenaiCompletions, "gpt-4o");
+        assert!(profile.is_some());
+        assert_eq!(profile.unwrap().name, "GPT-4o");
+    }
+
+    #[test]
+    fn test_azure_openai_uses_openai_profiles() {
+        let profile = get_model_profile(&LlmProviderType::AzureOpenai, "gpt-4o");
         assert!(profile.is_some());
         assert_eq!(profile.unwrap().name, "GPT-4o");
     }

--- a/crates/core/src/llm_models.rs
+++ b/crates/core/src/llm_models.rs
@@ -12,12 +12,15 @@ use crate::typed_id::{ModelId, ProviderId};
 use utoipa::ToSchema;
 
 /// LLM provider type
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum LlmProviderType {
     /// OpenAI using Open Responses API (<https://www.openresponses.org/>)
     Openai,
+    /// Azure OpenAI using the Azure-hosted OpenAI v1 API
+    #[serde(rename = "azure_openai")]
+    AzureOpenai,
     /// OpenAI using Chat Completions API (for backward compatibility)
     #[serde(rename = "openai_completions")]
     OpenaiCompletions,
@@ -33,6 +36,7 @@ impl std::fmt::Display for LlmProviderType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             LlmProviderType::Openai => write!(f, "openai"),
+            LlmProviderType::AzureOpenai => write!(f, "azure_openai"),
             LlmProviderType::OpenaiCompletions => write!(f, "openai_completions"),
             LlmProviderType::Anthropic => write!(f, "anthropic"),
             LlmProviderType::Gemini => write!(f, "gemini"),
@@ -47,6 +51,7 @@ impl std::str::FromStr for LlmProviderType {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "openai" => Ok(LlmProviderType::Openai),
+            "azure_openai" => Ok(LlmProviderType::AzureOpenai),
             "openai_completions" => Ok(LlmProviderType::OpenaiCompletions),
             "anthropic" => Ok(LlmProviderType::Anthropic),
             "gemini" => Ok(LlmProviderType::Gemini),
@@ -369,6 +374,10 @@ mod tests {
             "\"openai_completions\""
         );
         assert_eq!(
+            serde_json::to_string(&LlmProviderType::AzureOpenai).unwrap(),
+            "\"azure_openai\""
+        );
+        assert_eq!(
             serde_json::to_string(&LlmProviderType::Anthropic).unwrap(),
             "\"anthropic\""
         );
@@ -394,6 +403,10 @@ mod tests {
             LlmProviderType::OpenaiCompletions
         ));
         assert!(matches!(
+            serde_json::from_str::<LlmProviderType>("\"azure_openai\"").unwrap(),
+            LlmProviderType::AzureOpenai
+        ));
+        assert!(matches!(
             serde_json::from_str::<LlmProviderType>("\"anthropic\"").unwrap(),
             LlmProviderType::Anthropic
         ));
@@ -417,6 +430,10 @@ mod tests {
         assert!(matches!(
             "openai_completions".parse::<LlmProviderType>().unwrap(),
             LlmProviderType::OpenaiCompletions
+        ));
+        assert!(matches!(
+            "azure_openai".parse::<LlmProviderType>().unwrap(),
+            LlmProviderType::AzureOpenai
         ));
         assert!(matches!(
             "anthropic".parse::<LlmProviderType>().unwrap(),
@@ -469,6 +486,7 @@ mod tests {
     fn test_llm_provider_type_display() {
         // Verify Display works correctly
         assert_eq!(LlmProviderType::Openai.to_string(), "openai");
+        assert_eq!(LlmProviderType::AzureOpenai.to_string(), "azure_openai");
         assert_eq!(
             LlmProviderType::OpenaiCompletions.to_string(),
             "openai_completions"

--- a/crates/core/src/openai_protocol.rs
+++ b/crates/core/src/openai_protocol.rs
@@ -17,7 +17,7 @@
 use async_trait::async_trait;
 use eventsource_stream::Eventsource;
 use futures::StreamExt;
-use reqwest::Client;
+use reqwest::{Client, RequestBuilder, Url};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::sync::{Arc, Mutex};
@@ -33,6 +33,27 @@ use crate::llm_retry::{
 use crate::tool_types::{ToolCall, ToolDefinition};
 
 const DEFAULT_API_URL: &str = "https://api.openai.com/v1/chat/completions";
+
+pub(crate) fn apply_openai_api_auth(
+    request: RequestBuilder,
+    api_url: &str,
+    api_key: &str,
+) -> RequestBuilder {
+    if is_azure_openai_api_url(api_url) {
+        request.header("api-key", api_key)
+    } else {
+        request.header("Authorization", format!("Bearer {}", api_key))
+    }
+}
+
+pub fn is_azure_openai_api_url(api_url: &str) -> bool {
+    Url::parse(api_url)
+        .ok()
+        .and_then(|url| url.host_str().map(|host| host.to_ascii_lowercase()))
+        .is_some_and(|host| {
+            host.ends_with(".openai.azure.com") || host.ends_with(".services.ai.azure.com")
+        })
+}
 
 /// OpenAI Protocol LLM Driver
 ///
@@ -246,15 +267,16 @@ impl LlmDriver for OpenAIProtocolLlmDriver {
         let mut last_error: Option<String> = None;
 
         let response = loop {
-            let response = self
-                .client
-                .post(&self.api_url)
-                .header("Authorization", format!("Bearer {}", self.api_key))
-                .header("Content-Type", "application/json")
-                .json(&request)
-                .send()
-                .await
-                .map_err(|e| AgentLoopError::llm(format!("Failed to send request: {}", e)))?;
+            let response = apply_openai_api_auth(
+                self.client.post(&self.api_url),
+                &self.api_url,
+                &self.api_key,
+            )
+            .header("Content-Type", "application/json")
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| AgentLoopError::llm(format!("Failed to send request: {}", e)))?;
 
             let status = response.status();
 
@@ -768,6 +790,19 @@ mod tests {
         );
         assert!(format!("{:?}", driver).contains("OpenAIProtocolLlmDriver"));
         assert_eq!(driver.api_url(), "https://custom.api.com/v1/completions");
+    }
+
+    #[test]
+    fn test_is_azure_openai_api_url() {
+        assert!(is_azure_openai_api_url(
+            "https://example.openai.azure.com/openai/v1/chat/completions"
+        ));
+        assert!(is_azure_openai_api_url(
+            "https://example.services.ai.azure.com/openai/v1/responses"
+        ));
+        assert!(!is_azure_openai_api_url(
+            "https://api.openai.com/v1/chat/completions"
+        ));
     }
 
     #[test]

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -35,7 +35,9 @@ use crate::llm_driver_registry::{
 use crate::llm_retry::{
     LlmRetryConfig, RateLimitInfo, RetryMetadata, is_rate_limit_status, is_transient_error,
 };
-use crate::openai_protocol::{is_openai_model_not_found, is_openai_request_too_large};
+use crate::openai_protocol::{
+    apply_openai_api_auth, is_openai_model_not_found, is_openai_request_too_large,
+};
 use crate::openresponses_types::{self as types, StreamingEvent};
 use crate::tool_types::{ToolCall, ToolDefinition};
 
@@ -367,17 +369,15 @@ impl OpenResponsesProtocolLlmDriver {
         let mut last_error: Option<String> = None;
 
         let response = loop {
-            let response = self
-                .client
-                .post(&compact_url)
-                .header("Authorization", format!("Bearer {}", self.api_key))
-                .header("Content-Type", "application/json")
-                .json(&request)
-                .send()
-                .await
-                .map_err(|e| {
-                    AgentLoopError::llm(format!("Failed to send compact request: {}", e))
-                })?;
+            let response =
+                apply_openai_api_auth(self.client.post(&compact_url), &compact_url, &self.api_key)
+                    .header("Content-Type", "application/json")
+                    .json(&request)
+                    .send()
+                    .await
+                    .map_err(|e| {
+                        AgentLoopError::llm(format!("Failed to send compact request: {}", e))
+                    })?;
 
             let status = response.status();
 
@@ -654,15 +654,16 @@ impl LlmDriver for OpenResponsesProtocolLlmDriver {
         let mut last_error: Option<String> = None;
 
         let response = loop {
-            let response = self
-                .client
-                .post(&self.api_url)
-                .header("Authorization", format!("Bearer {}", self.api_key))
-                .header("Content-Type", "application/json")
-                .json(&request)
-                .send()
-                .await
-                .map_err(|e| AgentLoopError::llm(format!("Failed to send request: {}", e)))?;
+            let response = apply_openai_api_auth(
+                self.client.post(&self.api_url),
+                &self.api_url,
+                &self.api_key,
+            )
+            .header("Content-Type", "application/json")
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| AgentLoopError::llm(format!("Failed to send request: {}", e)))?;
 
             let status = response.status();
 

--- a/crates/openai/src/driver.rs
+++ b/crates/openai/src/driver.rs
@@ -11,6 +11,7 @@
 use async_trait::async_trait;
 use chrono::TimeZone;
 use reqwest::RequestBuilder;
+use reqwest::Url;
 
 use everruns_core::OpenAIProtocolLlmDriver;
 use everruns_core::OpenResponsesProtocolLlmDriver;
@@ -341,7 +342,14 @@ fn models_url_for_api_url(api_url: &str) -> String {
 }
 
 fn supports_model_listing(api_url: &str) -> bool {
-    api_url.contains("://api.openai.com/") || is_azure_openai_api_url(api_url)
+    is_openai_api_url(api_url) || is_azure_openai_api_url(api_url)
+}
+
+fn is_openai_api_url(api_url: &str) -> bool {
+    Url::parse(api_url)
+        .ok()
+        .and_then(|url| url.host_str().map(str::to_owned))
+        .is_some_and(|host| host.eq_ignore_ascii_case("api.openai.com"))
 }
 
 fn apply_models_auth(request: RequestBuilder, api_url: &str, api_key: &str) -> RequestBuilder {
@@ -398,4 +406,21 @@ pub fn register_driver(registry: &mut DriverRegistry) {
         };
         Box::new(driver) as BoxedLlmDriver
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_openai_api_url, supports_model_listing};
+
+    #[test]
+    fn supports_model_listing_for_openai_host_with_port() {
+        assert!(supports_model_listing(
+            "https://api.openai.com:443/v1/responses"
+        ));
+    }
+
+    #[test]
+    fn rejects_non_openai_hosts_for_model_listing() {
+        assert!(!is_openai_api_url("https://example.com/v1/responses"));
+    }
 }

--- a/crates/openai/src/driver.rs
+++ b/crates/openai/src/driver.rs
@@ -10,6 +10,7 @@
 
 use async_trait::async_trait;
 use chrono::TimeZone;
+use reqwest::RequestBuilder;
 
 use everruns_core::OpenAIProtocolLlmDriver;
 use everruns_core::OpenResponsesProtocolLlmDriver;
@@ -18,6 +19,7 @@ use everruns_core::llm_driver_registry::{
     BoxedLlmDriver, DiscoveredModel, DriverRegistry, LlmCallConfig, LlmDriver, LlmMessage,
     LlmResponseStream, ProviderType,
 };
+use everruns_core::openai_protocol::is_azure_openai_api_url;
 use everruns_core::{CompactRequest, CompactResponse};
 
 use crate::types::OpenAiModelsResponse;
@@ -80,6 +82,7 @@ impl OpenAILlmDriver {
 
     /// Create a new driver with a custom API URL
     pub fn with_base_url(api_key: impl Into<String>, api_url: impl Into<String>) -> Self {
+        let api_url = normalize_api_url(&api_url.into(), "/responses");
         Self {
             inner: OpenResponsesProtocolLlmDriver::with_base_url(api_key, api_url),
             uses_custom_url: true,
@@ -134,12 +137,13 @@ impl LlmDriver for OpenAILlmDriver {
     }
 
     async fn list_models(&self) -> Result<Option<Vec<DiscoveredModel>>> {
-        // Skip discovery for custom URLs (proxies, self-hosted)
-        if self.uses_custom_url {
+        // Skip discovery for non-standard custom URLs (proxies, self-hosted)
+        if self.uses_custom_url && !supports_model_listing(self.api_url()) {
             return Ok(None);
         }
 
-        list_openai_models(self.inner.client(), self.inner.api_key()).await
+        let models_url = models_url_for_api_url(self.api_url());
+        list_openai_models(self.inner.client(), self.inner.api_key(), &models_url).await
     }
 
     fn supports_compact(&self) -> bool {
@@ -213,6 +217,7 @@ impl OpenAICompletionsLlmDriver {
 
     /// Create a new driver with a custom API URL
     pub fn with_base_url(api_key: impl Into<String>, api_url: impl Into<String>) -> Self {
+        let api_url = normalize_api_url(&api_url.into(), "/chat/completions");
         Self {
             inner: OpenAIProtocolLlmDriver::with_base_url(api_key, api_url),
             uses_custom_url: true,
@@ -241,12 +246,13 @@ impl LlmDriver for OpenAICompletionsLlmDriver {
     }
 
     async fn list_models(&self) -> Result<Option<Vec<DiscoveredModel>>> {
-        // Skip discovery for custom URLs (proxies, self-hosted)
-        if self.uses_custom_url {
+        // Skip discovery for non-standard custom URLs (proxies, self-hosted)
+        if self.uses_custom_url && !supports_model_listing(self.api_url()) {
             return Ok(None);
         }
 
-        list_openai_models(self.inner.client(), self.inner.api_key()).await
+        let models_url = models_url_for_api_url(self.api_url());
+        list_openai_models(self.inner.client(), self.inner.api_key(), &models_url).await
     }
 }
 
@@ -268,10 +274,9 @@ impl std::fmt::Debug for OpenAICompletionsLlmDriver {
 async fn list_openai_models(
     client: &reqwest::Client,
     api_key: &str,
+    models_url: &str,
 ) -> Result<Option<Vec<DiscoveredModel>>> {
-    let response = client
-        .get(OPENAI_MODELS_URL)
-        .bearer_auth(api_key)
+    let response = apply_models_auth(client.get(models_url), models_url, api_key)
         .send()
         .await
         .map_err(|e| AgentLoopError::llm(format!("Failed to fetch models: {}", e)))?;
@@ -307,6 +312,46 @@ async fn list_openai_models(
     Ok(Some(discovered))
 }
 
+fn normalize_api_url(base_url: &str, endpoint_suffix: &str) -> String {
+    let trimmed = base_url.trim_end_matches('/');
+    if trimmed.ends_with(endpoint_suffix) {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed}{endpoint_suffix}")
+    }
+}
+
+fn models_url_for_api_url(api_url: &str) -> String {
+    let trimmed = api_url.trim_end_matches('/');
+
+    if let Some(prefix) = trimmed.strip_suffix("/responses") {
+        return format!("{prefix}/models");
+    }
+    if let Some(prefix) = trimmed.strip_suffix("/chat/completions") {
+        return format!("{prefix}/models");
+    }
+    if trimmed.ends_with("/models") {
+        return trimmed.to_string();
+    }
+    if trimmed.ends_with("/v1") || trimmed.ends_with("/openai/v1") {
+        return format!("{trimmed}/models");
+    }
+
+    OPENAI_MODELS_URL.to_string()
+}
+
+fn supports_model_listing(api_url: &str) -> bool {
+    api_url.contains("://api.openai.com/") || is_azure_openai_api_url(api_url)
+}
+
+fn apply_models_auth(request: RequestBuilder, api_url: &str, api_key: &str) -> RequestBuilder {
+    if is_azure_openai_api_url(api_url) {
+        request.header("api-key", api_key)
+    } else {
+        request.bearer_auth(api_key)
+    }
+}
+
 // ============================================================================
 // Driver Registration
 // ============================================================================
@@ -315,6 +360,7 @@ async fn list_openai_models(
 ///
 /// This registers:
 /// - `ProviderType::OpenAI` - Open Responses API (recommended)
+/// - `ProviderType::AzureOpenAI` - Azure OpenAI Responses API
 /// - `ProviderType::OpenAICompletions` - Chat Completions API (backward compatibility)
 ///
 /// # Example
@@ -329,6 +375,14 @@ async fn list_openai_models(
 pub fn register_driver(registry: &mut DriverRegistry) {
     // Register OpenAI with Open Responses API (recommended)
     registry.register(ProviderType::OpenAI, |api_key, base_url| {
+        let driver = match base_url {
+            Some(url) => OpenAILlmDriver::with_base_url(api_key, url),
+            None => OpenAILlmDriver::new(api_key),
+        };
+        Box::new(driver) as BoxedLlmDriver
+    });
+
+    registry.register(ProviderType::AzureOpenAI, |api_key, base_url| {
         let driver = match base_url {
             Some(url) => OpenAILlmDriver::with_base_url(api_key, url),
             None => OpenAILlmDriver::new(api_key),

--- a/crates/openai/src/tests.rs
+++ b/crates/openai/src/tests.rs
@@ -25,6 +25,24 @@ mod driver_tests {
     }
 
     #[test]
+    fn test_driver_normalizes_v1_base_url() {
+        let driver = OpenAILlmDriver::with_base_url("test-key", "https://api.openai.com/v1");
+        assert_eq!(driver.api_url(), "https://api.openai.com/v1/responses");
+    }
+
+    #[test]
+    fn test_driver_normalizes_azure_v1_base_url() {
+        let driver = OpenAILlmDriver::with_base_url(
+            "test-key",
+            "https://resource.openai.azure.com/openai/v1/",
+        );
+        assert_eq!(
+            driver.api_url(),
+            "https://resource.openai.azure.com/openai/v1/responses"
+        );
+    }
+
+    #[test]
     fn test_completions_driver_with_api_key() {
         let driver = OpenAICompletionsLlmDriver::new("test-key");
         assert!(format!("{:?}", driver).contains("OpenAICompletionsLlmDriver"));
@@ -51,17 +69,25 @@ mod driver_tests {
     fn test_register_driver() {
         let mut registry = DriverRegistry::new();
         assert!(!registry.has_driver(&ProviderType::OpenAI));
+        assert!(!registry.has_driver(&ProviderType::AzureOpenAI));
         assert!(!registry.has_driver(&ProviderType::OpenAICompletions));
 
         register_driver(&mut registry);
 
         assert!(registry.has_driver(&ProviderType::OpenAI));
+        assert!(registry.has_driver(&ProviderType::AzureOpenAI));
         assert!(registry.has_driver(&ProviderType::OpenAICompletions));
 
         // Verify OpenAI driver can be created
         let config = ProviderConfig::new(ProviderType::OpenAI).with_api_key("test-key");
         let driver = registry.create_driver(&config);
         assert!(driver.is_ok());
+
+        let azure_config = ProviderConfig::new(ProviderType::AzureOpenAI)
+            .with_api_key("test-key")
+            .with_base_url("https://resource.openai.azure.com/openai/v1");
+        let azure_driver = registry.create_driver(&azure_config);
+        assert!(azure_driver.is_ok());
 
         // Verify OpenAI Completions driver can be created
         let completions_config =

--- a/crates/server/src/api/common.rs
+++ b/crates/server/src/api/common.rs
@@ -115,6 +115,7 @@ fn classify_anyhow_error(message: &str) -> Option<(StatusCode, Json<ErrorRespons
     }
 
     let is_bad_request = [
+        "invalid base url",
         "cannot be assigned",
         "cannot be edited",
         "must be archived before deletion",

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1557,6 +1557,7 @@ impl DirectWorkerAdapters {
 fn string_to_provider_type(s: &str) -> LlmProviderType {
     match s.to_lowercase().as_str() {
         "openai" => LlmProviderType::Openai,
+        "azure_openai" => LlmProviderType::AzureOpenai,
         "openai_completions" => LlmProviderType::OpenaiCompletions,
         "anthropic" => LlmProviderType::Anthropic,
         "gemini" => LlmProviderType::Gemini,

--- a/crates/server/src/services/llm_provider.rs
+++ b/crates/server/src/services/llm_provider.rs
@@ -229,13 +229,10 @@ fn validate_azure_openai_base_url(url: &Url) -> Result<()> {
     }
 
     let path = url.path().trim_end_matches('/');
-    let valid_path = matches!(
-        path,
-        "/openai/v1" | "/openai/v1/responses" | "/openai/v1/chat/completions"
-    );
+    let valid_path = matches!(path, "/openai/v1" | "/openai/v1/responses");
     if !valid_path {
         return Err(anyhow!(
-            "Azure OpenAI base URL must point to /openai/v1, /openai/v1/responses, or /openai/v1/chat/completions"
+            "Azure OpenAI base URL must point to /openai/v1 or /openai/v1/responses"
         ));
     }
 
@@ -344,6 +341,19 @@ mod tests {
                 Some("https://resource.services.ai.azure.com/openai/v1/responses"),
             )
             .is_ok()
+        );
+    }
+
+    #[test]
+    fn azure_openai_rejects_chat_completions_base_url() {
+        let err = validate_provider_base_url(
+            LlmProviderType::AzureOpenai,
+            Some("https://resource.openai.azure.com/openai/v1/chat/completions"),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("/openai/v1 or /openai/v1/responses")
         );
     }
 

--- a/crates/server/src/services/llm_provider.rs
+++ b/crates/server/src/services/llm_provider.rs
@@ -13,6 +13,7 @@ use everruns_core::llm_models::LlmProvider;
 use everruns_core::url_validation::validate_safe_url;
 use everruns_core::{Caller, LlmProviderStatus, LlmProviderType, Permission, Policy, Rule};
 use everruns_macros::policy;
+use reqwest::Url;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -67,10 +68,7 @@ impl LlmProviderService {
         caller: &Caller,
         req: CreateLlmProviderRequest,
     ) -> Result<LlmProvider> {
-        // SSRF prevention: validate base_url before persisting (EVE-69)
-        if let Some(ref url) = req.base_url {
-            validate_safe_url(url).map_err(|e| anyhow!("Invalid base URL: {e}"))?;
-        }
+        validate_provider_base_url(req.provider_type.clone(), req.base_url.as_deref())?;
 
         // Encrypt API key if provided
         let api_key_encrypted = if let Some(api_key) = &req.api_key {
@@ -115,10 +113,19 @@ impl LlmProviderService {
         id: Uuid,
         req: UpdateLlmProviderRequest,
     ) -> Result<Option<LlmProvider>> {
-        // SSRF prevention: validate base_url before persisting (EVE-69)
-        if let Some(ref url) = req.base_url {
-            validate_safe_url(url).map_err(|e| anyhow!("Invalid base URL: {e}"))?;
-        }
+        let existing = match self.db.get_llm_provider(caller.org_id, id).await? {
+            Some(row) => row,
+            None => return Ok(None),
+        };
+
+        let provider_type = req.provider_type.clone().unwrap_or_else(|| {
+            existing
+                .provider_type
+                .parse()
+                .unwrap_or(LlmProviderType::Openai)
+        });
+        let base_url = req.base_url.as_deref().or(existing.base_url.as_deref());
+        validate_provider_base_url(provider_type, base_url)?;
 
         // Encrypt API key if provided
         let api_key_encrypted = if let Some(api_key) = &req.api_key {
@@ -186,6 +193,55 @@ impl LlmProviderService {
     }
 }
 
+fn validate_provider_base_url(
+    provider_type: LlmProviderType,
+    base_url: Option<&str>,
+) -> Result<()> {
+    let parsed = match base_url {
+        Some(url) => Some(validate_safe_url(url).map_err(|e| anyhow!("Invalid base URL: {e}"))?),
+        None => None,
+    };
+
+    if provider_type == LlmProviderType::AzureOpenai {
+        let parsed = parsed.ok_or_else(|| {
+            anyhow!(
+                "Invalid base URL: Azure OpenAI providers require a base URL ending in /openai/v1 on an Azure host"
+            )
+        })?;
+        validate_azure_openai_base_url(&parsed).map_err(|e| anyhow!("Invalid base URL: {e}"))?;
+    }
+
+    Ok(())
+}
+
+fn validate_azure_openai_base_url(url: &Url) -> Result<()> {
+    let host = url
+        .host_str()
+        .ok_or_else(|| anyhow!("Azure OpenAI base URL must include a host"))?
+        .to_ascii_lowercase();
+
+    let valid_host =
+        host.ends_with(".openai.azure.com") || host.ends_with(".services.ai.azure.com");
+    if !valid_host {
+        return Err(anyhow!(
+            "Azure OpenAI base URL must use *.openai.azure.com or *.services.ai.azure.com"
+        ));
+    }
+
+    let path = url.path().trim_end_matches('/');
+    let valid_path = matches!(
+        path,
+        "/openai/v1" | "/openai/v1/responses" | "/openai/v1/chat/completions"
+    );
+    if !valid_path {
+        return Err(anyhow!(
+            "Azure OpenAI base URL must point to /openai/v1, /openai/v1/responses, or /openai/v1/chat/completions"
+        ));
+    }
+
+    Ok(())
+}
+
 /// Check if a default API key is available from environment variable.
 ///
 /// Environment variables (for development convenience):
@@ -194,6 +250,7 @@ impl LlmProviderService {
 fn has_default_api_key_from_env(provider_type: &str) -> bool {
     let env_var = match provider_type.to_lowercase().as_str() {
         "openai" => "DEFAULT_OPENAI_API_KEY",
+        "azure_openai" => "DEFAULT_AZURE_OPENAI_API_KEY",
         "anthropic" => "DEFAULT_ANTHROPIC_API_KEY",
         "gemini" => "DEFAULT_GEMINI_API_KEY",
         _ => return false,
@@ -207,6 +264,8 @@ fn has_default_api_key_from_env(provider_type: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use super::validate_provider_base_url;
+    use everruns_core::LlmProviderType;
     use everruns_core::url_validation::validate_safe_url;
 
     // ---- SSRF prevention tests (EVE-69) ----
@@ -248,6 +307,44 @@ mod tests {
     fn create_accepts_valid_public_base_url() {
         assert!(validate_safe_url("https://api.openai.com/v1").is_ok());
         assert!(validate_safe_url("https://api.anthropic.com/v1").is_ok());
+        assert!(validate_safe_url("https://resource.openai.azure.com/openai/v1").is_ok());
+    }
+
+    #[test]
+    fn azure_openai_requires_base_url() {
+        let err = validate_provider_base_url(LlmProviderType::AzureOpenai, None).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Invalid base URL: Azure OpenAI providers require a base URL")
+        );
+    }
+
+    #[test]
+    fn azure_openai_rejects_non_azure_hosts() {
+        let err = validate_provider_base_url(
+            LlmProviderType::AzureOpenai,
+            Some("https://api.openai.com/v1"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("*.openai.azure.com"));
+    }
+
+    #[test]
+    fn azure_openai_accepts_supported_domains() {
+        assert!(
+            validate_provider_base_url(
+                LlmProviderType::AzureOpenai,
+                Some("https://resource.openai.azure.com/openai/v1"),
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_provider_base_url(
+                LlmProviderType::AzureOpenai,
+                Some("https://resource.services.ai.azure.com/openai/v1/responses"),
+            )
+            .is_ok()
+        );
     }
 
     /// Testable version with injectable env lookup (test-only).
@@ -257,6 +354,7 @@ mod tests {
     {
         let env_var = match provider_type.to_lowercase().as_str() {
             "openai" => "DEFAULT_OPENAI_API_KEY",
+            "azure_openai" => "DEFAULT_AZURE_OPENAI_API_KEY",
             "anthropic" => "DEFAULT_ANTHROPIC_API_KEY",
             "gemini" => "DEFAULT_GEMINI_API_KEY",
             _ => return false,
@@ -283,6 +381,18 @@ mod tests {
         let env = mock_env(&[("DEFAULT_OPENAI_API_KEY", "sk-test-key")]);
         assert!(has_default_api_key_with_lookup("openai", &env));
         assert!(has_default_api_key_with_lookup("OpenAI", &env));
+    }
+
+    #[test]
+    fn test_has_default_api_key_azure_openai() {
+        assert!(!has_default_api_key_with_lookup(
+            "azure_openai",
+            mock_env(&[])
+        ));
+
+        let env = mock_env(&[("DEFAULT_AZURE_OPENAI_API_KEY", "azure-test-key")]);
+        assert!(has_default_api_key_with_lookup("azure_openai", &env));
+        assert!(has_default_api_key_with_lookup("Azure_OpenAI", &env));
     }
 
     #[test]

--- a/crates/server/src/services/llm_resolver.rs
+++ b/crates/server/src/services/llm_resolver.rs
@@ -47,6 +47,7 @@ where
 {
     let env_var = match provider_type.to_lowercase().as_str() {
         "openai" => "DEFAULT_OPENAI_API_KEY",
+        "azure_openai" => "DEFAULT_AZURE_OPENAI_API_KEY",
         "anthropic" => "DEFAULT_ANTHROPIC_API_KEY",
         "gemini" => "DEFAULT_GEMINI_API_KEY",
         _ => return None,

--- a/crates/server/src/services/model_sync.rs
+++ b/crates/server/src/services/model_sync.rs
@@ -69,20 +69,21 @@ impl ModelSyncService {
             .await?
             .context("Provider not found")?;
 
-        // Skip sync for providers with custom base URLs
-        if provider_row.base_url.is_some() {
+        // Parse provider type
+        let provider_type: LlmProviderType = provider_row
+            .provider_type
+            .parse()
+            .map_err(|e| anyhow::anyhow!("Invalid provider type: {}", e))?;
+
+        // Skip sync for providers with custom base URLs unless the provider
+        // needs a tenant-specific endpoint for discovery.
+        if provider_row.base_url.is_some() && !supports_sync_with_base_url(&provider_type) {
             tracing::debug!(
                 provider_id = %provider_id,
                 "Skipping sync for provider with custom base URL"
             );
             return Ok(SyncResult::NotSupported);
         }
-
-        // Parse provider type
-        let provider_type: LlmProviderType = provider_row
-            .provider_type
-            .parse()
-            .map_err(|e| anyhow::anyhow!("Invalid provider type: {}", e))?;
 
         // Get API key (decrypt from DB first, then env fallback)
         let api_key = self.resolve_api_key(&provider_row)?;
@@ -95,6 +96,7 @@ impl ModelSyncService {
         // Create driver for the provider
         let driver_type = match provider_type {
             LlmProviderType::Openai => ProviderType::OpenAI,
+            LlmProviderType::AzureOpenai => ProviderType::AzureOpenAI,
             LlmProviderType::OpenaiCompletions => ProviderType::OpenAICompletions,
             LlmProviderType::Anthropic => ProviderType::Anthropic,
             LlmProviderType::Gemini => ProviderType::Gemini,
@@ -107,7 +109,7 @@ impl ModelSyncService {
         let config = ProviderConfig {
             provider_type: driver_type,
             api_key: Some(api_key),
-            base_url: None, // We already checked for custom URLs above
+            base_url: provider_row.base_url.clone(),
         };
 
         let driver = self
@@ -273,6 +275,10 @@ impl ModelSyncService {
     }
 }
 
+fn supports_sync_with_base_url(provider_type: &LlmProviderType) -> bool {
+    matches!(provider_type, LlmProviderType::AzureOpenai)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -316,6 +322,12 @@ mod tests {
 
         let deserialized: SyncResult = serde_json::from_str(&json).unwrap();
         assert!(matches!(deserialized, SyncResult::NotSupported));
+    }
+
+    #[test]
+    fn test_azure_openai_supports_sync_with_base_url() {
+        assert!(supports_sync_with_base_url(&LlmProviderType::AzureOpenai));
+        assert!(!supports_sync_with_base_url(&LlmProviderType::Openai));
     }
 
     #[test]

--- a/crates/server/src/services/model_sync.rs
+++ b/crates/server/src/services/model_sync.rs
@@ -276,7 +276,10 @@ impl ModelSyncService {
 }
 
 fn supports_sync_with_base_url(provider_type: &LlmProviderType) -> bool {
-    matches!(provider_type, LlmProviderType::AzureOpenai)
+    matches!(
+        provider_type,
+        LlmProviderType::Openai | LlmProviderType::AzureOpenai | LlmProviderType::OpenaiCompletions
+    )
 }
 
 #[cfg(test)]
@@ -327,7 +330,11 @@ mod tests {
     #[test]
     fn test_azure_openai_supports_sync_with_base_url() {
         assert!(supports_sync_with_base_url(&LlmProviderType::AzureOpenai));
-        assert!(!supports_sync_with_base_url(&LlmProviderType::Openai));
+        assert!(supports_sync_with_base_url(&LlmProviderType::Openai));
+        assert!(supports_sync_with_base_url(
+            &LlmProviderType::OpenaiCompletions
+        ));
+        assert!(!supports_sync_with_base_url(&LlmProviderType::Anthropic));
     }
 
     #[test]

--- a/crates/server/src/storage/llm_provider_store.rs
+++ b/crates/server/src/storage/llm_provider_store.rs
@@ -136,6 +136,7 @@ impl LlmProviderStore for DbLlmProviderStore {
 fn parse_provider_type(provider_type_str: &str) -> Result<LlmProviderType> {
     match provider_type_str.to_lowercase().as_str() {
         "openai" => Ok(LlmProviderType::Openai),
+        "azure_openai" => Ok(LlmProviderType::AzureOpenai),
         "openai_completions" => Ok(LlmProviderType::OpenaiCompletions),
         "anthropic" => Ok(LlmProviderType::Anthropic),
         "gemini" => Ok(LlmProviderType::Gemini),

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -918,6 +918,7 @@ fn proto_model_with_provider_to_model(
 ) -> Result<ModelWithProvider> {
     let provider_type = match proto.provider_type.to_lowercase().as_str() {
         "openai" => everruns_core::LlmProviderType::Openai,
+        "azure_openai" => everruns_core::LlmProviderType::AzureOpenai,
         "openai_completions" => everruns_core::LlmProviderType::OpenaiCompletions,
         "anthropic" => everruns_core::LlmProviderType::Anthropic,
         "gemini" => everruns_core::LlmProviderType::Gemini,

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -10589,6 +10589,7 @@
         "description": "LLM provider type",
         "enum": [
           "openai",
+          "azure_openai",
           "openai_completions",
           "anthropic",
           "gemini",

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -396,7 +396,7 @@ The core crate provides DB-agnostic agent abstractions with pluggable backends:
 OpenAI-specific LLM provider implementation:
 
 1. **Implements Core Traits**: `LlmDriver` trait from `everruns-core`
-2. **Dual API Support**: Supports both Chat Completions and Open Responses APIs
+2. **OpenAI + Azure OpenAI Support**: Supports OpenAI-hosted and Azure-hosted OpenAI v1 endpoints
 3. **Streaming Support**: Full SSE streaming with tool call support
 4. **Native API Access**: Direct methods for OpenAI-specific functionality
 

--- a/specs/concepts.md
+++ b/specs/concepts.md
@@ -217,7 +217,7 @@ erDiagram
 
 A configured API provider such as OpenAI or Anthropic. Stores encrypted API keys.
 
-- Provider types: `openai`, `openai_completions`, `anthropic`
+- Provider types: `openai`, `azure_openai`, `openai_completions`, `anthropic`, `gemini`, `llmsim`
 - Each provider contains many models
 - Default providers are seeded on startup
 

--- a/specs/models.md
+++ b/specs/models.md
@@ -183,12 +183,12 @@ Configuration for LLM API providers. See `crates/core/src/llm_models.rs` for ful
 
 Key design points:
 - `provider_type` stored as plain string without CHECK constraint (forward compatibility)
-- Supported types: `openai`, `openai_completions`, `anthropic`, `gemini`, `llmsim`
+- Supported types: `openai`, `azure_openai`, `openai_completions`, `anthropic`, `gemini`, `llmsim`
 - API keys encrypted with AES-256-GCM envelope encryption (see `specs/encryption.md`)
 
 **API Key Resolution Order:**
 1. **Database** (priority): Encrypted in `llm_providers.api_key_encrypted`
-2. **Environment Variable** (fallback): `DEFAULT_OPENAI_API_KEY` or `DEFAULT_ANTHROPIC_API_KEY`
+2. **Environment Variable** (fallback): provider-specific `DEFAULT_*_API_KEY` (for example `DEFAULT_OPENAI_API_KEY`, `DEFAULT_AZURE_OPENAI_API_KEY`, `DEFAULT_ANTHROPIC_API_KEY`)
 
 Default providers and models seeded on startup. See `crates/server/src/seed.rs` for default model configurations (idempotent, well-known UUIDs).
 


### PR DESCRIPTION
## What
Add Azure OpenAI as a first-class LLM provider across the server, worker, core driver registry, and settings UI.

## Why
Azure-hosted OpenAI endpoints need distinct handling for auth, endpoint validation, model sync, and UI configuration. Reusing the generic OpenAI path left Azure unsupported and produced incorrect behavior for invalid Azure endpoints.

## How
- add `azure_openai` to provider enums, parsing, resolver paths, worker adapters, and model profile lookup
- register Azure OpenAI through the OpenAI driver crate, normalize Azure `/openai/v1` endpoints, and use `api-key` auth on Azure hosts
- validate Azure provider base URLs server-side and allow Azure model sync with tenant-specific base URLs
- add Azure OpenAI to provider creation/setup UI with label, icon, and endpoint guidance
- update provider docs/specs to include Azure OpenAI support

## Risk
- Medium
- Touches provider config, request auth headers, model sync, and provider setup UX
- Main regression risk is breaking existing OpenAI-compatible endpoint handling; covered with targeted Rust tests, UI tests, and live dev-mode API smoke checks

## Security
- Threat categories reviewed: TM-LLM, TM-API, TM-WEB
- Findings and resolutions:
  - TM-LLM: Azure OpenAI requires `api-key` auth instead of bearer auth; implemented host-aware auth selection for OpenAI-style protocols
  - TM-API: Azure provider creation now validates allowed Azure domains and `/openai/v1` path shapes, and invalid endpoints return client-facing `400` errors instead of masked `500`s
  - TM-WEB: UI changes are limited to provider selection/rendering and do not introduce new script injection or auth surface
  - No new dependencies were added to shipped code

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `cargo test -p everruns-openai --lib`
- `cargo test -p everruns-core --lib openai_protocol::tests::test_is_azure_openai_api_url`
- `cargo test -p everruns-server --lib llm_provider`
- `cargo test -p everruns-server --lib model_sync::tests::test_azure_openai_supports_sync_with_base_url`
- `cd apps/ui && npm test -- --runInBand src/__tests__/provider-icon.test.tsx src/__tests__/settings-providers.test.tsx`
- `just pre-push`
- Live smoke: server-only dev startup on `127.0.0.1:28201`, `POST /api/v1/llm-providers` returns `400` for non-Azure hosts and `201` for `https://resource.openai.azure.com/openai/v1`, with the created provider visible in `GET /api/v1/llm-providers`
