### PR TITLE
fix(ci): scope live jobs to real integration changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,20 +26,20 @@ jobs:
     name: Detect Changes
     runs-on: ubuntu-latest
     outputs:
-      rust: ${{ steps.filter.outputs.rust }}
-      daytona: ${{ steps.filter.outputs.daytona }}
-      deno: ${{ steps.filter.outputs.deno }}
-      browserless: ${{ steps.filter.outputs.browserless }}
-      e2b: ${{ steps.filter.outputs.e2b }}
-      sdk_compat: ${{ steps.filter.outputs.sdk_compat }}
-      ui: ${{ steps.filter.outputs.ui }}
-      docs: ${{ steps.filter.outputs.docs }}
-      docker: ${{ steps.filter.outputs.docker }}
+      rust: ${{ steps.core_filter.outputs.rust }}
+      daytona: ${{ steps.live_filter.outputs.daytona }}
+      deno: ${{ steps.live_filter.outputs.deno }}
+      browserless: ${{ steps.live_filter.outputs.browserless }}
+      e2b: ${{ steps.live_filter.outputs.e2b }}
+      sdk_compat: ${{ steps.core_filter.outputs.sdk_compat }}
+      ui: ${{ steps.core_filter.outputs.ui }}
+      docs: ${{ steps.core_filter.outputs.docs }}
+      docker: ${{ steps.core_filter.outputs.docker }}
     steps:
       - uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
-        id: filter
+        id: core_filter
         with:
           filters: |
             rust:
@@ -49,23 +49,6 @@ jobs:
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
               - '.github/workflows/ci.yml'
-            # Live API jobs (daytona/deno/browserless/e2b) hit real external
-            # services and cost real API budget. Exclude doc-only changes so
-            # SPEC.md tweaks don't trigger the full paid matrix on every push
-            # to main. The weekly `integration-live-sweep.yml` backstop still
-            # catches shared-crate regressions that slip past these filters.
-            daytona:
-              - 'integrations/daytona/**'
-              - '!integrations/daytona/**/*.md'
-            deno:
-              - 'integrations/deno/**'
-              - '!integrations/deno/**/*.md'
-            browserless:
-              - 'integrations/browserless/**'
-              - '!integrations/browserless/**/*.md'
-            e2b:
-              - 'integrations/e2b/**'
-              - '!integrations/e2b/**/*.md'
             sdk_compat:
               - 'crates/**'
               - '.github/scripts/sdk-compat/**'
@@ -84,6 +67,32 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - '.github/workflows/ci.yml'
+
+      # Exclusion filters need `predicate-quantifier: every`; with the default
+      # `some`, a rule like `!integrations/foo/**/*.md` matches almost every
+      # non-markdown file and incorrectly enables the live paid matrix.
+      - uses: dorny/paths-filter@v3
+        id: live_filter
+        with:
+          predicate-quantifier: every
+          filters: |
+            # Live API jobs (daytona/deno/browserless/e2b) hit real external
+            # services and cost real API budget. Exclude doc-only changes so
+            # SPEC.md tweaks don't trigger the full paid matrix on every push
+            # to main. The weekly `integration-live-sweep.yml` backstop still
+            # catches shared-crate regressions that slip past these filters.
+            daytona:
+              - 'integrations/daytona/**'
+              - '!integrations/daytona/**/*.md'
+            deno:
+              - 'integrations/deno/**'
+              - '!integrations/deno/**/*.md'
+            browserless:
+              - 'integrations/browserless/**'
+              - '!integrations/browserless/**/*.md'
+            e2b:
+              - 'integrations/e2b/**'
+              - '!integrations/e2b/**/*.md'
 
   format:
     name: Format Check


### PR DESCRIPTION
## What
Split `Detect Changes` into two `dorny/paths-filter` steps so the paid live-integration filters (`daytona`, `deno`, `browserless`, `e2b`) run with `predicate-quantifier: every` while the broad positive-only filters keep the default behavior.

## Why
The previous single filter step mixed positive globs with negated `!**/*.md` rules under the default matching mode, which caused unrelated pushes to `main` to set the live-job outputs true and fire paid external CI jobs unnecessarily.

## How
Move the positive-only filters into `core_filter`, add a dedicated `live_filter` step for the exclusion-based integration filters, and wire the job outputs so only the paid live jobs read from the exclusion-safe step.

## Risk
- Low
- If the new filter wiring is wrong, live integration jobs could be skipped when integration code changes or still run when they should not.

## Security
- Threat categories reviewed: TM-DOS
- Findings and resolutions:
  - The broken filter routing caused unnecessary paid external jobs to run on unrelated pushes, which expands avoidable resource consumption. The workflow now scopes those jobs to real integration changes only.
  - No new secrets, permissions, third-party actions, or auth surfaces were introduced.

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- Reviewed `git diff origin/main...HEAD` and recent `Detect Changes` job logs for runs `24697942500` and `24697932336` to confirm the root cause.
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'`
- `git diff --check`
- `just pre-push`
- Smoke test skipped: workflow-only change, no runtime app/API behavior changed.
