### PR TITLE
test(ci): wire 12 server integration tests + fix EVE-195 cli no-org path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,6 +383,27 @@ jobs:
       - name: Run server integration tests (API + repository)
         run: cargo test -p everruns-server --test api_integration_test --test repository_integration_test -- --test-threads=1
 
+      # Domain-focused integration tests that previously only ran manually.
+      # Kept split so CI failures surface the offending area fast; each file
+      # exercises a cohesive slice (auth, org lifecycle, schedules, git sessions,
+      # evals, ag_ui, client-side tools, llm defaults, org isolation).
+      - name: Run domain integration tests
+        run: |
+          cargo test -p everruns-server \
+            --test ag_ui_integration_test \
+            --test auth_integration_test \
+            --test cli_auth_test \
+            --test cli_auth_no_org_test \
+            --test client_side_tools_test \
+            --test evals_integration_test \
+            --test llm_model_default_test \
+            --test org_creation_test \
+            --test org_isolation_test \
+            --test org_lifecycle_test \
+            --test schedule_integration_test \
+            --test session_git_integration_test \
+            -- --test-threads=1
+
       - name: Run durable integration tests
         run: cargo test -p everruns-durable --test postgres_integration_test --test postgres_repository_test --features postgres-tests -- --test-threads=1
 

--- a/crates/server/src/auth/cli_auth.rs
+++ b/crates/server/src/auth/cli_auth.rs
@@ -344,6 +344,15 @@ async fn cli_auth_exchange(
             AuthError::unauthorized("Failed to fetch organizations")
         })?;
 
+    // EVE-195: Reject CLI login for users with no organization membership.
+    // Falling back to DEFAULT_ORG_ID would silently cross tenant boundaries
+    // on self-hosted and cloud deployments, so require an explicit org first.
+    if orgs.is_empty() {
+        return Err(AuthError::unprocessable(
+            "You are not a member of any organization. Please create an organization in the web UI before using the CLI.",
+        ));
+    }
+
     // Generate API key with CLI metadata (user-scoped, no org)
     let generated = generate_api_key();
     let hostname = req.hostname.unwrap_or_else(|| "unknown".to_string());

--- a/crates/server/src/auth/middleware.rs
+++ b/crates/server/src/auth/middleware.rs
@@ -47,6 +47,13 @@ impl AuthError {
             status: StatusCode::FORBIDDEN,
         }
     }
+
+    pub fn unprocessable(message: &str) -> Self {
+        Self {
+            error: message.to_string(),
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+        }
+    }
 }
 
 impl IntoResponse for AuthError {

--- a/crates/server/tests/org_isolation_test.rs
+++ b/crates/server/tests/org_isolation_test.rs
@@ -785,8 +785,8 @@ async fn test_default_model_org_isolation() {
         .await
         .unwrap();
 
-    // Set default model in org1
-    let _model = db
+    // Create a model in org1 and register it as the org's default
+    let model = db
         .create_llm_model(
             ORG1,
             CreateLlmModelRow {
@@ -800,6 +800,9 @@ async fn test_default_model_org_isolation() {
                 provider_metadata: None,
             },
         )
+        .await
+        .unwrap();
+    db.upsert_organization_settings(ORG1, Some(model.id.into()))
         .await
         .unwrap();
 

--- a/justfile
+++ b/justfile
@@ -74,6 +74,20 @@ test-integration: start-infra
     cargo test -p everruns-server --lib
     cargo test -p everruns-server --test api_integration_test -- --test-threads=1
     cargo test -p everruns-server --test repository_integration_test -- --test-threads=1
+    cargo test -p everruns-server \
+        --test ag_ui_integration_test \
+        --test auth_integration_test \
+        --test cli_auth_test \
+        --test cli_auth_no_org_test \
+        --test client_side_tools_test \
+        --test evals_integration_test \
+        --test llm_model_default_test \
+        --test org_creation_test \
+        --test org_isolation_test \
+        --test org_lifecycle_test \
+        --test schedule_integration_test \
+        --test session_git_integration_test \
+        -- --test-threads=1
     cargo test -p everruns-durable --test postgres_integration_test --features postgres-tests -- --test-threads=1
     cargo test -p everruns-durable --test postgres_repository_test --features postgres-tests -- --test-threads=1
 

--- a/specs/code-organization.md
+++ b/specs/code-organization.md
@@ -101,8 +101,25 @@ just test-unit  # Runs in ~30s, no Docker needed
 **Test files:**
 - `crates/server/tests/api_integration_test.rs` - HTTP API tests (in-process, no TCP)
 - `crates/server/tests/repository_integration_test.rs` - Direct repository layer tests
+- `crates/server/tests/ag_ui_integration_test.rs` - AG-UI embedding + publish gating
+- `crates/server/tests/auth_integration_test.rs` - Refresh/revocation, cookie flags, JWT paths
+- `crates/server/tests/cli_auth_test.rs` - CLI login flow (start/callback/success)
+- `crates/server/tests/cli_auth_no_org_test.rs` - CLI exchange rejects no-org users (EVE-195)
+- `crates/server/tests/client_side_tools_test.rs` - Tool call / result wire format
+- `crates/server/tests/evals_integration_test.rs` - Eval case/score/run HTTP surface
+- `crates/server/tests/llm_model_default_test.rs` - Org default model upsert/clear
+- `crates/server/tests/org_creation_test.rs` - Organization + membership reconciliation
+- `crates/server/tests/org_isolation_test.rs` - Cross-org isolation (agents, mcp, models, sessions)
+- `crates/server/tests/org_lifecycle_test.rs` - Switch org, cookie scoping, unknown org rejection
+- `crates/server/tests/schedule_integration_test.rs` - Scheduled-task CRUD + pause/resume
+- `crates/server/tests/session_git_integration_test.rs` - Per-session git log/diff/refs
 - `crates/durable/tests/postgres_integration_test.rs` - Durable execution task queue, workflows
 - `crates/durable/tests/postgres_repository_test.rs` - Durable SQL queries, circuit breakers
+
+> Not yet CI-wired: `mcp_endpoint_test.rs` and `skills_integration_test.rs` fail
+> due to shared-fixture name collisions and stale catalog expectations; tracked
+> as follow-ups. `workflow_test.rs` requires a live server+worker and stays a
+> manual/live test.
 
 **What to test:**
 - CRUD operations for all entities


### PR DESCRIPTION
## What

Extend the `integration-test` PR job to cover **12** server integration suites that previously only ran manually. Along the way, fix two long-latent failures so the suites are actually green:

1. **EVE-195** — CLI exchange now rejects users with no org membership (HTTP `422`) instead of silently succeeding and forcing a downstream `DEFAULT_ORG_ID` fallback. New `AuthError::unprocessable` helper.
2. **`test_default_model_org_isolation`** — the test created an LLM model but never registered it as the org default, so `get_default_llm_model` legitimately returned `None`. The test now explicitly upserts `organization_settings.default_model_id`.

New CI-wired suites:
`ag_ui_integration_test`, `auth_integration_test`, `cli_auth_test`, `cli_auth_no_org_test`, `client_side_tools_test`, `evals_integration_test`, `llm_model_default_test`, `org_creation_test`, `org_isolation_test`, `org_lifecycle_test`, `schedule_integration_test`, `session_git_integration_test`.

## Why

13 of 18 server integration test files only ran manually. That meant org isolation, CLI auth, schedule CRUD, session-git, eval scoring, client-side tool wiring, etc. could rot silently between releases. EVE-348 establishes a baseline of CI coverage over these cohesive slices.

Fixing EVE-195 at the same time was required to get the existing `cli_auth_no_org_test` green — it documents the intended 422 behavior, but the server never implemented it.

## How

- `.github/workflows/ci.yml` — new step in `integration-test` runs the 12 suites with `--test-threads=1` against the shared CI PostgreSQL service.
- `crates/server/src/auth/middleware.rs` — add `AuthError::unprocessable(&str)`.
- `crates/server/src/auth/cli_auth.rs` — in `cli_auth_exchange`, return `422` with a user-facing "create an organization" message when `list_user_organizations` is empty.
- `crates/server/tests/org_isolation_test.rs` — register the created model as the org default before asserting `get_default_llm_model` returns it.
- `justfile` — mirror the new CI test list in `just test-integration` so the local recipe matches PR CI.
- `specs/code-organization.md` — list every wired test file and call out the two follow-up suites (`mcp_endpoint_test`, `skills_integration_test`) that still fail due to shared-fixture name collisions and stale catalog expectations.

## Risk

- Low.
- Blast radius is CI coverage + a stricter CLI exchange contract. The stricter contract matches the spec/test author's documented intent and targets an impossible-to-hit state on a normal signup flow (users always land in at least one org). Verified all 12 suites pass individually and as a composite under a fresh migrated DB locally.

## Security

- Threat categories reviewed: **TM-AUTH** (CLI exchange now fails closed for zero-org users), **TM-AUTHZ** (eliminates silent DEFAULT_ORG fallback that would cross tenant boundaries), **TM-TENANT** (isolation test coverage strengthened).
- Findings and resolutions: The pre-fix `cli_auth_exchange` would issue a user-scoped API key even when the user had no org membership. Downstream code paths then had to invent an org, with `DEFAULT_ORG_ID` the obvious fallback — a cross-tenant leak on self-hosted multi-org deployments. Now explicitly 422 with guidance to create an org.
- No new endpoints, no new data exposure, no new dependencies.

## Checklist

- [x] Tests added or updated (12 existing suites wired; `test_default_model_org_isolation` fixed; `test_cli_exchange_no_orgs_returns_422` now passes against a real implementation)
- [x] Backward compatibility considered (CLI clients on the happy path — user has >=1 org — are unaffected; only zero-org users see the new 422)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)