### PR TITLE
fix(server): use direct postgres listener urls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2063,6 +2063,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "url",
  "urlencoding",
  "utoipa",
  "uuid",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -92,6 +92,7 @@ prost.workspace = true
 prost-types.workspace = true
 serde_urlencoded = "0.7.1"
 ag-ui-core = "0.1.0"
+url = "2"
 
 [dev-dependencies]
 reqwest = { workspace = true, default-features = false, features = ["json", "stream", "rustls", "blocking", "http2"] }

--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -147,6 +147,7 @@ cargo clippy -p everruns-server -- -D warnings
 Currently configured via environment variables:
 
 - `DATABASE_URL` - PostgreSQL connection string (required)
+- `DATABASE_UNPOOLED_URL` - direct PostgreSQL URL for `LISTEN/NOTIFY` listeners when `DATABASE_URL` uses a pooler/proxy
 
 Default: `postgres://everruns:everruns@localhost:5432/everruns`
 

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -11,8 +11,10 @@
 
 use crate::auth::{self, AuthBackend};
 use crate::direct_worker_adapters::DirectWorkerAdapters;
+use crate::event_delivery::EventDelivery;
 use crate::grpc_service;
 use crate::openapi::ApiDoc;
+use crate::pg_listener_config::resolve_pg_listener_database_url;
 use crate::server::{ServerConfig, build_router_with_prefix};
 use crate::storage::{EncryptionService, StorageBackend};
 use crate::{api, seed, services};
@@ -221,7 +223,7 @@ impl ServerAppBuilder {
         // =====================================================================
         // Phase 1: Storage backend & runner
         // =====================================================================
-        let (db, runner, shared_durable_store) = if self.config.dev_mode {
+        let (db, runner, shared_durable_store, database_url) = if self.config.dev_mode {
             tracing::info!("Starting in DEV MODE (in-memory storage, no PostgreSQL required)");
 
             let db = Arc::new(StorageBackend::in_memory());
@@ -234,7 +236,7 @@ impl ServerAppBuilder {
             tracing::info!(
                 "Using in-memory storage and durable execution engine with in-process worker"
             );
-            (db, runner, Some(shared_store))
+            (db, runner, Some(shared_store), None)
         } else {
             let database_url = std::env::var("DATABASE_URL")
                 .context("DATABASE_URL environment variable required")?;
@@ -292,7 +294,7 @@ impl ServerAppBuilder {
                 .context("Failed to create agent runner")?;
 
             tracing::info!("Using Durable execution engine runner (PostgreSQL-backed)");
-            (Arc::new(backend), runner, None)
+            (Arc::new(backend), runner, None, Some(database_url))
         };
 
         // =====================================================================
@@ -483,6 +485,15 @@ impl ServerAppBuilder {
         } else {
             crate::event_delivery::EventDelivery::from_env().await
         };
+        let database_unpooled_url = std::env::var("DATABASE_UNPOOLED_URL").ok();
+        let resolve_listener_database_url = || {
+            database_url
+                .as_deref()
+                .map(|database_url| {
+                    resolve_pg_listener_database_url(database_url, database_unpooled_url.as_deref())
+                })
+                .transpose()
+        };
 
         let event_service = Arc::new(services::EventService::with_listeners(
             db.clone(),
@@ -494,9 +505,15 @@ impl ServerAppBuilder {
             crate::api::sse::SseConnectionLimits::from_env(),
         ));
 
-        let event_broadcaster = if let Some(pool) = db.pool() {
+        let event_broadcaster = if matches!(event_delivery, EventDelivery::Nats(_)) {
+            tracing::info!(
+                "Skipping legacy PostgreSQL event listener; NATS event delivery is active"
+            );
+            None
+        } else if let Some(database_url) = resolve_listener_database_url()?.as_ref() {
             let broadcaster =
-                crate::event_notifications::EventNotificationBroadcaster::new(pool.clone()).await;
+                crate::event_notifications::EventNotificationBroadcaster::new(database_url.clone())
+                    .await;
             tracing::info!("Event notification broadcaster initialized for push-based SSE");
             Some(Arc::new(broadcaster))
         } else {
@@ -506,10 +523,10 @@ impl ServerAppBuilder {
             None
         };
         let notification_broadcaster = if notifications_enabled {
-            if let Some(pool) = db.pool() {
+            if let Some(database_url) = resolve_listener_database_url()?.as_ref() {
                 let broadcaster =
                     crate::notification_notifications::NotificationNotificationBroadcaster::new(
-                        pool.clone(),
+                        database_url.clone(),
                     )
                     .await;
                 tracing::info!("Notification broadcaster initialized for push-based SSE");
@@ -729,9 +746,12 @@ impl ServerAppBuilder {
             };
         // Create TaskBroadcaster early so it can be shared between durable_state and gRPC service
         let task_broadcaster = if !self.config.dev_mode {
-            crate::task_notifications::TaskBroadcaster::from_env(db.pool())
-                .await
-                .map(Arc::new)
+            crate::task_notifications::TaskBroadcaster::from_env(
+                database_url.as_deref(),
+                database_unpooled_url.as_deref(),
+            )
+            .await
+            .map(Arc::new)
         } else {
             None
         };

--- a/crates/server/src/event_notifications.rs
+++ b/crates/server/src/event_notifications.rs
@@ -1,8 +1,7 @@
-// Event notification broadcaster for push-based SSE delivery
-// Decision: Uses PostgreSQL NOTIFY/LISTEN to replace SSE polling (100-500ms) with
-// push notifications (<20ms). Mirrors TaskNotificationBroadcaster pattern.
+// Event notification broadcaster for legacy PG-backed wakeups.
+// Decision: Connect listeners through a direct PostgreSQL URL instead of the shared
+// query pool so LISTEN/NOTIFY never shares a pooled session with ordinary queries.
 
-use sqlx::PgPool;
 use tokio::sync::{broadcast, mpsc};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
@@ -22,13 +21,13 @@ pub struct EventNotificationBroadcaster {
 
 impl EventNotificationBroadcaster {
     /// Create a new broadcaster and start listening for PostgreSQL NOTIFY events
-    pub async fn new(pool: PgPool) -> Self {
+    pub async fn new(database_url: String) -> Self {
         let (sender, _) = broadcast::channel(4096);
         let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
 
         let sender_clone = sender.clone();
         tokio::spawn(async move {
-            Self::listen_loop(pool, sender_clone, shutdown_rx).await;
+            Self::listen_loop(database_url, sender_clone, shutdown_rx).await;
         });
 
         Self {
@@ -50,14 +49,14 @@ impl EventNotificationBroadcaster {
 
     /// Background task that listens for PostgreSQL NOTIFY events
     async fn listen_loop(
-        pool: PgPool,
+        database_url: String,
         sender: broadcast::Sender<EventNotificationPayload>,
         mut shutdown_rx: mpsc::Receiver<()>,
     ) {
         info!("Starting PostgreSQL NOTIFY listener for event notifications");
 
         loop {
-            let mut listener = match sqlx::postgres::PgListener::connect_with(&pool).await {
+            let mut listener = match sqlx::postgres::PgListener::connect(&database_url).await {
                 Ok(listener) => listener,
                 Err(e) => {
                     error!("Failed to create PostgreSQL listener for events: {}", e);

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -67,6 +67,9 @@ pub use event_notifications::EventNotificationBroadcaster;
 pub mod event_delivery;
 pub use event_delivery::EventDelivery;
 
+// PostgreSQL LISTEN/NOTIFY listener connection guardrails
+pub mod pg_listener_config;
+
 // Notification broadcaster for push-based user inbox delivery
 pub mod notification_notifications;
 pub use notification_notifications::NotificationNotificationBroadcaster;

--- a/crates/server/src/notification_notifications.rs
+++ b/crates/server/src/notification_notifications.rs
@@ -3,7 +3,6 @@
 // across instances without falling back to short-polling.
 
 use serde::Deserialize;
-use sqlx::PgPool;
 use tokio::sync::{broadcast, mpsc};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
@@ -21,13 +20,13 @@ pub struct NotificationNotificationBroadcaster {
 }
 
 impl NotificationNotificationBroadcaster {
-    pub async fn new(pool: PgPool) -> Self {
+    pub async fn new(database_url: String) -> Self {
         let (sender, _) = broadcast::channel(4096);
         let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
 
         let sender_clone = sender.clone();
         tokio::spawn(async move {
-            Self::listen_loop(pool, sender_clone, shutdown_rx).await;
+            Self::listen_loop(database_url, sender_clone, shutdown_rx).await;
         });
 
         Self {
@@ -45,14 +44,14 @@ impl NotificationNotificationBroadcaster {
     }
 
     async fn listen_loop(
-        pool: PgPool,
+        database_url: String,
         sender: broadcast::Sender<NotificationNotificationPayload>,
         mut shutdown_rx: mpsc::Receiver<()>,
     ) {
         info!("Starting PostgreSQL NOTIFY listener for notifications");
 
         loop {
-            let mut listener = match sqlx::postgres::PgListener::connect_with(&pool).await {
+            let mut listener = match sqlx::postgres::PgListener::connect(&database_url).await {
                 Ok(listener) => listener,
                 Err(e) => {
                     error!(

--- a/crates/server/src/pg_listener_config.rs
+++ b/crates/server/src/pg_listener_config.rs
@@ -1,0 +1,141 @@
+// PostgreSQL LISTEN/NOTIFY connection selection.
+// Decision: Keep pooled DATABASE_URL for ordinary queries, but route session-scoped
+// LISTEN/NOTIFY traffic through a direct URL when provided.
+// Decision: Reject obvious pooler/proxy URLs for LISTEN/NOTIFY because pooled
+// endpoints can break sqlx listener semantics and surface NotificationResponse
+// frames on unrelated query traffic.
+
+use anyhow::{Result, bail};
+use url::Url;
+
+const DATABASE_URL_ENV: &str = "DATABASE_URL";
+const DATABASE_UNPOOLED_URL_ENV: &str = "DATABASE_UNPOOLED_URL";
+
+pub fn resolve_pg_listener_database_url(
+    database_url: &str,
+    database_unpooled_url: Option<&str>,
+) -> Result<String> {
+    let trimmed_unpooled = database_unpooled_url
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let listener_url = trimmed_unpooled.unwrap_or(database_url);
+    let source = if trimmed_unpooled.is_some() {
+        DATABASE_UNPOOLED_URL_ENV
+    } else {
+        DATABASE_URL_ENV
+    };
+
+    if looks_like_pooled_pg_endpoint(listener_url) {
+        bail!(
+            "{source} points to a pooled/proxied PostgreSQL endpoint. \
+             PG LISTEN/NOTIFY requires a direct session-scoped connection. \
+             Set {DATABASE_UNPOOLED_URL_ENV} to a direct PostgreSQL URL for listener paths."
+        );
+    }
+
+    Ok(listener_url.to_string())
+}
+
+fn looks_like_pooled_pg_endpoint(url: &str) -> bool {
+    let Ok(parsed) = Url::parse(url) else {
+        return false;
+    };
+
+    let host = parsed.host_str().map(str::to_ascii_lowercase);
+    let host_looks_pooled = host.as_deref().is_some_and(|host| {
+        host.contains("-pooler.") || host.contains(".pooler.") || host.contains("pgbouncer")
+    });
+    let query_requests_pooling = parsed
+        .query_pairs()
+        .any(|(key, _)| key.eq_ignore_ascii_case("pool_mode"));
+
+    host_looks_pooled || query_requests_pooling
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uses_direct_listener_url_when_present() {
+        let listener_url = resolve_pg_listener_database_url(
+            "postgres://app@ep-foo-pooler.us-east-1.aws.neon.tech/db",
+            Some("postgres://app@ep-foo.us-east-1.aws.neon.tech/db"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            listener_url,
+            "postgres://app@ep-foo.us-east-1.aws.neon.tech/db"
+        );
+    }
+
+    #[test]
+    fn allows_direct_database_url_without_override() {
+        let listener_url = resolve_pg_listener_database_url(
+            "postgres://postgres:postgres@localhost:5432/everruns",
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            listener_url,
+            "postgres://postgres:postgres@localhost:5432/everruns"
+        );
+    }
+
+    #[test]
+    fn rejects_pooled_database_url_for_listeners() {
+        let error = resolve_pg_listener_database_url(
+            "postgres://app@ep-foo-pooler.us-east-1.aws.neon.tech/db",
+            None,
+        )
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("PG LISTEN/NOTIFY requires a direct session-scoped connection")
+        );
+    }
+
+    #[test]
+    fn rejects_pooled_unpooled_override() {
+        let error = resolve_pg_listener_database_url(
+            "postgres://postgres:postgres@localhost:5432/everruns",
+            Some("postgres://app@ep-foo-pooler.us-east-1.aws.neon.tech/db"),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains(DATABASE_UNPOOLED_URL_ENV));
+    }
+
+    #[test]
+    fn ignores_passwords_that_happen_to_mention_poolers() {
+        let listener_url = resolve_pg_listener_database_url(
+            "postgres://app:pgbouncer-secret@localhost:5432/everruns",
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            listener_url,
+            "postgres://app:pgbouncer-secret@localhost:5432/everruns"
+        );
+    }
+
+    #[test]
+    fn rejects_explicit_pool_mode_query_params() {
+        let error = resolve_pg_listener_database_url(
+            "postgres://app@localhost:5432/everruns?pool_mode=session",
+            None,
+        )
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("PG LISTEN/NOTIFY requires a direct session-scoped connection")
+        );
+    }
+}

--- a/crates/server/src/task_notifications.rs
+++ b/crates/server/src/task_notifications.rs
@@ -7,7 +7,7 @@
 // The TaskBroadcaster enum wraps both backends with the same API.
 
 use crate::nats_task_notifications::NatsTaskNotificationBroadcaster;
-use sqlx::PgPool;
+use crate::pg_listener_config::resolve_pg_listener_database_url;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{RwLock, broadcast, mpsc};
@@ -39,7 +39,7 @@ pub struct TaskNotificationBroadcaster {
 
 impl TaskNotificationBroadcaster {
     /// Create a new broadcaster and start listening for PostgreSQL NOTIFY events
-    pub async fn new(pool: PgPool) -> Self {
+    pub async fn new(database_url: String) -> Self {
         // Create broadcast channel with reasonable capacity
         // If workers are slow to consume, older notifications are dropped (acceptable since
         // workers will poll as fallback)
@@ -49,9 +49,8 @@ impl TaskNotificationBroadcaster {
 
         // Start the LISTEN loop in a background task
         let sender_clone = sender.clone();
-        let pool_clone = pool.clone();
         tokio::spawn(async move {
-            Self::listen_loop(pool_clone, sender_clone, shutdown_rx).await;
+            Self::listen_loop(database_url, sender_clone, shutdown_rx).await;
         });
 
         Self {
@@ -105,15 +104,14 @@ impl TaskNotificationBroadcaster {
 
     /// Background task that listens for PostgreSQL NOTIFY events
     async fn listen_loop(
-        pool: PgPool,
+        database_url: String,
         sender: broadcast::Sender<TaskNotificationPayload>,
         mut shutdown_rx: mpsc::Receiver<()>,
     ) {
         info!("Starting PostgreSQL NOTIFY listener for task notifications");
 
         loop {
-            // Acquire a dedicated connection for LISTEN
-            let mut listener = match sqlx::postgres::PgListener::connect_with(&pool).await {
+            let mut listener = match sqlx::postgres::PgListener::connect(&database_url).await {
                 Ok(listener) => listener,
                 Err(e) => {
                     error!("Failed to create PostgreSQL listener: {}", e);
@@ -204,7 +202,10 @@ pub enum TaskBroadcaster {
 impl TaskBroadcaster {
     /// Create from environment: NATS if `NATS_URL` is set, otherwise PG NOTIFY.
     /// Returns None if neither is available (dev mode without PG).
-    pub async fn from_env(pool: Option<&PgPool>) -> Option<Self> {
+    pub async fn from_env(
+        database_url: Option<&str>,
+        database_unpooled_url: Option<&str>,
+    ) -> Option<Self> {
         // Try NATS first (preferred when configured)
         if let Ok(nats_url) = std::env::var("NATS_URL") {
             match NatsTaskNotificationBroadcaster::new(&nats_url).await {
@@ -222,8 +223,24 @@ impl TaskBroadcaster {
         }
 
         // Fall back to PG NOTIFY
-        if let Some(pool) = pool {
-            let broadcaster = TaskNotificationBroadcaster::new(pool.clone()).await;
+        let listener_database_url = match database_url {
+            Some(database_url) => {
+                match resolve_pg_listener_database_url(database_url, database_unpooled_url) {
+                    Ok(listener_database_url) => Some(listener_database_url),
+                    Err(error) => {
+                        error!(
+                            error = %error,
+                            "Task notifications unavailable: listener database URL is not usable"
+                        );
+                        None
+                    }
+                }
+            }
+            None => None,
+        };
+
+        if let Some(database_url) = listener_database_url {
+            let broadcaster = TaskNotificationBroadcaster::new(database_url).await;
             info!("Task notifications: PostgreSQL NOTIFY");
             return Some(Self::Postgres(broadcaster));
         }

--- a/docs/sre/environment-variables.md
+++ b/docs/sre/environment-variables.md
@@ -148,6 +148,29 @@ VALKEY_URL=rediss://user:password@valkey.example.com:6380
 - Only used by control-plane (server); workers don't need this variable
 - Uses sliding-window counters via Lua scripts for atomic rate limit checks
 
+## DATABASE_UNPOOLED_URL
+
+Direct PostgreSQL connection URL used only for session-scoped `LISTEN/NOTIFY` listeners.
+
+| Property | Value |
+|----------|-------|
+| **Required** | No |
+| **Default** | Not set (listeners reuse `DATABASE_URL` if it is a direct connection) |
+
+**Example:**
+
+```bash
+# Query traffic through a pooler, listeners through a direct endpoint
+DATABASE_URL=postgres://app:secret@ep-foo-pooler.us-east-1.aws.neon.tech/everruns?sslmode=require
+DATABASE_UNPOOLED_URL=postgres://app:secret@ep-foo.us-east-1.aws.neon.tech/everruns?sslmode=require
+```
+
+**Notes:**
+- Use this when `DATABASE_URL` points at Neon `-pooler`, PgBouncer, or another proxy that does not preserve session-scoped `LISTEN/NOTIFY` semantics.
+- Listener paths include PostgreSQL-backed event wakeups, notification SSE, and PG task notification fallback when NATS is unavailable.
+- If `DATABASE_URL` or `DATABASE_UNPOOLED_URL` appears to point at a pooled/proxied endpoint, startup now fails fast with guidance to set a direct listener URL.
+- Ordinary query traffic still uses `DATABASE_URL`.
+
 ## NATS_URL
 
 Connection URL for NATS with JetStream, used for push-based event delivery and task notifications.
@@ -172,6 +195,7 @@ NATS_URL=nats://nats1:4222,nats://nats2:4222,nats://nats3:4222
 - When set, enables two features:
   - **Ephemeral event delivery**: delta events (`output.message.delta`, `reason.thinking.delta`, `tool.output.delta`, `llm.generation`) skip PostgreSQL and flow only through NATS JetStream. SSE streams subscribe to NATS instead of polling PG.
   - **Task notifications**: `task.available.{activity_type}` subjects replace PG NOTIFY for push-based worker notification. Lower latency (~1ms vs ~30ms), supports multi-instance deployments.
+- When NATS event delivery is active, the server skips the legacy PostgreSQL event listener used only for SSE wakeups.
 - NATS JetStream must be enabled on the server (`--jetstream` flag)
 - Fail-graceful: if NATS connection fails at startup, falls back to PG NOTIFY + in-memory delivery with a warning
 - Only used by control-plane (server); workers communicate via gRPC and don't need NATS access


### PR DESCRIPTION
## What
Fixes EVE-375.

- add a dedicated PG listener URL resolver with startup guardrails for pooled/proxied endpoints
- move PostgreSQL LISTEN/NOTIFY listeners off the shared sqlx pool and onto direct connection URLs
- skip the legacy PG event listener when NATS event delivery is already active
- document `DATABASE_UNPOOLED_URL` for operators

## Why
Pooled Neon/pgbouncer-style endpoints can break session-scoped `LISTEN/NOTIFY`. That leaked `NotificationResponse` frames into ordinary query traffic and intermittently failed event-store writes.

## How
- resolve listener traffic through `DATABASE_UNPOOLED_URL` when provided, otherwise a direct `DATABASE_URL`
- fail fast if the selected listener URL still looks like a pooler/proxy endpoint
- wire event, notification, and PG task listeners to connect with `PgListener::connect(...)` instead of `PgListener::connect_with(&pool)`
- leave normal query traffic on the pooled application database URL

## Validation
- `cargo test -p everruns-server pg_listener_config -- --nocapture`
- `cargo clippy -p everruns-server --all-targets -- -D warnings`
- `just pre-push`
- `PORT_PREFIX=875 just start-all --no-watch` *(blocked locally: PostgreSQL/`pg_ctl` is not installed in this environment, so full-stack startup smoke could not complete here)*

## Risk
- Medium
- Startup is now stricter around listener DB configuration; deployments using pooled PostgreSQL endpoints for LISTEN/NOTIFY must set a direct `DATABASE_UNPOOLED_URL`

## Security
- Threat categories reviewed: TM-SQL, TM-DOS
- Findings and resolutions: no new query construction or data exposure paths. Listener URLs remain server-side env config only, and startup now rejects pooled/proxied LISTEN/NOTIFY endpoints before they can corrupt query traffic.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)