### PR TITLE
feat(daytona): standardize exec output contract

### DIFF
--- a/apps/ui/src/__tests__/tool-activity-group.test.tsx
+++ b/apps/ui/src/__tests__/tool-activity-group.test.tsx
@@ -147,6 +147,49 @@ describe("ToolActivityGroup", () => {
     expect(shellCard.className).not.toContain("bg-red");
   });
 
+  it("renders daytona_exec as a standalone shell row with metadata", () => {
+    const toolCalls: ToolCallContent[] = [
+      {
+        id: "tool-daytona",
+        name: "daytona_exec",
+        arguments: { command: "cargo test", sandbox_id: "sb_123", cwd: "/workspace" },
+      },
+    ];
+
+    const toolResultsMap = new Map<string, ToolCompletedData>([
+      [
+        "tool-daytona",
+        {
+          tool_call_id: "tool-daytona",
+          tool_name: "daytona_exec",
+          success: false,
+          status: "error",
+          result: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                stdout: "running 4 tests\n3 passed",
+                stderr: "thread 'tests' panicked",
+                exit_code: 101,
+                success: false,
+                cwd: "/workspace",
+                sandbox_id: "sb_123",
+              }),
+            },
+          ],
+        },
+      ],
+    ]);
+
+    render(<ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />);
+
+    expect(
+      screen.getByRole("button", { name: /\$ cargo test exit code 101/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("/workspace, sandbox sb_123")).toBeInTheDocument();
+    expect(screen.queryByText(/^Shell$/)).not.toBeInTheDocument();
+  });
+
   it("renders read_file as a standalone row and shows parsed file content", () => {
     const toolCalls: ToolCallContent[] = [
       {

--- a/apps/ui/src/components/chat/bash-tool-call-card.tsx
+++ b/apps/ui/src/components/chat/bash-tool-call-card.tsx
@@ -23,6 +23,9 @@ export interface BashOutput {
   stderr: string;
   exit_code: number;
   success: boolean;
+  cwd?: string;
+  sandbox_id?: string;
+  truncated?: boolean;
 }
 
 /**
@@ -42,6 +45,9 @@ export function parseBashOutput(text: string): BashOutput | null {
         stderr: String(parsed.stderr ?? ""),
         exit_code: Number(parsed.exit_code ?? 0),
         success: Boolean(parsed.success ?? parsed.exit_code === 0),
+        cwd: typeof parsed.cwd === "string" ? parsed.cwd : undefined,
+        sandbox_id: typeof parsed.sandbox_id === "string" ? parsed.sandbox_id : undefined,
+        truncated: typeof parsed.truncated === "boolean" ? parsed.truncated : undefined,
       };
     }
   } catch {
@@ -160,6 +166,11 @@ export function BashToolCallCard({ toolCall, toolResult, streamedOutput }: BashT
     bashOutput && bashOutput.exit_code !== 0
       ? t("exit_code", { value: bashOutput.exit_code })
       : null;
+  const metadataParts = [
+    bashOutput?.cwd,
+    bashOutput?.sandbox_id ? `sandbox ${bashOutput.sandbox_id}` : undefined,
+  ].filter(Boolean) as string[];
+  const metadataLabel = metadataParts.length > 0 ? metadataParts.join(", ") : null;
 
   // Status icon
   const statusIcon = isComplete ? (
@@ -219,8 +230,10 @@ export function BashToolCallCard({ toolCall, toolResult, streamedOutput }: BashT
       </div>
 
       {/* Description (if present, shown as subtitle) */}
-      {description && (
-        <div className="ml-[22px] text-[10px] opacity-40 truncate">{description}</div>
+      {(description || metadataLabel) && (
+        <div className="ml-[22px] text-[10px] opacity-40 truncate">
+          {[description, metadataLabel].filter(Boolean).join("  ")}
+        </div>
       )}
 
       {/* Tool-level error (not bash stderr) */}

--- a/apps/ui/src/lib/tool-registry.ts
+++ b/apps/ui/src/lib/tool-registry.ts
@@ -37,6 +37,7 @@ const TOOL_REGISTRY: Record<string, ToolRegistryEntry> = {
   bash: { category: "shell", segmentMode: "standalone" },
   shell: { category: "shell", segmentMode: "standalone" },
   execute_bash: { category: "shell", segmentMode: "standalone" },
+  daytona_exec: { category: "shell", segmentMode: "standalone" },
 
   // Read tools
   read_file: { category: "read", segmentMode: "standalone" },

--- a/crates/core/src/capabilities/session_sandbox.rs
+++ b/crates/core/src/capabilities/session_sandbox.rs
@@ -198,8 +198,10 @@ impl Tool for SandboxExecTool {
             .await
         {
             Ok(response) => ToolExecutionResult::success(json!({
+                "stdout": response.stdout,
+                "stderr": response.stderr,
                 "exit_code": response.exit_code,
-                "output": response.output,
+                "success": response.success,
                 "raw_output": response.raw_output,
                 "hint": response.hint,
             })),

--- a/crates/core/src/session_sandbox.rs
+++ b/crates/core/src/session_sandbox.rs
@@ -116,7 +116,9 @@ pub struct SessionSandboxExecRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SessionSandboxExecResponse {
     pub exit_code: i32,
-    pub output: String,
+    pub stdout: String,
+    pub stderr: String,
+    pub success: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub raw_output: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -480,7 +482,14 @@ pub async fn run_session_sandbox_init_if_needed(
             save_session_sandbox_state(context, state).await?;
             return Err(ToolExecutionResult::tool_error(format!(
                 "Session sandbox init failed for command '{}': {}",
-                command, response.output
+                command,
+                if response.stderr.is_empty() {
+                    response.stdout
+                } else if response.stdout.is_empty() {
+                    response.stderr
+                } else {
+                    format!("{}\n{}", response.stdout, response.stderr)
+                }
             )));
         }
     }

--- a/crates/core/src/tool_narration.rs
+++ b/crates/core/src/tool_narration.rs
@@ -475,7 +475,7 @@ pub fn render_tool_narration_with_locale(
     }
 
     match tool_call.name.as_str() {
-        "bash" => {
+        "bash" | "daytona_exec" => {
             let command = arg_str(args, &["command"])
                 .map(|value| format!("`{}`", truncate(value, 48)))
                 .unwrap_or_else(|| fallback_name.clone());
@@ -829,6 +829,24 @@ mod tests {
         assert_eq!(
             render_tool_narration(None, &tool_call, ToolNarrationPhase::Completed),
             "Edited main.rs"
+        );
+    }
+
+    #[test]
+    fn renders_daytona_exec_narration() {
+        let tool_call = ToolCall {
+            id: "call_1".to_string(),
+            name: "daytona_exec".to_string(),
+            arguments: json!({ "command": "cargo test -p everruns-core" }),
+        };
+
+        assert_eq!(
+            render_tool_narration(None, &tool_call, ToolNarrationPhase::Started),
+            "Running `cargo test -p everruns-core`"
+        );
+        assert_eq!(
+            render_tool_narration(None, &tool_call, ToolNarrationPhase::Completed),
+            "Ran `cargo test -p everruns-core`"
         );
     }
 

--- a/crates/server/src/services/session_sandbox.rs
+++ b/crates/server/src/services/session_sandbox.rs
@@ -331,7 +331,9 @@ mod tests {
         ) -> Result<SessionSandboxExecResponse, everruns_core::ToolExecutionResult> {
             Ok(SessionSandboxExecResponse {
                 exit_code: 0,
-                output: "ok".to_string(),
+                stdout: "ok".to_string(),
+                stderr: String::new(),
+                success: true,
                 raw_output: Some("ok".to_string()),
                 hint: None,
             })

--- a/integrations/daytona/SPEC.md
+++ b/integrations/daytona/SPEC.md
@@ -119,7 +119,7 @@ Executes a shell command in a sandbox with real-time output streaming.
   - `command`: string (required) — shell command
   - `cwd`: string (optional) — working directory
   - `timeout`: integer (optional) — timeout in ms (default: 300000)
-- **Returns**: `{ stdout, stderr, exit_code, success, cwd, sandbox_id, truncated?, stdout_lines?, stderr_lines?, hint?, full_output?, output_files? }`
+- **Returns**: `{ stdout, stderr, exit_code, success, cwd?, sandbox_id, truncated?, total_lines?, hint?, full_output?, output_files? }`
 - **Streaming**: Emits `tool.output.delta` events on the correct `stream` (`"stdout"` or `"stderr"`) as the command runs (polled every ~1s). The final tool result is the authoritative structured stdout/stderr snapshot.
 - **Recovery**: If a command times out or the shared exec shell is detected as dead, Everruns resets the Daytona exec session before returning the error so the next command can recover cleanly.
 - **Human representation**: Follows the shared exec-tool contract in `specs/tool-execution.md`. Command text is primary; sandbox metadata is secondary.

--- a/integrations/daytona/SPEC.md
+++ b/integrations/daytona/SPEC.md
@@ -69,7 +69,7 @@ This avoids entering the key in chat (see TM-AGENT-016).
 | Type | Fields | Source |
 |------|--------|--------|
 | `SandboxInfo` | `id`, `name?`, `state` | `POST /sandbox`, `GET /sandbox/{id}` |
-| `ExecResult` | `result`, `exit_code` | `POST /toolbox/{id}/process/execute` |
+| `ExecResult` | `stdout`, `stderr`, `result`, `exit_code` | Session exec logs + status APIs |
 
 ## API Integration
 
@@ -119,9 +119,10 @@ Executes a shell command in a sandbox with real-time output streaming.
   - `command`: string (required) — shell command
   - `cwd`: string (optional) — working directory
   - `timeout`: integer (optional) — timeout in ms (default: 300000)
-- **Returns**: `{ exit_code, output }`
-- **Streaming**: Emits `tool.output.delta` events with partial combined stdout/stderr output (emitted on stream `"stdout"`) as the command runs (polled every ~1s). The final tool result contains the complete combined output.
+- **Returns**: `{ stdout, stderr, exit_code, success, cwd, sandbox_id, truncated?, stdout_lines?, stderr_lines?, hint?, full_output?, output_files? }`
+- **Streaming**: Emits `tool.output.delta` events on the correct `stream` (`"stdout"` or `"stderr"`) as the command runs (polled every ~1s). The final tool result is the authoritative structured stdout/stderr snapshot.
 - **Recovery**: If a command times out or the shared exec shell is detected as dead, Everruns resets the Daytona exec session before returning the error so the next command can recover cleanly.
+- **Human representation**: Follows the shared exec-tool contract in `specs/tool-execution.md`. Command text is primary; sandbox metadata is secondary.
 
 ### daytona_read_file
 

--- a/integrations/daytona/src/client.rs
+++ b/integrations/daytona/src/client.rs
@@ -557,7 +557,7 @@ impl DaytonaClient {
         let deadline = std::time::Instant::now() + Duration::from_millis(timeout);
         let mut raw_bytes_emitted: usize = 0;
         let mut stale_polls: u32 = 0;
-        let mut current_stream = ExecStream::Stdout;
+        let mut delta_parser = ExecDeltaParserState::new(ExecStream::Stdout);
         let logs_path = format!("/process/session/{EXEC_SESSION_ID}/command/{cmd_id}/logs");
         let status_path = format!("/process/session/{EXEC_SESSION_ID}/command/{cmd_id}");
 
@@ -591,11 +591,11 @@ impl DaytonaClient {
             if let Some(raw_logs) = logs_ok.as_ref()
                 && raw_logs.len() > raw_bytes_emitted
             {
-                let delta = parse_exec_output_delta(&raw_logs[raw_bytes_emitted..], current_stream);
+                let delta =
+                    parse_exec_output_delta(&raw_logs[raw_bytes_emitted..], &mut delta_parser);
                 for chunk in delta.chunks {
                     on_output(chunk);
                 }
-                current_stream = delta.trailing_stream;
                 raw_bytes_emitted = raw_logs.len();
             }
 
@@ -614,11 +614,16 @@ impl DaytonaClient {
                     .unwrap_or_default();
 
                 if final_logs.len() > raw_bytes_emitted {
-                    let delta =
-                        parse_exec_output_delta(&final_logs[raw_bytes_emitted..], current_stream);
+                    let delta = parse_exec_output_delta(
+                        &final_logs[raw_bytes_emitted..],
+                        &mut delta_parser,
+                    );
                     for chunk in delta.chunks {
                         on_output(chunk);
                     }
+                }
+                for chunk in finish_exec_output_delta(&mut delta_parser).chunks {
+                    on_output(chunk);
                 }
                 let final_output = split_stream_markers(&final_logs);
 
@@ -760,7 +765,21 @@ struct ParsedExecOutput {
 
 struct ParsedExecDelta {
     chunks: Vec<ExecOutputChunk>,
-    trailing_stream: ExecStream,
+}
+
+#[derive(Debug, Clone)]
+struct ExecDeltaParserState {
+    current_stream: ExecStream,
+    pending_marker_prefix: Vec<u8>,
+}
+
+impl ExecDeltaParserState {
+    fn new(starting_stream: ExecStream) -> Self {
+        Self {
+            current_stream: starting_stream,
+            pending_marker_prefix: Vec::new(),
+        }
+    }
 }
 
 /// Split Daytona session log stream multiplexing markers into stdout/stderr.
@@ -806,52 +825,74 @@ fn split_stream_markers(raw: &[u8]) -> ParsedExecOutput {
     }
 }
 
-fn parse_exec_output_delta(raw: &[u8], starting_stream: ExecStream) -> ParsedExecDelta {
+fn flush_exec_output_buffer(
+    chunks: &mut Vec<ExecOutputChunk>,
+    stream: ExecStream,
+    buffer: &mut Vec<u8>,
+) {
+    if buffer.is_empty() {
+        return;
+    }
+    let text = String::from_utf8_lossy(buffer).into_owned();
+    if let Some(last) = chunks.last_mut()
+        && last.stream == stream
+    {
+        last.text.push_str(&text);
+    } else {
+        chunks.push(ExecOutputChunk { stream, text });
+    }
+    buffer.clear();
+}
+
+fn is_partial_stream_marker_prefix(bytes: &[u8]) -> bool {
+    if bytes.is_empty() || bytes.len() >= STDOUT_MARKER.len() {
+        return false;
+    }
+
+    bytes.iter().all(|b| *b == STDOUT_MARKER[0]) || bytes.iter().all(|b| *b == STDERR_MARKER[0])
+}
+
+fn parse_exec_output_delta(raw: &[u8], state: &mut ExecDeltaParserState) -> ParsedExecDelta {
     let mut chunks: Vec<ExecOutputChunk> = Vec::new();
-    let mut current_stream = starting_stream;
     let mut buffer = Vec::new();
+    let mut bytes = Vec::with_capacity(state.pending_marker_prefix.len() + raw.len());
+    bytes.extend_from_slice(&state.pending_marker_prefix);
+    bytes.extend_from_slice(raw);
+    state.pending_marker_prefix.clear();
     let mut i = 0;
 
-    let flush_buffer =
-        |chunks: &mut Vec<ExecOutputChunk>, stream: ExecStream, buffer: &mut Vec<u8>| {
-            if buffer.is_empty() {
-                return;
-            }
-            let text = String::from_utf8_lossy(buffer).into_owned();
-            if let Some(last) = chunks.last_mut()
-                && last.stream == stream
-            {
-                last.text.push_str(&text);
-            } else {
-                chunks.push(ExecOutputChunk { stream, text });
-            }
-            buffer.clear();
-        };
-
-    while i < raw.len() {
-        if i + 3 <= raw.len() && raw[i..i + 3] == STDOUT_MARKER {
-            flush_buffer(&mut chunks, current_stream, &mut buffer);
-            current_stream = ExecStream::Stdout;
+    while i < bytes.len() {
+        if i + 3 <= bytes.len() && bytes[i..i + 3] == STDOUT_MARKER {
+            flush_exec_output_buffer(&mut chunks, state.current_stream, &mut buffer);
+            state.current_stream = ExecStream::Stdout;
             i += 3;
             continue;
         }
-        if i + 3 <= raw.len() && raw[i..i + 3] == STDERR_MARKER {
-            flush_buffer(&mut chunks, current_stream, &mut buffer);
-            current_stream = ExecStream::Stderr;
+        if i + 3 <= bytes.len() && bytes[i..i + 3] == STDERR_MARKER {
+            flush_exec_output_buffer(&mut chunks, state.current_stream, &mut buffer);
+            state.current_stream = ExecStream::Stderr;
             i += 3;
             continue;
         }
+        if is_partial_stream_marker_prefix(&bytes[i..]) {
+            state.pending_marker_prefix.extend_from_slice(&bytes[i..]);
+            break;
+        }
 
-        buffer.push(raw[i]);
+        buffer.push(bytes[i]);
         i += 1;
     }
 
-    flush_buffer(&mut chunks, current_stream, &mut buffer);
+    flush_exec_output_buffer(&mut chunks, state.current_stream, &mut buffer);
 
-    ParsedExecDelta {
-        chunks,
-        trailing_stream: current_stream,
-    }
+    ParsedExecDelta { chunks }
+}
+
+fn finish_exec_output_delta(state: &mut ExecDeltaParserState) -> ParsedExecDelta {
+    let mut chunks = Vec::new();
+    let mut buffer = std::mem::take(&mut state.pending_marker_prefix);
+    flush_exec_output_buffer(&mut chunks, state.current_stream, &mut buffer);
+    ParsedExecDelta { chunks }
 }
 
 pub(crate) mod urlencoding {
@@ -1966,7 +2007,8 @@ mod tests {
         raw.extend_from_slice(&STDERR_MARKER);
         raw.extend_from_slice(b"stderr line\n");
 
-        let parsed = parse_exec_output_delta(&raw, ExecStream::Stdout);
+        let mut parser = ExecDeltaParserState::new(ExecStream::Stdout);
+        let parsed = parse_exec_output_delta(&raw, &mut parser);
         assert_eq!(
             parsed.chunks,
             vec![
@@ -1980,6 +2022,43 @@ mod tests {
                 },
             ]
         );
-        assert_eq!(parsed.trailing_stream, ExecStream::Stderr);
+        assert_eq!(parser.current_stream, ExecStream::Stderr);
+        assert!(parser.pending_marker_prefix.is_empty());
+    }
+
+    #[test]
+    fn test_parse_exec_output_delta_handles_split_marker_across_polls() {
+        let mut parser = ExecDeltaParserState::new(ExecStream::Stdout);
+
+        let mut first = Vec::new();
+        first.extend_from_slice(&STDOUT_MARKER);
+        first.extend_from_slice(b"stdout line\n");
+        first.extend_from_slice(&STDERR_MARKER[..2]);
+
+        let parsed_first = parse_exec_output_delta(&first, &mut parser);
+        assert_eq!(
+            parsed_first.chunks,
+            vec![ExecOutputChunk {
+                stream: ExecStream::Stdout,
+                text: "stdout line\n".to_string(),
+            }]
+        );
+        assert_eq!(parser.current_stream, ExecStream::Stdout);
+        assert_eq!(parser.pending_marker_prefix, STDERR_MARKER[..2].to_vec());
+
+        let mut second = Vec::new();
+        second.extend_from_slice(&STDERR_MARKER[2..]);
+        second.extend_from_slice(b"stderr line\n");
+
+        let parsed_second = parse_exec_output_delta(&second, &mut parser);
+        assert_eq!(
+            parsed_second.chunks,
+            vec![ExecOutputChunk {
+                stream: ExecStream::Stderr,
+                text: "stderr line\n".to_string(),
+            }]
+        );
+        assert_eq!(parser.current_stream, ExecStream::Stderr);
+        assert!(parser.pending_marker_prefix.is_empty());
     }
 }

--- a/integrations/daytona/src/client.rs
+++ b/integrations/daytona/src/client.rs
@@ -22,7 +22,7 @@ use serde_json::{Value, json};
 use std::time::Duration;
 use tracing::debug;
 
-use crate::state::{ExecResult, SandboxInfo, SnapshotInfo};
+use crate::state::{ExecOutputChunk, ExecResult, ExecStream, SandboxInfo, SnapshotInfo};
 use crate::{EXEC_POLL_INTERVAL, SANDBOX_READY_MAX_WAIT, SANDBOX_READY_POLL_INTERVAL};
 
 /// Fixed session ID used for all command execution in a sandbox.
@@ -508,7 +508,7 @@ impl DaytonaClient {
         mut on_output: F,
     ) -> Result<ExecResult, String>
     where
-        F: FnMut(&str),
+        F: FnMut(ExecOutputChunk),
     {
         self.ensure_session(sandbox_id).await?;
 
@@ -555,8 +555,9 @@ impl DaytonaClient {
         // polls we probe with a heartbeat command; if it also stalls, we
         // know the session is dead and reset it.
         let deadline = std::time::Instant::now() + Duration::from_millis(timeout);
-        let mut output_emitted: usize = 0;
+        let mut raw_bytes_emitted: usize = 0;
         let mut stale_polls: u32 = 0;
+        let mut current_stream = ExecStream::Stdout;
         let logs_path = format!("/process/session/{EXEC_SESSION_ID}/command/{cmd_id}/logs");
         let status_path = format!("/process/session/{EXEC_SESSION_ID}/command/{cmd_id}");
 
@@ -584,14 +585,18 @@ impl DaytonaClient {
             // Fetch session command logs (raw bytes with stream markers).
             let logs_ok = self.toolbox_download(sandbox_id, &logs_path).await.ok();
 
-            let text = logs_ok
-                .as_deref()
-                .map(strip_stream_markers)
-                .unwrap_or_default();
-            let had_new_output = text.len() > output_emitted;
-            if had_new_output {
-                on_output(&text[output_emitted..]);
-                output_emitted = text.len();
+            let had_new_output = logs_ok
+                .as_ref()
+                .is_some_and(|bytes| bytes.len() > raw_bytes_emitted);
+            if let Some(raw_logs) = logs_ok.as_ref()
+                && raw_logs.len() > raw_bytes_emitted
+            {
+                let delta = parse_exec_output_delta(&raw_logs[raw_bytes_emitted..], current_stream);
+                for chunk in delta.chunks {
+                    on_output(chunk);
+                }
+                current_stream = delta.trailing_stream;
+                raw_bytes_emitted = raw_logs.len();
             }
 
             // Check if command completed (exitCode is present).
@@ -608,13 +613,19 @@ impl DaytonaClient {
                     .await
                     .unwrap_or_default();
 
-                let final_text = strip_stream_markers(&final_logs);
-                if final_text.len() > output_emitted {
-                    on_output(&final_text[output_emitted..]);
+                if final_logs.len() > raw_bytes_emitted {
+                    let delta =
+                        parse_exec_output_delta(&final_logs[raw_bytes_emitted..], current_stream);
+                    for chunk in delta.chunks {
+                        on_output(chunk);
+                    }
                 }
+                let final_output = split_stream_markers(&final_logs);
 
                 return Ok(ExecResult {
-                    result: final_text,
+                    stdout: final_output.stdout,
+                    stderr: final_output.stderr,
+                    result: final_output.combined,
                     exit_code: exit_code as i32,
                 });
             }
@@ -738,29 +749,109 @@ impl DaytonaClient {
     }
 }
 
-/// Strip Daytona session log stream multiplexing markers from raw output.
+const STDOUT_MARKER: [u8; 3] = [0x01, 0x01, 0x01];
+const STDERR_MARKER: [u8; 3] = [0x02, 0x02, 0x02];
+
+struct ParsedExecOutput {
+    stdout: String,
+    stderr: String,
+    combined: String,
+}
+
+struct ParsedExecDelta {
+    chunks: Vec<ExecOutputChunk>,
+    trailing_stream: ExecStream,
+}
+
+/// Split Daytona session log stream multiplexing markers into stdout/stderr.
 ///
 /// The session API multiplexes stdout/stderr with 3-byte prefix markers:
 /// - `\x01\x01\x01` = stdout data follows
 /// - `\x02\x02\x02` = stderr data follows
 ///
-/// We strip the markers and return combined text (matching the previous
-/// behavior where `ExecResult.result` contains combined stdout+stderr).
-pub(crate) fn strip_stream_markers(raw: &[u8]) -> String {
-    let mut result = Vec::with_capacity(raw.len());
+/// The returned `combined` output matches the legacy `ExecResult.result`
+/// behavior so existing textual consumers can continue using it.
+fn split_stream_markers(raw: &[u8]) -> ParsedExecOutput {
+    let mut stdout = Vec::with_capacity(raw.len());
+    let mut stderr = Vec::new();
+    let mut combined = Vec::with_capacity(raw.len());
+    let mut current_stream = ExecStream::Stdout;
     let mut i = 0;
+
     while i < raw.len() {
-        if i + 3 <= raw.len()
-            && ((raw[i] == 0x01 && raw[i + 1] == 0x01 && raw[i + 2] == 0x01)
-                || (raw[i] == 0x02 && raw[i + 1] == 0x02 && raw[i + 2] == 0x02))
-        {
+        if i + 3 <= raw.len() && raw[i..i + 3] == STDOUT_MARKER {
+            current_stream = ExecStream::Stdout;
             i += 3;
             continue;
         }
-        result.push(raw[i]);
+        if i + 3 <= raw.len() && raw[i..i + 3] == STDERR_MARKER {
+            current_stream = ExecStream::Stderr;
+            i += 3;
+            continue;
+        }
+
+        let byte = raw[i];
+        combined.push(byte);
+        match current_stream {
+            ExecStream::Stdout => stdout.push(byte),
+            ExecStream::Stderr => stderr.push(byte),
+        }
         i += 1;
     }
-    String::from_utf8_lossy(&result).into_owned()
+
+    ParsedExecOutput {
+        stdout: String::from_utf8_lossy(&stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&stderr).into_owned(),
+        combined: String::from_utf8_lossy(&combined).into_owned(),
+    }
+}
+
+fn parse_exec_output_delta(raw: &[u8], starting_stream: ExecStream) -> ParsedExecDelta {
+    let mut chunks: Vec<ExecOutputChunk> = Vec::new();
+    let mut current_stream = starting_stream;
+    let mut buffer = Vec::new();
+    let mut i = 0;
+
+    let flush_buffer =
+        |chunks: &mut Vec<ExecOutputChunk>, stream: ExecStream, buffer: &mut Vec<u8>| {
+            if buffer.is_empty() {
+                return;
+            }
+            let text = String::from_utf8_lossy(buffer).into_owned();
+            if let Some(last) = chunks.last_mut()
+                && last.stream == stream
+            {
+                last.text.push_str(&text);
+            } else {
+                chunks.push(ExecOutputChunk { stream, text });
+            }
+            buffer.clear();
+        };
+
+    while i < raw.len() {
+        if i + 3 <= raw.len() && raw[i..i + 3] == STDOUT_MARKER {
+            flush_buffer(&mut chunks, current_stream, &mut buffer);
+            current_stream = ExecStream::Stdout;
+            i += 3;
+            continue;
+        }
+        if i + 3 <= raw.len() && raw[i..i + 3] == STDERR_MARKER {
+            flush_buffer(&mut chunks, current_stream, &mut buffer);
+            current_stream = ExecStream::Stderr;
+            i += 3;
+            continue;
+        }
+
+        buffer.push(raw[i]);
+        i += 1;
+    }
+
+    flush_buffer(&mut chunks, current_stream, &mut buffer);
+
+    ParsedExecDelta {
+        chunks,
+        trailing_stream: current_stream,
+    }
 }
 
 pub(crate) mod urlencoding {
@@ -944,6 +1035,8 @@ mod tests {
         assert!(result.is_ok());
         let exec_result = result.unwrap();
         assert_eq!(exec_result.exit_code, 0);
+        assert_eq!(exec_result.stdout, "hello world\n");
+        assert_eq!(exec_result.stderr, "");
         assert_eq!(exec_result.result, "hello world\n");
     }
 
@@ -1347,6 +1440,8 @@ mod tests {
         assert!(result.is_ok());
         let exec_result = result.unwrap();
         assert_eq!(exec_result.exit_code, 1);
+        assert_eq!(exec_result.stdout, "output");
+        assert_eq!(exec_result.stderr, "");
         assert_eq!(exec_result.result, "output");
     }
 
@@ -1570,7 +1665,7 @@ mod tests {
             mock_server.uri(),
         );
 
-        let chunks: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let chunks: Arc<Mutex<Vec<ExecOutputChunk>>> = Arc::new(Mutex::new(Vec::new()));
         let chunks_clone = chunks.clone();
 
         let result = client
@@ -1580,7 +1675,7 @@ mod tests {
                 None,
                 Some(30_000),
                 |chunk| {
-                    chunks_clone.lock().unwrap().push(chunk.to_string());
+                    chunks_clone.lock().unwrap().push(chunk);
                 },
             )
             .await;
@@ -1588,10 +1683,14 @@ mod tests {
         assert!(result.is_ok(), "exec_streaming failed: {:?}", result.err());
         let exec_result = result.unwrap();
         assert_eq!(exec_result.exit_code, 0);
+        assert_eq!(exec_result.stdout, "hello streaming\n");
+        assert_eq!(exec_result.stderr, "");
         assert_eq!(exec_result.result, "hello streaming\n");
 
         let collected = chunks.lock().unwrap();
         assert!(!collected.is_empty(), "should have received output chunks");
+        assert_eq!(collected[0].stream, ExecStream::Stdout);
+        assert_eq!(collected[0].text, "hello streaming\n");
     }
 
     #[tokio::test]
@@ -1701,6 +1800,8 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout, "still works\n");
+        assert_eq!(result.stderr, "");
         assert_eq!(result.result, "still works\n");
         assert_eq!(exec_call_count.load(Ordering::SeqCst), 2);
     }
@@ -1820,7 +1921,10 @@ mod tests {
     fn test_strip_stream_markers_stdout_only() {
         let mut raw = vec![0x01, 0x01, 0x01];
         raw.extend_from_slice(b"hello world\n");
-        assert_eq!(strip_stream_markers(&raw), "hello world\n");
+        let parsed = split_stream_markers(&raw);
+        assert_eq!(parsed.stdout, "hello world\n");
+        assert_eq!(parsed.stderr, "");
+        assert_eq!(parsed.combined, "hello world\n");
     }
 
     #[test]
@@ -1832,19 +1936,50 @@ mod tests {
         raw.extend_from_slice(b"stderr line\n");
         raw.extend_from_slice(&[0x01, 0x01, 0x01]);
         raw.extend_from_slice(b"more stdout\n");
-        assert_eq!(
-            strip_stream_markers(&raw),
-            "stdout line\nstderr line\nmore stdout\n"
-        );
+        let parsed = split_stream_markers(&raw);
+        assert_eq!(parsed.stdout, "stdout line\nmore stdout\n");
+        assert_eq!(parsed.stderr, "stderr line\n");
+        assert_eq!(parsed.combined, "stdout line\nstderr line\nmore stdout\n");
     }
 
     #[test]
     fn test_strip_stream_markers_no_markers() {
-        assert_eq!(strip_stream_markers(b"plain text\n"), "plain text\n");
+        let parsed = split_stream_markers(b"plain text\n");
+        assert_eq!(parsed.stdout, "plain text\n");
+        assert_eq!(parsed.stderr, "");
+        assert_eq!(parsed.combined, "plain text\n");
     }
 
     #[test]
     fn test_strip_stream_markers_empty() {
-        assert_eq!(strip_stream_markers(b""), "");
+        let parsed = split_stream_markers(b"");
+        assert_eq!(parsed.stdout, "");
+        assert_eq!(parsed.stderr, "");
+        assert_eq!(parsed.combined, "");
+    }
+
+    #[test]
+    fn test_parse_exec_output_delta_preserves_streams() {
+        let mut raw = Vec::new();
+        raw.extend_from_slice(&STDOUT_MARKER);
+        raw.extend_from_slice(b"stdout line\n");
+        raw.extend_from_slice(&STDERR_MARKER);
+        raw.extend_from_slice(b"stderr line\n");
+
+        let parsed = parse_exec_output_delta(&raw, ExecStream::Stdout);
+        assert_eq!(
+            parsed.chunks,
+            vec![
+                ExecOutputChunk {
+                    stream: ExecStream::Stdout,
+                    text: "stdout line\n".to_string(),
+                },
+                ExecOutputChunk {
+                    stream: ExecStream::Stderr,
+                    text: "stderr line\n".to_string(),
+                },
+            ]
+        );
+        assert_eq!(parsed.trailing_stream, ExecStream::Stderr);
     }
 }

--- a/integrations/daytona/src/session_sandbox_provider.rs
+++ b/integrations/daytona/src/session_sandbox_provider.rs
@@ -251,19 +251,36 @@ impl SessionSandboxProvider for DaytonaSessionSandboxProvider {
         let result = result.map_err(ToolExecutionResult::tool_error)?;
         touch_sandbox_lease(context, &lease_state, instance.display_name.clone()).await?;
 
-        let clean_output = everruns_core::tool_output_sanitizer::clean_exec_output(&result.result);
-        let output = if let Some(budget) =
+        let clean_stdout = everruns_core::tool_output_sanitizer::clean_exec_output(&result.stdout);
+        let clean_stderr = everruns_core::tool_output_sanitizer::clean_exec_output(&result.stderr);
+        let (stdout, stderr) = if let Some(budget) =
             everruns_core::tool_output_sanitizer::output_verbosity_budget(&request.output_mode)
         {
-            everruns_core::tool_output_sanitizer::priority_aware_truncate(&clean_output, budget)
+            (
+                everruns_core::tool_output_sanitizer::priority_aware_truncate(
+                    &clean_stdout,
+                    budget,
+                ),
+                everruns_core::tool_output_sanitizer::priority_aware_truncate(
+                    &clean_stderr,
+                    budget.min(4096),
+                ),
+            )
         } else {
-            clean_output.clone()
+            (clean_stdout.clone(), clean_stderr.clone())
         };
+        let mut raw = clean_stdout;
+        if !clean_stderr.is_empty() {
+            raw.push_str("\n--- stderr ---\n");
+            raw.push_str(&clean_stderr);
+        }
 
         Ok(SessionSandboxExecResponse {
             exit_code: result.exit_code,
-            output,
-            raw_output: Some(clean_output),
+            stdout,
+            stderr,
+            success: result.exit_code == 0,
+            raw_output: Some(raw),
             hint: exit_code_hint(result.exit_code).map(ToString::to_string),
         })
     }

--- a/integrations/daytona/src/state.rs
+++ b/integrations/daytona/src/state.rs
@@ -28,9 +28,35 @@ pub struct SandboxInfo {
 #[serde(rename_all = "camelCase")]
 pub struct ExecResult {
     #[serde(default)]
+    pub stdout: String,
+    #[serde(default)]
+    pub stderr: String,
+    #[serde(default)]
     pub result: String,
     #[serde(default)]
     pub exit_code: i32,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecStream {
+    Stdout,
+    Stderr,
+}
+
+impl ExecStream {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Stdout => "stdout",
+            Self::Stderr => "stderr",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExecOutputChunk {
+    pub stream: ExecStream,
+    pub text: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -387,8 +413,10 @@ mod tests {
 
     #[test]
     fn test_exec_result_deserialization() {
-        let json = r#"{"result": "hello\n", "exitCode": 0}"#;
+        let json = r#"{"stdout": "hello\n", "stderr": "", "result": "hello\n", "exitCode": 0}"#;
         let result: ExecResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.stdout, "hello\n");
+        assert_eq!(result.stderr, "");
         assert_eq!(result.result, "hello\n");
         assert_eq!(result.exit_code, 0);
     }
@@ -397,15 +425,18 @@ mod tests {
     fn test_exec_result_defaults() {
         let json = r#"{}"#;
         let result: ExecResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.stdout, "");
+        assert_eq!(result.stderr, "");
         assert_eq!(result.result, "");
         assert_eq!(result.exit_code, 0);
     }
 
     #[test]
     fn test_exec_result_nonzero_exit() {
-        let json = r#"{"result": "error msg", "exitCode": 1}"#;
+        let json = r#"{"stdout": "", "stderr": "error msg", "result": "error msg", "exitCode": 1}"#;
         let result: ExecResult = serde_json::from_str(json).unwrap();
         assert_eq!(result.exit_code, 1);
+        assert_eq!(result.stderr, "error msg");
         assert_eq!(result.result, "error msg");
     }
 

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -64,6 +64,53 @@ fn exit_code_hint(exit_code: i32) -> Option<&'static str> {
     }
 }
 
+fn build_exec_tool_result(
+    sandbox_id: &str,
+    cwd: Option<&str>,
+    result: &crate::state::ExecResult,
+    output_mode: &str,
+) -> ToolExecutionResult {
+    use everruns_core::tool_output_sanitizer::{
+        clean_exec_output, output_verbosity_budget, priority_aware_truncate,
+    };
+
+    let clean_stdout = clean_exec_output(&result.stdout);
+    let clean_stderr = clean_exec_output(&result.stderr);
+    let (stdout, stderr) = if let Some(budget) = output_verbosity_budget(output_mode) {
+        (
+            priority_aware_truncate(&clean_stdout, budget),
+            priority_aware_truncate(&clean_stderr, budget.min(4096)),
+        )
+    } else {
+        (clean_stdout.clone(), clean_stderr.clone())
+    };
+    let truncated = stdout != clean_stdout || stderr != clean_stderr;
+    let total_lines = clean_stdout.lines().count();
+    let mut raw = clean_stdout;
+    if !clean_stderr.is_empty() {
+        raw.push_str("\n--- stderr ---\n");
+        raw.push_str(&clean_stderr);
+    }
+
+    let mut response = json!({
+        "sandbox_id": sandbox_id,
+        "stdout": stdout,
+        "stderr": stderr,
+        "exit_code": result.exit_code,
+        "success": result.exit_code == 0,
+        "truncated": truncated,
+        "total_lines": total_lines,
+    });
+    if let Some(cwd) = cwd {
+        response["cwd"] = json!(cwd);
+    }
+    if let Some(hint) = exit_code_hint(result.exit_code) {
+        response["hint"] = json!(hint);
+    }
+
+    ToolExecutionResult::success_with_raw_output(response, raw)
+}
+
 /// Parse an optional integer resource parameter, validating type and range.
 fn parse_resource_param(
     arguments: &Value,
@@ -475,47 +522,7 @@ impl Tool for DaytonaExecTool {
                 if let Err(e) = touch_sandbox_lease(context, &state, None).await {
                     return e;
                 }
-                {
-                    use everruns_core::tool_output_sanitizer::{
-                        clean_exec_output, output_verbosity_budget, priority_aware_truncate,
-                    };
-                    let clean_stdout = clean_exec_output(&result.stdout);
-                    let clean_stderr = clean_exec_output(&result.stderr);
-                    let (stdout, stderr) =
-                        if let Some(budget) = output_verbosity_budget(output_mode) {
-                            (
-                                priority_aware_truncate(&clean_stdout, budget),
-                                priority_aware_truncate(&clean_stderr, budget.min(4096)),
-                            )
-                        } else {
-                            (clean_stdout.clone(), clean_stderr.clone())
-                        };
-                    let truncated = stdout != clean_stdout || stderr != clean_stderr;
-                    let stdout_lines = clean_stdout.lines().count();
-                    let stderr_lines = clean_stderr.lines().count();
-                    let mut raw = clean_stdout;
-                    if !clean_stderr.is_empty() {
-                        raw.push_str("\n--- stderr ---\n");
-                        raw.push_str(&clean_stderr);
-                    }
-                    let mut response = json!({
-                        "sandbox_id": sandbox_id,
-                        "cwd": cwd.unwrap_or(&state.workspace_path),
-                        "stdout": stdout,
-                        "stderr": stderr,
-                        "exit_code": result.exit_code,
-                        "success": result.exit_code == 0,
-                        "truncated": truncated,
-                        "stdout_lines": stdout_lines,
-                        "stderr_lines": stderr_lines,
-                    });
-                    // Add diagnostic hint for signal-based exit codes so agents
-                    // can adapt their retry strategy. See EVE-252.
-                    if let Some(hint) = exit_code_hint(result.exit_code) {
-                        response["hint"] = json!(hint);
-                    }
-                    ToolExecutionResult::success_with_raw_output(response, raw)
-                }
+                build_exec_tool_result(sandbox_id, cwd, &result, output_mode)
             }
             Err(e) => ToolExecutionResult::tool_error(e),
         }
@@ -2782,6 +2789,30 @@ mod tests {
         assert!(exit_code_hint(130).unwrap().contains("signal"));
         // Outside signal range
         assert!(exit_code_hint(200).is_none());
+    }
+
+    #[test]
+    fn test_build_exec_tool_result_omits_unknown_cwd_and_uses_total_lines() {
+        let result = crate::state::ExecResult {
+            stdout: "line one\nline two\n".to_string(),
+            stderr: "warning\n".to_string(),
+            result: "line one\nline two\nwarning\n".to_string(),
+            exit_code: 0,
+        };
+
+        let output = build_exec_tool_result("sb_test", None, &result, "normal");
+        match output {
+            ToolExecutionResult::Success(value) => {
+                assert_eq!(value["sandbox_id"], "sb_test");
+                assert_eq!(value["stdout"], "line one\nline two\n");
+                assert_eq!(value["stderr"], "warning\n");
+                assert_eq!(value["total_lines"], 2);
+                assert!(value.get("cwd").is_none(), "cwd should be omitted");
+                assert!(value.get("stdout_lines").is_none());
+                assert!(value.get("stderr_lines").is_none());
+            }
+            other => panic!("Expected Success, got {other:?}"),
+        }
     }
 
     // ========================================================================

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -451,19 +451,19 @@ impl Tool for DaytonaExecTool {
         // Use streaming exec to emit real-time output via tool.output.delta events.
         // Send chunks over an mpsc channel to a single emitter task to preserve
         // ordering and avoid unbounded task spawning.
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<crate::state::ExecOutputChunk>();
         let streaming_ctx = context.clone();
         let emitter = tokio::spawn(async move {
             while let Some(delta) = rx.recv().await {
                 streaming_ctx
-                    .emit_tool_output("daytona_exec", &delta, "stdout")
+                    .emit_tool_output("daytona_exec", &delta.text, delta.stream.as_str())
                     .await;
             }
         });
 
         let result = client
             .exec(sandbox_id, command, cwd, Some(timeout), |chunk| {
-                let _ = tx.send(chunk.to_string());
+                let _ = tx.send(chunk);
             })
             .await;
         drop(tx); // Close the channel so the emitter task finishes.
@@ -479,16 +479,35 @@ impl Tool for DaytonaExecTool {
                     use everruns_core::tool_output_sanitizer::{
                         clean_exec_output, output_verbosity_budget, priority_aware_truncate,
                     };
-                    let clean_output = clean_exec_output(&result.result);
-                    let output = if let Some(budget) = output_verbosity_budget(output_mode) {
-                        priority_aware_truncate(&clean_output, budget)
-                    } else {
-                        clean_output.clone()
-                    };
-                    let raw = clean_output;
+                    let clean_stdout = clean_exec_output(&result.stdout);
+                    let clean_stderr = clean_exec_output(&result.stderr);
+                    let (stdout, stderr) =
+                        if let Some(budget) = output_verbosity_budget(output_mode) {
+                            (
+                                priority_aware_truncate(&clean_stdout, budget),
+                                priority_aware_truncate(&clean_stderr, budget.min(4096)),
+                            )
+                        } else {
+                            (clean_stdout.clone(), clean_stderr.clone())
+                        };
+                    let truncated = stdout != clean_stdout || stderr != clean_stderr;
+                    let stdout_lines = clean_stdout.lines().count();
+                    let stderr_lines = clean_stderr.lines().count();
+                    let mut raw = clean_stdout;
+                    if !clean_stderr.is_empty() {
+                        raw.push_str("\n--- stderr ---\n");
+                        raw.push_str(&clean_stderr);
+                    }
                     let mut response = json!({
+                        "sandbox_id": sandbox_id,
+                        "cwd": cwd.unwrap_or(&state.workspace_path),
+                        "stdout": stdout,
+                        "stderr": stderr,
                         "exit_code": result.exit_code,
-                        "output": output
+                        "success": result.exit_code == 0,
+                        "truncated": truncated,
+                        "stdout_lines": stdout_lines,
+                        "stderr_lines": stderr_lines,
                     });
                     // Add diagnostic hint for signal-based exit codes so agents
                     // can adapt their retry strategy. See EVE-252.

--- a/integrations/daytona/tests/live_api_test.rs
+++ b/integrations/daytona/tests/live_api_test.rs
@@ -299,7 +299,7 @@ async fn test_live_exec_streaming_returns_output() {
     let mut chunks = Vec::new();
     let result = client
         .exec(id, "echo hello-streaming", None, Some(30_000), |chunk| {
-            chunks.push(chunk.to_string());
+            chunks.push(chunk);
         })
         .await
         .expect("exec_streaming failed");

--- a/integrations/daytona/tests/session_sandbox_provider.rs
+++ b/integrations/daytona/tests/session_sandbox_provider.rs
@@ -236,7 +236,7 @@ async fn daytona_provider_manages_managed_sandbox_flow() {
         .await
         .unwrap();
     assert_eq!(exec.exit_code, 0);
-    assert!(exec.output.contains("ready"));
+    assert!(exec.stdout.contains("ready"));
 
     let read = provider
         .read_file(&context, &config, &instance, "/home/daytona/main.rs")

--- a/integrations/daytona/tests/tool_integration.rs
+++ b/integrations/daytona/tests/tool_integration.rs
@@ -886,12 +886,13 @@ async fn test_exec_session_streaming_emits_chunks() {
     let client =
         DaytonaClient::with_base_urls("test_key".to_string(), mock_server.uri(), mock_server.uri());
 
-    let chunks: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let chunks: Arc<Mutex<Vec<everruns_integrations_daytona::state::ExecOutputChunk>>> =
+        Arc::new(Mutex::new(Vec::new()));
     let chunks_clone = chunks.clone();
 
     let result = client
         .exec("sb_stream", "echo streaming", None, Some(30_000), |chunk| {
-            chunks_clone.lock().unwrap().push(chunk.to_string());
+            chunks_clone.lock().unwrap().push(chunk);
         })
         .await
         .unwrap();
@@ -901,6 +902,8 @@ async fn test_exec_session_streaming_emits_chunks() {
 
     let collected = chunks.lock().unwrap();
     assert!(!collected.is_empty(), "should have received output chunks");
+    assert_eq!(collected[0].stream.as_str(), "stdout");
+    assert_eq!(collected[0].text, "chunk1\nchunk2\n");
 }
 
 #[tokio::test]

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -132,8 +132,7 @@ Human-facing exec tools should return a structured result instead of a single co
 | `cwd` | string | Effective working directory shown as secondary metadata |
 | `hint` | string | Short diagnostic hint for signal exits or common recovery advice |
 | `truncated` | boolean | Whether stdout or stderr was truncated for the inline result |
-| `stdout_lines` | integer | Total stdout line count before truncation |
-| `stderr_lines` | integer | Total stderr line count before truncation |
+| `total_lines` | integer | Total stdout line count before truncation |
 | `output_files` | string[] | Session VFS files containing full persisted output |
 | `full_output` | string | Canonical stdout path in session VFS when persisted |
 

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -112,6 +112,46 @@ Default is `concise`. Budgets apply to stdout; stderr is capped at `min(budget, 
 
 This is the tool's responsibility — each tool calls the helpers before constructing `ToolExecutionResult`. See `crates/core/src/tool_output_sanitizer.rs` for the primitives.
 
+### Structured Exec Result Contract
+
+Human-facing exec tools should return a structured result instead of a single combined `output` string. This keeps shell rendering, previews, persistence, and narration aligned across providers.
+
+**Required fields:**
+
+| Field | Type | Description |
+|------|------|-------------|
+| `stdout` | string | Sanitized stdout after verbosity truncation |
+| `stderr` | string | Sanitized stderr after verbosity truncation |
+| `exit_code` | integer | Process exit status |
+| `success` | boolean | `true` when `exit_code == 0` |
+
+**Recommended metadata:**
+
+| Field | Type | Description |
+|------|------|-------------|
+| `cwd` | string | Effective working directory shown as secondary metadata |
+| `hint` | string | Short diagnostic hint for signal exits or common recovery advice |
+| `truncated` | boolean | Whether stdout or stderr was truncated for the inline result |
+| `stdout_lines` | integer | Total stdout line count before truncation |
+| `stderr_lines` | integer | Total stderr line count before truncation |
+| `output_files` | string[] | Session VFS files containing full persisted output |
+| `full_output` | string | Canonical stdout path in session VFS when persisted |
+
+**Legacy compatibility:** Tools may continue to carry a combined pre-truncation string in `ToolResult.raw_output` for persistence hooks and logging, but the user-visible JSON contract should use `stdout`/`stderr`.
+
+### Exec Human Representation
+
+Exec-tool narration and cards should read like command execution, not generic infrastructure activity.
+
+Rules:
+- Title line is command-first: ``$ cargo test``, not the sandbox id or provider name
+- Infra metadata (`cwd`, sandbox label/id, container/session info) is secondary
+- `stderr` is visually distinct from `stdout` in both streaming and completed states
+- Exit status and duration are shown tersely beside the command
+- Standalone shell-like tools should render as their own transcript rows rather than being folded into grouped platform activity
+
+This applies to built-in `bash` and provider-backed exec tools such as `daytona_exec`, `sandbox_exec`, `e2b_exec`, `docker_exec`, and similar shell-like tools.
+
 ### Background Tool Execution
 
 `spawn_background` is a built-in meta-tool that schedules another built-in tool to run asynchronously and returns immediately with a run handle. It is generic: the caller passes `tool` plus `args`; the target tool determines whether background execution is supported.


### PR DESCRIPTION
## What
Standardize the `daytona_exec` result contract around structured `stdout`/`stderr` output, carry stream identity through Daytona exec streaming, and render `daytona_exec` as shell activity in the UI.

## Why
Daytona exec had drifted from the human representation we already use for shell-like tools. It flattened stdout/stderr into a single `output` field, emitted every delta as `stdout`, and rendered like a generic platform tool instead of a command execution step.

## How
- split Daytona session stream markers into stdout/stderr while preserving a combined raw form for persistence
- return structured exec output with `stdout`, `stderr`, `exit_code`, `success`, and secondary metadata such as `cwd` and `sandbox_id`
- document the shared exec-tool contract and align the Daytona spec to it
- treat `daytona_exec` as shell activity in the UI and add explicit narration coverage
- update Daytona/session-sandbox tests to the new contract
- follow up on review feedback for split markers, `cwd` metadata correctness, and `total_lines` naming

## Risk
- Medium
- Affects exec output transport, persistence metadata, and shell activity rendering in the transcript UI

## Security
- Threat categories reviewed: TM-TOOL, TM-WEB, TM-BASH, TM-FS, TM-DOS
- Findings and resolutions:
  - TM-TOOL: preserved tool-result boundaries; only changed structured result shape and stream labeling, no new tool execution capability
  - TM-WEB: UI renders new metadata fields through existing React escaping paths; no raw HTML injection added
  - TM-BASH: no sandbox capability expansion; command execution semantics unchanged beyond stream separation
  - TM-FS: persisted output behavior remains session-scoped and path generation stays on existing `/.outputs/{tool_call_id}` flow
  - TM-DOS: truncation and bounded stderr handling remain in place; added metadata is derived from already-bounded output
  - No new threat-model entry was needed because the change does not introduce a new trust boundary or mitigation class

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `cargo test -p everruns-integrations-daytona --lib --tests`
- `cargo test -p everruns-core tool_narration::tests::renders_daytona_exec_narration -- --exact`
- `cd apps/ui && npm test -- --runInBand src/__tests__/tool-activity-group.test.tsx`
- `PORT_PREFIX=271 just start-dev --no-watch` smoke test via browser on `/dev/tool-activity` confirming shell row render plus stdout/stderr expansion
- `just pre-push`

## Linear
- EVE-371
- EVE-372
- EVE-373