### PR TITLE
feat(capabilities): add A2UI as parallel generative-UI capability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,8 @@ Always make sure you are working on top of latest main from remote.
 - `specs/events.md` - Event types, SSE streaming, contract and compatibility guarantees
 - `specs/execution-phases.md` - Execution phases (Commentary/FinalAnswer) for multi-step tool flows
 - `specs/markdown-messages.md` - Chat message markdown rendering with llm-ui
+- `specs/openui.md` - OpenUI generative-UI capability (OpenUI Lang + `@openuidev/react-ui`)
+- `specs/a2ui.md` - A2UI generative-UI capability (Google A2UI JSON + native renderer)
 - `specs/tool-execution.md` - Tool types and execution flow
 - `specs/capabilities.md` - Agent capabilities system
 - `specs/agent-instructions.md` - AGENTS.md support (dynamic project instructions)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.8.14"
+version = "0.8.15"
 
 [[package]]
 name = "everruns-anthropic"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,6 +1556,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-a2ui"
+version = "0.8.14"
+
+[[package]]
 name = "everruns-anthropic"
 version = "0.8.15"
 dependencies = [
@@ -1638,6 +1642,7 @@ dependencies = [
  "chrono",
  "ed25519-dalek",
  "eventsource-stream",
+ "everruns-a2ui",
  "everruns-anthropic",
  "everruns-config",
  "everruns-gemini",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/durable",
     "crates/config",
     "crates/openui",
+    "crates/a2ui",
     "crates/session-sqldb",
     "crates/container-sandbox",
     "integrations/docker",

--- a/apps/ui/src/__tests__/a2ui-utils.test.ts
+++ b/apps/ui/src/__tests__/a2ui-utils.test.ts
@@ -1,0 +1,110 @@
+import { hasA2UIBlocks, hasOnlyA2UIBlocks, parseA2UI, splitA2UIBlocks } from "@/lib/a2ui-utils";
+
+describe("hasA2UIBlocks", () => {
+  it("returns true for a2ui fence", () => {
+    expect(hasA2UIBlocks('```a2ui\n{"type":"Card"}\n```')).toBe(true);
+  });
+
+  it("returns true for openui fence", () => {
+    expect(hasA2UIBlocks("```openui\nroot = Card([])\n```")).toBe(true);
+  });
+
+  it("returns false for unrelated fences", () => {
+    expect(hasA2UIBlocks("```python\nprint(1)\n```")).toBe(false);
+  });
+
+  it("returns false for empty text", () => {
+    expect(hasA2UIBlocks("")).toBe(false);
+  });
+});
+
+describe("hasOnlyA2UIBlocks", () => {
+  it("distinguishes a2ui from openui", () => {
+    expect(hasOnlyA2UIBlocks("```a2ui\n{}\n```")).toBe(true);
+    expect(hasOnlyA2UIBlocks("```openui\nroot = Card()\n```")).toBe(false);
+  });
+});
+
+describe("splitA2UIBlocks", () => {
+  it("returns whole text as markdown when no blocks present", () => {
+    expect(splitA2UIBlocks("Hello")).toEqual([{ type: "markdown", content: "Hello" }]);
+  });
+
+  it("splits an a2ui block surrounded by markdown", () => {
+    const text = 'Before\n```a2ui\n{"type":"Card"}\n```\nAfter';
+    expect(splitA2UIBlocks(text)).toEqual([
+      { type: "markdown", content: "Before\n" },
+      { type: "a2ui", content: '{"type":"Card"}\n' },
+      { type: "markdown", content: "\nAfter" },
+    ]);
+  });
+
+  it("interleaves a2ui and openui blocks correctly", () => {
+    const text = '```a2ui\n{"type":"Card"}\n```\nmiddle\n```openui\nroot = Card([])\n```';
+    const segs = splitA2UIBlocks(text);
+    expect(segs.map((s) => s.type)).toEqual(["a2ui", "markdown", "openui"]);
+  });
+
+  it("handles streaming a2ui (no closing fence)", () => {
+    const text = 'Here:\n```a2ui\n{"type":"Card"';
+    expect(splitA2UIBlocks(text)).toEqual([
+      { type: "markdown", content: "Here:\n" },
+      { type: "a2ui", content: '{"type":"Card"' },
+    ]);
+  });
+
+  it("skips empty blocks", () => {
+    const text = "Before\n```a2ui\n\n```\nAfter";
+    expect(splitA2UIBlocks(text)).toEqual([
+      { type: "markdown", content: "Before\n" },
+      { type: "markdown", content: "\nAfter" },
+    ]);
+  });
+});
+
+describe("parseA2UI", () => {
+  it("parses valid JSON", () => {
+    const result = parseA2UI('{"type":"Card","props":{"variant":"muted"}}');
+    expect(result).toEqual({ type: "Card", props: { variant: "muted" } });
+  });
+
+  it("returns null for empty input", () => {
+    expect(parseA2UI("")).toBeNull();
+    expect(parseA2UI("   ")).toBeNull();
+  });
+
+  it("returns null for completely garbage input", () => {
+    expect(parseA2UI("not json at all")).toBeNull();
+  });
+
+  it("recovers a parseable prefix from truncated JSON", () => {
+    // Streaming: object opened but not closed.
+    const partial = '{"type":"Card","children":[{"type":"Heading","props":{"text":"Hi"}';
+    const result = parseA2UI(partial);
+    expect(result).toBeTruthy();
+    // Should at least have recovered the outer type.
+    expect((result as { type: string }).type).toBe("Card");
+  });
+
+  it("handles unterminated strings by truncating", () => {
+    const partial = '{"type":"Card","props":{"variant":"muted';
+    const result = parseA2UI(partial);
+    // May recover outer type, may be null — either is acceptable as long as
+    // it doesn't throw.
+    if (result !== null) {
+      expect((result as { type: string }).type).toBe("Card");
+    }
+  });
+
+  it("parses nested children", () => {
+    const json = JSON.stringify({
+      type: "Card",
+      children: [
+        { type: "Heading", props: { text: "Title" } },
+        { type: "Text", props: { text: "Body" } },
+      ],
+    });
+    const result = parseA2UI(json) as { children: unknown[] };
+    expect(result.children).toHaveLength(2);
+  });
+});

--- a/apps/ui/src/components/chat/a2ui-renderer.tsx
+++ b/apps/ui/src/components/chat/a2ui-renderer.tsx
@@ -1,0 +1,714 @@
+"use client";
+
+/**
+ * A2UI Renderer — renders Google A2UI JSON component trees into React.
+ *
+ * The LLM emits A2UI JSON inside ```a2ui fenced code blocks when the `a2ui`
+ * capability is enabled. This renderer walks the JSON tree and dispatches each
+ * node to a React component implemented with our own shadcn/ui primitives,
+ * so the agent's UI matches the rest of Everruns.
+ *
+ * Streaming-safe:
+ * - Partial JSON parses to a best-effort tree (see parseA2UI).
+ * - Unknown types or malformed nodes render a subtle placeholder rather than
+ *   throwing.
+ * - Wrapped in an error boundary that falls back to the raw JSON code block.
+ *
+ * @see specs/a2ui.md
+ */
+
+import {
+  Component,
+  createContext,
+  useContext,
+  useState,
+  type ErrorInfo,
+  type FormEvent,
+  type ReactNode,
+} from "react";
+
+import { parseA2UI } from "@/lib/a2ui-utils";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import { useSessionContext } from "@/app/(main)/sessions/[sessionId]/session-context";
+import { useParams } from "next/navigation";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type A2UIAction =
+  | { type: "message"; text: string }
+  | { type: "open_url"; url: string }
+  | { type?: string; [k: string]: unknown };
+
+interface A2UINode {
+  type: string;
+  props?: Record<string, unknown>;
+  children?: A2UINode[];
+}
+
+interface A2UIBlockProps {
+  /** Raw A2UI JSON (without the ```a2ui fences) */
+  code: string;
+  /** Whether the LLM is still streaming this content */
+  isStreaming?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Error boundary
+// ---------------------------------------------------------------------------
+
+interface EBProps {
+  children: ReactNode;
+  fallback: ReactNode;
+}
+interface EBState {
+  hasError: boolean;
+}
+
+class A2UIErrorBoundary extends Component<EBProps, EBState> {
+  constructor(props: EBProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+  static getDerivedStateFromError(): EBState {
+    return { hasError: true };
+  }
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.warn("[a2ui] Render error caught by boundary:", error.message, info.componentStack);
+  }
+  componentDidUpdate(prevProps: EBProps) {
+    if (this.state.hasError && prevProps.children !== this.props.children) {
+      this.setState({ hasError: false });
+    }
+  }
+  render() {
+    return this.state.hasError ? this.props.fallback : this.props.children;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Action dispatch
+// ---------------------------------------------------------------------------
+
+/**
+ * Hook returning an action dispatcher tied to the current session.
+ * A2UI blocks only appear inside session-scoped pages, so the session context
+ * is guaranteed to be present.
+ */
+function useActionDispatch(): (action: A2UIAction) => void {
+  const ctx = useSessionContext();
+  const params = useParams<{ sessionId?: string }>();
+  const sessionId = params?.sessionId;
+
+  return (action: A2UIAction) => {
+    if (!action || typeof action !== "object") return;
+    if (action.type === "message" && typeof action.text === "string" && sessionId) {
+      ctx.sendMessage.mutate({ sessionId, content: action.text });
+    } else if (action.type === "open_url" && typeof action.url === "string") {
+      window.open(action.url, "_blank", "noopener,noreferrer");
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Prop helpers (safe narrowing for arbitrary LLM output)
+// ---------------------------------------------------------------------------
+
+function str(v: unknown, fallback = ""): string {
+  return typeof v === "string" ? v : fallback;
+}
+function optStr(v: unknown): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}
+function bool(v: unknown, fallback = false): boolean {
+  return typeof v === "boolean" ? v : fallback;
+}
+function num(v: unknown): number | undefined {
+  return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+function arr<T = unknown>(v: unknown): T[] {
+  return Array.isArray(v) ? (v as T[]) : [];
+}
+function oneOf<T extends string>(v: unknown, allowed: readonly T[], fallback: T): T {
+  return typeof v === "string" && (allowed as readonly string[]).includes(v) ? (v as T) : fallback;
+}
+
+// ---------------------------------------------------------------------------
+// Form context — collects field values within a <Form>
+// ---------------------------------------------------------------------------
+
+interface FormCtx {
+  values: Record<string, unknown>;
+  set: (name: string, value: unknown) => void;
+}
+
+const FormContext = createContext<FormCtx | null>(null);
+
+function useFieldValue<T>(name: string, initial: T): [T, (next: T) => void] {
+  const form = useContext(FormContext);
+  const [local, setLocal] = useState<T>(initial);
+  if (form) {
+    const current = (form.values[name] as T | undefined) ?? initial;
+    return [current, (next: T) => form.set(name, next)];
+  }
+  return [local, setLocal];
+}
+
+// ---------------------------------------------------------------------------
+// Node dispatcher
+// ---------------------------------------------------------------------------
+
+function renderNode(
+  node: unknown,
+  key: number | string,
+  dispatch: (a: A2UIAction) => void,
+): ReactNode {
+  if (!node || typeof node !== "object" || Array.isArray(node)) return null;
+  const n = node as A2UINode;
+  const type = typeof n.type === "string" ? n.type : "";
+  const props = (n.props && typeof n.props === "object" ? n.props : {}) as Record<string, unknown>;
+  const children = arr<A2UINode>(n.children);
+
+  const renderChildren = () => children.map((c, i) => renderNode(c, i, dispatch));
+
+  switch (type) {
+    // ---------- Layout ----------
+    case "Stack": {
+      const direction = oneOf(props.direction, ["row", "column"] as const, "column");
+      const gap = oneOf(props.gap, ["none", "sm", "md", "lg"] as const, "md");
+      const align = oneOf(props.align, ["start", "center", "end", "stretch"] as const, "stretch");
+      const gapCls = { none: "gap-0", sm: "gap-2", md: "gap-3", lg: "gap-5" }[gap];
+      const dirCls = direction === "row" ? "flex-row flex-wrap" : "flex-col";
+      const alignCls =
+        direction === "row"
+          ? {
+              start: "items-start",
+              center: "items-center",
+              end: "items-end",
+              stretch: "items-stretch",
+            }[align]
+          : {
+              start: "items-start",
+              center: "items-center",
+              end: "items-end",
+              stretch: "items-stretch",
+            }[align];
+      return (
+        <div key={key} className={cn("flex", dirCls, gapCls, alignCls)}>
+          {renderChildren()}
+        </div>
+      );
+    }
+
+    case "Card": {
+      const variant = oneOf(props.variant, ["default", "muted"] as const, "default");
+      return (
+        <Card key={key} className={cn("px-4", variant === "muted" && "bg-muted/40")}>
+          {renderChildren()}
+        </Card>
+      );
+    }
+
+    case "Separator":
+      return <Separator key={key} className="my-2" />;
+
+    // ---------- Content ----------
+    case "Heading": {
+      const level = num(props.level) ?? 3;
+      const clamped = Math.min(4, Math.max(1, Math.trunc(level))) as 1 | 2 | 3 | 4;
+      const sizeCls = {
+        1: "text-xl font-semibold",
+        2: "text-lg font-semibold",
+        3: "text-base font-semibold",
+        4: "text-sm font-semibold",
+      }[clamped];
+      const cls = cn("text-foreground", sizeCls);
+      const text = str(props.text);
+      switch (clamped) {
+        case 1:
+          return (
+            <h1 key={key} className={cls}>
+              {text}
+            </h1>
+          );
+        case 2:
+          return (
+            <h2 key={key} className={cls}>
+              {text}
+            </h2>
+          );
+        case 3:
+          return (
+            <h3 key={key} className={cls}>
+              {text}
+            </h3>
+          );
+        default:
+          return (
+            <h4 key={key} className={cls}>
+              {text}
+            </h4>
+          );
+      }
+    }
+
+    case "Text": {
+      const tone = oneOf(props.tone, ["default", "muted"] as const, "default");
+      return (
+        <p
+          key={key}
+          className={cn("text-sm leading-relaxed", tone === "muted" && "text-muted-foreground")}
+        >
+          {str(props.text)}
+        </p>
+      );
+    }
+
+    case "Callout": {
+      const variant = oneOf(
+        props.variant,
+        ["info", "success", "warning", "error"] as const,
+        "info",
+      );
+      const bg = {
+        info: "border-blue-500/40 bg-blue-500/10 text-blue-700 dark:text-blue-300",
+        success: "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+        warning: "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+        error: "border-red-500/40 bg-red-500/10 text-red-700 dark:text-red-300",
+      }[variant];
+      const title = optStr(props.title);
+      return (
+        <div key={key} className={cn("rounded-md border px-3 py-2 text-sm", bg)}>
+          {title && <div className="font-medium">{title}</div>}
+          <div>{str(props.text)}</div>
+        </div>
+      );
+    }
+
+    case "Badge": {
+      const variant = oneOf(
+        props.variant,
+        ["default", "success", "warning", "error"] as const,
+        "default",
+      );
+      const cls = {
+        default: "",
+        success: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 border-emerald-500/30",
+        warning: "bg-amber-500/15 text-amber-700 dark:text-amber-300 border-amber-500/30",
+        error: "bg-red-500/15 text-red-700 dark:text-red-300 border-red-500/30",
+      }[variant];
+      return (
+        <Badge key={key} variant="outline" className={cn(cls)}>
+          {str(props.label)}
+        </Badge>
+      );
+    }
+
+    case "Image": {
+      const src = str(props.src);
+      if (!src) return null;
+      const caption = optStr(props.caption);
+      return (
+        <figure key={key} className="flex flex-col gap-1">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={src} alt={str(props.alt, "")} className="max-w-full rounded-md" />
+          {caption && <figcaption className="text-xs text-muted-foreground">{caption}</figcaption>}
+        </figure>
+      );
+    }
+
+    case "CodeBlock":
+      return (
+        <pre key={key} className="overflow-x-auto rounded-md bg-muted p-3 text-xs">
+          <code>{str(props.code)}</code>
+        </pre>
+      );
+
+    // ---------- Data ----------
+    case "List": {
+      const ordered = bool(props.ordered);
+      const listCls = cn("space-y-1 pl-1", ordered ? "list-decimal pl-5" : "list-none");
+      return ordered ? (
+        <ol key={key} className={listCls}>
+          {renderChildren()}
+        </ol>
+      ) : (
+        <ul key={key} className={listCls}>
+          {renderChildren()}
+        </ul>
+      );
+    }
+
+    case "ListItem": {
+      const title = str(props.title);
+      const value = optStr(props.value);
+      const description = optStr(props.description);
+      return (
+        <li key={key} className="flex flex-col gap-0.5 text-sm">
+          <div className="flex items-start justify-between gap-2">
+            <span className="font-medium">{title}</span>
+            {value !== undefined && <span className="text-muted-foreground">{value}</span>}
+          </div>
+          {description && <span className="text-xs text-muted-foreground">{description}</span>}
+        </li>
+      );
+    }
+
+    case "Table": {
+      const columns = arr<unknown>(props.columns).map((c) => str(c));
+      const rows = arr<unknown>(props.rows);
+      return (
+        <Table key={key}>
+          <TableHeader>
+            <TableRow>
+              {columns.map((col, i) => (
+                <TableHead key={i}>{col}</TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((row, ri) => (
+              <TableRow key={ri}>
+                {arr<unknown>(row).map((cell, ci) => (
+                  <TableCell key={ci}>{cellToString(cell)}</TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      );
+    }
+
+    // ---------- Forms ----------
+    case "Form":
+      return (
+        <FormNode
+          key={key}
+          name={str(props.name, "form")}
+          submitLabel={str(props.submitLabel, "Submit")}
+          submitMessage={optStr(props.submitMessage)}
+          dispatch={dispatch}
+        >
+          {renderChildren()}
+        </FormNode>
+      );
+
+    case "TextField":
+      return (
+        <TextFieldNode
+          key={key}
+          name={str(props.name)}
+          label={optStr(props.label)}
+          placeholder={optStr(props.placeholder)}
+          defaultValue={str(props.defaultValue)}
+          required={bool(props.required)}
+        />
+      );
+
+    case "Textarea":
+      return (
+        <TextareaNode
+          key={key}
+          name={str(props.name)}
+          label={optStr(props.label)}
+          placeholder={optStr(props.placeholder)}
+          defaultValue={str(props.defaultValue)}
+          rows={num(props.rows)}
+        />
+      );
+
+    case "Select":
+      return (
+        <SelectNode
+          key={key}
+          name={str(props.name)}
+          label={optStr(props.label)}
+          options={arr<{ label?: unknown; value?: unknown }>(props.options).map((o) => ({
+            label: str(o?.label),
+            value: str(o?.value),
+          }))}
+          defaultValue={str(props.defaultValue)}
+        />
+      );
+
+    case "Checkbox":
+      return (
+        <CheckboxNode
+          key={key}
+          name={str(props.name)}
+          label={str(props.label)}
+          defaultChecked={bool(props.defaultChecked)}
+        />
+      );
+
+    // ---------- Actions ----------
+    case "Button": {
+      const action = props.action as A2UIAction | undefined;
+      const variant = oneOf(
+        props.variant,
+        ["primary", "secondary", "ghost", "destructive"] as const,
+        "primary",
+      );
+      const btnVariant =
+        variant === "primary" ? "default" : variant === "secondary" ? "secondary" : variant;
+      return (
+        <Button
+          key={key}
+          type="button"
+          variant={btnVariant}
+          size="sm"
+          onClick={() => action && dispatch(action)}
+          disabled={!action}
+        >
+          {str(props.label)}
+        </Button>
+      );
+    }
+
+    case "ButtonGroup": {
+      const align = oneOf(props.align, ["start", "center", "end"] as const, "start");
+      const alignCls = { start: "justify-start", center: "justify-center", end: "justify-end" }[
+        align
+      ];
+      return (
+        <div key={key} className={cn("flex flex-wrap gap-2", alignCls)}>
+          {renderChildren()}
+        </div>
+      );
+    }
+
+    default:
+      // Unknown or missing type — render a subtle placeholder during streaming.
+      if (!type) return null;
+      return (
+        <span
+          key={key}
+          className="inline-block rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+        >
+          Unknown component: {type}
+        </span>
+      );
+  }
+}
+
+function cellToString(v: unknown): string {
+  if (v === null || v === undefined) return "";
+  if (typeof v === "string") return v;
+  if (typeof v === "number" || typeof v === "boolean") return String(v);
+  return "";
+}
+
+// ---------------------------------------------------------------------------
+// Form node (manages collected values)
+// ---------------------------------------------------------------------------
+
+function FormNode({
+  name,
+  submitLabel,
+  submitMessage,
+  dispatch,
+  children,
+}: {
+  name: string;
+  submitLabel: string;
+  submitMessage: string | undefined;
+  dispatch: (a: A2UIAction) => void;
+  children: ReactNode;
+}) {
+  const [values, setValues] = useState<Record<string, unknown>>({});
+  const ctx: FormCtx = {
+    values,
+    set: (n, v) => setValues((prev) => ({ ...prev, [n]: v })),
+  };
+
+  const onSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const msg = submitMessage ?? defaultSubmitMessage(name, values);
+    dispatch({ type: "message", text: msg });
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-3">
+      <FormContext.Provider value={ctx}>{children}</FormContext.Provider>
+      <Button type="submit" size="sm" className="self-start">
+        {submitLabel}
+      </Button>
+    </form>
+  );
+}
+
+function defaultSubmitMessage(name: string, values: Record<string, unknown>): string {
+  const entries = Object.entries(values);
+  if (entries.length === 0) return `Submitted ${name} form`;
+  const pairs = entries.map(([k, v]) => `${k}=${JSON.stringify(v)}`).join(", ");
+  return `Submitted ${name} form: ${pairs}`;
+}
+
+// ---------------------------------------------------------------------------
+// Field nodes
+// ---------------------------------------------------------------------------
+
+function TextFieldNode({
+  name,
+  label,
+  placeholder,
+  defaultValue,
+  required,
+}: {
+  name: string;
+  label: string | undefined;
+  placeholder: string | undefined;
+  defaultValue: string;
+  required: boolean;
+}) {
+  const [value, setValue] = useFieldValue(name, defaultValue);
+  return (
+    <div className="flex flex-col gap-1">
+      {label && <Label htmlFor={`a2ui-${name}`}>{label}</Label>}
+      <Input
+        id={`a2ui-${name}`}
+        name={name}
+        placeholder={placeholder}
+        value={value}
+        required={required}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    </div>
+  );
+}
+
+function TextareaNode({
+  name,
+  label,
+  placeholder,
+  defaultValue,
+  rows,
+}: {
+  name: string;
+  label: string | undefined;
+  placeholder: string | undefined;
+  defaultValue: string;
+  rows: number | undefined;
+}) {
+  const [value, setValue] = useFieldValue(name, defaultValue);
+  return (
+    <div className="flex flex-col gap-1">
+      {label && <Label htmlFor={`a2ui-${name}`}>{label}</Label>}
+      <Textarea
+        id={`a2ui-${name}`}
+        name={name}
+        placeholder={placeholder}
+        rows={rows}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    </div>
+  );
+}
+
+function SelectNode({
+  name,
+  label,
+  options,
+  defaultValue,
+}: {
+  name: string;
+  label: string | undefined;
+  options: { label: string; value: string }[];
+  defaultValue: string;
+}) {
+  const [value, setValue] = useFieldValue(name, defaultValue);
+  return (
+    <div className="flex flex-col gap-1">
+      {label && <Label htmlFor={`a2ui-${name}`}>{label}</Label>}
+      <select
+        id={`a2ui-${name}`}
+        name={name}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        className="h-8 rounded-md border bg-background px-2 text-sm"
+      >
+        {!defaultValue && <option value="">Select…</option>}
+        {options.map((opt, i) => (
+          <option key={i} value={opt.value}>
+            {opt.label || opt.value}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function CheckboxNode({
+  name,
+  label,
+  defaultChecked,
+}: {
+  name: string;
+  label: string;
+  defaultChecked: boolean;
+}) {
+  const [checked, setChecked] = useFieldValue(name, defaultChecked);
+  return (
+    <label className="flex items-center gap-2 text-sm">
+      <Checkbox
+        id={`a2ui-${name}`}
+        checked={checked}
+        onCheckedChange={(v) => setChecked(v === true)}
+      />
+      <span>{label}</span>
+    </label>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public block component
+// ---------------------------------------------------------------------------
+
+/**
+ * Renders a single A2UI JSON block.
+ */
+export function A2UIBlock({ code }: A2UIBlockProps) {
+  if (!code.trim()) return null;
+
+  const fallback = (
+    <pre className="overflow-x-auto p-4 text-xs text-muted-foreground">
+      <code>{code}</code>
+    </pre>
+  );
+
+  const tree = parseA2UI(code);
+
+  return (
+    <div className="a2ui-block my-2 overflow-hidden rounded-md border border-border bg-card p-3">
+      <A2UIErrorBoundary fallback={fallback}>
+        <A2UIRoot tree={tree} />
+      </A2UIErrorBoundary>
+    </div>
+  );
+}
+
+function A2UIRoot({ tree }: { tree: unknown }) {
+  const dispatch = useActionDispatch();
+  if (tree === null || tree === undefined) {
+    return <div className="text-xs text-muted-foreground">…</div>;
+  }
+  return <>{renderNode(tree, "root", dispatch)}</>;
+}

--- a/apps/ui/src/components/chat/a2ui-renderer.tsx
+++ b/apps/ui/src/components/chat/a2ui-renderer.tsx
@@ -702,7 +702,7 @@ function CheckboxNode({
 /**
  * Renders a single A2UI JSON block.
  */
-export function A2UIBlock({ code }: A2UIBlockProps) {
+export function A2UIBlock({ code, isStreaming }: A2UIBlockProps) {
   if (!code.trim()) return null;
 
   const fallback = (
@@ -716,16 +716,34 @@ export function A2UIBlock({ code }: A2UIBlockProps) {
   return (
     <div className="a2ui-block my-2 overflow-hidden rounded-md border border-border bg-card p-3">
       <A2UIErrorBoundary fallback={fallback}>
-        <A2UIRoot tree={tree} />
+        <A2UIRoot tree={tree} isStreaming={isStreaming} rawCode={code} />
       </A2UIErrorBoundary>
     </div>
   );
 }
 
-function A2UIRoot({ tree }: { tree: unknown }) {
+function A2UIRoot({
+  tree,
+  isStreaming,
+  rawCode,
+}: {
+  tree: unknown;
+  isStreaming?: boolean;
+  rawCode: string;
+}) {
   const dispatch = useActionDispatch();
   if (tree === null || tree === undefined) {
-    return <div className="text-xs text-muted-foreground">…</div>;
+    // While streaming, a null tree just means the JSON hasn't arrived yet.
+    // Once streaming is complete and parsing still fails, show the raw JSON
+    // so users aren't stuck on an indeterminate placeholder.
+    if (isStreaming) {
+      return <div className="text-xs text-muted-foreground">…</div>;
+    }
+    return (
+      <pre className="overflow-x-auto p-2 text-xs text-muted-foreground">
+        <code>{rawCode}</code>
+      </pre>
+    );
   }
   return <>{renderNode(tree, "root", dispatch)}</>;
 }

--- a/apps/ui/src/components/chat/a2ui-renderer.tsx
+++ b/apps/ui/src/components/chat/a2ui-renderer.tsx
@@ -107,6 +107,19 @@ class A2UIErrorBoundary extends Component<EBProps, EBState> {
 // Action dispatch
 // ---------------------------------------------------------------------------
 
+// THREAT[TM-WEB-A2UI-01]: LLM-emitted URLs could use `javascript:`, `data:`, or
+// other non-navigational schemes to execute script in the app origin. Restrict
+// both `open_url` actions and `Image` src to http/https/mailto.
+const SAFE_URL_SCHEMES = ["http:", "https:", "mailto:"] as const;
+function isSafeUrl(url: string): boolean {
+  try {
+    const scheme = new URL(url, window.location.origin).protocol.toLowerCase();
+    return (SAFE_URL_SCHEMES as readonly string[]).includes(scheme);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Hook returning an action dispatcher tied to the current session.
  * A2UI blocks only appear inside session-scoped pages, so the session context
@@ -121,7 +134,11 @@ function useActionDispatch(): (action: A2UIAction) => void {
     if (!action || typeof action !== "object") return;
     if (action.type === "message" && typeof action.text === "string" && sessionId) {
       ctx.sendMessage.mutate({ sessionId, content: action.text });
-    } else if (action.type === "open_url" && typeof action.url === "string") {
+    } else if (
+      action.type === "open_url" &&
+      typeof action.url === "string" &&
+      isSafeUrl(action.url)
+    ) {
       window.open(action.url, "_blank", "noopener,noreferrer");
     }
   };
@@ -323,7 +340,7 @@ function renderNode(
 
     case "Image": {
       const src = str(props.src);
-      if (!src) return null;
+      if (!src || !isSafeUrl(src)) return null;
       const caption = optStr(props.caption);
       return (
         <figure key={key} className="flex flex-col gap-1">

--- a/apps/ui/src/components/chat/message-content.tsx
+++ b/apps/ui/src/components/chat/message-content.tsx
@@ -1,33 +1,36 @@
 "use client";
 
 /**
- * MessageContent - Renders message text with inline OpenUI blocks.
+ * MessageContent — renders message text with inline generative-UI blocks.
  *
- * Splits message text on ```openui fenced code blocks and renders
- * alternating StreamdownMessage (markdown) and OpenUIBlock segments.
- * Falls back to pure markdown when no openui blocks are present.
+ * Splits message text on both ```openui and ```a2ui fenced code blocks and
+ * renders each segment with its matching renderer. Markdown segments render
+ * via StreamdownMessage. Falls back to pure markdown when no UI blocks are
+ * present.
  *
  * @see specs/openui.md
+ * @see specs/a2ui.md
  */
 
-import { splitOpenUIBlocks, hasOpenUIBlocks } from "@/lib/openui-utils";
+import { hasA2UIBlocks, splitA2UIBlocks } from "@/lib/a2ui-utils";
 import { StreamdownMessage } from "@/components/chat/streamdown-message";
 import { OpenUIBlock } from "@/components/chat/openui-renderer";
+import { A2UIBlock } from "@/components/chat/a2ui-renderer";
 
 interface MessageContentProps {
-  /** Raw message text (may contain ```openui blocks) */
+  /** Raw message text (may contain ```openui or ```a2ui blocks) */
   text: string;
   /** Whether content is actively streaming */
   isStreaming?: boolean;
 }
 
 /**
- * Renders message text, splitting OpenUI code blocks into rendered UI
+ * Renders message text, splitting generative-UI code blocks into rendered UI
  * and surrounding markdown into Streamdown-rendered text.
  */
 export function MessageContent({ text, isStreaming = false }: MessageContentProps) {
-  // Fast path: no openui blocks → pure markdown
-  if (!hasOpenUIBlocks(text)) {
+  // Fast path: no generative-UI blocks → pure markdown.
+  if (!hasA2UIBlocks(text)) {
     return (
       <StreamdownMessage variant="inline" className="text-foreground">
         {text}
@@ -35,14 +38,18 @@ export function MessageContent({ text, isStreaming = false }: MessageContentProp
     );
   }
 
-  const segments = splitOpenUIBlocks(text);
+  const segments = splitA2UIBlocks(text);
 
   return (
     <div className="space-y-2">
-      {segments.map((segment, i) =>
-        segment.type === "openui" ? (
-          <OpenUIBlock key={i} code={segment.content} isStreaming={isStreaming} />
-        ) : (
+      {segments.map((segment, i) => {
+        if (segment.type === "openui") {
+          return <OpenUIBlock key={i} code={segment.content} isStreaming={isStreaming} />;
+        }
+        if (segment.type === "a2ui") {
+          return <A2UIBlock key={i} code={segment.content} isStreaming={isStreaming} />;
+        }
+        return (
           <StreamdownMessage
             key={i}
             variant="inline"
@@ -51,8 +58,8 @@ export function MessageContent({ text, isStreaming = false }: MessageContentProp
           >
             {segment.content}
           </StreamdownMessage>
-        ),
-      )}
+        );
+      })}
     </div>
   );
 }

--- a/apps/ui/src/lib/a2ui-utils.ts
+++ b/apps/ui/src/lib/a2ui-utils.ts
@@ -67,17 +67,19 @@ export function hasA2UIBlocks(text: string): boolean {
   return /```(?:a2ui|openui)\s*\n/.test(text);
 }
 
-/** True if `text` contains at least one ```a2ui fence. */
+/** True if `text` contains at least one ```a2ui fence and no ```openui fences. */
 export function hasOnlyA2UIBlocks(text: string): boolean {
-  return /```a2ui\s*\n/.test(text);
+  return /```a2ui\s*\n/.test(text) && !/```openui\s*\n/.test(text);
 }
 
 /**
  * Parse an A2UI JSON block with fault tolerance.
  *
  * Attempts JSON.parse first. If that fails (e.g. the block is still streaming
- * and has a trailing unterminated string), tries progressively shorter
- * prefixes to recover a partial tree. Returns `null` if no prefix parses.
+ * and has a trailing unterminated string), falls back to a single best-effort
+ * recovery pass (`tryPartialParse`) that truncates to the last syntactically
+ * safe position and auto-closes unbalanced brackets. Returns `null` if the
+ * recovery attempt also fails.
  */
 export function parseA2UI(code: string): unknown {
   const trimmed = code.trim();

--- a/apps/ui/src/lib/a2ui-utils.ts
+++ b/apps/ui/src/lib/a2ui-utils.ts
@@ -1,0 +1,173 @@
+/**
+ * A2UI utilities for detecting and splitting A2UI JSON code blocks from
+ * markdown text in chat messages.
+ *
+ * A2UI JSON is wrapped in ```a2ui fenced code blocks by the LLM when the
+ * `a2ui` capability is enabled. This module splits message text into
+ * alternating markdown, openui, and a2ui segments so the renderer can
+ * dispatch each to its own component.
+ *
+ * @see specs/a2ui.md
+ */
+
+export type A2UISegmentKind = "markdown" | "openui" | "a2ui";
+
+export interface A2UIMessageSegment {
+  type: A2UISegmentKind;
+  content: string;
+}
+
+/**
+ * Regex matching ```a2ui ... ``` and ```openui ... ``` fenced code blocks.
+ * Captures the fence kind in group 1 and the content in group 2.
+ * Unclosed blocks at end-of-string are captured so streaming output renders
+ * progressively.
+ */
+const BLOCK_RE = /```(a2ui|openui)\s*\n([\s\S]*?)(?:```|$)/g;
+
+/**
+ * Split message text into alternating markdown / openui / a2ui segments.
+ *
+ * Fast path: if no fenced blocks are present, the whole text is returned as
+ * a single markdown segment.
+ */
+export function splitA2UIBlocks(text: string): A2UIMessageSegment[] {
+  const segments: A2UIMessageSegment[] = [];
+  let lastIndex = 0;
+
+  BLOCK_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = BLOCK_RE.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      const md = text.slice(lastIndex, match.index);
+      if (md.trim()) segments.push({ type: "markdown", content: md });
+    }
+
+    const kind = match[1] as "a2ui" | "openui";
+    const content = match[2];
+    if (content.trim()) segments.push({ type: kind, content });
+
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    const trailing = text.slice(lastIndex);
+    if (trailing.trim()) segments.push({ type: "markdown", content: trailing });
+  }
+
+  if (segments.length === 0 && text.trim()) {
+    segments.push({ type: "markdown", content: text });
+  }
+
+  return segments;
+}
+
+/** True if `text` contains any generative-UI fenced code blocks. */
+export function hasA2UIBlocks(text: string): boolean {
+  return /```(?:a2ui|openui)\s*\n/.test(text);
+}
+
+/** True if `text` contains at least one ```a2ui fence. */
+export function hasOnlyA2UIBlocks(text: string): boolean {
+  return /```a2ui\s*\n/.test(text);
+}
+
+/**
+ * Parse an A2UI JSON block with fault tolerance.
+ *
+ * Attempts JSON.parse first. If that fails (e.g. the block is still streaming
+ * and has a trailing unterminated string), tries progressively shorter
+ * prefixes to recover a partial tree. Returns `null` if no prefix parses.
+ */
+export function parseA2UI(code: string): unknown {
+  const trimmed = code.trim();
+  if (!trimmed) return null;
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    // Attempt progressive truncation for streaming tolerance.
+    return tryPartialParse(trimmed);
+  }
+}
+
+/**
+ * Try to recover a parseable JSON prefix by closing unbalanced brackets.
+ * This is best-effort: if it cannot produce valid JSON, returns null.
+ */
+function tryPartialParse(text: string): unknown {
+  // Walk the text tracking brackets + string state; emit a "closed" version
+  // by padding the right number of close brackets.
+  let inString = false;
+  let escape = false;
+  const stack: Array<"{" | "["> = [];
+  let lastSafeIndex = -1;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (ch === "\\") {
+      if (inString) escape = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      if (!inString) lastSafeIndex = i;
+      continue;
+    }
+    if (inString) continue;
+
+    if (ch === "{" || ch === "[") {
+      stack.push(ch);
+    } else if (ch === "}" || ch === "]") {
+      stack.pop();
+      lastSafeIndex = i;
+    } else if (!/\s/.test(ch) && stack.length === 0) {
+      // After the top-level object closes, anything else is garbage.
+      break;
+    } else if (stack.length > 0) {
+      lastSafeIndex = i;
+    }
+  }
+
+  if (lastSafeIndex < 0) return null;
+
+  // Truncate to last safe point and close remaining brackets.
+  let truncated = text.slice(0, lastSafeIndex + 1);
+
+  // If we stopped mid-key/value (e.g. "foo": ), strip trailing comma/colon.
+  truncated = truncated.replace(/[,:\s]+$/, "");
+
+  // Re-scan truncated to recount open brackets.
+  const closes: string[] = [];
+  let inStr = false;
+  let esc = false;
+  for (const ch of truncated) {
+    if (esc) {
+      esc = false;
+      continue;
+    }
+    if (ch === "\\") {
+      if (inStr) esc = true;
+      continue;
+    }
+    if (ch === '"') {
+      inStr = !inStr;
+      continue;
+    }
+    if (inStr) continue;
+    if (ch === "{") closes.push("}");
+    else if (ch === "[") closes.push("]");
+    else if (ch === "}" || ch === "]") closes.pop();
+  }
+
+  const candidate = truncated + closes.reverse().join("");
+  try {
+    return JSON.parse(candidate);
+  } catch {
+    return null;
+  }
+}

--- a/crates/a2ui/Cargo.toml
+++ b/crates/a2ui/Cargo.toml
@@ -1,0 +1,19 @@
+# A2UI Component Catalog and Prompt Generator
+#
+# Decision: Separate crate from core — mirrors crates/openui/ and reusable elsewhere.
+# Decision: Static catalog definitions (no runtime validation) — we only need prompt text.
+# Decision: JSON wire format (not a DSL) — A2UI spec is JSON, enabling cross-framework renderers.
+# Ref: specs/a2ui.md
+# Ref: https://github.com/google/a2ui
+
+[package]
+name = "everruns-a2ui"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "A2UI component catalog and prompt generator for Everruns"
+
+[dependencies]
+
+[dev-dependencies]

--- a/crates/a2ui/src/catalog.rs
+++ b/crates/a2ui/src/catalog.rs
@@ -1,0 +1,79 @@
+//! A2UI Catalog and Category Definitions
+//!
+//! A Catalog is the agent-facing description of which components are available.
+//! Categories group components for readable prompt output.
+
+use crate::components::ComponentDef;
+
+/// One category of components in a catalog (e.g. "Layout", "Forms").
+pub struct ComponentCategory {
+    pub name: &'static str,
+    pub components: Vec<&'static str>,
+    /// Notes rendered after the category's component signatures.
+    pub notes: Vec<&'static str>,
+}
+
+/// A catalog describes the components an agent may emit.
+pub struct Catalog {
+    /// Hint for the recommended root component (typically "Card").
+    pub root_hint: &'static str,
+    pub components: Vec<ComponentDef>,
+    pub categories: Vec<ComponentCategory>,
+}
+
+/// Default category grouping for the built-in catalog.
+pub fn default_categories() -> Vec<ComponentCategory> {
+    vec![
+        ComponentCategory {
+            name: "Layout",
+            components: vec!["Card", "Stack", "Separator"],
+            notes: vec![],
+        },
+        ComponentCategory {
+            name: "Content",
+            components: vec!["Heading", "Text", "Callout", "Badge", "Image", "CodeBlock"],
+            notes: vec![],
+        },
+        ComponentCategory {
+            name: "Data",
+            components: vec!["List", "ListItem", "Table"],
+            notes: vec![],
+        },
+        ComponentCategory {
+            name: "Forms",
+            components: vec!["Form", "TextField", "Textarea", "Select", "Checkbox"],
+            notes: vec![
+                "Form submission posts a chat message (see `submitMessage`). \
+                 Form round-trips with typed responses are not yet supported.",
+            ],
+        },
+        ComponentCategory {
+            name: "Actions",
+            components: vec!["Button", "ButtonGroup"],
+            notes: vec![],
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn categories_have_no_duplicates() {
+        let mut seen = HashSet::new();
+        for cat in default_categories() {
+            for c in cat.components {
+                assert!(seen.insert(c), "duplicate component across categories: {c}");
+            }
+        }
+    }
+
+    #[test]
+    fn categories_non_empty() {
+        for cat in default_categories() {
+            assert!(!cat.components.is_empty(), "empty category: {}", cat.name);
+        }
+    }
+}

--- a/crates/a2ui/src/components.rs
+++ b/crates/a2ui/src/components.rs
@@ -1,0 +1,559 @@
+//! A2UI Component Definitions
+//!
+//! Static catalog of components the agent may emit. Each component maps to a
+//! React component in the UI renderer (apps/ui/src/components/chat/a2ui-renderer.tsx)
+//! and exposes a set of typed props.
+//!
+//! The prompt generator turns these definitions into textual signatures that
+//! teach the LLM what JSON to produce.
+
+/// One prop of a component.
+pub struct PropDef {
+    /// Prop name as it appears in the JSON `props` object.
+    pub name: &'static str,
+    /// Type annotation shown in the prompt signature.
+    pub type_annotation: &'static str,
+    /// Whether this prop is optional.
+    pub optional: bool,
+    /// Short prop description (optional; "" suppresses).
+    pub description: &'static str,
+}
+
+/// One component available to the agent.
+pub struct ComponentDef {
+    /// Component name (PascalCase) used as the `type` field in JSON.
+    pub name: &'static str,
+    /// Ordered list of props.
+    pub props: &'static [PropDef],
+    /// Whether the component accepts a `children` array of nested nodes.
+    pub has_children: bool,
+    /// Human-readable description.
+    pub description: &'static str,
+}
+
+/// All components in the default A2UI catalog.
+///
+/// Keep this catalog small and cross-platform friendly. Teams can add their own
+/// components in a forked catalog per spec v0.9's prompt-first design.
+#[allow(clippy::vec_init_then_push)]
+pub fn all_components() -> Vec<ComponentDef> {
+    let mut v = Vec::new();
+
+    // ---------- Layout ----------
+    v.push(ComponentDef {
+        name: "Stack",
+        props: &[
+            PropDef {
+                name: "direction",
+                type_annotation: "\"row\" | \"column\"",
+                optional: true,
+                description: "default column",
+            },
+            PropDef {
+                name: "gap",
+                type_annotation: "\"none\" | \"sm\" | \"md\" | \"lg\"",
+                optional: true,
+                description: "default md",
+            },
+            PropDef {
+                name: "align",
+                type_annotation: "\"start\" | \"center\" | \"end\" | \"stretch\"",
+                optional: true,
+                description: "",
+            },
+        ],
+        has_children: true,
+        description: "Flex container for stacking children vertically or horizontally.",
+    });
+
+    v.push(ComponentDef {
+        name: "Card",
+        props: &[PropDef {
+            name: "variant",
+            type_annotation: "\"default\" | \"muted\"",
+            optional: true,
+            description: "",
+        }],
+        has_children: true,
+        description: "Bordered container with padding. Preferred root for most responses.",
+    });
+
+    v.push(ComponentDef {
+        name: "Separator",
+        props: &[],
+        has_children: false,
+        description: "Horizontal divider line.",
+    });
+
+    // ---------- Content ----------
+    v.push(ComponentDef {
+        name: "Heading",
+        props: &[
+            PropDef {
+                name: "text",
+                type_annotation: "string",
+                optional: false,
+                description: "",
+            },
+            PropDef {
+                name: "level",
+                type_annotation: "1 | 2 | 3 | 4",
+                optional: true,
+                description: "default 3",
+            },
+        ],
+        has_children: false,
+        description: "Section heading.",
+    });
+
+    v.push(ComponentDef {
+        name: "Text",
+        props: &[
+            PropDef {
+                name: "text",
+                type_annotation: "string",
+                optional: false,
+                description: "Supports markdown inline.",
+            },
+            PropDef {
+                name: "tone",
+                type_annotation: "\"default\" | \"muted\"",
+                optional: true,
+                description: "",
+            },
+        ],
+        has_children: false,
+        description: "Paragraph of text.",
+    });
+
+    v.push(ComponentDef {
+        name: "Callout",
+        props: &[
+            PropDef {
+                name: "text",
+                type_annotation: "string",
+                optional: false,
+                description: "",
+            },
+            PropDef {
+                name: "variant",
+                type_annotation: "\"info\" | \"success\" | \"warning\" | \"error\"",
+                optional: true,
+                description: "default info",
+            },
+            PropDef {
+                name: "title",
+                type_annotation: "string",
+                optional: true,
+                description: "",
+            },
+        ],
+        has_children: false,
+        description: "Highlighted notice block.",
+    });
+
+    v.push(ComponentDef {
+        name: "Badge",
+        props: &[
+            PropDef {
+                name: "label",
+                type_annotation: "string",
+                optional: false,
+                description: "",
+            },
+            PropDef {
+                name: "variant",
+                type_annotation: "\"default\" | \"success\" | \"warning\" | \"error\"",
+                optional: true,
+                description: "",
+            },
+        ],
+        has_children: false,
+        description: "Compact tag/badge.",
+    });
+
+    v.push(ComponentDef {
+        name: "Image",
+        props: &[
+            PropDef {
+                name: "src",
+                type_annotation: "string",
+                optional: false,
+                description: "URL",
+            },
+            PropDef {
+                name: "alt",
+                type_annotation: "string",
+                optional: true,
+                description: "",
+            },
+            PropDef {
+                name: "caption",
+                type_annotation: "string",
+                optional: true,
+                description: "",
+            },
+        ],
+        has_children: false,
+        description: "Image with optional caption.",
+    });
+
+    v.push(ComponentDef {
+        name: "CodeBlock",
+        props: &[
+            PropDef {
+                name: "code",
+                type_annotation: "string",
+                optional: false,
+                description: "",
+            },
+            PropDef {
+                name: "language",
+                type_annotation: "string",
+                optional: true,
+                description: "",
+            },
+        ],
+        has_children: false,
+        description: "Monospaced code block.",
+    });
+
+    // ---------- Data ----------
+    v.push(ComponentDef {
+        name: "List",
+        props: &[PropDef {
+            name: "ordered",
+            type_annotation: "boolean",
+            optional: true,
+            description: "default false",
+        }],
+        has_children: true,
+        description: "List of ListItem children.",
+    });
+
+    v.push(ComponentDef {
+        name: "ListItem",
+        props: &[
+            PropDef {
+                name: "title",
+                type_annotation: "string",
+                optional: false,
+                description: "",
+            },
+            PropDef {
+                name: "value",
+                type_annotation: "string",
+                optional: true,
+                description: "Secondary right-aligned text.",
+            },
+            PropDef {
+                name: "description",
+                type_annotation: "string",
+                optional: true,
+                description: "",
+            },
+        ],
+        has_children: false,
+        description: "One list entry.",
+    });
+
+    v.push(ComponentDef {
+        name: "Table",
+        props: &[
+            PropDef {
+                name: "columns",
+                type_annotation: "string[]",
+                optional: false,
+                description: "Column header labels.",
+            },
+            PropDef {
+                name: "rows",
+                type_annotation: "(string | number | boolean)[][]",
+                optional: false,
+                description: "Row-major cell data.",
+            },
+        ],
+        has_children: false,
+        description: "Tabular data.",
+    });
+
+    // ---------- Forms ----------
+    v.push(ComponentDef {
+        name: "Form",
+        props: &[
+            PropDef {
+                name: "name",
+                type_annotation: "string",
+                optional: false,
+                description: "Form identifier.",
+            },
+            PropDef {
+                name: "submitLabel",
+                type_annotation: "string",
+                optional: true,
+                description: "default \"Submit\"",
+            },
+            PropDef {
+                name: "submitMessage",
+                type_annotation: "string",
+                optional: true,
+                description: "Chat message to send on submit. Default: \"Submitted {name} form\".",
+            },
+        ],
+        has_children: true,
+        description: "Form wrapping field children and a submit button. Submission sends a chat message summarizing field values.",
+    });
+
+    v.push(ComponentDef {
+        name: "TextField",
+        props: &[
+            PropDef {
+                name: "name",
+                type_annotation: "string",
+                optional: false,
+                description: "",
+            },
+            PropDef {
+                name: "label",
+                type_annotation: "string",
+                optional: true,
+                description: "",
+            },
+            PropDef {
+                name: "placeholder",
+                type_annotation: "string",
+                optional: true,
+                description: "",
+            },
+            PropDef {
+                name: "defaultValue",
+                type_annotation: "string",
+                optional: true,
+                description: "",
+            },
+            PropDef {
+                name: "required",
+                type_annotation: "boolean",
+                optional: true,
+                description: "",
+            },
+        ],
+        has_children: false,
+        description: "Single-line text input.",
+    });
+
+    v.push(ComponentDef {
+        name: "Textarea",
+        props: &[
+            PropDef {
+                name: "name",
+                type_annotation: "string",
+                optional: false,
+                description: "",
+            },
+            PropDef {
+                name: "label",
+                type_annotation: "string",
+                optional: true,
+                description: "",
+            },
+            PropDef {
+                name: "placeholder",
+                type_annotation: "string",
+                optional: true,
+                description: "",
+            },
+            PropDef {
+                name: "defaultValue",
+                type_annotation: "string",
+                optional: true,
+                description: "",
+            },
+            PropDef {
+                name: "rows",
+                type_annotation: "number",
+                optional: true,
+                description: "",
+            },
+        ],
+        has_children: false,
+        description: "Multi-line text input.",
+    });
+
+    v.push(ComponentDef {
+        name: "Select",
+        props: &[
+            PropDef {
+                name: "name",
+                type_annotation: "string",
+                optional: false,
+                description: "",
+            },
+            PropDef {
+                name: "label",
+                type_annotation: "string",
+                optional: true,
+                description: "",
+            },
+            PropDef {
+                name: "options",
+                type_annotation: "{ label: string, value: string }[]",
+                optional: false,
+                description: "",
+            },
+            PropDef {
+                name: "defaultValue",
+                type_annotation: "string",
+                optional: true,
+                description: "",
+            },
+        ],
+        has_children: false,
+        description: "Dropdown select.",
+    });
+
+    v.push(ComponentDef {
+        name: "Checkbox",
+        props: &[
+            PropDef {
+                name: "name",
+                type_annotation: "string",
+                optional: false,
+                description: "",
+            },
+            PropDef {
+                name: "label",
+                type_annotation: "string",
+                optional: false,
+                description: "",
+            },
+            PropDef {
+                name: "defaultChecked",
+                type_annotation: "boolean",
+                optional: true,
+                description: "",
+            },
+        ],
+        has_children: false,
+        description: "Single checkbox. Submitted as boolean.",
+    });
+
+    // ---------- Actions ----------
+    v.push(ComponentDef {
+        name: "Button",
+        props: &[
+            PropDef {
+                name: "label",
+                type_annotation: "string",
+                optional: false,
+                description: "",
+            },
+            PropDef {
+                name: "action",
+                type_annotation: "Action",
+                optional: true,
+                description: "See Actions section. Omit for non-interactive buttons.",
+            },
+            PropDef {
+                name: "variant",
+                type_annotation: "\"primary\" | \"secondary\" | \"ghost\" | \"destructive\"",
+                optional: true,
+                description: "default primary",
+            },
+        ],
+        has_children: false,
+        description: "Clickable button with optional action.",
+    });
+
+    v.push(ComponentDef {
+        name: "ButtonGroup",
+        props: &[PropDef {
+            name: "align",
+            type_annotation: "\"start\" | \"center\" | \"end\"",
+            optional: true,
+            description: "default start",
+        }],
+        has_children: true,
+        description: "Row of Button children.",
+    });
+
+    v
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn components_have_pascal_case_names() {
+        for c in all_components() {
+            assert!(
+                c.name.chars().next().unwrap().is_ascii_uppercase(),
+                "not PascalCase: {}",
+                c.name
+            );
+        }
+    }
+
+    #[test]
+    fn component_names_unique() {
+        let mut seen = HashSet::new();
+        for c in all_components() {
+            assert!(seen.insert(c.name), "duplicate: {}", c.name);
+        }
+    }
+
+    #[test]
+    fn all_components_have_descriptions() {
+        for c in all_components() {
+            assert!(!c.description.is_empty(), "empty description: {}", c.name);
+        }
+    }
+
+    #[test]
+    fn props_have_non_empty_type_annotations() {
+        for c in all_components() {
+            for p in c.props {
+                assert!(
+                    !p.type_annotation.is_empty(),
+                    "empty type annotation: {}.{}",
+                    c.name,
+                    p.name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn button_has_action_prop() {
+        let comps = all_components();
+        let b = comps.iter().find(|c| c.name == "Button").unwrap();
+        assert!(b.props.iter().any(|p| p.name == "action"));
+    }
+
+    #[test]
+    fn container_components_have_children() {
+        let comps = all_components();
+        for name in ["Card", "Stack", "List", "ButtonGroup", "Form"] {
+            let c = comps.iter().find(|c| c.name == name).unwrap();
+            assert!(c.has_children, "{name} should have children");
+        }
+    }
+
+    #[test]
+    fn leaf_components_have_no_children() {
+        let comps = all_components();
+        for name in [
+            "Heading",
+            "Text",
+            "Badge",
+            "Button",
+            "TextField",
+            "Checkbox",
+        ] {
+            let c = comps.iter().find(|c| c.name == name).unwrap();
+            assert!(!c.has_children, "{name} should not have children");
+        }
+    }
+}

--- a/crates/a2ui/src/components.rs
+++ b/crates/a2ui/src/components.rs
@@ -113,7 +113,7 @@ pub fn all_components() -> Vec<ComponentDef> {
                 name: "text",
                 type_annotation: "string",
                 optional: false,
-                description: "Supports markdown inline.",
+                description: "",
             },
             PropDef {
                 name: "tone",

--- a/crates/a2ui/src/lib.rs
+++ b/crates/a2ui/src/lib.rs
@@ -1,0 +1,133 @@
+//! A2UI Component Catalog and Prompt Generator
+//!
+//! Produces system prompts that instruct LLMs to emit A2UI JSON component trees.
+//! The JSON is transported in ```a2ui fenced code blocks and rendered by the UI
+//! using native shadcn/ui primitives.
+//!
+//! Ref: specs/a2ui.md
+//! Ref: https://github.com/google/a2ui
+
+mod catalog;
+mod components;
+mod prompt;
+
+pub use catalog::{Catalog, ComponentCategory};
+pub use components::{ComponentDef, PropDef};
+pub use prompt::{PromptOptions, generate_prompt};
+
+use std::sync::LazyLock;
+
+/// The default A2UI catalog.
+pub fn default_catalog() -> &'static Catalog {
+    &DEFAULT_CATALOG
+}
+
+static DEFAULT_CATALOG: LazyLock<Catalog> = LazyLock::new(|| Catalog {
+    root_hint: "Card",
+    components: components::all_components(),
+    categories: catalog::default_categories(),
+});
+
+/// Generate the default A2UI system prompt with standard options.
+pub fn default_prompt() -> &'static str {
+    &DEFAULT_PROMPT
+}
+
+static DEFAULT_PROMPT: LazyLock<String> =
+    LazyLock::new(|| generate_prompt(default_catalog(), &PromptOptions::default()));
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_catalog_has_components() {
+        let cat = default_catalog();
+        assert!(!cat.components.is_empty());
+    }
+
+    #[test]
+    fn default_catalog_contains_core_components() {
+        let cat = default_catalog();
+        let names: Vec<&str> = cat.components.iter().map(|c| c.name).collect();
+        for expected in [
+            "Card",
+            "Stack",
+            "Heading",
+            "Text",
+            "Button",
+            "ButtonGroup",
+            "List",
+            "ListItem",
+            "Table",
+            "Form",
+            "TextField",
+            "Select",
+            "Checkbox",
+            "Callout",
+            "Badge",
+        ] {
+            assert!(names.contains(&expected), "missing component: {expected}");
+        }
+    }
+
+    #[test]
+    fn default_prompt_is_substantial() {
+        let prompt = default_prompt();
+        assert!(
+            prompt.len() > 800,
+            "prompt too short: {} chars",
+            prompt.len()
+        );
+    }
+
+    #[test]
+    fn default_prompt_mentions_a2ui_fence() {
+        assert!(default_prompt().contains("```a2ui"));
+    }
+
+    #[test]
+    fn default_prompt_mentions_json_shape() {
+        let prompt = default_prompt();
+        assert!(prompt.contains("\"type\""));
+        assert!(prompt.contains("\"props\""));
+        assert!(prompt.contains("\"children\""));
+    }
+
+    #[test]
+    fn default_prompt_lists_every_component() {
+        let cat = default_catalog();
+        let prompt = default_prompt();
+        for comp in &cat.components {
+            assert!(
+                prompt.contains(comp.name),
+                "prompt missing component {}",
+                comp.name
+            );
+        }
+    }
+
+    #[test]
+    fn default_prompt_includes_action_types() {
+        let prompt = default_prompt();
+        assert!(prompt.contains("\"message\""));
+        assert!(prompt.contains("\"open_url\""));
+    }
+
+    #[test]
+    fn categories_cover_all_components() {
+        let cat = default_catalog();
+        let grouped: std::collections::HashSet<&str> = cat
+            .categories
+            .iter()
+            .flat_map(|g| g.components.iter().copied())
+            .collect();
+        for comp in &cat.components {
+            assert!(
+                grouped.contains(comp.name),
+                "component '{}' not in any category",
+                comp.name
+            );
+        }
+    }
+}

--- a/crates/a2ui/src/prompt.rs
+++ b/crates/a2ui/src/prompt.rs
@@ -1,0 +1,339 @@
+//! A2UI System Prompt Generator
+//!
+//! Generates the prompt that teaches the LLM how to emit A2UI JSON component
+//! trees inside ```a2ui fenced code blocks.
+
+use std::collections::HashMap;
+
+use crate::catalog::Catalog;
+use crate::components::ComponentDef;
+
+/// Options for customizing the generated prompt.
+#[derive(Default)]
+pub struct PromptOptions {
+    /// Replaces the default preamble text.
+    pub preamble: Option<String>,
+    /// Extra rules appended after the standard rules section.
+    pub additional_rules: Vec<String>,
+    /// Example ```a2ui blocks rendered into an Examples section.
+    pub examples: Vec<String>,
+}
+
+const PREAMBLE: &str = "You are an AI assistant with access to A2UI, an open generative-UI protocol. \
+When the user asks for visual content (summaries, dashboards, lists, forms, action buttons, etc.), \
+respond with a declarative UI tree as JSON wrapped in a ```a2ui fenced code block. \
+You may include plain markdown before and/or after the block.";
+
+fn schema_rules() -> &'static str {
+    r#"## Schema
+Every node is a JSON object with this shape:
+```
+{ "type": "ComponentName", "props": { ... }, "children": [ ... ] }
+```
+- `type` (required): one of the component names below. Emit `type` verbatim (PascalCase).
+- `props` (optional): object whose keys must match the component's declared props. Omit props you do not need.
+- `children` (optional): array of nested nodes. Only emit `children` on components that declare it.
+- Unknown components, props, or enum values are ignored by the renderer. Stay within the catalog."#
+}
+
+fn actions_section() -> &'static str {
+    r#"## Actions
+Some props (e.g. `Button.action`) accept an Action object. Supported actions:
+- `{ "type": "message", "text": string }` — sends `text` as a new chat message from the user.
+- `{ "type": "open_url", "url": string }` — opens `url` in a new tab.
+Omit the `action` prop for decorative buttons."#
+}
+
+fn streaming_rules(root_hint: &str) -> String {
+    format!(
+        r#"## Streaming
+Output is re-parsed as it streams. To render the shell fast:
+1. Emit the outer `{root_hint}` object first.
+2. Emit top-level children before their deep content.
+3. Emit leaf `props` like long strings last.
+Partial trees render progressively; keep the JSON syntactically valid as you go."#
+    )
+}
+
+fn important_rules(root_hint: &str) -> String {
+    format!(
+        r#"## Rules
+- Start with a single top-level node (usually `{root_hint}`). Do not wrap it in an array.
+- Only use components and props listed in the catalog.
+- Prefer `List`/`Table` over repeated handcrafted rows.
+- Keep trees small and focused — one A2UI block per idea.
+- Use action buttons to suggest follow-up questions or URLs, not to execute backend work.
+- You may mix markdown text before and after the block. Do NOT put markdown inside the JSON.
+- Always close the ```a2ui fence with ``` on its own line."#
+    )
+}
+
+fn build_component_line(component: &ComponentDef) -> String {
+    let mut params: Vec<String> = component
+        .props
+        .iter()
+        .map(|p| {
+            let head = if p.optional {
+                format!("{}?: {}", p.name, p.type_annotation)
+            } else {
+                format!("{}: {}", p.name, p.type_annotation)
+            };
+            if p.description.is_empty() {
+                head
+            } else {
+                format!("{head} ({})", p.description)
+            }
+        })
+        .collect();
+
+    if component.has_children {
+        params.push("children?: Node[]".to_string());
+    }
+
+    let sig = format!("{}({})", component.name, params.join(", "));
+
+    if component.description.is_empty() {
+        sig
+    } else {
+        format!("{sig} — {}", component.description)
+    }
+}
+
+fn generate_catalog_section(catalog: &Catalog) -> String {
+    let mut lines = vec![
+        "## Catalog".to_string(),
+        String::new(),
+        "Each signature shows the component's props and whether it accepts children. \
+         `?` marks optional props."
+            .to_string(),
+    ];
+
+    let comp_map: HashMap<&str, &ComponentDef> =
+        catalog.components.iter().map(|c| (c.name, c)).collect();
+
+    let mut covered = std::collections::HashSet::new();
+
+    for cat in &catalog.categories {
+        lines.push(String::new());
+        lines.push(format!("### {}", cat.name));
+        for name in &cat.components {
+            if covered.contains(name) {
+                continue;
+            }
+            if let Some(comp) = comp_map.get(name) {
+                covered.insert(*name);
+                lines.push(build_component_line(comp));
+            }
+        }
+        for note in &cat.notes {
+            lines.push(note.to_string());
+        }
+    }
+
+    // Ungrouped components (shouldn't happen, but included for robustness).
+    let ungrouped: Vec<&ComponentDef> = catalog
+        .components
+        .iter()
+        .filter(|c| !covered.contains(c.name))
+        .collect();
+    if !ungrouped.is_empty() {
+        lines.push(String::new());
+        lines.push("### Other".to_string());
+        for comp in ungrouped {
+            lines.push(build_component_line(comp));
+        }
+    }
+
+    lines.join("\n")
+}
+
+/// Build the full A2UI system prompt.
+#[allow(clippy::vec_init_then_push)]
+pub fn generate_prompt(catalog: &Catalog, options: &PromptOptions) -> String {
+    let mut parts = Vec::new();
+
+    parts.push(options.preamble.as_deref().unwrap_or(PREAMBLE).to_string());
+    parts.push(String::new());
+
+    parts.push(schema_rules().to_string());
+    parts.push(String::new());
+
+    parts.push(generate_catalog_section(catalog));
+    parts.push(String::new());
+
+    parts.push(actions_section().to_string());
+    parts.push(String::new());
+
+    parts.push(streaming_rules(catalog.root_hint));
+    parts.push(String::new());
+
+    parts.push(important_rules(catalog.root_hint));
+
+    if !options.examples.is_empty() {
+        parts.push(String::new());
+        parts.push("## Examples".to_string());
+        for ex in &options.examples {
+            parts.push(String::new());
+            parts.push(ex.clone());
+        }
+    }
+
+    if !options.additional_rules.is_empty() {
+        parts.push(String::new());
+        for rule in &options.additional_rules {
+            parts.push(format!("- {rule}"));
+        }
+    }
+
+    parts.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::catalog::ComponentCategory;
+    use crate::components::PropDef;
+
+    fn fixture() -> Catalog {
+        Catalog {
+            root_hint: "Card",
+            components: vec![
+                ComponentDef {
+                    name: "Card",
+                    props: &[],
+                    has_children: true,
+                    description: "Bordered container.",
+                },
+                ComponentDef {
+                    name: "Heading",
+                    props: &[
+                        PropDef {
+                            name: "text",
+                            type_annotation: "string",
+                            optional: false,
+                            description: "",
+                        },
+                        PropDef {
+                            name: "level",
+                            type_annotation: "1 | 2 | 3",
+                            optional: true,
+                            description: "default 3",
+                        },
+                    ],
+                    has_children: false,
+                    description: "Section heading.",
+                },
+            ],
+            categories: vec![ComponentCategory {
+                name: "Layout",
+                components: vec!["Card", "Heading"],
+                notes: vec!["Prefer Card as the root."],
+            }],
+        }
+    }
+
+    #[test]
+    fn prompt_contains_preamble_and_fence() {
+        let p = generate_prompt(&fixture(), &PromptOptions::default());
+        assert!(p.contains("A2UI"));
+        assert!(p.contains("```a2ui"));
+    }
+
+    #[test]
+    fn prompt_contains_schema() {
+        let p = generate_prompt(&fixture(), &PromptOptions::default());
+        assert!(p.contains("## Schema"));
+        assert!(p.contains("\"type\""));
+        assert!(p.contains("\"children\""));
+    }
+
+    #[test]
+    fn prompt_contains_actions() {
+        let p = generate_prompt(&fixture(), &PromptOptions::default());
+        assert!(p.contains("## Actions"));
+        assert!(p.contains("\"message\""));
+        assert!(p.contains("\"open_url\""));
+    }
+
+    #[test]
+    fn component_line_optional_prop() {
+        let comp = ComponentDef {
+            name: "Heading",
+            props: &[
+                PropDef {
+                    name: "text",
+                    type_annotation: "string",
+                    optional: false,
+                    description: "",
+                },
+                PropDef {
+                    name: "level",
+                    type_annotation: "1 | 2 | 3",
+                    optional: true,
+                    description: "",
+                },
+            ],
+            has_children: false,
+            description: "Section heading.",
+        };
+        let line = build_component_line(&comp);
+        assert_eq!(
+            line,
+            "Heading(text: string, level?: 1 | 2 | 3) — Section heading."
+        );
+    }
+
+    #[test]
+    fn component_line_with_children() {
+        let comp = ComponentDef {
+            name: "Card",
+            props: &[],
+            has_children: true,
+            description: "Container.",
+        };
+        let line = build_component_line(&comp);
+        assert_eq!(line, "Card(children?: Node[]) — Container.");
+    }
+
+    #[test]
+    fn category_notes_render() {
+        let p = generate_prompt(&fixture(), &PromptOptions::default());
+        assert!(p.contains("Prefer Card as the root."));
+    }
+
+    #[test]
+    fn custom_preamble_replaces_default() {
+        let opts = PromptOptions {
+            preamble: Some("CUSTOM PREAMBLE".to_string()),
+            ..Default::default()
+        };
+        let p = generate_prompt(&fixture(), &opts);
+        assert!(p.starts_with("CUSTOM PREAMBLE"));
+    }
+
+    #[test]
+    fn examples_section_included() {
+        let opts = PromptOptions {
+            examples: vec![
+                r#"```a2ui
+{"type":"Card"}
+```"#
+                    .to_string(),
+            ],
+            ..Default::default()
+        };
+        let p = generate_prompt(&fixture(), &opts);
+        assert!(p.contains("## Examples"));
+        assert!(p.contains("{\"type\":\"Card\"}"));
+    }
+
+    #[test]
+    fn additional_rules_render_as_bullets() {
+        let opts = PromptOptions {
+            additional_rules: vec!["Stay concise".to_string()],
+            ..Default::default()
+        };
+        let p = generate_prompt(&fixture(), &opts);
+        assert!(p.contains("- Stay concise"));
+    }
+}

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -99,6 +99,9 @@ llmsim = "0.2.1"
 # OpenUI component definitions and prompt generator
 everruns-openui = { path = "../openui" }
 
+# A2UI component catalog and prompt generator
+everruns-a2ui = { path = "../a2ui" }
+
 # Compile-time directory embedding for virtual mounts (platform docs)
 include_dir = "0.7"
 

--- a/crates/core/src/capabilities/a2ui.rs
+++ b/crates/core/src/capabilities/a2ui.rs
@@ -1,0 +1,120 @@
+//! A2UI Capability — enables agents to emit Google A2UI JSON component trees
+//!
+//! When enabled, this capability appends the A2UI system prompt to the agent's
+//! system prompt. The LLM wraps JSON component trees in ```a2ui fenced code
+//! blocks, which the UI detects and renders using native shadcn/ui primitives.
+//!
+//! Runs in parallel with `openui`. Both may be enabled on the same agent, but
+//! that is rarely useful — instruct the agent to prefer one protocol.
+//!
+//! Ref: specs/a2ui.md
+//! Ref: https://github.com/google/a2ui
+
+use super::{Capability, CapabilityStatus};
+
+/// Capability ID constant for external reference.
+pub const A2UI_CAPABILITY_ID: &str = "a2ui";
+
+/// A2UI capability — adds the A2UI catalog prompt and declares the `a2ui` feature.
+pub struct A2UiCapability;
+
+impl Capability for A2UiCapability {
+    fn id(&self) -> &str {
+        A2UI_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "A2UI"
+    }
+
+    fn description(&self) -> &str {
+        "Enables the agent to emit generative UI as Google A2UI JSON component trees, rendered by the UI with native design-system components."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("layout-grid")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("UI")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(everruns_a2ui::default_prompt())
+    }
+
+    fn features(&self) -> Vec<&'static str> {
+        vec!["a2ui"]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capabilities::CapabilityRegistry;
+
+    #[test]
+    fn capability_metadata() {
+        let cap = A2UiCapability;
+        assert_eq!(cap.id(), A2UI_CAPABILITY_ID);
+        assert_eq!(cap.name(), "A2UI");
+        assert_eq!(cap.category(), Some("UI"));
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+    }
+
+    #[test]
+    fn capability_has_no_tools() {
+        let cap = A2UiCapability;
+        assert!(cap.tools().is_empty());
+    }
+
+    #[test]
+    fn capability_has_system_prompt() {
+        let cap = A2UiCapability;
+        let prompt = cap.system_prompt_addition().expect("prompt present");
+        assert!(prompt.contains("```a2ui"));
+        assert!(prompt.contains("## Schema"));
+        assert!(prompt.contains("## Catalog"));
+        assert!(prompt.contains("## Actions"));
+    }
+
+    #[test]
+    fn capability_features() {
+        let cap = A2UiCapability;
+        assert_eq!(cap.features(), vec!["a2ui"]);
+    }
+
+    #[test]
+    fn capability_in_registry() {
+        let registry = CapabilityRegistry::with_builtins();
+        let cap = registry.get(A2UI_CAPABILITY_ID).expect("registered");
+        assert_eq!(cap.id(), A2UI_CAPABILITY_ID);
+        assert!(cap.system_prompt_addition().is_some());
+    }
+
+    #[test]
+    fn capability_coexists_with_openui() {
+        let registry = CapabilityRegistry::with_builtins();
+        assert!(
+            registry.get("openui").is_some(),
+            "openui should stay registered"
+        );
+        assert!(
+            registry.get(A2UI_CAPABILITY_ID).is_some(),
+            "a2ui should be registered"
+        );
+    }
+
+    #[test]
+    fn system_prompt_lists_core_components() {
+        let cap = A2UiCapability;
+        let p = cap.system_prompt_addition().unwrap();
+        for name in ["Card", "Stack", "Button", "Form", "List", "Table"] {
+            assert!(p.contains(name), "prompt missing component {name}");
+        }
+    }
+}

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -76,6 +76,7 @@ pub use crate::capability_types::{
 // Capability Modules
 // ============================================================================
 
+mod a2ui;
 mod agent_instructions;
 pub mod attach_skill;
 mod budgeting;
@@ -114,6 +115,7 @@ mod virtual_bash;
 mod web_fetch;
 
 // Re-export capabilities
+pub use a2ui::{A2UI_CAPABILITY_ID, A2UiCapability};
 pub use agent_instructions::{
     AGENT_INSTRUCTIONS_CAPABILITY_ID, AGENTS_MD_PATH, AgentInstructionsCapability,
     MAX_AGENTS_MD_SIZE, format_agents_md_content,
@@ -685,6 +687,7 @@ impl CapabilityRegistry {
 
         // OpenUI generative UI (all environments)
         registry.register(OpenUiCapability);
+        registry.register(A2UiCapability);
 
         // Demo capability with mount points (all environments)
         registry.register(SampleDataCapability);

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -1506,6 +1506,7 @@ mod tests {
             "subagents",
             "system_commands",
             "openui",
+            "a2ui",
             "sample_data",
             "data_knowledge",
             "tool_output_persistence",

--- a/specs/a2ui.md
+++ b/specs/a2ui.md
@@ -1,0 +1,227 @@
+# A2UI — Google Generative UI Integration
+
+## Purpose
+
+Parallel generative-UI capability alongside [OpenUI](./openui.md), built on Google's
+**A2UI (Agent-to-User Interface)** open protocol. A2UI lets the agent describe UI
+*intent* as declarative JSON; the client renders it using its own design system and
+component library.
+
+Two capabilities coexist:
+
+| Capability | DSL                       | Renderer library        | Strength                               |
+| ---------- | ------------------------- | ----------------------- | -------------------------------------- |
+| `openui`   | OpenUI Lang (custom DSL)  | `@openuidev/react-ui`   | ~55 prebuilt React components          |
+| `a2ui`     | JSON component tree       | Everruns shadcn/ui      | Design-system native, framework-neutral |
+
+They are independently opt-in per agent. Nothing switches; agents select whichever
+they prefer, or run neither.
+
+## Decisions
+
+- **Prompt-first, not strict schema.** Follow A2UI v0.9 — embed the catalog in the
+  system prompt and let the model emit JSON freely. We validate lightly at render
+  time and render partial trees rather than rejecting on the first error.
+- **JSON over DSL.** A2UI is JSON; parsers exist in every language. This is A2UI's
+  key portability win over OpenUI Lang.
+- **Fenced code block transport.** Agent emits `` ```a2ui `` fenced blocks inline
+  with markdown, mirroring the OpenUI pattern. No separate wire protocol needed —
+  our existing SSE message stream is enough.
+- **Native renderer.** The UI renders A2UI JSON using Everruns' own shadcn/ui
+  components. No third-party npm dependency. This is A2UI's model: the client owns
+  the design system.
+- **Small canonical catalog.** Ship the smallest useful cross-framework component
+  set. The spec explicitly encourages custom catalogs; teams can extend later.
+- **No bidirectional messaging yet.** A2UI v0.9 defines client→server updates for
+  interactive surface state. Our v1 is read-only (buttons that emit chat messages).
+  Form round-trips land in a follow-up.
+
+## Architecture
+
+```
+┌──────────────────┐    ┌───────────────────┐    ┌────────────────────────┐
+│  a2ui crate      │───▶│ a2ui capability   │───▶│   LLM system prompt    │
+│ (catalog +       │    │ (everruns-core)   │    │  with A2UI catalog +   │
+│  prompt gen)     │    │                   │    │  JSON emission rules   │
+└──────────────────┘    └───────────────────┘    └────────────────────────┘
+                                                           │
+                                                           ▼
+                                                 ┌───────────────────┐
+                                                 │  LLM response     │
+                                                 │  with ```a2ui     │
+                                                 │  JSON blocks      │
+                                                 └─────────┬─────────┘
+                                                           ▼
+                                                 ┌───────────────────┐
+                                                 │  Chat UI          │
+                                                 │  MessageContent   │
+                                                 │  splits blocks    │
+                                                 └─────────┬─────────┘
+                                                           ▼
+                                                 ┌───────────────────┐
+                                                 │  A2UIBlock        │
+                                                 │  (JSON tree →     │
+                                                 │   shadcn/ui)      │
+                                                 └───────────────────┘
+```
+
+## Wire Format
+
+The LLM emits one JSON object per block, fenced with `` ```a2ui ``:
+
+````
+```a2ui
+{
+  "type": "Card",
+  "children": [
+    { "type": "Heading", "props": { "text": "Monthly Revenue" } },
+    { "type": "Text", "props": { "text": "Q1 totaled $158k" } },
+    {
+      "type": "ButtonGroup",
+      "children": [
+        { "type": "Button", "props": { "label": "Details", "action": { "type": "message", "text": "Show details" } } }
+      ]
+    }
+  ]
+}
+```
+````
+
+Every node is `{ type, props?, children? }`. Props are per-component. Children is a
+flat array of nested nodes. Streaming-friendly: partial trees render as soon as
+they parse.
+
+## Crate: `everruns-a2ui`
+
+Path: `crates/a2ui/`.
+
+Mirrors the `everruns-openui` pattern: static Rust catalog definitions plus a
+prompt generator. No runtime parsing — the LLM receives a prompt and the renderer
+lives in the UI.
+
+### Types
+
+- `ComponentDef` — `{ name, props, description, has_children }`
+- `PropDef` — `{ name, type_annotation, optional, description }`
+- `ComponentCategory` — logical grouping for the prompt
+- `Catalog` — root component hint, components, categories
+- `PromptOptions` — custom preamble, additional rules, examples
+
+### Prompt sections
+
+`generate_prompt(catalog, options)` emits:
+
+1. **Preamble** — when and how to use `` ```a2ui `` blocks
+2. **Schema rules** — JSON shape, every node has `type`, optional `props`, optional `children`
+3. **Catalog** — components grouped by category with prop signatures and descriptions
+4. **Action types** — `{ type: "message", text }`, `{ type: "open_url", url }`
+5. **Streaming guidance** — emit shell first, fill children progressively
+6. **Important rules** — stay within catalog, omit unknown props, prefer lists over repeats
+
+Ref: `crates/a2ui/src/prompt.rs`.
+
+### Canonical catalog
+
+Minimal v1 catalog; extend later. All components map to existing Everruns UI
+primitives under `apps/ui/src/components/ui/`.
+
+| Category   | Components                                                |
+| ---------- | --------------------------------------------------------- |
+| Layout     | `Stack`, `Card`, `Separator`                              |
+| Content    | `Heading`, `Text`, `Callout`, `Badge`, `Image`, `CodeBlock` |
+| Data       | `List`, `ListItem`, `Table`                               |
+| Forms      | `Form`, `TextField`, `Textarea`, `Select`, `Checkbox`     |
+| Actions    | `Button`, `ButtonGroup`                                   |
+
+## Capability: `a2ui`
+
+ID: `a2ui`. Feature: `a2ui`. Category: `UI`.
+
+Registered as a built-in in `CapabilityRegistry::with_builtins_for_grade`. When
+enabled, the capability appends the A2UI prompt to the agent's system prompt. It
+contributes no tools.
+
+The capability coexists with `openui`. Enabling both is legal but wasteful —
+instruct the agent to prefer one. Neither is enabled by default.
+
+Ref: `crates/core/src/capabilities/a2ui.rs`.
+
+## UI Integration
+
+### Block detection
+
+`apps/ui/src/lib/a2ui-utils.ts` splits message text into alternating markdown and
+A2UI segments. Regex: `` /```a2ui\s*\n([\s\S]*?)(?:```|$)/g ``. Streaming-safe:
+unclosed blocks at end of string render as partial JSON.
+
+### Renderer
+
+`apps/ui/src/components/chat/a2ui-renderer.tsx`:
+
+- `<A2UIBlock code={json} isStreaming={bool} />`
+- Parses JSON with fault-tolerance: returns a partial tree for truncated input
+- Walks the tree, dispatching each node to a component map
+- Component map maps `type` string → React component using shadcn/ui primitives
+- Unknown types render a subtle placeholder (not a hard error)
+- Button actions `{ type: "message", text }` send a new user message through the
+  existing chat input
+- Wrapped in an error boundary that falls back to rendering the raw JSON as a
+  code block
+
+### Message content
+
+`apps/ui/src/components/chat/message-content.tsx` handles **both** openui and
+a2ui blocks. Fast path checks for either; the split walks both patterns.
+
+## Example
+
+User: "Show me a summary of last week's orders."
+
+LLM response:
+
+````
+Here's the weekly summary:
+
+```a2ui
+{
+  "type": "Card",
+  "children": [
+    { "type": "Heading", "props": { "text": "Orders — Week of Apr 7", "level": 3 } },
+    {
+      "type": "List",
+      "children": [
+        { "type": "ListItem", "props": { "title": "Shipped", "value": "247" } },
+        { "type": "ListItem", "props": { "title": "Pending", "value": "18" } },
+        { "type": "ListItem", "props": { "title": "Returned", "value": "4" } }
+      ]
+    },
+    {
+      "type": "ButtonGroup",
+      "children": [
+        { "type": "Button", "props": { "label": "See shipped", "action": { "type": "message", "text": "List shipped orders" } } },
+        { "type": "Button", "props": { "label": "Handle returns", "variant": "secondary", "action": { "type": "message", "text": "Process pending returns" } } }
+      ]
+    }
+  ]
+}
+```
+
+Let me know which you want to drill into.
+````
+
+Renders a Card with a heading, a three-row summary list, and two action buttons.
+Clicking a button sends the `action.text` as a new chat message.
+
+## Non-goals (v1)
+
+- Form submissions with typed responses (round-trip via tool call comes later)
+- Client→server surface-state updates (A2UI bidirectional messaging)
+- Catalog negotiation handshake (we ship a fixed catalog per capability)
+- Non-React renderers (A2UI JSON is portable; adding native renderers is a future
+  extension)
+
+## References
+
+- A2UI project: <https://github.com/google/a2ui>
+- CopilotKit writeup on A2UI v0.9: <https://www.copilotkit.ai/blog/a2ui-whats-new-in-google-generative-ui-spec>
+- Sibling spec: [`specs/openui.md`](./openui.md)

--- a/specs/a2ui.md
+++ b/specs/a2ui.md
@@ -167,6 +167,9 @@ unclosed blocks at end of string render as partial JSON.
   existing chat input
 - Wrapped in an error boundary that falls back to rendering the raw JSON as a
   code block
+- URLs in `Image.src` and `open_url` actions are restricted to
+  `http:`/`https:`/`mailto:` schemes to block `javascript:` and `data:` XSS
+  (see THREAT[TM-WEB-A2UI-01])
 
 ### Message content
 

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -224,6 +224,7 @@ Capabilities declare UI features they contribute to via `features()`. Features a
 | `session_sql_database` | `sql_database` |
 
 | `openui` | `openui` |
+| `a2ui` | `a2ui` |
 
 MCP and Skill virtual capabilities currently declare no features.
 
@@ -238,6 +239,7 @@ MCP and Skill virtual capabilities currently declare no features.
 | `schedules` | Schedules tab | Session can create/manage schedules |
 | `sql_database` | *(reserved)* | Session has SQL database access |
 | `openui` | OpenUI rendering | Session can render OpenUI Lang components |
+| `a2ui` | A2UI rendering | Session can render A2UI JSON component trees |
 
 #### compute_features()
 
@@ -456,6 +458,25 @@ OpenUI is a pure system prompt capability — it provides no tools. It instructs
 The system prompt is generated from the `everruns-openui` crate which defines the full component library (50+ components across 7 groups: Content, Tables, Charts 2D, Charts 1D, Forms, Buttons, Layout). Component signatures are included in the prompt so the LLM knows valid props.
 
 See `specs/openui.md` for full architecture and UI integration details.
+
+#### A2UI
+
+- **ID**: `a2ui`
+- **Purpose**: Enables agents to emit Google A2UI JSON component trees, rendered by the UI with native shadcn/ui primitives
+- **Tools**: None (prompt-only capability)
+- **Features**: `a2ui`
+- **Icon**: `layout-grid`
+- **Category**: `UI`
+
+##### Design Decision: Parallel to OpenUI
+
+A2UI is a *parallel* capability to `openui`, not a replacement. Both are opt-in per agent; neither is enabled by default. A2UI uses JSON (portable across frameworks) while OpenUI uses a custom DSL with a richer prebuilt React library. Enabling both is legal but usually wasteful.
+
+##### Design Decision: Prompt-First, Native Renderer
+
+Follows the A2UI v0.9 prompt-first model: the catalog is embedded in the system prompt and the LLM emits JSON freely, validated lightly at render time. The UI renderer is implemented using the project's own shadcn/ui primitives — no third-party npm dependency. This preserves design-system consistency and is A2UI's canonical pattern (the client owns the rendering).
+
+See `specs/a2ui.md` for full architecture, the canonical catalog, and the wire format.
 
 #### SkillsDiscovery
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -586,6 +586,7 @@ Full conversation data (user messages, LLM responses, tool results) is transmitt
 | TM-WEB-006 | Open redirect in OAuth flow | Medium | OAuth callbacks validated against configured redirect URIs | MITIGATED |
 | TM-WEB-007 | CORS wildcard exposure | Medium | `CORS_ALLOWED_ORIGINS` not set by default; must be explicitly configured | MITIGATED |
 | TM-WEB-008 | Open redirect via login page `return_to` | Medium | `sanitizeReturnTo` (`apps/ui/src/lib/auth-redirect.ts`) restricts `return_to` to relative paths on the frontend origin: must start with `/`, never `//` (protocol-relative), never `/\` (browser-normalized), never an absolute URL. Applied in login page and main layout (sessionStorage consumer). CLI auth start emits only relative `return_to` paths. See `specs/authentication.md` "Login Page Contract". | MITIGATED |
+| TM-WEB-A2UI-01 | XSS via `javascript:`/`data:` URL in A2UI `open_url` action or `Image.src` | High | A2UI JSON is LLM-emitted. `isSafeUrl` in `apps/ui/src/components/chat/a2ui-renderer.tsx` restricts action URLs and image sources to `http:`/`https:`/`mailto:` schemes; `window.open` also uses `noopener,noreferrer`. React auto-escapes all text props. See `specs/a2ui.md`. | MITIGATED |
 
 ### Mitigation Details
 

--- a/test_cases/agents/a2ui/TC001_form_submission.md
+++ b/test_cases/agents/a2ui/TC001_form_submission.md
@@ -1,0 +1,109 @@
+# TC001: A2UI Form Rendering and Submission
+
+## Description
+
+Verify that an agent with the **A2UI** capability enabled can emit a ```a2ui fenced JSON block describing a `Form` with multiple fields, that the chat UI renders the form using native shadcn/ui primitives, and that submitting the form sends a new chat message back to the agent summarizing the collected field values.
+
+Exercises the full A2UI round-trip for interactive UI: system-prompt catalog instruction, LLM JSON emission, fenced-block detection, streaming-tolerant parsing, native-primitive rendering, form-state collection via React context, and `message` action dispatch through the existing chat pipeline.
+
+## Preconditions
+
+- Control-plane running (`just start-dev` or `just start-all`)
+- LLM API key configured (OpenAI, Anthropic, or Gemini — catalog lives in the system prompt, so any frontier chat model works)
+- Branch with the `a2ui` capability registered in `CapabilityRegistry::with_builtins_for_grade`
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Agent name | A2UI Form Demo |
+| Harness | `base` (or any harness — A2UI is harness-agnostic) |
+| Capabilities | `a2ui` (enabled), no other UI capabilities |
+| Model | Any frontier chat model that reliably emits structured JSON |
+
+### Prompt
+
+```
+Render a feedback form with the following fields:
+- "name" — single-line text, required, label "Your name"
+- "email" — single-line text, label "Email"
+- "rating" — dropdown with options 1..5
+- "comments" — multi-line text, label "Comments", 4 rows
+- a "subscribe" checkbox, default checked, label "Send me product updates"
+
+Use the submit label "Send feedback". When the user submits, echo back a summary.
+```
+
+## Steps
+
+1. **Create an agent** named "A2UI Form Demo". In the capability picker, enable **A2UI** and confirm no other generative-UI capability (e.g. OpenUI) is enabled.
+
+2. **Start a session** on that agent.
+
+3. **Send the prompt above.**
+
+4. **Wait for the agent to finish.** The response should stream into the chat and contain exactly one ```a2ui fenced code block describing a `Form` with the five requested fields.
+
+5. **Inspect the rendered form** in the chat message. Confirm each field appears with the requested label, the dropdown lists options `1` through `5`, and the checkbox is pre-checked.
+
+6. **Fill in values:**
+   - name: `Ada Lovelace`
+   - email: `ada@example.com`
+   - rating: `5`
+   - comments: `Great product, loving it!`
+   - subscribe: leave checked
+
+7. **Click "Send feedback".** The form should submit as a new user chat message.
+
+8. **Wait for the agent's reply.** It should acknowledge the submission and echo the field values back.
+
+## Expected Result
+
+### Capability Wiring
+
+- The `a2ui` capability is registered on the agent and contributes its system-prompt addition (catalog + rules + action types).
+- The system prompt sent to the LLM includes the line ` ```a2ui ` and the signatures for `Form`, `TextField`, `Textarea`, `Select`, `Checkbox`, and `Button`.
+- No OpenUI prompt is included for this agent.
+
+### Turn 1 — Form Emission & Render
+
+- The raw assistant message contains a single ` ```a2ui `…` ``` ` fenced block.
+- Inside the block, the JSON parses to a `Form` with `name: "feedback"` (or similar) and five children in the requested order.
+- The chat UI **does not** show the raw JSON — it shows a styled form with:
+  - a `<label>Your name</label>` + single-line input (required)
+  - a `<label>Email</label>` + single-line input
+  - a `<label>Rating</label>` + native `<select>` with options 1..5
+  - a `<label>Comments</label>` + multi-line textarea with ~4 rows
+  - a checkbox labelled "Send me product updates", pre-checked
+  - a submit `<Button>` labelled **Send feedback**
+- The form is wrapped in the A2UI block container (border + padding).
+- No error-boundary fallback is rendered.
+
+### Turn 2 — Submission
+
+- Clicking **Send feedback** posts a new user message into the session. The message body either matches the agent's `submitMessage` prop or, if the prop was omitted, follows the default shape `Submitted {name} form: name="Ada Lovelace", email="ada@example.com", rating="5", comments="Great product, loving it!", subscribe=true`.
+- The agent receives the submission as a normal chat turn and replies with a summary that includes the collected values.
+
+### Security
+
+- In the raw emitted JSON, any `Button.action.type === "open_url"` with `url` starting `javascript:` or `data:` is rejected by the renderer (`isSafeUrl`). This is out of scope for the happy path but worth checking by asking the LLM to add an "Open homepage" button in a follow-up turn and confirming only `http://`/`https://`/`mailto:` URLs open a new tab.
+
+### Failure Modes
+
+| Failure | What to look for |
+|---------|-----------------|
+| Capability not registered | Agent cannot be saved with `a2ui` enabled, or the system prompt lacks the `## Catalog` section |
+| Raw JSON visible in chat | The ```a2ui block is rendered as a markdown code block instead of a form — check `splitA2UIBlocks` and `message-content.tsx` dispatch |
+| Form renders but unstyled | shadcn primitives missing from imports in `a2ui-renderer.tsx` |
+| Partial render during streaming freezes | The `…` placeholder never resolves after the stream ends — `isStreaming` not threaded through to `A2UIRoot` |
+| Submit button inert | `FormContext` not providing `set`, or the submit handler doesn't call `dispatch({ type: "message", text })` |
+| Empty submission message | `FormContext` collected values but `defaultSubmitMessage` returned a trivial string — field state may not be updating |
+| Checkbox toggles nothing | `CheckboxNode` not wired to `useFieldValue` |
+| `javascript:` URL opens | `isSafeUrl` not called before `window.open` — SECURITY regression |
+
+## Notes
+
+- Deterministic LLM output is not guaranteed; the model may add extra fields, reorder, or emit a slightly different JSON shape. Check rendered semantics (fields present, labels match, submission round-trips) rather than exact JSON.
+- Run the test on at least one OpenAI and one Anthropic model; catalog-in-prompt capabilities behave differently per provider.
+- If the LLM emits both ```openui and ```a2ui blocks, that indicates a prompt-ordering issue — only one generative-UI capability should be enabled per agent.
+- The A2UI capability ships the `message` and `open_url` action types only; full server-side form round-trips (typed responses via tool call) are a v2 non-goal (see `specs/a2ui.md`).


### PR DESCRIPTION
## What
Introduces **A2UI** (Google's Agent-to-User Interface protocol) as an optional agent capability that coexists with the existing `openui` capability.

- New crate `everruns-a2ui` — static component catalog (17 components across Layout / Content / Data / Forms / Actions) plus a streaming-aware prompt generator.
- New capability `A2UiCapability` in `everruns-core` — prompt-only; contributes no tools; sits next to `OpenUiCapability` in the built-in registry.
- New UI renderer `apps/ui/src/components/chat/a2ui-renderer.tsx` — walks JSON trees emitted by the LLM inside ```a2ui fenced blocks and renders them with the existing shadcn/ui primitives (Card, Table, Form, Button, …).
- `message-content.tsx` now splits both `openui` and `a2ui` fences via a single unified pass.
- Spec: `specs/a2ui.md`. Capability metadata row + section added to `specs/capabilities.md`; index entry added to `AGENTS.md`.

## Why
A2UI v0.9 is Google's open, framework-neutral generative-UI protocol. Unlike OpenUI Lang, A2UI is JSON (parsers exist everywhere) and explicitly leaves rendering to the client's design system. Offering it as a parallel capability lets users pick per agent — nothing is switched or replaced.

## How
- Mirror the `everruns-openui` pattern: Rust catalog + prompt generator + capability wired through `system_prompt_addition`, separate crate for catalog portability.
- Fenced-block transport (` ```a2ui `) reuses the existing SSE message pipeline — no new wire protocol.
- Renderer is fault-tolerant: partial JSON from mid-stream chunks auto-closes unbalanced brackets and renders progressively; unknown component types render a muted placeholder instead of throwing; error boundary falls back to a raw JSON code block on catastrophic parse failure.
- Forms collect field values via React context and submit them by dispatching a chat message (no server-side form round-trip yet; tracked as a v2 non-goal in the spec).

## Risk
- **Low–Medium**. No migrations, no API surface, no auth/tenancy changes. Pure additive capability + new UI render path that only activates when an agent has `a2ui` enabled **and** the LLM emits ```a2ui blocks. OpenUI path and every other chat render path are untouched.
- Possible failure mode: LLM emits malformed JSON → error boundary fallback to raw JSON block (tested).

## Security
- **Threat categories reviewed:** `TM-WEB`, `TM-LLM`.
- **Findings and resolutions:**
  - A2UI JSON is LLM-emitted. Initial `open_url` action and `Image` `src` accepted arbitrary URLs, which enables XSS via `javascript:` / `data:text/html` in the app origin. **Fixed** by restricting both to `http:` / `https:` / `mailto:` schemes via `isSafeUrl` (commit `a2d5541`). `window.open` also uses `noopener,noreferrer`. New entry `TM-WEB-A2UI-01` added to `specs/threat-model.md`.
  - React auto-escapes all text props; no `dangerouslySetInnerHTML`, no dynamic HTML injection.
  - Action dispatch only supports two typed actions (`message`, `open_url`) with strict field typing and origin-validated URLs.
  - `TM-LLM`: new capability adds a bounded prompt addition gated by opt-in. No change to prompt construction security.

## Checklist
- [x] Tests added or updated (16 jest tests for split/parse + 33 Rust tests for catalog/prompt/capability)
- [x] Backward compatibility considered (additive only; OpenUI and default agents unchanged)
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)