### PR TITLE
fix(container-sandbox): gate coding-container behind flag

### DIFF
--- a/crates/container-sandbox/src/lib.rs
+++ b/crates/container-sandbox/src/lib.rs
@@ -32,7 +32,7 @@ use tools::{
 inventory::submit! {
     IntegrationPlugin {
         experimental_only: false,
-        feature_flag: None,
+        feature_flag: Some("container_sandbox"),
         factory: || Box::new(ContainerSandboxCapability),
     }
 }

--- a/crates/container-sandbox/src/lib.rs
+++ b/crates/container-sandbox/src/lib.rs
@@ -32,7 +32,7 @@ use tools::{
 inventory::submit! {
     IntegrationPlugin {
         experimental_only: false,
-        feature_flag: Some("container_sandbox"),
+        feature_flag: None,
         factory: || Box::new(ContainerSandboxCapability),
     }
 }

--- a/crates/core/src/feature_flags.rs
+++ b/crates/core/src/feature_flags.rs
@@ -75,6 +75,10 @@ pub struct InternalFeatureFlags {
     /// Docker container capability. Disabled by default on all envs.
     /// Enable via `FEATURE_DOCKER_CAPABILITY=true`.
     pub docker_capability: bool,
+    /// Self-hosted container sandbox capability and coding harness.
+    /// Disabled by default on all envs.
+    /// Enable via `FEATURE_CONTAINER_SANDBOX=true`.
+    pub container_sandbox: bool,
     /// Managed session-owned sandbox capability and lifecycle orchestration.
     /// Experimental and disabled by default.
     pub session_sandbox: bool,
@@ -85,6 +89,10 @@ impl InternalFeatureFlags {
     pub fn from_env() -> Self {
         Self {
             docker_capability: standard_flag("FEATURE_DOCKER_CAPABILITY", false),
+            container_sandbox: standard_flag(
+                "FEATURE_CONTAINER_SANDBOX",
+                standard_flag("FEATURE_DOCKER_CAPABILITY", false),
+            ),
             session_sandbox: standard_flag("FEATURE_SESSION_SANDBOX", false),
         }
     }
@@ -93,6 +101,7 @@ impl InternalFeatureFlags {
     pub fn is_enabled(&self, flag: &str) -> bool {
         match flag {
             "docker_capability" => self.docker_capability,
+            "container_sandbox" => self.container_sandbox,
             "session_sandbox" => self.session_sandbox,
             _ => false,
         }
@@ -261,6 +270,7 @@ mod tests {
     fn test_internal_default_flags() {
         let flags = InternalFeatureFlags::default();
         assert!(!flags.docker_capability);
+        assert!(!flags.container_sandbox);
         assert!(!flags.session_sandbox);
     }
 
@@ -285,12 +295,45 @@ mod tests {
     }
 
     #[test]
+    fn test_container_sandbox_flag_disabled_by_default_in_dev() {
+        let _lock = lock_env();
+        unsafe { std::env::remove_var("FEATURE_CONTAINER_SANDBOX") };
+        unsafe { std::env::remove_var("FEATURE_DOCKER_CAPABILITY") };
+        let flags = InternalFeatureFlags::from_env();
+        assert!(
+            !flags.container_sandbox,
+            "container_sandbox should be disabled by default even in dev"
+        );
+    }
+
+    #[test]
+    fn test_container_sandbox_flag_enabled_by_env_override() {
+        let _lock = lock_env();
+        unsafe { std::env::set_var("FEATURE_CONTAINER_SANDBOX", "true") };
+        let flags = InternalFeatureFlags::from_env();
+        assert!(flags.container_sandbox);
+        unsafe { std::env::remove_var("FEATURE_CONTAINER_SANDBOX") };
+    }
+
+    #[test]
+    fn test_container_sandbox_flag_accepts_legacy_docker_alias() {
+        let _lock = lock_env();
+        unsafe { std::env::remove_var("FEATURE_CONTAINER_SANDBOX") };
+        unsafe { std::env::set_var("FEATURE_DOCKER_CAPABILITY", "true") };
+        let flags = InternalFeatureFlags::from_env();
+        assert!(flags.container_sandbox);
+        unsafe { std::env::remove_var("FEATURE_DOCKER_CAPABILITY") };
+    }
+
+    #[test]
     fn test_internal_is_enabled_dynamic() {
         let flags = InternalFeatureFlags {
             docker_capability: true,
+            container_sandbox: true,
             session_sandbox: true,
         };
         assert!(flags.is_enabled("docker_capability"));
+        assert!(flags.is_enabled("container_sandbox"));
         assert!(flags.is_enabled("session_sandbox"));
         assert!(!flags.is_enabled("nonexistent"));
     }

--- a/crates/server/src/harnesses/mod.rs
+++ b/crates/server/src/harnesses/mod.rs
@@ -16,15 +16,18 @@ use everruns_core::BuiltInHarnessDefinition;
 
 /// All built-in harness definitions in provisioning order.
 pub fn built_in_harnesses() -> Vec<BuiltInHarnessDefinition> {
+    let internal_flags = everruns_core::InternalFeatureFlags::from_env();
     let mut harnesses = vec![
         base::definition(),
         generic::definition(),
         data_analyst::definition(),
         coding_daytona::definition(),
-        coding_container::definition(),
-        platform_chat::definition(),
     ];
-    if everruns_core::InternalFeatureFlags::from_env().session_sandbox {
+    if internal_flags.container_sandbox {
+        harnesses.push(coding_container::definition());
+    }
+    harnesses.push(platform_chat::definition());
+    if internal_flags.session_sandbox {
         harnesses.push(coding_session_sandbox::definition());
     }
     harnesses

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -2304,6 +2304,27 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_coding_container_harness_capabilities_are_registered() {
+        let registry = everruns_core::capabilities::CapabilityRegistry::with_builtins_for_grade(
+            everruns_core::DeploymentGrade::Dev,
+        );
+
+        let built_in_harnesses = built_in_harnesses();
+        let coding_container = built_in_harnesses
+            .iter()
+            .find(|h| h.name == "coding-container")
+            .expect("Coding (Container) harness should exist");
+
+        for cap in &coding_container.capabilities {
+            assert!(
+                registry.has(&cap.id),
+                "Capability '{}' referenced by Coding (Container) harness must be registered",
+                cap.id
+            );
+        }
+    }
+
     /// Regression test for "Tool not found: bash" bug.
     ///
     /// When a session uses the Generic Harness without an agent, the worker must

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -2215,6 +2215,12 @@ mod tests {
         org_init::default_harness_definitions()
     }
 
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn lock_env() -> std::sync::MutexGuard<'static, ()> {
+        ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     // --- Harness seed data ---
 
     #[test]
@@ -2305,7 +2311,11 @@ mod tests {
     }
 
     #[test]
-    fn test_coding_container_harness_capabilities_are_registered() {
+    fn test_coding_container_harness_capabilities_are_registered_when_flag_enabled() {
+        let _lock = lock_env();
+        unsafe { std::env::set_var("FEATURE_CONTAINER_SANDBOX", "true") };
+        unsafe { std::env::remove_var("FEATURE_DOCKER_CAPABILITY") };
+
         let registry = everruns_core::capabilities::CapabilityRegistry::with_builtins_for_grade(
             everruns_core::DeploymentGrade::Dev,
         );
@@ -2323,6 +2333,23 @@ mod tests {
                 cap.id
             );
         }
+
+        unsafe { std::env::remove_var("FEATURE_CONTAINER_SANDBOX") };
+    }
+
+    #[test]
+    fn test_coding_container_harness_hidden_when_flag_disabled() {
+        let _lock = lock_env();
+        unsafe { std::env::remove_var("FEATURE_CONTAINER_SANDBOX") };
+        unsafe { std::env::remove_var("FEATURE_DOCKER_CAPABILITY") };
+
+        let built_in_harnesses = built_in_harnesses();
+        assert!(
+            built_in_harnesses
+                .iter()
+                .all(|h| h.name != "coding-container"),
+            "Coding (Container) harness should be hidden when container_sandbox is disabled"
+        );
     }
 
     /// Regression test for "Tool not found: bash" bug.


### PR DESCRIPTION
## What
Add an explicit backend-only `container_sandbox` feature flag, gate the `coding-container` built-in harness on that flag, and add regressions covering both the enabled and disabled paths.

## Why
`coding-container` was provisioned unconditionally, but its `container_sandbox` capability was gated by an internal flag name that did not exist in `InternalFeatureFlags`. That created a broken state in dev: the harness existed, but the capability registry did not expose `container_sandbox`, so agents never received the sandbox toolset.

## How
- add `InternalFeatureFlags.container_sandbox`, with `FEATURE_CONTAINER_SANDBOX` as the primary env var and `FEATURE_DOCKER_CAPABILITY` accepted as a legacy alias
- only include `coding-container` in built-in harnesses when that flag is enabled
- add seed regressions proving the harness is hidden when disabled and valid when enabled

## Risk
- Low
- The change narrows availability instead of broadening it: environments without the flag no longer advertise a broken harness. Environments that enable the flag must still provide the existing sandbox infra.

## Security
- Threat categories reviewed: TM-TOOL, TM-AGENT
- Findings and resolutions: reviewed the flag/harness gating path for accidental tool exposure. The patch prevents exposing a container harness unless the environment explicitly enables it.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)
