### PR TITLE
test(auth): expand org-scoped integration matrix

### DIFF
--- a/apps/ui/src/__tests__/main-layout-auth.test.tsx
+++ b/apps/ui/src/__tests__/main-layout-auth.test.tsx
@@ -63,6 +63,7 @@ jest.mock("@/providers/feature-flags-provider", () => ({
 describe("MainLayout auth availability", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    sessionStorage.clear();
     mockPathname.mockReturnValue("/settings/providers");
     mockSearchParams.mockReturnValue(new URLSearchParams("tab=models"));
 
@@ -138,5 +139,20 @@ describe("MainLayout auth availability", () => {
       );
     });
     expect(screen.queryByText("Authentication unavailable")).not.toBeInTheDocument();
+  });
+
+  it("resumes a stored frontend return_to after auth completes", async () => {
+    sessionStorage.setItem("everruns_return_to", "/settings/providers?tab=models");
+
+    render(
+      <MainLayout>
+        <div>Secret App</div>
+      </MainLayout>,
+    );
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/settings/providers?tab=models");
+    });
+    expect(sessionStorage.getItem("everruns_return_to")).toBeNull();
   });
 });

--- a/apps/ui/src/__tests__/org-provider.test.tsx
+++ b/apps/ui/src/__tests__/org-provider.test.tsx
@@ -87,6 +87,7 @@ describe("OrgProvider", () => {
   it("switches to a different existing org after cookie sync", async () => {
     mockUser = { organizations: [DEFAULT_ORG, SECOND_ORG] };
     mockAuthLoading = false;
+    const invalidateSpy = jest.spyOn(queryClient, "invalidateQueries");
 
     const { result } = renderHook(() => useOrg(), { wrapper });
 
@@ -100,6 +101,7 @@ describe("OrgProvider", () => {
     });
     expect(storageMap.get("everruns_current_org")).toBe(SECOND_ORG.public_id);
     expect(mockSwitchOrg).toHaveBeenCalledWith(SECOND_ORG.public_id);
+    expect(invalidateSpy).toHaveBeenCalled();
   });
 
   it("rolls back on failed org switch", async () => {

--- a/apps/ui/src/__tests__/use-auth.test.tsx
+++ b/apps/ui/src/__tests__/use-auth.test.tsx
@@ -1,7 +1,17 @@
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode } from "react";
-import { useLogin, useRegister, useLogout, useCurrentUser, authKeys } from "@/hooks/use-auth";
+import {
+  useLogin,
+  useRegister,
+  useLogout,
+  useCurrentUser,
+  useApiKeys,
+  useCreateApiKey,
+  useDeleteApiKey,
+  authKeys,
+} from "@/hooks/use-auth";
+import type { OrganizationMembership } from "@/lib/api/types";
 
 // Mock the API functions
 jest.mock("@/lib/api/auth", () => ({
@@ -20,9 +30,29 @@ import * as authApi from "@/lib/api/auth";
 const mockLogin = authApi.login as jest.MockedFunction<typeof authApi.login>;
 const mockRegister = authApi.register as jest.MockedFunction<typeof authApi.register>;
 const mockLogout = authApi.logout as jest.MockedFunction<typeof authApi.logout>;
+const mockListApiKeys = authApi.listApiKeys as jest.MockedFunction<typeof authApi.listApiKeys>;
+const mockCreateApiKey = authApi.createApiKey as jest.MockedFunction<typeof authApi.createApiKey>;
+const mockDeleteApiKey = authApi.deleteApiKey as jest.MockedFunction<typeof authApi.deleteApiKey>;
 const mockGetCurrentUser = authApi.getCurrentUser as jest.MockedFunction<
   typeof authApi.getCurrentUser
 >;
+
+const mockUseOrg = jest.fn();
+jest.mock("@/providers/org-provider", () => ({
+  useOrg: () => mockUseOrg(),
+}));
+
+const DEFAULT_ORG: OrganizationMembership = {
+  public_id: "org_default",
+  name: "Default Org",
+  role: "owner",
+};
+
+const SECOND_ORG: OrganizationMembership = {
+  public_id: "org_second",
+  name: "Second Org",
+  role: "owner",
+};
 
 describe("Auth Hooks", () => {
   let queryClient: QueryClient;
@@ -44,6 +74,10 @@ describe("Auth Hooks", () => {
     });
     jest.clearAllMocks();
     localStorage.clear();
+    mockUseOrg.mockReturnValue({
+      currentOrg: DEFAULT_ORG,
+      isLoading: false,
+    });
   });
 
   // Helper to initialize the user query so refetchQueries has something to refetch
@@ -320,7 +354,9 @@ describe("Auth Hooks", () => {
         roles: ["user"],
       };
       queryClient.setQueryData(authKeys.user(), mockUser);
-      queryClient.setQueryData(authKeys.apiKeys(), [{ id: "key-1", name: "Test Key" }]);
+      queryClient.setQueryData(authKeys.apiKeys(DEFAULT_ORG.public_id), [
+        { id: "key-1", name: "Test Key" },
+      ]);
       // Simulate org-sensitive cached data (e.g., durable workflows)
       queryClient.setQueryData(["durable", "workflows"], [{ id: "wf-1" }]);
 
@@ -340,7 +376,7 @@ describe("Auth Hooks", () => {
       const cachedUser = queryClient.getQueryData(authKeys.user());
       expect(cachedUser).toBeUndefined();
 
-      const cachedApiKeys = queryClient.getQueryData(authKeys.apiKeys());
+      const cachedApiKeys = queryClient.getQueryData(authKeys.apiKeys(DEFAULT_ORG.public_id));
       expect(cachedApiKeys).toBeUndefined();
 
       // Verify org-sensitive data is also cleared
@@ -373,6 +409,102 @@ describe("Auth Hooks", () => {
 
       // Verify user is cleared after logout
       expect(queryClient.getQueryData(authKeys.user())).toBeUndefined();
+    });
+  });
+
+  describe("org-scoped API key cache", () => {
+    it("stores API key queries under the active org key and refetches after an org switch", async () => {
+      mockListApiKeys.mockResolvedValueOnce([
+        {
+          id: "key-default",
+          name: "Default Key",
+          key_prefix: "evr_default",
+          scopes: ["*"],
+          expires_at: null,
+          last_used_at: null,
+          created_at: "2024-01-01T00:00:00Z",
+        },
+      ]);
+
+      const { result, rerender } = renderHook(() => useApiKeys(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.data).toEqual([
+          expect.objectContaining({ id: "key-default", name: "Default Key" }),
+        ]);
+      });
+      expect(queryClient.getQueryData(authKeys.apiKeys(DEFAULT_ORG.public_id))).toEqual([
+        expect.objectContaining({ id: "key-default", name: "Default Key" }),
+      ]);
+
+      mockUseOrg.mockReturnValue({
+        currentOrg: SECOND_ORG,
+        isLoading: false,
+      });
+      mockListApiKeys.mockResolvedValueOnce([
+        {
+          id: "key-second",
+          name: "Second Key",
+          key_prefix: "evr_second",
+          scopes: ["*"],
+          expires_at: null,
+          last_used_at: null,
+          created_at: "2024-01-02T00:00:00Z",
+        },
+      ]);
+
+      rerender();
+
+      await waitFor(() => {
+        expect(result.current.data).toEqual([
+          expect.objectContaining({ id: "key-second", name: "Second Key" }),
+        ]);
+      });
+
+      expect(queryClient.getQueryData(authKeys.apiKeys(DEFAULT_ORG.public_id))).toEqual([
+        expect.objectContaining({ id: "key-default", name: "Default Key" }),
+      ]);
+      expect(queryClient.getQueryData(authKeys.apiKeys(SECOND_ORG.public_id))).toEqual([
+        expect.objectContaining({ id: "key-second", name: "Second Key" }),
+      ]);
+    });
+
+    it("invalidates only the active org API key query after create", async () => {
+      const invalidateSpy = jest.spyOn(queryClient, "invalidateQueries");
+      mockCreateApiKey.mockResolvedValueOnce({
+        id: "key-created",
+        name: "Created Key",
+        key: "evr_secret",
+        key_prefix: "evr_created",
+        scopes: ["*"],
+        expires_at: null,
+        created_at: "2024-01-01T00:00:00Z",
+      });
+
+      const { result } = renderHook(() => useCreateApiKey(), { wrapper });
+
+      await act(async () => {
+        await result.current.mutateAsync({ name: "Created Key" });
+      });
+
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: authKeys.apiKeys(DEFAULT_ORG.public_id),
+      });
+    });
+
+    it("invalidates only the active org API key query after delete", async () => {
+      const invalidateSpy = jest.spyOn(queryClient, "invalidateQueries");
+      mockDeleteApiKey.mockResolvedValueOnce(undefined);
+
+      const { result } = renderHook(() => useDeleteApiKey(), { wrapper });
+
+      await act(async () => {
+        await result.current.mutateAsync("key-delete");
+      });
+
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: authKeys.apiKeys(DEFAULT_ORG.public_id),
+      });
     });
   });
 });

--- a/crates/server/tests/org_lifecycle_test.rs
+++ b/crates/server/tests/org_lifecycle_test.rs
@@ -11,10 +11,11 @@
 
 mod test_harness;
 
+use axum::http::Method;
 use axum::http::StatusCode;
 use axum::http::header::SET_COOKIE;
 use serde_json::{Value, json};
-use test_harness::TestServer;
+use test_harness::{TestServer, extract_cookie};
 
 // ============================================
 // Bug regression: created org must appear in list
@@ -319,5 +320,185 @@ async fn test_switch_org_cookie_has_secure_flag() {
     assert!(
         org_cookie.contains("Secure"),
         "everruns_org cookie must have Secure flag, got: {org_cookie}"
+    );
+}
+
+#[tokio::test]
+async fn test_switch_org_cookie_lists_built_in_harnesses_for_fresh_org() {
+    let server = TestServer::in_memory().await;
+
+    let created_org: Value = server
+        .post("/v1/orgs", json!({"name": "Matrix Org"}))
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    let org_id = created_org["id"].as_str().expect("org id");
+
+    let switch_resp = server
+        .post("/v1/users/me/switch-org", json!({"org_id": org_id}))
+        .await
+        .assert_status(StatusCode::OK);
+    let org_cookie = extract_cookie(switch_resp.headers(), "everruns_org");
+
+    let switched_harnesses: Value = server
+        .request_raw(
+            Method::GET,
+            "/v1/harnesses",
+            vec![("cookie", org_cookie.as_str())],
+            vec![],
+        )
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    let switched_names: Vec<&str> = switched_harnesses["data"]
+        .as_array()
+        .expect("data array")
+        .iter()
+        .map(|item| item["name"].as_str().expect("harness name"))
+        .collect();
+    assert!(
+        switched_names.contains(&"base"),
+        "freshly created org should have base harness after switch"
+    );
+    assert!(
+        switched_names.contains(&"generic"),
+        "freshly created org should have generic harness after switch"
+    );
+}
+
+#[tokio::test]
+async fn test_switch_org_cookie_allows_creating_and_listing_harnesses() {
+    let server = TestServer::in_memory().await;
+
+    let created_org: Value = server
+        .post("/v1/orgs", json!({"name": "Scoped Harness Org"}))
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    let org_id = created_org["id"].as_str().expect("org id");
+
+    let switch_resp = server
+        .post("/v1/users/me/switch-org", json!({"org_id": org_id}))
+        .await
+        .assert_status(StatusCode::OK);
+    let org_cookie = extract_cookie(switch_resp.headers(), "everruns_org");
+
+    let created_harness: Value = server
+        .request_raw(
+            Method::POST,
+            "/v1/harnesses",
+            vec![
+                ("content-type", "application/json"),
+                ("cookie", org_cookie.as_str()),
+            ],
+            serde_json::to_vec(&json!({
+                "name": "matrix-org-harness",
+                "display_name": "Matrix Org Harness",
+                "system_prompt": "Test org-scoped harness"
+            }))
+            .expect("serialize harness request"),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    assert_eq!(created_harness["name"], "matrix-org-harness");
+
+    let switched_after_create: Value = server
+        .request_raw(
+            Method::GET,
+            "/v1/harnesses",
+            vec![("cookie", org_cookie.as_str())],
+            vec![],
+        )
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    assert!(
+        switched_after_create["data"]
+            .as_array()
+            .expect("data array")
+            .iter()
+            .any(|item| item["name"] == "matrix-org-harness"),
+        "switched org should see the harness created under its cookie scope"
+    );
+}
+
+#[tokio::test]
+async fn test_api_keys_remain_visible_across_active_org_switches() {
+    let server = TestServer::in_memory().await;
+
+    let default_key: Value = server
+        .post("/v1/auth/api-keys", json!({"name": "default-org-key"}))
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    let default_key_id = default_key["id"].as_str().expect("api key id");
+
+    let created_org: Value = server
+        .post("/v1/orgs", json!({"name": "API Key Org"}))
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    let org_id = created_org["id"].as_str().expect("org id");
+
+    let switch_resp = server
+        .post("/v1/users/me/switch-org", json!({"org_id": org_id}))
+        .await
+        .assert_status(StatusCode::OK);
+    let org_cookie = extract_cookie(switch_resp.headers(), "everruns_org");
+
+    let switched_list: Value = server
+        .request_raw(
+            Method::GET,
+            "/v1/auth/api-keys",
+            vec![("cookie", org_cookie.as_str())],
+            vec![],
+        )
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    assert!(
+        switched_list["data"]
+            .as_array()
+            .expect("data array")
+            .iter()
+            .any(|item| item["id"] == default_key_id),
+        "user-scoped API keys should stay visible after switching orgs"
+    );
+
+    let switched_key: Value = server
+        .request_raw(
+            Method::POST,
+            "/v1/auth/api-keys",
+            vec![
+                ("content-type", "application/json"),
+                ("cookie", org_cookie.as_str()),
+            ],
+            serde_json::to_vec(&json!({"name": "switched-org-key"}))
+                .expect("serialize api key request"),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    let switched_key_id = switched_key["id"].as_str().expect("api key id");
+
+    let default_list: Value = server
+        .get("/v1/auth/api-keys")
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    let default_ids: Vec<&str> = default_list["data"]
+        .as_array()
+        .expect("data array")
+        .iter()
+        .map(|item| item["id"].as_str().expect("api key id"))
+        .collect();
+    assert!(
+        default_ids.contains(&default_key_id),
+        "default-org list should keep pre-switch keys"
+    );
+    assert!(
+        default_ids.contains(&switched_key_id),
+        "keys created while another org is active should still be visible to the user"
     );
 }

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -38,6 +38,21 @@ use everruns_server::{
 };
 use everruns_worker::{RunnerBackend, create_runner_with_backend};
 
+pub fn extract_cookie(headers: &HeaderMap, name: &str) -> String {
+    headers
+        .get_all(axum::http::header::SET_COOKIE)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .find_map(|cookie| {
+            let prefix = format!("{name}=");
+            cookie
+                .strip_prefix(&prefix)
+                .and_then(|rest| rest.split(';').next())
+                .map(|value| format!("{name}={value}"))
+        })
+        .unwrap_or_else(|| panic!("{name} cookie must be set"))
+}
+
 async fn lookup_built_in_harness(db: &Arc<StorageBackend>, name: &str) -> String {
     use everruns_core::DEFAULT_ORG_ID;
     db.get_harness_by_name(DEFAULT_ORG_ID, name)
@@ -441,6 +456,12 @@ impl TestServer {
         if feature_flags.evals {
             api_routes = api_routes.merge(api::evals::routes(evals_state));
         }
+
+        api_routes = api_routes.merge(auth::api_key_routes(auth::ApiKeyState {
+            db: db.clone(),
+            auth: auth_state.clone(),
+            resource_limits: everruns_server::server::ResourceLimitsConfig::from_env(),
+        }));
 
         let root_routes = Router::new()
             .merge(api::mcp_endpoint::routes(mcp_endpoint_state))


### PR DESCRIPTION
## What
Expand org-scoped auth coverage across the server integration suite and the UI auth/org tests.

## Why
EVE-342 calls out a weak auth/org matrix after several follow-up fixes. The gaps were mostly around switched-org behavior, fresh-org provisioning assumptions, org-keyed UI cache behavior, and auth resume redirects.

## How
- add server integration coverage for switched-org harness access and API-key visibility across active-org changes
- mount auth API-key routes in the in-process `TestServer` so integration tests match the real app router
- add UI tests for org-keyed API-key caches, org-switch query invalidation, and `return_to` resume in the main layout

## Risk
- Low
- Test-only behavior changes plus test-harness route parity; no production runtime logic changed

## Security
- Threat categories reviewed: No security-relevant code changes; this PR only updates tests and aligns the in-process test harness with already-shipped route wiring.
- Findings and resolutions:
  - No new production threat surface introduced.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `cargo test -p everruns-server --test org_lifecycle_test`
- `cd apps/ui && ./node_modules/.bin/jest --runTestsByPath src/__tests__/use-auth.test.tsx src/__tests__/org-provider.test.tsx src/__tests__/main-layout-auth.test.tsx`
- `just pre-push`

Closes EVE-342.
