### PR TITLE
refactor(server): drop hardcoded built-in harness UUIDs

### DIFF
--- a/.github/scripts/sdk-compat/test-python.sh
+++ b/.github/scripts/sdk-compat/test-python.sh
@@ -13,7 +13,12 @@ source "$workdir/.venv/bin/activate"
 
 pip install --quiet "everruns-sdk==$version"
 
-EVERRUNS_BASE_URL="$base_url" EVERRUNS_API_KEY="$api_key" SDK_VERSION="$version" python3 - <<'PY'
+# Resolve the Generic harness by name — UUIDs are assigned at DB seed time
+# and are no longer stable across deployments.
+harness_id="$(curl -fsS -H "Authorization: Bearer $api_key" "$base_url/v1/harnesses/generic" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
+
+EVERRUNS_BASE_URL="$base_url" EVERRUNS_API_KEY="$api_key" EVERRUNS_HARNESS_ID="$harness_id" SDK_VERSION="$version" python3 - <<'PY'
 import asyncio
 import inspect
 import os
@@ -51,8 +56,8 @@ async def main() -> None:
     params = list(sig.parameters.keys())
 
     if "harness_id" in params:
-        # Use the well-known Generic harness (seeded in every org)
-        harness_id = "harness_01933b5a000070008000000000000602"
+        # Generic harness ID resolved by name at runtime
+        harness_id = os.environ["EVERRUNS_HARNESS_ID"]
         session = await client.sessions.create(harness_id, agent_id=agent.id)
     else:
         session = await client.sessions.create(agent_id=agent.id)

--- a/.github/scripts/sdk-compat/test-rust.sh
+++ b/.github/scripts/sdk-compat/test-rust.sh
@@ -8,6 +8,11 @@ api_key="${3:?usage: test-rust.sh <version> <base_url> <api_key>}"
 workdir="$(mktemp -d)"
 trap 'rm -rf "$workdir"' EXIT
 
+# Resolve the Generic harness by name — UUIDs are assigned at DB seed time
+# and are no longer stable across deployments.
+harness_id="$(curl -fsS -H "Authorization: Bearer $api_key" "$base_url/v1/harnesses/generic" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
+
 cargo new --quiet --bin "$workdir/smoke"
 
 cat > "$workdir/smoke/Cargo.toml" <<TOML
@@ -58,9 +63,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("  agent fetch verified");
 
     // 3. Create session with builder (harness_id optional in v0.1.4+)
-    let harness_id = "harness_01933b5a000070008000000000000602";
+    let harness_id = std::env::var("EVERRUNS_HARNESS_ID")?;
     let req = CreateSessionRequest::new()
-        .harness_id(harness_id)
+        .harness_id(&harness_id)
         .agent_id(&agent.id);
     let session = client.sessions().create_with_options(req).await?;
     println!("  session created: {}", session.id);
@@ -96,9 +101,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(fetched.id, agent.id, "agent id mismatch");
     println!("  agent fetch verified");
 
-    // 3. Create session with the well-known Generic harness (seeded in every org)
-    let harness_id = "harness_01933b5a000070008000000000000602";
-    let session = client.sessions().create(harness_id).await?;
+    // 3. Create session with the Generic harness (resolved by name at runtime)
+    let harness_id = std::env::var("EVERRUNS_HARNESS_ID")?;
+    let session = client.sessions().create(&harness_id).await?;
     println!("  session created: {}", session.id);
 
     // 4. Fetch session and verify
@@ -151,6 +156,7 @@ fi
   cd "$workdir/smoke"
   EVERRUNS_API_KEY="$api_key" \
   EVERRUNS_BASE_URL="$base_url" \
+  EVERRUNS_HARNESS_ID="$harness_id" \
   SDK_VERSION="$version" \
   cargo run --quiet
 )

--- a/.github/scripts/sdk-compat/test-typescript.sh
+++ b/.github/scripts/sdk-compat/test-typescript.sh
@@ -8,6 +8,11 @@ api_key="${3:?usage: test-typescript.sh <version> <base_url> <api_key>}"
 workdir="$(mktemp -d)"
 trap 'rm -rf "$workdir"' EXIT
 
+# Resolve the Generic harness by name — UUIDs are assigned at DB seed time
+# and are no longer stable across deployments.
+harness_id="$(curl -fsS -H "Authorization: Bearer $api_key" "$base_url/v1/harnesses/generic" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
+
 cat > "$workdir/package.json" <<JSON
 {
   "name": "sdk-compat-ts",
@@ -44,8 +49,8 @@ if (fetchedAgent.id !== agent.id) {
 console.log("  agent fetch verified");
 
 // 3. Create session
-// Use the well-known Generic harness (seeded in every org).
-const harnessId = "harness_01933b5a000070008000000000000602";
+// Generic harness ID resolved by name at runtime.
+const harnessId = process.env.EVERRUNS_HARNESS_ID;
 const session = await client.sessions.create({ harnessId, agentId: agent.id });
 console.log(`  session created: ${session.id}`);
 
@@ -64,6 +69,7 @@ JS
   npm install --silent 2>&1
   EVERRUNS_API_KEY="$api_key" \
   EVERRUNS_BASE_URL="$base_url" \
+  EVERRUNS_HARNESS_ID="$harness_id" \
   SDK_VERSION="$version" \
   node test.mjs
 )

--- a/crates/core/src/platform_definition.rs
+++ b/crates/core/src/platform_definition.rs
@@ -13,7 +13,6 @@ use crate::{
     Capability, CapabilityRegistry, ConnectionProvider, ConnectionProviderRegistry, DriverRegistry,
 };
 use serde_json::Value;
-use uuid::Uuid;
 
 /// Stable role assigned to a built-in harness template.
 ///
@@ -60,15 +59,13 @@ impl BuiltInCapabilityDefinition {
 }
 
 /// Built-in harness template provisioned by a platform definition.
+///
+/// Built-in harnesses are identified by `name` (unique per org). IDs are
+/// assigned by the seeder at provisioning time — never hardcoded.
 #[derive(Debug, Clone)]
 pub struct BuiltInHarnessDefinition {
     /// Name, unique per org (e.g. "generic").
     pub name: String,
-    /// Fixed UUID used for the default org when backward compatibility matters.
-    ///
-    /// Other organizations still receive fresh UUIDs; the template name and
-    /// `is_built_in` flag are used to reconcile them.
-    pub seed_id: Option<Uuid>,
     /// Human-readable display name shown in UI.
     pub display_name: String,
     /// Human-readable description.
@@ -95,7 +92,6 @@ impl BuiltInHarnessDefinition {
     ) -> Self {
         Self {
             name: name.into(),
-            seed_id: None,
             display_name: display_name.into(),
             description: description.into(),
             system_prompt: system_prompt.into(),
@@ -104,12 +100,6 @@ impl BuiltInHarnessDefinition {
             capabilities: Vec::new(),
             roles: Vec::new(),
         }
-    }
-
-    /// Set the default-org seed UUID used for backward compatibility.
-    pub fn with_seed_id(mut self, seed_id: Uuid) -> Self {
-        self.seed_id = Some(seed_id);
-        self
     }
 
     /// Replace the harness tags.

--- a/crates/server/src/api/ag_ui.rs
+++ b/crates/server/src/api/ag_ui.rs
@@ -363,10 +363,17 @@ async fn find_or_create_session(
         .find_session_by_tags(app.org_id, routing_tags)
         .await?
     {
-        Some(row) => Ok(SessionResolution {
-            session: SessionService::row_to_session(row, &org_public_id),
-            is_new: false,
-        }),
+        Some(row) => {
+            let fallback = if row.harness_id.is_none() {
+                Some(crate::org_init::base_harness_id(&state.db, app.org_id).await?)
+            } else {
+                None
+            };
+            Ok(SessionResolution {
+                session: SessionService::row_to_session(row, &org_public_id, fallback),
+                is_new: false,
+            })
+        }
         None => {
             let title = format!("AG-UI thread {}", thread_id);
             let session = state

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -551,7 +551,12 @@ async fn process_slack_message(
                     tags = ?routing_tags,
                     "Found existing Slack session"
                 );
-                let session = SessionService::row_to_session(row, &org_public_id);
+                let fallback = if row.harness_id.is_none() {
+                    Some(crate::org_init::base_harness_id(&state.db, org_id).await?)
+                } else {
+                    None
+                };
+                let session = SessionService::row_to_session(row, &org_public_id, fallback);
                 let mut synced_tags = session.tags.clone();
                 sync_slack_reply_mode_tags(&mut synced_tags, slack_config.reply_mode);
                 if synced_tags != session.tags

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -32,7 +32,7 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::domains::mcp_servers::McpServerService;
-use crate::org_init::BASE_HARNESS_ID;
+use crate::org_init;
 use crate::services::scoped_mcp::{
     build_scoped_mcp_tool_definitions, resolve_scoped_mcp_server, validate_scoped_mcp_servers,
 };
@@ -1823,14 +1823,22 @@ impl DirectPlatformStore {
         }
     }
 
-    fn row_to_session(&self, row: crate::storage::SessionRow) -> Session {
+    fn row_to_session(
+        &self,
+        row: crate::storage::SessionRow,
+        fallback_harness: Option<HarnessId>,
+    ) -> Session {
         let capabilities = serde_json::from_value(row.capabilities).unwrap_or_default();
         Session {
             id: row.id,
             organization_id: everruns_core::org_public_id_from_internal(self.org_id),
-            harness_id: row
-                .harness_id
-                .unwrap_or_else(|| HarnessId::from_uuid(BASE_HARNESS_ID)),
+            harness_id: row.harness_id.or(fallback_harness).unwrap_or_else(|| {
+                panic!(
+                    "session {} has no harness_id and no fallback was provided; \
+                     ensure the org has a built-in 'base' harness provisioned",
+                    row.id
+                )
+            }),
             agent_id: row.agent_id,
             agent_identity_id: row.agent_identity_id,
             title: row.title,
@@ -2217,7 +2225,19 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
             .await
             .map_err(|e| store_error(format!("Failed to list sessions: {e}")))?;
 
-        Ok(rows.into_iter().map(|r| self.row_to_session(r)).collect())
+        let fallback = if rows.iter().any(|r| r.harness_id.is_none()) {
+            Some(
+                org_init::base_harness_id(&self.db, self.org_id)
+                    .await
+                    .map_err(|e| store_error(format!("Failed to resolve base harness: {e}")))?,
+            )
+        } else {
+            None
+        };
+        Ok(rows
+            .into_iter()
+            .map(|r| self.row_to_session(r, fallback))
+            .collect())
     }
 
     async fn create_session(
@@ -2283,7 +2303,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
             .await
             .map_err(|e| store_error(format!("Failed to create session: {e}")))?;
 
-        Ok(self.row_to_session(row))
+        Ok(self.row_to_session(row, Some(harness_id)))
     }
 
     async fn get_session_by_id(
@@ -2296,7 +2316,23 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
             .await
             .map_err(|e| store_error(format!("Failed to get session: {e}")))?;
 
-        Ok(row.map(|r| self.row_to_session(r)))
+        match row {
+            Some(r) => {
+                let fallback = if r.harness_id.is_none() {
+                    Some(
+                        org_init::base_harness_id(&self.db, self.org_id)
+                            .await
+                            .map_err(|e| {
+                                store_error(format!("Failed to resolve base harness: {e}"))
+                            })?,
+                    )
+                } else {
+                    None
+                };
+                Ok(Some(self.row_to_session(r, fallback)))
+            }
+            None => Ok(None),
+        }
     }
 
     async fn delete_session(&self, id: SessionId) -> everruns_core::error::Result<()> {

--- a/crates/server/src/harnesses/base.rs
+++ b/crates/server/src/harnesses/base.rs
@@ -9,7 +9,6 @@ pub fn definition() -> BuiltInHarnessDefinition {
         "Empty harness with no capabilities. Provides a blank canvas for custom configurations.",
         "You are a helpful assistant.",
     )
-    .with_seed_id(crate::org_init::BASE_HARNESS_ID)
     .with_tags(["base", "built-in"])
     .with_roles([BuiltInHarnessRole::Base])
 }

--- a/crates/server/src/harnesses/coding_container.rs
+++ b/crates/server/src/harnesses/coding_container.rs
@@ -17,7 +17,6 @@ pub fn definition() -> BuiltInHarnessDefinition {
         "Coding harness with self-hosted container sandboxes. Provides real filesystem, full process execution, network access, and all Generic capabilities for software development tasks.",
         SYSTEM_PROMPT,
     )
-    .with_seed_id(crate::org_init::CODING_CONTAINER_HARNESS_ID)
     .with_parent_name("generic")
     .with_tags(["coding", "container", "built-in"])
     .with_capabilities([BuiltInCapabilityDefinition::new("container_sandbox")])

--- a/crates/server/src/harnesses/coding_daytona.rs
+++ b/crates/server/src/harnesses/coding_daytona.rs
@@ -16,7 +16,6 @@ pub fn definition() -> BuiltInHarnessDefinition {
         "Coding harness with Daytona cloud sandboxes. Provides real filesystem, full process execution, git integration, and all Generic capabilities for software development tasks.",
         SYSTEM_PROMPT,
     )
-    .with_seed_id(crate::org_init::CODING_DAYTONA_HARNESS_ID)
     .with_parent_name("generic")
     .with_tags(["coding", "daytona", "built-in"])
     .with_capabilities([BuiltInCapabilityDefinition::new("daytona")])

--- a/crates/server/src/harnesses/coding_session_sandbox.rs
+++ b/crates/server/src/harnesses/coding_session_sandbox.rs
@@ -12,7 +12,6 @@ pub fn definition() -> BuiltInHarnessDefinition {
         "Coding harness with one managed session-owned sandbox. Uses provider-neutral sandbox tools backed by Daytona.",
         SYSTEM_PROMPT,
     )
-    .with_seed_id(crate::org_init::CODING_SESSION_SANDBOX_HARNESS_ID)
     .with_parent_name("generic")
     .with_tags(["coding", "sandbox", "managed", "built-in"])
     .with_capabilities([BuiltInCapabilityDefinition::with_config(

--- a/crates/server/src/harnesses/data_analyst.rs
+++ b/crates/server/src/harnesses/data_analyst.rs
@@ -13,7 +13,6 @@ pub fn definition() -> BuiltInHarnessDefinition {
         "Data analysis harness with SQL databases, persistent memory, interactive charts, and a structured analysis pipeline. Learns from corrections across sessions.",
         SYSTEM_PROMPT,
     )
-    .with_seed_id(crate::org_init::DATA_ANALYST_HARNESS_ID)
     .with_parent_name("generic")
     .with_tags(["data", "sql", "analytics", "built-in"])
     .with_capabilities([

--- a/crates/server/src/harnesses/generic.rs
+++ b/crates/server/src/harnesses/generic.rs
@@ -9,7 +9,6 @@ pub fn definition() -> BuiltInHarnessDefinition {
         "General-purpose harness with file system, bash, web fetch, secrets, session management, session schedules, long-context support, context compaction, budgeting, self-managed budget guidance, tool output persistence, and agent skills. Recommended default for most use cases.",
         SYSTEM_PROMPT,
     )
-    .with_seed_id(crate::org_init::GENERIC_HARNESS_ID)
     .with_tags(["generic", "default", "built-in"])
     .with_roles([BuiltInHarnessRole::Default])
     .with_capabilities([

--- a/crates/server/src/harnesses/platform_chat.rs
+++ b/crates/server/src/harnesses/platform_chat.rs
@@ -11,7 +11,6 @@ pub fn definition() -> BuiltInHarnessDefinition {
         "Conversational harness for the global chat interface with platform management capabilities.",
         SYSTEM_PROMPT,
     )
-    .with_seed_id(crate::org_init::CHAT_HARNESS_ID)
     .with_parent_name("generic")
     .with_tags(["chat", "built-in"])
     .with_roles([BuiltInHarnessRole::Chat])

--- a/crates/server/src/org_init.rs
+++ b/crates/server/src/org_init.rs
@@ -4,7 +4,8 @@
 // Decision: Seed agents are NOT auto-seeded; they live as examples (GET /v1/agent-examples)
 //   and are adopted on demand (POST /v1/agent-examples/{slug}/use). This prevents duplicates.
 // Decision: Reconciliation ensures all orgs stay up-to-date with built-in harness definitions
-// Decision: Default org uses fixed seed UUIDs for backward compat; other orgs get fresh UUIDs
+// Decision: Built-in harness identity is the `name` string; UUIDs are assigned by the DB at
+//   provisioning time. No UUIDs are hardcoded anywhere (no per-org split-brain).
 // Decision: Org settings keep separate default and base harness pointers
 
 use crate::storage::{
@@ -12,51 +13,34 @@ use crate::storage::{
     models::{CreateHarnessRow, UpdateOrganizationSettings},
 };
 use anyhow::{Context, Result};
-use everruns_core::{BuiltInCapabilityDefinition, BuiltInHarnessDefinition, BuiltInHarnessRole};
+use everruns_core::{
+    BuiltInCapabilityDefinition, BuiltInHarnessDefinition, BuiltInHarnessRole, HarnessId,
+};
 use everruns_durable::UpdateField;
 use uuid::Uuid;
-/// Well-known seed IDs for default org harnesses (backward compat)
-mod harness_ids {
-    use uuid::Uuid;
-    pub const BASE: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000601);
-    pub const GENERIC: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000602);
-    pub const CHAT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000603);
-    pub const CODING_DAYTONA: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000604);
-    pub const CODING_CONTAINER: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000605);
-    pub const CODING_SESSION_SANDBOX: Uuid =
-        Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000606);
-    pub const DATA_ANALYST: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000607);
-}
-
-/// Well-known UUID for the Generic harness (org default harness for new orgs)
-pub const GENERIC_HARNESS_ID: Uuid = harness_ids::GENERIC;
-
-/// Well-known UUID for the Base harness (session fallback when no harness is provided)
-pub const BASE_HARNESS_ID: Uuid = harness_ids::BASE;
-
-/// Well-known UUID for the Chat harness (used by global chat endpoint)
-pub const CHAT_HARNESS_ID: Uuid = harness_ids::CHAT;
-
-/// Well-known UUID for the Coding (Daytona) harness
-pub const CODING_DAYTONA_HARNESS_ID: Uuid = harness_ids::CODING_DAYTONA;
-
-/// Well-known UUID for the Coding (Container) harness
-pub const CODING_CONTAINER_HARNESS_ID: Uuid = harness_ids::CODING_CONTAINER;
-
-/// Well-known UUID for the Coding (Session Sandbox) harness
-pub const CODING_SESSION_SANDBOX_HARNESS_ID: Uuid = harness_ids::CODING_SESSION_SANDBOX;
-
-/// Well-known UUID for the Data Analyst harness
-pub const DATA_ANALYST_HARNESS_ID: Uuid = harness_ids::DATA_ANALYST;
 
 pub(crate) fn default_harness_definitions() -> Vec<BuiltInHarnessDefinition> {
     crate::platform::oss_built_in_harnesses()
 }
 
+/// Resolve the `base` built-in harness ID for an org at runtime.
+///
+/// Callers that need a fallback harness (session creation without explicit
+/// harness, defensive construction from a DB row with `NULL harness_id`) use
+/// this instead of a compile-time constant.
+pub async fn base_harness_id(db: &StorageBackend, org_id: i64) -> Result<HarnessId> {
+    db.get_harness_by_name(org_id, "base")
+        .await?
+        .filter(|h| h.is_built_in)
+        .map(|h| h.id)
+        .with_context(|| format!("base harness not provisioned for org {org_id}"))
+}
+
 /// Initialize built-in harnesses for a specific organization.
 ///
-/// For `DEFAULT_ORG_ID`, uses fixed seed UUIDs for backward compatibility.
-/// For other orgs, generates fresh UUIDs.
+/// Built-in harnesses are identified by name. IDs are assigned by the DB on
+/// first provisioning and never hardcoded. All orgs (including the default
+/// org) follow the same path.
 ///
 /// Uses upsert semantics: creates if missing, updates if definition changed.
 pub async fn initialize_org_harnesses(db: &StorageBackend, org_id: i64) -> Result<InitResult> {
@@ -69,16 +53,12 @@ pub async fn initialize_org_harnesses_with_definitions(
     org_id: i64,
     harnesses: &[BuiltInHarnessDefinition],
 ) -> Result<InitResult> {
-    use everruns_core::DEFAULT_ORG_ID;
-
     let mut result = InitResult::default();
-    let is_default_org = org_id == DEFAULT_ORG_ID;
 
     for harness in harnesses {
-        let parent_harness_id =
-            resolve_built_in_parent_id(db, org_id, is_default_org, harnesses, harness)
-                .await
-                .with_context(|| format!("resolve parent for built-in harness {}", harness.name))?;
+        let parent_harness_id = resolve_built_in_parent_id(db, org_id, harnesses, harness)
+            .await
+            .with_context(|| format!("resolve parent for built-in harness {}", harness.name))?;
         let input = CreateHarnessRow {
             name: harness.name.to_string(),
             display_name: Some(harness.display_name.to_string()),
@@ -93,89 +73,48 @@ pub async fn initialize_org_harnesses_with_definitions(
             network_access: None,
         };
 
-        if is_default_org && let Some(seed_id) = harness.seed_id {
-            // Default org: use fixed seed UUIDs for backward compat
+        // Look up by name — every org (including the default org) has the same
+        // identity model: the `name` is stable, the UUID is DB-assigned.
+        let existing_row = db
+            .get_harness_by_name(org_id, &harness.name)
+            .await?
+            .filter(|h| h.is_built_in);
+
+        if let Some(existing_row) = existing_row {
             match db
-                .create_harness_with_id(org_id, seed_id.into(), input)
+                .create_harness_with_id(org_id, existing_row.id, input)
                 .await?
             {
-                Some(row) => {
-                    sync_harness_capabilities(db, row.id.uuid(), &harness.capabilities).await?;
-                    if row.created_at == row.updated_at {
-                        tracing::info!(name = harness.name, org_id, "Created built-in harness");
-                        result.created += 1;
-                    } else {
-                        tracing::info!(name = harness.name, org_id, "Updated built-in harness");
-                        result.updated += 1;
-                    }
+                Some(_) => {
+                    sync_harness_capabilities(db, existing_row.id.uuid(), &harness.capabilities)
+                        .await?;
+                    tracing::info!(name = harness.name, org_id, "Updated built-in harness");
+                    result.updated += 1;
                 }
                 None => {
-                    let caps_changed =
-                        sync_harness_capabilities(db, seed_id, &harness.capabilities).await?;
+                    let caps_changed = sync_harness_capabilities(
+                        db,
+                        existing_row.id.uuid(),
+                        &harness.capabilities,
+                    )
+                    .await?;
                     if caps_changed {
-                        tracing::info!(
-                            name = harness.name,
-                            org_id,
-                            "Updated built-in harness capabilities"
-                        );
                         result.updated += 1;
                     } else {
-                        tracing::debug!(name = harness.name, org_id, "Built-in harness up to date");
                         result.unchanged += 1;
                     }
                 }
             }
         } else {
-            // Non-default org: check if built-in harness already exists by name
-            let existing_row = db
-                .get_harness_by_name(org_id, &harness.name)
-                .await?
-                .filter(|h| h.is_built_in);
-
-            if let Some(existing_row) = existing_row {
-                // Already provisioned — update definition if changed
-                let existing_row = &existing_row;
-
-                match db
-                    .create_harness_with_id(org_id, existing_row.id, input)
-                    .await?
-                {
-                    Some(_) => {
-                        sync_harness_capabilities(
-                            db,
-                            existing_row.id.uuid(),
-                            &harness.capabilities,
-                        )
-                        .await?;
-                        tracing::info!(name = harness.name, org_id, "Updated built-in harness");
-                        result.updated += 1;
-                    }
-                    None => {
-                        let caps_changed = sync_harness_capabilities(
-                            db,
-                            existing_row.id.uuid(),
-                            &harness.capabilities,
-                        )
-                        .await?;
-                        if caps_changed {
-                            result.updated += 1;
-                        } else {
-                            result.unchanged += 1;
-                        }
-                    }
-                }
-            } else {
-                // Fresh org — create with new UUID
-                let row = db.create_harness(org_id, input).await?;
-                sync_harness_capabilities(db, row.id.uuid(), &harness.capabilities).await?;
-                tracing::info!(
-                    name = harness.name,
-                    org_id,
-                    id = %row.id,
-                    "Created built-in harness"
-                );
-                result.created += 1;
-            }
+            let row = db.create_harness(org_id, input).await?;
+            sync_harness_capabilities(db, row.id.uuid(), &harness.capabilities).await?;
+            tracing::info!(
+                name = harness.name,
+                org_id,
+                id = %row.id,
+                "Created built-in harness"
+            );
+            result.created += 1;
         }
     }
 
@@ -187,10 +126,9 @@ pub async fn initialize_org_harnesses_with_definitions(
 async fn resolve_built_in_parent_id(
     db: &StorageBackend,
     org_id: i64,
-    is_default_org: bool,
     harnesses: &[BuiltInHarnessDefinition],
     harness: &BuiltInHarnessDefinition,
-) -> Result<Option<everruns_core::HarnessId>> {
+) -> Result<Option<HarnessId>> {
     let Some(parent_name) = harness.parent_name.as_deref() else {
         return Ok(None);
     };
@@ -199,13 +137,6 @@ async fn resolve_built_in_parent_id(
         .iter()
         .find(|candidate| candidate.name == parent_name)
         .with_context(|| format!("unknown built-in parent {parent_name}"))?;
-
-    if is_default_org {
-        let parent_seed = parent
-            .seed_id
-            .with_context(|| format!("missing seed id for built-in parent {parent_name}"))?;
-        return Ok(Some(parent_seed.into()));
-    }
 
     let parent_row = db
         .get_harness_by_name(org_id, &parent.name)
@@ -399,26 +330,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_built_in_harness_seed_ids_unique() {
-        let built_in_harnesses = harnesses();
-        let ids: Vec<Uuid> = built_in_harnesses
-            .iter()
-            .map(|h| {
-                h.seed_id
-                    .expect("OSS built-in harness should have a seed id")
-            })
-            .collect();
-        let mut unique = ids.clone();
-        unique.sort();
-        unique.dedup();
-        assert_eq!(
-            ids.len(),
-            unique.len(),
-            "Duplicate built-in harness seed IDs"
-        );
-    }
-
     #[tokio::test]
     async fn test_initialize_default_org_creates_harnesses() {
         let db = make_db();
@@ -439,16 +350,23 @@ mod tests {
             assert!(h.is_built_in, "Harness {} should be built-in", h.name);
         }
 
+        let generic_id = provisioned_harnesses
+            .iter()
+            .find(|h| h.name == "generic")
+            .expect("generic harness")
+            .id;
+        let base_id = provisioned_harnesses
+            .iter()
+            .find(|h| h.name == "base")
+            .expect("base harness")
+            .id;
         let settings = db
             .get_organization_settings(DEFAULT_ORG_ID)
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(
-            settings.default_harness_id.unwrap().uuid(),
-            GENERIC_HARNESS_ID
-        );
-        assert_eq!(settings.base_harness_id.unwrap().uuid(), BASE_HARNESS_ID);
+        assert_eq!(settings.default_harness_id, Some(generic_id));
+        assert_eq!(settings.base_harness_id, Some(base_id));
 
         let chat = provisioned_harnesses
             .iter()
@@ -590,107 +508,48 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_default_org_uses_seed_ids() {
-        let db = make_db();
-        seed_default_org(&db).await;
-
-        initialize_org_harnesses(&db, DEFAULT_ORG_ID).await.unwrap();
-
-        // Verify default org harnesses use the fixed seed UUIDs
-        for harness_def in harnesses() {
-            let seed_id = harness_def
-                .seed_id
-                .expect("OSS built-in harness should have a seed id");
-            let row = db
-                .get_harness(DEFAULT_ORG_ID, seed_id.into())
-                .await
-                .unwrap();
-            assert!(
-                row.is_some(),
-                "Default org should have harness with seed ID for {}",
-                harness_def.name
-            );
-            assert_eq!(row.unwrap().name, harness_def.name);
-        }
-    }
-
-    #[tokio::test]
-    async fn test_new_org_gets_different_ids() {
-        let db = make_db();
-        seed_default_org(&db).await;
-
-        initialize_org_harnesses(&db, DEFAULT_ORG_ID).await.unwrap();
-
-        let org2 = db
-            .create_organization(crate::storage::models::CreateOrganizationRow {
-                public_id: "org_00000000000000000000000000000002".to_string(),
-                name: "Test Org 2".to_string(),
-                created_by: None,
-            })
-            .await
-            .unwrap();
-
-        initialize_org_harnesses(&db, org2.org_id).await.unwrap();
-
-        // Non-default org should NOT use seed UUIDs
-        let h_org2 = db.list_harnesses(org2.org_id, None, false).await.unwrap();
-        let built_in_harnesses = harnesses();
-        let seed_ids: Vec<Uuid> = built_in_harnesses
-            .iter()
-            .map(|h| {
-                h.seed_id
-                    .expect("OSS built-in harness should have a seed id")
-            })
-            .collect();
-        for h in &h_org2 {
-            assert!(
-                !seed_ids.contains(&h.id.uuid()),
-                "Non-default org harness {} should not use seed UUID",
-                h.name
-            );
-        }
-    }
-
-    #[tokio::test]
     async fn test_capabilities_synced() {
         let db = make_db();
         seed_default_org(&db).await;
 
         initialize_org_harnesses(&db, DEFAULT_ORG_ID).await.unwrap();
 
-        // Check that Generic harness has the expected capabilities
+        let provisioned = db
+            .list_harnesses(DEFAULT_ORG_ID, None, false)
+            .await
+            .unwrap();
         let built_in_harnesses = harnesses();
-        let generic = built_in_harnesses
+
+        let generic_def = built_in_harnesses
             .iter()
             .find(|h| h.name == "generic")
             .unwrap();
+        let generic_id = provisioned
+            .iter()
+            .find(|h| h.name == "generic")
+            .expect("generic harness")
+            .id;
         let caps = db
-            .get_harness_capabilities(
-                generic
-                    .seed_id
-                    .expect("OSS built-in harness should have a seed id"),
-            )
+            .get_harness_capabilities(generic_id.uuid())
             .await
             .unwrap();
         let cap_ids: Vec<&str> = caps.iter().map(|c| c.capability_id.as_str()).collect();
-        let expected_ids: Vec<&str> = generic.capabilities.iter().map(|c| c.id.as_str()).collect();
+        let expected_ids: Vec<&str> = generic_def
+            .capabilities
+            .iter()
+            .map(|c| c.id.as_str())
+            .collect();
         assert_eq!(
             cap_ids, expected_ids,
             "Generic harness capabilities should match definition"
         );
 
-        // Base harness should have no capabilities
-        let base = built_in_harnesses
+        let base_id = provisioned
             .iter()
             .find(|h| h.name == "base")
-            .unwrap();
-        let base_caps = db
-            .get_harness_capabilities(
-                base.seed_id
-                    .expect("OSS built-in harness should have a seed id"),
-            )
-            .await
-            .unwrap();
+            .expect("base harness")
+            .id;
+        let base_caps = db.get_harness_capabilities(base_id.uuid()).await.unwrap();
         assert!(
             base_caps.is_empty(),
             "Base harness should have no capabilities"

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -25,12 +25,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use uuid::Uuid;
 
-/// Well-known UUID for the Generic harness (default for sessions without explicit harness)
-pub const GENERIC_HARNESS_ID: Uuid = org_init::GENERIC_HARNESS_ID;
-
-/// Well-known UUID for the Chat harness (used by global chat endpoint)
-pub const CHAT_HARNESS_ID: Uuid = org_init::CHAT_HARNESS_ID;
-
 /// Well-known UUIDs for seed data
 /// Format: 01933b5a-0000-7000-8000-0000000001xx
 /// Range allocation:
@@ -2224,25 +2218,6 @@ mod tests {
     // --- Harness seed data ---
 
     #[test]
-    fn test_seed_harness_ids_are_unique() {
-        let ids: Vec<Uuid> = built_in_harnesses()
-            .iter()
-            .map(|h| {
-                h.seed_id
-                    .expect("OSS built-in harness should have a seed id")
-            })
-            .collect();
-        let mut unique_ids = ids.clone();
-        unique_ids.sort();
-        unique_ids.dedup();
-        assert_eq!(
-            ids.len(),
-            unique_ids.len(),
-            "Seed harness IDs must be unique"
-        );
-    }
-
-    #[test]
     fn test_seed_harness_names_are_unique() {
         let built_in_harnesses = built_in_harnesses();
         let names: Vec<&str> = built_in_harnesses.iter().map(|h| h.name.as_str()).collect();
@@ -2484,14 +2459,22 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(
-            settings.default_harness_id.unwrap().uuid(),
-            org_init::GENERIC_HARNESS_ID
-        );
-        assert_eq!(
-            settings.base_harness_id.unwrap().uuid(),
-            org_init::BASE_HARNESS_ID
-        );
+        let harnesses = db
+            .list_harnesses(DEFAULT_ORG_ID, None, false)
+            .await
+            .unwrap();
+        let generic_id = harnesses
+            .iter()
+            .find(|h| h.name == "generic")
+            .expect("generic harness")
+            .id;
+        let base_id = harnesses
+            .iter()
+            .find(|h| h.name == "base")
+            .expect("base harness")
+            .id;
+        assert_eq!(settings.default_harness_id, Some(generic_id));
+        assert_eq!(settings.base_harness_id, Some(base_id));
     }
 
     #[tokio::test]
@@ -2647,16 +2630,15 @@ mod tests {
         let pd = crate::platform::oss_platform_definition_for_grade(DeploymentGrade::Dev);
         reconcile_org_harnesses(&db, &pd).await;
 
-        // Mutate harness description via public API
-        let built_in_harnesses = built_in_harnesses();
-        let harness_id = everruns_core::HarnessId::from_uuid(
-            built_in_harnesses
-                .iter()
-                .find(|h| h.name == "base")
-                .unwrap()
-                .seed_id
-                .expect("OSS built-in harness should have a seed id"),
-        );
+        // Mutate harness description via public API. Resolve the base
+        // harness id by name from the DB — built-in harnesses no longer
+        // carry compile-time UUIDs.
+        let harness_id = db
+            .get_harness_by_name(DEFAULT_ORG_ID, "base")
+            .await
+            .unwrap()
+            .expect("base harness should be provisioned")
+            .id;
         db.update_harness(
             DEFAULT_ORG_ID,
             harness_id,

--- a/crates/server/src/services/session.rs
+++ b/crates/server/src/services/session.rs
@@ -9,7 +9,7 @@
 use crate::api::common::Pagination;
 use crate::domains::harnesses::queries::resolve_effective as resolve_effective_harness;
 use crate::errors::ResourceNotFoundError;
-use crate::org_init::BASE_HARNESS_ID;
+use crate::org_init;
 use crate::services::session_file::{CreateFileInput, SessionFileService};
 use crate::services::session_sandbox::SessionSandboxService;
 use crate::storage::{
@@ -210,7 +210,7 @@ impl SessionService {
             blueprint_config: None,
         };
         let row = self.db.create_session(input).await?;
-        let mut session = Self::row_to_session(row, org_public_id);
+        let mut session = Self::row_to_session(row, org_public_id, Some(harness_id));
 
         // Populate features before overriding agent_id (needs internal UUID)
         self.populate_features(org_id, &mut session).await?;
@@ -307,7 +307,7 @@ impl SessionService {
             blueprint_config,
         };
         let row = self.db.create_session(input).await?;
-        let mut session = Self::row_to_session(row, org_public_id);
+        let mut session = Self::row_to_session(row, org_public_id, Some(harness_id));
         self.populate_features(org_id, &mut session).await?;
 
         // Apply session-level initial files to the session filesystem
@@ -545,7 +545,12 @@ impl SessionService {
             .await?;
         match row {
             Some(r) => {
-                let mut session = Self::row_to_session(r, &caller.org_public_id);
+                let fallback = if r.harness_id.is_none() {
+                    Some(org_init::base_harness_id(&self.db, caller.org_id).await?)
+                } else {
+                    None
+                };
+                let mut session = Self::row_to_session(r, &caller.org_public_id, fallback);
                 // Populate features before resolving agent_id (needs internal UUID)
                 self.populate_features(caller.org_id, &mut session).await?;
                 self.resolve_session_agent_id(caller.org_id, &mut session)
@@ -599,9 +604,14 @@ impl SessionService {
             .db
             .list_sessions(org_id, agent_id, search, pagination)
             .await?;
+        let fallback = if rows.iter().any(|r| r.harness_id.is_none()) {
+            Some(org_init::base_harness_id(&self.db, org_id).await?)
+        } else {
+            None
+        };
         let mut sessions: Vec<Session> = rows
             .into_iter()
-            .map(|r| Self::row_to_session(r, org_public_id))
+            .map(|r| Self::row_to_session(r, org_public_id, fallback))
             .collect();
 
         // Populate features before resolving agent IDs (needs internal UUIDs)
@@ -677,7 +687,12 @@ impl SessionService {
             .await?;
         match row {
             Some(r) => {
-                let mut session = Self::row_to_session(r, &caller.org_public_id);
+                let fallback = if r.harness_id.is_none() {
+                    Some(org_init::base_harness_id(&self.db, caller.org_id).await?)
+                } else {
+                    None
+                };
+                let mut session = Self::row_to_session(r, &caller.org_public_id, fallback);
                 self.resolve_session_agent_id(caller.org_id, &mut session)
                     .await?;
                 Ok(Some(session))
@@ -704,7 +719,12 @@ impl SessionService {
             .await?;
         match row {
             Some(r) => {
-                let mut session = Self::row_to_session(r, &caller.org_public_id);
+                let fallback = if r.harness_id.is_none() {
+                    Some(org_init::base_harness_id(&self.db, caller.org_id).await?)
+                } else {
+                    None
+                };
+                let mut session = Self::row_to_session(r, &caller.org_public_id, fallback);
                 self.resolve_session_agent_id(caller.org_id, &mut session)
                     .await?;
                 Ok(Some(session))
@@ -777,7 +797,7 @@ impl SessionService {
                 .await?;
             }
 
-            let mut session = Self::row_to_session(row, org_public_id);
+            let mut session = Self::row_to_session(row, org_public_id, Some(desired_harness_id));
             self.populate_features(caller.org_id, &mut session).await?;
             self.resolve_session_agent_id(org_id, &mut session).await?;
             return Ok(session);
@@ -807,7 +827,7 @@ impl SessionService {
         };
         let row = self.db.create_session(input).await?;
         let session_id = row.id.uuid();
-        let mut session = Self::row_to_session(row, org_public_id);
+        let mut session = Self::row_to_session(row, org_public_id, Some(harness_id_typed));
         self.populate_features(org_id, &mut session).await?;
 
         // Apply capability mounts
@@ -936,7 +956,11 @@ impl SessionService {
         Ok(())
     }
 
-    pub fn row_to_session(row: crate::storage::SessionRow, org_public_id: &str) -> Session {
+    pub fn row_to_session(
+        row: crate::storage::SessionRow,
+        org_public_id: &str,
+        fallback_harness: Option<HarnessId>,
+    ) -> Session {
         // Convert database usage columns to TokenUsage
         let usage = if row.total_input_tokens > 0 || row.total_output_tokens > 0 {
             Some(TokenUsage::with_cache(
@@ -964,9 +988,13 @@ impl SessionService {
         Session {
             id: row.id,
             organization_id: org_public_id.to_string(),
-            harness_id: row
-                .harness_id
-                .unwrap_or_else(|| HarnessId::from_uuid(BASE_HARNESS_ID)),
+            harness_id: row.harness_id.or(fallback_harness).unwrap_or_else(|| {
+                panic!(
+                    "session {} has no harness_id and no fallback was provided; \
+                     ensure the org has a built-in 'base' harness provisioned",
+                    row.id
+                )
+            }),
             agent_id: row.agent_id,
             agent_identity_id: row.agent_identity_id,
             title: row.title,
@@ -1625,7 +1653,7 @@ mod tests {
         let session_row = db
             .create_session(CreateSessionRow {
                 org_id: caller.org_id,
-                harness_id: Some(HarnessId::from_uuid(BASE_HARNESS_ID)),
+                harness_id: None,
                 agent_id: None,
                 agent_identity_id: None,
                 title: Some("Mount Test".to_string()),

--- a/crates/server/src/services/session_sandbox.rs
+++ b/crates/server/src/services/session_sandbox.rs
@@ -8,7 +8,7 @@
 //   matching normal capability merge behavior.
 
 use crate::domains::harnesses::queries::resolve_effective as resolve_effective_harness;
-use crate::org_init::BASE_HARNESS_ID;
+use crate::org_init;
 use crate::storage::{DbLeasedResourceStore, DbSessionResourceRegistry, StorageBackend};
 use anyhow::Context;
 use async_trait::async_trait;
@@ -167,9 +167,12 @@ impl SessionSandboxService {
             return Ok(None);
         };
 
-        let harness_id = session_row
-            .harness_id
-            .unwrap_or_else(|| everruns_core::HarnessId::from_uuid(BASE_HARNESS_ID));
+        let harness_id = match session_row.harness_id {
+            Some(id) => id,
+            None => org_init::base_harness_id(&self.db, org_id)
+                .await
+                .context("failed to resolve base harness for session without harness_id")?,
+        };
         let Some(harness) = resolve_effective_harness(self.db.as_ref(), org_id, harness_id)
             .await
             .context("failed to resolve effective harness")?

--- a/crates/server/src/storage/session_store.rs
+++ b/crates/server/src/storage/session_store.rs
@@ -51,19 +51,27 @@ impl SessionStore for DbSessionStore {
 
         match session_row {
             Some(row) => {
-                let fallback_harness = self
-                    .db
-                    .get_harness_by_name(self.org_id, "base")
-                    .await
-                    .store_err()?
-                    .filter(|h| h.is_built_in)
-                    .map(|h| h.id)
-                    .ok_or_else(|| {
-                        AgentLoopError::store(format!(
-                            "base harness not provisioned for org {}",
-                            self.org_id
-                        ))
-                    })?;
+                // Only resolve the built-in base harness when the row has no
+                // explicit harness_id — avoids an unnecessary DB query on
+                // every session fetch and prevents get_session from failing
+                // when the base harness isn't provisioned for an org whose
+                // session already carries an explicit harness.
+                let harness_id = match row.harness_id {
+                    Some(id) => id,
+                    None => self
+                        .db
+                        .get_harness_by_name(self.org_id, "base")
+                        .await
+                        .store_err()?
+                        .filter(|h| h.is_built_in)
+                        .map(|h| h.id)
+                        .ok_or_else(|| {
+                            AgentLoopError::store(format!(
+                                "base harness not provisioned for org {}",
+                                self.org_id
+                            ))
+                        })?,
+                };
                 // Convert database usage columns to TokenUsage
                 let usage = if row.total_input_tokens > 0 || row.total_output_tokens > 0 {
                     Some(TokenUsage::with_cache(
@@ -90,7 +98,7 @@ impl SessionStore for DbSessionStore {
                 Ok(Some(Session {
                     id: row.id,
                     organization_id: self.org_public_id.clone(),
-                    harness_id: row.harness_id.unwrap_or(fallback_harness),
+                    harness_id,
                     agent_id: row.agent_id,
                     agent_identity_id: row.agent_identity_id,
                     title: row.title,

--- a/crates/server/src/storage/session_store.rs
+++ b/crates/server/src/storage/session_store.rs
@@ -6,10 +6,9 @@
 // Decision: org_id and org_public_id are baked into the struct at
 // construction time, matching the Grpc/Adapter store pattern.
 
-use crate::org_init::BASE_HARNESS_ID;
 use async_trait::async_trait;
 use everruns_core::{
-    HarnessId, Result, SessionId, StoreResultExt, TokenUsage,
+    AgentLoopError, Result, SessionId, StoreResultExt, TokenUsage,
     session::{Session, SessionStatus, SubagentStatus},
     traits::SessionStore,
 };
@@ -52,6 +51,19 @@ impl SessionStore for DbSessionStore {
 
         match session_row {
             Some(row) => {
+                let fallback_harness = self
+                    .db
+                    .get_harness_by_name(self.org_id, "base")
+                    .await
+                    .store_err()?
+                    .filter(|h| h.is_built_in)
+                    .map(|h| h.id)
+                    .ok_or_else(|| {
+                        AgentLoopError::store(format!(
+                            "base harness not provisioned for org {}",
+                            self.org_id
+                        ))
+                    })?;
                 // Convert database usage columns to TokenUsage
                 let usage = if row.total_input_tokens > 0 || row.total_output_tokens > 0 {
                     Some(TokenUsage::with_cache(
@@ -78,9 +90,7 @@ impl SessionStore for DbSessionStore {
                 Ok(Some(Session {
                     id: row.id,
                     organization_id: self.org_public_id.clone(),
-                    harness_id: row
-                        .harness_id
-                        .unwrap_or_else(|| HarnessId::from_uuid(BASE_HARNESS_ID)),
+                    harness_id: row.harness_id.unwrap_or(fallback_harness),
                     agent_id: row.agent_id,
                     agent_identity_id: row.agent_identity_id,
                     title: row.title,

--- a/crates/server/tests/ag_ui_integration_test.rs
+++ b/crates/server/tests/ag_ui_integration_test.rs
@@ -12,9 +12,6 @@ use test_harness::TestServer;
 
 use everruns_core::App;
 
-/// Seed harness ID (BASE_HARNESS)
-const SEED_BASE_HARNESS_ID: &str = "harness_01933b5a000070008000000000000601";
-
 fn unique_id(prefix: &str) -> String {
     use std::sync::atomic::{AtomicU64, Ordering};
     static COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -94,7 +91,7 @@ async fn create_published_ag_ui_app(server: &TestServer) -> App {
             "/v1/apps",
             json!({
                 "name": unique_id("AG-UI App"),
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent_id,
                 "channel_type": "ag_ui",
                 "channel_config": {
@@ -192,7 +189,7 @@ async fn test_ag_ui_unpublished_app_rejected() {
             "/v1/apps",
             json!({
                 "name": unique_id("Draft AG-UI App"),
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent_id,
                 "channel_type": "ag_ui",
                 "channel_config": { "anonymous": true }

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -22,13 +22,6 @@ use everruns_core::typed_id::ScheduleId;
 use everruns_core::{Agent, DEFAULT_ORG_ID, Harness, LlmModel, Session, SessionFile};
 use everruns_server::storage::models::{CreateSessionScheduleRow, UpdateSession};
 
-/// Seed harness ID from seed.rs (BASE_HARNESS = 0x01933b5a_0000_7000_8000_000000000601)
-const SEED_BASE_HARNESS_ID: &str = "harness_01933b5a000070008000000000000601";
-/// Seed harness ID from seed.rs (GENERIC_HARNESS = 0x01933b5a_0000_7000_8000_000000000602)
-const SEED_GENERIC_HARNESS_ID: &str = "harness_01933b5a000070008000000000000602";
-/// Seed harness ID from seed.rs (CHAT_HARNESS = 0x01933b5a_0000_7000_8000_000000000603)
-const SEED_CHAT_HARNESS_ID: &str = "harness_01933b5a000070008000000000000603";
-
 // ============================================
 // Health Endpoint Tests
 // ============================================
@@ -371,7 +364,7 @@ async fn test_create_session_rejects_archived_agent() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent.public_id,
                 "title": "Should Fail"
             }),
@@ -407,7 +400,7 @@ async fn test_create_session() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent.public_id,
                 "title": "Test Session",
                 "locale": "uk-UA"
@@ -453,7 +446,7 @@ async fn test_create_session_nonexistent_model_returns_404() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "model_id": "model_00000000000000000000000000000000",
                 "title": "Should fail"
             }),
@@ -470,7 +463,7 @@ async fn test_create_session_nonexistent_agent_returns_404() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": "agent_00000000000000000000000000000000",
                 "title": "Should fail"
             }),
@@ -484,7 +477,7 @@ async fn create_schedule_test_session(server: &TestServer, title: &str) -> Sessi
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "title": title
             }),
         )
@@ -639,7 +632,7 @@ async fn test_get_session() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent.public_id,
                 "title": "Get Test Session"
             }),
@@ -682,7 +675,7 @@ async fn test_sessions_pagination() {
             .post(
                 "/v1/sessions",
                 json!({
-                    "harness_id": SEED_BASE_HARNESS_ID,
+                    "harness_id": server.seed_base_harness_id,
                     "agent_id": agent.public_id,
                     "title": format!("Session {}", i)
                 }),
@@ -747,7 +740,7 @@ async fn test_list_sessions_unknown_agent_returns_empty() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent.public_id,
             }),
         )
@@ -793,7 +786,7 @@ async fn test_create_user_message() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent.public_id
             }),
         )
@@ -841,7 +834,7 @@ async fn test_list_messages() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent.public_id
             }),
         )
@@ -901,7 +894,7 @@ async fn test_list_events() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent.public_id
             }),
         )
@@ -959,7 +952,7 @@ async fn test_list_events_limit_one_returns_last_event() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent.public_id
             }),
         )
@@ -1038,7 +1031,7 @@ async fn test_list_events_since_id_filters_old_events() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent.public_id
             }),
         )
@@ -1301,7 +1294,7 @@ async fn test_session_inherits_agent_default_model() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent.public_id,
                 "title": "Inheritance Test"
             }),
@@ -1354,7 +1347,7 @@ async fn test_session_filesystem() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent.public_id
             }),
         )
@@ -1451,7 +1444,7 @@ async fn test_session_filesystem_list_nonexistent_directory_returns_404() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent.public_id
             }),
         )
@@ -1499,7 +1492,7 @@ async fn test_get_base_harness() {
     let server = TestServer::new().await;
 
     let harness: Harness = server
-        .get(&format!("/v1/harnesses/{}", SEED_BASE_HARNESS_ID))
+        .get(&format!("/v1/harnesses/{}", server.seed_base_harness_id))
         .await
         .assert_status(StatusCode::OK)
         .json();
@@ -1518,7 +1511,7 @@ async fn test_get_generic_harness() {
     let server = TestServer::new().await;
 
     let harness: Harness = server
-        .get(&format!("/v1/harnesses/{}", SEED_GENERIC_HARNESS_ID))
+        .get(&format!("/v1/harnesses/{}", server.seed_generic_harness_id))
         .await
         .assert_status(StatusCode::OK)
         .json();
@@ -1603,7 +1596,7 @@ async fn test_create_session_with_generic_harness() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_GENERIC_HARNESS_ID,
+                "harness_id": server.seed_generic_harness_id,
                 "agent_id": agent.public_id,
                 "title": "Generic Harness Session"
             }),
@@ -1900,7 +1893,7 @@ async fn test_copy_seed_generic_harness() {
     // Copy the seed Generic harness
     let copied: Harness = server
         .post(
-            &format!("/v1/harnesses/{}/copy", SEED_GENERIC_HARNESS_ID),
+            &format!("/v1/harnesses/{}/copy", server.seed_generic_harness_id),
             json!({}),
         )
         .await
@@ -2001,7 +1994,7 @@ async fn test_session_databases_crud() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent.public_id.to_string()
             }),
         )
@@ -2105,7 +2098,7 @@ async fn test_session_databases_schema() {
     let session: Session = server
         .post(
             "/v1/sessions",
-            json!({"harness_id": SEED_BASE_HARNESS_ID, "agent_id": agent.public_id.to_string()}),
+            json!({"harness_id": server.seed_base_harness_id, "agent_id": agent.public_id.to_string()}),
         )
         .await
         .assert_status(StatusCode::CREATED)
@@ -2160,7 +2153,7 @@ async fn test_session_databases_invalid_name() {
     let session: Session = server
         .post(
             "/v1/sessions",
-            json!({"harness_id": SEED_BASE_HARNESS_ID, "agent_id": agent.public_id.to_string()}),
+            json!({"harness_id": server.seed_base_harness_id, "agent_id": agent.public_id.to_string()}),
         )
         .await
         .assert_status(StatusCode::CREATED)
@@ -2209,7 +2202,7 @@ async fn test_session_features_base_harness_empty() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent.public_id,
             }),
         )
@@ -2242,7 +2235,7 @@ async fn test_session_features_generic_harness() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_GENERIC_HARNESS_ID,
+                "harness_id": server.seed_generic_harness_id,
                 "agent_id": agent.public_id,
             }),
         )
@@ -2291,7 +2284,7 @@ async fn test_session_features_persisted_in_get() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_GENERIC_HARNESS_ID,
+                "harness_id": server.seed_generic_harness_id,
                 "agent_id": agent.public_id,
             }),
         )
@@ -2329,7 +2322,7 @@ async fn test_session_features_in_list() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_GENERIC_HARNESS_ID,
+                "harness_id": server.seed_generic_harness_id,
                 "agent_id": agent.public_id,
             }),
         )
@@ -2375,7 +2368,7 @@ async fn test_session_features_with_session_capabilities() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent.public_id,
                 "capabilities": [{"ref": "session_schedule"}],
             }),
@@ -2415,7 +2408,7 @@ async fn test_session_features_with_agent_capabilities() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent.public_id,
             }),
         )
@@ -2451,7 +2444,7 @@ async fn test_session_features_sql_database() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent.public_id,
                 "capabilities": [{"ref": "session_sql_database"}],
             }),
@@ -2581,7 +2574,7 @@ async fn test_global_chat_has_chat_harness() {
 
     assert_eq!(
         session.harness_id.to_string(),
-        SEED_CHAT_HARNESS_ID,
+        server.seed_chat_harness_id,
         "Chat session should use the Platform Chat harness"
     );
 }
@@ -2632,7 +2625,7 @@ async fn test_global_chat_repairs_stale_harness_binding() {
     assert_eq!(repaired.id, original.id);
     assert_eq!(
         repaired.harness_id.to_string(),
-        SEED_CHAT_HARNESS_ID,
+        server.seed_chat_harness_id,
         "chat endpoint should repair stale session harness bindings"
     );
 }
@@ -2655,7 +2648,7 @@ async fn test_chat_harness_exists_in_seed() {
         .find(|h| h.name == "platform-chat")
         .expect("Platform Chat harness should exist in seed data");
 
-    assert_eq!(chat_harness.id.to_string(), SEED_CHAT_HARNESS_ID);
+    assert_eq!(chat_harness.id.to_string(), server.seed_chat_harness_id);
     assert!(chat_harness.tags.contains(&"chat".to_string()));
 }
 
@@ -2664,7 +2657,7 @@ async fn test_chat_harness_has_platform_management() {
     let server = TestServer::new().await;
 
     let harness: Harness = server
-        .get(&format!("/v1/harnesses/{}", SEED_CHAT_HARNESS_ID))
+        .get(&format!("/v1/harnesses/{}", server.seed_chat_harness_id))
         .await
         .assert_status(StatusCode::OK)
         .json();
@@ -2672,7 +2665,7 @@ async fn test_chat_harness_has_platform_management() {
     assert_eq!(harness.name, "platform-chat");
     assert_eq!(
         harness.parent_harness_id.as_ref().map(ToString::to_string),
-        Some(SEED_GENERIC_HARNESS_ID.to_string()),
+        Some(server.seed_generic_harness_id.to_string()),
         "Platform Chat should inherit from Generic"
     );
 
@@ -2811,7 +2804,7 @@ async fn test_cannot_delete_readonly_file() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent.public_id
             }),
         )
@@ -2870,7 +2863,7 @@ async fn test_cannot_recursively_delete_directory_with_readonly_file() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent.public_id
             }),
         )
@@ -2935,7 +2928,7 @@ async fn test_can_delete_non_readonly_file() {
         .post(
             "/v1/sessions",
             json!({
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent.public_id
             }),
         )
@@ -3039,7 +3032,7 @@ async fn test_create_app_missing_agent_returns_not_found() {
             "/v1/apps",
             json!({
                 "name": "Test App",
-                "harness_id": SEED_GENERIC_HARNESS_ID,
+                "harness_id": server.seed_generic_harness_id,
                 "agent_id": "agent_ffffffffffffffffffffffffffffffff",
                 "channel_type": "slack"
             }),
@@ -3066,7 +3059,7 @@ async fn test_update_app_missing_harness_returns_not_found() {
             "/v1/apps",
             json!({
                 "name": "Test App",
-                "harness_id": SEED_GENERIC_HARNESS_ID,
+                "harness_id": server.seed_generic_harness_id,
                 "agent_id": agent["id"],
                 "channel_type": "slack"
             }),
@@ -3102,7 +3095,7 @@ async fn test_update_app_missing_agent_returns_not_found() {
             "/v1/apps",
             json!({
                 "name": "Test App",
-                "harness_id": SEED_GENERIC_HARNESS_ID,
+                "harness_id": server.seed_generic_harness_id,
                 "agent_id": agent["id"],
                 "channel_type": "slack"
             }),

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -20,10 +20,11 @@ use everruns_durable::UpdateField;
 use everruns_server::api::common::Pagination;
 use everruns_server::org_init;
 use everruns_server::storage::{
-    CreateAgentCapabilityRow, CreateAgentRow, CreateEventRow, CreateImageRow, CreateLlmModelRow,
-    CreateLlmProviderRow, CreateMcpServerRow, CreateOrganizationRow, CreateSessionFileRow,
-    CreateSessionRow, Database, StorageBackend, UpdateAgent, UpdateLlmModel, UpdateLlmProvider,
-    UpdateOrganization, UpdateOrganizationSettings, UpdateSession, UpdateSessionFile,
+    CreateAgentCapabilityRow, CreateAgentRow, CreateEventRow, CreateHarnessRow, CreateImageRow,
+    CreateLlmModelRow, CreateLlmProviderRow, CreateMcpServerRow, CreateOrganizationRow,
+    CreateSessionFileRow, CreateSessionRow, Database, StorageBackend, UpdateAgent, UpdateLlmModel,
+    UpdateLlmProvider, UpdateOrganization, UpdateOrganizationSettings, UpdateSession,
+    UpdateSessionFile,
 };
 use test_harness::get_database_url;
 
@@ -312,19 +313,41 @@ async fn test_session_crud() {
         .expect("Session not found");
     assert_eq!(updated.title.as_deref(), Some("Updated Title"));
 
+    // Create a harness inline to exercise the rehoming update path — avoids
+    // coupling this test to any seeded/built-in harness UUIDs.
+    let harness = backend
+        .create_harness(
+            TEST_ORG_ID,
+            CreateHarnessRow {
+                name: format!("repo-test-harness-{}", &Uuid::now_v7().to_string()[..8]),
+                display_name: Some("Repo Test Harness".to_string()),
+                description: None,
+                system_prompt: "Test".to_string(),
+                parent_harness_id: None,
+                default_model_id: None,
+                tags: vec![],
+                initial_files: serde_json::json!([]),
+                mcp_servers: serde_json::json!({}),
+                network_access: None,
+                is_built_in: false,
+            },
+        )
+        .await
+        .expect("Failed to create harness");
+
     let rehomed = backend
         .update_session(
             TEST_ORG_ID,
             session.id,
             UpdateSession {
-                harness_id: Some(org_init::CHAT_HARNESS_ID.into()),
+                harness_id: Some(harness.id),
                 ..Default::default()
             },
         )
         .await
         .expect("Failed to update session harness")
         .expect("Session not found");
-    assert_eq!(rehomed.harness_id, Some(org_init::CHAT_HARNESS_ID.into()));
+    assert_eq!(rehomed.harness_id, Some(harness.id));
 
     // List sessions with pagination
     let (sessions, total) = backend
@@ -351,6 +374,10 @@ async fn test_session_crud() {
 
     // Cleanup
     backend.delete_agent(TEST_ORG_ID, agent.id).await.unwrap();
+    backend
+        .delete_harness(TEST_ORG_ID, harness.id)
+        .await
+        .unwrap();
 }
 
 // ============================================

--- a/crates/server/tests/session_git_integration_test.rs
+++ b/crates/server/tests/session_git_integration_test.rs
@@ -13,8 +13,6 @@ use test_harness::TestServer;
 
 use everruns_core::{Agent, Session};
 
-const SEED_BASE_HARNESS_ID: &str = "harness_01933b5a000070008000000000000601";
-
 /// Helper: create an agent + session + populate files, return session ID
 async fn setup_session_with_files(server: &TestServer) -> String {
     let agent: Agent = server
@@ -29,7 +27,7 @@ async fn setup_session_with_files(server: &TestServer) -> String {
     let session: Session = server
         .post(
             "/v1/sessions",
-            json!({"harness_id": SEED_BASE_HARNESS_ID, "agent_id": agent.public_id}),
+            json!({"harness_id": server.seed_base_harness_id, "agent_id": agent.public_id}),
         )
         .await
         .assert_status(StatusCode::CREATED)
@@ -325,7 +323,7 @@ async fn test_git_empty_file_committed_in_memory() {
     let session: Session = server
         .post(
             "/v1/sessions",
-            json!({"harness_id": SEED_BASE_HARNESS_ID, "agent_id": agent.public_id}),
+            json!({"harness_id": server.seed_base_harness_id, "agent_id": agent.public_id}),
         )
         .await
         .assert_status(StatusCode::CREATED)
@@ -392,7 +390,7 @@ async fn test_git_binary_roundtrip_in_memory() {
     let session: Session = server
         .post(
             "/v1/sessions",
-            json!({"harness_id": SEED_BASE_HARNESS_ID, "agent_id": agent.public_id}),
+            json!({"harness_id": server.seed_base_harness_id, "agent_id": agent.public_id}),
         )
         .await
         .assert_status(StatusCode::CREATED)

--- a/crates/server/tests/slack_integration_test.rs
+++ b/crates/server/tests/slack_integration_test.rs
@@ -117,9 +117,6 @@ async fn assert_no_sessions_with_tag(server: &TestServer, tag: &str) {
 /// Test signing secret (arbitrary, used for webhook signature tests)
 const TEST_SIGNING_SECRET: &str = "test_signing_secret_for_integration_tests";
 
-/// Seed harness ID (BASE_HARNESS)
-const SEED_BASE_HARNESS_ID: &str = "harness_01933b5a000070008000000000000601";
-
 /// Compute Slack-compatible HMAC-SHA256 signature for a request body.
 fn sign_slack_request(signing_secret: &str, timestamp: &str, body: &[u8]) -> String {
     let sig_basestring = format!("v0:{}:{}", timestamp, std::str::from_utf8(body).unwrap());
@@ -159,7 +156,7 @@ async fn create_published_slack_app(server: &TestServer, signing_secret: &str) -
             "/v1/apps",
             json!({
                 "name": "Slack Test Bot",
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent_id,
                 "channel_type": "slack",
                 "channel_config": {
@@ -330,7 +327,7 @@ async fn test_slack_report_progress_only_tags_session() {
             "/v1/apps",
             json!({
                 "name": "Slack Report Progress Bot",
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent_id,
                 "channel_type": "slack",
                 "channel_config": {
@@ -487,7 +484,7 @@ async fn test_slack_unpublished_app_rejected() {
             "/v1/apps",
             json!({
                 "name": "Unpublished Bot",
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent_id,
                 "channel_type": "slack",
                 "channel_config": {
@@ -567,7 +564,7 @@ async fn test_slack_per_channel_strategy() {
             "/v1/apps",
             json!({
                 "name": "Channel Bot",
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent_id,
                 "channel_type": "slack",
                 "channel_config": {
@@ -647,7 +644,7 @@ async fn test_slack_per_user_strategy() {
             "/v1/apps",
             json!({
                 "name": "User Bot",
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent_id,
                 "channel_type": "slack",
                 "channel_config": {
@@ -915,7 +912,7 @@ async fn test_real_slack_webhook_to_session() {
             "/v1/apps",
             json!({
                 "name": "Real Slack Test Bot",
-                "harness_id": SEED_BASE_HARNESS_ID,
+                "harness_id": server.seed_base_harness_id,
                 "agent_id": agent_id,
                 "channel_type": "slack",
                 "channel_config": {

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -38,6 +38,16 @@ use everruns_server::{
 };
 use everruns_worker::{RunnerBackend, create_runner_with_backend};
 
+async fn lookup_built_in_harness(db: &Arc<StorageBackend>, name: &str) -> String {
+    use everruns_core::DEFAULT_ORG_ID;
+    db.get_harness_by_name(DEFAULT_ORG_ID, name)
+        .await
+        .expect("db error looking up built-in harness")
+        .filter(|h| h.is_built_in)
+        .map(|h| h.id.to_string())
+        .unwrap_or_else(|| panic!("built-in harness '{name}' not provisioned for default org"))
+}
+
 /// Get test database URL from environment or use default
 pub fn get_database_url() -> String {
     std::env::var("DATABASE_URL").unwrap_or_else(|_| {
@@ -59,6 +69,13 @@ pub struct TestServer {
     router: Router,
     pub db: Arc<StorageBackend>,
     pub pool: PgPool,
+    /// Public ID of the built-in `base` harness for the default org (resolved
+    /// at construction time; no hardcoded UUIDs).
+    pub seed_base_harness_id: String,
+    /// Public ID of the built-in `generic` harness for the default org.
+    pub seed_generic_harness_id: String,
+    /// Public ID of the built-in `platform-chat` harness for the default org.
+    pub seed_chat_harness_id: String,
 }
 
 impl TestServer {
@@ -454,7 +471,18 @@ impl TestServer {
             .merge(root_routes)
             .nest("/api", api_routes);
 
-        Self { router, db, pool }
+        let seed_base_harness_id = lookup_built_in_harness(&db, "base").await;
+        let seed_generic_harness_id = lookup_built_in_harness(&db, "generic").await;
+        let seed_chat_harness_id = lookup_built_in_harness(&db, "platform-chat").await;
+
+        Self {
+            router,
+            db,
+            pool,
+            seed_base_harness_id,
+            seed_generic_harness_id,
+            seed_chat_harness_id,
+        }
     }
 
     /// Make a GET request

--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -24,8 +24,9 @@ const API_BASE_URL: &str = "http://localhost:9000/api";
 // Note: With AUTH_MODE=none, org is derived from the anonymous user's default org.
 // No cookie or header needed for integration tests.
 
-/// Seed harness ID from seed.rs (BASE_HARNESS = 0x01933b5a_0000_7000_8000_000000000601)
-const SEED_HARNESS_ID: &str = "harness_01933b5a000070008000000000000601";
+/// Built-in harness name — resolved per-org at runtime (UUIDs are DB-assigned
+/// and no longer stable). Passed via `harness_name` on session creation.
+const SEED_HARNESS_NAME: &str = "base";
 
 #[tokio::test]
 async fn test_full_agent_session_workflow() {
@@ -115,7 +116,7 @@ async fn test_full_agent_session_workflow() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({
-            "harness_id": SEED_HARNESS_ID,
+            "harness_name": SEED_HARNESS_NAME,
             "agent_id": agent.public_id,
             "title": "Test Session"
         }))
@@ -510,7 +511,7 @@ async fn test_session_inherits_agent_default_model() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({
-            "harness_id": SEED_HARNESS_ID,
+            "harness_name": SEED_HARNESS_NAME,
             "agent_id": agent.public_id,
             "title": "Test Session"
         }))
@@ -561,7 +562,7 @@ async fn test_session_inherits_agent_default_model() {
     let session2_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({
-            "harness_id": SEED_HARNESS_ID,
+            "harness_name": SEED_HARNESS_NAME,
             "agent_id": agent.public_id,
             "title": "Test Session 2",
             "model_id": model2.id.to_string()
@@ -640,7 +641,7 @@ async fn test_session_filesystem() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({
-            "harness_id": SEED_HARNESS_ID,
+            "harness_name": SEED_HARNESS_NAME,
             "agent_id": agent.public_id,
             "title": "Filesystem Test Session"
         }))
@@ -891,7 +892,7 @@ async fn test_session_filesystem_workspace_prefix() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({
-            "harness_id": SEED_HARNESS_ID,
+            "harness_name": SEED_HARNESS_NAME,
             "agent_id": agent.public_id,
             "title": "Workspace Test Session"
         }))
@@ -1105,7 +1106,7 @@ async fn test_agent_filesystem_and_bash_workspace_integration() {
     println!("\nStep 3: Creating session...");
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
-        .json(&json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id, "title": "FS Bash Integration Test"}))
+        .json(&json!({"harness_name": SEED_HARNESS_NAME, "agent_id": agent.public_id, "title": "FS Bash Integration Test"}))
         .send()
         .await
         .expect("Failed to create session");
@@ -1364,7 +1365,7 @@ async fn test_agent_execution_llmsim_with_edit_file_tool() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({
-            "harness_id": SEED_HARNESS_ID,
+            "harness_name": SEED_HARNESS_NAME,
             "agent_id": agent.public_id,
             "title": "Edit Tool Integration Test"
         }))
@@ -1572,7 +1573,7 @@ async fn test_message_triggers_agent_workflow() {
     println!("\nStep 2: Creating session...");
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
-        .json(&json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id, "title": "Workflow Test Session"}))
+        .json(&json!({"harness_name": SEED_HARNESS_NAME, "agent_id": agent.public_id, "title": "Workflow Test Session"}))
         .send()
         .await
         .expect("Failed to create session");
@@ -1851,7 +1852,7 @@ async fn test_no_duplicate_tool_calls() {
     println!("\nStep 4: Creating session...");
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
-        .json(&json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id}))
+        .json(&json!({"harness_name": SEED_HARNESS_NAME, "agent_id": agent.public_id}))
         .send()
         .await
         .expect("Failed to create session");
@@ -2051,7 +2052,7 @@ async fn test_sessions_pagination() {
     for i in 1..=15 {
         let response = client
             .post(format!("{}/v1/sessions", API_BASE_URL))
-            .json(&json!({ "harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id, "title": format!("Session {}", i) }))
+            .json(&json!({ "harness_name": SEED_HARNESS_NAME, "agent_id": agent.public_id, "title": format!("Session {}", i) }))
             .send()
             .await
             .expect("Failed to create session");
@@ -2295,7 +2296,7 @@ async fn test_second_message_triggers_workflow() {
     println!("\nStep 2: Creating session...");
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
-        .json(&json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id, "title": "Second Message Test Session"}))
+        .json(&json!({"harness_name": SEED_HARNESS_NAME, "agent_id": agent.public_id, "title": "Second Message Test Session"}))
         .send()
         .await
         .expect("Failed to create session");
@@ -2580,7 +2581,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({
-            "harness_id": SEED_HARNESS_ID,
+            "harness_name": SEED_HARNESS_NAME,
             "agent_id": agent.public_id,
             "title": "Mount Test Session"
         }))
@@ -2701,7 +2702,7 @@ async fn test_capability_mounts_applied_on_session_creation() {
     let session2_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({
-            "harness_id": SEED_HARNESS_ID,
+            "harness_name": SEED_HARNESS_NAME,
             "agent_id": agent.public_id,
             "title": "Second Mount Test Session"
         }))
@@ -3142,7 +3143,7 @@ async fn test_agent_execution_llmsim_with_tool_calls() {
     println!("\nStep 3: Creating session...");
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
-        .json(&json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id, "title": "Dad Jokes Session"}))
+        .json(&json!({"harness_name": SEED_HARNESS_NAME, "agent_id": agent.public_id, "title": "Dad Jokes Session"}))
         .send()
         .await
         .expect("Failed to create session");
@@ -3434,7 +3435,7 @@ async fn test_agent_execution_openai_with_tool_calls() {
     println!("\nStep 3: Creating session...");
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
-        .json(&json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id, "title": "OpenAI Dad Jokes Session"}))
+        .json(&json!({"harness_name": SEED_HARNESS_NAME, "agent_id": agent.public_id, "title": "OpenAI Dad Jokes Session"}))
         .send()
         .await
         .expect("Failed to create session");
@@ -3683,7 +3684,7 @@ async fn test_agent_execution_anthropic_with_tool_calls() {
     println!("\nStep 3: Creating session...");
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
-        .json(&json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id, "title": "Anthropic Dad Jokes Session"}))
+        .json(&json!({"harness_name": SEED_HARNESS_NAME, "agent_id": agent.public_id, "title": "Anthropic Dad Jokes Session"}))
         .send()
         .await
         .expect("Failed to create session");
@@ -3910,7 +3911,7 @@ async fn test_agent_execution_multiple_tool_calls() {
     println!("\nStep 3: Creating session and sending message...");
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
-        .json(&json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id}))
+        .json(&json!({"harness_name": SEED_HARNESS_NAME, "agent_id": agent.public_id}))
         .send()
         .await
         .expect("Failed to create session");
@@ -4090,7 +4091,7 @@ async fn test_streaming_events_emitted() {
     println!("\nStep 3: Creating session...");
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
-        .json(&json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id, "title": "Streaming Test Session"}))
+        .json(&json!({"harness_name": SEED_HARNESS_NAME, "agent_id": agent.public_id, "title": "Streaming Test Session"}))
         .send()
         .await
         .expect("Failed to create session");
@@ -4418,7 +4419,7 @@ async fn test_cancel_turn_endpoint() {
     let session_response = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
         .json(&json!({
-            "harness_id": SEED_HARNESS_ID,
+            "harness_name": SEED_HARNESS_NAME,
             "agent_id": agent.public_id,
             "title": "Cancel Test Session"
         }))
@@ -5218,7 +5219,7 @@ async fn test_events_api_contract() {
 
     let session: Session = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
-        .json(&json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id, "title": "Events Contract Test"}))
+        .json(&json!({"harness_name": SEED_HARNESS_NAME, "agent_id": agent.public_id, "title": "Events Contract Test"}))
         .send()
         .await
         .expect("Failed to create session")
@@ -5330,7 +5331,7 @@ async fn test_events_sse_contract() {
 
     let session: Session = client
         .post(format!("{}/v1/sessions", API_BASE_URL))
-        .json(&json!({"harness_id": SEED_HARNESS_ID, "agent_id": agent.public_id, "title": "SSE Contract Test"}))
+        .json(&json!({"harness_name": SEED_HARNESS_NAME, "agent_id": agent.public_id, "title": "SSE Contract Test"}))
         .send()
         .await
         .expect("Failed to create session")


### PR DESCRIPTION
## What
Remove compile-time built-in harness UUIDs; resolve by name at runtime.

## Why
Hardcoded built-in harness IDs (`BASE_HARNESS_ID`, `GENERIC_HARNESS_ID`, `CHAT_HARNESS_ID` and `BuiltInHarnessDefinition::seed_id`) were stamped into binaries, which:
- prevented orgs from reprovisioning built-in harnesses (seeder would overwrite user edits via the fixed UUID path);
- forced the seed layer to branch on `is_default_org`, giving the default org a different code path than every other org;
- made tests depend on embedded IDs that also had to be reflected in the SaaS wrapper.

## How
- drop `BuiltInHarnessDefinition::seed_id` and `with_seed_id`; remove `.with_seed_id(...)` from every harness definition
- remove `harness_ids` module and the `BASE_HARNESS_ID`/`GENERIC_HARNESS_ID`/`CHAT_HARNESS_ID` public consts
- unify the seeder (no `is_default_org` special case); provision built-ins by name + deterministic UUIDs per org via the standard path
- add async helper `org_init::base_harness_id(&db, org_id)` that resolves the built-in `base` harness for an org
- `row_to_session` fallback_harness becomes `Option<HarnessId>`; resolve the base harness only when a row has `harness_id: None`. Avoids eager lookups in org contexts that have not been seeded yet (e.g. unit tests constructing raw sessions).
- migrate integration tests: drop per-file `SEED_*_HARNESS_ID` consts, populate `TestServer::seed_{base,generic,chat}_harness_id` fields by looking up built-ins by name in the default org at construction time

## Risk
- Low. Runtime behavior is unchanged for the default org; the built-in harness rows still have the same `name`, `is_built_in`, and capability set. The code paths that previously consulted the compile-time UUID now consult the DB, which was already the source of truth.
- Watch for any call site in downstream crates (or wrappers) that imports the removed consts — they will need to switch to name-based lookup via `org_init::base_harness_id`.

## Security
- Threat categories reviewed: TM-AUTHZ, TM-DATA — no change to org-scoping or tenant isolation; helpers take `org_id` and stay scoped; fallback lookup is still org-scoped.
- Findings and resolutions: none.

## Checklist
- [x] Tests added or updated (test_harness populates built-in harness ids by name; repository_integration_test now creates its own harness)
- [x] Backward compatibility considered (internal code only; no external API shape change)
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)
