### PR TITLE
fix(ui): remove Azure OpenAI from org setup

### DIFF
--- a/apps/ui/src/__tests__/org-setup-page.test.tsx
+++ b/apps/ui/src/__tests__/org-setup-page.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import OrgSetupPage from "@/app/(main)/orgs/[orgId]/setup/page";
+
+const mockPush = jest.fn();
+const mockSetCurrentOrg = jest.fn();
+const mockCreateProvider = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useParams: () => ({ orgId: "org_test123" }),
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@/lib/api/organizations", () => ({
+  getOrganization: jest.fn().mockResolvedValue({
+    id: "org_test123",
+    name: "Test Org",
+    default_harness_id: "harness_default",
+    base_harness_id: "harness_base",
+  }),
+}));
+
+jest.mock("@/lib/api/harnesses", () => ({
+  listHarnesses: jest.fn().mockResolvedValue([
+    { id: "harness_default", name: "generic" },
+    { id: "harness_base", name: "base" },
+  ]),
+}));
+
+jest.mock("@/hooks/use-llm-providers", () => ({
+  useLlmProviders: () => ({
+    data: [],
+    isLoading: false,
+    isError: false,
+  }),
+  useCreateLlmProvider: () => ({
+    mutateAsync: mockCreateProvider,
+    isPending: false,
+  }),
+}));
+
+jest.mock("@/providers/org-provider", () => ({
+  useOrg: () => ({
+    currentOrg: { public_id: "org_test123", name: "Test Org", role: "owner" },
+    organizations: [{ public_id: "org_test123", name: "Test Org", role: "owner" }],
+    setCurrentOrg: mockSetCurrentOrg,
+    isSwitching: false,
+  }),
+}));
+
+describe("OrgSetupPage", () => {
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    mockPush.mockClear();
+    mockSetCurrentOrg.mockClear();
+    mockCreateProvider.mockClear();
+  });
+
+  it("offers OpenAI and Anthropic during org setup, but not Azure OpenAI", async () => {
+    render(<OrgSetupPage />, { wrapper });
+
+    expect(await screen.findByText("Setting up Test Org")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "OpenAI" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Anthropic" })).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole("button", { name: "Azure OpenAI" })).not.toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/app/(main)/orgs/[orgId]/setup/page.tsx
+++ b/apps/ui/src/app/(main)/orgs/[orgId]/setup/page.tsx
@@ -20,6 +20,8 @@ import { useOrg } from "@/providers/org-provider";
 import type { ApiError } from "@/lib/api/client";
 import type { LlmProviderType } from "@/lib/api/types";
 
+type SetupProviderType = Extract<LlmProviderType, "openai" | "anthropic">;
+
 interface SetupStep {
   label: string;
   description: string;
@@ -59,25 +61,17 @@ const SETUP_STEPS: SetupStep[] = [
 
 const STEP_DELAY_MS = 400;
 
-const PROVIDER_OPTIONS: { type: LlmProviderType; label: string }[] = [
+const PROVIDER_OPTIONS: { type: SetupProviderType; label: string }[] = [
   { type: "openai", label: "OpenAI" },
-  { type: "azure_openai", label: "Azure OpenAI" },
   { type: "anthropic", label: "Anthropic" },
 ];
 
-function getProviderName(providerType: LlmProviderType): string {
+function getProviderName(providerType: SetupProviderType): string {
   switch (providerType) {
     case "openai":
-    case "openai_completions":
       return "OpenAI";
-    case "azure_openai":
-      return "Azure OpenAI";
     case "anthropic":
       return "Anthropic";
-    case "gemini":
-      return "Gemini";
-    default:
-      return providerType;
   }
 }
 
@@ -171,7 +165,7 @@ export default function OrgSetupPage() {
   const allAnimated = completedCount >= SETUP_STEPS.length;
 
   // --- LLM provider form state ---
-  const [selectedProvider, setSelectedProvider] = useState<LlmProviderType>("openai");
+  const [selectedProvider, setSelectedProvider] = useState<SetupProviderType>("openai");
   const [apiKey, setApiKey] = useState("");
   const createProvider = useCreateLlmProvider();
   const [providerError, setProviderError] = useState<string | null>(null);

--- a/test_cases/ui/org_creation/TC003_setup_page_progress.md
+++ b/test_cases/ui/org_creation/TC003_setup_page_progress.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Verify that the org setup page displays three sequential setup steps with animated completion.
+Verify that the org setup page displays four sequential setup steps with animated completion, then offers the supported onboarding provider choices.
 
 ## Preconditions
 
@@ -11,15 +11,20 @@ Verify that the org setup page displays three sequential setup steps with animat
 ## Steps
 
 1. Observe the setup page immediately after redirect
-2. Wait for all three steps to animate to completion
-3. Note the final state of the page
+2. Wait for all four steps to animate to completion
+3. Review the provider choices shown below the completed steps
+4. Note the final state of the page
 
 ## Expected Result
 
 - Page header shows "Setting up <org name>" with a Building icon
-- Three steps appear in sequence:
+- Four steps appear in sequence:
   1. "Organisation created" — "Your new organisation has been provisioned"
-  2. "Harnesses initialised" — "Built-in harnesses (base, generic, platform-chat) are ready"
+  2. "Harnesses initialised" — "Built-in harnesses are ready"
   3. "Default settings configured" — "Default and base harnesses have been assigned"
+  4. "LLM provider configured" — "API provider and credentials set up"
 - Each step transitions from pending (faded) to a spinner to a green checkmark
-- After all steps complete, a "Go to dashboard" button appears
+- After all steps complete, the page shows "Select your LLM provider"
+- Provider choices are limited to "OpenAI" and "Anthropic"
+- "Azure OpenAI" is not shown on the org setup page
+- The page still offers "Skip for now" and "Continue"

--- a/test_cases/ui/org_creation/TC004_verify_harnesses_after_setup.md
+++ b/test_cases/ui/org_creation/TC004_verify_harnesses_after_setup.md
@@ -6,11 +6,11 @@ Verify that built-in harnesses are provisioned for the new organisation by navig
 
 ## Preconditions
 
-- User just completed org setup (all three steps show checkmarks)
+- User just completed org setup (all four steps show checkmarks)
 
 ## Steps
 
-1. On the setup page, click "Go to dashboard"
+1. On the setup page, click "Skip for now" or finish provider setup and click "Continue"
 2. Navigate to the Harnesses page via the sidebar
 3. Review the list of harnesses displayed
 


### PR DESCRIPTION
## What
Remove Azure OpenAI from the organisation setup onboarding picker while leaving Azure provider support in the main provider settings.

## Why
New org setup should only offer the onboarding paths we want to support there. Azure OpenAI still exists as a general provider option, but it should not appear in the setup flow.

## How
Narrow the setup page provider type to `openai | anthropic`, remove the Azure setup option, add a focused setup-page regression test, and update the org-creation manual test cases to match the current setup flow.

## Risk
- Low
- Could only affect the org setup provider picker and its submit payload
- Azure OpenAI remains available from Settings > Providers

## Security
- Threat categories reviewed: TM-WEB
- Findings and resolutions: reviewed the UI-only diff for auth bypass, data exposure, and input handling regressions. No new security-relevant surface or findings. This change only removes one setup-page option and narrows the local provider union used by that page.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
