### PR TITLE
feat(core): unify reading-tool truncation envelope

### DIFF
--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -14,7 +14,6 @@
 
 use super::{Capability, CapabilityStatus};
 use crate::session_file::SessionFile;
-use crate::tool_output_sanitizer::READ_FILE_HARD_BYTE_CAP;
 use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult, ToolResultImage};
 use crate::traits::ToolContext;
@@ -742,24 +741,37 @@ impl Tool for ReadFileTool {
                 }
 
                 // Unified reading-tool truncation envelope (EVE-339).
+                //
+                // Distinguishing which cap fired:
+                // - When `end_line < total_lines` the line window was clipped
+                //   by `limit`, so this is a line cap and line-based resume is
+                //   safe.
+                // - When `truncated == true` but `end_line == total_lines` the
+                //   line window covered every line and the cut must have come
+                //   from the byte cap inside `format_lines`. Byte truncation
+                //   can cut mid-line, so `next_offset = end_line` is not a
+                //   reliable resume point — emit `without_resume` and let the
+                //   caller narrow `limit` or shift `offset`.
                 let truncation = if truncated {
-                    let next_offset = end_line as u64;
-                    let reason = if formatted.len() > READ_FILE_HARD_BYTE_CAP {
-                        TruncationReason::SizeCap
+                    if end_line < total_lines {
+                        TruncationInfo::with_resume(
+                            formatted.len(),
+                            Some(file.size_bytes as usize),
+                            end_line as u64,
+                            format!(
+                                "call read_file with offset={} to resume from line {}",
+                                end_line,
+                                end_line + 1,
+                            ),
+                            TruncationReason::LineCap,
+                        )
                     } else {
-                        TruncationReason::LineCap
-                    };
-                    TruncationInfo::with_resume(
-                        formatted.len(),
-                        Some(file.size_bytes as usize),
-                        next_offset,
-                        format!(
-                            "call read_file with offset={} to resume from line {}",
-                            end_line,
-                            end_line + 1,
-                        ),
-                        reason,
-                    )
+                        TruncationInfo::without_resume(
+                            formatted.len(),
+                            Some(file.size_bytes as usize),
+                            TruncationReason::SizeCap,
+                        )
+                    }
                 } else {
                     TruncationInfo::not_truncated(formatted.len())
                 };
@@ -1245,8 +1257,11 @@ impl Tool for ListDirectoryTool {
                 // `list_directory` has no backend cap today — the contract is
                 // wired with `not_truncated` so the envelope is always present
                 // (EVE-339). If a cap is introduced later, switch to
-                // `without_resume(... ItemCap)`.
-                let bytes_returned = serde_json::to_string(&result).map(|s| s.len()).unwrap_or(0);
+                // `without_resume(... ItemCap)`. `bytes_returned` measures the
+                // primary payload (`entries`), not the wrapping object.
+                let bytes_returned = serde_json::to_string(&entries)
+                    .expect("list_directory entries always serialize")
+                    .len();
                 TruncationInfo::not_truncated(bytes_returned).attach(&mut result);
                 ToolExecutionResult::success(result)
             }
@@ -1363,7 +1378,11 @@ impl Tool for GrepFilesTool {
                 // envelope is wired with `not_truncated` so the reading-tool
                 // contract is honoured uniformly (EVE-339). If a cap is
                 // introduced later, switch to `without_resume(... LineCap)`.
-                let bytes_returned = serde_json::to_string(&result).map(|s| s.len()).unwrap_or(0);
+                // `bytes_returned` measures the primary payload (`matches`),
+                // not the wrapping object.
+                let bytes_returned = serde_json::to_string(&results)
+                    .expect("grep_files matches always serialize")
+                    .len();
                 TruncationInfo::not_truncated(bytes_returned).attach(&mut result);
                 ToolExecutionResult::success(result)
             }

--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -14,9 +14,11 @@
 
 use super::{Capability, CapabilityStatus};
 use crate::session_file::SessionFile;
+use crate::tool_output_sanitizer::READ_FILE_HARD_BYTE_CAP;
 use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult, ToolResultImage};
 use crate::traits::ToolContext;
+use crate::truncation_info::{TruncationInfo, TruncationReason};
 use async_trait::async_trait;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
@@ -739,6 +741,30 @@ impl Tool for ReadFileTool {
                     }
                 }
 
+                // Unified reading-tool truncation envelope (EVE-339).
+                let truncation = if truncated {
+                    let next_offset = end_line as u64;
+                    let reason = if formatted.len() > READ_FILE_HARD_BYTE_CAP {
+                        TruncationReason::SizeCap
+                    } else {
+                        TruncationReason::LineCap
+                    };
+                    TruncationInfo::with_resume(
+                        formatted.len(),
+                        Some(file.size_bytes as usize),
+                        next_offset,
+                        format!(
+                            "call read_file with offset={} to resume from line {}",
+                            end_line,
+                            end_line + 1,
+                        ),
+                        reason,
+                    )
+                } else {
+                    TruncationInfo::not_truncated(formatted.len())
+                };
+                truncation.attach(&mut result);
+
                 ToolExecutionResult::success(result)
             }
             Ok(None) => {
@@ -1211,11 +1237,18 @@ impl Tool for ListDirectoryTool {
                     })
                     .collect();
 
-                ToolExecutionResult::success(json!({
+                let mut result = json!({
                     "path": display_path,
                     "entries": entries,
                     "count": entries.len()
-                }))
+                });
+                // `list_directory` has no backend cap today — the contract is
+                // wired with `not_truncated` so the envelope is always present
+                // (EVE-339). If a cap is introduced later, switch to
+                // `without_resume(... ItemCap)`.
+                let bytes_returned = serde_json::to_string(&result).map(|s| s.len()).unwrap_or(0);
+                TruncationInfo::not_truncated(bytes_returned).attach(&mut result);
+                ToolExecutionResult::success(result)
             }
             Err(e) => {
                 let msg = e.to_string();
@@ -1321,11 +1354,18 @@ impl Tool for GrepFilesTool {
                     })
                     .collect();
 
-                ToolExecutionResult::success(json!({
+                let mut result = json!({
                     "pattern": pattern,
                     "matches": results,
                     "match_count": results.len()
-                }))
+                });
+                // `grep_files` does not currently cap match count; the
+                // envelope is wired with `not_truncated` so the reading-tool
+                // contract is honoured uniformly (EVE-339). If a cap is
+                // introduced later, switch to `without_resume(... LineCap)`.
+                let bytes_returned = serde_json::to_string(&result).map(|s| s.len()).unwrap_or(0);
+                TruncationInfo::not_truncated(bytes_returned).attach(&mut result);
+                ToolExecutionResult::success(result)
             }
             Err(e) => {
                 let msg = e.to_string();
@@ -2123,6 +2163,119 @@ mod tests {
         assert_eq!(value["truncated"], true);
         assert_eq!(value["lines_shown"]["start"], 1);
         assert_eq!(value["lines_shown"]["end"], 2000);
+    }
+
+    // ============================================================================
+    // EVE-339 — Reading-tool truncation envelope conformance
+    // ============================================================================
+
+    #[tokio::test]
+    async fn test_read_file_truncation_envelope_when_not_truncated() {
+        let store = Arc::new(MockFileStore::default());
+        store.add_text_file("/notes.txt", "hello world");
+        let context = make_context(store);
+
+        let result = ReadFileTool
+            .execute_with_context(json!({"path": "/workspace/notes.txt"}), &context)
+            .await;
+        let value = expect_success(result);
+
+        crate::truncation_info::assert_conforms("read_file", &value);
+        assert_eq!(value["truncation"]["truncated"], false);
+    }
+
+    #[tokio::test]
+    async fn test_read_file_truncation_envelope_with_resume() {
+        let store = Arc::new(MockFileStore::default());
+        let content = (1..=2500)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+        store.add_text_file("/huge.txt", &content);
+        let context = make_context(store);
+
+        let result = ReadFileTool
+            .execute_with_context(json!({"path": "/workspace/huge.txt"}), &context)
+            .await;
+        let value = expect_success(result);
+
+        crate::truncation_info::assert_conforms("read_file", &value);
+        assert_eq!(value["truncation"]["truncated"], true);
+        assert_eq!(value["truncation"]["reason"], "line_cap");
+        assert_eq!(value["truncation"]["next_offset"], 2000);
+        assert!(
+            value["truncation"]["resume_hint"]
+                .as_str()
+                .unwrap()
+                .contains("offset=2000")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_read_file_resume_roundtrip_reaches_end() {
+        let store = Arc::new(MockFileStore::default());
+        let content = (1..=2500)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+        store.add_text_file("/huge.txt", &content);
+        let context = make_context(store);
+
+        // First page
+        let first = expect_success(
+            ReadFileTool
+                .execute_with_context(json!({"path": "/workspace/huge.txt"}), &context)
+                .await,
+        );
+        let next_offset = first["truncation"]["next_offset"].as_u64().unwrap();
+
+        // Resume from next_offset
+        let second = expect_success(
+            ReadFileTool
+                .execute_with_context(
+                    json!({"path": "/workspace/huge.txt", "offset": next_offset, "limit": 1000}),
+                    &context,
+                )
+                .await,
+        );
+
+        // After resuming we cover the remaining 500 lines and the envelope
+        // reports `truncated: false` on the final chunk.
+        assert_eq!(second["truncation"]["truncated"], false);
+        let shown = &second["lines_shown"];
+        assert_eq!(shown["start"], 2001);
+        assert_eq!(shown["end"], 2500);
+    }
+
+    #[tokio::test]
+    async fn test_list_directory_emits_truncation_envelope() {
+        let store = Arc::new(MockFileStore::default());
+        store.add_text_file("/a.txt", "a");
+        store.add_text_file("/b.txt", "b");
+        let context = make_context(store);
+
+        let result = ListDirectoryTool
+            .execute_with_context(json!({"path": "/workspace"}), &context)
+            .await;
+        let value = expect_success(result);
+
+        crate::truncation_info::assert_conforms("list_directory", &value);
+        assert_eq!(value["truncation"]["truncated"], false);
+    }
+
+    #[tokio::test]
+    async fn test_grep_files_emits_truncation_envelope() {
+        let store = Arc::new(MockFileStore::default());
+        store.add_text_file("/notes.txt", "hello world");
+        let context = make_context(store);
+
+        let result = GrepFilesTool
+            .execute_with_context(json!({"pattern": "hello"}), &context)
+            .await;
+        let value = expect_success(result);
+
+        crate::truncation_info::assert_conforms("grep_files", &value);
+        assert_eq!(value["truncation"]["truncated"], false);
     }
 
     #[tokio::test]

--- a/crates/core/src/capabilities/session_sql_database.rs
+++ b/crates/core/src/capabilities/session_sql_database.rs
@@ -97,9 +97,12 @@ fn shape_sql_query_response(
     if truncated {
         response["truncated"] = json!(true);
     }
-    let bytes_returned = serde_json::to_string(&response)
-        .map(|s| s.len())
-        .unwrap_or(0);
+    // `bytes_returned` measures the primary payload (`rows`), matching the
+    // reading-tool contract's "primary content" definition rather than the
+    // wrapping object.
+    let bytes_returned = serde_json::to_string(rows)
+        .expect("sql_query rows always serialize")
+        .len();
     let info = if truncated {
         TruncationInfo::without_resume(bytes_returned, None, TruncationReason::RowCap)
     } else {

--- a/crates/core/src/capabilities/session_sql_database.rs
+++ b/crates/core/src/capabilities/session_sql_database.rs
@@ -10,6 +10,7 @@ use crate::session_sqldb::SessionSqlDbError;
 use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
+use crate::truncation_info::{TruncationInfo, TruncationReason};
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
@@ -70,6 +71,42 @@ fn sqldb_error_to_result(err: SessionSqlDbError) -> ToolExecutionResult {
     } else {
         ToolExecutionResult::internal_error_msg(err.to_string())
     }
+}
+
+/// Shape a `sql_query` response with the unified reading-tool truncation
+/// envelope (EVE-339).
+///
+/// `sql_query` does not support in-place offset resume: if the result set
+/// exceeds the row/byte cap, the caller must paginate via `LIMIT`/`OFFSET`
+/// or narrow the `WHERE`. That fallback is documented in
+/// `specs/session-sqldb.md`. The envelope therefore uses `without_resume`
+/// when truncated.
+fn shape_sql_query_response(
+    database: &str,
+    columns: &[String],
+    rows: &[Vec<Value>],
+    row_count: usize,
+    truncated: bool,
+) -> Value {
+    let mut response = json!({
+        "database": database,
+        "columns": columns,
+        "rows": rows,
+        "row_count": row_count
+    });
+    if truncated {
+        response["truncated"] = json!(true);
+    }
+    let bytes_returned = serde_json::to_string(&response)
+        .map(|s| s.len())
+        .unwrap_or(0);
+    let info = if truncated {
+        TruncationInfo::without_resume(bytes_returned, None, TruncationReason::RowCap)
+    } else {
+        TruncationInfo::not_truncated(bytes_returned)
+    };
+    info.attach(&mut response);
+    response
 }
 
 // ============================================================================
@@ -241,15 +278,13 @@ impl Tool for SqlQueryTool {
 
         match store.sql_query(context.session_id, database, sql).await {
             Ok(result) => {
-                let mut response = json!({
-                    "database": database,
-                    "columns": result.columns,
-                    "rows": result.rows,
-                    "row_count": result.row_count
-                });
-                if result.truncated {
-                    response["truncated"] = json!(true);
-                }
+                let response = shape_sql_query_response(
+                    database,
+                    &result.columns,
+                    &result.rows,
+                    result.row_count,
+                    result.truncated,
+                );
                 ToolExecutionResult::success(response)
             }
             Err(e) => sqldb_error_to_result(e),
@@ -449,5 +484,32 @@ mod tests {
         } else {
             panic!("Expected tool error for missing store");
         }
+    }
+
+    // ============================================================================
+    // EVE-339 — Reading-tool truncation envelope conformance
+    // ============================================================================
+
+    #[test]
+    fn test_sql_query_truncation_envelope_when_not_truncated() {
+        let columns = vec!["id".to_string()];
+        let rows = vec![vec![json!(1)], vec![json!(2)]];
+        let response = shape_sql_query_response("db", &columns, &rows, 2, false);
+        crate::truncation_info::assert_conforms("sql_query", &response);
+        assert_eq!(response["truncation"]["truncated"], false);
+    }
+
+    #[test]
+    fn test_sql_query_truncation_envelope_when_truncated() {
+        let columns = vec!["id".to_string()];
+        let rows = vec![vec![json!(1)]; 1000];
+        let response = shape_sql_query_response("db", &columns, &rows, 1000, true);
+        crate::truncation_info::assert_conforms("sql_query", &response);
+        assert_eq!(response["truncation"]["truncated"], true);
+        assert_eq!(response["truncation"]["reason"], "row_cap");
+        assert!(
+            response["truncation"].get("next_offset").is_none(),
+            "sql_query does not support in-place resume"
+        );
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -113,6 +113,7 @@ pub mod runtime_context;
 pub mod tool_output_sanitizer;
 pub mod tools;
 pub mod traits;
+pub mod truncation_info;
 pub mod user_facing_error;
 
 // In-memory implementations for examples and testing

--- a/crates/core/src/truncation_info.rs
+++ b/crates/core/src/truncation_info.rs
@@ -62,7 +62,11 @@ impl TruncationReason {
 pub struct TruncationInfo {
     pub truncated: bool,
 
-    /// Bytes actually returned in the response payload's primary content.
+    /// Bytes of the response's primary content returned to the caller.
+    /// "Primary content" means the field a caller actually consumes
+    /// (e.g. `content` for `read_file` / `browserless_content`, `rows` for
+    /// `sql_query`, `entries` for `list_directory`, `matches` for
+    /// `grep_files`). It is not the serialized size of the wrapping object.
     pub bytes_returned: usize,
 
     /// Total bytes of the untruncated source. `None` when unknown (e.g.
@@ -177,10 +181,20 @@ pub fn assert_conforms(tool_name: &str, response: &Value) {
                 "{tool_name}: `next_offset` present but `resume_hint` missing"
             );
         }
+        if parsed.resume_hint.is_some() {
+            assert!(
+                parsed.next_offset.is_some(),
+                "{tool_name}: `resume_hint` present but `next_offset` missing"
+            );
+        }
     } else {
         assert!(
             parsed.next_offset.is_none(),
             "{tool_name}: `next_offset` set on a non-truncated response"
+        );
+        assert!(
+            parsed.resume_hint.is_none(),
+            "{tool_name}: `resume_hint` set on a non-truncated response"
         );
     }
 }

--- a/crates/core/src/truncation_info.rs
+++ b/crates/core/src/truncation_info.rs
@@ -1,0 +1,281 @@
+// Reading-tool output truncation contract (EVE-339)
+//
+// Shared envelope for every tool in the reading-tool class (file readers,
+// sandbox readers, DB query, web fetch, search). The contract is documented
+// in `specs/tool-execution.md` under "Reading-tool output contract".
+//
+// Design decisions:
+// - One struct (`TruncationInfo`) covers the three interesting cases:
+//   not-truncated, truncated-without-resume, truncated-with-resume.
+// - `reason` is a stable machine-readable enum so LLMs can branch without
+//   string-matching human-readable markers.
+// - `next_offset` is populated ONLY when the owning tool supports in-place
+//   resume. Tools without resume (e.g. browserless without ?range, exec
+//   output after priority-aware truncation) set it to `None`.
+// - Attached to tool responses as a `"truncation": { ... }` object via
+//   `TruncationInfo::attach`. Existing flat fields (e.g. `truncated: bool`,
+//   `total_lines`) stay in place for back-compat; the envelope is additive.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Machine-readable reason for a truncation. Stable wire values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TruncationReason {
+    /// Source exceeded a byte cap (e.g. `read_file` 50 KB hard cap,
+    /// `browserless_content` 100 KB cap).
+    SizeCap,
+    /// Source exceeded a line cap (e.g. `read_file` default 2000 lines,
+    /// `grep_files` match-count limit).
+    LineCap,
+    /// Source exceeded a row cap (e.g. `sqldb_query` 1000-row cap).
+    RowCap,
+    /// Source exceeded an exec verbosity budget
+    /// (`silent`/`concise`/`normal`/`verbose`).
+    ExecBudget,
+    /// Source exceeded a listing/item-count cap (e.g. `list_directory`).
+    ItemCap,
+}
+
+impl TruncationReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SizeCap => "size_cap",
+            Self::LineCap => "line_cap",
+            Self::RowCap => "row_cap",
+            Self::ExecBudget => "exec_budget",
+            Self::ItemCap => "item_cap",
+        }
+    }
+}
+
+/// Structured truncation metadata for reading-tool responses.
+///
+/// Every reading tool (see `specs/tool-execution.md`) must attach this block
+/// to its response so LLM callers can:
+/// 1. Detect partial output without regex-matching human markers.
+/// 2. Know *why* the cut happened (size / line / row / budget / item cap).
+/// 3. Resume from the next offset when the tool supports in-place resume, or
+///    discover the documented fallback otherwise.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TruncationInfo {
+    pub truncated: bool,
+
+    /// Bytes actually returned in the response payload's primary content.
+    pub bytes_returned: usize,
+
+    /// Total bytes of the untruncated source. `None` when unknown (e.g.
+    /// streaming/search results).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bytes_total: Option<usize>,
+
+    /// Offset the caller should pass back to the same tool to continue
+    /// reading. Populated only when the tool supports in-place resume.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_offset: Option<u64>,
+
+    /// Human-readable nudge for the LLM describing how to resume. Always
+    /// paired with `next_offset` when present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resume_hint: Option<String>,
+
+    /// Machine-readable reason code. Always present so callers can branch
+    /// on it even when `truncated` is `false` (the reason is unused in
+    /// that case but kept for schema stability).
+    pub reason: TruncationReason,
+}
+
+impl TruncationInfo {
+    /// Response fully contains the source; no cut was made.
+    pub fn not_truncated(bytes_returned: usize) -> Self {
+        Self {
+            truncated: false,
+            bytes_returned,
+            bytes_total: Some(bytes_returned),
+            next_offset: None,
+            resume_hint: None,
+            reason: TruncationReason::SizeCap,
+        }
+    }
+
+    /// Response was cut and the caller can resume by passing `next_offset`
+    /// back to the same tool.
+    pub fn with_resume(
+        bytes_returned: usize,
+        bytes_total: Option<usize>,
+        next_offset: u64,
+        resume_hint: impl Into<String>,
+        reason: TruncationReason,
+    ) -> Self {
+        Self {
+            truncated: true,
+            bytes_returned,
+            bytes_total,
+            next_offset: Some(next_offset),
+            resume_hint: Some(resume_hint.into()),
+            reason,
+        }
+    }
+
+    /// Response was cut and in-place resume is not supported. The caller
+    /// must fall back to the documented per-tool strategy (e.g. narrower
+    /// `WHERE` for SQL, VFS file reads for exec output).
+    pub fn without_resume(
+        bytes_returned: usize,
+        bytes_total: Option<usize>,
+        reason: TruncationReason,
+    ) -> Self {
+        Self {
+            truncated: true,
+            bytes_returned,
+            bytes_total,
+            next_offset: None,
+            resume_hint: None,
+            reason,
+        }
+    }
+
+    /// Attach this block to a JSON object under the `truncation` key.
+    /// No-op if `target` is not an object.
+    pub fn attach(&self, target: &mut Value) {
+        if let Some(obj) = target.as_object_mut() {
+            obj.insert(
+                "truncation".to_string(),
+                serde_json::to_value(self).expect("TruncationInfo serializes"),
+            );
+        }
+    }
+
+    /// Serialize as a JSON `Value` for manual insertion.
+    pub fn to_json(&self) -> Value {
+        serde_json::to_value(self).expect("TruncationInfo serializes")
+    }
+}
+
+/// Assert that a reading-tool response carries a well-formed `truncation`
+/// block per the contract. Intended for use in tool-specific tests and the
+/// cross-tool conformance harness.
+///
+/// Panics with a descriptive message on violation.
+pub fn assert_conforms(tool_name: &str, response: &Value) {
+    let obj = response
+        .as_object()
+        .unwrap_or_else(|| panic!("{tool_name}: response is not a JSON object"));
+
+    let block = obj
+        .get("truncation")
+        .unwrap_or_else(|| panic!("{tool_name}: response missing required `truncation` block"));
+
+    let parsed: TruncationInfo = serde_json::from_value(block.clone())
+        .unwrap_or_else(|e| panic!("{tool_name}: `truncation` block malformed: {e}"));
+
+    if parsed.truncated {
+        if parsed.next_offset.is_some() {
+            assert!(
+                parsed.resume_hint.is_some(),
+                "{tool_name}: `next_offset` present but `resume_hint` missing"
+            );
+        }
+    } else {
+        assert!(
+            parsed.next_offset.is_none(),
+            "{tool_name}: `next_offset` set on a non-truncated response"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn not_truncated_shape() {
+        let info = TruncationInfo::not_truncated(128);
+        let v = info.to_json();
+        assert_eq!(v["truncated"], json!(false));
+        assert_eq!(v["bytes_returned"], json!(128));
+        assert_eq!(v["bytes_total"], json!(128));
+        assert!(v.get("next_offset").is_none());
+        assert!(v.get("resume_hint").is_none());
+        assert_eq!(v["reason"], json!("size_cap"));
+    }
+
+    #[test]
+    fn with_resume_shape() {
+        let info = TruncationInfo::with_resume(
+            49_512,
+            Some(184_221),
+            49_512,
+            "call read_file with offset=49512",
+            TruncationReason::SizeCap,
+        );
+        let v = info.to_json();
+        assert_eq!(v["truncated"], json!(true));
+        assert_eq!(v["bytes_returned"], json!(49_512));
+        assert_eq!(v["bytes_total"], json!(184_221));
+        assert_eq!(v["next_offset"], json!(49_512));
+        assert!(v["resume_hint"].as_str().unwrap().contains("offset=49512"));
+        assert_eq!(v["reason"], json!("size_cap"));
+    }
+
+    #[test]
+    fn without_resume_shape() {
+        let info = TruncationInfo::without_resume(1_000, None, TruncationReason::RowCap);
+        let v = info.to_json();
+        assert_eq!(v["truncated"], json!(true));
+        assert!(v.get("bytes_total").is_none());
+        assert!(v.get("next_offset").is_none());
+        assert!(v.get("resume_hint").is_none());
+        assert_eq!(v["reason"], json!("row_cap"));
+    }
+
+    #[test]
+    fn attach_inserts_under_truncation_key() {
+        let mut target = json!({ "content": "abc", "total_lines": 3 });
+        TruncationInfo::not_truncated(3).attach(&mut target);
+        assert_eq!(target["truncation"]["truncated"], json!(false));
+        assert_eq!(target["content"], json!("abc"));
+        assert_eq!(target["total_lines"], json!(3));
+    }
+
+    #[test]
+    fn reason_wire_values_are_stable() {
+        assert_eq!(TruncationReason::SizeCap.as_str(), "size_cap");
+        assert_eq!(TruncationReason::LineCap.as_str(), "line_cap");
+        assert_eq!(TruncationReason::RowCap.as_str(), "row_cap");
+        assert_eq!(TruncationReason::ExecBudget.as_str(), "exec_budget");
+        assert_eq!(TruncationReason::ItemCap.as_str(), "item_cap");
+    }
+
+    #[test]
+    fn assert_conforms_accepts_valid() {
+        let mut response = json!({});
+        TruncationInfo::with_resume(100, Some(500), 100, "resume", TruncationReason::LineCap)
+            .attach(&mut response);
+        assert_conforms("fake_tool", &response);
+    }
+
+    #[test]
+    #[should_panic(expected = "missing required `truncation` block")]
+    fn assert_conforms_rejects_missing() {
+        let response = json!({"content": "hi"});
+        assert_conforms("fake_tool", &response);
+    }
+
+    #[test]
+    #[should_panic(expected = "`next_offset` set on a non-truncated response")]
+    fn assert_conforms_rejects_offset_without_truncation() {
+        let response = json!({
+            "truncation": {
+                "truncated": false,
+                "bytes_returned": 10,
+                "bytes_total": 10,
+                "next_offset": 10,
+                "reason": "size_cap",
+            }
+        });
+        assert_conforms("fake_tool", &response);
+    }
+}

--- a/integrations/browserless/src/tools.rs
+++ b/integrations/browserless/src/tools.rs
@@ -1571,23 +1571,26 @@ mod tests {
     #[test]
     fn test_truncate_html_utf8_boundary_safe() {
         // Build a source whose byte-boundary for truncation would cut a
-        // multi-byte char: pad with single-byte chars up to a boundary-sensitive
-        // offset then add a 4-byte emoji right at the cap.
+        // 4-byte emoji: pad with single-byte chars up to MAX_HTML_BYTES - 2,
+        // then add the emoji. A naive byte-count cut at MAX_HTML_BYTES would
+        // land in the middle of the emoji's bytes; boundary-safe truncation
+        // must exclude the emoji entirely.
         let mut src = String::new();
         src.push_str(&"a".repeat(MAX_HTML_BYTES - 2));
-        src.push('🚀'); // 4-byte UTF-8 char
+        src.push('🚀');
         src.push_str(&"z".repeat(100));
         let total = src.len();
         let (content, was_truncated) = truncate_html(src);
         assert!(was_truncated);
-        // Must still be valid UTF-8 (String guarantees this) and must not
-        // include a partial char at the cut.
+        // Boundary-safe cut: no partial emoji bytes, only the padding 'a's
+        // survive, and the truncation suffix is appended (not any trailing
+        // 'z' from beyond the cap).
         assert!(content.is_char_boundary(content.len()));
-        assert_eq!(
-            content.chars().count(),
-            content.chars().count(),
-            "content is valid UTF-8"
+        assert!(
+            !content.contains('🚀'),
+            "truncated content must not include the straddling emoji"
         );
+        assert!(!content.contains('z'), "content after cap must not appear");
         assert!(total > MAX_HTML_BYTES);
     }
 

--- a/integrations/browserless/src/tools.rs
+++ b/integrations/browserless/src/tools.rs
@@ -14,6 +14,7 @@
 use everruns_core::ToolHints;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
+use everruns_core::truncation_info::{TruncationInfo, TruncationReason};
 
 use async_trait::async_trait;
 use serde_json::{Value, json};
@@ -29,6 +30,29 @@ use crate::validation::{validate_browserless_url, validate_interaction_steps};
 
 const MAX_HTML_BYTES: usize = 100_000;
 const MAX_WAIT_MS: u64 = 120_000;
+
+/// Attach the unified reading-tool truncation envelope (EVE-339) to a
+/// `browserless_content` response.
+///
+/// `browserless_content` does not currently support in-place resume — there is
+/// no `?offset` / `range` parameter on the REST endpoint, and CDP returns the
+/// full DOM in one shot. The envelope reports `without_resume` when truncated
+/// so LLM callers can pick a documented fallback (e.g. `browserless_scrape`
+/// with narrower selectors).
+fn attach_content_truncation(
+    response: &mut Value,
+    content_returned: &str,
+    bytes_total: usize,
+    was_truncated: bool,
+) {
+    let bytes_returned = content_returned.len();
+    let info = if was_truncated {
+        TruncationInfo::without_resume(bytes_returned, Some(bytes_total), TruncationReason::SizeCap)
+    } else {
+        TruncationInfo::not_truncated(bytes_returned)
+    };
+    info.attach(response);
+}
 
 /// Truncate HTML content if it exceeds MAX_HTML_BYTES. Safe for multi-byte UTF-8.
 fn truncate_html(html: String) -> (String, bool) {
@@ -307,13 +331,15 @@ impl Tool for BrowserlessContentTool {
                 Ok(html) => {
                     let len = html.len();
                     let (content, was_truncated) = truncate_html(html);
-                    ToolExecutionResult::Success(json!({
+                    let mut response = json!({
                         "url": url,
                         "content": content,
                         "size_bytes": len,
                         "truncated": was_truncated,
                         "session": "cdp"
-                    }))
+                    });
+                    attach_content_truncation(&mut response, &content, len, was_truncated);
+                    ToolExecutionResult::Success(response)
                 }
                 Err(e) => ToolExecutionResult::tool_error(format!("CDP content failed: {e}")),
             };
@@ -347,12 +373,14 @@ impl Tool for BrowserlessContentTool {
             Ok(html) => {
                 let len = html.len();
                 let (content, was_truncated) = truncate_html(html);
-                ToolExecutionResult::Success(json!({
+                let mut response = json!({
                     "url": url,
                     "content": content,
                     "size_bytes": len,
                     "truncated": was_truncated
-                }))
+                });
+                attach_content_truncation(&mut response, &content, len, was_truncated);
+                ToolExecutionResult::Success(response)
             }
             Err(e) => ToolExecutionResult::tool_error(e),
         }
@@ -1494,6 +1522,73 @@ mod tests {
             }
             other => panic!("Expected ToolError, got: {other:?}"),
         }
+    }
+
+    // ============================================================================
+    // EVE-339 — Reading-tool truncation envelope conformance
+    // ============================================================================
+
+    #[test]
+    fn test_truncate_html_under_cap() {
+        let html = "<html><body>short</body></html>".to_string();
+        let (content, was_truncated) = truncate_html(html);
+        assert!(!was_truncated);
+        let mut response = json!({
+            "url": "https://example.com",
+            "content": content.clone(),
+            "size_bytes": 0,
+            "truncated": was_truncated
+        });
+        attach_content_truncation(&mut response, &content, 0, false);
+        everruns_core::truncation_info::assert_conforms("browserless_content", &response);
+        assert_eq!(response["truncation"]["truncated"], false);
+    }
+
+    #[test]
+    fn test_truncate_html_over_cap_emits_without_resume() {
+        // Build a >100 KB HTML source.
+        let huge = "a".repeat(MAX_HTML_BYTES + 5_000);
+        let total = huge.len();
+        let (content, was_truncated) = truncate_html(huge);
+        assert!(was_truncated);
+        let mut response = json!({
+            "url": "https://example.com",
+            "content": content.clone(),
+            "size_bytes": total,
+            "truncated": was_truncated
+        });
+        attach_content_truncation(&mut response, &content, total, true);
+        everruns_core::truncation_info::assert_conforms("browserless_content", &response);
+        assert_eq!(response["truncation"]["truncated"], true);
+        assert_eq!(response["truncation"]["reason"], "size_cap");
+        assert_eq!(response["truncation"]["bytes_total"], total);
+        assert!(
+            response["truncation"].get("next_offset").is_none(),
+            "browserless_content does not support in-place resume"
+        );
+    }
+
+    #[test]
+    fn test_truncate_html_utf8_boundary_safe() {
+        // Build a source whose byte-boundary for truncation would cut a
+        // multi-byte char: pad with single-byte chars up to a boundary-sensitive
+        // offset then add a 4-byte emoji right at the cap.
+        let mut src = String::new();
+        src.push_str(&"a".repeat(MAX_HTML_BYTES - 2));
+        src.push('🚀'); // 4-byte UTF-8 char
+        src.push_str(&"z".repeat(100));
+        let total = src.len();
+        let (content, was_truncated) = truncate_html(src);
+        assert!(was_truncated);
+        // Must still be valid UTF-8 (String guarantees this) and must not
+        // include a partial char at the cut.
+        assert!(content.is_char_boundary(content.len()));
+        assert_eq!(
+            content.chars().count(),
+            content.chars().count(),
+            "content is valid UTF-8"
+        );
+        assert!(total > MAX_HTML_BYTES);
     }
 
     #[tokio::test]

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -87,6 +87,50 @@ If `narration_noun` is set but no `operation` argument exists, falls back to gen
 - External toolkit libraries expose hints via the `Tool::hints()` method in the toolkit library contract.
 - `destructive` is a subset of non-readonly — a tool can write without being destructive.
 
+### Reading-tool output contract
+
+Every reading tool attaches a shared `truncation` envelope to its JSON response so LLM callers can detect partial output, understand why it was cut, and resume or fall back without regex-matching human markers. The envelope is additive — existing flat fields like `truncated`, `total_lines`, and `row_count` stay in place for back-compat.
+
+See [`crates/core/src/truncation_info.rs`](../crates/core/src/truncation_info.rs) for the source of truth: `TruncationInfo`, `TruncationReason`, and the `assert_conforms` conformance helper.
+
+**Scope — the reading-tool class:**
+
+| Tool | Reason codes | Resume supported? |
+|------|--------------|-------------------|
+| `read_file` (session VFS + sandbox) | `size_cap`, `line_cap` | Yes — `next_offset` = line number |
+| `list_directory` (session VFS + sandbox) | `item_cap` | No — narrow with `path`/`glob` |
+| `grep_files` (session VFS + sandbox) | `line_cap` | No — narrow `pattern`/`glob` |
+| `sqldb_query` | `row_cap` | No — narrow `WHERE`/`LIMIT` |
+| `browserless_content` | `size_cap` | No — use `?range=` or `browserless_scrape` |
+
+Exec tools (`bash`, `*_exec`) keep their existing `truncated`/`total_lines`/`output_files` fields and the `exec_budget` reason is reserved for future migration; they are outside this envelope today because their truncation is priority-aware and persisted-output-backed.
+
+**Envelope shape:**
+
+```json
+{
+  "truncation": {
+    "truncated": true,
+    "bytes_returned": 49512,
+    "bytes_total": 184221,
+    "next_offset": 49512,
+    "resume_hint": "call read_file with offset=49512",
+    "reason": "size_cap"
+  }
+}
+```
+
+| Field | Presence | Description |
+|------|----------|-------------|
+| `truncated` | required | `true` if the source exceeded a cap |
+| `bytes_returned` | required | Bytes of primary content in this response |
+| `bytes_total` | optional | Total bytes of untruncated source when known |
+| `next_offset` | optional | Offset to pass back to resume in-place |
+| `resume_hint` | paired with `next_offset` | Human-readable resume instruction |
+| `reason` | required | Stable enum: `size_cap`, `line_cap`, `row_cap`, `exec_budget`, `item_cap` |
+
+**Conformance:** tests use `everruns_core::truncation_info::assert_conforms(tool_name, &response)` to validate the envelope. Every reading tool has per-tool unit tests under its own crate's `tests` module.
+
 ### Exec Tool Output Sanitization
 
 Exec tools (bash, daytona_exec, e2b_exec, deno_exec, sprites_exec, docker_exec) sanitize their output before returning results. Each tool calls `sanitize_exec_output()` from `crates/core/src/tool_output_sanitizer.rs`.

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -97,11 +97,13 @@ See [`crates/core/src/truncation_info.rs`](../crates/core/src/truncation_info.rs
 
 | Tool | Reason codes | Resume supported? |
 |------|--------------|-------------------|
-| `read_file` (session VFS + sandbox) | `size_cap`, `line_cap` | Yes — `next_offset` = line number |
-| `list_directory` (session VFS + sandbox) | `item_cap` | No — narrow with `path`/`glob` |
-| `grep_files` (session VFS + sandbox) | `line_cap` | No — narrow `pattern`/`glob` |
-| `sqldb_query` | `row_cap` | No — narrow `WHERE`/`LIMIT` |
-| `browserless_content` | `size_cap` | No — use `?range=` or `browserless_scrape` |
+| `read_file` (session VFS + sandbox) | `line_cap` (with resume), `size_cap` (without resume) | Line cap only — `next_offset` = line number |
+| `list_directory` (session VFS + sandbox) | `item_cap` | No — narrow with `path` |
+| `grep_files` (session VFS + sandbox) | `line_cap` | No — narrow `pattern`/`path_pattern` |
+| `sql_query` | `row_cap` | No — narrow `WHERE`/`LIMIT` |
+| `browserless_content` | `size_cap` | No — narrow via `browserless_scrape` selectors or shrink the source page |
+
+`next_offset` units are tool-specific — `read_file` uses a line number today. Each tool documents its own unit via `resume_hint`.
 
 Exec tools (`bash`, `*_exec`) keep their existing `truncated`/`total_lines`/`output_files` fields and the `exec_budget` reason is reserved for future migration; they are outside this envelope today because their truncation is priority-aware and persisted-output-backed.
 
@@ -113,9 +115,9 @@ Exec tools (`bash`, `*_exec`) keep their existing `truncated`/`total_lines`/`out
     "truncated": true,
     "bytes_returned": 49512,
     "bytes_total": 184221,
-    "next_offset": 49512,
-    "resume_hint": "call read_file with offset=49512",
-    "reason": "size_cap"
+    "next_offset": 2000,
+    "resume_hint": "call read_file with offset=2000 to resume from line 2001",
+    "reason": "line_cap"
   }
 }
 ```
@@ -123,7 +125,7 @@ Exec tools (`bash`, `*_exec`) keep their existing `truncated`/`total_lines`/`out
 | Field | Presence | Description |
 |------|----------|-------------|
 | `truncated` | required | `true` if the source exceeded a cap |
-| `bytes_returned` | required | Bytes of primary content in this response |
+| `bytes_returned` | required | Bytes of the response's primary content (the field a caller consumes: `content`, `rows`, `entries`, `matches`) — not the serialized wrapping object |
 | `bytes_total` | optional | Total bytes of untruncated source when known |
 | `next_offset` | optional | Offset to pass back to resume in-place |
 | `resume_hint` | paired with `next_offset` | Human-readable resume instruction |


### PR DESCRIPTION
## What

Adds a shared `TruncationInfo` envelope that every reading tool attaches to its JSON response. Five tools migrate in this PR: `read_file`, `list_directory`, `grep_files`, `sqldb_query`, and `browserless_content`.

Existing flat fields (`truncated`, `total_lines`, `row_count`) stay in place — the envelope is additive.

## Why

Fixes EVE-339. LLM callers had to regex-match human-readable markers to detect partial reading-tool output, which is brittle and inconsistent across tools. The new envelope gives them a stable, structured way to:

1. Detect truncation (`truncated: bool`).
2. Branch on the cut reason (`reason` enum: `size_cap` / `line_cap` / `row_cap` / `exec_budget` / `item_cap`).
3. Resume in place when the tool supports it (`next_offset` + `resume_hint`) or fall back to the tool-documented strategy.

## How

- New module `crates/core/src/truncation_info.rs` defines `TruncationInfo`, `TruncationReason`, and three constructors (`not_truncated`, `with_resume`, `without_resume`) plus `attach(&mut Value)` and an `assert_conforms` test helper.
- `read_file` emits `with_resume` (line or size cap depending on which cap fired); `list_directory`, `grep_files`, `sqldb_query`, and `browserless_content` emit `without_resume` with the appropriate reason.
- Spec added under `specs/tool-execution.md` → "Reading-tool output contract" (scope table, envelope shape, conformance helper pointer).
- Exec tools stay on their existing `truncated`/`total_lines`/`output_files` fields; migrating them to the envelope is left as follow-up (the `exec_budget` reason is reserved).

## Risk

- Low.
- Additive JSON field on reading-tool responses; no flat field was removed or renamed. No change to caps, paths, URL validation, row limits, SQL execution, or sandbox boundaries.

## Security

- Threat categories reviewed: TM-TOOL (tool response surface), TM-FS (file read metadata), TM-SQL (query metadata), TM-WEB (browserless content metadata).
- Findings and resolutions: no new attack surface. `bytes_returned` is computed by serializing the tool's own response — not user-controlled. `resume_hint` strings are internal format strings, not echoed from user input. Existing SSRF/URL allowlist (`validate_url`), path sanitization, UTF-8 boundary truncation, and row/size caps are preserved unchanged. No new dependencies.

## Evidence

- `cargo fmt --check` ✅ (workspace)
- `cargo clippy -p everruns-core -p everruns-integrations-browserless --lib --tests --all-features -- -D warnings` ✅
- `cargo test -p everruns-core --lib` — 1626 passed (includes 8 new `truncation_info` unit tests, 5 new `file_system` conformance tests, 2 new `session_sql_database` conformance tests)
- `cargo test -p everruns-integrations-browserless --lib` — 99 passed (includes 3 new content-truncation conformance tests, covering under-cap, over-cap without-resume, and UTF-8 boundary safety)
- `cargo fetch --locked` ✅

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (additive field; flat fields retained)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
