### PR TITLE
test(scripts): formalize shell helper CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,19 +260,24 @@ jobs:
       - name: Install shell test dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y netcat-openbsd ripgrep
+          sudo apt-get install -y lsof netcat-openbsd ripgrep
 
           CADDY_VERSION="2.9.1"
+          CADDY_TARBALL=""
+          CADDY_CHECKSUMS="caddy_${CADDY_VERSION}_checksums.txt"
+          CADDY_BASE_URL="https://github.com/caddyserver/caddy/releases/download/v${CADDY_VERSION}"
           case "$(uname -m)" in
             x86_64) CADDY_ARCH="amd64" ;;
             aarch64) CADDY_ARCH="arm64" ;;
             *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
           esac
 
-          curl -fsSL \
-            "https://github.com/caddyserver/caddy/releases/download/v${CADDY_VERSION}/caddy_${CADDY_VERSION}_linux_${CADDY_ARCH}.tar.gz" \
-            -o /tmp/caddy.tar.gz
-          tar -xzf /tmp/caddy.tar.gz -C /tmp caddy
+          CADDY_TARBALL="caddy_${CADDY_VERSION}_linux_${CADDY_ARCH}.tar.gz"
+          curl -fsSL "${CADDY_BASE_URL}/${CADDY_TARBALL}" -o "/tmp/${CADDY_TARBALL}"
+          curl -fsSL "${CADDY_BASE_URL}/${CADDY_CHECKSUMS}" -o "/tmp/${CADDY_CHECKSUMS}"
+          grep "  ${CADDY_TARBALL}$" "/tmp/${CADDY_CHECKSUMS}" > /tmp/caddy.sha256
+          (cd /tmp && sha256sum -c caddy.sha256)
+          tar -xzf "/tmp/${CADDY_TARBALL}" -C /tmp caddy
           sudo install -m 0755 /tmp/caddy /usr/local/bin/caddy
 
       - name: Run repo shell tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,8 +275,8 @@ jobs:
           CADDY_TARBALL="caddy_${CADDY_VERSION}_linux_${CADDY_ARCH}.tar.gz"
           curl -fsSL "${CADDY_BASE_URL}/${CADDY_TARBALL}" -o "/tmp/${CADDY_TARBALL}"
           curl -fsSL "${CADDY_BASE_URL}/${CADDY_CHECKSUMS}" -o "/tmp/${CADDY_CHECKSUMS}"
-          grep "  ${CADDY_TARBALL}$" "/tmp/${CADDY_CHECKSUMS}" > /tmp/caddy.sha256
-          (cd /tmp && sha256sum -c caddy.sha256)
+          grep "  ${CADDY_TARBALL}$" "/tmp/${CADDY_CHECKSUMS}" > /tmp/caddy.sha512
+          (cd /tmp && sha512sum -c caddy.sha512)
           tar -xzf "/tmp/${CADDY_TARBALL}" -C /tmp caddy
           sudo install -m 0755 /tmp/caddy /usr/local/bin/caddy
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       browserless: ${{ steps.live_filter.outputs.browserless }}
       e2b: ${{ steps.live_filter.outputs.e2b }}
       sdk_compat: ${{ steps.core_filter.outputs.sdk_compat }}
+      shell: ${{ steps.core_filter.outputs.shell }}
       ui: ${{ steps.core_filter.outputs.ui }}
       docs: ${{ steps.core_filter.outputs.docs }}
       docker: ${{ steps.core_filter.outputs.docker }}
@@ -52,6 +53,17 @@ jobs:
             sdk_compat:
               - 'crates/**'
               - '.github/scripts/sdk-compat/**'
+              - '.github/workflows/ci.yml'
+            # Repo-owned shell tests cover scripts/test-*.sh plus the shell
+            # libraries/assets they exercise. Workflow-specific harnesses under
+            # .github/scripts stay owned by their dedicated jobs.
+            shell:
+              - 'scripts/run-shell-tests.sh'
+              - 'scripts/test-*.sh'
+              - 'scripts/lib/**'
+              - 'local/Caddyfile'
+              - 'examples/docker-compose-full.yaml'
+              - 'justfile'
               - '.github/workflows/ci.yml'
             ui:
               - 'apps/ui/**'
@@ -235,6 +247,36 @@ jobs:
 
       - name: Run worker library tests
         run: cargo test -p everruns-worker --lib -- --test-threads=1
+
+  shell-test:
+    name: Shell Tests (Repo Scripts)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.shell == 'true'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install shell test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y netcat-openbsd ripgrep
+
+          CADDY_VERSION="2.9.1"
+          case "$(uname -m)" in
+            x86_64) CADDY_ARCH="amd64" ;;
+            aarch64) CADDY_ARCH="arm64" ;;
+            *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+          esac
+
+          curl -fsSL \
+            "https://github.com/caddyserver/caddy/releases/download/v${CADDY_VERSION}/caddy_${CADDY_VERSION}_linux_${CADDY_ARCH}.tar.gz" \
+            -o /tmp/caddy.tar.gz
+          tar -xzf /tmp/caddy.tar.gz -C /tmp caddy
+          sudo install -m 0755 /tmp/caddy /usr/local/bin/caddy
+
+      - name: Run repo shell tests
+        run: ./scripts/run-shell-tests.sh
 
   # Live Daytona API tests — only when integrations/daytona/** changes and secret exists
   daytona-live-test:
@@ -1044,6 +1086,7 @@ jobs:
       - clippy
       - unit-test
       - worker-test
+      - shell-test
       - integration-test
       - build-binaries
       - workflow-test

--- a/justfile
+++ b/justfile
@@ -52,6 +52,10 @@ test:
     cargo test
     cd apps/ui && npm run e2e 2>/dev/null || echo "(e2e skipped)"
 
+# Run repository shell-layer tests (scripts/test-*.sh)
+test-shell:
+    ./scripts/run-shell-tests.sh
+
 # Run pure unit tests (no PostgreSQL required) - fast feedback
 test-unit:
     cargo test -p everruns-anthropic --lib --all-features

--- a/scripts/run-shell-tests.sh
+++ b/scripts/run-shell-tests.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Repository-owned shell tests live in scripts/test-*.sh.
+# Workflow-specific shell harnesses under .github/scripts stay owned by their jobs.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_ROOT"
+
+declare -a tests=()
+
+if [ "$#" -gt 0 ]; then
+  tests=("$@")
+else
+  while IFS= read -r test_script; do
+    tests+=("$test_script")
+  done < <(find "$PROJECT_ROOT/scripts" -maxdepth 1 -type f -name 'test-*.sh' | LC_ALL=C sort)
+fi
+
+if [ "${#tests[@]}" -eq 0 ]; then
+  echo "No repo shell tests found."
+  exit 0
+fi
+
+failures=0
+
+echo "Running ${#tests[@]} repo shell test(s)..."
+
+for i in "${!tests[@]}"; do
+  test_script="${tests[$i]}"
+
+  if [ ! -f "$test_script" ] && [ -f "$PROJECT_ROOT/$test_script" ]; then
+    test_script="$PROJECT_ROOT/$test_script"
+  fi
+
+  if [ ! -f "$test_script" ]; then
+    echo "[$((i + 1))/${#tests[@]}] FAIL: missing test script '$test_script'" >&2
+    failures=$((failures + 1))
+    continue
+  fi
+
+  rel_path="${test_script#$PROJECT_ROOT/}"
+  echo "[$((i + 1))/${#tests[@]}] $rel_path"
+
+  if bash "$test_script"; then
+    echo "PASS: $rel_path"
+  else
+    echo "FAIL: $rel_path" >&2
+    failures=$((failures + 1))
+  fi
+
+  echo ""
+done
+
+if [ "$failures" -ne 0 ]; then
+  echo "$failures repo shell test(s) failed." >&2
+  exit 1
+fi
+
+echo "All repo shell tests passed."

--- a/scripts/run-shell-tests.sh
+++ b/scripts/run-shell-tests.sh
@@ -11,8 +11,37 @@ cd "$PROJECT_ROOT"
 
 declare -a tests=()
 
+resolve_repo_shell_test() {
+  local candidate="$1"
+  local resolved_dir resolved_path
+
+  if [ ! -f "$candidate" ] && [ -f "$PROJECT_ROOT/$candidate" ]; then
+    candidate="$PROJECT_ROOT/$candidate"
+  fi
+
+  if [ ! -f "$candidate" ]; then
+    echo "missing test script '$candidate'" >&2
+    return 1
+  fi
+
+  resolved_dir="$(cd "$(dirname "$candidate")" && pwd -P)"
+  resolved_path="$resolved_dir/$(basename "$candidate")"
+
+  case "$resolved_path" in
+    "$PROJECT_ROOT"/scripts/test-*.sh)
+      printf '%s\n' "$resolved_path"
+      ;;
+    *)
+      echo "test script must stay under scripts/test-*.sh: '$candidate'" >&2
+      return 1
+      ;;
+  esac
+}
+
 if [ "$#" -gt 0 ]; then
-  tests=("$@")
+  for candidate in "$@"; do
+    tests+=("$(resolve_repo_shell_test "$candidate")")
+  done
 else
   while IFS= read -r test_script; do
     tests+=("$test_script")
@@ -30,17 +59,6 @@ echo "Running ${#tests[@]} repo shell test(s)..."
 
 for i in "${!tests[@]}"; do
   test_script="${tests[$i]}"
-
-  if [ ! -f "$test_script" ] && [ -f "$PROJECT_ROOT/$test_script" ]; then
-    test_script="$PROJECT_ROOT/$test_script"
-  fi
-
-  if [ ! -f "$test_script" ]; then
-    echo "[$((i + 1))/${#tests[@]}] FAIL: missing test script '$test_script'" >&2
-    failures=$((failures + 1))
-    continue
-  fi
-
   rel_path="${test_script#$PROJECT_ROOT/}"
   echo "[$((i + 1))/${#tests[@]}] $rel_path"
 

--- a/scripts/test-port-layout.sh
+++ b/scripts/test-port-layout.sh
@@ -19,7 +19,7 @@ assert_eq() {
 }
 
 check_default_ports() {
-  unset PORT_PREFIX API_PORT WORKER_GRPC_PORT CADDY_ADMIN_PORT UI_PORT PROXY_PORT OTEL_GRPC_PORT OTEL_HTTP_PORT VALKEY_PORT DB_PORT COMPOSE_PROJECT_NAME
+  unset PORT_PREFIX API_PORT WORKER_GRPC_PORT CADDY_ADMIN_PORT UI_PORT PROXY_PORT OTEL_GRPC_PORT OTEL_HTTP_PORT VICTORIAMETRICS_PORT VALKEY_PORT NATS_PORT DB_PORT COMPOSE_PROJECT_NAME
   apply_port_prefix_defaults
 
   assert_eq "9300" "$PROXY_PORT" "default proxy port"
@@ -29,14 +29,16 @@ check_default_ports() {
   assert_eq "9305" "$UI_PORT" "default ui port"
   assert_eq "4317" "$OTEL_GRPC_PORT" "default OTLP gRPC port"
   assert_eq "4318" "$OTEL_HTTP_PORT" "default OTLP HTTP port"
+  assert_eq "8428" "$VICTORIAMETRICS_PORT" "default VictoriaMetrics port"
   assert_eq "6379" "$VALKEY_PORT" "default valkey port"
+  assert_eq "4222" "$NATS_PORT" "default nats port"
   assert_eq "9332" "$DB_PORT" "default db port"
   assert_eq "everruns" "$COMPOSE_PROJECT_NAME" "default compose project"
 }
 
 check_prefixed_ports() {
   export PORT_PREFIX=271
-  unset API_PORT WORKER_GRPC_PORT CADDY_ADMIN_PORT UI_PORT PROXY_PORT OTEL_GRPC_PORT OTEL_HTTP_PORT VALKEY_PORT DB_PORT COMPOSE_PROJECT_NAME
+  unset API_PORT WORKER_GRPC_PORT CADDY_ADMIN_PORT UI_PORT PROXY_PORT OTEL_GRPC_PORT OTEL_HTTP_PORT VICTORIAMETRICS_PORT VALKEY_PORT NATS_PORT DB_PORT COMPOSE_PROJECT_NAME
   apply_port_prefix_defaults
 
   assert_eq "27100" "$PROXY_PORT" "prefixed proxy port"
@@ -46,7 +48,9 @@ check_prefixed_ports() {
   assert_eq "27105" "$UI_PORT" "prefixed ui port"
   assert_eq "27117" "$OTEL_GRPC_PORT" "prefixed OTLP gRPC port"
   assert_eq "27118" "$OTEL_HTTP_PORT" "prefixed OTLP HTTP port"
+  assert_eq "27128" "$VICTORIAMETRICS_PORT" "prefixed VictoriaMetrics port"
   assert_eq "27179" "$VALKEY_PORT" "prefixed valkey port"
+  assert_eq "27122" "$NATS_PORT" "prefixed nats port"
   assert_eq "27132" "$DB_PORT" "prefixed db port"
   assert_eq "everruns-271" "$COMPOSE_PROJECT_NAME" "prefixed compose project"
 }
@@ -58,7 +62,7 @@ check_example_ports() {
     echo "FAIL: example compose should not hardcode container_name" >&2
     exit 1
   fi
-  rg -q 'PORT: "9301"' "$compose_file"
+  rg -q 'ADDR: "0.0.0.0:9301"' "$compose_file"
   rg -q 'PORT: "9305"' "$compose_file"
   rg -q 'reverse_proxy server:9301' "$compose_file"
   rg -q 'reverse_proxy ui:9305' "$compose_file"

--- a/specs/code-organization.md
+++ b/specs/code-organization.md
@@ -66,6 +66,7 @@ Tests are organized by dependency requirements and execution speed:
 
 | Category | CI Job | Dependencies | Speed | Run Command |
 |----------|--------|--------------|-------|-------------|
+| Shell (Repo Scripts) | `shell-test` | Bash + repo script deps | ~10s | `just test-shell` |
 | Unit (Pure) | `unit-test` | None | ~30s | `just test-unit` |
 | Integration | `integration-test` | PostgreSQL | ~2min | `just test-integration` |
 | Workflow | `workflow-test` | Server + Worker | ~3min | `just test-workflow` |
@@ -205,6 +206,22 @@ just start-dev --no-watch &
 ./scripts/cli-e2e-test.sh --skip-chat
 ```
 
+### Shell Helper Tests
+
+Repo-owned shell-layer tests live in `scripts/test-*.sh` and run through the
+shared `just test-shell` / `scripts/run-shell-tests.sh` entrypoint. Keep these
+tests in shell when they need to exercise shell libraries, git config/env
+behavior, port-prefix expansion, or process-control scripts directly.
+
+Scope:
+- `scripts/test-*.sh` covers repository shell libraries and helper behavior
+- `.github/scripts/**` stays workflow-specific and is validated by the CI jobs
+  that invoke those scripts directly
+
+```bash
+just test-shell
+```
+
 ### Test Infrastructure
 
 **In-process API testing:**
@@ -231,6 +248,7 @@ just start-dev --no-watch &
 ### Running Tests
 
 ```bash
+just test-shell        # Repo shell helper tests
 just test-unit         # Pure unit tests (~30s)
 just test-integration  # PostgreSQL tests (~2min)
 just test-workflow     # E2E with server/worker


### PR DESCRIPTION
## What
Add a repo-owned shell test entrypoint and wire the existing shell helper tests into CI.

## Why
The shell helper tests existed as ad hoc scripts, so regressions in git identity, port layout, and stop-all behavior were easy to miss.

## How
- add `scripts/run-shell-tests.sh` and `just test-shell` as the supported shell-test entrypoint
- add a `shell-test` CI job plus path filtering and branch-protection aggregation
- document the shell-test scope in `specs/code-organization.md`
- repair `scripts/test-port-layout.sh` so it matches the current example compose contract and covers the full port-prefix defaults from `common.sh`

## Risk
- Low
- What can break: the new CI job could fail if GitHub runner dependencies change or if repo shell tests drift from the assets they validate

## Security
- Threat categories reviewed: `TM-BASH`
- Findings and resolutions: No production/runtime behavior changed. Reviewed the new shell runner and CI job for command injection and scope creep; the runner only executes repo-owned `scripts/test-*.sh` files, and the CI job installs a fixed Caddy version before invoking that entrypoint.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (none yet)
