### PR TITLE
feat(media): add gpt_image_gen capability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1930,10 +1930,12 @@ version = "0.8.15"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64",
  "chrono",
  "eventsource-stream",
  "everruns-core",
  "futures",
+ "inventory",
  "reqwest 0.13.2",
  "serde",
  "serde_json",
@@ -1941,6 +1943,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -158,6 +158,10 @@ where
     sqldb_store: Option<crate::traits::SessionSqlDbStoreRef>,
     /// Optional session storage store for kv_store/secret_store tools
     storage_store: Option<Arc<dyn crate::traits::SessionStorageStore>>,
+    /// Optional image artifact store for durable image persistence
+    image_store: Option<Arc<dyn crate::traits::ImageArtifactStore>>,
+    /// Optional provider credential store for tool-side API clients
+    provider_credential_store: Option<Arc<dyn crate::traits::ProviderCredentialStore>>,
     /// Optional resolver for user connection tokens
     connection_resolver: Option<Arc<dyn crate::traits::UserConnectionResolver>>,
     /// Optional session store for session metadata reads
@@ -210,6 +214,8 @@ where
             file_store: None,
             sqldb_store: None,
             storage_store: None,
+            image_store: None,
+            provider_credential_store: None,
             connection_resolver: None,
             session_store: None,
             session_mutator: None,
@@ -242,6 +248,8 @@ where
             file_store: Some(file_store),
             sqldb_store: None,
             storage_store: None,
+            image_store: None,
+            provider_credential_store: None,
             connection_resolver: None,
             session_store: None,
             session_mutator: None,
@@ -295,6 +303,21 @@ where
         store: Arc<dyn crate::traits::SessionStorageStore>,
     ) -> Self {
         self.storage_store = Some(store);
+        self
+    }
+
+    /// Set the image artifact store on this atom
+    pub fn with_image_store(mut self, store: Arc<dyn crate::traits::ImageArtifactStore>) -> Self {
+        self.image_store = Some(store);
+        self
+    }
+
+    /// Set the provider credential store on this atom
+    pub fn with_provider_credential_store(
+        mut self,
+        store: Arc<dyn crate::traits::ProviderCredentialStore>,
+    ) -> Self {
+        self.provider_credential_store = Some(store);
         self
     }
 
@@ -809,6 +832,12 @@ where
         }
         if let Some(ref store) = self.storage_store {
             tool_context.storage_store = Some(store.clone());
+        }
+        if let Some(ref store) = self.image_store {
+            tool_context.image_store = Some(store.clone());
+        }
+        if let Some(ref store) = self.provider_credential_store {
+            tool_context.provider_credential_store = Some(store.clone());
         }
         if let Some(ref resolver) = self.connection_resolver {
             tool_context.connection_resolver = Some(resolver.clone());

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -10,8 +10,9 @@ use crate::harness::Harness;
 use crate::llm_models::LlmProviderType;
 use crate::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
 use crate::tool_types::{ToolCall, ToolDefinition, ToolResult};
-use crate::typed_id::{AgentId, HarnessId, ModelId, SessionId};
+use crate::typed_id::{AgentId, HarnessId, ImageId, ModelId, SessionId};
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -126,6 +127,72 @@ pub trait LlmProviderStore: Send + Sync {
     ///
     /// Returns the system default model when an agent has no default_model_id set.
     async fn get_default_model(&self) -> Result<Option<ModelWithProvider>>;
+}
+
+// ============================================================================
+// ImageArtifactStore - For durable image persistence from tools
+// ============================================================================
+
+/// Metadata for a stored image artifact.
+#[derive(Debug, Clone)]
+pub struct StoredImageInfo {
+    pub id: ImageId,
+    pub filename: String,
+    pub content_type: String,
+    pub size_bytes: i64,
+    pub metadata: serde_json::Value,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Stored image artifact with binary data.
+#[derive(Debug, Clone)]
+pub struct StoredImage {
+    pub info: StoredImageInfo,
+    pub data: Vec<u8>,
+}
+
+/// Input for creating a stored image artifact.
+#[derive(Debug, Clone)]
+pub struct CreateStoredImage {
+    pub filename: String,
+    pub content_type: String,
+    pub data: Vec<u8>,
+    pub metadata: serde_json::Value,
+}
+
+#[async_trait]
+pub trait ImageArtifactStore: Send + Sync {
+    /// Persist an image artifact and return its durable metadata.
+    async fn create_image(&self, input: CreateStoredImage) -> Result<StoredImageInfo>;
+
+    /// Load a stored image artifact including bytes.
+    async fn get_image(&self, image_id: ImageId) -> Result<Option<StoredImage>>;
+
+    /// Load stored image metadata without binary data.
+    async fn get_image_info(&self, image_id: ImageId) -> Result<Option<StoredImageInfo>>;
+}
+
+// ============================================================================
+// ProviderCredentialStore - For tool-side provider credential resolution
+// ============================================================================
+
+/// Provider credentials resolved for tool-side API clients.
+#[derive(Debug, Clone)]
+pub struct ProviderCredentials {
+    pub api_key: String,
+    pub base_url: Option<String>,
+}
+
+#[async_trait]
+pub trait ProviderCredentialStore: Send + Sync {
+    /// Resolve default credentials for a provider type (for example `openai`).
+    ///
+    /// Implementations may apply environment fallbacks internally, but tools
+    /// should never read provider env vars directly.
+    async fn get_default_provider_credentials(
+        &self,
+        provider_type: &str,
+    ) -> Result<Option<ProviderCredentials>>;
 }
 
 // ============================================================================
@@ -559,6 +626,12 @@ pub struct ToolContext {
     /// Optional storage store for key/value and secret storage
     pub storage_store: Option<Arc<dyn SessionStorageStore>>,
 
+    /// Optional durable image artifact store for tool-side media persistence.
+    pub image_store: Option<Arc<dyn ImageArtifactStore>>,
+
+    /// Optional provider credential store for tool-side API clients.
+    pub provider_credential_store: Option<Arc<dyn ProviderCredentialStore>>,
+
     /// Optional session SQL database store
     pub sqldb_store: Option<SessionSqlDbStoreRef>,
 
@@ -632,6 +705,8 @@ impl ToolContext {
             session_id,
             file_store: None,
             storage_store: None,
+            image_store: None,
+            provider_credential_store: None,
             sqldb_store: None,
             message_retriever: None,
             session_store: None,
@@ -661,6 +736,8 @@ impl ToolContext {
             session_id,
             file_store: Some(file_store),
             storage_store: None,
+            image_store: None,
+            provider_credential_store: None,
             sqldb_store: None,
             message_retriever: None,
             session_store: None,
@@ -693,6 +770,8 @@ impl ToolContext {
             session_id,
             file_store: None,
             storage_store: Some(storage_store),
+            image_store: None,
+            provider_credential_store: None,
             sqldb_store: None,
             message_retriever: None,
             session_store: None,
@@ -727,6 +806,8 @@ impl ToolContext {
             file_store: Some(file_store),
             storage_store: Some(storage_store),
             sqldb_store: None,
+            image_store: None,
+            provider_credential_store: None,
             message_retriever: None,
             session_store: None,
             session_mutator: None,
@@ -785,6 +866,49 @@ impl ToolContext {
     /// Add a connection resolver to this context
     pub fn with_connection_resolver(mut self, resolver: Arc<dyn UserConnectionResolver>) -> Self {
         self.connection_resolver = Some(resolver);
+        self
+    }
+
+    /// Create a context with an image artifact store.
+    pub fn with_image_store(
+        session_id: SessionId,
+        image_store: Arc<dyn ImageArtifactStore>,
+    ) -> Self {
+        Self {
+            session_id,
+            file_store: None,
+            storage_store: None,
+            image_store: Some(image_store),
+            provider_credential_store: None,
+            sqldb_store: None,
+            message_retriever: None,
+            session_store: None,
+            session_mutator: None,
+            agent_store: None,
+            connection_resolver: None,
+            schedule_store: None,
+            platform_store: None,
+            leased_resource_store: None,
+            session_resource_registry: None,
+            event_emitter: None,
+            event_context: None,
+            tool_call_id: None,
+            capability_registry: None,
+            tool_registry: None,
+            memory_store: None,
+            org_id: None,
+            network_access: None,
+            locale: None,
+            budget_checker: None,
+        }
+    }
+
+    /// Set the provider credential store on this context.
+    pub fn with_provider_credential_store(
+        mut self,
+        store: Arc<dyn ProviderCredentialStore>,
+    ) -> Self {
+        self.provider_credential_store = Some(store);
         self
     }
 
@@ -919,6 +1043,11 @@ impl std::fmt::Debug for ToolContext {
             .field("session_id", &self.session_id)
             .field("file_store", &self.file_store.is_some())
             .field("storage_store", &self.storage_store.is_some())
+            .field("image_store", &self.image_store.is_some())
+            .field(
+                "provider_credential_store",
+                &self.provider_credential_store.is_some(),
+            )
             .field("sqldb_store", &self.sqldb_store.is_some())
             .field("message_retriever", &self.message_retriever.is_some())
             .field("session_store", &self.session_store.is_some())

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -129,6 +129,14 @@ service WorkerService {
     // Resolve multiple images in a batch (more efficient for multimodal messages)
     rpc ResolveImages(ResolveImagesRequest) returns (ResolveImagesResponse);
 
+    // Persist and read image artifacts for tool-side image generation/editing.
+    rpc CreateImageArtifact(CreateImageArtifactRequest) returns (CreateImageArtifactResponse);
+    rpc GetImageArtifact(GetImageArtifactRequest) returns (GetImageArtifactResponse);
+    rpc GetImageArtifactInfo(GetImageArtifactInfoRequest) returns (GetImageArtifactInfoResponse);
+
+    // Resolve default provider credentials for tool-side API clients.
+    rpc GetDefaultProviderCredentials(GetDefaultProviderCredentialsRequest) returns (GetDefaultProviderCredentialsResponse);
+
     // === MCP server operations ===
     // Get MCP server info by name prefix (for tool execution)
     rpc GetMcpServerByPrefix(GetMcpServerByPrefixRequest) returns (GetMcpServerByPrefixResponse);
@@ -968,6 +976,61 @@ message ResolveImagesResponse {
     // Map from image_id string to resolved image
     // Only contains entries for found images
     map<string, ResolvedImageData> images = 1;
+}
+
+message StoredImageInfo {
+    Uuid id = 1;
+    string filename = 2;
+    string content_type = 3;
+    int64 size_bytes = 4;
+    optional google.protobuf.Struct metadata = 5;
+    optional Timestamp created_at = 6;
+}
+
+message StoredImage {
+    StoredImageInfo info = 1;
+    bytes data = 2;
+}
+
+message CreateImageArtifactRequest {
+    int64 org_id = 1;
+    string filename = 2;
+    string content_type = 3;
+    bytes data = 4;
+    optional google.protobuf.Struct metadata = 5;
+}
+
+message CreateImageArtifactResponse {
+    StoredImageInfo image = 1;
+}
+
+message GetImageArtifactRequest {
+    int64 org_id = 1;
+    Uuid image_id = 2;
+}
+
+message GetImageArtifactResponse {
+    optional StoredImage image = 1;
+}
+
+message GetImageArtifactInfoRequest {
+    int64 org_id = 1;
+    Uuid image_id = 2;
+}
+
+message GetImageArtifactInfoResponse {
+    optional StoredImageInfo image = 1;
+}
+
+message GetDefaultProviderCredentialsRequest {
+    int64 org_id = 1;
+    string provider_type = 2;
+}
+
+message GetDefaultProviderCredentialsResponse {
+    bool found = 1;
+    string api_key = 2;
+    string base_url = 3;
 }
 
 // Resolved image data for batch response

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -21,7 +21,7 @@ tokio.workspace = true
 futures.workspace = true
 
 # HTTP client
-reqwest.workspace = true
+reqwest = { workspace = true, features = ["multipart"] }
 eventsource-stream.workspace = true
 
 # Serialization
@@ -30,9 +30,11 @@ serde_json.workspace = true
 
 # Date/time
 chrono.workspace = true
+base64.workspace = true
 
 # Tracing
 tracing.workspace = true
+inventory.workspace = true
 
 # Internal dependencies
 everruns-core = { path = "../core" }
@@ -40,3 +42,4 @@ everruns-core = { path = "../core" }
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }
 tracing-subscriber.workspace = true
+wiremock = "0.6"

--- a/crates/openai/src/image_capability.rs
+++ b/crates/openai/src/image_capability.rs
@@ -74,7 +74,7 @@ impl Capability for GptImageGenCapability {
     }
 
     fn dependencies(&self) -> Vec<&'static str> {
-        vec!["file_system", "session_storage"]
+        vec!["session_file_system", "session_storage"]
     }
 }
 
@@ -460,6 +460,28 @@ async fn resolve_client_config(
         if let Some(api_key) = api_key {
             return Ok(ResolvedClientConfig { api_key, base_url });
         }
+
+        if let Some(base_url) = base_url {
+            let Some(provider_store) = &context.provider_credential_store else {
+                return Err(ToolExecutionResult::tool_error(
+                    "OpenAI credentials are not configured. Store OPENAI_API_KEY via secret_store or configure an OpenAI provider.",
+                ));
+            };
+
+            return match provider_store
+                .get_default_provider_credentials("openai")
+                .await
+            {
+                Ok(Some(credentials)) => Ok(ResolvedClientConfig {
+                    api_key: credentials.api_key,
+                    base_url: Some(base_url),
+                }),
+                Ok(None) => Err(ToolExecutionResult::tool_error(
+                    "OpenAI credentials are not configured. Store OPENAI_API_KEY via secret_store or configure an OpenAI provider.",
+                )),
+                Err(error) => Err(ToolExecutionResult::internal_error(error)),
+            };
+        }
     }
 
     let Some(provider_store) = &context.provider_credential_store else {
@@ -800,5 +822,14 @@ mod tests {
         });
         let args: EditImageArgs = serde_json::from_value(value).unwrap();
         assert!(args.image_id.is_some());
+    }
+
+    #[test]
+    fn capability_declares_session_file_system_dependency() {
+        let capability = GptImageGenCapability;
+        assert_eq!(
+            capability.dependencies(),
+            vec!["session_file_system", "session_storage"]
+        );
     }
 }

--- a/crates/openai/src/image_capability.rs
+++ b/crates/openai/src/image_capability.rs
@@ -1,0 +1,804 @@
+use crate::images::{
+    EditImageInput, EditImageRequest, GenerateImageRequest, ImageApiImage, OpenAiImageClient,
+};
+use async_trait::async_trait;
+use base64::Engine;
+use everruns_core::ImageId;
+use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin};
+use everruns_core::session_file::SessionFile;
+use everruns_core::tool_types::ToolHints;
+use everruns_core::tools::{Tool, ToolExecutionResult, ToolResultImage};
+use everruns_core::traits::{CreateStoredImage, ToolContext};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use std::sync::LazyLock;
+
+const GPT_IMAGE_GEN_CAPABILITY_ID: &str = "gpt_image_gen";
+const OPENAI_IMAGE_MODEL: &str = "gpt-image-1";
+const DEFAULT_OUTPUT_DIR: &str = "/workspace/.outputs/images";
+const DEFAULT_GENERATE_PREFIX: &str = "generated-image";
+const DEFAULT_EDIT_PREFIX: &str = "edited-image";
+const SESSION_API_KEY_SECRET_NAMES: &[&str] = &["OPENAI_API_KEY", "openai_api_key"];
+const SESSION_BASE_URL_SECRET_NAMES: &[&str] = &["OPENAI_BASE_URL", "openai_base_url"];
+const MAX_EDIT_SOURCE_BYTES: usize = 50 * 1024 * 1024;
+
+inventory::submit! {
+    IntegrationPlugin {
+        experimental_only: false,
+        feature_flag: None,
+        factory: || Box::new(GptImageGenCapability),
+    }
+}
+
+static SYSTEM_PROMPT: LazyLock<String> = LazyLock::new(|| {
+    r#"Use `generate_image` for raster image generation and `edit_image` to transform existing images.
+
+Store per-session OpenAI overrides in `secret_store` under `OPENAI_API_KEY` and optionally `OPENAI_BASE_URL`.
+When saving files, write under `/workspace/.outputs/images` unless the user requests another directory."#
+        .to_string()
+});
+
+pub struct GptImageGenCapability;
+
+impl Capability for GptImageGenCapability {
+    fn id(&self) -> &str {
+        GPT_IMAGE_GEN_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "OpenAI Image Generation"
+    }
+
+    fn description(&self) -> &str {
+        "Generate and edit raster images with OpenAI's GPT Image API."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("image")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Media")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(&SYSTEM_PROMPT)
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![Box::new(GenerateImageTool), Box::new(EditImageTool)]
+    }
+
+    fn dependencies(&self) -> Vec<&'static str> {
+        vec!["file_system", "session_storage"]
+    }
+}
+
+pub struct GenerateImageTool;
+
+#[async_trait]
+impl Tool for GenerateImageTool {
+    fn name(&self) -> &str {
+        "generate_image"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Generate Image")
+    }
+
+    fn description(&self) -> &str {
+        "Generate raster images with OpenAI's GPT Image API and optionally persist them as artifacts or session files."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "prompt": { "type": "string", "description": "Image generation prompt." },
+                "size": {
+                    "type": "string",
+                    "enum": ["1024x1024", "1536x1024", "1024x1536", "auto"],
+                    "description": "Output size. Defaults to auto."
+                },
+                "quality": {
+                    "type": "string",
+                    "enum": ["low", "medium", "high", "auto"],
+                    "description": "Generation quality. Defaults to auto."
+                },
+                "background": {
+                    "type": "string",
+                    "enum": ["transparent", "opaque", "auto"],
+                    "description": "Background treatment. Transparent requires png or webp."
+                },
+                "format": {
+                    "type": "string",
+                    "enum": ["png", "jpeg", "webp"],
+                    "description": "Output image format. Defaults to png."
+                },
+                "count": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 10,
+                    "description": "Number of images to generate. Defaults to 1."
+                },
+                "save_to_session_fs": {
+                    "type": "boolean",
+                    "description": "When true, save each generated image into the session filesystem."
+                },
+                "output_dir": {
+                    "type": "string",
+                    "description": "Session filesystem directory used when save_to_session_fs is true. Defaults to /workspace/.outputs/images."
+                },
+                "filename_prefix": {
+                    "type": "string",
+                    "description": "Filename prefix used for saved/generated artifacts."
+                },
+                "persist_artifact": {
+                    "type": "boolean",
+                    "description": "When true, persist each image in the durable image artifact store. Defaults to true."
+                }
+            },
+            "required": ["prompt"],
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("generate_image requires session context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let args = match parse_arguments::<GenerateImageArgs>(arguments) {
+            Ok(args) => args,
+            Err(result) => return result,
+        };
+        if let Err(message) = validate_output_options(&args.common) {
+            return ToolExecutionResult::tool_error(message);
+        }
+
+        let client = match build_client(context).await {
+            Ok(client) => client,
+            Err(result) => return result,
+        };
+
+        let response = match client
+            .generate(GenerateImageRequest {
+                model: OPENAI_IMAGE_MODEL.to_string(),
+                prompt: args.prompt.clone(),
+                size: args.common.size.clone(),
+                quality: args.common.quality.clone(),
+                background: args.common.background.clone(),
+                output_format: args.common.format.clone(),
+                count: args.common.count(),
+            })
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => return ToolExecutionResult::internal_error_msg(error.to_string()),
+        };
+
+        materialize_outputs(
+            context,
+            &args.prompt,
+            None,
+            &args.common,
+            response.data,
+            args.common
+                .filename_prefix
+                .clone()
+                .unwrap_or_else(|| DEFAULT_GENERATE_PREFIX.to_string()),
+        )
+        .await
+    }
+}
+
+pub struct EditImageTool;
+
+#[async_trait]
+impl Tool for EditImageTool {
+    fn name(&self) -> &str {
+        "edit_image"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Edit Image")
+    }
+
+    fn description(&self) -> &str {
+        "Edit one or more source images from a stored image artifact and/or a session file path."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "prompt": { "type": "string", "description": "Editing prompt." },
+                "image_id": {
+                    "type": "string",
+                    "description": "Optional stored image artifact ID to use as an edit source."
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Optional session file path to use as an edit source."
+                },
+                "size": {
+                    "type": "string",
+                    "enum": ["1024x1024", "1536x1024", "1024x1536", "auto"],
+                    "description": "Output size. Defaults to auto."
+                },
+                "quality": {
+                    "type": "string",
+                    "enum": ["low", "medium", "high", "auto"],
+                    "description": "Generation quality. Defaults to auto."
+                },
+                "background": {
+                    "type": "string",
+                    "enum": ["transparent", "opaque", "auto"],
+                    "description": "Background treatment. Transparent requires png or webp."
+                },
+                "format": {
+                    "type": "string",
+                    "enum": ["png", "jpeg", "webp"],
+                    "description": "Output image format. Defaults to png."
+                },
+                "count": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 10,
+                    "description": "Number of images to generate. Defaults to 1."
+                },
+                "save_to_session_fs": { "type": "boolean" },
+                "output_dir": { "type": "string" },
+                "filename_prefix": { "type": "string" },
+                "persist_artifact": { "type": "boolean" }
+            },
+            "required": ["prompt"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("edit_image requires session context")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let args = match parse_arguments::<EditImageArgs>(arguments) {
+            Ok(args) => args,
+            Err(result) => return result,
+        };
+        if args.image_id.is_none() && args.path.is_none() {
+            return ToolExecutionResult::tool_error(
+                "edit_image requires at least one source: image_id and/or path",
+            );
+        }
+        if let Err(message) = validate_output_options(&args.common) {
+            return ToolExecutionResult::tool_error(message);
+        }
+
+        let sources = match collect_edit_sources(context, &args).await {
+            Ok(sources) => sources,
+            Err(result) => return result,
+        };
+        let client = match build_client(context).await {
+            Ok(client) => client,
+            Err(result) => return result,
+        };
+
+        let response = match client
+            .edit(EditImageRequest {
+                model: OPENAI_IMAGE_MODEL.to_string(),
+                prompt: args.prompt.clone(),
+                images: sources,
+                size: args.common.size.clone(),
+                quality: args.common.quality.clone(),
+                background: args.common.background.clone(),
+                output_format: args.common.format.clone(),
+                count: args.common.count(),
+            })
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => return ToolExecutionResult::internal_error_msg(error.to_string()),
+        };
+
+        materialize_outputs(
+            context,
+            &args.prompt,
+            Some(json!({
+                "image_id": args.image_id.map(|id| id.to_string()),
+                "path": args.path,
+            })),
+            &args.common,
+            response.data,
+            args.common
+                .filename_prefix
+                .clone()
+                .unwrap_or_else(|| DEFAULT_EDIT_PREFIX.to_string()),
+        )
+        .await
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct GenerateImageArgs {
+    prompt: String,
+    #[serde(flatten)]
+    common: CommonImageArgs,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EditImageArgs {
+    prompt: String,
+    image_id: Option<ImageId>,
+    path: Option<String>,
+    #[serde(flatten)]
+    common: CommonImageArgs,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CommonImageArgs {
+    size: Option<String>,
+    quality: Option<String>,
+    background: Option<String>,
+    format: Option<String>,
+    count: Option<usize>,
+    save_to_session_fs: Option<bool>,
+    output_dir: Option<String>,
+    filename_prefix: Option<String>,
+    persist_artifact: Option<bool>,
+}
+
+impl CommonImageArgs {
+    fn count(&self) -> usize {
+        self.count.unwrap_or(1)
+    }
+
+    fn save_to_session_fs(&self) -> bool {
+        self.save_to_session_fs.unwrap_or(false)
+    }
+
+    fn persist_artifact(&self) -> bool {
+        self.persist_artifact.unwrap_or(true)
+    }
+
+    fn output_dir(&self) -> &str {
+        self.output_dir.as_deref().unwrap_or(DEFAULT_OUTPUT_DIR)
+    }
+
+    fn format(&self) -> &str {
+        self.format.as_deref().unwrap_or("png")
+    }
+}
+
+impl CommonImageArgs {
+    fn cloned_with_defaults(&self) -> CommonImageArgsWithDefaults {
+        CommonImageArgsWithDefaults {
+            format: Some(self.format().to_string()),
+            count: self.count(),
+            save_to_session_fs: self.save_to_session_fs(),
+            output_dir: self.output_dir().to_string(),
+            persist_artifact: self.persist_artifact(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CommonImageArgsWithDefaults {
+    format: Option<String>,
+    count: usize,
+    save_to_session_fs: bool,
+    output_dir: String,
+    persist_artifact: bool,
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedClientConfig {
+    api_key: String,
+    base_url: Option<String>,
+}
+
+fn parse_arguments<T: for<'de> Deserialize<'de>>(
+    arguments: Value,
+) -> Result<T, ToolExecutionResult> {
+    serde_json::from_value(arguments)
+        .map_err(|error| ToolExecutionResult::tool_error(format!("Invalid arguments: {error}")))
+}
+
+async fn build_client(context: &ToolContext) -> Result<OpenAiImageClient, ToolExecutionResult> {
+    let config = match resolve_client_config(context).await {
+        Ok(config) => config,
+        Err(result) => return Err(result),
+    };
+
+    OpenAiImageClient::new(config.api_key, config.base_url)
+        .map_err(|error| ToolExecutionResult::internal_error_msg(error.to_string()))
+}
+
+async fn resolve_client_config(
+    context: &ToolContext,
+) -> Result<ResolvedClientConfig, ToolExecutionResult> {
+    if let Some(storage_store) = &context.storage_store {
+        let api_key = match get_first_secret(
+            storage_store.as_ref(),
+            context,
+            SESSION_API_KEY_SECRET_NAMES,
+        )
+        .await
+        {
+            Ok(api_key) => api_key,
+            Err(error) => return Err(ToolExecutionResult::internal_error_msg(error.to_string())),
+        };
+        let base_url = match get_first_secret(
+            storage_store.as_ref(),
+            context,
+            SESSION_BASE_URL_SECRET_NAMES,
+        )
+        .await
+        {
+            Ok(base_url) => base_url,
+            Err(error) => return Err(ToolExecutionResult::internal_error_msg(error.to_string())),
+        };
+        if let Some(api_key) = api_key {
+            return Ok(ResolvedClientConfig { api_key, base_url });
+        }
+    }
+
+    let Some(provider_store) = &context.provider_credential_store else {
+        return Err(ToolExecutionResult::tool_error(
+            "OpenAI credentials are not configured. Store OPENAI_API_KEY via secret_store or configure an OpenAI provider.",
+        ));
+    };
+
+    match provider_store
+        .get_default_provider_credentials("openai")
+        .await
+    {
+        Ok(Some(credentials)) => Ok(ResolvedClientConfig {
+            api_key: credentials.api_key,
+            base_url: credentials.base_url,
+        }),
+        Ok(None) => Err(ToolExecutionResult::tool_error(
+            "OpenAI credentials are not configured. Store OPENAI_API_KEY via secret_store or configure an OpenAI provider.",
+        )),
+        Err(error) => Err(ToolExecutionResult::internal_error(error)),
+    }
+}
+
+async fn get_first_secret(
+    store: &dyn everruns_core::traits::SessionStorageStore,
+    context: &ToolContext,
+    names: &[&str],
+) -> anyhow::Result<Option<String>> {
+    for name in names {
+        if let Some(value) = store.get_secret(context.session_id, name).await? {
+            return Ok(Some(value));
+        }
+    }
+    Ok(None)
+}
+
+fn validate_output_options(common: &CommonImageArgs) -> Result<(), String> {
+    if !(1..=10).contains(&common.count()) {
+        return Err("count must be between 1 and 10".to_string());
+    }
+    if matches!(common.background.as_deref(), Some("transparent"))
+        && matches!(common.format(), "jpeg")
+    {
+        return Err("transparent background requires png or webp output".to_string());
+    }
+    Ok(())
+}
+
+async fn collect_edit_sources(
+    context: &ToolContext,
+    args: &EditImageArgs,
+) -> Result<Vec<EditImageInput>, ToolExecutionResult> {
+    let mut sources = Vec::new();
+
+    if let Some(image_id) = args.image_id {
+        let Some(image_store) = &context.image_store else {
+            return Err(ToolExecutionResult::internal_error_msg(
+                "Image artifact store not available in this context",
+            ));
+        };
+        let image = match image_store.get_image(image_id).await {
+            Ok(Some(image)) => image,
+            Ok(None) => {
+                return Err(ToolExecutionResult::tool_error(format!(
+                    "Image artifact not found: {image_id}"
+                )));
+            }
+            Err(error) => return Err(ToolExecutionResult::internal_error(error)),
+        };
+        if image.data.len() > MAX_EDIT_SOURCE_BYTES {
+            return Err(ToolExecutionResult::tool_error(format!(
+                "Image artifact {image_id} exceeds the 50MB edit limit"
+            )));
+        }
+        sources.push(EditImageInput {
+            filename: image.info.filename,
+            content_type: image.info.content_type,
+            data: image.data,
+        });
+    }
+
+    if let Some(path) = args.path.as_deref() {
+        let Some(file_store) = &context.file_store else {
+            return Err(ToolExecutionResult::internal_error_msg(
+                "Session file store not available in this context",
+            ));
+        };
+        let normalized_path = normalize_workspace_path(path);
+        let display_path = add_workspace_prefix(&normalized_path);
+        let file = match file_store
+            .read_file(context.session_id, &normalized_path)
+            .await
+        {
+            Ok(Some(file)) => file,
+            Ok(None) => {
+                return Err(ToolExecutionResult::tool_error(format!(
+                    "Session file not found: {display_path}"
+                )));
+            }
+            Err(error) => return Err(ToolExecutionResult::internal_error(error)),
+        };
+        if file.is_directory {
+            return Err(ToolExecutionResult::tool_error(format!(
+                "Path is a directory, not an image file: {display_path}"
+            )));
+        }
+        let Some(content) = file.content.as_deref() else {
+            return Err(ToolExecutionResult::tool_error(format!(
+                "Session file has no content: {display_path}"
+            )));
+        };
+        let bytes = match SessionFile::decode_content(content, &file.encoding) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                return Err(ToolExecutionResult::tool_error(format!(
+                    "Failed to decode session file content for {display_path}: {error}"
+                )));
+            }
+        };
+        if bytes.len() > MAX_EDIT_SOURCE_BYTES {
+            return Err(ToolExecutionResult::tool_error(format!(
+                "Session file exceeds the 50MB edit limit: {display_path}"
+            )));
+        }
+        let Some(content_type) = infer_image_content_type(&display_path) else {
+            return Err(ToolExecutionResult::tool_error(format!(
+                "Unsupported image file type for {display_path}. Use png, jpg, jpeg, or webp."
+            )));
+        };
+        sources.push(EditImageInput {
+            filename: file.name,
+            content_type: content_type.to_string(),
+            data: bytes,
+        });
+    }
+
+    Ok(sources)
+}
+
+async fn materialize_outputs(
+    context: &ToolContext,
+    prompt: &str,
+    source: Option<Value>,
+    common: &CommonImageArgs,
+    images: Vec<ImageApiImage>,
+    filename_prefix: String,
+) -> ToolExecutionResult {
+    let options = common.cloned_with_defaults();
+    let Some(output_format) = options.format.clone() else {
+        return ToolExecutionResult::internal_error_msg("missing output format");
+    };
+    let mut rendered_images = Vec::with_capacity(images.len());
+    let mut rendered_results = Vec::with_capacity(images.len());
+
+    for (index, image) in images.into_iter().enumerate() {
+        let bytes = match base64::engine::general_purpose::STANDARD.decode(&image.b64_json) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                return ToolExecutionResult::internal_error_msg(format!(
+                    "invalid base64 image data from OpenAI: {error}"
+                ));
+            }
+        };
+        let filename = output_filename(&filename_prefix, index, options.count, &output_format);
+        let media_type = format_media_type(&output_format);
+
+        let artifact_id = if options.persist_artifact {
+            let Some(image_store) = &context.image_store else {
+                return ToolExecutionResult::internal_error_msg(
+                    "Image artifact store not available in this context",
+                );
+            };
+            match image_store
+                .create_image(CreateStoredImage {
+                    filename: filename.clone(),
+                    content_type: media_type.to_string(),
+                    data: bytes.clone(),
+                    metadata: json!({
+                        "provider": "openai",
+                        "model": OPENAI_IMAGE_MODEL,
+                        "prompt": prompt,
+                        "revised_prompt": image.revised_prompt,
+                    }),
+                })
+                .await
+            {
+                Ok(info) => Some(info.id),
+                Err(error) => return ToolExecutionResult::internal_error(error),
+            }
+        } else {
+            None
+        };
+
+        let session_path = if options.save_to_session_fs {
+            let Some(file_store) = &context.file_store else {
+                return ToolExecutionResult::internal_error_msg(
+                    "Session file store not available in this context",
+                );
+            };
+            let normalized_output_dir = normalize_workspace_path(&options.output_dir);
+            let normalized_path = join_workspace_path(&normalized_output_dir, &filename);
+            match file_store
+                .write_file(
+                    context.session_id,
+                    &normalized_path,
+                    &image.b64_json,
+                    "base64",
+                )
+                .await
+            {
+                Ok(_) => Some(add_workspace_prefix(&normalized_path)),
+                Err(error) => return ToolExecutionResult::internal_error(error),
+            }
+        } else {
+            None
+        };
+
+        rendered_images.push(ToolResultImage {
+            base64: image.b64_json.clone(),
+            media_type: media_type.to_string(),
+        });
+        rendered_results.push(json!({
+            "index": index + 1,
+            "artifact_id": artifact_id.map(|id| id.to_string()),
+            "session_file": session_path,
+            "filename": filename,
+            "media_type": media_type,
+            "size_bytes": bytes.len(),
+            "revised_prompt": image.revised_prompt,
+        }));
+    }
+
+    ToolExecutionResult::success_with_images(
+        json!({
+            "provider": "openai",
+            "model": OPENAI_IMAGE_MODEL,
+            "prompt": prompt,
+            "count": rendered_results.len(),
+            "source": source,
+            "images": rendered_results,
+        }),
+        rendered_images,
+    )
+}
+
+fn output_filename(prefix: &str, index: usize, count: usize, format: &str) -> String {
+    let extension = match format {
+        "jpeg" => "jpg",
+        other => other,
+    };
+    if count == 1 {
+        format!("{prefix}.{extension}")
+    } else {
+        format!("{prefix}-{}.{extension}", index + 1)
+    }
+}
+
+fn format_media_type(format: &str) -> &'static str {
+    match format {
+        "jpeg" => "image/jpeg",
+        "webp" => "image/webp",
+        _ => "image/png",
+    }
+}
+
+fn normalize_workspace_path(path: &str) -> String {
+    let path = if path == "/workspace" {
+        "/".to_string()
+    } else if let Some(stripped) = path.strip_prefix("/workspace") {
+        if stripped.starts_with('/') {
+            stripped.to_string()
+        } else {
+            path.to_string()
+        }
+    } else if path.starts_with('/') {
+        path.to_string()
+    } else {
+        format!("/{}", path)
+    };
+
+    if path.is_empty() {
+        "/".to_string()
+    } else {
+        path
+    }
+}
+
+fn add_workspace_prefix(path: &str) -> String {
+    if path == "/" {
+        "/workspace".to_string()
+    } else {
+        format!("/workspace{path}")
+    }
+}
+
+fn join_workspace_path(dir: &str, filename: &str) -> String {
+    if dir == "/" {
+        format!("/{filename}")
+    } else {
+        format!("{}/{}", dir.trim_end_matches('/'), filename)
+    }
+}
+
+fn infer_image_content_type(path: &str) -> Option<&'static str> {
+    let lower = path.to_ascii_lowercase();
+    if lower.ends_with(".png") {
+        Some("image/png")
+    } else if lower.ends_with(".jpg") || lower.ends_with(".jpeg") {
+        Some("image/jpeg")
+    } else if lower.ends_with(".webp") {
+        Some("image/webp")
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_workspace_paths() {
+        assert_eq!(normalize_workspace_path("/workspace/out"), "/out");
+        assert_eq!(normalize_workspace_path("out/file.png"), "/out/file.png");
+    }
+
+    #[test]
+    fn output_filename_indexes_multiple_images() {
+        assert_eq!(output_filename("image", 0, 1, "png"), "image.png");
+        assert_eq!(output_filename("image", 1, 3, "jpeg"), "image-2.jpg");
+    }
+
+    #[test]
+    fn parse_image_id_strings() {
+        let value = json!({
+            "prompt": "edit",
+            "image_id": ImageId::new().to_string()
+        });
+        let args: EditImageArgs = serde_json::from_value(value).unwrap();
+        assert!(args.image_id.is_some());
+    }
+}

--- a/crates/openai/src/images.rs
+++ b/crates/openai/src/images.rs
@@ -1,0 +1,261 @@
+use anyhow::{Context, Result, anyhow};
+use reqwest::multipart::{Form, Part};
+use reqwest::{Client, RequestBuilder, Url};
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
+
+#[derive(Debug, Clone)]
+pub struct OpenAiImageClient {
+    client: Client,
+    api_key: String,
+    base_url: Option<String>,
+}
+
+impl OpenAiImageClient {
+    pub fn new(api_key: impl Into<String>, base_url: Option<String>) -> Result<Self> {
+        Ok(Self {
+            client: Client::builder()
+                .timeout(std::time::Duration::from_secs(120))
+                .build()
+                .context("failed to build OpenAI image client")?,
+            api_key: api_key.into(),
+            base_url,
+        })
+    }
+
+    pub async fn generate(&self, request: GenerateImageRequest) -> Result<ImageApiResponse> {
+        let url = image_endpoint_url(self.base_url.as_deref(), "images/generations")?;
+        let response = self
+            .apply_auth(self.client.post(url.clone()), url.as_str())
+            .json(&request)
+            .send()
+            .await
+            .context("failed to call OpenAI image generation API")?;
+
+        parse_image_response(response).await
+    }
+
+    pub async fn edit(&self, request: EditImageRequest) -> Result<ImageApiResponse> {
+        let url = image_endpoint_url(self.base_url.as_deref(), "images/edits")?;
+        let image_field_name = if request.images.len() > 1 {
+            "image[]"
+        } else {
+            "image"
+        };
+
+        let mut form = Form::new()
+            .text("model", request.model)
+            .text("prompt", request.prompt)
+            .text("n", request.count.to_string());
+
+        if let Some(size) = request.size {
+            form = form.text("size", size);
+        }
+        if let Some(quality) = request.quality {
+            form = form.text("quality", quality);
+        }
+        if let Some(background) = request.background {
+            form = form.text("background", background);
+        }
+        if let Some(output_format) = request.output_format {
+            form = form.text("output_format", output_format);
+        }
+
+        for image in request.images {
+            let part = Part::bytes(image.data)
+                .file_name(image.filename)
+                .mime_str(&image.content_type)
+                .context("invalid source image content type")?;
+            form = form.part(image_field_name.to_string(), part);
+        }
+
+        let response = self
+            .apply_auth(self.client.post(url.clone()), url.as_str())
+            .multipart(form)
+            .send()
+            .await
+            .context("failed to call OpenAI image edit API")?;
+
+        parse_image_response(response).await
+    }
+
+    fn apply_auth(&self, request: RequestBuilder, api_url: &str) -> RequestBuilder {
+        if everruns_core::openai_protocol::is_azure_openai_api_url(api_url) {
+            request.header("api-key", &self.api_key)
+        } else {
+            request.bearer_auth(&self.api_key)
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GenerateImageRequest {
+    pub model: String,
+    pub prompt: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quality: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub background: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "output_format")]
+    pub output_format: Option<String>,
+    #[serde(rename = "n")]
+    pub count: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct EditImageRequest {
+    pub model: String,
+    pub prompt: String,
+    pub images: Vec<EditImageInput>,
+    pub size: Option<String>,
+    pub quality: Option<String>,
+    pub background: Option<String>,
+    pub output_format: Option<String>,
+    pub count: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct EditImageInput {
+    pub filename: String,
+    pub content_type: String,
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ImageApiResponse {
+    pub data: Vec<ImageApiImage>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ImageApiImage {
+    pub b64_json: String,
+    #[serde(default)]
+    pub revised_prompt: Option<String>,
+}
+
+fn image_endpoint_url(base_url: Option<&str>, endpoint: &str) -> Result<Url> {
+    let mut normalized = base_url
+        .unwrap_or(DEFAULT_OPENAI_BASE_URL)
+        .trim_end_matches('/');
+
+    for suffix in [
+        "/responses",
+        "/chat/completions",
+        "/images/generations",
+        "/images/edits",
+    ] {
+        if let Some(prefix) = normalized.strip_suffix(suffix) {
+            normalized = prefix;
+            break;
+        }
+    }
+
+    Url::parse(&format!(
+        "{}/{}",
+        normalized,
+        endpoint.trim_start_matches('/')
+    ))
+    .map_err(|error| anyhow!("invalid OpenAI image API URL: {error}"))
+}
+
+async fn parse_image_response(response: reqwest::Response) -> Result<ImageApiResponse> {
+    let status = response.status();
+    if !status.is_success() {
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "<unreadable response body>".to_string());
+        return Err(anyhow!("OpenAI image API returned {status}: {body}"));
+    }
+
+    response
+        .json::<ImageApiResponse>()
+        .await
+        .context("failed to decode OpenAI image API response")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{body_json, header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn generate_uses_bearer_auth_and_json_payload() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/images/generations"))
+            .and(header("authorization", "Bearer sk-test"))
+            .and(body_json(serde_json::json!({
+                "model": "gpt-image-1",
+                "prompt": "otter",
+                "size": "1024x1024",
+                "quality": "high",
+                "background": "transparent",
+                "output_format": "png",
+                "n": 1
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [{"b64_json": "aGVsbG8=", "revised_prompt": "otter"}]
+            })))
+            .mount(&server)
+            .await;
+
+        let client =
+            OpenAiImageClient::new("sk-test", Some(format!("{}/v1", server.uri()))).unwrap();
+        let response = client
+            .generate(GenerateImageRequest {
+                model: "gpt-image-1".to_string(),
+                prompt: "otter".to_string(),
+                size: Some("1024x1024".to_string()),
+                quality: Some("high".to_string()),
+                background: Some("transparent".to_string()),
+                output_format: Some("png".to_string()),
+                count: 1,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(response.data.len(), 1);
+        assert_eq!(response.data[0].b64_json, "aGVsbG8=");
+    }
+
+    #[tokio::test]
+    async fn edit_uses_multipart_endpoint_with_custom_base_url() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/openai/v1/images/edits"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [{"b64_json": "aGVsbG8="}]
+            })))
+            .mount(&server)
+            .await;
+
+        let client =
+            OpenAiImageClient::new("azure-key", Some(format!("{}/openai/v1", server.uri())))
+                .unwrap();
+
+        let response = client
+            .edit(EditImageRequest {
+                model: "gpt-image-1".to_string(),
+                prompt: "edit it".to_string(),
+                images: vec![EditImageInput {
+                    filename: "source.png".to_string(),
+                    content_type: "image/png".to_string(),
+                    data: vec![1, 2, 3],
+                }],
+                size: Some("1024x1024".to_string()),
+                quality: Some("medium".to_string()),
+                background: Some("opaque".to_string()),
+                output_format: Some("png".to_string()),
+                count: 1,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(response.data.len(), 1);
+    }
+}

--- a/crates/openai/src/lib.rs
+++ b/crates/openai/src/lib.rs
@@ -13,12 +13,15 @@
 // inversion - core has no knowledge of specific provider implementations.
 
 mod driver;
+mod image_capability;
+mod images;
 mod types;
 
 #[cfg(test)]
 mod tests;
 
 pub use driver::{OpenAICompletionsLlmDriver, OpenAILlmDriver, register_driver};
+pub use image_capability::{EditImageTool, GenerateImageTool, GptImageGenCapability};
 pub use types::{
     ChatMessage, ChatRequest, CompletionMetadata, LlmConfig, LlmStreamEvent, MessageRole,
 };

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -16,10 +16,10 @@ use everruns_core::message_retriever::MessageRetriever;
 use everruns_core::platform_store::PlatformStore;
 use everruns_core::session::SessionStatus;
 use everruns_core::traits::{
-    AgentStore, BudgetChecker, EventEmitter, HarnessStore, ImageResolver, LeasedResourceStore,
-    LlmProviderStore, ModelWithProvider, SessionFileStore, SessionMutator, SessionResourceRegistry,
-    SessionScheduleStore, SessionSqlDbStoreRef, SessionStorageStore, SessionStore,
-    UserConnectionResolver,
+    AgentStore, BudgetChecker, EventEmitter, HarnessStore, ImageArtifactStore, ImageResolver,
+    LeasedResourceStore, LlmProviderStore, ModelWithProvider, ProviderCredentialStore,
+    SessionFileStore, SessionMutator, SessionResourceRegistry, SessionScheduleStore,
+    SessionSqlDbStoreRef, SessionStorageStore, SessionStore, UserConnectionResolver,
 };
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
 use everruns_core::{
@@ -213,6 +213,14 @@ pub trait RuntimeHostAdapter: Send + Sync + Clone + 'static {
     fn file_store(&self) -> Arc<dyn SessionFileStore>;
 
     fn image_resolver(&self, _org_id: i64) -> Option<Arc<dyn ImageResolver>> {
+        None
+    }
+
+    fn image_artifact_store(&self, _org_id: i64) -> Option<Arc<dyn ImageArtifactStore>> {
+        None
+    }
+
+    fn provider_credential_store(&self, _org_id: i64) -> Option<Arc<dyn ProviderCredentialStore>> {
         None
     }
 
@@ -687,6 +695,12 @@ pub async fn execute_act_activity<A: RuntimeHostAdapter>(
 
     if let Some(storage_store) = adapter.storage_store() {
         atom = atom.with_storage_store(storage_store);
+    }
+    if let Some(image_store) = adapter.image_artifact_store(org_id) {
+        atom = atom.with_image_store(image_store);
+    }
+    if let Some(provider_credential_store) = adapter.provider_credential_store(org_id) {
+        atom = atom.with_provider_credential_store(provider_credential_store);
     }
     if let Some(memory_store) = adapter.memory_store() {
         atom = atom.with_memory_store(memory_store);

--- a/crates/server/src/api/images.rs
+++ b/crates/server/src/api/images.rs
@@ -31,7 +31,7 @@ use uuid::Uuid;
 // ============================================
 
 /// Maximum image size in bytes (100 MB)
-const MAX_IMAGE_SIZE: usize = 100 * 1024 * 1024;
+pub(crate) const MAX_IMAGE_SIZE: usize = 100 * 1024 * 1024;
 
 /// Thumbnail max dimension (width or height)
 const THUMBNAIL_MAX_DIM: u32 = 200;

--- a/crates/server/src/api/images.rs
+++ b/crates/server/src/api/images.rs
@@ -139,7 +139,7 @@ fn format_from_content_type(content_type: &str) -> Option<ImageFormat> {
 }
 
 /// Generate thumbnail from image data
-fn generate_thumbnail(data: &[u8], content_type: &str) -> Option<(Vec<u8>, String)> {
+pub(crate) fn generate_thumbnail(data: &[u8], content_type: &str) -> Option<(Vec<u8>, String)> {
     let format = format_from_content_type(content_type)?;
 
     // Load image

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -15,7 +15,10 @@ use everruns_core::capabilities::{
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::events::{Event, EventRequest};
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
-use everruns_core::traits::{BudgetChecker, ModelWithProvider, ResolvedImage};
+use everruns_core::traits::{
+    BudgetChecker, CreateStoredImage, ImageArtifactStore, ModelWithProvider,
+    ProviderCredentialStore, ProviderCredentials, ResolvedImage, StoredImage, StoredImageInfo,
+};
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId};
 use everruns_core::{
     Agent, AgentStatus, Caller, ContentPart, DriverRegistry, EventData, Harness, HarnessStatus,
@@ -58,6 +61,111 @@ struct DirectBudgetChecker {
     budget_service: Arc<BudgetService>,
     org_id: i64,
     agent_id: Option<String>,
+}
+
+struct DirectImageArtifactStore {
+    db: Arc<StorageBackend>,
+    org_id: i64,
+}
+
+#[async_trait]
+impl ImageArtifactStore for DirectImageArtifactStore {
+    async fn create_image(&self, input: CreateStoredImage) -> Result<StoredImageInfo> {
+        let (thumbnail_data, thumbnail_content_type) =
+            crate::api::images::generate_thumbnail(&input.data, &input.content_type)
+                .map(|(data, content_type)| (Some(data), Some(content_type)))
+                .unwrap_or((None, None));
+
+        let row = self
+            .db
+            .create_image(
+                self.org_id,
+                crate::storage::models::CreateImageRow {
+                    org_id: self.org_id,
+                    filename: input.filename,
+                    content_type: input.content_type,
+                    size_bytes: input.data.len() as i64,
+                    data: input.data,
+                    thumbnail_data,
+                    thumbnail_content_type,
+                    metadata: input.metadata,
+                },
+            )
+            .await
+            .map_err(|e| store_error(format!("Failed to create image artifact: {e}")))?;
+
+        Ok(StoredImageInfo {
+            id: row.id,
+            filename: row.filename,
+            content_type: row.content_type,
+            size_bytes: row.size_bytes,
+            metadata: row.metadata,
+            created_at: row.created_at,
+        })
+    }
+
+    async fn get_image(&self, image_id: everruns_core::ImageId) -> Result<Option<StoredImage>> {
+        let row = self
+            .db
+            .get_image(self.org_id, image_id.uuid())
+            .await
+            .map_err(|e| store_error(format!("Failed to get image artifact: {e}")))?;
+
+        Ok(row.map(|row| StoredImage {
+            info: StoredImageInfo {
+                id: row.id,
+                filename: row.filename,
+                content_type: row.content_type,
+                size_bytes: row.size_bytes,
+                metadata: row.metadata,
+                created_at: row.created_at,
+            },
+            data: row.data,
+        }))
+    }
+
+    async fn get_image_info(
+        &self,
+        image_id: everruns_core::ImageId,
+    ) -> Result<Option<StoredImageInfo>> {
+        let row = self
+            .db
+            .get_image_info(self.org_id, image_id.uuid())
+            .await
+            .map_err(|e| store_error(format!("Failed to get image artifact info: {e}")))?;
+
+        Ok(row.map(|row| StoredImageInfo {
+            id: row.id,
+            filename: row.filename,
+            content_type: row.content_type,
+            size_bytes: row.size_bytes,
+            metadata: row.metadata,
+            created_at: row.created_at,
+        }))
+    }
+}
+
+struct DirectProviderCredentialStore {
+    llm_resolver: Arc<LlmResolverService>,
+    org_id: i64,
+}
+
+#[async_trait]
+impl ProviderCredentialStore for DirectProviderCredentialStore {
+    async fn get_default_provider_credentials(
+        &self,
+        provider_type: &str,
+    ) -> Result<Option<ProviderCredentials>> {
+        Ok(self
+            .llm_resolver
+            .resolve_provider_credentials(self.org_id, provider_type)
+            .await
+            .map_err(|e| store_error(format!("Failed to resolve provider credentials: {e}")))?
+            .map(|resolved| ProviderCredentials {
+                api_key: resolved.api_key,
+                base_url: resolved.base_url,
+            }))
+    }
 }
 
 #[async_trait]
@@ -1192,6 +1300,20 @@ impl WorkerAdapters for DirectWorkerAdapters {
         self.storage_store
             .clone()
             .expect("DirectWorkerAdapters: storage_store not set (call with_storage_store)")
+    }
+
+    fn image_artifact_store(&self, org_id: i64) -> Arc<dyn ImageArtifactStore> {
+        Arc::new(DirectImageArtifactStore {
+            db: self.db.clone(),
+            org_id,
+        })
+    }
+
+    fn provider_credential_store(&self, org_id: i64) -> Arc<dyn ProviderCredentialStore> {
+        Arc::new(DirectProviderCredentialStore {
+            llm_resolver: self.llm_resolver.clone(),
+            org_id,
+        })
     }
 
     fn connection_resolver(&self) -> Arc<dyn everruns_core::traits::UserConnectionResolver> {

--- a/crates/server/src/grpc_service/mod.rs
+++ b/crates/server/src/grpc_service/mod.rs
@@ -56,6 +56,8 @@ use everruns_internal_protocol::proto::{
     CountActiveSessionSchedulesResponse,
     CreateDurableWorkflowRequest,
     CreateDurableWorkflowResponse,
+    CreateImageArtifactRequest,
+    CreateImageArtifactResponse,
     CreateSessionScheduleRequest,
     CreateSessionScheduleResponse,
     DeregisterDurableWorkerRequest,
@@ -84,10 +86,16 @@ use everruns_internal_protocol::proto::{
     GetConnectionUserResponse,
     GetDefaultModelRequest,
     GetDefaultModelResponse,
+    GetDefaultProviderCredentialsRequest,
+    GetDefaultProviderCredentialsResponse,
     GetDurableWorkflowStatusRequest,
     GetDurableWorkflowStatusResponse,
     GetHarnessRequest,
     GetHarnessResponse,
+    GetImageArtifactInfoRequest,
+    GetImageArtifactInfoResponse,
+    GetImageArtifactRequest,
+    GetImageArtifactResponse,
     GetMcpServerByPrefixRequest,
     GetMcpServerByPrefixResponse,
     GetMessageRequest,
@@ -623,6 +631,40 @@ impl WorkerServiceImpl {
             provider_type: resolved.provider_type,
             api_key: resolved.api_key,
             base_url: resolved.base_url,
+        }
+    }
+
+    fn image_info_row_to_proto(
+        row: crate::storage::models::ImageInfoRow,
+    ) -> proto::StoredImageInfo {
+        proto::StoredImageInfo {
+            id: Some(proto::Uuid {
+                value: row.id.to_string(),
+            }),
+            filename: row.filename,
+            content_type: row.content_type,
+            size_bytes: row.size_bytes,
+            metadata: Some(everruns_internal_protocol::json_to_proto_struct(
+                &row.metadata,
+            )),
+            created_at: Some(ip_datetime_to_proto_timestamp(row.created_at)),
+        }
+    }
+
+    fn image_row_to_proto(row: crate::storage::models::ImageRow) -> proto::StoredImage {
+        proto::StoredImage {
+            info: Some(Self::image_info_row_to_proto(
+                crate::storage::models::ImageInfoRow {
+                    id: row.id,
+                    org_id: row.org_id,
+                    filename: row.filename,
+                    content_type: row.content_type,
+                    size_bytes: row.size_bytes,
+                    metadata: row.metadata,
+                    created_at: row.created_at,
+                },
+            )),
+            data: row.data,
         }
     }
 

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -2025,6 +2025,12 @@ impl WorkerService for WorkerServiceImpl {
         request: Request<CreateImageArtifactRequest>,
     ) -> Result<Response<CreateImageArtifactResponse>, Status> {
         let req = request.into_inner();
+        if req.data.len() > crate::api::images::MAX_IMAGE_SIZE {
+            return Err(Status::invalid_argument(format!(
+                "Image exceeds maximum size of {}MB",
+                crate::api::images::MAX_IMAGE_SIZE / (1024 * 1024)
+            )));
+        }
         let metadata = req
             .metadata
             .as_ref()

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -2020,6 +2020,125 @@ impl WorkerService for WorkerServiceImpl {
         Ok(Response::new(ResolveImagesResponse { images }))
     }
 
+    async fn create_image_artifact(
+        &self,
+        request: Request<CreateImageArtifactRequest>,
+    ) -> Result<Response<CreateImageArtifactResponse>, Status> {
+        let req = request.into_inner();
+        let metadata = req
+            .metadata
+            .as_ref()
+            .map(everruns_internal_protocol::proto_struct_to_json)
+            .unwrap_or_else(|| serde_json::json!({}));
+        let (thumbnail_data, thumbnail_content_type) =
+            crate::api::images::generate_thumbnail(&req.data, &req.content_type)
+                .map(|(data, content_type)| (Some(data), Some(content_type)))
+                .unwrap_or((None, None));
+
+        let row = self
+            .db
+            .create_image(
+                req.org_id,
+                crate::storage::models::CreateImageRow {
+                    org_id: req.org_id,
+                    filename: req.filename,
+                    content_type: req.content_type,
+                    size_bytes: req.data.len() as i64,
+                    data: req.data,
+                    thumbnail_data,
+                    thumbnail_content_type,
+                    metadata,
+                },
+            )
+            .await
+            .map_err(|e| {
+                tracing::error!(error = %e, "Failed to create image artifact");
+                Status::internal("Failed to create image artifact")
+            })?;
+
+        Ok(Response::new(CreateImageArtifactResponse {
+            image: Some(Self::image_info_row_to_proto(
+                crate::storage::models::ImageInfoRow {
+                    id: row.id,
+                    org_id: row.org_id,
+                    filename: row.filename,
+                    content_type: row.content_type,
+                    size_bytes: row.size_bytes,
+                    metadata: row.metadata,
+                    created_at: row.created_at,
+                },
+            )),
+        }))
+    }
+
+    async fn get_image_artifact(
+        &self,
+        request: Request<GetImageArtifactRequest>,
+    ) -> Result<Response<GetImageArtifactResponse>, Status> {
+        let req = request.into_inner();
+        let image_id = parse_uuid(req.image_id.as_ref())?;
+        let row = self.db.get_image(req.org_id, image_id).await.map_err(|e| {
+            tracing::error!(%image_id, error = %e, "Failed to get image artifact");
+            Status::internal("Failed to get image artifact")
+        })?;
+
+        Ok(Response::new(GetImageArtifactResponse {
+            image: row.map(Self::image_row_to_proto),
+        }))
+    }
+
+    async fn get_image_artifact_info(
+        &self,
+        request: Request<GetImageArtifactInfoRequest>,
+    ) -> Result<Response<GetImageArtifactInfoResponse>, Status> {
+        let req = request.into_inner();
+        let image_id = parse_uuid(req.image_id.as_ref())?;
+        let row = self
+            .db
+            .get_image_info(req.org_id, image_id)
+            .await
+            .map_err(|e| {
+                tracing::error!(%image_id, error = %e, "Failed to get image artifact info");
+                Status::internal("Failed to get image artifact info")
+            })?;
+
+        Ok(Response::new(GetImageArtifactInfoResponse {
+            image: row.map(Self::image_info_row_to_proto),
+        }))
+    }
+
+    async fn get_default_provider_credentials(
+        &self,
+        request: Request<GetDefaultProviderCredentialsRequest>,
+    ) -> Result<Response<GetDefaultProviderCredentialsResponse>, Status> {
+        let req = request.into_inner();
+        let resolved = self
+            .llm_resolver_service
+            .resolve_provider_credentials(req.org_id, &req.provider_type)
+            .await
+            .map_err(|e| {
+                tracing::error!(
+                    provider_type = %req.provider_type,
+                    error = %e,
+                    "Failed to resolve provider credentials"
+                );
+                Status::internal("Failed to resolve provider credentials")
+            })?;
+
+        Ok(Response::new(match resolved {
+            Some(credentials) => GetDefaultProviderCredentialsResponse {
+                found: true,
+                api_key: credentials.api_key,
+                base_url: credentials.base_url.unwrap_or_default(),
+            },
+            None => GetDefaultProviderCredentialsResponse {
+                found: false,
+                api_key: String::new(),
+                base_url: String::new(),
+            },
+        }))
+    }
+
     // ========================================================================
     // MCP server operations
     // ========================================================================

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -71,6 +71,7 @@ mod seed_ids {
     pub const KNOWLEDGE_BASE_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000112);
     pub const SESSION_SANDBOX_CODER_AGENT: Uuid =
         Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000113);
+    pub const IMAGE_STUDIO_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000114);
 
     // MCP Servers (0x500-0x5FF)
     pub const MS_LEARN_MCP: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000501);
@@ -693,6 +694,30 @@ Do not use raw provider tools when the managed sandbox tools can handle the task
                     }
                 })
             }),
+            SeedCapability::new("session_storage"),
+            SeedCapability::new("session_file_system"),
+        ],
+        dev_only: false,
+    },
+    SeedAgent {
+        id: seed_ids::IMAGE_STUDIO_AGENT,
+        name: "image-studio-agent",
+        display_name: "Image Studio Agent",
+        description: "An agent specialized in generating and editing images, saving results to the workspace, and iterating on art direction.",
+        system_prompt: r#"You are an image generation specialist.
+
+Use `generate_image` for fresh concepts and `edit_image` when refining an existing artifact or workspace image.
+
+Workflow:
+1. Clarify the visual goal from the user's request.
+2. Prefer saving outputs into `/workspace/.outputs/images/` so the user can inspect and reuse them.
+3. When revising, keep track of which artifact ID or workspace file produced the best result and build on it.
+4. Use `secret_store` for per-session OpenAI overrides when the user provides alternate credentials or base URLs.
+
+Keep prompts concrete: subject, composition, lighting, materials, color palette, camera angle, and constraints."#,
+        tags: &["media", "images", "openai", "seed"],
+        capabilities: &[
+            SeedCapability::new("gpt_image_gen"),
             SeedCapability::new("session_storage"),
             SeedCapability::new("session_file_system"),
         ],

--- a/crates/server/src/services/llm_resolver.rs
+++ b/crates/server/src/services/llm_resolver.rs
@@ -106,6 +106,13 @@ pub struct ResolvedModel {
     pub base_url: Option<String>,
 }
 
+/// Resolved provider credentials for tool-side API clients.
+#[derive(Debug, Clone)]
+pub struct ResolvedProviderCredentials {
+    pub api_key: String,
+    pub base_url: Option<String>,
+}
+
 /// Cache key: (org_id, model_uuid). Default-model lookups use DEFAULT_MODEL_SENTINEL.
 type CacheKey = (i64, Uuid);
 
@@ -158,6 +165,57 @@ impl LlmResolverService {
         let result = self.resolve_default_model_uncached(org_id).await?;
         self.cache.insert(key, result.clone()).await;
         Ok(result)
+    }
+
+    /// Resolve default credentials for a provider type.
+    ///
+    /// Preference order:
+    /// 1. Active providers matching the requested type, newest first
+    /// 2. Other matching providers, newest first
+    /// 3. Environment fallback for the provider type with no base URL
+    pub async fn resolve_provider_credentials(
+        &self,
+        org_id: i64,
+        provider_type: &str,
+    ) -> Result<Option<ResolvedProviderCredentials>> {
+        let providers = self.db.list_llm_providers(org_id).await?;
+        let provider_type_lower = provider_type.to_lowercase();
+
+        let matching: Vec<_> = providers
+            .into_iter()
+            .filter(|provider| {
+                provider
+                    .provider_type
+                    .eq_ignore_ascii_case(&provider_type_lower)
+            })
+            .collect();
+
+        let iter = matching
+            .iter()
+            .filter(|provider| provider.status.eq_ignore_ascii_case("active"))
+            .chain(
+                matching
+                    .iter()
+                    .filter(|provider| !provider.status.eq_ignore_ascii_case("active")),
+            );
+
+        for provider in iter {
+            if let Some(api_key) = self.resolve_api_key(provider)? {
+                return Ok(Some(ResolvedProviderCredentials {
+                    api_key,
+                    base_url: provider.base_url.clone(),
+                }));
+            }
+        }
+
+        Ok(
+            get_default_api_key_from_env(provider_type).map(|api_key| {
+                ResolvedProviderCredentials {
+                    api_key,
+                    base_url: None,
+                }
+            }),
+        )
     }
 
     /// Invalidate all cached resolutions for an org.

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -16,8 +16,10 @@ use everruns_core::leased_resource::{LeasedResource, LeasedResourceStatus, Upser
 use everruns_core::message_retriever::{InputMessage, MessageRetriever};
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
 use everruns_core::traits::{
-    AgentStore, EventEmitter, HarnessStore, LeasedResourceStore, LlmProviderStore,
-    ModelWithProvider, ResolvedImage, SessionFileStore, SessionStore,
+    AgentStore, CreateStoredImage, EventEmitter, HarnessStore, ImageArtifactStore,
+    LeasedResourceStore, LlmProviderStore, ModelWithProvider, ProviderCredentialStore,
+    ProviderCredentials, ResolvedImage, SessionFileStore, SessionStore, StoredImage,
+    StoredImageInfo,
 };
 use everruns_core::typed_id::{AgentId, LeasedResourceId, MessageId, ModelId, SessionId};
 use everruns_core::{Agent, Harness, HarnessStatus, Message, Session};
@@ -213,6 +215,106 @@ impl GrpcClient {
         proto_session_to_session(proto_session)
     }
 
+    pub async fn create_image_artifact(
+        &self,
+        org_id: i64,
+        input: CreateStoredImage,
+    ) -> Result<StoredImageInfo> {
+        let request = proto::CreateImageArtifactRequest {
+            org_id,
+            filename: input.filename,
+            content_type: input.content_type,
+            data: input.data,
+            metadata: Some(json_to_proto_struct(&input.metadata)),
+        };
+
+        let mut client = self.inner.lock().await;
+        let response = client
+            .create_image_artifact(request)
+            .await
+            .map_err(grpc_status_to_error)?;
+
+        let proto_image = response
+            .into_inner()
+            .image
+            .ok_or_else(|| grpc_missing_field("No image in response"))?;
+
+        proto_stored_image_info_to_schema(proto_image)
+    }
+
+    pub async fn get_image_artifact(
+        &self,
+        org_id: i64,
+        image_id: everruns_core::ImageId,
+    ) -> Result<Option<StoredImage>> {
+        let request = proto::GetImageArtifactRequest {
+            org_id,
+            image_id: Some(uuid_to_proto(image_id.uuid())),
+        };
+
+        let mut client = self.inner.lock().await;
+        let response = client
+            .get_image_artifact(request)
+            .await
+            .map_err(grpc_status_to_error)?;
+
+        response
+            .into_inner()
+            .image
+            .map(proto_stored_image_to_schema)
+            .transpose()
+    }
+
+    pub async fn get_image_artifact_info(
+        &self,
+        org_id: i64,
+        image_id: everruns_core::ImageId,
+    ) -> Result<Option<StoredImageInfo>> {
+        let request = proto::GetImageArtifactInfoRequest {
+            org_id,
+            image_id: Some(uuid_to_proto(image_id.uuid())),
+        };
+
+        let mut client = self.inner.lock().await;
+        let response = client
+            .get_image_artifact_info(request)
+            .await
+            .map_err(grpc_status_to_error)?;
+
+        response
+            .into_inner()
+            .image
+            .map(proto_stored_image_info_to_schema)
+            .transpose()
+    }
+
+    pub async fn get_default_provider_credentials(
+        &self,
+        org_id: i64,
+        provider_type: &str,
+    ) -> Result<Option<ProviderCredentials>> {
+        let request = proto::GetDefaultProviderCredentialsRequest {
+            org_id,
+            provider_type: provider_type.to_string(),
+        };
+
+        let mut client = self.inner.lock().await;
+        let response = client
+            .get_default_provider_credentials(request)
+            .await
+            .map_err(grpc_status_to_error)?;
+
+        let response = response.into_inner();
+        if !response.found {
+            return Ok(None);
+        }
+
+        Ok(Some(ProviderCredentials {
+            api_key: response.api_key,
+            base_url: non_empty_string(response.base_url),
+        }))
+    }
+
     /// Get MCP server info by name prefix (for MCP tool execution)
     pub async fn get_mcp_server_by_prefix(
         &self,
@@ -376,6 +478,8 @@ pub type GrpcHarnessStore = GrpcOrgAdapter;
 pub type GrpcSessionStore = GrpcOrgAdapter;
 pub type GrpcLlmProviderStore = GrpcOrgAdapter;
 pub type GrpcImageResolver = GrpcOrgAdapter;
+pub type GrpcImageArtifactStore = GrpcOrgAdapter;
+pub type GrpcProviderCredentialStore = GrpcOrgAdapter;
 pub type GrpcSessionMutator = GrpcOrgAdapter;
 pub type GrpcScheduleStore = GrpcOrgAdapter;
 pub type GrpcPlatformStore = GrpcOrgAdapter;
@@ -438,6 +542,33 @@ fn proto_timestamp_or_now(ts: Option<&proto::Timestamp>) -> chrono::DateTime<chr
 /// Reduces the repeated `if s.is_empty() { None } else { Some(s) }` pattern.
 fn non_empty_string(s: String) -> Option<String> {
     if s.is_empty() { None } else { Some(s) }
+}
+
+fn proto_stored_image_info_to_schema(
+    proto_info: proto::StoredImageInfo,
+) -> Result<StoredImageInfo> {
+    Ok(StoredImageInfo {
+        id: proto_uuid_to_uuid(proto_info.id.as_ref())?.into(),
+        filename: proto_info.filename,
+        content_type: proto_info.content_type,
+        size_bytes: proto_info.size_bytes,
+        metadata: proto_info
+            .metadata
+            .as_ref()
+            .map(proto_struct_to_json)
+            .unwrap_or_else(|| serde_json::json!({})),
+        created_at: proto_timestamp_or_now(proto_info.created_at.as_ref()),
+    })
+}
+
+fn proto_stored_image_to_schema(proto_image: proto::StoredImage) -> Result<StoredImage> {
+    let info = proto_image
+        .info
+        .ok_or_else(|| grpc_missing_field("No image info in response"))?;
+    Ok(StoredImage {
+        info: proto_stored_image_info_to_schema(info)?,
+        data: proto_image.data,
+    })
 }
 
 // ============================================================================
@@ -910,6 +1041,38 @@ impl LlmProviderStore for GrpcOrgAdapter {
             }
             None => Ok(None),
         }
+    }
+}
+
+#[async_trait]
+impl ImageArtifactStore for GrpcOrgAdapter {
+    async fn create_image(&self, input: CreateStoredImage) -> Result<StoredImageInfo> {
+        self.client.create_image_artifact(self.org_id, input).await
+    }
+
+    async fn get_image(&self, image_id: everruns_core::ImageId) -> Result<Option<StoredImage>> {
+        self.client.get_image_artifact(self.org_id, image_id).await
+    }
+
+    async fn get_image_info(
+        &self,
+        image_id: everruns_core::ImageId,
+    ) -> Result<Option<StoredImageInfo>> {
+        self.client
+            .get_image_artifact_info(self.org_id, image_id)
+            .await
+    }
+}
+
+#[async_trait]
+impl ProviderCredentialStore for GrpcOrgAdapter {
+    async fn get_default_provider_credentials(
+        &self,
+        provider_type: &str,
+    ) -> Result<Option<ProviderCredentials>> {
+        self.client
+            .get_default_provider_credentials(self.org_id, provider_type)
+            .await
     }
 }
 

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -11,7 +11,9 @@ use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::events::{Event, EventRequest};
 use everruns_core::leased_resource::LeasedResource;
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
-use everruns_core::traits::{AgentStore, ModelWithProvider, ResolvedImage};
+use everruns_core::traits::{
+    AgentStore, ImageArtifactStore, ModelWithProvider, ProviderCredentialStore, ResolvedImage,
+};
 use everruns_core::typed_id::{
     AgentId, HarnessId, LeasedResourceId, MessageId, ModelId, SessionId,
 };
@@ -24,8 +26,9 @@ use uuid::Uuid;
 
 use crate::grpc_adapters::{
     GrpcAgentStore, GrpcBudgetChecker, GrpcClient, GrpcEventEmitter, GrpcHarnessStore,
-    GrpcImageResolver, GrpcLeasedResourceStore, GrpcLlmProviderStore, GrpcMessageRetriever,
-    GrpcSessionFileStore, GrpcSessionSqlDbStore, GrpcSessionStorageStore, GrpcSessionStore,
+    GrpcImageArtifactStore, GrpcImageResolver, GrpcLeasedResourceStore, GrpcLlmProviderStore,
+    GrpcMessageRetriever, GrpcProviderCredentialStore, GrpcSessionFileStore, GrpcSessionSqlDbStore,
+    GrpcSessionStorageStore, GrpcSessionStore,
 };
 use crate::mcp_executor::McpServerInfo;
 use crate::worker_adapters::{TurnContext, WorkerAdapters};
@@ -377,6 +380,17 @@ impl WorkerAdapters for GrpcWorkerAdapters {
 
     fn storage_store(&self) -> Arc<dyn everruns_core::traits::SessionStorageStore> {
         Arc::new(GrpcSessionStorageStore::new(self.client.clone()))
+    }
+
+    fn image_artifact_store(&self, org_id: i64) -> Arc<dyn ImageArtifactStore> {
+        Arc::new(GrpcImageArtifactStore::new(self.client.clone(), org_id))
+    }
+
+    fn provider_credential_store(&self, org_id: i64) -> Arc<dyn ProviderCredentialStore> {
+        Arc::new(GrpcProviderCredentialStore::new(
+            self.client.clone(),
+            org_id,
+        ))
     }
 
     fn platform_store(&self, org_id: i64) -> Arc<dyn everruns_core::platform_store::PlatformStore> {

--- a/crates/worker/src/runtime_host.rs
+++ b/crates/worker/src/runtime_host.rs
@@ -5,8 +5,8 @@
 use async_trait::async_trait;
 use everruns_core::error::Result;
 use everruns_core::traits::{
-    AgentStore, EventEmitter, HarnessStore, ImageResolver, LlmProviderStore, SessionFileStore,
-    SessionMutator, SessionStore,
+    AgentStore, EventEmitter, HarnessStore, ImageArtifactStore, ImageResolver, LlmProviderStore,
+    ProviderCredentialStore, SessionFileStore, SessionMutator, SessionStore,
 };
 use everruns_core::typed_id::{AgentId, HarnessId, SessionId};
 use everruns_core::{Agent, CapabilityRegistry, DriverRegistry, Harness, Session, SessionStatus};
@@ -148,6 +148,14 @@ impl<A: WorkerAdapters> RuntimeHostAdapter for WorkerRuntimeHost<A> {
             self.adapters.clone(),
             org_id,
         )))
+    }
+
+    fn image_artifact_store(&self, org_id: i64) -> Option<Arc<dyn ImageArtifactStore>> {
+        Some(self.adapters.image_artifact_store(org_id))
+    }
+
+    fn provider_credential_store(&self, org_id: i64) -> Option<Arc<dyn ProviderCredentialStore>> {
+        Some(self.adapters.provider_credential_store(org_id))
     }
 
     fn storage_store(&self) -> Option<Arc<dyn everruns_core::traits::SessionStorageStore>> {

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -17,7 +17,8 @@ use everruns_core::events::{Event, EventRequest};
 use everruns_core::leased_resource::LeasedResource;
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
 use everruns_core::traits::{
-    BudgetChecker, ImageResolver, LeasedResourceStore, ModelWithProvider, ResolvedImage,
+    BudgetChecker, ImageArtifactStore, ImageResolver, LeasedResourceStore, ModelWithProvider,
+    ProviderCredentialStore, ResolvedImage,
 };
 use everruns_core::typed_id::{
     AgentId, HarnessId, LeasedResourceId, MessageId, ModelId, SessionId,
@@ -269,6 +270,12 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
 
     /// Get the session storage store for kv_store/secret_store tools.
     fn storage_store(&self) -> Arc<dyn everruns_core::traits::SessionStorageStore>;
+
+    /// Get the image artifact store for tool-side image persistence.
+    fn image_artifact_store(&self, org_id: i64) -> Arc<dyn ImageArtifactStore>;
+
+    /// Get the provider credential store for tool-side provider auth lookup.
+    fn provider_credential_store(&self, org_id: i64) -> Arc<dyn ProviderCredentialStore>;
 
     /// Get the platform store for org-level management tools.
     /// Takes org_id so the store is scoped to the current session's organization.

--- a/docs/capabilities/index.md
+++ b/docs/capabilities/index.md
@@ -37,6 +37,22 @@ Structured data, time awareness, task tracking, and scheduling.
 | [Task Management](/capabilities/task-management/) | `stateless_todo_list` | 1 |
 | [Schedules](/capabilities/session-schedules/) | `session_schedule` | 3 |
 
+### Media
+
+Image generation and editing workflows.
+
+| Capability | ID | Tools |
+|---|---|---|
+| [OpenAI Image Generation](/capabilities/openai-image-generation/) | `gpt_image_gen` | 2 |
+
+### Media
+
+Image generation and editing workflows.
+
+| Capability | ID | Tools |
+|---|---|---|
+| [OpenAI Image Generation](/capabilities/openai-image-generation/) | `gpt_image_gen` | 2 |
+
 ### Orchestration
 
 Delegate and coordinate work across multiple agent sessions.

--- a/docs/capabilities/index.md
+++ b/docs/capabilities/index.md
@@ -45,14 +45,6 @@ Image generation and editing workflows.
 |---|---|---|
 | [OpenAI Image Generation](/capabilities/openai-image-generation/) | `gpt_image_gen` | 2 |
 
-### Media
-
-Image generation and editing workflows.
-
-| Capability | ID | Tools |
-|---|---|---|
-| [OpenAI Image Generation](/capabilities/openai-image-generation/) | `gpt_image_gen` | 2 |
-
 ### Orchestration
 
 Delegate and coordinate work across multiple agent sessions.

--- a/docs/capabilities/openai-image-generation.md
+++ b/docs/capabilities/openai-image-generation.md
@@ -1,0 +1,89 @@
+---
+title: OpenAI Image Generation
+description: Generate and edit raster images with OpenAI's GPT Image API, persist artifacts, and save outputs into the session workspace.
+---
+
+| | |
+|---|---|
+| **ID** | `gpt_image_gen` |
+| **Category** | Media |
+| **Features** | None |
+| **Dependencies** | [`session_file_system`](/capabilities/file-system/), [`session_storage`](/capabilities/session-storage/) |
+
+Generate new raster images and edit existing ones with OpenAI's `gpt-image-1` model.
+
+This capability resolves credentials server-side, persists durable image artifacts, and can also write generated outputs into the session filesystem under `/workspace/.outputs/images/`.
+
+## Credential Resolution
+
+The tool layer never reads provider environment variables directly. Resolution order:
+
+1. Session secret `OPENAI_API_KEY` (or `openai_api_key`)
+2. Session secret `OPENAI_BASE_URL` (or `openai_base_url`) for endpoint override
+3. Default OpenAI provider credentials from the control plane
+
+Use [`secret_store`](/capabilities/session-storage/) for per-session overrides.
+
+## Tools
+
+### `generate_image`
+
+Generate one or more images from a prompt.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `prompt` | string | yes | Image generation prompt |
+| `size` | enum | no | `1024x1024`, `1536x1024`, `1024x1536`, `auto` |
+| `quality` | enum | no | `low`, `medium`, `high`, `auto` |
+| `background` | enum | no | `transparent`, `opaque`, `auto` |
+| `format` | enum | no | `png`, `jpeg`, `webp` |
+| `count` | integer | no | Number of images to generate (1-10) |
+| `save_to_session_fs` | boolean | no | Save images into the session filesystem |
+| `output_dir` | string | no | Filesystem output directory (default `/workspace/.outputs/images`) |
+| `filename_prefix` | string | no | Prefix for artifact and file names |
+| `persist_artifact` | boolean | no | Persist into durable image storage (default `true`) |
+
+### `edit_image`
+
+Edit one or more existing images using a prompt.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `prompt` | string | yes | Editing prompt |
+| `image_id` | string | conditional | Durable image artifact ID to use as an edit source |
+| `path` | string | conditional | Session filesystem path to use as an edit source |
+| `size` | enum | no | `1024x1024`, `1536x1024`, `1024x1536`, `auto` |
+| `quality` | enum | no | `low`, `medium`, `high`, `auto` |
+| `background` | enum | no | `transparent`, `opaque`, `auto` |
+| `format` | enum | no | `png`, `jpeg`, `webp` |
+| `count` | integer | no | Number of images to produce (1-10) |
+| `save_to_session_fs` | boolean | no | Save outputs into the session filesystem |
+| `output_dir` | string | no | Filesystem output directory (default `/workspace/.outputs/images`) |
+| `filename_prefix` | string | no | Prefix for artifact and file names |
+| `persist_artifact` | boolean | no | Persist into durable image storage (default `true`) |
+
+At least one of `image_id` or `path` is required. When both are present, both source images are sent to the edit request.
+
+## Result Shape
+
+Both tools return:
+
+- Native image blocks for direct model consumption
+- Structured JSON with:
+  - `artifact_id` when durable storage is enabled
+  - `session_file` when workspace save is enabled
+  - `media_type`, `filename`, `size_bytes`
+  - `revised_prompt` when OpenAI returns one
+
+## Notes
+
+- Transparent background requires `png` or `webp` output
+- Session file edits must be `png`, `jpg`, `jpeg`, or `webp`
+- Edit sources larger than 50 MB are rejected before the API call
+- Saved workspace files are written as base64-encoded binary files
+
+## See Also
+
+- [File System](/capabilities/file-system/) — read and reuse workspace images
+- [Storage](/capabilities/session-storage/) — store per-session OpenAI overrides
+- [Capabilities Overview](/capabilities/)

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -188,6 +188,16 @@ See `crates/core/src/capabilities/mod.rs` for `resolve_dependencies()` and `Reso
 | `sample_data` | `session_file_system` | `file_system` |
 | `skills` | `session_file_system` | *(none)* |
 | `virtual_bash` | `session_file_system` | `file_system` |
+| `gpt_image_gen` | `session_file_system`, `session_storage` | *(none)* |
+
+#### Tool-Side Provider Clients
+
+Some capabilities call provider APIs directly instead of routing through the LLM driver abstraction. For those cases the worker-side `ToolContext` may include:
+
+- `provider_credential_store` for resolving default provider credentials without reading provider environment variables in tool code
+- `image_store` for durable image artifact persistence and later reuse by ID
+
+`gpt_image_gen` is the first built-in example of this pattern: it resolves OpenAI credentials through session secrets or the provider credential store, persists generated outputs in org-scoped image storage, and can optionally mirror them into the session filesystem.
 
 ### Capability Features
 

--- a/specs/session-filesystem.md
+++ b/specs/session-filesystem.md
@@ -45,6 +45,7 @@ This document defines the session-level virtual filesystem for Everruns. Each se
 - Mount at `/home/agent`: Confusing with bash HOME directory
 - Mount at `/app/session`: Less intuitive
 **Rationale:** `/workspace` is a common convention (similar to VS Code DevContainers, GitHub Codespaces) and clearly indicates agent work area. All capabilities (file_system, virtual_bash) normalize paths by stripping/adding the `/workspace` prefix when interfacing with the session file store.
+Generated media can also be written here as base64-encoded binary files. The `gpt_image_gen` capability uses `/workspace/.outputs/images/` by default when the caller requests filesystem persistence.
 
 ## Requirements
 

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -148,6 +148,18 @@ V1 limitation:
 - Background runs are best-effort and worker-local. They are started with `tokio::spawn` inside the worker process and are not yet durable across worker restarts.
 - This is intentional for the first iteration; durable resumption can be layered later without changing the tool contract.
 
+### Tool-Side Service Stores
+
+`ToolContext` may carry worker-backed service stores in addition to filesystem and session metadata handles. These stores let tools perform org-scoped operations without bypassing worker authorization boundaries.
+
+Current examples:
+
+- `storage_store` for key/value and secret storage
+- `image_store` for durable image artifact persistence and lookup by `image_id`
+- `provider_credential_store` for default provider credentials used by tool-side API clients
+
+This pattern is intended for tools that must call an external API directly while still relying on the control plane for secrets, org scoping, and durable storage.
+
 ### PostToolExecHook (per-tool hooks)
 
 `PostToolExecHook` is an async hook that runs after each individual tool execution, before ActAtom emits events. Capabilities contribute hooks via `Capability::post_tool_exec_hooks()`.


### PR DESCRIPTION
## What
Adds the `gpt_image_gen` capability with `generate_image` and `edit_image` tools backed by OpenAI `gpt-image-1`.

## Why
Agents need first-class raster image generation and editing that can persist outputs as org-scoped image artifacts and optional session workspace files.

## How
- adds image artifact and provider credential stores to `ToolContext`, direct worker adapters, and gRPC workers
- adds worker RPCs for image artifact create/read and default provider credential lookup
- registers the OpenAI image capability from `everruns-openai`, resolving credentials via session secrets or provider configuration
- adds docs/spec updates and an Image Studio seed agent

## Risk
- Medium
- Touches shared worker/runtime context and gRPC protocol. Main risks are missing store wiring in a host path, incorrect credential resolution, and image payload size and format handling.

## Security
- Threat categories reviewed: TM-LLM, TM-API, TM-FS, TM-DURABLE, TM-TENANT
- Findings and resolutions:
  - tool code does not read provider env vars directly; credentials resolve through session secrets or control-plane provider configuration
  - image artifact reads and writes stay org-scoped through direct and gRPC store adapters
  - edit sources are limited to persisted image IDs or current session file paths; no arbitrary URL fetch path is added
  - edit source images over 50 MB are rejected before provider egress
  - generated workspace files are written through the session file store as base64 content

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)
