### PR TITLE
feat(mcp): expose command param schemas

### DIFF
--- a/crates/server/src/api/mcp_endpoint/catalog.rs
+++ b/crates/server/src/api/mcp_endpoint/catalog.rs
@@ -100,16 +100,9 @@ pub fn build_toolset(ctx: CatalogContext) -> ScriptingToolSet {
     builder.build()
 }
 
-/// Convert a domain CommandDescriptor to a bashkit ToolDef.
-///
-/// Domain commands don't carry param schemas (the request types own them via
-/// serde), so the schema is open: any JSON object accepted.
 fn command_descriptor_to_def(desc: &crate::domains::common::CommandDescriptor) -> ToolDef {
     let meta = (desc.meta)();
-    let schema = json!({
-        "type": "object",
-        "additionalProperties": true,
-    });
+    let schema = (desc.param_schema)();
     ToolDef::new(meta.name, meta.description)
         .with_schema(schema)
         .with_category(meta.category)
@@ -841,3 +834,30 @@ pub static CATALOG: &[Operation] = &[
         handler: |p, c| Box::pin(handlers::health_check(p, c)),
     },
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inventory_command_defs_expose_structured_param_schemas() {
+        let desc = inventory::iter::<crate::domains::common::CommandDescriptor>
+            .into_iter()
+            .find(|desc| (desc.meta)().name == "create_agent")
+            .expect("create_agent command descriptor");
+
+        let def = command_descriptor_to_def(desc);
+        let properties = def
+            .input_schema
+            .get("properties")
+            .and_then(|value| value.as_object())
+            .expect("create_agent schema properties");
+
+        assert!(properties.contains_key("name"));
+        assert!(properties.contains_key("system_prompt"));
+        assert_ne!(
+            def.input_schema.get("additionalProperties"),
+            Some(&serde_json::Value::Bool(true))
+        );
+    }
+}

--- a/crates/server/src/api/mcp_endpoint/catalog.rs
+++ b/crates/server/src/api/mcp_endpoint/catalog.rs
@@ -7,8 +7,10 @@
 use super::handlers;
 use bashkit::{ScriptingToolSet, ToolArgs, ToolDef};
 use serde_json::json;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::LazyLock;
 /// Handler function type for catalog operations.
 pub type Handler = for<'a> fn(
     &'a serde_json::Value,
@@ -39,6 +41,27 @@ pub struct CatalogContext {
     pub org_id: i64,
     pub user_id: Option<uuid::Uuid>,
 }
+
+static INVENTORY_NAMES: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+    inventory::iter::<crate::domains::common::CommandDescriptor>
+        .into_iter()
+        .map(|d| (d.meta)().name)
+        .collect()
+});
+
+static INVENTORY_TOOL_DEFS: LazyLock<HashMap<&'static str, ToolDef>> = LazyLock::new(|| {
+    inventory::iter::<crate::domains::common::CommandDescriptor>
+        .into_iter()
+        .map(|desc| {
+            let meta = (desc.meta)();
+            let schema = (desc.param_schema)();
+            let def = ToolDef::new(meta.name, meta.description)
+                .with_schema(schema)
+                .with_category(meta.category);
+            (meta.name, def)
+        })
+        .collect()
+});
 
 impl CatalogContext {
     /// Convert to a domain Ctx for inventory-registered Command dispatch.
@@ -74,12 +97,6 @@ pub fn build_toolset(ctx: CatalogContext) -> ScriptingToolSet {
         );
 
     // Collect inventory command names so we can skip static CATALOG duplicates.
-    let inventory_names: std::collections::HashSet<&'static str> =
-        inventory::iter::<crate::domains::common::CommandDescriptor>
-            .into_iter()
-            .map(|d| (d.meta)().name)
-            .collect();
-
     // Inventory commands first — they own the namespace.
     for desc in inventory::iter::<crate::domains::common::CommandDescriptor> {
         let def = command_descriptor_to_def(desc);
@@ -89,7 +106,7 @@ pub fn build_toolset(ctx: CatalogContext) -> ScriptingToolSet {
 
     // Static CATALOG fills in everything not yet migrated.
     for op in CATALOG {
-        if inventory_names.contains(op.name) {
+        if INVENTORY_NAMES.contains(op.name) {
             continue;
         }
         let def = op_to_def(op);
@@ -102,10 +119,14 @@ pub fn build_toolset(ctx: CatalogContext) -> ScriptingToolSet {
 
 fn command_descriptor_to_def(desc: &crate::domains::common::CommandDescriptor) -> ToolDef {
     let meta = (desc.meta)();
-    let schema = (desc.param_schema)();
-    ToolDef::new(meta.name, meta.description)
-        .with_schema(schema)
-        .with_category(meta.category)
+    INVENTORY_TOOL_DEFS
+        .get(meta.name)
+        .cloned()
+        .unwrap_or_else(|| {
+            ToolDef::new(meta.name, meta.description)
+                .with_schema((desc.param_schema)())
+                .with_category(meta.category)
+        })
 }
 
 /// Build a callback that dispatches an inventory command via domain dispatch.

--- a/crates/server/src/domains/agent_identities/commands.rs
+++ b/crates/server/src/domains/agent_identities/commands.rs
@@ -12,6 +12,7 @@ use super::{AGENT_IDENTITY_DANGEROUS, AGENT_IDENTITY_MANAGE, AGENT_IDENTITY_VIEW
 use crate::domains::common::*;
 use everruns_core::{AgentIdentity, AgentIdentityId, Policy};
 use serde::Deserialize;
+use utoipa::ToSchema;
 
 // ============================================================================
 // CreateAgentIdentity
@@ -20,6 +21,12 @@ use serde::Deserialize;
 /// Create a new agent identity (virtual principal for unattended execution).
 #[derive(Debug, Deserialize)]
 pub struct CreateAgentIdentity(pub CreateAgentIdentityRequest);
+
+impl CommandSchema for CreateAgentIdentity {
+    fn param_schema() -> serde_json::Value {
+        delegated_param_schema::<CreateAgentIdentityRequest>()
+    }
+}
 
 impl Command for CreateAgentIdentity {
     type Output = AgentIdentity;
@@ -75,7 +82,7 @@ inventory::submit! { CommandDescriptor::of::<CreateAgentIdentity>() }
 // ============================================================================
 
 /// List agent identities. Supports search and include_archived.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct ListAgentIdentities {
     pub search: Option<String>,
     #[serde(default, deserialize_with = "deserialize_bool_lenient")]
@@ -116,7 +123,7 @@ inventory::submit! { CommandDescriptor::of::<ListAgentIdentities>() }
 // ============================================================================
 
 /// Get a single agent identity by ID.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct GetAgentIdentity {
     pub id: String,
 }
@@ -162,7 +169,7 @@ inventory::submit! { CommandDescriptor::of::<GetAgentIdentity>() }
 // ============================================================================
 
 /// Update an agent identity. Only provided fields are changed.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateAgentIdentityCmd {
     pub id: String,
     #[serde(flatten)]
@@ -236,7 +243,7 @@ inventory::submit! { CommandDescriptor::of::<UpdateAgentIdentityCmd>() }
 // ============================================================================
 
 /// Archive an agent identity (soft delete).
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct DeleteAgentIdentity {
     pub id: String,
 }
@@ -289,7 +296,7 @@ inventory::submit! { CommandDescriptor::of::<DeleteAgentIdentity>() }
 // ============================================================================
 
 /// Permanently delete an agent identity.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct DestroyAgentIdentity {
     pub id: String,
 }

--- a/crates/server/src/domains/agents/commands.rs
+++ b/crates/server/src/domains/agents/commands.rs
@@ -12,6 +12,7 @@ use everruns_core::{
     Agent, AgentCapabilityConfig, InitialFile, OrgRole, Policy, ScopedMcpServers, ToolDefinition,
 };
 use serde::Deserialize;
+use utoipa::ToSchema;
 
 // ============================================================================
 // Input validation
@@ -113,6 +114,12 @@ async fn persist_capabilities(
 /// Create a new agent with a name, system prompt, and optional capabilities.
 #[derive(Debug, Deserialize)]
 pub struct CreateAgent(pub CreateAgentRequest);
+
+impl CommandSchema for CreateAgent {
+    fn param_schema() -> serde_json::Value {
+        delegated_param_schema::<CreateAgentRequest>()
+    }
+}
 
 impl Command for CreateAgent {
     type Output = Agent;
@@ -226,7 +233,7 @@ inventory::submit! { CommandDescriptor::of::<CreateAgent>() }
 // ============================================================================
 
 /// List agents. Supports search, include_archived, pagination.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct ListAgents {
     pub search: Option<String>,
     #[serde(default, deserialize_with = "deserialize_bool_lenient")]
@@ -285,7 +292,7 @@ inventory::submit! { CommandDescriptor::of::<ListAgents>() }
 // ============================================================================
 
 /// Get a single agent by ID or name.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct GetAgent {
     pub id: String,
 }
@@ -326,7 +333,7 @@ inventory::submit! { CommandDescriptor::of::<GetAgent>() }
 // ============================================================================
 
 /// Update an agent. Only provided fields are changed.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateAgentCmd {
     pub id: String,
     #[serde(flatten)]
@@ -478,7 +485,7 @@ inventory::submit! { CommandDescriptor::of::<UpdateAgentCmd>() }
 // ============================================================================
 
 /// Archive an agent (soft delete).
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct DeleteAgent {
     pub id: String,
 }
@@ -533,7 +540,7 @@ inventory::submit! { CommandDescriptor::of::<DeleteAgent>() }
 // ============================================================================
 
 /// Upsert agent — create or update by ID.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct UpsertAgent {
     pub id: String,
     #[serde(flatten)]
@@ -643,7 +650,7 @@ inventory::submit! { CommandDescriptor::of::<UpsertAgent>() }
 // ============================================================================
 
 /// Copy an agent. Generates a unique name ({name}-copy, -copy-2, etc.)
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct CopyAgent {
     pub id: String,
 }
@@ -707,7 +714,7 @@ inventory::submit! { CommandDescriptor::of::<CopyAgent>() }
 // ============================================================================
 
 /// Get agent data for export.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct ExportAgent {
     pub id: String,
 }
@@ -751,6 +758,12 @@ inventory::submit! { CommandDescriptor::of::<ExportAgent>() }
 #[derive(Debug, Deserialize)]
 pub struct ImportAgent(pub CreateAgentRequest);
 
+impl CommandSchema for ImportAgent {
+    fn param_schema() -> serde_json::Value {
+        delegated_param_schema::<CreateAgentRequest>()
+    }
+}
+
 impl Command for ImportAgent {
     type Output = Agent;
 
@@ -780,7 +793,7 @@ inventory::submit! { CommandDescriptor::of::<ImportAgent>() }
 // ============================================================================
 
 /// Preview the final agent shape with capabilities applied.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct PreviewAgent {
     pub system_prompt: Option<String>,
     #[serde(default)]
@@ -842,7 +855,7 @@ inventory::submit! { CommandDescriptor::of::<PreviewAgent>() }
 // ============================================================================
 
 /// Check whether an agent name is available.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct CheckAgentName {
     pub name: String,
     pub exclude_id: Option<String>,
@@ -905,7 +918,7 @@ inventory::submit! { CommandDescriptor::of::<CheckAgentName>() }
 // ============================================================================
 
 /// Permanently delete an archived agent.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct DestroyAgent {
     pub id: String,
 }

--- a/crates/server/src/domains/apps/commands.rs
+++ b/crates/server/src/domains/apps/commands.rs
@@ -16,6 +16,7 @@ use everruns_core::typed_id::{AgentId, AppChannelId, HarnessId};
 use everruns_core::{App, AppChannel, AppId, Policy};
 use everruns_durable::UpdateField;
 use serde::Deserialize;
+use utoipa::ToSchema;
 use uuid::Uuid;
 
 // ============================================================================
@@ -77,6 +78,12 @@ async fn validate_agent_identity(
 /// Create a new app with an agent, harness, and initial channel.
 #[derive(Debug, Deserialize)]
 pub struct CreateApp(pub CreateAppRequest);
+
+impl CommandSchema for CreateApp {
+    fn param_schema() -> serde_json::Value {
+        delegated_param_schema::<CreateAppRequest>()
+    }
+}
 
 impl Command for CreateApp {
     type Output = App;
@@ -159,7 +166,7 @@ inventory::submit! { CommandDescriptor::of::<CreateApp>() }
 // ============================================================================
 
 /// List apps. Supports search and include_archived.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct ListApps {
     pub search: Option<String>,
     #[serde(default, deserialize_with = "deserialize_bool_lenient")]
@@ -203,7 +210,7 @@ inventory::submit! { CommandDescriptor::of::<ListApps>() }
 // ============================================================================
 
 /// Get a single app by ID.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct GetApp {
     pub id: String,
 }
@@ -250,7 +257,7 @@ inventory::submit! { CommandDescriptor::of::<GetApp>() }
 // ============================================================================
 
 /// Update an app. Only provided fields are changed.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateAppCmd {
     pub id: String,
     #[serde(flatten)]
@@ -353,7 +360,7 @@ inventory::submit! { CommandDescriptor::of::<UpdateAppCmd>() }
 // ============================================================================
 
 /// Archive an app (soft delete).
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct DeleteApp {
     pub id: String,
 }
@@ -408,7 +415,7 @@ inventory::submit! { CommandDescriptor::of::<DeleteApp>() }
 // ============================================================================
 
 /// Permanently delete an archived app.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct DestroyApp {
     pub id: String,
 }
@@ -469,7 +476,7 @@ inventory::submit! { CommandDescriptor::of::<DestroyApp>() }
 // ============================================================================
 
 /// Publish an app (start accepting requests).
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct PublishApp {
     pub id: String,
 }
@@ -533,7 +540,7 @@ inventory::submit! { CommandDescriptor::of::<PublishApp>() }
 // ============================================================================
 
 /// Unpublish an app (stop accepting requests).
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct UnpublishApp {
     pub id: String,
 }
@@ -596,7 +603,7 @@ inventory::submit! { CommandDescriptor::of::<UnpublishApp>() }
 // ============================================================================
 
 /// Add a channel to an app.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct AddChannel {
     pub app_id: String,
     #[serde(flatten)]
@@ -671,7 +678,7 @@ inventory::submit! { CommandDescriptor::of::<AddChannel>() }
 // ============================================================================
 
 /// Update a channel on an app.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateChannelCmd {
     pub app_id: String,
     pub channel_id: String,
@@ -763,7 +770,7 @@ inventory::submit! { CommandDescriptor::of::<UpdateChannelCmd>() }
 // ============================================================================
 
 /// Remove a channel from an app.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct DeleteChannel {
     pub app_id: String,
     pub channel_id: String,

--- a/crates/server/src/domains/audit_logs/commands.rs
+++ b/crates/server/src/domains/audit_logs/commands.rs
@@ -10,6 +10,7 @@ use crate::domains::common::*;
 use chrono::{DateTime, Utc};
 use everruns_core::Policy;
 use serde::Deserialize;
+use utoipa::ToSchema;
 use uuid::Uuid;
 
 // ============================================================================
@@ -17,7 +18,7 @@ use uuid::Uuid;
 // ============================================================================
 
 /// List audit logs for the caller's organization. Policy-gated read.
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, ToSchema)]
 pub struct ListAuditLogs {
     /// Max entries to return (default 50, max 200).
     pub limit: Option<i64>,

--- a/crates/server/src/domains/capabilities/commands.rs
+++ b/crates/server/src/domains/capabilities/commands.rs
@@ -9,6 +9,7 @@ use super::types::CapabilityInfo;
 use crate::domains::common::*;
 use everruns_core::CapabilityId;
 use serde::Deserialize;
+use utoipa::ToSchema;
 
 // Capabilities are a bounded set (~30-50 items), so default to showing all.
 const DEFAULT_LIMIT: u32 = 100;
@@ -19,7 +20,7 @@ const MAX_LIMIT: u32 = 200;
 // ============================================================================
 
 /// List available capabilities with optional search and pagination.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct ListCapabilities {
     pub search: Option<String>,
     #[serde(default, deserialize_with = "deserialize_opt_u32_lenient")]
@@ -78,7 +79,7 @@ inventory::submit! { CommandDescriptor::of::<ListCapabilities>() }
 // ============================================================================
 
 /// Get a specific capability by ID.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct GetCapability {
     pub id: String,
 }

--- a/crates/server/src/domains/common.rs
+++ b/crates/server/src/domains/common.rs
@@ -233,12 +233,17 @@ fn json_schema_for<T>() -> Value
 where
     T: ToSchema,
 {
-    let mut schema = serde_json::to_value(T::schema()).unwrap_or_else(|_| {
-        serde_json::json!({
-            "type": "object",
-            "additionalProperties": true,
-        })
-    });
+    let mut schema = match serde_json::to_value(T::schema()) {
+        Ok(schema) => schema,
+        Err(err) => {
+            tracing::warn!(
+                schema_type = std::any::type_name::<T>(),
+                error = %err,
+                "failed to serialize command schema; falling back to open object schema"
+            );
+            return open_object_schema();
+        }
+    };
 
     rewrite_schema_refs(&mut schema);
 
@@ -246,7 +251,18 @@ where
     let mut refs = Vec::new();
     T::schemas(&mut refs);
     for (name, ref_or_schema) in refs {
-        let mut value = serde_json::to_value(ref_or_schema).unwrap_or(Value::Null);
+        let mut value = match serde_json::to_value(ref_or_schema) {
+            Ok(value) => value,
+            Err(err) => {
+                tracing::warn!(
+                    schema_type = std::any::type_name::<T>(),
+                    schema_name = %name,
+                    error = %err,
+                    "failed to serialize referenced schema; using open object schema in $defs"
+                );
+                open_object_schema()
+            }
+        };
         rewrite_schema_refs(&mut value);
         defs.insert(name, value);
     }
@@ -258,6 +274,13 @@ where
     }
 
     schema
+}
+
+fn open_object_schema() -> Value {
+    serde_json::json!({
+        "type": "object",
+        "additionalProperties": true,
+    })
 }
 
 fn rewrite_schema_refs(value: &mut Value) {

--- a/crates/server/src/domains/common.rs
+++ b/crates/server/src/domains/common.rs
@@ -8,9 +8,11 @@ use axum::Json;
 use axum::http::StatusCode;
 use everruns_core::{Caller, Policy, PolicyError};
 use serde::{Serialize, de::DeserializeOwned};
+use serde_json::Value;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use utoipa::ToSchema;
 
 use crate::api::common::ErrorResponse;
 
@@ -171,7 +173,7 @@ impl Ctx {
 // Command trait
 // ============================================================================
 
-pub trait Command: DeserializeOwned + Send + 'static {
+pub trait Command: DeserializeOwned + Send + 'static + CommandSchema {
     type Output: Serialize + Send;
 
     /// Static metadata — drives MCP catalog generation.
@@ -191,8 +193,93 @@ pub trait Command: DeserializeOwned + Send + 'static {
         None
     }
 
+    /// JSON Schema for the command input surfaced in the MCP catalog.
+    fn param_schema() -> Value {
+        json_schema_for_command::<Self>()
+    }
+
     /// Execute the command. Validation + business logic + persistence.
     fn execute(self, ctx: &Ctx) -> impl Future<Output = Result<Self::Output, CommandError>> + Send;
+}
+
+pub trait CommandSchema {
+    fn param_schema() -> Value;
+}
+
+impl<T> CommandSchema for T
+where
+    T: ToSchema,
+{
+    fn param_schema() -> Value {
+        json_schema_for::<T>()
+    }
+}
+
+fn json_schema_for_command<T>() -> Value
+where
+    T: Command + CommandSchema,
+{
+    <T as CommandSchema>::param_schema()
+}
+
+pub fn delegated_param_schema<T>() -> Value
+where
+    T: ToSchema,
+{
+    json_schema_for::<T>()
+}
+
+fn json_schema_for<T>() -> Value
+where
+    T: ToSchema,
+{
+    let mut schema = serde_json::to_value(T::schema()).unwrap_or_else(|_| {
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": true,
+        })
+    });
+
+    rewrite_schema_refs(&mut schema);
+
+    let mut defs = serde_json::Map::new();
+    let mut refs = Vec::new();
+    T::schemas(&mut refs);
+    for (name, ref_or_schema) in refs {
+        let mut value = serde_json::to_value(ref_or_schema).unwrap_or(Value::Null);
+        rewrite_schema_refs(&mut value);
+        defs.insert(name, value);
+    }
+
+    if !defs.is_empty()
+        && let Some(obj) = schema.as_object_mut()
+    {
+        obj.insert("$defs".to_string(), Value::Object(defs));
+    }
+
+    schema
+}
+
+fn rewrite_schema_refs(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            if let Some(Value::String(reference)) = map.get_mut("$ref")
+                && let Some(name) = reference.strip_prefix("#/components/schemas/")
+            {
+                *reference = format!("#/$defs/{name}");
+            }
+
+            for child in map.values_mut() {
+                rewrite_schema_refs(child);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                rewrite_schema_refs(item);
+            }
+        }
+        _ => {}
+    }
 }
 
 // ============================================================================
@@ -220,6 +307,7 @@ type DispatchFn =
 pub struct CommandDescriptor {
     pub meta: fn() -> CommandMeta,
     pub positional_arg: fn() -> Option<&'static str>,
+    pub param_schema: fn() -> Value,
     pub dispatch: DispatchFn,
 }
 
@@ -231,6 +319,7 @@ impl CommandDescriptor {
         Self {
             meta: C::meta,
             positional_arg: C::positional_arg,
+            param_schema: <C as Command>::param_schema,
             dispatch: dispatch_for::<C>,
         }
     }

--- a/crates/server/src/domains/harnesses/commands.rs
+++ b/crates/server/src/domains/harnesses/commands.rs
@@ -12,6 +12,7 @@ use everruns_core::{
     merge_scoped_mcp_servers,
 };
 use serde::Deserialize;
+use utoipa::ToSchema;
 
 // ============================================================================
 // Input validation
@@ -99,6 +100,12 @@ async fn persist_capabilities(
 /// Create a new harness with a name, system prompt, and optional capabilities.
 #[derive(Debug, Deserialize)]
 pub struct CreateHarness(pub CreateHarnessRequest);
+
+impl CommandSchema for CreateHarness {
+    fn param_schema() -> serde_json::Value {
+        delegated_param_schema::<CreateHarnessRequest>()
+    }
+}
 
 impl Command for CreateHarness {
     type Output = Harness;
@@ -194,7 +201,7 @@ inventory::submit! { CommandDescriptor::of::<CreateHarness>() }
 // ============================================================================
 
 /// List harnesses. Supports search and include_archived.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct ListHarnesses {
     pub search: Option<String>,
     #[serde(default, deserialize_with = "deserialize_bool_lenient")]
@@ -237,7 +244,7 @@ inventory::submit! { CommandDescriptor::of::<ListHarnesses>() }
 // ============================================================================
 
 /// Get a single harness by ID or name.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct GetHarness {
     pub id: String,
 }
@@ -278,7 +285,7 @@ inventory::submit! { CommandDescriptor::of::<GetHarness>() }
 // ============================================================================
 
 /// Update a harness. Only provided fields are changed.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateHarnessCmd {
     pub id: String,
     #[serde(flatten)]
@@ -457,7 +464,7 @@ inventory::submit! { CommandDescriptor::of::<UpdateHarnessCmd>() }
 // ============================================================================
 
 /// Archive a harness (soft delete).
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct DeleteHarness {
     pub id: String,
 }
@@ -522,7 +529,7 @@ inventory::submit! { CommandDescriptor::of::<DeleteHarness>() }
 // ============================================================================
 
 /// Permanently delete an archived harness.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct DestroyHarness {
     pub id: String,
 }
@@ -600,7 +607,7 @@ inventory::submit! { CommandDescriptor::of::<DestroyHarness>() }
 // ============================================================================
 
 /// Copy a harness. Generates a unique name ({name}-copy, -copy-2, etc.)
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct CopyHarness {
     pub id: String,
 }
@@ -662,7 +669,7 @@ inventory::submit! { CommandDescriptor::of::<CopyHarness>() }
 // ============================================================================
 
 /// Preview the final harness shape with capabilities applied.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct PreviewHarness {
     pub system_prompt: Option<String>,
     #[serde(default)]
@@ -739,7 +746,7 @@ inventory::submit! { CommandDescriptor::of::<PreviewHarness>() }
 // ============================================================================
 
 /// Check whether a harness name is available.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct CheckHarnessName {
     pub name: String,
     pub exclude_id: Option<String>,

--- a/crates/server/src/domains/mcp_servers/commands.rs
+++ b/crates/server/src/domains/mcp_servers/commands.rs
@@ -13,6 +13,7 @@ use crate::domains::common::*;
 use everruns_core::typed_id::McpServerId;
 use everruns_core::{McpServer, McpServerAuthMode, Policy, validate_safe_url};
 use serde::Deserialize;
+use utoipa::ToSchema;
 
 // ============================================================================
 // Input validation
@@ -58,6 +59,12 @@ fn encrypt_api_key(ctx: &Ctx, api_key: &str) -> Result<Vec<u8>, CommandError> {
 /// Create a new MCP server with a name, URL, and optional authentication.
 #[derive(Debug, Deserialize)]
 pub struct CreateMcpServer(pub CreateMcpServerRequest);
+
+impl CommandSchema for CreateMcpServer {
+    fn param_schema() -> serde_json::Value {
+        delegated_param_schema::<CreateMcpServerRequest>()
+    }
+}
 
 impl Command for CreateMcpServer {
     type Output = McpServer;
@@ -147,7 +154,7 @@ inventory::submit! { CommandDescriptor::of::<CreateMcpServer>() }
 // ============================================================================
 
 /// List MCP servers. Supports search and include_archived.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct ListMcpServers {
     pub search: Option<String>,
     #[serde(default, deserialize_with = "deserialize_bool_lenient")]
@@ -189,7 +196,7 @@ inventory::submit! { CommandDescriptor::of::<ListMcpServers>() }
 // ============================================================================
 
 /// Get a single MCP server by ID.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct GetMcpServer {
     pub id: String,
 }
@@ -235,7 +242,7 @@ inventory::submit! { CommandDescriptor::of::<GetMcpServer>() }
 // ============================================================================
 
 /// Update an MCP server. Only provided fields are changed.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateMcpServerCmd {
     pub id: String,
     #[serde(flatten)]
@@ -365,7 +372,7 @@ inventory::submit! { CommandDescriptor::of::<UpdateMcpServerCmd>() }
 // ============================================================================
 
 /// Archive an MCP server (soft delete).
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct DeleteMcpServer {
     pub id: String,
 }
@@ -418,7 +425,7 @@ inventory::submit! { CommandDescriptor::of::<DeleteMcpServer>() }
 // ============================================================================
 
 /// Permanently delete an archived MCP server.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct DestroyMcpServer {
     pub id: String,
 }

--- a/crates/server/src/domains/skills/commands.rs
+++ b/crates/server/src/domains/skills/commands.rs
@@ -13,6 +13,7 @@ use crate::domains::common::*;
 use everruns_core::{Policy, Skill, SkillContent, SkillFileEntry, SkillId, parse_skill_md};
 use serde::Deserialize;
 use std::collections::HashMap;
+use utoipa::ToSchema;
 
 // ============================================================================
 // CreateSkill
@@ -21,6 +22,12 @@ use std::collections::HashMap;
 /// Create a new skill from SKILL.md content.
 #[derive(Debug, Deserialize)]
 pub struct CreateSkill(pub CreateSkillRequest);
+
+impl CommandSchema for CreateSkill {
+    fn param_schema() -> serde_json::Value {
+        delegated_param_schema::<CreateSkillRequest>()
+    }
+}
 
 impl Command for CreateSkill {
     type Output = Skill;
@@ -107,7 +114,7 @@ inventory::submit! { CommandDescriptor::of::<CreateSkill>() }
 // ============================================================================
 
 /// List skills. Supports search and include_archived.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct ListSkills {
     pub search: Option<String>,
     #[serde(default, deserialize_with = "deserialize_bool_lenient")]
@@ -148,7 +155,7 @@ inventory::submit! { CommandDescriptor::of::<ListSkills>() }
 // ============================================================================
 
 /// Get a single skill by ID.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct GetSkill {
     pub id: String,
 }
@@ -199,7 +206,7 @@ inventory::submit! { CommandDescriptor::of::<GetSkill>() }
 // ============================================================================
 
 /// Get full skill content (SKILL.md + files).
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct GetSkillContent {
     pub id: String,
 }
@@ -295,7 +302,7 @@ inventory::submit! { CommandDescriptor::of::<GetSkillContent>() }
 // ============================================================================
 
 /// Update a skill. Only provided fields are changed.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateSkillCmd {
     pub id: String,
     #[serde(flatten)]
@@ -411,7 +418,7 @@ inventory::submit! { CommandDescriptor::of::<UpdateSkillCmd>() }
 // ============================================================================
 
 /// Archive a skill (soft delete).
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct DeleteSkill {
     pub id: String,
 }
@@ -467,7 +474,7 @@ inventory::submit! { CommandDescriptor::of::<DeleteSkill>() }
 // ============================================================================
 
 /// Permanently delete an archived skill.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct DestroySkill {
     pub id: String,
 }


### PR DESCRIPTION
## What
- replace the MCP catalog's open `additionalProperties: true` schema for inventory commands with structured schemas derived from command input types
- add command-schema plumbing in the domain command registry, including delegation for wrapper commands like `CreateAgent(pub CreateAgentRequest)`
- add a regression test that verifies `create_agent` exposes concrete input properties in the generated catalog

## Why
- `EVE-318` asks for accurate MCP command parameter schemas so clients can discover accepted fields and types without reading server source
- the previous catalog shape hid command inputs behind a generic object, which made the `execute` catalog much less useful to MCP clients

## How
- taught `CommandDescriptor` to carry a `param_schema` callback
- generated JSON Schema from `utoipa::ToSchema` metadata for command inputs and rewrote component refs into local `$defs`
- derived schema metadata for local command structs and delegated wrapper commands to their underlying request types

## Risk
- Medium
- touches MCP catalog metadata for inventory-backed commands; malformed schema generation could make command discovery or argument coercion worse for `execute`

## Security
- Threat categories reviewed: TM-TOOL
- Findings and resolutions:
  - Reviewed the schema-generation path to ensure it only serializes compile-time command metadata and does not execute user input.
  - Reviewed `$ref` rewriting to ensure refs stay local (`#/$defs/...`) and do not introduce external schema fetches.
  - No authz or data-exposure behavior changed; runtime command dispatch still deserializes and enforces policy exactly as before.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `cargo test -p everruns-server --lib api::mcp_endpoint::catalog::tests::inventory_command_defs_expose_structured_param_schemas -- --exact`
- `cargo test -p everruns-server --lib domains::common::lenient_tests::opt_u32_lenient_accepts_integer -- --exact`
- `cargo clippy -p everruns-server --lib -- -D warnings`
- `just pre-push`
- `PORT_PREFIX=271 just start-dev --no-watch` then `curl -X POST http://localhost:27100/mcp ... tools/call discover` smoke check, then `PORT_PREFIX=271 just stop-all`

Fixes EVE-318