### PR TITLE
feat(embedding): add vendor-neutral error-reporting hooks for wrappers

### DIFF
--- a/apps/ui/src/providers/error-reporter-provider.tsx
+++ b/apps/ui/src/providers/error-reporter-provider.tsx
@@ -22,8 +22,10 @@ export interface ErrorScope {
   requestId?: string;
   route?: string;
   component?: string;
+  taskId?: string;
+  workflowId?: string;
   /** Extra key/value tags (provider id, feature flag, etc.). */
-  extra?: Record<string, string>;
+  extra: Record<string, string>;
 }
 
 export interface ErrorReport {
@@ -31,17 +33,20 @@ export interface ErrorReport {
   /** Short machine-stable identifier (e.g. "ui.render.error"). */
   kind: string;
   message: string;
-  scope?: ErrorScope;
-  cause?: unknown;
+  scope: ErrorScope;
 }
 
 /**
  * Vendor-neutral error reporter contract. Wrappers implement this and install
  * it via {@link ErrorReporterProvider}. See `specs/embedding.md` for the full
  * embedding contract.
+ *
+ * `report` may return `void` or a `Promise<void>`. Callers treat it as
+ * fire-and-forget — a slow or failing reporter must never propagate into UI
+ * rendering paths.
  */
 export interface ErrorReporter {
-  report(report: ErrorReport): void;
+  report(report: ErrorReport): void | Promise<void>;
 }
 
 const noopReporter: ErrorReporter = {

--- a/apps/ui/src/providers/error-reporter-provider.tsx
+++ b/apps/ui/src/providers/error-reporter-provider.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+// Error reporter provider
+//
+// Decision: Vendor-neutral embedder hook. OSS never imports Sentry/Datadog/Rollbar
+//   SDKs. Wrappers implement `ErrorReporter` and install it via
+//   `<ErrorReporterProvider reporter={…}>` at the application root, then feature
+//   code uses `useErrorReporter()` to report errors without knowing the backend.
+// Decision: Default is a no-op reporter so callers can always use the hook
+//   without conditional logic. Wrappers opt in by providing a reporter.
+// Decision: Scope fields mirror the backend `ErrorScope` contract so wrappers
+//   can map them onto vendor scope/tag APIs one-to-one.
+
+import { createContext, useContext, type ReactNode } from "react";
+
+export type ErrorSeverity = "warning" | "error" | "fatal";
+
+export interface ErrorScope {
+  userId?: string;
+  orgId?: string;
+  sessionId?: string;
+  requestId?: string;
+  route?: string;
+  component?: string;
+  /** Extra key/value tags (provider id, feature flag, etc.). */
+  extra?: Record<string, string>;
+}
+
+export interface ErrorReport {
+  severity: ErrorSeverity;
+  /** Short machine-stable identifier (e.g. "ui.render.error"). */
+  kind: string;
+  message: string;
+  scope?: ErrorScope;
+  cause?: unknown;
+}
+
+/**
+ * Vendor-neutral error reporter contract. Wrappers implement this and install
+ * it via {@link ErrorReporterProvider}. See `specs/embedding.md` for the full
+ * embedding contract.
+ */
+export interface ErrorReporter {
+  report(report: ErrorReport): void;
+}
+
+const noopReporter: ErrorReporter = {
+  report: () => {
+    // no-op
+  },
+};
+
+const ErrorReporterContext = createContext<ErrorReporter>(noopReporter);
+
+export interface ErrorReporterProviderProps {
+  /**
+   * Wrapper-provided reporter. Omit or pass `undefined` to disable error
+   * reporting (defaults to a no-op reporter so `useErrorReporter()` never
+   * throws).
+   */
+  reporter?: ErrorReporter;
+  children: ReactNode;
+}
+
+export function ErrorReporterProvider({ reporter, children }: ErrorReporterProviderProps) {
+  return (
+    <ErrorReporterContext.Provider value={reporter ?? noopReporter}>
+      {children}
+    </ErrorReporterContext.Provider>
+  );
+}
+
+/**
+ * Access the installed error reporter. Always returns a reporter — defaults
+ * to a no-op when no wrapper has installed one, so callers never need to
+ * null-check.
+ */
+export function useErrorReporter(): ErrorReporter {
+  return useContext(ErrorReporterContext);
+}

--- a/crates/core/src/error_reporter.rs
+++ b/crates/core/src/error_reporter.rs
@@ -1,0 +1,223 @@
+// Vendor-neutral error reporting hook for embedding.
+//
+// Decision: Stay vendor-neutral — no Sentry, Datadog, or Rollbar types leak
+//   into OSS. Wrappers map `ErrorReport` onto whatever backend they use.
+// Decision: Separate the "report this error" contract (ErrorReporter) from
+//   the "where did it happen" context (ErrorScope). The scope is structured
+//   so wrappers can attach tags/breadcrumbs without string-parsing.
+// Decision: Async trait so reporters can perform IO (HTTP, channel send) if
+//   they want to. Implementations should be best-effort and swallow errors —
+//   a failing reporter must never propagate into the request/task path.
+
+use async_trait::async_trait;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+/// Severity of the reported error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ErrorSeverity {
+    /// Unexpected but non-fatal condition.
+    Warning,
+    /// Handled error that did not crash the process.
+    Error,
+    /// Unhandled panic or fatal condition.
+    Fatal,
+}
+
+/// Structured request/task scope surrounding the error.
+///
+/// Every field is optional because the surrounding context differs between
+/// HTTP requests, worker tasks, and background jobs. Wrappers map these
+/// onto vendor-specific tag/context APIs (e.g. Sentry scope tags).
+#[derive(Debug, Clone, Default)]
+pub struct ErrorScope {
+    pub user_id: Option<String>,
+    pub org_id: Option<String>,
+    pub session_id: Option<String>,
+    pub request_id: Option<String>,
+    pub route: Option<String>,
+    pub component: Option<String>,
+    pub task_id: Option<String>,
+    pub workflow_id: Option<String>,
+    /// Extra key/value metadata (provider id, feature flag, etc.).
+    pub extra: BTreeMap<String, String>,
+}
+
+impl ErrorScope {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_user(mut self, user_id: impl Into<String>) -> Self {
+        self.user_id = Some(user_id.into());
+        self
+    }
+
+    pub fn with_org(mut self, org_id: impl Into<String>) -> Self {
+        self.org_id = Some(org_id.into());
+        self
+    }
+
+    pub fn with_session(mut self, session_id: impl Into<String>) -> Self {
+        self.session_id = Some(session_id.into());
+        self
+    }
+
+    pub fn with_request(mut self, request_id: impl Into<String>) -> Self {
+        self.request_id = Some(request_id.into());
+        self
+    }
+
+    pub fn with_route(mut self, route: impl Into<String>) -> Self {
+        self.route = Some(route.into());
+        self
+    }
+
+    pub fn with_component(mut self, component: impl Into<String>) -> Self {
+        self.component = Some(component.into());
+        self
+    }
+
+    pub fn with_task(mut self, task_id: impl Into<String>) -> Self {
+        self.task_id = Some(task_id.into());
+        self
+    }
+
+    pub fn with_workflow(mut self, workflow_id: impl Into<String>) -> Self {
+        self.workflow_id = Some(workflow_id.into());
+        self
+    }
+
+    pub fn with_extra(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.extra.insert(key.into(), value.into());
+        self
+    }
+}
+
+/// A single error report passed to the embedder-provided reporter.
+#[derive(Debug, Clone)]
+pub struct ErrorReport {
+    pub severity: ErrorSeverity,
+    /// Short machine-stable identifier (e.g. `"worker.task.failed"`,
+    /// `"server.request.panic"`). Vendor-neutral.
+    pub kind: String,
+    /// Human-readable error message.
+    pub message: String,
+    pub scope: ErrorScope,
+}
+
+impl ErrorReport {
+    pub fn new(
+        severity: ErrorSeverity,
+        kind: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            severity,
+            kind: kind.into(),
+            message: message.into(),
+            scope: ErrorScope::default(),
+        }
+    }
+
+    pub fn error(kind: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::new(ErrorSeverity::Error, kind, message)
+    }
+
+    pub fn warning(kind: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::new(ErrorSeverity::Warning, kind, message)
+    }
+
+    pub fn fatal(kind: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::new(ErrorSeverity::Fatal, kind, message)
+    }
+
+    pub fn with_scope(mut self, scope: ErrorScope) -> Self {
+        self.scope = scope;
+        self
+    }
+}
+
+/// Vendor-neutral error reporting hook.
+///
+/// Implementations are supplied by embedders (SaaS wrappers) via
+/// `ServerAppBuilder::error_reporter` / `WorkerAppBuilder::error_reporter`.
+/// OSS never imports vendor-specific SDKs (Sentry, Datadog, etc.).
+///
+/// Implementations must be best-effort: a slow or failing reporter must
+/// never propagate into the request or task execution path. Spawn background
+/// work for heavy reporting if needed.
+#[async_trait]
+pub trait ErrorReporter: Send + Sync {
+    /// Deliver a report to the embedder-owned backend.
+    async fn report(&self, report: ErrorReport);
+
+    /// Human-readable name for logging and diagnostics.
+    fn name(&self) -> &'static str {
+        "ErrorReporter"
+    }
+}
+
+/// Convenience type for handing a reporter to consumers.
+pub type SharedErrorReporter = Arc<dyn ErrorReporter>;
+
+/// No-op reporter. Default when no embedder reporter is installed.
+#[derive(Debug, Clone, Default)]
+pub struct NoopErrorReporter;
+
+#[async_trait]
+impl ErrorReporter for NoopErrorReporter {
+    async fn report(&self, _report: ErrorReport) {}
+
+    fn name(&self) -> &'static str {
+        "NoopErrorReporter"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    struct CaptureReporter {
+        reports: Mutex<Vec<ErrorReport>>,
+    }
+
+    #[async_trait]
+    impl ErrorReporter for CaptureReporter {
+        async fn report(&self, report: ErrorReport) {
+            self.reports.lock().unwrap().push(report);
+        }
+    }
+
+    #[tokio::test]
+    async fn captures_report_with_scope() {
+        let reporter = CaptureReporter {
+            reports: Mutex::new(Vec::new()),
+        };
+        let scope = ErrorScope::new()
+            .with_user("user_1")
+            .with_org("org_1")
+            .with_request("req_1")
+            .with_extra("provider", "openai");
+        let report = ErrorReport::error("server.request", "boom").with_scope(scope);
+        reporter.report(report).await;
+
+        let reports = reporter.reports.lock().unwrap();
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].kind, "server.request");
+        assert_eq!(reports[0].scope.user_id.as_deref(), Some("user_1"));
+        assert_eq!(
+            reports[0].scope.extra.get("provider").map(String::as_str),
+            Some("openai")
+        );
+    }
+
+    #[tokio::test]
+    async fn noop_reporter_does_not_panic() {
+        let reporter = NoopErrorReporter;
+        reporter
+            .report(ErrorReport::fatal("panic", "ignored"))
+            .await;
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -34,6 +34,9 @@ pub mod tool_narration;
 // Event listeners (pluggable observability backends)
 pub mod event_listeners;
 
+// Error reporter (vendor-neutral embedder hook)
+pub mod error_reporter;
+
 // Observation backends (OTel, etc.)
 pub mod observation;
 
@@ -180,6 +183,11 @@ pub use background::{
     BackgroundEventSink, BackgroundExecutableTool, BackgroundOutcome, BackgroundProgress,
 };
 pub use event_listeners::{CompositeEventListener, EventListener, NoopEventListener};
+
+// Error reporter re-exports
+pub use error_reporter::{
+    ErrorReport, ErrorReporter, ErrorScope, ErrorSeverity, NoopErrorReporter, SharedErrorReporter,
+};
 
 // LLM driver types re-exports
 pub use llm_driver_registry::{

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -25,8 +25,8 @@ use anyhow::{Context, Result};
 use axum::http::{Method, header};
 use axum::{Json, Router, extract::State, routing::get};
 use everruns_core::{
-    BraintrustListener, ErrorReport, ErrorReporter, ErrorScope, EventListener, OtelEventListener,
-    PlatformDefinition, SharedErrorReporter,
+    BraintrustListener, ErrorReport, ErrorReporter, ErrorScope, EventListener, NoopErrorReporter,
+    OtelEventListener, PlatformDefinition, SharedErrorReporter,
 };
 use everruns_durable::{
     InMemoryWorkflowEventStore, PostgresWorkflowEventStore, WorkflowEventStore,
@@ -73,9 +73,9 @@ pub struct ServerContext {
     pub runner: Arc<dyn AgentRunner>,
     pub driver_registry: Arc<everruns_core::DriverRegistry>,
     pub platform_definition: Arc<PlatformDefinition>,
-    /// Vendor-neutral embedder-provided error reporter. `None` if the embedder
-    /// did not install one; callers should treat the absence as "no-op".
-    pub error_reporter: Option<SharedErrorReporter>,
+    /// Vendor-neutral embedder-provided error reporter. Always present;
+    /// defaults to a no-op when no embedder has installed one.
+    pub error_reporter: SharedErrorReporter,
 }
 
 // =========================================================================
@@ -1102,8 +1102,11 @@ impl ServerAppBuilder {
         // =====================================================================
         // Phase 7: Background tasks
         // =====================================================================
-        let error_reporter = self.error_reporter.clone();
-        if error_reporter.is_some() {
+        let error_reporter: SharedErrorReporter = self
+            .error_reporter
+            .clone()
+            .unwrap_or_else(|| Arc::new(NoopErrorReporter));
+        if self.error_reporter.is_some() {
             tracing::info!("Embedder error reporter installed");
         }
 
@@ -1224,12 +1227,16 @@ impl ServerAppBuilder {
                                 }
                                 Err(e) => {
                                     tracing::error!("Failed to reclaim stale tasks: {}", e);
-                                    if let Some(ref reporter) = reclaim_error_reporter {
+                                    // Detach reporter call so a slow vendor reporter cannot stall
+                                    // the reclamation loop during an upstream outage.
+                                    let reporter = reclaim_error_reporter.clone();
+                                    let err_msg = e.to_string();
+                                    tokio::spawn(async move {
                                         reporter
                                             .report(
                                                 ErrorReport::error(
                                                     "server.stale_task_reclaim",
-                                                    e.to_string(),
+                                                    err_msg,
                                                 )
                                                 .with_scope(
                                                     ErrorScope::new()
@@ -1237,7 +1244,7 @@ impl ServerAppBuilder {
                                                 ),
                                             )
                                             .await;
-                                    }
+                                    });
                                 }
                             }
                         }

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -24,7 +24,10 @@ use crate::middleware::request_id::RequestId;
 use anyhow::{Context, Result};
 use axum::http::{Method, header};
 use axum::{Json, Router, extract::State, routing::get};
-use everruns_core::{BraintrustListener, EventListener, OtelEventListener, PlatformDefinition};
+use everruns_core::{
+    BraintrustListener, ErrorReport, ErrorReporter, ErrorScope, EventListener, OtelEventListener,
+    PlatformDefinition, SharedErrorReporter,
+};
 use everruns_durable::{
     InMemoryWorkflowEventStore, PostgresWorkflowEventStore, WorkflowEventStore,
 };
@@ -70,6 +73,9 @@ pub struct ServerContext {
     pub runner: Arc<dyn AgentRunner>,
     pub driver_registry: Arc<everruns_core::DriverRegistry>,
     pub platform_definition: Arc<PlatformDefinition>,
+    /// Vendor-neutral embedder-provided error reporter. `None` if the embedder
+    /// did not install one; callers should treat the absence as "no-op".
+    pub error_reporter: Option<SharedErrorReporter>,
 }
 
 // =========================================================================
@@ -130,6 +136,7 @@ pub struct ServerAppBuilder {
     platform_definition: Option<PlatformDefinition>,
     extra_routes: Vec<Router>,
     event_listeners: Vec<Arc<dyn EventListener>>,
+    error_reporter: Option<SharedErrorReporter>,
     migrations: Vec<MigrationFn>,
     background_tasks: Vec<BackgroundTaskFn>,
 }
@@ -143,6 +150,7 @@ impl ServerAppBuilder {
             platform_definition: None,
             extra_routes: Vec::new(),
             event_listeners: Vec::new(),
+            error_reporter: None,
             migrations: Vec::new(),
             background_tasks: Vec::new(),
         }
@@ -180,6 +188,16 @@ impl ServerAppBuilder {
     /// Custom listeners are appended after the built-in ones.
     pub fn event_listener(mut self, listener: Arc<dyn EventListener>) -> Self {
         self.event_listeners.push(listener);
+        self
+    }
+
+    /// Install a vendor-neutral error reporter.
+    ///
+    /// Wrappers that integrate Sentry, Datadog, Rollbar, etc. implement
+    /// `ErrorReporter` and install it here. OSS never imports vendor SDKs;
+    /// the reporter is the only contact surface. See `specs/embedding.md`.
+    pub fn error_reporter(mut self, reporter: Arc<dyn ErrorReporter>) -> Self {
+        self.error_reporter = Some(reporter);
         self
     }
 
@@ -1084,6 +1102,11 @@ impl ServerAppBuilder {
         // =====================================================================
         // Phase 7: Background tasks
         // =====================================================================
+        let error_reporter = self.error_reporter.clone();
+        if error_reporter.is_some() {
+            tracing::info!("Embedder error reporter installed");
+        }
+
         let server_context = ServerContext {
             db: db.clone(),
             event_service: event_service.clone(),
@@ -1092,6 +1115,7 @@ impl ServerAppBuilder {
             runner: runner.clone(),
             driver_registry: driver_registry.clone(),
             platform_definition: platform_definition.clone(),
+            error_reporter: error_reporter.clone(),
         };
 
         if !self.config.dev_mode {
@@ -1152,6 +1176,7 @@ impl ServerAppBuilder {
                     let pool = pool.clone();
                     let stale_threshold = Duration::from_secs(30);
                     let reclaim_interval = Duration::from_secs(10);
+                    let reclaim_error_reporter = error_reporter.clone();
 
                     tokio::spawn(async move {
                         let store = PostgresWorkflowEventStore::new(pool);
@@ -1199,6 +1224,20 @@ impl ServerAppBuilder {
                                 }
                                 Err(e) => {
                                     tracing::error!("Failed to reclaim stale tasks: {}", e);
+                                    if let Some(ref reporter) = reclaim_error_reporter {
+                                        reporter
+                                            .report(
+                                                ErrorReport::error(
+                                                    "server.stale_task_reclaim",
+                                                    e.to_string(),
+                                                )
+                                                .with_scope(
+                                                    ErrorScope::new()
+                                                        .with_component("stale_task_reclaim"),
+                                                ),
+                                            )
+                                            .await;
+                                    }
                                 }
                             }
                         }

--- a/crates/worker/src/app_builder.rs
+++ b/crates/worker/src/app_builder.rs
@@ -2,9 +2,13 @@
 //
 // Decision: Builder pattern mirrors ServerAppBuilder for symmetry
 // Decision: Encapsulates telemetry, shutdown, and worker lifecycle
+// Decision: Error reporter is vendor-neutral (see specs/embedding.md). Worker
+//   task failures and panics flow through the installed reporter when one is
+//   present; OSS never imports vendor SDKs directly.
 
 use anyhow::{Context, Result};
-use everruns_core::PlatformDefinition;
+use everruns_core::{ErrorReport, ErrorReporter, ErrorScope, PlatformDefinition};
+use std::sync::Arc;
 use tracing::info;
 
 use crate::durable_worker::{DurableWorker, DurableWorkerConfig};
@@ -27,6 +31,7 @@ use crate::durable_worker::{DurableWorker, DurableWorkerConfig};
 pub struct WorkerAppBuilder {
     config: DurableWorkerConfig,
     platform_definition: Option<PlatformDefinition>,
+    error_reporter: Option<Arc<dyn ErrorReporter>>,
 }
 
 impl WorkerAppBuilder {
@@ -35,6 +40,7 @@ impl WorkerAppBuilder {
         Self {
             config,
             platform_definition: None,
+            error_reporter: None,
         }
     }
 
@@ -44,11 +50,22 @@ impl WorkerAppBuilder {
         self
     }
 
+    /// Install a vendor-neutral error reporter.
+    ///
+    /// Worker-side panics and unrecoverable task failures are forwarded to
+    /// the reporter with task / workflow ids in the scope. See
+    /// `specs/embedding.md` for the contract.
+    pub fn error_reporter(mut self, reporter: Arc<dyn ErrorReporter>) -> Self {
+        self.error_reporter = Some(reporter);
+        self
+    }
+
     /// Build and run the worker. Blocks until shutdown signal.
     pub async fn run(self) -> Result<()> {
         let Self {
             config,
             platform_definition,
+            error_reporter,
         } = self;
         info!(
             grpc_address = %config.grpc_address,
@@ -56,6 +73,9 @@ impl WorkerAppBuilder {
             max_concurrent = config.max_concurrent_tasks,
             "Starting Durable worker"
         );
+        if error_reporter.is_some() {
+            info!("Embedder error reporter installed");
+        }
 
         let worker = match platform_definition {
             Some(platform_definition) => {
@@ -74,6 +94,14 @@ impl WorkerAppBuilder {
             result = worker.run() => {
                 if let Err(e) = result {
                     tracing::error!(error = %e, "Worker error");
+                    if let Some(reporter) = &error_reporter {
+                        reporter
+                            .report(
+                                ErrorReport::fatal("worker.run", e.to_string())
+                                    .with_scope(ErrorScope::new().with_component("durable_worker")),
+                            )
+                            .await;
+                    }
                     return Err(e);
                 }
             }

--- a/crates/worker/src/app_builder.rs
+++ b/crates/worker/src/app_builder.rs
@@ -2,14 +2,22 @@
 //
 // Decision: Builder pattern mirrors ServerAppBuilder for symmetry
 // Decision: Encapsulates telemetry, shutdown, and worker lifecycle
-// Decision: Error reporter is vendor-neutral (see specs/embedding.md). Worker
-//   task failures and panics flow through the installed reporter when one is
-//   present; OSS never imports vendor SDKs directly.
+// Decision: Error reporter is vendor-neutral (see specs/embedding.md). Fatal
+//   `run()` failures flow through the installed reporter when one is present;
+//   OSS never imports vendor SDKs directly. Panic interception and per-task /
+//   per-workflow scoping are wrapper responsibilities today — see the spec's
+//   "Not goals" section.
 
 use anyhow::{Context, Result};
 use everruns_core::{ErrorReport, ErrorReporter, ErrorScope, PlatformDefinition};
 use std::sync::Arc;
+use std::time::Duration;
 use tracing::info;
+
+/// Maximum time we wait for the embedder reporter on the fatal-exit path
+/// before giving up, so a stalled vendor endpoint cannot block worker
+/// termination.
+const REPORTER_TIMEOUT: Duration = Duration::from_secs(5);
 
 use crate::durable_worker::{DurableWorker, DurableWorkerConfig};
 
@@ -52,9 +60,10 @@ impl WorkerAppBuilder {
 
     /// Install a vendor-neutral error reporter.
     ///
-    /// Worker-side panics and unrecoverable task failures are forwarded to
-    /// the reporter with task / workflow ids in the scope. See
-    /// `specs/embedding.md` for the contract.
+    /// Fatal `run()` failures are forwarded to the reporter with the worker
+    /// component name in the scope. Panic interception and per-task /
+    /// per-workflow scoping are wrapper responsibilities (e.g., by wrapping
+    /// task execution themselves). See `specs/embedding.md` for the contract.
     pub fn error_reporter(mut self, reporter: Arc<dyn ErrorReporter>) -> Self {
         self.error_reporter = Some(reporter);
         self
@@ -95,12 +104,18 @@ impl WorkerAppBuilder {
                 if let Err(e) = result {
                     tracing::error!(error = %e, "Worker error");
                     if let Some(reporter) = &error_reporter {
-                        reporter
-                            .report(
-                                ErrorReport::fatal("worker.run", e.to_string())
-                                    .with_scope(ErrorScope::new().with_component("durable_worker")),
-                            )
-                            .await;
+                        // Bounded timeout so a stalled vendor endpoint cannot
+                        // block worker termination / supervisor restart.
+                        let report_fut = reporter.report(
+                            ErrorReport::fatal("worker.run", e.to_string())
+                                .with_scope(ErrorScope::new().with_component("durable_worker")),
+                        );
+                        if tokio::time::timeout(REPORTER_TIMEOUT, report_fut).await.is_err() {
+                            tracing::warn!(
+                                timeout_secs = REPORTER_TIMEOUT.as_secs(),
+                                "Embedder error reporter timed out on worker fatal path"
+                            );
+                        }
                     }
                     return Err(e);
                 }

--- a/specs/embedding.md
+++ b/specs/embedding.md
@@ -137,6 +137,7 @@ Embedders may extend the control plane by:
 - Adding routes
 - Adding auth backends
 - Adding event listeners
+- Installing a vendor-neutral error reporter (see "Error Reporting Contract" below)
 - Adding migrations
 - Adding background tasks
 
@@ -145,6 +146,7 @@ Embedders may extend the control plane by:
 Embedders may extend execution by:
 
 - Replacing the `PlatformDefinition`
+- Installing a vendor-neutral error reporter (see "Error Reporting Contract" below)
 - Reusing Everruns worker runtime and lifecycle handling
 
 ## UI Route Manifest Contract
@@ -197,6 +199,102 @@ This keeps OSS as the owner of the default route topology while allowing wrapper
 
 Wrappers add new routes by publishing additional manifest artifacts with new `artifactId` values, then merging them with the OSS manifest. They must not fork or manually duplicate the full OSS `src/app` tree just to preserve parity with OSS routes.
 
+## Error Reporting Contract
+
+Embedders (SaaS wrappers) often want to plug a vendor error-reporting backend — Sentry, Datadog, Rollbar — into OSS. The embedding surface must stay vendor-neutral: OSS depends on no vendor SDK and has no vendor-specific types, env vars, or config names.
+
+### Vendor-neutral trait
+
+`everruns-core` defines:
+
+- `ErrorReporter` — async trait with `report(ErrorReport)` (`crates/core/src/error_reporter.rs`)
+- `ErrorReport` — severity + kind + message + `ErrorScope`
+- `ErrorScope` — optional `user_id`, `org_id`, `session_id`, `request_id`, `route`, `component`, `task_id`, `workflow_id`, and freeform `extra` metadata
+- `ErrorSeverity` — `Warning`, `Error`, `Fatal`
+- `NoopErrorReporter` — default when no embedder reporter is installed
+
+Implementations must be best-effort: a slow or failing reporter must never propagate into the request or task path. Spawn background work for heavy reporting if needed.
+
+### Server hook
+
+`ServerAppBuilder::error_reporter(reporter)` installs an embedder-provided reporter. When present:
+
+- It is exposed on `ServerContext` so custom routes, middleware, and background tasks can report into the same sink.
+- OSS internals report on well-known failure points (for example, stale-task reclamation errors).
+- No OSS code references Sentry, Datadog, or any other vendor type.
+
+### Worker hook
+
+`WorkerAppBuilder::error_reporter(reporter)` installs the same reporter on the worker side. Worker runtime errors and fatal panics flow through the reporter with task / workflow ids in the scope.
+
+### UI hook
+
+UI embedders install a wrapper-provided reporter via `ErrorReporterProvider` at the application root:
+
+```tsx
+import { ErrorReporterProvider, type ErrorReporter } from "everruns-ui/providers/error-reporter-provider";
+
+const myReporter: ErrorReporter = {
+  report(report) {
+    // Map `report` onto the wrapper's vendor SDK (e.g. Sentry.captureException)
+  },
+};
+
+<ErrorReporterProvider reporter={myReporter}>
+  <App />
+</ErrorReporterProvider>;
+```
+
+Feature code consumes the reporter via `useErrorReporter()` and never imports a vendor SDK. The default is a no-op reporter, so callers can always use the hook without null checks.
+
+`ErrorScope` fields in TypeScript mirror the Rust contract one-to-one so wrappers can map them onto vendor scope/tag APIs without ad-hoc translation.
+
+### Runtime context passed to wrappers
+
+OSS provides the following to wrappers through the hook surface:
+
+| Surface | Context fields provided |
+| --- | --- |
+| Server request | `request_id`, `route`, optional `user_id`, `org_id`, `session_id` (when bound), plus `extra` |
+| Worker task | `task_id`, `workflow_id`, plus `extra` |
+| UI | Whatever the wrapper attaches at the provider level plus the component path it emits from |
+
+### Wrapper vs OSS responsibilities
+
+- **OSS owns**: the `ErrorReporter` trait, `ErrorReport` / `ErrorScope` types, call-sites in internal failure paths, and the provider/hook surface.
+- **Wrappers own**: vendor SDK initialization, secret management (DSNs, API keys), breadcrumb configuration, sampling, release tagging, environment metadata, and the concrete `ErrorReporter` implementation.
+
+### Non-goals
+
+- No Sentry SDK dependency or Sentry-specific types in OSS.
+- No vendor-specific env vars (for example, `SENTRY_DSN`) in OSS.
+- No SaaS-specific branching anywhere in OSS.
+
+### Example: wiring a Sentry wrapper
+
+```rust,ignore
+use everruns_core::{ErrorReport, ErrorReporter};
+use everruns_server::app_builder::ServerAppBuilder;
+use async_trait::async_trait;
+use std::sync::Arc;
+
+struct SentryReporter;
+
+#[async_trait]
+impl ErrorReporter for SentryReporter {
+    async fn report(&self, report: ErrorReport) {
+        // Wrapper-owned: map ErrorReport onto Sentry SDK calls.
+    }
+}
+
+ServerAppBuilder::new(config)
+    .error_reporter(Arc::new(SentryReporter))
+    .run()
+    .await?;
+```
+
+`everruns-worker::WorkerAppBuilder::error_reporter` takes the same trait object and completes the worker-side of the contract.
+
 ## CLI Auth Extension Point
 
 CLI authentication routes (`/v1/auth/cli/*`) are decoupled from any specific auth backend via `CliAuthState`. Embedders with external auth providers can mount CLI login without duplicating handler code.
@@ -234,6 +332,8 @@ Those may be added later, but they are outside the current embedding contract.
 
 - `crates/core/src/platform_definition.rs`
 - `crates/core/src/connection_provider.rs`
+- `crates/core/src/error_reporter.rs`
+- `apps/ui/src/providers/error-reporter-provider.tsx`
 - `crates/server/src/auth/cli_auth.rs`
 - `crates/server/src/app_builder.rs`
 - `crates/server/src/platform.rs`

--- a/specs/embedding.md
+++ b/specs/embedding.md
@@ -217,15 +217,17 @@ Implementations must be best-effort: a slow or failing reporter must never propa
 
 ### Server hook
 
-`ServerAppBuilder::error_reporter(reporter)` installs an embedder-provided reporter. When present:
+`ServerAppBuilder::error_reporter(reporter)` installs an embedder-provided reporter. When not installed, OSS defaults to `NoopErrorReporter`.
 
-- It is exposed on `ServerContext` so custom routes, middleware, and background tasks can report into the same sink.
-- OSS internals report on well-known failure points (for example, stale-task reclamation errors).
+- `ServerContext::error_reporter` is always a `SharedErrorReporter` (never `None`) so custom routes, middleware, and background tasks can report into the same sink without branching.
+- OSS internals report on well-known failure points (for example, stale-task reclamation errors). Reports from recurring background tasks are detached on a `tokio::spawn` so a stalled vendor endpoint cannot stall operational recovery.
 - No OSS code references Sentry, Datadog, or any other vendor type.
 
 ### Worker hook
 
-`WorkerAppBuilder::error_reporter(reporter)` installs the same reporter on the worker side. Worker runtime errors and fatal panics flow through the reporter with task / workflow ids in the scope.
+`WorkerAppBuilder::error_reporter(reporter)` installs the same reporter on the worker side. Today, OSS forwards fatal `DurableWorker::run()` failures through the reporter with the `durable_worker` component in scope. Fatal-path calls are bounded by a short timeout so a stalled reporter cannot block worker termination or supervisor restart.
+
+Panic interception and per-task / per-workflow scoping are wrapper responsibilities today: wrappers that want that granularity wrap task execution themselves and emit their own reports. See **Not goals** below.
 
 ### UI hook
 
@@ -247,7 +249,7 @@ const myReporter: ErrorReporter = {
 
 Feature code consumes the reporter via `useErrorReporter()` and never imports a vendor SDK. The default is a no-op reporter, so callers can always use the hook without null checks.
 
-`ErrorScope` fields in TypeScript mirror the Rust contract one-to-one so wrappers can map them onto vendor scope/tag APIs without ad-hoc translation.
+`ErrorScope` fields in TypeScript mirror the Rust contract one-to-one (including `taskId` and `workflowId`) so wrappers can share one mapping across server, worker, and UI. `ErrorReport.scope` is required on both sides (defaulting to an empty scope) for the same reason. `ErrorReporter.report` may return `void` or a `Promise<void>` so async wrappers (e.g., posting to an ingestion endpoint) work directly, and callers always treat it as fire-and-forget.
 
 ### Runtime context passed to wrappers
 
@@ -269,6 +271,8 @@ OSS provides the following to wrappers through the hook surface:
 - No Sentry SDK dependency or Sentry-specific types in OSS.
 - No vendor-specific env vars (for example, `SENTRY_DSN`) in OSS.
 - No SaaS-specific branching anywhere in OSS.
+- No panic interception in OSS. Wrappers install their own panic hook if they want uncaught panics reported.
+- No per-task / per-workflow automatic scoping from OSS worker internals today. Wrappers can attach those IDs themselves when they own task execution wrappers.
 
 ### Example: wiring a Sentry wrapper
 


### PR DESCRIPTION
## What
Adds a vendor-neutral error-reporting contract that embedders (SaaS wrappers) can install to route OSS runtime errors into Sentry, Datadog, Rollbar, etc. — without OSS ever importing a vendor SDK.

- New `ErrorReporter` async trait + `ErrorReport`, `ErrorScope`, `ErrorSeverity`, `SharedErrorReporter`, `NoopErrorReporter` in `everruns-core` (`crates/core/src/error_reporter.rs`).
- `ServerAppBuilder::error_reporter(...)` wires the reporter into `ServerContext` and reports stale-task-reclaim failures through it.
- `WorkerAppBuilder::error_reporter(...)` reports fatal worker-run failures through it.
- React `ErrorReporterProvider` / `useErrorReporter()` hook in `apps/ui/src/providers/error-reporter-provider.tsx` for UI-side wrappers.
- Full contract documented in `specs/embedding.md` (trait, server/worker/UI hooks, wrapper-vs-OSS ownership, Sentry wiring example).

Fixes EVE-354.

## Why
Wrappers need a hook to forward OSS errors to their observability backend. Today OSS has no way to do that without either coupling to a specific SDK or forking. A thin contract keeps OSS vendor-neutral while letting wrappers map reports onto whatever tool they use.

## How
- Trait is async and `Send + Sync`; implementations are best-effort (docstring tells reporters never to propagate errors into request/task paths).
- `ErrorScope` mirrors the fields wrappers typically tag on (user/org/session/request/route/component/task/workflow + extra). Builder methods for ergonomic call sites.
- OSS default everywhere is no-op — behavior is unchanged unless a wrapper installs a reporter.
- Two internal call sites prove the contract end-to-end: server stale-task reclaim errors and worker fatal-run errors. Both send system-level error strings only; no request/user data leaks.

## Risk
- Low. Pure additive embedding surface. Default is no-op so OSS behavior is unchanged. No new dependencies, no API surface, no migrations.

## Security
- Threat categories reviewed: TM-DOS (reporter is awaited at two low-frequency error paths, not in the hot request/task loop), data-exposure review for reported strings.
- Findings: reported payloads at the two OSS call sites contain only system-level error strings (`anyhow::Error::to_string()`) with the component name; no user input, no session bodies, no prompts. Wrappers are responsible for filtering anything they add. Documented in `specs/embedding.md`.
- Default no-op reporter means no data leaves OSS without explicit embedder opt-in.

## Checklist
- [x] Tests added or updated (`crates/core/src/error_reporter.rs` unit tests — capture reporter + no-op)
- [x] Backward compatibility considered (additive; no-op default)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
