### PR TITLE
fix(ci): add missing container-sandbox live_api_test target

### DIFF
--- a/.github/workflows/container-sandbox-integration.yml
+++ b/.github/workflows/container-sandbox-integration.yml
@@ -51,7 +51,17 @@ jobs:
     services:
       docker:
         image: docker:dind
+        env:
+          # Disable TLS so the daemon listens on plain HTTP :2375.
+          DOCKER_TLS_CERTDIR: ""
         options: --privileged
+        ports:
+          - 2375:2375
+
+    env:
+      # Steer the DockerClient at the service-mapped daemon. See
+      # `crates/container-sandbox/tests/live_api_test.rs` for the contract.
+      CONTAINER_SANDBOX_DOCKER_HOST: http://localhost:2375
 
     steps:
       - uses: actions/checkout@v4
@@ -63,6 +73,18 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "debug"
+
+      - name: Wait for Docker daemon
+        run: |
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:2375/_ping >/dev/null 2>&1; then
+              echo "Docker daemon is ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Docker daemon did not become ready within 60s" >&2
+          exit 1
 
       - name: Run live integration tests
         run: cargo test -p everruns-container-sandbox --features container-sandbox-live-tests --test live_api_test -- --test-threads=1

--- a/crates/container-sandbox/SPEC.md
+++ b/crates/container-sandbox/SPEC.md
@@ -97,10 +97,16 @@ The container runtime (`runc`, `sysbox-runc`, `kata`, `gvisor`) is a deployment-
 crates/container-sandbox/
 ├── Cargo.toml
 ├── SPEC.md
-└── src/
-    ├── lib.rs           # ContainerSandboxCapability + tool registration
-    ├── client.rs        # Docker Engine REST API client
-    ├── config.rs        # Configuration with env var defaults
-    ├── state.rs         # Sandbox state + leased resources
-    └── tools.rs         # All 8 tool implementations
+├── src/
+│   ├── lib.rs           # ContainerSandboxCapability + tool registration
+│   ├── client.rs        # Docker Engine REST API client
+│   ├── config.rs        # Configuration with env var defaults
+│   ├── state.rs         # Sandbox state + leased resources
+│   └── tools.rs         # All 8 tool implementations
+└── tests/
+    └── live_api_test.rs # Feature-gated live Docker Engine API tests
 ```
+
+## Live API tests
+
+`tests/live_api_test.rs` is the canonical live-test entrypoint for the container-sandbox capability. It is gated behind the `container-sandbox-live-tests` cargo feature and expects an unauthenticated Docker daemon reachable via `CONTAINER_SANDBOX_DOCKER_HOST` (default `http://localhost:2375`). `.github/workflows/container-sandbox-integration.yml` runs these tests on pushes to `main` against a `docker:dind` service container with TLS disabled.

--- a/crates/container-sandbox/tests/live_api_test.rs
+++ b/crates/container-sandbox/tests/live_api_test.rs
@@ -1,0 +1,67 @@
+//! Live Docker Engine API integration tests for the container-sandbox capability.
+//!
+//! Gated behind:
+//! - Feature flag: `container-sandbox-live-tests`
+//! - Daemon availability on `CONTAINER_SANDBOX_DOCKER_HOST` (default `http://localhost:2375`).
+//!   The workflow `.github/workflows/container-sandbox-integration.yml` runs a
+//!   `docker:dind` service with TLS disabled to provide this endpoint.
+//!
+//! Run locally (requires an unauthenticated Docker daemon on localhost:2375):
+//!     docker run -d --privileged -p 2375:2375 -e DOCKER_TLS_CERTDIR='' docker:dind
+//!     cargo test -p everruns-container-sandbox \
+//!         --features container-sandbox-live-tests --test live_api_test -- --test-threads=1
+//!
+//! The test is intentionally narrow: it proves the `DockerClient` speaks the
+//! Docker Engine API end-to-end (TCP, HTTP, JSON, filter encoding) without
+//! pulling images or depending on container runtime features that the repo's
+//! unit tests already cover via wiremock.
+
+#![cfg(feature = "container-sandbox-live-tests")]
+
+use everruns_container_sandbox::client::DockerClient;
+
+/// Round-trip a scoped `list_containers` call against a real daemon.
+///
+/// Uses a label filter that cannot match anything on a fresh dind daemon, so
+/// the assertion stays stable while still exercising the full HTTP + JSON
+/// path through the client.
+#[tokio::test(flavor = "multi_thread")]
+async fn list_containers_round_trips_against_live_daemon() {
+    let client = DockerClient::new(None);
+    let probe = ("everruns-live-test", "does-not-exist");
+    let containers = client
+        .list_containers(&[probe])
+        .await
+        .expect("list_containers must round-trip against the live daemon");
+    assert!(
+        containers.is_empty(),
+        "unexpected containers matched probe label {probe:?}: {containers:?}"
+    );
+}
+
+/// Create and remove an isolated bridge network. Proves write-path plumbing
+/// (POST /networks/create + DELETE /networks/{id}) without needing any image.
+#[tokio::test(flavor = "multi_thread")]
+async fn network_lifecycle_against_live_daemon() {
+    let client = DockerClient::new(None);
+    let name = format!(
+        "everruns-live-net-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("unix epoch")
+            .as_nanos()
+    );
+    let mut labels = std::collections::HashMap::new();
+    labels.insert("everruns.live-test".to_string(), "1".to_string());
+
+    let id = client
+        .create_network(&name, labels)
+        .await
+        .expect("create_network must succeed against the live daemon");
+    assert!(!id.is_empty(), "network id must not be empty");
+
+    client
+        .remove_network(&id)
+        .await
+        .expect("remove_network must succeed against the live daemon");
+}


### PR DESCRIPTION
## What
- Add `crates/container-sandbox/tests/live_api_test.rs` as the canonical live-test entrypoint (feature-gated on `container-sandbox-live-tests`).
- Fix `.github/workflows/container-sandbox-integration.yml` so the `docker:dind` service actually exposes port `2375` with TLS disabled, and point `CONTAINER_SANDBOX_DOCKER_HOST` at it.
- Add a daemon `/_ping` wait step to avoid races on cold dind boot.
- Document the entrypoint in `crates/container-sandbox/SPEC.md` so workflow and test target can't drift again.

## Why
The dedicated container-sandbox workflow has been failing on pushes to `main` since it was introduced (initial import commit `8bd123a`). Root cause: the workflow invokes `--test live_api_test`, but `tests/live_api_test.rs` was never written. Cargo correctly errors with `no test target named live_api_test`. The `unit-test` job is unaffected — only the `live-test` job breaks.

Beyond the missing file, the `services.docker` block also lacked `DOCKER_TLS_CERTDIR: ""` and a port mapping, so even a correctly-built test would have hit a TLS-protected daemon on `:2376` it never agreed to.

## How
The two new live tests are intentionally narrow:
- `list_containers_round_trips_against_live_daemon` exercises the GET + JSON + filter-encoding path with a probe label that cannot match.
- `network_lifecycle_against_live_daemon` exercises write-path plumbing (`POST /networks/create` + `DELETE /networks/{id}`).

Neither pulls an image, so the job stays cheap and deterministic. If we later want image/exec coverage, it can layer on the same file.

## Risk
- Low. Only the previously-dead `live-test` job changes behavior. Unit tests are untouched.
- The job is still `if: github.event_name == 'push'`, so PR load is unchanged.

## Security
- Threat categories reviewed: workflow + new test-only code. No runtime surface touched.
- Exposing dind on `:2375` without TLS is confined to the service container on the ephemeral runner and only the runner itself can reach it. No secret exposure added.
- Findings and resolutions: None.

## Validation
- `just pre-push` green (fmt, clippy, lockfile, migrations, author attribution).
- `cargo build -p everruns-container-sandbox --tests --features container-sandbox-live-tests` compiles cleanly.
- `cargo test -p everruns-container-sandbox` passes (31 unit tests; live tests correctly compile-out without the feature).
- `actionlint` clean on the updated workflow.
- End-to-end live-job verification will happen on merge when the push-triggered workflow runs on `main`.

## Checklist
- [x] Tests added (two live-gated integration tests)
- [x] Security review performed
- [x] Specs updated (`crates/container-sandbox/SPEC.md`)

Fixes EVE-346.
