### PR TITLE
fix(ci): pin deno live tests to ams

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,6 +365,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.deno == 'true' && github.event_name == 'push'
     timeout-minutes: 10
+    env:
+      DENO_SANDBOX_REGION: ams
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/integration-live-sweep.yml
+++ b/.github/workflows/integration-live-sweep.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 10
     env:
       DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+      DENO_SANDBOX_REGION: ${{ matrix.deno_sandbox_region || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -41,6 +42,7 @@ jobs:
             command: cargo test -p everruns-integrations-e2b --features e2b-live-tests --test live_api_test -- --test-threads=1
           - name: Deno Live API Tests
             command: cargo test -p everruns-integrations-deno --features deno-live-tests --test live_api_test -- --test-threads=1
+            deno_sandbox_region: ams
           - name: Sprites Live API Tests
             command: cargo test -p everruns-integrations-sprites --features sprites-live-tests --test live_api_test -- --test-threads=1
           - name: Brave Search API Tests

--- a/integrations/deno/SPEC.md
+++ b/integrations/deno/SPEC.md
@@ -56,6 +56,8 @@ Parameters:
 
 Returns: `{ sandbox_id, region, workspace_path, status, timeout }`
 
+Current platform behavior: the sandbox workspace path is `/home/app`.
+
 ### `deno_exec`
 
 Run a shell command with `bash -lc` inside a sandbox.
@@ -129,4 +131,5 @@ See `specs/threat-model.md` for the Deno-specific threat section.
 
 - `tests/live_api_test.rs` is feature-gated behind `deno-live-tests`.
 - Missing-credential behavior is **fail-closed**: with the feature flag on, the test panics when `DENO_DEPLOY_TOKEN` is missing, or when a personal `ddp_...` token is used without `DENO_DEPLOY_ORG`. See `specs/integrations.md`.
+- `DENO_SANDBOX_REGION` optionally overrides the create region for live tests. CI pins Deno live coverage to `ams` because upstream `ord` websocket handshakes were returning transport errors while `ams` continued to provision sandboxes successfully.
 - `.github/workflows/ci.yml` runs the live test only on pushes to `main` when `integrations/deno/**` changes; `.github/workflows/integration-live-sweep.yml` reruns it weekly and on demand as the shared-code backstop.

--- a/integrations/deno/src/lib.rs
+++ b/integrations/deno/src/lib.rs
@@ -51,7 +51,7 @@ const DENO_DEFAULT_MEMORY_MB: u64 = 1_280;
 const DENO_MAX_MEMORY_MB: u64 = 16 * 1_024;
 const DENO_RPC_TIMEOUT: Duration = Duration::from_secs(30);
 const DENO_STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(2);
-const DENO_WORKSPACE_PATH: &str = "/home/sandbox";
+const DENO_WORKSPACE_PATH: &str = "/home/app";
 
 static SYSTEM_PROMPT: LazyLock<String> = LazyLock::new(|| {
     let mut prompt = String::from(

--- a/integrations/deno/src/state.rs
+++ b/integrations/deno/src/state.rs
@@ -276,7 +276,7 @@ mod tests {
             sandbox_id: "sb_123".to_string(),
             region: "ord".to_string(),
             org: Some("everruns".to_string()),
-            workspace_path: "/home/sandbox".to_string(),
+            workspace_path: "/home/app".to_string(),
             started_at: "2026-03-22T00:00:00Z".to_string(),
         };
         let json = serde_json::to_string(&state).unwrap();

--- a/integrations/deno/src/tools.rs
+++ b/integrations/deno/src/tools.rs
@@ -661,6 +661,6 @@ mod tests {
             schema["properties"]["timeout"]["default"],
             DENO_SANDBOX_TIMEOUT
         );
-        assert_eq!(crate::DENO_WORKSPACE_PATH, "/home/sandbox");
+        assert_eq!(crate::DENO_WORKSPACE_PATH, "/home/app");
     }
 }

--- a/integrations/deno/tests/live_api_test.rs
+++ b/integrations/deno/tests/live_api_test.rs
@@ -6,7 +6,7 @@
 //! - Environment variable: `DENO_DEPLOY_ORG` (required when the token is a
 //!   personal `ddp_...` token; missing in that case ⇒ panic)
 //! - Environment variable: `DENO_SANDBOX_REGION` (optional; defaults to the
-//!   service default when unset)
+//!   client region default `ord` when unset)
 //!
 //! Missing-credential policy: these tests fail closed. If the feature flag is
 //! set but credentials are missing or inconsistent, the tests panic rather

--- a/integrations/deno/tests/live_api_test.rs
+++ b/integrations/deno/tests/live_api_test.rs
@@ -5,6 +5,8 @@
 //! - Environment variable: `DENO_DEPLOY_TOKEN` (required; missing ⇒ panic)
 //! - Environment variable: `DENO_DEPLOY_ORG` (required when the token is a
 //!   personal `ddp_...` token; missing in that case ⇒ panic)
+//! - Environment variable: `DENO_SANDBOX_REGION` (optional; defaults to the
+//!   service default when unset)
 //!
 //! Missing-credential policy: these tests fail closed. If the feature flag is
 //! set but credentials are missing or inconsistent, the tests panic rather
@@ -67,6 +69,13 @@ fn org() -> Option<String> {
         .filter(|v| !v.trim().is_empty())
 }
 
+fn sandbox_region() -> Option<String> {
+    std::env::var("DENO_SANDBOX_REGION")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
 /// Require `DENO_DEPLOY_TOKEN` (plus `DENO_DEPLOY_ORG` for personal `ddp_...`
 /// tokens) or panic. Live tests fail closed so CI cannot silently pass when
 /// credentials are missing. See `specs/integrations.md`.
@@ -94,7 +103,7 @@ async fn test_live_sandbox_lifecycle() {
     let client = DenoClient::new(token, org());
     let created = client
         .create_sandbox(CreateSandboxRequest {
-            region: None,
+            region: sandbox_region(),
             timeout_seconds: Some(10 * 60),
             memory_mb: Some(1_280),
             labels: serde_json::Map::from_iter([(
@@ -109,6 +118,7 @@ async fn test_live_sandbox_lifecycle() {
         sandbox_id: created.sandbox_id.clone(),
         region: created.region.clone(),
     };
+    let live_file = format!("{}/live.txt", created.workspace_path);
 
     let exec = client
         .exec(
@@ -126,7 +136,7 @@ async fn test_live_sandbox_lifecycle() {
         exec.stdout
     );
     assert!(
-        exec.stdout.contains("/home/sandbox"),
+        exec.stdout.contains(&created.workspace_path),
         "stdout: {}",
         exec.stdout
     );
@@ -135,17 +145,13 @@ async fn test_live_sandbox_lifecycle() {
         .write_text_file(
             &created.sandbox_id,
             &created.region,
-            "/home/sandbox/live.txt",
+            &live_file,
             "hello from everruns\n",
         )
         .await
         .expect("write file");
     let content = client
-        .read_text_file(
-            &created.sandbox_id,
-            &created.region,
-            "/home/sandbox/live.txt",
-        )
+        .read_text_file(&created.sandbox_id, &created.region, &live_file)
         .await
         .expect("read file");
     assert_eq!(content, "hello from everruns\n");

--- a/integrations/deno/tests/tool_integration.rs
+++ b/integrations/deno/tests/tool_integration.rs
@@ -239,7 +239,7 @@ async fn setup_context_with_sandbox(
         sandbox_id: sandbox_id.to_string(),
         region: "ord".to_string(),
         org: None,
-        workspace_path: "/home/sandbox".to_string(),
+        workspace_path: "/home/app".to_string(),
         started_at: "2026-03-22T10:00:00Z".to_string(),
     };
     store
@@ -581,7 +581,7 @@ async fn test_list_sandboxes_with_entries() {
         sandbox_id: "sb_two".to_string(),
         region: "ams".to_string(),
         org: Some("test-org".to_string()),
-        workspace_path: "/home/sandbox".to_string(),
+        workspace_path: "/home/app".to_string(),
         started_at: "2026-03-22T11:00:00Z".to_string(),
     };
     store
@@ -633,7 +633,7 @@ async fn test_sandbox_state_persistence_roundtrip() {
             let sandbox = &output["sandboxes"][0];
             assert_eq!(sandbox["sandbox_id"], "sb_persist");
             assert_eq!(sandbox["region"], "ord");
-            assert_eq!(sandbox["workspace_path"], "/home/sandbox");
+            assert_eq!(sandbox["workspace_path"], "/home/app");
         }
         other => panic!("Expected Success, got: {other:?}"),
     }


### PR DESCRIPTION
## What
Pin Deno live CI coverage to the `ams` region and update the integration’s reported workspace path to the current Deno platform value.

## Why
After fixing the Deno org plan/token issue, sandbox creation still failed in `ord` with a websocket transport error. The same token can create sandboxes in `ams`, so CI needs an explicit region override to keep the live smoke meaningful while `ord` is unhealthy upstream. The live probe also exposed that the current sandbox workspace is `/home/app`, not `/home/sandbox`.

## How
Add a `DENO_SANDBOX_REGION` override to the Deno live test, set the Deno CI jobs to `ams`, and align the Deno workspace path constant and tests with the observed `/home/app` sandbox layout.

## Risk
- Medium
- Deno live coverage now exercises `ams` instead of the default region, so an `ord`-only regression could be missed until Deno fixes the upstream transport issue.

## Security
- Threat categories reviewed: TM-TOOL, TM-AGENT-019
- Findings and resolutions: No new secret handling or trust boundary was introduced. The change only selects a healthy Deno region for CI and corrects the reported sandbox workspace path so agents and tests target the actual sandbox filesystem.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
