### PR TITLE
refactor(errors): use structured runtime error metadata

### DIFF
--- a/apps/ui/src/__tests__/runtime-errors.test.ts
+++ b/apps/ui/src/__tests__/runtime-errors.test.ts
@@ -1,0 +1,41 @@
+import { getLocalizedOutputMessageText, localizeRuntimeError } from "@/lib/runtime-errors";
+
+describe("runtime error localization", () => {
+  it("localizes output message text from structured budget metadata instead of fallback prose", () => {
+    const text = getLocalizedOutputMessageText("uk", {
+      message: {
+        id: "msg-1",
+        session_id: "session-1",
+        sequence: 1,
+        role: "agent",
+        content: [{ type: "text", text: "backend fallback changed" }],
+        metadata: {
+          error_code: "budget_exhausted",
+          error_fields: { spent: 12.5, limit: 10, currency: "usd" },
+        },
+        tool_call_id: null,
+        created_at: "2025-01-01T00:00:00.000Z",
+      },
+      error_code: "budget_exhausted",
+      error_fields: { spent: 12.5, limit: 10, currency: "usd" },
+    });
+
+    expect(text).toContain("Бюджет вичерпано");
+    expect(text).toContain("12,50");
+    expect(text).toContain("10,00");
+  });
+
+  it("falls back to structured provider rate-limit copy when retry_after is present", () => {
+    const text = localizeRuntimeError(
+      "uk",
+      {
+        code: "provider_rate_limited",
+        fields: { retry_after: 9 },
+      },
+      "backend fallback changed",
+    );
+
+    expect(text).toContain("9 с");
+    expect(text).not.toContain("backend fallback changed");
+  });
+});

--- a/apps/ui/src/__tests__/trajectory-utils.test.ts
+++ b/apps/ui/src/__tests__/trajectory-utils.test.ts
@@ -115,6 +115,32 @@ function outputMessageCompletedEvent(turnId: string, inputMessageId: string, tex
   );
 }
 
+function structuredOutputMessageCompletedEvent(
+  turnId: string,
+  inputMessageId: string,
+  text: string,
+  errorCode: string,
+  errorFields: Record<string, unknown>,
+): Event {
+  return makeEvent(
+    "output.message.completed",
+    {
+      message: {
+        id: `msg-out-${seqCounter}`,
+        role: "agent",
+        content: [{ type: "text", text }],
+        metadata: {
+          error_code: errorCode,
+          error_fields: errorFields,
+        },
+      },
+      error_code: errorCode,
+      error_fields: errorFields,
+    },
+    turnContext(turnId, inputMessageId),
+  );
+}
+
 function turnCompletedEvent(turnId: string, inputMessageId: string, iterations: number = 1): Event {
   return makeEvent(
     "turn.completed",
@@ -125,6 +151,20 @@ function turnCompletedEvent(turnId: string, inputMessageId: string, iterations: 
 
 function turnFailedEvent(turnId: string, inputMessageId: string, error: string): Event {
   return makeEvent("turn.failed", { turn_id: turnId, error }, turnContext(turnId, inputMessageId));
+}
+
+function structuredTurnFailedEvent(
+  turnId: string,
+  inputMessageId: string,
+  error: string,
+  errorCode: string,
+  errorFields: Record<string, unknown>,
+): Event {
+  return makeEvent(
+    "turn.failed",
+    { turn_id: turnId, error, error_code: errorCode, error_fields: errorFields },
+    turnContext(turnId, inputMessageId),
+  );
 }
 
 // --- Tests ---
@@ -350,6 +390,38 @@ describe("trajectory-utils", () => {
       const groupNodes = nodes.filter((n) => n.type === "turnGroup");
       expect(groupNodes).toHaveLength(1);
       expect(stats.turnCount).toBe(1);
+    });
+
+    it("localizes structured runtime errors for agent and failed turn nodes", () => {
+      const events = [
+        inputMessageEvent("msg-1", "Break"),
+        turnStartedEvent("turn-1", "msg-1"),
+        structuredOutputMessageCompletedEvent(
+          "turn-1",
+          "msg-1",
+          "backend wording changed completely",
+          "budget_exhausted",
+          { spent: 12.5, limit: 10, currency: "usd" },
+        ),
+        structuredTurnFailedEvent(
+          "turn-1",
+          "msg-1",
+          "another backend fallback",
+          "provider_rate_limited",
+          { retry_after: 8 },
+        ),
+      ];
+
+      const { nodes } = buildTrajectory(events, "uk");
+      const agentNode = nodes.find((node) => node.type === "agentMessage");
+      const groupNode = nodes.find((node) => node.type === "turnGroup");
+
+      expect((agentNode?.data as { preview?: string } | undefined)?.preview).toContain(
+        "Бюджет вичерпано",
+      );
+      expect((groupNode?.data as { errorMessage?: string } | undefined)?.errorMessage).toContain(
+        "8 с",
+      );
     });
 
     it("stats reflect merged turns", () => {

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
@@ -14,6 +14,7 @@ import { useAgent, useSession, useEvents, useLlmModel } from "@/hooks";
 import { sendUserMessage, cancelTurn } from "@/lib/api/sessions";
 import { useMutation } from "@tanstack/react-query";
 import { useOrg } from "@/providers/org-provider";
+import { useLocale } from "@/providers/locale-provider";
 import type {
   Agent,
   Session,
@@ -30,6 +31,7 @@ import type {
   TokenUsage,
 } from "@/lib/api/types";
 import { getTextFromContent, isToolCallPart, getEventData } from "@/lib/api/types";
+import { getLocalizedOutputMessageText } from "@/lib/runtime-errors";
 import type { UseMutationResult } from "@tanstack/react-query";
 
 /** Accumulated streamed output for a single tool call */
@@ -113,6 +115,7 @@ interface SessionProviderProps {
 // Session provider that derives agentId from the session (for org-level routes)
 export function SessionProvider({ sessionId, children }: SessionProviderProps) {
   const { currentOrg } = useOrg();
+  const { locale } = useLocale();
   const org = currentOrg?.public_id;
 
   // Fetch session first to get agent_id
@@ -545,9 +548,11 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
     (data: InputMessageData | OutputMessageCompletedData): string => {
       const content = data.message?.content;
       if (!content) return "";
-      return getTextFromContent(content);
+      return data.message?.role === "agent"
+        ? getLocalizedOutputMessageText(locale, data as OutputMessageCompletedData)
+        : getTextFromContent(content);
     },
-    [],
+    [locale],
   );
 
   // Get tool calls from message event data (stable ref — no deps)

--- a/apps/ui/src/components/trajectory/trajectory-nodes.tsx
+++ b/apps/ui/src/components/trajectory/trajectory-nodes.tsx
@@ -59,6 +59,11 @@ export const TurnGroupNode = memo(function TurnGroupNode({
           </span>
         )}
       </div>
+      {failed && d.errorMessage && (
+        <div className="px-3 py-2 text-[11px] leading-relaxed text-red-700/85 dark:text-red-200/85 line-clamp-2">
+          {d.errorMessage}
+        </div>
+      )}
     </div>
   );
 });

--- a/apps/ui/src/components/trajectory/trajectory-utils.ts
+++ b/apps/ui/src/components/trajectory/trajectory-utils.ts
@@ -12,6 +12,13 @@
 import type { Node, Edge } from "@xyflow/react";
 import type { Event, ToolCompletedData } from "@/lib/api/types";
 import { getTextFromContent, getEventData } from "@/lib/api/types";
+import type { SupportedLocale } from "@/lib/i18n";
+import {
+  getRuntimeErrorFromOutputMessage,
+  getRuntimeErrorFromTurnFailed,
+  localizeRuntimeError,
+  type RuntimeErrorInfo,
+} from "@/lib/runtime-errors";
 
 // --- Node data types ---
 
@@ -142,10 +149,12 @@ export interface TurnAccumulator {
     ts: string;
     hasToolCalls: boolean;
     phase?: string;
+    runtimeError?: RuntimeErrorInfo;
   };
   completed: boolean;
   failed: boolean;
   errorMessage?: string;
+  runtimeError?: RuntimeErrorInfo;
   durationMs?: number;
   iterationCount?: number;
 }
@@ -308,6 +317,7 @@ export function buildTurns(events: Event[]): TurnAccumulator[] {
           ts: event.ts,
           hasToolCalls,
           phase: data.message?.phase,
+          runtimeError: getRuntimeErrorFromOutputMessage(data),
         };
         break;
       }
@@ -331,6 +341,7 @@ export function buildTurns(events: Event[]): TurnAccumulator[] {
         currentTurn.completed = true;
         currentTurn.failed = true;
         currentTurn.errorMessage = data.error;
+        currentTurn.runtimeError = getRuntimeErrorFromTurnFailed(data);
         currentTurn = null;
         currentIteration = null;
         break;
@@ -381,7 +392,10 @@ function computeStats(turns: TurnAccumulator[]): TrajectoryStats {
  * Edges connect children sequentially within a turn,
  * and from the last child of one turn to the first child of the next.
  */
-export function buildTrajectory(events: Event[]): {
+export function buildTrajectory(
+  events: Event[],
+  locale: SupportedLocale = "en",
+): {
   nodes: Node[];
   edges: Edge[];
   stats: TrajectoryStats;
@@ -473,9 +487,14 @@ export function buildTrajectory(events: Event[]): {
     // Agent message
     if (turn.agentMessage) {
       const amId = `turn-${turnIdx}-agent`;
+      const localizedAgentText = localizeRuntimeError(
+        locale,
+        turn.agentMessage.runtimeError,
+        turn.agentMessage.text,
+      );
       addChild(amId, "agentMessage", {
         label: "Agent",
-        preview: truncate(turn.agentMessage.text, 100),
+        preview: truncate(localizedAgentText, 100),
         eventId: turn.agentMessage.eventId,
         timestamp: turn.agentMessage.ts,
         hasToolCalls: turn.agentMessage.hasToolCalls,
@@ -499,7 +518,7 @@ export function buildTrajectory(events: Event[]): {
         iterations: turn.iterationCount ?? turn.iterations.length,
         durationMs: turn.durationMs,
         failed: turn.failed,
-        errorMessage: turn.errorMessage,
+        errorMessage: localizeRuntimeError(locale, turn.runtimeError, turn.errorMessage ?? ""),
         timestamp: turn.startTs,
       } as TurnGroupNodeData & Record<string, unknown>, // single cast: TS interface -> Record
       style: {

--- a/apps/ui/src/components/trajectory/trajectory-view.tsx
+++ b/apps/ui/src/components/trajectory/trajectory-view.tsx
@@ -23,6 +23,7 @@ import { Repeat, Wrench, XCircle, Clock } from "lucide-react";
 
 import type { Event } from "@/lib/api/types";
 import { formatDurationCompact } from "@/lib/formatting";
+import { useLocale } from "@/providers/locale-provider";
 import { buildTrajectory, countStructuralEvents, type TrajectoryStats } from "./trajectory-utils";
 import { trajectoryNodeTypes } from "./trajectory-nodes";
 
@@ -96,6 +97,7 @@ function StatsBar({ stats }: { stats: TrajectoryStats }) {
 }
 
 export function TrajectoryView({ events, colorMode }: TrajectoryViewProps) {
+  const { locale } = useLocale();
   // Count structural events as a stable primitive memoization key.
   // This number only changes when a turn/reason/act/tool/message event arrives,
   // NOT on every output.message.delta or reason.thinking.delta (which fire 10-30x/sec).
@@ -103,9 +105,9 @@ export function TrajectoryView({ events, colorMode }: TrajectoryViewProps) {
 
   // Build nodes/edges/stats only when structural events change
   const { nodes, edges, stats } = useMemo(
-    () => buildTrajectory(events),
+    () => buildTrajectory(events, locale),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: gate on structuralCount, not events ref
-    [structuralCount],
+    [structuralCount, locale],
   );
 
   // Fit view on mount

--- a/apps/ui/src/lib/api/types/event-types.ts
+++ b/apps/ui/src/lib/api/types/event-types.ts
@@ -86,6 +86,8 @@ export interface OutputMessageCompletedData {
   message: Message;
   metadata?: ModelMetadata;
   usage?: TokenUsage;
+  error_code?: string;
+  error_fields?: Record<string, unknown>;
 }
 
 /** Data for turn.started event */
@@ -112,6 +114,7 @@ export interface TurnFailedData {
   turn_id: string;
   error: string;
   error_code?: string;
+  error_fields?: Record<string, unknown>;
 }
 
 /** Data for reason.started event */

--- a/apps/ui/src/lib/i18n.ts
+++ b/apps/ui/src/lib/i18n.ts
@@ -66,6 +66,36 @@ const messages = {
     collapse_activity_group: "Collapse activity group",
     expand_activity_group: "Expand activity group",
     error_prefix: "Error: {value}",
+    runtime_error_budget_exhausted_reached:
+      "Budget exhausted. {spent} {currency} spent reached the {limit} {currency} limit. Increase the budget to continue.",
+    runtime_error_budget_exhausted_exceeded:
+      "Budget exhausted. {spent} {currency} spent exceeded the {limit} {currency} limit. Increase the budget to continue.",
+    runtime_error_budget_exhausted_generic: "Budget exhausted. Increase the budget to continue.",
+    runtime_error_budget_paused_reached:
+      "Budget paused. {spent} {currency} spent reached the {soft_limit} {currency} soft limit. Increase or resume the budget to continue.",
+    runtime_error_budget_paused_exceeded:
+      "Budget paused. {spent} {currency} spent exceeded the {soft_limit} {currency} soft limit. Increase or resume the budget to continue.",
+    runtime_error_budget_paused_with_spent:
+      "Budget paused with {spent} {currency} spent. Increase or resume the budget to continue.",
+    runtime_error_budget_paused_generic:
+      "Budget paused. Increase or resume the budget to continue.",
+    runtime_error_model_unavailable:
+      "The model `{value}` is not available. It may have been removed, renamed, or your API key may not have access to it. Please select a different model.",
+    runtime_error_model_unavailable_generic:
+      "The selected model is not available. Please select a different model.",
+    runtime_error_request_too_large:
+      "The conversation has become too long for the model to process. Please start a new session or reduce the context size.",
+    runtime_error_provider_rate_limited: "Rate limited by the AI provider. Please wait a moment.",
+    runtime_error_provider_rate_limited_retry_after:
+      "Rate limited by the AI provider. Please wait {retry_after}s and try again.",
+    runtime_error_provider_misconfigured:
+      "There is a misconfiguration with the AI provider. Please contact support.",
+    runtime_error_provider_unavailable:
+      "The AI provider is experiencing issues. Please try again shortly.",
+    runtime_error_processing_error:
+      "I encountered an error while processing your request. Please try again later.",
+    runtime_error_dependency_unavailable:
+      "Execution stopped because a required dependency is unavailable.",
     binary_file: "binary file{value}",
     image_count_one: "{count} image",
     image_count_few: "{count} images",
@@ -165,6 +195,35 @@ const messages = {
     collapse_activity_group: "Згорнути групу активності",
     expand_activity_group: "Розгорнути групу активності",
     error_prefix: "Помилка: {value}",
+    runtime_error_budget_exhausted_reached:
+      "Бюджет вичерпано. Витрачено {spent} {currency}, що досягло ліміту {limit} {currency}. Збільште бюджет, щоб продовжити.",
+    runtime_error_budget_exhausted_exceeded:
+      "Бюджет вичерпано. Витрачено {spent} {currency}, що перевищило ліміт {limit} {currency}. Збільште бюджет, щоб продовжити.",
+    runtime_error_budget_exhausted_generic: "Бюджет вичерпано. Збільште бюджет, щоб продовжити.",
+    runtime_error_budget_paused_reached:
+      "Бюджет призупинено. Витрачено {spent} {currency}, що досягло м'якого ліміту {soft_limit} {currency}. Збільште бюджет або відновіть його, щоб продовжити.",
+    runtime_error_budget_paused_exceeded:
+      "Бюджет призупинено. Витрачено {spent} {currency}, що перевищило м'який ліміт {soft_limit} {currency}. Збільште бюджет або відновіть його, щоб продовжити.",
+    runtime_error_budget_paused_with_spent:
+      "Бюджет призупинено після витрати {spent} {currency}. Збільште бюджет або відновіть його, щоб продовжити.",
+    runtime_error_budget_paused_generic:
+      "Бюджет призупинено. Збільште бюджет або відновіть його, щоб продовжити.",
+    runtime_error_model_unavailable:
+      "Модель `{value}` недоступна. Її могли видалити, перейменувати або ваш API-ключ не має до неї доступу. Виберіть іншу модель.",
+    runtime_error_model_unavailable_generic: "Вибрана модель недоступна. Виберіть іншу модель.",
+    runtime_error_request_too_large:
+      "Розмова стала надто довгою для цієї моделі. Почніть нову сесію або зменште розмір контексту.",
+    runtime_error_provider_rate_limited:
+      "AI-провайдер тимчасово обмежив запити. Зачекайте трохи й спробуйте ще раз.",
+    runtime_error_provider_rate_limited_retry_after:
+      "AI-провайдер тимчасово обмежив запити. Зачекайте {retry_after} с і спробуйте ще раз.",
+    runtime_error_provider_misconfigured:
+      "AI-провайдер налаштований некоректно. Зверніться до підтримки.",
+    runtime_error_provider_unavailable:
+      "AI-провайдер зараз недоступний. Спробуйте ще раз трохи пізніше.",
+    runtime_error_processing_error:
+      "Під час обробки вашого запиту сталася помилка. Спробуйте ще раз пізніше.",
+    runtime_error_dependency_unavailable: "Виконання зупинено, бо потрібна залежність недоступна.",
     binary_file: "бінарний файл{value}",
     image_count_one: "{count} зображення",
     image_count_few: "{count} зображення",

--- a/apps/ui/src/lib/runtime-errors.ts
+++ b/apps/ui/src/lib/runtime-errors.ts
@@ -1,0 +1,177 @@
+import type { OutputMessageCompletedData, TurnFailedData } from "@/lib/api/types";
+import { getTextFromContent, isRecord } from "@/lib/api/types";
+import { formatMessage, type SupportedLocale } from "@/lib/i18n";
+
+export interface RuntimeErrorInfo {
+  code: string;
+  fields?: Record<string, unknown>;
+}
+
+export function getRuntimeErrorFromOutputMessage(
+  data?: OutputMessageCompletedData | null,
+): RuntimeErrorInfo | undefined {
+  if (!data) return undefined;
+
+  if (typeof data.error_code === "string") {
+    return {
+      code: data.error_code,
+      fields: isRecord(data.error_fields) ? data.error_fields : undefined,
+    };
+  }
+
+  const metadata = isRecord(data.message?.metadata) ? data.message.metadata : undefined;
+  if (!metadata || typeof metadata.error_code !== "string") {
+    return undefined;
+  }
+
+  return {
+    code: metadata.error_code,
+    fields: isRecord(metadata.error_fields) ? metadata.error_fields : undefined,
+  };
+}
+
+export function getRuntimeErrorFromTurnFailed(
+  data?: TurnFailedData | null,
+): RuntimeErrorInfo | undefined {
+  if (!data?.error_code) return undefined;
+  return {
+    code: data.error_code,
+    fields: isRecord(data.error_fields) ? data.error_fields : undefined,
+  };
+}
+
+export function getLocalizedOutputMessageText(
+  locale: SupportedLocale,
+  data: OutputMessageCompletedData,
+): string {
+  const fallback = getTextFromContent(data.message?.content ?? []);
+  return localizeRuntimeError(locale, getRuntimeErrorFromOutputMessage(data), fallback);
+}
+
+export function localizeRuntimeError(
+  locale: SupportedLocale,
+  error: RuntimeErrorInfo | undefined,
+  fallback: string,
+): string {
+  if (!error?.code) return fallback;
+
+  switch (error.code) {
+    case "budget_exhausted":
+      return localizeBudgetExhausted(locale, error.fields, fallback);
+    case "budget_paused":
+      return localizeBudgetPaused(locale, error.fields, fallback);
+    case "model_unavailable": {
+      const modelId = stringField(error.fields, "model_id");
+      return modelId
+        ? formatMessage(locale, "runtime_error_model_unavailable", { value: modelId })
+        : formatMessage(locale, "runtime_error_model_unavailable_generic");
+    }
+    case "request_too_large":
+      return formatMessage(locale, "runtime_error_request_too_large");
+    case "provider_rate_limited": {
+      const retryAfter = integerField(error.fields, "retry_after");
+      return retryAfter != null
+        ? formatMessage(locale, "runtime_error_provider_rate_limited_retry_after", {
+            retry_after: retryAfter,
+          })
+        : formatMessage(locale, "runtime_error_provider_rate_limited");
+    }
+    case "provider_misconfigured":
+      return formatMessage(locale, "runtime_error_provider_misconfigured");
+    case "provider_unavailable":
+      return formatMessage(locale, "runtime_error_provider_unavailable");
+    case "processing_error":
+      return formatMessage(locale, "runtime_error_processing_error");
+    case "dependency_unavailable":
+      return formatMessage(locale, "runtime_error_dependency_unavailable");
+    default:
+      return fallback;
+  }
+}
+
+function localizeBudgetExhausted(
+  locale: SupportedLocale,
+  fields: Record<string, unknown> | undefined,
+  fallback: string,
+): string {
+  const spent = numberField(fields, "spent");
+  const limit = numberField(fields, "limit");
+  const currency = stringField(fields, "currency");
+  if (spent == null || limit == null || !currency) {
+    return fallback || formatMessage(locale, "runtime_error_budget_exhausted_generic");
+  }
+
+  return formatMessage(
+    locale,
+    spent > limit
+      ? "runtime_error_budget_exhausted_exceeded"
+      : "runtime_error_budget_exhausted_reached",
+    {
+      spent: formatFixed(locale, spent),
+      limit: formatFixed(locale, limit),
+      currency,
+    },
+  );
+}
+
+function localizeBudgetPaused(
+  locale: SupportedLocale,
+  fields: Record<string, unknown> | undefined,
+  fallback: string,
+): string {
+  const spent = numberField(fields, "spent");
+  const softLimit = numberField(fields, "soft_limit");
+  const currency = stringField(fields, "currency");
+
+  if (spent == null || !currency) {
+    return fallback || formatMessage(locale, "runtime_error_budget_paused_generic");
+  }
+
+  if (softLimit == null) {
+    return formatMessage(locale, "runtime_error_budget_paused_with_spent", {
+      spent: formatFixed(locale, spent),
+      currency,
+    });
+  }
+
+  return formatMessage(
+    locale,
+    spent > softLimit
+      ? "runtime_error_budget_paused_exceeded"
+      : "runtime_error_budget_paused_reached",
+    {
+      spent: formatFixed(locale, spent),
+      soft_limit: formatFixed(locale, softLimit),
+      currency,
+    },
+  );
+}
+
+function formatFixed(locale: SupportedLocale, value: number): string {
+  return new Intl.NumberFormat(locale === "uk" ? "uk-UA" : "en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function stringField(fields: Record<string, unknown> | undefined, key: string): string | undefined {
+  return typeof fields?.[key] === "string" ? (fields[key] as string) : undefined;
+}
+
+function numberField(fields: Record<string, unknown> | undefined, key: string): number | undefined {
+  const value = fields?.[key];
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function integerField(
+  fields: Record<string, unknown> | undefined,
+  key: string,
+): number | undefined {
+  const value = numberField(fields, key);
+  return value == null ? undefined : Math.round(value);
+}

--- a/apps/ui/src/lib/runtime-errors.ts
+++ b/apps/ui/src/lib/runtime-errors.ts
@@ -173,5 +173,5 @@ function integerField(
   key: string,
 ): number | undefined {
   const value = numberField(fields, key);
-  return value == null ? undefined : Math.round(value);
+  return value == null ? undefined : Math.trunc(value);
 }

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -125,6 +125,7 @@ fn is_error_placeholder_message(msg: &Message) -> bool {
                 | user_facing_error_codes::PROVIDER_RATE_LIMITED
                 | user_facing_error_codes::PROVIDER_MISCONFIGURED
                 | user_facing_error_codes::PROVIDER_UNAVAILABLE
+                | user_facing_error_codes::DEPENDENCY_UNAVAILABLE
                 | user_facing_error_codes::PROCESSING_ERROR
         );
     }

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -52,6 +52,7 @@ use crate::traits::{
     ResolvedImage, SessionStore,
 };
 use crate::typed_id::{AgentId, HarnessId, SessionId};
+use crate::{UserFacingErrorContext, user_facing_error_codes};
 
 // ============================================================================
 // Helper Functions
@@ -111,6 +112,21 @@ fn is_error_placeholder_message(msg: &Message) -> bool {
     // Must have no tool calls (pure text-only error message)
     if msg.has_tool_calls() {
         return false;
+    }
+    if let Some(metadata) = &msg.metadata
+        && let Some(serde_json::Value::String(code)) = metadata.get("error_code")
+    {
+        return matches!(
+            code.as_str(),
+            user_facing_error_codes::BUDGET_EXHAUSTED
+                | user_facing_error_codes::BUDGET_PAUSED
+                | user_facing_error_codes::MODEL_UNAVAILABLE
+                | user_facing_error_codes::REQUEST_TOO_LARGE
+                | user_facing_error_codes::PROVIDER_RATE_LIMITED
+                | user_facing_error_codes::PROVIDER_MISCONFIGURED
+                | user_facing_error_codes::PROVIDER_UNAVAILABLE
+                | user_facing_error_codes::PROCESSING_ERROR
+        );
     }
     let text = msg.text().unwrap_or("");
     ERROR_PLACEHOLDER_MESSAGES.contains(&text) || is_dynamic_error_placeholder(text)
@@ -511,9 +527,8 @@ impl ReasonAtom {
                 );
 
                 let error_msg = e.to_string();
-
-                // User-facing error message based on error classification
-                let user_error_text = e.user_facing_message();
+                let user_error = e.user_facing_error(UserFacingErrorContext::default());
+                let user_error_text = user_error.fallback_message();
 
                 // Only emit user-facing error events for non-transient errors.
                 // Transient errors (server errors, rate limits, timeouts) will be
@@ -525,7 +540,10 @@ impl ReasonAtom {
 
                 if !is_transient {
                     // Create error message for the user to see
-                    let error_message = Message::assistant(&user_error_text);
+                    let mut error_message = Message::assistant(&user_error_text);
+                    let mut metadata = std::collections::HashMap::new();
+                    user_error.apply_to_message_metadata(&mut metadata);
+                    error_message.metadata = Some(metadata);
 
                     // Emit output.message.completed event (stores message as event with proper turn context)
                     // output.message.completed is child of reason span
@@ -539,7 +557,8 @@ impl ReasonAtom {
                         .emit(EventRequest::new(
                             context.session_id,
                             error_msg_context,
-                            OutputMessageCompletedData::new(error_message),
+                            OutputMessageCompletedData::new(error_message)
+                                .with_user_facing_error(&user_error),
                         ))
                         .await
                     {

--- a/crates/core/src/budget.rs
+++ b/crates/core/src/budget.rs
@@ -8,10 +8,9 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
-use std::collections::BTreeMap;
 
 use crate::typed_id::{BudgetId, SessionId};
+use crate::user_facing_error::UserFacingErrorFields;
 
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
@@ -206,7 +205,7 @@ pub struct BudgetCheckResult {
     /// Structured interpolation fields for localized error rendering.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "openapi", schema(value_type = Option<Object>))]
-    pub error_fields: Option<BTreeMap<String, Value>>,
+    pub error_fields: Option<UserFacingErrorFields>,
 }
 
 impl BudgetCheckResult {

--- a/crates/core/src/budget.rs
+++ b/crates/core/src/budget.rs
@@ -8,6 +8,8 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeMap;
 
 use crate::typed_id::{BudgetId, SessionId};
 
@@ -198,6 +200,13 @@ pub struct BudgetCheckResult {
     /// Currency of the most restrictive budget.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub currency: Option<String>,
+    /// Stable error code for user-facing budget failures.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<String>,
+    /// Structured interpolation fields for localized error rendering.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<Object>))]
+    pub error_fields: Option<BTreeMap<String, Value>>,
 }
 
 impl BudgetCheckResult {
@@ -208,6 +217,8 @@ impl BudgetCheckResult {
             budget_id: None,
             balance: None,
             currency: None,
+            error_code: None,
+            error_fields: None,
         }
     }
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -4,6 +4,10 @@
 // json_val / from_json: helpers to replace repeated serde_json::to_value/from_value boilerplate
 
 use crate::typed_id::{AgentId, HarnessId, SessionId};
+use crate::user_facing_error::{
+    UserFacingError, UserFacingErrorContext, classify_runtime_error_message,
+    codes as user_facing_error_codes,
+};
 use serde::{Serialize, de::DeserializeOwned};
 use thiserror::Error;
 
@@ -218,26 +222,30 @@ impl AgentLoopError {
 
     /// Get user-facing error message based on error classification
     pub fn user_facing_message(&self) -> String {
-        if let Some(model_id) = self.model_not_available_id() {
-            format!(
-                "The model `{}` is not available. It may have been removed, \
-                 renamed, or your API key may not have access to it. \
-                 Please select a different model.",
-                model_id
-            )
-        } else if self.is_request_too_large() {
-            "The conversation has become too long for the model to process. \
-             Please start a new session or reduce the context size."
-                .to_string()
-        } else if self.is_rate_limited() {
-            "Rate limited by the AI provider. Please wait a moment.".to_string()
-        } else if self.is_auth_error() {
-            "There is a misconfiguration with the AI provider. Please contact support.".to_string()
-        } else if self.is_server_error() {
-            "The AI provider is experiencing issues. Please try again shortly.".to_string()
-        } else {
-            "I encountered an error while processing your request. Please try again later."
-                .to_string()
+        self.user_facing_error(UserFacingErrorContext::default())
+            .fallback_message()
+    }
+
+    /// Get structured user-facing error metadata based on error classification.
+    pub fn user_facing_error(&self, context: UserFacingErrorContext) -> UserFacingError {
+        match self {
+            AgentLoopError::ModelNotAvailable(model_id) => {
+                UserFacingError::new(user_facing_error_codes::MODEL_UNAVAILABLE)
+                    .with_field("model_id", model_id)
+                    .with_optional_field("provider", context.provider)
+            }
+            AgentLoopError::RequestTooLarge(_) => {
+                UserFacingError::new(user_facing_error_codes::REQUEST_TOO_LARGE)
+                    .with_optional_field("provider", context.provider)
+                    .with_optional_field("model_id", context.model_id)
+            }
+            AgentLoopError::MaxIterationsReached(max_iterations) => {
+                UserFacingError::new("max_iterations").with_field("max_iterations", max_iterations)
+            }
+            AgentLoopError::Llm(message) => classify_runtime_error_message(message, &context),
+            _ => UserFacingError::new(user_facing_error_codes::PROCESSING_ERROR)
+                .with_optional_field("provider", context.provider)
+                .with_optional_field("model_id", context.model_id),
         }
     }
 }
@@ -439,6 +447,46 @@ mod tests {
     fn test_user_facing_message_request_too_large() {
         let err = AgentLoopError::request_too_large("context length exceeded");
         assert!(err.user_facing_message().contains("too long"));
+    }
+
+    #[test]
+    fn test_user_facing_error_model_not_available_includes_model_id() {
+        let err = AgentLoopError::model_not_available("gpt-99");
+        let user_error = err.user_facing_error(UserFacingErrorContext::default());
+
+        assert_eq!(user_error.code, user_facing_error_codes::MODEL_UNAVAILABLE);
+        assert_eq!(
+            user_error.fields.get("model_id"),
+            Some(&serde_json::Value::String("gpt-99".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_user_facing_error_rate_limited_includes_provider_context() {
+        let err = AgentLoopError::llm("Anthropic API error (429): rate limit exceeded");
+        let user_error = err.user_facing_error(
+            UserFacingErrorContext::default()
+                .with_provider("anthropic")
+                .with_model_id("claude-sonnet-4-5")
+                .with_retry_after(12),
+        );
+
+        assert_eq!(
+            user_error.code,
+            user_facing_error_codes::PROVIDER_RATE_LIMITED
+        );
+        assert_eq!(
+            user_error.fields.get("provider"),
+            Some(&serde_json::Value::String("anthropic".to_string()))
+        );
+        assert_eq!(
+            user_error.fields.get("model_id"),
+            Some(&serde_json::Value::String("claude-sonnet-4-5".to_string()))
+        );
+        assert_eq!(
+            user_error.fields.get("retry_after"),
+            Some(&serde_json::json!(12))
+        );
     }
 
     #[test]

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -240,7 +240,8 @@ impl AgentLoopError {
                     .with_optional_field("model_id", context.model_id)
             }
             AgentLoopError::MaxIterationsReached(max_iterations) => {
-                UserFacingError::new("max_iterations").with_field("max_iterations", max_iterations)
+                UserFacingError::new(user_facing_error_codes::MAX_ITERATIONS)
+                    .with_field("max_iterations", max_iterations)
             }
             AgentLoopError::Llm(message) => classify_runtime_error_message(message, &context),
             _ => UserFacingError::new(user_facing_error_codes::PROCESSING_ERROR)

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -29,6 +29,7 @@ use utoipa::ToSchema;
 
 use crate::localization::localized_tool_display_name;
 use crate::typed_id::{AgentId, EventId, ExecId, HarnessId, MessageId, ModelId, SessionId, TurnId};
+use crate::user_facing_error::{UserFacingError, UserFacingErrorFields};
 
 // ============================================================================
 // Event Type Constants
@@ -554,6 +555,15 @@ pub struct OutputMessageCompletedData {
     /// Token usage
     #[serde(skip_serializing_if = "Option::is_none")]
     pub usage: Option<TokenUsage>,
+
+    /// Stable error code for user-facing failures surfaced as assistant text.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<String>,
+
+    /// Structured interpolation fields for localized error rendering.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<Object>))]
+    pub error_fields: Option<UserFacingErrorFields>,
 }
 
 impl OutputMessageCompletedData {
@@ -562,6 +572,8 @@ impl OutputMessageCompletedData {
             message,
             metadata: None,
             usage: None,
+            error_code: None,
+            error_fields: None,
         }
     }
 
@@ -572,6 +584,11 @@ impl OutputMessageCompletedData {
 
     pub fn with_usage(mut self, usage: TokenUsage) -> Self {
         self.usage = Some(usage);
+        self
+    }
+
+    pub fn with_user_facing_error(mut self, error: &UserFacingError) -> Self {
+        error.apply_to_event_fields(&mut self.error_code, &mut self.error_fields);
         self
     }
 }
@@ -1503,8 +1520,13 @@ pub struct TurnFailedData {
     pub error: String,
 
     /// Error code
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error_code: Option<String>,
+
+    /// Structured interpolation fields for localized error rendering.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<Object>))]
+    pub error_fields: Option<UserFacingErrorFields>,
 }
 
 /// Data for turn.cancelled event
@@ -2924,6 +2946,7 @@ mod contract_tests {
             turn_id: test_turn_id(),
             error: "Rate limit exceeded".to_string(),
             error_code: Some("RATE_LIMIT".to_string()),
+            error_fields: None,
         };
         with_settings!({
             sort_maps => true,
@@ -3411,6 +3434,7 @@ mod contract_tests {
                     turn_id: test_turn_id(),
                     error: "err".to_string(),
                     error_code: None,
+                    error_fields: None,
                 }
                 .into(),
             ),

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -113,6 +113,7 @@ pub mod runtime_context;
 pub mod tool_output_sanitizer;
 pub mod tools;
 pub mod traits;
+pub mod user_facing_error;
 
 // In-memory implementations for examples and testing
 pub mod memory;
@@ -155,6 +156,10 @@ pub use traits::{
     ModelWithProvider, NoopEventEmitter, ResolvedImage, SecretInfo, SessionFileStore,
     SessionMutator, SessionResourceRegistry, SessionSqlDbStoreRef, SessionStorageStore,
     SessionStore, ToolContext, ToolExecutor, UserConnectionResolver,
+};
+pub use user_facing_error::{
+    UserFacingError, UserFacingErrorContext, UserFacingErrorFields, classify_runtime_error_message,
+    codes as user_facing_error_codes, trim_error_chain_prefixes,
 };
 
 // Memory store re-exports

--- a/crates/core/src/observation/otel.rs
+++ b/crates/core/src/observation/otel.rs
@@ -942,6 +942,7 @@ mod tests {
             turn_id,
             error: "model overloaded".to_string(),
             error_code: Some("overloaded".to_string()),
+            error_fields: None,
         };
         listener
             .on_event(&Event::new(
@@ -1016,6 +1017,7 @@ mod tests {
             turn_id: make_turn_id(),
             error: "something broke".to_string(),
             error_code: None,
+            error_fields: None,
         };
         listener
             .on_event(&Event::new(

--- a/crates/core/src/user_facing_error.rs
+++ b/crates/core/src/user_facing_error.rs
@@ -1,0 +1,438 @@
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::OnceLock;
+
+#[cfg(feature = "openapi")]
+use utoipa::ToSchema;
+
+pub mod codes {
+    pub const BUDGET_EXHAUSTED: &str = "budget_exhausted";
+    pub const BUDGET_PAUSED: &str = "budget_paused";
+    pub const MODEL_UNAVAILABLE: &str = "model_unavailable";
+    pub const REQUEST_TOO_LARGE: &str = "request_too_large";
+    pub const PROVIDER_RATE_LIMITED: &str = "provider_rate_limited";
+    pub const PROVIDER_MISCONFIGURED: &str = "provider_misconfigured";
+    pub const PROVIDER_UNAVAILABLE: &str = "provider_unavailable";
+    pub const PROCESSING_ERROR: &str = "processing_error";
+    pub const DEPENDENCY_UNAVAILABLE: &str = "dependency_unavailable";
+    pub const SOFT_LIMIT_REACHED: &str = "soft_limit_reached";
+}
+
+pub type UserFacingErrorFields = BTreeMap<String, Value>;
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct UserFacingError {
+    pub code: String,
+    #[serde(default, skip_serializing_if = "UserFacingErrorFields::is_empty")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
+    pub fields: UserFacingErrorFields,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct UserFacingErrorContext {
+    pub provider: Option<String>,
+    pub model_id: Option<String>,
+    pub retry_after: Option<u64>,
+}
+
+impl UserFacingErrorContext {
+    pub fn with_provider(mut self, provider: impl Into<String>) -> Self {
+        self.provider = Some(provider.into());
+        self
+    }
+
+    pub fn with_model_id(mut self, model_id: impl Into<String>) -> Self {
+        self.model_id = Some(model_id.into());
+        self
+    }
+
+    pub fn with_retry_after(mut self, retry_after: u64) -> Self {
+        self.retry_after = Some(retry_after);
+        self
+    }
+}
+
+impl UserFacingError {
+    pub fn new(code: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            fields: UserFacingErrorFields::new(),
+        }
+    }
+
+    pub fn with_field<T: Serialize>(mut self, key: impl Into<String>, value: T) -> Self {
+        let value = serde_json::to_value(value).unwrap_or(Value::Null);
+        if !value.is_null() {
+            self.fields.insert(key.into(), value);
+        }
+        self
+    }
+
+    pub fn with_optional_field<T: Serialize>(
+        self,
+        key: impl Into<String>,
+        value: Option<T>,
+    ) -> Self {
+        match value {
+            Some(value) => self.with_field(key, value),
+            None => self,
+        }
+    }
+
+    pub fn error_fields(&self) -> Option<UserFacingErrorFields> {
+        (!self.fields.is_empty()).then_some(self.fields.clone())
+    }
+
+    pub fn apply_to_event_fields(
+        &self,
+        error_code: &mut Option<String>,
+        error_fields: &mut Option<UserFacingErrorFields>,
+    ) {
+        *error_code = Some(self.code.clone());
+        *error_fields = self.error_fields();
+    }
+
+    pub fn apply_to_message_metadata(&self, metadata: &mut HashMap<String, Value>) {
+        metadata.insert("error_code".to_string(), Value::String(self.code.clone()));
+        if let Some(fields) = self.error_fields() {
+            metadata.insert(
+                "error_fields".to_string(),
+                serde_json::to_value(fields).unwrap_or(Value::Null),
+            );
+        }
+    }
+
+    pub fn fallback_message(&self) -> String {
+        match self.code.as_str() {
+            codes::BUDGET_EXHAUSTED => budget_exhausted_message(&self.fields),
+            codes::BUDGET_PAUSED => budget_paused_message(&self.fields),
+            codes::SOFT_LIMIT_REACHED => string_field(&self.fields, "message")
+                .unwrap_or("Soft limit reached.")
+                .to_string(),
+            codes::MODEL_UNAVAILABLE => {
+                if let Some(model_id) = string_field(&self.fields, "model_id") {
+                    format!(
+                        "The model `{}` is not available. It may have been removed, renamed, or your API key may not have access to it. Please select a different model.",
+                        model_id
+                    )
+                } else {
+                    "The selected model is not available. Please select a different model."
+                        .to_string()
+                }
+            }
+            codes::REQUEST_TOO_LARGE => {
+                "The conversation has become too long for the model to process. Please start a new session or reduce the context size.".to_string()
+            }
+            codes::PROVIDER_RATE_LIMITED => {
+                "Rate limited by the AI provider. Please wait a moment.".to_string()
+            }
+            codes::PROVIDER_MISCONFIGURED => {
+                "There is a misconfiguration with the AI provider. Please contact support."
+                    .to_string()
+            }
+            codes::PROVIDER_UNAVAILABLE => {
+                "The AI provider is experiencing issues. Please try again shortly.".to_string()
+            }
+            codes::DEPENDENCY_UNAVAILABLE => {
+                "Execution stopped because a required dependency is unavailable.".to_string()
+            }
+            _ => "I encountered an error while processing your request. Please try again later."
+                .to_string(),
+        }
+    }
+}
+
+pub fn classify_runtime_error_message(
+    error: &str,
+    context: &UserFacingErrorContext,
+) -> UserFacingError {
+    let normalized = trim_error_chain_prefixes(error).trim();
+    let lower = normalized.to_ascii_lowercase();
+
+    if let Some(fields) = parse_budget_exhausted_fields(normalized) {
+        return UserFacingError {
+            code: codes::BUDGET_EXHAUSTED.to_string(),
+            fields,
+        };
+    }
+
+    if normalized.starts_with("Budget exhausted.") {
+        return UserFacingError::new(codes::BUDGET_EXHAUSTED);
+    }
+
+    if normalized.starts_with("Budget exhausted (") {
+        return UserFacingError::new(codes::BUDGET_EXHAUSTED);
+    }
+
+    if let Some(fields) = parse_budget_paused_fields(normalized) {
+        return UserFacingError {
+            code: codes::BUDGET_PAUSED.to_string(),
+            fields,
+        };
+    }
+
+    if normalized.starts_with("Budget paused.") || normalized.starts_with("Budget paused with ") {
+        return UserFacingError::new(codes::BUDGET_PAUSED);
+    }
+
+    if normalized.starts_with("Budget paused (") || normalized.starts_with("Soft limit reached.") {
+        return if normalized.starts_with("Soft limit reached.") {
+            UserFacingError::new(codes::SOFT_LIMIT_REACHED).with_field("message", normalized)
+        } else {
+            UserFacingError::new(codes::BUDGET_PAUSED)
+        };
+    }
+
+    if let Some(model_id) = normalized.strip_prefix("Model not available: ") {
+        return UserFacingError::new(codes::MODEL_UNAVAILABLE).with_field("model_id", model_id);
+    }
+
+    if normalized.starts_with("Request too large:")
+        || lower.contains("context length")
+        || lower.contains("maximum context length")
+    {
+        return UserFacingError::new(codes::REQUEST_TOO_LARGE)
+            .with_optional_field("provider", context.provider.clone())
+            .with_optional_field("model_id", context.model_id.clone());
+    }
+
+    if lower.contains("(429)")
+        || lower.contains("rate limit")
+        || lower.contains("too many requests")
+    {
+        return UserFacingError::new(codes::PROVIDER_RATE_LIMITED)
+            .with_optional_field("provider", context.provider.clone())
+            .with_optional_field("model_id", context.model_id.clone())
+            .with_optional_field("retry_after", context.retry_after);
+    }
+
+    if lower.contains("(401)") || lower.contains("(403)") {
+        return UserFacingError::new(codes::PROVIDER_MISCONFIGURED)
+            .with_optional_field("provider", context.provider.clone())
+            .with_optional_field("model_id", context.model_id.clone());
+    }
+
+    if lower.contains("api key is required")
+        || lower.contains("configure the api key")
+        || lower.contains("api key missing")
+        || lower.contains("missing api key")
+        || lower.contains("invalid api key")
+    {
+        return UserFacingError::new(codes::PROVIDER_MISCONFIGURED)
+            .with_optional_field("provider", context.provider.clone())
+            .with_optional_field("model_id", context.model_id.clone());
+    }
+
+    if ["(500)", "(502)", "(503)", "(504)", "(529)"]
+        .iter()
+        .any(|code| lower.contains(code))
+    {
+        return UserFacingError::new(codes::PROVIDER_UNAVAILABLE)
+            .with_optional_field("provider", context.provider.clone())
+            .with_optional_field("model_id", context.model_id.clone());
+    }
+
+    UserFacingError::new(codes::PROCESSING_ERROR)
+        .with_optional_field("provider", context.provider.clone())
+        .with_optional_field("model_id", context.model_id.clone())
+}
+
+pub fn trim_error_chain_prefixes(error_chain: &str) -> &str {
+    error_chain
+        .trim()
+        .trim_start_matches("InputAtom execution failed: ")
+        .trim_start_matches("ReasonAtom execution failed: ")
+        .trim_start_matches("ActAtom execution failed: ")
+}
+
+fn budget_exhausted_message(fields: &UserFacingErrorFields) -> String {
+    if let (Some(spent), Some(limit), Some(currency)) = (
+        number_field(fields, "spent"),
+        number_field(fields, "limit"),
+        string_field(fields, "currency"),
+    ) {
+        let comparison = if spent > limit { "exceeded" } else { "reached" };
+        return format!(
+            "Budget exhausted. {:.2} {} spent {} the {:.2} {} limit. Increase the budget to continue.",
+            spent, currency, comparison, limit, currency
+        );
+    }
+
+    "Budget exhausted. Increase the budget to continue.".to_string()
+}
+
+fn budget_paused_message(fields: &UserFacingErrorFields) -> String {
+    let spent = number_field(fields, "spent");
+    let currency = string_field(fields, "currency");
+    let soft_limit = number_field(fields, "soft_limit");
+
+    match (spent, currency, soft_limit) {
+        (Some(spent), Some(currency), Some(soft_limit)) => {
+            let comparison = if spent > soft_limit {
+                "exceeded"
+            } else if spent >= soft_limit {
+                "reached"
+            } else {
+                "with"
+            };
+            if comparison == "with" {
+                format!(
+                    "Budget paused with {:.2} {} spent. Increase or resume the budget to continue.",
+                    spent, currency
+                )
+            } else {
+                format!(
+                    "Budget paused. {:.2} {} spent {} the {:.2} {} soft limit. Increase or resume the budget to continue.",
+                    spent, currency, comparison, soft_limit, currency
+                )
+            }
+        }
+        (Some(spent), Some(currency), None) => format!(
+            "Budget paused with {:.2} {} spent. Increase or resume the budget to continue.",
+            spent, currency
+        ),
+        _ => "Budget paused. Increase or resume the budget to continue.".to_string(),
+    }
+}
+
+fn parse_budget_exhausted_fields(message: &str) -> Option<UserFacingErrorFields> {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        Regex::new(
+            r"^Budget exhausted\. (?P<spent>\d+(?:\.\d+)?) (?P<currency>\S+) spent (?:reached|exceeded) the (?P<limit>\d+(?:\.\d+)?) \S+ limit\.",
+        )
+        .expect("valid budget exhausted regex")
+    });
+    let caps = re.captures(message)?;
+    Some(
+        UserFacingErrorFields::new()
+            .with_number("spent", caps.name("spent")?.as_str())
+            .with_number("limit", caps.name("limit")?.as_str())
+            .with_string("currency", caps.name("currency")?.as_str()),
+    )
+}
+
+fn parse_budget_paused_fields(message: &str) -> Option<UserFacingErrorFields> {
+    static SOFT_LIMIT_RE: OnceLock<Regex> = OnceLock::new();
+    static SIMPLE_RE: OnceLock<Regex> = OnceLock::new();
+
+    let soft_limit_re = SOFT_LIMIT_RE.get_or_init(|| {
+        Regex::new(
+            r"^Budget paused\. (?P<spent>\d+(?:\.\d+)?) (?P<currency>\S+) spent (?:reached|exceeded) the (?P<soft_limit>\d+(?:\.\d+)?) \S+ soft limit\.",
+        )
+        .expect("valid budget paused regex")
+    });
+    if let Some(caps) = soft_limit_re.captures(message) {
+        return Some(
+            UserFacingErrorFields::new()
+                .with_number("spent", caps.name("spent")?.as_str())
+                .with_number("soft_limit", caps.name("soft_limit")?.as_str())
+                .with_string("currency", caps.name("currency")?.as_str()),
+        );
+    }
+
+    let simple_re = SIMPLE_RE.get_or_init(|| {
+        Regex::new(r"^Budget paused with (?P<spent>\d+(?:\.\d+)?) (?P<currency>\S+) spent\.")
+            .expect("valid budget paused simple regex")
+    });
+    let caps = simple_re.captures(message)?;
+    Some(
+        UserFacingErrorFields::new()
+            .with_number("spent", caps.name("spent")?.as_str())
+            .with_string("currency", caps.name("currency")?.as_str()),
+    )
+}
+
+fn string_field<'a>(fields: &'a UserFacingErrorFields, key: &str) -> Option<&'a str> {
+    fields.get(key)?.as_str()
+}
+
+fn number_field(fields: &UserFacingErrorFields, key: &str) -> Option<f64> {
+    match fields.get(key)? {
+        Value::Number(number) => number.as_f64(),
+        Value::String(value) => value.parse().ok(),
+        _ => None,
+    }
+}
+
+trait ErrorFieldsExt {
+    fn with_string(self, key: &str, value: &str) -> Self;
+    fn with_number(self, key: &str, value: &str) -> Self;
+}
+
+impl ErrorFieldsExt for UserFacingErrorFields {
+    fn with_string(mut self, key: &str, value: &str) -> Self {
+        self.insert(key.to_string(), Value::String(value.to_string()));
+        self
+    }
+
+    fn with_number(mut self, key: &str, value: &str) -> Self {
+        if let Ok(number) = value.parse::<f64>()
+            && let Some(json_number) = serde_json::Number::from_f64(number)
+        {
+            self.insert(key.to_string(), Value::Number(json_number));
+        }
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_budget_exhausted_parses_fields() {
+        let error = classify_runtime_error_message(
+            "ReasonAtom execution failed: Budget exhausted. 12.50 usd spent exceeded the 10.00 usd limit. Increase the budget to continue.",
+            &UserFacingErrorContext::default(),
+        );
+
+        assert_eq!(error.code, codes::BUDGET_EXHAUSTED);
+        assert_eq!(number_field(&error.fields, "spent"), Some(12.5));
+        assert_eq!(number_field(&error.fields, "limit"), Some(10.0));
+        assert_eq!(string_field(&error.fields, "currency"), Some("usd"));
+    }
+
+    #[test]
+    fn classify_provider_rate_limit_keeps_context() {
+        let error = classify_runtime_error_message(
+            "OpenAI API error (429): rate limit exceeded",
+            &UserFacingErrorContext::default()
+                .with_provider("openai")
+                .with_model_id("gpt-5")
+                .with_retry_after(7),
+        );
+
+        assert_eq!(error.code, codes::PROVIDER_RATE_LIMITED);
+        assert_eq!(string_field(&error.fields, "provider"), Some("openai"));
+        assert_eq!(string_field(&error.fields, "model_id"), Some("gpt-5"));
+        assert_eq!(number_field(&error.fields, "retry_after"), Some(7.0));
+    }
+
+    #[test]
+    fn classify_missing_api_key_as_provider_misconfigured() {
+        let error = classify_runtime_error_message(
+            "LLM error: API key is required. Configure the API key in provider settings.",
+            &UserFacingErrorContext::default().with_provider("openai"),
+        );
+
+        assert_eq!(error.code, codes::PROVIDER_MISCONFIGURED);
+        assert_eq!(string_field(&error.fields, "provider"), Some("openai"));
+    }
+
+    #[test]
+    fn fallback_message_reuses_budget_fields() {
+        let error = UserFacingError::new(codes::BUDGET_PAUSED)
+            .with_field("spent", 5.0)
+            .with_field("soft_limit", 5.0)
+            .with_field("currency", "tokens");
+
+        assert_eq!(
+            error.fallback_message(),
+            "Budget paused. 5.00 tokens spent reached the 5.00 tokens soft limit. Increase or resume the budget to continue."
+        );
+    }
+}

--- a/crates/core/src/user_facing_error.rs
+++ b/crates/core/src/user_facing_error.rs
@@ -17,6 +17,7 @@ pub mod codes {
     pub const PROVIDER_UNAVAILABLE: &str = "provider_unavailable";
     pub const PROCESSING_ERROR: &str = "processing_error";
     pub const DEPENDENCY_UNAVAILABLE: &str = "dependency_unavailable";
+    pub const MAX_ITERATIONS: &str = "max_iterations";
     pub const SOFT_LIMIT_REACHED: &str = "soft_limit_reached";
 }
 

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -25,7 +25,8 @@ use everruns_core::traits::{
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
 use everruns_core::{
     Agent, CapabilityRegistry, DependencyBlocker, DriverRegistry, Harness, Session, TokenUsage,
-    ToolDefinition, ToolRegistry, org_public_id_from_internal, resolve_runtime_capabilities,
+    ToolDefinition, ToolRegistry, UserFacingError, org_public_id_from_internal,
+    resolve_runtime_capabilities,
 };
 use std::sync::Arc;
 use tracing::warn;
@@ -501,7 +502,7 @@ impl<A: RuntimeHostAdapter> RuntimeSessionLifecycle<A> {
         turn_id: TurnId,
         input_message_id: MessageId,
         error: &str,
-        error_code: Option<&str>,
+        user_error: Option<&UserFacingError>,
     ) {
         self.set_session_status(SessionStatus::Idle, "turn_failed")
             .await;
@@ -509,10 +510,17 @@ impl<A: RuntimeHostAdapter> RuntimeSessionLifecycle<A> {
         self.emit_event(EventRequest::new(
             self.session_id,
             EventContext::turn(turn_id, input_message_id),
-            TurnFailedData {
-                turn_id,
-                error: error.to_string(),
-                error_code: error_code.map(str::to_string),
+            {
+                let mut data = TurnFailedData {
+                    turn_id,
+                    error: error.to_string(),
+                    error_code: None,
+                    error_fields: None,
+                };
+                if let Some(user_error) = user_error {
+                    user_error.apply_to_event_fields(&mut data.error_code, &mut data.error_fields);
+                }
+                data
             },
         ))
         .await;
@@ -543,10 +551,36 @@ impl<A: RuntimeHostAdapter> RuntimeSessionLifecycle<A> {
         input_message_id: MessageId,
         blocker: DependencyBlocker,
     ) {
+        let user_error = UserFacingError::new(blocker.error_code())
+            .with_field(
+                "dependency",
+                match blocker {
+                    DependencyBlocker::HarnessArchived | DependencyBlocker::HarnessDeleted => {
+                        "harness"
+                    }
+                    DependencyBlocker::AgentArchived | DependencyBlocker::AgentDeleted => "agent",
+                },
+            )
+            .with_field(
+                "state",
+                match blocker {
+                    DependencyBlocker::HarnessArchived | DependencyBlocker::AgentArchived => {
+                        "archived"
+                    }
+                    DependencyBlocker::HarnessDeleted | DependencyBlocker::AgentDeleted => {
+                        "deleted"
+                    }
+                },
+            );
+        let mut error_message = Message::assistant(blocker.message());
+        let mut metadata = std::collections::HashMap::new();
+        user_error.apply_to_message_metadata(&mut metadata);
+        error_message.metadata = Some(metadata);
+
         self.emit_event(EventRequest::new(
             self.session_id,
             EventContext::turn(turn_id, input_message_id),
-            OutputMessageCompletedData::new(Message::assistant(blocker.message())),
+            OutputMessageCompletedData::new(error_message).with_user_facing_error(&user_error),
         ))
         .await;
 
@@ -554,7 +588,7 @@ impl<A: RuntimeHostAdapter> RuntimeSessionLifecycle<A> {
             turn_id,
             input_message_id,
             blocker.message(),
-            Some(blocker.error_code()),
+            Some(&user_error),
         )
         .await;
     }

--- a/crates/runtime/src/turn_strategy.rs
+++ b/crates/runtime/src/turn_strategy.rs
@@ -5,7 +5,10 @@ use crate::{RuntimeHostAdapter, RuntimeSessionLifecycle};
 use everruns_core::atoms::{ActInput, AtomContext};
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::typed_id::{AgentId, ExecId, HarnessId, MessageId, SessionId, TurnId};
-use everruns_core::{Controls, ReasonResult};
+use everruns_core::{
+    Controls, ReasonResult, UserFacingError, UserFacingErrorContext,
+    classify_runtime_error_message, user_facing_error_codes,
+};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 
@@ -60,6 +63,30 @@ pub enum RuntimeTurnPlan {
     ScheduleAct(RuntimeActPlan),
     Complete { error: Option<String> },
     WaitForToolResults { resume: RuntimeTurnState },
+}
+
+fn classify_reason_failure(reason_result: &ReasonResult) -> UserFacingError {
+    let from_text =
+        classify_runtime_error_message(&reason_result.text, &UserFacingErrorContext::default());
+
+    let Some(error) = reason_result.error.as_deref() else {
+        return from_text;
+    };
+
+    let from_error = classify_runtime_error_message(error, &UserFacingErrorContext::default());
+
+    if from_error.code == user_facing_error_codes::PROCESSING_ERROR {
+        return from_text;
+    }
+
+    if from_error.code == from_text.code
+        && from_error.fields.is_empty()
+        && !from_text.fields.is_empty()
+    {
+        return from_text;
+    }
+
+    from_error
 }
 
 /// Determine the next host step after an activity finishes.
@@ -170,12 +197,13 @@ pub async fn plan_next_host_turn<A: RuntimeHostAdapter>(
                     )
                     .await;
             } else {
+                let user_error = classify_reason_failure(&reason_result);
                 lifecycle
                     .turn_failed(
                         turn_id,
                         state.input_message_id,
                         &reason_result.text,
-                        Some("llm_error"),
+                        Some(&user_error),
                     )
                     .await;
             }

--- a/crates/runtime/tests/runtime_host_test.rs
+++ b/crates/runtime/tests/runtime_host_test.rs
@@ -23,6 +23,7 @@ use everruns_core::{
     Agent, AgentCapabilityConfig, AgentStatus, CapabilityRegistry, EventData, Harness,
     HarnessStatus, InputMessage, LlmProviderType, ModelWithProvider, Session, SessionStatus, Tool,
     ToolCall, ToolExecutionResult, ToolRegistry, ToolResult, inspect_turn_context,
+    user_facing_error_codes,
 };
 use everruns_runtime::{
     InMemorySessionFileStore, RuntimeHostAdapter, RuntimeHostTurnContext, RuntimeSessionLifecycle,
@@ -1023,6 +1024,65 @@ async fn plan_next_host_turn_preserves_reason_failure_message() {
     assert_eq!(
         turn_failed.error,
         "Budget exhausted. 100.00 tokens spent reached the 100.00 tokens limit. Increase the budget to continue."
+    );
+    assert_eq!(
+        turn_failed.error_code.as_deref(),
+        Some(user_facing_error_codes::BUDGET_EXHAUSTED)
+    );
+    let error_fields = turn_failed.error_fields.expect("budget fields");
+    assert_eq!(error_fields.get("spent"), Some(&json!(100.0)));
+    assert_eq!(error_fields.get("limit"), Some(&json!(100.0)));
+    assert_eq!(error_fields.get("currency"), Some(&json!("tokens")));
+}
+
+#[tokio::test]
+async fn plan_next_host_turn_classifies_missing_api_key_as_provider_misconfigured() {
+    let adapter = mock_host();
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    adapter.harness_store.add_harness(harness(harness_id)).await;
+    adapter
+        .session_store
+        .insert(session(session_id, harness_id))
+        .await;
+
+    let input = turn_state(session_id, harness_id);
+    let output = serde_json::to_value(ReasonResult {
+        success: false,
+        text: "I encountered an error while processing your request. Please try again later."
+            .into(),
+        tool_calls: vec![],
+        has_tool_calls: false,
+        tool_definitions: vec![],
+        max_iterations: 8,
+        error: Some(
+            "LLM error: API key is required. Configure the API key in provider settings.".into(),
+        ),
+        usage: None,
+        response_id: None,
+        locale: None,
+        network_access: None,
+    })
+    .unwrap();
+
+    let plan = plan_next_host_turn(&adapter, "reason", &input, &output, 0)
+        .await
+        .unwrap();
+
+    assert!(matches!(plan, RuntimeTurnPlan::Complete { .. }));
+
+    let events = adapter.event_emitter.events().await;
+    let turn_failed = events
+        .into_iter()
+        .find_map(|event| match event.data {
+            EventData::TurnFailed(data) => Some(data),
+            _ => None,
+        })
+        .expect("turn.failed event emitted");
+
+    assert_eq!(
+        turn_failed.error_code.as_deref(),
+        Some(user_facing_error_codes::PROVIDER_MISCONFIGURED)
     );
 }
 

--- a/crates/server/src/services/budget.rs
+++ b/crates/server/src/services/budget.rs
@@ -14,6 +14,7 @@ use everruns_core::events::{Event, EventData, LLM_GENERATION};
 use everruns_core::llm_model_profiles::get_model_profile;
 use everruns_core::llm_models::LlmProviderType;
 use everruns_core::typed_id::{BudgetId, SessionId};
+use everruns_core::{UserFacingError, user_facing_error_codes};
 use std::sync::Arc;
 use tracing::{error, info, instrument, warn};
 
@@ -356,12 +357,15 @@ impl BudgetService {
 
             if priority > most_restrictive_priority {
                 most_restrictive_priority = priority;
+                let user_error = self.user_facing_error_for_action(budget, action_str);
                 most_restrictive = BudgetCheckResult {
                     action: action_str.into(),
                     message: Some(message),
                     budget_id: Some(BudgetId::from_uuid(budget.id)),
                     balance: Some(budget.balance),
                     currency: Some(budget.currency.clone()),
+                    error_code: user_error.as_ref().map(|error| error.code.clone()),
+                    error_fields: user_error.and_then(|error| error.error_fields()),
                 };
             }
         }
@@ -374,42 +378,36 @@ impl BudgetService {
     }
 
     fn format_exhausted_message(&self, budget: &BudgetRow) -> String {
-        let spent = self.spent_amount(budget);
-        let comparison = if spent > budget.limit {
-            "exceeded"
-        } else {
-            "reached"
-        };
-        format!(
-            "Budget exhausted. {:.2} {} spent {} the {:.2} {} limit. Increase the budget to continue.",
-            spent, budget.currency, comparison, budget.limit, budget.currency
-        )
+        self.budget_exhausted_error(budget).fallback_message()
     }
 
     fn format_paused_message(&self, budget: &BudgetRow) -> String {
-        let spent = self.spent_amount(budget);
-        if let Some(soft_limit) = budget.soft_limit {
-            if spent > soft_limit {
-                format!(
-                    "Budget paused. {:.2} {} spent exceeded the {:.2} {} soft limit. Increase or resume the budget to continue.",
-                    spent, budget.currency, soft_limit, budget.currency
-                )
-            } else if spent >= soft_limit {
-                format!(
-                    "Budget paused. {:.2} {} spent reached the {:.2} {} soft limit. Increase or resume the budget to continue.",
-                    spent, budget.currency, soft_limit, budget.currency
-                )
-            } else {
-                format!(
-                    "Budget paused with {:.2} {} spent. Increase or resume the budget to continue.",
-                    spent, budget.currency
-                )
-            }
-        } else {
-            format!(
-                "Budget paused with {:.2} {} spent. Increase or resume the budget to continue.",
-                spent, budget.currency
-            )
+        self.budget_paused_error(budget).fallback_message()
+    }
+
+    fn budget_exhausted_error(&self, budget: &BudgetRow) -> UserFacingError {
+        UserFacingError::new(user_facing_error_codes::BUDGET_EXHAUSTED)
+            .with_field("spent", self.spent_amount(budget))
+            .with_field("limit", budget.limit)
+            .with_field("currency", budget.currency.clone())
+    }
+
+    fn budget_paused_error(&self, budget: &BudgetRow) -> UserFacingError {
+        UserFacingError::new(user_facing_error_codes::BUDGET_PAUSED)
+            .with_field("spent", self.spent_amount(budget))
+            .with_optional_field("soft_limit", budget.soft_limit)
+            .with_field("currency", budget.currency.clone())
+    }
+
+    fn user_facing_error_for_action(
+        &self,
+        budget: &BudgetRow,
+        action: &str,
+    ) -> Option<UserFacingError> {
+        match action {
+            "stop" => Some(self.budget_exhausted_error(budget)),
+            "pause" => Some(self.budget_paused_error(budget)),
+            _ => None,
         }
     }
 }

--- a/crates/server/src/services/budget_tests.rs
+++ b/crates/server/src/services/budget_tests.rs
@@ -621,6 +621,28 @@ mod tests {
                 "Budget exhausted. 100.00 tokens spent reached the 100.00 tokens limit. Increase the budget to continue."
             )
         );
+        assert_eq!(result.error_code.as_deref(), Some("budget_exhausted"));
+        assert_eq!(
+            result
+                .error_fields
+                .as_ref()
+                .and_then(|fields| fields.get("spent")),
+            Some(&serde_json::json!(100.0))
+        );
+        assert_eq!(
+            result
+                .error_fields
+                .as_ref()
+                .and_then(|fields| fields.get("limit")),
+            Some(&serde_json::json!(100.0))
+        );
+        assert_eq!(
+            result
+                .error_fields
+                .as_ref()
+                .and_then(|fields| fields.get("currency")),
+            Some(&serde_json::json!("tokens"))
+        );
     }
 
     #[tokio::test]
@@ -658,6 +680,14 @@ mod tests {
             Some(
                 "Budget paused. 8.00 usd spent reached the 8.00 usd soft limit. Increase or resume the budget to continue."
             )
+        );
+        assert_eq!(result.error_code.as_deref(), Some("budget_paused"));
+        assert_eq!(
+            result
+                .error_fields
+                .as_ref()
+                .and_then(|fields| fields.get("soft_limit")),
+            Some(&serde_json::json!(8.0))
         );
     }
 

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -27,7 +27,7 @@ use crate::grpc_durable_store::{
     ClaimedTask, GrpcDurableStore, TaskNotificationEvent, TaskNotificationStream, WorkflowStatus,
 };
 use crate::runtime_host::WorkerRuntimeHost;
-use crate::task_error::{summarize_task_failure, user_facing_failure_message};
+use crate::task_error::{summarize_task_failure, user_facing_failure};
 use serde::{Deserialize, Serialize};
 
 // =============================================================================
@@ -1082,14 +1082,18 @@ impl DurableWorker {
             turn_id,
             input_message_id,
         } = ctx;
-        let error_message = Message::assistant(user_facing_failure_message(persisted_error));
+        let user_error = user_facing_failure(persisted_error);
+        let mut error_message = Message::assistant(user_error.fallback_message());
+        let mut metadata = std::collections::HashMap::new();
+        user_error.apply_to_message_metadata(&mut metadata);
+        error_message.metadata = Some(metadata);
         let context = EventContext::turn(turn_id, input_message_id);
 
         if let Err(e) = event_emitter
             .emit(EventRequest::new(
                 session_id,
                 context,
-                OutputMessageCompletedData::new(error_message),
+                OutputMessageCompletedData::new(error_message).with_user_facing_error(&user_error),
             ))
             .await
         {

--- a/crates/worker/src/session_lifecycle.rs
+++ b/crates/worker/src/session_lifecycle.rs
@@ -12,7 +12,9 @@ use everruns_core::events::{
     TurnCompletedData, TurnFailedData, TurnStartedData,
 };
 use everruns_core::typed_id::{MessageId, SessionId, TurnId};
-use everruns_core::{DependencyBlocker, Message, TokenUsage};
+use everruns_core::{
+    DependencyBlocker, Message, TokenUsage, UserFacingError, user_facing_error_codes,
+};
 use tracing::warn;
 
 use crate::worker_adapters::WorkerAdapters;
@@ -172,7 +174,7 @@ impl<A: WorkerAdapters> SessionLifecycle<A> {
         turn_id: TurnId,
         input_message_id: MessageId,
         error: &str,
-        error_code: Option<&str>,
+        user_error: Option<&UserFacingError>,
     ) {
         if let Err(e) = self
             .adapters
@@ -185,10 +187,17 @@ impl<A: WorkerAdapters> SessionLifecycle<A> {
         let turn_failed_event = EventRequest::new(
             self.session_id,
             EventContext::turn(turn_id, input_message_id),
-            TurnFailedData {
-                turn_id,
-                error: error.to_string(),
-                error_code: error_code.map(|s| s.to_string()),
+            {
+                let mut data = TurnFailedData {
+                    turn_id,
+                    error: error.to_string(),
+                    error_code: None,
+                    error_fields: None,
+                };
+                if let Some(user_error) = user_error {
+                    user_error.apply_to_event_fields(&mut data.error_code, &mut data.error_fields);
+                }
+                data
             },
         );
         if let Err(e) = self.adapters.emit_event(turn_failed_event).await {
@@ -234,30 +243,52 @@ impl<A: WorkerAdapters> SessionLifecycle<A> {
         blocker: DependencyBlocker,
     ) {
         let message = blocker.message();
+        let user_error = UserFacingError::new(blocker.error_code())
+            .with_field(
+                "dependency",
+                match blocker {
+                    DependencyBlocker::HarnessArchived | DependencyBlocker::HarnessDeleted => {
+                        "harness"
+                    }
+                    DependencyBlocker::AgentArchived | DependencyBlocker::AgentDeleted => "agent",
+                },
+            )
+            .with_field(
+                "state",
+                match blocker {
+                    DependencyBlocker::HarnessArchived | DependencyBlocker::AgentArchived => {
+                        "archived"
+                    }
+                    DependencyBlocker::HarnessDeleted | DependencyBlocker::AgentDeleted => {
+                        "deleted"
+                    }
+                },
+            );
+        let mut error_message = Message::assistant(message);
+        let mut metadata = std::collections::HashMap::new();
+        user_error.apply_to_message_metadata(&mut metadata);
+        error_message.metadata = Some(metadata);
 
         let output_event = EventRequest::new(
             self.session_id,
             EventContext::turn(turn_id, input_message_id),
-            OutputMessageCompletedData::new(Message::assistant(message)),
+            OutputMessageCompletedData::new(error_message).with_user_facing_error(&user_error),
         );
         if let Err(e) = self.adapters.emit_event(output_event).await {
             warn!(error = %e, "Failed to emit dependency blocked message");
         }
 
-        self.turn_failed(
-            turn_id,
-            input_message_id,
-            message,
-            Some(blocker.error_code()),
-        )
-        .await;
+        self.turn_failed(turn_id, input_message_id, message, Some(&user_error))
+            .await;
     }
 
     /// DLQ error: emit user-facing error + session.idled, set session to "idle".
     pub async fn dlq_error(&self, turn_id: TurnId, input_message_id: MessageId) {
-        let error_message = Message::assistant(
-            "I encountered an error while processing your request. Please try again later.",
-        );
+        let user_error = UserFacingError::new(user_facing_error_codes::PROCESSING_ERROR);
+        let mut error_message = Message::assistant(user_error.fallback_message());
+        let mut metadata = std::collections::HashMap::new();
+        user_error.apply_to_message_metadata(&mut metadata);
+        error_message.metadata = Some(metadata);
         let context = EventContext::turn(turn_id, input_message_id);
 
         if let Err(e) = self
@@ -265,7 +296,7 @@ impl<A: WorkerAdapters> SessionLifecycle<A> {
             .emit_event(EventRequest::new(
                 self.session_id,
                 context,
-                OutputMessageCompletedData::new(error_message),
+                OutputMessageCompletedData::new(error_message).with_user_facing_error(&user_error),
             ))
             .await
         {

--- a/crates/worker/src/task_error.rs
+++ b/crates/worker/src/task_error.rs
@@ -3,6 +3,7 @@
 // task metadata and the full anyhow error chain for durable task surfaces.
 
 use anyhow::Error;
+use everruns_core::{UserFacingError, UserFacingErrorContext, classify_runtime_error_message};
 use serde_json::Value;
 use uuid::Uuid;
 
@@ -55,72 +56,14 @@ pub(crate) fn summarize_task_failure(
     }
 }
 
-pub(crate) fn user_facing_failure_message(error: &str) -> String {
+pub(crate) fn user_facing_failure(error: &str) -> UserFacingError {
     let error_chain = error.split("error_chain=").nth(1).unwrap_or(error).trim();
-
-    let normalized = trim_error_chain_prefixes(error_chain);
-    let lower = normalized.to_ascii_lowercase();
-
-    if normalized.starts_with("Budget exhausted.")
-        || normalized.starts_with("Budget paused.")
-        || normalized.starts_with("Soft limit reached.")
-    {
-        return normalized.to_string();
-    }
-
-    if normalized.starts_with("Budget exhausted (") {
-        return "Budget exhausted. Increase the budget to continue.".to_string();
-    }
-
-    if normalized.starts_with("Budget paused (") {
-        return "Budget paused. Increase or resume the budget to continue.".to_string();
-    }
-
-    if normalized.starts_with("Model not available: ") {
-        let model_id = normalized
-            .trim_start_matches("Model not available: ")
-            .trim();
-        return format!(
-            "The model `{}` is not available. It may have been removed, renamed, or your API key may not have access to it. Please select a different model.",
-            model_id
-        );
-    }
-
-    if normalized.starts_with("Request too large:")
-        || lower.contains("context length")
-        || lower.contains("maximum context length")
-    {
-        return "The conversation has become too long for the model to process. Please start a new session or reduce the context size.".to_string();
-    }
-
-    if lower.contains("(429)")
-        || lower.contains("rate limit")
-        || lower.contains("too many requests")
-    {
-        return "Rate limited by the AI provider. Please wait a moment.".to_string();
-    }
-
-    if lower.contains("(401)") || lower.contains("(403)") {
-        return "There is a misconfiguration with the AI provider. Please contact support."
-            .to_string();
-    }
-
-    if ["(500)", "(502)", "(503)", "(504)", "(529)"]
-        .iter()
-        .any(|code| lower.contains(code))
-    {
-        return "The AI provider is experiencing issues. Please try again shortly.".to_string();
-    }
-
-    "I encountered an error while processing your request. Please try again later.".to_string()
+    classify_runtime_error_message(error_chain, &UserFacingErrorContext::default())
 }
 
-fn trim_error_chain_prefixes(error_chain: &str) -> &str {
-    error_chain
-        .trim()
-        .trim_start_matches("InputAtom execution failed: ")
-        .trim_start_matches("ReasonAtom execution failed: ")
-        .trim_start_matches("ActAtom execution failed: ")
+#[cfg(test)]
+pub(crate) fn user_facing_failure_message(error: &str) -> String {
+    user_facing_failure(error).fallback_message()
 }
 
 fn format_error_chain(error: &Error) -> String {

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -11138,6 +11138,20 @@
           "message"
         ],
         "properties": {
+          "error_code": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Stable error code for user-facing failures surfaced as assistant text."
+          },
+          "error_fields": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "description": "Structured interpolation fields for localized error rendering."
+          },
           "message": {
             "$ref": "#/components/schemas/Message",
             "description": "The agent message"
@@ -14384,6 +14398,13 @@
               "null"
             ],
             "description": "Error code"
+          },
+          "error_fields": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "description": "Structured interpolation fields for localized error rendering."
           },
           "turn_id": {
             "type": "string",

--- a/specs/events.md
+++ b/specs/events.md
@@ -322,7 +322,10 @@ Agent response message. Emitted when LLM generation completes.
       "id": "01937abc-...",
       "role": "agent",
       "content": [
-        { "type": "text", "text": "Hello! How can I help?" }
+        {
+          "type": "text",
+          "text": "Budget exhausted. 12.50 usd spent reached the 10.00 usd limit. Increase the budget to continue."
+        }
       ],
       "metadata": {
         "model": "gpt-4o",

--- a/specs/events.md
+++ b/specs/events.md
@@ -324,6 +324,15 @@ Agent response message. Emitted when LLM generation completes.
       "content": [
         { "type": "text", "text": "Hello! How can I help?" }
       ],
+      "metadata": {
+        "model": "gpt-4o",
+        "error_code": "budget_exhausted",
+        "error_fields": {
+          "spent": 12.5,
+          "limit": 10.0,
+          "currency": "usd"
+        }
+      },
       "phase": "completed",
       "created_at": "2024-01-15T10:30:01.000Z"
     },
@@ -331,6 +340,12 @@ Agent response message. Emitted when LLM generation completes.
       "model": "gpt-4o",
       "model_id": "01937abc-...",
       "provider_id": "01937abc-..."
+    },
+    "error_code": "budget_exhausted",
+    "error_fields": {
+      "spent": 12.5,
+      "limit": 10.0,
+      "currency": "usd"
     },
     "usage": {
       "input_tokens": 50,
@@ -412,7 +427,7 @@ Turn execution failed. This event is emitted when:
 - Max iterations exceeded
 - Other unrecoverable errors during turn execution
 
-When a turn fails, an `output.message.completed` event with a user-friendly error message is also emitted so users see feedback in the chat.
+When a turn fails, an `output.message.completed` event with a user-friendly fallback message is also emitted so users see feedback in the chat. Consumers should localize from `error_code` + `error_fields` when present instead of matching English prose.
 
 ```json
 {
@@ -424,16 +439,19 @@ When a turn fails, an `output.message.completed` event with a user-friendly erro
   "data": {
     "turn_id": "...",
     "error": "An error occurred while processing your request.",
-    "error_code": "llm_error"
+    "error_code": "provider_rate_limited",
+    "error_fields": {
+      "provider": "anthropic",
+      "retry_after": 8
+    }
   }
 }
 ```
 
-**Error Codes:**
-| Code | Description |
-|------|-------------|
-| `llm_error` | LLM call failed (API key missing, rate limit, network error) |
-| `max_iterations` | Maximum iterations exceeded |
+**Structured runtime errors:**
+- `error` remains the plain-English fallback for older clients and debugging.
+- `error_code` carries the stable user-facing classification.
+- `error_fields` carries interpolation values such as `spent`, `limit`, `soft_limit`, `currency`, `model_id`, `provider`, and `retry_after`.
 
 #### `turn.cancelled`
 


### PR DESCRIPTION
## What
Add stable user-facing runtime error codes plus structured interpolation fields, and have the UI localize runtime failures from that metadata instead of backend English strings.

## Why
Runtime failures were being transported as raw prose, which made frontend localization brittle and left some surfaces matching backend wording instead of structured error intent.

## How
- add a shared runtime error classifier/model in core and attach `error_code` / `error_fields` to `turn.failed`, `output.message.completed`, and persisted assistant message metadata
- plumb structured budget, dependency, provider, and processing failures through worker and in-process runtime paths
- localize transcript and trajectory rendering from structured metadata in the UI, with regression tests that ignore fallback English wording
- document the event contract and add runtime regression coverage for the in-process failure path

## Risk
- Medium
- Event consumers could mishandle the new optional fields or still rely on legacy prose if they ignore the structured metadata

## Security
- Threat categories reviewed: TM-API, TM-WEB, TM-LLM
- Findings and resolutions: reviewed new event payload fields and UI rendering for injection/data-leak regressions. The change only transports scalar error metadata through existing authenticated event channels, preserves fallback strings for compatibility, introduces no new dependencies, and continues rendering localized strings as plain text rather than HTML.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
