### PR TITLE
feat(ui): expose route manifest for wrappers

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -3,6 +3,7 @@
   "version": "0.8.16",
   "private": true,
   "exports": {
+    "./route-manifest": "./src/lib/ui-route-manifest.ts",
     "./providers/*": "./src/providers/*.tsx",
     "./components/*": "./src/components/*.tsx",
     "./hooks/*": "./src/hooks/*.ts",

--- a/apps/ui/src/lib/__tests__/ui-route-manifest.test.ts
+++ b/apps/ui/src/lib/__tests__/ui-route-manifest.test.ts
@@ -1,0 +1,172 @@
+/** @jest-environment node */
+
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  createUiRouteManifest,
+  mergeUiRouteManifests,
+  resolveUiRouteArtifactFilePath,
+  type UiRouteManifestArtifact,
+} from "@/lib/ui-route-manifest";
+
+function writeArtifact(
+  appDir: string,
+  relativePath: string,
+  contents = "export default function Test() {}",
+) {
+  const filePath = path.join(appDir, relativePath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, contents);
+}
+
+function findArtifact(artifacts: UiRouteManifestArtifact[], artifactId: string) {
+  const artifact = artifacts.find((entry) => entry.artifactId === artifactId);
+  expect(artifact).toBeDefined();
+  return artifact!;
+}
+
+describe("createUiRouteManifest", () => {
+  it("derives app-tree identity and public path from the app router tree", () => {
+    const appDir = mkdtempSync(path.join(tmpdir(), "everruns-ui-route-manifest-"));
+
+    writeArtifact(appDir, "layout.tsx");
+    writeArtifact(appDir, "not-found.tsx");
+    writeArtifact(appDir, "favicon.ico", "ico");
+    writeArtifact(appDir, "(main)/layout.tsx");
+    writeArtifact(appDir, "(main)/dashboard/page.tsx");
+    writeArtifact(appDir, "(auth)/login/page.tsx");
+    writeArtifact(appDir, "api/health/route.ts");
+
+    const manifest = createUiRouteManifest({
+      appDir,
+      packageName: "test-ui",
+    });
+
+    expect(manifest.version).toBe(1);
+    expect(manifest.sourcePackage).toBe("test-ui");
+
+    expect(findArtifact(manifest.artifacts, "/:layout.tsx")).toMatchObject({
+      sourcePackage: "test-ui",
+      kind: "layout",
+      appPath: "/",
+      pathname: "/",
+      sourcePath: "src/app/layout.tsx",
+      packageRelativePath: "src/app/layout.tsx",
+    });
+
+    expect(findArtifact(manifest.artifacts, "/(main):layout.tsx")).toMatchObject({
+      sourcePackage: "test-ui",
+      kind: "layout",
+      appPath: "/(main)",
+      pathname: "/",
+      sourcePath: "src/app/(main)/layout.tsx",
+    });
+
+    expect(findArtifact(manifest.artifacts, "/(main)/dashboard:page.tsx")).toMatchObject({
+      sourcePackage: "test-ui",
+      kind: "page",
+      appPath: "/(main)/dashboard",
+      pathname: "/dashboard",
+      sourcePath: "src/app/(main)/dashboard/page.tsx",
+    });
+
+    expect(findArtifact(manifest.artifacts, "/(auth)/login:page.tsx")).toMatchObject({
+      sourcePackage: "test-ui",
+      kind: "page",
+      appPath: "/(auth)/login",
+      pathname: "/login",
+    });
+
+    expect(findArtifact(manifest.artifacts, "/api/health:route.ts")).toMatchObject({
+      sourcePackage: "test-ui",
+      kind: "route",
+      appPath: "/api/health",
+      pathname: "/api/health",
+    });
+
+    expect(findArtifact(manifest.artifacts, "/:favicon.ico")).toMatchObject({
+      sourcePackage: "test-ui",
+      kind: "favicon",
+      appPath: "/",
+      pathname: "/",
+    });
+  });
+});
+
+describe("mergeUiRouteManifests", () => {
+  it("lets wrapper artifacts override OSS artifacts by artifact id while keeping extra routes", () => {
+    const base = {
+      version: 1 as const,
+      sourcePackage: "everruns-ui",
+      appDir: "src/app",
+      artifacts: [
+        {
+          artifactId: "/(main)/dashboard:page.tsx",
+          sourcePackage: "everruns-ui",
+          kind: "page" as const,
+          appPath: "/(main)/dashboard",
+          pathname: "/dashboard",
+          fileName: "page.tsx",
+          sourcePath: "src/app/(main)/dashboard/page.tsx",
+          packageRelativePath: "src/app/(main)/dashboard/page.tsx",
+        },
+      ],
+    };
+    const wrapper = {
+      version: 1 as const,
+      sourcePackage: "wrapper-ui",
+      appDir: "src/app",
+      artifacts: [
+        {
+          artifactId: "/(main)/dashboard:page.tsx",
+          sourcePackage: "wrapper-ui",
+          kind: "page" as const,
+          appPath: "/(main)/dashboard",
+          pathname: "/dashboard",
+          fileName: "page.tsx",
+          sourcePath: "src/app/(main)/dashboard/page.tsx",
+          packageRelativePath: "src/app/(main)/dashboard/page.tsx",
+        },
+        {
+          artifactId: "/billing:page.tsx",
+          sourcePackage: "wrapper-ui",
+          kind: "page" as const,
+          appPath: "/billing",
+          pathname: "/billing",
+          fileName: "page.tsx",
+          sourcePath: "src/app/billing/page.tsx",
+          packageRelativePath: "src/app/billing/page.tsx",
+        },
+      ],
+    };
+
+    const merged = mergeUiRouteManifests(base, wrapper);
+
+    expect(merged.artifacts).toHaveLength(2);
+    expect(merged.sourcePackage).toBe("wrapper-ui");
+    expect(findArtifact(merged.artifacts, "/(main)/dashboard:page.tsx").sourcePackage).toBe(
+      "wrapper-ui",
+    );
+    expect(findArtifact(merged.artifacts, "/billing:page.tsx")).toMatchObject({
+      sourcePackage: "wrapper-ui",
+      pathname: "/billing",
+      sourcePath: "src/app/billing/page.tsx",
+    });
+  });
+
+  it("rejects packageRelativePath values outside the published src/ contract", () => {
+    expect(() =>
+      resolveUiRouteArtifactFilePath({
+        artifactId: "/dashboard:page.tsx",
+        sourcePackage: "everruns-ui",
+        kind: "page",
+        appPath: "/dashboard",
+        pathname: "/dashboard",
+        fileName: "page.tsx",
+        sourcePath: "src/app/dashboard/page.tsx",
+        packageRelativePath: "app/dashboard/page.tsx",
+      }),
+    ).toThrow('packageRelativePath must start with "src/"');
+  });
+});

--- a/apps/ui/src/lib/ui-route-manifest.ts
+++ b/apps/ui/src/lib/ui-route-manifest.ts
@@ -1,0 +1,220 @@
+// Decision: artifact identity uses app-tree path plus filename, not public pathname.
+// Route groups can share the same public pathname while applying different layouts.
+// Wrappers need the app-tree identity to override intentionally without flattening Next's structure.
+
+import { readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+export const UI_ROUTE_MANIFEST_VERSION = 1 as const;
+export const UI_ROUTE_MANIFEST_APP_DIR = "src/app" as const;
+export const UI_ROUTE_MANIFEST_PACKAGE = "everruns-ui" as const;
+
+export type UiRouteArtifactKind =
+  | "page"
+  | "layout"
+  | "loading"
+  | "error"
+  | "template"
+  | "route"
+  | "not-found"
+  | "icon"
+  | "apple-icon"
+  | "opengraph-image"
+  | "twitter-image"
+  | "favicon";
+
+export interface UiRouteManifestArtifact {
+  artifactId: string;
+  sourcePackage: string;
+  kind: UiRouteArtifactKind;
+  appPath: string;
+  pathname: string;
+  fileName: string;
+  sourcePath: string;
+  packageRelativePath: string;
+}
+
+export interface UiRouteManifest {
+  version: typeof UI_ROUTE_MANIFEST_VERSION;
+  sourcePackage: string;
+  appDir: typeof UI_ROUTE_MANIFEST_APP_DIR;
+  artifacts: UiRouteManifestArtifact[];
+}
+
+interface CreateUiRouteManifestOptions {
+  appDir?: string;
+  packageName?: string;
+}
+
+const ROUTE_ARTIFACT_KINDS = new Set<UiRouteArtifactKind>([
+  "page",
+  "layout",
+  "loading",
+  "error",
+  "template",
+  "route",
+  "not-found",
+  "icon",
+  "apple-icon",
+  "opengraph-image",
+  "twitter-image",
+  "favicon",
+]);
+const PACKAGE_RELATIVE_PATH_PREFIX = "src/";
+
+let ossUiRouteManifestCache: UiRouteManifest | undefined;
+
+function defaultAppDir(): string {
+  return fileURLToPath(new URL("../app", import.meta.url));
+}
+
+function isRouteGroupSegment(segment: string): boolean {
+  return /^\([^/]+\)$/.test(segment);
+}
+
+function isInvisibleUrlSegment(segment: string): boolean {
+  return isRouteGroupSegment(segment) || segment.startsWith("@");
+}
+
+function normalizePosixPath(value: string): string {
+  return value.split(path.sep).join("/");
+}
+
+function toAppPath(segments: string[]): string {
+  return segments.length === 0 ? "/" : `/${segments.join("/")}`;
+}
+
+function toPublicPath(segments: string[]): string {
+  const pathnameSegments = segments.filter((segment) => !isInvisibleUrlSegment(segment));
+  return pathnameSegments.length === 0 ? "/" : `/${pathnameSegments.join("/")}`;
+}
+
+function classifyArtifact(fileName: string): UiRouteArtifactKind | null {
+  if (fileName === "favicon.ico") {
+    return "favicon";
+  }
+
+  const basename = fileName.replace(/\.[^.]+$/, "") as UiRouteArtifactKind;
+  return ROUTE_ARTIFACT_KINDS.has(basename) ? basename : null;
+}
+
+function compareArtifacts(left: UiRouteManifestArtifact, right: UiRouteManifestArtifact): number {
+  return left.sourcePath.localeCompare(right.sourcePath);
+}
+
+function walkArtifacts(
+  appDir: string,
+  currentDir: string,
+  packageName: string,
+  artifacts: UiRouteManifestArtifact[],
+) {
+  for (const entry of readdirSync(currentDir, { withFileTypes: true })) {
+    const absolutePath = path.join(currentDir, entry.name);
+
+    if (entry.isDirectory()) {
+      walkArtifacts(appDir, absolutePath, packageName, artifacts);
+      continue;
+    }
+
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    const kind = classifyArtifact(entry.name);
+    if (!kind) {
+      continue;
+    }
+
+    const routeDir = path.dirname(absolutePath);
+    const routeSegments = path.relative(appDir, routeDir).split(path.sep).filter(Boolean);
+    const sourcePath = normalizePosixPath(
+      path.join(UI_ROUTE_MANIFEST_APP_DIR, ...routeSegments, entry.name),
+    );
+
+    artifacts.push({
+      artifactId: `${toAppPath(routeSegments)}:${entry.name}`,
+      sourcePackage: packageName,
+      kind,
+      appPath: toAppPath(routeSegments),
+      pathname: toPublicPath(routeSegments),
+      fileName: entry.name,
+      sourcePath,
+      packageRelativePath: sourcePath,
+    });
+  }
+}
+
+export function createUiRouteManifest(options: CreateUiRouteManifestOptions = {}): UiRouteManifest {
+  const appDir = options.appDir ?? defaultAppDir();
+  const packageName = options.packageName ?? UI_ROUTE_MANIFEST_PACKAGE;
+  const artifacts: UiRouteManifestArtifact[] = [];
+
+  walkArtifacts(appDir, appDir, packageName, artifacts);
+
+  return {
+    version: UI_ROUTE_MANIFEST_VERSION,
+    sourcePackage: packageName,
+    appDir: UI_ROUTE_MANIFEST_APP_DIR,
+    artifacts: artifacts.sort(compareArtifacts),
+  };
+}
+
+export function mergeUiRouteManifests(
+  base: UiRouteManifest,
+  overrides: UiRouteManifest,
+): UiRouteManifest {
+  if (base.version !== overrides.version) {
+    throw new Error(
+      `Cannot merge UI route manifests with different versions (${base.version} vs ${overrides.version})`,
+    );
+  }
+
+  const merged = new Map(base.artifacts.map((artifact) => [artifact.artifactId, artifact]));
+  for (const artifact of overrides.artifacts) {
+    merged.set(artifact.artifactId, artifact);
+  }
+
+  return {
+    version: base.version,
+    // Merged manifests reflect the effective override layer, not the original OSS base.
+    sourcePackage: overrides.sourcePackage,
+    appDir: base.appDir,
+    artifacts: [...merged.values()].sort(compareArtifacts),
+  };
+}
+
+export function resolveUiRouteArtifactFilePath(artifact: UiRouteManifestArtifact): string {
+  if (artifact.sourcePackage !== UI_ROUTE_MANIFEST_PACKAGE) {
+    throw new Error(
+      `Cannot resolve ${artifact.artifactId} from ${artifact.sourcePackage} with the ${UI_ROUTE_MANIFEST_PACKAGE} loader`,
+    );
+  }
+
+  if (!artifact.packageRelativePath.startsWith(PACKAGE_RELATIVE_PATH_PREFIX)) {
+    throw new Error(
+      `Cannot resolve ${artifact.artifactId} because packageRelativePath must start with "${PACKAGE_RELATIVE_PATH_PREFIX}", received "${artifact.packageRelativePath}"`,
+    );
+  }
+
+  return fileURLToPath(
+    new URL(
+      `../${artifact.packageRelativePath.slice(PACKAGE_RELATIVE_PATH_PREFIX.length)}`,
+      import.meta.url,
+    ),
+  );
+}
+
+export async function loadUiRouteArtifactModule(
+  artifact: UiRouteManifestArtifact,
+): Promise<unknown> {
+  return import(pathToFileURL(resolveUiRouteArtifactFilePath(artifact)).href);
+}
+
+export function getOssUiRouteManifest(): UiRouteManifest {
+  if (!ossUiRouteManifestCache) {
+    ossUiRouteManifestCache = createUiRouteManifest();
+  }
+
+  return ossUiRouteManifestCache;
+}

--- a/specs/embedding.md
+++ b/specs/embedding.md
@@ -147,6 +147,56 @@ Embedders may extend execution by:
 - Replacing the `PlatformDefinition`
 - Reusing Everruns worker runtime and lifecycle handling
 
+## UI Route Manifest Contract
+
+UI embedders and SaaS wrappers must discover the OSS App Router tree through the published route manifest instead of mirroring `apps/ui/src/app` by hand.
+
+### Stable export
+
+`apps/ui/package.json` must export the manifest module at `everruns-ui/route-manifest`.
+
+This module is a build-time/server-side contract. It is not part of the browser bundle.
+
+### Manifest API
+
+The manifest module lives at `apps/ui/src/lib/ui-route-manifest.ts` and exposes:
+
+- `UI_ROUTE_MANIFEST_VERSION` - current schema version (`1`)
+- `createUiRouteManifest()` - derives the current manifest from `src/app`
+- `getOssUiRouteManifest()` - lazily returns the manifest for the bundled OSS route tree
+- `mergeUiRouteManifests(base, overrides)` - applies wrapper override precedence
+- `resolveUiRouteArtifactFilePath()` / `loadUiRouteArtifactModule()` - OSS helper APIs for build-time access to discovered artifacts
+
+### Artifact shape
+
+Each manifest artifact includes:
+
+- `artifactId` - stable override key, formed from `appPath + ":" + fileName`
+- `sourcePackage` - owning package name (`everruns-ui` for OSS artifacts)
+- `kind` - App Router artifact kind (`page`, `layout`, `loading`, `error`, `template`, `route`, `not-found`, metadata assets)
+- `appPath` - App Router tree path including route groups (example: `/(main)/dashboard`)
+- `pathname` - public URL path with route groups removed (example: `/dashboard`)
+- `fileName` - concrete artifact filename (example: `page.tsx`, `icon.svg`)
+- `sourcePath` / `packageRelativePath` - stable package-relative source location under `src/app`
+
+At the manifest level, `sourcePackage` identifies the package providing the effective override layer for the returned manifest. Artifact-level `sourcePackage` identifies the owner of each winning artifact.
+
+`appPath` is required because public pathname alone is not enough to identify layout ownership. Route groups can share the same URL space while applying different `layout.tsx` or `error.tsx` files.
+
+### Override precedence
+
+Wrapper manifests override OSS manifests by exact `artifactId`.
+
+- Same `artifactId`: wrapper artifact wins
+- New `artifactId`: wrapper artifact is appended
+- Missing wrapper artifact: OSS artifact remains in effect
+
+This keeps OSS as the owner of the default route topology while allowing wrappers to replace specific routes or layouts intentionally.
+
+### Wrapper-added routes
+
+Wrappers add new routes by publishing additional manifest artifacts with new `artifactId` values, then merging them with the OSS manifest. They must not fork or manually duplicate the full OSS `src/app` tree just to preserve parity with OSS routes.
+
 ## CLI Auth Extension Point
 
 CLI authentication routes (`/v1/auth/cli/*`) are decoupled from any specific auth backend via `CliAuthState`. Embedders with external auth providers can mount CLI login without duplicating handler code.
@@ -193,3 +243,5 @@ Those may be added later, but they are outside the current embedding contract.
 - `crates/worker/src/platform.rs`
 - `crates/worker/src/durable_worker.rs`
 - `crates/worker/src/activities.rs`
+- `apps/ui/src/lib/ui-route-manifest.ts`
+- `apps/ui/package.json`


### PR DESCRIPTION
## What
- add a stable `everruns-ui/route-manifest` export for wrapper apps
- derive App Router artifacts from `apps/ui/src/app` instead of hand-maintained mirrors
- include artifact ids that preserve app-tree route groups alongside public pathnames
- document manifest versioning and wrapper override precedence in the embedding spec

## Why
Wrappers should not mirror the OSS Next route tree by hand. That makes routine OSS route churn expensive and brittle.

Fixes EVE-365.

## How
- scan `src/app` for App Router artifacts and metadata assets
- publish manifest entries with `artifactId`, `appPath`, `pathname`, and package-relative source paths
- merge wrapper manifests by exact `artifactId` so explicit overrides win and extra wrapper routes append cleanly
- add focused tests for route-group identity and merge precedence

## Risk
- Low
- The new export is build-time/server-side only. A bad path calculation would affect wrapper integration, not browser runtime behavior.

## Security
- Threat categories reviewed: TM-FS, TM-WEB
- Findings and resolutions:
  - `createUiRouteManifest()` only scans the package-owned `src/app` tree; no user-controlled paths or input parsing were introduced.
  - `route-manifest` is documented as a build-time/server-side export, so no new browser-exposed runtime surface was added.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
