### PR TITLE
fix(daytona): suffix sandbox names on create

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1657,6 +1657,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "rand 0.9.4",
  "regex",
  "reqwest 0.13.2",
  "rstest",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -34,6 +34,7 @@ serde_yaml.workspace = true
 # UUID and time
 uuid.workspace = true
 chrono.workspace = true
+rand.workspace = true
 
 # Tracing
 tracing.workspace = true

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -79,6 +79,7 @@ pub mod channel;
 // Permissions model (policies, rules, caller context)
 pub mod permissions;
 pub mod progress_reporting;
+pub mod resource_names;
 
 // URL validation for SSRF prevention (shared utility)
 pub mod url_validation;

--- a/crates/core/src/resource_names.rs
+++ b/crates/core/src/resource_names.rs
@@ -1,0 +1,65 @@
+//! Shared helpers for naming external resources created from user-visible titles.
+
+use rand::Rng;
+
+const SUFFIX_ALPHABET: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
+const SUFFIX_LEN: usize = 6;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UniqueResourceName {
+    pub requested_name: String,
+    pub canonical_name: String,
+}
+
+pub fn unique_resource_name(requested_name: &str) -> UniqueResourceName {
+    let requested_name = requested_name.trim().to_string();
+    let base_name = requested_name.trim_end_matches('-');
+    let mut rng = rand::rng();
+    let suffix: String = (0..SUFFIX_LEN)
+        .map(|_| {
+            let index = rng.random_range(0..SUFFIX_ALPHABET.len());
+            SUFFIX_ALPHABET[index] as char
+        })
+        .collect();
+    let canonical_name = if base_name.is_empty() {
+        suffix
+    } else {
+        format!("{base_name}-{suffix}")
+    };
+
+    UniqueResourceName {
+        requested_name,
+        canonical_name,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unique_resource_name_appends_lowercase_alphanumeric_suffix() {
+        let name = unique_resource_name("sandbox-name");
+        let suffix = name
+            .canonical_name
+            .strip_prefix("sandbox-name-")
+            .expect("suffix should be appended");
+
+        assert_eq!(name.requested_name, "sandbox-name");
+        assert_eq!(suffix.len(), 6);
+        assert!(
+            suffix
+                .chars()
+                .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit())
+        );
+    }
+
+    #[test]
+    fn unique_resource_name_trims_input_and_trailing_dash() {
+        let name = unique_resource_name("  sandbox-name-  ");
+
+        assert_eq!(name.requested_name, "sandbox-name-");
+        assert!(name.canonical_name.starts_with("sandbox-name-"));
+        assert!(!name.canonical_name.starts_with("sandbox-name--"));
+    }
+}

--- a/integrations/daytona/SPEC.md
+++ b/integrations/daytona/SPEC.md
@@ -107,7 +107,8 @@ Creates a new sandbox. Optionally uploads files from session storage.
   - `size`: string (optional) — sandbox size tier: `small` (1 vCPU, 1 GiB RAM, 3 GiB disk), `medium` (2 vCPU, 4 GiB RAM, 8 GiB disk), `large` (4 vCPU, 8 GiB RAM, 10 GiB disk). Default: `small`.
   - `snapshot`: string (optional) — explicit Daytona snapshot name (advanced, overrides `size`)
   - `upload_files`: array (optional) — `[{session_path, sandbox_path}]`
-- **Returns**: `{ sandbox_id, status, workspace_path }`
+- **Naming**: Everruns appends a 6-character lowercase alphanumeric suffix before sending the sandbox name to Daytona, and retries once with a fresh suffix if Daytona reports a name conflict. This preserves the readable prefix while making concurrent creates statistically unique.
+- **Returns**: `{ sandbox_id, name, requested_name, status, workspace_path }`
 - **Resource mapping**: The `size` parameter maps to a pre-built Daytona snapshot with the appropriate resources. The Daytona REST API does not support per-sandbox resource overrides for snapshot-based creation (see [daytonaio/daytona#2296](https://github.com/daytonaio/daytona/issues/2296)), so we use tiered snapshots instead.
 
 ### daytona_exec

--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -13,6 +13,7 @@
 
 pub mod client;
 pub mod connection;
+mod naming;
 pub mod openapi_spec;
 mod session_sandbox_provider;
 pub mod state;

--- a/integrations/daytona/src/naming.rs
+++ b/integrations/daytona/src/naming.rs
@@ -1,0 +1,67 @@
+use everruns_core::resource_names::{UniqueResourceName, unique_resource_name};
+use serde_json::{Value, json};
+
+use crate::client::DaytonaClient;
+use crate::state::SandboxInfo;
+
+pub(crate) async fn create_sandbox_with_unique_name(
+    client: &DaytonaClient,
+    requested_name: &str,
+    mut body: Value,
+) -> Result<(SandboxInfo, UniqueResourceName), String> {
+    for attempt in 0..2 {
+        let mut generated_name = unique_resource_name(requested_name);
+        set_create_body_name(&mut body, &generated_name.canonical_name);
+
+        match client.create_sandbox(body.clone()).await {
+            Ok(info) => {
+                if let Some(actual_name) = info.name.clone() {
+                    generated_name.canonical_name = actual_name;
+                }
+                return Ok((info, generated_name));
+            }
+            Err(error) if attempt == 0 && is_daytona_name_conflict(&error) => continue,
+            Err(error) => return Err(error),
+        }
+    }
+
+    unreachable!("loop returns success or error")
+}
+
+fn set_create_body_name(body: &mut Value, name: &str) {
+    match body {
+        Value::Object(object) => {
+            object.insert("name".to_string(), json!(name));
+        }
+        _ => {
+            *body = json!({ "name": name });
+        }
+    }
+}
+
+fn is_daytona_name_conflict(error: &str) -> bool {
+    let lower = error.to_ascii_lowercase();
+    lower.contains("409")
+        || lower.contains("conflict")
+        || lower.contains("already exists")
+        || lower.contains("already taken")
+        || lower.contains("duplicate")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_conflict_errors() {
+        assert!(is_daytona_name_conflict(
+            "Daytona API error (409 Conflict): sandbox already exists"
+        ));
+        assert!(is_daytona_name_conflict(
+            "Daytona API error (422 Unprocessable Entity): duplicate sandbox name"
+        ));
+        assert!(!is_daytona_name_conflict(
+            "Daytona API error (401 Unauthorized): invalid credentials"
+        ));
+    }
+}

--- a/integrations/daytona/src/naming.rs
+++ b/integrations/daytona/src/naming.rs
@@ -11,7 +11,7 @@ pub(crate) async fn create_sandbox_with_unique_name(
 ) -> Result<(SandboxInfo, UniqueResourceName), String> {
     for attempt in 0..2 {
         let mut generated_name = unique_resource_name(requested_name);
-        set_create_body_name(&mut body, &generated_name.canonical_name);
+        set_create_body_name(&mut body, &generated_name.canonical_name)?;
 
         match client.create_sandbox(body.clone()).await {
             Ok(info) => {
@@ -28,14 +28,13 @@ pub(crate) async fn create_sandbox_with_unique_name(
     unreachable!("loop returns success or error")
 }
 
-fn set_create_body_name(body: &mut Value, name: &str) {
+fn set_create_body_name(body: &mut Value, name: &str) -> Result<(), String> {
     match body {
         Value::Object(object) => {
             object.insert("name".to_string(), json!(name));
+            Ok(())
         }
-        _ => {
-            *body = json!({ "name": name });
-        }
+        _ => Err("Daytona sandbox create body must be a JSON object".to_string()),
     }
 }
 
@@ -63,5 +62,15 @@ mod tests {
         assert!(!is_daytona_name_conflict(
             "Daytona API error (401 Unauthorized): invalid credentials"
         ));
+    }
+
+    #[test]
+    fn rejects_non_object_create_body() {
+        let mut body = json!(["invalid"]);
+
+        let error = set_create_body_name(&mut body, "sandbox-name").unwrap_err();
+
+        assert_eq!(error, "Daytona sandbox create body must be a JSON object");
+        assert_eq!(body, json!(["invalid"]));
     }
 }

--- a/integrations/daytona/src/session_sandbox_provider.rs
+++ b/integrations/daytona/src/session_sandbox_provider.rs
@@ -12,6 +12,7 @@ use serde_json::json;
 use tracing::{debug, warn};
 
 use crate::client::DaytonaClient;
+use crate::naming::create_sandbox_with_unique_name;
 use crate::state::{SandboxState, get_api_key, release_sandbox_lease, touch_sandbox_lease};
 use crate::{
     AUTO_ARCHIVE_INTERVAL_MINUTES, AUTO_DELETE_INTERVAL_MINUTES, AUTO_STOP_INTERVAL_MINUTES,
@@ -33,7 +34,7 @@ impl SessionSandboxProvider for DaytonaSessionSandboxProvider {
     ) -> Result<SessionSandboxInstance, ToolExecutionResult> {
         let api_key = get_api_key(context).await?;
         let client = build_client(api_key, config);
-        let title = config
+        let requested_name = config
             .provider_config
             .get("title")
             .and_then(|v| v.as_str())
@@ -66,17 +67,21 @@ impl SessionSandboxProvider for DaytonaSessionSandboxProvider {
             }
         }
 
-        let sandbox_info = client
-            .create_sandbox(json!({
-                "name": title,
+        let (sandbox_info, sandbox_name) = create_sandbox_with_unique_name(
+            &client,
+            &requested_name,
+            json!({
+                "name": requested_name,
                 "snapshot": snapshot,
                 "autoStopInterval": auto_stop,
                 "autoArchiveInterval": AUTO_ARCHIVE_INTERVAL_MINUTES,
                 "autoDeleteInterval": AUTO_DELETE_INTERVAL_MINUTES,
                 "labels": labels,
-            }))
-            .await
-            .map_err(ToolExecutionResult::tool_error)?;
+            }),
+        )
+        .await
+        .map_err(ToolExecutionResult::tool_error)?;
+        let canonical_name = sandbox_name.canonical_name;
 
         if let Err(err) = client.wait_for_ready(&sandbox_info.id).await {
             warn!(
@@ -108,11 +113,11 @@ impl SessionSandboxProvider for DaytonaSessionSandboxProvider {
             workspace_path: workspace_path.clone(),
             started_at: chrono::Utc::now().to_rfc3339(),
         };
-        touch_sandbox_lease(context, &state, sandbox_info.name.clone()).await?;
+        touch_sandbox_lease(context, &state, Some(canonical_name.clone())).await?;
 
         Ok(SessionSandboxInstance {
             external_id: sandbox_info.id,
-            display_name: sandbox_info.name.or(Some(title)),
+            display_name: Some(canonical_name),
             workspace_path: Some(workspace_path),
             provider_state: json!({}),
             metadata: json!({ "remote_state": sandbox_info.state }),

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -10,6 +10,7 @@ use serde_json::{Value, json};
 use tracing::{debug, warn};
 
 use crate::client::DaytonaClient;
+use crate::naming::create_sandbox_with_unique_name;
 use crate::state::{
     SandboxState, delete_sandbox_state, get_api_key, get_sandbox_state, list_sandbox_states,
     release_sandbox_lease, required_str, save_sandbox_state, touch_sandbox_lease,
@@ -84,6 +85,23 @@ fn parse_resource_param(
         return Err(format!("Invalid '{name}': must be between {min} and {max}"));
     }
     Ok(Some(n))
+}
+
+fn create_sandbox_result_payload(
+    sandbox_id: &str,
+    requested_name: &str,
+    canonical_name: &str,
+    workspace_path: &str,
+    uploaded_count: usize,
+) -> Value {
+    json!({
+        "sandbox_id": sandbox_id,
+        "name": canonical_name,
+        "requested_name": requested_name,
+        "status": "running",
+        "workspace_path": workspace_path,
+        "files_uploaded": uploaded_count
+    })
 }
 
 // ============================================================================
@@ -172,7 +190,7 @@ impl Tool for DaytonaCreateSandboxTool {
         let client = DaytonaClient::new(api_key);
 
         // Build create request
-        let title = arguments
+        let requested_name = arguments
             .get("title")
             .and_then(|v| v.as_str())
             .unwrap_or("Everruns Sandbox");
@@ -206,7 +224,7 @@ impl Tool for DaytonaCreateSandboxTool {
         };
 
         let mut create_body = json!({
-            "name": title,
+            "name": requested_name,
             "autoStopInterval": auto_stop,
             "autoArchiveInterval": AUTO_ARCHIVE_INTERVAL_MINUTES,
             "autoDeleteInterval": AUTO_DELETE_INTERVAL_MINUTES,
@@ -233,17 +251,19 @@ impl Tool for DaytonaCreateSandboxTool {
         create_body["snapshot"] = json!(snapshot_name);
 
         // Create sandbox
-        debug!("Creating Daytona sandbox: {title}");
-        let sandbox_info = match client.create_sandbox(create_body).await {
-            Ok(info) => info,
-            Err(e) => return ToolExecutionResult::tool_error(e),
-        };
-
-        let sandbox_id = &sandbox_info.id;
+        debug!("Creating Daytona sandbox: {requested_name}");
+        let (sandbox_info, sandbox_name) =
+            match create_sandbox_with_unique_name(&client, requested_name, create_body).await {
+                Ok(result) => result,
+                Err(e) => return ToolExecutionResult::tool_error(e),
+            };
+        let canonical_name = sandbox_name.canonical_name;
+        let sandbox_id = sandbox_info.id.clone();
+        let requested_name = sandbox_name.requested_name;
 
         // Wait for sandbox to reach "started" state
         debug!("Waiting for sandbox to start: {sandbox_id}");
-        if let Err(e) = client.wait_for_ready(sandbox_id).await {
+        if let Err(e) = client.wait_for_ready(&sandbox_id).await {
             warn!("Sandbox readiness check failed: {e}");
             // Continue anyway — the sandbox was created, agent can retry later
         }
@@ -253,7 +273,7 @@ impl Tool for DaytonaCreateSandboxTool {
         // Ensure workspace directory exists
         if let Err(e) = client
             .exec(
-                sandbox_id,
+                &sandbox_id,
                 &format!("mkdir -p {}", crate::DAYTONA_WORKSPACE_PATH),
                 None,
                 None,
@@ -273,7 +293,7 @@ impl Tool for DaytonaCreateSandboxTool {
         if let Err(e) = save_sandbox_state(context, &state).await {
             return e;
         }
-        if let Err(e) = touch_sandbox_lease(context, &state, Some(title.to_string())).await {
+        if let Err(e) = touch_sandbox_lease(context, &state, Some(canonical_name.clone())).await {
             return e;
         }
 
@@ -304,7 +324,7 @@ impl Tool for DaytonaCreateSandboxTool {
                     Ok(Some(file)) => {
                         let content = file.content.unwrap_or_default();
                         if let Err(e) = client
-                            .file_upload(sandbox_id, sandbox_path, content.as_bytes())
+                            .file_upload(&sandbox_id, sandbox_path, content.as_bytes())
                             .await
                         {
                             warn!("Failed to upload {session_path} to sandbox: {e}");
@@ -322,12 +342,13 @@ impl Tool for DaytonaCreateSandboxTool {
             }
         }
 
-        ToolExecutionResult::success(json!({
-            "sandbox_id": sandbox_id,
-            "status": "running",
-            "workspace_path": workspace_path,
-            "files_uploaded": uploaded_count
-        }))
+        ToolExecutionResult::success(create_sandbox_result_payload(
+            &sandbox_id,
+            &requested_name,
+            &canonical_name,
+            &workspace_path,
+            uploaded_count,
+        ))
     }
 
     fn requires_context(&self) -> bool {
@@ -2050,6 +2071,23 @@ mod tests {
         assert!(
             matches!(result, ToolExecutionResult::ToolError(msg) if msg.contains("requires context"))
         );
+    }
+
+    #[test]
+    fn test_create_sandbox_result_payload_includes_requested_and_canonical_name() {
+        let payload = create_sandbox_result_payload(
+            "sb_123",
+            "Requested Sandbox",
+            "Requested Sandbox-abc123",
+            "/home/daytona",
+            2,
+        );
+
+        assert_eq!(payload["sandbox_id"], "sb_123");
+        assert_eq!(payload["requested_name"], "Requested Sandbox");
+        assert_eq!(payload["name"], "Requested Sandbox-abc123");
+        assert_eq!(payload["workspace_path"], "/home/daytona");
+        assert_eq!(payload["files_uploaded"], 2);
     }
 
     #[test]

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -251,7 +251,6 @@ impl Tool for DaytonaCreateSandboxTool {
         create_body["snapshot"] = json!(snapshot_name);
 
         // Create sandbox
-        debug!("Creating Daytona sandbox: {requested_name}");
         let (sandbox_info, sandbox_name) =
             match create_sandbox_with_unique_name(&client, requested_name, create_body).await {
                 Ok(result) => result,
@@ -260,6 +259,10 @@ impl Tool for DaytonaCreateSandboxTool {
         let canonical_name = sandbox_name.canonical_name;
         let sandbox_id = sandbox_info.id.clone();
         let requested_name = sandbox_name.requested_name;
+        debug!(
+            "Created Daytona sandbox from requested name '{}' as canonical name '{}'",
+            requested_name, canonical_name
+        );
 
         // Wait for sandbox to reach "started" state
         debug!("Waiting for sandbox to start: {sandbox_id}");

--- a/integrations/daytona/tests/session_sandbox_provider.rs
+++ b/integrations/daytona/tests/session_sandbox_provider.rs
@@ -348,3 +348,66 @@ async fn daytona_provider_escapes_workspace_path_when_creating_directory() {
         Some("/tmp/it's workspace; rm -rf /")
     );
 }
+
+#[tokio::test]
+async fn daytona_provider_retries_conflict_and_uses_canonical_display_name() {
+    use std::sync::Mutex as StdMutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let mock_server = MockServer::start().await;
+    let context = test_context();
+    let mut config = test_config(&mock_server);
+    config.provider_config["title"] = json!("Managed Sandbox");
+    let provider = create_session_sandbox_provider("daytona").unwrap();
+
+    let seen_names = Arc::new(StdMutex::new(Vec::<String>::new()));
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let seen_names_clone = seen_names.clone();
+    let call_count_clone = call_count.clone();
+    Mock::given(method("POST"))
+        .and(path("/sandbox"))
+        .respond_with(move |request: &wiremock::Request| {
+            let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+            let name = body["name"].as_str().unwrap().to_string();
+            seen_names_clone.lock().unwrap().push(name.clone());
+
+            if call_count_clone.fetch_add(1, Ordering::SeqCst) == 0 {
+                ResponseTemplate::new(409).set_body_string("sandbox already exists")
+            } else {
+                ResponseTemplate::new(200).set_body_json(json!({
+                    "id": "sb_retry",
+                    "name": name,
+                    "state": "started"
+                }))
+            }
+        })
+        .expect(2)
+        .mount(&mock_server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/sandbox/sb_retry"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "sb_retry",
+            "name": "ready-name",
+            "state": "started"
+        })))
+        .mount(&mock_server)
+        .await;
+    setup_exec_mocks(&mock_server, "sb_retry", 0, "ready\n").await;
+
+    let instance = provider.create(&context, &config).await.unwrap();
+
+    assert_eq!(instance.external_id, "sb_retry");
+    let display_name = instance.display_name.as_deref().unwrap();
+    assert!(display_name.starts_with("Managed Sandbox-"));
+
+    let seen_names = seen_names.lock().unwrap();
+    assert_eq!(seen_names.len(), 2);
+    assert!(
+        seen_names
+            .iter()
+            .all(|name| name.starts_with("Managed Sandbox-"))
+    );
+    assert_ne!(seen_names[0], seen_names[1]);
+    assert_eq!(display_name, seen_names[1]);
+}

--- a/integrations/daytona/tests/session_sandbox_provider.rs
+++ b/integrations/daytona/tests/session_sandbox_provider.rs
@@ -403,11 +403,11 @@ async fn daytona_provider_retries_conflict_and_uses_canonical_display_name() {
 
     let seen_names = seen_names.lock().unwrap();
     assert_eq!(seen_names.len(), 2);
+    assert_eq!(call_count.load(Ordering::SeqCst), 2);
     assert!(
         seen_names
             .iter()
             .all(|name| name.starts_with("Managed Sandbox-"))
     );
-    assert_ne!(seen_names[0], seen_names[1]);
     assert_eq!(display_name, seen_names[1]);
 }


### PR DESCRIPTION
## What
- add a shared `everruns_core::resource_names` helper for suffixing external resource names
- retry Daytona sandbox creation once on name conflict and keep the canonical backend name
- return `name` and `requested_name` from `daytona_create_sandbox`, and document the updated contract

## Why
Repeated eval and coding runs reuse similar Daytona titles and hit backend name collisions. When that happens, sandbox creation fails and the agent loses track of the actual resource name.

## How
- generate a 6-character lowercase alphanumeric suffix in shared core code
- wrap Daytona create calls in a helper that detects conflict responses and retries once with a fresh suffix
- store and return the canonical Daytona name everywhere the create flow surfaces a sandbox name

## Risk
- Low
- Touches Daytona create/display-name paths only; callers that assumed the display name always matched the unsuffixed title now receive the canonical backend name instead.

## Security
- Threat categories reviewed: TM-API, TM-DOS
- Findings and resolutions:
  - No new auth, tenant, or secret-handling paths were introduced.
  - Retry is bounded to one extra create attempt, so the change does not create unbounded retry pressure.
  - Returning the canonical Daytona name reduces agent ambiguity without exposing new sensitive data.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)
