### PR TITLE
test(ci): wire runtime, CLI, and durable failpoint coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,8 @@ jobs:
       - name: Run pure unit tests
         run: |
           cargo test -p everruns-anthropic -p everruns-openai -p everruns-gemini -p everruns-internal-protocol -p everruns-core --lib --all-features
+          cargo test -p everruns-runtime --test in_process_runtime_test --test runtime_host_test -- --test-threads=1
+          cargo test -p everruns-cli --test auth_integration_test --test chat_integration_test --test files_integration_test -- --test-threads=1
           # Do not pass --all-features to integration crates: it enables their *-live-tests
           # features, which fail closed without real credentials. Live tests run in their
           # own dedicated jobs (e.g. `daytona-live-test`) that provide Doppler secrets.
@@ -385,6 +387,12 @@ jobs:
 
       - name: Run durable integration tests
         run: cargo test -p everruns-durable --test postgres_integration_test --test postgres_repository_test --features postgres-tests -- --test-threads=1
+
+      # `agent_reliability_test` was audited for EVE-349 but still fails on a
+      # clean PostgreSQL-backed run; keep it out of required CI until its
+      # restart/reclaim scenarios are stabilized.
+      - name: Run durable failpoint tests
+        run: cargo test -p everruns-durable --test failure_injection_test --features "failpoints,postgres-tests" -- --test-threads=1
 
       - name: Install Doppler CLI
         if: env.DOPPLER_TOKEN != ''

--- a/justfile
+++ b/justfile
@@ -58,24 +58,37 @@ test-unit:
     cargo test -p everruns-openai --lib --all-features
     cargo test -p everruns-internal-protocol --lib --all-features
     cargo test -p everruns-core --lib --all-features
+    cargo test -p everruns-runtime --test in_process_runtime_test --test runtime_host_test -- --test-threads=1
+    cargo test -p everruns-cli --test auth_integration_test --test chat_integration_test --test files_integration_test -- --test-threads=1
 
 # Run integration tests (requires PostgreSQL via start-infra or externally)
 test-integration: start-infra
     #!/usr/bin/env bash
     set -e
-    # Wait for postgres
-    for i in {1..30}; do
-        if pg_isready -h localhost -p "${DB_PORT:-9332}" -U everruns 2>/dev/null; then break; fi
-        sleep 1
-    done
+    if [ -z "${DATABASE_URL:-}" ]; then
+        DB_HOST="${DB_HOST:-localhost}"
+        DB_PORT="${DB_PORT:-${PORT_PREFIX:+${PORT_PREFIX}32}}"
+        DB_PORT="${DB_PORT:-9332}"
+        DB_USER="${DB_USER:-everruns}"
+        DB_NAME="${DB_NAME:-everruns_test}"
+        export DB_HOST DB_PORT DB_USER DB_NAME
+        export DATABASE_URL="postgres://everruns:everruns@${DB_HOST}:${DB_PORT}/${DB_NAME}"
+        # Wait for postgres
+        for i in {1..30}; do
+            if pg_isready -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" 2>/dev/null; then break; fi
+            sleep 1
+        done
+        createdb -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" "${DB_NAME}" 2>/dev/null || true
+    fi
     # Run migrations
-    sqlx migrate run --source crates/server/migrations 2>/dev/null || true
+    sqlx migrate run --source crates/server/migrations
     # Run tests
     cargo test -p everruns-server --lib
     cargo test -p everruns-server --test api_integration_test -- --test-threads=1
     cargo test -p everruns-server --test repository_integration_test -- --test-threads=1
     cargo test -p everruns-durable --test postgres_integration_test --features postgres-tests -- --test-threads=1
     cargo test -p everruns-durable --test postgres_repository_test --features postgres-tests -- --test-threads=1
+    cargo test -p everruns-durable --test failure_injection_test --features "failpoints,postgres-tests" -- --test-threads=1
 
 # Run workflow tests (requires running server + worker)
 test-workflow:

--- a/specs/agent-reliability-tests.md
+++ b/specs/agent-reliability-tests.md
@@ -4,6 +4,11 @@
 
 End-to-end reliability tests that verify agent execution survives infrastructure failures. Four failure domains: worker crashes, control plane restarts, worker↔CP network partitions, and CP↔DB network partitions.
 
+Status: audited in EVE-349. This binary is not part of required CI coverage
+yet because a clean PostgreSQL-backed run still fails several restart/reclaim
+scenarios; keep it as an explicit manual harness until those cases are
+stabilized.
+
 ## Goals
 
 1. Verify workflow completion when workers crash mid-task (stale reclamation path)
@@ -95,6 +100,10 @@ cargo test -p everruns-durable --test agent_reliability_test --features "failpoi
 # Specific scenario
 cargo test -p everruns-durable --test agent_reliability_test worker_crash --features "failpoints,postgres-tests"
 ```
+
+These tests are still manual reliability harnesses. Do not claim durable
+recovery coverage from CI until this binary passes consistently under a clean
+PostgreSQL-backed run.
 
 ## Decisions
 

--- a/specs/code-organization.md
+++ b/specs/code-organization.md
@@ -81,8 +81,12 @@ Tests are organized by dependency requirements and execution speed:
 - `everruns-openai` - LLM client SDK, request/response parsing
 - `everruns-internal-protocol` - Protobuf definitions
 - `everruns-core` - Agent logic, tool handling, prompt building
+- `everruns-runtime` - in-process runtime and shared host-phase orchestration
+- `everruns-cli` - subprocess integration tests for help text, auth profile handling, and file-sync argument validation
 
-Note: `everruns-cli` is binary-only (no lib target) and tested via CLI E2E tests.
+Note: `everruns-cli` is binary-only (no lib target). Keep its lightweight subprocess
+coverage in `crates/cli/tests/*.rs`; use CLI E2E tests for full round-trip flows
+against a running server.
 
 **What to test:**
 - Serialization/deserialization
@@ -103,6 +107,8 @@ just test-unit  # Runs in ~30s, no Docker needed
 - `crates/server/tests/repository_integration_test.rs` - Direct repository layer tests
 - `crates/durable/tests/postgres_integration_test.rs` - Durable execution task queue, workflows
 - `crates/durable/tests/postgres_repository_test.rs` - Durable SQL queries, circuit breakers
+- `crates/durable/tests/failure_injection_test.rs` - fail-rs rollback and retry coverage (`failpoints,postgres-tests`)
+- `crates/durable/tests/agent_reliability_test.rs` - manual executor/store reliability harness; not CI-gated until the restart/reclaim scenarios pass cleanly
 
 **What to test:**
 - CRUD operations for all entities

--- a/specs/fail-rs-testing.md
+++ b/specs/fail-rs-testing.md
@@ -100,11 +100,14 @@ async fn test_failure_scenario() {
 
 ```bash
 # Run all failure injection tests
-cargo test -p everruns-durable --test failure_injection_test --features failpoints -- --test-threads=1
+cargo test -p everruns-durable --test failure_injection_test --features "failpoints,postgres-tests" -- --test-threads=1
 
 # Run specific test
-cargo test -p everruns-durable --test failure_injection_test test_append_events_failure --features failpoints
+cargo test -p everruns-durable --test failure_injection_test test_append_events_failure --features "failpoints,postgres-tests"
 ```
+
+These tests are expected to run in CI anywhere PostgreSQL-backed durable
+integration coverage runs; do not leave them as manual-only coverage.
 
 ## Decisions
 

--- a/specs/runtime.md
+++ b/specs/runtime.md
@@ -228,6 +228,18 @@ This spec does not require runtime to own:
 
 Those remain separate concerns outside the runtime host orchestration contract.
 
+## Validation
+
+The in-process runtime contract is regression-tested in CI with the pure Rust
+test binaries in `crates/runtime/tests/`.
+
+- `crates/runtime/tests/in_process_runtime_test.rs` proves embedded runtimes
+  can execute turns, persist message history, seed files, and emit the shared
+  event shapes without PostgreSQL or worker infrastructure.
+- `crates/runtime/tests/runtime_host_test.rs` proves the reusable host adapter
+  contract drives `input -> reason -> act` planning and lifecycle state changes
+  for server-backed or durable hosts.
+
 ## Source Index
 
 - `crates/runtime/src/lib.rs`


### PR DESCRIPTION
## What
Wire the uninvoked runtime, CLI, and durable failpoint test binaries into maintained coverage, and document the audited status of the durable reliability harness.

## Why
EVE-349 called out dead coverage zones where runtime, CLI, and durable regression tests existed in-tree but were not exercised by CI or the default local validation path.

## How
- add `everruns-runtime` and `everruns-cli` integration-style test binaries to the CI unit-test job and `just test-unit`
- add `failure_injection_test` to the PostgreSQL-backed CI/local integration path
- make `just test-integration` honor `PORT_PREFIX`, create its test database, and fail loudly on migration errors instead of silently continuing
- update specs to document the runtime/failpoint coverage and record that `agent_reliability_test` was audited but is still manual because it fails under a clean PostgreSQL-backed run

## Risk
- Low
- Main risk is CI/runtime cost from the added test invocations; no production code paths changed

## Security
- Threat categories reviewed: No security-relevant code changes; this patch only touches CI wiring, local test recipes, and specs
- Findings and resolutions:
  - No auth, data-path, command-execution, or network trust-boundary behavior changed in shipped code

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
