### PR TITLE
refactor(server): use bashkit async_tool for MCP catalog callbacks

### DIFF
--- a/crates/server/src/api/mcp_endpoint/catalog.rs
+++ b/crates/server/src/api/mcp_endpoint/catalog.rs
@@ -101,7 +101,7 @@ pub fn build_toolset(ctx: CatalogContext) -> ScriptingToolSet {
     for desc in inventory::iter::<crate::domains::common::CommandDescriptor> {
         let def = command_descriptor_to_def(desc);
         let callback = make_inventory_callback(desc, ctx.clone());
-        builder = builder.tool(def, callback);
+        builder = builder.async_tool(def, callback);
     }
 
     // Static CATALOG fills in everything not yet migrated.
@@ -111,7 +111,7 @@ pub fn build_toolset(ctx: CatalogContext) -> ScriptingToolSet {
         }
         let def = op_to_def(op);
         let callback = make_direct_callback(op, ctx.clone());
-        builder = builder.tool(def, callback);
+        builder = builder.async_tool(def, callback);
     }
 
     builder.build()
@@ -129,41 +129,41 @@ fn command_descriptor_to_def(desc: &crate::domains::common::CommandDescriptor) -
         })
 }
 
-/// Build a callback that dispatches an inventory command via domain dispatch.
+/// Build an async callback that dispatches an inventory command via domain dispatch.
 fn make_inventory_callback(
     desc: &'static crate::domains::common::CommandDescriptor,
     ctx: CatalogContext,
-) -> impl Fn(&ToolArgs) -> Result<String, String> + Send + Sync + 'static {
-    move |args: &ToolArgs| {
-        let params = args.params.clone();
+) -> impl Fn(ToolArgs) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>>
++ Send
++ Sync
++ 'static {
+    move |args: ToolArgs| {
+        let params = args.params;
         let domain_ctx = ctx.to_domain_ctx();
-        tokio::task::block_in_place(|| {
-            let handle = tokio::runtime::Handle::current();
-            handle.block_on(async {
-                (desc.dispatch)(params, &domain_ctx)
-                    .await
-                    .map_err(|e| e.to_string())
-            })
+        Box::pin(async move {
+            (desc.dispatch)(params, &domain_ctx)
+                .await
+                .map_err(|e| e.to_string())
         })
     }
 }
 
-/// Create a callback that calls a handler function directly via service layer.
+/// Create an async callback that calls a handler function directly via service layer.
 fn make_direct_callback(
     op: &'static Operation,
     ctx: CatalogContext,
-) -> impl Fn(&ToolArgs) -> Result<String, String> + Send + Sync + 'static {
-    move |args: &ToolArgs| {
-        let params = &args.params;
-
-        if is_flag_set(params, "help") {
-            return Ok(format_help(op));
+) -> impl Fn(ToolArgs) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>>
++ Send
++ Sync
++ 'static {
+    move |args: ToolArgs| {
+        if is_flag_set(&args.params, "help") {
+            let help = format_help(op);
+            return Box::pin(async move { Ok(help) });
         }
-
-        tokio::task::block_in_place(|| {
-            let handle = tokio::runtime::Handle::current();
-            handle.block_on(async { (op.handler)(params, &ctx).await })
-        })
+        let params = args.params;
+        let ctx = ctx.clone();
+        Box::pin(async move { (op.handler)(&params, &ctx).await })
     }
 }
 


### PR DESCRIPTION
## What

Switch the MCP endpoint catalog from the sync `ScriptingToolSet::tool()` + `tokio::task::block_in_place` bridge to the native `ScriptingToolSet::async_tool()` API that bashkit v0.1.18 exposes. Both the inventory-registered commands and the static `CATALOG` operations are now registered with async callbacks that return `Pin<Box<dyn Future<Output = Result<String, String>> + Send>>` instead of sync closures that blocked the tokio runtime.

## Why

Fixes EVE-301. The sync-callback bridge was a leftover from earlier bashkit versions that only supported `Fn(&ToolArgs) -> Result<String, String>`. Bashkit v0.1.18 ships a `async_tool<F, Fut>()` method (`crates/bashkit/src/scripted_tool/toolset.rs:246-257`) that accepts async callbacks directly, so the `block_in_place` + `Handle::current().block_on(...)` bridge is pure dead weight today: it forces each MCP tool invocation onto a blocking thread, even though the handlers are already async and the interpreter task is already async.

## How

One file changed, 25 lines in / 25 lines out:

1. `build_toolset` now calls `builder.async_tool(def, callback)` for both inventory commands (`for desc in inventory::iter::<CommandDescriptor>`) and the static `CATALOG` loop.
2. `make_inventory_callback` is now `Fn(ToolArgs) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>> + Send + Sync + 'static`. The body just moves `params` / builds `domain_ctx` / `Box::pin(async move { (desc.dispatch)(params, &domain_ctx).await.map_err(|e| e.to_string()) })`.
3. `make_direct_callback` has the same shape. The `--help` short-circuit returns `Box::pin(async move { Ok(format_help(op)) })` before touching the handler, preserving the existing fast path.
4. Request-scoped context capture is unchanged — `CatalogContext` (org_id, caller, user_id, state) is still cloned per registered tool and once more per invocation inside the `Fn` closure, so concurrent tool calls remain independent.
5. `args.params` is now moved by value (was cloned) since `async_tool`'s signature takes `ToolArgs` by value; the sync signature took `&ToolArgs` and required the clone. Net allocation is equivalent.

No behavior changes for callers: the same `String` response values propagate back, same error mapping, same help-flag output.

## Risk

- **Low**. Pure replacement of a sync-bridged callback with its native async equivalent; the handlers and inventory dispatch functions were already async.
- `cargo fmt --check`, `cargo clippy -p everruns-server --all-targets --all-features -- -D warnings`, `cargo test -p everruns-server --lib` (973/973) all green.
- `./scripts/export-openapi.sh` → `docs/api/openapi.json` byte-identical vs `origin/main`.
- Integration tests in `tests/mcp_endpoint_test.rs` require Postgres (`DATABASE_URL`), so they're covered by CI — not locally on this cloud env.
- Removes a blocking path that previously pinned a thread per MCP tool call under load. No regression expected; only an improvement in runtime behavior.

## Security

- Threat categories reviewed: `TM-TOOL` (tool execution paths). No change to tool dispatch semantics, auth/org scoping, or input validation — `CatalogContext` capture is identical.
- No new input, no new endpoint, no new dependency. `block_in_place` removal reduces blocking-thread usage but does not broaden the attack surface.
- Findings and resolutions: none.

## Checklist

- [x] Tests added or updated — existing 973 server lib tests cover the catalog code path; no new behaviour to test.
- [x] Backward compatibility considered — internal MCP tool registration; no external API changes.
- [x] Security review performed against relevant threat model categories.
- [x] All review comments addressed — awaiting review.