### PR TITLE
chore(maintenance): require Claude Code plugin freshness review

### DIFF
--- a/.claude/skills/maintenance/SKILL.md
+++ b/.claude/skills/maintenance/SKILL.md
@@ -45,6 +45,7 @@ Use this skill when the task is about repo maintenance rather than a single feat
 - Prefer the highest-signal path first: recent diffs, flaky areas, failing checks, stale specs, outdated dependencies, or known security/performance hotspots.
 - Always run `cargo outdated` (or `cargo search` per-crate) and `npm outdated` during release-readiness or dependency-scoped maintenance — even when no security advisory exists. Patch/minor bumps are cheap to miss and cheap to apply; skipping them silently accumulates drift.
 - Check Linear issues in the OSS project (EVE team) already in `In Progress` when maintenance covers release readiness or workflow hygiene. Treat issues whose `updatedAt` is older than 1 day as stale by default, then triage or report them.
+- When maintenance covers release readiness or repo workflow hygiene, review recent upstream Claude Code changes before declaring the local plugin current. Read the Claude Code changelog, the weekly "What's New" digest, and the plugins reference; compare them against `.claude-plugin/marketplace.json`, `integrations/claude-code-plugin/.claude-plugin/plugin.json`, and any shipped plugin behavior, then either update the plugin or record a concrete follow-up with evidence.
 - Skip untouched areas when there is a clear reason. Say why they were skipped.
 - Prefer fixing over reporting.
 - For bugs uncovered during maintenance, prefer a failing test before the fix when practical.
@@ -135,6 +136,7 @@ Goal: agent instructions, commands, skills, examples, and release helpers still 
 Good evidence:
 - `AGENTS.md`, `.claude/commands/`, and `.claude/skills/` do not contradict each other
 - release or maintenance instructions point at the canonical workflow instead of duplicating stale detail
+- `.claude-plugin/marketplace.json`, `integrations/claude-code-plugin/.claude-plugin/plugin.json`, and shipped Claude Code plugin behavior were checked against recent upstream Claude Code changes; compatibility, versioning, or discoverability gaps were fixed or captured
 
 ## Common Evidence Commands
 

--- a/specs/maintenance.md
+++ b/specs/maintenance.md
@@ -31,6 +31,9 @@ Relevant references:
 - [GitHub Security Overview](https://github.com/everruns/everruns/security)
 - [Dependabot Alerts](https://github.com/everruns/everruns/security/dependabot)
 - [Secret Scanning Alerts](https://github.com/everruns/everruns/security/secret-scanning?query=is%3Aopen+results%3Ageneric)
+- [Claude Code Changelog](https://code.claude.com/docs/en/changelog)
+- [Claude Code What's New](https://code.claude.com/docs/en/whats-new)
+- [Claude Code Plugins Reference](https://code.claude.com/docs/en/plugins-reference)
 
 ## Constraints
 
@@ -62,8 +65,8 @@ Before a release, maintenance should cover:
 - the latest push-only integration live workflows on `main` plus the latest `.github/workflows/integration-live-sweep.yml` result; unresolved failures there block a "release ready" claim until triaged
 - Linear issues already marked `In Progress` whose `updatedAt` is older than 1 day, signaling execution drift; use that `updatedAt` threshold as the default review threshold unless the task sets a stricter bar
 - GitHub Security tab: security overview, Dependabot alerts, and open secret scanning alerts
-
 - dependency versions across all packages (Cargo workspace crates, npm packages, CLI) checked for outdated major versions and deprecated crates
+- the Claude Code plugin surface reviewed against recent upstream Claude Code changes: inspect the latest changelog, the weekly "What's New" digest, and the plugins reference, then compare them to `.claude-plugin/marketplace.json`, `integrations/claude-code-plugin/.claude-plugin/plugin.json`, and shipped plugin behavior; if upstream changes affect compatibility, versioning, or discoverability, update the plugin or record a follow-up with evidence before claiming release readiness
 
 A full-repo sweep is not mandatory if the evidence is already strong. The bar is confidence, not checklist completion theater.
 

--- a/specs/maintenance.md
+++ b/specs/maintenance.md
@@ -40,6 +40,7 @@ Relevant references:
 - Maintenance is risk-proportional, not sweep-proportional. A larger checklist is not inherently better.
 - The selected maintenance scope must be explained, including what was skipped and why.
 - If maintenance changes code or behavior, affected artifacts must stay in sync: specs, docs, OpenAPI, threat model, test cases, agent instructions, and release materials as applicable.
+- When maintenance covers repo workflow hygiene, treat the Claude Code plugin surface as a maintained workflow artifact. Review recent upstream Claude Code changes before claiming the plugin is current.
 - Specs should not duplicate operational workflow text that belongs in skills or commands.
 - Maintenance should prefer concrete fixes over ceremonial audits when a safe local fix exists.
 


### PR DESCRIPTION
## What
Update the maintenance spec and maintenance skill to require a Claude Code plugin freshness review during release-readiness and repo-workflow-hygiene maintenance.

## Why
The repo already ships a Claude Code plugin surface, but maintenance guidance did not explicitly require comparing it against recent upstream Claude Code changes. That made it easy to call the repo current while the plugin metadata or behavior drifted behind upstream expectations.

## How
Add Claude Code changelog, What's New, and plugins-reference links to `specs/maintenance.md`, then add a release-readiness requirement to compare those upstream changes against `.claude-plugin/marketplace.json`, `integrations/claude-code-plugin/.claude-plugin/plugin.json`, and shipped plugin behavior. Mirror the same requirement in `.claude/skills/maintenance/SKILL.md` so the operational workflow stays aligned with the spec.

## Risk
- Low
- Docs/skill guidance only. The main risk is over-scoping future maintenance work, which is limited by keeping the requirement focused on release readiness and repo workflow hygiene.

## Security
- Threat categories reviewed: No security-relevant code changes. Reviewed as docs-only spec/skill markdown updates with no runtime, auth, API, tool-execution, or infrastructure behavior changes.
- Findings and resolutions: No security findings. No threat-model update required.

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
