### PR TITLE
refactor(server): move request types from api/ to domains/*/types.rs

### DIFF
--- a/crates/server/src/api/agent_identities.rs
+++ b/crates/server/src/api/agent_identities.rs
@@ -2,6 +2,9 @@
 // Routes use ResolvedOrg: org derived from auth context (API key or cookie).
 
 use crate::auth::{AuthState, ResolvedOrg};
+use crate::domains::agent_identities::types::{
+    CreateAgentIdentityRequest, ListAgentIdentitiesQuery, UpdateAgentIdentityRequest,
+};
 use crate::domains::agent_identities::{
     AGENT_IDENTITY_DANGEROUS, AGENT_IDENTITY_MANAGE, AGENT_IDENTITY_VIEW,
 };
@@ -13,53 +16,11 @@ use axum::{
     http::StatusCode,
     routing::{get, post},
 };
-use everruns_core::{
-    AgentIdentity, AgentIdentityStatus, Caller, ResourceConfigResponse, evaluate_policies_with,
-};
-use serde::Deserialize;
+use everruns_core::{AgentIdentity, Caller, ResourceConfigResponse, evaluate_policies_with};
 use std::sync::Arc;
-use utoipa::{IntoParams, ToSchema};
 
-use super::common::deserialize_nullable_update_field;
 use super::common::{ErrorResponse, ListResponse, impl_auth_state};
 use crate::domains::common::Command;
-use everruns_durable::UpdateField;
-
-#[derive(Debug, Clone, Deserialize, ToSchema)]
-pub struct CreateAgentIdentityRequest {
-    #[schema(example = "Ops Bot")]
-    pub name: String,
-    pub description: Option<String>,
-    pub avatar_url: Option<String>,
-    #[schema(example = "en-US")]
-    pub locale: Option<String>,
-    #[schema(example = "America/Los_Angeles")]
-    pub timezone: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize, ToSchema)]
-pub struct UpdateAgentIdentityRequest {
-    pub name: Option<String>,
-    #[serde(default, deserialize_with = "deserialize_nullable_update_field")]
-    #[schema(value_type = Option<String>, nullable = true)]
-    pub description: UpdateField<String>,
-    #[serde(default, deserialize_with = "deserialize_nullable_update_field")]
-    #[schema(value_type = Option<String>, nullable = true)]
-    pub avatar_url: UpdateField<String>,
-    #[serde(default, deserialize_with = "deserialize_nullable_update_field")]
-    #[schema(value_type = Option<String>, nullable = true)]
-    pub locale: UpdateField<String>,
-    #[serde(default, deserialize_with = "deserialize_nullable_update_field")]
-    #[schema(value_type = Option<String>, nullable = true)]
-    pub timezone: UpdateField<String>,
-    pub status: Option<AgentIdentityStatus>,
-}
-
-#[derive(Debug, Clone, Deserialize, IntoParams)]
-pub struct ListAgentIdentitiesQuery {
-    pub search: Option<String>,
-    pub include_archived: Option<bool>,
-}
 
 #[derive(Clone)]
 pub struct AppState {
@@ -202,42 +163,4 @@ pub async fn destroy_agent_identity(
         .execute(&state.ctx(&org))
         .await?;
     Ok(StatusCode::NO_CONTENT)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_create_agent_identity_request_roundtrip() {
-        let json = r#"{"name":"Ops Bot","locale":"en-US","timezone":"America/Los_Angeles"}"#;
-        let req: CreateAgentIdentityRequest = serde_json::from_str(json).unwrap();
-        assert_eq!(req.name, "Ops Bot");
-        assert_eq!(req.locale.as_deref(), Some("en-US"));
-        assert_eq!(req.timezone.as_deref(), Some("America/Los_Angeles"));
-    }
-
-    #[test]
-    fn test_update_agent_identity_request_status() {
-        let json = r#"{"status":"archived"}"#;
-        let req: UpdateAgentIdentityRequest = serde_json::from_str(json).unwrap();
-        assert_eq!(req.status, Some(AgentIdentityStatus::Archived));
-    }
-
-    #[test]
-    fn update_agent_identity_request_defaults_to_unchanged() {
-        let req: UpdateAgentIdentityRequest = serde_json::from_str("{}").unwrap();
-        assert_eq!(req.description, UpdateField::Unchanged);
-        assert_eq!(req.avatar_url, UpdateField::Unchanged);
-        assert_eq!(req.locale, UpdateField::Unchanged);
-        assert_eq!(req.timezone, UpdateField::Unchanged);
-    }
-
-    #[test]
-    fn update_agent_identity_request_supports_clear() {
-        let req: UpdateAgentIdentityRequest =
-            serde_json::from_str(r#"{"description":null,"locale":null}"#).unwrap();
-        assert_eq!(req.description, UpdateField::Clear);
-        assert_eq!(req.locale, UpdateField::Clear);
-    }
 }

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -14,9 +14,8 @@ use axum::{
 use chrono::Utc;
 use everruns_core::typed_id::{AgentId, ModelId};
 use everruns_core::{
-    Agent, AgentCapabilityConfig, AgentStatus, Caller, DeploymentGrade, InitialFile, OrgRole,
-    PlatformDefinition, ResourceConfigResponse, ScopedMcpServers, ToolDefinition,
-    evaluate_policies_with,
+    Agent, AgentCapabilityConfig, Caller, DeploymentGrade, InitialFile, OrgRole,
+    PlatformDefinition, ResourceConfigResponse, ScopedMcpServers, evaluate_policies_with,
 };
 
 use super::common::{
@@ -25,156 +24,13 @@ use super::common::{
 use super::validation::{
     validate_agent_name_format, validate_create_agent_input, validate_import_file_size,
 };
+use crate::domains::agents::types::{
+    AgentPreviewResponse, CheckAgentNameQuery, CheckAgentNameResponse, CreateAgentRequest,
+    ImportAgentQuery, ListAgentsQuery, PreviewAgentRequest, UpdateAgentRequest,
+};
 use crate::domains::common::Command;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use utoipa::{IntoParams, ToSchema};
-
-/// Request to create a new agent
-#[derive(Debug, Clone, Deserialize, ToSchema)]
-pub struct CreateAgentRequest {
-    /// Client-supplied agent ID (format: agent_{32-hex}).
-    /// If not provided, one is auto-generated.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = Option<String>, example = "agent_01933b5a00007000800000000000001")]
-    pub id: Option<AgentId>,
-    /// Name, unique per org. Lowercase alphanumeric and hyphens.
-    /// Format: lowercase alphanumeric and hyphens (e.g. "customer-support").
-    #[schema(example = "customer-support")]
-    pub name: String,
-    /// Human-readable display name shown in UI.
-    /// Falls back to `name` when absent.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schema(example = "Customer Support Agent")]
-    pub display_name: Option<String>,
-    /// A human-readable description of what the agent does.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(example = "Handles customer inquiries and support tickets")]
-    pub description: Option<String>,
-    /// The system prompt that defines the agent's behavior and capabilities.
-    /// This is sent as the first message in every conversation.
-    #[schema(example = "You are a helpful customer support agent. Be polite and professional.")]
-    pub system_prompt: String,
-    /// The ID of the default LLM model to use for this agent.
-    /// If not specified, the system default model will be used.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = Option<String>, example = "model_01933b5a00007000800000000000001")]
-    pub default_model_id: Option<ModelId>,
-    /// Tags for organizing and filtering agents.
-    #[serde(default)]
-    #[schema(example = json!(["support", "customer-facing"]))]
-    pub tags: Vec<String>,
-    /// Capabilities to enable for this agent with per-agent configuration.
-    /// Each capability has a `ref` (capability ID) and optional `config`.
-    #[serde(default)]
-    #[schema(example = json!([{"ref": "current_time", "config": {}}, {"ref": "web_fetch", "config": {}}]))]
-    pub capabilities: Vec<AgentCapabilityConfig>,
-    /// Starter files copied into each new session for this agent.
-    #[serde(default)]
-    pub initial_files: Vec<InitialFile>,
-    /// Client-side tools for this agent.
-    /// These tools are sent to the LLM but executed by the client, not the server.
-    #[serde(default)]
-    pub tools: Vec<ToolDefinition>,
-    /// Remote MCP servers scoped to this agent.
-    #[serde(default, rename = "mcpServers", alias = "mcp_servers")]
-    pub mcp_servers: ScopedMcpServers,
-    /// Network access list controlling which hosts/URLs this agent's sessions can reach.
-    /// If set, merged with harness and session layers (allowed: intersect, blocked: union).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub network_access: Option<everruns_core::network_access::NetworkAccessList>,
-    /// Maximum number of LLM iterations per turn for this agent.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub max_iterations: Option<usize>,
-}
-
-/// Request to update an agent. Only provided fields will be updated.
-#[derive(Debug, Clone, Deserialize, ToSchema)]
-pub struct UpdateAgentRequest {
-    /// Name, unique per org. Lowercase alphanumeric and hyphens.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(example = "updated-support")]
-    pub name: Option<String>,
-    /// Human-readable display name shown in UI.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(example = "Updated Support Agent")]
-    pub display_name: Option<String>,
-    /// A human-readable description of what the agent does.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(example = "Updated description for the agent")]
-    pub description: Option<String>,
-    /// The system prompt that defines the agent's behavior and capabilities.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(example = "You are an updated helpful assistant.")]
-    pub system_prompt: Option<String>,
-    /// The ID of the default LLM model to use for this agent.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = Option<String>, example = "model_01933b5a00007000800000000000001")]
-    pub default_model_id: Option<ModelId>,
-    /// Tags for organizing and filtering agents.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(example = json!(["updated-tag"]))]
-    pub tags: Option<Vec<String>>,
-    /// Capabilities to enable for this agent with per-agent configuration.
-    /// Replaces existing capabilities. Each has a `ref` (capability ID) and optional `config`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(example = json!([{"ref": "current_time", "config": {}}, {"ref": "web_fetch", "config": {}}]))]
-    pub capabilities: Option<Vec<AgentCapabilityConfig>>,
-    /// Starter files copied into each new session for this agent.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub initial_files: Option<Vec<InitialFile>>,
-    /// The status of the agent. Set to "archived" to soft-delete.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<AgentStatus>,
-    /// Client-side tools for this agent.
-    /// Replaces existing tools if provided.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tools: Option<Vec<ToolDefinition>>,
-    /// Remote MCP servers scoped to this agent.
-    #[serde(
-        default,
-        rename = "mcpServers",
-        alias = "mcp_servers",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub mcp_servers: Option<ScopedMcpServers>,
-    /// Network access list controlling which hosts/URLs this agent's sessions can reach.
-    /// Send `{}` (empty object) to clear restrictions. Omit to leave unchanged.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub network_access: Option<everruns_core::network_access::NetworkAccessList>,
-    /// Maximum number of LLM iterations per turn for this agent.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub max_iterations: Option<usize>,
-}
-
-/// Request to preview the final agent shape with capabilities applied
-#[derive(Debug, Clone, Deserialize, ToSchema)]
-pub struct PreviewAgentRequest {
-    /// The base system prompt (before capability additions)
-    #[schema(example = "You are a helpful customer support agent.")]
-    pub system_prompt: String,
-    /// Capabilities to apply with per-agent configuration.
-    #[serde(default)]
-    #[schema(example = json!([{"ref": "current_time", "config": {}}, {"ref": "test_math", "config": {}}]))]
-    pub capabilities: Vec<AgentCapabilityConfig>,
-    /// Client-side tools to include in the preview.
-    #[serde(default)]
-    #[schema(value_type = Vec<Object>)]
-    pub tools: Vec<ToolDefinition>,
-    /// Remote MCP servers scoped to the previewed agent.
-    #[serde(default, rename = "mcpServers", alias = "mcp_servers")]
-    pub mcp_servers: ScopedMcpServers,
-}
-
-/// Response showing the final agent shape after applying capabilities
-#[derive(Debug, Clone, Serialize, ToSchema)]
-pub struct AgentPreviewResponse {
-    /// The full system prompt with capability additions prepended
-    pub system_prompt: String,
-    /// All tool definitions from capabilities
-    #[schema(value_type = Vec<Object>)]
-    pub tools: Vec<ToolDefinition>,
-}
 
 /// Capability entry in agent file - supports both string and object formats
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -257,37 +113,6 @@ struct AgentFile {
 
 use crate::domains::agents::{AGENT_DANGEROUS, AGENT_MANAGE, AGENT_VIEW};
 use crate::services::CapabilityService;
-
-/// Query parameters for listing agents.
-#[derive(Debug, Clone, Deserialize, IntoParams)]
-pub struct ListAgentsQuery {
-    /// Search by name or description (case-insensitive substring match).
-    pub search: Option<String>,
-    /// Include archived agents. Deleted agents never appear in lists.
-    pub include_archived: Option<bool>,
-    /// Pagination offset (default 0).
-    #[param(minimum = 0, default = 0)]
-    pub offset: Option<u32>,
-    /// Maximum items to return (default 20, max 100).
-    #[param(minimum = 1, maximum = 100, default = 20)]
-    pub limit: Option<u32>,
-}
-
-/// Query parameters for checking agent name availability.
-#[derive(Debug, Clone, Deserialize, IntoParams)]
-pub struct CheckAgentNameQuery {
-    /// The agent name to check.
-    pub name: String,
-    /// Optional agent ID to exclude (for edit forms where the current agent's own name is valid).
-    pub exclude_id: Option<String>,
-}
-
-/// Response for agent name availability check.
-#[derive(Debug, Clone, Serialize, ToSchema)]
-pub struct CheckAgentNameResponse {
-    /// Whether the name is available for use.
-    pub available: bool,
-}
 
 /// App state for agents routes
 #[derive(Clone)]
@@ -760,16 +585,6 @@ pub async fn export_agent(
         )
         .body(Body::from(markdown))
         .unwrap())
-}
-
-/// Query parameters for POST /v1/agents/import
-#[derive(Debug, Clone, Deserialize, IntoParams)]
-#[into_params(parameter_in = Query)]
-pub struct ImportAgentQuery {
-    /// Import from a built-in example by name (e.g. `dad-jokes-agent`).
-    /// When set, the request body is ignored.
-    #[serde(rename = "from-example")]
-    pub from_example: Option<String>,
 }
 
 /// POST /v1/agents/import - Import agent from file or built-in example

--- a/crates/server/src/api/apps.rs
+++ b/crates/server/src/api/apps.rs
@@ -3,6 +3,9 @@
 // Handlers call domain commands; policy enforcement happens inside commands.
 
 use crate::auth::{AuthState, ResolvedOrg};
+use crate::domains::apps::types::{
+    AddChannelRequest, CreateAppRequest, ListAppsQuery, UpdateAppRequest, UpdateChannelRequest,
+};
 use crate::domains::apps::{APP_DANGEROUS, APP_MANAGE, APP_VIEW};
 use crate::services::CapabilityService;
 use crate::storage::{EncryptionService, StorageBackend};
@@ -12,111 +15,13 @@ use axum::{
     http::StatusCode,
     routing::{get, post},
 };
-use everruns_core::typed_id::{AgentId, AgentIdentityId, HarnessId};
-use everruns_core::{
-    App, AppChannel, AppStatus, Caller, ChannelType, ResourceConfigResponse, evaluate_policies_with,
-};
+use everruns_core::{App, AppChannel, Caller, ResourceConfigResponse, evaluate_policies_with};
 
 use super::common::{
-    ApiResult, ErrorResponse, ListResponse, UrlBuilder, WithUrls,
-    deserialize_nullable_update_field, impl_auth_state,
+    ApiResult, ErrorResponse, ListResponse, UrlBuilder, WithUrls, impl_auth_state,
 };
 use crate::domains::common::Command;
-use everruns_durable::UpdateField;
-use serde::Deserialize;
 use std::sync::Arc;
-use utoipa::{IntoParams, ToSchema};
-
-/// Request to create a new app
-#[derive(Debug, Clone, Deserialize, ToSchema)]
-pub struct CreateAppRequest {
-    /// Display name of the app.
-    #[schema(example = "Support Bot")]
-    pub name: String,
-    /// Description of what the app does.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(example = "Customer support bot connected to Slack")]
-    pub description: Option<String>,
-    /// ID of the harness to use.
-    #[schema(value_type = String, example = "harness_01933b5a00007000800000000000001")]
-    pub harness_id: HarnessId,
-    /// Optional ID of the agent to use.
-    #[serde(default)]
-    #[schema(value_type = Option<String>, example = "agent_01933b5a00007000800000000000001")]
-    pub agent_id: Option<AgentId>,
-    /// Optional resident agent identity for unattended/channel execution.
-    #[serde(default)]
-    #[schema(value_type = Option<String>, example = "identity_01933b5a00007000800000000000001")]
-    pub agent_identity_id: Option<AgentIdentityId>,
-    /// Optional initial channel type (creates the first channel on the app).
-    #[serde(default)]
-    pub channel_type: Option<ChannelType>,
-    /// Initial channel configuration.
-    #[serde(default)]
-    pub channel_config: Option<serde_json::Value>,
-}
-
-/// Request to update an app. Only provided fields will be updated.
-#[derive(Debug, Clone, Deserialize, ToSchema)]
-pub struct UpdateAppRequest {
-    /// Display name of the app.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    /// Description of what the app does.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    /// ID of the harness to use.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = Option<String>)]
-    pub harness_id: Option<HarnessId>,
-    /// ID of the agent to use.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = Option<String>)]
-    pub agent_id: Option<AgentId>,
-    /// Optional resident agent identity for unattended/channel execution.
-    #[serde(default, deserialize_with = "deserialize_nullable_update_field")]
-    #[schema(value_type = Option<String>, nullable = true)]
-    pub agent_identity_id: UpdateField<AgentIdentityId>,
-    /// Lifecycle status (draft or archived). Use publish/unpublish endpoints for publishing.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<AppStatus>,
-}
-
-/// Request to add a channel to an app.
-#[derive(Debug, Clone, Deserialize, ToSchema)]
-pub struct AddChannelRequest {
-    /// Channel type.
-    pub channel_type: ChannelType,
-    /// Channel-specific configuration.
-    #[serde(default)]
-    pub channel_config: Option<serde_json::Value>,
-    /// Whether the channel is enabled (default: true).
-    #[serde(default)]
-    pub enabled: Option<bool>,
-}
-
-/// Request to update a channel.
-#[derive(Debug, Clone, Deserialize, ToSchema)]
-pub struct UpdateChannelRequest {
-    /// Channel type.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub channel_type: Option<ChannelType>,
-    /// Channel-specific configuration.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub channel_config: Option<serde_json::Value>,
-    /// Whether the channel is enabled.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub enabled: Option<bool>,
-}
-
-/// Query parameters for listing apps.
-#[derive(Debug, Clone, Deserialize, IntoParams)]
-pub struct ListAppsQuery {
-    /// Search by name or description (case-insensitive substring match).
-    pub search: Option<String>,
-    /// Include archived apps. Deleted apps never appear in lists.
-    pub include_archived: Option<bool>,
-}
 
 /// App state for routes
 #[derive(Clone)]
@@ -435,49 +340,4 @@ pub async fn delete_channel(
         .execute(&state.ctx(&org))
         .await?;
     Ok(StatusCode::NO_CONTENT)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    const TEST_HARNESS_ID: &str = "harness_550e8400e29b41d4a716446655440001";
-    const TEST_AGENT_IDENTITY_ID: &str = "identity_550e8400e29b41d4a716446655440000";
-
-    #[test]
-    fn create_app_request_allows_missing_agent_and_channel() {
-        let req: CreateAppRequest = serde_json::from_str(&format!(
-            r#"{{"name":"Draft App","harness_id":"{}"}}"#,
-            TEST_HARNESS_ID
-        ))
-        .unwrap();
-
-        assert_eq!(req.name, "Draft App");
-        assert_eq!(req.agent_id, None);
-        assert_eq!(req.channel_type, None);
-        assert_eq!(req.channel_config, None);
-    }
-
-    #[test]
-    fn update_app_request_leaves_agent_identity_unchanged_when_omitted() {
-        let req: UpdateAppRequest = serde_json::from_str("{}").unwrap();
-        assert_eq!(req.agent_identity_id, UpdateField::Unchanged);
-    }
-
-    #[test]
-    fn update_app_request_clears_agent_identity_when_null() {
-        let req: UpdateAppRequest = serde_json::from_str(r#"{"agent_identity_id":null}"#).unwrap();
-        assert_eq!(req.agent_identity_id, UpdateField::Clear);
-    }
-
-    #[test]
-    fn update_app_request_sets_agent_identity_when_present() {
-        let req: UpdateAppRequest = serde_json::from_str(&format!(
-            r#"{{"agent_identity_id":"{}"}}"#,
-            TEST_AGENT_IDENTITY_ID
-        ))
-        .unwrap();
-        let expected: AgentIdentityId = TEST_AGENT_IDENTITY_ID.parse().unwrap();
-        assert_eq!(req.agent_identity_id, UpdateField::Set(expected));
-    }
 }

--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -4,6 +4,10 @@
 
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::domains::common::Command;
+use crate::domains::harnesses::types::{
+    CheckNameQuery, CheckNameResponse, CreateHarnessRequest, HarnessPreviewResponse,
+    PreviewHarnessRequest, UpdateHarnessRequest,
+};
 use crate::domains::harnesses::{HARNESS_DANGEROUS, HARNESS_MANAGE, HARNESS_VIEW};
 use crate::storage::StorageBackend;
 use axum::{
@@ -12,127 +16,16 @@ use axum::{
     http::StatusCode,
     routing::{get, post},
 };
-use everruns_core::typed_id::{HarnessId, ModelId};
-use everruns_core::{
-    AgentCapabilityConfig, Caller, Harness, HarnessStatus, InitialFile, ResourceConfigResponse,
-    ScopedMcpServers, ToolDefinition, evaluate_policies_with,
-};
+use everruns_core::{Caller, Harness, ResourceConfigResponse, evaluate_policies_with};
 
 use super::common::{
     ApiResult, ErrorResponse, ListResponse, UrlBuilder, WithUrls, impl_auth_state,
 };
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::sync::Arc;
-use utoipa::{IntoParams, ToSchema};
+use utoipa::IntoParams;
 
 use crate::services::CapabilityService;
-
-/// Request to create a new harness
-#[derive(Debug, Clone, Deserialize, ToSchema)]
-pub struct CreateHarnessRequest {
-    /// Name, unique per org. Lowercase alphanumeric and hyphens.
-    #[schema(example = "deep-research")]
-    pub name: String,
-    /// Human-readable display name shown in UI.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(example = "Deep Research")]
-    pub display_name: Option<String>,
-    /// Description of what the harness does.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(example = "Research harness with planning and web capabilities")]
-    pub description: Option<String>,
-    /// The system prompt defining the harness's base behavior.
-    #[schema(example = "You are a research assistant with deep analytical capabilities.")]
-    pub system_prompt: String,
-    /// Optional parent harness to inherit from.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = Option<String>, example = "harness_01933b5a000070008000000000000602")]
-    pub parent_harness_id: Option<HarnessId>,
-    /// Default LLM model ID for this harness. Lowest priority in model chain.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = Option<String>, example = "model_01933b5a00007000800000000000001")]
-    pub default_model_id: Option<ModelId>,
-    /// Tags for organizing harnesses.
-    #[serde(default)]
-    #[schema(example = json!(["research", "planning"]))]
-    pub tags: Vec<String>,
-    /// Capabilities to enable with per-harness configuration.
-    #[serde(default)]
-    #[schema(example = json!([{"ref": "current_time", "config": {}}, {"ref": "web_fetch", "config": {}}]))]
-    pub capabilities: Vec<AgentCapabilityConfig>,
-    /// Starter files copied into each new session for this harness.
-    #[serde(default)]
-    pub initial_files: Vec<InitialFile>,
-    /// Remote MCP servers scoped to this harness.
-    #[serde(default, rename = "mcpServers", alias = "mcp_servers")]
-    pub mcp_servers: ScopedMcpServers,
-    /// Network access list controlling which hosts/URLs sessions can reach.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub network_access: Option<everruns_core::network_access::NetworkAccessList>,
-}
-
-/// Request to update a harness. Only provided fields will be updated.
-#[derive(Debug, Clone, Deserialize, ToSchema)]
-pub struct UpdateHarnessRequest {
-    /// Name, unique per org.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(example = "updated-research")]
-    pub name: Option<String>,
-    /// Human-readable display name.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(example = "Updated Research Harness")]
-    pub display_name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub system_prompt: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = Option<String>, nullable = true)]
-    pub parent_harness_id: Option<Option<HarnessId>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = Option<String>)]
-    pub default_model_id: Option<ModelId>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tags: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub capabilities: Option<Vec<AgentCapabilityConfig>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub initial_files: Option<Vec<InitialFile>>,
-    #[serde(
-        default,
-        rename = "mcpServers",
-        alias = "mcp_servers",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub mcp_servers: Option<ScopedMcpServers>,
-    /// Network access list. Send `{}` (empty object) to clear. Omit to leave unchanged.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub network_access: Option<everruns_core::network_access::NetworkAccessList>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<HarnessStatus>,
-}
-
-/// Request to preview harness shape with capabilities applied
-#[derive(Debug, Clone, Deserialize, ToSchema)]
-pub struct PreviewHarnessRequest {
-    #[schema(example = "You are a research assistant.")]
-    pub system_prompt: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = Option<String>, example = "harness_01933b5a000070008000000000000602")]
-    pub parent_harness_id: Option<HarnessId>,
-    #[serde(default)]
-    pub capabilities: Vec<AgentCapabilityConfig>,
-    #[serde(default, rename = "mcpServers", alias = "mcp_servers")]
-    pub mcp_servers: ScopedMcpServers,
-}
-
-/// Preview response showing merged prompt and tools
-#[derive(Debug, Clone, Serialize, ToSchema)]
-pub struct HarnessPreviewResponse {
-    pub system_prompt: String,
-    #[schema(value_type = Vec<Object>)]
-    pub tools: Vec<ToolDefinition>,
-}
 
 /// Query parameters for listing harnesses.
 #[derive(Debug, Clone, Deserialize, IntoParams)]
@@ -141,22 +34,6 @@ pub struct ListHarnessesQuery {
     pub search: Option<String>,
     /// Include archived harnesses. Deleted harnesses never appear in lists.
     pub include_archived: Option<bool>,
-}
-
-/// Query parameters for checking harness name availability.
-#[derive(Debug, Clone, Deserialize, IntoParams)]
-pub struct CheckNameQuery {
-    /// The harness name to check.
-    pub name: String,
-    /// Optional harness ID to exclude (for edit forms where the current harness's own name is valid).
-    pub exclude_id: Option<String>,
-}
-
-/// Response for name availability check.
-#[derive(Debug, Clone, Serialize, ToSchema)]
-pub struct CheckNameResponse {
-    /// Whether the name is available for use.
-    pub available: bool,
 }
 
 /// App state for harness routes

--- a/crates/server/src/api/mcp_servers.rs
+++ b/crates/server/src/api/mcp_servers.rs
@@ -5,6 +5,7 @@
 
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::domains::common::Command;
+use crate::domains::mcp_servers::types::{CreateMcpServerRequest, UpdateMcpServerRequest};
 use crate::domains::mcp_servers::{MCP_SERVER_DANGEROUS, MCP_SERVER_MANAGE, MCP_SERVER_VIEW};
 use crate::services::CapabilityService;
 use crate::storage::{EncryptionService, StorageBackend};
@@ -14,16 +15,12 @@ use axum::{
     http::StatusCode,
     routing::{get, post},
 };
-use everruns_core::{
-    Caller, McpServer, McpServerAuthMode, McpServerStatus, McpServerTransportType,
-    ResourceConfigResponse, evaluate_policies_with,
-};
+use everruns_core::{Caller, McpServer, ResourceConfigResponse, evaluate_policies_with};
 
 use super::common::{
     ApiResult, ErrorResponse, ListResponse, UrlBuilder, WithUrls, impl_auth_state,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::sync::Arc;
 use utoipa::{IntoParams, ToSchema};
 
@@ -34,69 +31,6 @@ pub struct ListMcpServersQuery {
     pub search: Option<String>,
     /// Include archived MCP servers. Deleted MCP servers never appear in lists.
     pub include_archived: Option<bool>,
-}
-
-/// Request to create a new MCP server
-#[derive(Debug, Clone, Deserialize, ToSchema)]
-pub struct CreateMcpServerRequest {
-    /// The name of the MCP server. Must be unique.
-    #[schema(example = "atlassian-mcp-server")]
-    pub name: String,
-    /// A human-readable description of what the MCP server provides.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(example = "Atlassian MCP Server for Jira and Confluence")]
-    pub description: Option<String>,
-    /// The URL of the MCP server endpoint.
-    #[schema(example = "https://mcp.atlassian.com/v1/mcp")]
-    pub url: String,
-    /// Transport type. Currently only "http" is supported.
-    #[serde(default = "default_transport_type")]
-    pub transport_type: McpServerTransportType,
-    /// Authentication mode. Defaults to `api_key` when `api_key` is provided, otherwise `none`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub auth_mode: Option<McpServerAuthMode>,
-    /// API key for authentication (optional).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub api_key: Option<String>,
-    /// Additional HTTP headers for authentication.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub headers: Option<HashMap<String, String>>,
-}
-
-fn default_transport_type() -> McpServerTransportType {
-    McpServerTransportType::Http
-}
-
-/// Request to update an MCP server. Only provided fields will be updated.
-#[derive(Debug, Clone, Deserialize, ToSchema)]
-pub struct UpdateMcpServerRequest {
-    /// The name of the MCP server.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(example = "updated-mcp-server")]
-    pub name: Option<String>,
-    /// A human-readable description of what the MCP server provides.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(example = "Updated description")]
-    pub description: Option<String>,
-    /// The URL of the MCP server endpoint.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(example = "https://mcp.example.com/v1/mcp")]
-    pub url: Option<String>,
-    /// Transport type.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub transport_type: Option<McpServerTransportType>,
-    /// Authentication mode.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub auth_mode: Option<McpServerAuthMode>,
-    /// The status of the MCP server. Set to "disabled" to disable.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<McpServerStatus>,
-    /// API key for authentication. Set to update.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub api_key: Option<String>,
-    /// Additional HTTP headers for authentication.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub headers: Option<HashMap<String, String>>,
 }
 
 /// Response for a simple MCP server config (matches Claude Desktop format)
@@ -336,135 +270,4 @@ pub async fn destroy_mcp_server(
         .execute(&state.ctx(&org))
         .await?;
     Ok(StatusCode::NO_CONTENT)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json;
-
-    #[test]
-    fn test_create_request_serialization() {
-        let json = r#"{
-            "name": "test-server",
-            "url": "https://mcp.example.com/v1/mcp"
-        }"#;
-
-        let req: CreateMcpServerRequest = serde_json::from_str(json).unwrap();
-        assert_eq!(req.name, "test-server");
-        assert_eq!(req.url, "https://mcp.example.com/v1/mcp");
-        assert_eq!(req.transport_type, McpServerTransportType::Http);
-        assert!(req.description.is_none());
-        assert!(req.api_key.is_none());
-        assert!(req.headers.is_none());
-    }
-
-    #[test]
-    fn test_create_request_with_all_fields() {
-        let json = r#"{
-            "name": "full-server",
-            "description": "A test MCP server",
-            "url": "https://mcp.example.com/v1/mcp",
-            "transport_type": "http",
-            "api_key": "secret-key",
-            "headers": {"X-Custom": "value"}
-        }"#;
-
-        let req: CreateMcpServerRequest = serde_json::from_str(json).unwrap();
-        assert_eq!(req.name, "full-server");
-        assert_eq!(req.description, Some("A test MCP server".to_string()));
-        assert_eq!(req.api_key, Some("secret-key".to_string()));
-        assert!(req.headers.is_some());
-        assert_eq!(
-            req.headers.unwrap().get("X-Custom"),
-            Some(&"value".to_string())
-        );
-    }
-
-    #[test]
-    fn test_update_request_partial() {
-        let json = r#"{
-            "description": "Updated description"
-        }"#;
-
-        let req: UpdateMcpServerRequest = serde_json::from_str(json).unwrap();
-        assert!(req.name.is_none());
-        assert_eq!(req.description, Some("Updated description".to_string()));
-        assert!(req.url.is_none());
-        assert!(req.status.is_none());
-    }
-
-    #[test]
-    fn test_update_request_status() {
-        let json = r#"{
-            "status": "disabled"
-        }"#;
-
-        let req: UpdateMcpServerRequest = serde_json::from_str(json).unwrap();
-        assert_eq!(req.status, Some(McpServerStatus::Disabled));
-    }
-
-    #[test]
-    fn test_transport_type_deserialization() {
-        let json = r#"{"name": "test", "url": "http://test", "transport_type": "http"}"#;
-        let req: CreateMcpServerRequest = serde_json::from_str(json).unwrap();
-        assert_eq!(req.transport_type, McpServerTransportType::Http);
-    }
-
-    #[test]
-    fn test_default_transport_type() {
-        assert_eq!(default_transport_type(), McpServerTransportType::Http);
-    }
-
-    // --- SSRF validation tests (URL safety) ---
-
-    use everruns_core::validate_safe_url;
-
-    #[test]
-    fn ssrf_rejects_localhost_url() {
-        assert!(validate_safe_url("http://localhost/mcp").is_err());
-        assert!(validate_safe_url("http://localhost:8080/mcp").is_err());
-    }
-
-    #[test]
-    fn ssrf_rejects_loopback_ip() {
-        assert!(validate_safe_url("http://127.0.0.1/mcp").is_err());
-        assert!(validate_safe_url("http://127.0.0.2:9999/mcp").is_err());
-    }
-
-    #[test]
-    fn ssrf_rejects_private_ips() {
-        assert!(validate_safe_url("http://10.0.0.1/mcp").is_err());
-        assert!(validate_safe_url("http://172.16.0.1/mcp").is_err());
-        assert!(validate_safe_url("http://192.168.1.1/mcp").is_err());
-    }
-
-    #[test]
-    fn ssrf_rejects_cloud_metadata() {
-        assert!(validate_safe_url("http://169.254.169.254/latest/meta-data/").is_err());
-        assert!(validate_safe_url("http://metadata.google.internal/computeMetadata/v1/").is_err());
-    }
-
-    #[test]
-    fn ssrf_rejects_ipv6_loopback() {
-        assert!(validate_safe_url("http://[::1]/mcp").is_err());
-    }
-
-    #[test]
-    fn ssrf_rejects_ipv4_mapped_ipv6() {
-        assert!(validate_safe_url("http://[::ffff:127.0.0.1]/mcp").is_err());
-        assert!(validate_safe_url("http://[::ffff:169.254.169.254]/mcp").is_err());
-    }
-
-    #[test]
-    fn ssrf_rejects_disallowed_schemes() {
-        assert!(validate_safe_url("ftp://example.com/mcp").is_err());
-        assert!(validate_safe_url("file:///etc/passwd").is_err());
-    }
-
-    #[test]
-    fn ssrf_allows_valid_public_https() {
-        assert!(validate_safe_url("https://mcp.atlassian.com/v1/mcp").is_ok());
-        assert!(validate_safe_url("https://mcp.example.com:8443/v1").is_ok());
-    }
 }

--- a/crates/server/src/api/skills.rs
+++ b/crates/server/src/api/skills.rs
@@ -9,6 +9,7 @@ use crate::api::common::{
 };
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::domains::common::Command;
+use crate::domains::skills::types::{CreateSkillRequest, UpdateSkillRequest};
 use crate::domains::skills::{SKILL_DANGEROUS, SKILL_MANAGE, SKILL_VIEW};
 use crate::services::CapabilityService;
 use crate::storage::StorageBackend;
@@ -20,7 +21,7 @@ use axum::{
 };
 use axum_extra::extract::Multipart;
 use everruns_core::{
-    Caller, ResourceConfigResponse, Skill, SkillContent, SkillStatus, SkillValidationResult,
+    Caller, ResourceConfigResponse, Skill, SkillContent, SkillValidationResult,
     evaluate_policies_with, validate_skill_md,
 };
 use serde::Deserialize;
@@ -37,27 +38,6 @@ const MAX_ARCHIVE_UPLOAD: usize = 11 * 1024 * 1024;
 // ============================================
 // Request/Response types
 // ============================================
-
-/// Request to create a skill from SKILL.md content
-#[derive(Debug, Clone, Deserialize, ToSchema)]
-pub struct CreateSkillRequest {
-    /// Full SKILL.md content (YAML frontmatter + markdown body)
-    #[schema(
-        example = "---\nname: pdf-processing\ndescription: Extract text from PDFs.\n---\n\n# PDF Processing\n\nUse pdfplumber..."
-    )]
-    pub skill_md: String,
-}
-
-/// Request to update a skill
-#[derive(Debug, Clone, Deserialize, ToSchema)]
-pub struct UpdateSkillRequest {
-    /// Updated SKILL.md content (re-parses frontmatter)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub skill_md: Option<String>,
-    /// Update status
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<SkillStatus>,
-}
 
 /// Request to validate a SKILL.md
 #[derive(Debug, Clone, Deserialize, ToSchema)]

--- a/crates/server/src/domains/agent_identities/types.rs
+++ b/crates/server/src/domains/agent_identities/types.rs
@@ -1,11 +1,86 @@
-// Agent identity domain types — re-exports from existing locations.
+// Agent identity domain types — canonical definitions for request shapes.
 //
-// During migration, request types still live in api/agent_identities.rs and
-// storage row types in storage/models.rs. This module re-exports them so
-// domain code has a single import path. Once all callers are migrated,
-// types will move here.
+// Storage row types are re-exported from `storage::models` so domain code
+// has a single import path.
 
-pub use crate::api::agent_identities::{
-    CreateAgentIdentityRequest, ListAgentIdentitiesQuery, UpdateAgentIdentityRequest,
-};
+use crate::api::common::deserialize_nullable_update_field;
+use everruns_core::AgentIdentityStatus;
+use everruns_durable::UpdateField;
+use serde::Deserialize;
+use utoipa::{IntoParams, ToSchema};
+
 pub use crate::storage::models::{AgentIdentityRow, CreateAgentIdentityRow, UpdateAgentIdentity};
+
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct CreateAgentIdentityRequest {
+    #[schema(example = "Ops Bot")]
+    pub name: String,
+    pub description: Option<String>,
+    pub avatar_url: Option<String>,
+    #[schema(example = "en-US")]
+    pub locale: Option<String>,
+    #[schema(example = "America/Los_Angeles")]
+    pub timezone: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct UpdateAgentIdentityRequest {
+    pub name: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_nullable_update_field")]
+    #[schema(value_type = Option<String>, nullable = true)]
+    pub description: UpdateField<String>,
+    #[serde(default, deserialize_with = "deserialize_nullable_update_field")]
+    #[schema(value_type = Option<String>, nullable = true)]
+    pub avatar_url: UpdateField<String>,
+    #[serde(default, deserialize_with = "deserialize_nullable_update_field")]
+    #[schema(value_type = Option<String>, nullable = true)]
+    pub locale: UpdateField<String>,
+    #[serde(default, deserialize_with = "deserialize_nullable_update_field")]
+    #[schema(value_type = Option<String>, nullable = true)]
+    pub timezone: UpdateField<String>,
+    pub status: Option<AgentIdentityStatus>,
+}
+
+#[derive(Debug, Clone, Deserialize, IntoParams)]
+pub struct ListAgentIdentitiesQuery {
+    pub search: Option<String>,
+    pub include_archived: Option<bool>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_agent_identity_request_roundtrip() {
+        let json = r#"{"name":"Ops Bot","locale":"en-US","timezone":"America/Los_Angeles"}"#;
+        let req: CreateAgentIdentityRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.name, "Ops Bot");
+        assert_eq!(req.locale.as_deref(), Some("en-US"));
+        assert_eq!(req.timezone.as_deref(), Some("America/Los_Angeles"));
+    }
+
+    #[test]
+    fn test_update_agent_identity_request_status() {
+        let json = r#"{"status":"archived"}"#;
+        let req: UpdateAgentIdentityRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.status, Some(AgentIdentityStatus::Archived));
+    }
+
+    #[test]
+    fn update_agent_identity_request_defaults_to_unchanged() {
+        let req: UpdateAgentIdentityRequest = serde_json::from_str("{}").unwrap();
+        assert_eq!(req.description, UpdateField::Unchanged);
+        assert_eq!(req.avatar_url, UpdateField::Unchanged);
+        assert_eq!(req.locale, UpdateField::Unchanged);
+        assert_eq!(req.timezone, UpdateField::Unchanged);
+    }
+
+    #[test]
+    fn update_agent_identity_request_supports_clear() {
+        let req: UpdateAgentIdentityRequest =
+            serde_json::from_str(r#"{"description":null,"locale":null}"#).unwrap();
+        assert_eq!(req.description, UpdateField::Clear);
+        assert_eq!(req.locale, UpdateField::Clear);
+    }
+}

--- a/crates/server/src/domains/agents/types.rs
+++ b/crates/server/src/domains/agents/types.rs
@@ -1,11 +1,200 @@
-// Agent domain types — re-exports from existing locations.
+// Agents domain types — canonical definitions for request/response shapes.
 //
-// During migration, request types still live in api/agents.rs and storage
-// row types in storage/models.rs. This module re-exports them so domain
-// code has a single import path. Once all callers are migrated, types
-// will move here.
+// Storage row types are re-exported from `storage::models` so domain code
+// has a single import path.
 
-pub use crate::api::agents::{
-    CheckAgentNameQuery, CheckAgentNameResponse, CreateAgentRequest, UpdateAgentRequest,
+use everruns_core::typed_id::{AgentId, ModelId};
+use everruns_core::{
+    AgentCapabilityConfig, AgentStatus, InitialFile, ScopedMcpServers, ToolDefinition,
 };
+use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
+
 pub use crate::storage::models::{AgentRow, CreateAgentRow, UpdateAgent};
+
+/// Request to create a new agent
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct CreateAgentRequest {
+    /// Client-supplied agent ID (format: agent_{32-hex}).
+    /// If not provided, one is auto-generated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>, example = "agent_01933b5a00007000800000000000001")]
+    pub id: Option<AgentId>,
+    /// Name, unique per org. Lowercase alphanumeric and hyphens.
+    /// Format: lowercase alphanumeric and hyphens (e.g. "customer-support").
+    #[schema(example = "customer-support")]
+    pub name: String,
+    /// Human-readable display name shown in UI.
+    /// Falls back to `name` when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(example = "Customer Support Agent")]
+    pub display_name: Option<String>,
+    /// A human-readable description of what the agent does.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "Handles customer inquiries and support tickets")]
+    pub description: Option<String>,
+    /// The system prompt that defines the agent's behavior and capabilities.
+    /// This is sent as the first message in every conversation.
+    #[schema(example = "You are a helpful customer support agent. Be polite and professional.")]
+    pub system_prompt: String,
+    /// The ID of the default LLM model to use for this agent.
+    /// If not specified, the system default model will be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>, example = "model_01933b5a00007000800000000000001")]
+    pub default_model_id: Option<ModelId>,
+    /// Tags for organizing and filtering agents.
+    #[serde(default)]
+    #[schema(example = json!(["support", "customer-facing"]))]
+    pub tags: Vec<String>,
+    /// Capabilities to enable for this agent with per-agent configuration.
+    /// Each capability has a `ref` (capability ID) and optional `config`.
+    #[serde(default)]
+    #[schema(example = json!([{"ref": "current_time", "config": {}}, {"ref": "web_fetch", "config": {}}]))]
+    pub capabilities: Vec<AgentCapabilityConfig>,
+    /// Starter files copied into each new session for this agent.
+    #[serde(default)]
+    pub initial_files: Vec<InitialFile>,
+    /// Client-side tools for this agent.
+    /// These tools are sent to the LLM but executed by the client, not the server.
+    #[serde(default)]
+    pub tools: Vec<ToolDefinition>,
+    /// Remote MCP servers scoped to this agent.
+    #[serde(default, rename = "mcpServers", alias = "mcp_servers")]
+    pub mcp_servers: ScopedMcpServers,
+    /// Network access list controlling which hosts/URLs this agent's sessions can reach.
+    /// If set, merged with harness and session layers (allowed: intersect, blocked: union).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network_access: Option<everruns_core::network_access::NetworkAccessList>,
+    /// Maximum number of LLM iterations per turn for this agent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_iterations: Option<usize>,
+}
+
+/// Request to update an agent. Only provided fields will be updated.
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct UpdateAgentRequest {
+    /// Name, unique per org. Lowercase alphanumeric and hyphens.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "updated-support")]
+    pub name: Option<String>,
+    /// Human-readable display name shown in UI.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "Updated Support Agent")]
+    pub display_name: Option<String>,
+    /// A human-readable description of what the agent does.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "Updated description for the agent")]
+    pub description: Option<String>,
+    /// The system prompt that defines the agent's behavior and capabilities.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "You are an updated helpful assistant.")]
+    pub system_prompt: Option<String>,
+    /// The ID of the default LLM model to use for this agent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>, example = "model_01933b5a00007000800000000000001")]
+    pub default_model_id: Option<ModelId>,
+    /// Tags for organizing and filtering agents.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = json!(["updated-tag"]))]
+    pub tags: Option<Vec<String>>,
+    /// Capabilities to enable for this agent with per-agent configuration.
+    /// Replaces existing capabilities. Each has a `ref` (capability ID) and optional `config`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = json!([{"ref": "current_time", "config": {}}, {"ref": "web_fetch", "config": {}}]))]
+    pub capabilities: Option<Vec<AgentCapabilityConfig>>,
+    /// Starter files copied into each new session for this agent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub initial_files: Option<Vec<InitialFile>>,
+    /// The status of the agent. Set to "archived" to soft-delete.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<AgentStatus>,
+    /// Client-side tools for this agent.
+    /// Replaces existing tools if provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<ToolDefinition>>,
+    /// Remote MCP servers scoped to this agent.
+    #[serde(
+        default,
+        rename = "mcpServers",
+        alias = "mcp_servers",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub mcp_servers: Option<ScopedMcpServers>,
+    /// Network access list controlling which hosts/URLs this agent's sessions can reach.
+    /// Send `{}` (empty object) to clear restrictions. Omit to leave unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network_access: Option<everruns_core::network_access::NetworkAccessList>,
+    /// Maximum number of LLM iterations per turn for this agent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_iterations: Option<usize>,
+}
+
+/// Request to preview the final agent shape with capabilities applied
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct PreviewAgentRequest {
+    /// The base system prompt (before capability additions)
+    #[schema(example = "You are a helpful customer support agent.")]
+    pub system_prompt: String,
+    /// Capabilities to apply with per-agent configuration.
+    #[serde(default)]
+    #[schema(example = json!([{"ref": "current_time", "config": {}}, {"ref": "test_math", "config": {}}]))]
+    pub capabilities: Vec<AgentCapabilityConfig>,
+    /// Client-side tools to include in the preview.
+    #[serde(default)]
+    #[schema(value_type = Vec<Object>)]
+    pub tools: Vec<ToolDefinition>,
+    /// Remote MCP servers scoped to the previewed agent.
+    #[serde(default, rename = "mcpServers", alias = "mcp_servers")]
+    pub mcp_servers: ScopedMcpServers,
+}
+
+/// Response showing the final agent shape after applying capabilities
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct AgentPreviewResponse {
+    /// The full system prompt with capability additions prepended
+    pub system_prompt: String,
+    /// All tool definitions from capabilities
+    #[schema(value_type = Vec<Object>)]
+    pub tools: Vec<ToolDefinition>,
+}
+
+/// Query parameters for listing agents.
+#[derive(Debug, Clone, Deserialize, IntoParams)]
+pub struct ListAgentsQuery {
+    /// Search by name or description (case-insensitive substring match).
+    pub search: Option<String>,
+    /// Include archived agents. Deleted agents never appear in lists.
+    pub include_archived: Option<bool>,
+    /// Pagination offset (default 0).
+    #[param(minimum = 0, default = 0)]
+    pub offset: Option<u32>,
+    /// Maximum items to return (default 20, max 100).
+    #[param(minimum = 1, maximum = 100, default = 20)]
+    pub limit: Option<u32>,
+}
+
+/// Query parameters for checking agent name availability.
+#[derive(Debug, Clone, Deserialize, IntoParams)]
+pub struct CheckAgentNameQuery {
+    /// The agent name to check.
+    pub name: String,
+    /// Optional agent ID to exclude (for edit forms where the current agent's own name is valid).
+    pub exclude_id: Option<String>,
+}
+
+/// Response for agent name availability check.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct CheckAgentNameResponse {
+    /// Whether the name is available for use.
+    pub available: bool,
+}
+
+/// Query parameters for POST /v1/agents/import
+#[derive(Debug, Clone, Deserialize, IntoParams)]
+#[into_params(parameter_in = Query)]
+pub struct ImportAgentQuery {
+    /// Import from a built-in example by name (e.g. `dad-jokes-agent`).
+    /// When set, the request body is ignored.
+    #[serde(rename = "from-example")]
+    pub from_example: Option<String>,
+}

--- a/crates/server/src/domains/apps/types.rs
+++ b/crates/server/src/domains/apps/types.rs
@@ -1,13 +1,151 @@
-// App domain types — re-exports from existing locations.
+// Apps domain types — canonical definitions for request shapes.
 //
-// During migration, request types still live in api/apps.rs and storage
-// row types in storage/models.rs. This module re-exports them so domain
-// code has a single import path. Once all callers are migrated, types
-// will move here.
+// Storage row types are re-exported from `storage::models` so domain code
+// has a single import path.
 
-pub use crate::api::apps::{
-    AddChannelRequest, CreateAppRequest, ListAppsQuery, UpdateAppRequest, UpdateChannelRequest,
-};
+use crate::api::common::deserialize_nullable_update_field;
+use everruns_core::typed_id::{AgentId, AgentIdentityId, HarnessId};
+use everruns_core::{AppStatus, ChannelType};
+use everruns_durable::UpdateField;
+use serde::Deserialize;
+use utoipa::{IntoParams, ToSchema};
+
 pub use crate::storage::models::{
     AppChannelRow, AppRow, CreateAppChannelRow, CreateAppRow, UpdateApp, UpdateAppChannel,
 };
+
+/// Request to create a new app
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct CreateAppRequest {
+    /// Display name of the app.
+    #[schema(example = "Support Bot")]
+    pub name: String,
+    /// Description of what the app does.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "Customer support bot connected to Slack")]
+    pub description: Option<String>,
+    /// ID of the harness to use.
+    #[schema(value_type = String, example = "harness_01933b5a00007000800000000000001")]
+    pub harness_id: HarnessId,
+    /// Optional ID of the agent to use.
+    #[serde(default)]
+    #[schema(value_type = Option<String>, example = "agent_01933b5a00007000800000000000001")]
+    pub agent_id: Option<AgentId>,
+    /// Optional resident agent identity for unattended/channel execution.
+    #[serde(default)]
+    #[schema(value_type = Option<String>, example = "identity_01933b5a00007000800000000000001")]
+    pub agent_identity_id: Option<AgentIdentityId>,
+    /// Optional initial channel type (creates the first channel on the app).
+    #[serde(default)]
+    pub channel_type: Option<ChannelType>,
+    /// Initial channel configuration.
+    #[serde(default)]
+    pub channel_config: Option<serde_json::Value>,
+}
+
+/// Request to update an app. Only provided fields will be updated.
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct UpdateAppRequest {
+    /// Display name of the app.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Description of what the app does.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// ID of the harness to use.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>)]
+    pub harness_id: Option<HarnessId>,
+    /// ID of the agent to use.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>)]
+    pub agent_id: Option<AgentId>,
+    /// Optional resident agent identity for unattended/channel execution.
+    #[serde(default, deserialize_with = "deserialize_nullable_update_field")]
+    #[schema(value_type = Option<String>, nullable = true)]
+    pub agent_identity_id: UpdateField<AgentIdentityId>,
+    /// Lifecycle status (draft or archived). Use publish/unpublish endpoints for publishing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<AppStatus>,
+}
+
+/// Request to add a channel to an app.
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct AddChannelRequest {
+    /// Channel type.
+    pub channel_type: ChannelType,
+    /// Channel-specific configuration.
+    #[serde(default)]
+    pub channel_config: Option<serde_json::Value>,
+    /// Whether the channel is enabled (default: true).
+    #[serde(default)]
+    pub enabled: Option<bool>,
+}
+
+/// Request to update a channel.
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct UpdateChannelRequest {
+    /// Channel type.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channel_type: Option<ChannelType>,
+    /// Channel-specific configuration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channel_config: Option<serde_json::Value>,
+    /// Whether the channel is enabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+}
+
+/// Query parameters for listing apps.
+#[derive(Debug, Clone, Deserialize, IntoParams)]
+pub struct ListAppsQuery {
+    /// Search by name or description (case-insensitive substring match).
+    pub search: Option<String>,
+    /// Include archived apps. Deleted apps never appear in lists.
+    pub include_archived: Option<bool>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_HARNESS_ID: &str = "harness_550e8400e29b41d4a716446655440001";
+    const TEST_AGENT_IDENTITY_ID: &str = "identity_550e8400e29b41d4a716446655440000";
+
+    #[test]
+    fn create_app_request_allows_missing_agent_and_channel() {
+        let req: CreateAppRequest = serde_json::from_str(&format!(
+            r#"{{"name":"Draft App","harness_id":"{}"}}"#,
+            TEST_HARNESS_ID
+        ))
+        .unwrap();
+
+        assert_eq!(req.name, "Draft App");
+        assert_eq!(req.agent_id, None);
+        assert_eq!(req.channel_type, None);
+        assert_eq!(req.channel_config, None);
+    }
+
+    #[test]
+    fn update_app_request_leaves_agent_identity_unchanged_when_omitted() {
+        let req: UpdateAppRequest = serde_json::from_str("{}").unwrap();
+        assert_eq!(req.agent_identity_id, UpdateField::Unchanged);
+    }
+
+    #[test]
+    fn update_app_request_clears_agent_identity_when_null() {
+        let req: UpdateAppRequest = serde_json::from_str(r#"{"agent_identity_id":null}"#).unwrap();
+        assert_eq!(req.agent_identity_id, UpdateField::Clear);
+    }
+
+    #[test]
+    fn update_app_request_sets_agent_identity_when_present() {
+        let req: UpdateAppRequest = serde_json::from_str(&format!(
+            r#"{{"agent_identity_id":"{}"}}"#,
+            TEST_AGENT_IDENTITY_ID
+        ))
+        .unwrap();
+        let expected: AgentIdentityId = TEST_AGENT_IDENTITY_ID.parse().unwrap();
+        assert_eq!(req.agent_identity_id, UpdateField::Set(expected));
+    }
+}

--- a/crates/server/src/domains/harnesses/types.rs
+++ b/crates/server/src/domains/harnesses/types.rs
@@ -1,12 +1,136 @@
-// Harness domain types — re-exports from existing locations.
+// Harnesses domain types — canonical definitions for request/response shapes.
 //
-// During migration, request types still live in api/harnesses.rs and storage
-// row types in storage/models.rs. This module re-exports them so domain
-// code has a single import path. Once all callers are migrated, types
-// will move here.
+// Storage row types are re-exported from `storage::models` so domain code
+// has a single import path.
 
-pub use crate::api::harnesses::{
-    CheckNameQuery, CheckNameResponse, CreateHarnessRequest, HarnessPreviewResponse,
-    PreviewHarnessRequest, UpdateHarnessRequest,
+use everruns_core::typed_id::{HarnessId, ModelId};
+use everruns_core::{
+    AgentCapabilityConfig, HarnessStatus, InitialFile, ScopedMcpServers, ToolDefinition,
 };
+use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
+
 pub use crate::storage::models::{CreateHarnessRow, HarnessRow, UpdateHarness};
+
+/// Request to create a new harness
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct CreateHarnessRequest {
+    /// Name, unique per org. Lowercase alphanumeric and hyphens.
+    #[schema(example = "deep-research")]
+    pub name: String,
+    /// Human-readable display name shown in UI.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "Deep Research")]
+    pub display_name: Option<String>,
+    /// Description of what the harness does.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "Research harness with planning and web capabilities")]
+    pub description: Option<String>,
+    /// The system prompt defining the harness's base behavior.
+    #[schema(example = "You are a research assistant with deep analytical capabilities.")]
+    pub system_prompt: String,
+    /// Optional parent harness to inherit from.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>, example = "harness_01933b5a000070008000000000000602")]
+    pub parent_harness_id: Option<HarnessId>,
+    /// Default LLM model ID for this harness. Lowest priority in model chain.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>, example = "model_01933b5a00007000800000000000001")]
+    pub default_model_id: Option<ModelId>,
+    /// Tags for organizing harnesses.
+    #[serde(default)]
+    #[schema(example = json!(["research", "planning"]))]
+    pub tags: Vec<String>,
+    /// Capabilities to enable with per-harness configuration.
+    #[serde(default)]
+    #[schema(example = json!([{"ref": "current_time", "config": {}}, {"ref": "web_fetch", "config": {}}]))]
+    pub capabilities: Vec<AgentCapabilityConfig>,
+    /// Starter files copied into each new session for this harness.
+    #[serde(default)]
+    pub initial_files: Vec<InitialFile>,
+    /// Remote MCP servers scoped to this harness.
+    #[serde(default, rename = "mcpServers", alias = "mcp_servers")]
+    pub mcp_servers: ScopedMcpServers,
+    /// Network access list controlling which hosts/URLs sessions can reach.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network_access: Option<everruns_core::network_access::NetworkAccessList>,
+}
+
+/// Request to update a harness. Only provided fields will be updated.
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct UpdateHarnessRequest {
+    /// Name, unique per org.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "updated-research")]
+    pub name: Option<String>,
+    /// Human-readable display name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "Updated Research Harness")]
+    pub display_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_prompt: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>, nullable = true)]
+    pub parent_harness_id: Option<Option<HarnessId>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>)]
+    pub default_model_id: Option<ModelId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<Vec<AgentCapabilityConfig>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub initial_files: Option<Vec<InitialFile>>,
+    #[serde(
+        default,
+        rename = "mcpServers",
+        alias = "mcp_servers",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub mcp_servers: Option<ScopedMcpServers>,
+    /// Network access list. Send `{}` (empty object) to clear. Omit to leave unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network_access: Option<everruns_core::network_access::NetworkAccessList>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<HarnessStatus>,
+}
+
+/// Request to preview harness shape with capabilities applied
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct PreviewHarnessRequest {
+    #[schema(example = "You are a research assistant.")]
+    pub system_prompt: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>, example = "harness_01933b5a000070008000000000000602")]
+    pub parent_harness_id: Option<HarnessId>,
+    #[serde(default)]
+    pub capabilities: Vec<AgentCapabilityConfig>,
+    #[serde(default, rename = "mcpServers", alias = "mcp_servers")]
+    pub mcp_servers: ScopedMcpServers,
+}
+
+/// Preview response showing merged prompt and tools
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct HarnessPreviewResponse {
+    pub system_prompt: String,
+    #[schema(value_type = Vec<Object>)]
+    pub tools: Vec<ToolDefinition>,
+}
+
+/// Query parameters for checking harness name availability.
+#[derive(Debug, Clone, Deserialize, IntoParams)]
+pub struct CheckNameQuery {
+    /// The harness name to check.
+    pub name: String,
+    /// Optional harness ID to exclude (for edit forms where the current harness's own name is valid).
+    pub exclude_id: Option<String>,
+}
+
+/// Response for name availability check.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct CheckNameResponse {
+    /// Whether the name is available for use.
+    pub available: bool,
+}

--- a/crates/server/src/domains/mcp_servers/service.rs
+++ b/crates/server/src/domains/mcp_servers/service.rs
@@ -31,7 +31,7 @@ use uuid::Uuid;
 
 use everruns_core::validate_safe_url;
 
-use crate::api::mcp_servers::{CreateMcpServerRequest, UpdateMcpServerRequest};
+use crate::domains::mcp_servers::types::{CreateMcpServerRequest, UpdateMcpServerRequest};
 
 /// How long cached tools are considered fresh (1 hour)
 const TOOL_CACHE_TTL: Duration = Duration::from_secs(3600);

--- a/crates/server/src/domains/mcp_servers/types.rs
+++ b/crates/server/src/domains/mcp_servers/types.rs
@@ -78,7 +78,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_create_request_serialization() {
+    fn test_create_request_deserialization() {
         let json = r#"{
             "name": "test-server",
             "url": "https://mcp.example.com/v1/mcp"

--- a/crates/server/src/domains/mcp_servers/types.rs
+++ b/crates/server/src/domains/mcp_servers/types.rs
@@ -1,9 +1,204 @@
-// MCP Server domain types — re-exports from existing locations.
+// MCP Server domain types — canonical definitions for request shapes.
 //
-// During migration, request types still live in api/mcp_servers.rs and storage
-// row types in storage/models.rs. This module re-exports them so domain
-// code has a single import path. Once all callers are migrated, types
-// will move here.
+// Storage row types are re-exported from `storage::models` so domain code
+// has a single import path.
 
-pub use crate::api::mcp_servers::{CreateMcpServerRequest, UpdateMcpServerRequest};
+use everruns_core::{McpServerAuthMode, McpServerStatus, McpServerTransportType};
+use serde::Deserialize;
+use std::collections::HashMap;
+use utoipa::ToSchema;
+
 pub use crate::storage::models::{CreateMcpServerRow, McpServerRow, UpdateMcpServer};
+
+/// Request to create a new MCP server
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct CreateMcpServerRequest {
+    /// The name of the MCP server. Must be unique.
+    #[schema(example = "atlassian-mcp-server")]
+    pub name: String,
+    /// A human-readable description of what the MCP server provides.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "Atlassian MCP Server for Jira and Confluence")]
+    pub description: Option<String>,
+    /// The URL of the MCP server endpoint.
+    #[schema(example = "https://mcp.atlassian.com/v1/mcp")]
+    pub url: String,
+    /// Transport type. Currently only "http" is supported.
+    #[serde(default = "default_transport_type")]
+    pub transport_type: McpServerTransportType,
+    /// Authentication mode. Defaults to `api_key` when `api_key` is provided, otherwise `none`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth_mode: Option<McpServerAuthMode>,
+    /// API key for authentication (optional).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_key: Option<String>,
+    /// Additional HTTP headers for authentication.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub headers: Option<HashMap<String, String>>,
+}
+
+pub(crate) fn default_transport_type() -> McpServerTransportType {
+    McpServerTransportType::Http
+}
+
+/// Request to update an MCP server. Only provided fields will be updated.
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct UpdateMcpServerRequest {
+    /// The name of the MCP server.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "updated-mcp-server")]
+    pub name: Option<String>,
+    /// A human-readable description of what the MCP server provides.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "Updated description")]
+    pub description: Option<String>,
+    /// The URL of the MCP server endpoint.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "https://mcp.example.com/v1/mcp")]
+    pub url: Option<String>,
+    /// Transport type.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transport_type: Option<McpServerTransportType>,
+    /// Authentication mode.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth_mode: Option<McpServerAuthMode>,
+    /// The status of the MCP server. Set to "disabled" to disable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<McpServerStatus>,
+    /// API key for authentication. Set to update.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_key: Option<String>,
+    /// Additional HTTP headers for authentication.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub headers: Option<HashMap<String, String>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_request_serialization() {
+        let json = r#"{
+            "name": "test-server",
+            "url": "https://mcp.example.com/v1/mcp"
+        }"#;
+
+        let req: CreateMcpServerRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.name, "test-server");
+        assert_eq!(req.url, "https://mcp.example.com/v1/mcp");
+        assert_eq!(req.transport_type, McpServerTransportType::Http);
+        assert!(req.description.is_none());
+        assert!(req.api_key.is_none());
+        assert!(req.headers.is_none());
+    }
+
+    #[test]
+    fn test_create_request_with_all_fields() {
+        let json = r#"{
+            "name": "full-server",
+            "description": "A test MCP server",
+            "url": "https://mcp.example.com/v1/mcp",
+            "transport_type": "http",
+            "api_key": "secret-key",
+            "headers": {"X-Custom": "value"}
+        }"#;
+
+        let req: CreateMcpServerRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.name, "full-server");
+        assert_eq!(req.description, Some("A test MCP server".to_string()));
+        assert_eq!(req.api_key, Some("secret-key".to_string()));
+        assert!(req.headers.is_some());
+        assert_eq!(
+            req.headers.unwrap().get("X-Custom"),
+            Some(&"value".to_string())
+        );
+    }
+
+    #[test]
+    fn test_update_request_partial() {
+        let json = r#"{
+            "description": "Updated description"
+        }"#;
+
+        let req: UpdateMcpServerRequest = serde_json::from_str(json).unwrap();
+        assert!(req.name.is_none());
+        assert_eq!(req.description, Some("Updated description".to_string()));
+        assert!(req.url.is_none());
+        assert!(req.status.is_none());
+    }
+
+    #[test]
+    fn test_update_request_status() {
+        let json = r#"{
+            "status": "disabled"
+        }"#;
+
+        let req: UpdateMcpServerRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.status, Some(McpServerStatus::Disabled));
+    }
+
+    #[test]
+    fn test_transport_type_deserialization() {
+        let json = r#"{"name": "test", "url": "http://test", "transport_type": "http"}"#;
+        let req: CreateMcpServerRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.transport_type, McpServerTransportType::Http);
+    }
+
+    #[test]
+    fn test_default_transport_type() {
+        assert_eq!(default_transport_type(), McpServerTransportType::Http);
+    }
+
+    // --- SSRF validation tests (URL safety) ---
+
+    use everruns_core::validate_safe_url;
+
+    #[test]
+    fn ssrf_rejects_localhost_url() {
+        assert!(validate_safe_url("http://localhost/mcp").is_err());
+        assert!(validate_safe_url("http://localhost:8080/mcp").is_err());
+    }
+
+    #[test]
+    fn ssrf_rejects_loopback_ip() {
+        assert!(validate_safe_url("http://127.0.0.1/mcp").is_err());
+        assert!(validate_safe_url("http://127.0.0.2:9999/mcp").is_err());
+    }
+
+    #[test]
+    fn ssrf_rejects_private_ips() {
+        assert!(validate_safe_url("http://10.0.0.1/mcp").is_err());
+        assert!(validate_safe_url("http://172.16.0.1/mcp").is_err());
+        assert!(validate_safe_url("http://192.168.1.1/mcp").is_err());
+    }
+
+    #[test]
+    fn ssrf_rejects_cloud_metadata() {
+        assert!(validate_safe_url("http://169.254.169.254/latest/meta-data/").is_err());
+        assert!(validate_safe_url("http://metadata.google.internal/computeMetadata/v1/").is_err());
+    }
+
+    #[test]
+    fn ssrf_rejects_ipv6_loopback() {
+        assert!(validate_safe_url("http://[::1]/mcp").is_err());
+    }
+
+    #[test]
+    fn ssrf_rejects_ipv4_mapped_ipv6() {
+        assert!(validate_safe_url("http://[::ffff:127.0.0.1]/mcp").is_err());
+        assert!(validate_safe_url("http://[::ffff:169.254.169.254]/mcp").is_err());
+    }
+
+    #[test]
+    fn ssrf_rejects_disallowed_schemes() {
+        assert!(validate_safe_url("ftp://example.com/mcp").is_err());
+        assert!(validate_safe_url("file:///etc/passwd").is_err());
+    }
+
+    #[test]
+    fn ssrf_allows_valid_public_https() {
+        assert!(validate_safe_url("https://mcp.atlassian.com/v1/mcp").is_ok());
+        assert!(validate_safe_url("https://mcp.example.com:8443/v1").is_ok());
+    }
+}

--- a/crates/server/src/domains/skills/types.rs
+++ b/crates/server/src/domains/skills/types.rs
@@ -1,9 +1,31 @@
-// Skills domain types — re-exports from existing locations.
+// Skills domain types — canonical definitions for request shapes.
 //
-// During migration, request types still live in api/skills.rs and storage
-// row types in storage/models.rs. This module re-exports them so domain
-// code has a single import path. Once all callers are migrated, types
-// will move here.
+// Storage row types are re-exported from `storage::models` so domain code
+// has a single import path.
 
-pub use crate::api::skills::{CreateSkillRequest, UpdateSkillRequest};
+use everruns_core::SkillStatus;
+use serde::Deserialize;
+use utoipa::ToSchema;
+
 pub use crate::storage::models::{CreateSkillRow, SkillRow, UpdateSkill};
+
+/// Request to create a skill from SKILL.md content
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct CreateSkillRequest {
+    /// Full SKILL.md content (YAML frontmatter + markdown body)
+    #[schema(
+        example = "---\nname: pdf-processing\ndescription: Extract text from PDFs.\n---\n\n# PDF Processing\n\nUse pdfplumber..."
+    )]
+    pub skill_md: String,
+}
+
+/// Request to update a skill
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct UpdateSkillRequest {
+    /// Updated SKILL.md content (re-parses frontmatter)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skill_md: Option<String>,
+    /// Update status
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<SkillStatus>,
+}

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -3112,7 +3112,7 @@ impl WorkerService for WorkerServiceImpl {
             .map(|id| everruns_core::AgentCapabilityConfig::new(id.as_str()))
             .collect();
 
-        let create_req = crate::api::harnesses::CreateHarnessRequest {
+        let create_req = crate::domains::harnesses::types::CreateHarnessRequest {
             name: req.name,
             display_name: req.display_name,
             description: req.description,
@@ -3150,7 +3150,7 @@ impl WorkerService for WorkerServiceImpl {
         let req = request.into_inner();
         let harness_id = parse_uuid(req.harness_id.as_ref())?;
 
-        let update_req = crate::api::harnesses::UpdateHarnessRequest {
+        let update_req = crate::domains::harnesses::types::UpdateHarnessRequest {
             name: req.name,
             display_name: req.display_name,
             description: req.description,
@@ -3229,7 +3229,7 @@ impl WorkerService for WorkerServiceImpl {
 
         // If a new_name was provided, update the copy with the new name
         let harness = if let Some(new_name) = req.new_name {
-            let update_req = crate::api::harnesses::UpdateHarnessRequest {
+            let update_req = crate::domains::harnesses::types::UpdateHarnessRequest {
                 name: Some(new_name),
                 display_name: None,
                 description: None,
@@ -3292,7 +3292,7 @@ impl WorkerService for WorkerServiceImpl {
             .map(|id| everruns_core::AgentCapabilityConfig::new(id.as_str()))
             .collect();
 
-        let create_req = crate::api::agents::CreateAgentRequest {
+        let create_req = crate::domains::agents::types::CreateAgentRequest {
             id: None,
             name: req.name.clone(),
             display_name: req.display_name,
@@ -3329,7 +3329,7 @@ impl WorkerService for WorkerServiceImpl {
 
         let public_id = everruns_core::typed_id::AgentId::from_uuid(agent_id).to_string();
 
-        let update_req = crate::api::agents::UpdateAgentRequest {
+        let update_req = crate::domains::agents::types::UpdateAgentRequest {
             name: req.name,
             display_name: req.display_name,
             description: req.description,

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -6,6 +6,7 @@
 
 use crate::api;
 use crate::api::{ListResponse, PaginatedResponse};
+use crate::domains;
 use crate::services;
 use everruns_core::llm_models::LlmProvider;
 use everruns_core::{
@@ -164,7 +165,7 @@ use utoipa::OpenApi;
             LlmGenerationData, LlmGenerationOutput, LlmGenerationMetadata,
             SessionStartedData,
             // Agent/Session types
-            api::agents::CreateAgentRequest, api::agents::UpdateAgentRequest,
+            domains::agents::types::CreateAgentRequest, domains::agents::types::UpdateAgentRequest,
             api::sessions::CreateSessionRequest, api::sessions::UpdateSessionRequest,
             api::sessions::CancelTurnResponse, api::sessions::CancelStatus,
             api::messages::Message, api::messages::MessageRole, api::messages::ContentPart, api::messages::InputContentPart,
@@ -184,10 +185,10 @@ use utoipa::OpenApi;
             ListResponse<CapabilityInfo>,
             // Harness types
             everruns_core::Harness, everruns_core::HarnessStatus, everruns_core::ResourceConfigResponse,
-            api::harnesses::CreateHarnessRequest,
-            api::harnesses::UpdateHarnessRequest,
-            api::harnesses::PreviewHarnessRequest,
-            api::harnesses::HarnessPreviewResponse,
+            domains::harnesses::types::CreateHarnessRequest,
+            domains::harnesses::types::UpdateHarnessRequest,
+            domains::harnesses::types::PreviewHarnessRequest,
+            domains::harnesses::types::HarnessPreviewResponse,
             ListResponse<everruns_core::Harness>,
             api::users::User,
             api::users::ListUsersQuery,
@@ -218,8 +219,8 @@ use utoipa::OpenApi;
             // MCP Server types
             McpServer, McpServerStatus, McpServerTransportType,
             everruns_core::mcp_server::McpToolAnnotations,
-            api::mcp_servers::CreateMcpServerRequest,
-            api::mcp_servers::UpdateMcpServerRequest,
+            domains::mcp_servers::types::CreateMcpServerRequest,
+            domains::mcp_servers::types::UpdateMcpServerRequest,
             ListResponse<McpServer>,
             // Schedule types
             api::schedules::ScheduleTarget,
@@ -237,8 +238,8 @@ use utoipa::OpenApi;
             // Skill types
             Skill, SkillSourceType, SkillStatus, SkillContent, SkillFileEntry,
             SkillValidationResult,
-            api::skills::CreateSkillRequest,
-            api::skills::UpdateSkillRequest,
+            domains::skills::types::CreateSkillRequest,
+            domains::skills::types::UpdateSkillRequest,
             api::skills::ValidateSkillRequest,
             ListResponse<Skill>,
         )

--- a/crates/server/src/services/session.rs
+++ b/crates/server/src/services/session.rs
@@ -1152,8 +1152,10 @@ impl SessionService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::{agents::CreateAgentRequest, harnesses::CreateHarnessRequest};
     use crate::domains::common::{Command, Ctx};
+    use crate::domains::{
+        agents::types::CreateAgentRequest, harnesses::types::CreateHarnessRequest,
+    };
     use crate::services::CapabilityService;
     use crate::storage::{
         CreateLlmModelRow, CreateLlmProviderRow, CreateOrganizationRow, StorageBackend,


### PR DESCRIPTION
## What

Move request/response/query types from `crates/server/src/api/{x}.rs` into `crates/server/src/domains/{x}/types.rs` for the 6 migrated domains (agents, agent_identities, apps, harnesses, mcp_servers, skills). `api/*.rs` now imports FROM `domains/*/types.rs` instead of the reverse.

## Why

Fixes EVE-317. Before this change, `domains/*/types.rs` re-exported types from `api/`, which preserved a backwards dependency: domain/business logic transitively referenced the HTTP wiring module. This blocks extracting `domains/` into its own crate and confuses the dependency direction.

## How

For each of the 6 migrated domains:

1. Moved `Create*Request`, `Update*Request`, `List*Query`, `Check*Response`, `*PreviewResponse`, `ImportAgentQuery`, `AddChannelRequest`, `UpdateChannelRequest` (and all sibling request/response/query structs) from `api/{x}.rs` into `domains/{x}/types.rs`.
2. Kept `AppState`, `routes()`, HTTP handlers, integration tests, and HTTP-level helpers in `api/{x}.rs`.
3. Replaced `pub use crate::api::{x}::*` re-exports with the canonical definitions. Storage-row re-exports from `storage::models` are preserved.
4. Updated imports in `crates/server/src/openapi.rs`, `grpc_service/worker_service_impl.rs`, `services/session.rs`, and `domains/mcp_servers/service.rs` to consume from `domains::*::types`.
5. Preserved every `ToSchema`, `IntoParams`, `#[schema(...)]`, `#[serde(...)]` derive/attribute so OpenAPI generation is unaffected.

## Risk

- **Low**. Pure move + rewire; no behaviour changes.
- OpenAPI export (`./scripts/export-openapi.sh` → `docs/api/openapi.json`) is **byte-identical** vs `origin/main`.
- `cargo fmt`, `cargo clippy -p everruns-server --all-targets --all-features -- -D warnings`, `cargo test -p everruns-server --lib` (972/972) all clean.
- Pre-push checks all green.

Follow-up work (not in scope): `crate::api::common::{ErrorResponse, Pagination, deserialize_nullable_update_field}` and `crate::api::validation::*` are still referenced from `domains/common.rs` + a couple of domain commands/types. Those are HTTP/validation helpers rather than request types and should move in a separate PR if the goal is a fully standalone `domains/` crate.

## Security

- Threat categories reviewed: none touched. This is a pure internal refactor — no new endpoints, no new inputs, no new validation, no changes to auth/permissions/queries/responses. Serde + schema attributes preserved verbatim.
- Findings and resolutions: none.

## Checklist

- [x] Tests added or updated — existing 972 server lib tests cover the moved types; no new behaviour to test.
- [x] Backward compatibility considered — internal crate refactor only; no external API surface changed.
- [x] Security review performed against relevant threat model categories — no security-relevant code changes.
- [x] All review comments addressed — awaiting review.