### PR TITLE
feat(core): add observational bashkit hooks for virtual_bash

### DIFF
--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -617,7 +617,7 @@ fn install_observability_hooks(builder: BashBuilder, session_id: SessionId) -> B
             HookAction::Continue(res)
         }))
         .on_error(Box::new(move |ev: ErrorEvent| {
-            let preview = redact_for_log(&ev.message, 256);
+            let preview = truncate_for_log(&ev.message, 256);
             tracing::warn!(
                 target: "bashkit.hook",
                 capability = "virtual_bash",
@@ -630,18 +630,30 @@ fn install_observability_hooks(builder: BashBuilder, session_id: SessionId) -> B
         }))
 }
 
-/// Bounded diagnostic preview for hook log fields. Cuts on a UTF-8 char
-/// boundary to avoid emitting invalid data and keeps a trailing marker so
-/// truncated entries are visible in logs.
-fn redact_for_log(msg: &str, max_bytes: usize) -> String {
+/// Bounded diagnostic preview for hook log fields. The return value is
+/// guaranteed to be no longer than `max_bytes` and to end on a valid UTF-8
+/// char boundary. When there is room, a trailing marker is appended so
+/// truncated entries remain visible in logs without exceeding the budget.
+fn truncate_for_log(msg: &str, max_bytes: usize) -> String {
+    const MARKER: &str = "…[truncated]";
     if msg.len() <= max_bytes {
         return msg.to_string();
     }
-    let mut cut = max_bytes;
+    let budget = max_bytes.saturating_sub(MARKER.len());
+    let mut cut = budget.min(msg.len());
     while cut > 0 && !msg.is_char_boundary(cut) {
         cut -= 1;
     }
-    format!("{}…[truncated]", &msg[..cut])
+    if max_bytes > MARKER.len() {
+        format!("{}{}", &msg[..cut], MARKER)
+    } else {
+        // Budget too small to fit the marker; return just the bounded slice.
+        let mut cut = max_bytes.min(msg.len());
+        while cut > 0 && !msg.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        msg[..cut].to_string()
+    }
 }
 
 /// Drain all buffered chunks from the partial output channel into a single string.
@@ -2922,28 +2934,43 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn redact_for_log_returns_short_strings_unchanged() {
-        assert_eq!(redact_for_log("hello", 100), "hello");
-        assert_eq!(redact_for_log("", 100), "");
+    fn truncate_for_log_returns_short_strings_unchanged() {
+        assert_eq!(truncate_for_log("hello", 100), "hello");
+        assert_eq!(truncate_for_log("", 100), "");
     }
 
     #[test]
-    fn redact_for_log_truncates_and_marks() {
+    fn truncate_for_log_stays_within_budget_and_marks() {
         let input = "a".repeat(500);
-        let out = redact_for_log(&input, 100);
-        assert!(out.starts_with(&"a".repeat(100)));
-        assert!(out.ends_with("[truncated]"));
-        assert!(out.len() < input.len());
+        let out = truncate_for_log(&input, 100);
+        assert!(
+            out.len() <= 100,
+            "output exceeded budget: {} bytes",
+            out.len()
+        );
+        assert!(out.ends_with("…[truncated]"));
+        assert!(out.starts_with('a'));
     }
 
     #[test]
-    fn redact_for_log_respects_utf8_boundaries() {
-        // Each '🦀' is 4 bytes. Cap of 5 must back off to a char boundary.
-        let input = "🦀🦀🦀🦀🦀";
-        let out = redact_for_log(input, 5);
+    fn truncate_for_log_respects_utf8_boundaries() {
+        // Each '🦀' is 4 bytes; marker is 14 bytes. Budget 20 leaves 6 for content,
+        // which backs off to a 4-byte char boundary (one crab).
+        let input = "🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀";
+        let out = truncate_for_log(input, 20);
+        assert!(out.len() <= 20);
         assert!(out.starts_with('🦀'));
-        assert!(out.ends_with("[truncated]"));
-        assert!(out.is_char_boundary(out.find('…').unwrap()));
+        assert!(out.ends_with("…[truncated]"));
+    }
+
+    #[test]
+    fn truncate_for_log_omits_marker_when_budget_is_too_small() {
+        // Budget smaller than the marker -> marker is dropped, content is still
+        // cut on a valid UTF-8 boundary and fits within max_bytes.
+        let input = "abcdefghijklmnop";
+        let out = truncate_for_log(input, 4);
+        assert_eq!(out, "abcd");
+        assert!(out.len() <= 4);
     }
 
     #[tokio::test]

--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -25,10 +25,10 @@ use crate::traits::{SessionFileStore, ToolContext};
 use crate::typed_id::SessionId;
 use async_trait::async_trait;
 use bashkit::{
-    Bash, BashTool as BashkitTool, DirEntry, ExecutionLimits, FileSystem, FileSystemExt, FileType,
-    Metadata, OutputCallback, SearchCapabilities, SearchCapable, SearchMatch as BashkitSearchMatch,
-    SearchProvider, SearchQuery, SearchResults, Tool as BashkitToolTrait, TraceEventKind,
-    TraceMode,
+    Bash, BashBuilder, BashTool as BashkitTool, DirEntry, ExecutionLimits, FileSystem,
+    FileSystemExt, FileType, Metadata, OutputCallback, SearchCapabilities, SearchCapable,
+    SearchMatch as BashkitSearchMatch, SearchProvider, SearchQuery, SearchResults,
+    Tool as BashkitToolTrait, TraceEventKind, TraceMode,
 };
 use serde_json::{Value, json};
 use std::path::{Path, PathBuf};
@@ -240,8 +240,10 @@ impl Tool for BashTool {
         // Resolve locale from context (defaults to en-US).
         let locale = context.locale.as_deref().unwrap_or("en-US");
 
-        // Configure bash with resource limits (uses shared execution_limits)
-        let mut bash = Bash::builder()
+        // Configure bash with resource limits (uses shared execution_limits).
+        // Observability hooks are installed last so per-builtin / error telemetry
+        // is available without changing any existing limits or boundaries.
+        let builder = Bash::builder()
             .fs(session_fs)
             .cwd(working_dir)
             .username("everruns")
@@ -253,8 +255,8 @@ impl Tool for BashTool {
             .env("LANG", locale)
             .limits(execution_limits())
             .max_memory(10 * 1024 * 1024) // 10 MB — prevent OOM from untrusted input
-            .trace_mode(TraceMode::Redacted)
-            .build();
+            .trace_mode(TraceMode::Redacted);
+        let mut bash = install_observability_hooks(builder, context.session_id).build();
 
         // Stream output via tool.output.delta events for live UI/CLI rendering.
         // bashkit's exec_streaming calls OutputCallback with (stdout_chunk, stderr_chunk)
@@ -456,7 +458,7 @@ impl BackgroundExecutableTool for BashTool {
         ));
         let locale = context.locale.as_deref().unwrap_or("en-US");
 
-        let mut bash = Bash::builder()
+        let builder = Bash::builder()
             .fs(session_fs)
             .cwd(working_dir)
             .username("everruns")
@@ -468,8 +470,8 @@ impl BackgroundExecutableTool for BashTool {
             .env("LANG", locale)
             .limits(execution_limits())
             .max_memory(10 * 1024 * 1024)
-            .trace_mode(TraceMode::Redacted)
-            .build();
+            .trace_mode(TraceMode::Redacted);
+        let mut bash = install_observability_hooks(builder, context.session_id).build();
 
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<(String, String)>();
         let (partial_tx, partial_rx) = tokio::sync::mpsc::channel::<(String, String)>(128);
@@ -575,6 +577,71 @@ impl BackgroundExecutableTool for BashTool {
             }
         }
     }
+}
+
+// Observational-only. Emits `tracing` events for each bashkit builtin
+// invocation and interpreter error, tagged with the active `session_id` for
+// audit correlation. Every hook returns `HookAction::Continue`; none widen
+// bashkit's existing limits or sandbox (TM-BASH). Hook callbacks log
+// structural metadata (tool name, arg count, exit code, byte lengths) but
+// never the argument values or builtin stdout — those surfaces can carry
+// tenant paths, URLs, or embedded secrets. HTTP hooks (`before_http` /
+// `after_http`) require bashkit's `http_client` feature, which everruns does
+// not enable for `virtual_bash` (TM-BASH-003: no network builtins).
+fn install_observability_hooks(builder: BashBuilder, session_id: SessionId) -> BashBuilder {
+    use bashkit::hooks::{ErrorEvent, HookAction, ToolEvent, ToolResult};
+    builder
+        .before_tool(Box::new(move |ev: ToolEvent| {
+            tracing::debug!(
+                target: "bashkit.hook",
+                capability = "virtual_bash",
+                session_id = %session_id,
+                event = "before_tool",
+                tool = %ev.name,
+                arg_count = ev.args.len(),
+                "builtin invoked"
+            );
+            HookAction::Continue(ev)
+        }))
+        .after_tool(Box::new(move |res: ToolResult| {
+            tracing::debug!(
+                target: "bashkit.hook",
+                capability = "virtual_bash",
+                session_id = %session_id,
+                event = "after_tool",
+                tool = %res.name,
+                exit_code = res.exit_code,
+                stdout_bytes = res.stdout.len(),
+                "builtin completed"
+            );
+            HookAction::Continue(res)
+        }))
+        .on_error(Box::new(move |ev: ErrorEvent| {
+            let preview = redact_for_log(&ev.message, 256);
+            tracing::warn!(
+                target: "bashkit.hook",
+                capability = "virtual_bash",
+                session_id = %session_id,
+                event = "on_error",
+                message = %preview,
+                "interpreter error"
+            );
+            HookAction::Continue(ev)
+        }))
+}
+
+/// Bounded diagnostic preview for hook log fields. Cuts on a UTF-8 char
+/// boundary to avoid emitting invalid data and keeps a trailing marker so
+/// truncated entries are visible in logs.
+fn redact_for_log(msg: &str, max_bytes: usize) -> String {
+    if msg.len() <= max_bytes {
+        return msg.to_string();
+    }
+    let mut cut = max_bytes;
+    while cut > 0 && !msg.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    format!("{}…[truncated]", &msg[..cut])
 }
 
 /// Drain all buffered chunks from the partial output channel into a single string.
@@ -2847,6 +2914,66 @@ mod tests {
         assert!(
             our_props.contains_key("working_dir"),
             "working_dir must be in parameters_schema"
+        );
+    }
+
+    // ========================================================================
+    // Observability hooks (EVE-299)
+    // ========================================================================
+
+    #[test]
+    fn redact_for_log_returns_short_strings_unchanged() {
+        assert_eq!(redact_for_log("hello", 100), "hello");
+        assert_eq!(redact_for_log("", 100), "");
+    }
+
+    #[test]
+    fn redact_for_log_truncates_and_marks() {
+        let input = "a".repeat(500);
+        let out = redact_for_log(&input, 100);
+        assert!(out.starts_with(&"a".repeat(100)));
+        assert!(out.ends_with("[truncated]"));
+        assert!(out.len() < input.len());
+    }
+
+    #[test]
+    fn redact_for_log_respects_utf8_boundaries() {
+        // Each '🦀' is 4 bytes. Cap of 5 must back off to a char boundary.
+        let input = "🦀🦀🦀🦀🦀";
+        let out = redact_for_log(input, 5);
+        assert!(out.starts_with('🦀'));
+        assert!(out.ends_with("[truncated]"));
+        assert!(out.is_char_boundary(out.find('…').unwrap()));
+    }
+
+    #[tokio::test]
+    async fn install_observability_hooks_fires_on_builtin_and_preserves_exit() {
+        use bashkit::hooks::{HookAction, ToolResult};
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        let tool_calls = Arc::new(AtomicU64::new(0));
+        let counter = tool_calls.clone();
+
+        // Start from the shared hook installer, then stack a test observer.
+        // This proves the installer leaves the builtin pipeline intact and
+        // that additional hooks compose cleanly.
+        let session_id: SessionId = "session_0197a4a4c0c0780180000000000000ff".parse().unwrap();
+        let builder = install_observability_hooks(Bash::builder(), session_id).after_tool(
+            Box::new(move |r: ToolResult| {
+                counter.fetch_add(1, Ordering::Relaxed);
+                HookAction::Continue(r)
+            }),
+        );
+
+        let mut bash = builder.build();
+        let result = bash.exec("echo hook-smoke").await.unwrap();
+
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout.trim(), "hook-smoke");
+        assert!(
+            tool_calls.load(Ordering::Relaxed) >= 1,
+            "after_tool hook should fire at least once for `echo`"
         );
     }
 }

--- a/specs/bashkit-requirements.md
+++ b/specs/bashkit-requirements.md
@@ -35,6 +35,17 @@ Pipeline: strip ANSI escape codes → collapse `\r`-overwritten lines → middle
 
 This reduces token waste from verbose build output (`cargo build`, `npm install`) by 40-60%. The EVE-225 hard limit (64 KiB) acts as a safety net for any tool that skips sanitization.
 
+## Observability Hooks
+
+`virtual_bash` installs observational-only bashkit interceptors on every `Bash` instance it builds (`install_observability_hooks` in `crates/core/src/capabilities/virtual_bash.rs`). The hooks emit structured `tracing` events at the `bashkit.hook` target, tagged with the active `session_id` for audit correlation:
+
+- `before_tool` / `after_tool` — per-builtin invocation and completion. Logs tool name, arg count, exit code, and stdout byte length. Argument values and stdout bytes are never logged (tenant paths, URLs, or embedded secrets may appear there).
+- `on_error` — interpreter errors. The error message is truncated to 256 bytes on a UTF-8 boundary before logging to bound per-event payload size.
+
+Every hook returns `HookAction::Continue`; none widen bashkit's existing limits, network allowlist, or sandbox boundaries (TM-BASH).
+
+HTTP hooks (`before_http` / `after_http`) require bashkit's `http_client` feature, which is **not** enabled for `virtual_bash` (see TM-BASH-003 — no network builtins). If that changes, register HTTP hooks alongside the existing ones.
+
 ## Benefits
 
 1. **Live file visibility** - Files written by other tools during bash execution are immediately visible


### PR DESCRIPTION
## What

Installs observational-only `bashkit` interceptor hooks on every `Bash` instance built by the `virtual_bash` capability. The hooks emit structured `tracing` events tagged with the active `session_id` so operators can audit per-builtin activity and interpreter errors without touching the script text or stdout.

Hooks registered:
- `before_tool` — logs `tool`, `arg_count` (values not logged)
- `after_tool` — logs `tool`, `exit_code`, `stdout_bytes` (content not logged)
- `on_error` — logs a 256-byte UTF-8-safe truncated preview of the error message at `warn!`

HTTP hooks (`before_http` / `after_http`) are deliberately not installed: `virtual_bash` does not enable bashkit's `http_client` feature and has no network builtins (TM-BASH-003).

## Why

EVE-299 — bashkit v0.1.18 ships a hook system, but `virtual_bash` still builds Bash instances without any interceptors. The existing `tracing::info!` at the end of `execute()` only exposes aggregate counts from `TraceEventKind` events. Per-builtin audit granularity (which builtin ran, with what exit code) and first-class interpreter-error capture were not previously reachable without additional bashkit features. The issue asks for a narrow observational prototype first; this is that prototype.

## How

- Added `install_observability_hooks(builder, session_id) -> BashBuilder` in `crates/core/src/capabilities/virtual_bash.rs`. Every hook returns `HookAction::Continue` — zero behavior change.
- Wired the installer into both `Tool::execute` and `BackgroundExecutableTool::execute_background` for `BashTool`, so both the foreground and background bash paths get the same telemetry.
- Added `redact_for_log(msg, max_bytes)` helper for bounded UTF-8-safe error previews.
- Added four unit tests: three cover `redact_for_log` edge cases (short, truncated + marker, multi-byte char boundary); one end-to-end smoke test composes the installer with an observer hook, runs a script, and asserts both the exit code and that `after_tool` fired.
- Documented the hook surface in `specs/bashkit-requirements.md` (new "Observability Hooks" section).

## Risk

- Low.
- Every hook is observational; closures return `HookAction::Continue` and cannot widen bashkit's existing limits (TM-BASH-005/006/007) or sandbox boundaries. The hook pipeline is a `Vec::is_empty()` check when no hooks are registered and a few closure calls otherwise — no perceptible overhead. Worst case is a noisy `tracing` subscriber, which is configurable per-deployment.

## Security

- Threat categories reviewed: **TM-BASH** (Bash sandbox), **TM-WEB** (HTTP hooks), general logging exposure.
- Findings and resolutions:
  - **Secret exfiltration via logs.** Hook callbacks log only structural metadata (tool name, arg count, exit code, byte lengths). Argument values and builtin stdout are never logged — those surfaces may carry tenant paths, URLs, or embedded secrets.
  - **Unbounded error payloads.** `on_error` can receive arbitrarily long error messages. Each error is truncated to 256 bytes on a UTF-8 char boundary before being passed to `tracing::warn!`, preventing log amplification.
  - **Sandbox bypass.** Every hook returns `HookAction::Continue`. None modify `ExecInput`, `ToolEvent`, or cancel execution. Bashkit's limits, allowlist, and VFS adapter boundaries remain the sole enforcement surface.
  - **Network allowlist bypass (TM-BASH-003).** HTTP hooks are not installed; they would require bashkit's `http_client` feature which this crate does not enable. No network builtins exist inside `virtual_bash`, so there is no TM-WEB-relevant surface to observe. Comment on the helper documents this so a future contributor enabling `http_client` registers HTTP hooks explicitly.
- No new THREAT comments added; no existing THREAT comments in `virtual_bash.rs` were moved or altered.

## Checklist
- [x] Tests added or updated (4 new unit tests in `crates/core/src/capabilities/virtual_bash.rs`)
- [x] Backward compatibility considered (observational-only, no output / behavior changes)
- [x] Security review performed against relevant threat model categories (TM-BASH, TM-WEB)
- [ ] All review comments addressed (code change or written reasoning)