### PR TITLE
feat(llm): add prompt cache request metadata

### DIFF
--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -122,14 +122,20 @@ impl AnthropicLlmDriver {
         }
     }
 
-    fn convert_content(content: &LlmMessageContent) -> Vec<AnthropicContentBlock> {
+    fn convert_content(
+        content: &LlmMessageContent,
+        prompt_cache_enabled: bool,
+    ) -> Vec<AnthropicContentBlock> {
         match content {
             LlmMessageContent::Text(text) => {
                 // Skip empty text to avoid Anthropic API error
                 if text.is_empty() {
                     vec![]
                 } else {
-                    vec![AnthropicContentBlock::Text { text: text.clone() }]
+                    vec![AnthropicContentBlock::Text {
+                        text: text.clone(),
+                        cache_control: prompt_cache_enabled.then(AnthropicCacheControl::ephemeral),
+                    }]
                 }
             }
             LlmMessageContent::Parts(parts) => parts
@@ -140,7 +146,11 @@ impl AnthropicLlmDriver {
                         if text.is_empty() {
                             None
                         } else {
-                            Some(AnthropicContentBlock::Text { text: text.clone() })
+                            Some(AnthropicContentBlock::Text {
+                                text: text.clone(),
+                                cache_control: prompt_cache_enabled
+                                    .then(AnthropicCacheControl::ephemeral),
+                            })
                         }
                     }
                     LlmContentPart::Image { url } => {
@@ -168,13 +178,17 @@ impl AnthropicLlmDriver {
                     }
                     LlmContentPart::Audio { .. } => Some(AnthropicContentBlock::Text {
                         text: AUDIO_CONTENT_PLACEHOLDER.to_string(),
+                        cache_control: prompt_cache_enabled.then(AnthropicCacheControl::ephemeral),
                     }),
                 })
                 .collect(),
         }
     }
 
-    fn convert_messages(messages: &[LlmMessage]) -> (Option<String>, Vec<AnthropicMessage>) {
+    fn convert_messages(
+        messages: &[LlmMessage],
+        prompt_cache_enabled: bool,
+    ) -> (Option<String>, Vec<AnthropicMessage>) {
         let mut system_prompt = None;
         let mut converted = Vec::new();
 
@@ -277,7 +291,7 @@ impl AnthropicLlmDriver {
                     }
 
                     // Add text/image content
-                    content.extend(Self::convert_content(&msg.content));
+                    content.extend(Self::convert_content(&msg.content, prompt_cache_enabled));
 
                     // Add tool_use blocks if present
                     if let Some(tool_calls) = &msg.tool_calls {
@@ -298,7 +312,7 @@ impl AnthropicLlmDriver {
                 _ => {
                     converted.push(AnthropicMessage {
                         role: Self::convert_role(&msg.role).to_string(),
-                        content: Self::convert_content(&msg.content),
+                        content: Self::convert_content(&msg.content, prompt_cache_enabled),
                     });
                 }
             }
@@ -329,7 +343,9 @@ impl LlmDriver for AnthropicLlmDriver {
         // Note: OTel instrumentation is handled via event listeners.
         // ReasonAtom emits llm.generation events, and OtelEventListener
         // creates gen-ai spans from those events.
-        let (system_prompt, anthropic_messages) = Self::convert_messages(&messages);
+        let prompt_cache_enabled = config.prompt_cache.as_ref().is_some_and(|cfg| cfg.enabled);
+        let (system_prompt, anthropic_messages) =
+            Self::convert_messages(&messages, prompt_cache_enabled);
 
         let tools = if config.tools.is_empty() {
             None
@@ -893,6 +909,19 @@ struct AnthropicRequest {
     thinking: Option<AnthropicThinking>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AnthropicCacheControl {
+    r#type: String,
+}
+
+impl AnthropicCacheControl {
+    fn ephemeral() -> Self {
+        Self {
+            r#type: "ephemeral".to_string(),
+        }
+    }
+}
+
 /// Extended thinking configuration for Claude
 #[derive(Debug, Serialize)]
 struct AnthropicThinking {
@@ -921,7 +950,11 @@ struct AnthropicMessage {
 #[serde(tag = "type")]
 enum AnthropicContentBlock {
     #[serde(rename = "text")]
-    Text { text: String },
+    Text {
+        text: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<AnthropicCacheControl>,
+    },
     #[serde(rename = "image")]
     Image { source: AnthropicImageSource },
     #[serde(rename = "thinking")]
@@ -1419,15 +1452,24 @@ mod tests {
     fn test_convert_content_filters_empty_text() {
         // Empty text content should produce empty vec
         let content = LlmMessageContent::Text(String::new());
-        let blocks = AnthropicLlmDriver::convert_content(&content);
+        let blocks = AnthropicLlmDriver::convert_content(&content, false);
         assert!(blocks.is_empty(), "Empty text should be filtered out");
+    }
+
+    #[test]
+    fn test_convert_content_adds_cache_control_when_enabled() {
+        let content = LlmMessageContent::Text("Hello".to_string());
+        let blocks = AnthropicLlmDriver::convert_content(&content, true);
+        let json = serde_json::to_value(&blocks[0]).unwrap();
+        assert_eq!(json["type"], "text");
+        assert_eq!(json["cache_control"]["type"], "ephemeral");
     }
 
     #[test]
     fn test_convert_content_keeps_non_empty_text() {
         // Non-empty text should be kept
         let content = LlmMessageContent::Text("Hello, world!".to_string());
-        let blocks = AnthropicLlmDriver::convert_content(&content);
+        let blocks = AnthropicLlmDriver::convert_content(&content, false);
         assert_eq!(blocks.len(), 1, "Non-empty text should be kept");
     }
 
@@ -1445,7 +1487,7 @@ mod tests {
                 text: String::new(),
             },
         ]);
-        let blocks = AnthropicLlmDriver::convert_content(&content);
+        let blocks = AnthropicLlmDriver::convert_content(&content, false);
         assert_eq!(blocks.len(), 1, "Only non-empty text should be kept");
     }
 
@@ -1460,7 +1502,7 @@ mod tests {
                 url: "https://example.com/image.png".to_string(),
             },
         ]);
-        let blocks = AnthropicLlmDriver::convert_content(&content);
+        let blocks = AnthropicLlmDriver::convert_content(&content, false);
         assert_eq!(blocks.len(), 1, "Image should be kept, empty text filtered");
     }
 
@@ -1475,7 +1517,7 @@ mod tests {
                 text: String::new(),
             },
         ]);
-        let blocks = AnthropicLlmDriver::convert_content(&content);
+        let blocks = AnthropicLlmDriver::convert_content(&content, false);
         assert!(blocks.is_empty(), "All empty text should produce empty vec");
     }
 
@@ -1497,7 +1539,7 @@ mod tests {
             thinking_signature: None,
         }];
 
-        let (_, converted) = AnthropicLlmDriver::convert_messages(&messages);
+        let (_, converted) = AnthropicLlmDriver::convert_messages(&messages, false);
 
         assert_eq!(converted.len(), 1);
         // Content should have tool_use block but no empty text block
@@ -1512,7 +1554,7 @@ mod tests {
     fn test_convert_content_whitespace_is_kept() {
         // Whitespace-only text is kept (not empty after is_empty() check)
         let content = LlmMessageContent::Text("   ".to_string());
-        let blocks = AnthropicLlmDriver::convert_content(&content);
+        let blocks = AnthropicLlmDriver::convert_content(&content, false);
         assert_eq!(blocks.len(), 1, "Whitespace-only text is kept");
     }
 
@@ -1522,7 +1564,7 @@ mod tests {
         let content = LlmMessageContent::Parts(vec![LlmContentPart::Image {
             url: "data:image/png;base64,iVBORw0KGgo=".to_string(),
         }]);
-        let blocks = AnthropicLlmDriver::convert_content(&content);
+        let blocks = AnthropicLlmDriver::convert_content(&content, false);
         assert_eq!(blocks.len(), 1, "Base64 image should be converted");
         match &blocks[0] {
             AnthropicContentBlock::Image { source } => match source {
@@ -1541,7 +1583,7 @@ mod tests {
         let content = LlmMessageContent::Parts(vec![LlmContentPart::Image {
             url: "https://example.com/photo.jpg".to_string(),
         }]);
-        let blocks = AnthropicLlmDriver::convert_content(&content);
+        let blocks = AnthropicLlmDriver::convert_content(&content, false);
         assert_eq!(blocks.len(), 1, "HTTP image should be converted");
         match &blocks[0] {
             AnthropicContentBlock::Image { source } => match source {
@@ -1560,10 +1602,10 @@ mod tests {
         let content = LlmMessageContent::Parts(vec![LlmContentPart::Audio {
             url: "data:audio/wav;base64,AAAA".to_string(),
         }]);
-        let blocks = AnthropicLlmDriver::convert_content(&content);
+        let blocks = AnthropicLlmDriver::convert_content(&content, false);
         assert_eq!(blocks.len(), 1, "Audio should fallback to text note");
         match &blocks[0] {
-            AnthropicContentBlock::Text { text } => {
+            AnthropicContentBlock::Text { text, .. } => {
                 assert!(text.contains("not supported"));
             }
             _ => panic!("Expected Text block for audio fallback"),
@@ -1594,7 +1636,7 @@ mod tests {
             },
         ];
 
-        let (system, converted) = AnthropicLlmDriver::convert_messages(&messages);
+        let (system, converted) = AnthropicLlmDriver::convert_messages(&messages, false);
 
         assert_eq!(system, Some("You are helpful".to_string()));
         assert_eq!(converted.len(), 1); // Only user message
@@ -1613,7 +1655,7 @@ mod tests {
             thinking_signature: None,
         }];
 
-        let (_, converted) = AnthropicLlmDriver::convert_messages(&messages);
+        let (_, converted) = AnthropicLlmDriver::convert_messages(&messages, false);
 
         assert_eq!(converted.len(), 1);
         assert_eq!(converted[0].role, "user");
@@ -1656,7 +1698,7 @@ mod tests {
             thinking_signature: None,
         };
 
-        let (_, converted) = AnthropicLlmDriver::convert_messages(&[msg]);
+        let (_, converted) = AnthropicLlmDriver::convert_messages(&[msg], false);
 
         assert_eq!(converted.len(), 1);
         assert_eq!(converted[0].role, "user");
@@ -1709,7 +1751,7 @@ mod tests {
             thinking_signature: None,
         };
 
-        let (_, converted) = AnthropicLlmDriver::convert_messages(&[msg]);
+        let (_, converted) = AnthropicLlmDriver::convert_messages(&[msg], false);
 
         match &converted[0].content[0] {
             AnthropicContentBlock::ToolResult { content, .. } => match content {

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -19,6 +19,7 @@
 use async_trait::async_trait;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
@@ -28,10 +29,11 @@ use super::{Atom, AtomContext};
 use crate::capabilities::CapabilityRegistry;
 use crate::error::{AgentLoopError, Result};
 use crate::events::{
-    EventContext, EventRequest, LlmCompactionInfo, LlmGenerationData, LlmRetryInfo,
-    OutputMessageCompletedData, OutputMessageDeltaData, OutputMessageStartedData,
-    ReasonCompletedData, ReasonStartedData, ReasonThinkingCompletedData, ReasonThinkingDeltaData,
-    ReasonThinkingStartedData, TokenUsage, ToolDefinitionSummary,
+    EventContext, EventRequest, LlmCompactionInfo, LlmGenerationData, LlmPromptCacheInfo,
+    LlmRequestOptions, LlmRetryInfo, LlmToolSearchInfo, OutputMessageCompletedData,
+    OutputMessageDeltaData, OutputMessageStartedData, ReasonCompletedData, ReasonStartedData,
+    ReasonThinkingCompletedData, ReasonThinkingDeltaData, ReasonThinkingStartedData, TokenUsage,
+    ToolDefinitionSummary,
 };
 use crate::llm_driver_registry::{
     DriverRegistry, LlmCallConfigBuilder, LlmCompletionMetadata, LlmMessage, LlmMessageContent,
@@ -197,6 +199,68 @@ pub struct ReasonResult {
 
 fn default_max_iterations() -> usize {
     500
+}
+
+fn build_request_options(
+    config: &crate::llm_driver_registry::LlmCallConfig,
+    provider: &str,
+) -> Option<LlmRequestOptions> {
+    let prompt_cache = config
+        .prompt_cache
+        .as_ref()
+        .filter(|cfg| cfg.enabled)
+        .map(|cfg| LlmPromptCacheInfo {
+            enabled: true,
+            strategy: cfg.strategy,
+            provider_mode: match provider {
+                "openai" => Some("prompt_cache_key".to_string()),
+                "anthropic" => Some("cache_control".to_string()),
+                "gemini" => Some(
+                    if cfg.gemini_cached_content.is_some() {
+                        "cached_content"
+                    } else {
+                        "implicit"
+                    }
+                    .to_string(),
+                ),
+                _ => None,
+            },
+        });
+
+    let tool_search = config
+        .tool_search
+        .as_ref()
+        .filter(|cfg| cfg.enabled)
+        .map(|cfg| LlmToolSearchInfo {
+            enabled: true,
+            threshold: cfg.threshold,
+        });
+
+    let mut provider_options = HashMap::new();
+    if provider == "openai" && config.previous_response_id.is_some() {
+        provider_options.insert(
+            "openai".to_string(),
+            json!({ "previous_response_id": true }),
+        );
+    }
+    if provider == "gemini"
+        && config
+            .prompt_cache
+            .as_ref()
+            .filter(|cfg| cfg.enabled)
+            .and_then(|cfg| cfg.gemini_cached_content.as_ref())
+            .is_some()
+    {
+        provider_options.insert("gemini".to_string(), json!({ "cached_content": true }));
+    }
+
+    let request_options = LlmRequestOptions {
+        prompt_cache,
+        tool_search,
+        provider_options,
+    };
+
+    (!request_options.is_empty()).then_some(request_options)
 }
 
 // ============================================================================
@@ -1175,6 +1239,7 @@ impl ReasonAtom {
                                 metadata: HashMap::new(),
                                 previous_response_id: None,
                                 tool_search: None,
+                                prompt_cache: None,
                             };
 
                             match llm_driver
@@ -1589,6 +1654,12 @@ impl ReasonAtom {
             generation_data = generation_data.with_compaction(info);
         }
 
+        if let Some(request_options) =
+            build_request_options(&llm_config, &model_with_provider.provider_type.to_string())
+        {
+            generation_data = generation_data.with_request_options(request_options);
+        }
+
         if let Err(e) = self
             .event_emitter
             .emit(EventRequest::new(
@@ -1789,6 +1860,8 @@ impl ReasonAtom {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::llm_driver_registry::{LlmCallConfig, PromptCacheConfig, PromptCacheStrategy};
+    use std::collections::HashMap;
 
     #[test]
     fn test_reason_result_default() {
@@ -1853,5 +1926,88 @@ mod tests {
         assert_eq!(patched.len(), 4);
         assert_eq!(patched[2].role, MessageRole::ToolResult);
         assert_eq!(patched[2].tool_call_id(), Some("call_456"));
+    }
+
+    #[test]
+    fn test_build_request_options_for_openai_prompt_cache() {
+        let config = LlmCallConfig {
+            model: "gpt-5.4".to_string(),
+            temperature: None,
+            max_tokens: None,
+            tools: vec![],
+            reasoning_effort: None,
+            metadata: HashMap::new(),
+            previous_response_id: Some("resp_123".to_string()),
+            tool_search: None,
+            prompt_cache: Some(PromptCacheConfig {
+                enabled: true,
+                strategy: PromptCacheStrategy::Auto,
+                gemini_cached_content: None,
+            }),
+        };
+
+        let request_options = build_request_options(&config, "openai").unwrap();
+        assert_eq!(
+            request_options
+                .prompt_cache
+                .and_then(|info| info.provider_mode),
+            Some("prompt_cache_key".to_string())
+        );
+        assert_eq!(
+            request_options.provider_options.get("openai"),
+            Some(&json!({ "previous_response_id": true }))
+        );
+    }
+
+    #[test]
+    fn test_build_request_options_for_gemini_explicit_cache() {
+        let config = LlmCallConfig {
+            model: "gemini-2.5-pro".to_string(),
+            temperature: None,
+            max_tokens: None,
+            tools: vec![],
+            reasoning_effort: None,
+            metadata: HashMap::new(),
+            previous_response_id: None,
+            tool_search: None,
+            prompt_cache: Some(PromptCacheConfig {
+                enabled: true,
+                strategy: PromptCacheStrategy::Auto,
+                gemini_cached_content: Some("cachedContents/demo-cache".to_string()),
+            }),
+        };
+
+        let request_options = build_request_options(&config, "gemini").unwrap();
+        assert_eq!(
+            request_options
+                .prompt_cache
+                .and_then(|info| info.provider_mode),
+            Some("cached_content".to_string())
+        );
+        assert_eq!(
+            request_options.provider_options.get("gemini"),
+            Some(&json!({ "cached_content": true }))
+        );
+    }
+
+    #[test]
+    fn test_build_request_options_omits_gemini_cache_flag_when_disabled() {
+        let config = LlmCallConfig {
+            model: "gemini-2.5-pro".to_string(),
+            temperature: None,
+            max_tokens: None,
+            tools: vec![],
+            reasoning_effort: None,
+            metadata: HashMap::new(),
+            previous_response_id: None,
+            tool_search: None,
+            prompt_cache: Some(PromptCacheConfig {
+                enabled: false,
+                strategy: PromptCacheStrategy::Auto,
+                gemini_cached_content: Some("cachedContents/demo-cache".to_string()),
+            }),
+        };
+
+        assert!(build_request_options(&config, "gemini").is_none());
     }
 }

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -96,6 +96,7 @@ mod openai_tool_search;
 mod openui;
 pub mod persistent_memory;
 mod platform_management;
+mod prompt_caching;
 mod research;
 mod sample_data;
 mod self_budget;
@@ -182,6 +183,7 @@ pub use platform_management::{
     ReadAgentsTool, ReadCapabilitiesTool, ReadHarnessesTool, ReadSessionsTool,
     SessionReadMessagesTool, SessionReadResponseTool, SessionSendMessageTool,
 };
+pub use prompt_caching::{PROMPT_CACHING_CAPABILITY_ID, PromptCachingCapability};
 pub use research::ResearchCapability;
 pub use sample_data::SampleDataCapability;
 pub use self_budget::{SELF_BUDGET_CAPABILITY_ID, SelfBudgetCapability};
@@ -669,6 +671,7 @@ impl CapabilityRegistry {
 
         // OpenAI tool_search (deferred tool loading, all environments)
         registry.register(OpenAiToolSearchCapability::new());
+        registry.register(PromptCachingCapability::new());
 
         // Skills (filesystem-based discovery + activation, all environments)
         registry.register(SkillsCapability);
@@ -871,6 +874,8 @@ pub struct CollectedCapabilities {
     pub applied_ids: Vec<String>,
     /// Tool search configuration (set when openai_tool_search capability is present)
     pub tool_search: Option<crate::llm_driver_registry::ToolSearchConfig>,
+    /// Prompt caching configuration (set when prompt_caching capability is present)
+    pub prompt_cache: Option<crate::llm_driver_registry::PromptCacheConfig>,
 }
 
 impl CollectedCapabilities {
@@ -1293,6 +1298,7 @@ pub async fn collect_capabilities_with_configs(
         Vec::new();
     let mut applied_ids: Vec<String> = Vec::new();
     let mut tool_search: Option<crate::llm_driver_registry::ToolSearchConfig> = None;
+    let mut prompt_cache: Option<crate::llm_driver_registry::PromptCacheConfig> = None;
 
     for cap_config in capability_configs {
         let cap_id = cap_config.capability_ref.as_str();
@@ -1338,6 +1344,28 @@ pub async fn collect_capabilities_with_configs(
                 });
             }
 
+            if cap_id == PROMPT_CACHING_CAPABILITY_ID {
+                let strategy = cap_config
+                    .config
+                    .get("strategy")
+                    .and_then(|v| v.as_str())
+                    .map(|value| match value {
+                        "auto" => crate::llm_driver_registry::PromptCacheStrategy::Auto,
+                        _ => crate::llm_driver_registry::PromptCacheStrategy::Auto,
+                    })
+                    .unwrap_or(crate::llm_driver_registry::PromptCacheStrategy::Auto);
+                let gemini_cached_content = cap_config
+                    .config
+                    .get("gemini_cached_content")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string);
+                prompt_cache = Some(crate::llm_driver_registry::PromptCacheConfig {
+                    enabled: true,
+                    strategy,
+                    gemini_cached_content,
+                });
+            }
+
             // Collect mount points
             mounts.extend(capability.mounts());
 
@@ -1368,6 +1396,7 @@ pub async fn collect_capabilities_with_configs(
         message_filter_providers,
         applied_ids,
         tool_search,
+        prompt_cache,
     }
 }
 
@@ -1453,6 +1482,7 @@ pub async fn apply_capabilities(
         temperature: base_runtime_agent.temperature,
         max_tokens: base_runtime_agent.max_tokens,
         tool_search: collected.tool_search,
+        prompt_cache: collected.prompt_cache,
         network_access: base_runtime_agent.network_access,
     };
 
@@ -1502,6 +1532,7 @@ mod tests {
             "compaction",
             "memory",
             "openai_tool_search",
+            "prompt_caching",
             "skills",
             "subagents",
             "system_commands",
@@ -3123,6 +3154,76 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[tokio::test]
+    async fn test_apply_capabilities_prompt_caching() {
+        let registry = CapabilityRegistry::with_builtins();
+        let base_runtime_agent = RuntimeAgent::new("You are a helpful assistant.", "gpt-5.4");
+
+        let applied = apply_capabilities(
+            base_runtime_agent.clone(),
+            &["prompt_caching".to_string()],
+            &registry,
+            &test_ctx(),
+        )
+        .await;
+
+        assert_eq!(
+            applied.runtime_agent.system_prompt,
+            base_runtime_agent.system_prompt
+        );
+        assert!(applied.tool_registry.is_empty());
+        assert_eq!(applied.applied_ids, vec!["prompt_caching"]);
+
+        let prompt_cache = applied.runtime_agent.prompt_cache.as_ref().unwrap();
+        assert!(prompt_cache.enabled);
+        assert_eq!(
+            prompt_cache.strategy,
+            crate::llm_driver_registry::PromptCacheStrategy::Auto
+        );
+        assert!(prompt_cache.gemini_cached_content.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_collect_capabilities_prompt_caching_custom_strategy() {
+        let registry = CapabilityRegistry::with_builtins();
+
+        let configs = vec![AgentCapabilityConfig {
+            capability_ref: CapabilityId::new("prompt_caching"),
+            config: serde_json::json!({"strategy": "auto"}),
+        }];
+
+        let collected = collect_capabilities_with_configs(&configs, &registry, &test_ctx()).await;
+
+        let prompt_cache = collected.prompt_cache.as_ref().unwrap();
+        assert!(prompt_cache.enabled);
+        assert_eq!(
+            prompt_cache.strategy,
+            crate::llm_driver_registry::PromptCacheStrategy::Auto
+        );
+        assert!(prompt_cache.gemini_cached_content.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_collect_capabilities_prompt_caching_gemini_cached_content() {
+        let registry = CapabilityRegistry::with_builtins();
+
+        let configs = vec![AgentCapabilityConfig {
+            capability_ref: CapabilityId::new("prompt_caching"),
+            config: serde_json::json!({
+                "strategy": "auto",
+                "gemini_cached_content": "cachedContents/demo-cache"
+            }),
+        }];
+
+        let collected = collect_capabilities_with_configs(&configs, &registry, &test_ctx()).await;
+
+        let prompt_cache = collected.prompt_cache.as_ref().unwrap();
+        assert_eq!(
+            prompt_cache.gemini_cached_content.as_deref(),
+            Some("cachedContents/demo-cache")
+        );
     }
 
     // ========================================================================

--- a/crates/core/src/capabilities/prompt_caching.rs
+++ b/crates/core/src/capabilities/prompt_caching.rs
@@ -1,0 +1,126 @@
+// Prompt Caching Capability
+//
+// When added to an agent, enables provider-specific prompt caching behavior for
+// drivers that support it. This capability does not add tools or prompt text;
+// it only configures the outbound LLM request.
+
+use super::{Capability, CapabilityStatus, SystemPromptContext};
+use crate::llm_driver_registry::{PromptCacheConfig, PromptCacheStrategy};
+use async_trait::async_trait;
+
+/// Capability ID for provider prompt caching.
+pub const PROMPT_CACHING_CAPABILITY_ID: &str = "prompt_caching";
+
+/// Prompt caching capability.
+///
+/// Drivers translate this generic config into provider-specific request
+/// controls when possible. Unsupported providers or models ignore it.
+pub struct PromptCachingCapability {
+    strategy: PromptCacheStrategy,
+    gemini_cached_content: Option<String>,
+}
+
+impl PromptCachingCapability {
+    pub fn new() -> Self {
+        Self {
+            strategy: PromptCacheStrategy::Auto,
+            gemini_cached_content: None,
+        }
+    }
+
+    pub fn with_strategy(strategy: PromptCacheStrategy) -> Self {
+        Self {
+            strategy,
+            gemini_cached_content: None,
+        }
+    }
+
+    pub fn with_gemini_cached_content(
+        strategy: PromptCacheStrategy,
+        gemini_cached_content: impl Into<String>,
+    ) -> Self {
+        Self {
+            strategy,
+            gemini_cached_content: Some(gemini_cached_content.into()),
+        }
+    }
+
+    /// Returns the PromptCacheConfig for this capability.
+    pub fn prompt_cache_config(&self) -> PromptCacheConfig {
+        PromptCacheConfig {
+            enabled: true,
+            strategy: self.strategy,
+            gemini_cached_content: self.gemini_cached_content.clone(),
+        }
+    }
+}
+
+impl Default for PromptCachingCapability {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Capability for PromptCachingCapability {
+    fn id(&self) -> &str {
+        PROMPT_CACHING_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Prompt Caching"
+    }
+
+    fn description(&self) -> &str {
+        "Enables provider-specific prompt caching where supported and records \
+         that request intent in llm.generation metadata."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Optimization")
+    }
+
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_capability_metadata() {
+        let cap = PromptCachingCapability::new();
+        assert_eq!(cap.id(), PROMPT_CACHING_CAPABILITY_ID);
+        assert_eq!(cap.name(), "Prompt Caching");
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+        assert!(cap.tools().is_empty());
+    }
+
+    #[test]
+    fn test_default_strategy() {
+        let cap = PromptCachingCapability::new();
+        let config = cap.prompt_cache_config();
+        assert!(config.enabled);
+        assert_eq!(config.strategy, PromptCacheStrategy::Auto);
+        assert!(config.gemini_cached_content.is_none());
+    }
+
+    #[test]
+    fn test_capability_with_gemini_cached_content() {
+        let cap = PromptCachingCapability::with_gemini_cached_content(
+            PromptCacheStrategy::Auto,
+            "cachedContents/example",
+        );
+        let config = cap.prompt_cache_config();
+        assert_eq!(
+            config.gemini_cached_content.as_deref(),
+            Some("cachedContents/example")
+        );
+    }
+}

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -20,6 +20,8 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
 use uuid::Uuid;
 
 #[cfg(feature = "openapi")]
@@ -1042,6 +1044,55 @@ pub struct LlmGenerationOutput {
     pub tool_calls: Vec<ToolCall>,
 }
 
+/// Request options applied to an LLM generation.
+///
+/// These fields capture request-side intent such as prompt caching or deferred
+/// tool loading. They complement `usage`, which captures what actually happened.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct LlmRequestOptions {
+    /// Prompt caching configuration for this request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_cache: Option<LlmPromptCacheInfo>,
+    /// Deferred tool-loading configuration for this request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_search: Option<LlmToolSearchInfo>,
+    /// Provider-specific request options that do not warrant dedicated fields.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub provider_options: HashMap<String, Value>,
+}
+
+impl LlmRequestOptions {
+    pub fn is_empty(&self) -> bool {
+        self.prompt_cache.is_none()
+            && self.tool_search.is_none()
+            && self.provider_options.is_empty()
+    }
+}
+
+/// Request-side prompt cache settings for an LLM generation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct LlmPromptCacheInfo {
+    /// Whether prompt caching was enabled on the request.
+    pub enabled: bool,
+    /// Strategy used to enable prompt caching.
+    pub strategy: crate::llm_driver_registry::PromptCacheStrategy,
+    /// Provider-specific prompt-cache mode used by the driver.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider_mode: Option<String>,
+}
+
+/// Request-side tool_search settings for an LLM generation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct LlmToolSearchInfo {
+    /// Whether tool_search was enabled on the request.
+    pub enabled: bool,
+    /// Minimum number of tools before deferred loading activates.
+    pub threshold: usize,
+}
+
 /// Metadata about an LLM generation
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
@@ -1091,6 +1142,10 @@ pub struct LlmGenerationMetadata {
     /// Occurs when the conversation context exceeded the model's limit
     #[serde(skip_serializing_if = "Option::is_none")]
     pub compaction: Option<LlmCompactionInfo>,
+
+    /// Request-side driver options that were enabled for this generation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_options: Option<LlmRequestOptions>,
 }
 
 /// Information about rate limit retries during LLM generation
@@ -1201,6 +1256,7 @@ impl LlmGenerationData {
                 response_id: None,
                 retry: None,
                 compaction: None,
+                request_options: None,
             },
         }
     }
@@ -1236,6 +1292,7 @@ impl LlmGenerationData {
                 response_id,
                 retry: None,
                 compaction: None,
+                request_options: None,
             },
         }
     }
@@ -1272,6 +1329,7 @@ impl LlmGenerationData {
                 response_id,
                 retry,
                 compaction: None,
+                request_options: None,
             },
         }
     }
@@ -1305,6 +1363,7 @@ impl LlmGenerationData {
                 response_id: None,
                 retry: None,
                 compaction: None,
+                request_options: None,
             },
         }
     }
@@ -1320,6 +1379,14 @@ impl LlmGenerationData {
     /// Set retry info on this generation event
     pub fn with_retry(mut self, retry: LlmRetryInfo) -> Self {
         self.metadata.retry = Some(retry);
+        self
+    }
+
+    /// Set request-side options on this generation event.
+    pub fn with_request_options(mut self, request_options: LlmRequestOptions) -> Self {
+        if !request_options.is_empty() {
+            self.metadata.request_options = Some(request_options);
+        }
         self
     }
 }
@@ -2163,6 +2230,9 @@ impl EventBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::llm_driver_registry::PromptCacheStrategy;
+    use serde_json::json;
+    use std::collections::HashMap;
 
     #[test]
     fn test_event_creation() {
@@ -2399,6 +2469,53 @@ mod tests {
 
         let event_data: EventData = data.into();
         assert_eq!(event_data.event_type(), LLM_GENERATION);
+    }
+
+    #[test]
+    fn test_llm_generation_data_with_request_options() {
+        let mut provider_options = HashMap::new();
+        provider_options.insert(
+            "openai".to_string(),
+            json!({ "previous_response_id": true }),
+        );
+
+        let data = LlmGenerationData::success(
+            vec![Message::user("Hello")],
+            vec![],
+            Some("Hi".to_string()),
+            vec![],
+            "gpt-5.4".to_string(),
+            Some("openai".to_string()),
+            None,
+            Some(42),
+            Some(12),
+        )
+        .with_request_options(LlmRequestOptions {
+            prompt_cache: Some(LlmPromptCacheInfo {
+                enabled: true,
+                strategy: PromptCacheStrategy::Auto,
+                provider_mode: Some("prompt_cache_key".to_string()),
+            }),
+            tool_search: Some(LlmToolSearchInfo {
+                enabled: true,
+                threshold: 8,
+            }),
+            provider_options,
+        });
+
+        let json = serde_json::to_value(&data).unwrap();
+        assert_eq!(
+            json["metadata"]["request_options"]["prompt_cache"]["provider_mode"],
+            "prompt_cache_key"
+        );
+        assert_eq!(
+            json["metadata"]["request_options"]["tool_search"]["threshold"],
+            8
+        );
+        assert_eq!(
+            json["metadata"]["request_options"]["provider_options"]["openai"]["previous_response_id"],
+            true
+        );
     }
 
     #[test]

--- a/crates/core/src/llm_driver_registry.rs
+++ b/crates/core/src/llm_driver_registry.rs
@@ -433,6 +433,38 @@ pub struct ToolSearchConfig {
     pub threshold: usize,
 }
 
+/// Strategy for prompt caching.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum PromptCacheStrategy {
+    /// Let each driver choose the safest provider-specific behavior.
+    #[default]
+    Auto,
+}
+
+/// Configuration for prompt caching.
+///
+/// Drivers translate this into provider-specific request options when possible.
+/// Unsupported providers or models should ignore it without failing the call.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct PromptCacheConfig {
+    /// Enable prompt caching for this request.
+    pub enabled: bool,
+    /// Strategy the driver should use when enabling prompt caching.
+    #[serde(default)]
+    pub strategy: PromptCacheStrategy,
+    /// Existing Gemini cached content resource name (`cachedContents/{id}`).
+    ///
+    /// When set, the Gemini driver uses explicit caching via the
+    /// `cachedContent` request field. When absent, Gemini falls back to its
+    /// default provider behavior (for example implicit caching on supported
+    /// models).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gemini_cached_content: Option<String>,
+}
+
 /// Configuration for an LLM call
 #[derive(Debug, Clone)]
 pub struct LlmCallConfig {
@@ -451,6 +483,8 @@ pub struct LlmCallConfig {
     pub previous_response_id: Option<String>,
     /// Tool search configuration for deferred tool loading
     pub tool_search: Option<ToolSearchConfig>,
+    /// Prompt caching configuration for provider-specific cache controls.
+    pub prompt_cache: Option<PromptCacheConfig>,
 }
 
 impl From<&RuntimeAgent> for LlmCallConfig {
@@ -464,6 +498,7 @@ impl From<&RuntimeAgent> for LlmCallConfig {
             metadata: HashMap::new(), // Set by ReasonAtom with session/agent context
             previous_response_id: None,
             tool_search: runtime_agent.tool_search.clone(),
+            prompt_cache: runtime_agent.prompt_cache.clone(),
         }
     }
 }
@@ -564,6 +599,12 @@ impl LlmCallConfigBuilder {
     /// Set tool_search configuration
     pub fn tool_search(mut self, config: ToolSearchConfig) -> Self {
         self.config.tool_search = Some(config);
+        self
+    }
+
+    /// Set prompt caching configuration
+    pub fn prompt_cache(mut self, config: PromptCacheConfig) -> Self {
+        self.config.prompt_cache = Some(config);
         self
     }
 

--- a/crates/core/src/llmsim_driver.rs
+++ b/crates/core/src/llmsim_driver.rs
@@ -600,6 +600,7 @@ mod tests {
             metadata: std::collections::HashMap::new(),
             previous_response_id: None,
             tool_search: None,
+            prompt_cache: None,
         }
     }
 

--- a/crates/core/src/observation/braintrust.rs
+++ b/crates/core/src/observation/braintrust.rs
@@ -504,6 +504,10 @@ impl BraintrustListener {
         if let Some(finish_reasons) = &data.metadata.finish_reasons {
             metadata["finish_reasons"] = serde_json::json!(finish_reasons);
         }
+        if let Some(request_options) = &data.metadata.request_options {
+            metadata["request_options"] =
+                serde_json::to_value(request_options).unwrap_or_else(|_| serde_json::json!({}));
+        }
         if let Some(turn_id) = &event.context.turn_id {
             metadata["turn_id"] = serde_json::json!(turn_id.to_string());
         }
@@ -1421,6 +1425,7 @@ mod tests {
                 response_id: Some("resp_123".to_string()),
                 retry: None,
                 compaction: None,
+                request_options: None,
             },
         };
 
@@ -1635,6 +1640,7 @@ mod tests {
                 response_id: None,
                 retry: None,
                 compaction: None,
+                request_options: None,
             },
         };
         let event = Event::new(
@@ -1907,6 +1913,7 @@ mod tests {
                 response_id: None,
                 retry: None,
                 compaction: None,
+                request_options: None,
             },
         };
         let llm_event = Event::new(

--- a/crates/core/src/observation/otel.rs
+++ b/crates/core/src/observation/otel.rs
@@ -1312,6 +1312,7 @@ mod tests {
                 response_id: Some("resp_123".to_string()),
                 retry: None,
                 compaction: None,
+                request_options: None,
             },
         };
 
@@ -1351,6 +1352,7 @@ mod tests {
                 response_id: Some("resp_456".to_string()),
                 retry: None,
                 compaction: None,
+                request_options: None,
             },
         };
 
@@ -1386,6 +1388,7 @@ mod tests {
                 response_id: None,
                 retry: None,
                 compaction: None,
+                request_options: None,
             },
         };
 
@@ -1426,6 +1429,7 @@ mod tests {
                 response_id: None,
                 retry: None,
                 compaction: None,
+                request_options: None,
             },
         };
 
@@ -1461,6 +1465,7 @@ mod tests {
                 response_id: None,
                 retry: None,
                 compaction: None,
+                request_options: None,
             },
         };
 
@@ -1502,6 +1507,7 @@ mod tests {
                 response_id: None,
                 retry: None,
                 compaction: None,
+                request_options: None,
             },
         };
 
@@ -1538,6 +1544,7 @@ mod tests {
                 response_id: None,
                 retry: None,
                 compaction: None,
+                request_options: None,
             },
         };
 
@@ -1656,6 +1663,7 @@ mod tests {
                 response_id: None,
                 retry: None,
                 compaction: None,
+                request_options: None,
             },
         };
         listener
@@ -1905,6 +1913,7 @@ mod tests {
                 response_id: Some("resp_001".to_string()),
                 retry: None,
                 compaction: None,
+                request_options: None,
             },
         };
         listener
@@ -2044,6 +2053,7 @@ mod tests {
                 response_id: Some("resp_002".to_string()),
                 retry: None,
                 compaction: None,
+                request_options: None,
             },
         };
         listener

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -25,6 +25,7 @@ use futures::StreamExt;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 use std::sync::{Arc, Mutex};
 
 use crate::error::{AgentLoopError, Result};
@@ -313,6 +314,24 @@ impl OpenResponsesProtocolLlmDriver {
         });
 
         result
+    }
+
+    fn build_prompt_cache_key(
+        config: &LlmCallConfig,
+        input_items: &[ResponsesInputItem],
+        instructions: &Option<String>,
+        tools: &Option<Vec<ResponsesTool>>,
+    ) -> Option<String> {
+        let prompt_cache = config.prompt_cache.as_ref().filter(|cfg| cfg.enabled)?;
+        let fingerprint = json!({
+            "strategy": prompt_cache.strategy,
+            "model": config.model,
+            "instructions": instructions,
+            "input": input_items,
+            "tools": tools,
+        });
+        let payload = serde_json::to_vec(&fingerprint).ok()?;
+        Some(format!("everruns:{:x}", Sha256::digest(payload)))
     }
 
     /// Compact a conversation to reduce context size
@@ -606,6 +625,8 @@ impl LlmDriver for OpenResponsesProtocolLlmDriver {
         } else {
             Some(config.metadata.clone())
         };
+        let prompt_cache_key =
+            Self::build_prompt_cache_key(config, &input_items, &instructions, &tools);
 
         let request = ResponsesRequest {
             model: config.model.clone(),
@@ -618,6 +639,7 @@ impl LlmDriver for OpenResponsesProtocolLlmDriver {
             tools,
             reasoning,
             metadata,
+            prompt_cache_key,
         };
 
         // Log request details for debugging LLM errors.
@@ -1609,6 +1631,8 @@ struct ResponsesRequest {
     /// Useful for correlating requests with session_id, agent_id, org_id, etc.
     #[serde(skip_serializing_if = "Option::is_none")]
     metadata: Option<std::collections::HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prompt_cache_key: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1752,6 +1776,7 @@ mod tests {
             tools: None,
             reasoning: None,
             metadata: None,
+            prompt_cache_key: None,
         };
 
         let json = serde_json::to_value(&request).unwrap();
@@ -1782,6 +1807,7 @@ mod tests {
                 summary: "detailed".to_string(),
             }),
             metadata: None,
+            prompt_cache_key: None,
         };
 
         let json = serde_json::to_value(&request).unwrap();
@@ -1811,11 +1837,47 @@ mod tests {
             tools: None,
             reasoning: None,
             metadata: Some(metadata),
+            prompt_cache_key: None,
         };
 
         let json = serde_json::to_value(&request).unwrap();
         assert_eq!(json["metadata"]["session_id"], "session_abc123");
         assert_eq!(json["metadata"]["agent_id"], "agent_xyz789");
+    }
+
+    #[test]
+    fn test_build_prompt_cache_key_when_enabled() {
+        let config = LlmCallConfig {
+            model: "gpt-5.4".to_string(),
+            temperature: None,
+            max_tokens: None,
+            tools: vec![],
+            reasoning_effort: None,
+            metadata: std::collections::HashMap::new(),
+            previous_response_id: None,
+            tool_search: None,
+            prompt_cache: Some(crate::llm_driver_registry::PromptCacheConfig {
+                enabled: true,
+                strategy: crate::llm_driver_registry::PromptCacheStrategy::Auto,
+                gemini_cached_content: None,
+            }),
+        };
+        let input = vec![ResponsesInputItem::Message {
+            r#type: "message".to_string(),
+            role: "user".to_string(),
+            content: ResponsesContent::Text("Hello".to_string()),
+            phase: None,
+        }];
+
+        let key = OpenResponsesProtocolLlmDriver::build_prompt_cache_key(
+            &config,
+            &input,
+            &Some("You are helpful".to_string()),
+            &None,
+        );
+
+        assert!(key.is_some());
+        assert!(key.unwrap().starts_with("everruns:"));
     }
 
     #[test]
@@ -2509,6 +2571,7 @@ mod tests {
             metadata: std::collections::HashMap::new(),
             previous_response_id: None,
             tool_search: None,
+            prompt_cache: None,
         };
 
         // Simulate the driver's filter logic
@@ -2539,6 +2602,7 @@ mod tests {
             metadata: std::collections::HashMap::new(),
             previous_response_id: None,
             tool_search: None,
+            prompt_cache: None,
         };
 
         let reasoning = config

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -20,7 +20,7 @@ use crate::capabilities::{
 };
 use crate::config_layer::AgentConfigOverlay;
 use crate::harness::Harness;
-use crate::llm_driver_registry::ToolSearchConfig;
+use crate::llm_driver_registry::{PromptCacheConfig, ToolSearchConfig};
 use crate::llm_model_profiles::get_model_profile;
 use crate::llm_models::LlmProviderType;
 use crate::tool_types::ToolDefinition;
@@ -55,6 +55,10 @@ pub struct RuntimeAgent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_search: Option<ToolSearchConfig>,
 
+    /// Prompt caching config (set by prompt_caching capability)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_cache: Option<PromptCacheConfig>,
+
     /// Merged network access list (harness ∩ agent ∩ session).
     /// Used by tools (web_fetch) to enforce URL access policy.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -79,6 +83,7 @@ impl RuntimeAgent {
             temperature: None,
             max_tokens: None,
             tool_search: None,
+            prompt_cache: None,
             network_access: None,
         }
     }
@@ -94,6 +99,7 @@ impl Default for RuntimeAgent {
             temperature: None,
             max_tokens: None,
             tool_search: None,
+            prompt_cache: None,
             network_access: None,
         }
     }
@@ -284,6 +290,10 @@ impl RuntimeAgentBuilder {
             self.runtime_agent.tool_search = Some(ts_config);
         }
 
+        if let Some(pc_config) = collected.prompt_cache {
+            self.runtime_agent.prompt_cache = Some(pc_config);
+        }
+
         self
     }
 
@@ -368,6 +378,12 @@ impl RuntimeAgentBuilder {
         self
     }
 
+    /// Set prompt caching configuration
+    pub fn prompt_cache(mut self, config: PromptCacheConfig) -> Self {
+        self.runtime_agent.prompt_cache = Some(config);
+        self
+    }
+
     /// Build the runtime agent.
     ///
     /// Validates that tool_search is only enabled for models that support it
@@ -407,6 +423,7 @@ impl RuntimeAgentBuilder {
                 self.runtime_agent.tool_search = None;
             }
         }
+
         self.runtime_agent
     }
 }
@@ -956,6 +973,27 @@ mod tests {
         assert_eq!(
             ts.threshold, 5,
             "custom threshold from capability must be preserved"
+        );
+    }
+
+    #[test]
+    fn test_build_preserves_prompt_cache_for_supported_provider() {
+        let agent = RuntimeAgentBuilder::new()
+            .model("gpt-5.4")
+            .prompt_cache(PromptCacheConfig {
+                enabled: true,
+                strategy: crate::llm_driver_registry::PromptCacheStrategy::Auto,
+                gemini_cached_content: None,
+            })
+            .build();
+
+        let prompt_cache = agent
+            .prompt_cache
+            .expect("explicit prompt_cache should be preserved");
+        assert!(prompt_cache.enabled);
+        assert_eq!(
+            prompt_cache.strategy,
+            crate::llm_driver_registry::PromptCacheStrategy::Auto
         );
     }
 

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -1090,6 +1090,7 @@ async fn test_driver_registry_integration() {
         metadata: std::collections::HashMap::new(),
         previous_response_id: None,
         tool_search: None,
+        prompt_cache: None,
     };
 
     let response = driver

--- a/crates/gemini/src/driver.rs
+++ b/crates/gemini/src/driver.rs
@@ -324,6 +324,11 @@ impl LlmDriver for GeminiLlmDriver {
             system_instruction,
             tools,
             generation_config: Some(generation_config),
+            cached_content: config
+                .prompt_cache
+                .as_ref()
+                .filter(|cfg| cfg.enabled)
+                .and_then(|cfg| cfg.gemini_cached_content.clone()),
         };
 
         // Retry loop for rate limit (429) and transient errors
@@ -873,6 +878,8 @@ struct GeminiRequest {
     tools: Option<Vec<GeminiTool>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     generation_config: Option<GeminiGenerationConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cached_content: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1316,6 +1323,28 @@ mod tests {
 
         assert_eq!(contents.len(), 1);
         assert_eq!(contents[0].role.as_deref(), Some("user"));
+    }
+
+    #[test]
+    fn test_request_serialization_with_cached_content() {
+        let request = GeminiRequest {
+            contents: vec![GeminiContent {
+                role: Some("user".to_string()),
+                parts: vec![GeminiPart::Text {
+                    text: "Summarize this".to_string(),
+                }],
+            }],
+            system_instruction: None,
+            tools: None,
+            generation_config: Some(GeminiGenerationConfig {
+                temperature: None,
+                max_output_tokens: Some(256),
+            }),
+            cached_content: Some("cachedContents/demo-cache".to_string()),
+        };
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["cachedContent"], "cachedContents/demo-cache");
     }
 
     // ========================================================================

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -10098,6 +10098,17 @@
             ],
             "description": "Provider type (openai, anthropic, etc.)"
           },
+          "request_options": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/LlmRequestOptions",
+                "description": "Request-side driver options that were enabled for this generation."
+              }
+            ]
+          },
           "response_id": {
             "type": [
               "string",
@@ -10543,6 +10554,31 @@
           }
         }
       },
+      "LlmPromptCacheInfo": {
+        "type": "object",
+        "description": "Request-side prompt cache settings for an LLM generation.",
+        "required": [
+          "enabled",
+          "strategy"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether prompt caching was enabled on the request."
+          },
+          "provider_mode": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Provider-specific prompt-cache mode used by the driver."
+          },
+          "strategy": {
+            "$ref": "#/components/schemas/PromptCacheStrategy",
+            "description": "Strategy used to enable prompt caching."
+          }
+        }
+      },
       "LlmProvider": {
         "type": "object",
         "description": "LLM Provider entity (API keys never exposed)\nNote: This is the entity struct, separate from the LlmProvider trait in llm.rs",
@@ -10617,6 +10653,42 @@
           "llmsim"
         ]
       },
+      "LlmRequestOptions": {
+        "type": "object",
+        "description": "Request options applied to an LLM generation.\n\nThese fields capture request-side intent such as prompt caching or deferred\ntool loading. They complement `usage`, which captures what actually happened.",
+        "properties": {
+          "prompt_cache": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/LlmPromptCacheInfo",
+                "description": "Prompt caching configuration for this request."
+              }
+            ]
+          },
+          "provider_options": {
+            "type": "object",
+            "description": "Provider-specific request options that do not warrant dedicated fields.",
+            "additionalProperties": {},
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "tool_search": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/LlmToolSearchInfo",
+                "description": "Deferred tool-loading configuration for this request."
+              }
+            ]
+          }
+        }
+      },
       "LlmRetryInfo": {
         "type": "object",
         "description": "Information about rate limit retries during LLM generation",
@@ -10635,6 +10707,25 @@
             "type": "integer",
             "format": "int64",
             "description": "Total time spent waiting between retries in milliseconds",
+            "minimum": 0
+          }
+        }
+      },
+      "LlmToolSearchInfo": {
+        "type": "object",
+        "description": "Request-side tool_search settings for an LLM generation.",
+        "required": [
+          "enabled",
+          "threshold"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether tool_search was enabled on the request."
+          },
+          "threshold": {
+            "type": "integer",
+            "description": "Minimum number of tools before deferred loading activates.",
             "minimum": 0
           }
         }
@@ -12240,6 +12331,13 @@
             "format": "uuid"
           }
         }
+      },
+      "PromptCacheStrategy": {
+        "type": "string",
+        "description": "Strategy for prompt caching.",
+        "enum": [
+          "auto"
+        ]
       },
       "ReasonCompletedData": {
         "type": "object",

--- a/specs/events.md
+++ b/specs/events.md
@@ -671,6 +671,13 @@ Emitted after each LLM API call to provide full visibility into the messages sen
 - `error` - Error message if failed
 - `finish_reasons` - Array of finish reasons (e.g., `["stop"]`, `["tool_calls"]`)
 - `response_id` - Provider's response ID for correlation
+- `request_options` - Optional bag of request-side driver options that were enabled for the call
+
+`request_options` captures request intent rather than provider-reported usage. Current fields:
+
+- `prompt_cache` - Whether prompt caching was enabled, which generic strategy was requested, and the provider-specific mode the driver used (`prompt_cache_key`, `cache_control`, `cached_content`, or `implicit`)
+- `tool_search` - Whether deferred tool loading was enabled and the activation threshold
+- `provider_options` - Provider-specific booleans that do not warrant dedicated top-level fields (for example `openai.previous_response_id` or `gemini.cached_content`)
 
 ```json
 {
@@ -713,7 +720,23 @@ Emitted after each LLM API call to provide full visibility into the messages sen
       "time_to_first_token_ms": 180,
       "success": true,
       "finish_reasons": ["stop"],
-      "response_id": "chatcmpl-abc123"
+      "response_id": "chatcmpl-abc123",
+      "request_options": {
+        "prompt_cache": {
+          "enabled": true,
+          "strategy": "auto",
+          "provider_mode": "prompt_cache_key"
+        },
+        "tool_search": {
+          "enabled": true,
+          "threshold": 8
+        },
+        "provider_options": {
+          "openai": {
+            "previous_response_id": true
+          }
+        }
+      }
     }
   }
 }

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -87,6 +87,22 @@ Provider crates register factories at startup. Drivers created on-demand from `P
    - `max_tokens`: Optional token limit
    - `tools`: Tool definitions
    - `reasoning_effort`: Optional reasoning level (low, medium, high)
+   - `metadata`: Optional request metadata for provider-side correlation
+   - `previous_response_id`: Optional OpenAI Responses continuation handle
+   - `tool_search`: Optional deferred tool-loading config
+   - `prompt_cache`: Optional provider-agnostic prompt-cache config
+
+### Prompt Cache Request Contract
+
+Prompt caching is modeled as request intent on `LlmCallConfig.prompt_cache`. Drivers may ignore it when the provider or model does not support cache controls, but they must not fail a request solely because prompt caching was enabled.
+
+Current provider mappings:
+
+- **OpenAI Responses API** — derives a deterministic `prompt_cache_key`
+- **Anthropic** — adds `cache_control: { type: "ephemeral" }` to eligible text blocks
+- **Gemini** — uses `cachedContent` when the config includes an existing cached-content resource name; otherwise the request remains in implicit/default Gemini behavior
+
+`llm.generation.metadata.request_options.prompt_cache` records which provider-specific mode the driver actually attempted.
 
 ### Default `max_tokens` Policy
 


### PR DESCRIPTION
## What
Add prompt-cache request configuration across runtime/driver plumbing, introduce a `prompt_caching` capability, and record enabled request-side driver options on `llm.generation` events.

## Why
We needed three things together:
1. each driver to have an explicit cache option,
2. a capability that enables that option per agent,
3. event metadata that records which request options were actually turned on.

Without that, cache behavior was not configurable in a provider-agnostic way and observability could not tell whether prompt caching or related request options were enabled.

## How
- add `PromptCacheConfig` / `PromptCacheStrategy` to `RuntimeAgent` and `LlmCallConfig`
- add built-in `prompt_caching` capability, including optional `gemini_cached_content` config for explicit Gemini cached-content handles
- extend `llm.generation.metadata` with a `request_options` bag for prompt cache, tool search, and provider-specific request flags
- map provider behavior:
  - OpenAI Responses: send deterministic `prompt_cache_key`
  - Anthropic: add ephemeral `cache_control` to cacheable text blocks
  - Gemini: send `cachedContent` when an explicit cached-content resource is configured
- sync `specs/events.md` and `specs/llm-drivers.md`

## Risk
- Medium
- Touches shared LLM request construction, capability application, and event schema/observability.
- Main failure modes are malformed provider requests or misleading telemetry. Tests cover the provider-specific request mapping and event serialization paths.

## Security
- Threat categories reviewed: TM-LLM, TM-DOS
- Findings and resolutions:
  - Reviewed new request-shaping logic for prompt-cache controls. All cache behavior is opt-in and additive; unsupported providers/models can ignore it without failing closed.
  - Reviewed telemetry additions for data exposure risk. `request_options` records booleans/config intent, not prompt contents or secrets.
  - Reviewed Gemini explicit cache path for incorrect claims. The event metadata reports `implicit` mode unless an explicit `cachedContents/{id}` handle is present, so observability does not overstate provider behavior.
  - No new unbounded loops or unvalidated external inputs added beyond existing capability config parsing.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

## Validation
- `cargo test -p everruns-core --lib prompt_cache -- --nocapture`
- `cargo test -p everruns-core --lib prompt_caching -- --nocapture`
- `cargo test -p everruns-core --lib request_options -- --nocapture`
- `cargo test -p everruns-anthropic --lib test_convert_content_adds_cache_control_when_enabled -- --nocapture`
- `cargo test -p everruns-gemini --lib cached_content -- --nocapture`
- `cargo test -p everruns-server --test workflow_test test_agent_execution_llmsim_with_tool_calls -- --exact --nocapture --test-threads=1`
- `just pre-push`
