### PR TITLE
fix(cli): forward EVERRUNS_ORG_ID as X-Org-Id on agent import

### DIFF
--- a/crates/cli/src/commands/agents.rs
+++ b/crates/cli/src/commands/agents.rs
@@ -289,10 +289,14 @@ async fn import_from_file(
     };
 
     let http = reqwest::Client::new();
-    let resp = http
+    let mut req = http
         .post(format!("{}/v1/agents/import", api_url))
         .header("Authorization", format!("Bearer {}", api_key))
-        .header("Content-Type", content_type)
+        .header("Content-Type", content_type);
+    if let Ok(org) = std::env::var("EVERRUNS_ORG_ID") {
+        req = req.header("X-Org-Id", org);
+    }
+    let resp = req
         .body(body)
         .send()
         .await


### PR DESCRIPTION
## What
Forward `EVERRUNS_ORG_ID` as the `X-Org-Id` header on the CLI's direct `POST /v1/agents/import` call.

## Why
EVE-338: The CLI's direct `reqwest` call to `/v1/agents/import` in `crates/cli/src/commands/agents.rs` did not propagate `X-Org-Id`. API-key principals with access to multiple orgs hit `"Multiple organizations available. Specify the target organization via the X-Org-Id header."` on import, even though the rest of the CLI (which goes through the SDK) does forward the header.

The fix was authored on branch `claude/setup-a11y-audit-agent-1Tzkq` (commit `ee17a05`) but never landed on `main`. This PR is a clean cherry-pick of that commit.

## How
- 6-line diff. When `EVERRUNS_ORG_ID` is set, attach `X-Org-Id: <value>` to the request builder before `.body(..)`.
- Mirrors the env-driven behaviour used by the Everruns SDK client.

## Risk
- Low. Single function in a single CLI command. No behavioural change when `EVERRUNS_ORG_ID` is unset (the header is simply not attached).

## Security
- Threat categories reviewed: `TM-TENANT`.
- The server already validates any `X-Org-Id` value against the principal's org memberships (`crates/server/src/auth/middleware.rs`), so forwarding a client-supplied value does not expand the principal's authority.
- No new secret exposure; no changes to how the API key is handled.
- Findings and resolutions: none.

## Validation
- `cargo build -p everruns-cli` green.
- `just pre-push` green (fmt, clippy, lockfile, migrations, author attribution).
- Follow-up left to a separate issue: consolidate the remaining direct `reqwest` calls in `crates/cli/` behind the SDK so header policy stays in one place.

## Checklist
- [x] Tests: no behavioural change when env var is unset; existing CLI flow unchanged.
- [x] Docs: no user-facing doc change required; `specs/multitenancy.md` already documents the header contract.
- [x] Security review performed.

Fixes EVE-338.
