### PR TITLE
feat(ui): add chats view for owned sessions

### DIFF
--- a/apps/ui/src/__tests__/middleware.test.ts
+++ b/apps/ui/src/__tests__/middleware.test.ts
@@ -38,6 +38,7 @@ describe("auth proxy", () => {
       "/apps/:path*",
       "/capabilities/:path*",
       "/chat/:path*",
+      "/chats/:path*",
       "/dashboard/:path*",
       "/durable/:path*",
       "/evals/:path*",

--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -150,6 +150,8 @@ describe("Sidebar", () => {
 
     expect(screen.getByText("Chat")).toBeInTheDocument();
     expect(screen.getByText("Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Chats")).toBeInTheDocument();
+    expect(screen.getByText("Sessions")).toBeInTheDocument();
     expect(screen.getByText("Harnesses")).toBeInTheDocument();
     expect(screen.getByText("Agents")).toBeInTheDocument();
     expect(screen.getByText("Capabilities")).toBeInTheDocument();
@@ -160,12 +162,16 @@ describe("Sidebar", () => {
     render(<Sidebar />);
 
     const dashboardLink = screen.getByRole("link", { name: "Dashboard" });
+    const chatsLink = screen.getByRole("link", { name: "Chats" });
+    const sessionsLink = screen.getByRole("link", { name: "Sessions" });
     const harnessesLink = screen.getByRole("link", { name: "Harnesses" });
     const agentsLink = screen.getByRole("link", { name: "Agents" });
     const capabilitiesLink = screen.getByRole("link", { name: "Capabilities" });
     const settingsLink = screen.getByRole("link", { name: "Settings" });
 
     expect(dashboardLink).toHaveAttribute("href", "/dashboard");
+    expect(chatsLink).toHaveAttribute("href", "/chats");
+    expect(sessionsLink).toHaveAttribute("href", "/sessions");
     expect(harnessesLink).toHaveAttribute("href", "/harnesses");
     expect(agentsLink).toHaveAttribute("href", "/agents");
     expect(capabilitiesLink).toHaveAttribute("href", "/capabilities");
@@ -219,7 +225,7 @@ describe("Sidebar", () => {
     expect(dashboardLink).toHaveClass("text-[13px]");
   });
 
-  it("has exactly 6 navigation items", () => {
+  it("has exactly 8 navigation items", () => {
     render(<Sidebar />);
 
     // Get nav links (excluding logo link)
@@ -229,12 +235,21 @@ describe("Sidebar", () => {
         (link) =>
           link.getAttribute("href") !== "/dashboard" || link.textContent?.includes("Dashboard"),
       );
-    // Filter to only nav items (Chat, Dashboard, Harnesses, Agents, Capabilities, Settings)
-    const navItems = ["Chat", "Dashboard", "Harnesses", "Agents", "Capabilities", "Settings"];
+    // Filter to only nav items (Chat, Dashboard, Chats, Sessions, Harnesses, Agents, Capabilities, Settings)
+    const navItems = [
+      "Chat",
+      "Dashboard",
+      "Chats",
+      "Sessions",
+      "Harnesses",
+      "Agents",
+      "Capabilities",
+      "Settings",
+    ];
     const foundNavLinks = navLinks.filter((link) =>
       navItems.some((item) => link.textContent?.includes(item)),
     );
-    expect(foundNavLinks).toHaveLength(6);
+    expect(foundNavLinks).toHaveLength(8);
   });
 
   it("renders section labels for Building Blocks and Durable Execution", () => {

--- a/apps/ui/src/app/(main)/chats/page.tsx
+++ b/apps/ui/src/app/(main)/chats/page.tsx
@@ -10,11 +10,11 @@ import {
   serverGetPaginated,
 } from "@/lib/server-query";
 import type { Agent, Harness, LlmModelWithProvider, Organization, Session } from "@/lib/api/types";
-import SessionsPageClient from "./sessions-page-client";
+import SessionsPageClient from "../sessions/sessions-page-client";
 
 const PAGE_SIZE = 20;
 
-export default async function SessionsPage() {
+export default async function ChatsPage() {
   const queryClient = createServerQueryClient();
   const requestContext = await getServerRequestContext();
   const { currentOrgId } = await prefetchAuthBootstrap(queryClient, requestContext);
@@ -32,9 +32,12 @@ export default async function SessionsPage() {
       ),
       seedQueryData(
         queryClient,
-        queryKeys.sessions.list(currentOrgId, undefined, false, 0, PAGE_SIZE),
+        queryKeys.sessions.list(currentOrgId, undefined, true, 0, PAGE_SIZE),
         () =>
-          serverGetPaginated<Session>(requestContext, `/v1/sessions?offset=0&limit=${PAGE_SIZE}`),
+          serverGetPaginated<Session>(
+            requestContext,
+            `/v1/sessions?owned_by_me=true&offset=0&limit=${PAGE_SIZE}`,
+          ),
       ),
       seedQueryData(queryClient, [...queryKeys.llmModels.list(), currentOrgId], () =>
         serverGetList<LlmModelWithProvider>(requestContext, "/v1/llm-models"),
@@ -44,7 +47,12 @@ export default async function SessionsPage() {
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <SessionsPageClient />
+      <SessionsPageClient
+        title="Chats"
+        ownedByMe
+        newSessionLabel="New Chat"
+        emptyStateText="No chats yet. Start a new chat to begin."
+      />
     </HydrationBoundary>
   );
 }

--- a/apps/ui/src/app/(main)/sessions/sessions-page-client.tsx
+++ b/apps/ui/src/app/(main)/sessions/sessions-page-client.tsx
@@ -36,7 +36,19 @@ import { useOrganization } from "@/hooks/use-organizations";
 
 const PAGE_SIZE = 20;
 
-export default function SessionsPageClient() {
+interface SessionsPageClientProps {
+  title?: string;
+  ownedByMe?: boolean;
+  newSessionLabel?: string;
+  emptyStateText?: string;
+}
+
+export default function SessionsPageClient({
+  title = "Sessions",
+  ownedByMe = false,
+  newSessionLabel = "New Session",
+  emptyStateText = "No sessions yet. Start a new session to begin chatting.",
+}: SessionsPageClientProps) {
   const router = useRouter();
   const [page, setPage] = useState(0);
   const [selectedAgentId, setSelectedAgentId] = useState<string>("");
@@ -53,7 +65,7 @@ export default function SessionsPageClient() {
   const { data: harnesses } = useHarnesses();
   const { data: sessionsResponse, isLoading: sessionsLoading } = useSessions(
     selectedAgentId || undefined,
-    { offset, limit: PAGE_SIZE },
+    { offset, limit: PAGE_SIZE, ownedByMe },
   );
   const { data: llmModels } = useLlmModels();
   const createSession = useCreateSession();
@@ -139,10 +151,10 @@ export default function SessionsPageClient() {
   return (
     <div className="container mx-auto p-6">
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold">Sessions</h1>
+        <h1 className="text-2xl font-bold">{title}</h1>
         <Button variant="accent" onClick={handleOpenNewSessionDialog} disabled={!harnesses?.length}>
           <Plus className="w-4 h-4 mr-2" />
-          New Session
+          {newSessionLabel}
         </Button>
       </div>
 
@@ -168,9 +180,7 @@ export default function SessionsPageClient() {
               ))}
             </div>
           ) : sessions.length === 0 ? (
-            <p className="text-center py-8 text-muted-foreground">
-              No sessions yet. Start a new session to begin chatting.
-            </p>
+            <p className="text-center py-8 text-muted-foreground">{emptyStateText}</p>
           ) : (
             <div className="space-y-2">
               {sessions.map((session) => {
@@ -235,7 +245,7 @@ export default function SessionsPageClient() {
       <Dialog open={newSessionDialogOpen} onOpenChange={setNewSessionDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>New Session</DialogTitle>
+            <DialogTitle>{newSessionLabel}</DialogTitle>
             <DialogDescription>
               Select a harness and optionally an agent to start a new conversation.
             </DialogDescription>
@@ -275,7 +285,7 @@ export default function SessionsPageClient() {
               onClick={handleCreateSession}
               disabled={!newSessionHarnessId || createSession.isPending}
             >
-              {createSession.isPending ? "Creating..." : "Create Session"}
+              {createSession.isPending ? "Creating..." : newSessionLabel}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -82,6 +82,7 @@ export interface SidebarConfig {
 export const defaultTopNavigation: NavigationItem[] = [
   { name: "Chat", href: "/chat", icon: MessageCircle, flag: "global_chat", experimental: true },
   { name: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
+  { name: "Chats", href: "/chats", icon: MessageSquare },
   { name: "Sessions", href: "/sessions", icon: MessageSquare },
 ];
 

--- a/apps/ui/src/hooks/use-global-search.ts
+++ b/apps/ui/src/hooks/use-global-search.ts
@@ -88,10 +88,16 @@ const NAVIGATION_PAGES: NavigationPage[] = [
     keywords: ["home", "overview"],
   },
   {
+    title: "Chats",
+    href: "/chats",
+    icon: MessageSquare,
+    keywords: ["my chats", "my sessions", "conversation"],
+  },
+  {
     title: "Sessions",
     href: "/sessions",
     icon: MessageSquare,
-    keywords: ["chat", "conversation"],
+    keywords: ["session", "debug", "trace", "review"],
   },
   {
     title: "Chat",

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -33,12 +33,18 @@ import { createEventStream, type EventStreamLike } from "@/lib/event-stream";
  * Optionally filter by agentId.
  * Returns { data, total, offset, limit } for pagination controls.
  */
-export function useSessions(agentId?: string, params?: PaginationParams) {
+export function useSessions(agentId?: string, params?: PaginationParams & { ownedByMe?: boolean }) {
   const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
   const query = useQuery({
-    queryKey: queryKeys.sessions.list(org, agentId, params?.offset ?? 0, params?.limit ?? 20),
+    queryKey: queryKeys.sessions.list(
+      org,
+      agentId,
+      params?.ownedByMe ?? false,
+      params?.offset ?? 0,
+      params?.limit ?? 20,
+    ),
     queryFn: () => listSessions({ ...params, agentId }),
     enabled: !!org,
   });

--- a/apps/ui/src/lib/api/sessions.ts
+++ b/apps/ui/src/lib/api/sessions.ts
@@ -33,11 +33,14 @@ export async function createSession(request: CreateSessionRequest): Promise<Sess
  * @param agentId - Optional filter by agent ID
  */
 export async function listSessions(
-  params?: PaginationParams & { agentId?: string },
+  params?: PaginationParams & { agentId?: string; ownedByMe?: boolean },
 ): Promise<PaginatedResponse<Session>> {
   const searchParams = new URLSearchParams();
   if (params?.agentId) {
     searchParams.set("agent_id", params.agentId);
+  }
+  if (params?.ownedByMe) {
+    searchParams.set("owned_by_me", "true");
   }
   if (params?.offset !== undefined) {
     searchParams.set("offset", String(params.offset));

--- a/apps/ui/src/lib/query-keys.ts
+++ b/apps/ui/src/lib/query-keys.ts
@@ -32,11 +32,11 @@ export const queryKeys = {
     detail: (harnessId: string) => ["harness", harnessId] as const,
   },
 
-  // Session queries (sessions are org-level, with optional agent filter)
+  // Session queries (sessions are org-level, with optional agent/owner filters)
   sessions: {
     all: () => ["sessions"] as const,
-    list: (org?: string, agentId?: string, offset?: number, limit?: number) =>
-      ["sessions", org, agentId ?? "all", offset ?? 0, limit ?? 20] as const,
+    list: (org?: string, agentId?: string, ownedByMe?: boolean, offset?: number, limit?: number) =>
+      ["sessions", org, agentId ?? "all", ownedByMe ?? false, offset ?? 0, limit ?? 20] as const,
     byAgent: (agentId: string) => ["sessions", "agent", agentId] as const,
     detail: (org?: string, sessionId?: string) => ["session", org, sessionId] as const,
     stats: (org?: string) => ["sessions", "stats", org] as const,

--- a/apps/ui/src/proxy.ts
+++ b/apps/ui/src/proxy.ts
@@ -21,6 +21,7 @@ export const config = {
     "/apps/:path*",
     "/capabilities/:path*",
     "/chat/:path*",
+    "/chats/:path*",
     "/dashboard/:path*",
     "/durable/:path*",
     "/evals/:path*",

--- a/crates/server/migrations/017_session_created_by.sql
+++ b/crates/server/migrations/017_session_created_by.sql
@@ -1,0 +1,19 @@
+-- Track which user created a session so Chats can scope to "my sessions".
+ALTER TABLE sessions
+    ADD COLUMN IF NOT EXISTS created_by UUID;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'sessions_created_by_fkey'
+    ) THEN
+        ALTER TABLE sessions
+            ADD CONSTRAINT sessions_created_by_fkey
+            FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL;
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_sessions_org_created_by_created_at
+    ON sessions(org_id, created_by, created_at DESC);

--- a/crates/server/src/api/mcp_endpoint/handlers.rs
+++ b/crates/server/src/api/mcp_endpoint/handlers.rs
@@ -131,6 +131,7 @@ pub async fn list_sessions(params: &Value, ctx: &CatalogContext) -> Result<Strin
             &ctx.caller,
             agent_id.as_ref().map(|id| id.uuid()),
             ctx.user_id,
+            None,
             search.as_deref(),
             pg,
         )

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -169,6 +169,9 @@ pub struct ListSessionsQuery {
     /// Filter sessions by agent ID.
     #[param(value_type = Option<String>, example = "agent_01933b5a00007000800000000000001")]
     pub agent_id: Option<AgentId>,
+    /// Filter to sessions created by the current user.
+    #[serde(default)]
+    pub owned_by_me: bool,
     /// Search by title (case-insensitive substring match).
     pub search: Option<String>,
     /// Number of items to skip (for pagination).
@@ -577,12 +580,17 @@ pub async fn list_sessions(
     };
 
     let caller = Caller::from(&org);
+    let created_by = if query.owned_by_me { org.user_id } else { None };
+    if query.owned_by_me && created_by.is_none() {
+        return Ok(Json(PaginatedResponse::new(vec![], 0, offset, limit)));
+    }
     let (sessions, total) = state
         .session_service
         .list(
             &caller,
             agent_internal_id,
             org.user_id,
+            created_by,
             query.search.as_deref(),
             pagination,
         )

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -2265,6 +2265,7 @@ mod tests {
 
         let row = CreateSessionRow {
             org_id: 1,
+            created_by: None,
             harness_id: Some(everruns_core::typed_id::HarnessId::from_uuid(
                 uuid::Uuid::nil(),
             )),

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -2221,7 +2221,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
         };
         let (rows, _total) = self
             .db
-            .list_sessions(self.org_id, agent_id, None, pagination)
+            .list_sessions(self.org_id, agent_id, None, None, pagination)
             .await
             .map_err(|e| store_error(format!("Failed to list sessions: {e}")))?;
 
@@ -2279,6 +2279,7 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
 
         let input = CreateSessionRow {
             org_id: self.org_id,
+            created_by: None,
             harness_id: Some(harness_id),
             agent_id,
             agent_identity_id: None,
@@ -3363,6 +3364,7 @@ mod tests {
             .db
             .create_session(CreateSessionRow {
                 org_id: everruns_core::DEFAULT_ORG_ID,
+                created_by: None,
                 agent_id: Some(AgentId::from_uuid(agent_id)),
                 agent_identity_id: None,
                 harness_id: Some(HarnessId::from_seed(1)),

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -3487,7 +3487,7 @@ impl WorkerService for WorkerServiceImpl {
 
         let (sessions, _total) = self
             .session_service
-            .list(&internal_caller, agent_id, None, None, pagination)
+            .list(&internal_caller, agent_id, None, None, None, pagination)
             .await
             .map_err(|e| Status::internal(format!("Failed to list sessions: {}", e)))?;
 

--- a/crates/server/src/services/notification.rs
+++ b/crates/server/src/services/notification.rs
@@ -262,6 +262,7 @@ mod tests {
         let session = db
             .create_session(CreateSessionRow {
                 org_id: 1,
+                created_by: None,
                 harness_id: None,
                 agent_id: None,
                 agent_identity_id: None,

--- a/crates/server/src/services/session.rs
+++ b/crates/server/src/services/session.rs
@@ -188,6 +188,7 @@ impl SessionService {
 
         let input = CreateSessionRow {
             org_id,
+            created_by: caller.user_id,
             harness_id: Some(harness_id),
             agent_id,
             agent_identity_id,
@@ -285,6 +286,7 @@ impl SessionService {
 
         let input = CreateSessionRow {
             org_id,
+            created_by: caller.user_id,
             harness_id: Some(harness_id),
             agent_id: None,
             agent_identity_id: None,
@@ -594,6 +596,7 @@ impl SessionService {
         caller: &Caller,
         agent_id: Option<Uuid>,
         user_id: Option<Uuid>,
+        created_by: Option<Uuid>,
         search: Option<&str>,
         pagination: Pagination,
     ) -> Result<(Vec<Session>, u32)> {
@@ -602,7 +605,7 @@ impl SessionService {
         let agent_id = agent_id.map(AgentId::from_uuid);
         let (rows, total) = self
             .db
-            .list_sessions(org_id, agent_id, search, pagination)
+            .list_sessions(org_id, agent_id, created_by, search, pagination)
             .await?;
         let fallback = if rows.iter().any(|r| r.harness_id.is_none()) {
             Some(org_init::base_harness_id(&self.db, org_id).await?)
@@ -807,6 +810,7 @@ impl SessionService {
         let harness_id_typed = HarnessId::from_uuid(harness_id);
         let input = CreateSessionRow {
             org_id,
+            created_by: Some(user_id),
             harness_id: Some(harness_id_typed),
             agent_id: None,
             agent_identity_id: None,
@@ -1558,6 +1562,7 @@ mod tests {
         let session_row = db
             .create_session(CreateSessionRow {
                 org_id: caller.org_id,
+                created_by: None,
                 harness_id: Some(other_harness.id),
                 agent_id: Some(AgentId::from_uuid(other_agent.internal_id)),
                 agent_identity_id: None,
@@ -1653,6 +1658,7 @@ mod tests {
         let session_row = db
             .create_session(CreateSessionRow {
                 org_id: caller.org_id,
+                created_by: None,
                 harness_id: None,
                 agent_id: None,
                 agent_identity_id: None,

--- a/crates/server/src/services/session_sandbox.rs
+++ b/crates/server/src/services/session_sandbox.rs
@@ -433,6 +433,7 @@ mod tests {
         let session = db
             .create_session(CreateSessionRow {
                 org_id: DEFAULT_ORG_ID,
+                created_by: None,
                 harness_id: Some(harness_id),
                 agent_id: None,
                 agent_identity_id: None,
@@ -486,6 +487,7 @@ mod tests {
         let session = db
             .create_session(CreateSessionRow {
                 org_id: DEFAULT_ORG_ID,
+                created_by: None,
                 harness_id: Some(harness_id),
                 agent_id: None,
                 agent_identity_id: None,

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -509,10 +509,19 @@ impl StorageBackend {
         &self,
         org_id: i64,
         agent_id: Option<AgentId>,
+        created_by: Option<uuid::Uuid>,
         search: Option<&str>,
         pagination: Pagination,
     ) -> Result<(Vec<SessionRow>, u32)> {
-        dispatch!(self, list_sessions, org_id, agent_id, search, pagination)
+        dispatch!(
+            self,
+            list_sessions,
+            org_id,
+            agent_id,
+            created_by,
+            search,
+            pagination
+        )
     }
 
     /// List child sessions (subagents) for a parent session.

--- a/crates/server/src/storage/leased_resource_store.rs
+++ b/crates/server/src/storage/leased_resource_store.rs
@@ -217,6 +217,7 @@ mod tests {
     async fn create_test_session(db: &StorageBackend) -> SessionId {
         db.create_session(CreateSessionRow {
             org_id: DEFAULT_ORG_ID,
+            created_by: None,
             harness_id: None,
             agent_id: None,
             agent_identity_id: None,

--- a/crates/server/src/storage/memory/sessions.rs
+++ b/crates/server/src/storage/memory/sessions.rs
@@ -19,6 +19,7 @@ impl InMemoryDatabase {
         let row = SessionRow {
             id,
             org_id: input.org_id,
+            created_by: input.created_by,
             harness_id: input.harness_id,
             agent_id: input.agent_id,
             agent_identity_id: input.agent_identity_id,
@@ -78,6 +79,7 @@ impl InMemoryDatabase {
         &self,
         org_id: i64,
         agent_id: Option<AgentId>,
+        created_by: Option<Uuid>,
         search: Option<&str>,
         pagination: crate::api::common::Pagination,
     ) -> Result<(Vec<SessionRow>, u32)> {
@@ -96,7 +98,11 @@ impl InMemoryDatabase {
         let sessions = self.sessions.read();
         let mut result: Vec<_> = sessions
             .values()
-            .filter(|s| s.org_id == org_id && agent_id.is_none_or(|aid| s.agent_id == Some(aid)))
+            .filter(|s| {
+                s.org_id == org_id
+                    && agent_id.is_none_or(|aid| s.agent_id == Some(aid))
+                    && created_by.is_none_or(|uid| s.created_by == Some(uid))
+            })
             .filter(|s| matches_search_tokens(search, &[s.title.as_deref().unwrap_or("")]))
             .cloned()
             .collect();

--- a/crates/server/src/storage/memory/tests.rs
+++ b/crates/server/src/storage/memory/tests.rs
@@ -73,6 +73,7 @@ async fn test_create_and_list_sessions() {
     let session = db
         .create_session(CreateSessionRow {
             org_id: DEFAULT_ORG_ID,
+            created_by: None,
             harness_id: None,
             agent_id: Some(agent.id),
             agent_identity_id: None,
@@ -96,7 +97,7 @@ async fn test_create_and_list_sessions() {
 
     let pagination = crate::api::common::Pagination::new(0, 20);
     let (sessions, total) = db
-        .list_sessions(DEFAULT_ORG_ID, Some(agent.id), None, pagination)
+        .list_sessions(DEFAULT_ORG_ID, Some(agent.id), None, None, pagination)
         .await
         .unwrap();
     assert_eq!(sessions.len(), 1);
@@ -133,6 +134,7 @@ async fn test_session_updated_at() {
     let session = db
         .create_session(CreateSessionRow {
             org_id: DEFAULT_ORG_ID,
+            created_by: None,
             harness_id: None,
             agent_id: Some(agent.id),
             agent_identity_id: None,
@@ -208,6 +210,7 @@ async fn test_events_sequence() {
     let session = db
         .create_session(CreateSessionRow {
             org_id: DEFAULT_ORG_ID,
+            created_by: None,
             harness_id: None,
             agent_id: Some(agent.id),
             agent_identity_id: None,
@@ -280,6 +283,7 @@ async fn create_session_with_events(db: &InMemoryDatabase) -> SessionId {
     let session = db
         .create_session(CreateSessionRow {
             org_id: DEFAULT_ORG_ID,
+            created_by: None,
             harness_id: None,
             agent_id: Some(agent.id),
             agent_identity_id: None,
@@ -767,6 +771,7 @@ async fn test_list_events_empty_session_with_limit() {
     let session = db
         .create_session(CreateSessionRow {
             org_id: DEFAULT_ORG_ID,
+            created_by: None,
             harness_id: None,
             agent_id: Some(agent.id),
             agent_identity_id: None,
@@ -825,6 +830,7 @@ async fn test_sessions_pagination() {
     for i in 0..15 {
         db.create_session(CreateSessionRow {
             org_id: DEFAULT_ORG_ID,
+            created_by: None,
             harness_id: None,
             agent_id: Some(agent.id),
             agent_identity_id: None,
@@ -850,7 +856,7 @@ async fn test_sessions_pagination() {
     // Test default pagination (all sessions fit within limit)
     let pagination = crate::api::common::Pagination::new(0, 20);
     let (sessions, total) = db
-        .list_sessions(DEFAULT_ORG_ID, Some(agent.id), None, pagination)
+        .list_sessions(DEFAULT_ORG_ID, Some(agent.id), None, None, pagination)
         .await
         .unwrap();
     assert_eq!(total, 15);
@@ -859,7 +865,7 @@ async fn test_sessions_pagination() {
     // Test with limit=5
     let pagination = crate::api::common::Pagination::new(0, 5);
     let (sessions, total) = db
-        .list_sessions(DEFAULT_ORG_ID, Some(agent.id), None, pagination)
+        .list_sessions(DEFAULT_ORG_ID, Some(agent.id), None, None, pagination)
         .await
         .unwrap();
     assert_eq!(total, 15);
@@ -868,7 +874,7 @@ async fn test_sessions_pagination() {
     // Test with offset=5, limit=5
     let pagination = crate::api::common::Pagination::new(5, 5);
     let (sessions, total) = db
-        .list_sessions(DEFAULT_ORG_ID, Some(agent.id), None, pagination)
+        .list_sessions(DEFAULT_ORG_ID, Some(agent.id), None, None, pagination)
         .await
         .unwrap();
     assert_eq!(total, 15);
@@ -877,7 +883,7 @@ async fn test_sessions_pagination() {
     // Test last partial page (offset=10, limit=10 should return 5)
     let pagination = crate::api::common::Pagination::new(10, 10);
     let (sessions, total) = db
-        .list_sessions(DEFAULT_ORG_ID, Some(agent.id), None, pagination)
+        .list_sessions(DEFAULT_ORG_ID, Some(agent.id), None, None, pagination)
         .await
         .unwrap();
     assert_eq!(total, 15);
@@ -886,7 +892,7 @@ async fn test_sessions_pagination() {
     // Test beyond range (offset=20)
     let pagination = crate::api::common::Pagination::new(20, 10);
     let (sessions, total) = db
-        .list_sessions(DEFAULT_ORG_ID, Some(agent.id), None, pagination)
+        .list_sessions(DEFAULT_ORG_ID, Some(agent.id), None, None, pagination)
         .await
         .unwrap();
     assert_eq!(total, 15);
@@ -922,6 +928,7 @@ async fn test_sessions_pagination_ordering() {
     for i in 1..=5 {
         db.create_session(CreateSessionRow {
             org_id: DEFAULT_ORG_ID,
+            created_by: None,
             harness_id: None,
             agent_id: Some(agent.id),
             agent_identity_id: None,
@@ -949,7 +956,7 @@ async fn test_sessions_pagination_ordering() {
     // Sessions should be ordered by created_at DESC (newest first)
     let pagination = crate::api::common::Pagination::new(0, 10);
     let (sessions, _) = db
-        .list_sessions(DEFAULT_ORG_ID, Some(agent.id), None, pagination)
+        .list_sessions(DEFAULT_ORG_ID, Some(agent.id), None, None, pagination)
         .await
         .unwrap();
 
@@ -1648,6 +1655,7 @@ async fn test_search_sessions_by_title() {
 
     db.create_session(CreateSessionRow {
         org_id: DEFAULT_ORG_ID,
+        created_by: None,
         harness_id: None,
         agent_id: Some(agent.id),
         agent_identity_id: None,
@@ -1671,6 +1679,7 @@ async fn test_search_sessions_by_title() {
 
     db.create_session(CreateSessionRow {
         org_id: DEFAULT_ORG_ID,
+        created_by: None,
         harness_id: None,
         agent_id: Some(agent.id),
         agent_identity_id: None,
@@ -1694,7 +1703,7 @@ async fn test_search_sessions_by_title() {
 
     let pagination = crate::api::common::Pagination::new(0, 20);
     let (results, total) = db
-        .list_sessions(DEFAULT_ORG_ID, None, Some("memory leak"), pagination)
+        .list_sessions(DEFAULT_ORG_ID, None, None, Some("memory leak"), pagination)
         .await
         .unwrap();
     assert_eq!(total, 1);
@@ -1710,6 +1719,7 @@ async fn test_search_sessions_with_agent_filter() {
 
     db.create_session(CreateSessionRow {
         org_id: DEFAULT_ORG_ID,
+        created_by: None,
         harness_id: None,
         agent_id: Some(agent1.id),
         agent_identity_id: None,
@@ -1733,6 +1743,7 @@ async fn test_search_sessions_with_agent_filter() {
 
     db.create_session(CreateSessionRow {
         org_id: DEFAULT_ORG_ID,
+        created_by: None,
         harness_id: None,
         agent_id: Some(agent2.id),
         agent_identity_id: None,
@@ -1760,6 +1771,7 @@ async fn test_search_sessions_with_agent_filter() {
         .list_sessions(
             DEFAULT_ORG_ID,
             Some(agent1.id),
+            None,
             Some("shared keyword"),
             pagination,
         )
@@ -1779,11 +1791,107 @@ async fn test_search_sessions_poem_input() {
                     Rough winds do shake the darling buds of May, \
                     And summer's lease hath all too short a date.";
     let (results, total) = db
-        .list_sessions(DEFAULT_ORG_ID, None, Some(poem), pagination)
+        .list_sessions(DEFAULT_ORG_ID, None, None, Some(poem), pagination)
         .await
         .unwrap();
     assert_eq!(total, 0);
     assert!(results.is_empty());
+}
+
+#[tokio::test]
+async fn test_list_sessions_filters_by_creator() {
+    let db = InMemoryDatabase::new();
+    let agent = create_test_agent(&db, "Agent", None).await;
+    let first_user = uuid::Uuid::now_v7();
+    let second_user = uuid::Uuid::now_v7();
+
+    db.create_session(CreateSessionRow {
+        org_id: DEFAULT_ORG_ID,
+        created_by: Some(first_user),
+        harness_id: None,
+        agent_id: Some(agent.id),
+        agent_identity_id: None,
+        title: Some("First user's session".to_string()),
+        locale: None,
+        tags: vec![],
+        model_id: None,
+        capabilities: serde_json::json!([]),
+        tools: serde_json::json!([]),
+        mcp_servers: serde_json::json!({}),
+        system_prompt: None,
+        initial_files: serde_json::Value::Array(vec![]),
+        hints: None,
+        network_access: None,
+        max_iterations: None,
+        blueprint_id: None,
+        blueprint_config: None,
+    })
+    .await
+    .unwrap();
+
+    db.create_session(CreateSessionRow {
+        org_id: DEFAULT_ORG_ID,
+        created_by: Some(second_user),
+        harness_id: None,
+        agent_id: Some(agent.id),
+        agent_identity_id: None,
+        title: Some("Second user's session".to_string()),
+        locale: None,
+        tags: vec![],
+        model_id: None,
+        capabilities: serde_json::json!([]),
+        tools: serde_json::json!([]),
+        mcp_servers: serde_json::json!({}),
+        system_prompt: None,
+        initial_files: serde_json::Value::Array(vec![]),
+        hints: None,
+        network_access: None,
+        max_iterations: None,
+        blueprint_id: None,
+        blueprint_config: None,
+    })
+    .await
+    .unwrap();
+
+    db.create_session(CreateSessionRow {
+        org_id: DEFAULT_ORG_ID,
+        created_by: None,
+        harness_id: None,
+        agent_id: Some(agent.id),
+        agent_identity_id: None,
+        title: Some("Legacy session".to_string()),
+        locale: None,
+        tags: vec![],
+        model_id: None,
+        capabilities: serde_json::json!([]),
+        tools: serde_json::json!([]),
+        mcp_servers: serde_json::json!({}),
+        system_prompt: None,
+        initial_files: serde_json::Value::Array(vec![]),
+        hints: None,
+        network_access: None,
+        max_iterations: None,
+        blueprint_id: None,
+        blueprint_config: None,
+    })
+    .await
+    .unwrap();
+
+    let (results, total) = db
+        .list_sessions(
+            DEFAULT_ORG_ID,
+            Some(agent.id),
+            Some(first_user),
+            None,
+            default_pagination(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(total, 1);
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].created_by, Some(first_user));
+    assert_eq!(results[0].title.as_deref(), Some("First user's session"));
 }
 
 #[tokio::test]
@@ -1949,6 +2057,7 @@ async fn create_session_with_content_events(db: &InMemoryDatabase) -> SessionId 
     let session = db
         .create_session(CreateSessionRow {
             org_id: DEFAULT_ORG_ID,
+            created_by: None,
             harness_id: None,
             agent_id: Some(agent.id),
             agent_identity_id: None,
@@ -2109,6 +2218,7 @@ async fn test_list_sessions_waiting_tool_results_before() {
     let s1 = db
         .create_session(CreateSessionRow {
             org_id: DEFAULT_ORG_ID,
+            created_by: None,
             harness_id: None,
             agent_id: None,
             agent_identity_id: None,
@@ -2132,6 +2242,7 @@ async fn test_list_sessions_waiting_tool_results_before() {
     let s2 = db
         .create_session(CreateSessionRow {
             org_id: DEFAULT_ORG_ID,
+            created_by: None,
             harness_id: None,
             agent_id: None,
             agent_identity_id: None,
@@ -2155,6 +2266,7 @@ async fn test_list_sessions_waiting_tool_results_before() {
     let s3 = db
         .create_session(CreateSessionRow {
             org_id: DEFAULT_ORG_ID,
+            created_by: None,
             harness_id: None,
             agent_id: None,
             agent_identity_id: None,
@@ -2230,6 +2342,7 @@ async fn test_session_system_prompt_and_initial_files_round_trip() {
     let session = db
         .create_session(CreateSessionRow {
             org_id: DEFAULT_ORG_ID,
+            created_by: None,
             harness_id: None,
             agent_id: None,
             agent_identity_id: None,
@@ -2277,6 +2390,7 @@ async fn test_session_system_prompt_defaults_to_none() {
     let session = db
         .create_session(CreateSessionRow {
             org_id: DEFAULT_ORG_ID,
+            created_by: None,
             harness_id: None,
             agent_id: None,
             agent_identity_id: None,

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -490,6 +490,8 @@ pub struct SessionRow {
     pub id: SessionId,
     pub org_id: i64,
     #[sqlx(default)]
+    pub created_by: Option<Uuid>,
+    #[sqlx(default)]
     pub harness_id: Option<HarnessId>,
     pub agent_id: Option<AgentId>,
     #[sqlx(default)]
@@ -559,6 +561,7 @@ pub struct SessionRow {
 #[derive(Debug, Clone)]
 pub struct CreateSessionRow {
     pub org_id: i64,
+    pub created_by: Option<Uuid>,
     pub harness_id: Option<HarnessId>,
     pub agent_id: Option<AgentId>,
     pub agent_identity_id: Option<AgentIdentityId>,

--- a/crates/server/src/storage/repositories/sessions.rs
+++ b/crates/server/src/storage/repositories/sessions.rs
@@ -17,14 +17,15 @@ impl Database {
     pub async fn create_session(&self, input: CreateSessionRow) -> Result<SessionRow> {
         let row = sqlx::query_as::<_, SessionRow>(
             r#"
-            INSERT INTO sessions (org_id, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, blueprint_id, blueprint_config, status)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, 'started')
-            RETURNING id, org_id, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, status, created_at, updated_at, started_at, finished_at,
+            INSERT INTO sessions (org_id, created_by, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, blueprint_id, blueprint_config, status)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, 'started')
+            RETURNING id, org_id, created_by, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, status, created_at, updated_at, started_at, finished_at,
                       total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, parent_session_id, subagent_name, subagent_task, subagent_status,
                       blueprint_id, blueprint_config
             "#,
         )
         .bind(input.org_id)
+        .bind(input.created_by)
         .bind(input.harness_id.map(|h| h.uuid()))
         .bind(input.agent_id.map(|a| a.uuid()))
         .bind(input.agent_identity_id.map(|a: AgentIdentityId| a.uuid()))
@@ -52,7 +53,7 @@ impl Database {
     pub async fn get_session(&self, org_id: i64, id: SessionId) -> Result<Option<SessionRow>> {
         let row = sqlx::query_as::<_, SessionRow>(
             r#"
-            SELECT id, org_id, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, status, created_at, updated_at, started_at, finished_at,
+            SELECT id, org_id, created_by, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, status, created_at, updated_at, started_at, finished_at,
                    total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, parent_session_id, subagent_name, subagent_task, subagent_status,
                    blueprint_id, blueprint_config
             FROM sessions
@@ -71,7 +72,7 @@ impl Database {
     pub async fn get_session_unscoped(&self, id: SessionId) -> Result<Option<SessionRow>> {
         let row = sqlx::query_as::<_, SessionRow>(
             r#"
-            SELECT id, org_id, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, status, created_at, updated_at, started_at, finished_at,
+            SELECT id, org_id, created_by, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, status, created_at, updated_at, started_at, finished_at,
                    total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, parent_session_id, subagent_name, subagent_task, subagent_status,
                    blueprint_id, blueprint_config
             FROM sessions
@@ -91,6 +92,7 @@ impl Database {
         &self,
         org_id: i64,
         agent_id: Option<AgentId>,
+        created_by: Option<Uuid>,
         search: Option<&str>,
         pagination: crate::api::common::Pagination,
     ) -> Result<(Vec<SessionRow>, u32)> {
@@ -100,6 +102,11 @@ impl Database {
 
         if agent_id.is_some() {
             where_clause.push_str(&format!(" AND agent_id = ${param_idx}"));
+            param_idx += 1;
+        }
+
+        if created_by.is_some() {
+            where_clause.push_str(&format!(" AND created_by = ${param_idx}"));
             param_idx += 1;
         }
 
@@ -114,6 +121,9 @@ impl Database {
                 let mut q = $q.bind(org_id);
                 if let Some(aid) = agent_id {
                     q = q.bind(aid);
+                }
+                if let Some(uid) = created_by {
+                    q = q.bind(uid);
                 }
                 for pat in &patterns {
                     q = q.bind(pat);
@@ -131,7 +141,7 @@ impl Database {
         let limit_idx = param_idx;
         let offset_idx = param_idx + 1;
         let select_sql = format!(
-            r#"SELECT id, org_id, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, status, created_at, updated_at, started_at, finished_at,
+            r#"SELECT id, org_id, created_by, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, status, created_at, updated_at, started_at, finished_at,
                    total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, parent_session_id, subagent_name, subagent_task, subagent_status,
                    blueprint_id, blueprint_config
             FROM sessions {where_clause}
@@ -155,7 +165,7 @@ impl Database {
     ) -> Result<Vec<SessionRow>> {
         let rows = sqlx::query_as::<_, SessionRow>(
             r#"
-            SELECT id, org_id, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, status, created_at, updated_at, started_at, finished_at,
+            SELECT id, org_id, created_by, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, status, created_at, updated_at, started_at, finished_at,
                    total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, parent_session_id, subagent_name, subagent_task, subagent_status,
                    blueprint_id, blueprint_config
             FROM sessions
@@ -196,7 +206,7 @@ impl Database {
     ) -> Result<Option<SessionRow>> {
         let row = sqlx::query_as::<_, SessionRow>(
             r#"
-            SELECT id, org_id, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, status, created_at, updated_at, started_at, finished_at,
+            SELECT id, org_id, created_by, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, status, created_at, updated_at, started_at, finished_at,
                    total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, parent_session_id, subagent_name, subagent_task, subagent_status,
                    blueprint_id, blueprint_config
             FROM sessions
@@ -218,7 +228,7 @@ impl Database {
     pub async fn find_active_slack_sessions(&self) -> Result<Vec<SessionRow>> {
         let rows = sqlx::query_as::<_, SessionRow>(
             r#"
-            SELECT id, org_id, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, status, created_at, updated_at, started_at, finished_at,
+            SELECT id, org_id, created_by, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, status, created_at, updated_at, started_at, finished_at,
                    total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, parent_session_id, subagent_name, subagent_task, subagent_status,
                    blueprint_id, blueprint_config
             FROM sessions
@@ -278,7 +288,7 @@ impl Database {
                 started_at = COALESCE($11, started_at),
                 finished_at = COALESCE($12, finished_at)
             WHERE org_id = $1 AND id = $2
-            RETURNING id, org_id, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, status, created_at, updated_at, started_at, finished_at,
+            RETURNING id, org_id, created_by, harness_id, agent_id, agent_identity_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, status, created_at, updated_at, started_at, finished_at,
                       total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, parent_session_id, subagent_name, subagent_task, subagent_status,
                       blueprint_id, blueprint_config
             "#,

--- a/crates/server/tests/org_isolation_test.rs
+++ b/crates/server/tests/org_isolation_test.rs
@@ -929,6 +929,7 @@ async fn create_session_in_org(backend: &StorageBackend, org_id: i64) -> everrun
     let row = backend
         .create_session(CreateSessionRow {
             org_id,
+            created_by: None,
             harness_id: None,
             agent_id: None,
             agent_identity_id: None,

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -267,6 +267,7 @@ async fn test_session_crud() {
     let session = backend
         .create_session(CreateSessionRow {
             org_id: TEST_ORG_ID,
+            created_by: None,
             harness_id: None,
             agent_id: Some(agent.id),
             agent_identity_id: None,
@@ -355,6 +356,7 @@ async fn test_session_crud() {
             TEST_ORG_ID,
             Some(agent.id),
             None,
+            None,
             Pagination {
                 limit: 10,
                 offset: 0,
@@ -413,6 +415,7 @@ async fn test_event_crud() {
     let session = backend
         .create_session(CreateSessionRow {
             org_id: TEST_ORG_ID,
+            created_by: None,
             harness_id: None,
             agent_id: Some(agent.id),
             agent_identity_id: None,
@@ -500,6 +503,7 @@ async fn test_event_exclude_types() {
     let session = backend
         .create_session(CreateSessionRow {
             org_id: TEST_ORG_ID,
+            created_by: None,
             harness_id: None,
             agent_id: Some(agent.id),
             agent_identity_id: None,
@@ -595,6 +599,7 @@ async fn test_event_filter_types() {
     let session = backend
         .create_session(CreateSessionRow {
             org_id: TEST_ORG_ID,
+            created_by: None,
             harness_id: None,
             agent_id: Some(agent.id),
             agent_identity_id: None,
@@ -892,6 +897,7 @@ async fn test_session_file_crud() {
     let session = backend
         .create_session(CreateSessionRow {
             org_id: TEST_ORG_ID,
+            created_by: None,
             harness_id: None,
             agent_id: Some(agent.id),
             agent_identity_id: None,
@@ -1350,6 +1356,7 @@ async fn test_session_usage_tracking() {
     let session = backend
         .create_session(CreateSessionRow {
             org_id: TEST_ORG_ID,
+            created_by: None,
             harness_id: None,
             agent_id: Some(agent.id),
             agent_identity_id: None,
@@ -1443,6 +1450,7 @@ async fn test_session_previews() {
     let session = backend
         .create_session(CreateSessionRow {
             org_id: TEST_ORG_ID,
+            created_by: None,
             harness_id: None,
             agent_id: Some(agent.id),
             agent_identity_id: None,

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -22,9 +22,9 @@ use everruns_server::org_init;
 use everruns_server::storage::{
     CreateAgentCapabilityRow, CreateAgentRow, CreateEventRow, CreateHarnessRow, CreateImageRow,
     CreateLlmModelRow, CreateLlmProviderRow, CreateMcpServerRow, CreateOrganizationRow,
-    CreateSessionFileRow, CreateSessionRow, Database, StorageBackend, UpdateAgent, UpdateLlmModel,
-    UpdateLlmProvider, UpdateOrganization, UpdateOrganizationSettings, UpdateSession,
-    UpdateSessionFile,
+    CreateSessionFileRow, CreateSessionRow, CreateUserRow, Database, StorageBackend, UpdateAgent,
+    UpdateLlmModel, UpdateLlmProvider, UpdateOrganization, UpdateOrganizationSettings,
+    UpdateSession, UpdateSessionFile,
 };
 use test_harness::get_database_url;
 
@@ -380,6 +380,158 @@ async fn test_session_crud() {
         .delete_harness(TEST_ORG_ID, harness.id)
         .await
         .unwrap();
+}
+
+#[tokio::test]
+async fn test_list_sessions_filters_by_creator() {
+    let backend = create_test_backend().await;
+
+    let first_user = backend
+        .create_user(CreateUserRow {
+            email: format!("repo-sessions-a-{}@example.com", Uuid::now_v7()),
+            name: "Repo Sessions A".to_string(),
+            avatar_url: None,
+            roles: vec![],
+            password_hash: None,
+            email_verified: true,
+            auth_provider: None,
+            auth_provider_id: None,
+            external_id: None,
+        })
+        .await
+        .expect("Failed to create first user");
+
+    let second_user = backend
+        .create_user(CreateUserRow {
+            email: format!("repo-sessions-b-{}@example.com", Uuid::now_v7()),
+            name: "Repo Sessions B".to_string(),
+            avatar_url: None,
+            roles: vec![],
+            password_hash: None,
+            email_verified: true,
+            auth_provider: None,
+            auth_provider_id: None,
+            external_id: None,
+        })
+        .await
+        .expect("Failed to create second user");
+
+    let agent = backend
+        .create_agent(
+            TEST_ORG_ID,
+            CreateAgentRow {
+                public_id: everruns_core::AgentId::new().to_string(),
+                name: format!("session-owner-agent-{}", &Uuid::now_v7().to_string()[..8]),
+                display_name: Some("Session Owner Agent".to_string()),
+                description: None,
+                system_prompt: "Test".to_string(),
+                default_model_id: None,
+                tags: vec![],
+                initial_files: serde_json::json!([]),
+                tools: serde_json::json!([]),
+                mcp_servers: serde_json::json!({}),
+                network_access: None,
+                max_iterations: None,
+            },
+        )
+        .await
+        .expect("Failed to create agent");
+
+    let first_session = backend
+        .create_session(CreateSessionRow {
+            org_id: TEST_ORG_ID,
+            created_by: Some(first_user.id),
+            harness_id: None,
+            agent_id: Some(agent.id),
+            agent_identity_id: None,
+            title: Some("First User Session".to_string()),
+            locale: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+            mcp_servers: serde_json::json!({}),
+            system_prompt: None,
+            initial_files: serde_json::Value::Array(vec![]),
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            blueprint_id: None,
+            blueprint_config: None,
+        })
+        .await
+        .expect("Failed to create first session");
+
+    backend
+        .create_session(CreateSessionRow {
+            org_id: TEST_ORG_ID,
+            created_by: Some(second_user.id),
+            harness_id: None,
+            agent_id: Some(agent.id),
+            agent_identity_id: None,
+            title: Some("Second User Session".to_string()),
+            locale: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+            mcp_servers: serde_json::json!({}),
+            system_prompt: None,
+            initial_files: serde_json::Value::Array(vec![]),
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            blueprint_id: None,
+            blueprint_config: None,
+        })
+        .await
+        .expect("Failed to create second session");
+
+    backend
+        .create_session(CreateSessionRow {
+            org_id: TEST_ORG_ID,
+            created_by: None,
+            harness_id: None,
+            agent_id: Some(agent.id),
+            agent_identity_id: None,
+            title: Some("Unowned Session".to_string()),
+            locale: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+            mcp_servers: serde_json::json!({}),
+            system_prompt: None,
+            initial_files: serde_json::Value::Array(vec![]),
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            blueprint_id: None,
+            blueprint_config: None,
+        })
+        .await
+        .expect("Failed to create unowned session");
+
+    let (sessions, total) = backend
+        .list_sessions(
+            TEST_ORG_ID,
+            None,
+            Some(first_user.id),
+            None,
+            Pagination {
+                limit: 10,
+                offset: 0,
+            },
+        )
+        .await
+        .expect("Failed to list sessions");
+
+    assert_eq!(total, 1);
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].id, first_session.id);
+    assert_eq!(sessions[0].created_by, Some(first_user.id));
+
+    backend.delete_agent(TEST_ORG_ID, agent.id).await.unwrap();
 }
 
 // ============================================

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2887,6 +2887,15 @@
             "example": "agent_01933b5a00007000800000000000001"
           },
           {
+            "name": "owned_by_me",
+            "in": "query",
+            "description": "Filter to sessions created by the current user.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
             "name": "search",
             "in": "query",
             "description": "Search by title (case-insensitive substring match).",

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -184,13 +184,16 @@ Returns the calling user's singleton global chat session. Creates one with the P
 
 #### List Sessions
 
-Supports optional filtering by agent:
+Supports optional filtering by agent and by the current user:
 
 ```
 GET /v1/sessions?agent_id=agent_01234567-...
+GET /v1/sessions?owned_by_me=true
 ```
 
-Without the `agent_id` query parameter, returns all sessions in the organization.
+Without filters, returns all sessions in the organization.
+
+`owned_by_me=true` powers the Chats surface: today Chats are just user-owned sessions rendered with a narrower list filter, while the broader Sessions view continues to include debugging, tracing, and review-oriented session records.
 
 #### Cancel Turn
 
@@ -431,7 +434,7 @@ Endpoints that return lists support pagination via query parameters:
 
 | Endpoint | Default Limit | Notes |
 |----------|---------------|-------|
-| `GET /v1/sessions` | 20 | Ordered by `created_at DESC`, optional `agent_id` filter |
+| `GET /v1/sessions` | 20 | Ordered by `created_at DESC`, optional `agent_id` and `owned_by_me` filters |
 
 **Non-Paginated List Endpoints:**
 

--- a/specs/models.md
+++ b/specs/models.md
@@ -52,6 +52,7 @@ See `specs/localization.md` for locale/timezone resolution and durable preferenc
 
 Key design points:
 - Sessions are direct children of organizations (not agents). The `agent_id` specifies which agent is assigned.
+- UI naming is starting to split: **Chats** are user-owned conversational sessions, while **Sessions** remains the broader execution record used for debugging, tracing, and review. Both still point at the same underlying session model today.
 - `locale` is an optional session-level BCP 47 tag (for example `uk-UA`). The worker carries it through turn loading and prompt construction so scheduled runs, resumed runs, and subagents can inherit localized behavior.
 - `timezone` should be a separate optional session-level IANA timezone for unattended execution defaults. Interactive turns may override it with live browser timezone for that turn.
 - `features` field is computed at read time by aggregating `features()` from all active capabilities (not stored). See `specs/capabilities.md#capability-features`.


### PR DESCRIPTION
## What
Add a top-level `Chats` navigation item between Dashboard and Sessions, backed by the existing sessions UI and a new owner-scoped sessions filter.

## Why
This is the first step in splitting conversational chats from broader session records used for debugging, tracing, and review.

## How
- add a new `/chats` page that reuses the shared sessions list client
- add `owned_by_me=true` to `GET /v1/sessions`
- persist `created_by` on newly created sessions and global chat sessions
- update nav, search, proxy protection, tests, and specs to reflect the Chats/Sessions split

## Risk
- Medium
- Can affect session listing behavior, auth-scoped filtering, and top-level navigation

## Security
- Threat categories reviewed: TM-API, TM-TENANT, TM-WEB
- Findings and resolutions:
  - TM-API: added an explicit boolean query param instead of inferring ownership from client-side state
  - TM-TENANT: owner filtering is still bounded by org scoping; `owned_by_me=true` returns empty when no authenticated user is present rather than broadening access
  - TM-WEB: `/chats` is protected by the same auth proxy path set as the rest of the main app; no new external data rendering paths were introduced
  - No new threat-model entries were needed; this change narrows reads rather than expanding cross-tenant or unauthenticated access

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

## Validation
- `just pre-push`
- `cargo test -p everruns-server test_list_sessions_filters_by_creator -- --nocapture`
- `cd apps/ui && npm test -- --runTestsByPath src/__tests__/sidebar.test.tsx src/__tests__/middleware.test.ts`
- Smoke test: started local dev app, registered a user, created a session, verified `/api/v1/sessions?owned_by_me=true` returned that session, and confirmed `/chats` resolved through the authenticated app route
