### PR TITLE
ci: guard release-prep PRs from un-squashed migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,39 @@ jobs:
       - name: Check Cargo.lock is up to date
         run: cargo fetch --locked
 
+  release-prep-check:
+    # Fires only when a PR bumps [workspace.package].version (release-prep
+    # signal). Catches the v0.8.15-style hole where feature-named migrations
+    # leak into a release tag. See specs/release-process.md.
+    name: Release Prep Squash Check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect workspace version change
+        id: ver
+        run: |
+          extract() {
+            awk '/^\[workspace.package\]/{p=1;next} p && /^\[/{p=0} p && /^version[[:space:]]*=/' "$1" \
+              | head -1 | sed -E 's/.*"(.*)".*/\1/'
+          }
+          OLD=$(git show "origin/${{ github.base_ref }}:Cargo.toml" | extract /dev/stdin)
+          NEW=$(extract Cargo.toml)
+          echo "old=$OLD"
+          echo "new=$NEW"
+          if [ "$OLD" != "$NEW" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify all feature migrations are squashed
+        if: steps.ver.outputs.changed == 'true'
+        run: ./scripts/check-release-squash.sh
+
   clippy:
     name: Clippy Lints
     runs-on: ubuntu-latest
@@ -881,6 +914,7 @@ jobs:
       - changes
       - format
       - lockfile
+      - release-prep-check
       - clippy
       - unit-test
       - integration-test

--- a/scripts/check-release-squash.sh
+++ b/scripts/check-release-squash.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Verify a release-prep PR squashed all feature migrations.
+#
+# Run this when a PR bumps `[workspace.package].version` (i.e., the PR is a
+# release prep). The CI job in `.github/workflows/ci.yml` triggers it on that
+# signal, so feature-named migrations cannot leak into a release tag the way
+# `016_eval_case_result_metadata.sql` and `017_eval_artifacts.sql` did in
+# v0.8.15. See `specs/release-process.md` ("Migration Squashing").
+#
+# Rule: every file under crates/server/migrations/ matching `[0-9]+*.sql` must
+# be either a foundational baseline migration or a `NNN_vX.Y.Z.sql` release
+# migration. Feature-named migrations are forbidden in a release-prep PR.
+
+set -euo pipefail
+
+ROOT="${1:-$(git rev-parse --show-toplevel)}"
+MIG_DIR="$ROOT/crates/server/migrations"
+
+if [ ! -d "$MIG_DIR" ]; then
+  echo "no migrations dir at $MIG_DIR — nothing to check"
+  exit 0
+fi
+
+# Foundational baseline migrations exist before the version-named convention
+# was adopted. They are the only allowed non-version names.
+FOUNDATIONAL=("001_base_schema.sql" "002_durable_execution.sql")
+
+bad=()
+shopt -s nullglob
+for f in "$MIG_DIR"/[0-9]*.sql; do
+  name=$(basename "$f")
+  is_foundational=false
+  for fnd in "${FOUNDATIONAL[@]}"; do
+    if [ "$name" = "$fnd" ]; then
+      is_foundational=true
+      break
+    fi
+  done
+  if $is_foundational; then
+    continue
+  fi
+  if [[ "$name" =~ ^[0-9]{3}_v[0-9]+\.[0-9]+\.[0-9]+\.sql$ ]]; then
+    continue
+  fi
+  bad+=("$name")
+done
+
+if [ ${#bad[@]} -gt 0 ]; then
+  {
+    echo "ERROR: release prep left these feature migrations un-squashed:"
+    printf '  - %s\n' "${bad[@]}"
+    echo
+    echo "Fold them into the release migration per specs/release-process.md"
+    echo "(Migration Squashing). The /prepare-release command does this; if you"
+    echo "ran it manually, re-run the squash step now."
+  } >&2
+  exit 1
+fi
+
+echo "OK: every migration is either foundational or NNN_vX.Y.Z.sql"

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -50,6 +50,8 @@ Squashing is a **BREAKING CHANGE** — it requires a fresh database, because `_s
 
 If no feature migrations were added since the last release, skip this step — do not create an empty `NNN_vX.Y.Z.sql`.
 
+CI enforces the squash via the `release-prep-check` job in `.github/workflows/ci.yml`, which fires whenever a PR changes `[workspace.package].version`. It runs `scripts/check-release-squash.sh`, which fails if any non-foundational migration under `crates/server/migrations/` has a stem other than `NNN_vX.Y.Z`. This catches the v0.8.15-style hole where feature-named migrations leaked into a release tag.
+
 ### Lock File Updates
 
 Lock files must be updated when preparing a release:


### PR DESCRIPTION
## What
Add a CI guard that fails a release-prep PR when `crates/server/migrations/` still contains feature-named migrations alongside the new `NNN_vX.Y.Z.sql`.

- `scripts/check-release-squash.sh` — enforces the rule (every non-foundational migration must match `NNN_vX.Y.Z.sql`).
- `.github/workflows/ci.yml` — new `release-prep-check` job that runs the script only when the PR diff changes `[workspace.package].version` against the base ref. Wired into the `ci-success` aggregator.
- `specs/release-process.md` — references the guard in the Migration Squashing section.

## Why
`v0.8.15` shipped with migrations `016_eval_case_result_metadata.sql` and `017_eval_artifacts.sql` raw — the release-prep step only squashed `015_scoped_mcp_servers.sql` and missed the trailing feature migrations. `v0.8.16` then correctly folded `016 + 017` into `016_v0.8.16.sql`, which mismatched what was already recorded in `_sqlx_migrations` on any DB that had run `v0.8.15`. `dev.everruns.com` hit this on the `v0.8.16` deploy and crashlooped until the bookkeeping table was hand-repaired.

This guard would have failed the `prepare v0.8.15` PR before merge.

## How
- The script walks `crates/server/migrations/[0-9]*.sql`, skips the two foundational baseline files, and fails on anything that doesn't match `^[0-9]{3}_v[0-9]+\.[0-9]+\.[0-9]+\.sql$`.
- The CI job compares `[workspace.package].version` between PR head and base using `git show origin/$BASE:Cargo.toml`. No change → job completes with no enforcement (dev PRs adding feature migrations are unaffected). Version change → script runs; any feature-named migration fails the job.
- Smoke-tested both ways locally: passes on current `main` (v0.8.16 layout), fails on a fixture that mirrors the v0.8.15 layout.

## Risk
- Low. Additive CI job, no production code. Cannot produce false positives on dev PRs because the gate only fires when the workspace version diffs vs. base.

## Security
- Threat categories reviewed: No security-relevant code changes (CI / docs / bash script operating on a fixed, repo-local directory).
- Findings and resolutions: none.

## Checklist
- [x] Script smoke-tested positive and negative
- [x] YAML validated (`python3 -c 'yaml.safe_load(...)'`)
- [x] Spec updated
- [ ] CI passes on this PR itself (expected: `release-prep-check` skips because Cargo.toml version is unchanged)
