### PR TITLE
feat(ui): preview initial files for agents and harnesses

### DIFF
--- a/apps/ui/src/__tests__/agent-detail-model.test.tsx
+++ b/apps/ui/src/__tests__/agent-detail-model.test.tsx
@@ -49,6 +49,10 @@ jest.mock("@/components/chat/streamdown-message", () => ({
   ),
 }));
 
+jest.mock("@/components/agents/agent-preview", () => ({
+  AgentPreview: () => <div data-testid="agent-preview">agent preview</div>,
+}));
+
 // Mock data
 const mockAgent: Agent = {
   id: "agent-1",

--- a/apps/ui/src/__tests__/initial-files-preview.test.tsx
+++ b/apps/ui/src/__tests__/initial-files-preview.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { InitialFilesPreview } from "@/components/files/initial-files-preview";
+import type { InitialFile } from "@/lib/api/types";
+
+jest.mock("streamdown", () => ({
+  Streamdown: ({ children }: { children: string }) => (
+    <pre data-testid="streamdown-mock">{children}</pre>
+  ),
+}));
+
+jest.mock("@streamdown/code", () => ({
+  code: {},
+}));
+
+describe("InitialFilesPreview", () => {
+  it("renders empty state when no files are configured", () => {
+    render(<InitialFilesPreview files={[]} />);
+
+    expect(screen.getByText("No initial files configured.")).toBeInTheDocument();
+  });
+
+  it("shows text file contents inline and lets the user switch files", () => {
+    const files: InitialFile[] = [
+      {
+        path: "/notes.txt",
+        content: "plain text preview",
+        encoding: "text",
+        is_readonly: false,
+      },
+      {
+        path: "/src/app.ts",
+        content: "export const value = 1;",
+        encoding: "text",
+        is_readonly: true,
+      },
+    ];
+
+    render(<InitialFilesPreview files={files} />);
+
+    expect(screen.getByText("plain text preview")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /\/src\/app\.ts/i }));
+
+    expect(screen.getByText(/export const value = 1;/)).toBeInTheDocument();
+    expect(screen.getByText("read-only")).toBeInTheDocument();
+  });
+
+  it("shows a binary fallback when inline preview is unavailable", () => {
+    const files: InitialFile[] = [
+      {
+        path: "/assets/archive.bin",
+        content: "SGVsbG8=",
+        encoding: "base64",
+        is_readonly: false,
+      },
+    ];
+
+    render(<InitialFilesPreview files={files} />);
+
+    expect(screen.getByText("Binary file")).toBeInTheDocument();
+    expect(
+      screen.getByText(/stored as base64 and can be copied into new sessions/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -471,6 +471,7 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
               <AgentPreview
                 systemPrompt={formData.system_prompt}
                 capabilities={selectedCapabilities}
+                initialFiles={selectedInitialFiles}
                 tools={agent.tools ?? []}
               />
             </div>

--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -377,6 +377,7 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
               ref: cap.ref,
               config: cap.config,
             }))}
+            initialFiles={agent.initial_files}
             tools={agent.tools ?? []}
           />
         </TabsContent>

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
@@ -488,6 +488,7 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
               <HarnessPreview
                 systemPrompt={formData.system_prompt}
                 capabilities={selectedCapabilities}
+                initialFiles={selectedInitialFiles}
                 parentHarnessId={formData.parent_harness_id || undefined}
               />
             </div>

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
@@ -299,6 +299,7 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
               ref: cap.ref,
               config: cap.config,
             }))}
+            initialFiles={harness.initial_files}
           />
         </TabsContent>
       </Tabs>

--- a/apps/ui/src/components/agents/agent-preview.tsx
+++ b/apps/ui/src/components/agents/agent-preview.tsx
@@ -6,16 +6,28 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import type { AgentCapabilityConfig, AgentPreviewResponse, ToolDefinition } from "@/lib/api/types";
+import { InitialFilesPreview } from "@/components/files/initial-files-preview";
+import type {
+  AgentCapabilityConfig,
+  AgentPreviewResponse,
+  InitialFile,
+  ToolDefinition,
+} from "@/lib/api/types";
 import { Wrench, FileText, AlertCircle } from "lucide-react";
 
 interface AgentPreviewProps {
   systemPrompt: string;
   capabilities: AgentCapabilityConfig[];
+  initialFiles: InitialFile[];
   tools?: ToolDefinition[];
 }
 
-export function AgentPreview({ systemPrompt, capabilities, tools = [] }: AgentPreviewProps) {
+export function AgentPreview({
+  systemPrompt,
+  capabilities,
+  initialFiles,
+  tools = [],
+}: AgentPreviewProps) {
   const previewMutation = usePreviewAgent();
   const [preview, setPreview] = useState<AgentPreviewResponse | null>(null);
 
@@ -127,6 +139,8 @@ export function AgentPreview({ systemPrompt, capabilities, tools = [] }: AgentPr
           )}
         </CardContent>
       </Card>
+
+      <InitialFilesPreview files={initialFiles} />
     </div>
   );
 }

--- a/apps/ui/src/components/files/initial-files-preview.tsx
+++ b/apps/ui/src/components/files/initial-files-preview.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+/**
+ * Shared initial_files preview used by agent and harness preview surfaces.
+ * Keep rendering local to the UI because file content already exists client-side.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { FilePreview, getPreviewType, type PreviewType } from "@/components/files/file-previews";
+import type { InitialFile } from "@/lib/api/types";
+import {
+  File,
+  FileArchive,
+  FileCode,
+  FileImage,
+  FileJson,
+  FileSpreadsheet,
+  FileText,
+  Lock,
+} from "lucide-react";
+
+interface InitialFilesPreviewProps {
+  files: InitialFile[];
+  title?: string;
+  description?: string;
+}
+
+export function InitialFilesPreview({
+  files,
+  title = "Initial Files",
+  description = "Files configured on this item. New sessions may merge files from other layers, with later layers overriding earlier files by path.",
+}: InitialFilesPreviewProps) {
+  const sortedFiles = useMemo(
+    () => [...files].sort((left, right) => left.path.localeCompare(right.path)),
+    [files],
+  );
+  const [selectedPath, setSelectedPath] = useState<string | null>(sortedFiles[0]?.path ?? null);
+
+  useEffect(() => {
+    if (sortedFiles.length === 0) {
+      setSelectedPath(null);
+      return;
+    }
+
+    if (!sortedFiles.some((file) => file.path === selectedPath)) {
+      setSelectedPath(sortedFiles[0].path);
+    }
+  }, [selectedPath, sortedFiles]);
+
+  const selectedFile =
+    sortedFiles.find((file) => file.path === selectedPath) ?? sortedFiles[0] ?? null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <FileText className="w-5 h-5" />
+          {title}
+          <Badge variant="secondary" className="ml-2">
+            {sortedFiles.length}
+          </Badge>
+        </CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {sortedFiles.length === 0 ? (
+          <p className="text-sm text-muted-foreground italic">No initial files configured.</p>
+        ) : (
+          <div className="grid gap-4 lg:grid-cols-[minmax(0,260px)_minmax(0,1fr)]">
+            <ScrollArea className="h-[420px] border bg-muted/20">
+              <div className="p-2 space-y-1">
+                {sortedFiles.map((file) => {
+                  const previewType = getInitialFilePreviewType(file);
+                  const Icon = getPreviewIcon(previewType);
+                  const isSelected = file.path === selectedFile?.path;
+
+                  return (
+                    <Button
+                      key={file.path}
+                      type="button"
+                      variant={isSelected ? "secondary" : "ghost"}
+                      className="h-auto w-full justify-start px-3 py-2"
+                      onClick={() => setSelectedPath(file.path)}
+                    >
+                      <div className="flex min-w-0 flex-1 items-start gap-2 text-left">
+                        <Icon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                        <div className="min-w-0 space-y-1">
+                          <div className="truncate font-mono text-xs">{file.path}</div>
+                          <div className="flex flex-wrap gap-1">
+                            <Badge variant="outline" className="text-[10px]">
+                              {file.encoding}
+                            </Badge>
+                            {file.is_readonly && (
+                              <Badge variant="outline" className="gap-1 text-[10px]">
+                                <Lock className="h-3 w-3" />
+                                read-only
+                              </Badge>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    </Button>
+                  );
+                })}
+              </div>
+            </ScrollArea>
+
+            <div className="border bg-muted/20">
+              {selectedFile ? (
+                <InitialFileContentPreview file={selectedFile} />
+              ) : (
+                <div className="flex h-[420px] items-center justify-center p-6 text-sm text-muted-foreground">
+                  Select a file to preview its contents.
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function InitialFileContentPreview({ file }: { file: InitialFile }) {
+  const previewType = getInitialFilePreviewType(file);
+  const extension = getFileExtension(file.path);
+
+  if (previewType === "binary") {
+    return (
+      <div className="flex h-[420px] flex-col items-center justify-center gap-3 p-6 text-center">
+        <FileArchive className="h-10 w-10 text-muted-foreground" />
+        <div className="space-y-1">
+          <p className="text-sm font-medium">Binary file</p>
+          <p className="text-sm text-muted-foreground">
+            This asset is stored as base64 and can be copied into new sessions, but it does not have
+            an inline preview.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (previewType === "text") {
+    return (
+      <ScrollArea className="h-[420px]">
+        <pre className="min-h-full whitespace-pre-wrap break-words p-4 font-mono text-sm">
+          {file.content}
+        </pre>
+      </ScrollArea>
+    );
+  }
+
+  return (
+    <div className="h-[420px]">
+      <FilePreview content={file.content} extension={extension} encoding={file.encoding} />
+    </div>
+  );
+}
+
+function getInitialFilePreviewType(file: InitialFile): PreviewType {
+  return getPreviewType(getFileExtension(file.path), file.encoding);
+}
+
+function getFileExtension(path: string): string {
+  const normalizedPath = path.split("/").pop() ?? path;
+  const extension = normalizedPath.includes(".") ? normalizedPath.split(".").pop() : "";
+  return extension?.toLowerCase() ?? "";
+}
+
+function getPreviewIcon(type: PreviewType) {
+  switch (type) {
+    case "code":
+      return FileCode;
+    case "csv":
+      return FileSpreadsheet;
+    case "json":
+      return FileJson;
+    case "image":
+      return FileImage;
+    case "markdown":
+    case "text":
+      return FileText;
+    case "binary":
+      return FileArchive;
+    default:
+      return File;
+  }
+}

--- a/apps/ui/src/components/harnesses/harness-preview.tsx
+++ b/apps/ui/src/components/harnesses/harness-preview.tsx
@@ -6,18 +6,26 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import type { AgentCapabilityConfig, AgentPreviewResponse, ToolDefinition } from "@/lib/api/types";
+import { InitialFilesPreview } from "@/components/files/initial-files-preview";
+import type {
+  AgentCapabilityConfig,
+  AgentPreviewResponse,
+  InitialFile,
+  ToolDefinition,
+} from "@/lib/api/types";
 import { Wrench, FileText, AlertCircle } from "lucide-react";
 
 interface HarnessPreviewProps {
   systemPrompt: string;
   capabilities: AgentCapabilityConfig[];
+  initialFiles: InitialFile[];
   parentHarnessId?: string;
 }
 
 export function HarnessPreview({
   systemPrompt,
   capabilities,
+  initialFiles,
   parentHarnessId,
 }: HarnessPreviewProps) {
   const previewMutation = usePreviewHarness();
@@ -128,6 +136,8 @@ export function HarnessPreview({
           )}
         </CardContent>
       </Card>
+
+      <InitialFilesPreview files={initialFiles} />
     </div>
   );
 }


### PR DESCRIPTION
## What
Add an initial file preview card to agent and harness preview UIs so users can inspect starter files directly from detail and edit preview tabs.

## Why
Agents and harnesses already let users configure `initial_files`, but the UI had no way to preview what would actually be copied into a session.

## How
Add a shared `InitialFilesPreview` component that lists seeded files, renders text/code/markdown/JSON/CSV/image content inline, and falls back gracefully for binary assets. Wire it into both `AgentPreview` and `HarnessPreview`, then pass `initial_files` from the detail and edit pages. Add focused UI tests for the new preview behavior.

## Risk
- Low
- UI-only change to preview surfaces for agents and harnesses. Main risk is rendering regressions in preview tabs.

## Security
- Threat categories reviewed: TM-WEB, TM-DOS
- Findings and resolutions: No new trust boundary or data exposure path. The change only renders already-configured local `initial_files` in existing authenticated UI surfaces. Reviewed for unsafe HTML/script injection and unbounded rendering behavior; rendering stays within existing preview components and bounded scroll areas.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
