### PR TITLE
chore(specs): document postgres listener deployment

### DIFF
--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -59,6 +59,26 @@ Events are classified as **ephemeral** or **durable**:
 
 `EventService.emit()` routes automatically based on `EventRequest::is_ephemeral()`. Ephemeral events (~80% of volume) never hit PostgreSQL, reducing write pressure significantly. SSE reconnection replays durable events from PG; missed deltas are acceptable since the completed event has the full content.
 
+### Listener Transport Boundary
+
+Push-style PostgreSQL listeners are intentionally separated from the ordinary sqlx query pool.
+
+- regular reads and writes may use pooled database connections
+- PostgreSQL `LISTEN/NOTIFY` listeners must use a direct session-scoped connection
+- `DATABASE_UNPOOLED_URL` is the deployment-facing override for those listener paths when `DATABASE_URL` points at a pooler/proxy
+
+Reasoning:
+
+- `LISTEN/NOTIFY` is bound to a backend session, not just a database endpoint
+- pooled/proxied PostgreSQL endpoints can surface `NotificationResponse` frames on connections that the application expects to be ordinary query channels
+- when that happens, the failure appears as intermittent query protocol errors rather than an obvious deployment misconfiguration
+
+Production event routing therefore prefers:
+
+- NATS JetStream for event push delivery when `NATS_URL` is configured
+- no legacy PostgreSQL event wakeup listener when NATS event delivery is active
+- direct PostgreSQL listener connections only for the remaining PostgreSQL-backed push paths, such as notification SSE and task notification fallback
+
 ## Requirements
 
 ### Core Architecture
@@ -225,7 +245,7 @@ The worker binary mirrors this pattern through `WorkerAppBuilder` in `crates/wor
 1. **Runner Abstraction**: `AgentRunner` trait provides the execution backend interface
 2. **Durable Execution**: Workflows run via PostgreSQL-backed durable execution engine
 3. **Workflow Isolation**: Backend concepts (workflow IDs, task queues) never exposed in public API
-4. **Event Streaming**: SSE for real-time event delivery via database-backed events
+4. **Event Streaming**: SSE for real-time event delivery via PostgreSQL-backed durable events plus `EventDelivery` push channels
 
 See [specs/durable-execution-engine.md](durable-execution-engine.md) for the durable engine architecture.
 

--- a/specs/durable-execution-engine.md
+++ b/specs/durable-execution-engine.md
@@ -92,7 +92,19 @@ Workers claim tasks partitioned by `activity_type`. See `crates/durable/src/pers
 
 ### Task Notifications
 
-Push-based via gRPC streaming (`SubscribeTaskNotifications`), backed by PostgreSQL NOTIFY or NATS. Falls back to polling (10s) on disconnect.
+Push-based via gRPC streaming (`SubscribeTaskNotifications`), backed by NATS when available and PostgreSQL `NOTIFY` otherwise. Falls back to polling (10s) on disconnect.
+
+Operational contract:
+
+- NATS is the preferred backend when configured
+- PostgreSQL fallback must use a direct session-scoped listener connection, not an ordinary pooled query connection
+- deployments that pool `DATABASE_URL` for regular queries should provide `DATABASE_UNPOOLED_URL` for PostgreSQL listener traffic
+
+Reasoning:
+
+- task notifications are latency-sensitive, but correctness matters more than transport choice
+- PostgreSQL `LISTEN/NOTIFY` through a pooler/proxy can fail intermittently and surface as protocol errors on unrelated query traffic
+- failing fast on an invalid listener URL is better than allowing a deployment that corrupts the control-plane's normal database interactions
 
 ### Generic Queue (Standalone Tasks)
 
@@ -166,4 +178,3 @@ Workers heartbeat every 5s. `WORKER_HEARTBEAT_TIMEOUT_SECS` (60s, in `crates/dur
 2. Mutual TLS (`WORKER_GRPC_TLS_*`) -- optional transport encryption
 
 **Design decision**: Workers are intentionally cross-org. Org-scoping is enforced at the HTTP API layer, not the gRPC transport.
-

--- a/specs/notifications.md
+++ b/specs/notifications.md
@@ -106,3 +106,13 @@ This avoids flicker while keeping the server model simple.
 - SSE for incremental `notification.upsert` delivery
 - PostgreSQL `LISTEN/NOTIFY` wakes streams in production
 - DEV mode falls back to timeout-based polling
+
+Deployment constraint:
+
+- notification SSE wakeups use a dedicated PostgreSQL listener connection
+- if the deployment pools `DATABASE_URL`, operators should provide `DATABASE_UNPOOLED_URL` for notification listener traffic
+
+Reasoning:
+
+- notification wakeups are session-scoped PostgreSQL listener traffic
+- sharing them with pooled query sessions can produce intermittent protocol-level failures that are hard to attribute from the notification surface alone

--- a/specs/production-deployment.md
+++ b/specs/production-deployment.md
@@ -45,6 +45,7 @@ Every production deployment must make explicit decisions for:
 - ingress / reverse proxy
 - TLS termination
 - database connectivity and TLS mode
+- listener connectivity for PostgreSQL `LISTEN/NOTIFY` paths
 - auth mode
 - worker authentication
 - secrets encryption keys
@@ -58,6 +59,33 @@ See:
 - [`specs/prometheus-metrics.md`](./prometheus-metrics.md)
 - [`specs/observability.md`](./observability.md)
 - [`specs/threat-model.md`](./threat-model.md)
+
+### PostgreSQL Listener Connectivity
+
+Production deployments may use a pooled `DATABASE_URL` for ordinary query traffic, but any server path that relies on PostgreSQL `LISTEN/NOTIFY` must use a direct session-scoped connection.
+
+Canonical operator contract:
+
+- `DATABASE_URL` may point at a pooler/proxy for normal queries
+- `DATABASE_UNPOOLED_URL` is the canonical override for PostgreSQL listener traffic
+- if the selected listener URL still points at an obvious pooler/proxy endpoint, startup must fail fast instead of silently accepting a broken deployment
+
+Reasoning:
+
+- PostgreSQL `LISTEN/NOTIFY` is session-scoped
+- pooled/proxied endpoints can interleave notification frames with ordinary query traffic
+- that failure mode is intermittent and looks like storage corruption or driver protocol errors even when the underlying writes are correct
+
+NATS changes the requirement only partially:
+
+- when NATS event delivery is active, the legacy PostgreSQL event wakeup listener is skipped
+- PostgreSQL-backed notification SSE and PostgreSQL task-notification fallback still require a direct listener connection when those paths are active
+
+See:
+- [`specs/architecture.md`](./architecture.md)
+- [`specs/durable-execution-engine.md`](./durable-execution-engine.md)
+- [`specs/notifications.md`](./notifications.md)
+- [`docs/sre/environment-variables.md`](../docs/sre/environment-variables.md)
 
 ## Production Reverse Proxy Setup
 


### PR DESCRIPTION
## What
Add a docs/spec follow-up for the PG listener fix from EVE-375.

- document direct listener connectivity as an explicit production deployment decision
- explain why PostgreSQL `LISTEN/NOTIFY` listener traffic must not share pooled query connections
- clarify how NATS changes the requirement for event delivery, notification SSE, and task-notification fallback

## Why
The implementation now enforces direct listener URLs and lazy listener resolution, but the durable reasoning belonged in the specs as well. Without that, operators only see the behavior in env docs and code comments, not in the deployment and architecture contracts.

## How
- update `specs/production-deployment.md` with the deployment contract for `DATABASE_UNPOOLED_URL`
- update `specs/architecture.md` with the listener transport boundary and protocol-level reasoning
- update `specs/durable-execution-engine.md` and `specs/notifications.md` so the subsystem specs describe the same operational rule

## Risk
- Low
- Docs-only. The main risk is spec drift if the wording is unclear or disagrees with the implementation.

## Security
- Threat categories reviewed: No security-relevant code changes; this PR only updates deployment and architecture documentation for an existing mitigation.
- Findings and resolutions: No new security surface. The docs now make the existing mitigation easier for operators to apply correctly.

## Validation
- `just pre-push`
- `git diff --check`
- Runtime smoke test skipped: docs/spec-only follow-up with no executable or config changes

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
