### PR TITLE
feat(capabilities): add prompt-only self_budget capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+### Added
+
+- **Self-Budget capability** — New prompt-only `self_budget` capability teaches agents how to reason about a user-requested indicative budget (e.g. "you have $7") using `get_session_info` cumulative usage. Distinct from the platform-enforced `budgeting` capability; both are bundled in the Generic harness. See [`docs/capabilities/self-budget.md`](docs/capabilities/self-budget.md).
+
 ## [0.8.15] - 2026-04-18
 
 ### Highlights

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -96,6 +96,7 @@ pub mod persistent_memory;
 mod platform_management;
 mod research;
 mod sample_data;
+mod self_budget;
 mod session;
 mod session_sandbox;
 mod session_schedule;
@@ -179,6 +180,7 @@ pub use platform_management::{
 };
 pub use research::ResearchCapability;
 pub use sample_data::SampleDataCapability;
+pub use self_budget::{SELF_BUDGET_CAPABILITY_ID, SelfBudgetCapability};
 pub use session::{GetSessionInfoTool, SessionCapability, WriteSessionTitleTool};
 pub use session_sandbox::{
     SESSION_SANDBOX_CAPABILITY_ID, SandboxExecTool, SandboxManageTool, SandboxReadFileTool,
@@ -657,6 +659,7 @@ impl CapabilityRegistry {
         registry.register(SessionScheduleCapability);
         registry.register(InfinityContextCapability);
         registry.register(budgeting::BudgetingCapability);
+        registry.register(SelfBudgetCapability);
         registry.register(CompactionCapability);
         registry.register(MemoryCapability);
 
@@ -1472,6 +1475,7 @@ mod tests {
         [
             "agent_instructions",
             "budgeting",
+            "self_budget",
             "noop",
             "current_time",
             "research",

--- a/crates/core/src/capabilities/self_budget.rs
+++ b/crates/core/src/capabilities/self_budget.rs
@@ -1,0 +1,139 @@
+// Self-Budget Capability
+//
+// Prompt-only capability that teaches agents how to reason about a user-requested
+// *indicative* budget ("you have $7") using session usage data. Distinct from the
+// `budgeting` capability, which wires platform-enforced budgets and the
+// `check_budget` tool. `self_budget` ships NO tools — it relies on
+// `get_session_info` (already provided by the `session` capability in the generic
+// harness) for cumulative usage and on the agent's own judgment about when and
+// how to adapt behavior.
+//
+// See specs/budgeting.md (Self-Managed vs Platform-Enforced Budgets).
+
+use super::{Capability, CapabilityStatus};
+
+pub const SELF_BUDGET_CAPABILITY_ID: &str = "self_budget";
+
+/// Self-budget capability — prompt-only guidance for agent-managed indicative budgets.
+pub struct SelfBudgetCapability;
+
+impl Capability for SelfBudgetCapability {
+    fn id(&self) -> &str {
+        SELF_BUDGET_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Self-Budget"
+    }
+
+    fn description(&self) -> &str {
+        "Prompt-only guidance for reasoning about a user-requested indicative budget. \
+         The agent self-manages the target using session usage data; no tools are added \
+         and no platform enforcement is performed. Use alongside `budgeting` for \
+         authoritative platform budgets."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("gauge")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("System")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(SELF_BUDGET_SYSTEM_PROMPT)
+    }
+
+    fn features(&self) -> Vec<&'static str> {
+        vec![]
+    }
+}
+
+const SELF_BUDGET_SYSTEM_PROMPT: &str = "\
+## Self-Managed Budget
+
+If the user gives you an indicative budget (e.g. \"you have $7\" or \"keep this under 20k tokens\"), \
+treat it as an **agent-managed soft target**, not as a platform-enforced limit.
+
+**This is different from platform budgets.** The Everruns platform may also enforce \
+session-level budgets — those are authoritative and will pause or stop the session \
+automatically. A self-managed budget is a goal *you* are trying to respect on the \
+user's behalf. Do not conflate the two when reporting progress or remaining spend.
+
+**How to track it:**
+
+- Use `get_session_info` to read cumulative session usage (tokens, and cost where \
+  available) as the source of truth for current spend.
+- Decide for yourself when to start tracking, when to re-check, and when to stop. \
+  You do not need to check on every turn — re-check around expensive or long-running \
+  work, or before kicking off a new phase.
+- Avoid claiming exact cost certainty when only token counts or partial pricing \
+  information are available. Qualify estimates (\"roughly\", \"on the order of\").
+
+**How to adapt as the budget tightens:**
+
+- Prefer shorter, more direct outputs over verbose narration.
+- Reduce retries and exploratory tool calls; commit to a plan sooner.
+- Narrow the scope — finish the core request well rather than covering every adjacent \
+  concern.
+- Skip redundant confirmations and intermediate summaries unless the user asked for them.
+
+**What not to do:**
+
+- Do not create, modify, or delete platform budgets in response to a self-managed \
+  target. Self-managed budgets live only in this conversation.
+- Do not refuse work solely because a self-managed target is close to exhausted; \
+  inform the user and offer a scoped-down option instead.";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_capability_metadata() {
+        let cap = SelfBudgetCapability;
+        assert_eq!(cap.id(), "self_budget");
+        assert_eq!(cap.name(), "Self-Budget");
+        assert_eq!(cap.icon(), Some("gauge"));
+        assert_eq!(cap.category(), Some("System"));
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+    }
+
+    #[test]
+    fn test_capability_has_no_tools() {
+        let cap = SelfBudgetCapability;
+        assert!(cap.tools().is_empty());
+        assert!(cap.tool_definitions().is_empty());
+    }
+
+    #[test]
+    fn test_capability_has_system_prompt() {
+        let cap = SelfBudgetCapability;
+        let prompt = cap.system_prompt_addition().expect("prompt present");
+        assert!(prompt.contains("Self-Managed Budget"));
+        assert!(prompt.contains("agent-managed soft target"));
+        assert!(prompt.contains("get_session_info"));
+        assert!(prompt.contains("different from platform budgets"));
+    }
+
+    #[test]
+    fn test_capability_has_no_features() {
+        let cap = SelfBudgetCapability;
+        assert!(cap.features().is_empty());
+    }
+
+    #[test]
+    fn test_prompt_distinguishes_from_budgeting() {
+        let cap = SelfBudgetCapability;
+        let prompt = cap.system_prompt_addition().unwrap();
+        // Must NOT direct the agent to the platform-budget tool
+        assert!(!prompt.contains("check_budget"));
+        // Must NOT direct the agent to mutate budgets
+        assert!(!prompt.to_lowercase().contains("create budget"));
+    }
+}

--- a/crates/server/src/harnesses/generic.rs
+++ b/crates/server/src/harnesses/generic.rs
@@ -6,7 +6,7 @@ pub fn definition() -> BuiltInHarnessDefinition {
     BuiltInHarnessDefinition::new(
         "generic",
         "Generic",
-        "General-purpose harness with file system, bash, web fetch, secrets, session management, session schedules, long-context support, context compaction, budgeting, tool output persistence, and agent skills. Recommended default for most use cases.",
+        "General-purpose harness with file system, bash, web fetch, secrets, session management, session schedules, long-context support, context compaction, budgeting, self-managed budget guidance, tool output persistence, and agent skills. Recommended default for most use cases.",
         SYSTEM_PROMPT,
     )
     .with_seed_id(crate::org_init::GENERIC_HARNESS_ID)
@@ -27,6 +27,7 @@ pub fn definition() -> BuiltInHarnessDefinition {
         BuiltInCapabilityDefinition::new("infinity_context"),
         BuiltInCapabilityDefinition::new("openai_tool_search"),
         BuiltInCapabilityDefinition::new("budgeting"),
+        BuiltInCapabilityDefinition::new("self_budget"),
         BuiltInCapabilityDefinition::with_config(
             "compaction",
             serde_json::json!({

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -2257,7 +2257,7 @@ mod tests {
             .expect("Generic harness should exist");
 
         let cap_ids: Vec<&str> = generic.capabilities.iter().map(|c| c.id.as_str()).collect();
-        assert_eq!(cap_ids.len(), 13);
+        assert_eq!(cap_ids.len(), 14);
         assert!(cap_ids.contains(&"session_file_system"));
         assert!(cap_ids.contains(&"virtual_bash"));
         assert!(cap_ids.contains(&"web_fetch"));
@@ -2269,6 +2269,7 @@ mod tests {
         assert!(cap_ids.contains(&"infinity_context"));
         assert!(cap_ids.contains(&"openai_tool_search"));
         assert!(cap_ids.contains(&"budgeting"));
+        assert!(cap_ids.contains(&"self_budget"));
         assert!(cap_ids.contains(&"compaction"));
         assert!(cap_ids.contains(&"tool_output_persistence"));
         // Verify compaction default config

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -1535,8 +1535,8 @@ async fn test_get_generic_harness() {
         .collect();
     assert_eq!(
         cap_ids.len(),
-        13,
-        "Generic harness should have 13 capabilities"
+        14,
+        "Generic harness should have 14 capabilities"
     );
     assert!(
         cap_ids.contains(&"session_file_system"),
@@ -1912,8 +1912,8 @@ async fn test_copy_seed_generic_harness() {
     // Generic harness capabilities should be preserved on copy
     assert_eq!(
         copied.capabilities.len(),
-        13,
-        "Copied harness should have same 13 capabilities"
+        14,
+        "Copied harness should have same 14 capabilities"
     );
 }
 

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -1573,6 +1573,10 @@ async fn test_get_generic_harness() {
         "Should have OpenAI tool search"
     );
     assert!(cap_ids.contains(&"budgeting"), "Should have budgeting");
+    assert!(
+        cap_ids.contains(&"self_budget"),
+        "Should have self_budget guidance"
+    );
     assert!(cap_ids.contains(&"compaction"), "Should have compaction");
 }
 

--- a/docs/built-ins/harnesses/generic.md
+++ b/docs/built-ins/harnesses/generic.md
@@ -3,7 +3,7 @@ title: Generic Harness
 description: The recommended default harness bundling core capabilities for general-purpose agent sessions.
 ---
 
-The **Generic** harness is the recommended default for most use cases. It bundles 12 core capabilities that cover file operations, command execution, web access, memory, budgeting, and context management.
+The **Generic** harness is the recommended default for most use cases. It bundles 13 core capabilities that cover file operations, command execution, web access, memory, budgeting, and context management.
 
 ## When to Use
 
@@ -35,6 +35,7 @@ The **Generic** harness is the recommended default for most use cases. It bundle
 | [OpenAI Tool Search](/capabilities/openai-tool-search/) | Defers tool schema loading on supported models to reduce prompt size |
 | [Context Compaction](/advanced/compaction/) | Auto-compacts context at 85% budget via cascading strategies |
 | [Budgeting](/capabilities/budgeting/) | Token budget enforcement with configurable meters and rules |
+| [Self-Budget](/capabilities/self-budget/) | Prompt-only guidance for reasoning about a user-requested indicative budget using session usage data |
 | Tool Output Persistence | Persists full tool output to `/.outputs/` before truncation for lossless retrieval |
 
 Infinity Context and Context Compaction work together to keep long sessions unbounded. See [Context Compaction](/advanced/compaction/#generic-harness-defaults) for details.

--- a/docs/built-ins/harnesses/generic.md
+++ b/docs/built-ins/harnesses/generic.md
@@ -3,7 +3,7 @@ title: Generic Harness
 description: The recommended default harness bundling core capabilities for general-purpose agent sessions.
 ---
 
-The **Generic** harness is the recommended default for most use cases. It bundles 13 core capabilities that cover file operations, command execution, web access, memory, budgeting, and context management.
+The **Generic** harness is the recommended default for most use cases. It bundles 14 core capabilities that cover file operations, command execution, web access, memory, budgeting, and context management.
 
 ## When to Use
 
@@ -29,6 +29,7 @@ The **Generic** harness is the recommended default for most use cases. It bundle
 | [Web Fetch](/capabilities/web-fetch/) | Fetch web content with file download support |
 | [Storage](/capabilities/session-storage/) | Key/value store for general data and encrypted secret storage |
 | [Session](/capabilities/session/) | Access session metadata and manage session title |
+| [Session Schedules](/capabilities/session-schedules/) | Create and manage cron-style schedules that wake the session |
 | [AGENTS.md](/capabilities/agent-instructions/) | Reads AGENTS.md from workspace and injects project-level instructions |
 | [Agent Skills](/capabilities/agent-skills/) | Discover and activate skills from `/.agents/skills/` |
 | [Infinity Context](/capabilities/infinity-context/) | Trims older messages from the live prompt while exposing earlier history via `query_history` |

--- a/docs/capabilities/index.md
+++ b/docs/capabilities/index.md
@@ -63,6 +63,8 @@ Performance and cost optimization for LLM interactions.
 |---|---|---|
 | [Infinity Context](/capabilities/infinity-context/) | `infinity_context` | 1 |
 | [OpenAI Tool Search](/capabilities/openai-tool-search/) | `openai_tool_search` | 0 |
+| [Budgeting](/capabilities/budgeting/) | `budgeting` | 1 |
+| [Self-Budget](/capabilities/self-budget/) | `self_budget` | 0 |
 
 ### Demo
 

--- a/docs/capabilities/self-budget.md
+++ b/docs/capabilities/self-budget.md
@@ -1,0 +1,69 @@
+---
+title: Self-Budget
+description: Prompt-only guidance for agents to reason about a user-requested indicative budget using session usage data. Distinct from the platform-enforced `budgeting` capability.
+---
+
+| | |
+|---|---|
+| **ID** | `self_budget` |
+| **Category** | System |
+| **Features** | *(none)* |
+| **Tools** | *(none)* |
+| **Included in** | Generic harness (default) |
+| **Dependencies** | None |
+
+Teaches the agent how to self-manage an **indicative** budget that the user mentions in conversation — for example, "you have $7" or "keep this under 20k tokens". The capability contributes prompt text only; it adds no tools and performs no enforcement.
+
+For platform-enforced budgets (authoritative limits that pause or stop sessions automatically), use the separate [`budgeting`](/capabilities/budgeting/) capability.
+
+## How It Works
+
+`self_budget` is prompt-only. When the capability is enabled the agent's system prompt gets a "Self-Managed Budget" section that explains:
+
+- The self-budget is an **agent-managed soft target**, not a hard limit.
+- Session usage metadata (exposed via `get_session_info`) is the source of truth for current spend.
+- The agent decides when to start tracking, when to re-check, and when to stop.
+- As the target tightens, the agent should adapt — shorter outputs, fewer retries, narrower exploration, fewer redundant tool calls.
+- The agent avoids claiming exact cost certainty when only token counts or partial pricing are available.
+- The agent distinguishes between platform-enforced budgets and user-requested indicative budgets when reporting progress.
+
+There is no `self_budget` tool. Usage data comes from `get_session_info`, which is provided by the [`session`](/capabilities/session/) capability (bundled by default in the Generic harness).
+
+## Self-Budget vs Budgeting
+
+| Aspect | `self_budget` | `budgeting` |
+|---|---|---|
+| What it is | Agent-managed soft target | Platform-enforced limit |
+| Tools | None | `check_budget` |
+| Enforcement | None (prompt guidance only) | Session is paused/stopped automatically |
+| Data source | `get_session_info` cumulative usage | Budgets table / ledger |
+| Use case | User says "you have $7" in chat | Org/session has a configured budget in the platform |
+
+The two capabilities are non-conflicting and can run together. The Generic harness includes both.
+
+## Use Cases
+
+- **User-set budget in prompt** — "Spend at most $3 on this investigation." The agent tracks usage via `get_session_info`, adapts scope, and reports progress.
+- **Coaching the agent to be frugal** — Even without an exact dollar target, the prompt guidance nudges the agent toward shorter outputs and fewer redundant tool calls.
+- **Budget-aware estimation** — The agent qualifies cost estimates ("roughly", "on the order of") rather than over-stating certainty.
+
+## Example
+
+```
+User: You have about $2 of compute for this task. Analyze the three largest
+      dependencies in package.json and tell me which one to remove.
+
+Agent: [calls get_session_info — current usage $0.14]
+Agent: Got it. I'll focus on the three largest dependencies and keep this tight.
+       [... scoped analysis ...]
+Agent: [calls get_session_info — current usage $1.62]
+Agent: Roughly $1.60 spent so far. Based on size and use count, `moment` is the
+       best removal candidate — replacement path is straightforward. I'll stop
+       here to stay under your $2 target.
+```
+
+## Related
+
+- [Budgeting](/capabilities/budgeting/) — platform-enforced budgets with the `check_budget` tool
+- [Session](/capabilities/session/) — provides `get_session_info`, the usage data source
+- [Budgets](/advanced/budgets/) — full budgeting system documentation

--- a/specs/budgeting.md
+++ b/specs/budgeting.md
@@ -206,6 +206,29 @@ The `budgeting` capability adds budget self-regulation to agents:
 
 Enable on an agent by adding `budgeting` to its capabilities list.
 
+## Self-Managed vs Platform-Enforced Budgets
+
+Everruns distinguishes two orthogonal concerns:
+
+| Concern | Capability | Source of truth | Enforcement |
+|---------|-----------|-----------------|-------------|
+| Platform-enforced limit | `budgeting` | Budgets table / ledger | Session paused/stopped automatically at exhaustion |
+| User-requested indicative target ("you have $7") | `self_budget` | Session cumulative usage (`get_session_info`) | None — agent adapts behavior via prompt guidance |
+
+The `self_budget` capability contributes prompt-only guidance. It ships no tools (cumulative usage is already exposed by `get_session_info` from the `session` capability, which is present in the Generic harness). The prompt:
+
+- frames the self-budget as an **agent-managed soft target**, not a hard limit
+- directs the agent to `get_session_info` for current spend
+- encourages periodic re-checks around expensive work rather than every turn
+- coaches the agent to adapt (shorter outputs, fewer retries, narrower exploration) as the target tightens
+- warns the agent not to claim exact cost certainty from token-only data
+- explicitly separates the two budget types so the agent does not conflate platform enforcement with user-stated targets
+- explicitly forbids creating or mutating platform budgets in response to a user-stated target
+
+The two capabilities are non-conflicting and co-exist in the built-in `generic` harness. Agents without a need for platform enforcement can still enable only `self_budget`; agents that need strict enforcement should enable `budgeting` (and typically both).
+
+File: `crates/core/src/capabilities/self_budget.rs`.
+
 ## Design Decisions
 
 | Question | Decision | Rationale |


### PR DESCRIPTION
## What

Adds a new built-in capability `self_budget` that contributes prompt guidance only (no tools), teaching agents how to self-manage a user-requested indicative budget (e.g. "you have $7") using session cumulative usage from `get_session_info`.

The new capability is registered in the built-in registry and added to the Generic harness alongside the existing `budgeting` capability.

## Why

Resolves [EVE-314](https://linear.app/everruns/issue/EVE-314). We want lightweight budget-aware behavior that does not depend on creating/updating platform budgets or a dedicated tool — the agent reasons about a user-stated target and adapts behavior (shorter outputs, fewer retries, narrower exploration) as the target tightens.

`get_session_info` (already exposed by the `session` capability in the Generic harness) now carries cumulative usage, so no additional tool is needed.

## How

- New file `crates/core/src/capabilities/self_budget.rs` — prompt-only capability, no tools, `features()` empty.
- Registered in `CapabilityRegistry::with_builtins_for_grade` and added to the expected built-in id set used by `test_capability_registry_with_builtins_*` tests.
- Added `self_budget` to `crates/server/src/harnesses/generic.rs` (additive — coexists with `budgeting`).
- Updated `seed.rs` and `api_integration_test.rs` generic-harness capability assertions (count 13 → 14, new id).
- Prompt explicitly separates self-managed targets from platform-enforced budgets, points agents at `get_session_info`, and forbids creating/mutating platform budgets in response to user-stated targets.

### Open design question (from the issue) — resolved

Generic harness includes **both** `budgeting` and `self_budget`. The two capabilities are non-conflicting because they address different budget types (platform-enforced vs user-indicated). The `self_budget` prompt never references `check_budget` and explicitly distinguishes the two sources.

### Specs & docs

- `specs/budgeting.md` — new "Self-Managed vs Platform-Enforced Budgets" section.
- `docs/capabilities/self-budget.md` — new capability doc page with comparison table and example.
- `docs/capabilities/index.md` — added under Optimization (also surfaced the existing `budgeting` entry, which was missing).
- `docs/built-ins/harnesses/generic.md` — updated capability count (12 → 13) and description.
- `CHANGELOG.md` — Unreleased entry.

## Risk

- **Low.** Prompt-only, static text wrapped via the default `system_prompt_contribution()` XML-tag implementation. No tool dispatch, no DB, no external calls. The only behavioral surface is that every generic-harness session now ships with an additional `<capability id="self_budget">` prompt section.

## Security

- Threat categories reviewed: `TM-LLM` (prompt construction).
- Findings: None. The prompt text is a compile-time `const &str` with no user input interpolation. The capability adds no tools, no network/file/db side effects, and no new dependencies. The prompt explicitly forbids the agent from mutating platform budgets in response to self-managed targets — net-neutral to slightly reducing attack surface.
- No `THREAT[...]` comments touched or required; no `specs/threat-model.md` entries required.

## Validation

- `cargo build -p everruns-core -p everruns-server` — clean.
- `cargo test -p everruns-core --lib capabilities::self_budget` — 5/5 pass (metadata, no tools, prompt present, no features, distinguishes from `budgeting`).
- `cargo test -p everruns-core --lib capabilities::tests::test_capability_registry` — 4/4 pass (built-in registry in dev + prod modes includes `self_budget`).
- `cargo test -p everruns-server --lib seed::tests::test_generic` — 5/5 pass (generic harness now asserts `self_budget` in its capability list).
- `just pre-push` — all 7 checks green (fmt, clippy, lockfile, migration ordering, author attribution).

No smoke test necessary: change contributes static prompt text only. No runtime branches, no handlers, no tool dispatch. Capability and harness tests cover the behavior end-to-end (registry membership + harness inclusion + prompt content).

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (additive capability; no removed behavior)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (n/a on create)
