### PR TITLE
chore(issue-tracking): tighten issue pickup ownership

### DIFF
--- a/.claude/skills/maintenance/SKILL.md
+++ b/.claude/skills/maintenance/SKILL.md
@@ -44,7 +44,7 @@ Use this skill when the task is about repo maintenance rather than a single feat
 - Start from goals and risk surface, not checklist order.
 - Prefer the highest-signal path first: recent diffs, flaky areas, failing checks, stale specs, outdated dependencies, or known security/performance hotspots.
 - Always run `cargo outdated` (or `cargo search` per-crate) and `npm outdated` during release-readiness or dependency-scoped maintenance — even when no security advisory exists. Patch/minor bumps are cheap to miss and cheap to apply; skipping them silently accumulates drift.
-- Check Linear issues in the OSS project (EVE team) already in `In Progress` when maintenance covers release readiness or workflow hygiene. Treat issues whose `updatedAt` is older than 2 days as stale by default, then triage or report them.
+- Check Linear issues in the OSS project (EVE team) already in `In Progress` when maintenance covers release readiness or workflow hygiene. Treat issues whose `updatedAt` is older than 1 day as stale by default, then triage or report them.
 - Skip untouched areas when there is a clear reason. Say why they were skipped.
 - Prefer fixing over reporting.
 - For bugs uncovered during maintenance, prefer a failing test before the fix when practical.
@@ -125,7 +125,7 @@ Goal: Linear reflects reality closely enough that active work is visible, stalle
 
 Good evidence:
 - OSS project issues already in `In Progress` were reviewed for stale ownership or stalled execution
-- issues whose `updatedAt` was older than 2 days were triaged, commented, re-scoped, or moved out of `In Progress`
+- issues whose `updatedAt` was older than 1 day were triaged, commented, re-scoped, or moved out of `In Progress`
 - maintenance findings that should not be fixed immediately were captured as actionable Linear issues or comments instead of left implicit
 
 ### Repo Workflow Hygiene
@@ -150,7 +150,7 @@ Pick only what matches the task:
 - `./scripts/export-openapi.sh`
 - `doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" gh api repos/everruns/everruns/dependabot/alerts --jq "[.[] | select(.state==\"open\")] | length"'` — open Dependabot alert count
 - `doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" gh api repos/everruns/everruns/secret-scanning/alerts --jq "[.[] | select(.state==\"open\")] | length"'` — open secret scanning alert count
-- Linear MCP: list OSS project issues in `In Progress`, compare each issue's `updatedAt` to current time, and flag items older than 2 days for triage
+- Linear MCP: list OSS project issues in `In Progress`, compare each issue's `updatedAt` to current time, and flag items older than 1 day for triage
 
 ## Deliverable
 

--- a/.claude/skills/process-issues/SKILL.md
+++ b/.claude/skills/process-issues/SKILL.md
@@ -38,16 +38,23 @@ Use this skill when the user asks to:
 
 3. **Issues are fully resolved or explicitly skipped.**
    - Resolved: PR merged via `/ship`, issue marked **Done** in Linear with a comment linking the merged PR.
-   - Skipped: Linear comment explaining why (blocked, ambiguous requirements, missing access). Issue left as **In Progress** or unchanged.
+   - Skipped: leave a Linear comment only when the current run investigated the issue and the skip is due to a blocker, missing clarification, or missing access. For ownership-only skips, raise the issue to the human user without leaving an automated takeover comment. Leave the issue as **In Progress** or unchanged.
 
-4. **Sequential merging prevents conflicts.**
+4. **Ownership is checked before pickup.**
+   - Before touching an issue, inspect its Linear state, `updatedAt`, recent comments, and linked PRs to detect active ownership.
+   - If the issue is already **In Progress** and was updated within the last 1 day, treat it as actively owned by somebody else and skip it.
+   - If the issue is already **In Progress** and `updatedAt` is older than 1 day, raise it to the human user as a stale-ownership conflict. Do not auto-take over, auto-reassign, or silently reset the issue.
+   - If the issue is available to pick up, immediately move it to **In Progress** and assign it before starting implementation.
+
+5. **Sequential merging prevents conflicts.**
    - After `/ship` merges each PR, rebase remaining open PRs onto updated `main` before shipping the next.
    - When multiple PRs touch `Cargo.toml` workspace deps, the second merge can create duplicate key errors — rebase catches this.
    - Never ship a PR whose CI ran against a stale base.
 
-5. **A summary report is delivered.**
+6. **A summary report is delivered.**
    - Issues completed (with PR links)
    - Issues skipped (with reasons)
+   - Issues raised to the human because stale **In Progress** ownership needed a decision
    - Issues that failed (with error details)
 
 ## Operating Model
@@ -66,15 +73,19 @@ Linear MCP server must be configured in `.mcp.json`.
 ### Query and Prioritize
 
 1. Query open issues from the **OSS** project via Linear MCP (apply `$ARGUMENTS` filters if provided)
-2. Read each issue's title, description, labels, priority, and linked PRs
-3. Sort by priority (Urgent > Critical > High > Medium > Low), then oldest first within same priority
-4. Select up to **5 issues** to process
+2. Read each issue's title, description, labels, priority, state, `updatedAt`, recent comments, and linked PRs
+3. Check ownership before pickup:
+   - **In Progress**, updated within 1 day: somebody else is actively working on it; skip
+   - **In Progress**, updated more than 1 day ago: raise to the human user for a takeover decision; do not auto-claim it
+   - Any other state: eligible to pick up
+4. Sort eligible issues by priority (Urgent > Critical > High > Medium > Low), then oldest first within same priority
+5. Select up to **5 issues** to process
 
 ### Per-Issue Execution
 
 For each issue, process up to 5 concurrently using subagents:
 
-1. **Pick up** — mark as **In Progress** in Linear, assign if unassigned
+1. **Pick up** — only after the ownership check passes, mark as **In Progress** in Linear and assign it
 2. **Analyze** — parse requirements, search codebase, identify root cause or scope. If ambiguous: comment in Linear requesting clarification, skip
 3. **Branch** — `git fetch origin main && git checkout -b {issue-id}-{short-description} origin/main`
 4. **Implement** — write the code change:
@@ -98,11 +109,13 @@ When multiple issues produce PRs, merge sequentially (not in parallel):
 
 Skip an issue if:
 
+- Already **In Progress** and updated within the last 1 day (active owner)
+- Already **In Progress** and older than 1 day until a human decides whether to take it over
 - Blocked by external dependency
 - Requirements ambiguous and clarification pending
 - Requires access/permissions not available
 
-Always add a Linear comment explaining why.
+Leave a Linear comment explaining the skip only when the current run actively investigated the issue and the skip is due to a blocker, missing clarification, or missing access. Do **not** leave an automated Linear comment for ownership-only skips: if the issue is already **In Progress** and stale, raise it to the human user for a takeover decision instead.
 
 ## Constraints
 

--- a/specs/issue-tracking.md
+++ b/specs/issue-tracking.md
@@ -17,3 +17,9 @@ We use [Linear](https://linear.app) for issue tracking. All issues for this repo
 ## Processing Issues
 
 Use the [`/process-issues`](../.claude/skills/process-issues/SKILL.md) skill to pick up, fix, and ship open issues. One PR per issue, up to 5 in parallel.
+
+Before claiming an issue, check whether someone else is already working on it:
+
+- issues already in `In Progress` with `updatedAt` within the last 1 day are considered actively owned and should not be auto-claimed
+- issues already in `In Progress` with `updatedAt` older than 1 day require a human takeover decision; agents should raise them instead of silently reassigning or resetting them
+- once an issue is available to pick up, the agent should move it to `In Progress` immediately before implementation starts

--- a/specs/maintenance.md
+++ b/specs/maintenance.md
@@ -59,7 +59,7 @@ Before a release, maintenance should cover:
 - areas changed since the last release
 - historically fragile or high-risk surfaces
 - release artifacts affected by those changes
-- Linear issues already marked `In Progress` whose `updatedAt` is older than 2 days, signaling execution drift; use that `updatedAt` threshold as the default review threshold unless the task sets a stricter bar
+- Linear issues already marked `In Progress` whose `updatedAt` is older than 1 day, signaling execution drift; use that `updatedAt` threshold as the default review threshold unless the task sets a stricter bar
 - GitHub Security tab: security overview, Dependabot alerts, and open secret scanning alerts
 
 - dependency versions across all packages (Cargo workspace crates, npm packages, CLI) checked for outdated major versions and deprecated crates


### PR DESCRIPTION
## What
- require `/process-issues` to check Linear ownership before taking an issue
- require available issues to be moved to `In Progress` immediately when picked up
- require stale `In Progress` issues older than 1 day to be raised to a human instead of auto-claimed
- align maintenance and issue-tracking docs to the same 1-day stale threshold

## Why
The existing workflow said to mark issues `In Progress`, but it did not force an ownership check first and it left the stale-ownership threshold inconsistent across repo guidance.

## How
- updated the process-issues skill required outcomes, prioritization flow, pickup step, skip rules, and reporting
- added the ownership guard to the issue-tracking spec
- tightened maintenance skill/spec stale-ownership guidance from 2 days to 1 day

## Risk
- Low
- Docs and skill guidance only; no runtime behavior or shipped product code changed

## Security
- Threat categories reviewed: No security-relevant code changes; docs/spec/skill text only
- Findings and resolutions: None

## Validation
- `just pre-push`
- Smoke test skipped: docs/spec/skill-only change with no runtime behavior to exercise

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)