### PR TITLE
chore(release): document migration squashing in release process

### DIFF
--- a/.claude/commands/prepare-release.md
+++ b/.claude/commands/prepare-release.md
@@ -77,7 +77,19 @@ See `specs/release-process.md` for the full release process specification.
    -->
    ```
 
-5. **Update lock files**:
+5. **Squash feature migrations into a version-named migration**:
+
+   See `specs/release-process.md` ("Migration Squashing") and `specs/migrations.md`.
+
+   - List `crates/server/migrations/*.sql` and find the last `NNN_vA.B.C.sql` file.
+   - Identify every feature migration with a number strictly greater than that (these are the unsquashed feature migrations added since the last release).
+   - If there are none, skip this step entirely — do not create an empty migration file.
+   - Otherwise, create `NNN_vX.Y.Z.sql` (using the lowest number of the unsquashed set and the new release version) containing the concatenated DDL of those migrations, in their original numeric order.
+   - Preserve the origin of each block with an inline section header comment referencing the original filename, e.g. `-- from 016_eval_case_result_metadata.sql`.
+   - Delete the original feature migration files so numbering stays strictly sequential with no gaps.
+   - Verify `ls crates/server/migrations/*.sql | sort` yields 001..N with no gaps or duplicates.
+
+6. **Update lock files**:
    ```bash
    # Regenerate Cargo.lock with new workspace version
    cargo generate-lockfile
@@ -85,18 +97,18 @@ See `specs/release-process.md` for the full release process specification.
    cd apps/ui && npm install --package-lock-only
    ```
 
-6. **Skip migration notes unless necessary**:
+7. **Skip migration notes unless necessary**:
    - Do not add a dedicated migration section by default
    - Add one only when a release needs user-facing upgrade guidance
    - If migration behavior only needs engineering discussion, capture it in the canonical migration locations, for example `crates/server/migrations/` and/or `specs/migrations.md`, instead of the changelog
 
-7. **Create commit**:
+8. **Create commit**:
    ```bash
    git add -A
    git commit -m "chore(release): prepare vX.Y.Z"
    ```
 
-8. **Create PR**:
+9. **Create PR**:
    ```bash
    git push -u origin <current-branch>
    gh pr create --title "chore(release): prepare vX.Y.Z" --body "$(cat <<'EOF'
@@ -119,7 +131,7 @@ See `specs/release-process.md` for the full release process specification.
    )"
    ```
 
-9. **Remind user**:
+10. **Remind user**:
    - Review the PR, especially CHANGELOG.md
    - Add any highlights or screenshots by editing CHANGELOG.md
    - Merge when CI is green

--- a/.claude/commands/prepare-release.md
+++ b/.claude/commands/prepare-release.md
@@ -84,10 +84,10 @@ See `specs/release-process.md` for the full release process specification.
    - List `crates/server/migrations/*.sql` and find the last `NNN_vA.B.C.sql` file.
    - Identify every feature migration with a number strictly greater than that (these are the unsquashed feature migrations added since the last release).
    - If there are none, skip this step entirely — do not create an empty migration file.
-   - Otherwise, create `NNN_vX.Y.Z.sql` (using the lowest number of the unsquashed set and the new release version) containing the concatenated DDL of those migrations, in their original numeric order.
+   - Otherwise, create `NNN_vX.Y.Z.sql` (using the lowest number of the unsquashed set and the new release version) containing the concatenated SQL statements from those migrations, in their original numeric order, including any DDL/DML.
    - Preserve the origin of each block with an inline section header comment referencing the original filename, e.g. `-- from 016_eval_case_result_metadata.sql`.
    - Delete the original feature migration files so numbering stays strictly sequential with no gaps.
-   - Verify `ls crates/server/migrations/*.sql | sort` yields 001..N with no gaps or duplicates.
+   - Verify the sorted list of migration file basenames starts at `001_` and remains strictly sequential with no gaps or duplicates (matching `specs/migrations.md`).
 
 6. **Update lock files**:
    ```bash

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -41,7 +41,7 @@ As part of release preparation, all feature migrations added since the last rele
 Procedure:
 
 1. Identify the set of feature migrations added since the previous `NNN_vA.B.C.sql` release migration (all files with numbers strictly greater than the last version-named migration).
-2. Concatenate their DDL in execution order into a new file whose number is the lowest of that set and whose name is the release version, e.g. `016_v0.9.0.sql`.
+2. Concatenate their SQL statements (including any DDL/DML) in execution order into a new file whose number is the lowest of that set and whose name is the release version, e.g. `016_v0.9.0.sql`.
 3. Preserve section headers that reference each original migration filename as inline comments for traceability.
 4. Delete the original feature migration files so the final numbering stays strictly sequential with no gaps.
 5. Re-run the sequential-ordering validation from `specs/migrations.md` (no gaps, no duplicates).

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -34,6 +34,22 @@ The `/prepare-release` command updates version in:
 
 All packages (Rust crates and UI) are released together with the same version number.
 
+### Migration Squashing
+
+As part of release preparation, all feature migrations added since the last release **MUST** be squashed into a single version-named migration `NNN_vX.Y.Z.sql` under `crates/server/migrations/`.
+
+Procedure:
+
+1. Identify the set of feature migrations added since the previous `NNN_vA.B.C.sql` release migration (all files with numbers strictly greater than the last version-named migration).
+2. Concatenate their DDL in execution order into a new file whose number is the lowest of that set and whose name is the release version, e.g. `016_v0.9.0.sql`.
+3. Preserve section headers that reference each original migration filename as inline comments for traceability.
+4. Delete the original feature migration files so the final numbering stays strictly sequential with no gaps.
+5. Re-run the sequential-ordering validation from `specs/migrations.md` (no gaps, no duplicates).
+
+Squashing is a **BREAKING CHANGE** — it requires a fresh database, because `_sqlx_migrations` rows from a prior release will not match the squashed checksums. This is acceptable because in-place upgrades across releases are not supported. See `specs/migrations.md` for the full migration contract.
+
+If no feature migrations were added since the last release, skip this step — do not create an empty `NNN_vX.Y.Z.sql`.
+
 ### Lock File Updates
 
 Lock files must be updated when preparing a release:


### PR DESCRIPTION
## What
Add a **Migration Squashing** section to `specs/release-process.md` and a corresponding squashing step in the `/prepare-release` slash command, so every release collapses unsquashed feature migrations into a single `NNN_vX.Y.Z.sql` file.

## Why
The migration spec (`specs/migrations.md`) already requires release-time squashing, but the release process spec and the `/prepare-release` runbook did not mention it. Releases were relying on tribal knowledge to remember to squash. This wires the requirement into the release workflow itself so coding agents and humans both perform the squash by default.

## How
- `specs/release-process.md`: new **Migration Squashing** section between **Version Updates** and **Lock File Updates**, describing the procedure (identify unsquashed feature migrations after the last `NNN_vA.B.C.sql`, concatenate DDL into `NNN_vX.Y.Z.sql` using the lowest of those numbers, preserve origin headers as comments, delete originals, re-validate sequential ordering). Notes that squashing is a breaking change (per `_sqlx_migrations` checksums) and that the step is skipped when no feature migrations were added since the last release.
- `.claude/commands/prepare-release.md`: new step 5 that performs the squash before lock-file regeneration; subsequent steps renumbered (lock files → 6, migration notes → 7, commit → 8, PR → 9, remind → 10).

## Risk
- Low. Documentation/runbook only. No code, no migrations, no schema, no runtime behavior changed.
- Worst case: an agent following the new step on a release where no feature migrations exist must skip rather than create an empty file — this is called out explicitly in both the spec and the command.

## Security
- Threat categories reviewed: **No security-relevant code changes.** Diff touches only `specs/release-process.md` and `.claude/commands/prepare-release.md`. No code, configuration, or infrastructure paths are modified, no trust boundaries change, no new dependencies, and no auth/authz/data flow is altered.
- Findings and resolutions: none.

## Checklist
- [x] Tests added or updated — N/A (docs-only)
- [x] Backward compatibility considered — runbook addition; the workflow it documents was already required by `specs/migrations.md`
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)