### PR TITLE
chore(ci): codify integration live-test policy

### DIFF
--- a/.github/workflows/integration-live-sweep.yml
+++ b/.github/workflows/integration-live-sweep.yml
@@ -1,0 +1,125 @@
+# Weekly/on-demand backstop for path-filtered integration workflows.
+# PRs stay fast by keeping costly/stateful live jobs off the hot path; pushes to
+# main still run change-scoped live coverage; this workflow runs the full live
+# matrix so shared crate, harness, and dependency regressions cannot hide behind
+# per-integration path filters.
+name: Integration Live Sweep
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 14 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: 0
+  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+
+jobs:
+  doppler-backed-live-tests:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Daytona Live API Tests
+            command: cargo test -p everruns-integrations-daytona --features daytona-live-tests --test live_api_test -- --test-threads=1
+          - name: Browserless Live API Tests
+            command: cargo test -p everruns-integrations-browserless --features browserless-live-tests --test live_api -- --test-threads=1
+          - name: E2B Live API Tests
+            command: cargo test -p everruns-integrations-e2b --features e2b-live-tests --test live_api_test -- --test-threads=1
+          - name: Deno Live API Tests
+            command: cargo test -p everruns-integrations-deno --features deno-live-tests --test live_api_test -- --test-threads=1
+          - name: Sprites Live API Tests
+            command: cargo test -p everruns-integrations-sprites --features sprites-live-tests --test live_api_test -- --test-threads=1
+          - name: Brave Search API Tests
+            command: cargo test -p everruns-integrations-brave-search --features integration
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@v3
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "debug"
+
+      - name: Run live tests
+        run: doppler run -- ${{ matrix.command }}
+
+  duckduckgo-integration-test:
+    name: DuckDuckGo API Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "debug"
+
+      - name: Run integration tests
+        run: cargo test -p everruns-integrations-duckduckgo --features integration
+
+  container-sandbox-live-test:
+    name: Container Sandbox Live API Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      docker:
+        image: docker:dind
+        env:
+          DOCKER_TLS_CERTDIR: ""
+        options: --privileged
+        ports:
+          - 2375:2375
+
+    env:
+      CONTAINER_SANDBOX_DOCKER_HOST: http://localhost:2375
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "debug"
+
+      - name: Wait for Docker daemon
+        run: |
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:2375/_ping >/dev/null 2>&1; then
+              echo "Docker daemon is ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Docker daemon did not become ready within 60s" >&2
+          exit 1
+
+      - name: Run live integration tests
+        run: cargo test -p everruns-container-sandbox --features container-sandbox-live-tests --test live_api_test -- --test-threads=1

--- a/.github/workflows/integration-live-sweep.yml
+++ b/.github/workflows/integration-live-sweep.yml
@@ -21,13 +21,14 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   CARGO_INCREMENTAL: 0
-  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
 jobs:
   doppler-backed-live-tests:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
     strategy:
       fail-fast: false
       matrix:

--- a/crates/container-sandbox/SPEC.md
+++ b/crates/container-sandbox/SPEC.md
@@ -109,4 +109,4 @@ crates/container-sandbox/
 
 ## Live API tests
 
-`tests/live_api_test.rs` is the canonical live-test entrypoint for the container-sandbox capability. It is gated behind the `container-sandbox-live-tests` cargo feature and expects an unauthenticated Docker daemon reachable via `CONTAINER_SANDBOX_DOCKER_HOST` (default `http://localhost:2375`). `.github/workflows/container-sandbox-integration.yml` runs these tests on pushes to `main` against a `docker:dind` service container with TLS disabled.
+`tests/live_api_test.rs` is the canonical live-test entrypoint for the container-sandbox capability. It is gated behind the `container-sandbox-live-tests` cargo feature and expects an unauthenticated Docker daemon reachable via `CONTAINER_SANDBOX_DOCKER_HOST` (default `http://localhost:2375`). `.github/workflows/container-sandbox-integration.yml` runs these tests on pushes to `main` against a `docker:dind` service container with TLS disabled when `crates/container-sandbox/**` changes. `.github/workflows/integration-live-sweep.yml` reruns the same live path weekly and on demand without path filters so shared regressions still surface.

--- a/integrations/brave-search/SPEC.md
+++ b/integrations/brave-search/SPEC.md
@@ -136,9 +136,11 @@ Tests use a `require_api_key!` macro that panics when `BRAVE_SEARCH_API_KEY` is 
 Dedicated workflow `.github/workflows/brave-search-integration.yml`:
 
 - **Path-filtered**: only triggers when `integrations/brave-search/**` changes.
+- Runs on both `pull_request` and `push` because the coverage is cheap enough for PRs.
 - Fetches `BRAVE_SEARCH_API_KEY` from Doppler via `DOPPLER_TOKEN` GitHub Actions secret.
 - Fails if `DOPPLER_TOKEN` is not set (required, not optional).
 - Passes `--features integration` to compile and run the real-API tests.
+- `.github/workflows/integration-live-sweep.yml` reruns the same job weekly and on demand without path filters to catch shared regressions outside `integrations/brave-search/**`.
 
 Adding a new API-key-gated integration crate should follow this pattern: feature-gate the tests, use a panic macro for missing keys, add a path-filtered workflow, fetch the key from Doppler.
 

--- a/integrations/browserless/SPEC.md
+++ b/integrations/browserless/SPEC.md
@@ -225,6 +225,8 @@ Tests against the real Browserless API require `BROWSERLESS_TOKEN` in Doppler. G
 doppler run -- cargo test -p everruns-integrations-browserless --features browserless-live-tests
 ```
 
+CI keeps Browserless live coverage off `pull_request`: `.github/workflows/ci.yml` runs the live job only on pushes to `main` when `integrations/browserless/**` changes. `.github/workflows/integration-live-sweep.yml` provides the weekly/on-demand full-sweep backstop so shared regressions are still exercised.
+
 ## Crate Structure
 
 `integrations/browserless/` → `everruns-integrations-browserless`

--- a/integrations/daytona/SPEC.md
+++ b/integrations/daytona/SPEC.md
@@ -336,6 +336,8 @@ External integration crate, auto-registered via `inventory::submit!` plugin syst
 | `tests/tool_integration.rs` | Integration tests: tool execution + wiremock Daytona API |
 | `tests/live_api_test.rs` | Live API integration tests (feature-gated: `daytona-live-tests`; fail-closed on missing `DAYTONA_API_KEY` — see `specs/integrations.md`) |
 
+Change-scoped CI keeps Daytona live coverage off `pull_request`: `.github/workflows/ci.yml` runs this job only on pushes to `main` when `integrations/daytona/**` changes. The weekly/on-demand backstop in `.github/workflows/integration-live-sweep.yml` reruns the same live test without path filters so shared regressions in crates, harness code, or dependencies still surface.
+
 ## Capability Registration
 
 - **ID**: `daytona`

--- a/integrations/deno/SPEC.md
+++ b/integrations/deno/SPEC.md
@@ -123,3 +123,4 @@ See `specs/threat-model.md` for the Deno-specific threat section.
 
 - `tests/live_api_test.rs` is feature-gated behind `deno-live-tests`.
 - Missing-credential behavior is **fail-closed**: with the feature flag on, the test panics when `DENO_DEPLOY_TOKEN` is missing, or when a personal `ddp_...` token is used without `DENO_DEPLOY_ORG`. See `specs/integrations.md`.
+- `.github/workflows/ci.yml` runs the live test only on pushes to `main` when `integrations/deno/**` changes; `.github/workflows/integration-live-sweep.yml` reruns it weekly and on demand as the shared-code backstop.

--- a/integrations/duckduckgo/SPEC.md
+++ b/integrations/duckduckgo/SPEC.md
@@ -118,8 +118,10 @@ No API key is needed even for integration tests (the DuckDuckGo API is free), bu
 Dedicated workflow `.github/workflows/duckduckgo-integration.yml`:
 
 - **Path-filtered**: only triggers when `integrations/duckduckgo/**` changes.
+- Runs on both `pull_request` and `push` because the API is free and the smoke coverage is lightweight.
 - No secrets needed (free API).
 - Passes `--features integration` to compile and run the real-API tests.
+- `.github/workflows/integration-live-sweep.yml` reruns the same job weekly and on demand without path filters to catch shared regressions outside `integrations/duckduckgo/**`.
 
 ## Crate Structure
 

--- a/integrations/e2b/SPEC.md
+++ b/integrations/e2b/SPEC.md
@@ -146,3 +146,5 @@ E2B_API_KEY=<key> cargo test -p everruns-integrations-e2b --features e2b-live-te
 ```
 
 Exercises sandbox create → file write/read → command exec → cleanup against the real E2B service. Missing-credential behavior is **fail-closed**: with the feature flag on but `E2B_API_KEY` unset, the test panics (see `specs/integrations.md`).
+
+CI keeps E2B live coverage off `pull_request`: `.github/workflows/ci.yml` runs the live test only on pushes to `main` when `integrations/e2b/**` changes. `.github/workflows/integration-live-sweep.yml` reruns the same live path weekly and on demand to catch shared regressions that path filters miss.

--- a/integrations/sprites/SPEC.md
+++ b/integrations/sprites/SPEC.md
@@ -89,3 +89,4 @@ This means sprite names must be unique per user account (not per session). The i
 
 - `tests/live_api_test.rs` is feature-gated behind `sprites-live-tests`.
 - Missing-credential behavior is **fail-closed**: with the feature flag on but `SPRITES_API_TOKEN` unset, the test panics. See `specs/integrations.md`.
+- `.github/workflows/sprites-integration.yml` keeps the live job off `pull_request` and runs it only on pushes to `main` when `integrations/sprites/**` changes. `.github/workflows/integration-live-sweep.yml` reruns the same live path weekly and on demand so shared regressions do not hide behind that path filter.

--- a/specs/integrations.md
+++ b/specs/integrations.md
@@ -15,13 +15,23 @@ Every sandbox/execution integration crate must ship with the following artifacts
 | **Live API tests** | `tests/live_api_test.rs` — feature-gated (`<name>-live-tests`), credentials read from required environment variables. In CI, those env vars are injected via Doppler. Missing-credential behavior is **fail-closed**: when the feature flag is on but the required env var is missing or empty, the test must `panic!` (not `eprintln!` + `return`). CI live jobs must never silently pass. Reference implementations: `integrations/brave-search/tests/smoke_real_api.rs`, `integrations/daytona/tests/live_api_test.rs`. |
 | **CI: unit tests** | Crate listed in the `unit-test` job: `cargo test -p everruns-integrations-<name>`. |
 | **CI: change detection** | Path filter in `changes` job: `<name>: integrations/<name>/**`. |
-| **CI: live-test job** | Live API test job conditional on `push` event + Doppler token. New integrations: dedicated `.github/workflows/<name>-integration.yml` workflow, path-filtered to `integrations/<name>/**`. Legacy integrations (Daytona, Browserless, etc.) may still use a job in `ci.yml` gated on change detection. |
+| **CI: live-test job** | Live API or real-API coverage must follow the repo trigger policy: cheap/path-local API smoke may run on `pull_request`; costly or stateful live jobs stay on `push` to `main`; path-filtered workflows must also be covered by the weekly/on-demand backstop in `.github/workflows/integration-live-sweep.yml`. New integrations: dedicated `.github/workflows/<name>-integration.yml` workflow for change-scoped runs plus inclusion in the full sweep. Legacy integrations (Daytona, Browserless, etc.) may still use a job in `ci.yml` for change-scoped runs. |
 | **User docs** | `docs/integrations/<name>.md` — quick start, tool table, lifecycle, security. |
 | **UI test case** | `test_cases/ui/<name>_connection/TC001_*.md` — manual test for connection + sandbox lifecycle. |
 | **Seed agent** | Entry in `crates/server/src/seed.rs` with capabilities wired. |
 | **Threat model** | Section in `specs/threat-model.md` covering integration-specific threats. |
 
 New integrations should check off every row before merging. Existing integrations that are missing items should be brought up to parity incrementally.
+
+## CI Trigger Policy
+
+Integration coverage is intentionally split by cost and blast radius:
+
+- **`pull_request`**: keep PR feedback fast. Only cheap/path-local real-API coverage belongs here (for example DuckDuckGo and Brave Search). Stateful or higher-cost live sandbox jobs do not run on every PR.
+- **`push` to `main`**: run change-scoped live jobs for integrations whose real coverage needs secrets, remote sandboxes, browsers, or Docker-in-Docker. These jobs stay path-filtered so unrelated PRs do not pay that cost before merge.
+- **Weekly + on demand**: `.github/workflows/integration-live-sweep.yml` runs the full live/real-API matrix on a schedule and via `workflow_dispatch`. This is the backstop for regressions introduced through shared crates, harness code, workflow glue, or dependency bumps that per-integration path filters would miss.
+
+The policy trades PR load for a bounded amount of post-merge and scheduled coverage. If a new integration needs a different trigger shape, document the cost/risk reason in its co-located spec.
 
 ## Integration Crates (`integrations/`)
 
@@ -60,4 +70,3 @@ Embedded in the server crate.
 | Integration | Spec | Summary |
 |---|---|---|
 | Braintrust + OpenTelemetry | [`specs/observability.md`](observability.md) | Observability providers — OTel Gen-AI tracing and Braintrust event forwarding. |
-

--- a/specs/maintenance.md
+++ b/specs/maintenance.md
@@ -59,6 +59,7 @@ Before a release, maintenance should cover:
 - areas changed since the last release
 - historically fragile or high-risk surfaces
 - release artifacts affected by those changes
+- the latest push-only integration live workflows on `main` plus the latest `.github/workflows/integration-live-sweep.yml` result; unresolved failures there block a "release ready" claim until triaged
 - Linear issues already marked `In Progress` whose `updatedAt` is older than 1 day, signaling execution drift; use that `updatedAt` threshold as the default review threshold unless the task sets a stricter bar
 - GitHub Security tab: security overview, Dependabot alerts, and open secret scanning alerts
 

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -15,6 +15,8 @@ This specification defines the release process for Everruns. The process is desi
 5. **User merges PR**: Squash merge to main
 6. **Auto-tagging**: GitHub Action detects release commit, creates tag + GitHub Release using CHANGELOG.md content
 
+Release readiness also includes the integration backstops that are intentionally kept off the `pull_request` hot path. Before cutting a release PR or merging it, review the latest push-only live integration workflow runs on `main` and the latest `.github/workflows/integration-live-sweep.yml` result. Do not release through unresolved failures there unless the failure is understood, documented, and explicitly accepted.
+
 ### CHANGELOG.md as Source of Truth
 
 1. CHANGELOG.md is the canonical source for release notes


### PR DESCRIPTION
## What
- add `.github/workflows/integration-live-sweep.yml` for a weekly and on-demand full live/real-API integration sweep
- document the repo trigger policy in `specs/integrations.md` and align the affected integration/container specs with the checked-in workflow behavior
- update maintenance and release guidance so push-only live workflow failures and the sweep result are part of release readiness

## Why
Push-only, path-filtered live jobs kept PR load down, but there was no checked-in backstop for shared changes in `crates/**`, harness code, workflow glue, or dependency updates.

## How
- keep cheap/path-local real-API smoke on `pull_request` where that cost is acceptable today
- keep costly or stateful live jobs change-scoped on `push` to `main`
- run the full matrix weekly and via `workflow_dispatch` so path filters do not hide shared regressions
- validated the new workflow YAML locally with `ruby -e "require \"yaml\"; YAML.load_file(\".github/workflows/integration-live-sweep.yml\"); puts :ok"`
- ran `just pre-push`

## Risk
- Low
- Adds one weekly CI workflow plus manual dispatch; no runtime product behavior changes

## Security
- Threat categories reviewed: No security-relevant runtime code changes; reviewed GitHub Actions permissions and secret flow for least privilege
- Findings and resolutions:
  - kept the new workflow at `contents: read`
  - reused the existing Doppler-backed secret pattern rather than introducing a new secret path
  - limited the new workflow to `schedule` and `workflow_dispatch`, so it does not expand secret exposure on `pull_request`
  - no threat-model update needed because runtime trust boundaries and credential handling are unchanged

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Fixes EVE-351
