### PR TITLE
fix(gemini): strip additionalProperties recursively from tool schemas

### DIFF
--- a/crates/gemini/src/driver.rs
+++ b/crates/gemini/src/driver.rs
@@ -207,17 +207,32 @@ impl GeminiLlmDriver {
         (system_instruction, contents)
     }
 
-    /// Strip fields that Gemini doesn't accept in JSON Schema (e.g. `additionalProperties`).
+    /// Recursively strip fields that Gemini doesn't accept in JSON Schema.
+    ///
+    /// Gemini's function-calling API uses an OpenAPI 3.0 subset that rejects
+    /// `additionalProperties`. The field can appear at any depth — inside
+    /// `properties`, `items`, `anyOf`, etc. — so we walk the entire value
+    /// instead of only the top level.
     fn clean_schema(mut value: Value) -> Value {
-        if let Some(obj) = value.as_object_mut() {
-            obj.remove("additionalProperties");
-            if let Some(props_obj) = obj.get_mut("properties").and_then(|p| p.as_object_mut()) {
-                for v in props_obj.values_mut() {
-                    *v = Self::clean_schema(v.clone());
+        Self::strip_unsupported(&mut value);
+        value
+    }
+
+    fn strip_unsupported(value: &mut Value) {
+        match value {
+            Value::Object(obj) => {
+                obj.remove("additionalProperties");
+                for v in obj.values_mut() {
+                    Self::strip_unsupported(v);
                 }
             }
+            Value::Array(arr) => {
+                for v in arr.iter_mut() {
+                    Self::strip_unsupported(v);
+                }
+            }
+            _ => {}
         }
-        value
     }
 
     fn convert_tools(tools: &[ToolDefinition]) -> Option<Vec<GeminiTool>> {
@@ -1104,6 +1119,76 @@ mod tests {
                 .get("additionalProperties")
                 .is_none()
         );
+    }
+
+    #[test]
+    fn test_convert_tools_strips_additional_properties_nested() {
+        use everruns_core::tool_types::{BuiltinTool, DeferrablePolicy, ToolPolicy};
+        let tools = vec![ToolDefinition::Builtin(BuiltinTool {
+            name: "complex".to_string(),
+            display_name: None,
+            description: "Complex schema".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "nested": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "deep": {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                        }
+                                    }
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    },
+                    "variant": {
+                        "anyOf": [
+                            {"type": "string"},
+                            {"type": "object", "additionalProperties": false}
+                        ]
+                    }
+                },
+                "additionalProperties": false
+            }),
+            policy: ToolPolicy::Auto,
+            category: None,
+            deferrable: DeferrablePolicy::default(),
+            hints: everruns_core::tool_types::ToolHints::default(),
+        })];
+
+        let gemini_tools = GeminiLlmDriver::convert_tools(&tools).unwrap();
+        let params = &gemini_tools[0].function_declarations[0].parameters;
+
+        fn assert_no_additional_properties(v: &Value) {
+            match v {
+                Value::Object(obj) => {
+                    assert!(
+                        !obj.contains_key("additionalProperties"),
+                        "additionalProperties still present in {obj:?}"
+                    );
+                    for child in obj.values() {
+                        assert_no_additional_properties(child);
+                    }
+                }
+                Value::Array(arr) => {
+                    for child in arr {
+                        assert_no_additional_properties(child);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        assert_no_additional_properties(params);
     }
 
     #[test]

--- a/crates/gemini/src/driver.rs
+++ b/crates/gemini/src/driver.rs
@@ -222,8 +222,25 @@ impl GeminiLlmDriver {
         match value {
             Value::Object(obj) => {
                 obj.remove("additionalProperties");
-                for v in obj.values_mut() {
-                    Self::strip_unsupported(v);
+                for (key, v) in obj.iter_mut() {
+                    // Schema-composition keywords whose value is a map of
+                    // arbitrary name -> schema. The keys are caller-supplied
+                    // names, so we must not treat the map itself as a schema
+                    // (otherwise a property literally named
+                    // `additionalProperties` would be dropped). Recurse into
+                    // each value instead.
+                    if matches!(
+                        key.as_str(),
+                        "properties" | "patternProperties" | "definitions" | "$defs"
+                    ) {
+                        if let Value::Object(map) = v {
+                            for sub in map.values_mut() {
+                                Self::strip_unsupported(sub);
+                            }
+                        }
+                    } else {
+                        Self::strip_unsupported(v);
+                    }
                 }
             }
             Value::Array(arr) => {
@@ -1189,6 +1206,44 @@ mod tests {
         }
 
         assert_no_additional_properties(params);
+    }
+
+    #[test]
+    fn test_convert_tools_preserves_property_named_additional_properties() {
+        use everruns_core::tool_types::{BuiltinTool, DeferrablePolicy, ToolPolicy};
+        let tools = vec![ToolDefinition::Builtin(BuiltinTool {
+            name: "configure".to_string(),
+            display_name: None,
+            description: "Configure allowing extras".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "additionalProperties": {
+                        "type": "boolean",
+                        "description": "Allow extras in the request"
+                    }
+                },
+                "required": ["additionalProperties"],
+                "additionalProperties": false
+            }),
+            policy: ToolPolicy::Auto,
+            category: None,
+            deferrable: DeferrablePolicy::default(),
+            hints: everruns_core::tool_types::ToolHints::default(),
+        })];
+
+        let gemini_tools = GeminiLlmDriver::convert_tools(&tools).unwrap();
+        let params = &gemini_tools[0].function_declarations[0].parameters;
+
+        assert!(params.get("additionalProperties").is_none());
+        let properties = params
+            .get("properties")
+            .and_then(|p| p.as_object())
+            .unwrap();
+        let prop = properties
+            .get("additionalProperties")
+            .expect("property named additionalProperties must be preserved");
+        assert_eq!(prop["type"], "boolean");
     }
 
     #[test]


### PR DESCRIPTION
## What
Make the Gemini driver's `clean_schema` walk the full JSON Schema tree so `additionalProperties` is stripped at every depth (nested `properties`, array `items`, `anyOf`/`oneOf`/`allOf`, etc.), not just the top level plus one nested `properties` layer.

## Why
Gemini's function-calling API rejects `additionalProperties` anywhere in the schema with:

```
400 Bad Request: Invalid JSON payload received. Unknown name "additionalProperties"
at 'tools[0].function_declarations[2]...
```

The previous implementation only walked the top level and one nested layer under `properties`, so schemas with `additionalProperties` inside array `items` or `anyOf` branches slipped through and broke the first LLM call for any agent with tools.

Fixes [EVE-333](https://linear.app/everruns/issue/EVE-333/gemini-provider-tool-schemas-with-additionalproperties-cause-400-bad).

## How
Replace the shallow `clean_schema` with a generic recursive walk over `Value::Object`/`Value::Array`, removing `additionalProperties` from every object encountered.

## Risk
- Low
- Only affects the Gemini LLM driver; OpenAI/Anthropic paths are untouched
- Cannot produce a more-permissive schema than before (we can only remove more fields, never add)

## Security
- Threat categories reviewed: TM-LLM (tool schema construction), TM-DOS (recursion on untrusted nested JSON)
- Findings and resolutions:
  - TM-LLM: the change only removes fields before they leave the process; it cannot leak data or introduce injection. No credentials or user data touched.
  - TM-DOS: tool schemas come from internal `BuiltinTool`/MCP definitions that are already bounded and in-process. Recursion depth is bounded by schema depth; consistent with existing OpenAI/Anthropic driver behavior.

## Checklist
- [x] Tests added or updated (new `test_convert_tools_strips_additional_properties_nested` covers items/anyOf/deep nesting)
- [x] Backward compatibility considered (internal change, no public API)
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)
