### PR TITLE
fix(api-keys): use expiry presets and drop key quota

### DIFF
--- a/apps/ui/src/__tests__/settings-api-keys.test.tsx
+++ b/apps/ui/src/__tests__/settings-api-keys.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode } from "react";
 import ApiKeysPage from "@/app/(main)/settings/api-keys/page";
@@ -180,6 +180,77 @@ describe("ApiKeysPage", () => {
       expect(
         screen.getByText(/Create a personal API key for programmatic access/),
       ).toBeInTheDocument();
+    });
+  });
+
+  it("shows fixed expiration presets with 90 days selected by default", async () => {
+    render(<ApiKeysPage />, { wrapper });
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Create API Key/i })[0]);
+
+    const dialog = await screen.findByRole("dialog");
+
+    expect(within(dialog).getByRole("button", { name: "1 day" })).toBeInTheDocument();
+    expect(within(dialog).getByRole("button", { name: "30 days" })).toBeInTheDocument();
+    expect(within(dialog).getByRole("button", { name: "90 days" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(
+      within(dialog).getByRole("button", { name: /Unrestricted \(not recommended\)/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("submits the default 90 day expiration when creating a key", async () => {
+    const mutateAsync = jest.fn().mockResolvedValue({ key: "evr_secret_test" });
+    mockUseCreateApiKey.mockReturnValue({
+      mutateAsync,
+      isPending: false,
+    });
+
+    render(<ApiKeysPage />, { wrapper });
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Create API Key/i })[0]);
+
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.change(within(dialog).getByLabelText("Name"), {
+      target: { value: "Test Key" },
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: /^Create API Key$/i }));
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({
+        name: "Test Key",
+        expires_in_days: 90,
+      });
+    });
+  });
+
+  it("omits expiration when unrestricted is selected", async () => {
+    const mutateAsync = jest.fn().mockResolvedValue({ key: "evr_secret_test" });
+    mockUseCreateApiKey.mockReturnValue({
+      mutateAsync,
+      isPending: false,
+    });
+
+    render(<ApiKeysPage />, { wrapper });
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Create API Key/i })[0]);
+
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.change(within(dialog).getByLabelText("Name"), {
+      target: { value: "Unlimited Key" },
+    });
+    fireEvent.click(
+      within(dialog).getByRole("button", { name: /Unrestricted \(not recommended\)/i }),
+    );
+    fireEvent.click(within(dialog).getByRole("button", { name: /^Create API Key$/i }));
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({
+        name: "Unlimited Key",
+        expires_in_days: undefined,
+      });
     });
   });
 

--- a/apps/ui/src/app/(main)/settings/api-keys/page.tsx
+++ b/apps/ui/src/app/(main)/settings/api-keys/page.tsx
@@ -53,6 +53,9 @@ type ApiKeyExpiryOption = (typeof API_KEY_EXPIRY_OPTIONS)[number];
 type ApiKeyExpiryValue = ApiKeyExpiryOption["value"];
 
 const DEFAULT_API_KEY_EXPIRY: ApiKeyExpiryValue = "90";
+const DEFAULT_API_KEY_EXPIRY_OPTION =
+  API_KEY_EXPIRY_OPTIONS.find((option) => option.value === DEFAULT_API_KEY_EXPIRY) ??
+  API_KEY_EXPIRY_OPTIONS[0];
 
 function ApiKeyRow({
   apiKey,
@@ -113,7 +116,7 @@ function CreateApiKeyDialog({
   const createApiKey = useCreateApiKey();
   const selectedExpiryOption =
     API_KEY_EXPIRY_OPTIONS.find((option) => option.value === expiryPreset) ??
-    API_KEY_EXPIRY_OPTIONS[2];
+    DEFAULT_API_KEY_EXPIRY_OPTION;
 
   const resetForm = () => {
     setName("");

--- a/apps/ui/src/app/(main)/settings/api-keys/page.tsx
+++ b/apps/ui/src/app/(main)/settings/api-keys/page.tsx
@@ -22,6 +22,38 @@ import { useAuth } from "@/providers/auth-provider";
 import { Plus, Key, Trash2, Copy, Check, Clock, ShieldAlert } from "lucide-react";
 import type { ApiKeyListItem, CreateApiKeyRequest } from "@/lib/api/types";
 
+const API_KEY_EXPIRY_OPTIONS = [
+  {
+    value: "1",
+    label: "1 day",
+    expiresInDays: 1,
+    description: "Short-lived key for temporary use.",
+  },
+  {
+    value: "30",
+    label: "30 days",
+    expiresInDays: 30,
+    description: "Reasonable default for ongoing integration work.",
+  },
+  {
+    value: "90",
+    label: "90 days",
+    expiresInDays: 90,
+    description: "Recommended balance between longevity and rotation.",
+  },
+  {
+    value: "unrestricted",
+    label: "Unrestricted (not recommended)",
+    expiresInDays: undefined,
+    description: "This key never expires. Use only when you own the rotation process.",
+  },
+] as const;
+
+type ApiKeyExpiryOption = (typeof API_KEY_EXPIRY_OPTIONS)[number];
+type ApiKeyExpiryValue = ApiKeyExpiryOption["value"];
+
+const DEFAULT_API_KEY_EXPIRY: ApiKeyExpiryValue = "90";
+
 function ApiKeyRow({
   apiKey,
   onDelete,
@@ -76,24 +108,38 @@ function CreateApiKeyDialog({
   onKeyCreated: (key: string) => void;
 }) {
   const [name, setName] = useState("");
-  const [expiresInDays, setExpiresInDays] = useState("");
+  const [expiryPreset, setExpiryPreset] = useState<ApiKeyExpiryValue>(DEFAULT_API_KEY_EXPIRY);
 
   const createApiKey = useCreateApiKey();
+  const selectedExpiryOption =
+    API_KEY_EXPIRY_OPTIONS.find((option) => option.value === expiryPreset) ??
+    API_KEY_EXPIRY_OPTIONS[2];
+
+  const resetForm = () => {
+    setName("");
+    setExpiryPreset(DEFAULT_API_KEY_EXPIRY);
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    onOpenChange(nextOpen);
+    if (!nextOpen) {
+      resetForm();
+    }
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const data: CreateApiKeyRequest = {
       name,
-      expires_in_days: expiresInDays ? parseInt(expiresInDays) : undefined,
+      expires_in_days: selectedExpiryOption.expiresInDays,
     };
     const result = await createApiKey.mutateAsync(data);
     onKeyCreated(result.key);
-    setName("");
-    setExpiresInDays("");
+    resetForm();
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Create API Key</DialogTitle>
@@ -114,21 +160,28 @@ function CreateApiKeyDialog({
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="expires-in">Expires In (days, optional)</Label>
-            <Input
-              id="expires-in"
-              type="number"
-              value={expiresInDays}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setExpiresInDays(e.target.value)
-              }
-              placeholder="30"
-              min="1"
-            />
-            <p className="text-xs text-muted-foreground">Leave empty for no expiration</p>
+            <Label>Expiration</Label>
+            <div className="grid grid-cols-2 gap-2" role="group" aria-label="Expiration">
+              {API_KEY_EXPIRY_OPTIONS.map((option) => {
+                const selected = option.value === expiryPreset;
+                return (
+                  <Button
+                    key={option.value}
+                    type="button"
+                    variant={selected ? "default" : "outline"}
+                    aria-pressed={selected}
+                    className="h-auto justify-start whitespace-normal px-3 py-2 text-left"
+                    onClick={() => setExpiryPreset(option.value)}
+                  >
+                    {option.label}
+                  </Button>
+                );
+              })}
+            </div>
+            <p className="text-xs text-muted-foreground">{selectedExpiryOption.description}</p>
           </div>
           <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            <Button type="button" variant="outline" onClick={() => handleOpenChange(false)}>
               Cancel
             </Button>
             <Button type="submit" disabled={createApiKey.isPending || !name}>

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -962,7 +962,6 @@ impl ServerAppBuilder {
         api_routes = api_routes.merge(crate::auth::api_key_routes(crate::auth::ApiKeyState {
             db: db.clone(),
             auth: auth_state.clone(),
-            resource_limits: crate::server::ResourceLimitsConfig::from_env(),
         }));
 
         // Auth-specific routes (login, register, OAuth — provider-dependent)

--- a/crates/server/src/auth/api_key_routes.rs
+++ b/crates/server/src/auth/api_key_routes.rs
@@ -19,7 +19,6 @@ use super::api_key::generate_api_key;
 use super::audit;
 use super::middleware::{AuthError, AuthMethod, AuthState, AuthUser};
 use crate::api::common::ListResponse;
-use crate::server::ResourceLimitsConfig;
 use crate::storage::StorageBackend;
 use crate::storage::models::CreateApiKeyRow;
 
@@ -30,7 +29,6 @@ use crate::storage::models::CreateApiKeyRow;
 pub struct ApiKeyState {
     pub db: Arc<StorageBackend>,
     pub auth: AuthState,
-    pub resource_limits: ResourceLimitsConfig,
 }
 
 /// Enable AuthUser extractor when ApiKeyState is the route state.
@@ -132,28 +130,6 @@ async fn create_api_key(
         return Err(AuthError::forbidden(
             "Cannot create API key using API key authentication",
         ));
-    }
-
-    // Enforce API key limit per user
-    let key_count = state
-        .db
-        .count_api_keys_for_user(user.id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to count API keys: {e}");
-            AuthError {
-                error: "Internal server error".to_string(),
-                status: StatusCode::INTERNAL_SERVER_ERROR,
-            }
-        })?;
-    if key_count >= state.resource_limits.max_api_keys_per_user {
-        return Err(AuthError {
-            error: format!(
-                "API key limit reached (max {})",
-                state.resource_limits.max_api_keys_per_user
-            ),
-            status: StatusCode::CONFLICT,
-        });
     }
 
     let generated = generate_api_key();

--- a/crates/server/src/auth/builtin.rs
+++ b/crates/server/src/auth/builtin.rs
@@ -35,7 +35,6 @@ pub struct BuiltinAuthBackend {
     pub jwt_service: Arc<JwtService>,
     pub db: Arc<StorageBackend>,
     pub rate_limiter: AuthRateLimiter,
-    pub resource_limits: crate::server::ResourceLimitsConfig,
     /// In-process cache: key_hash -> AuthUser. Avoids 4 sequential DB queries per API-key request.
     api_key_cache: Cache<String, AuthUser>,
 }
@@ -71,7 +70,6 @@ impl BuiltinAuthBackend {
             jwt_service,
             db,
             rate_limiter: AuthRateLimiter::new(),
-            resource_limits: crate::server::ResourceLimitsConfig::from_env(),
             api_key_cache: build_api_key_cache(),
         }
     }
@@ -84,7 +82,6 @@ impl BuiltinAuthBackend {
             jwt_service,
             db,
             rate_limiter: AuthRateLimiter::with_valkey(valkey),
-            resource_limits: crate::server::ResourceLimitsConfig::from_env(),
             api_key_cache: build_api_key_cache(),
         }
     }

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -8,14 +8,13 @@ use everruns_config::{env_bool, env_list, env_or, env_string};
 
 pub const DEFAULT_API_PREFIX: &str = "/api";
 
-/// Configurable resource limits for orgs, members, API keys.
+/// Configurable resource limits for orgs and members.
 ///
 /// Defaults are sane for self-hosted. SaaS overrides per plan.
 #[derive(Debug, Clone)]
 pub struct ResourceLimitsConfig {
     pub max_orgs_per_user: i64,
     pub max_members_per_org: i64,
-    pub max_api_keys_per_user: i64,
 }
 
 impl Default for ResourceLimitsConfig {
@@ -23,7 +22,6 @@ impl Default for ResourceLimitsConfig {
         Self {
             max_orgs_per_user: 5,
             max_members_per_org: 50,
-            max_api_keys_per_user: 25,
         }
     }
 }
@@ -33,7 +31,6 @@ impl ResourceLimitsConfig {
         Self {
             max_orgs_per_user: env_or("RESOURCE_LIMIT_MAX_ORGS_PER_USER", 5),
             max_members_per_org: env_or("RESOURCE_LIMIT_MAX_MEMBERS_PER_ORG", 50),
-            max_api_keys_per_user: env_or("RESOURCE_LIMIT_MAX_API_KEYS_PER_USER", 25),
         }
     }
 }

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -1608,10 +1608,6 @@ impl StorageBackend {
         dispatch!(self, count_organization_members, org_id)
     }
 
-    pub async fn count_api_keys_for_user(&self, user_id: Uuid) -> Result<i64> {
-        dispatch!(self, count_api_keys_for_user, user_id)
-    }
-
     pub async fn list_user_organizations(
         &self,
         user_id: Uuid,

--- a/crates/server/src/storage/memory/auth.rs
+++ b/crates/server/src/storage/memory/auth.rs
@@ -38,12 +38,6 @@ impl InMemoryDatabase {
             .cloned())
     }
 
-    pub async fn count_api_keys_for_user(&self, user_id: Uuid) -> Result<i64> {
-        let keys = self.api_keys.read();
-        let count = keys.values().filter(|k| k.user_id == user_id).count();
-        Ok(count as i64)
-    }
-
     pub async fn list_api_keys_for_user(&self, user_id: Uuid) -> Result<Vec<ApiKeyRow>> {
         let keys = self.api_keys.read();
         let mut result: Vec<_> = keys

--- a/crates/server/src/storage/repositories/auth.rs
+++ b/crates/server/src/storage/repositories/auth.rs
@@ -48,15 +48,6 @@ impl Database {
         Ok(row)
     }
 
-    /// Count API keys for a user (for resource limits).
-    pub async fn count_api_keys_for_user(&self, user_id: Uuid) -> Result<i64> {
-        let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM api_keys WHERE user_id = $1")
-            .bind(user_id)
-            .fetch_one(&self.pool)
-            .await?;
-        Ok(row.0)
-    }
-
     pub async fn list_api_keys_for_user(&self, user_id: Uuid) -> Result<Vec<ApiKeyRow>> {
         let rows = sqlx::query_as::<_, ApiKeyRow>(
             r#"

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -478,7 +478,6 @@ impl TestServer {
         api_routes = api_routes.merge(auth::api_key_routes(auth::ApiKeyState {
             db: db.clone(),
             auth: auth_state.clone(),
-            resource_limits: everruns_server::server::ResourceLimitsConfig::from_env(),
         }));
 
         let root_routes = Router::new()

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -520,7 +520,6 @@ Configurable limits on resource creation. See `crates/server/src/server.rs` for 
 |----------|---------|---------|
 | Orgs per user | 5 | `RESOURCE_LIMIT_MAX_ORGS_PER_USER` |
 | Members per org | 50 | `RESOURCE_LIMIT_MAX_MEMBERS_PER_ORG` |
-| API keys per user per org | 10 | `RESOURCE_LIMIT_MAX_API_KEYS_PER_USER_PER_ORG` |
 
 Returns `409 Conflict` when a limit is exceeded.
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -815,6 +815,7 @@ When a bash script calls `bash` or `sh` or uses `eval`, bashkit re-invokes its o
 | TM-DOS-009 | Valkey unauthenticated access | Medium | Valkey listens on localhost:6379 by default; no AUTH configured in local/example compose | **CALLER RISK** |
 | TM-DOS-010 | AG-UI SSE connection exhaustion | Medium | AG-UI app streams reuse the shared `SseConnectionTracker`, enforcing the same global/per-org/per-session limits as other SSE endpoints | MITIGATED |
 | TM-DOS-010 | Rate limit bypass via Valkey failure | Low | Fail-open design: if Valkey is down, requests are allowed without rate limiting | **ACCEPTED** |
+| TM-DOS-011 | Authenticated API key sprawl | Low | No server-side per-user API key quota; API key creation requires an authenticated user session and keys remain user-owned/revocable. Operators must monitor and clean up excessive key creation if they need stricter controls. | **ACCEPTED** |
 
 ### Mitigation Details
 

--- a/test_cases/ui/api_keys/TC001_api_key_org_binding.md
+++ b/test_cases/ui/api_keys/TC001_api_key_org_binding.md
@@ -23,7 +23,7 @@ Verify that an API key created through the UI grants access to all organizations
 2. Navigate to Settings > API Keys
 3. Verify the "Full account access" warning banner is visible
 4. Click "Create API Key"
-5. Enter name `user-scoped-key`, leave expiration empty
+5. Enter name `user-scoped-key`, keep the default `90 days` expiration
 6. Click "Create API Key"
 7. Copy the full API key from the "API Key Created" dialog
 8. Click "Done"
@@ -40,6 +40,7 @@ Verify that an API key created through the UI grants access to all organizations
 ## Expected Result
 
 - Step 3: Warning banner says API keys grant access to all organizations
+- Step 5: `90 days` is selected by default in the expiration presets
 - Steps 10-11: Both agents created successfully (same key, different orgs)
 - Step 12: Only org A's agent appears
 - Step 13: Only org B's agent appears


### PR DESCRIPTION
## What
Replace the free-form API key expiration input with fixed presets (1 day, 30 days, 90 days by default, and unrestricted marked as not recommended) and remove the server-side per-user API key quota.

Update the API docs, threat model, regression tests, and the manual API-key test case to match.

## Why
Requested product change: key creation should use fixed lifetime choices and should not enforce a backend key cap.

This also removes the mismatch between the UI guidance and the backend quota behavior.

## How
Added preset-button state in the API key dialog, defaulting to 90 days and resetting on close.

Mapped preset selection back to the existing `expires_in_days` API payload and added UI tests for the default and unrestricted paths.

Deleted the API key quota counting/enforcement plumbing and documented the accepted DoS tradeoff as `TM-DOS-011`.

## Risk
- Medium
- API key creation is now unbounded on the server side for authenticated users by design; operators who relied on the old quota lose that guardrail.

## Security
- Threat categories reviewed: TM-AUTH, TM-WEB, TM-DOS
- Findings and resolutions:
  - TM-AUTH: expiry selection still produces the same optional `expires_in_days` contract; no auth/authz behavior changed.
  - TM-WEB: the UI change is preset-only and renders static strings; no new injection surface was added.
  - TM-DOS: removing the per-user key quota changes a prior resource guardrail, so the accepted tradeoff is documented in `specs/threat-model.md` as `TM-DOS-011`.

## Validation
- `npm test -- --runTestsByPath src/__tests__/settings-api-keys.test.tsx --watch=false`
- `CARGO_INCREMENTAL=0 cargo check -p everruns-server`
- `CARGO_INCREMENTAL=0 just pre-push`
- Attempted live smoke: `PORT_PREFIX=271 AUTH_MODE=full AUTH_JWT_SECRET=... just start-dev --no-watch` plus browser automation against `http://localhost:27100/register`. UI/Caddy came up, but the backend never finished binding `:27101` before shutdown because this machine had multiple concurrent `rustc` processes from other worktrees consuming the build capacity.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
