### PR TITLE
feat(authz): make platform-user authz first-class

### DIFF
--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -85,10 +85,22 @@ jest.mock("@/hooks/use-llm-providers", () => ({
   useLlmProviders: () => mockUseLlmProviders(),
 }));
 
+const mockUsePolicies = jest.fn(() => ({
+  data: { policies: { "durable.view": true } },
+  can: (policyId: string) => policyId === "durable.view",
+}));
+jest.mock("@/hooks/use-policies", () => ({
+  usePolicies: () => mockUsePolicies(),
+}));
+
 describe("Sidebar", () => {
   beforeEach(() => {
     mockPathname.mockReturnValue("/dashboard");
     mockPush.mockClear();
+    mockUsePolicies.mockReturnValue({
+      data: { policies: { "durable.view": true } },
+      can: (policyId: string) => policyId === "durable.view",
+    });
     mockUseAuth.mockReturnValue({
       user: null,
       requiresAuth: false,
@@ -295,6 +307,17 @@ describe("Sidebar", () => {
     const workersLink = screen.getByRole("link", { name: /workers/i });
     expect(workersLink).toHaveClass("border-l-primary");
     expect(workersLink).toHaveClass("bg-card");
+  });
+
+  it("hides Durable Execution when durable policy is denied", () => {
+    mockUsePolicies.mockReturnValue({
+      data: { policies: { "durable.view": false } },
+      can: () => false,
+    });
+
+    render(<Sidebar />);
+
+    expect(screen.queryByText("Durable Execution")).not.toBeInTheDocument();
   });
 });
 

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -41,6 +41,7 @@ import {
 import { capabilityIconMap } from "@/lib/capability-icons";
 import { useCommandPalette } from "@/hooks/use-command-palette";
 import { useLlmProviders } from "@/hooks/use-llm-providers";
+import { usePolicies } from "@/hooks/use-policies";
 import { useAuth } from "@/providers/auth-provider";
 import { useFeatureFlags } from "@/providers/feature-flags-provider";
 import type { FeatureFlags } from "@/lib/api/types";
@@ -135,12 +136,18 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
     isLoading: llmProvidersLoading,
     isError: llmProvidersError,
   } = useLlmProviders();
+  const durablePolicies = usePolicies("durable");
   const { setOpen: openCommandPalette } = useCommandPalette();
 
   const llmProvidersReady = !llmProvidersLoading && !llmProvidersError;
   const shouldShowChatWarning = llmProvidersReady && (!llmProviders || llmProviders.length === 0);
 
-  const baseSections = config?.navigation ?? defaultNavigationSections;
+  const durableAllowed = durablePolicies.data ? durablePolicies.can("durable.view") : false;
+  const baseSections = config?.navigation
+    ? config.navigation
+    : defaultNavigationSections.filter(
+        (section) => section.label !== "Durable Execution" || durableAllowed,
+      );
   const sections = shouldShowChatWarning
     ? baseSections.map((section) => ({
         ...section,

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -121,6 +121,12 @@ export const defaultNavigationSections: NavigationSection[] = [
   { label: "Dev", items: defaultDevNavigation, devOnly: true },
 ];
 
+function isDurableSection(section: NavigationSection) {
+  return section.items.some(
+    (item) => item.href === "/durable" || item.href.startsWith("/durable/"),
+  );
+}
+
 export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
   const pathname = usePathname();
   const {
@@ -145,9 +151,7 @@ export function Sidebar({ config }: { config?: Partial<SidebarConfig> }) {
   const durableAllowed = durablePolicies.data ? durablePolicies.can("durable.view") : false;
   const baseSections = config?.navigation
     ? config.navigation
-    : defaultNavigationSections.filter(
-        (section) => section.label !== "Durable Execution" || durableAllowed,
-      );
+    : defaultNavigationSections.filter((section) => !isDurableSection(section) || durableAllowed);
   const sections = shouldShowChatWarning
     ? baseSections.map((section) => ({
         ...section,

--- a/crates/server/src/api/durable.rs
+++ b/crates/server/src/api/durable.rs
@@ -767,11 +767,11 @@ pub struct SendSignalRequest {
 )]
 pub async fn durable_config(
     org: ResolvedOrg,
-    State(state): State<AppState>,
+    State(state): State<AuthState>,
 ) -> Json<ResourceConfigResponse> {
     let caller = Caller::from(&org);
     let policies = evaluate_policies_with(
-        state.auth.permission_resolver.as_ref(),
+        state.permission_resolver.as_ref(),
         &caller,
         &[&DURABLE_VIEW, &DURABLE_MANAGE],
     );
@@ -3527,7 +3527,7 @@ mod tests {
         use crate::auth::middleware::{AuthError, AuthMethod, AuthUser};
         use crate::auth::routes::AuthConfigResponse;
         use async_trait::async_trait;
-        use axum::body::Body;
+        use axum::body::{Body, to_bytes};
         use axum::http::Request;
         use everruns_core::{OrgMembership, OrgRole};
         use tower::ServiceExt;
@@ -3625,7 +3625,7 @@ mod tests {
             .status()
         }
 
-        // --- Non-platform user gets 403 on read endpoints ---
+        // --- Non-platform user gets 403 on protected read endpoints ---
 
         #[tokio::test]
         async fn non_platform_user_cannot_get_health() {
@@ -3670,9 +3670,24 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn non_platform_user_cannot_read_durable_config() {
-            let status = get_with_auth(test_app(false), "/v1/durable/config").await;
-            assert_eq!(status, StatusCode::OK);
+        async fn non_platform_user_can_read_durable_config() {
+            let response = test_app(false)
+                .oneshot(
+                    Request::builder()
+                        .uri("/v1/durable/config")
+                        .header("Authorization", "Bearer test-token")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::OK);
+
+            let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+            assert_eq!(payload["policies"]["durable.view"], false);
+            assert_eq!(payload["policies"]["durable.manage"], false);
         }
 
         // --- Non-platform user gets 403 on mutate endpoints ---

--- a/crates/server/src/api/durable.rs
+++ b/crates/server/src/api/durable.rs
@@ -17,6 +17,7 @@ use axum::{
     routing::{get, post},
 };
 use chrono::{DateTime, Utc};
+use everruns_core::{Caller, Policy, ResourceConfigResponse, Rule, evaluate_policies_with};
 use everruns_durable::{
     CircuitBreakerState, CircuitState, DlqEntry, DlqFilter, Pagination, SystemHealth, TaskFilter,
     TaskInfo, TaskStatus, WorkerFilter, WorkerInfo, WorkflowEventInfo, WorkflowEventStore,
@@ -35,10 +36,20 @@ use uuid::Uuid;
 
 use super::common::{ApiResult, ErrorResponse, impl_auth_state};
 use super::sse::{DisconnectReason, SseStreamConfig};
-use crate::auth::middleware::{AdminUser, AuthState};
+use crate::auth::{AuthState, PlatformUser, ResolvedOrg};
+
+pub const DURABLE_VIEW: Policy = Policy {
+    id: "durable.view",
+    rules: &[Rule::IsPlatformUser],
+};
+
+pub const DURABLE_MANAGE: Policy = Policy {
+    id: "durable.manage",
+    rules: &[Rule::IsPlatformUser],
+};
 
 /// App state for durable routes
-/// TM-DURABLE-010: All durable endpoints require admin role (not just authentication).
+/// TM-DURABLE-010: All durable endpoints require platform-user auth, not tenant admin inference.
 #[derive(Clone)]
 pub struct AppState {
     store: Option<Arc<dyn WorkflowEventStore + Send + Sync>>,
@@ -169,6 +180,7 @@ impl AppState {
 /// Create durable routes
 pub fn routes(state: AppState) -> Router {
     Router::new()
+        .route("/v1/durable/config", get(durable_config))
         // SSE streaming
         .route("/v1/durable/sse", get(stream_durable_sse))
         .route(
@@ -744,6 +756,28 @@ pub struct SendSignalRequest {
 // Route handlers
 // ============================================================================
 
+/// GET /v1/durable/config - Durable policy results for UI gating.
+#[utoipa::path(
+    get,
+    path = "/v1/durable/config",
+    responses(
+        (status = 200, description = "Resource config for durable surfaces", body = ResourceConfigResponse),
+    ),
+    tag = "durable"
+)]
+pub async fn durable_config(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+) -> Json<ResourceConfigResponse> {
+    let caller = Caller::from(&org);
+    let policies = evaluate_policies_with(
+        state.auth.permission_resolver.as_ref(),
+        &caller,
+        &[&DURABLE_VIEW, &DURABLE_MANAGE],
+    );
+    Json(ResourceConfigResponse { policies })
+}
+
 /// GET /v1/durable/health - Get system health
 #[utoipa::path(
     get,
@@ -755,7 +789,7 @@ pub struct SendSignalRequest {
     tag = "durable"
 )]
 pub async fn get_health(
-    _auth: AdminUser,
+    _auth: PlatformUser,
     State(state): State<AppState>,
 ) -> ApiResult<HealthResponse> {
     let store = state.get_store()?;
@@ -784,7 +818,7 @@ pub async fn get_health(
     tag = "durable"
 )]
 pub async fn get_metrics_timeseries(
-    _auth: AdminUser,
+    _auth: PlatformUser,
     State(state): State<AppState>,
 ) -> ApiResult<MetricsTimeSeriesResponse> {
     let points = state.metrics.get_points().await;
@@ -815,7 +849,7 @@ pub async fn get_metrics_timeseries(
     tag = "durable"
 )]
 pub async fn list_workers(
-    _auth: AdminUser,
+    _auth: PlatformUser,
     State(state): State<AppState>,
     Query(query): Query<ListWorkersQuery>,
 ) -> ApiResult<WorkersListResponse> {
@@ -875,7 +909,7 @@ pub async fn list_workers(
     tag = "durable"
 )]
 pub async fn drain_worker(
-    _auth: AdminUser,
+    _auth: PlatformUser,
     State(state): State<AppState>,
     Path(worker_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
@@ -907,7 +941,7 @@ pub async fn drain_worker(
     tag = "durable"
 )]
 pub async fn resume_worker(
-    _auth: AdminUser,
+    _auth: PlatformUser,
     State(state): State<AppState>,
     Path(worker_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
@@ -942,7 +976,7 @@ pub async fn resume_worker(
     tag = "durable"
 )]
 pub async fn list_workflows(
-    _auth: AdminUser,
+    _auth: PlatformUser,
     State(state): State<AppState>,
     Query(query): Query<ListWorkflowsQuery>,
 ) -> ApiResult<WorkflowsListResponse> {
@@ -1001,7 +1035,7 @@ pub async fn list_workflows(
     tag = "durable"
 )]
 pub async fn get_workflow(
-    _auth: AdminUser,
+    _auth: PlatformUser,
     State(state): State<AppState>,
     Path(workflow_id): Path<Uuid>,
 ) -> ApiResult<WorkflowResponse> {
@@ -1051,7 +1085,7 @@ pub async fn get_workflow(
     tag = "durable"
 )]
 pub async fn get_workflow_events(
-    _auth: AdminUser,
+    _auth: PlatformUser,
     State(state): State<AppState>,
     Path(workflow_id): Path<Uuid>,
 ) -> ApiResult<WorkflowEventsListResponse> {
@@ -1090,7 +1124,7 @@ pub async fn get_workflow_events(
     tag = "durable"
 )]
 pub async fn cancel_workflow(
-    _auth: AdminUser,
+    _auth: PlatformUser,
     State(state): State<AppState>,
     Path(workflow_id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
@@ -1135,7 +1169,7 @@ pub async fn cancel_workflow(
     tag = "durable"
 )]
 pub async fn send_signal(
-    _auth: AdminUser,
+    _auth: PlatformUser,
     State(state): State<AppState>,
     Path(workflow_id): Path<Uuid>,
     Json(req): Json<SendSignalRequest>,
@@ -1178,7 +1212,7 @@ pub async fn send_signal(
     tag = "durable"
 )]
 pub async fn list_tasks(
-    _auth: AdminUser,
+    _auth: PlatformUser,
     State(state): State<AppState>,
     Query(query): Query<ListTasksQuery>,
 ) -> ApiResult<TasksListResponse> {
@@ -1260,7 +1294,7 @@ pub struct EnqueueTaskResponse {
     tag = "durable"
 )]
 pub async fn enqueue_task(
-    _auth: AdminUser,
+    _auth: PlatformUser,
     State(state): State<AppState>,
     Json(body): Json<EnqueueTaskRequest>,
 ) -> Result<(StatusCode, Json<EnqueueTaskResponse>), (StatusCode, Json<ErrorResponse>)> {
@@ -1320,7 +1354,7 @@ pub async fn enqueue_task(
     tag = "durable"
 )]
 pub async fn list_dlq(
-    _auth: AdminUser,
+    _auth: PlatformUser,
     State(state): State<AppState>,
     Query(query): Query<ListDlqQuery>,
 ) -> ApiResult<DlqListResponse> {
@@ -1366,7 +1400,7 @@ pub async fn list_dlq(
     tag = "durable"
 )]
 pub async fn retry_dlq(
-    _auth: AdminUser,
+    _auth: PlatformUser,
     State(state): State<AppState>,
     Path(dlq_id): Path<Uuid>,
 ) -> ApiResult<Uuid> {
@@ -1403,7 +1437,7 @@ pub async fn retry_dlq(
     tag = "durable"
 )]
 pub async fn list_circuit_breakers(
-    _auth: AdminUser,
+    _auth: PlatformUser,
     State(state): State<AppState>,
 ) -> ApiResult<CircuitBreakersListResponse> {
     let store = state.get_store()?;
@@ -1441,7 +1475,7 @@ pub async fn list_circuit_breakers(
     tag = "durable"
 )]
 pub async fn get_circuit_breaker(
-    _auth: AdminUser,
+    _auth: PlatformUser,
     State(state): State<AppState>,
     Path(key): Path<String>,
 ) -> ApiResult<CircuitBreakerResponse> {
@@ -1483,7 +1517,7 @@ pub async fn get_circuit_breaker(
     tag = "durable"
 )]
 pub async fn force_open_circuit_breaker(
-    _auth: AdminUser,
+    _auth: PlatformUser,
     State(state): State<AppState>,
     Path(key): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
@@ -1517,7 +1551,7 @@ pub async fn force_open_circuit_breaker(
     tag = "durable"
 )]
 pub async fn force_close_circuit_breaker(
-    _auth: AdminUser,
+    _auth: PlatformUser,
     State(state): State<AppState>,
     Path(key): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
@@ -1562,7 +1596,7 @@ pub async fn force_close_circuit_breaker(
     tag = "durable"
 )]
 pub async fn delete_circuit_breaker(
-    _auth: AdminUser,
+    _auth: PlatformUser,
     State(state): State<AppState>,
     Path(key): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
@@ -1647,7 +1681,7 @@ struct WorkflowSnapshot {
     tag = "durable"
 )]
 pub async fn stream_durable_sse(
-    _auth: AdminUser,
+    _auth: PlatformUser,
     State(state): State<AppState>,
 ) -> Result<Sse<impl Stream<Item = Result<SseEvent, Infallible>>>, StatusCode> {
     // Verify store is available
@@ -1985,7 +2019,7 @@ pub async fn stream_durable_sse(
     tag = "durable"
 )]
 pub async fn stream_workflow_sse(
-    _auth: AdminUser,
+    _auth: PlatformUser,
     State(state): State<AppState>,
     Path(workflow_id): Path<Uuid>,
 ) -> Result<Sse<impl Stream<Item = Result<SseEvent, Infallible>>>, StatusCode> {
@@ -3483,10 +3517,10 @@ mod tests {
     }
 
     // ============================================
-    // Admin-only access control tests (EVE-64)
+    // Platform-user access control tests
     // ============================================
 
-    mod admin_access {
+    mod platform_user_access {
         use super::*;
         use crate::auth::backend::AuthBackend;
         use crate::auth::config::{AuthConfig, AuthMode};
@@ -3495,12 +3529,13 @@ mod tests {
         use async_trait::async_trait;
         use axum::body::Body;
         use axum::http::Request;
+        use everruns_core::{OrgMembership, OrgRole};
         use tower::ServiceExt;
 
-        /// Mock auth backend returning user with configurable roles
+        /// Mock auth backend returning user with configurable platform access.
         #[derive(Clone)]
         struct MockAuthBackend {
-            roles: Vec<String>,
+            is_platform_user: bool,
         }
 
         #[async_trait]
@@ -3510,9 +3545,15 @@ mod tests {
                     id: Uuid::new_v4(),
                     email: "test@example.com".to_string(),
                     name: "Test User".to_string(),
-                    roles: self.roles.clone(),
+                    roles: vec!["user".to_string()],
+                    is_platform_user: self.is_platform_user,
                     auth_method: AuthMethod::Jwt,
-                    organizations: vec![],
+                    organizations: vec![OrgMembership {
+                        org_id: 1,
+                        public_id: "org_00000000000000000000000000000001".to_string(),
+                        name: "Test Org".to_string(),
+                        role: OrgRole::Owner,
+                    }],
                 })
             }
 
@@ -3534,8 +3575,8 @@ mod tests {
             }
         }
 
-        /// Build test router with given roles for the authenticated user
-        fn test_app(roles: Vec<String>) -> axum::Router {
+        /// Build test router with configurable platform-user access.
+        fn test_app(is_platform_user: bool) -> axum::Router {
             let config = AuthConfig {
                 mode: AuthMode::Full,
                 jwt: crate::auth::config::JwtConfig {
@@ -3544,7 +3585,7 @@ mod tests {
                 },
                 ..Default::default()
             };
-            let backend = Arc::new(MockAuthBackend { roles });
+            let backend = Arc::new(MockAuthBackend { is_platform_user });
             let auth = AuthState::new(config, backend);
             let state = AppState::new(None, auth, None, "in_memory".to_string());
             routes(state)
@@ -3584,77 +3625,70 @@ mod tests {
             .status()
         }
 
-        // --- Non-admin user gets 403 on read endpoints ---
+        // --- Non-platform user gets 403 on read endpoints ---
 
         #[tokio::test]
-        async fn non_admin_cannot_get_health() {
-            let status = get_with_auth(test_app(vec!["user".into()]), "/v1/durable/health").await;
+        async fn non_platform_user_cannot_get_health() {
+            let status = get_with_auth(test_app(false), "/v1/durable/health").await;
             assert_eq!(status, StatusCode::FORBIDDEN);
         }
 
         #[tokio::test]
-        async fn non_admin_cannot_list_workers() {
-            let status = get_with_auth(test_app(vec!["user".into()]), "/v1/durable/workers").await;
+        async fn non_platform_user_cannot_list_workers() {
+            let status = get_with_auth(test_app(false), "/v1/durable/workers").await;
             assert_eq!(status, StatusCode::FORBIDDEN);
         }
 
         #[tokio::test]
-        async fn non_admin_cannot_list_workflows() {
+        async fn non_platform_user_cannot_list_workflows() {
+            let status = get_with_auth(test_app(false), "/v1/durable/workflows").await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+
+        #[tokio::test]
+        async fn non_platform_user_cannot_list_tasks() {
+            let status = get_with_auth(test_app(false), "/v1/durable/tasks").await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+
+        #[tokio::test]
+        async fn non_platform_user_cannot_list_dlq() {
+            let status = get_with_auth(test_app(false), "/v1/durable/dlq").await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+
+        #[tokio::test]
+        async fn non_platform_user_cannot_list_circuit_breakers() {
+            let status = get_with_auth(test_app(false), "/v1/durable/circuit-breakers").await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+
+        #[tokio::test]
+        async fn non_platform_user_cannot_get_metrics() {
+            let status = get_with_auth(test_app(false), "/v1/durable/metrics/timeseries").await;
+            assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+
+        #[tokio::test]
+        async fn non_platform_user_cannot_read_durable_config() {
+            let status = get_with_auth(test_app(false), "/v1/durable/config").await;
+            assert_eq!(status, StatusCode::OK);
+        }
+
+        // --- Non-platform user gets 403 on mutate endpoints ---
+
+        #[tokio::test]
+        async fn non_platform_user_cannot_drain_worker() {
             let status =
-                get_with_auth(test_app(vec!["user".into()]), "/v1/durable/workflows").await;
+                post_with_auth(test_app(false), "/v1/durable/workers/w1/drain", "{}").await;
             assert_eq!(status, StatusCode::FORBIDDEN);
         }
 
         #[tokio::test]
-        async fn non_admin_cannot_list_tasks() {
-            let status = get_with_auth(test_app(vec!["user".into()]), "/v1/durable/tasks").await;
-            assert_eq!(status, StatusCode::FORBIDDEN);
-        }
-
-        #[tokio::test]
-        async fn non_admin_cannot_list_dlq() {
-            let status = get_with_auth(test_app(vec!["user".into()]), "/v1/durable/dlq").await;
-            assert_eq!(status, StatusCode::FORBIDDEN);
-        }
-
-        #[tokio::test]
-        async fn non_admin_cannot_list_circuit_breakers() {
-            let status = get_with_auth(
-                test_app(vec!["user".into()]),
-                "/v1/durable/circuit-breakers",
-            )
-            .await;
-            assert_eq!(status, StatusCode::FORBIDDEN);
-        }
-
-        #[tokio::test]
-        async fn non_admin_cannot_get_metrics() {
-            let status = get_with_auth(
-                test_app(vec!["user".into()]),
-                "/v1/durable/metrics/timeseries",
-            )
-            .await;
-            assert_eq!(status, StatusCode::FORBIDDEN);
-        }
-
-        // --- Non-admin user gets 403 on mutate endpoints ---
-
-        #[tokio::test]
-        async fn non_admin_cannot_drain_worker() {
-            let status = post_with_auth(
-                test_app(vec!["user".into()]),
-                "/v1/durable/workers/w1/drain",
-                "{}",
-            )
-            .await;
-            assert_eq!(status, StatusCode::FORBIDDEN);
-        }
-
-        #[tokio::test]
-        async fn non_admin_cannot_cancel_workflow() {
+        async fn non_platform_user_cannot_cancel_workflow() {
             let wf_id = Uuid::nil();
             let status = post_with_auth(
-                test_app(vec!["user".into()]),
+                test_app(false),
                 &format!("/v1/durable/workflows/{wf_id}/cancel"),
                 "{}",
             )
@@ -3663,10 +3697,10 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn non_admin_cannot_send_signal() {
+        async fn non_platform_user_cannot_send_signal() {
             let wf_id = Uuid::nil();
             let status = post_with_auth(
-                test_app(vec!["user".into()]),
+                test_app(false),
                 &format!("/v1/durable/workflows/{wf_id}/signal"),
                 r#"{"signal_type":"test","payload":{}}"#,
             )
@@ -3675,9 +3709,9 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn non_admin_cannot_enqueue_task() {
+        async fn non_platform_user_cannot_enqueue_task() {
             let status = post_with_auth(
-                test_app(vec!["user".into()]),
+                test_app(false),
                 "/v1/durable/tasks",
                 r#"{"activity_type":"test","input":{}}"#,
             )
@@ -3686,10 +3720,10 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn non_admin_cannot_retry_dlq() {
+        async fn non_platform_user_cannot_retry_dlq() {
             let dlq_id = Uuid::nil();
             let status = post_with_auth(
-                test_app(vec!["user".into()]),
+                test_app(false),
                 &format!("/v1/durable/dlq/{dlq_id}/retry"),
                 "{}",
             )
@@ -3698,9 +3732,9 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn non_admin_cannot_force_open_circuit_breaker() {
+        async fn non_platform_user_cannot_force_open_circuit_breaker() {
             let status = post_with_auth(
-                test_app(vec!["user".into()]),
+                test_app(false),
                 "/v1/durable/circuit-breakers/test-key/open",
                 "{}",
             )
@@ -3708,61 +3742,72 @@ mod tests {
             assert_eq!(status, StatusCode::FORBIDDEN);
         }
 
-        // --- Non-admin user gets 403 on SSE ---
+        // --- Non-platform user gets 403 on SSE ---
 
         #[tokio::test]
-        async fn non_admin_cannot_stream_durable_sse() {
-            let status = get_with_auth(test_app(vec!["user".into()]), "/v1/durable/sse").await;
+        async fn non_platform_user_cannot_stream_durable_sse() {
+            let status = get_with_auth(test_app(false), "/v1/durable/sse").await;
             assert_eq!(status, StatusCode::FORBIDDEN);
         }
 
-        // --- Admin user gets access (503 = store unavailable, not 403) ---
+        // --- Platform user gets access (503 = store unavailable, not 403) ---
 
         #[tokio::test]
-        async fn admin_can_get_health() {
-            let status = get_with_auth(test_app(vec!["admin".into()]), "/v1/durable/health").await;
+        async fn platform_user_can_get_health() {
+            let status = get_with_auth(test_app(true), "/v1/durable/health").await;
             assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
         }
 
         #[tokio::test]
-        async fn admin_can_list_workers() {
-            let status = get_with_auth(test_app(vec!["admin".into()]), "/v1/durable/workers").await;
+        async fn platform_user_can_list_workers() {
+            let status = get_with_auth(test_app(true), "/v1/durable/workers").await;
             assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
         }
 
         #[tokio::test]
-        async fn admin_can_list_workflows() {
-            let status =
-                get_with_auth(test_app(vec!["admin".into()]), "/v1/durable/workflows").await;
+        async fn platform_user_can_list_workflows() {
+            let status = get_with_auth(test_app(true), "/v1/durable/workflows").await;
             assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
         }
 
         #[tokio::test]
-        async fn admin_can_list_tasks() {
-            let status = get_with_auth(test_app(vec!["admin".into()]), "/v1/durable/tasks").await;
+        async fn platform_user_can_list_tasks() {
+            let status = get_with_auth(test_app(true), "/v1/durable/tasks").await;
             assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
         }
 
         #[tokio::test]
-        async fn admin_can_list_dlq() {
-            let status = get_with_auth(test_app(vec!["admin".into()]), "/v1/durable/dlq").await;
+        async fn platform_user_can_list_dlq() {
+            let status = get_with_auth(test_app(true), "/v1/durable/dlq").await;
             assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
         }
 
         #[tokio::test]
-        async fn admin_can_list_circuit_breakers() {
-            let status = get_with_auth(
-                test_app(vec!["admin".into()]),
-                "/v1/durable/circuit-breakers",
-            )
-            .await;
+        async fn platform_user_can_list_circuit_breakers() {
+            let status = get_with_auth(test_app(true), "/v1/durable/circuit-breakers").await;
             assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
         }
 
         #[tokio::test]
-        async fn admin_can_stream_durable_sse() {
-            let status = get_with_auth(test_app(vec!["admin".into()]), "/v1/durable/sse").await;
+        async fn platform_user_can_stream_durable_sse() {
+            let status = get_with_auth(test_app(true), "/v1/durable/sse").await;
             assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        }
+
+        #[tokio::test]
+        async fn durable_config_exposes_platform_policy_from_resolved_org() {
+            let response = test_app(true)
+                .oneshot(
+                    Request::builder()
+                        .uri("/v1/durable/config")
+                        .header("Authorization", "Bearer test-token")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::OK);
         }
     }
 }

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -739,6 +739,7 @@ async fn resolve_org_by_id(
         name: org_row.name.clone(),
         user_id: Some(auth_user.id),
         role,
+        is_platform_user: auth_user.is_platform_user,
     })
 }
 

--- a/crates/server/src/api/schedules.rs
+++ b/crates/server/src/api/schedules.rs
@@ -1,7 +1,7 @@
 // Durable Scheduled Tasks API routes
 //
-// Decision: All endpoints require authentication via AuthUser extractor.
-//   Matches the pattern used by durable control plane handlers (api/durable.rs).
+// Decision: All endpoints require explicit platform-user auth.
+//   Matches the durable control-plane contract for global/system surfaces.
 //
 // Provides CRUD operations and management for scheduled tasks:
 // - Schedule creation, listing, updates, and deletion
@@ -27,10 +27,10 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 use super::common::{ApiResult, ErrorResponse, impl_auth_state};
-use crate::auth::middleware::{AuthState, AuthUser};
+use crate::auth::{AuthState, PlatformUser};
 
 /// App state for schedule routes
-/// All schedule endpoints require authentication.
+/// All schedule endpoints require platform-user auth.
 #[derive(Clone)]
 pub struct ScheduleAppState {
     store: Option<Arc<dyn WorkflowEventStore + Send + Sync>>,
@@ -397,7 +397,7 @@ pub struct ListExecutionsQuery {
     tag = "durable-schedules"
 )]
 pub async fn create_schedule(
-    _auth: AuthUser,
+    _auth: PlatformUser,
     State(state): State<ScheduleAppState>,
     Json(req): Json<CreateScheduleRequest>,
 ) -> Result<(StatusCode, Json<ScheduleResponse>), (StatusCode, Json<ErrorResponse>)> {
@@ -507,7 +507,7 @@ pub async fn create_schedule(
     tag = "durable-schedules"
 )]
 pub async fn list_schedules(
-    _auth: AuthUser,
+    _auth: PlatformUser,
     State(state): State<ScheduleAppState>,
     Query(query): Query<ListSchedulesQuery>,
 ) -> ApiResult<SchedulesListResponse> {
@@ -573,7 +573,7 @@ pub async fn list_schedules(
     tag = "durable-schedules"
 )]
 pub async fn get_schedule(
-    _auth: AuthUser,
+    _auth: PlatformUser,
     State(state): State<ScheduleAppState>,
     Path(schedule_id): Path<Uuid>,
 ) -> ApiResult<ScheduleResponse> {
@@ -618,7 +618,7 @@ pub async fn get_schedule(
     tag = "durable-schedules"
 )]
 pub async fn update_schedule(
-    _auth: AuthUser,
+    _auth: PlatformUser,
     State(state): State<ScheduleAppState>,
     Path(schedule_id): Path<Uuid>,
     Json(req): Json<UpdateScheduleRequest>,
@@ -724,7 +724,7 @@ pub async fn update_schedule(
     tag = "durable-schedules"
 )]
 pub async fn delete_schedule(
-    _auth: AuthUser,
+    _auth: PlatformUser,
     State(state): State<ScheduleAppState>,
     Path(schedule_id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
@@ -770,7 +770,7 @@ pub async fn delete_schedule(
     tag = "durable-schedules"
 )]
 pub async fn pause_schedule(
-    _auth: AuthUser,
+    _auth: PlatformUser,
     State(state): State<ScheduleAppState>,
     Path(schedule_id): Path<Uuid>,
 ) -> ApiResult<ScheduleResponse> {
@@ -837,7 +837,7 @@ pub async fn pause_schedule(
     tag = "durable-schedules"
 )]
 pub async fn resume_schedule(
-    _auth: AuthUser,
+    _auth: PlatformUser,
     State(state): State<ScheduleAppState>,
     Path(schedule_id): Path<Uuid>,
 ) -> ApiResult<ScheduleResponse> {
@@ -924,7 +924,7 @@ pub async fn resume_schedule(
     tag = "durable-schedules"
 )]
 pub async fn trigger_schedule(
-    _auth: AuthUser,
+    _auth: PlatformUser,
     State(state): State<ScheduleAppState>,
     Path(schedule_id): Path<Uuid>,
 ) -> ApiResult<TriggerResponse> {
@@ -988,7 +988,7 @@ pub async fn trigger_schedule(
     tag = "durable-schedules"
 )]
 pub async fn list_schedule_executions(
-    _auth: AuthUser,
+    _auth: PlatformUser,
     State(state): State<ScheduleAppState>,
     Path(schedule_id): Path<Uuid>,
     Query(query): Query<ListExecutionsQuery>,
@@ -1070,7 +1070,7 @@ pub async fn list_schedule_executions(
     tag = "durable-schedules"
 )]
 pub async fn get_execution(
-    _auth: AuthUser,
+    _auth: PlatformUser,
     State(state): State<ScheduleAppState>,
     Path(execution_id): Path<Uuid>,
 ) -> ApiResult<ScheduleExecutionResponse> {
@@ -1116,7 +1116,7 @@ pub async fn get_execution(
     tag = "durable-schedules"
 )]
 pub async fn get_schedule_stats(
-    _auth: AuthUser,
+    _auth: PlatformUser,
     State(state): State<ScheduleAppState>,
     Path(schedule_id): Path<Uuid>,
 ) -> ApiResult<ScheduleStatsResponse> {
@@ -1172,11 +1172,16 @@ fn calculate_next_trigger(cron_expression: &str) -> Result<Option<DateTime<Utc>>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::auth::backend::AuthBackend;
+    use async_trait::async_trait;
     use axum::body::Body;
     use axum::http::Request;
+    use everruns_core::{OrgMembership, OrgRole};
     use tower::ServiceExt;
 
     use crate::auth::config::{AuthConfig, AuthMode, JwtConfig};
+    use crate::auth::middleware::{AuthError, AuthMethod, AuthUser};
+    use crate::auth::routes::AuthConfigResponse;
 
     /// AuthState with auth disabled (anonymous admin user)
     fn test_auth_state_none() -> AuthState {
@@ -1375,6 +1380,111 @@ mod tests {
     async fn test_get_stats_authenticated() {
         let id = Uuid::now_v7();
         assert_authenticated_passes("GET", &format!("/v1/durable/schedules/{id}/stats")).await;
+    }
+
+    #[derive(Clone)]
+    struct MockAuthBackend {
+        is_platform_user: bool,
+    }
+
+    #[async_trait]
+    impl AuthBackend for MockAuthBackend {
+        async fn validate_token(&self, _token: &str) -> Result<AuthUser, AuthError> {
+            Ok(AuthUser {
+                id: Uuid::new_v4(),
+                email: "test@example.com".to_string(),
+                name: "Test User".to_string(),
+                roles: vec!["user".to_string()],
+                is_platform_user: self.is_platform_user,
+                auth_method: AuthMethod::Jwt,
+                organizations: vec![OrgMembership {
+                    org_id: 1,
+                    public_id: "org_00000000000000000000000000000001".to_string(),
+                    name: "Test Org".to_string(),
+                    role: OrgRole::Owner,
+                }],
+            })
+        }
+
+        async fn validate_api_key(&self, _key: &str) -> Result<AuthUser, AuthError> {
+            Err(AuthError::unauthorized("not supported"))
+        }
+
+        fn auth_routes(&self) -> Option<Router> {
+            None
+        }
+
+        fn auth_config_response(&self) -> AuthConfigResponse {
+            AuthConfigResponse {
+                mode: "full".to_string(),
+                password_auth_enabled: false,
+                signup_enabled: false,
+                oauth_providers: vec![],
+            }
+        }
+    }
+
+    fn app_with_platform_user(is_platform_user: bool) -> Router {
+        let config = AuthConfig {
+            mode: AuthMode::Full,
+            jwt: JwtConfig {
+                secret: "test-secret-for-unit-tests-only".to_string(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let auth = AuthState::new(config, Arc::new(MockAuthBackend { is_platform_user }));
+        routes(ScheduleAppState::new(None, auth))
+    }
+
+    #[tokio::test]
+    async fn non_platform_user_cannot_list_schedules() {
+        let response = app_with_platform_user(false)
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/durable/schedules")
+                    .header("Authorization", "Bearer test-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn platform_user_can_list_schedules() {
+        let response = app_with_platform_user(true)
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/durable/schedules")
+                    .header("Authorization", "Bearer test-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn non_platform_user_cannot_create_schedule() {
+        let response = app_with_platform_user(false)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/durable/schedules")
+                    .header("Authorization", "Bearer test-token")
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
 
     // ---- Existing unit tests ----

--- a/crates/server/src/auth/builtin.rs
+++ b/crates/server/src/auth/builtin.rs
@@ -58,6 +58,10 @@ fn root_url_from_api_base(api_base_url: &str) -> String {
     trimmed.strip_suffix("/api").unwrap_or(trimmed).to_string()
 }
 
+fn platform_user_from_roles(roles: &[String]) -> bool {
+    roles.iter().any(|role| role == "admin")
+}
+
 impl BuiltinAuthBackend {
     /// Create with in-memory rate limiting (per-instance).
     pub fn new(config: AuthConfig, db: Arc<StorageBackend>) -> Self {
@@ -170,6 +174,7 @@ impl BuiltinAuthBackend {
             id: user.id,
             email: user.email,
             name: user.name,
+            is_platform_user: platform_user_from_roles(&roles),
             roles,
             auth_method: AuthMethod::ApiKey,
             organizations,
@@ -200,11 +205,14 @@ impl AuthBackend for BuiltinAuthBackend {
         }
         let organizations = organizations_or_default(organizations);
 
+        let is_platform_user = platform_user_from_roles(&claims.roles);
+
         Ok(AuthUser {
             id: user_id,
             email: claims.email,
             name: claims.name,
             roles: claims.roles,
+            is_platform_user,
             auth_method: AuthMethod::Jwt,
             organizations,
         })
@@ -342,6 +350,7 @@ mod tests {
             email: "test@example.com".to_string(),
             name: "Test User".to_string(),
             roles: vec!["user".to_string()],
+            is_platform_user: false,
             auth_method: AuthMethod::ApiKey,
             organizations: vec![OrgMembership {
                 org_id: 1,

--- a/crates/server/src/auth/middleware.rs
+++ b/crates/server/src/auth/middleware.rs
@@ -66,6 +66,8 @@ pub struct AuthUser {
     pub name: String,
     /// User roles
     pub roles: Vec<String>,
+    /// Whether this user may access global/platform surfaces.
+    pub is_platform_user: bool,
     /// Authentication method used
     pub auth_method: AuthMethod,
     /// Organizations the user belongs to
@@ -82,6 +84,7 @@ impl AuthUser {
             email: ANONYMOUS_USER_EMAIL.to_string(),
             name: ANONYMOUS_USER_NAME.to_string(),
             roles: vec!["admin".to_string()], // Full access in no-auth mode
+            is_platform_user: true,
             auth_method: AuthMethod::None,
             organizations: vec![OrgMembership {
                 org_id: DEFAULT_ORG_ID,
@@ -287,6 +290,28 @@ where
     }
 }
 
+/// Require platform-user access for global/system surfaces.
+#[derive(Debug, Clone)]
+pub struct PlatformUser(pub AuthUser);
+
+impl<S> FromRequestParts<S> for PlatformUser
+where
+    S: Send + Sync,
+    AuthState: FromRef<S>,
+{
+    type Rejection = AuthError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let user = AuthUser::from_request_parts(parts, state).await?;
+
+        if !user.is_platform_user {
+            return Err(AuthError::forbidden("Platform user access required"));
+        }
+
+        Ok(PlatformUser(user))
+    }
+}
+
 // ============================================================================
 // OrgContext - Organization context extractor
 // ============================================================================
@@ -453,6 +478,8 @@ pub struct ResolvedOrg {
     pub user_id: Option<Uuid>,
     /// User's role in this organization
     pub role: OrgRole,
+    /// Whether the authenticated user may access global/platform surfaces.
+    pub is_platform_user: bool,
 }
 
 impl From<&ResolvedOrg> for Caller {
@@ -462,7 +489,7 @@ impl From<&ResolvedOrg> for Caller {
             org_public_id: org.public_id.clone(),
             user_id: org.user_id,
             role: org.role,
-            is_platform_user: false,
+            is_platform_user: org.is_platform_user,
         }
     }
 }
@@ -506,6 +533,7 @@ where
                         name: org.name.clone(),
                         user_id: Some(user.id),
                         role: org.role,
+                        is_platform_user: user.is_platform_user,
                     });
                 }
 
@@ -518,6 +546,7 @@ where
                         name: org.name.clone(),
                         user_id: Some(user.id),
                         role: org.role,
+                        is_platform_user: user.is_platform_user,
                     });
                 }
 
@@ -548,6 +577,7 @@ where
                         name: org_row.name,
                         user_id: None,
                         role: OrgRole::Owner, // Anonymous user is owner of all orgs
+                        is_platform_user: user.is_platform_user,
                     });
                 }
 
@@ -562,6 +592,7 @@ where
                     name: org.name.clone(),
                     user_id: None,
                     role: org.role,
+                    is_platform_user: user.is_platform_user,
                 })
             }
             AuthMethod::Jwt => {
@@ -584,6 +615,7 @@ where
                         name: org.name.clone(),
                         user_id: Some(user.id),
                         role: org.role,
+                        is_platform_user: user.is_platform_user,
                     });
                 }
 
@@ -612,6 +644,7 @@ where
                             name: org_row.name.clone(),
                             user_id: Some(user.id),
                             role,
+                            is_platform_user: user.is_platform_user,
                         });
                     }
                     // DB available, user not a member → 404
@@ -634,6 +667,7 @@ where
                     name: org.name.clone(),
                     user_id: Some(user.id),
                     role: org.role,
+                    is_platform_user: user.is_platform_user,
                 })
             }
         }
@@ -651,6 +685,7 @@ mod tests {
         assert!(!user.id.is_nil(), "anonymous user should not use nil UUID");
         assert!(user.is_admin());
         assert!(user.has_role("admin"));
+        assert!(user.is_platform_user);
         assert_eq!(user.auth_method, AuthMethod::None);
         // Anonymous user should belong to default org with Owner role
         assert_eq!(user.organizations.len(), 1);
@@ -666,6 +701,7 @@ mod tests {
             email: "test@example.com".to_string(),
             name: "Test".to_string(),
             roles: vec!["user".to_string(), "editor".to_string()],
+            is_platform_user: false,
             auth_method: AuthMethod::Jwt,
             organizations: vec![],
         };
@@ -683,6 +719,7 @@ mod tests {
             email: "admin@example.com".to_string(),
             name: "Admin".to_string(),
             roles: vec!["admin".to_string()],
+            is_platform_user: true,
             auth_method: AuthMethod::Jwt,
             organizations: vec![],
         };
@@ -699,6 +736,7 @@ mod tests {
             email: "test@example.com".to_string(),
             name: "Test".to_string(),
             roles: vec!["user".to_string()],
+            is_platform_user: false,
             auth_method: AuthMethod::Jwt,
             organizations: vec![
                 OrgMembership {
@@ -949,6 +987,7 @@ mod tests {
             email: "test@example.com".to_string(),
             name: "Test User".to_string(),
             roles: vec!["user".to_string()],
+            is_platform_user: false,
             auth_method: AuthMethod::Jwt,
             organizations: vec![OrgMembership {
                 org_id: 1,
@@ -1007,6 +1046,7 @@ mod tests {
             email: "test@example.com".to_string(),
             name: "Test User".to_string(),
             roles: vec!["user".to_string()],
+            is_platform_user: false,
             auth_method: AuthMethod::Jwt,
             organizations: vec![OrgMembership {
                 org_id: 1,
@@ -1055,6 +1095,7 @@ mod tests {
             email: "test@example.com".to_string(),
             name: "Test User".to_string(),
             roles: vec!["user".to_string()],
+            is_platform_user: false,
             auth_method: AuthMethod::Jwt,
             organizations: vec![OrgMembership {
                 org_id: 1,
@@ -1152,6 +1193,7 @@ mod tests {
             email: "apiuser@example.com".to_string(),
             name: "API User".to_string(),
             roles: vec!["user".to_string()],
+            is_platform_user: false,
             auth_method: AuthMethod::ApiKey,
             organizations: vec![
                 OrgMembership {
@@ -1179,6 +1221,7 @@ mod tests {
             email: "apiuser@example.com".to_string(),
             name: "API User".to_string(),
             roles: vec!["user".to_string()],
+            is_platform_user: false,
             auth_method: AuthMethod::ApiKey,
             organizations: vec![OrgMembership {
                 org_id: 1,

--- a/crates/server/src/auth/mod.rs
+++ b/crates/server/src/auth/mod.rs
@@ -24,6 +24,7 @@ pub use cli_auth::CliAuthState;
 pub use config::AuthConfig;
 pub use mcp_oauth::McpOAuthState;
 pub use middleware::{
-    AuthError, AuthMethod, AuthState, AuthUser, OrgAdmin, OrgContext, OrgOwner, ResolvedOrg,
+    AuthError, AuthMethod, AuthState, AuthUser, OrgAdmin, OrgContext, OrgOwner, PlatformUser,
+    ResolvedOrg,
 };
 pub use routes::routes;

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -314,6 +314,10 @@ pub async fn login(
         email: user.email,
         name: user.name,
         roles,
+        is_platform_user: user
+            .roles
+            .as_array()
+            .is_some_and(|roles| roles.iter().any(|role| role.as_str() == Some("admin"))),
         auth_method: AuthMethod::Jwt,
         organizations: builtin::organizations_or_default(organizations),
     };
@@ -409,6 +413,7 @@ pub async fn register(
         email: user.email,
         name: user.name,
         roles: vec!["user".to_string()],
+        is_platform_user: false,
         auth_method: AuthMethod::Jwt,
         organizations: builtin::organizations_or_default(organizations),
     };
@@ -497,6 +502,10 @@ pub async fn refresh_token(
         email: user.email,
         name: user.name,
         roles,
+        is_platform_user: user
+            .roles
+            .as_array()
+            .is_some_and(|roles| roles.iter().any(|role| role.as_str() == Some("admin"))),
         auth_method: AuthMethod::Jwt,
         organizations: builtin::organizations_or_default(organizations),
     };
@@ -788,6 +797,10 @@ pub async fn oauth_callback(
         email: user.email,
         name: user.name,
         roles,
+        is_platform_user: user
+            .roles
+            .as_array()
+            .is_some_and(|roles| roles.iter().any(|role| role.as_str() == Some("admin"))),
         auth_method: AuthMethod::Jwt,
         organizations: builtin::organizations_or_default(organizations),
     };
@@ -980,6 +993,10 @@ async fn get_or_create_admin_user(
         email: user.email,
         name: user.name,
         roles,
+        is_platform_user: user
+            .roles
+            .as_array()
+            .is_some_and(|roles| roles.iter().any(|role| role.as_str() == Some("admin"))),
         auth_method: AuthMethod::Jwt,
         organizations: builtin::organizations_or_default(organizations),
     })

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -89,6 +89,7 @@ use utoipa::OpenApi;
         api::mcp_servers::update_mcp_server,
         api::mcp_servers::delete_mcp_server,
         // Durable schedules
+        api::durable::durable_config,
         api::schedules::create_schedule,
         api::schedules::list_schedules,
         api::schedules::get_schedule,

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -685,6 +685,27 @@
         }
       }
     },
+    "/v1/durable/config": {
+      "get": {
+        "tags": [
+          "durable"
+        ],
+        "summary": "GET /v1/durable/config - Durable policy results for UI gating.",
+        "operationId": "durable_config",
+        "responses": {
+          "200": {
+            "description": "Resource config for durable surfaces",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceConfigResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/durable/executions/{execution_id}": {
       "get": {
         "tags": [

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -396,10 +396,11 @@ The spec is defined in `crates/server/src/openapi.rs` using `utoipa` derive macr
 
 ### Durable Execution Admin
 
-Administrative endpoints for monitoring and managing the durable execution engine.
+Platform-user endpoints for monitoring and managing the durable execution engine.
 
 | Method | Path | Description |
 |--------|------|-------------|
+| GET | `/v1/durable/config` | Durable policy results for UI gating |
 | GET | `/v1/durable/workers` | List registered workers |
 | POST | `/v1/durable/workers/{id}/drain` | Drain worker (stop accepting tasks) |
 | POST | `/v1/durable/workers/{id}/resume` | Resume draining worker |

--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -54,6 +54,17 @@ AuthState::with_resolver(config, backend, Arc::new(MyResolver))
 
 The `#[policy]` macro continues to call `Policy::evaluate()`, which uses `DefaultPermissionResolver`. Custom resolvers are opt-in at explicit call sites (config endpoints, or manual `evaluate_with()` calls); the macro behavior does not change.
 
+### Platform User Contract
+
+OSS exposes platform/system authorization as explicit auth context, not tenant-role inference:
+
+- `AuthUser.is_platform_user` is the first-class flag returned by the auth backend.
+- `ResolvedOrg` preserves that flag when HTTP auth is converted into a `Caller`.
+- `Rule::IsPlatformUser` is the gate for global/system surfaces such as `/v1/durable/*`.
+- `GET /v1/durable/config` exposes durable policy results so wrapper UIs can gate navigation from the same contract.
+
+Built-in OSS auth preserves previous behavior by deriving `is_platform_user` from the `admin` auth role. Wrappers can supply their own value from their auth backend without mapping tenant org roles into global platform access.
+
 ## Enforcement
 
 ### Service Layer
@@ -142,6 +153,8 @@ All new service methods MUST have `#[policy]` enforcement with a `Caller` parame
 - Service-layer enforcement
 - Config endpoints for UI
 - `IsPlatformUser` rule with allowlist
+- `AuthUser.is_platform_user` and `ResolvedOrg.is_platform_user` carry wrapper-defined platform access through HTTP caller construction
+- `/v1/durable/config` exposes platform-user policy results for UI gating
 - No DB changes
 
 ### Phase 2 (future)

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -504,7 +504,7 @@ Indirect prompt injection via tool results or user messages is an inherent LLM l
 | TM-DURABLE-007 | Task state manipulation | Medium | Tasks immutable after creation; only status transitions allowed via state machine | MITIGATED |
 | TM-DURABLE-008 | Worker impersonation | High | Bearer token auth + optional mTLS prevents unauthorized access (see TM-DURABLE-002) | MITIGATED |
 | TM-DURABLE-009 | Replay attack on workflow events | Low | Event store is append-only; events processed in sequence order | MITIGATED |
-| TM-DURABLE-010 | Durable API endpoints unauthenticated | High | All `/v1/durable/*` endpoints require `AuthUser` extractor | MITIGATED |
+| TM-DURABLE-010 | Durable API endpoints accessible to ordinary tenant users | High | All `/v1/durable/*` endpoints require explicit platform-user auth; `ResolvedOrg -> Caller` preserves `is_platform_user` for policy/config evaluation | MITIGATED |
 | TM-DURABLE-011 | Presigned image URL forgery | Medium | HMAC-SHA256 signed with `WORKER_GRPC_AUTH_TOKEN`; 5-min expiry; signature covers image_id + org_id + expires; constant-time comparison | MITIGATED |
 
 ### Mitigation Details
@@ -532,13 +532,13 @@ Workers authenticate to control plane gRPC (port 9001) via two layered mechanism
 **Design decision:** Workers are intentionally cross-org. They are stateless task executors that process work from any organization's queue. Org-scoping is enforced at the application layer (HTTP API), not the internal gRPC transport.
 
 **TM-DURABLE-010 — Durable API Endpoints (MITIGATED):**
-All `/v1/durable/*` HTTP endpoints require `AuthUser` extractor. Unauthenticated requests are rejected.
+All `/v1/durable/*` HTTP endpoints require explicit platform-user auth. The auth backend returns `AuthUser.is_platform_user`, HTTP caller construction preserves it through `ResolvedOrg`, and `/v1/durable/config` exposes the same policy result for UI gating.
 
 ## 10. Scheduled Tasks (TM-SCHED)
 
 | ID | Threat | Severity | Mitigation | Status |
 |----|--------|----------|------------|--------|
-| TM-SCHED-001 | Malicious schedule creation | Medium | Only authenticated users with appropriate permissions can create schedules | MITIGATED |
+| TM-SCHED-001 | Malicious schedule creation | Medium | Only platform users can create or manage durable schedules | MITIGATED |
 | TM-SCHED-002 | Catch-up explosion on restart | High | `max_catch_up` limits catch-up runs (default: 1); prevents hundreds of executions on restart | MITIGATED |
 | TM-SCHED-003 | Concurrent execution overload | Medium | `max_concurrent` field enforced; trigger skipped if limit reached | MITIGATED |
 | TM-SCHED-004 | Invalid cron expression DoS | Low | Cron parser validates expression at creation time; invalid expressions rejected | MITIGATED |


### PR DESCRIPTION
## What
Make platform-user authorization a first-class OSS contract for global durable surfaces.

Closes EVE-358.

## Why
Wrapper products need to decide global/system access from their own auth backend without inferring it from tenant org adminship or patching OSS durable routes downstream.

## How
- add explicit `is_platform_user` to `AuthUser` and propagate it through `ResolvedOrg -> Caller`
- add a `PlatformUser` extractor and move durable control-plane + durable schedule routes to that gate
- expose `/v1/durable/config` so the default sidebar can hide durable navigation when the platform-user policy is denied
- preserve built-in OSS behavior by deriving platform-user access from the built-in `admin` auth role
- update specs and exported OpenAPI for the new contract

## Risk
- Medium
- Custom auth backends now need to populate `AuthUser.is_platform_user` intentionally
- A regression here could block access to durable pages or let non-platform users see them

## Security
- Threat categories reviewed: TM-AUTHZ, TM-DURABLE, TM-SCHED, TM-API
- Findings and resolutions:
  - Replaced tenant-admin inference on global durable routes with an explicit platform-user gate
  - Preserved HTTP caller propagation so policy/config evaluation sees the same platform-user state as route auth
  - Exposed UI gating from the same durable policy contract instead of a separate frontend-only check
  - No new injection or data exposure paths introduced; new route returns only policy booleans

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
