### PR TITLE
fix(core): unify exec presentation contract

### DIFF
--- a/apps/ui/src/__tests__/tool-activity-group.test.tsx
+++ b/apps/ui/src/__tests__/tool-activity-group.test.tsx
@@ -190,6 +190,91 @@ describe("ToolActivityGroup", () => {
     expect(screen.queryByText(/^Shell$/)).not.toBeInTheDocument();
   });
 
+  it("renders sandbox_exec as a standalone shell row with metadata", () => {
+    const toolCalls: ToolCallContent[] = [
+      {
+        id: "tool-sandbox",
+        name: "sandbox_exec",
+        arguments: { command: "cargo test", cwd: "/workspace" },
+      },
+    ];
+
+    const toolResultsMap = new Map<string, ToolCompletedData>([
+      [
+        "tool-sandbox",
+        {
+          tool_call_id: "tool-sandbox",
+          tool_name: "sandbox_exec",
+          success: false,
+          status: "error",
+          result: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                stdout: "running 4 tests\n3 passed",
+                stderr: "thread 'tests' panicked",
+                exit_code: 101,
+                success: false,
+                cwd: "/workspace",
+              }),
+            },
+          ],
+        },
+      ],
+    ]);
+
+    render(<ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />);
+
+    expect(
+      screen.getByRole("button", { name: /\$ cargo test exit code 101/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("/workspace")).toBeInTheDocument();
+    expect(screen.queryByText(/^Shell$/)).not.toBeInTheDocument();
+  });
+
+  it("renders e2b_exec as a standalone shell row with metadata", () => {
+    const toolCalls: ToolCallContent[] = [
+      {
+        id: "tool-e2b",
+        name: "e2b_exec",
+        arguments: { command: "cargo test", sandbox_id: "sb_456", cwd: "/workspace" },
+      },
+    ];
+
+    const toolResultsMap = new Map<string, ToolCompletedData>([
+      [
+        "tool-e2b",
+        {
+          tool_call_id: "tool-e2b",
+          tool_name: "e2b_exec",
+          success: false,
+          status: "error",
+          result: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                stdout: "running 4 tests\n3 passed",
+                stderr: "thread 'tests' panicked",
+                exit_code: 101,
+                success: false,
+                cwd: "/workspace",
+                sandbox_id: "sb_456",
+              }),
+            },
+          ],
+        },
+      ],
+    ]);
+
+    render(<ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />);
+
+    expect(
+      screen.getByRole("button", { name: /\$ cargo test exit code 101/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("/workspace, sandbox sb_456")).toBeInTheDocument();
+    expect(screen.queryByText(/^Shell$/)).not.toBeInTheDocument();
+  });
+
   it("renders read_file as a standalone row and shows parsed file content", () => {
     const toolCalls: ToolCallContent[] = [
       {

--- a/apps/ui/src/lib/tool-registry.ts
+++ b/apps/ui/src/lib/tool-registry.ts
@@ -38,6 +38,11 @@ const TOOL_REGISTRY: Record<string, ToolRegistryEntry> = {
   shell: { category: "shell", segmentMode: "standalone" },
   execute_bash: { category: "shell", segmentMode: "standalone" },
   daytona_exec: { category: "shell", segmentMode: "standalone" },
+  sandbox_exec: { category: "shell", segmentMode: "standalone" },
+  e2b_exec: { category: "shell", segmentMode: "standalone" },
+  deno_exec: { category: "shell", segmentMode: "standalone" },
+  docker_exec: { category: "shell", segmentMode: "standalone" },
+  sprites_exec: { category: "shell", segmentMode: "standalone" },
 
   // Read tools
   read_file: { category: "read", segmentMode: "standalone" },

--- a/crates/core/src/capabilities/session_sandbox.rs
+++ b/crates/core/src/capabilities/session_sandbox.rs
@@ -131,7 +131,8 @@ impl Tool for SandboxExecTool {
             "properties": {
                 "command": { "type": "string", "description": "Shell command to execute" },
                 "cwd": { "type": "string", "description": "Optional working directory inside the sandbox" },
-                "timeout_ms": { "type": "integer", "minimum": 1, "description": "Optional execution timeout in milliseconds" }
+                "timeout_ms": { "type": "integer", "minimum": 1, "description": "Optional execution timeout in milliseconds" },
+                "output": crate::tool_output_sanitizer::output_verbosity_schema()
             },
             "required": ["command"],
             "additionalProperties": false
@@ -192,19 +193,34 @@ impl Tool for SandboxExecTool {
                         .and_then(|v| v.as_str())
                         .map(ToString::to_string),
                     timeout_ms,
-                    output_mode: "concise".to_string(),
+                    output_mode: arguments
+                        .get("output")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("concise")
+                        .to_string(),
                 },
             )
             .await
         {
-            Ok(response) => ToolExecutionResult::success(json!({
-                "stdout": response.stdout,
-                "stderr": response.stderr,
-                "exit_code": response.exit_code,
-                "success": response.success,
-                "raw_output": response.raw_output,
-                "hint": response.hint,
-            })),
+            Ok(response) => {
+                let mut result = json!({
+                    "stdout": response.stdout,
+                    "stderr": response.stderr,
+                    "exit_code": response.exit_code,
+                    "success": response.success,
+                    "truncated": response.truncated,
+                    "total_lines": response.total_lines,
+                    "hint": response.hint,
+                });
+                if let Some(cwd) = arguments.get("cwd").and_then(|v| v.as_str()) {
+                    result["cwd"] = json!(cwd);
+                }
+
+                ToolExecutionResult::success_with_raw_output(
+                    result,
+                    response.raw_output.unwrap_or_default(),
+                )
+            }
             Err(err) => err,
         }
     }

--- a/crates/core/src/capabilities/session_sandbox.rs
+++ b/crates/core/src/capabilities/session_sandbox.rs
@@ -104,6 +104,30 @@ fn provider_for_config(
     })
 }
 
+fn build_sandbox_exec_result(
+    response: crate::SessionSandboxExecResponse,
+    cwd: Option<&str>,
+) -> ToolExecutionResult {
+    let mut result = json!({
+        "stdout": response.stdout,
+        "stderr": response.stderr,
+        "exit_code": response.exit_code,
+        "success": response.success,
+        "truncated": response.truncated,
+        "total_lines": response.total_lines,
+        "hint": response.hint,
+    });
+    if let Some(cwd) = cwd {
+        result["cwd"] = json!(cwd);
+    }
+
+    if let Some(raw_output) = response.raw_output {
+        ToolExecutionResult::success_with_raw_output(result, raw_output)
+    } else {
+        ToolExecutionResult::success(result)
+    }
+}
+
 #[derive(Clone)]
 pub struct SandboxExecTool {
     config: Value,
@@ -203,23 +227,7 @@ impl Tool for SandboxExecTool {
             .await
         {
             Ok(response) => {
-                let mut result = json!({
-                    "stdout": response.stdout,
-                    "stderr": response.stderr,
-                    "exit_code": response.exit_code,
-                    "success": response.success,
-                    "truncated": response.truncated,
-                    "total_lines": response.total_lines,
-                    "hint": response.hint,
-                });
-                if let Some(cwd) = arguments.get("cwd").and_then(|v| v.as_str()) {
-                    result["cwd"] = json!(cwd);
-                }
-
-                ToolExecutionResult::success_with_raw_output(
-                    result,
-                    response.raw_output.unwrap_or_default(),
-                )
+                build_sandbox_exec_result(response, arguments.get("cwd").and_then(|v| v.as_str()))
             }
             Err(err) => err,
         }
@@ -647,5 +655,50 @@ mod tests {
             }
             other => panic!("expected ToolError, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn sandbox_exec_result_preserves_absent_raw_output() {
+        let result = build_sandbox_exec_result(
+            crate::SessionSandboxExecResponse {
+                exit_code: 0,
+                stdout: "ok".to_string(),
+                stderr: String::new(),
+                success: true,
+                truncated: false,
+                total_lines: 1,
+                raw_output: None,
+                hint: None,
+            },
+            Some("/workspace"),
+        )
+        .into_tool_result("call_1", "sandbox_exec");
+
+        assert_eq!(result.raw_output, None);
+        assert_eq!(result.result.unwrap()["cwd"], "/workspace");
+    }
+
+    #[test]
+    fn sandbox_exec_result_keeps_raw_output_sidecar_when_present() {
+        let result = build_sandbox_exec_result(
+            crate::SessionSandboxExecResponse {
+                exit_code: 17,
+                stdout: "trimmed".to_string(),
+                stderr: "warn".to_string(),
+                success: false,
+                truncated: true,
+                total_lines: 42,
+                raw_output: Some("full output".to_string()),
+                hint: Some("non-zero".to_string()),
+            },
+            None,
+        )
+        .into_tool_result("call_1", "sandbox_exec");
+
+        assert_eq!(result.raw_output.as_deref(), Some("full output"));
+        let payload = result.result.unwrap();
+        assert_eq!(payload["exit_code"], 17);
+        assert_eq!(payload["truncated"], true);
+        assert_eq!(payload["hint"], "non-zero");
     }
 }

--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -17,6 +17,7 @@ use super::{Capability, CapabilityStatus};
 use crate::background::{
     BackgroundEventSink, BackgroundExecutableTool, BackgroundOutcome, BackgroundProgress,
 };
+use crate::exec_tool_result::ExecToolResultPayload;
 use crate::session_file::SessionFile;
 use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
@@ -307,10 +308,6 @@ impl Tool for BashTool {
 
         match result {
             Ok(Ok(output)) => {
-                use crate::tool_output_sanitizer::{
-                    clean_exec_output, output_verbosity_budget, priority_aware_truncate,
-                };
-
                 // Extract metadata from trace events (EVE-240)
                 let commands_executed = output
                     .events
@@ -340,30 +337,31 @@ impl Tool for BashTool {
                     "bashkit execution completed"
                 );
 
-                let clean_stdout = clean_exec_output(&output.stdout);
-                let clean_stderr = clean_exec_output(&output.stderr);
-                let (stdout, stderr) = if let Some(budget) = output_verbosity_budget(output_mode) {
-                    (
-                        priority_aware_truncate(&clean_stdout, budget),
-                        priority_aware_truncate(&clean_stderr, budget.min(4096)),
-                    )
-                } else {
-                    (clean_stdout.clone(), clean_stderr.clone())
-                };
-                // Build raw output for persistence hook (cleaned but not truncated)
-                let mut raw = clean_stdout;
-                if !clean_stderr.is_empty() {
-                    raw.push_str("\n--- stderr ---\n");
-                    raw.push_str(&clean_stderr);
-                }
+                let payload = ExecToolResultPayload::new(
+                    &output.stdout,
+                    &output.stderr,
+                    output.exit_code,
+                    output_mode,
+                );
+                let ExecToolResultPayload {
+                    stdout,
+                    stderr,
+                    exit_code,
+                    success,
+                    truncated,
+                    total_lines,
+                    raw_output,
+                } = payload;
                 ToolExecutionResult::success_with_raw_output(
                     json!({
                         "stdout": stdout,
                         "stderr": stderr,
-                        "exit_code": output.exit_code,
-                        "success": output.exit_code == 0
+                        "exit_code": exit_code,
+                        "success": success,
+                        "truncated": truncated,
+                        "total_lines": total_lines,
                     }),
-                    raw,
+                    raw_output,
                 )
             }
             Ok(Err(e)) => {
@@ -506,25 +504,21 @@ impl BackgroundExecutableTool for BashTool {
 
         match result {
             Ok(Ok(output)) => {
-                use crate::tool_output_sanitizer::{
-                    clean_exec_output, output_verbosity_budget, priority_aware_truncate,
-                };
-
-                let clean_stdout = clean_exec_output(&output.stdout);
-                let clean_stderr = clean_exec_output(&output.stderr);
-                let (stdout, stderr) = if let Some(budget) = output_verbosity_budget(output_mode) {
-                    (
-                        priority_aware_truncate(&clean_stdout, budget),
-                        priority_aware_truncate(&clean_stderr, budget.min(4096)),
-                    )
-                } else {
-                    (clean_stdout.clone(), clean_stderr.clone())
-                };
-                let mut raw = clean_stdout;
-                if !clean_stderr.is_empty() {
-                    raw.push_str("\n--- stderr ---\n");
-                    raw.push_str(&clean_stderr);
-                }
+                let payload = ExecToolResultPayload::new(
+                    &output.stdout,
+                    &output.stderr,
+                    output.exit_code,
+                    output_mode,
+                );
+                let ExecToolResultPayload {
+                    stdout,
+                    stderr,
+                    exit_code,
+                    success,
+                    truncated,
+                    total_lines,
+                    raw_output,
+                } = payload;
                 let _ = sink
                     .progress(BackgroundProgress {
                         current: Some(exec_duration.as_millis() as u64),
@@ -536,16 +530,18 @@ impl BackgroundExecutableTool for BashTool {
                 Ok(BackgroundOutcome {
                     summary: format!(
                         "Bash command exited with code {} after {} ms",
-                        output.exit_code,
+                        exit_code,
                         exec_duration.as_millis()
                     ),
                     result: json!({
                         "stdout": stdout,
                         "stderr": stderr,
-                        "exit_code": output.exit_code,
-                        "success": output.exit_code == 0
+                        "exit_code": exit_code,
+                        "success": success,
+                        "truncated": truncated,
+                        "total_lines": total_lines,
                     }),
-                    raw_output: Some(raw),
+                    raw_output: Some(raw_output),
                 })
             }
             Ok(Err(e)) => Err(ToolExecutionResult::tool_error(format!(

--- a/crates/core/src/exec_tool_result.rs
+++ b/crates/core/src/exec_tool_result.rs
@@ -1,0 +1,86 @@
+//! Shared shaping helpers for human-facing exec tool results.
+//!
+//! Important decision: keep the visible JSON contract stable across shell-like
+//! tools and keep pre-truncation output in the raw sidecar only. UI cards,
+//! previews, persistence hooks, and narration all depend on this split.
+
+use crate::tool_output_sanitizer::{
+    clean_exec_output, output_verbosity_budget, priority_aware_truncate,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecToolResultPayload {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+    pub success: bool,
+    pub truncated: bool,
+    pub total_lines: usize,
+    pub raw_output: String,
+}
+
+impl ExecToolResultPayload {
+    pub fn new(stdout: &str, stderr: &str, exit_code: i32, output_mode: &str) -> Self {
+        let clean_stdout = clean_exec_output(stdout);
+        let clean_stderr = clean_exec_output(stderr);
+        let (stdout, stderr) = if let Some(budget) = output_verbosity_budget(output_mode) {
+            (
+                priority_aware_truncate(&clean_stdout, budget),
+                priority_aware_truncate(&clean_stderr, budget.min(4096)),
+            )
+        } else {
+            (clean_stdout.clone(), clean_stderr.clone())
+        };
+        let truncated = stdout != clean_stdout || stderr != clean_stderr;
+        let total_lines = clean_stdout.lines().count();
+        let mut raw_output = clean_stdout;
+        if !clean_stderr.is_empty() {
+            raw_output.push_str("\n--- stderr ---\n");
+            raw_output.push_str(&clean_stderr);
+        }
+
+        Self {
+            stdout,
+            stderr,
+            exit_code,
+            success: exit_code == 0,
+            truncated,
+            total_lines,
+            raw_output,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ExecToolResultPayload;
+
+    #[test]
+    fn preserves_full_raw_output_and_marks_truncation() {
+        let stdout = (0..400)
+            .map(|index| format!("line {index}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let payload = ExecToolResultPayload::new(&stdout, "warn\n", 17, "concise");
+
+        assert_eq!(payload.exit_code, 17);
+        assert!(!payload.success);
+        assert!(payload.truncated);
+        assert_eq!(payload.total_lines, 400);
+        assert!(payload.stdout.len() < stdout.len());
+        assert!(payload.raw_output.contains("line 0"));
+        assert!(payload.raw_output.contains("line 399"));
+        assert!(payload.raw_output.contains("--- stderr ---"));
+    }
+
+    #[test]
+    fn full_mode_keeps_complete_output_inline() {
+        let payload = ExecToolResultPayload::new("alpha\nbeta\n", "", 0, "full");
+
+        assert_eq!(payload.stdout, "alpha\nbeta\n");
+        assert_eq!(payload.stderr, "");
+        assert!(!payload.truncated);
+        assert_eq!(payload.total_lines, 2);
+        assert_eq!(payload.raw_output, "alpha\nbeta\n");
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod tool_types;
 
 // Deployment configuration
 pub mod deployment;
+pub mod exec_tool_result;
 
 // Feature flags
 pub mod feature_flags;

--- a/crates/core/src/session_sandbox.rs
+++ b/crates/core/src/session_sandbox.rs
@@ -119,6 +119,8 @@ pub struct SessionSandboxExecResponse {
     pub stdout: String,
     pub stderr: String,
     pub success: bool,
+    pub truncated: bool,
+    pub total_lines: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub raw_output: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/core/src/tool_narration.rs
+++ b/crates/core/src/tool_narration.rs
@@ -475,7 +475,8 @@ pub fn render_tool_narration_with_locale(
     }
 
     match tool_call.name.as_str() {
-        "bash" | "daytona_exec" => {
+        "bash" | "daytona_exec" | "sandbox_exec" | "e2b_exec" | "deno_exec" | "docker_exec"
+        | "sprites_exec" => {
             let command = arg_str(args, &["command"])
                 .map(|value| format!("`{}`", truncate(value, 48)))
                 .unwrap_or_else(|| fallback_name.clone());
@@ -847,6 +848,24 @@ mod tests {
         assert_eq!(
             render_tool_narration(None, &tool_call, ToolNarrationPhase::Completed),
             "Ran `cargo test -p everruns-core`"
+        );
+    }
+
+    #[test]
+    fn renders_sandbox_exec_narration() {
+        let tool_call = ToolCall {
+            id: "call_1".to_string(),
+            name: "sandbox_exec".to_string(),
+            arguments: json!({ "command": "npm test" }),
+        };
+
+        assert_eq!(
+            render_tool_narration(None, &tool_call, ToolNarrationPhase::Started),
+            "Running `npm test`"
+        );
+        assert_eq!(
+            render_tool_narration(None, &tool_call, ToolNarrationPhase::Completed),
+            "Ran `npm test`"
         );
     }
 

--- a/crates/core/src/tool_narration.rs
+++ b/crates/core/src/tool_narration.rs
@@ -146,6 +146,19 @@ fn generic_phrase(
     }
 }
 
+fn is_shell_exec_tool(name: &str) -> bool {
+    matches!(
+        name,
+        "bash"
+            | "daytona_exec"
+            | "sandbox_exec"
+            | "e2b_exec"
+            | "deno_exec"
+            | "docker_exec"
+            | "sprites_exec"
+    )
+}
+
 fn ukrainian_phrase(
     _tool_def: Option<&ToolDefinition>,
     tool_call: &ToolCall,
@@ -154,7 +167,7 @@ fn ukrainian_phrase(
 ) -> String {
     let args = &tool_call.arguments;
     match tool_call.name.as_str() {
-        "bash" => {
+        name if is_shell_exec_tool(name) => {
             let command = arg_str(args, &["command"])
                 .map(|value| format!("`{}`", truncate(value, 48)))
                 .unwrap_or_else(|| fallback_name.to_string());
@@ -475,8 +488,7 @@ pub fn render_tool_narration_with_locale(
     }
 
     match tool_call.name.as_str() {
-        "bash" | "daytona_exec" | "sandbox_exec" | "e2b_exec" | "deno_exec" | "docker_exec"
-        | "sprites_exec" => {
+        name if is_shell_exec_tool(name) => {
             let command = arg_str(args, &["command"])
                 .map(|value| format!("`{}`", truncate(value, 48)))
                 .unwrap_or_else(|| fallback_name.clone());
@@ -923,6 +935,34 @@ mod tests {
                 Some("uk-UA"),
             ),
             "Прочитав AGENTS.md"
+        );
+    }
+
+    #[test]
+    fn renders_ukrainian_sandbox_exec_narration() {
+        let tool_call = ToolCall {
+            id: "call_1".to_string(),
+            name: "sandbox_exec".to_string(),
+            arguments: json!({ "command": "npm test" }),
+        };
+
+        assert_eq!(
+            render_tool_narration_with_locale(
+                None,
+                &tool_call,
+                ToolNarrationPhase::Started,
+                Some("uk-UA"),
+            ),
+            "Запускаю `npm test`"
+        );
+        assert_eq!(
+            render_tool_narration_with_locale(
+                None,
+                &tool_call,
+                ToolNarrationPhase::Completed,
+                Some("uk-UA"),
+            ),
+            "Запустив `npm test`"
         );
     }
 

--- a/crates/server/src/services/session_sandbox.rs
+++ b/crates/server/src/services/session_sandbox.rs
@@ -334,6 +334,8 @@ mod tests {
                 stdout: "ok".to_string(),
                 stderr: String::new(),
                 success: true,
+                truncated: false,
+                total_lines: 1,
                 raw_output: Some("ok".to_string()),
                 hint: None,
             })

--- a/integrations/daytona/src/session_sandbox_provider.rs
+++ b/integrations/daytona/src/session_sandbox_provider.rs
@@ -1,5 +1,6 @@
 //! Daytona implementation of the provider-neutral session_sandbox contract.
 
+use everruns_core::exec_tool_result::ExecToolResultPayload;
 use everruns_core::session_sandbox::{
     SessionSandboxConfig, SessionSandboxExecRequest, SessionSandboxExecResponse,
     SessionSandboxInstance, SessionSandboxProvider, SessionSandboxReadFileResponse,
@@ -256,37 +257,22 @@ impl SessionSandboxProvider for DaytonaSessionSandboxProvider {
         let result = result.map_err(ToolExecutionResult::tool_error)?;
         touch_sandbox_lease(context, &lease_state, instance.display_name.clone()).await?;
 
-        let clean_stdout = everruns_core::tool_output_sanitizer::clean_exec_output(&result.stdout);
-        let clean_stderr = everruns_core::tool_output_sanitizer::clean_exec_output(&result.stderr);
-        let (stdout, stderr) = if let Some(budget) =
-            everruns_core::tool_output_sanitizer::output_verbosity_budget(&request.output_mode)
-        {
-            (
-                everruns_core::tool_output_sanitizer::priority_aware_truncate(
-                    &clean_stdout,
-                    budget,
-                ),
-                everruns_core::tool_output_sanitizer::priority_aware_truncate(
-                    &clean_stderr,
-                    budget.min(4096),
-                ),
-            )
-        } else {
-            (clean_stdout.clone(), clean_stderr.clone())
-        };
-        let mut raw = clean_stdout;
-        if !clean_stderr.is_empty() {
-            raw.push_str("\n--- stderr ---\n");
-            raw.push_str(&clean_stderr);
-        }
+        let payload = ExecToolResultPayload::new(
+            &result.stdout,
+            &result.stderr,
+            result.exit_code,
+            &request.output_mode,
+        );
 
         Ok(SessionSandboxExecResponse {
-            exit_code: result.exit_code,
-            stdout,
-            stderr,
-            success: result.exit_code == 0,
-            raw_output: Some(raw),
-            hint: exit_code_hint(result.exit_code).map(ToString::to_string),
+            exit_code: payload.exit_code,
+            stdout: payload.stdout,
+            stderr: payload.stderr,
+            success: payload.success,
+            truncated: payload.truncated,
+            total_lines: payload.total_lines,
+            raw_output: Some(payload.raw_output),
+            hint: exit_code_hint(payload.exit_code).map(ToString::to_string),
         })
     }
 

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -2,6 +2,7 @@
 
 use everruns_core::SessionFile;
 use everruns_core::ToolHints;
+use everruns_core::exec_tool_result::ExecToolResultPayload;
 use everruns_core::resource_ownership::{
     list_owned_external_resource_ids, ownership_tracking_unavailable_error,
     require_owned_external_resource,
@@ -76,45 +77,39 @@ fn build_exec_tool_result(
     result: &crate::state::ExecResult,
     output_mode: &str,
 ) -> ToolExecutionResult {
-    use everruns_core::tool_output_sanitizer::{
-        clean_exec_output, output_verbosity_budget, priority_aware_truncate,
-    };
-
-    let clean_stdout = clean_exec_output(&result.stdout);
-    let clean_stderr = clean_exec_output(&result.stderr);
-    let (stdout, stderr) = if let Some(budget) = output_verbosity_budget(output_mode) {
-        (
-            priority_aware_truncate(&clean_stdout, budget),
-            priority_aware_truncate(&clean_stderr, budget.min(4096)),
-        )
-    } else {
-        (clean_stdout.clone(), clean_stderr.clone())
-    };
-    let truncated = stdout != clean_stdout || stderr != clean_stderr;
-    let total_lines = clean_stdout.lines().count();
-    let mut raw = clean_stdout;
-    if !clean_stderr.is_empty() {
-        raw.push_str("\n--- stderr ---\n");
-        raw.push_str(&clean_stderr);
-    }
+    let payload = ExecToolResultPayload::new(
+        &result.stdout,
+        &result.stderr,
+        result.exit_code,
+        output_mode,
+    );
+    let ExecToolResultPayload {
+        stdout,
+        stderr,
+        exit_code,
+        success,
+        truncated,
+        total_lines,
+        raw_output,
+    } = payload;
 
     let mut response = json!({
         "sandbox_id": sandbox_id,
         "stdout": stdout,
         "stderr": stderr,
-        "exit_code": result.exit_code,
-        "success": result.exit_code == 0,
+        "exit_code": exit_code,
+        "success": success,
         "truncated": truncated,
         "total_lines": total_lines,
     });
     if let Some(cwd) = cwd {
         response["cwd"] = json!(cwd);
     }
-    if let Some(hint) = exit_code_hint(result.exit_code) {
+    if let Some(hint) = exit_code_hint(exit_code) {
         response["hint"] = json!(hint);
     }
 
-    ToolExecutionResult::success_with_raw_output(response, raw)
+    ToolExecutionResult::success_with_raw_output(response, raw_output)
 }
 
 /// Parse an optional integer resource parameter, validating type and range.

--- a/integrations/e2b/SPEC.md
+++ b/integrations/e2b/SPEC.md
@@ -66,7 +66,8 @@ Executes a shell command in a sandbox using E2B's process service.
   - `command` (required)
   - `cwd` (optional)
   - `timeout_ms` (optional)
-- **Returns**: `{ sandbox_id, cwd, stdout, stderr, exit_code, error }`
+- **Returns**: `{ sandbox_id, cwd, stdout, stderr, exit_code, success, truncated, total_lines, error }`
+- **Human representation**: Follows the shared exec-tool contract in `specs/tool-execution.md`. Command text is primary; sandbox metadata is secondary.
 
 ### e2b_read_file
 

--- a/integrations/e2b/src/tools.rs
+++ b/integrations/e2b/src/tools.rs
@@ -2,6 +2,7 @@
 
 use async_trait::async_trait;
 use everruns_core::ToolHints;
+use everruns_core::exec_tool_result::ExecToolResultPayload;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
 use serde_json::{Value, json};
@@ -306,37 +307,35 @@ impl Tool for E2BExecTool {
             return err;
         }
 
-        {
-            use everruns_core::tool_output_sanitizer::{
-                clean_exec_output, output_verbosity_budget, priority_aware_truncate,
-            };
-            let clean_stdout = clean_exec_output(&result.stdout);
-            let clean_stderr = clean_exec_output(&result.stderr);
-            let (stdout, stderr) = if let Some(budget) = output_verbosity_budget(output_mode) {
-                (
-                    priority_aware_truncate(&clean_stdout, budget),
-                    priority_aware_truncate(&clean_stderr, budget.min(4096)),
-                )
-            } else {
-                (clean_stdout.clone(), clean_stderr.clone())
-            };
-            let mut raw = clean_stdout;
-            if !clean_stderr.is_empty() {
-                raw.push_str("\n--- stderr ---\n");
-                raw.push_str(&clean_stderr);
-            }
-            ToolExecutionResult::success_with_raw_output(
-                json!({
-                    "sandbox_id": sandbox_id,
-                    "cwd": cwd.unwrap_or(E2B_DEFAULT_WORKSPACE_PATH),
-                    "stdout": stdout,
-                    "stderr": stderr,
-                    "exit_code": result.exit_code,
-                    "error": result.error,
-                }),
-                raw,
-            )
-        }
+        let payload = ExecToolResultPayload::new(
+            &result.stdout,
+            &result.stderr,
+            result.exit_code,
+            output_mode,
+        );
+        let ExecToolResultPayload {
+            stdout,
+            stderr,
+            exit_code,
+            success,
+            truncated,
+            total_lines,
+            raw_output,
+        } = payload;
+        ToolExecutionResult::success_with_raw_output(
+            json!({
+                "sandbox_id": sandbox_id,
+                "cwd": cwd.unwrap_or(E2B_DEFAULT_WORKSPACE_PATH),
+                "stdout": stdout,
+                "stderr": stderr,
+                "exit_code": exit_code,
+                "success": success,
+                "truncated": truncated,
+                "total_lines": total_lines,
+                "error": result.error,
+            }),
+            raw_output,
+        )
     }
 
     fn requires_context(&self) -> bool {

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -138,6 +138,8 @@ Human-facing exec tools should return a structured result instead of a single co
 
 **Legacy compatibility:** Tools may continue to carry a combined pre-truncation string in `ToolResult.raw_output` for persistence hooks and logging, but the user-visible JSON contract should use `stdout`/`stderr`.
 
+Implementation note: shared shaping helpers live in [`crates/core/src/exec_tool_result.rs`](../crates/core/src/exec_tool_result.rs). New shell-like tools should use that helper or match its contract exactly.
+
 ### Exec Human Representation
 
 Exec-tool narration and cards should read like command execution, not generic infrastructure activity.


### PR DESCRIPTION
## What
- add a shared exec result helper so shell-like tools shape stdout/stderr/exit metadata the same way
- align `sandbox_exec` and `e2b_exec` with the shared contract, and keep raw output in the sidecar instead of visible JSON
- classify shell exec tools consistently in the UI/narration layer and add focused tests/docs updates

## Why
Shell-like tools had drifted in both result shape and presentation. `daytona_exec` already exposed the richer contract the UI expects, while other exec tools lagged or rendered as generic tool activity.

## How
- introduce `ExecToolResultPayload` in `crates/core` for sanitization, truncation metadata, success derivation, and raw-output sidecar construction
- route bash, Daytona exec, E2B exec, and session-managed sandbox exec through that helper
- expose the shell category for additional exec tools in the UI registry and narration logic, with Jest coverage for `sandbox_exec` and `e2b_exec`

## Risk
- Medium
- touches shared exec-tool output and shell activity rendering; regressions would show up as malformed tool cards or missing metadata in chat

## Security
- Threat categories reviewed: TM-TOOL, TM-BASH, TM-WEB
- Findings and resolutions:
  - kept pre-truncation command output in `ToolResult.raw_output` sidecar storage instead of exposing it as a visible JSON field
  - preserved the existing exec-output sanitization and verbosity-budget rules while centralizing them in one helper
  - no new auth, permission, or command-execution surface was introduced

## Validation
- `cargo test -p everruns-core preserves_full_raw_output_and_marks_truncation`
- `cargo test -p everruns-core renders_sandbox_exec_narration`
- `cargo test -p everruns-integrations-daytona test_build_exec_tool_result_omits_unknown_cwd_and_uses_total_lines`
- `cargo test -p everruns-integrations-e2b test_exec_tool_missing_command_param`
- `cargo test -p everruns-server session_sandbox --lib`
- `npm test -- --runInBand src/__tests__/tool-activity-group.test.tsx` (in `apps/ui`)
- manual browser smoke on `http://localhost:9120/dev/tool-activity` via Playwright screenshot and agent-browser snapshot
- `just pre-push`

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
