### PR TITLE
fix(integrations): scope sandbox resources to sessions

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -102,6 +102,7 @@ pub mod openresponses_types;
 pub mod outline;
 pub mod platform_definition;
 pub mod platform_store;
+pub mod resource_ownership;
 pub mod runtime_agent;
 pub mod runtime_context;
 pub mod tool_output_sanitizer;
@@ -163,6 +164,12 @@ pub use channel::{
 
 // Platform store re-exports
 pub use platform_store::{PlatformMessage, PlatformStore};
+pub use resource_ownership::{
+    LEASED_RESOURCE_EXTERNAL_ID_KEY, LEASED_RESOURCE_ID_KEY, LEASED_RESOURCE_PROVIDER_KEY,
+    LEASED_RESOURCE_TYPE_KEY, list_owned_external_resource_ids,
+    ownership_tracking_unavailable_error, require_owned_external_resource,
+    resource_not_owned_error, verify_owned_external_resource_if_available,
+};
 
 // Event listener re-exports
 pub use background::{

--- a/crates/core/src/resource_ownership.rs
+++ b/crates/core/src/resource_ownership.rs
@@ -1,0 +1,395 @@
+// Shared helpers for session-scoped ownership checks over leased resources.
+//
+// Decision: tools that accept provider-owned external IDs (sandbox_id,
+// browserless reconnect endpoint, etc.) should resolve ownership through the
+// leased-resource store when available, with session-resource metadata as a
+// fallback for runtimes that only wire the generic registry.
+
+use std::collections::HashSet;
+
+use crate::leased_resource::LeasedResourceStatus;
+use crate::session_resource::{SessionResourceFilter, SessionResourceStatus};
+use crate::tools::ToolExecutionResult;
+use crate::traits::ToolContext;
+
+/// Reserved metadata key storing the provider name on session-resource entries
+/// auto-registered from leased resources.
+pub const LEASED_RESOURCE_PROVIDER_KEY: &str = "leased_resource_provider";
+/// Reserved metadata key storing the provider resource type on session-resource
+/// entries auto-registered from leased resources.
+pub const LEASED_RESOURCE_TYPE_KEY: &str = "leased_resource_type";
+/// Reserved metadata key storing the provider external ID on session-resource
+/// entries auto-registered from leased resources.
+pub const LEASED_RESOURCE_EXTERNAL_ID_KEY: &str = "leased_resource_external_id";
+/// Reserved metadata key storing the leased-resource public ID.
+pub const LEASED_RESOURCE_ID_KEY: &str = "leased_resource_id";
+
+/// Return the set of provider-owned external IDs currently attached to the
+/// active session.
+///
+/// Returns `Ok(None)` when the runtime has no ownership registry/store wired
+/// into the tool context. Callers that already have another scoped state source
+/// (such as session secrets) can degrade gracefully in that case; callers that
+/// would otherwise trust raw provider IDs should reject the operation.
+pub async fn list_owned_external_resource_ids(
+    context: &ToolContext,
+    provider: &str,
+    resource_type: &str,
+) -> Result<Option<HashSet<String>>, ToolExecutionResult> {
+    if let Some(store) = context.leased_resource_store.as_ref() {
+        let resources = store
+            .list_resources(context.session_id)
+            .await
+            .map_err(|e| {
+                ToolExecutionResult::internal_error_msg(format!(
+                    "Failed to read leased resources: {e}"
+                ))
+            })?;
+        let owned = resources
+            .into_iter()
+            .filter(|resource| {
+                resource.provider == provider
+                    && resource.resource_type == resource_type
+                    && resource.status == LeasedResourceStatus::Active
+            })
+            .map(|resource| resource.external_id)
+            .collect();
+        return Ok(Some(owned));
+    }
+
+    if let Some(registry) = context.session_resource_registry.as_ref() {
+        let filter = SessionResourceFilter {
+            kind: Some(resource_type.to_string()),
+            status: Some(SessionResourceStatus::Active),
+        };
+        let entries = registry
+            .list(context.session_id, Some(&filter))
+            .await
+            .map_err(|e| {
+                ToolExecutionResult::internal_error_msg(format!(
+                    "Failed to read session resources: {e}"
+                ))
+            })?;
+
+        let mut owned = HashSet::new();
+        let mut saw_untracked_entry = false;
+
+        for entry in entries {
+            let Some(metadata) = entry.metadata.as_object() else {
+                saw_untracked_entry = true;
+                continue;
+            };
+
+            let Some(entry_provider) = metadata
+                .get(LEASED_RESOURCE_PROVIDER_KEY)
+                .and_then(|value| value.as_str())
+            else {
+                saw_untracked_entry = true;
+                continue;
+            };
+
+            let Some(entry_resource_type) = metadata
+                .get(LEASED_RESOURCE_TYPE_KEY)
+                .and_then(|value| value.as_str())
+            else {
+                saw_untracked_entry = true;
+                continue;
+            };
+
+            let Some(external_id) = metadata
+                .get(LEASED_RESOURCE_EXTERNAL_ID_KEY)
+                .and_then(|value| value.as_str())
+            else {
+                saw_untracked_entry = true;
+                continue;
+            };
+
+            if entry_provider == provider && entry_resource_type == resource_type {
+                owned.insert(external_id.to_owned());
+            }
+        }
+
+        if saw_untracked_entry {
+            return Ok(None);
+        }
+
+        return Ok(Some(owned));
+    }
+
+    Ok(None)
+}
+
+/// Check ownership when a runtime has tracking wired in, but degrade gracefully
+/// when it does not.
+pub async fn verify_owned_external_resource_if_available(
+    context: &ToolContext,
+    provider: &str,
+    resource_type: &str,
+    external_id: &str,
+) -> Result<(), ToolExecutionResult> {
+    if let Some(owned_ids) =
+        list_owned_external_resource_ids(context, provider, resource_type).await?
+        && !owned_ids.contains(external_id)
+    {
+        return Err(resource_not_owned_error(external_id));
+    }
+
+    Ok(())
+}
+
+/// Require ownership tracking to be present and reject when the external ID is
+/// not attached to the active session.
+pub async fn require_owned_external_resource(
+    context: &ToolContext,
+    provider: &str,
+    resource_type: &str,
+    external_id: &str,
+) -> Result<(), ToolExecutionResult> {
+    let Some(owned_ids) =
+        list_owned_external_resource_ids(context, provider, resource_type).await?
+    else {
+        return Err(ownership_tracking_unavailable_error(
+            provider,
+            resource_type,
+        ));
+    };
+
+    if owned_ids.contains(external_id) {
+        Ok(())
+    } else {
+        Err(resource_not_owned_error(external_id))
+    }
+}
+
+pub fn resource_not_owned_error(external_id: &str) -> ToolExecutionResult {
+    // THREAT[TM-AGENT-020]: Block cross-session resource access via guessed or
+    // stale provider IDs by rejecting any external resource handle that the
+    // active session does not own.
+    ToolExecutionResult::tool_error(format!(
+        "Resource {external_id} was not created by this session"
+    ))
+}
+
+pub fn ownership_tracking_unavailable_error(
+    provider: &str,
+    resource_type: &str,
+) -> ToolExecutionResult {
+    ToolExecutionResult::tool_error(format!(
+        "Session resource tracking is unavailable; cannot verify ownership for {provider} {resource_type} resources"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use chrono::{TimeDelta, Utc};
+    use serde_json::json;
+    use std::sync::Arc;
+
+    use crate::error::Result;
+    use crate::leased_resource::{LeasedResource, LeasedResourceStatus, UpsertLeasedResource};
+    use crate::session_resource::{RegisterSessionResource, SessionResourceEntry};
+    use crate::traits::{LeasedResourceStore, SessionResourceRegistry};
+    use crate::typed_id::{LeasedResourceId, SessionId};
+
+    #[derive(Default)]
+    struct TestLeasedResourceStore {
+        resources: tokio::sync::Mutex<Vec<LeasedResource>>,
+    }
+
+    #[async_trait]
+    impl LeasedResourceStore for TestLeasedResourceStore {
+        async fn upsert_resource(&self, input: UpsertLeasedResource) -> Result<LeasedResource> {
+            let now = Utc::now();
+            let resource = LeasedResource {
+                id: LeasedResourceId::new(),
+                session_id: Some(input.session_id),
+                provider: input.provider,
+                resource_type: input.resource_type,
+                external_id: input.external_id,
+                display_name: input.display_name,
+                status: LeasedResourceStatus::Active,
+                owner_user_id: input.owner_user_id,
+                lease_duration_seconds: input.lease_duration_seconds,
+                last_touched_at: now,
+                lease_expires_at: now + TimeDelta::seconds(i64::from(input.lease_duration_seconds)),
+                cleanup_started_at: None,
+                cleanup_completed_at: None,
+                cleanup_attempts: 0,
+                last_cleanup_error: None,
+                metadata: input.metadata,
+                created_at: now,
+                updated_at: now,
+            };
+            self.resources.lock().await.push(resource.clone());
+            Ok(resource)
+        }
+
+        async fn release_resource(
+            &self,
+            _session_id: SessionId,
+            _provider: &str,
+            _resource_type: &str,
+            _external_id: &str,
+        ) -> Result<Option<LeasedResource>> {
+            Ok(None)
+        }
+
+        async fn list_resources(&self, session_id: SessionId) -> Result<Vec<LeasedResource>> {
+            Ok(self
+                .resources
+                .lock()
+                .await
+                .iter()
+                .filter(|resource| resource.session_id == Some(session_id))
+                .cloned()
+                .collect())
+        }
+    }
+
+    #[derive(Default)]
+    struct TestSessionResourceRegistry {
+        entries: tokio::sync::Mutex<Vec<SessionResourceEntry>>,
+    }
+
+    #[async_trait]
+    impl SessionResourceRegistry for TestSessionResourceRegistry {
+        async fn register(&self, entry: RegisterSessionResource) -> Result<SessionResourceEntry> {
+            let now = Utc::now();
+            let entry = SessionResourceEntry {
+                resource_id: entry.resource_id,
+                session_id: entry.session_id,
+                kind: entry.kind,
+                display_name: entry.display_name,
+                status: entry.status,
+                metadata: entry.metadata,
+                created_at: now,
+                updated_at: now,
+            };
+            self.entries.lock().await.push(entry.clone());
+            Ok(entry)
+        }
+
+        async fn update_status(
+            &self,
+            _session_id: SessionId,
+            _resource_id: &str,
+            _status: SessionResourceStatus,
+        ) -> Result<Option<SessionResourceEntry>> {
+            Ok(None)
+        }
+
+        async fn get(
+            &self,
+            _session_id: SessionId,
+            _resource_id: &str,
+        ) -> Result<Option<SessionResourceEntry>> {
+            Ok(None)
+        }
+
+        async fn list(
+            &self,
+            session_id: SessionId,
+            filter: Option<&SessionResourceFilter>,
+        ) -> Result<Vec<SessionResourceEntry>> {
+            let entries = self.entries.lock().await;
+            Ok(entries
+                .iter()
+                .filter(|entry| entry.session_id == session_id)
+                .filter(|entry| {
+                    filter
+                        .and_then(|filter| filter.kind.as_deref())
+                        .is_none_or(|kind| entry.kind == kind)
+                })
+                .filter(|entry| {
+                    filter
+                        .and_then(|filter| filter.status)
+                        .is_none_or(|status| entry.status == status)
+                })
+                .cloned()
+                .collect())
+        }
+
+        async fn deregister(&self, _session_id: SessionId, _resource_id: &str) -> Result<bool> {
+            Ok(false)
+        }
+    }
+
+    #[tokio::test]
+    async fn list_owned_ids_prefers_leased_resources() {
+        let session_id = SessionId::new();
+        let store = Arc::new(TestLeasedResourceStore::default());
+        store
+            .upsert_resource(UpsertLeasedResource {
+                session_id,
+                provider: "daytona".to_string(),
+                resource_type: "sandbox".to_string(),
+                external_id: "sb_test".to_string(),
+                display_name: None,
+                owner_user_id: None,
+                lease_duration_seconds: 60,
+                metadata: json!({}),
+            })
+            .await
+            .unwrap();
+
+        let context = ToolContext::new(session_id).with_leased_resource_store(store);
+        let owned = list_owned_external_resource_ids(&context, "daytona", "sandbox")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(owned.contains("sb_test"));
+    }
+
+    #[tokio::test]
+    async fn list_owned_ids_falls_back_to_session_resources() {
+        let session_id = SessionId::new();
+        let registry = Arc::new(TestSessionResourceRegistry::default());
+        registry
+            .register(RegisterSessionResource {
+                session_id,
+                resource_id: "resource_1".to_string(),
+                kind: "sandbox".to_string(),
+                display_name: "sandbox".to_string(),
+                status: SessionResourceStatus::Active,
+                metadata: json!({
+                    LEASED_RESOURCE_PROVIDER_KEY: "daytona",
+                    LEASED_RESOURCE_TYPE_KEY: "sandbox",
+                    LEASED_RESOURCE_EXTERNAL_ID_KEY: "sb_test",
+                }),
+            })
+            .await
+            .unwrap();
+
+        let context = ToolContext::new(session_id).with_session_resource_registry(registry);
+        let owned = list_owned_external_resource_ids(&context, "daytona", "sandbox")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(owned.contains("sb_test"));
+    }
+
+    #[tokio::test]
+    async fn list_owned_ids_returns_none_for_legacy_session_resources() {
+        let session_id = SessionId::new();
+        let registry = Arc::new(TestSessionResourceRegistry::default());
+        registry
+            .register(RegisterSessionResource {
+                session_id,
+                resource_id: "resource_legacy".to_string(),
+                kind: "sandbox".to_string(),
+                display_name: "sandbox".to_string(),
+                status: SessionResourceStatus::Active,
+                metadata: json!({}),
+            })
+            .await
+            .unwrap();
+
+        let context = ToolContext::new(session_id).with_session_resource_registry(registry);
+        let owned = list_owned_external_resource_ids(&context, "daytona", "sandbox")
+            .await
+            .unwrap();
+        assert!(owned.is_none());
+    }
+}

--- a/crates/server/src/storage/leased_resource_store.rs
+++ b/crates/server/src/storage/leased_resource_store.rs
@@ -8,6 +8,10 @@
 
 use async_trait::async_trait;
 use chrono::{TimeDelta, Utc};
+use everruns_core::resource_ownership::{
+    LEASED_RESOURCE_EXTERNAL_ID_KEY, LEASED_RESOURCE_ID_KEY, LEASED_RESOURCE_PROVIDER_KEY,
+    LEASED_RESOURCE_TYPE_KEY,
+};
 use everruns_core::session_resource::{RegisterSessionResource, SessionResourceStatus};
 use everruns_core::traits::{LeasedResourceStore, SessionResourceRegistry};
 use everruns_core::{
@@ -17,6 +21,43 @@ use everruns_core::{
 use super::backend::StorageBackend;
 use super::models::{LeasedResourceRow, ReleaseLeasedResourceRow, UpsertLeasedResourceRow};
 use std::sync::Arc;
+
+fn build_registry_metadata(
+    metadata: serde_json::Value,
+    resource_id: &str,
+    provider: &str,
+    resource_type: &str,
+    external_id: &str,
+) -> serde_json::Value {
+    let mut object = match metadata {
+        serde_json::Value::Object(map) => map,
+        serde_json::Value::Null => serde_json::Map::new(),
+        other => {
+            let mut map = serde_json::Map::new();
+            map.insert("provider_metadata".to_string(), other);
+            map
+        }
+    };
+
+    object.insert(
+        LEASED_RESOURCE_PROVIDER_KEY.to_string(),
+        serde_json::Value::String(provider.to_string()),
+    );
+    object.insert(
+        LEASED_RESOURCE_TYPE_KEY.to_string(),
+        serde_json::Value::String(resource_type.to_string()),
+    );
+    object.insert(
+        LEASED_RESOURCE_EXTERNAL_ID_KEY.to_string(),
+        serde_json::Value::String(external_id.to_string()),
+    );
+    object.insert(
+        LEASED_RESOURCE_ID_KEY.to_string(),
+        serde_json::Value::String(resource_id.to_string()),
+    );
+
+    serde_json::Value::Object(object)
+}
 
 /// Convert a storage row into the public leased-resource domain type.
 pub fn row_to_domain(row: &LeasedResourceRow) -> Result<LeasedResource> {
@@ -100,7 +141,9 @@ impl LeasedResourceStore for DbLeasedResourceStore {
             .display_name
             .clone()
             .unwrap_or_else(|| input.external_id.clone());
-        let registry_metadata = input.metadata.clone();
+        let registry_provider = input.provider.clone();
+        let registry_external_id = input.external_id.clone();
+        let provider_metadata = input.metadata.clone();
 
         let row = self
             .db
@@ -120,6 +163,13 @@ impl LeasedResourceStore for DbLeasedResourceStore {
             .map_err(|e| AgentLoopError::store(format!("Failed to upsert leased resource: {e}")))?;
 
         let resource = row_to_domain(&row)?;
+        let registry_metadata = build_registry_metadata(
+            provider_metadata,
+            &resource.id.to_string(),
+            &registry_provider,
+            &registry_kind,
+            &registry_external_id,
+        );
 
         // Auto-register in session resource registry for agent visibility.
         if let Some(ref registry) = self.registry
@@ -212,6 +262,11 @@ mod tests {
     use super::*;
     use crate::storage::{StorageBackend, models::CreateSessionRow};
     use everruns_core::DEFAULT_ORG_ID;
+    use everruns_core::resource_ownership::{
+        LEASED_RESOURCE_EXTERNAL_ID_KEY, LEASED_RESOURCE_ID_KEY, LEASED_RESOURCE_PROVIDER_KEY,
+        LEASED_RESOURCE_TYPE_KEY,
+    };
+    use everruns_core::traits::SessionResourceRegistry;
     use serde_json::json;
 
     async fn create_test_session(db: &StorageBackend) -> SessionId {
@@ -361,5 +416,45 @@ mod tests {
             .await
             .expect("stale failure transition should be checked");
         assert!(failed.is_none());
+    }
+
+    #[tokio::test]
+    async fn upsert_registers_external_id_metadata_in_session_resources() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let session_id = create_test_session(db.as_ref()).await;
+        let registry = Arc::new(crate::storage::DbSessionResourceRegistry::new(db.clone()));
+        let store = DbLeasedResourceStore::new(db.clone()).with_registry(registry.clone());
+
+        let created = store
+            .upsert_resource(UpsertLeasedResource {
+                session_id,
+                provider: "daytona".to_string(),
+                resource_type: "sandbox".to_string(),
+                external_id: "sandbox-123".to_string(),
+                display_name: Some("Build sandbox".to_string()),
+                owner_user_id: None,
+                lease_duration_seconds: 20 * 60,
+                metadata: json!({ "workspace_path": "/workspace" }),
+            })
+            .await
+            .expect("leased resource should be created");
+
+        let registered = registry
+            .get(session_id, &created.id.to_string())
+            .await
+            .expect("session resource should load")
+            .expect("session resource should exist");
+
+        assert_eq!(registered.metadata[LEASED_RESOURCE_PROVIDER_KEY], "daytona");
+        assert_eq!(registered.metadata[LEASED_RESOURCE_TYPE_KEY], "sandbox");
+        assert_eq!(
+            registered.metadata[LEASED_RESOURCE_EXTERNAL_ID_KEY],
+            "sandbox-123"
+        );
+        assert_eq!(
+            registered.metadata[LEASED_RESOURCE_ID_KEY],
+            created.id.to_string()
+        );
+        assert_eq!(registered.metadata["workspace_path"], "/workspace");
     }
 }

--- a/integrations/daytona/src/state.rs
+++ b/integrations/daytona/src/state.rs
@@ -1,6 +1,7 @@
 //! Daytona API types and session state management.
 
 use everruns_core::UpsertLeasedResource;
+use everruns_core::resource_ownership::verify_owned_external_resource_if_available;
 use everruns_core::tools::ToolExecutionResult;
 use everruns_core::traits::ToolContext;
 
@@ -106,6 +107,8 @@ pub async fn get_sandbox_state(
     context: &ToolContext,
     sandbox_id: &str,
 ) -> Result<SandboxState, ToolExecutionResult> {
+    verify_owned_external_resource_if_available(context, "daytona", "sandbox", sandbox_id).await?;
+
     let storage = context
         .storage_store
         .as_ref()

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -2,11 +2,16 @@
 
 use everruns_core::SessionFile;
 use everruns_core::ToolHints;
+use everruns_core::resource_ownership::{
+    list_owned_external_resource_ids, ownership_tracking_unavailable_error,
+    require_owned_external_resource,
+};
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
 
 use async_trait::async_trait;
 use serde_json::{Value, json};
+use std::collections::HashSet;
 use tracing::{debug, warn};
 
 use crate::client::DaytonaClient;
@@ -1611,6 +1616,13 @@ async fn get_github_token(context: &ToolContext) -> Option<String> {
 /// Session filesystem path where the Daytona OpenAPI spec is mounted.
 pub const DAYTONA_OPENAPI_MOUNT_PATH: &str = "/daytona/openapi.yaml";
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ScopedSandboxPath<'a> {
+    SandboxCollection,
+    Sandbox(&'a str),
+    Toolbox(&'a str),
+}
+
 pub struct DaytonaApiCallTool;
 
 #[async_trait]
@@ -1694,15 +1706,19 @@ impl Tool for DaytonaApiCallTool {
         };
 
         // Normalize path: ensure leading /, strip trailing /, strip query string
-        let path = {
-            let p = path.split('?').next().unwrap_or(&path);
-            let p = p.trim_end_matches('/');
-            if p.starts_with('/') {
-                p.to_string()
-            } else {
-                format!("/{p}")
-            }
+        let path = Self::normalize_api_path(&path);
+
+        let sandbox_scope = match Self::enforce_session_scope(context, &method_str, &path).await {
+            Ok(scope) => scope,
+            Err(e) => return e,
         };
+
+        if method_str == "GET"
+            && path == "/sandbox"
+            && sandbox_scope.as_ref().is_some_and(HashSet::is_empty)
+        {
+            return ToolExecutionResult::success(json!([]));
+        }
 
         let method = match method_str.as_str() {
             "GET" => reqwest::Method::GET,
@@ -1732,6 +1748,11 @@ impl Tool for DaytonaApiCallTool {
         let client = DaytonaClient::new(api_key);
         match client.api_call(method, &path, body).await {
             Ok(response) => {
+                let response = if let Some(owned_ids) = sandbox_scope.as_ref() {
+                    Self::filter_owned_sandboxes(response, owned_ids)
+                } else {
+                    response
+                };
                 // Track sandbox resources created/deleted via raw API calls
                 self.track_resources(context, &method_str, &path, &response)
                     .await;
@@ -1743,6 +1764,80 @@ impl Tool for DaytonaApiCallTool {
 }
 
 impl DaytonaApiCallTool {
+    fn normalize_api_path(path: &str) -> String {
+        let path = path.split('?').next().unwrap_or(path);
+        let segments: Vec<&str> = path
+            .split('/')
+            .filter(|segment| !segment.is_empty())
+            .collect();
+        if segments.is_empty() {
+            "/".to_string()
+        } else {
+            format!("/{}", segments.join("/"))
+        }
+    }
+
+    fn scoped_sandbox_path(path: &str) -> Option<ScopedSandboxPath<'_>> {
+        if path == "/sandbox" {
+            return Some(ScopedSandboxPath::SandboxCollection);
+        }
+
+        if let Some(rest) = path.strip_prefix("/sandbox/")
+            && let Some(sandbox_id) = rest.split('/').next()
+            && !sandbox_id.is_empty()
+        {
+            return Some(ScopedSandboxPath::Sandbox(sandbox_id));
+        }
+
+        if let Some(rest) = path.strip_prefix("/toolbox/")
+            && let Some(sandbox_id) = rest.split('/').next()
+            && !sandbox_id.is_empty()
+        {
+            return Some(ScopedSandboxPath::Toolbox(sandbox_id));
+        }
+
+        None
+    }
+
+    async fn enforce_session_scope(
+        context: &ToolContext,
+        method: &str,
+        path: &str,
+    ) -> Result<Option<HashSet<String>>, ToolExecutionResult> {
+        match Self::scoped_sandbox_path(path) {
+            Some(ScopedSandboxPath::SandboxCollection) if method == "GET" => {
+                let Some(owned_ids) =
+                    list_owned_external_resource_ids(context, "daytona", "sandbox").await?
+                else {
+                    return Err(ownership_tracking_unavailable_error("daytona", "sandbox"));
+                };
+                Ok(Some(owned_ids))
+            }
+            Some(ScopedSandboxPath::Sandbox(sandbox_id))
+            | Some(ScopedSandboxPath::Toolbox(sandbox_id)) => {
+                require_owned_external_resource(context, "daytona", "sandbox", sandbox_id).await?;
+                Ok(None)
+            }
+            _ => Ok(None),
+        }
+    }
+
+    fn filter_owned_sandboxes(response: Value, owned_ids: &HashSet<String>) -> Value {
+        match response {
+            Value::Array(items) => Value::Array(
+                items
+                    .into_iter()
+                    .filter(|item| {
+                        item.get("id")
+                            .and_then(|value| value.as_str())
+                            .is_some_and(|id| owned_ids.contains(id))
+                    })
+                    .collect(),
+            ),
+            other => other,
+        }
+    }
+
     /// Build ownership labels for Daytona sandbox audit/cleanup.
     ///
     /// Mirrors the labels added by `DaytonaCreateSandboxTool` so that sandboxes
@@ -2395,6 +2490,55 @@ mod tests {
         assert_eq!(
             extract_owner_repo("git@github.com:user/repo.git"),
             Some("user/repo".to_string())
+        );
+    }
+
+    #[test]
+    fn test_daytona_api_call_scoped_sandbox_path_collection() {
+        assert_eq!(
+            DaytonaApiCallTool::scoped_sandbox_path("/sandbox"),
+            Some(ScopedSandboxPath::SandboxCollection)
+        );
+    }
+
+    #[test]
+    fn test_daytona_api_call_normalizes_paths_for_scope() {
+        assert_eq!(
+            DaytonaApiCallTool::normalize_api_path("//sandbox//sb_test//files/?raw=1"),
+            "/sandbox/sb_test/files"
+        );
+    }
+
+    #[test]
+    fn test_daytona_api_call_scoped_sandbox_path_management() {
+        assert_eq!(
+            DaytonaApiCallTool::scoped_sandbox_path("/sandbox/sb_test/files"),
+            Some(ScopedSandboxPath::Sandbox("sb_test"))
+        );
+    }
+
+    #[test]
+    fn test_daytona_api_call_scoped_sandbox_path_toolbox() {
+        assert_eq!(
+            DaytonaApiCallTool::scoped_sandbox_path("/toolbox/sb_test/process/execute"),
+            Some(ScopedSandboxPath::Toolbox("sb_test"))
+        );
+    }
+
+    #[test]
+    fn test_daytona_api_call_filters_sandbox_list() {
+        let filtered = DaytonaApiCallTool::filter_owned_sandboxes(
+            json!([
+                {"id": "sb_owned", "state": "started"},
+                {"id": "sb_other", "state": "started"}
+            ]),
+            &HashSet::from(["sb_owned".to_string()]),
+        );
+        assert_eq!(
+            filtered,
+            json!([
+                {"id": "sb_owned", "state": "started"}
+            ])
         );
     }
 

--- a/integrations/daytona/tests/tool_integration.rs
+++ b/integrations/daytona/tests/tool_integration.rs
@@ -9,11 +9,13 @@
 
 use async_trait::async_trait;
 use everruns_core::error::Result;
+use everruns_core::leased_resource::{LeasedResource, LeasedResourceStatus, UpsertLeasedResource};
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::{
-    KeyInfo, SecretInfo, SessionStorageStore, ToolContext, UserConnectionResolver,
+    KeyInfo, LeasedResourceStore, SecretInfo, SessionStorageStore, ToolContext,
+    UserConnectionResolver,
 };
-use everruns_core::typed_id::SessionId;
+use everruns_core::typed_id::{LeasedResourceId, SessionId};
 use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -45,6 +47,48 @@ impl MockStorageStore {
     async fn seed_secret(&self, session_id: SessionId, name: &str, value: &str) {
         let key = format!("{}:{}", session_id, name);
         self.secrets.lock().await.insert(key, value.to_string());
+    }
+}
+
+struct MockLeasedResourceStore {
+    resources: Mutex<Vec<LeasedResource>>,
+}
+
+impl MockLeasedResourceStore {
+    fn new() -> Self {
+        Self {
+            resources: Mutex::new(Vec::new()),
+        }
+    }
+
+    async fn seed_active(
+        &self,
+        session_id: SessionId,
+        provider: &str,
+        resource_type: &str,
+        external_id: &str,
+    ) {
+        let now = chrono::Utc::now();
+        self.resources.lock().await.push(LeasedResource {
+            id: LeasedResourceId::new(),
+            session_id: Some(session_id),
+            provider: provider.to_string(),
+            resource_type: resource_type.to_string(),
+            external_id: external_id.to_string(),
+            display_name: Some(external_id.to_string()),
+            status: LeasedResourceStatus::Active,
+            owner_user_id: None,
+            lease_duration_seconds: 1200,
+            last_touched_at: now,
+            lease_expires_at: now + chrono::TimeDelta::seconds(1200),
+            cleanup_started_at: None,
+            cleanup_completed_at: None,
+            cleanup_attempts: 0,
+            last_cleanup_error: None,
+            metadata: json!({}),
+            created_at: now,
+            updated_at: now,
+        });
     }
 }
 
@@ -86,6 +130,69 @@ impl SessionStorageStore for MockStorageStore {
                 created_at: chrono::Utc::now(),
                 updated_at: chrono::Utc::now(),
             })
+            .collect())
+    }
+}
+
+#[async_trait]
+impl LeasedResourceStore for MockLeasedResourceStore {
+    async fn upsert_resource(&self, input: UpsertLeasedResource) -> Result<LeasedResource> {
+        let now = chrono::Utc::now();
+        let resource = LeasedResource {
+            id: LeasedResourceId::new(),
+            session_id: Some(input.session_id),
+            provider: input.provider,
+            resource_type: input.resource_type,
+            external_id: input.external_id,
+            display_name: input.display_name,
+            status: LeasedResourceStatus::Active,
+            owner_user_id: input.owner_user_id,
+            lease_duration_seconds: input.lease_duration_seconds,
+            last_touched_at: now,
+            lease_expires_at: now
+                + chrono::TimeDelta::seconds(i64::from(input.lease_duration_seconds)),
+            cleanup_started_at: None,
+            cleanup_completed_at: None,
+            cleanup_attempts: 0,
+            last_cleanup_error: None,
+            metadata: input.metadata,
+            created_at: now,
+            updated_at: now,
+        };
+        self.resources.lock().await.push(resource.clone());
+        Ok(resource)
+    }
+
+    async fn release_resource(
+        &self,
+        session_id: SessionId,
+        provider: &str,
+        resource_type: &str,
+        external_id: &str,
+    ) -> Result<Option<LeasedResource>> {
+        let mut resources = self.resources.lock().await;
+        let resource = resources.iter_mut().find(|resource| {
+            resource.session_id == Some(session_id)
+                && resource.provider == provider
+                && resource.resource_type == resource_type
+                && resource.external_id == external_id
+        });
+        if let Some(resource) = resource {
+            resource.status = LeasedResourceStatus::Released;
+            resource.updated_at = chrono::Utc::now();
+            return Ok(Some(resource.clone()));
+        }
+        Ok(None)
+    }
+
+    async fn list_resources(&self, session_id: SessionId) -> Result<Vec<LeasedResource>> {
+        Ok(self
+            .resources
+            .lock()
+            .await
+            .iter()
+            .filter(|resource| resource.session_id == Some(session_id))
+            .cloned()
             .collect())
     }
 }
@@ -401,6 +508,39 @@ async fn test_exec_tool_missing_sandbox_state() {
     match result {
         ToolExecutionResult::ToolError(msg) => {
             assert!(msg.contains("not found"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_exec_tool_rejects_cross_session_sandbox_id() {
+    let tool = get_tool("daytona_exec");
+    let owner_session = SessionId::new();
+    let attacker_session = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let leased_resources = Arc::new(MockLeasedResourceStore::new());
+    leased_resources
+        .seed_active(owner_session, "daytona", "sandbox", "sb_foreign")
+        .await;
+
+    let context = ToolContext::with_storage_store(attacker_session, store)
+        .with_connection_resolver(daytona_resolver())
+        .with_leased_resource_store(leased_resources);
+
+    let result = tool
+        .execute_with_context(
+            json!({"sandbox_id": "sb_foreign", "command": "ls"}),
+            &context,
+        )
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(
+                msg.contains("was not created by this session"),
+                "Got: {msg}"
+            );
         }
         other => panic!("Expected ToolError, got: {other:?}"),
     }

--- a/integrations/deno/src/state.rs
+++ b/integrations/deno/src/state.rs
@@ -4,6 +4,7 @@
 //! resolve credentials fresh from user connections or operator env vars.
 
 use everruns_core::UpsertLeasedResource;
+use everruns_core::resource_ownership::verify_owned_external_resource_if_available;
 use everruns_core::tools::ToolExecutionResult;
 use everruns_core::traits::ToolContext;
 use serde::{Deserialize, Serialize};
@@ -88,6 +89,8 @@ pub async fn get_sandbox_state(
     context: &ToolContext,
     sandbox_id: &str,
 ) -> Result<SandboxState, ToolExecutionResult> {
+    verify_owned_external_resource_if_available(context, "deno", "sandbox", sandbox_id).await?;
+
     let storage = context
         .storage_store
         .as_ref()

--- a/integrations/deno/tests/tool_integration.rs
+++ b/integrations/deno/tests/tool_integration.rs
@@ -14,11 +14,13 @@
 
 use async_trait::async_trait;
 use everruns_core::error::Result;
+use everruns_core::leased_resource::{LeasedResource, LeasedResourceStatus, UpsertLeasedResource};
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::{
-    KeyInfo, SecretInfo, SessionStorageStore, ToolContext, UserConnectionResolver,
+    KeyInfo, LeasedResourceStore, SecretInfo, SessionStorageStore, ToolContext,
+    UserConnectionResolver,
 };
-use everruns_core::typed_id::SessionId;
+use everruns_core::typed_id::{LeasedResourceId, SessionId};
 use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -47,6 +49,48 @@ impl MockStorageStore {
     async fn seed_secret(&self, session_id: SessionId, name: &str, value: &str) {
         let key = format!("{}:{}", session_id, name);
         self.secrets.lock().await.insert(key, value.to_string());
+    }
+}
+
+struct MockLeasedResourceStore {
+    resources: Mutex<Vec<LeasedResource>>,
+}
+
+impl MockLeasedResourceStore {
+    fn new() -> Self {
+        Self {
+            resources: Mutex::new(Vec::new()),
+        }
+    }
+
+    async fn seed_active(
+        &self,
+        session_id: SessionId,
+        provider: &str,
+        resource_type: &str,
+        external_id: &str,
+    ) {
+        let now = chrono::Utc::now();
+        self.resources.lock().await.push(LeasedResource {
+            id: LeasedResourceId::new(),
+            session_id: Some(session_id),
+            provider: provider.to_string(),
+            resource_type: resource_type.to_string(),
+            external_id: external_id.to_string(),
+            display_name: Some(external_id.to_string()),
+            status: LeasedResourceStatus::Active,
+            owner_user_id: None,
+            lease_duration_seconds: 1200,
+            last_touched_at: now,
+            lease_expires_at: now + chrono::TimeDelta::seconds(1200),
+            cleanup_started_at: None,
+            cleanup_completed_at: None,
+            cleanup_attempts: 0,
+            last_cleanup_error: None,
+            metadata: json!({}),
+            created_at: now,
+            updated_at: now,
+        });
     }
 }
 
@@ -88,6 +132,69 @@ impl SessionStorageStore for MockStorageStore {
                 created_at: chrono::Utc::now(),
                 updated_at: chrono::Utc::now(),
             })
+            .collect())
+    }
+}
+
+#[async_trait]
+impl LeasedResourceStore for MockLeasedResourceStore {
+    async fn upsert_resource(&self, input: UpsertLeasedResource) -> Result<LeasedResource> {
+        let now = chrono::Utc::now();
+        let resource = LeasedResource {
+            id: LeasedResourceId::new(),
+            session_id: Some(input.session_id),
+            provider: input.provider,
+            resource_type: input.resource_type,
+            external_id: input.external_id,
+            display_name: input.display_name,
+            status: LeasedResourceStatus::Active,
+            owner_user_id: input.owner_user_id,
+            lease_duration_seconds: input.lease_duration_seconds,
+            last_touched_at: now,
+            lease_expires_at: now
+                + chrono::TimeDelta::seconds(i64::from(input.lease_duration_seconds)),
+            cleanup_started_at: None,
+            cleanup_completed_at: None,
+            cleanup_attempts: 0,
+            last_cleanup_error: None,
+            metadata: input.metadata,
+            created_at: now,
+            updated_at: now,
+        };
+        self.resources.lock().await.push(resource.clone());
+        Ok(resource)
+    }
+
+    async fn release_resource(
+        &self,
+        session_id: SessionId,
+        provider: &str,
+        resource_type: &str,
+        external_id: &str,
+    ) -> Result<Option<LeasedResource>> {
+        let mut resources = self.resources.lock().await;
+        let resource = resources.iter_mut().find(|resource| {
+            resource.session_id == Some(session_id)
+                && resource.provider == provider
+                && resource.resource_type == resource_type
+                && resource.external_id == external_id
+        });
+        if let Some(resource) = resource {
+            resource.status = LeasedResourceStatus::Released;
+            resource.updated_at = chrono::Utc::now();
+            return Ok(Some(resource.clone()));
+        }
+        Ok(None)
+    }
+
+    async fn list_resources(&self, session_id: SessionId) -> Result<Vec<LeasedResource>> {
+        Ok(self
+            .resources
+            .lock()
+            .await
+            .iter()
+            .filter(|resource| resource.session_id == Some(session_id))
+            .cloned()
             .collect())
     }
 }
@@ -215,6 +322,39 @@ async fn test_exec_tool_missing_sandbox_state() {
     match result {
         ToolExecutionResult::ToolError(msg) => {
             assert!(msg.contains("not found"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_exec_tool_rejects_cross_session_sandbox_id() {
+    let tool = get_tool("deno_exec");
+    let owner_session = SessionId::new();
+    let attacker_session = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let leased_resources = Arc::new(MockLeasedResourceStore::new());
+    leased_resources
+        .seed_active(owner_session, "deno", "sandbox", "sb_foreign")
+        .await;
+
+    let context = ToolContext::with_storage_store(attacker_session, store)
+        .with_connection_resolver(deno_resolver())
+        .with_leased_resource_store(leased_resources);
+
+    let result = tool
+        .execute_with_context(
+            json!({"sandbox_id": "sb_foreign", "command": "ls"}),
+            &context,
+        )
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(
+                msg.contains("was not created by this session"),
+                "Got: {msg}"
+            );
         }
         other => panic!("Expected ToolError, got: {other:?}"),
     }

--- a/integrations/e2b/src/state.rs
+++ b/integrations/e2b/src/state.rs
@@ -3,6 +3,7 @@
 use std::env;
 
 use everruns_core::UpsertLeasedResource;
+use everruns_core::resource_ownership::verify_owned_external_resource_if_available;
 use everruns_core::tools::ToolExecutionResult;
 use everruns_core::traits::ToolContext;
 use serde::{Deserialize, Serialize};
@@ -98,6 +99,8 @@ pub async fn get_sandbox_state(
     context: &ToolContext,
     sandbox_id: &str,
 ) -> Result<SandboxState, ToolExecutionResult> {
+    verify_owned_external_resource_if_available(context, "e2b", "sandbox", sandbox_id).await?;
+
     let storage = context
         .storage_store
         .as_ref()

--- a/integrations/e2b/tests/tool_integration.rs
+++ b/integrations/e2b/tests/tool_integration.rs
@@ -10,9 +10,12 @@
 use async_trait::async_trait;
 use everruns_core::capabilities::Capability;
 use everruns_core::error::Result;
+use everruns_core::leased_resource::{LeasedResource, LeasedResourceStatus, UpsertLeasedResource};
 use everruns_core::tools::{Tool, ToolExecutionResult};
-use everruns_core::traits::{KeyInfo, SecretInfo, SessionStorageStore, ToolContext};
-use everruns_core::typed_id::SessionId;
+use everruns_core::traits::{
+    KeyInfo, LeasedResourceStore, SecretInfo, SessionStorageStore, ToolContext,
+};
+use everruns_core::typed_id::{LeasedResourceId, SessionId};
 use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -46,6 +49,48 @@ impl MockStorageStore {
     async fn seed_secret(&self, session_id: SessionId, name: &str, value: &str) {
         let key = format!("{}:{}", session_id, name);
         self.secrets.lock().await.insert(key, value.to_string());
+    }
+}
+
+struct MockLeasedResourceStore {
+    resources: Mutex<Vec<LeasedResource>>,
+}
+
+impl MockLeasedResourceStore {
+    fn new() -> Self {
+        Self {
+            resources: Mutex::new(Vec::new()),
+        }
+    }
+
+    async fn seed_active(
+        &self,
+        session_id: SessionId,
+        provider: &str,
+        resource_type: &str,
+        external_id: &str,
+    ) {
+        let now = chrono::Utc::now();
+        self.resources.lock().await.push(LeasedResource {
+            id: LeasedResourceId::new(),
+            session_id: Some(session_id),
+            provider: provider.to_string(),
+            resource_type: resource_type.to_string(),
+            external_id: external_id.to_string(),
+            display_name: Some(external_id.to_string()),
+            status: LeasedResourceStatus::Active,
+            owner_user_id: None,
+            lease_duration_seconds: 1200,
+            last_touched_at: now,
+            lease_expires_at: now + chrono::TimeDelta::seconds(1200),
+            cleanup_started_at: None,
+            cleanup_completed_at: None,
+            cleanup_attempts: 0,
+            last_cleanup_error: None,
+            metadata: json!({}),
+            created_at: now,
+            updated_at: now,
+        });
     }
 }
 
@@ -87,6 +132,69 @@ impl SessionStorageStore for MockStorageStore {
                 created_at: chrono::Utc::now(),
                 updated_at: chrono::Utc::now(),
             })
+            .collect())
+    }
+}
+
+#[async_trait]
+impl LeasedResourceStore for MockLeasedResourceStore {
+    async fn upsert_resource(&self, input: UpsertLeasedResource) -> Result<LeasedResource> {
+        let now = chrono::Utc::now();
+        let resource = LeasedResource {
+            id: LeasedResourceId::new(),
+            session_id: Some(input.session_id),
+            provider: input.provider,
+            resource_type: input.resource_type,
+            external_id: input.external_id,
+            display_name: input.display_name,
+            status: LeasedResourceStatus::Active,
+            owner_user_id: input.owner_user_id,
+            lease_duration_seconds: input.lease_duration_seconds,
+            last_touched_at: now,
+            lease_expires_at: now
+                + chrono::TimeDelta::seconds(i64::from(input.lease_duration_seconds)),
+            cleanup_started_at: None,
+            cleanup_completed_at: None,
+            cleanup_attempts: 0,
+            last_cleanup_error: None,
+            metadata: input.metadata,
+            created_at: now,
+            updated_at: now,
+        };
+        self.resources.lock().await.push(resource.clone());
+        Ok(resource)
+    }
+
+    async fn release_resource(
+        &self,
+        session_id: SessionId,
+        provider: &str,
+        resource_type: &str,
+        external_id: &str,
+    ) -> Result<Option<LeasedResource>> {
+        let mut resources = self.resources.lock().await;
+        let resource = resources.iter_mut().find(|resource| {
+            resource.session_id == Some(session_id)
+                && resource.provider == provider
+                && resource.resource_type == resource_type
+                && resource.external_id == external_id
+        });
+        if let Some(resource) = resource {
+            resource.status = LeasedResourceStatus::Released;
+            resource.updated_at = chrono::Utc::now();
+            return Ok(Some(resource.clone()));
+        }
+        Ok(None)
+    }
+
+    async fn list_resources(&self, session_id: SessionId) -> Result<Vec<LeasedResource>> {
+        Ok(self
+            .resources
+            .lock()
+            .await
+            .iter()
+            .filter(|resource| resource.session_id == Some(session_id))
+            .cloned()
             .collect())
     }
 }
@@ -362,6 +470,39 @@ async fn test_exec_tool_missing_sandbox_state() {
     match result {
         ToolExecutionResult::ToolError(msg) => {
             assert!(msg.contains("not found"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_exec_tool_rejects_cross_session_sandbox_id() {
+    let tool = get_tool("e2b_exec");
+    let owner_session = SessionId::new();
+    let attacker_session = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let leased_resources = Arc::new(MockLeasedResourceStore::new());
+    setup_api_key(attacker_session, &store).await;
+    leased_resources
+        .seed_active(owner_session, "e2b", "sandbox", "sb_foreign")
+        .await;
+
+    let context = ToolContext::with_storage_store(attacker_session, store)
+        .with_leased_resource_store(leased_resources);
+
+    let result = tool
+        .execute_with_context(
+            json!({"sandbox_id": "sb_foreign", "command": "ls"}),
+            &context,
+        )
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(
+                msg.contains("was not created by this session"),
+                "Got: {msg}"
+            );
         }
         other => panic!("Expected ToolError, got: {other:?}"),
     }

--- a/specs/session-resources.md
+++ b/specs/session-resources.md
@@ -100,6 +100,16 @@ On `upsert_resource`, it also calls `registry.register()`. On `release_resource`
 it calls `registry.update_status(Released)`. This ensures all leased resources
 appear in the registry without changing tool code.
 
+Reserved metadata keys added during auto-registration:
+- `leased_resource_provider`
+- `leased_resource_type`
+- `leased_resource_external_id`
+- `leased_resource_id`
+
+These keys let tools verify that a provider-owned external ID belongs to the
+active session even in runtimes that only expose the generic session resource
+registry and not the leased-resource store directly.
+
 ### Feature flag
 
 `LEASED_RESOURCES_FEATURE` gates UI tab visibility. Renamed concept: the tab

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -623,6 +623,7 @@ The agent loop is a core trust boundary: an LLM decides which tools to call with
 | TM-AGENT-017 | Agent-initiated entity management | High | Agents with `platform_management` can create/update/delete harnesses, agents, sessions org-wide; no fine-grained RBAC within org; capability must be explicitly assigned | **OPEN** |
 | TM-AGENT-018 | No outbound URL filtering on web_fetch | Medium | Agent with `web_fetch` can POST session data to any URL; no allowlist/blocklist for outbound destinations; prompt injection could chain file read + web_fetch for exfiltration | **OPEN** |
 | TM-AGENT-019 | Internal network probing via high-risk execution capabilities | High | `daytona` and `e2b` provide full network access by design; `docker_container` uses host networking in dev mode; all rely on Admin-only assignment plus infrastructure egress isolation | **ACCEPTED** |
+| TM-AGENT-020 | Cross-session resource reuse via stale or guessed external IDs | Critical | Provider-owned resource IDs are checked against the active session's leased-resource/session-resource ownership before tool execution; raw sandbox list endpoints are filtered to owned IDs only | MITIGATED |
 
 ### Mitigation Details
 
@@ -715,6 +716,13 @@ This means an agent with one of these capabilities can probe whatever network th
 - `docker_container` is gated to development-grade deployments
 
 Residual risk remains with the deployment topology. Production operators must enforce egress filtering and network segmentation for any execution environment that can reach internal services.
+
+**TM-AGENT-020 — Cross-Session Resource Reuse (MITIGATED):**
+Tools that accept provider-owned external IDs (`sandbox_id`, raw Daytona toolbox paths, and
+similar handles) resolve ownership through the active session's leased resources before calling
+the backend. The session resource registry carries the same external-ID metadata for runtimes
+that only expose the generic registry. Raw sandbox list calls are filtered to the IDs owned by
+the active session before results are returned to the agent.
 
 ## 14. Bash Sandbox (TM-BASH)
 
@@ -828,7 +836,7 @@ Daytona sandboxes are remote Linux environments managed via REST API. The agent 
 | TM-DAYTONA-002 | Git token expiry — stale credentials | Low | GitHub App installation tokens expire in ~1 hour; tool hint tells agent to call `daytona_git_credentials` again to refresh | MITIGATED |
 | TM-DAYTONA-003 | Git token scope — over-privileged access | Medium | Token scoped by GitHub App installation permissions; user controls repo access via GitHub App settings | **CALLER RISK** |
 | TM-DAYTONA-004 | Daytona API key compromise | High | Stored in user connections (Settings > Connections); encrypted at rest via envelope encryption (AES-256-GCM) | MITIGATED |
-| TM-DAYTONA-005 | Cross-session sandbox access | Critical | Sandbox IDs stored in session-scoped secrets (`daytona_sandbox:{id}`); session isolation enforced by storage store | MITIGATED |
+| TM-DAYTONA-005 | Cross-session sandbox access | Critical | Daytona tools require session-owned sandbox IDs via leased-resource/session-resource ownership checks; persisted sandbox state stays session-scoped in `daytona_sandbox:{id}` | MITIGATED |
 | TM-DAYTONA-006 | Sandbox not deleted — resource leak | Low | Auto-stop 5 min, auto-archive 30 min, auto-delete 60 min (Daytona-native); leased-resource cleanup 20 min (control plane); system prompt instructs agent to delete when done | MITIGATED |
 | TM-DAYTONA-007 | Git credential helper persists after sandbox reuse | Low | Credential file in `/tmp` cleared on stop; sandbox stop resets environment | MITIGATED |
 
@@ -852,7 +860,8 @@ The GitHub token's scope depends on the GitHub App installation permissions. Use
 Session A stores: daytona_sandbox:sb_abc → {sandbox_id, workspace_path, started_at}
 Session B stores: daytona_sandbox:sb_xyz → {sandbox_id, workspace_path, started_at}
 
-Session A cannot access sb_xyz (different session_id in storage query)
+Session A cannot access sb_xyz because tool-side ownership checks reject non-owned sandbox IDs
+before the Daytona API call, and persisted sandbox state is still scoped by session_id.
 ```
 
 
@@ -863,7 +872,7 @@ Deno sandboxes are remote Linux microVMs managed over a websocket + REST control
 | ID | Threat | Severity | Mitigation | Status |
 |----|--------|----------|------------|--------|
 | TM-DENO-001 | Service-wide token misuse via env fallback | High | Prefer user connections; env fallback is operator-controlled and intended for managed deployments/tests | **CALLER RISK** |
-| TM-DENO-002 | Cross-session sandbox access | Critical | Sandbox IDs stored in session-scoped secrets (`deno_sandbox:{id}`); tool access requires matching session state | MITIGATED |
+| TM-DENO-002 | Cross-session sandbox access | Critical | Deno tools require session-owned sandbox IDs via leased-resource/session-resource ownership checks; persisted sandbox state remains session-scoped in `deno_sandbox:{id}` | MITIGATED |
 | TM-DENO-003 | Sandbox leak from default `session` timeout | Medium | `deno_create_sandbox` forbids `timeout="session"`; Everruns always uses explicit TTLs plus leased-resource cleanup | MITIGATED |
 | TM-API-015 | Lease metadata exposure | Medium | Deno lease metadata stores only non-secret routing/debug fields (`region`, optional `org`, workspace path, timestamps); tokens still resolve from connections/env at cleanup time | MITIGATED |
 | TM-DENO-004 | Network probing from remote sandbox | High | Capability is Admin-gated; residual exposure depends on operator egress controls | **ACCEPTED** |
@@ -876,7 +885,7 @@ E2B sandboxes are remote Linux environments managed through the E2B Management A
 |----|--------|----------|------------|--------|
 | TM-E2B-001 | Platform-owned E2B API key compromise | High | `E2B_API_KEY` stays in server/worker environment or encrypted session secret override; never emitted in tool output | MITIGATED |
 | TM-E2B-002 | envd access token disclosure | Medium | envd access token stored only in encrypted session secrets and sent only to E2B runtime headers | MITIGATED |
-| TM-E2B-003 | Cross-session sandbox access | Critical | Sandbox IDs + envd tokens stored under `e2b_sandbox:{id}` in session-scoped secrets; storage queries enforce session isolation | MITIGATED |
+| TM-E2B-003 | Cross-session sandbox access | Critical | E2B tools require session-owned sandbox IDs via leased-resource/session-resource ownership checks; envd state remains session-scoped under `e2b_sandbox:{id}` | MITIGATED |
 | TM-E2B-004 | Sandbox not deleted or paused — resource leak | Low | E2B timeout + auto-pause on create/resume, plus Everruns leased-resource cleanup | MITIGATED |
 | TM-E2B-005 | Full-network sandbox misuse | High | Capability is high-risk/Admin-gated via capability assignment policy; residual network exposure depends on deployment egress isolation | **CALLER RISK** |
 
@@ -887,7 +896,8 @@ E2B sandboxes are remote Linux environments managed through the E2B Management A
 Session A stores: e2b_sandbox:sb_abc → {sandbox_id, sandbox_domain, envd_access_token, ...}
 Session B stores: e2b_sandbox:sb_xyz → {sandbox_id, sandbox_domain, envd_access_token, ...}
 
-Session A cannot access sb_xyz because storage lookups are scoped by session_id.
+Session A cannot access sb_xyz because tool-side ownership checks reject non-owned sandbox IDs
+before the E2B API call, and storage lookups remain scoped by session_id.
 ```
 
 ## 18. Client-Side Tools (TM-CLIENT)


### PR DESCRIPTION
## What
Add a shared resource-ownership guard for provider-owned sandbox IDs, enforce it in Daytona/Deno/E2B sandbox tools, and scope raw `daytona_api_call` sandbox paths/list responses to resources owned by the active session.

Fixes EVE-377.

## Why
Agents could reuse stale or guessed external resource IDs across sessions. Dedicated sandbox tools mostly relied on session-scoped persisted state, but raw provider IDs still needed an explicit ownership check, and raw Daytona list/path access needed session scoping.

## How
- add `everruns_core::resource_ownership` helpers backed by leased resources with session-resource metadata fallback
- include external ID metadata when leased resources auto-register into the session resource registry
- verify sandbox ownership in Daytona, Deno, and E2B state lookups before backend access
- enforce/filter sandbox-scoped paths in `daytona_api_call`
- add cross-session regression tests plus raw Daytona path/list helper coverage
- update session-resource and threat-model specs

## Risk
- Medium
- Sandbox tools and raw Daytona API calls now reject non-owned IDs earlier; regressions would show up as false ownership failures on legitimate session resources

## Security
- Threat categories reviewed: TM-AGENT, TM-DAYTONA, TM-DENO, TM-E2B, TM-API
- Findings and resolutions:
  - Addressed cross-session sandbox reuse via stale or guessed external IDs by checking ownership against the active session before tool execution
  - Filtered raw Daytona sandbox list results to the IDs owned by the active session
  - Kept the leased-resource/session-resource metadata non-secret; only provider ID/type/external ID/public lease ID were added

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
