### PR TITLE
feat(ui): add initial files editor

### DIFF
--- a/apps/ui/src/__tests__/initial-files-editor.test.tsx
+++ b/apps/ui/src/__tests__/initial-files-editor.test.tsx
@@ -1,0 +1,161 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { InitialFilesEditor } from "@/components/initial-files-editor";
+import type { InitialFile } from "@/lib/api/types";
+
+const originalError = console.error;
+beforeAll(() => {
+  console.error = (...args: unknown[]) => {
+    if (typeof args[0] === "string" && args[0].includes("not wrapped in act")) {
+      return;
+    }
+    originalError.call(console, ...args);
+  };
+});
+
+afterAll(() => {
+  console.error = originalError;
+});
+
+jest.mock("@/components/files/file-previews", () => ({
+  FilePreview: ({
+    content,
+    extension,
+    encoding,
+  }: {
+    content: string;
+    extension: string;
+    encoding: string;
+  }) => <div data-testid="file-preview">{`${extension}:${encoding}:${content}`}</div>,
+  canPreview: (extension: string, encoding: string) => encoding === "base64" && extension === "png",
+  getPreviewType: (extension: string, encoding: string) => {
+    if (encoding === "base64") {
+      return extension === "png" ? "image" : "binary";
+    }
+    return "text";
+  },
+}));
+
+jest.mock("@/lib/api/session-files", () => ({
+  formatFileSize: (bytes: number) => `${bytes} B`,
+}));
+
+function TestHarness({ initialFiles = [] }: { initialFiles?: InitialFile[] }) {
+  const [files, setFiles] = useState(initialFiles);
+
+  return (
+    <>
+      <InitialFilesEditor value={files} onChange={setFiles} />
+      <pre data-testid="files-state">{JSON.stringify(files)}</pre>
+    </>
+  );
+}
+
+function readFilesState(): InitialFile[] {
+  const raw = screen.getByTestId("files-state").textContent ?? "[]";
+  return JSON.parse(raw) as InitialFile[];
+}
+
+describe("InitialFilesEditor", () => {
+  it("shows an empty state when no files are configured", () => {
+    render(<TestHarness />);
+
+    expect(screen.getByText(/No starter files configured/i)).toBeInTheDocument();
+  });
+
+  it("adds a new text file and selects it", () => {
+    render(<TestHarness />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Text File" }));
+
+    expect(screen.getByDisplayValue("/file-1.txt")).toBeInTheDocument();
+    expect(readFilesState()).toEqual([
+      {
+        path: "/file-1.txt",
+        content: "",
+        encoding: "text",
+        is_readonly: false,
+      },
+    ]);
+  });
+
+  it("updates file path, content, and readonly state", () => {
+    render(
+      <TestHarness
+        initialFiles={[
+          {
+            path: "/notes.txt",
+            content: "hello",
+            encoding: "text",
+            is_readonly: false,
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Path"), {
+      target: { value: "/docs/notes.md" },
+    });
+    fireEvent.click(screen.getByRole("checkbox", { name: "Read-only in session" }));
+    fireEvent.change(screen.getByLabelText("Content"), {
+      target: { value: "updated" },
+    });
+
+    expect(readFilesState()).toEqual([
+      {
+        path: "/docs/notes.md",
+        content: "updated",
+        encoding: "text",
+        is_readonly: true,
+      },
+    ]);
+  });
+
+  it("renders the filesystem tree and switches selection", () => {
+    render(
+      <TestHarness
+        initialFiles={[
+          {
+            path: "/docs/readme.md",
+            content: "# hello",
+            encoding: "text",
+            is_readonly: false,
+          },
+          {
+            path: "/logo.png",
+            content: "Zm9v",
+            encoding: "base64",
+            is_readonly: false,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("docs")).toBeInTheDocument();
+    expect(screen.getAllByText("readme.md")).not.toHaveLength(0);
+
+    fireEvent.click(screen.getByText("logo.png"));
+
+    expect(screen.getByDisplayValue("/logo.png")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Preview" })).toBeInTheDocument();
+  });
+
+  it("shows the preview pane for previewable files", () => {
+    render(
+      <TestHarness
+        initialFiles={[
+          {
+            path: "/logo.png",
+            content: "Zm9v",
+            encoding: "base64",
+            is_readonly: false,
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview" }));
+
+    expect(screen.getByTestId("file-preview")).toHaveTextContent("png:base64:Zm9v");
+  });
+});

--- a/apps/ui/src/components/initial-files-editor.tsx
+++ b/apps/ui/src/components/initial-files-editor.tsx
@@ -1,14 +1,48 @@
 "use client";
 
-import { useMemo, useRef } from "react";
+/**
+ * Model initial_files as an in-memory filesystem so agent and harness forms can
+ * reuse the session file browser/viewer patterns without requiring a session.
+ */
+
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  FileTree,
+  FileTreeActions,
+  FileTreeFile,
+  FileTreeFolder,
+  FileTreeName,
+} from "@/components/ai-elements/file-tree";
+import {
+  FilePreview,
+  canPreview,
+  getPreviewType,
+  type PreviewType,
+} from "@/components/files/file-previews";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { Textarea } from "@/components/ui/textarea";
-import { Badge } from "@/components/ui/badge";
-import { Upload, Plus, Trash2, FileText, FileArchive } from "lucide-react";
+import { formatFileSize } from "@/lib/api/session-files";
 import type { InitialFile } from "@/lib/api/types";
+import {
+  Eye,
+  File,
+  FileArchive,
+  FileCode,
+  FileImage,
+  FileJson,
+  FileSpreadsheet,
+  FileText,
+  Lock,
+  PencilLine,
+  Plus,
+  Trash2,
+  Upload,
+} from "lucide-react";
 
 interface InitialFilesEditorProps {
   value: InitialFile[];
@@ -16,6 +50,22 @@ interface InitialFilesEditorProps {
   disabled?: boolean;
   title?: string;
   description?: string;
+}
+
+type TreeNode = TreeDirectoryNode | TreeFileNode;
+
+interface TreeDirectoryNode {
+  kind: "directory";
+  id: string;
+  name: string;
+  children: TreeNode[];
+}
+
+interface TreeFileNode {
+  kind: "file";
+  id: string;
+  index: number;
+  name: string;
 }
 
 const EMPTY_TEXT_FILE: InitialFile = {
@@ -32,9 +82,50 @@ export function InitialFilesEditor({
   title = "Starter Files",
   description = "Files copied into each new session. Add text files directly or upload binary assets.",
 }: InitialFilesEditorProps) {
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
   const files = useMemo(() => value ?? [], [value]);
+  const uploadInputRef = useRef<HTMLInputElement>(null);
+  const replaceInputRef = useRef<HTMLInputElement>(null);
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(files[0] ? 0 : null);
+  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set());
+  const [activeView, setActiveView] = useState<"source" | "preview">("source");
+
+  const tree = useMemo(() => buildTree(files), [files]);
+  const selectedFile = selectedIndex !== null ? (files[selectedIndex] ?? null) : null;
+  const selectedFileId = selectedIndex !== null ? getFileId(selectedIndex) : undefined;
+  const selectedPreviewType = selectedFile ? getInitialFilePreviewType(selectedFile) : null;
+  const selectedCanPreview =
+    selectedFile != null && canPreview(getFileExtension(selectedFile.path), selectedFile.encoding);
+
+  useEffect(() => {
+    if (files.length === 0) {
+      setSelectedIndex(null);
+      return;
+    }
+
+    if (selectedIndex === null || selectedIndex >= files.length) {
+      setSelectedIndex(0);
+    }
+  }, [files, selectedIndex]);
+
+  useEffect(() => {
+    if (!selectedCanPreview && activeView === "preview") {
+      setActiveView("source");
+    }
+  }, [activeView, selectedCanPreview]);
+
+  useEffect(() => {
+    setExpandedPaths((previous) => {
+      if (tree.rootDirectoryIds.length === 0) {
+        return previous;
+      }
+
+      const next = new Set(previous);
+      for (const id of tree.rootDirectoryIds) {
+        next.add(id);
+      }
+      return next;
+    });
+  }, [tree.rootDirectoryIds]);
 
   const updateFile = (index: number, patch: Partial<InitialFile>) => {
     const next = [...files];
@@ -43,11 +134,34 @@ export function InitialFilesEditor({
   };
 
   const removeFile = (index: number) => {
-    onChange(files.filter((_, current) => current !== index));
+    const next = files.filter((_, current) => current !== index);
+    onChange(next);
+
+    if (next.length === 0) {
+      setSelectedIndex(null);
+      return;
+    }
+
+    if (selectedIndex === null) {
+      setSelectedIndex(0);
+      return;
+    }
+
+    if (index < selectedIndex) {
+      setSelectedIndex(selectedIndex - 1);
+      return;
+    }
+
+    if (index === selectedIndex) {
+      setSelectedIndex(Math.min(index, next.length - 1));
+    }
   };
 
   const addTextFile = () => {
-    onChange([...files, { ...EMPTY_TEXT_FILE, path: `/file-${files.length + 1}.txt` }]);
+    const next = [...files, { ...EMPTY_TEXT_FILE, path: `/file-${files.length + 1}.txt` }];
+    onChange(next);
+    setSelectedIndex(next.length - 1);
+    setActiveView("source");
   };
 
   const addUploadedFiles = async (selected: FileList | null) => {
@@ -65,11 +179,15 @@ export function InitialFilesEditor({
       }),
     );
 
-    onChange([...files, ...uploaded]);
+    const next = [...files, ...uploaded];
+    onChange(next);
+    setSelectedIndex(files.length);
+    setActiveView("source");
   };
 
   const replaceWithUpload = async (index: number, selected: FileList | null) => {
     if (!selected?.length) return;
+
     const file = selected[0];
     const encoded = await encodeFile(file);
     updateFile(index, {
@@ -77,6 +195,20 @@ export function InitialFilesEditor({
       content: encoded.content,
       encoding: encoded.encoding,
     });
+    setActiveView("source");
+  };
+
+  const handleTreeSelect = (nodeId: string) => {
+    if (!nodeId.startsWith("file:")) {
+      return;
+    }
+
+    const index = Number(nodeId.slice("file:".length));
+    if (Number.isNaN(index) || !files[index]) {
+      return;
+    }
+
+    setSelectedIndex(index);
   };
 
   return (
@@ -86,23 +218,24 @@ export function InitialFilesEditor({
         <p className="text-xs text-muted-foreground">{description}</p>
       </div>
 
-      <div className="flex flex-wrap gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         <Button type="button" variant="outline" size="sm" onClick={addTextFile} disabled={disabled}>
-          <Plus className="w-4 h-4 mr-2" />
+          <Plus className="mr-2 h-4 w-4" />
           Add Text File
         </Button>
         <Button
           type="button"
           variant="outline"
           size="sm"
-          onClick={() => fileInputRef.current?.click()}
+          onClick={() => uploadInputRef.current?.click()}
           disabled={disabled}
         >
-          <Upload className="w-4 h-4 mr-2" />
+          <Upload className="mr-2 h-4 w-4" />
           Upload File
         </Button>
+        <Badge variant="secondary">{files.length} files</Badge>
         <input
-          ref={fileInputRef}
+          ref={uploadInputRef}
           type="file"
           multiple
           className="hidden"
@@ -114,94 +247,409 @@ export function InitialFilesEditor({
       </div>
 
       {files.length === 0 ? (
-        <div className="border border-dashed p-4 text-sm text-muted-foreground">
-          No starter files configured.
+        <div className="border border-dashed p-6 text-sm text-muted-foreground">
+          No starter files configured. Add a text file or upload an asset to seed new sessions.
         </div>
       ) : (
-        <div className="space-y-3">
-          {files.map((file, index) => (
-            <div key={`${file.path}-${index}`} className="border p-4 space-y-3">
-              <div className="flex items-center justify-between gap-3">
-                <div className="flex items-center gap-2 min-w-0">
-                  {file.encoding === "text" ? (
-                    <FileText className="w-4 h-4 text-muted-foreground" />
-                  ) : (
-                    <FileArchive className="w-4 h-4 text-muted-foreground" />
-                  )}
-                  <span className="font-medium truncate">{file.path}</span>
-                  <Badge variant="secondary">{file.encoding}</Badge>
-                  {file.is_readonly && <Badge variant="outline">read-only</Badge>}
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,300px)_minmax(0,1fr)]">
+          <div className="flex min-h-[520px] flex-col border bg-muted/20">
+            <div className="border-b px-3 py-2 text-xs text-muted-foreground">Files</div>
+            <ScrollArea className="flex-1 min-h-0">
+              <FileTree
+                expanded={expandedPaths}
+                selectedPath={selectedFileId}
+                onExpandedChange={setExpandedPaths}
+                onSelect={handleTreeSelect}
+              >
+                {tree.nodes.map((node) => renderTreeNode(node, files, removeFile, disabled))}
+              </FileTree>
+            </ScrollArea>
+          </div>
+
+          <div className="flex min-h-[520px] flex-col border bg-muted/20">
+            {selectedFile ? (
+              <>
+                <div className="flex flex-wrap items-center justify-between gap-3 border-b px-4 py-3">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <div className="shrink-0">{getPreviewIcon(selectedPreviewType)}</div>
+                    <div className="min-w-0">
+                      <div className="truncate font-medium">
+                        {getDisplayName(selectedFile.path)}
+                      </div>
+                      <div className="truncate text-xs text-muted-foreground">
+                        {selectedFile.path}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant="outline">{selectedFile.encoding}</Badge>
+                    {selectedFile.is_readonly && (
+                      <Badge variant="outline" className="gap-1">
+                        <Lock className="h-3 w-3" />
+                        read-only
+                      </Badge>
+                    )}
+                    <Badge variant="secondary">
+                      {formatFileSize(getFileSizeBytes(selectedFile))}
+                    </Badge>
+                  </div>
                 </div>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => removeFile(index)}
-                  disabled={disabled}
-                >
-                  <Trash2 className="w-4 h-4" />
-                </Button>
-              </div>
 
-              <div className="space-y-2">
-                <Label htmlFor={`initial-file-path-${index}`}>Path</Label>
-                <Input
-                  id={`initial-file-path-${index}`}
-                  value={file.path}
-                  onChange={(event) => updateFile(index, { path: event.target.value })}
-                  placeholder="/.agents/skills/my-skill/SKILL.md"
-                  disabled={disabled}
-                />
-                <p className="text-xs text-muted-foreground">
-                  Absolute path inside the session workspace. `/workspace/...` is also accepted.
-                </p>
-              </div>
-
-              <div className="flex items-center gap-2">
-                <Checkbox
-                  id={`initial-file-readonly-${index}`}
-                  checked={file.is_readonly}
-                  onCheckedChange={(checked) =>
-                    updateFile(index, { is_readonly: checked === true })
-                  }
-                  disabled={disabled}
-                />
-                <Label htmlFor={`initial-file-readonly-${index}`}>Read-only in session</Label>
-              </div>
-
-              <div className="space-y-2">
-                <div className="flex items-center justify-between gap-3">
-                  <Label htmlFor={`initial-file-content-${index}`}>
-                    {file.encoding === "text" ? "Content" : "Base64 Content"}
-                  </Label>
-                  <label className="text-xs text-muted-foreground cursor-pointer">
-                    <input
-                      type="file"
-                      className="hidden"
+                <div className="space-y-4 p-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="initial-file-path">Path</Label>
+                    <Input
+                      id="initial-file-path"
+                      value={selectedFile.path}
+                      onChange={(event) => updateFile(selectedIndex!, { path: event.target.value })}
+                      placeholder="/.agents/skills/my-skill/SKILL.md"
                       disabled={disabled}
-                      onChange={(event) => {
-                        void replaceWithUpload(index, event.target.files);
-                        event.target.value = "";
-                      }}
                     />
-                    Replace from file
-                  </label>
+                    <p className="text-xs text-muted-foreground">
+                      Absolute path inside the session workspace. `/workspace/...` is also accepted.
+                    </p>
+                  </div>
+
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div className="flex items-center gap-2">
+                      <Checkbox
+                        id="initial-file-readonly"
+                        checked={selectedFile.is_readonly}
+                        onCheckedChange={(checked) =>
+                          updateFile(selectedIndex!, { is_readonly: checked === true })
+                        }
+                        disabled={disabled}
+                      />
+                      <Label htmlFor="initial-file-readonly">Read-only in session</Label>
+                    </div>
+
+                    <div className="flex flex-wrap items-center gap-2">
+                      {selectedCanPreview && (
+                        <>
+                          <Button
+                            type="button"
+                            variant={activeView === "source" ? "secondary" : "ghost"}
+                            size="sm"
+                            onClick={() => setActiveView("source")}
+                          >
+                            <PencilLine className="mr-2 h-4 w-4" />
+                            Source
+                          </Button>
+                          <Button
+                            type="button"
+                            variant={activeView === "preview" ? "secondary" : "ghost"}
+                            size="sm"
+                            onClick={() => setActiveView("preview")}
+                          >
+                            <Eye className="mr-2 h-4 w-4" />
+                            Preview
+                          </Button>
+                        </>
+                      )}
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => replaceInputRef.current?.click()}
+                        disabled={disabled}
+                      >
+                        <Upload className="mr-2 h-4 w-4" />
+                        Replace
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => removeFile(selectedIndex!)}
+                        disabled={disabled}
+                      >
+                        <Trash2 className="mr-2 h-4 w-4" />
+                        Remove
+                      </Button>
+                      <input
+                        ref={replaceInputRef}
+                        type="file"
+                        className="hidden"
+                        disabled={disabled}
+                        onChange={(event) => {
+                          void replaceWithUpload(selectedIndex!, event.target.files);
+                          event.target.value = "";
+                        }}
+                      />
+                    </div>
+                  </div>
                 </div>
-                <Textarea
-                  id={`initial-file-content-${index}`}
-                  value={file.content}
-                  onChange={(event) => updateFile(index, { content: event.target.value })}
-                  rows={file.encoding === "text" ? 8 : 5}
-                  className="font-mono text-xs"
-                  disabled={disabled}
-                />
+
+                <div className="flex min-h-0 flex-1 flex-col border-t">
+                  <div className="border-b px-4 py-2 text-xs text-muted-foreground">
+                    <Label htmlFor="initial-file-content" className="text-xs font-normal">
+                      {activeView === "preview"
+                        ? "Preview"
+                        : selectedFile.encoding === "text"
+                          ? "Content"
+                          : "Base64 Content"}
+                    </Label>
+                  </div>
+                  <div className="min-h-0 flex-1">
+                    {activeView === "preview" && selectedCanPreview ? (
+                      <InitialFilePreviewPane file={selectedFile} />
+                    ) : (
+                      <div className="h-full p-4">
+                        <Textarea
+                          id="initial-file-content"
+                          value={selectedFile.content}
+                          onChange={(event) =>
+                            updateFile(selectedIndex!, { content: event.target.value })
+                          }
+                          rows={selectedFile.encoding === "text" ? 16 : 12}
+                          className="h-full min-h-[280px] resize-none font-mono text-xs"
+                          disabled={disabled}
+                        />
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </>
+            ) : (
+              <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
+                Select a file to edit its contents.
               </div>
-            </div>
-          ))}
+            )}
+          </div>
         </div>
       )}
     </div>
   );
+}
+
+function InitialFilePreviewPane({ file }: { file: InitialFile }) {
+  const extension = getFileExtension(file.path);
+  const previewType = getInitialFilePreviewType(file);
+
+  if (previewType === "text") {
+    return (
+      <ScrollArea className="h-full">
+        <pre className="min-h-full whitespace-pre-wrap break-words p-4 font-mono text-sm">
+          {file.content}
+        </pre>
+      </ScrollArea>
+    );
+  }
+
+  if (previewType === "binary") {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
+        <FileArchive className="h-10 w-10 text-muted-foreground" />
+        <div className="space-y-1">
+          <p className="text-sm font-medium">Binary file</p>
+          <p className="text-sm text-muted-foreground">
+            This asset is stored as base64 and does not have an inline preview.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full">
+      <FilePreview content={file.content} extension={extension} encoding={file.encoding} />
+    </div>
+  );
+}
+
+function renderTreeNode(
+  node: TreeNode,
+  files: InitialFile[],
+  removeFile: (index: number) => void,
+  disabled?: boolean,
+): ReactNode {
+  if (node.kind === "directory") {
+    return (
+      <FileTreeFolder key={node.id} path={node.id} name={node.name}>
+        {node.children.map((child) => renderTreeNode(child, files, removeFile, disabled))}
+      </FileTreeFolder>
+    );
+  }
+
+  const file = files[node.index];
+  const previewType = getInitialFilePreviewType(file);
+
+  return (
+    <FileTreeFile key={node.id} path={node.id} name={node.name} icon={getPreviewIcon(previewType)}>
+      <span className="size-3.5" />
+      {getPreviewIcon(previewType)}
+      <FileTreeName className="flex-1">{node.name}</FileTreeName>
+      <FileTreeActions>
+        {file.is_readonly && <Lock className="size-3 text-muted-foreground" />}
+        <span className="text-xs text-muted-foreground tabular-nums">
+          {formatFileSize(getFileSizeBytes(file))}
+        </span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="size-5"
+          onClick={() => removeFile(node.index)}
+          disabled={disabled}
+          title="Remove file"
+        >
+          <Trash2 className="size-3 text-destructive" />
+        </Button>
+      </FileTreeActions>
+    </FileTreeFile>
+  );
+}
+
+function buildTree(files: InitialFile[]): { nodes: TreeNode[]; rootDirectoryIds: string[] } {
+  const rootNodes: TreeNode[] = [];
+  const directories = new Map<string, TreeDirectoryNode>();
+  const rootDirectoryIds = new Set<string>();
+
+  const ensureDirectory = (path: string, name: string, parent: TreeDirectoryNode | null) => {
+    const id = getDirectoryId(path);
+    const existing = directories.get(id);
+    if (existing) {
+      return existing;
+    }
+
+    const directory: TreeDirectoryNode = {
+      kind: "directory",
+      id,
+      name,
+      children: [],
+    };
+
+    directories.set(id, directory);
+    if (parent) {
+      parent.children.push(directory);
+    } else {
+      rootNodes.push(directory);
+      rootDirectoryIds.add(id);
+    }
+
+    return directory;
+  };
+
+  files.forEach((file, index) => {
+    const normalizedPath = normalizeInitialFilePath(file.path);
+    const segments = normalizedPath.split("/").filter(Boolean);
+
+    if (segments.length === 0) {
+      rootNodes.push({
+        kind: "file",
+        id: getFileId(index),
+        index,
+        name: getDisplayName(file.path),
+      });
+      return;
+    }
+
+    let parent: TreeDirectoryNode | null = null;
+    let currentPath = "";
+    const filename = segments[segments.length - 1];
+
+    for (const segment of segments.slice(0, -1)) {
+      currentPath = `${currentPath}/${segment}`;
+      parent = ensureDirectory(currentPath, segment, parent);
+    }
+
+    const fileNode: TreeFileNode = {
+      kind: "file",
+      id: getFileId(index),
+      index,
+      name: filename || getDisplayName(file.path),
+    };
+
+    if (parent) {
+      parent.children.push(fileNode);
+    } else {
+      rootNodes.push(fileNode);
+    }
+  });
+
+  const sortNodes = (nodes: TreeNode[]) => {
+    nodes.sort((left, right) => {
+      if (left.kind !== right.kind) {
+        return left.kind === "directory" ? -1 : 1;
+      }
+      return left.name.localeCompare(right.name);
+    });
+
+    nodes.forEach((node) => {
+      if (node.kind === "directory") {
+        sortNodes(node.children);
+      }
+    });
+  };
+
+  sortNodes(rootNodes);
+
+  return {
+    nodes: rootNodes,
+    rootDirectoryIds: Array.from(rootDirectoryIds),
+  };
+}
+
+function getInitialFilePreviewType(file: InitialFile): PreviewType {
+  return getPreviewType(getFileExtension(file.path), file.encoding);
+}
+
+function getPreviewIcon(type: PreviewType | null) {
+  switch (type) {
+    case "code":
+      return <FileCode className="h-4 w-4 text-sky-600 dark:text-sky-400" />;
+    case "csv":
+      return <FileSpreadsheet className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />;
+    case "json":
+      return <FileJson className="h-4 w-4 text-amber-600 dark:text-amber-400" />;
+    case "image":
+      return <FileImage className="h-4 w-4 text-violet-600 dark:text-violet-400" />;
+    case "markdown":
+    case "text":
+      return <FileText className="h-4 w-4 text-muted-foreground" />;
+    case "binary":
+      return <FileArchive className="h-4 w-4 text-muted-foreground" />;
+    default:
+      return <File className="h-4 w-4 text-muted-foreground" />;
+  }
+}
+
+function getFileId(index: number) {
+  return `file:${index}`;
+}
+
+function getDirectoryId(path: string) {
+  return `dir:${path}`;
+}
+
+function getDisplayName(path: string) {
+  const normalized = normalizeInitialFilePath(path);
+  const name = normalized.split("/").filter(Boolean).pop();
+  return name || "untitled";
+}
+
+function getFileExtension(path: string) {
+  const name = getDisplayName(path);
+  const extension = name.includes(".") ? name.split(".").pop() : "";
+  return extension?.toLowerCase() ?? "";
+}
+
+function normalizeInitialFilePath(path: string) {
+  if (!path.trim()) {
+    return "/";
+  }
+
+  return path.startsWith("/") ? path : `/${path}`;
+}
+
+function getFileSizeBytes(file: InitialFile) {
+  if (file.encoding === "text") {
+    return new Blob([file.content]).size;
+  }
+
+  const normalized = file.content.replace(/\s+/g, "");
+  const padding = normalized.endsWith("==") ? 2 : normalized.endsWith("=") ? 1 : 0;
+  return Math.max(0, Math.floor((normalized.length * 3) / 4) - padding);
 }
 
 async function encodeFile(file: File): Promise<Pick<InitialFile, "content" | "encoding">> {


### PR DESCRIPTION
## What
Replace the raw `initial_files` repeater with a two-pane editor that behaves like an in-memory filesystem for both agent and harness forms.

## Why
Editing starter files as a flat list of textareas was clumsy once paths became nested or assets needed previewing.

## How
Reuse the existing file tree and file preview primitives in a local adapter over `InitialFile[]`, then add focused tests for add/edit/select/preview behavior.

## Risk
- Medium
- Agent and harness create/edit flows could regress when selecting, editing, or previewing starter files.

## Security
- Threat categories reviewed: TM-WEB, TM-DOS
- Findings and resolutions:
  - Reviewed rendering of user-provided file content and base64 assets. The editor continues to rely on the existing `FilePreview` path, so there is no new raw HTML injection path beyond the already-reviewed preview components.
  - Reviewed tree construction and file-size display for large `initial_files` payloads. The change is UI-only, keeps work bounded to the provided array, and does not add any new network or storage surface.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `cd apps/ui && npm test -- --runInBand src/__tests__/initial-files-editor.test.tsx`
- `cd apps/ui && npm run build`
- `just pre-push`
- Browser smoke on a local-only dev mount of `InitialFilesEditor`: verified add/select/edit flow and image preview, then removed the temporary route before commit
