### PR TITLE
test(ci): add worker PR coverage for durable execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,30 @@ jobs:
           cargo test -p everruns-integrations-e2b
           cargo test -p everruns-integrations-sprites
 
+  # Durable-worker PR coverage. Catches regressions in the worker crate's
+  # durable execution paths (act/reason/input task handling, DLQ emission,
+  # session.idled, org_id roundtripping, task error mapping) before merge.
+  # Serialized because a handful of tests mutate process-wide env vars.
+  worker-test:
+    name: Worker Tests (Durable Execution)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "debug"
+
+      - name: Run worker library tests
+        run: cargo test -p everruns-worker --lib -- --test-threads=1
+
   # Live Daytona API tests — only when integrations/daytona/** changes and secret exists
   daytona-live-test:
     name: Daytona Live API Tests
@@ -883,6 +907,7 @@ jobs:
       - lockfile
       - clippy
       - unit-test
+      - worker-test
       - integration-test
       - build-binaries
       - workflow-test

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -1639,4 +1639,154 @@ mod tests {
         let decoded: ActTaskInput = serde_json::from_value(json).unwrap();
         assert_eq!(decoded.act_input.org_id, Some(7));
     }
+
+    /// Regression guard: `ActTaskInput` carries a `request_id` alongside the
+    /// flattened `ActInput`. A serde round-trip must preserve both without
+    /// collisions so durable act-task replay observes the same correlation ID.
+    #[test]
+    fn act_task_input_roundtrip_preserves_request_id_and_inner_context() {
+        use everruns_core::atoms::{ActInput, AtomContext};
+        use everruns_core::typed_id::ExecId;
+
+        let session_id = SessionId::new();
+        let turn_id = TurnId::new();
+        let input_message_id = MessageId::new();
+        let exec_id = ExecId::new();
+
+        let input = ActTaskInput {
+            request_id: Some("req_abc".to_string()),
+            act_input: ActInput {
+                org_id: Some(42),
+                context: AtomContext {
+                    session_id,
+                    turn_id,
+                    input_message_id,
+                    exec_id,
+                },
+                harness_id: HarnessId::new(),
+                agent_id: None,
+                tool_calls: vec![],
+                tool_definitions: vec![],
+                locale: None,
+                blueprint_id: None,
+                network_access: None,
+            },
+        };
+        let json = serde_json::to_value(&input).unwrap();
+        let decoded: ActTaskInput = serde_json::from_value(json).unwrap();
+        assert_eq!(decoded.request_id.as_deref(), Some("req_abc"));
+        assert_eq!(decoded.act_input.org_id, Some(42));
+        assert_eq!(decoded.act_input.context.session_id, session_id);
+        assert_eq!(decoded.act_input.context.turn_id, turn_id);
+        assert_eq!(decoded.act_input.context.input_message_id, input_message_id);
+        assert_eq!(decoded.act_input.context.exec_id, exec_id);
+    }
+
+    /// When an act task reaches DLQ with its inner `org_id` missing, the
+    /// extractor still returns a usable session context so the worker can
+    /// emit `session.idled` and unblock the UI. The wrapper falls back to 0
+    /// on purpose — `require_org_id` handles the refusal on the execution
+    /// path, but DLQ emission must tolerate the missing value.
+    #[test]
+    fn test_extract_task_session_context_act_tolerates_missing_inner_org_id() {
+        use everruns_core::atoms::{ActInput, AtomContext};
+        use everruns_core::typed_id::ExecId;
+
+        let session_id = SessionId::new();
+        let turn_id = TurnId::new();
+        let input_message_id = MessageId::new();
+        let act_task_input = ActTaskInput {
+            request_id: None,
+            act_input: ActInput {
+                org_id: None,
+                context: AtomContext {
+                    session_id,
+                    turn_id,
+                    input_message_id,
+                    exec_id: ExecId::new(),
+                },
+                harness_id: HarnessId::new(),
+                agent_id: None,
+                tool_calls: vec![],
+                tool_definitions: vec![],
+                locale: None,
+                blueprint_id: None,
+                network_access: None,
+            },
+        };
+        let value = serde_json::to_value(&act_task_input).unwrap();
+
+        let ctx = extract_task_session_context("act", &value)
+            .expect("act input without inner org_id must still parse for DLQ path");
+
+        assert_eq!(ctx.org_id, 0);
+        assert_eq!(ctx.session_id, session_id);
+        assert_eq!(ctx.turn_id, turn_id);
+        assert_eq!(ctx.input_message_id, input_message_id);
+    }
+
+    /// `process_input`/`reason` tasks may land without a `turn_id` (very
+    /// early lifecycle). Extraction must return a default rather than
+    /// erroring so the DLQ path can still surface user-facing events.
+    #[test]
+    fn test_extract_task_session_context_reason_defaults_missing_turn_id() {
+        let session_id = SessionId::new();
+        let input_message_id = MessageId::new();
+        let turn_input = DurableTurnInput {
+            org_id: 3,
+            session_id,
+            harness_id: HarnessId::new(),
+            agent_id: None,
+            input_message_id,
+            turn_id: None,
+            previous_response_id: None,
+            iteration: 0,
+            request_id: None,
+        };
+        let value = serde_json::to_value(&turn_input).unwrap();
+
+        let ctx =
+            extract_task_session_context("reason", &value).expect("turn_id=None still parses");
+
+        assert_eq!(ctx.org_id, 3);
+        assert_eq!(ctx.session_id, session_id);
+        assert_eq!(ctx.input_message_id, input_message_id);
+        // A synthesised TurnId is used so downstream EventContext::turn
+        // still accepts the value and DLQ emission is not short-circuited.
+        // We only assert the context was constructed successfully above.
+        let _ = ctx.turn_id;
+    }
+
+    /// Guard against classifier drift: transient LLM failures that the
+    /// worker retries must not be marked non-retryable. Missing-user-message
+    /// and missing-act-org-id remain the only non-retryable patterns.
+    #[test]
+    fn test_is_non_retryable_task_error_does_not_match_generic_not_found() {
+        // A 404 from the LLM provider is not the same as a missing user
+        // message — the retry loop must keep handling those.
+        assert!(!is_non_retryable_task_error(
+            "OpenAI API error (404): model not found"
+        ));
+        assert!(!is_non_retryable_task_error(
+            "ReasonAtom execution failed: OpenAI API error (404): model not found"
+        ));
+        // Budget exhausted surfaces as a task failure, but the worker still
+        // funnels it through the single DLQ emission path rather than
+        // short-circuiting retries here.
+        assert!(!is_non_retryable_task_error(
+            "ReasonAtom execution failed: Budget exhausted. 1.00 tokens spent reached the 1.00 tokens limit."
+        ));
+    }
+
+    /// Non-retryable detection is case-insensitive so the classifier keeps
+    /// matching even if upstream error wrapping changes casing.
+    #[test]
+    fn test_is_non_retryable_task_error_is_case_insensitive() {
+        assert!(is_non_retryable_task_error(
+            "Message store error: USER MESSAGE NOT FOUND: msg_abc"
+        ));
+        assert!(is_non_retryable_task_error(
+            "ACTTASKINPUT.ACT_INPUT.ORG_ID MUST BE SET"
+        ));
+    }
 }

--- a/crates/worker/src/leased_resource_cleanup.rs
+++ b/crates/worker/src/leased_resource_cleanup.rs
@@ -515,11 +515,20 @@ fn is_browserless_already_gone(error: &str) -> bool {
 mod tests {
     use super::*;
     use std::collections::HashMap;
-    use std::sync::Mutex;
+    use std::sync::{Mutex, OnceLock};
 
     use async_trait::async_trait;
     use everruns_core::{KeyInfo, LeasedResourceStatus, SecretInfo};
     use uuid::Uuid;
+
+    // Tests that mutate process-wide env vars (e.g. E2B_API_KEY) must not run
+    // in parallel; `cargo test` schedules them on separate threads by default.
+    // The async-aware tokio Mutex is required because the guard is held
+    // across `.await` points while env-var state has to remain stable.
+    fn env_mutex() -> &'static tokio::sync::Mutex<()> {
+        static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+    }
 
     struct TestSessionStorageStore {
         secrets: Mutex<HashMap<(String, String), String>>,
@@ -646,6 +655,7 @@ mod tests {
 
     #[tokio::test]
     async fn e2b_cleanup_prefers_session_secret_override() {
+        let _guard = env_mutex().lock().await;
         let session_id = SessionId::from_uuid(Uuid::nil());
         let storage =
             TestSessionStorageStore::with_secret(session_id, "E2B_API_KEY", "session-key");
@@ -685,6 +695,7 @@ mod tests {
 
     #[tokio::test]
     async fn e2b_cleanup_falls_back_to_env_key() {
+        let _guard = env_mutex().lock().await;
         let session_id = SessionId::from_uuid(Uuid::nil());
         let storage = TestSessionStorageStore::empty();
         let resource = LeasedResource {
@@ -723,6 +734,7 @@ mod tests {
 
     #[tokio::test]
     async fn e2b_cleanup_rejects_blank_env_key() {
+        let _guard = env_mutex().lock().await;
         let session_id = SessionId::from_uuid(Uuid::nil());
         let storage = TestSessionStorageStore::empty();
         let resource = LeasedResource {

--- a/crates/worker/src/task_error.rs
+++ b/crates/worker/src/task_error.rs
@@ -389,4 +389,102 @@ mod tests {
             "The AI provider is experiencing issues. Please try again shortly."
         );
     }
+
+    #[test]
+    fn user_facing_failure_message_preserves_soft_limit_copy() {
+        // Soft-limit copy is authored downstream (budgeting). The task-error
+        // extractor must pass it through verbatim rather than falling back to
+        // the generic copy.
+        let message = user_facing_failure_message(
+            "activity_type=reason | error_chain=ReasonAtom execution failed: Soft limit reached. Continue to keep going past the budget.",
+        );
+
+        assert_eq!(
+            message,
+            "Soft limit reached. Continue to keep going past the budget."
+        );
+    }
+
+    #[test]
+    fn user_facing_failure_message_falls_back_for_unclassified_errors() {
+        // Anything the classifier cannot recognise must funnel to the
+        // generic copy so the UI never shows raw error chains.
+        let message = user_facing_failure_message(
+            "activity_type=reason | error_chain=mysterious bug: something internal broke",
+        );
+
+        assert_eq!(
+            message,
+            "I encountered an error while processing your request. Please try again later."
+        );
+    }
+
+    #[test]
+    fn user_facing_failure_message_normalizes_rate_limit_variants() {
+        // Providers surface rate limits in a few shapes; all collapse to the
+        // same user-facing copy.
+        for raw in [
+            "activity_type=reason | error_chain=ReasonAtom execution failed: Rate limit exceeded",
+            "activity_type=reason | error_chain=Too Many Requests",
+            "activity_type=reason | error_chain=OpenAI API error (429): slow down",
+        ] {
+            assert_eq!(
+                user_facing_failure_message(raw),
+                "Rate limited by the AI provider. Please wait a moment.",
+                "unexpected mapping for: {raw}"
+            );
+        }
+    }
+
+    /// Tool identifiers are capped so a pathological turn with many tool
+    /// calls cannot blow up the persisted failure message or leak every tool
+    /// name into the log line. The extractor truncates and records an
+    /// `+N more` marker instead.
+    #[test]
+    fn summarize_task_failure_truncates_long_tool_identifier_lists() {
+        let mut tool_calls = Vec::new();
+        for i in 0..10 {
+            tool_calls.push(json!({"name": format!("tool_{i}")}));
+        }
+        let input = json!({
+            "context": { "session_id": "session_truncate" },
+            "tool_calls": tool_calls,
+        });
+        let error = anyhow::anyhow!("boom");
+
+        let summary = summarize_task_failure(Uuid::nil(), None, "act", 1, Some(1), &input, &error);
+
+        assert_eq!(summary.tool_identifiers.len(), 6);
+        assert_eq!(summary.tool_identifiers[0], "tool_0");
+        assert_eq!(summary.tool_identifiers[5], "+5 more");
+        assert!(
+            summary.persisted_message.contains("+5 more"),
+            "persisted message should surface truncation marker: {}",
+            summary.persisted_message
+        );
+    }
+
+    /// Missing attempt limits still produce a readable summary — the
+    /// attempt field is written as a plain counter rather than `N/None`.
+    #[test]
+    fn summarize_task_failure_without_max_attempts_emits_plain_counter() {
+        let input = json!({
+            "context": { "session_id": "session_plain" },
+            "tool_calls": []
+        });
+        let error = anyhow::anyhow!("retryable transient");
+
+        let summary = summarize_task_failure(Uuid::nil(), None, "reason", 4, None, &input, &error);
+
+        assert!(
+            summary.persisted_message.contains("attempt=4"),
+            "expected plain counter, got: {}",
+            summary.persisted_message
+        );
+        assert!(
+            !summary.persisted_message.contains("attempt=4/"),
+            "should omit the `/max` suffix when max_attempts is None: {}",
+            summary.persisted_message
+        );
+    }
 }


### PR DESCRIPTION
## What

Adds a dedicated `worker-test` CI job that runs `cargo test -p everruns-worker --lib -- --test-threads=1` on every PR, plus focused unit tests covering the worker invariants where recent regressions clustered.

## Why

Per EVE-340, PR CI treated `everruns-worker` as an unowned target even though `crates/worker/src/{durable_worker,unified_worker,task_error}.rs` recently absorbed three regressions:

- `8bd123a2` fix(worker): preserve inner act activity failures
- `919dfbb5` fix(worker): emit session.idled when act tasks hit DLQ
- `34b4a6d0` fix(worker): preserve ActInput.org_id through durable act-task roundtrip

Without PR gating, the next regression in this area lands in `main`.

## How

**CI:**

- New `worker-test` job running `cargo test -p everruns-worker --lib -- --test-threads=1`. Serialized because a handful of tests mutate process-wide env vars.
- Added to the `ci-success` aggregation gate so branch protection enforces it.

**Test race fix:**

- The `e2b_cleanup_*` tests in `leased_resource_cleanup.rs` set/unset `E2B_API_KEY` concurrently, producing a flake under the default test scheduler. Serialized them with a `tokio::sync::Mutex` (async-aware since the guard spans `.await` points).

**Focused tests:**

- `durable_worker.rs`:
  - `ActTaskInput` roundtrip preserves `request_id` alongside inner `ActInput` (EVE-325-adjacent).
  - `extract_task_session_context("act", ...)` tolerates missing inner `org_id` so DLQ emission still surfaces `session.idled`.
  - `extract_task_session_context("reason", ...)` defaults missing `turn_id` so DLQ paths are not short-circuited.
  - `is_non_retryable_task_error` does not match generic 404s or budget copy, and is case-insensitive.
- `task_error.rs`:
  - `user_facing_failure_message` passes through soft-limit copy, normalizes rate-limit variants, and falls back to generic copy for unclassified errors.
  - `summarize_task_failure` truncates tool identifier lists with `+N more` and emits plain attempt counters when `max_attempts` is `None`.

All 98 worker lib tests pass locally with `--test-threads=1`; `cargo clippy -p everruns-worker --all-targets --all-features -- -D warnings` is clean.

## Risk

- Low. CI-only + test-only change. No runtime code paths modified. The new job adds wall-clock cost to PR CI (~1 min on cached runner).

## Security

- Threat categories reviewed: no security-relevant code changes. Changes are limited to `.github/workflows/ci.yml` and `#[cfg(test)]` modules inside `crates/worker`. No auth, API, tool execution, or data-flow paths are affected.
- Findings and resolutions: none.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Fixes EVE-340.
