### PR TITLE
fix(evals): open session links in new tab

### DIFF
--- a/apps/ui/src/__tests__/eval-run-detail-page.test.tsx
+++ b/apps/ui/src/__tests__/eval-run-detail-page.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, act } from "@testing-library/react";
+import { Suspense, type ReactNode } from "react";
+import EvalRunDetailPage from "@/app/(main)/evals/[evalId]/runs/[runId]/page";
+import type { Eval, EvalRun } from "@/lib/api/types";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const mockUseEval = jest.fn();
+const mockUseEvalRun = jest.fn();
+const mockUseCancelEvalRun = jest.fn();
+
+jest.mock("@/hooks", () => ({
+  useEval: (...args: unknown[]) => mockUseEval(...args),
+  useEvalRun: (...args: unknown[]) => mockUseEvalRun(...args),
+  useCancelEvalRun: (...args: unknown[]) => mockUseCancelEvalRun(...args),
+}));
+
+const mockEval: Eval = {
+  id: "eval_123",
+  name: "Session link eval",
+  tags: [],
+  status: "active",
+  case_count: 1,
+  created_at: "2026-04-19T10:00:00Z",
+  updated_at: "2026-04-19T10:00:00Z",
+};
+
+const mockRun: EvalRun = {
+  id: "evalrun_123",
+  status: "completed",
+  triggered_by: "user",
+  results: [
+    {
+      id: "evalresult_123",
+      eval_case_id: "evalcase_123",
+      case_name: "Case with session",
+      session_id: "session_123",
+      status: "passed",
+      created_at: "2026-04-19T10:00:00Z",
+      updated_at: "2026-04-19T10:00:00Z",
+    },
+  ],
+  created_at: "2026-04-19T10:00:00Z",
+  updated_at: "2026-04-19T10:01:00Z",
+};
+
+async function renderWithSuspense(params: { evalId: string; runId: string }) {
+  const paramsPromise = Promise.resolve(params);
+
+  await act(async () => {
+    render(
+      <Suspense fallback={<div>Loading...</div>}>
+        <EvalRunDetailPage params={paramsPromise} />
+      </Suspense>,
+    );
+    await paramsPromise;
+  });
+}
+
+describe("EvalRunDetailPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseEval.mockReturnValue({ data: mockEval });
+    mockUseEvalRun.mockReturnValue({ data: mockRun, isLoading: false });
+    mockUseCancelEvalRun.mockReturnValue({
+      mutateAsync: jest.fn(),
+      isPending: false,
+    });
+  });
+
+  it("opens result session links in a new tab", async () => {
+    await renderWithSuspense({ evalId: "eval_123", runId: "evalrun_123" });
+
+    const link = screen.getByLabelText("Open session in new tab");
+    expect(link).toHaveAttribute("href", "/sessions/session_123");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+});

--- a/apps/ui/src/__tests__/eval-run-detail-page.test.tsx
+++ b/apps/ui/src/__tests__/eval-run-detail-page.test.tsx
@@ -14,6 +14,7 @@ jest.mock("next/link", () => ({
     href: string;
     [key: string]: unknown;
   }) => (
+    // eslint-disable-next-line @next/next/no-html-link-for-pages
     <a href={href} {...props}>
       {children}
     </a>
@@ -86,7 +87,7 @@ describe("EvalRunDetailPage", () => {
   it("opens result session links in a new tab", async () => {
     await renderWithSuspense({ evalId: "eval_123", runId: "evalrun_123" });
 
-    const link = screen.getByLabelText("Open session in new tab");
+    const link = screen.getByLabelText("Open session for Case with session in new tab");
     expect(link).toHaveAttribute("href", "/sessions/session_123");
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", "noopener noreferrer");

--- a/apps/ui/src/app/(main)/evals/[evalId]/runs/[runId]/page.tsx
+++ b/apps/ui/src/app/(main)/evals/[evalId]/runs/[runId]/page.tsx
@@ -71,7 +71,12 @@ function ResultRow({ result }: { result: EvalCaseResult }) {
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium">{result.case_name ?? result.eval_case_id}</span>
           {result.session_id && (
-            <Link href={`/sessions/${result.session_id}`}>
+            <Link
+              href={`/sessions/${result.session_id}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Open session in new tab"
+            >
               <ExternalLink className="w-3 h-3 text-muted-foreground hover:text-foreground" />
             </Link>
           )}

--- a/apps/ui/src/app/(main)/evals/[evalId]/runs/[runId]/page.tsx
+++ b/apps/ui/src/app/(main)/evals/[evalId]/runs/[runId]/page.tsx
@@ -75,7 +75,7 @@ function ResultRow({ result }: { result: EvalCaseResult }) {
               href={`/sessions/${result.session_id}`}
               target="_blank"
               rel="noopener noreferrer"
-              aria-label="Open session in new tab"
+              aria-label={`Open session for ${result.case_name ?? result.eval_case_id} in new tab`}
             >
               <ExternalLink className="w-3 h-3 text-muted-foreground hover:text-foreground" />
             </Link>


### PR DESCRIPTION
## What
Open eval run result session links in a new tab from the run detail page.

## Why
The eval spec says the session link icon on run results should open the linked session in a new tab, but the current UI navigates the current tab instead.

## How
Add `target="_blank"` and `rel="noopener noreferrer"` to the session link in the eval run detail results table, and add a focused Jest test that asserts the rendered link carries the expected attributes.

## Risk
- Low
- Touches one link in the eval run detail UI only

## Security
- Threat categories reviewed: TM-WEB
- Findings and resolutions:
  - Reviewed the link attribute change for navigation safety. Added `rel="noopener noreferrer"` alongside `_blank` to avoid opener exposure. No other security-relevant surface changed.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `npm test -- --runInBand eval-run-detail-page.test.tsx`
- `npm run build` in `apps/ui`
- `just pre-push`
- Runtime smoke: seeded an eval, case, and run via the local API and confirmed the run result carries a real `session_id`. Attempted browser verification against the live page, but the dev app stayed on its main-layout loading spinner even though `/api/v1/auth/config`, `/api/v1/auth/me`, and the eval run API all returned 200 in-browser.
