### PR TITLE
fix(mcp): return 202 for JSON-RPC notifications

### DIFF
--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -395,23 +395,19 @@ async fn handle_mcp(
     // server MUST NOT reply. MCP lifecycle uses this for
     // `notifications/initialized`, `notifications/cancelled`, etc. We're
     // stateless, so there's nothing to do — acknowledge with 202 Accepted and
-    // no body.
-    let is_notification = req.id.is_none();
+    // no body. Short-circuit before the jsonrpc version check because the
+    // spec gives no addressable id to return an error against.
+    if req.id.is_none() {
+        return StatusCode::ACCEPTED.into_response();
+    }
 
     if req.jsonrpc != "2.0" {
-        if is_notification {
-            return StatusCode::ACCEPTED.into_response();
-        }
         return Json(JsonRpcResponse::error(
             req.id,
             -32600,
             "Invalid Request: jsonrpc must be \"2.0\"",
         ))
         .into_response();
-    }
-
-    if is_notification {
-        return StatusCode::ACCEPTED.into_response();
     }
 
     let response = match req.method.as_str() {

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -23,7 +23,13 @@ use crate::services::{
     BudgetService, CapabilityService, EventService, MessageService, SessionService,
 };
 use crate::storage::StorageBackend;
-use axum::{Json, Router, extract::State, routing::post};
+use axum::{
+    Json, Router,
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::post,
+};
 use bashkit::ScriptingToolSet;
 use everruns_core::{Caller, OrgRole, PlatformDefinition, validate_org_public_id};
 use everruns_worker::AgentRunner;
@@ -384,13 +390,28 @@ async fn handle_mcp(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Json(req): Json<JsonRpcRequest>,
-) -> Json<JsonRpcResponse> {
+) -> Response {
+    // Per JSON-RPC 2.0, a request without an `id` is a notification and the
+    // server MUST NOT reply. MCP lifecycle uses this for
+    // `notifications/initialized`, `notifications/cancelled`, etc. We're
+    // stateless, so there's nothing to do — acknowledge with 202 Accepted and
+    // no body.
+    let is_notification = req.id.is_none();
+
     if req.jsonrpc != "2.0" {
+        if is_notification {
+            return StatusCode::ACCEPTED.into_response();
+        }
         return Json(JsonRpcResponse::error(
             req.id,
             -32600,
             "Invalid Request: jsonrpc must be \"2.0\"",
-        ));
+        ))
+        .into_response();
+    }
+
+    if is_notification {
+        return StatusCode::ACCEPTED.into_response();
     }
 
     let response = match req.method.as_str() {
@@ -405,7 +426,7 @@ async fn handle_mcp(
         _ => JsonRpcResponse::method_not_found(req.id),
     };
 
-    Json(response)
+    Json(response).into_response()
 }
 
 // ============================================================================

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -182,6 +182,70 @@ async fn test_mcp_unknown_method() {
     assert_eq!(resp["error"]["code"], -32601);
 }
 
+// Regression for EVE-322: JSON-RPC requests without an `id` are notifications.
+// Per the spec the server MUST NOT reply. MCP clients send
+// `notifications/initialized` after the handshake; returning a JSON-RPC object
+// breaks strict clients. Verify 202 Accepted with an empty body.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_notifications_initialized_no_response() {
+    let server = TestServer::new().await;
+    let resp = server
+        .post(
+            "/mcp",
+            json!({
+                "jsonrpc": "2.0",
+                "method": "notifications/initialized"
+            }),
+        )
+        .await;
+
+    assert_eq!(resp.status(), axum::http::StatusCode::ACCEPTED);
+    assert!(
+        resp.text().is_empty(),
+        "Notification response body must be empty, got: {}",
+        resp.text()
+    );
+}
+
+// Any method sent without an `id` is a notification and must be ignored
+// silently, even if the method is unknown or the params are malformed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_notification_unknown_method_no_response() {
+    let server = TestServer::new().await;
+    let resp = server
+        .post(
+            "/mcp",
+            json!({
+                "jsonrpc": "2.0",
+                "method": "notifications/cancelled",
+                "params": { "requestId": "abc" }
+            }),
+        )
+        .await;
+
+    assert_eq!(resp.status(), axum::http::StatusCode::ACCEPTED);
+    assert!(resp.text().is_empty());
+}
+
+// Even an invalid `jsonrpc` version must not produce a reply when `id` is
+// absent — the spec gives the server no way to address the error response.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_notification_invalid_jsonrpc_version_no_response() {
+    let server = TestServer::new().await;
+    let resp = server
+        .post(
+            "/mcp",
+            json!({
+                "jsonrpc": "1.0",
+                "method": "notifications/initialized"
+            }),
+        )
+        .await;
+
+    assert_eq!(resp.status(), axum::http::StatusCode::ACCEPTED);
+    assert!(resp.text().is_empty());
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mcp_tools_call_unknown_tool() {
     let server = TestServer::new().await;


### PR DESCRIPTION
## What
`/mcp` now replies with HTTP 202 Accepted and an empty body for any JSON-RPC request without an `id` (i.e., a notification). Previously the server returned a JSON-RPC response object for every request, including notifications.

## Why
Per [JSON-RPC 2.0 §4.1](https://www.jsonrpc.org/specification#notification), a notification is a request with no `id` and the server MUST NOT reply to it. The [MCP 2025-06-18 lifecycle](https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle) relies on this: clients send `notifications/initialized` after the handshake, and strict clients treat a reply as a protocol violation.

Closes [EVE-322](https://linear.app/everruns/issue/EVE-322).

## How
- Added an early `req.id.is_none()` check in `handle_mcp` that returns `StatusCode::ACCEPTED` with no body.
- Applied it before the `jsonrpc` version check and the method dispatch, so notifications with invalid versions or unknown methods are also silently accepted — the server has no valid way to address an error response to a missing id.
- Changed the handler return type from `Json<JsonRpcResponse>` to `axum::response::Response` so the same endpoint can return either JSON-RPC replies or bare 202s.

## Risk
- Low
- Only the `/mcp` endpoint behavior is changed, and only for requests that omit `id`. Regular requests (with `id`) still receive a `Json<JsonRpcResponse>` body and `200 OK`.

## Security
- Threat categories reviewed: `TM-API` (HTTP endpoint response semantics), `TM-AUTH` (`AuthUser` and `ResolvedOrg` extractors still run before the notification shortcut, so auth is enforced).
- Findings and resolutions: None. The change tightens protocol conformance; it does not introduce unauthenticated access, relax input validation, or change the tool-execution path.

## Checklist
- [x] Tests added or updated (three new tests in `crates/server/tests/mcp_endpoint_test.rs` covering `notifications/initialized`, other notification methods, and notifications with an invalid `jsonrpc` version)
- [x] Backward compatibility considered (clients with `id` unaffected; strict clients that previously failed now work)
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (will be addressed post-review)