### PR TITLE
fix(ci): repair sprites live-test job-level if

### DIFF
--- a/.github/workflows/sprites-integration.yml
+++ b/.github/workflows/sprites-integration.yml
@@ -46,7 +46,9 @@ jobs:
   live-test:
     name: Sprites Live API Tests
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && env.DOPPLER_TOKEN != ''
+    # `env` context is not available in job-level `if`; gate on event only.
+    # Secrets are validated by the Doppler step; see EVE-345 for missing-secret failure semantics.
+    if: github.event_name == 'push'
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
## What
Drop `env.DOPPLER_TOKEN != ''` from the `live-test` job `if:` in `.github/workflows/sprites-integration.yml`. Job-level `if` now gates only on `github.event_name == 'push'`.

## Why
GitHub rejected the workflow at parse time (`run likely failed because of a workflow file issue`), so no jobs — including `unit-test` — ran on pushes to main. Root cause: the `env` context is not available in `jobs.<job_id>.if`. Allowed contexts there are `github`, `needs`, `vars`, and `inputs` (see GitHub Actions context availability). Confirmed by `actionlint` on all workflows and by reviewing the failure history on the default branch.

## How
Replace the unsupported `env.DOPPLER_TOKEN` gate with an event-only gate. Doppler CLI / step-level invocations remain the source of truth for missing-secret failure semantics (tracked separately in EVE-345).

## Risk
- Low
- The `live-test` job now always runs on `push` events to `main`. If `DOPPLER_TOKEN` is ever unset (e.g. external fork push), the step will fail loudly — desired behavior per EVE-345.

## Security
- Threat categories reviewed: workflow only, no runtime code path. No secret exposure added; `DOPPLER_TOKEN` still sourced from workflow secrets. `permissions: contents: read` unchanged. No new external actions.
- Findings and resolutions: None.

## Validation
- `actionlint` passes on `sprites-integration.yml` and all other workflows.
- `just pre-push` green: fmt, clippy, Cargo.lock, migrations, author attribution.
- Smoke test N/A — pure CI/config change; exercised by the workflow itself on merge.

## Checklist
- [x] Security review performed (workflow-only change; no runtime surface)
- [x] Validated via actionlint + pre-push

Fixes EVE-347.
