### PR TITLE
chore(release): prepare v0.8.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
-### Added
+## [0.8.16] - 2026-04-19
 
-- **Self-Budget capability** — New prompt-only `self_budget` capability teaches agents how to reason about a user-requested indicative budget (e.g. "you have $7") using `get_session_info` cumulative usage. Distinct from the platform-enforced `budgeting` capability; both are bundled in the Generic harness. See [`docs/capabilities/self-budget.md`](docs/capabilities/self-budget.md).
+### Highlights
 
-### Changed
+- **Data Analyst harness** - New built-in harness tuned for data-analysis workflows ([#1340](https://github.com/everruns/everruns/pull/1340))
+- **Azure OpenAI provider** - First-class LLM driver for Azure OpenAI deployments ([#1339](https://github.com/everruns/everruns/pull/1339))
+- **A2UI generative UI** - Google A2UI JSON added as a parallel generative-UI capability alongside OpenUI ([#1354](https://github.com/everruns/everruns/pull/1354))
+- **Image generation** - New `gpt_image_gen` capability exposes OpenAI image generation to agents ([#1350](https://github.com/everruns/everruns/pull/1350))
+- **Self-Budget capability** - Prompt-only `self_budget` teaches agents to reason about user-indicated budgets using cumulative usage from `get_session_info` ([#1342](https://github.com/everruns/everruns/pull/1342))
 
-- **Domain pattern** — Migrated `audit_logs` to the `domains/` pattern. `AuditLogService` was removed; the `list_audit_logs` command now owns validation, policy, and persistence, and is surfaced automatically through both the HTTP route and the MCP catalog. See [`specs/domains.md`](specs/domains.md).
+### What's Changed
+
+- refactor(server): drop hardcoded built-in harness UUIDs ([#1360](https://github.com/everruns/everruns/pull/1360)) by [@chaliy](https://github.com/chaliy)
+- feat(mcp): expose command param schemas by [@chaliy](https://github.com/chaliy)
+- docs(docs): render notebooks as cookbook pages ([#1352](https://github.com/everruns/everruns/pull/1352)) by [@chaliy](https://github.com/chaliy)
+- refactor(worker): unify platform CRUD via execute_command ([#1357](https://github.com/everruns/everruns/pull/1357)) by [@chaliy](https://github.com/chaliy)
+- docs(test-cases): add Platform Chat create-and-run agent manual test ([#1362](https://github.com/everruns/everruns/pull/1362)) by [@chaliy](https://github.com/chaliy)
+- chore(harness): scrub hardcoded UUID refs from specs and examples ([#1359](https://github.com/everruns/everruns/pull/1359)) by [@chaliy](https://github.com/chaliy)
+- feat(capabilities): add A2UI as parallel generative-UI capability ([#1354](https://github.com/everruns/everruns/pull/1354)) by [@chaliy](https://github.com/chaliy)
+- chore(release): document migration squashing in release process ([#1358](https://github.com/everruns/everruns/pull/1358)) by [@chaliy](https://github.com/chaliy)
+- refactor(server): delete App/McpServer/Skill services ([#1356](https://github.com/everruns/everruns/pull/1356)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump rust from 1.92-slim-bookworm to 1.95-slim-bookworm in /docker ([#1347](https://github.com/everruns/everruns/pull/1347))
+- chore(deps): bump rust from 1.92-slim to 1.95-slim in /crates/worker ([#1346](https://github.com/everruns/everruns/pull/1346))
+- chore(deps): bump rust from 1.92-slim to 1.95-slim in /crates/server ([#1345](https://github.com/everruns/everruns/pull/1345))
+- chore(deps): bump node from 22-alpine to 25-alpine in /apps/ui ([#1344](https://github.com/everruns/everruns/pull/1344))
+- fix(mcp): return 202 for JSON-RPC notifications ([#1355](https://github.com/everruns/everruns/pull/1355)) by [@chaliy](https://github.com/chaliy)
+- fix(gemini): strip additionalProperties recursively from tool schemas ([#1353](https://github.com/everruns/everruns/pull/1353)) by [@chaliy](https://github.com/chaliy)
+- fix(daytona): reset exec session after timeout ([#1351](https://github.com/everruns/everruns/pull/1351)) by [@chaliy](https://github.com/chaliy)
+- feat(media): add gpt_image_gen capability ([#1350](https://github.com/everruns/everruns/pull/1350)) by [@chaliy](https://github.com/chaliy)
+- fix(server): repair stale platform chat sessions by [@chaliy](https://github.com/chaliy)
+- ci(docker): publish on release only, gate PR builds by paths ([#1343](https://github.com/everruns/everruns/pull/1343)) by [@chaliy](https://github.com/chaliy)
+- refactor(server): migrate audit_logs to domains/ pattern ([#1348](https://github.com/everruns/everruns/pull/1348)) by [@chaliy](https://github.com/chaliy)
+- fix(docker): harden images against common Dockerfile footguns ([#1331](https://github.com/everruns/everruns/pull/1331)) by [@chaliy](https://github.com/chaliy)
+- feat(capabilities): add prompt-only self_budget capability ([#1342](https://github.com/everruns/everruns/pull/1342)) by [@chaliy](https://github.com/chaliy)
+- docs(docs): add notebook-backed tutorial pipeline ([#1341](https://github.com/everruns/everruns/pull/1341)) by [@chaliy](https://github.com/chaliy)
+- feat(harness): add Data Analyst built-in harness ([#1340](https://github.com/everruns/everruns/pull/1340)) by [@chaliy](https://github.com/chaliy)
+- feat(llm): add Azure OpenAI provider ([#1339](https://github.com/everruns/everruns/pull/1339)) by [@chaliy](https://github.com/chaliy)
+- fix(server): accept positional id args on MCP execute commands ([#1338](https://github.com/everruns/everruns/pull/1338)) by [@chaliy](https://github.com/chaliy)
 
 ## [0.8.15] - 2026-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### What's Changed
 
 - refactor(server): drop hardcoded built-in harness UUIDs ([#1360](https://github.com/everruns/everruns/pull/1360)) by [@chaliy](https://github.com/chaliy)
-- feat(mcp): expose command param schemas by [@chaliy](https://github.com/chaliy)
+- feat(mcp): expose command param schemas ([#1363](https://github.com/everruns/everruns/pull/1363)) by [@chaliy](https://github.com/chaliy)
 - docs(docs): render notebooks as cookbook pages ([#1352](https://github.com/everruns/everruns/pull/1352)) by [@chaliy](https://github.com/chaliy)
 - refactor(worker): unify platform CRUD via execute_command ([#1357](https://github.com/everruns/everruns/pull/1357)) by [@chaliy](https://github.com/chaliy)
 - docs(test-cases): add Platform Chat create-and-run agent manual test ([#1362](https://github.com/everruns/everruns/pull/1362)) by [@chaliy](https://github.com/chaliy)
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(gemini): strip additionalProperties recursively from tool schemas ([#1353](https://github.com/everruns/everruns/pull/1353)) by [@chaliy](https://github.com/chaliy)
 - fix(daytona): reset exec session after timeout ([#1351](https://github.com/everruns/everruns/pull/1351)) by [@chaliy](https://github.com/chaliy)
 - feat(media): add gpt_image_gen capability ([#1350](https://github.com/everruns/everruns/pull/1350)) by [@chaliy](https://github.com/chaliy)
-- fix(server): repair stale platform chat sessions by [@chaliy](https://github.com/chaliy)
+- fix(server): repair stale platform chat sessions ([#1349](https://github.com/everruns/everruns/pull/1349)) by [@chaliy](https://github.com/chaliy)
 - ci(docker): publish on release only, gate PR builds by paths ([#1343](https://github.com/everruns/everruns/pull/1343)) by [@chaliy](https://github.com/chaliy)
 - refactor(server): migrate audit_logs to domains/ pattern ([#1348](https://github.com/everruns/everruns/pull/1348)) by [@chaliy](https://github.com/chaliy)
 - fix(docker): harden images against common Dockerfile footguns ([#1331](https://github.com/everruns/everruns/pull/1331)) by [@chaliy](https://github.com/chaliy)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1557,11 +1557,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.8.15"
+version = "0.8.16"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "anyhow",
  "base64",
@@ -1607,14 +1607,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "async-trait",
  "base64",
@@ -1633,7 +1633,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1720,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1738,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "async-trait",
  "base64",
@@ -1775,7 +1775,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1791,7 +1791,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "async-trait",
  "base64",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "async-trait",
  "base64",
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-pi"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1904,7 +1904,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -1921,7 +1921,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1931,7 +1931,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1953,11 +1953,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.8.15"
+version = "0.8.16"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "aes-gcm",
  "ag-ui-core",
@@ -2072,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2091,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6348,9 +6348,9 @@ dependencies = [
 
 [[package]]
 name = "test-log"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d53ac171c92a39e4769491c4b4dde7022c60042254b5fc044ae409d34a24d4"
+checksum = "2f46bf474f0a4afebf92f076d54fd5e63423d9438b8c278a3d2ccb0f47f7cdb3"
 dependencies = [
  "env_logger",
  "test-log-macros",
@@ -6358,14 +6358,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "test-log-macros"
-version = "0.2.19"
+name = "test-log-core"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be35209fd0781c5401458ab66e4f98accf63553e8fae7425503e92fdd319783b"
+checksum = "37d4d41320b48bc4a211a9021678fcc0c99569b594ea31c93735b8e517102b4c"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9beb9249a81e430dffd42400a49019bcf548444f1968ff23080a625de0d4d320"
+dependencies = [
+ "syn 2.0.117",
+ "test-log-core",
 ]
 
 [[package]]
@@ -7011,9 +7021,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.15"
+version = "0.8.16"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "everruns-ui",
-      "version": "0.8.15",
+      "version": "0.8.16",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@openuidev/react-lang": "^0.1.3",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "private": true,
   "exports": {
     "./providers/*": "./src/providers/*.tsx",

--- a/crates/server/migrations/016_eval_case_result_metadata.sql
+++ b/crates/server/migrations/016_eval_case_result_metadata.sql
@@ -1,2 +1,0 @@
-ALTER TABLE eval_case_results
-ADD COLUMN metadata JSONB;

--- a/crates/server/migrations/016_v0.8.16.sql
+++ b/crates/server/migrations/016_v0.8.16.sql
@@ -1,0 +1,20 @@
+-- v0.8.16: eval case result metadata and artifacts
+-- Squashed from: 016_eval_case_result_metadata.sql, 017_eval_artifacts.sql
+
+-- ============================================
+-- from 016_eval_case_result_metadata.sql
+-- ============================================
+
+ALTER TABLE eval_case_results
+ADD COLUMN metadata JSONB;
+
+-- ============================================
+-- from 017_eval_artifacts.sql
+-- ============================================
+-- Add artifact specs to eval cases and collected artifact payloads to eval case results.
+
+ALTER TABLE eval_cases
+    ADD COLUMN artifacts JSONB;
+
+ALTER TABLE eval_case_results
+    ADD COLUMN artifacts JSONB;

--- a/crates/server/migrations/016_v0.8.16.sql
+++ b/crates/server/migrations/016_v0.8.16.sql
@@ -6,7 +6,7 @@
 -- ============================================
 
 ALTER TABLE eval_case_results
-ADD COLUMN metadata JSONB;
+    ADD COLUMN metadata JSONB;
 
 -- ============================================
 -- from 017_eval_artifacts.sql

--- a/crates/server/migrations/017_eval_artifacts.sql
+++ b/crates/server/migrations/017_eval_artifacts.sql
@@ -1,7 +1,0 @@
--- Add artifact specs to eval cases and collected artifact payloads to eval case results.
-
-ALTER TABLE eval_cases
-    ADD COLUMN artifacts JSONB;
-
-ALTER TABLE eval_case_results
-    ADD COLUMN artifacts JSONB;


### PR DESCRIPTION
## What
Prepares the v0.8.16 patch release:
- Bumps workspace version to 0.8.16 (`Cargo.toml`, `apps/ui/package.json`).
- Regenerates `Cargo.lock` and `apps/ui/package-lock.json`.
- Adds `CHANGELOG.md` section for 0.8.16 with highlights and full commit list.
- Squashes unreleased feature migrations (`016_eval_case_result_metadata.sql`, `017_eval_artifacts.sql`) into `016_v0.8.16.sql`.

## Why
Routine patch release bundling the 26 commits landed since v0.8.15 (Data Analyst harness, Azure OpenAI provider, A2UI, `gpt_image_gen`, `self_budget`, audit-logs domain migration, assorted fixes, dep bumps).

## How
Followed `specs/release-process.md` / `/prepare-release`:
1. Collected commits since `6f98eb4` (v0.8.15).
2. Drafted Highlights (user-visible features) and What's Changed list in `CHANGELOG.md`.
3. Bumped workspace + UI versions; regenerated lock files.
4. Squashed feature migrations into `016_v0.8.16.sql`; preserved per-source section headers.
5. Verified `crates/server/migrations/` is strictly sequential (001..016).

## Risk
- Low / Medium: release packaging only; no code logic changes. Migration squashing is a release-standard breaking change (fresh DB required on upgrade) — same contract as every prior release.

## Security
- Threat categories reviewed: No security-relevant code changes — release prep touches only versions, CHANGELOG, and a migration squash that concatenates already-merged-and-reviewed migration SQL verbatim.
- Findings and resolutions: none.

## Checklist
- [x] Tests added or updated (n/a — release packaging)
- [x] Backward compatibility considered (squash requires fresh DB per release spec)
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

### Post-merge
The Release workflow will automatically:
- Create git tag `v0.8.16`
- Create GitHub Release with notes from CHANGELOG.md
- Dispatch Docker image build and CLI binary publish
