### PR TITLE
feat(mcp): standardize server tool metadata

### DIFF
--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -16,6 +16,7 @@
 // - Multi-org: all tools accept optional `organization_id` to override the default org
 
 mod handlers;
+mod tool_registry;
 
 use crate::auth::middleware::AuthUser;
 use crate::auth::{AuthState, ResolvedOrg};
@@ -26,7 +27,7 @@ use crate::storage::StorageBackend;
 use axum::{
     Json, Router,
     extract::State,
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     routing::post,
 };
@@ -112,206 +113,57 @@ impl JsonRpcResponse {
 
 const MCP_SERVER_NAME: &str = "everruns";
 const MCP_SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
-const MCP_PROTOCOL_VERSION: &str = "2025-03-26";
+const MCP_PROTOCOL_VERSION_FALLBACK: &str = "2025-03-26";
+const MCP_PROTOCOL_VERSION_LATEST: &str = "2025-06-18";
+const SUPPORTED_PROTOCOL_VERSIONS: &[&str] =
+    &[MCP_PROTOCOL_VERSION_LATEST, MCP_PROTOCOL_VERSION_FALLBACK];
 
 const ORG_ID_DESCRIPTION: &str = "Optional organization ID (format: org_{32-hex}). Overrides the default organization for this call. Use list_organizations to see available orgs.";
 
-fn tool_definitions() -> Value {
-    json!([
-        // ── Tier 0: identity & org context ──────────────────────────
-        {
-            "name": "me",
-            "description": "Get the current authenticated user's profile and active organization context. Returns user ID, email, name, and the organization currently used for all operations.",
-            "inputSchema": {
-                "type": "object",
-                "properties": {}
-            }
-        },
-        {
-            "name": "list_organizations",
-            "description": "List all organizations the authenticated user belongs to, with their role in each. Use this to discover available orgs before switching with switch_organization or passing organization_id to other tools.",
-            "inputSchema": {
-                "type": "object",
-                "properties": {}
-            }
-        },
-        {
-            "name": "switch_organization",
-            "description": "Validate and select an organization. Returns the validated organization details. Pass the returned organization_id to subsequent tool calls to operate in that org's context. You can also pass organization_id directly to individual tools without calling this first.",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "organization_id": {
-                        "type": "string",
-                        "description": "Organization ID to switch to (format: org_{32-hex}). Must be an org the user belongs to."
-                    }
-                },
-                "required": ["organization_id"]
-            }
-        },
-        // ── Tier 1: agent conversation loop ─────────────────────────
-        {
-            "name": "agent_run",
-            "description": "Create a new session and send the first message to an agent. Returns the session ID and message ID. Use session_get_status to poll for the agent's response, or connect to the SSE stream at /api/v1/sessions/{session_id}/sse for real-time events.",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "agent_id": {
-                        "type": "string",
-                        "description": "Agent ID (format: agent_{32-hex}). The agent to run."
-                    },
-                    "message": {
-                        "type": "string",
-                        "description": "The initial user message to send to the agent."
-                    },
-                    "title": {
-                        "type": "string",
-                        "description": "Optional session title."
-                    },
-                    "model_id": {
-                        "type": "string",
-                        "description": "Optional model override (format: model_{32-hex})."
-                    },
-                    "budget_limit": {
-                        "type": "number",
-                        "description": "Optional budget limit. Creates a session budget that stops the agent at this amount. Currency defaults to 'usd'."
-                    },
-                    "budget_currency": {
-                        "type": "string",
-                        "description": "Budget currency (default: 'usd'). Options: usd, tokens, credits, or custom."
-                    },
-                    "budget_soft_limit": {
-                        "type": "number",
-                        "description": "Optional soft limit — pauses the session at this amount before the hard stop. Must be less than budget_limit."
-                    },
-                    "organization_id": {
-                        "type": "string",
-                        "description": ORG_ID_DESCRIPTION
-                    }
-                },
-                "required": ["message"]
-            }
-        },
-        {
-            "name": "session_send_message",
-            "description": "Send a follow-up message to an existing session. The agent will process the message and generate a response. Use session_get_status to poll for completion, or connect to the SSE stream.",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "session_id": {
-                        "type": "string",
-                        "description": "Session ID (format: session_{32-hex})."
-                    },
-                    "message": {
-                        "type": "string",
-                        "description": "The user message to send."
-                    },
-                    "organization_id": {
-                        "type": "string",
-                        "description": ORG_ID_DESCRIPTION
-                    }
-                },
-                "required": ["session_id", "message"]
-            }
-        },
-        {
-            "name": "session_get_status",
-            "description": "Get the current status of a session and its recent events. Returns the session status (started/active/idle), the latest agent message if available, and recent events. Use this to poll for agent responses after sending a message.",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "session_id": {
-                        "type": "string",
-                        "description": "Session ID (format: session_{32-hex})."
-                    },
-                    "since_event_id": {
-                        "type": "string",
-                        "description": "Only return events after this event ID (for incremental polling)."
-                    },
-                    "event_types": {
-                        "type": "array",
-                        "items": { "type": "string" },
-                        "description": "Filter to specific event types. Useful types: turn.completed, output.message.completed, tool.completed, session.idled"
-                    },
-                    "organization_id": {
-                        "type": "string",
-                        "description": ORG_ID_DESCRIPTION
-                    }
-                },
-                "required": ["session_id"]
-            }
-        },
-        // ── Tier 2: catalog & scripting ─────────────────────────────
-        {
-            "name": "discover",
-            "description": concat!(
-                "Search the Everruns API catalog to find available operations. ",
-                "Returns matching operations with description and parameters.\n\n",
-                "Available resource types: agents, sessions, harnesses, capabilities, models, ",
-                "providers, mcp servers, skills, budgets, schedules, files, events, messages, ",
-                "images, organizations, users, databases, storage.\n\n",
-                "Example queries: 'create agent', 'list sessions', 'capabilities', 'mcp'\n\n",
-                "Use `all: true` to list every operation grouped by category.\n\n",
-                "The discovered operations are available as bash builtins in the 'execute' tool."
-            ),
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "query": {
-                        "type": "string",
-                        "description": "Search query to find API operations (e.g., 'create agent', 'sessions', 'mcp'). Supports natural language — tokens are matched against names, descriptions, and categories."
-                    },
-                    "all": {
-                        "type": "boolean",
-                        "description": "List all available operations grouped by category. When true, query is ignored."
-                    }
-                }
-            }
-        },
-        {
-            "name": "execute",
-            "description": concat!(
-                "Execute a bash script in an environment where every Everruns API operation is a built-in command.\n\n",
-                "## Available commands (~50 builtins across 20 categories)\n",
-                "agents: list_agents, create_agent, get_agent, update_agent, delete_agent, ...\n",
-                "sessions: list_sessions, create_session, get_session, ...\n",
-                "events: list_events, subscribe_events\n",
-                "models: list_models, get_model\n",
-                "capabilities, budgets, harnesses, mcp_servers, files, messages, schedules, skills, and more.\n\n",
-                "Run `discover --categories` to list all categories, or `discover --search <query>` to find a specific command.\n",
-                "Run `<command> --help` for usage details on any command.\n\n",
-                "## Bash features available\n",
-                "Pipes, jq (built-in), variables, loops, conditionals, subshells.\n\n",
-                "## Examples\n",
-                "# List all agent names\n",
-                "list_agents | jq '.data[].name'\n\n",
-                "# Create a session and capture its ID\n",
-                "SID=$(create_session --agent_id agent_abc123 --title 'Test' | jq -r .id)\n\n",
-                "# Iterate over agents\n",
-                "list_agents | jq -r '.data[].id' | while read id; do get_agent --id \"$id\"; done\n\n",
-                "# Search for commands related to events\n",
-                "discover --search events"
-            ),
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "commands": {
-                        "type": "string",
-                        "description": "Bash script to execute. API operations are available as built-in commands."
-                    },
-                    "timeout_ms": {
-                        "type": "integer",
-                        "description": "Execution timeout in milliseconds (default: 30000, max: 60000)."
-                    },
-                    "organization_id": {
-                        "type": "string",
-                        "description": ORG_ID_DESCRIPTION
-                    }
-                },
-                "required": ["commands"]
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct InitializeParams {
+    #[serde(default)]
+    protocol_version: Option<String>,
+}
+
+fn tool_definitions(protocol_version: &str) -> Vec<tool_registry::McpEndpointToolDefinition> {
+    tool_registry::tool_definitions(protocol_version, ORG_ID_DESCRIPTION)
+}
+
+fn find_tool_definition(
+    tool_name: &str,
+    protocol_version: &str,
+) -> Option<tool_registry::McpEndpointToolDefinition> {
+    tool_registry::tool_definition(tool_name, protocol_version, ORG_ID_DESCRIPTION)
+}
+
+fn negotiate_protocol_version(requested: Option<&str>) -> &'static str {
+    match requested {
+        Some(MCP_PROTOCOL_VERSION_FALLBACK) => MCP_PROTOCOL_VERSION_FALLBACK,
+        Some(version) if version < MCP_PROTOCOL_VERSION_LATEST => MCP_PROTOCOL_VERSION_FALLBACK,
+        Some(_) => MCP_PROTOCOL_VERSION_LATEST,
+        None => MCP_PROTOCOL_VERSION_FALLBACK,
+    }
+}
+
+fn protocol_version_from_headers(headers: &HeaderMap) -> Result<&'static str, String> {
+    match headers.get("MCP-Protocol-Version") {
+        None => Ok(MCP_PROTOCOL_VERSION_FALLBACK),
+        Some(value) => {
+            let version = value
+                .to_str()
+                .map_err(|_| "Invalid MCP-Protocol-Version header".to_string())?;
+            match version {
+                MCP_PROTOCOL_VERSION_FALLBACK => Ok(MCP_PROTOCOL_VERSION_FALLBACK),
+                MCP_PROTOCOL_VERSION_LATEST => Ok(MCP_PROTOCOL_VERSION_LATEST),
+                _ => Err(format!(
+                    "Unsupported MCP-Protocol-Version: {version}. Supported: {}",
+                    SUPPORTED_PROTOCOL_VERSIONS.join(", ")
+                )),
             }
         }
-    ])
+    }
 }
 
 // ============================================================================
@@ -389,8 +241,24 @@ async fn handle_mcp(
     auth_user: AuthUser,
     org: ResolvedOrg,
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(req): Json<JsonRpcRequest>,
 ) -> Response {
+    let protocol_version = if req.method == "initialize" {
+        None
+    } else {
+        match protocol_version_from_headers(&headers) {
+            Ok(version) => Some(version),
+            Err(msg) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(JsonRpcResponse::error(req.id.clone(), -32600, msg)),
+                )
+                    .into_response();
+            }
+        }
+    };
+
     // Per JSON-RPC 2.0, a request without an `id` is a notification and the
     // server MUST NOT reply. MCP lifecycle uses this for
     // `notifications/initialized`, `notifications/cancelled`, etc. We're
@@ -411,10 +279,21 @@ async fn handle_mcp(
     }
 
     let response = match req.method.as_str() {
-        "initialize" => handle_initialize(req.id),
-        "tools/list" => handle_tools_list(req.id),
+        "initialize" => handle_initialize(req.id, req.params),
+        "tools/list" => handle_tools_list(
+            req.id,
+            protocol_version.unwrap_or(MCP_PROTOCOL_VERSION_FALLBACK),
+        ),
         "tools/call" => {
-            handle_tools_call(req.id.clone(), req.params, &auth_user, &org, &state).await
+            handle_tools_call(
+                req.id.clone(),
+                req.params,
+                &auth_user,
+                &org,
+                &state,
+                protocol_version.unwrap_or(MCP_PROTOCOL_VERSION_FALLBACK),
+            )
+            .await
         }
         "resources/list" => handle_resources_list(req.id),
         "resources/read" => handle_resources_read(req.id, req.params, &org, &state).await,
@@ -429,13 +308,17 @@ async fn handle_mcp(
 // Protocol handlers
 // ============================================================================
 
-fn handle_initialize(id: Option<Value>) -> JsonRpcResponse {
+fn handle_initialize(id: Option<Value>, params: Value) -> JsonRpcResponse {
+    let params: InitializeParams = serde_json::from_value(params).unwrap_or_default();
+    let protocol_version = negotiate_protocol_version(params.protocol_version.as_deref());
     JsonRpcResponse::success(
         id,
         json!({
-            "protocolVersion": MCP_PROTOCOL_VERSION,
+            "protocolVersion": protocol_version,
             "capabilities": {
-                "tools": {},
+                "tools": {
+                    "listChanged": false
+                },
                 "resources": {}
             },
             "serverInfo": {
@@ -446,8 +329,8 @@ fn handle_initialize(id: Option<Value>) -> JsonRpcResponse {
     )
 }
 
-fn handle_tools_list(id: Option<Value>) -> JsonRpcResponse {
-    JsonRpcResponse::success(id, json!({ "tools": tool_definitions() }))
+fn handle_tools_list(id: Option<Value>, protocol_version: &str) -> JsonRpcResponse {
+    JsonRpcResponse::success(id, json!({ "tools": tool_definitions(protocol_version) }))
 }
 
 // ============================================================================
@@ -622,6 +505,7 @@ async fn handle_tools_call(
     auth_user: &AuthUser,
     org: &ResolvedOrg,
     state: &AppState,
+    _protocol_version: &str,
 ) -> JsonRpcResponse {
     let tool_name = match params.get("name").and_then(|v| v.as_str()) {
         Some(name) => name,
@@ -633,47 +517,80 @@ async fn handle_tools_call(
         .cloned()
         .unwrap_or(Value::Object(Default::default()));
 
-    let result = match tool_name {
-        // Tier 0: identity & org context
-        "me" => tool_me(auth_user, org, state).await,
-        "list_organizations" => tool_list_organizations(auth_user, state).await,
-        "switch_organization" => tool_switch_organization(&arguments, auth_user, org, state).await,
-        // Tier 1: agent conversation (org-scoped — accept organization_id override)
-        "agent_run" => match resolve_org_override(&arguments, auth_user, org, state).await {
-            Ok(org) => tool_agent_run(&arguments, &org, state).await,
-            Err(e) => Err(e),
-        },
-        "session_send_message" => {
-            match resolve_org_override(&arguments, auth_user, org, state).await {
-                Ok(org) => tool_session_send_message(&arguments, &org, state).await,
-                Err(e) => Err(e),
-            }
-        }
-        "session_get_status" => {
-            match resolve_org_override(&arguments, auth_user, org, state).await {
-                Ok(org) => tool_session_get_status(&arguments, &org, state).await,
-                Err(e) => Err(e),
-            }
-        }
-        // Tier 2: catalog & scripting (org-scoped)
-        "discover" => match resolve_org_override(&arguments, auth_user, org, state).await {
-            Ok(org) => tool_discover(&arguments, &org, state).await,
-            Err(e) => Err(e),
-        },
-        "execute" => match resolve_org_override(&arguments, auth_user, org, state).await {
-            Ok(org) => tool_execute(&arguments, &org, state).await,
-            Err(e) => Err(e),
-        },
-        _ => Err(format!("Unknown tool: {tool_name}")),
-    };
-
-    match result {
-        Ok(content) => JsonRpcResponse::success(
+    let Some(tool_def) = find_tool_definition(tool_name, _protocol_version) else {
+        return JsonRpcResponse::success(
             id,
             json!({
-                "content": [{ "type": "text", "text": content }]
+                "content": [{ "type": "text", "text": format!("Unknown tool: {tool_name}") }],
+                "isError": true
             }),
-        ),
+        );
+    };
+
+    let result = tokio::time::timeout(
+        std::time::Duration::from_millis(tool_def.timeout_ms()),
+        async {
+            match tool_name {
+                // Tier 0: identity & org context
+                "me" => tool_me(auth_user, org, state).await,
+                "list_organizations" => tool_list_organizations(auth_user, state).await,
+                "switch_organization" => {
+                    tool_switch_organization(&arguments, auth_user, org, state).await
+                }
+                // Tier 1: agent conversation (org-scoped — accept organization_id override)
+                "agent_run" => {
+                    match resolve_org_override(&arguments, auth_user, org, state).await {
+                        Ok(org) => tool_agent_run(&arguments, &org, state).await,
+                        Err(e) => Err(e),
+                    }
+                }
+                "session_send_message" => {
+                    match resolve_org_override(&arguments, auth_user, org, state).await {
+                        Ok(org) => tool_session_send_message(&arguments, &org, state).await,
+                        Err(e) => Err(e),
+                    }
+                }
+                "session_get_status" => {
+                    match resolve_org_override(&arguments, auth_user, org, state).await {
+                        Ok(org) => tool_session_get_status(&arguments, &org, state).await,
+                        Err(e) => Err(e),
+                    }
+                }
+                // Tier 2: catalog & scripting (org-scoped)
+                "discover" => match resolve_org_override(&arguments, auth_user, org, state).await {
+                    Ok(org) => tool_discover(&arguments, &org, state).await,
+                    Err(e) => Err(e),
+                },
+                "execute" => match resolve_org_override(&arguments, auth_user, org, state).await {
+                    Ok(org) => tool_execute(&arguments, &org, state).await,
+                    Err(e) => Err(e),
+                },
+                _ => Err(format!("Unknown tool: {tool_name}")),
+            }
+        },
+    )
+    .await
+    .unwrap_or_else(|_| Err(format!("Tool timed out after {}ms", tool_def.timeout_ms())));
+
+    match result {
+        Ok(content) => {
+            let structured_content = if _protocol_version == MCP_PROTOCOL_VERSION_LATEST
+                && tool_def.has_output_schema()
+            {
+                serde_json::from_str::<Value>(&content).ok()
+            } else {
+                None
+            };
+
+            let mut result = json!({
+                "content": [{ "type": "text", "text": content }]
+            });
+            if let Some(structured_content) = structured_content {
+                result["structuredContent"] = structured_content;
+            }
+
+            JsonRpcResponse::success(id, result)
+        }
         Err(msg) => JsonRpcResponse::success(
             id,
             json!({

--- a/crates/server/src/api/mcp_endpoint/tool_registry.rs
+++ b/crates/server/src/api/mcp_endpoint/tool_registry.rs
@@ -1,0 +1,554 @@
+// MCP endpoint tool registry for Everruns' own MCP server.
+//
+// Decisions:
+// - Emit only standard MCP tool fields.
+// - Shape tool discovery/results to the negotiated protocol version:
+//   `2025-06-18` gets `title`, `outputSchema`, and structured output support;
+//   `2025-03-26` omits those newer fields.
+// - Keep execution-only data such as timeout internal to the registry.
+
+use everruns_core::McpToolAnnotations;
+use serde::Serialize;
+use serde_json::{Value, json};
+
+const MCP_PROTOCOL_VERSION_LATEST: &str = "2025-06-18";
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpEndpointToolDefinition {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    pub description: String,
+    #[serde(rename = "inputSchema")]
+    pub input_schema: Value,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "outputSchema")]
+    pub output_schema: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<McpToolAnnotations>,
+    #[serde(skip_serializing)]
+    timeout_ms: u64,
+}
+
+impl McpEndpointToolDefinition {
+    pub fn timeout_ms(&self) -> u64 {
+        self.timeout_ms
+    }
+
+    pub fn has_output_schema(&self) -> bool {
+        self.output_schema.is_some()
+    }
+}
+
+pub fn tool_definitions(
+    protocol_version: &str,
+    org_id_description: &str,
+) -> Vec<McpEndpointToolDefinition> {
+    vec![
+        me_tool(protocol_version),
+        list_organizations_tool(protocol_version),
+        switch_organization_tool(protocol_version, org_id_description),
+        agent_run_tool(protocol_version, org_id_description),
+        session_send_message_tool(protocol_version, org_id_description),
+        session_get_status_tool(protocol_version, org_id_description),
+        discover_tool(protocol_version, org_id_description),
+        execute_tool(protocol_version, org_id_description),
+    ]
+}
+
+pub fn tool_definition(
+    tool_name: &str,
+    protocol_version: &str,
+    org_id_description: &str,
+) -> Option<McpEndpointToolDefinition> {
+    tool_definitions(protocol_version, org_id_description)
+        .into_iter()
+        .find(|tool| tool.name == tool_name)
+}
+
+fn me_tool(protocol_version: &str) -> McpEndpointToolDefinition {
+    tool(
+        protocol_version,
+        "me",
+        "Current User",
+        "Get the current authenticated user's profile and active organization context. Returns user ID, email, name, and the organization currently used for all operations.",
+        object_schema(vec![], vec![]),
+        Some(me_output_schema()),
+        Some(read_only_annotations()),
+        5_000,
+    )
+}
+
+fn list_organizations_tool(protocol_version: &str) -> McpEndpointToolDefinition {
+    tool(
+        protocol_version,
+        "list_organizations",
+        "List Organizations",
+        "List all organizations the authenticated user belongs to, with their role in each. Use this to discover available orgs before switching with switch_organization or passing organization_id to other tools.",
+        object_schema(vec![], vec![]),
+        Some(json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "organizations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "id": { "type": "string" },
+                            "name": { "type": "string" },
+                            "role": { "type": "string" }
+                        },
+                        "required": ["id", "name", "role"]
+                    }
+                },
+                "count": { "type": "integer" }
+            },
+            "required": ["organizations", "count"]
+        })),
+        Some(read_only_annotations()),
+        5_000,
+    )
+}
+
+fn switch_organization_tool(
+    protocol_version: &str,
+    org_id_description: &str,
+) -> McpEndpointToolDefinition {
+    tool(
+        protocol_version,
+        "switch_organization",
+        "Switch Organization",
+        "Validate and select an organization. Returns the validated organization details. Pass the returned organization_id to subsequent tool calls to operate in that org's context. You can also pass organization_id directly to individual tools without calling this first.",
+        object_schema(
+            vec![(
+                "organization_id",
+                json!({
+                    "type": "string",
+                    "description": org_id_description,
+                    "pattern": "^org_[0-9a-f]{32}$"
+                }),
+            )],
+            vec!["organization_id"],
+        ),
+        Some(json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "switched": { "type": "boolean" },
+                "organization_id": { "type": "string" },
+                "name": { "type": "string" },
+                "role": { "type": "string" },
+                "hint": { "type": "string" }
+            },
+            "required": ["switched", "organization_id", "name", "role", "hint"]
+        })),
+        Some(read_only_annotations()),
+        5_000,
+    )
+}
+
+fn agent_run_tool(protocol_version: &str, org_id_description: &str) -> McpEndpointToolDefinition {
+    tool(
+        protocol_version,
+        "agent_run",
+        "Run Agent",
+        "Create a new session and send the first message to an agent. Returns the session ID and message ID. Use session_get_status to poll for the agent's response, or connect to the SSE stream at /api/v1/sessions/{session_id}/sse for real-time events.",
+        object_schema(
+            vec![
+                id_property(
+                    "agent_id",
+                    "Agent ID (format: agent_{32-hex}). The agent to run.",
+                ),
+                id_property(
+                    "harness_id",
+                    "Optional harness ID (format: harness_{32-hex}). Used when no agent_id is provided.",
+                ),
+                (
+                    "message",
+                    json!({
+                        "type": "string",
+                        "description": "The initial user message to send to the agent.",
+                        "minLength": 1
+                    }),
+                ),
+                (
+                    "title",
+                    json!({
+                        "type": "string",
+                        "description": "Optional session title."
+                    }),
+                ),
+                id_property(
+                    "model_id",
+                    "Optional model override (format: model_{32-hex}).",
+                ),
+                (
+                    "budget_limit",
+                    json!({
+                        "type": "number",
+                        "description": "Optional budget limit. Creates a session budget that stops the agent at this amount."
+                    }),
+                ),
+                (
+                    "budget_currency",
+                    json!({
+                        "type": "string",
+                        "description": "Budget currency (default: usd)."
+                    }),
+                ),
+                (
+                    "budget_soft_limit",
+                    json!({
+                        "type": "number",
+                        "description": "Optional soft limit. Must be less than or equal to budget_limit."
+                    }),
+                ),
+                (
+                    "organization_id",
+                    json!({
+                        "type": "string",
+                        "description": org_id_description,
+                        "pattern": "^org_[0-9a-f]{32}$"
+                    }),
+                ),
+            ],
+            vec!["message"],
+        ),
+        Some(json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "session_id": { "type": "string" },
+                "message_id": { "type": "string" },
+                "status": { "type": "string" },
+                "hint": { "type": "string" },
+                "budget_id": { "type": "string" }
+            },
+            "required": ["session_id", "message_id", "status", "hint"],
+            "additionalProperties": false
+        })),
+        Some(McpToolAnnotations {
+            read_only_hint: Some(false),
+            destructive_hint: Some(false),
+            idempotent_hint: Some(false),
+            open_world_hint: Some(true),
+        }),
+        15_000,
+    )
+}
+
+fn session_send_message_tool(
+    protocol_version: &str,
+    org_id_description: &str,
+) -> McpEndpointToolDefinition {
+    tool(
+        protocol_version,
+        "session_send_message",
+        "Send Session Message",
+        "Send a follow-up message to an existing session. The agent will process the message and generate a response. Use session_get_status to poll for completion, or connect to the SSE stream.",
+        object_schema(
+            vec![
+                id_property("session_id", "Session ID (format: session_{32-hex})."),
+                (
+                    "message",
+                    json!({
+                        "type": "string",
+                        "description": "The user message to send.",
+                        "minLength": 1
+                    }),
+                ),
+                (
+                    "organization_id",
+                    json!({
+                        "type": "string",
+                        "description": org_id_description,
+                        "pattern": "^org_[0-9a-f]{32}$"
+                    }),
+                ),
+            ],
+            vec!["session_id", "message"],
+        ),
+        Some(json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "message_id": { "type": "string" },
+                "session_status": { "type": "string" },
+                "hint": { "type": "string" }
+            },
+            "required": ["message_id", "session_status", "hint"]
+        })),
+        Some(McpToolAnnotations {
+            read_only_hint: Some(false),
+            destructive_hint: Some(false),
+            idempotent_hint: Some(false),
+            open_world_hint: Some(true),
+        }),
+        15_000,
+    )
+}
+
+fn session_get_status_tool(
+    protocol_version: &str,
+    org_id_description: &str,
+) -> McpEndpointToolDefinition {
+    tool(
+        protocol_version,
+        "session_get_status",
+        "Get Session Status",
+        "Get the current status of a session and its recent events. Returns the session status (started/active/idle), the latest agent message if available, and recent events. Use this to poll for agent responses after sending a message.",
+        object_schema(
+            vec![
+                id_property("session_id", "Session ID (format: session_{32-hex})."),
+                (
+                    "since_event_id",
+                    json!({
+                        "type": "string",
+                        "description": "Only return events after this event ID (for incremental polling)."
+                    }),
+                ),
+                (
+                    "event_types",
+                    json!({
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Filter to specific event types."
+                    }),
+                ),
+                (
+                    "organization_id",
+                    json!({
+                        "type": "string",
+                        "description": org_id_description,
+                        "pattern": "^org_[0-9a-f]{32}$"
+                    }),
+                ),
+            ],
+            vec!["session_id"],
+        ),
+        Some(json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "session_id": { "type": "string" },
+                "status": { "type": ["string", "null"] },
+                "agent_id": { "type": ["string", "null"] },
+                "title": { "type": ["string", "null"] },
+                "latest_output": { "type": ["string", "null"] },
+                "last_event_id": { "type": ["string", "null"] },
+                "event_count": { "type": "integer" },
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "id": { "type": ["string", "null"] },
+                            "type": { "type": ["string", "null"] },
+                            "ts": { "type": ["string", "null"] }
+                        },
+                        "required": ["id", "type", "ts"]
+                    }
+                }
+            },
+            "required": ["session_id", "status", "agent_id", "title", "latest_output", "last_event_id", "event_count", "events"]
+        })),
+        Some(read_only_annotations()),
+        10_000,
+    )
+}
+
+fn discover_tool(protocol_version: &str, org_id_description: &str) -> McpEndpointToolDefinition {
+    tool(
+        protocol_version,
+        "discover",
+        "Discover Operations",
+        "Search the Everruns API catalog to find available operations. Returns matching operations with description and parameters. Use all: true to list every operation grouped by category. The discovered operations are available as bash builtins in the execute tool.",
+        object_schema(
+            vec![
+                (
+                    "query",
+                    json!({
+                        "type": "string",
+                        "description": "Search query to find API operations."
+                    }),
+                ),
+                (
+                    "all",
+                    json!({
+                        "type": "boolean",
+                        "description": "List all available operations grouped by category. When true, query is ignored."
+                    }),
+                ),
+                (
+                    "organization_id",
+                    json!({
+                        "type": "string",
+                        "description": org_id_description,
+                        "pattern": "^org_[0-9a-f]{32}$"
+                    }),
+                ),
+            ],
+            vec![],
+        ),
+        None,
+        Some(read_only_annotations()),
+        10_000,
+    )
+}
+
+fn execute_tool(protocol_version: &str, org_id_description: &str) -> McpEndpointToolDefinition {
+    tool(
+        protocol_version,
+        "execute",
+        "Execute Commands",
+        "Execute a bash script in an environment where every Everruns API operation is a built-in command. Supports pipes, variables, loops, conditionals, jq, and direct access to the catalog builtins. Use discover first if you need to find command names.",
+        object_schema(
+            vec![
+                (
+                    "commands",
+                    json!({
+                        "type": "string",
+                        "description": "Bash script to execute. API operations are available as built-in commands.",
+                        "minLength": 1
+                    }),
+                ),
+                (
+                    "timeout_ms",
+                    json!({
+                        "type": "integer",
+                        "description": "Execution timeout in milliseconds (default: 30000, max: 60000).",
+                        "minimum": 1,
+                        "maximum": 60000
+                    }),
+                ),
+                (
+                    "organization_id",
+                    json!({
+                        "type": "string",
+                        "description": org_id_description,
+                        "pattern": "^org_[0-9a-f]{32}$"
+                    }),
+                ),
+            ],
+            vec!["commands"],
+        ),
+        None,
+        Some(McpToolAnnotations {
+            read_only_hint: Some(false),
+            destructive_hint: Some(true),
+            idempotent_hint: Some(false),
+            open_world_hint: Some(true),
+        }),
+        65_000,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn tool(
+    protocol_version: &str,
+    name: &str,
+    title: &str,
+    description: &str,
+    input_schema: Value,
+    output_schema: Option<Value>,
+    annotations: Option<McpToolAnnotations>,
+    timeout_ms: u64,
+) -> McpEndpointToolDefinition {
+    let supports_2025_06 = protocol_version == MCP_PROTOCOL_VERSION_LATEST;
+    McpEndpointToolDefinition {
+        name: name.to_string(),
+        title: supports_2025_06.then(|| title.to_string()),
+        description: description.to_string(),
+        input_schema,
+        output_schema: supports_2025_06.then_some(output_schema).flatten(),
+        annotations,
+        timeout_ms,
+    }
+}
+
+fn read_only_annotations() -> McpToolAnnotations {
+    McpToolAnnotations {
+        read_only_hint: Some(true),
+        destructive_hint: Some(false),
+        idempotent_hint: Some(true),
+        open_world_hint: Some(false),
+    }
+}
+
+fn object_schema(properties: Vec<(&str, Value)>, required: Vec<&str>) -> Value {
+    let props = properties
+        .into_iter()
+        .map(|(name, schema)| (name.to_string(), schema))
+        .collect::<serde_json::Map<String, Value>>();
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": props,
+        "required": required
+    })
+}
+
+fn id_property<'a>(name: &'a str, description: &str) -> (&'a str, Value) {
+    let pattern = match name {
+        "agent_id" => "^agent_[0-9a-f]{32}$",
+        "harness_id" => "^harness_[0-9a-f]{32}$",
+        "model_id" => "^model_[0-9a-f]{32}$",
+        "session_id" => "^session_[0-9a-f]{32}$",
+        _ => "^[a-z]+_[0-9a-f]{32}$",
+    };
+    (
+        name,
+        json!({
+            "type": "string",
+            "description": description,
+            "pattern": pattern
+        }),
+    )
+}
+
+fn me_output_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "user": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "id": { "type": "string" },
+                    "email": { "type": ["string", "null"] },
+                    "name": { "type": ["string", "null"] }
+                },
+                "required": ["id", "email", "name"]
+            },
+            "current_organization": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "id": { "type": "string" },
+                    "name": { "type": "string" },
+                    "role": { "type": "string" }
+                },
+                "required": ["id", "name", "role"]
+            },
+            "organizations": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "id": { "type": "string" },
+                        "name": { "type": "string" },
+                        "role": { "type": "string" },
+                        "current": { "type": "boolean" }
+                    },
+                    "required": ["id", "name", "role", "current"]
+                }
+            }
+        },
+        "required": ["user", "current_organization", "organizations"]
+    })
+}

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -12,6 +12,7 @@
 
 mod test_harness;
 
+use axum::http::{Method, StatusCode};
 use serde_json::{Value, json};
 use test_harness::TestServer;
 
@@ -20,6 +21,8 @@ use test_harness::TestServer;
 // ============================================================================
 
 static UNIQUE_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+const MCP_PROTOCOL_VERSION_FALLBACK: &str = "2025-03-26";
+const MCP_PROTOCOL_VERSION_LATEST: &str = "2025-06-18";
 
 /// Make a JSON-RPC 2.0 call to POST /mcp via the in-process TestServer.
 async fn mcp_call(server: &TestServer, method: &str, params: Value) -> Value {
@@ -38,12 +41,79 @@ async fn mcp_call(server: &TestServer, method: &str, params: Value) -> Value {
         .json()
 }
 
+async fn mcp_call_with_headers(
+    server: &TestServer,
+    method: &str,
+    params: Value,
+    extra_headers: Vec<(&str, &str)>,
+) -> Value {
+    let mut headers = vec![("content-type", "application/json")];
+    headers.extend(extra_headers);
+
+    server
+        .request_raw(
+            Method::POST,
+            "/mcp",
+            headers,
+            serde_json::to_vec(&json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": method,
+                "params": params
+            }))
+            .expect("Failed to encode MCP request"),
+        )
+        .await
+        .assert_success()
+        .json()
+}
+
+async fn mcp_request_raw(
+    server: &TestServer,
+    method: &str,
+    params: Value,
+    extra_headers: Vec<(&str, &str)>,
+) -> test_harness::TestResponse {
+    let mut headers = vec![("content-type", "application/json")];
+    headers.extend(extra_headers);
+
+    server
+        .request_raw(
+            Method::POST,
+            "/mcp",
+            headers,
+            serde_json::to_vec(&json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": method,
+                "params": params
+            }))
+            .expect("Failed to encode MCP request"),
+        )
+        .await
+}
+
 /// Call tools/call with a given tool name and arguments.
 async fn mcp_tool_call(server: &TestServer, tool: &str, arguments: Value) -> Value {
     mcp_call(
         server,
         "tools/call",
         json!({ "name": tool, "arguments": arguments }),
+    )
+    .await
+}
+
+async fn mcp_tool_call_with_headers(
+    server: &TestServer,
+    tool: &str,
+    arguments: Value,
+    extra_headers: Vec<(&str, &str)>,
+) -> Value {
+    mcp_call_with_headers(
+        server,
+        "tools/call",
+        json!({ "name": tool, "arguments": arguments }),
+        extra_headers,
     )
     .await
 }
@@ -167,20 +237,43 @@ async fn create_session_via_execute(base_url: &str, title_prefix: &str) -> (Stri
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mcp_initialize() {
-    let server = TestServer::new().await;
-    let resp = mcp_call(&server, "initialize", json!({})).await;
+    let server = TestServer::in_memory().await;
+    let resp = mcp_call(
+        &server,
+        "initialize",
+        json!({ "protocolVersion": MCP_PROTOCOL_VERSION_LATEST }),
+    )
+    .await;
 
     assert_eq!(resp["jsonrpc"], "2.0");
     assert_eq!(resp["id"], 1);
-    assert_eq!(resp["result"]["protocolVersion"], "2025-03-26");
+    assert_eq!(
+        resp["result"]["protocolVersion"],
+        MCP_PROTOCOL_VERSION_LATEST
+    );
     assert_eq!(resp["result"]["serverInfo"]["name"], "everruns");
     assert!(resp["result"]["serverInfo"]["version"].is_string());
     assert!(resp["result"]["capabilities"]["tools"].is_object());
+    assert_eq!(
+        resp["result"]["capabilities"]["tools"]["listChanged"],
+        false
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_initialize_defaults_to_fallback_protocol() {
+    let server = TestServer::in_memory().await;
+    let resp = mcp_call(&server, "initialize", json!({})).await;
+
+    assert_eq!(
+        resp["result"]["protocolVersion"],
+        MCP_PROTOCOL_VERSION_FALLBACK
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mcp_ping() {
-    let server = TestServer::new().await;
+    let server = TestServer::in_memory().await;
     let resp = mcp_call(&server, "ping", json!({})).await;
 
     assert_eq!(resp["jsonrpc"], "2.0");
@@ -189,15 +282,30 @@ async fn test_mcp_ping() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mcp_tools_list() {
-    let server = TestServer::new().await;
-    let resp = mcp_call(&server, "tools/list", json!({})).await;
+    let server = TestServer::in_memory().await;
+    let resp = mcp_call_with_headers(
+        &server,
+        "tools/list",
+        json!({}),
+        vec![("MCP-Protocol-Version", MCP_PROTOCOL_VERSION_LATEST)],
+    )
+    .await;
 
     let tools = resp["result"]["tools"]
         .as_array()
         .expect("Expected tools array");
-    assert_eq!(tools.len(), 5, "Expected 5 MCP tools");
+    assert_eq!(tools.len(), 8, "Expected 8 MCP tools");
 
     let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+    assert!(names.contains(&"me"), "Missing me");
+    assert!(
+        names.contains(&"list_organizations"),
+        "Missing list_organizations"
+    );
+    assert!(
+        names.contains(&"switch_organization"),
+        "Missing switch_organization"
+    );
     assert!(names.contains(&"agent_run"), "Missing agent_run");
     assert!(
         names.contains(&"session_send_message"),
@@ -219,11 +327,134 @@ async fn test_mcp_tools_list() {
         );
         assert_eq!(tool["inputSchema"]["type"], "object");
     }
+
+    let me = tools.iter().find(|tool| tool["name"] == "me").unwrap();
+    assert_eq!(me["title"], "Current User");
+    assert_eq!(me["annotations"]["readOnlyHint"], true);
+    assert_eq!(me["outputSchema"]["type"], "object");
+    assert!(me.as_object().unwrap().get("_meta").is_none());
+
+    let agent_run = tools
+        .iter()
+        .find(|tool| tool["name"] == "agent_run")
+        .unwrap();
+    assert_eq!(agent_run["title"], "Run Agent");
+    assert_eq!(agent_run["outputSchema"]["type"], "object");
+    assert_eq!(agent_run["annotations"]["openWorldHint"], true);
+    assert!(agent_run.as_object().unwrap().get("_meta").is_none());
+
+    let discover = tools
+        .iter()
+        .find(|tool| tool["name"] == "discover")
+        .unwrap();
+    assert_eq!(discover["title"], "Discover Operations");
+    assert_eq!(
+        discover["inputSchema"]["properties"]["organization_id"]["pattern"],
+        "^org_[0-9a-f]{32}$"
+    );
+    assert!(discover.as_object().unwrap().get("outputSchema").is_none());
+    assert!(discover.as_object().unwrap().get("_meta").is_none());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_tools_list_fallback_omits_2025_06_fields() {
+    let server = TestServer::in_memory().await;
+    let resp = mcp_call_with_headers(
+        &server,
+        "tools/list",
+        json!({}),
+        vec![("MCP-Protocol-Version", MCP_PROTOCOL_VERSION_FALLBACK)],
+    )
+    .await;
+
+    let tools = resp["result"]["tools"]
+        .as_array()
+        .expect("Expected tools array");
+    let me = tools.iter().find(|tool| tool["name"] == "me").unwrap();
+    assert!(me.as_object().unwrap().get("title").is_none());
+    assert!(me.as_object().unwrap().get("outputSchema").is_none());
+    assert!(me.as_object().unwrap().get("_meta").is_none());
+
+    let agent_run = tools
+        .iter()
+        .find(|tool| tool["name"] == "agent_run")
+        .unwrap();
+    assert!(agent_run.as_object().unwrap().get("title").is_none());
+    assert!(agent_run.as_object().unwrap().get("outputSchema").is_none());
+    assert_eq!(agent_run["annotations"]["openWorldHint"], true);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_rejects_unsupported_protocol_header() {
+    let server = TestServer::in_memory().await;
+    let resp = mcp_request_raw(
+        &server,
+        "ping",
+        json!({}),
+        vec![("MCP-Protocol-Version", "2024-11-05")],
+    )
+    .await;
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body: Value = resp.json();
+    assert_eq!(body["error"]["code"], -32600);
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("Unsupported MCP-Protocol-Version")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_tool_call_returns_structured_content() {
+    let server = TestServer::in_memory().await;
+    let resp = mcp_tool_call_with_headers(
+        &server,
+        "me",
+        json!({}),
+        vec![("MCP-Protocol-Version", MCP_PROTOCOL_VERSION_LATEST)],
+    )
+    .await;
+
+    assert!(
+        !tool_is_error(&resp),
+        "tool returned error: {}",
+        tool_text(&resp)
+    );
+    let structured = resp["result"]["structuredContent"].clone();
+    assert!(
+        structured.is_object(),
+        "structuredContent should be present"
+    );
+    assert!(structured["user"]["id"].is_string());
+    assert!(structured["current_organization"]["id"].is_string());
+    assert_eq!(tool_json(&resp), structured);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_tool_call_fallback_omits_structured_content() {
+    let server = TestServer::in_memory().await;
+    let resp = mcp_tool_call_with_headers(
+        &server,
+        "me",
+        json!({}),
+        vec![("MCP-Protocol-Version", MCP_PROTOCOL_VERSION_FALLBACK)],
+    )
+    .await;
+
+    assert!(
+        !tool_is_error(&resp),
+        "tool returned error: {}",
+        tool_text(&resp)
+    );
+    assert!(resp["result"].get("structuredContent").is_none());
+    assert!(tool_json(&resp)["user"]["id"].is_string());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mcp_invalid_jsonrpc_version() {
-    let server = TestServer::new().await;
+    let server = TestServer::in_memory().await;
     let resp: Value = server
         .post(
             "/mcp",
@@ -244,7 +475,7 @@ async fn test_mcp_invalid_jsonrpc_version() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mcp_unknown_method() {
-    let server = TestServer::new().await;
+    let server = TestServer::in_memory().await;
     let resp = mcp_call(&server, "nonexistent/method", json!({})).await;
 
     assert!(resp["error"].is_object());
@@ -255,7 +486,7 @@ async fn test_mcp_unknown_method() {
 // - EVE-322: notifications must always return 202 with an empty body
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mcp_notification_contract_matrix() {
-    let server = TestServer::new().await;
+    let server = TestServer::in_memory().await;
     let cases = vec![
         (
             "initialized lifecycle notification",

--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -10,12 +10,19 @@ Routing is intentionally split:
 - MCP OAuth lives at `/oauth/*` (authorize, token, register)
 - MCP JSON-RPC lives at `/mcp`
 - OAuth discovery metadata lives at `/.well-known/oauth-authorization-server`
+- Protected-resource metadata lives at `/.well-known/oauth-protected-resource`
 
 Everruns also acts as an **MCP client** (connecting to remote MCP servers). That side is covered in [`specs/mcp-servers.md`](mcp-servers.md).
 
 ## Protocol
 
 JSON-RPC 2.0 over Streamable HTTP (`POST /mcp` with JSON-RPC body).
+
+Everruns supports MCP protocol versions `2025-06-18` and `2025-03-26`.
+
+- `initialize` negotiates `protocolVersion` from the request body. When the client omits a version, Everruns falls back to `2025-03-26`.
+- All non-`initialize` requests may send `MCP-Protocol-Version`. When omitted, Everruns falls back to `2025-03-26`.
+- Requests that send an unsupported `MCP-Protocol-Version` are rejected with HTTP `400 Bad Request` and a JSON-RPC error payload.
 
 ### Supported Methods
 
@@ -25,6 +32,17 @@ JSON-RPC 2.0 over Streamable HTTP (`POST /mcp` with JSON-RPC body).
 | `ping` | Health check / keep-alive |
 | `tools/list` | Discover available tools |
 | `tools/call` | Execute a tool |
+| `resources/list` | Discover static Everruns resources |
+| `resources/read` | Read a static Everruns resource by URI |
+
+### Tool Metadata
+
+`tools/list` returns only standard MCP tool fields.
+
+- Under negotiated protocol `2025-06-18`, tool definitions may include `title`, `description`, `inputSchema`, `outputSchema`, and `annotations`.
+- Under negotiated protocol `2025-03-26`, Everruns emits the older compatibility shape and omits newer `2025-06-18` fields such as `title` and `outputSchema`.
+- `outputSchema` is attached only to tools with stable JSON outputs.
+- Under negotiated protocol `2025-06-18`, when a tool has an `outputSchema` and returns valid JSON text, `tools/call` also returns `structuredContent` alongside the textual content block.
 
 ### Content Types
 
@@ -105,6 +123,12 @@ The `issuer` is the backend root URL (e.g. `https://app.example.com`). OAuth end
   "scopes_supported": ["mcp"]
 }
 ```
+
+#### GET /.well-known/oauth-protected-resource
+
+Protected Resource Metadata for MCP-aware OAuth clients. No auth required.
+
+Everruns advertises `/mcp` as the protected resource and points clients at the same OAuth issuer and token endpoints used by the rest of the MCP flow.
 
 #### POST /oauth/register
 
@@ -316,7 +340,7 @@ When omitted, the default org is used (first org from the user's membership list
 
 1. **Stateless per-call override** — no session state needed. Each tool call independently targets an org.
 2. **DB-validated membership** — JWT org claims may be stale; always check DB for fresh membership.
-3. **`discover` is org-agnostic** — catalog search doesn't depend on org context.
+3. **`discover` accepts `organization_id` for consistency** — catalog search itself is effectively org-agnostic today, but the argument keeps org-scoped routing uniform across tools and leaves room for future org-specific catalog visibility.
 4. **`switch_organization` is advisory** — returns the validated org for the client to use in subsequent calls. The MCP transport is stateless, so there's no server-side "current org" to switch.
 
 ## Implementation


### PR DESCRIPTION
## What
Standardize Everruns `/mcp` tool metadata to emit only standard MCP fields and make the payload version-aware between `2025-06-18` and `2025-03-26`.

## Why
The previous implementation introduced Everruns-specific metadata under `_meta.everruns`, which third-party MCP clients would generally ignore. This change keeps the endpoint interoperable and aligns the emitted surface with the MCP spec.

## How
Centralized `/mcp` tool definitions in a registry that emits only standard MCP fields.
Negotiated protocol version now controls whether `title`, `outputSchema`, and `structuredContent` are returned.
Updated endpoint tests and MCP spec documentation to cover latest/fallback behavior and header validation.

## Risk
- Low
- Can break MCP clients only if they depended on the non-standard `_meta.everruns` extension; standard MCP clients should behave better after this change.

## Security
- Threat categories reviewed: TM-API, TM-TOOL, TM-TENANT, TM-DOS
- Findings and resolutions:
- Checked request/header parsing for protocol negotiation and ensured unsupported `MCP-Protocol-Version` values fail closed with HTTP 400.
- Kept org-scoped routing and `organization_id` validation intact for MCP tool execution paths.
- Kept `structuredContent` gated to `2025-06-18` so older clients do not receive newer protocol fields unexpectedly.
- No new external integrations, secrets handling, or unbounded resource usage were introduced.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
