### PR TITLE
fix(server): repair stale platform chat sessions

### DIFF
--- a/crates/server/src/services/session.rs
+++ b/crates/server/src/services/session.rs
@@ -19,12 +19,14 @@ use crate::storage::{
 use anyhow::Result;
 use everruns_core::{
     AgentCapabilityConfig, AgentId, Caller, CapabilityRegistry, HarnessId, InitialFile, ModelId,
-    Permission, Policy, Rule, Session, SessionId, SessionStatus, SubagentStatus, TokenUsage,
+    MountPoint, Permission, Policy, Rule, Session, SessionId, SessionStatus, SubagentStatus,
+    TokenUsage,
     capabilities::{SystemPromptContext, collect_capabilities, compute_features},
     merge_capabilities, merge_initial_files, normalize_initial_file_path,
 };
 use everruns_durable::UpdateField;
 use everruns_macros::policy;
+use std::collections::HashSet;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -336,27 +338,23 @@ impl SessionService {
     ) -> Result<()> {
         let session_id = session_id.into();
 
-        let capability_ids = self
-            .collect_session_capability_ids(org_id, harness_id, agent_id, session_capabilities)
+        let mounts = self
+            .collect_capability_mounts(
+                org_id,
+                harness_id,
+                agent_id,
+                session_capabilities,
+                session_id,
+            )
             .await?;
-
-        if capability_ids.is_empty() {
-            return Ok(()); // No capabilities, nothing to mount
-        }
-
-        // Collect mounts from all capabilities
-        let ctx = SystemPromptContext::without_file_store(SessionId::from_uuid(session_id));
-        let collected =
-            collect_capabilities(&capability_ids, &self.capability_registry, &ctx).await;
-
-        if collected.mounts.is_empty() {
+        if mounts.is_empty() {
             return Ok(()); // No mounts to apply
         }
 
         // Apply mounts to session filesystem
         let result = self
             .session_file_service
-            .apply_capability_mounts(session_id, &collected.mounts)
+            .apply_capability_mounts(session_id, &mounts)
             .await?;
 
         if !result.is_success() {
@@ -374,6 +372,84 @@ impl SessionService {
                 directories_created = result.directories_created,
                 mount_points = result.mount_points_applied,
                 "Capability mounts applied successfully"
+            );
+        }
+
+        Ok(())
+    }
+
+    async fn collect_capability_mounts(
+        &self,
+        org_id: i64,
+        harness_id: Uuid,
+        agent_id: Option<Uuid>,
+        session_capabilities: &[AgentCapabilityConfig],
+        session_id: Uuid,
+    ) -> Result<Vec<MountPoint>> {
+        let capability_ids = self
+            .collect_session_capability_ids(org_id, harness_id, agent_id, session_capabilities)
+            .await?;
+        if capability_ids.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let ctx = SystemPromptContext::without_file_store(SessionId::from_uuid(session_id));
+        Ok(
+            collect_capabilities(&capability_ids, &self.capability_registry, &ctx)
+                .await
+                .mounts,
+        )
+    }
+
+    async fn reconcile_capability_mounts(
+        &self,
+        org_id: i64,
+        harness_id: Uuid,
+        agent_id: Option<Uuid>,
+        session_capabilities: &[AgentCapabilityConfig],
+        session_id: Uuid,
+    ) -> Result<()> {
+        let mounts = self
+            .collect_capability_mounts(
+                org_id,
+                harness_id,
+                agent_id,
+                session_capabilities,
+                session_id,
+            )
+            .await?;
+
+        self.session_file_service.evict_virtual_mounts(session_id);
+
+        let mut seen_paths = HashSet::new();
+        let mut mount_paths: Vec<String> = mounts
+            .iter()
+            .map(|mount| mount.path.clone())
+            .filter(|path| seen_paths.insert(path.clone()))
+            .collect();
+        mount_paths.sort_by_key(|path| path.len());
+        for path in mount_paths {
+            let _ = self
+                .db
+                .delete_session_file_recursive(session_id, &path)
+                .await?;
+        }
+
+        if mounts.is_empty() {
+            return Ok(());
+        }
+
+        let result = self
+            .session_file_service
+            .apply_capability_mounts(session_id, &mounts)
+            .await?;
+
+        if !result.is_success() {
+            tracing::warn!(
+                session_id = %session_id,
+                agent_id = ?agent_id,
+                errors = ?result.errors,
+                "Some capability mounts failed to apply after session repair"
             );
         }
 
@@ -653,9 +729,54 @@ impl SessionService {
         let org_public_id = &caller.org_public_id;
         let user_tag = format!("user:{}", user_id);
         let tags = vec!["global-chat".to_string(), user_tag.clone()];
+        let desired_harness_id = HarnessId::from_uuid(harness_id);
 
         // Look for existing chat session
-        if let Some(row) = self.db.find_session_by_tags(org_id, &tags).await? {
+        if let Some(mut row) = self.db.find_session_by_tags(org_id, &tags).await? {
+            if row.harness_id != Some(desired_harness_id) {
+                tracing::info!(
+                    session_id = %row.id,
+                    previous_harness_id = ?row.harness_id,
+                    desired_harness_id = %desired_harness_id,
+                    "Repairing global chat session harness binding"
+                );
+
+                row = self
+                    .db
+                    .update_session(
+                        org_id,
+                        row.id,
+                        UpdateSession {
+                            harness_id: Some(desired_harness_id),
+                            ..Default::default()
+                        },
+                    )
+                    .await?
+                    .ok_or_else(|| anyhow::anyhow!("chat session disappeared during repair"))?;
+
+                let session_capabilities: Vec<AgentCapabilityConfig> = match serde_json::from_value(
+                    row.capabilities.clone(),
+                ) {
+                    Ok(capabilities) => capabilities,
+                    Err(error) => {
+                        tracing::error!(
+                            session_id = %row.id,
+                            error = %error,
+                            "Failed to deserialize session capabilities during global chat repair; continuing with empty capabilities"
+                        );
+                        Vec::new()
+                    }
+                };
+                self.reconcile_capability_mounts(
+                    org_id,
+                    desired_harness_id.uuid(),
+                    row.agent_id.map(|agent_id| agent_id.uuid()),
+                    &session_capabilities,
+                    row.id.uuid(),
+                )
+                .await?;
+            }
+
             let mut session = Self::row_to_session(row, org_public_id);
             self.populate_features(caller.org_id, &mut session).await?;
             self.resolve_session_agent_id(org_id, &mut session).await?;

--- a/crates/server/src/storage/memory/sessions.rs
+++ b/crates/server/src/storage/memory/sessions.rs
@@ -201,6 +201,9 @@ impl InMemoryDatabase {
 
         let mut sessions = self.sessions.write();
         if let Some(session) = sessions.get_mut(&id) {
+            if let Some(harness_id) = input.harness_id {
+                session.harness_id = Some(harness_id);
+            }
             if let Some(title) = input.title {
                 session.title = Some(title);
             }

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -590,6 +590,7 @@ pub struct CreateSessionRow {
 
 #[derive(Debug, Clone, Default)]
 pub struct UpdateSession {
+    pub harness_id: Option<HarnessId>,
     pub title: Option<String>,
     pub agent_identity_id: UpdateField<AgentIdentityId>,
     pub locale: Option<String>,

--- a/crates/server/src/storage/repositories/sessions.rs
+++ b/crates/server/src/storage/repositories/sessions.rs
@@ -268,14 +268,15 @@ impl Database {
             r#"
             UPDATE sessions
             SET
-                title = COALESCE($3, title),
-                agent_identity_id = CASE WHEN $4 THEN $5 ELSE agent_identity_id END,
-                locale = COALESCE($6, locale),
-                tags = COALESCE($7, tags),
-                model_id = COALESCE($8, model_id),
-                status = COALESCE($9, status),
-                started_at = COALESCE($10, started_at),
-                finished_at = COALESCE($11, finished_at)
+                harness_id = COALESCE($3, harness_id),
+                title = COALESCE($4, title),
+                agent_identity_id = CASE WHEN $5 THEN $6 ELSE agent_identity_id END,
+                locale = COALESCE($7, locale),
+                tags = COALESCE($8, tags),
+                model_id = COALESCE($9, model_id),
+                status = COALESCE($10, status),
+                started_at = COALESCE($11, started_at),
+                finished_at = COALESCE($12, finished_at)
             WHERE org_id = $1 AND id = $2
             RETURNING id, org_id, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, status, created_at, updated_at, started_at, finished_at,
                       total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, parent_session_id, subagent_name, subagent_task, subagent_status,
@@ -284,6 +285,7 @@ impl Database {
         )
         .bind(org_id)
         .bind(id)
+        .bind(input.harness_id.map(|h| h.uuid()))
         .bind(&input.title)
         .bind(input.agent_identity_id.is_changed())
         .bind(input.agent_identity_id.into_value().map(|a: AgentIdentityId| a.uuid()))

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -19,8 +19,8 @@ use test_harness::TestServer;
 
 use everruns_core::llm_models::LlmProvider;
 use everruns_core::typed_id::ScheduleId;
-use everruns_core::{Agent, Harness, LlmModel, Session, SessionFile};
-use everruns_server::storage::models::CreateSessionScheduleRow;
+use everruns_core::{Agent, DEFAULT_ORG_ID, Harness, LlmModel, Session, SessionFile};
+use everruns_server::storage::models::{CreateSessionScheduleRow, UpdateSession};
 
 /// Seed harness ID from seed.rs (BASE_HARNESS = 0x01933b5a_0000_7000_8000_000000000601)
 const SEED_BASE_HARNESS_ID: &str = "harness_01933b5a000070008000000000000601";
@@ -2583,6 +2583,57 @@ async fn test_global_chat_has_chat_harness() {
         session.harness_id.to_string(),
         SEED_CHAT_HARNESS_ID,
         "Chat session should use the Platform Chat harness"
+    );
+}
+
+#[tokio::test]
+async fn test_global_chat_repairs_stale_harness_binding() {
+    let server = TestServer::in_memory().await;
+
+    let original: Session = server
+        .post("/v1/sessions/chat", json!({}))
+        .await
+        .assert_success()
+        .json();
+
+    let other_harness: Harness = server
+        .post(
+            "/v1/harnesses",
+            json!({
+                "name": "chat-repair-test",
+                "display_name": "Chat Repair Test",
+                "system_prompt": "Test harness"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    server
+        .db
+        .update_session(
+            DEFAULT_ORG_ID,
+            original.id,
+            UpdateSession {
+                harness_id: Some(other_harness.id),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("failed to mutate chat session")
+        .expect("chat session should exist");
+
+    let repaired: Session = server
+        .post("/v1/sessions/chat", json!({}))
+        .await
+        .assert_success()
+        .json();
+
+    assert_eq!(repaired.id, original.id);
+    assert_eq!(
+        repaired.harness_id.to_string(),
+        SEED_CHAT_HARNESS_ID,
+        "chat endpoint should repair stale session harness bindings"
     );
 }
 

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -312,6 +312,20 @@ async fn test_session_crud() {
         .expect("Session not found");
     assert_eq!(updated.title.as_deref(), Some("Updated Title"));
 
+    let rehomed = backend
+        .update_session(
+            TEST_ORG_ID,
+            session.id,
+            UpdateSession {
+                harness_id: Some(org_init::CHAT_HARNESS_ID.into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("Failed to update session harness")
+        .expect("Session not found");
+    assert_eq!(rehomed.harness_id, Some(org_init::CHAT_HARNESS_ID.into()));
+
     // List sessions with pagination
     let (sessions, total) = backend
         .list_sessions(


### PR DESCRIPTION
## What
Repair stale Platform Chat singleton sessions by rebinding them to the current configured chat harness when `/v1/sessions/chat` loads an existing session with the wrong `harness_id`.

## Why
Users could get stuck on an old Platform Chat session whose harness pointer no longer matched the active `platform-chat` harness, which left chat broken until manual DB/API cleanup.

Fixes EVE-334.

## How
- extend the internal session update path to allow server-side `harness_id` repairs
- on global chat session lookup, detect a stored harness mismatch and persist the current chat harness onto the existing singleton session
- reconcile capability mount roots during repair, evict stale virtual mounts, and then re-apply the current mounts
- log malformed session capability JSON instead of silently discarding it
- add an API regression test for stale chat harness repair and a PostgreSQL-backed repository assertion for `harness_id` updates

## Risk
- Low
- Touches chat-session lookup/update behavior only; no auth or routing changes

## Security
- Threat categories reviewed: TM-API
- Findings and resolutions: no new trust boundary or privilege change; the endpoint stays behind existing auth/session policies and only repairs the harness binding on the already-owned singleton session.

## Validation
- `cargo test -p everruns-server --test api_integration_test test_global_chat_repairs_stale_harness_binding -- --test-threads=1`
- `cargo fmt --check`
- `just pre-push`
- `PORT_PREFIX=271 just start-dev --no-watch` then authenticated `POST /api/v1/sessions/chat` -> `200` with `harness_id=harness_01933b5a000070008000000000000603`
- PostgreSQL `harness_id` update path covered by the new repository integration assertion in CI

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
