### PR TITLE
ci(docker): publish on release only, gate PR builds by paths

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,14 @@
 name: Docker Publish
 
+# Trigger strategy (see specs/release-process.md#docker-image-tagging):
+# - Tag push (v*) / workflow_dispatch: publish multi-arch release images.
+# - Pull request: validate Docker build only when Docker-relevant files change.
+# - No main-branch push: per-commit Docker images are intentionally not
+#   produced. Image builds (especially arm64 via QEMU) are expensive and the
+#   previous `:development` rolling tag hid tag drift behind a moving target.
+#   Consumers should pin to a released tag.
 on:
   push:
-    branches: [main]
     tags: ['v*']
   # Triggered by Release workflow after creating tag (GITHUB_TOKEN tag pushes
   # don't fire push events, so Release calls this via workflow_dispatch)
@@ -12,8 +18,17 @@ on:
         description: 'Git tag to build and publish (e.g., v0.8.0)'
         required: true
         type: string
+  # Gate PR builds on Docker-relevant paths. PR validation exists to catch
+  # Dockerfile / workflow regressions before they land, not to produce
+  # pullable artifacts. Rust/UI source changes are validated by tag builds
+  # at release time.
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
+    paths:
+      - 'docker/**'
+      - 'apps/ui/Dockerfile'
+      - '.dockerignore'
+      - '.github/workflows/docker-publish.yml'
 
 permissions:
   contents: read
@@ -77,8 +92,8 @@ jobs:
             echo "is_release=false" >> $GITHUB_OUTPUT
           fi
 
-      # Build ARM64 only on main push, version tags, and release dispatches
-      # PRs only build amd64 for faster CI
+      # Build ARM64 on version tags and release dispatches.
+      # PRs only build amd64 since PR validation only confirms the build works.
       - name: Determine platforms
         id: platforms
         run: |
@@ -98,7 +113,6 @@ jobs:
             type=ref,event=tag
             type=raw,value=${{ steps.release_tag.outputs.tag }},enable=${{ steps.release_tag.outputs.is_release == 'true' }}
             type=raw,value=latest,enable=${{ steps.release_tag.outputs.is_release == 'true' }}
-            type=raw,value=development,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
             type=raw,value=${{ steps.sha.outputs.sha_short }}
             type=raw,value=${{ steps.sha.outputs.sha }}
 
@@ -125,7 +139,6 @@ jobs:
             type=ref,event=tag
             type=raw,value=${{ steps.release_tag.outputs.tag }},enable=${{ steps.release_tag.outputs.is_release == 'true' }}
             type=raw,value=latest,enable=${{ steps.release_tag.outputs.is_release == 'true' }}
-            type=raw,value=development,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
             type=raw,value=${{ steps.sha.outputs.sha_short }}
             type=raw,value=${{ steps.sha.outputs.sha }}
 
@@ -153,7 +166,6 @@ jobs:
             type=ref,event=tag
             type=raw,value=${{ steps.release_tag.outputs.tag }},enable=${{ steps.release_tag.outputs.is_release == 'true' }}
             type=raw,value=latest,enable=${{ steps.release_tag.outputs.is_release == 'true' }}
-            type=raw,value=development,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
             type=raw,value=${{ steps.sha.outputs.sha_short }}
             type=raw,value=${{ steps.sha.outputs.sha }}
 
@@ -239,7 +251,6 @@ jobs:
             type=ref,event=tag
             type=raw,value=${{ steps.release_tag.outputs.tag }},enable=${{ steps.release_tag.outputs.is_release == 'true' }}
             type=raw,value=latest,enable=${{ steps.release_tag.outputs.is_release == 'true' }}
-            type=raw,value=development,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
             type=raw,value=${{ steps.sha.outputs.sha_short }}
             type=raw,value=${{ steps.sha.outputs.sha }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,14 +19,16 @@ on:
         required: true
         type: string
   # Gate PR builds on Docker-relevant paths. PR validation exists to catch
-  # Dockerfile / workflow regressions before they land, not to produce
-  # pullable artifacts. Rust/UI source changes are validated by tag builds
-  # at release time.
+  # Dockerfile / workflow regressions before they land. Rust/UI source
+  # changes are validated by tag builds at release time. PR builds still
+  # push SHA-tagged images to GHCR (pre-existing behavior) — these are
+  # traceability artifacts, not a consumer-facing channel.
   pull_request:
     types: [opened, reopened, synchronize]
     paths:
       - 'docker/**'
       - 'apps/ui/Dockerfile'
+      - 'apps/ui/.dockerignore'
       - '.dockerignore'
       - '.github/workflows/docker-publish.yml'
 

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -104,7 +104,7 @@ Docker images are expensive to build — the slow path is `linux/arm64` via QEMU
 The current trigger shape (`docker-publish.yml`):
 
 1. **Release-only publish.** Multi-arch images are built only on version tag pushes and the `workflow_dispatch` the Release workflow fires after creating the tag. The slow arm64 path runs a handful of times per week instead of on every merge.
-2. **Path-filtered PR validation.** The workflow still runs on PRs, but only when Docker-relevant paths change (`docker/**`, `apps/ui/Dockerfile`, `.dockerignore`, `.github/workflows/docker-publish.yml`). Rust/UI source changes are not validated per-PR; a broken Dockerfile will be caught by this gate, a source regression that only manifests inside the image is caught at release-tag time.
+2. **Path-filtered PR validation.** The workflow still runs on PRs, but only when Docker-relevant paths change (`docker/**`, `apps/ui/Dockerfile`, `apps/ui/.dockerignore`, `.dockerignore`, `.github/workflows/docker-publish.yml`). Rust/UI source changes are not validated per-PR; a broken Dockerfile will be caught by this gate, a source regression that only manifests inside the image is caught at release-tag time.
 3. **No rolling main-branch tag.** Dropping `:development` removes the hidden-drift problem where `:development` could silently lag main (e.g., under a paths-filter) or produce images for every commit (expensive). Consumers that need a mainline image should build locally or use a released tag.
 
 When a Dockerfile change is the *point* of a PR, the workflow runs and validates the amd64 build before merge. When the Dockerfile has not changed, the workflow is skipped entirely.

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -88,15 +88,26 @@ After all CLI binaries are built and uploaded, the `Publish CLI Binaries` workfl
 
 ### Docker Image Tagging
 
-| Event | Tags Generated |
-|-------|----------------|
-| Version tag (v0.4.0) | `v0.4.0`, `latest`, SHA |
-| Main branch push | `development`, SHA |
-| Pull request | SHA only (no push) |
+| Event | Platforms | Tags Generated |
+|-------|-----------|----------------|
+| Version tag (`v*`) / `workflow_dispatch` | `linux/amd64` + `linux/arm64` | `vX.Y.Z`, `latest`, SHA |
+| Pull request (Docker-relevant paths only) | `linux/amd64` | SHA |
 
 - **`latest`**: Only updated on version tags. Safe for production use.
-- **`development`**: Tracks main branch. Updated on every commit to main.
-- **SHA tags**: Always generated for traceability (short + full SHA).
+- **SHA tags**: Generated on every build for traceability (short + full SHA).
+- **No `:development` tag and no per-main-commit images.** Docker images are a release artifact, not a per-commit artifact. Pin consumers to a released version (`vX.Y.Z` or `latest`).
+
+#### Trigger rationale
+
+Docker images are expensive to build — the slow path is `linux/arm64` via QEMU cross-compilation. Earlier versions of this workflow built on every push to `main` to keep a `:development` rolling tag, and on every PR to validate the build. That produced ~40–60 min of multi-arch build time per merge to main and ~18 min per PR, almost all of which was wasted when the change did not touch Docker infrastructure.
+
+The current trigger shape (`docker-publish.yml`):
+
+1. **Release-only publish.** Multi-arch images are built only on version tag pushes and the `workflow_dispatch` the Release workflow fires after creating the tag. The slow arm64 path runs a handful of times per week instead of on every merge.
+2. **Path-filtered PR validation.** The workflow still runs on PRs, but only when Docker-relevant paths change (`docker/**`, `apps/ui/Dockerfile`, `.dockerignore`, `.github/workflows/docker-publish.yml`). Rust/UI source changes are not validated per-PR; a broken Dockerfile will be caught by this gate, a source regression that only manifests inside the image is caught at release-tag time.
+3. **No rolling main-branch tag.** Dropping `:development` removes the hidden-drift problem where `:development` could silently lag main (e.g., under a paths-filter) or produce images for every commit (expensive). Consumers that need a mainline image should build locally or use a released tag.
+
+When a Dockerfile change is the *point* of a PR, the workflow runs and validates the amd64 build before merge. When the Dockerfile has not changed, the workflow is skipped entirely.
 
 ### Tooling
 


### PR DESCRIPTION
## Summary

Publish Docker images on release only; gate PR builds behind Docker-relevant paths.

**Why**

Docker images are a release artifact, not a per-commit artifact. The previous workflow built a multi-arch image (amd64 + arm64 via QEMU, ~40–60 min) on every push to `main`, plus an amd64 build (~18 min) on every PR. Almost all of that work was wasted — the arm64 leg is the slow path, and the rolling `:development` tag it fed hides drift from consumers while encouraging pin-free use.

**What changes**

- **Drop `push: main`**. No more per-commit multi-arch build. No `:development` rolling tag.
- **Gate `pull_request`** on Docker-relevant paths only (`docker/**`, `apps/ui/Dockerfile`, `.dockerignore`, `.github/workflows/docker-publish.yml`). Source-only PRs skip Docker entirely; Dockerfile changes still validate amd64 pre-merge.
- **Keep `push: tags v*` and `workflow_dispatch`** unchanged — full multi-arch publish on release tags (this is what the Release workflow already dispatches).
- Remove dead `development` tag lines in the three image metadata blocks.
- Add `synchronize` to the `pull_request` types list so follow-up commits that touch Docker paths re-validate.
- Update `specs/release-process.md` Docker Image Tagging section with the new trigger matrix and the rationale.

**Trade-off explicitly accepted**

A Rust / UI source regression that only surfaces inside the Docker image will now be caught at release-tag time instead of on the originating PR. In exchange, source-only PRs lose ~18 min of wasted Docker CI and main-branch merges lose ~40–60 min of wasted multi-arch build.

## Expected impact

| Event | Before | After |
|---|---|---|
| Source-only PR | amd64 Docker build (~18 min) | skipped |
| Dockerfile-touching PR | amd64 Docker build | amd64 Docker build (unchanged) |
| Merge to main | multi-arch build (~40–60 min) | skipped |
| Release tag | multi-arch build | multi-arch build (unchanged) |

## Test plan

- [x] `just pre-push` green
- [ ] CI green on this PR (the path filter means this PR itself will trigger `docker-publish` because it touches `.github/workflows/docker-publish.yml` — that's the expected self-validation)
- [ ] After merge, confirm next source-only PR does not trigger `docker-publish`
- [ ] On next release tag, confirm multi-arch images still publish and Homebrew still updates