### PR TITLE
fix(ui): position notification submenu flyout

### DIFF
--- a/apps/ui/src/__tests__/dropdown-menu.test.tsx
+++ b/apps/ui/src/__tests__/dropdown-menu.test.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import {
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+} from "@/components/ui/dropdown-menu";
+
+jest.mock("@base-ui/react/menu", () => {
+  const ReactActual = jest.requireActual<typeof import("react")>("react");
+
+  type PassthroughProps = React.HTMLAttributes<HTMLElement> & {
+    children?: React.ReactNode;
+    sideOffset?: number;
+  };
+
+  const divPassthrough = ReactActual.forwardRef<HTMLElement, PassthroughProps>(
+    function DivPassthrough({ children, sideOffset, ...props }, ref) {
+      return (
+        <div ref={ref as React.Ref<HTMLDivElement>} data-side-offset={sideOffset} {...props}>
+          {children}
+        </div>
+      );
+    },
+  );
+
+  const buttonPassthrough = ReactActual.forwardRef<
+    HTMLButtonElement,
+    React.ButtonHTMLAttributes<HTMLButtonElement>
+  >(function ButtonPassthrough({ children, ...props }, ref) {
+    return (
+      <button ref={ref} type="button" {...props}>
+        {children}
+      </button>
+    );
+  });
+
+  return {
+    Menu: {
+      Root: divPassthrough,
+      Portal: divPassthrough,
+      Trigger: buttonPassthrough,
+      Positioner: divPassthrough,
+      Popup: divPassthrough,
+      Group: divPassthrough,
+      Item: divPassthrough,
+      CheckboxItem: divPassthrough,
+      CheckboxItemIndicator: divPassthrough,
+      RadioGroup: divPassthrough,
+      RadioItem: divPassthrough,
+      RadioItemIndicator: divPassthrough,
+      GroupLabel: divPassthrough,
+      Separator: divPassthrough,
+      SubmenuRoot: divPassthrough,
+      SubmenuTrigger: buttonPassthrough,
+    },
+  };
+});
+
+describe("DropdownMenuSubContent", () => {
+  it("renders submenu content inside a portal and positioner", () => {
+    render(
+      <DropdownMenuSub>
+        <DropdownMenuSubTrigger>Notifications</DropdownMenuSubTrigger>
+        <DropdownMenuSubContent>Submenu content</DropdownMenuSubContent>
+      </DropdownMenuSub>,
+    );
+
+    const submenuContent = screen.getByText("Submenu content");
+    const positioner = submenuContent.closest('[data-slot="dropdown-menu-positioner"]');
+    const portal = submenuContent.closest('[data-slot="dropdown-menu-portal"]');
+
+    expect(positioner).not.toBeNull();
+    expect(positioner).toHaveClass("z-50");
+    expect(portal).not.toBeNull();
+    expect(portal).toContainElement(positioner);
+  });
+});

--- a/apps/ui/src/components/ui/dropdown-menu.tsx
+++ b/apps/ui/src/components/ui/dropdown-menu.tsx
@@ -22,14 +22,14 @@ function DropdownMenuPositioner({
   ...props
 }: MenuPrimitive.Positioner.Props) {
   return (
-    <MenuPrimitive.Portal>
+    <DropdownMenuPortal>
       <MenuPrimitive.Positioner
         data-slot="dropdown-menu-positioner"
         sideOffset={sideOffset}
         className={cn("z-50", className)}
         {...props}
       />
-    </MenuPrimitive.Portal>
+    </DropdownMenuPortal>
   );
 }
 
@@ -193,14 +193,16 @@ function DropdownMenuSubTrigger({
 
 function DropdownMenuSubContent({ className, ...props }: MenuPrimitive.Popup.Props) {
   return (
-    <MenuPrimitive.Popup
-      data-slot="dropdown-menu-sub-content"
-      className={cn(
-        "bg-popover text-popover-foreground data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:zoom-out-95 data-[open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--transform-origin) overflow-hidden border p-1 shadow-lg",
-        className,
-      )}
-      {...props}
-    />
+    <DropdownMenuPositioner>
+      <MenuPrimitive.Popup
+        data-slot="dropdown-menu-sub-content"
+        className={cn(
+          "bg-popover text-popover-foreground data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:zoom-out-95 data-[open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 min-w-[8rem] origin-(--transform-origin) overflow-hidden border p-1 shadow-lg",
+          className,
+        )}
+        {...props}
+      />
+    </DropdownMenuPositioner>
   );
 }
 


### PR DESCRIPTION
## What
Render dropdown submenu content through a portal and positioner so the sidebar notifications panel opens as a flyout instead of inline.

## Why
EVE-369 tracks the notifications submenu rendering inside the parent account dropdown, which breaks layout and makes the panel unusable.

## How
Reuse the shared dropdown positioning helpers so `DropdownMenuSubContent` goes through the same portal + positioner path as other dropdown content, and add a focused regression test that asserts submenu content is wrapped by that structure.

## Risk
- Low
- Touches shared dropdown submenu rendering in the UI. Regression surface is other submenu popups.

## Security
- Threat categories reviewed: TM-WEB
- Findings and resolutions: Reviewed the submenu rendering change for unintended DOM injection, auth exposure, and broken client-side boundaries. No new security-relevant surface was introduced.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `cd apps/ui && npm test -- --runInBand src/__tests__/dropdown-menu.test.tsx src/__tests__/sidebar.test.tsx`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run build`
- `just pre-push`
- Playwright smoke against local full-auth stack with `FEATURE_NOTIFICATIONS=true`; confirmed the submenu rendered as a separate flyout and captured `/tmp/eve369-notification-flyout.png`

Fixes EVE-369
