### PR TITLE
docs(tool-execution): specify exec-tool result contract (EVE-371)

### DIFF
--- a/integrations/daytona/SPEC.md
+++ b/integrations/daytona/SPEC.md
@@ -119,10 +119,10 @@ Executes a shell command in a sandbox with real-time output streaming.
   - `command`: string (required) — shell command
   - `cwd`: string (optional) — working directory
   - `timeout`: integer (optional) — timeout in ms (default: 300000)
-- **Returns**: Conforms to the [Standard Exec-Tool Result Contract](../../specs/tool-execution.md#standard-exec-tool-result-contract-eve-371) — required `{ stdout, stderr, exit_code, success }` plus the recommended metadata (`cwd`, `sandbox_id`, `timed_out`, `signal`, `truncated`, `output_files`, `hint`) when available.
-- **Streaming**: Emits `tool.output.delta` events with the `stream` field set per the shared contract. Daytona's underlying exec shell serializes stdout and stderr into a single stream; the tool still tags deltas per that contract.
+- **Returns (current)**: Historical Daytona exec result: `{ exit_code, output }`, plus optional `hint` (diagnostic text for signal-based exit codes, see EVE-252).
+- **Streaming (current)**: Emits `tool.output.delta` events with `stream: "stdout"` for all deltas. Daytona's underlying exec shell serializes stdout and stderr into a single combined stream, so the tool does not currently distinguish stdout from stderr in streamed output.
 - **Recovery**: If a command times out or the shared exec shell is detected as dead, Everruns resets the Daytona exec session before returning the error so the next command can recover cleanly.
-- **Contract alignment**: Historical `{ exit_code, output }` shape is being migrated to the standard contract under EVE-372 (backend) and EVE-373 (UI shell card). Until migration lands, the combined `output` field is still returned alongside `exit_code`.
+- **Contract alignment (target)**: Migration to the [Standard Exec-Tool Result Contract](../../specs/tool-execution.md#standard-exec-tool-result-contract-eve-371) is tracked under EVE-372 (backend: split `output` into `stdout`/`stderr`, add `success`, attach recommended metadata such as `cwd`, `sandbox_id`, `timed_out`, `signal`, `truncated`, `output_files`) and EVE-373 (UI shell card). Per-stream delta tagging is covered by the same follow-ups.
 
 ### daytona_read_file
 

--- a/integrations/daytona/SPEC.md
+++ b/integrations/daytona/SPEC.md
@@ -119,9 +119,10 @@ Executes a shell command in a sandbox with real-time output streaming.
   - `command`: string (required) — shell command
   - `cwd`: string (optional) — working directory
   - `timeout`: integer (optional) — timeout in ms (default: 300000)
-- **Returns**: `{ exit_code, output }`
-- **Streaming**: Emits `tool.output.delta` events with partial combined stdout/stderr output (emitted on stream `"stdout"`) as the command runs (polled every ~1s). The final tool result contains the complete combined output.
+- **Returns**: Conforms to the [Standard Exec-Tool Result Contract](../../specs/tool-execution.md#standard-exec-tool-result-contract-eve-371) — required `{ stdout, stderr, exit_code, success }` plus the recommended metadata (`cwd`, `sandbox_id`, `timed_out`, `signal`, `truncated`, `output_files`, `hint`) when available.
+- **Streaming**: Emits `tool.output.delta` events with the `stream` field set per the shared contract. Daytona's underlying exec shell serializes stdout and stderr into a single stream; the tool still tags deltas per that contract.
 - **Recovery**: If a command times out or the shared exec shell is detected as dead, Everruns resets the Daytona exec session before returning the error so the next command can recover cleanly.
+- **Contract alignment**: Historical `{ exit_code, output }` shape is being migrated to the standard contract under EVE-372 (backend) and EVE-373 (UI shell card). Until migration lands, the combined `output` field is still returned alongside `exit_code`.
 
 ### daytona_read_file
 

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -136,10 +136,10 @@ Tools MUST NOT merge stdout and stderr into a single `output` field. Preserving 
 | `timed_out` | boolean | `true` when the runtime killed the process due to a timeout. |
 | `signal` | string | Name of the terminating signal (e.g. `"SIGTERM"`) when the process was killed rather than exited. |
 | `truncated` | boolean | `true` when the returned `stdout` or `stderr` were shortened by the sanitizer or verbosity budget. |
-| `output_files` | object | Map of `{ "stdout": "/.outputs/{tool_call_id}.stdout", "stderr": "..." }` when the full output was persisted to session VFS. |
+| `output_files` | array | Array of persisted output file paths (for example `["/workspace/.outputs/{tool_call_id}.stdout", "/workspace/.outputs/{tool_call_id}.stderr"]`) when the full output was written to the session VFS. |
 | `hint` | string | Short LLM-facing hint when truncation or timeout occurred (e.g. `"Output was truncated; read the stdout file for the full log."`). |
 
-Tools that already use `tool_output_persistence` get `output_files` for free via the `PersistOutputHook`.
+Tools that already use `tool_output_persistence` get the currently injected persistence fields for free via the `PersistOutputHook`, including `output_files` plus related metadata such as `full_output` (path to the stdout file) and `total_lines`.
 
 **Streaming contract:**
 

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -112,6 +112,57 @@ Default is `concise`. Budgets apply to stdout; stderr is capped at `min(budget, 
 
 This is the tool's responsibility — each tool calls the helpers before constructing `ToolExecutionResult`. See `crates/core/src/tool_output_sanitizer.rs` for the primitives.
 
+### Standard Exec-Tool Result Contract (EVE-371)
+
+All exec tools (bash, daytona_exec, e2b_exec, deno_exec, sprites_exec, docker_exec, and any future shell-like tool) share a common result shape so the agent, the streaming pipeline, and the UI can treat them uniformly.
+
+**Required fields** (every exec tool MUST return these):
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `stdout` | string | Sanitized standard-output stream. Empty string if none. |
+| `stderr` | string | Sanitized standard-error stream. Empty string if none. |
+| `exit_code` | integer | Process exit status. `0` means success. Non-zero or negative codes indicate failure per the underlying runtime. |
+| `success` | boolean | `true` iff the command ran to completion with `exit_code == 0` and was not terminated by the runtime. |
+
+Tools MUST NOT merge stdout and stderr into a single `output` field. Preserving the split lets the UI visually emphasize stderr, lets the LLM disambiguate warnings from results, and keeps parity with the bash card renderer in `apps/ui/src/components/chat/bash-tool-call-card.tsx`.
+
+**Recommended metadata** (exec tools SHOULD return these when meaningful):
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `cwd` | string | Working directory the command ran in, when the runtime can report it. |
+| `sandbox_id` | string | Opaque identifier for the sandbox or container that executed the command. |
+| `timed_out` | boolean | `true` when the runtime killed the process due to a timeout. |
+| `signal` | string | Name of the terminating signal (e.g. `"SIGTERM"`) when the process was killed rather than exited. |
+| `truncated` | boolean | `true` when the returned `stdout` or `stderr` were shortened by the sanitizer or verbosity budget. |
+| `output_files` | object | Map of `{ "stdout": "/.outputs/{tool_call_id}.stdout", "stderr": "..." }` when the full output was persisted to session VFS. |
+| `hint` | string | Short LLM-facing hint when truncation or timeout occurred (e.g. `"Output was truncated; read the stdout file for the full log."`). |
+
+Tools that already use `tool_output_persistence` get `output_files` for free via the `PersistOutputHook`.
+
+**Streaming contract:**
+
+While the command runs, exec tools stream partial output via `tool.output.delta` events. Each event MUST carry a `stream` field set to `"stdout"` or `"stderr"` so the UI can route the delta into the correct lane. Combined-stream tools (where the underlying runtime does not expose the split, e.g. Daytona's shared exec shell) SHOULD still pick the best match per delta rather than collapsing everything to `"stdout"`.
+
+**Narration expectations:**
+
+The generic exec narration is command-first: the visible line should read `"Ran <first-token-of-command>"` (e.g. `"Ran cargo"`, `"Ran pytest"`), matching the existing bash narration in `crates/core/src/tool_narration.rs`. Infrastructure metadata (sandbox id, runtime name) belongs in secondary UI surfaces (tooltips, details), not the narration line. New exec tools inherit this behavior by keeping their `display_name` generic (`"Run shell command"`, not `"Daytona Exec"`) and relying on the shared narration path.
+
+**UI presentation expectations:**
+
+Exec tools render through the shared shell card:
+
+- Tool registry entry MUST declare `category: "shell"` and `segmentMode: "standalone"` (see `apps/ui/src/lib/tool-registry.ts`). This prevents exec calls from being folded into grouped read/edit segments.
+- The card renders `stdout` and `stderr` as distinct panes, with stderr visually emphasized (color/background) when non-empty.
+- Exit status is shown as a badge: green for `exit_code == 0`, red for non-zero, with the numeric code displayed.
+- Duration, `cwd`, and `sandbox_id` (when present) are rendered in the card header or details drawer.
+- When `truncated` is `true`, the card surfaces a link to the persisted `output_files.stdout` / `.stderr` paths so the user can read the full log.
+
+**Rationale:**
+
+Keeping the contract shared rather than per-integration means: (1) the LLM sees a uniform shape across sandboxes; (2) the UI needs one exec card, not one per backend; (3) new exec tools (future runtimes, custom toolkits) become automatically first-class without plumbing changes. Integration-specific specs reference this section rather than documenting their own exec shape. Backend alignment work is tracked under EVE-372 (daytona_exec field split) and EVE-373 (UI shell treatment for daytona_exec).
+
 ### Background Tool Execution
 
 `spawn_background` is a built-in meta-tool that schedules another built-in tool to run asynchronously and returns immediately with a run handle. It is generic: the caller passes `tool` plus `args`; the target tool determines whether background execution is supported.


### PR DESCRIPTION
## What
Adds a new "Standard Exec-Tool Result Contract (EVE-371)" section to `specs/tool-execution.md` and updates `integrations/daytona/SPEC.md` to reference it.

The new section defines, for all exec tools (bash, daytona_exec, e2b_exec, deno_exec, sprites_exec, docker_exec, and future shell-like tools):

- **Required fields**: `{ stdout, stderr, exit_code, success }` — tools MUST NOT merge streams into a single `output`.
- **Recommended metadata**: `cwd`, `sandbox_id`, `timed_out`, `signal`, `truncated`, `output_files`, `hint`.
- **Streaming**: `tool.output.delta` events MUST tag `stream: "stdout" | "stderr"`.
- **Narration**: command-first (`"Ran cargo"`), infra metadata in secondary surfaces.
- **UI presentation**: `category: "shell"`, `segmentMode: "standalone"`, distinct stdout/stderr panes with stderr emphasis, exit-code badge, truncation link to persisted `output_files`.

`integrations/daytona/SPEC.md` now points daytona_exec at the shared contract instead of documenting its own `{ exit_code, output }` shape, with an explicit "Contract alignment" note that the backend migration is tracked under EVE-372 and the UI work under EVE-373.

## Why
Daytona's `daytona_exec` currently returns `{ exit_code, output }` while bash (the reference) returns `{ stdout, stderr, exit_code, success }`. The shared UI shell card (`apps/ui/src/components/chat/bash-tool-call-card.tsx`) expects the bash shape, so daytona_exec results render awkwardly. Before changing backend or UI code, we need a single authoritative spec that every exec tool (today and future) can conform to. This PR establishes that contract. Backend and UI alignment follow in EVE-372 / EVE-373.

## How
- Inserted the new section into `specs/tool-execution.md` immediately after "Output Verbosity (EVE-236)" and before "Background Tool Execution". Cross-references the existing bash card, tool registry, tool narration, and sanitizer files.
- Updated `integrations/daytona/SPEC.md#daytona_exec` to link the shared section and call out the deferred migration work.

## Risk
- Low. Docs-only change. No runtime behavior, no API surface, no code paths affected.
- Blast radius: spec drift between this section and later EVE-372/EVE-373 implementations. Mitigated by explicit "Contract alignment" notes pointing at the follow-up issues.

## Security
- Threat categories reviewed: No security-relevant code changes — this PR only adds spec prose describing fields, streaming, narration, and UI expectations for exec tools. No authentication, authorization, input-handling, or sandbox boundary changes.
- Findings and resolutions: none.

## Checklist
- [x] Tests added or updated (N/A — docs-only)
- [x] Backward compatibility considered (spec documents current + target shape; backend still returns legacy field until EVE-372)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
