### PR TITLE
chore(harness): scrub hardcoded UUID refs from specs and examples

### DIFF
--- a/examples/weekend-concierge-host/Cargo.lock
+++ b/examples/weekend-concierge-host/Cargo.lock
@@ -948,14 +948,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.8.14"
+version = "0.8.15"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-core"
-version = "0.8.14"
+version = "0.8.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -994,11 +994,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.8.14"
+version = "0.8.15"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.8.14"
+version = "0.8.15"
 dependencies = [
  "async-trait",
  "chrono",

--- a/examples/weekend-concierge-host/src/lib.rs
+++ b/examples/weekend-concierge-host/src/lib.rs
@@ -335,9 +335,9 @@ pub async fn run_weekend_concierge_demo() -> ExampleResult<ExampleRun> {
     capabilities.register(WeekendConciergeCapability);
     let platform = PlatformDefinition::new(capabilities, DriverRegistry::new());
 
-    let harness_id = "harness_00000000000000000000000000000090".parse()?;
-    let agent_id = "agent_00000000000000000000000000000090".parse()?;
-    let session_id = "session_00000000000000000000000000000090".parse()?;
+    let harness_id = everruns_core::HarnessId::new();
+    let agent_id = everruns_core::AgentId::new();
+    let session_id = everruns_core::typed_id::SessionId::new();
 
     let runtime = everruns_runtime::InProcessRuntimeBuilder::new()
         .platform_definition(platform)

--- a/specs/embedding.md
+++ b/specs/embedding.md
@@ -40,9 +40,8 @@ See [specs/runtime.md](runtime.md) for the public embedded runtime contract.
 
 Built-in harness templates are data, not code plugins. Each template carries:
 
-- Stable internal key
-- Optional default-org seed UUID
-- Name, description, system prompt, tags
+- Stable `name` (the durable identifier — see "Harness Identity" below)
+- Display name, description, system prompt, tags
 - Built-in capability definitions with optional per-capability config
 - Explicit roles
 
@@ -51,6 +50,12 @@ Roles replace hard-coded harness names for platform behavior:
 - `Base`: fallback harness for session creation
 - `Default`: org default harness for new orgs
 - `Chat`: global chat harness
+
+### Harness Identity
+
+Built-in harnesses are identified by `name` (e.g. `base`, `generic`, `platform-chat`), not by UUID. Each org gets its own freshly-generated `harness_id` row at provisioning time; lookups, reconciliation, and tests must resolve harnesses by name + `is_built_in`, never by hardcoded UUID literals.
+
+Hardcoded harness UUIDs are forbidden in production code, tests, examples, fixtures, and migrations. See [`specs/harness-types.md`](harness-types.md) for the full rule and the narrow default-org seeding exception.
 
 ## Presets
 
@@ -120,7 +125,7 @@ This prevents broken seeded data such as agents referencing Daytona when Daytona
 
 Organization initialization must provision built-in harnesses from the supplied harness templates and resolve default/base settings through harness roles, not hard-coded harness names or global constants.
 
-Default-org fixed UUIDs remain allowed for backward compatibility when a template includes `seed_id`.
+Each org receives freshly-generated `harness_id` rows. The default org is the only place where pinned UUIDs are tolerated, and that exception exists solely to keep historical seed rows stable; all consumer code must still resolve harnesses by `name` + `is_built_in`.
 
 ## Builder Contract
 

--- a/specs/embedding.md
+++ b/specs/embedding.md
@@ -53,9 +53,9 @@ Roles replace hard-coded harness names for platform behavior:
 
 ### Harness Identity
 
-Built-in harnesses are identified by `name` (e.g. `base`, `generic`, `platform-chat`), not by UUID. Each org gets its own freshly-generated `harness_id` row at provisioning time; lookups, reconciliation, and tests must resolve harnesses by name + `is_built_in`, never by hardcoded UUID literals.
+Built-in harnesses are identified by `name` (e.g. `base`, `generic`, `platform-chat`), not by UUID. Each org gets its own freshly-generated `harness_id` row at provisioning time; consumers must resolve built-in harnesses by name + `is_built_in`, never by hardcoded UUID literals.
 
-Hardcoded harness UUIDs are forbidden in production code, tests, examples, fixtures, and migrations. See [`specs/harness-types.md`](harness-types.md) for the full rule and the narrow default-org seeding exception.
+The rule is scoped to *built-in* harness identity. UUID literals used in tests, examples, or fixtures for org-owned (non-built-in) harnesses are unaffected. See [`specs/harness-types.md`](harness-types.md) for the full rule and the narrow default-org seeding exception.
 
 ## Presets
 

--- a/specs/harness-types.md
+++ b/specs/harness-types.md
@@ -107,16 +107,11 @@ Conversational harness for the global chat interface. Extends Generic capabiliti
 
 ## Built-in Harness Identity
 
-**Built-in harnesses are identified by `name`, not by UUID.** The `harness_id` row is per-org and is generated when the harness is provisioned. Reconciliation, lookups, tests, examples, and migrations must resolve built-in harnesses by `name` + `is_built_in`.
+**Built-in harnesses are identified by `name`, not by UUID.** The `harness_id` row is per-org and is generated when the harness is provisioned. Reconciliation, lookups, tests, examples, and migrations must address built-in harnesses (`is_built_in = true`) by `name`.
 
-**Hardcoded harness UUID literals are forbidden** anywhere in the codebase, including:
+**Hardcoded UUID literals must not be used to address built-in harnesses.** This rule applies in production code, tests, examples, fixtures, and new migrations. It does not affect literals used for non-built-in harness fixtures (e.g. a test that creates an org-owned custom harness with a fixed ID for setup) — those are unaffected because they do not depend on the built-in identity.
 
-- production code (`crates/**/src/`)
-- integration and unit tests
-- example crates and fixtures
-- new database migrations
-
-The single exception is the historical default-org seed range (see "UUID Allocation" below) — those literals exist purely to keep already-provisioned default-org rows stable and must not grow.
+The single exception is the historical default-org seed range (see "UUID Allocation" below). Those literals exist purely to keep already-provisioned default-org rows stable and must not grow.
 
 ## Built-in Harness Lifecycle
 

--- a/specs/harness-types.md
+++ b/specs/harness-types.md
@@ -105,6 +105,19 @@ Conversational harness for the global chat interface. Extends Generic capabiliti
 | How are built-in harnesses upgraded? | Reconciliation runs at startup — iterates all orgs and upserts built-in harness definitions. Changes to `org_init::BUILT_IN_HARNESSES` propagate automatically. |
 | How do starter files interact with capabilities? | Starter files are first-class harness or agent data, not capability config. If starter files exist, `session_file_system` is automatically retained so the session has a visible workspace and file tools. |
 
+## Built-in Harness Identity
+
+**Built-in harnesses are identified by `name`, not by UUID.** The `harness_id` row is per-org and is generated when the harness is provisioned. Reconciliation, lookups, tests, examples, and migrations must resolve built-in harnesses by `name` + `is_built_in`.
+
+**Hardcoded harness UUID literals are forbidden** anywhere in the codebase, including:
+
+- production code (`crates/**/src/`)
+- integration and unit tests
+- example crates and fixtures
+- new database migrations
+
+The single exception is the historical default-org seed range (see "UUID Allocation" below) — those literals exist purely to keep already-provisioned default-org rows stable and must not grow.
+
 ## Built-in Harness Lifecycle
 
 Built-in harnesses are managed by `crates/server/src/org_init.rs`:
@@ -116,7 +129,7 @@ Built-in harnesses are managed by `crates/server/src/org_init.rs`:
 
 ### UUID Allocation (Default Org Only)
 
-Harness seed UUIDs occupy the `0x600-0x6FF` range. These fixed UUIDs are only used for the default org; other orgs get auto-generated UUIDs. See `crates/server/src/seed.rs` for seed harness definitions and capability assignments.
+Harness seed UUIDs occupy the `0x600-0x6FF` range. These fixed UUIDs exist solely so historical default-org rows stay stable across upgrades; they are an implementation detail of org seeding and are not addressable identity. New code, tests, and migrations must always use name-based lookups. See `crates/server/src/seed.rs` for seed harness definitions and capability assignments.
 
 ### Data Analyst
 


### PR DESCRIPTION
## What
Documentation + one example cleanup that finishes the spec/audit half of EVE-336 (follow-up to EVE-334).

- `specs/embedding.md` — removed the `seed_id` bullet from "Built-in Harness Templates" and added a new "Harness Identity" section documenting that built-in harnesses are identified by `name`, not UUID. Reworded the "Org Initialization Contract" paragraph to make the default-org UUID exception explicit and narrow.
- `specs/harness-types.md` — added an explicit "Built-in Harness Identity" section: built-in harnesses are addressed by `name`, and hardcoded harness UUID literals are forbidden in production code, tests, examples, and migrations. The existing "UUID Allocation (Default Org Only)" paragraph is reworded to make the historical seed range an implementation detail rather than addressable identity.
- `examples/weekend-concierge-host/src/lib.rs` — replaced the three hardcoded `..._00000000000000000000000000000090` IDs with generated typed IDs (`HarnessId::new()`, `AgentId::new()`, `SessionId::new()`) so `examples/` joins `crates/cli/` in being free of harness UUID literals. `Cargo.lock` was refreshed alongside the `cargo check`.

## Why
EVE-334 removed the `harness_ids` module and `seed_id` from `BuiltInHarnessDefinition` in code, but the durable "name-based identity" rule was not yet documented and one example still pinned built-in IDs. Without the spec rule and the audit, name-vs-UUID identity for built-in harnesses can regrow in new code, tests, or migrations.

## How
Pure docs + one self-contained example swap. Audit findings:
- `crates/cli/` — clean (no UUID literals).
- `examples/` — only `weekend-concierge-host/src/lib.rs` had a literal; replaced with `*::new()`.
- `evals/` — none in repo; no eval fixtures with UUID literals.
- `crates/server/migrations/` — historical `007_v0.8.6.sql` literals untouched (they're the default-org seed range and live entirely in past migrations).
- `crates/server/tests/` and `crates/server/benches/` — out of scope for this issue (issue scope is cli/, examples/, eval fixtures); tracked separately if we want to scrub server tests.

## Risk
- Low. Spec text + one example swap. No production runtime path changed.
- `cargo check` on `weekend-concierge-host` passes locally.

## Out of scope (deferred to follow-up issue)
- Make `DELETE /api/v1/sessions/<id>` tolerate a dangling `harness_id` FK. Initial code review of the handler (`crates/server/src/api/sessions.rs:743` → `services/session.rs:821` → `db.delete_session`) shows session deletion is a simple FK-less DELETE and shouldn't 500 on orphan `harness_id`; needs a clearer reproduction before changing behavior.
- One-shot migration that remaps orphan `sessions.harness_id` rows to the same-named built-in harness per org. Higher risk surface; deserves its own PR with explicit migration spec compliance.

## Security
- Threat categories reviewed: No security-relevant code changes — this PR only modifies two spec markdown files and the in-process example crate that is not built or shipped as part of the server binary. No auth, authz, API surface, tools, or data paths touched.
- Findings: none.

## Checklist
- [x] Tests added or updated (n/a — docs + example only)
- [x] Backward compatibility considered (no API or schema changes)
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (will do before merge)

Refs EVE-336.