### PR TITLE
fix(runtime): unify overlay capability execution path

### DIFF
--- a/.github/scripts/sdk-compat/resolve-harness-id.sh
+++ b/.github/scripts/sdk-compat/resolve-harness-id.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_url="${1:?usage: resolve-harness-id.sh <base_url> <api_key> [harness_name] [timeout_seconds]}"
+api_key="${2:?usage: resolve-harness-id.sh <base_url> <api_key> [harness_name] [timeout_seconds]}"
+harness_name="${3:-generic}"
+timeout_seconds="${4:-30}"
+
+deadline=$((SECONDS + timeout_seconds))
+
+while (( SECONDS < deadline )); do
+  if response="$(curl -fsS -H "Authorization: Bearer $api_key" "$base_url/v1/harnesses/$harness_name" 2>/dev/null)"; then
+    python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])' <<<"$response"
+    exit 0
+  fi
+
+  sleep 1
+done
+
+echo "Timed out waiting for harness '$harness_name' at $base_url/v1/harnesses/$harness_name" >&2
+exit 1

--- a/.github/scripts/sdk-compat/test-python.sh
+++ b/.github/scripts/sdk-compat/test-python.sh
@@ -14,9 +14,10 @@ source "$workdir/.venv/bin/activate"
 pip install --quiet "everruns-sdk==$version"
 
 # Resolve the Generic harness by name — UUIDs are assigned at DB seed time
-# and are no longer stable across deployments.
-harness_id="$(curl -fsS -H "Authorization: Bearer $api_key" "$base_url/v1/harnesses/generic" \
-  | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
+# and are no longer stable across deployments. Built-in harness seeding
+# happens after server startup, so wait for it explicitly instead of assuming
+# /health implies the harness is already queryable.
+harness_id="$("$(dirname "$0")/resolve-harness-id.sh" "$base_url" "$api_key")"
 
 EVERRUNS_BASE_URL="$base_url" EVERRUNS_API_KEY="$api_key" EVERRUNS_HARNESS_ID="$harness_id" SDK_VERSION="$version" python3 - <<'PY'
 import asyncio

--- a/.github/scripts/sdk-compat/test-rust.sh
+++ b/.github/scripts/sdk-compat/test-rust.sh
@@ -9,9 +9,10 @@ workdir="$(mktemp -d)"
 trap 'rm -rf "$workdir"' EXIT
 
 # Resolve the Generic harness by name — UUIDs are assigned at DB seed time
-# and are no longer stable across deployments.
-harness_id="$(curl -fsS -H "Authorization: Bearer $api_key" "$base_url/v1/harnesses/generic" \
-  | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
+# and are no longer stable across deployments. Built-in harness seeding
+# happens after server startup, so wait for it explicitly instead of assuming
+# /health implies the harness is already queryable.
+harness_id="$("$(dirname "$0")/resolve-harness-id.sh" "$base_url" "$api_key")"
 
 cargo new --quiet --bin "$workdir/smoke"
 

--- a/.github/scripts/sdk-compat/test-typescript.sh
+++ b/.github/scripts/sdk-compat/test-typescript.sh
@@ -9,9 +9,10 @@ workdir="$(mktemp -d)"
 trap 'rm -rf "$workdir"' EXIT
 
 # Resolve the Generic harness by name — UUIDs are assigned at DB seed time
-# and are no longer stable across deployments.
-harness_id="$(curl -fsS -H "Authorization: Bearer $api_key" "$base_url/v1/harnesses/generic" \
-  | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
+# and are no longer stable across deployments. Built-in harness seeding
+# happens after server startup, so wait for it explicitly instead of assuming
+# /health implies the harness is already queryable.
+harness_id="$("$(dirname "$0")/resolve-harness-id.sh" "$base_url" "$api_key")"
 
 cat > "$workdir/package.json" <<JSON
 {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -140,7 +140,10 @@ pub use message_filter::{
 };
 pub use message_retriever::{InputMessage, MessageRetriever};
 pub use runtime_agent::{RuntimeAgent, RuntimeAgentBuilder};
-pub use runtime_context::{AssembledTurnContext, assemble_turn_context, inspect_turn_context};
+pub use runtime_context::{
+    AssembledTurnContext, ResolvedRuntimeCapabilities, assemble_turn_context, inspect_turn_context,
+    resolve_runtime_capabilities,
+};
 pub use traits::{
     EventEmitter, HarnessStore, ImageResolver, KeyInfo, LeasedResourceStore, LlmProviderStore,
     ModelWithProvider, NoopEventEmitter, ResolvedImage, SecretInfo, SessionFileStore,

--- a/crates/core/src/runtime_context.rs
+++ b/crates/core/src/runtime_context.rs
@@ -53,6 +53,15 @@ pub struct AssembledTurnContext {
     pub compaction_config: Option<CompactionConfig>,
 }
 
+/// Shared capability-resolution result for runtime execution.
+#[derive(Debug, Clone)]
+pub struct ResolvedRuntimeCapabilities {
+    /// Effective overlay after merging harness chain -> agent -> session.
+    pub effective_overlay: AgentConfigOverlay,
+    /// Capability configs after dependency resolution.
+    pub resolved_capability_configs: Vec<AgentCapabilityConfig>,
+}
+
 /// Assemble the shared reason-phase context for a turn.
 #[allow(clippy::too_many_arguments)]
 pub async fn assemble_turn_context(
@@ -162,15 +171,15 @@ async fn assemble_turn_context_with_mode(
         .await?
         .ok_or_else(|| AgentLoopError::session_not_found(session_id))?;
 
-    let effective_overlay = {
-        let mut layers: Vec<AgentConfigOverlay> =
-            harness_chain.iter().map(AgentConfigOverlay::from).collect();
-        if let Some(ref agent) = agent {
-            layers.push(AgentConfigOverlay::from(agent));
-        }
-        layers.push(AgentConfigOverlay::from(&session));
-        AgentConfigOverlay::fold(layers)
-    };
+    let ResolvedRuntimeCapabilities {
+        effective_overlay,
+        resolved_capability_configs,
+    } = resolve_runtime_capabilities(
+        &harness_chain,
+        agent.as_ref(),
+        &session,
+        capability_registry,
+    );
 
     let message_filters = crate::capabilities::collect_message_filters_only(
         &effective_overlay.capabilities,
@@ -197,16 +206,6 @@ async fn assemble_turn_context_with_mode(
         effective_overlay.default_model_id,
     )
     .await?;
-
-    let resolved_capability_configs =
-        resolve_capability_configs(&effective_overlay.capabilities, capability_registry)
-            .unwrap_or_else(|error| {
-                tracing::warn!(
-                    error = ?error,
-                    "failed to resolve capability configs; falling back to overlay capabilities"
-                );
-                effective_overlay.capabilities.clone()
-            });
 
     let resolved_locale = extract_locale_override(&messages).or_else(|| session.locale.clone());
     let prompt_ctx = SystemPromptContext {
@@ -245,6 +244,37 @@ async fn assemble_turn_context_with_mode(
         resolved_locale,
         compaction_config,
     })
+}
+
+/// Resolve the merged overlay and dependency-expanded capability configs for a runtime session.
+pub fn resolve_runtime_capabilities(
+    harness_chain: &[Harness],
+    agent: Option<&Agent>,
+    session: &Session,
+    capability_registry: &CapabilityRegistry,
+) -> ResolvedRuntimeCapabilities {
+    let harness_layers = harness_chain.iter().map(AgentConfigOverlay::from);
+    let agent_layers = agent.into_iter().map(AgentConfigOverlay::from);
+    let effective_overlay = AgentConfigOverlay::fold(
+        harness_layers
+            .chain(agent_layers)
+            .chain([AgentConfigOverlay::from(session)]),
+    );
+
+    let resolved_capability_configs =
+        resolve_capability_configs(&effective_overlay.capabilities, capability_registry)
+            .unwrap_or_else(|error| {
+                tracing::warn!(
+                    error = ?error,
+                    "failed to resolve capability configs; falling back to overlay capabilities"
+                );
+                effective_overlay.capabilities.clone()
+            });
+
+    ResolvedRuntimeCapabilities {
+        effective_overlay,
+        resolved_capability_configs,
+    }
 }
 
 async fn build_runtime_agent(

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -7,6 +7,7 @@ use everruns_core::atoms::{
     ActAtom, ActInput, ActResult, Atom, InputAtom, InputAtomInput, InputAtomResult, ReasonAtom,
     ReasonInput, ReasonResult,
 };
+use everruns_core::capabilities::{SystemPromptContext, collect_capabilities_with_configs};
 use everruns_core::events::{
     EventContext, EventRequest, OutputMessageCompletedData, SessionActivatedData, SessionIdledData,
     TurnCompletedData, TurnFailedData, TurnStartedData,
@@ -24,7 +25,7 @@ use everruns_core::traits::{
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
 use everruns_core::{
     Agent, CapabilityRegistry, DependencyBlocker, DriverRegistry, Harness, Session, TokenUsage,
-    ToolDefinition, ToolRegistry, org_public_id_from_internal,
+    ToolDefinition, ToolRegistry, org_public_id_from_internal, resolve_runtime_capabilities,
 };
 use std::sync::Arc;
 use tracing::warn;
@@ -184,18 +185,6 @@ pub trait RuntimeHostAdapter: Send + Sync + Clone + 'static {
 
     fn driver_registry(&self) -> DriverRegistry;
 
-    async fn build_tool_registry_for_agent(
-        &self,
-        org_id: i64,
-        agent_id: AgentId,
-    ) -> everruns_core::error::Result<ToolRegistry>;
-
-    async fn build_tool_registry_for_harness(
-        &self,
-        org_id: i64,
-        harness_id: HarnessId,
-    ) -> everruns_core::error::Result<ToolRegistry>;
-
     fn harness_store(&self, org_id: i64) -> Arc<dyn HarnessStore>;
 
     fn agent_store(&self, org_id: i64) -> Arc<dyn AgentStore>;
@@ -263,72 +252,104 @@ pub trait RuntimeHostAdapter: Send + Sync + Clone + 'static {
     ) -> Option<Arc<dyn BudgetChecker>> {
         None
     }
+}
 
-    async fn build_tool_registry(
-        &self,
-        org_id: i64,
-        harness_id: HarnessId,
-        agent_id: Option<AgentId>,
-        blueprint_id: Option<&str>,
-    ) -> everruns_core::error::Result<ToolRegistry> {
-        if let Some(blueprint_id) = blueprint_id {
-            let mut registry = ToolRegistry::with_defaults();
-            let capability_registry = self.capability_registry();
-            let blueprint = capability_registry.blueprint(blueprint_id).ok_or_else(|| {
-                everruns_core::error::AgentLoopError::config(format!(
-                    "Blueprint \"{blueprint_id}\" not found in registry"
-                ))
-            })?;
-            for tool in blueprint.tools {
-                registry.register_boxed(tool);
-            }
-            return Ok(registry);
-        }
+struct RuntimeExecutionCapabilities {
+    tool_registry: ToolRegistry,
+    post_tool_hooks: Vec<Arc<dyn everruns_core::PostToolExecHook>>,
+}
 
-        match agent_id {
-            Some(agent_id) => self.build_tool_registry_for_agent(org_id, agent_id).await,
-            None => {
-                self.build_tool_registry_for_harness(org_id, harness_id)
-                    .await
-            }
+async fn load_execution_capabilities<A: RuntimeHostAdapter>(
+    adapter: &A,
+    org_id: i64,
+    session_id: SessionId,
+    harness_id: HarnessId,
+    agent_id: Option<AgentId>,
+    locale: Option<String>,
+    blueprint_id: Option<&str>,
+) -> everruns_core::error::Result<RuntimeExecutionCapabilities> {
+    let capability_registry = adapter.capability_registry();
+    if let Some(blueprint_id) = blueprint_id {
+        let mut registry = ToolRegistry::with_defaults();
+        let blueprint = capability_registry.blueprint(blueprint_id).ok_or_else(|| {
+            everruns_core::error::AgentLoopError::config(format!(
+                "Blueprint \"{blueprint_id}\" not found in registry"
+            ))
+        })?;
+        for tool in blueprint.tools {
+            registry.register_boxed(tool);
         }
+        return Ok(RuntimeExecutionCapabilities {
+            tool_registry: registry,
+            post_tool_hooks: Vec::new(),
+        });
     }
 
-    async fn post_tool_hooks(
-        &self,
-        org_id: i64,
-        harness_id: HarnessId,
-        agent_id: Option<AgentId>,
-        blueprint_id: Option<&str>,
-    ) -> everruns_core::error::Result<Vec<Arc<dyn everruns_core::PostToolExecHook>>> {
-        if blueprint_id.is_some() {
-            return Ok(Vec::new());
-        }
-
-        let capability_registry = self.capability_registry();
-        let capability_configs = match agent_id {
-            Some(agent_id) => self
-                .get_agent(org_id, agent_id)
-                .await?
-                .map(|agent| agent.capabilities)
-                .unwrap_or_default(),
-            None => self
-                .get_harness(org_id, harness_id)
-                .await?
-                .map(|harness| harness.capabilities)
-                .unwrap_or_default(),
-        };
-
-        Ok(capability_configs
-            .iter()
-            .flat_map(|config| {
-                capability_registry
-                    .get(config.capability_id())
-                    .map(|capability| capability.post_tool_exec_hooks())
-                    .unwrap_or_default()
-            })
-            .collect())
+    let harness_chain = adapter
+        .harness_store(org_id)
+        .get_harness_chain(harness_id)
+        .await?;
+    if harness_chain.is_empty() {
+        return Err(everruns_core::error::AgentLoopError::harness_not_found(
+            harness_id,
+        ));
     }
+
+    let session = adapter
+        .session_store(org_id)
+        .get_session(session_id)
+        .await?
+        .ok_or_else(|| everruns_core::error::AgentLoopError::session_not_found(session_id))?;
+
+    let agent_store = adapter.agent_store(org_id);
+    let agent = match agent_id {
+        Some(agent_id) => Some(
+            agent_store
+                .get_agent(agent_id)
+                .await?
+                .ok_or_else(|| everruns_core::error::AgentLoopError::agent_not_found(agent_id))?,
+        ),
+        None => None,
+    };
+
+    let resolved = resolve_runtime_capabilities(
+        &harness_chain,
+        agent.as_ref(),
+        &session,
+        &capability_registry,
+    );
+    let prompt_ctx = SystemPromptContext {
+        session_id,
+        locale: locale.or(session.locale.clone()),
+        file_store: Some(adapter.file_store()),
+    };
+    let collected = collect_capabilities_with_configs(
+        &resolved.resolved_capability_configs,
+        &capability_registry,
+        &prompt_ctx,
+    )
+    .await;
+
+    let mut registry = ToolRegistry::with_defaults();
+    for tool in collected.tools {
+        registry.register_boxed(tool);
+    }
+
+    let post_tool_hooks = resolved
+        .resolved_capability_configs
+        .iter()
+        .flat_map(|config| {
+            capability_registry
+                .get(config.capability_id())
+                .map(|capability| capability.post_tool_exec_hooks())
+                .unwrap_or_default()
+        })
+        .collect();
+
+    Ok(RuntimeExecutionCapabilities {
+        tool_registry: registry,
+        post_tool_hooks,
+    })
 }
 
 /// Shared lifecycle helper for runtime-backed hosts.
@@ -657,14 +678,17 @@ pub async fn execute_act_activity<A: RuntimeHostAdapter>(
         });
     }
 
-    let tool_registry = adapter
-        .build_tool_registry(
-            org_id,
-            input.harness_id,
-            input.agent_id,
-            input.blueprint_id.as_deref(),
-        )
-        .await?;
+    let execution_capabilities = load_execution_capabilities(
+        adapter,
+        org_id,
+        input.context.session_id,
+        input.harness_id,
+        input.agent_id,
+        input.locale.clone(),
+        input.blueprint_id.as_deref(),
+    )
+    .await?;
+    let tool_registry = execution_capabilities.tool_registry;
     let builtin_tool_registry = Arc::new(tool_registry.clone());
 
     let mut atom = ActAtom::with_file_store(
@@ -682,16 +706,7 @@ pub async fn execute_act_activity<A: RuntimeHostAdapter>(
             .expect("internal org id converts to valid public org id"),
     )
     .with_capability_registry(adapter.capability_registry())
-    .with_post_tool_hooks(
-        adapter
-            .post_tool_hooks(
-                org_id,
-                input.harness_id,
-                input.agent_id,
-                input.blueprint_id.as_deref(),
-            )
-            .await?,
-    );
+    .with_post_tool_hooks(execution_capabilities.post_tool_hooks);
 
     if let Some(storage_store) = adapter.storage_store() {
         atom = atom.with_storage_store(storage_store);

--- a/crates/runtime/tests/runtime_host_test.rs
+++ b/crates/runtime/tests/runtime_host_test.rs
@@ -1,10 +1,12 @@
 use async_trait::async_trait;
 use chrono::Utc;
 use everruns_core::MessageRetriever;
+use everruns_core::ToolContext;
 use everruns_core::atoms::ReasonResult;
 use everruns_core::atoms::{ActInput, AtomContext, InputAtomInput};
 use everruns_core::capabilities::{
-    MemoryCapability, SystemPromptContext, TestMathCapability, collect_capabilities_with_configs,
+    Capability, CapabilityStatus, MemoryCapability, SystemPromptContext, TestMathCapability,
+    collect_capabilities_with_configs,
 };
 use everruns_core::llm_driver_registry::DriverRegistry;
 use everruns_core::memory::{
@@ -18,14 +20,16 @@ use everruns_core::traits::{
 };
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
 use everruns_core::{
-    Agent, AgentCapabilityConfig, CapabilityRegistry, EventData, Harness, HarnessStatus,
-    InputMessage, Session, SessionStatus, ToolCall, ToolRegistry,
+    Agent, AgentCapabilityConfig, AgentStatus, CapabilityRegistry, EventData, Harness,
+    HarnessStatus, InputMessage, LlmProviderType, ModelWithProvider, Session, SessionStatus, Tool,
+    ToolCall, ToolExecutionResult, ToolRegistry, ToolResult, inspect_turn_context,
 };
 use everruns_runtime::{
     InMemorySessionFileStore, RuntimeHostAdapter, RuntimeHostTurnContext, RuntimeSessionLifecycle,
     RuntimeTurnPlan, RuntimeTurnState, execute_act_activity, execute_input_activity,
     plan_next_host_turn,
 };
+use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -146,44 +150,6 @@ impl RuntimeHostAdapter for MockHostAdapter {
         self.driver_registry.clone()
     }
 
-    async fn build_tool_registry_for_agent(
-        &self,
-        _org_id: i64,
-        agent_id: AgentId,
-    ) -> everruns_core::error::Result<ToolRegistry> {
-        let agent = self
-            .agent_store
-            .get_agent(agent_id)
-            .await?
-            .expect("agent exists");
-        build_registry(
-            &self.capability_registry,
-            SessionId::new(),
-            &agent.capabilities,
-        )
-        .await
-    }
-
-    async fn build_tool_registry_for_harness(
-        &self,
-        _org_id: i64,
-        harness_id: HarnessId,
-    ) -> everruns_core::error::Result<ToolRegistry> {
-        let harness = self
-            .harness_store
-            .get_harness_chain(harness_id)
-            .await?
-            .into_iter()
-            .last()
-            .expect("harness exists");
-        build_registry(
-            &self.capability_registry,
-            SessionId::new(),
-            &harness.capabilities,
-        )
-        .await
-    }
-
     fn harness_store(&self, _org_id: i64) -> Arc<dyn HarnessStore> {
         self.harness_store.clone()
     }
@@ -234,6 +200,109 @@ async fn build_registry(
         registry.register_boxed(tool);
     }
     Ok(registry)
+}
+
+struct OverlayEchoTool;
+
+#[async_trait]
+impl Tool for OverlayEchoTool {
+    fn name(&self) -> &str {
+        "overlay_echo"
+    }
+
+    fn description(&self) -> &str {
+        "Returns the provided value."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "value": {"type": "string"}
+            },
+            "required": ["value"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, arguments: serde_json::Value) -> ToolExecutionResult {
+        ToolExecutionResult::success(json!({
+            "value": arguments["value"].as_str().unwrap_or_default(),
+        }))
+    }
+}
+
+struct OverlayHook;
+
+#[async_trait]
+impl everruns_core::atoms::PostToolExecHook for OverlayHook {
+    async fn after_exec(
+        &self,
+        _tool_call: &ToolCall,
+        _tool_def: &everruns_core::ToolDefinition,
+        result: &mut ToolResult,
+        _context: &ToolContext,
+    ) {
+        if let Some(value) = result
+            .result
+            .as_mut()
+            .and_then(|value| value.as_object_mut())
+        {
+            value.insert("hooked".to_string(), json!(true));
+        }
+    }
+}
+
+struct OverlayEchoCapability;
+
+impl Capability for OverlayEchoCapability {
+    fn id(&self) -> &str {
+        "overlay_echo"
+    }
+
+    fn name(&self) -> &str {
+        "Overlay Echo"
+    }
+
+    fn description(&self) -> &str {
+        "Test capability that contributes a tool and a post-tool hook."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![Box::new(OverlayEchoTool)]
+    }
+
+    fn post_tool_exec_hooks(&self) -> Vec<Arc<dyn everruns_core::atoms::PostToolExecHook>> {
+        vec![Arc::new(OverlayHook)]
+    }
+}
+
+struct OverlayAliasCapability;
+
+impl Capability for OverlayAliasCapability {
+    fn id(&self) -> &str {
+        "overlay_alias"
+    }
+
+    fn name(&self) -> &str {
+        "Overlay Alias"
+    }
+
+    fn description(&self) -> &str {
+        "Test capability that depends on overlay_echo."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn dependencies(&self) -> Vec<&'static str> {
+        vec!["overlay_echo"]
+    }
 }
 
 fn harness(harness_id: HarnessId) -> Harness {
@@ -302,6 +371,31 @@ fn session(session_id: SessionId, harness_id: HarnessId) -> Session {
     }
 }
 
+fn agent(agent_id: AgentId, capabilities: Vec<AgentCapabilityConfig>) -> Agent {
+    Agent {
+        public_id: agent_id,
+        internal_id: Uuid::nil(),
+        name: "test-agent".into(),
+        display_name: Some("Test Agent".into()),
+        description: None,
+        system_prompt: "Use tools when needed.".into(),
+        default_model_id: None,
+        tags: vec![],
+        capabilities,
+        initial_files: vec![],
+        network_access: None,
+        max_iterations: Some(8),
+        tools: vec![],
+        mcp_servers: Default::default(),
+        status: AgentStatus::Active,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        archived_at: None,
+        deleted_at: None,
+        usage: None,
+    }
+}
+
 fn turn_state(session_id: SessionId, harness_id: HarnessId) -> RuntimeTurnState {
     RuntimeTurnState {
         org_id: 1,
@@ -331,6 +425,43 @@ fn mock_host() -> MockHostAdapter {
         file_store: Arc::new(InMemorySessionFileStore::new()),
         memory_store: None,
     }
+}
+
+async fn set_default_model(adapter: &MockHostAdapter) {
+    adapter
+        .provider_store
+        .set_default_model(ModelWithProvider {
+            model: "llmsim-model".into(),
+            provider_type: LlmProviderType::LlmSim,
+            api_key: None,
+            base_url: None,
+        })
+        .await;
+}
+
+async fn reason_tool_definitions(
+    adapter: &MockHostAdapter,
+    session_id: SessionId,
+    harness_id: HarnessId,
+    agent_id: Option<AgentId>,
+) -> Vec<everruns_core::ToolDefinition> {
+    inspect_turn_context(
+        adapter.harness_store.as_ref(),
+        adapter.agent_store.as_ref(),
+        adapter.session_store.as_ref(),
+        adapter.message_store.as_ref(),
+        adapter.provider_store.as_ref(),
+        &adapter.capability_registry,
+        session_id,
+        harness_id,
+        agent_id,
+        &[],
+        Some(adapter.file_store.clone()),
+    )
+    .await
+    .expect("reason context")
+    .runtime_agent
+    .tools
 }
 
 #[tokio::test]
@@ -428,6 +559,205 @@ async fn act_activity_executes_capability_tools_from_harness_registry() {
     assert_eq!(result.success_count, 1);
     assert_eq!(result.error_count, 0);
     assert_eq!(result.results.len(), 1);
+}
+
+#[tokio::test]
+async fn act_activity_agent_session_executes_harness_overlay_tools_from_reason_path() {
+    let mut adapter = mock_host();
+    adapter.capability_registry.register(OverlayEchoCapability);
+    set_default_model(&adapter).await;
+
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    let agent_id = AgentId::from_uuid(Uuid::now_v7());
+    let input_message_id = MessageId::from_uuid(Uuid::now_v7());
+
+    adapter
+        .harness_store
+        .add_harness(Harness {
+            capabilities: vec![AgentCapabilityConfig::new("overlay_echo")],
+            ..harness(harness_id)
+        })
+        .await;
+    adapter.agent_store.add_agent(agent(agent_id, vec![])).await;
+    adapter
+        .session_store
+        .insert(Session {
+            agent_id: Some(agent_id),
+            ..session(session_id, harness_id)
+        })
+        .await;
+
+    let result = execute_act_activity(
+        &adapter,
+        ActInput {
+            org_id: Some(1),
+            context: AtomContext::new(
+                session_id,
+                TurnId::from_uuid(Uuid::now_v7()),
+                input_message_id,
+            ),
+            harness_id,
+            agent_id: Some(agent_id),
+            tool_calls: vec![ToolCall {
+                id: "call_overlay_echo".into(),
+                name: "overlay_echo".into(),
+                arguments: json!({"value": "merged"}),
+            }],
+            tool_definitions: reason_tool_definitions(
+                &adapter,
+                session_id,
+                harness_id,
+                Some(agent_id),
+            )
+            .await,
+            locale: None,
+            blueprint_id: None,
+            network_access: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.success_count, 1);
+    assert_eq!(result.error_count, 0);
+    assert_eq!(
+        result.results[0].result.result.as_ref().unwrap()["value"],
+        "merged"
+    );
+}
+
+#[tokio::test]
+async fn act_activity_agent_session_resolves_transitive_overlay_capabilities() {
+    let mut adapter = mock_host();
+    adapter.capability_registry.register(OverlayEchoCapability);
+    adapter.capability_registry.register(OverlayAliasCapability);
+    set_default_model(&adapter).await;
+
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    let agent_id = AgentId::from_uuid(Uuid::now_v7());
+    let input_message_id = MessageId::from_uuid(Uuid::now_v7());
+
+    adapter
+        .harness_store
+        .add_harness(Harness {
+            capabilities: vec![AgentCapabilityConfig::new("overlay_alias")],
+            ..harness(harness_id)
+        })
+        .await;
+    adapter.agent_store.add_agent(agent(agent_id, vec![])).await;
+    adapter
+        .session_store
+        .insert(Session {
+            agent_id: Some(agent_id),
+            ..session(session_id, harness_id)
+        })
+        .await;
+
+    let result = execute_act_activity(
+        &adapter,
+        ActInput {
+            org_id: Some(1),
+            context: AtomContext::new(
+                session_id,
+                TurnId::from_uuid(Uuid::now_v7()),
+                input_message_id,
+            ),
+            harness_id,
+            agent_id: Some(agent_id),
+            tool_calls: vec![ToolCall {
+                id: "call_overlay_dep".into(),
+                name: "overlay_echo".into(),
+                arguments: json!({"value": "dependency"}),
+            }],
+            tool_definitions: reason_tool_definitions(
+                &adapter,
+                session_id,
+                harness_id,
+                Some(agent_id),
+            )
+            .await,
+            locale: None,
+            blueprint_id: None,
+            network_access: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.success_count, 1);
+    assert_eq!(result.error_count, 0);
+    assert_eq!(
+        result.results[0].result.result.as_ref().unwrap()["value"],
+        "dependency"
+    );
+}
+
+#[tokio::test]
+async fn act_activity_agent_session_runs_post_tool_hooks_from_merged_overlay() {
+    let mut adapter = mock_host();
+    adapter.capability_registry.register(OverlayEchoCapability);
+    set_default_model(&adapter).await;
+
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    let agent_id = AgentId::from_uuid(Uuid::now_v7());
+    let input_message_id = MessageId::from_uuid(Uuid::now_v7());
+
+    adapter
+        .harness_store
+        .add_harness(Harness {
+            capabilities: vec![AgentCapabilityConfig::new("overlay_echo")],
+            ..harness(harness_id)
+        })
+        .await;
+    adapter.agent_store.add_agent(agent(agent_id, vec![])).await;
+    adapter
+        .session_store
+        .insert(Session {
+            agent_id: Some(agent_id),
+            ..session(session_id, harness_id)
+        })
+        .await;
+
+    let result = execute_act_activity(
+        &adapter,
+        ActInput {
+            org_id: Some(1),
+            context: AtomContext::new(
+                session_id,
+                TurnId::from_uuid(Uuid::now_v7()),
+                input_message_id,
+            ),
+            harness_id,
+            agent_id: Some(agent_id),
+            tool_calls: vec![ToolCall {
+                id: "call_overlay_hook".into(),
+                name: "overlay_echo".into(),
+                arguments: json!({"value": "hook"}),
+            }],
+            tool_definitions: reason_tool_definitions(
+                &adapter,
+                session_id,
+                harness_id,
+                Some(agent_id),
+            )
+            .await,
+            locale: None,
+            blueprint_id: None,
+            network_access: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.success_count, 1);
+    assert_eq!(result.error_count, 0);
+    assert_eq!(
+        result.results[0].result.result.as_ref().unwrap()["hooked"],
+        true
+    );
 }
 
 #[tokio::test]

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -8,10 +8,7 @@
 
 use async_trait::async_trait;
 use everruns_core::budget::{BudgetSummary, BudgetToolResponse};
-use everruns_core::capabilities::{
-    AgentCapabilityConfig, CapabilityRegistry, SystemPromptContext, collect_capabilities,
-    is_mcp_capability,
-};
+use everruns_core::capabilities::{AgentCapabilityConfig, CapabilityRegistry};
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::events::{Event, EventRequest};
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
@@ -22,7 +19,7 @@ use everruns_core::traits::{
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId};
 use everruns_core::{
     Agent, AgentStatus, Caller, ContentPart, DriverRegistry, EventData, Harness, HarnessStatus,
-    LlmProviderType, Message, MessageRole, Session, SessionStatus, ToolDefinition, ToolRegistry,
+    LlmProviderType, Message, MessageRole, Session, SessionStatus, ToolDefinition,
     ToolResultContentPart, merge_harness,
 };
 use everruns_worker::mcp_executor::McpServerInfo;
@@ -1425,31 +1422,6 @@ impl WorkerAdapters for DirectWorkerAdapters {
             })?
             .is_some())
     }
-
-    async fn build_tool_registry(&self, org_id: i64, agent_id: Uuid) -> Result<ToolRegistry> {
-        // Resolve public UUID → internal UUID for capability lookup (org-scoped)
-        let public_id = AgentId::from_uuid(agent_id).to_string();
-        let capability_rows = match self
-            .db
-            .get_agent_by_public_id(org_id, &public_id)
-            .await
-            .map_err(|e| {
-                tracing::error!("Failed to resolve agent: {}", e);
-                store_error("Failed to resolve agent")
-            })? {
-            Some(row) => self
-                .db
-                .get_agent_capabilities(row.id.uuid())
-                .await
-                .map_err(|e| {
-                    tracing::error!("Failed to get agent capabilities: {}", e);
-                    store_error("Failed to get agent capabilities")
-                })?,
-            None => vec![],
-        };
-        self.build_tool_registry_with_capabilities(&capability_rows)
-            .await
-    }
 }
 
 impl DirectWorkerAdapters {
@@ -1569,39 +1541,6 @@ impl DirectWorkerAdapters {
             deleted_at: r.deleted_at,
             usage: None,
         }
-    }
-
-    /// Build a tool registry from pre-loaded capability rows.
-    ///
-    /// Shared logic for `build_tool_registry` (standalone, loads its own rows)
-    /// and `load_turn_context` (passes pre-loaded rows).
-    async fn build_tool_registry_with_capabilities(
-        &self,
-        capability_rows: &[AgentCapabilityRow],
-    ) -> Result<ToolRegistry> {
-        let mut registry = ToolRegistry::with_defaults();
-
-        let builtin_cap_ids: Vec<String> = capability_rows
-            .iter()
-            .map(|r| r.capability_id.clone())
-            .filter(|id| !is_mcp_capability(id))
-            .collect();
-
-        if !builtin_cap_ids.is_empty() {
-            let ctx = SystemPromptContext::without_file_store(everruns_core::SessionId::new());
-            let collected =
-                collect_capabilities(&builtin_cap_ids, &self.capability_registry, &ctx).await;
-            for tool in collected.tools {
-                registry.register_boxed(tool);
-            }
-            tracing::debug!(
-                capability_count = builtin_cap_ids.len(),
-                tool_count = collected.tool_definitions.len(),
-                "Registered capability tools"
-            );
-        }
-
-        Ok(registry)
     }
 
     /// Build MCP tool definitions from pre-loaded capability rows.
@@ -2627,18 +2566,6 @@ mod tests {
             .expect("agent should exist");
 
         assert_eq!(agent.name, "test-agent");
-    }
-
-    #[tokio::test]
-    async fn build_tool_registry_with_empty_capabilities() {
-        let adapters = test_adapters();
-        let registry = adapters
-            .build_tool_registry_with_capabilities(&[])
-            .await
-            .unwrap();
-        // Default registry has built-in tools; verify it returns a valid
-        // registry without panicking.
-        assert!(!registry.is_empty());
     }
 
     #[tokio::test]

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -4,9 +4,7 @@
 // Decision: Used by external workers that connect to control-plane via gRPC
 
 use async_trait::async_trait;
-use everruns_core::capabilities::{
-    CapabilityRegistry, SystemPromptContext, collect_capabilities, is_mcp_capability,
-};
+use everruns_core::capabilities::CapabilityRegistry;
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::events::{Event, EventRequest};
 use everruns_core::leased_resource::LeasedResource;
@@ -17,9 +15,7 @@ use everruns_core::traits::{
 use everruns_core::typed_id::{
     AgentId, HarnessId, LeasedResourceId, MessageId, ModelId, SessionId,
 };
-use everruns_core::{
-    Agent, DriverRegistry, Harness, Message, PlatformDefinition, Session, ToolRegistry,
-};
+use everruns_core::{Agent, DriverRegistry, Harness, Message, PlatformDefinition, Session};
 use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -471,35 +467,5 @@ impl WorkerAdapters for GrpcWorkerAdapters {
                 error,
             )
             .await
-    }
-
-    async fn build_tool_registry(&self, org_id: i64, agent_id: Uuid) -> Result<ToolRegistry> {
-        let mut registry = ToolRegistry::with_defaults();
-
-        // Get agent to access capabilities
-        if let Ok(Some(agent)) = self.get_agent(org_id, agent_id).await {
-            let builtin_cap_ids: Vec<String> = agent
-                .capabilities
-                .iter()
-                .map(|c| c.capability_id().to_string())
-                .filter(|id| !is_mcp_capability(id))
-                .collect();
-
-            if !builtin_cap_ids.is_empty() {
-                let cap_registry = self.capability_registry();
-                let ctx = SystemPromptContext::without_file_store(everruns_core::SessionId::new());
-                let collected = collect_capabilities(&builtin_cap_ids, &cap_registry, &ctx).await;
-                for tool in collected.tools {
-                    registry.register_boxed(tool);
-                }
-                tracing::debug!(
-                    capability_count = builtin_cap_ids.len(),
-                    tool_count = collected.tool_definitions.len(),
-                    "Registered capability tools"
-                );
-            }
-        }
-
-        Ok(registry)
     }
 }

--- a/crates/worker/src/runtime_host.rs
+++ b/crates/worker/src/runtime_host.rs
@@ -91,26 +91,6 @@ impl<A: WorkerAdapters> RuntimeHostAdapter for WorkerRuntimeHost<A> {
         self.adapters.driver_registry()
     }
 
-    async fn build_tool_registry_for_agent(
-        &self,
-        org_id: i64,
-        agent_id: AgentId,
-    ) -> Result<everruns_core::ToolRegistry> {
-        self.adapters
-            .build_tool_registry(org_id, agent_id.uuid())
-            .await
-    }
-
-    async fn build_tool_registry_for_harness(
-        &self,
-        org_id: i64,
-        harness_id: HarnessId,
-    ) -> Result<everruns_core::ToolRegistry> {
-        self.adapters
-            .build_tool_registry_for_harness(org_id, harness_id.uuid())
-            .await
-    }
-
     fn harness_store(&self, org_id: i64) -> Arc<dyn HarnessStore> {
         Arc::new(AdapterHarnessStore::new(self.adapters.clone(), org_id))
     }

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -9,9 +9,7 @@
 // This allows a single Worker implementation to work with either backend.
 
 use async_trait::async_trait;
-use everruns_core::capabilities::{
-    CapabilityRegistry, SystemPromptContext, collect_capabilities, is_mcp_capability,
-};
+use everruns_core::capabilities::CapabilityRegistry;
 use everruns_core::error::Result;
 use everruns_core::events::{Event, EventRequest};
 use everruns_core::leased_resource::LeasedResource;
@@ -23,9 +21,7 @@ use everruns_core::traits::{
 use everruns_core::typed_id::{
     AgentId, HarnessId, LeasedResourceId, MessageId, ModelId, SessionId,
 };
-use everruns_core::{
-    Agent, DriverRegistry, Harness, Message, Session, ToolDefinition, ToolRegistry,
-};
+use everruns_core::{Agent, DriverRegistry, Harness, Message, Session, ToolDefinition};
 use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -215,41 +211,6 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
 
     /// Get the LLM driver registry
     fn driver_registry(&self) -> DriverRegistry;
-
-    /// Create a tool registry with defaults and agent capabilities
-    async fn build_tool_registry(&self, org_id: i64, agent_id: Uuid) -> Result<ToolRegistry>;
-
-    /// Create a tool registry with defaults and harness capabilities.
-    ///
-    /// Fallback for sessions without an agent — builds the registry from the
-    /// harness's capability list so harness-provided tools (e.g. bash) are
-    /// available. Without this, only `ToolRegistry::with_defaults()` would be
-    /// used, which doesn't include capability-provided tools.
-    async fn build_tool_registry_for_harness(
-        &self,
-        org_id: i64,
-        harness_id: Uuid,
-    ) -> Result<ToolRegistry> {
-        let mut registry = ToolRegistry::with_defaults();
-        if let Ok(Some(harness)) = self.get_harness(org_id, harness_id).await {
-            let builtin_cap_ids: Vec<String> = harness
-                .capabilities
-                .iter()
-                .map(|c| c.capability_id().to_string())
-                .filter(|id| !is_mcp_capability(id))
-                .collect();
-
-            if !builtin_cap_ids.is_empty() {
-                let cap_registry = self.capability_registry();
-                let ctx = SystemPromptContext::without_file_store(everruns_core::SessionId::new());
-                let collected = collect_capabilities(&builtin_cap_ids, &cap_registry, &ctx).await;
-                for tool in collected.tools {
-                    registry.register_boxed(tool);
-                }
-            }
-        }
-        Ok(registry)
-    }
 
     /// Get the session SQL database store.
     fn sqldb_store(&self) -> everruns_core::traits::SessionSqlDbStoreRef;


### PR DESCRIPTION
## What
Unify runtime act-time capability resolution around the same merged overlay that reason already uses.

## Why
Agent-backed sessions could advertise harness-contributed tools during reason, then fail during act because execution rebuilt the registry from agent capabilities only. The same split also left post-tool hooks and transitive capability resolution on a different path.

## How
- factor merged overlay + dependency-expanded capability resolution into a shared core helper
- make runtime host act execution derive tool implementations and post-tool hooks from that resolved overlay
- remove the old worker/host adapter registry builders that split on agent vs harness
- add runtime-host regressions that build tool definitions from reason context and then verify act can execute harness tools, dependency-provided tools, and merged-overlay hooks in agent-backed sessions

## Risk
- Low
- Runtime act execution now resolves capabilities through the same overlay path as reason; the main risk is changing tool/hook availability for worker-backed sessions, which is covered by the new regressions and full workspace clippy/pre-push checks.

## Security
- Threat categories reviewed: TM-TOOL, TM-BASH, TM-DOS
- Findings and resolutions:
  - Reviewed tool registration and hook execution paths for accidental capability expansion. The change does not add new capabilities or bypass existing gating; it only removes the divergent execution path and reuses the already-merged overlay.
  - Reviewed dependency expansion for resource-exhaustion regressions. Dependency resolution still goes through the existing bounded resolver in core; no new unbounded inputs were introduced.
  - Reviewed bash/tool execution exposure. Harness-contributed tools already existed on the reason path; this change makes act use the same effective set instead of silently dropping them.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Linear: https://linear.app/everruns/issue/EVE-370/fixruntime-use-one-overlay-based-capability-path-for-reason-act-and

Validation:
- `cargo test -p everruns-runtime --test runtime_host_test -- --nocapture`
- `cargo test -p everruns-worker --no-run`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `just pre-push`
