### PR TITLE
fix(daytona): reset exec session after timeout

### DIFF
--- a/integrations/daytona/SPEC.md
+++ b/integrations/daytona/SPEC.md
@@ -121,6 +121,7 @@ Executes a shell command in a sandbox with real-time output streaming.
   - `timeout`: integer (optional) — timeout in ms (default: 300000)
 - **Returns**: `{ exit_code, output }`
 - **Streaming**: Emits `tool.output.delta` events with partial combined stdout/stderr output (emitted on stream `"stdout"`) as the command runs (polled every ~1s). The final tool result contains the complete combined output.
+- **Recovery**: If a command times out or the shared exec shell is detected as dead, Everruns resets the Daytona exec session before returning the error so the next command can recover cleanly.
 
 ### daytona_read_file
 

--- a/integrations/daytona/src/client.rs
+++ b/integrations/daytona/src/client.rs
@@ -562,10 +562,21 @@ impl DaytonaClient {
 
         loop {
             if std::time::Instant::now() >= deadline {
-                return Err(format!(
-                    "Command timed out after {timeout}ms. \
-                     Increase the timeout parameter or break the command into smaller steps."
-                ));
+                return match self.reset_session(sandbox_id).await {
+                    Ok(()) => Err(format!(
+                        "Command timed out after {timeout}ms. \
+                         The exec session has been automatically reset so \
+                         your next command will work. Increase the timeout \
+                         parameter or break the command into smaller steps."
+                    )),
+                    Err(e) => {
+                        debug!("Failed to reset session {EXEC_SESSION_ID} after timeout: {e}");
+                        Err(format!(
+                            "Command timed out after {timeout}ms. \
+                             Additionally, failed to reset the exec session: {e}"
+                        ))
+                    }
+                };
             }
 
             tokio::time::sleep(EXEC_POLL_INTERVAL).await;
@@ -1601,6 +1612,97 @@ mod tests {
         );
         let result = client.ensure_session("sb_test").await;
         assert!(result.is_ok(), "409 should be treated as success");
+    }
+
+    #[tokio::test]
+    async fn test_exec_timeout_resets_session_and_next_command_succeeds() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        let mock_server = MockServer::start().await;
+        let exec_call_count = std::sync::Arc::new(AtomicU32::new(0));
+
+        Mock::given(method("POST"))
+            .and(path("/sb_timeout/process/session"))
+            .respond_with(ResponseTemplate::new(201))
+            .mount(&mock_server)
+            .await;
+
+        let counter = exec_call_count.clone();
+        Mock::given(method("POST"))
+            .and(path("/sb_timeout/process/session/everruns-exec/exec"))
+            .respond_with(move |_: &wiremock::Request| {
+                let n = counter.fetch_add(1, Ordering::SeqCst);
+                let cmd_id = if n == 0 { "cmd_timeout" } else { "cmd_ok" };
+                ResponseTemplate::new(202).set_body_json(json!({ "cmdId": cmd_id }))
+            })
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path(
+                "/sb_timeout/process/session/everruns-exec/command/cmd_timeout/logs",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(vec![]))
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/sb_timeout/process/session/everruns-exec/command/cmd_timeout",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "cmd_timeout",
+                "command": "sleep 999"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let mut ok_log_bytes = vec![0x01, 0x01, 0x01];
+        ok_log_bytes.extend_from_slice(b"still works\n");
+        Mock::given(method("GET"))
+            .and(path(
+                "/sb_timeout/process/session/everruns-exec/command/cmd_ok/logs",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(ok_log_bytes))
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/sb_timeout/process/session/everruns-exec/command/cmd_ok",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "cmd_ok",
+                "command": "echo still works",
+                "exitCode": 0
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("DELETE"))
+            .and(path("/sb_timeout/process/session/everruns-exec"))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&mock_server)
+            .await;
+
+        let client = DaytonaClient::with_base_urls(
+            "test_key".to_string(),
+            mock_server.uri(),
+            mock_server.uri(),
+        );
+
+        let timeout_err = client
+            .exec("sb_timeout", "sleep 999", None, Some(1_200), |_| {})
+            .await
+            .unwrap_err();
+        assert!(timeout_err.contains("Command timed out after"));
+        assert!(timeout_err.contains("automatically reset"));
+
+        let result = client
+            .exec("sb_timeout", "echo still works", None, Some(5_000), |_| {})
+            .await
+            .unwrap();
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.result, "still works\n");
+        assert_eq!(exec_call_count.load(Ordering::SeqCst), 2);
     }
 
     #[tokio::test]

--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -6,8 +6,9 @@
 //! Decision: External integration crate, auto-registered via inventory plugin system
 //! Decision: Use secrets store for all state (API key + per-sandbox connection info)
 //! Decision: Two-tier API: Management API for lifecycle, Toolbox API for in-sandbox ops
-//! Decision: All exec goes through Session API (/process/session) — persistent shell,
-//!           async execution, and log polling for real-time streaming output
+//! Decision: All exec goes through the Session API (/process/session) using a
+//!           shared session, async execution, and log polling for real-time
+//!           streaming output
 //! Decision: session_storage dependency for API key and state persistence
 
 pub mod client;

--- a/integrations/daytona/tests/live_api_test.rs
+++ b/integrations/daytona/tests/live_api_test.rs
@@ -205,6 +205,34 @@ async fn test_live_exec_cwd_and_exit_code() {
     );
 }
 
+/// A timed-out command must not poison the next exec in the same sandbox.
+#[tokio::test]
+async fn test_live_exec_timeout_does_not_poison_next_command() {
+    let api_key = require_api_key!();
+    let (client, guard) = create_test_sandbox(api_key, "exec-timeout-recovery").await;
+    let id = &guard.sandbox_id;
+
+    let timeout_err = client
+        .exec(id, "sleep 10", None, Some(1_500), |_| {})
+        .await
+        .expect_err("sleep 10 should time out");
+    assert!(
+        timeout_err.contains("Command timed out after"),
+        "Expected timeout error, got: {timeout_err}"
+    );
+
+    let result = client
+        .exec(id, "echo timeout-recovered", None, None, |_| {})
+        .await
+        .expect("exec after timeout failed");
+    assert_eq!(result.exit_code, 0);
+    assert!(
+        result.result.contains("timeout-recovered"),
+        "Expected recovery output, got: {}",
+        result.result
+    );
+}
+
 /// Folder creation and file listing.
 #[tokio::test]
 async fn test_live_folder_and_list() {


### PR DESCRIPTION
## What
Reset the shared Daytona exec session when a command times out, and add regression coverage at both unit and live-API layers.

## Why
Fixes EVE-332. A timed-out `daytona_exec` could leave the shared `everruns-exec` shell wedged, so later trivial commands would time out too.

## How
Keep the existing shared exec-session model, but treat timeout as a terminal session failure: delete and recreate the Daytona exec session before returning the timeout error. Add a unit test and a live Daytona test that prove the next command succeeds after a timeout, and document the recovery behavior in the Daytona spec.

## Risk
- Medium
- Daytona timeout handling changed in the core exec path. The main risk is resetting the session too aggressively and surprising workflows that expected a timed-out command to keep the old shell alive.

## Security
- Threat categories reviewed: TM-DAYTONA, TM-DOS
- Findings and resolutions:
  - No new auth or secret-handling paths were introduced.
  - Resetting the poisoned exec shell reduces availability risk after timeout without widening the sandbox trust boundary.
  - No threat model update needed because the trust boundary is unchanged; this is failure-recovery hardening inside the existing Daytona execution surface.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `cargo test -p everruns-integrations-daytona --test session_sandbox_provider -- --nocapture`
- `cargo test -p everruns-integrations-daytona client::tests:: -- --nocapture`
- `doppler run -- cargo test -p everruns-integrations-daytona --features daytona-live-tests --test live_api_test test_live_exec_timeout_does_not_poison_next_command -- --nocapture --test-threads=1`
- `just pre-push`
