### PR TITLE
fix(deno): resolve sandbox A records explicitly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,6 +704,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,6 +1043,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "cron"
@@ -1799,6 +1816,7 @@ dependencies = [
  "chrono",
  "everruns-core",
  "futures-util",
+ "hickory-resolver",
  "http",
  "inventory",
  "reqwest 0.13.2",
@@ -2549,6 +2567,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -2722,6 +2741,76 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-net"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61c8db47fae51ba9f8f2a2748bd87542acfbe22f2ec9cf9c8ec72d1ee6e9a6"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "rand 0.10.1",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a916d0494600d99ecb15aadfab677ad97c4de559e8f1af0c129353a733ac1fcc"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a10bd64d950b4d38ca21e25c8ae230712e4955fb8290cfcb29a5e5dc6017e544"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto",
+ "ipconfig",
+ "ipnet",
+ "jni 0.22.4",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.1",
+ "resolv-conf",
+ "smallvec",
+ "system-configuration",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "hkdf"
@@ -3218,10 +3307,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.3",
+ "widestring",
+ "windows-registry",
+ "windows-result 0.4.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -4122,6 +4227,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -4560,6 +4669,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23370be78b7e5bcbb0cab4a02047eb040279a693c78daad04c2c5f1c24a83503"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4825,6 +4945,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4861,6 +4992,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -5198,6 +5335,12 @@ dependencies = [
  "reqwest 0.12.28",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "ring"
@@ -7551,6 +7694,12 @@ dependencies = [
  "libredox",
  "wasite",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"

--- a/integrations/deno/Cargo.toml
+++ b/integrations/deno/Cargo.toml
@@ -21,6 +21,7 @@ chrono.workspace = true
 tracing.workspace = true
 futures-util.workspace = true
 tokio-tungstenite.workspace = true
+hickory-resolver = "0.26"
 
 # TLS: custom rustls config to force http/1.1 ALPN for WebSocket
 rustls.workspace = true

--- a/integrations/deno/SPEC.md
+++ b/integrations/deno/SPEC.md
@@ -17,11 +17,11 @@ Deno sandboxes use two APIs:
 
 Everruns opens a fresh websocket per tool call. This keeps tool execution stateless between calls while preserving sandbox state remotely.
 
-When the sandbox hostname resolves to both `A` and `AAAA` records, Everruns
-attempts IPv4 endpoints first. GitHub-hosted CI runners currently lack outbound
-IPv6, so IPv4-first dialing keeps live tests and production calls aligned with
-the reachable network path while still falling back to IPv6 if no IPv4 address
-is published.
+Everruns explicitly resolves `A` records for sandbox websocket hosts before
+falling back to the system resolver. GitHub-hosted CI runners currently lack
+outbound IPv6, and their resolver can still surface `AAAA` records, so querying
+IPv4 directly keeps live tests and production calls aligned with the reachable
+network path while still preserving IPv6 fallback when no `A` record exists.
 
 ### State management
 

--- a/integrations/deno/SPEC.md
+++ b/integrations/deno/SPEC.md
@@ -17,6 +17,12 @@ Deno sandboxes use two APIs:
 
 Everruns opens a fresh websocket per tool call. This keeps tool execution stateless between calls while preserving sandbox state remotely.
 
+When the sandbox hostname resolves to both `A` and `AAAA` records, Everruns
+attempts IPv4 endpoints first. GitHub-hosted CI runners currently lack outbound
+IPv6, so IPv4-first dialing keeps live tests and production calls aligned with
+the reachable network path while still falling back to IPv6 if no IPv4 address
+is published.
+
 ### State management
 
 Per-sandbox state is stored in session secrets (encrypted at rest):

--- a/integrations/deno/src/client.rs
+++ b/integrations/deno/src/client.rs
@@ -4,8 +4,10 @@
 //! needs Rust dependencies at runtime.
 //! Decision: open a fresh websocket per tool call; operations are short-lived
 //! and this keeps session state small and deterministic.
+//! Decision: prefer IPv4 websocket endpoints when both address families resolve
+//! because GitHub-hosted CI runners do not have outbound IPv6 connectivity.
 
-use std::sync::Arc;
+use std::{net::SocketAddr, sync::Arc};
 
 use base64::Engine;
 use futures_util::{SinkExt, StreamExt};
@@ -27,6 +29,22 @@ use crate::{
 const DEFAULT_REGION: &str = "ord";
 
 type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+fn prefer_ipv4_addrs(addrs: impl IntoIterator<Item = SocketAddr>) -> Vec<SocketAddr> {
+    let mut ipv4 = Vec::new();
+    let mut ipv6 = Vec::new();
+
+    for addr in addrs {
+        if addr.is_ipv4() {
+            ipv4.push(addr);
+        } else {
+            ipv6.push(addr);
+        }
+    }
+
+    ipv4.extend(ipv6);
+    ipv4
+}
 
 async fn connect_async_all_addrs(
     request: Request<()>,
@@ -53,9 +71,11 @@ async fn connect_async_all_addrs(
     }
 
     let mut last_error = None;
-    let addrs = tokio::net::lookup_host((host.as_str(), port))
-        .await
-        .map_err(|e| format!("Failed to resolve Deno sandbox host {host}:{port}: {e}"))?;
+    let addrs = prefer_ipv4_addrs(
+        tokio::net::lookup_host((host.as_str(), port))
+            .await
+            .map_err(|e| format!("Failed to resolve Deno sandbox host {host}:{port}: {e}"))?,
+    );
 
     for addr in addrs {
         match TcpStream::connect(addr).await {
@@ -947,6 +967,26 @@ mod tests {
             panic!("Expected Connector::Rustls");
         };
         assert_eq!(config.alpn_protocols, vec![b"http/1.1".to_vec()]);
+    }
+
+    #[test]
+    fn prefer_ipv4_addrs_keeps_ipv4_first() {
+        let reordered = prefer_ipv4_addrs([
+            "[2602:f70f::1]:443".parse().expect("parse ipv6"),
+            "69.67.170.170:443".parse().expect("parse ipv4"),
+            "[2602:f70f::2]:443".parse().expect("parse ipv6"),
+            "69.67.170.171:443".parse().expect("parse ipv4"),
+        ]);
+
+        assert_eq!(
+            reordered,
+            vec![
+                "69.67.170.170:443".parse().expect("parse ipv4"),
+                "69.67.170.171:443".parse().expect("parse ipv4"),
+                "[2602:f70f::1]:443".parse().expect("parse ipv6"),
+                "[2602:f70f::2]:443".parse().expect("parse ipv6"),
+            ]
+        );
     }
 
     /// Verify that connect_via_http_proxy sends Proxy-Authorization when

--- a/integrations/deno/src/client.rs
+++ b/integrations/deno/src/client.rs
@@ -4,13 +4,15 @@
 //! needs Rust dependencies at runtime.
 //! Decision: open a fresh websocket per tool call; operations are short-lived
 //! and this keeps session state small and deterministic.
-//! Decision: prefer IPv4 websocket endpoints when both address families resolve
-//! because GitHub-hosted CI runners do not have outbound IPv6 connectivity.
+//! Decision: explicitly resolve IPv4 sandbox endpoints first because
+//! GitHub-hosted CI runners do not have outbound IPv6 connectivity and the
+//! system resolver can still surface AAAA records.
 
 use std::{net::SocketAddr, sync::Arc};
 
 use base64::Engine;
 use futures_util::{SinkExt, StreamExt};
+use hickory_resolver::TokioResolver;
 use http::Request;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -25,6 +27,7 @@ use crate::{
     DENO_CONSOLE_API_BASE, DENO_DEFAULT_MEMORY_MB, DENO_RPC_TIMEOUT, DENO_SANDBOX_BASE_DOMAIN,
     DENO_STREAM_IDLE_TIMEOUT, DENO_WORKSPACE_PATH,
 };
+use hickory_resolver::proto::rr::RData;
 
 const DEFAULT_REGION: &str = "ord";
 
@@ -44,6 +47,59 @@ fn prefer_ipv4_addrs(addrs: impl IntoIterator<Item = SocketAddr>) -> Vec<SocketA
 
     ipv4.extend(ipv6);
     ipv4
+}
+
+fn select_connect_addrs(
+    ipv4_addrs: Vec<SocketAddr>,
+    fallback_addrs: impl IntoIterator<Item = SocketAddr>,
+) -> Vec<SocketAddr> {
+    if !ipv4_addrs.is_empty() {
+        return ipv4_addrs;
+    }
+
+    prefer_ipv4_addrs(fallback_addrs)
+}
+
+async fn resolve_ipv4_addrs(host: &str, port: u16) -> Result<Vec<SocketAddr>, String> {
+    let resolver = TokioResolver::builder_tokio()
+        .map_err(|e| format!("Failed to configure Deno sandbox IPv4 resolver: {e}"))?
+        .build()
+        .map_err(|e| format!("Failed to build Deno sandbox IPv4 resolver: {e}"))?;
+    let lookup = resolver
+        .ipv4_lookup(format!("{host}."))
+        .await
+        .map_err(|e| format!("Failed to resolve Deno sandbox IPv4 host {host}:{port}: {e}"))?;
+
+    Ok(lookup
+        .answers()
+        .iter()
+        .filter_map(|record| match &record.data {
+            RData::A(addr) => Some(SocketAddr::from((addr.0, port))),
+            _ => None,
+        })
+        .collect())
+}
+
+async fn resolve_connect_addrs(host: &str, port: u16) -> Result<Vec<SocketAddr>, String> {
+    let ipv4_addrs = resolve_ipv4_addrs(host, port).await.unwrap_or_default();
+    if !ipv4_addrs.is_empty() {
+        return Ok(select_connect_addrs(ipv4_addrs, std::iter::empty()));
+    }
+
+    let addrs = select_connect_addrs(
+        Vec::new(),
+        tokio::net::lookup_host((host, port))
+            .await
+            .map_err(|e| format!("Failed to resolve Deno sandbox host {host}:{port}: {e}"))?,
+    );
+
+    if addrs.is_empty() {
+        return Err(format!(
+            "Failed to resolve Deno sandbox host {host}:{port}: no addresses returned"
+        ));
+    }
+
+    Ok(addrs)
 }
 
 async fn connect_async_all_addrs(
@@ -71,11 +127,7 @@ async fn connect_async_all_addrs(
     }
 
     let mut last_error = None;
-    let addrs = prefer_ipv4_addrs(
-        tokio::net::lookup_host((host.as_str(), port))
-            .await
-            .map_err(|e| format!("Failed to resolve Deno sandbox host {host}:{port}: {e}"))?,
-    );
+    let addrs = resolve_connect_addrs(&host, port).await?;
 
     for addr in addrs {
         match TcpStream::connect(addr).await {
@@ -985,6 +1037,28 @@ mod tests {
                 "69.67.170.171:443".parse().expect("parse ipv4"),
                 "[2602:f70f::1]:443".parse().expect("parse ipv6"),
                 "[2602:f70f::2]:443".parse().expect("parse ipv6"),
+            ]
+        );
+    }
+
+    #[test]
+    fn select_connect_addrs_prefers_ipv4_lookup_results() {
+        let selected = select_connect_addrs(
+            vec![
+                "69.67.170.170:443".parse().expect("parse ipv4"),
+                "69.67.170.171:443".parse().expect("parse ipv4"),
+            ],
+            [
+                "[2602:f70f::1]:443".parse().expect("parse ipv6"),
+                "69.67.170.170:443".parse().expect("parse ipv4"),
+            ],
+        );
+
+        assert_eq!(
+            selected,
+            vec![
+                "69.67.170.170:443".parse().expect("parse ipv4"),
+                "69.67.170.171:443".parse().expect("parse ipv4"),
             ]
         );
     }


### PR DESCRIPTION
## What
Resolve Deno sandbox websocket hosts via explicit `A` record lookup before falling back to the system resolver, add regression coverage for the selection logic, and document the behavior in the Deno integration spec.

## Why
GitHub-hosted runners fail the Deno live test because they can still receive `AAAA` answers for the sandbox host even though they have no outbound IPv6 connectivity. Reordering the system resolver output was not enough; the client needs an explicit IPv4 path when an `A` record exists.

## How
Add `hickory-resolver` to query sandbox `A` records directly, use those IPv4 socket addresses when available, preserve the old system-resolver path only as a fallback when no IPv4 answer exists, and cover the selection behavior with unit tests.

## Risk
- Low
- Affects only the Deno websocket dial path; when no IPv4 record exists the client still falls back to the existing resolver behavior.

## Security
- Threat categories reviewed: TM-DENO, TM-DOS
- Findings and resolutions: No new trust boundary. The change narrows address-family selection for the same TLS-protected Deno sandbox host and does not broaden network reachability or secret exposure.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)
