### PR TITLE
fix(ui): harden malformed tag rendering

### DIFF
--- a/apps/ui/src/__tests__/agent-edit-page.test.tsx
+++ b/apps/ui/src/__tests__/agent-edit-page.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen, act } from "@testing-library/react";
+import { Suspense } from "react";
+import EditAgentPage from "@/app/(main)/agents/[agentId]/edit/page";
+import type { Agent } from "@/lib/api/types";
+
+const push = jest.fn();
+const replace = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push,
+    replace,
+    back: jest.fn(),
+  }),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    // eslint-disable-next-line @next/next/no-html-link-for-pages
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("@/components/ui/prompt-editor", () => ({
+  PromptEditor: ({ value, onChange }: { value: string; onChange: (value: string) => void }) => (
+    <textarea aria-label="System prompt" value={value} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+
+jest.mock("@/components/agents/capability-selector", () => ({
+  CapabilitySelector: () => <div data-testid="capability-selector" />,
+}));
+
+jest.mock("@/components/agents/agent-preview", () => ({
+  AgentPreview: () => <div data-testid="agent-preview" />,
+}));
+
+jest.mock("@/components/initial-files-editor", () => ({
+  InitialFilesEditor: () => <div data-testid="initial-files-editor" />,
+}));
+
+jest.mock("@/components/models/model-picker", () => ({
+  ModelPicker: ({
+    value,
+    onChange,
+  }: {
+    value?: string | null;
+    onChange: (value: string) => void;
+  }) => (
+    <input
+      aria-label="Default model"
+      value={value ?? ""}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+
+const mockUseAgent = jest.fn();
+const mockUseUpdateAgent = jest.fn();
+const mockUseDeleteAgent = jest.fn();
+const mockUseDestroyAgent = jest.fn();
+const mockUseCapabilities = jest.fn();
+const mockUseAgentNameAvailability = jest.fn();
+
+jest.mock("@/hooks", () => ({
+  useAgent: (...args: unknown[]) => mockUseAgent(...args),
+  useUpdateAgent: () => mockUseUpdateAgent(),
+  useDeleteAgent: () => mockUseDeleteAgent(),
+  useDestroyAgent: () => mockUseDestroyAgent(),
+  useCapabilities: () => mockUseCapabilities(),
+  useAgentNameAvailability: (...args: unknown[]) => mockUseAgentNameAvailability(...args),
+}));
+
+jest.mock("@/hooks/use-policies", () => ({
+  usePolicies: () => ({
+    can: () => true,
+  }),
+}));
+
+const malformedAgent: Agent = {
+  id: "agent_123",
+  name: "test-agent",
+  display_name: "Test Agent",
+  description: "Agent description",
+  system_prompt: "You are helpful.",
+  default_model_id: null,
+  tags: null as unknown as string[],
+  capabilities: [],
+  initial_files: [],
+  status: "active",
+  created_at: "2026-04-19T10:00:00Z",
+  updated_at: "2026-04-19T10:00:00Z",
+  archived_at: null,
+  deleted_at: null,
+};
+
+async function renderWithSuspense(params: { agentId: string }) {
+  const paramsPromise = Promise.resolve(params);
+
+  await act(async () => {
+    render(
+      <Suspense fallback={<div>Loading...</div>}>
+        <EditAgentPage params={paramsPromise} />
+      </Suspense>,
+    );
+    await paramsPromise;
+  });
+}
+
+describe("EditAgentPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAgent.mockReturnValue({ data: malformedAgent, isLoading: false });
+    mockUseUpdateAgent.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
+    mockUseDeleteAgent.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
+    mockUseDestroyAgent.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
+    mockUseCapabilities.mockReturnValue({ data: [], isLoading: false });
+    mockUseAgentNameAvailability.mockReturnValue({
+      isChecking: false,
+      isAvailable: true,
+      error: null,
+    });
+  });
+
+  it("renders the form when tags is null", async () => {
+    await renderWithSuspense({ agentId: "agent_123" });
+
+    expect(screen.getByRole("heading", { name: "Edit Agent" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Tags")).toHaveValue("");
+    expect(screen.getByDisplayValue("test-agent")).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -41,6 +41,7 @@ import {
 } from "@/lib/form-validation";
 import type { AgentCapabilityConfig, InitialFile } from "@/lib/api/types";
 import { getDisplayName, isReadOnlyStatus } from "@/lib/entity-lifecycle";
+import { joinTags } from "@/lib/tags";
 
 interface FormData {
   display_name: string;
@@ -90,7 +91,7 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
       name: agent.name,
       description: agent.description || "",
       system_prompt: agent.system_prompt,
-      tags: agent.tags.join(", "),
+      tags: joinTags(agent.tags),
       default_model_id: agent.default_model_id || "",
     };
   }, [agent]);

--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/lib/entity-lifecycle";
 import { useOrganization } from "@/hooks/use-organizations";
 import { formatTokens } from "@/lib/formatting";
+import { normalizeTags } from "@/lib/tags";
 
 // Helper function to calculate total tokens
 function totalTokens(usage: TokenUsage): number {
@@ -68,6 +69,7 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
 
   // Get the agent's default model
   const defaultModel = agent?.default_model_id ? modelMap.get(agent.default_model_id) : undefined;
+  const agentTags = normalizeTags(agent?.tags);
 
   const handleNewSession = async () => {
     const harnessId = organization?.default_harness_id || harnesses?.[0]?.id;
@@ -318,11 +320,11 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
                     </div>
                   )}
 
-                  {agent.tags.length > 0 && (
+                  {agentTags.length > 0 && (
                     <div>
                       <p className="text-sm font-medium mb-2">Tags</p>
                       <div className="flex flex-wrap gap-1">
-                        {agent.tags.map((tag) => (
+                        {agentTags.map((tag) => (
                           <Badge key={tag} variant="outline">
                             {tag}
                           </Badge>

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
@@ -43,6 +43,7 @@ import {
 } from "@/lib/form-validation";
 import type { AgentCapabilityConfig, InitialFile } from "@/lib/api/types";
 import { getDisplayName, isReadOnlyStatus } from "@/lib/entity-lifecycle";
+import { joinTags } from "@/lib/tags";
 
 interface FormData {
   display_name: string;
@@ -90,7 +91,7 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
       description: harness.description || "",
       system_prompt: harness.system_prompt,
       parent_harness_id: harness.parent_harness_id || "",
-      tags: harness.tags.join(", "),
+      tags: joinTags(harness.tags),
       default_model_id: harness.default_model_id || "",
     };
   }, [harness]);

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
@@ -29,6 +29,7 @@ import {
   getEntityNameClassName,
   getEntityStatusBadgeVariant,
 } from "@/lib/entity-lifecycle";
+import { normalizeTags } from "@/lib/tags";
 
 export default function HarnessDetailPage({ params }: { params: Promise<{ harnessId: string }> }) {
   const { harnessId } = use(params);
@@ -52,6 +53,7 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
   const parentHarness = harness?.parent_harness_id
     ? harnesses.find((candidate) => candidate.id === harness.parent_harness_id)
     : undefined;
+  const harnessTags = normalizeTags(harness?.tags);
 
   const getCapabilityInfo = (capabilityId: string): Capability | undefined =>
     allCapabilities?.find((c) => c.id === capabilityId);
@@ -259,11 +261,11 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
                     </div>
                   )}
 
-                  {harness.tags.length > 0 && (
+                  {harnessTags.length > 0 && (
                     <div>
                       <p className="text-sm font-medium mb-2">Tags</p>
                       <div className="flex flex-wrap gap-1">
-                        {harness.tags.map((tag) => (
+                        {harnessTags.map((tag) => (
                           <Badge key={tag} variant="outline">
                             {tag}
                           </Badge>

--- a/apps/ui/src/components/agents/agent-card.tsx
+++ b/apps/ui/src/components/agents/agent-card.tsx
@@ -15,6 +15,7 @@ import {
   getEntityNameClassName,
   getEntityStatusBadgeVariant,
 } from "@/lib/entity-lifecycle";
+import { normalizeTags } from "@/lib/tags";
 
 interface AgentCardProps {
   agent: Agent;
@@ -35,6 +36,7 @@ export function AgentCard({
 
   // Capabilities are now directly on the agent
   const agentCapabilities = agent.capabilities ?? [];
+  const tags = normalizeTags(agent.tags);
 
   return (
     <Card className="bg-background transition-colors hover:bg-card">
@@ -88,9 +90,9 @@ export function AgentCard({
         )}
 
         {/* Tags */}
-        {agent.tags.length > 0 && (
+        {tags.length > 0 && (
           <div className="flex flex-wrap gap-1 mb-3">
-            {agent.tags.map((tag) => (
+            {tags.map((tag) => (
               <Badge key={tag} variant="outline" className="text-xs">
                 {tag}
               </Badge>

--- a/apps/ui/src/components/harnesses/harness-card.tsx
+++ b/apps/ui/src/components/harnesses/harness-card.tsx
@@ -15,6 +15,7 @@ import {
   getEntityNameClassName,
   getEntityStatusBadgeVariant,
 } from "@/lib/entity-lifecycle";
+import { normalizeTags } from "@/lib/tags";
 
 interface HarnessCardProps {
   harness: Harness;
@@ -33,6 +34,7 @@ export function HarnessCard({
     allCapabilities?.find((c) => c.id === capabilityId);
 
   const harnessCapabilities = harness.capabilities ?? [];
+  const tags = normalizeTags(harness.tags);
 
   return (
     <Card className="bg-background transition-colors hover:bg-card">
@@ -90,9 +92,9 @@ export function HarnessCard({
         )}
 
         {/* Tags */}
-        {harness.tags.length > 0 && (
+        {tags.length > 0 && (
           <div className="flex flex-wrap gap-1 mb-3">
-            {harness.tags.map((tag) => (
+            {tags.map((tag) => (
               <Badge key={tag} variant="outline" className="text-xs">
                 {tag}
               </Badge>

--- a/apps/ui/src/components/session/session-card.tsx
+++ b/apps/ui/src/components/session/session-card.tsx
@@ -19,6 +19,7 @@ import { formatRelativeTime, formatTokens } from "@/lib/formatting";
 import { CopyButton } from "@/components/ui/copy-button";
 import type { Session, SessionStatus, LlmModelWithProvider, TokenUsage } from "@/lib/api/types";
 import { getEntityReferenceClassName, getEntityReferenceLabel } from "@/lib/entity-lifecycle";
+import { joinTags } from "@/lib/tags";
 
 /**
  * Format total tokens from usage
@@ -85,6 +86,7 @@ function SessionInfoIcon({ session }: { session: Session }) {
   const formattedStartedAt = session.started_at
     ? new Date(session.started_at).toLocaleString()
     : null;
+  const tagList = joinTags(session.tags);
 
   return (
     <Tooltip>
@@ -121,10 +123,10 @@ function SessionInfoIcon({ session }: { session: Session }) {
               <span>{formattedStartedAt}</span>
             </div>
           )}
-          {session.tags.length > 0 && (
+          {tagList && (
             <div className="flex gap-2">
               <span className="text-muted-foreground">Tags:</span>
-              <span>{session.tags.join(", ")}</span>
+              <span>{tagList}</span>
             </div>
           )}
         </div>

--- a/apps/ui/src/lib/__tests__/tags.test.ts
+++ b/apps/ui/src/lib/__tests__/tags.test.ts
@@ -1,0 +1,18 @@
+import { joinTags, normalizeTags } from "@/lib/tags";
+
+describe("tags helpers", () => {
+  it("returns an empty list for non-array values", () => {
+    expect(normalizeTags(null)).toEqual([]);
+    expect(normalizeTags(undefined)).toEqual([]);
+    expect(normalizeTags("ops")).toEqual([]);
+  });
+
+  it("filters non-string and blank entries", () => {
+    expect(normalizeTags([" ops ", "", 42, null, "alerts"])).toEqual(["ops", "alerts"]);
+  });
+
+  it("joins normalized tags for form display", () => {
+    expect(joinTags([" ops ", "", "alerts"])).toBe("ops, alerts");
+    expect(joinTags(null)).toBe("");
+  });
+});

--- a/apps/ui/src/lib/tags.ts
+++ b/apps/ui/src/lib/tags.ts
@@ -1,0 +1,15 @@
+// Boundary hardening: tolerate malformed or legacy API tag payloads during UI render.
+export function normalizeTags(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .filter((tag): tag is string => typeof tag === "string")
+    .map((tag) => tag.trim())
+    .filter((tag) => tag.length > 0);
+}
+
+export function joinTags(value: unknown): string {
+  return normalizeTags(value).join(", ");
+}


### PR DESCRIPTION
## What
Harden UI tag rendering against malformed or legacy payloads by normalizing tag values before render.

## Why
The agent edit page crashed when `agent.tags` was not a real string array. That surfaced as the generic `Something went wrong` boundary instead of the edit form.

## How
- added shared `normalizeTags` / `joinTags` helpers in the UI layer
- used the helpers in agent and harness edit pages when building form defaults
- hardened remaining shared render paths that still assumed `tags` was always a valid array during render
- added helper coverage plus an edit-page regression test for `tags: null`

## Risk
- Low
- UI-only change in tag display/form initialization paths; malformed tag values now collapse to an empty list/string instead of throwing during render

## Security
- Threat categories reviewed: TM-WEB
- Findings and resolutions:
  - No new trust boundary or data exposure added.
  - The change only normalizes already-fetched tag data before rendering, which reduces crash surface from malformed payloads.

## Validation
- `npm run lint`
- `npm run build`
- `just pre-push`
- `NODE_PATH=/Users/mykhailochalyi/Projects/everruns/everruns/apps/ui/node_modules /Users/mykhailochalyi/Projects/everruns/everruns/apps/ui/node_modules/.bin/jest --runInBand src/lib/__tests__/tags.test.ts src/__tests__/agent-edit-page.test.tsx src/__tests__/agent-detail-model.test.tsx`
- Playwright smoke: created a dev-mode agent, forced `/api/v1/agents/:id` to return `tags: null`, loaded `/agents/:id/edit`, and verified `Edit Agent` rendered with an empty Tags field and no error boundary

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
