### PR TITLE
fix(server): gate coding-container behind container sandbox flag

### DIFF
--- a/crates/container-sandbox/SPEC.md
+++ b/crates/container-sandbox/SPEC.md
@@ -4,7 +4,7 @@
 
 Self-hosted container-based agent execution via Docker Engine REST API. Provides real filesystem, full process execution, and network access in isolated Docker containers. Fills the gap between virtual bash (safe but limited) and cloud sandboxes like Daytona/E2B (powerful but SaaS dependency).
 
-**Status**: Available (All environments with Docker Engine access)
+**Status**: Available when the internal `container_sandbox` feature flag is enabled (`FEATURE_CONTAINER_SANDBOX=true`, with legacy fallback from `FEATURE_DOCKER_CAPABILITY=true`) and Docker Engine access is configured
 
 ## Architecture
 
@@ -87,6 +87,7 @@ The container runtime (`runc`, `sysbox-runc`, `kata`, `gvisor`) is a deployment-
 - **ID**: `container_sandbox`
 - **Name**: Container Sandbox
 - **Category**: Execution
+- **Feature flag**: `container_sandbox`
 - **Dependencies**: None (Docker Engine is infrastructure, not a user connection)
 
 ## Crate Structure

--- a/crates/core/src/feature_flags.rs
+++ b/crates/core/src/feature_flags.rs
@@ -75,6 +75,10 @@ pub struct InternalFeatureFlags {
     /// Docker container capability. Disabled by default on all envs.
     /// Enable via `FEATURE_DOCKER_CAPABILITY=true`.
     pub docker_capability: bool,
+    /// Self-hosted container sandbox capability and coding harness.
+    /// Disabled by default on all envs.
+    /// Enable via `FEATURE_CONTAINER_SANDBOX=true`.
+    pub container_sandbox: bool,
     /// Managed session-owned sandbox capability and lifecycle orchestration.
     /// Experimental and disabled by default.
     pub session_sandbox: bool,
@@ -85,6 +89,10 @@ impl InternalFeatureFlags {
     pub fn from_env() -> Self {
         Self {
             docker_capability: standard_flag("FEATURE_DOCKER_CAPABILITY", false),
+            container_sandbox: standard_flag(
+                "FEATURE_CONTAINER_SANDBOX",
+                standard_flag("FEATURE_DOCKER_CAPABILITY", false),
+            ),
             session_sandbox: standard_flag("FEATURE_SESSION_SANDBOX", false),
         }
     }
@@ -93,6 +101,7 @@ impl InternalFeatureFlags {
     pub fn is_enabled(&self, flag: &str) -> bool {
         match flag {
             "docker_capability" => self.docker_capability,
+            "container_sandbox" => self.container_sandbox,
             "session_sandbox" => self.session_sandbox,
             _ => false,
         }
@@ -261,6 +270,7 @@ mod tests {
     fn test_internal_default_flags() {
         let flags = InternalFeatureFlags::default();
         assert!(!flags.docker_capability);
+        assert!(!flags.container_sandbox);
         assert!(!flags.session_sandbox);
     }
 
@@ -285,12 +295,34 @@ mod tests {
     }
 
     #[test]
+    fn test_container_sandbox_flag_enabled_by_env_override() {
+        let _lock = lock_env();
+        unsafe { std::env::set_var("FEATURE_CONTAINER_SANDBOX", "true") };
+        unsafe { std::env::remove_var("FEATURE_DOCKER_CAPABILITY") };
+        let flags = InternalFeatureFlags::from_env();
+        assert!(flags.container_sandbox);
+        unsafe { std::env::remove_var("FEATURE_CONTAINER_SANDBOX") };
+    }
+
+    #[test]
+    fn test_container_sandbox_flag_falls_back_to_legacy_docker_flag() {
+        let _lock = lock_env();
+        unsafe { std::env::remove_var("FEATURE_CONTAINER_SANDBOX") };
+        unsafe { std::env::set_var("FEATURE_DOCKER_CAPABILITY", "true") };
+        let flags = InternalFeatureFlags::from_env();
+        assert!(flags.container_sandbox);
+        unsafe { std::env::remove_var("FEATURE_DOCKER_CAPABILITY") };
+    }
+
+    #[test]
     fn test_internal_is_enabled_dynamic() {
         let flags = InternalFeatureFlags {
             docker_capability: true,
+            container_sandbox: true,
             session_sandbox: true,
         };
         assert!(flags.is_enabled("docker_capability"));
+        assert!(flags.is_enabled("container_sandbox"));
         assert!(flags.is_enabled("session_sandbox"));
         assert!(!flags.is_enabled("nonexistent"));
     }

--- a/crates/core/src/feature_flags.rs
+++ b/crates/core/src/feature_flags.rs
@@ -77,7 +77,9 @@ pub struct InternalFeatureFlags {
     pub docker_capability: bool,
     /// Self-hosted container sandbox capability and coding harness.
     /// Disabled by default on all envs.
-    /// Enable via `FEATURE_CONTAINER_SANDBOX=true`.
+    /// Enable via `FEATURE_CONTAINER_SANDBOX=true`, or via the legacy
+    /// fallback `FEATURE_DOCKER_CAPABILITY=true` when
+    /// `FEATURE_CONTAINER_SANDBOX` is unset.
     pub container_sandbox: bool,
     /// Managed session-owned sandbox capability and lifecycle orchestration.
     /// Experimental and disabled by default.
@@ -87,12 +89,11 @@ pub struct InternalFeatureFlags {
 impl InternalFeatureFlags {
     /// Compute internal feature flags from environment variables.
     pub fn from_env() -> Self {
+        let docker_capability = standard_flag("FEATURE_DOCKER_CAPABILITY", false);
+
         Self {
-            docker_capability: standard_flag("FEATURE_DOCKER_CAPABILITY", false),
-            container_sandbox: standard_flag(
-                "FEATURE_CONTAINER_SANDBOX",
-                standard_flag("FEATURE_DOCKER_CAPABILITY", false),
-            ),
+            docker_capability,
+            container_sandbox: standard_flag("FEATURE_CONTAINER_SANDBOX", docker_capability),
             session_sandbox: standard_flag("FEATURE_SESSION_SANDBOX", false),
         }
     }

--- a/crates/server/src/harnesses/mod.rs
+++ b/crates/server/src/harnesses/mod.rs
@@ -22,13 +22,73 @@ pub fn built_in_harnesses() -> Vec<BuiltInHarnessDefinition> {
         generic::definition(),
         data_analyst::definition(),
         coding_daytona::definition(),
-        platform_chat::definition(),
     ];
     if internal_flags.container_sandbox {
         harnesses.push(coding_container::definition());
     }
+    harnesses.push(platform_chat::definition());
     if internal_flags.session_sandbox {
         harnesses.push(coding_session_sandbox::definition());
     }
     harnesses
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct EnvVarGuard {
+        previous: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvVarGuard {
+        fn capture(keys: &[&'static str]) -> Self {
+            Self {
+                previous: keys
+                    .iter()
+                    .map(|&key| (key, std::env::var(key).ok()))
+                    .collect(),
+            }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            for (key, value) in self.previous.drain(..) {
+                match value {
+                    Some(value) => unsafe { std::env::set_var(key, value) },
+                    None => unsafe { std::env::remove_var(key) },
+                }
+            }
+        }
+    }
+
+    fn lock_env() -> std::sync::MutexGuard<'static, ()> {
+        ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    #[test]
+    fn test_coding_container_preserves_previous_provisioning_order_when_enabled() {
+        let _lock = lock_env();
+        let _env_guard =
+            EnvVarGuard::capture(&["FEATURE_CONTAINER_SANDBOX", "FEATURE_DOCKER_CAPABILITY"]);
+        unsafe { std::env::set_var("FEATURE_CONTAINER_SANDBOX", "true") };
+        unsafe { std::env::remove_var("FEATURE_DOCKER_CAPABILITY") };
+
+        let names: Vec<String> = built_in_harnesses().into_iter().map(|h| h.name).collect();
+
+        assert_eq!(
+            names,
+            vec![
+                "base",
+                "generic",
+                "data-analyst",
+                "coding-daytona",
+                "coding-container",
+                "platform-chat",
+            ]
+        );
+    }
 }

--- a/crates/server/src/harnesses/mod.rs
+++ b/crates/server/src/harnesses/mod.rs
@@ -16,15 +16,18 @@ use everruns_core::BuiltInHarnessDefinition;
 
 /// All built-in harness definitions in provisioning order.
 pub fn built_in_harnesses() -> Vec<BuiltInHarnessDefinition> {
+    let internal_flags = everruns_core::InternalFeatureFlags::from_env();
     let mut harnesses = vec![
         base::definition(),
         generic::definition(),
         data_analyst::definition(),
         coding_daytona::definition(),
-        coding_container::definition(),
         platform_chat::definition(),
     ];
-    if everruns_core::InternalFeatureFlags::from_env().session_sandbox {
+    if internal_flags.container_sandbox {
+        harnesses.push(coding_container::definition());
+    }
+    if internal_flags.session_sandbox {
         harnesses.push(coding_session_sandbox::definition());
     }
     harnesses

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -2215,6 +2215,12 @@ mod tests {
         org_init::default_harness_definitions()
     }
 
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn lock_env() -> std::sync::MutexGuard<'static, ()> {
+        ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     // --- Harness seed data ---
 
     #[test]
@@ -2302,6 +2308,48 @@ mod tests {
                 cap.id
             );
         }
+    }
+
+    #[test]
+    fn test_coding_container_harness_capabilities_are_registered_when_flag_enabled() {
+        let _lock = lock_env();
+        unsafe { std::env::set_var("FEATURE_CONTAINER_SANDBOX", "true") };
+        unsafe { std::env::remove_var("FEATURE_DOCKER_CAPABILITY") };
+
+        let registry = everruns_core::capabilities::CapabilityRegistry::with_builtins_for_grade(
+            everruns_core::DeploymentGrade::Dev,
+        );
+
+        let built_in_harnesses = built_in_harnesses();
+        let coding_container = built_in_harnesses
+            .iter()
+            .find(|h| h.name == "coding-container")
+            .expect("Coding (Container) harness should exist when the feature is enabled");
+
+        for cap in &coding_container.capabilities {
+            assert!(
+                registry.has(&cap.id),
+                "Capability '{}' referenced by Coding (Container) harness must be registered",
+                cap.id
+            );
+        }
+
+        unsafe { std::env::remove_var("FEATURE_CONTAINER_SANDBOX") };
+    }
+
+    #[test]
+    fn test_coding_container_harness_hidden_when_flag_disabled() {
+        let _lock = lock_env();
+        unsafe { std::env::remove_var("FEATURE_CONTAINER_SANDBOX") };
+        unsafe { std::env::remove_var("FEATURE_DOCKER_CAPABILITY") };
+
+        let built_in_harnesses = built_in_harnesses();
+        assert!(
+            built_in_harnesses
+                .iter()
+                .all(|h| h.name != "coding-container"),
+            "Coding (Container) harness should be hidden when container_sandbox is disabled"
+        );
     }
 
     /// Regression test for "Tool not found: bash" bug.

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -2217,6 +2217,32 @@ mod tests {
 
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+    struct EnvVarGuard {
+        previous: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvVarGuard {
+        fn capture(keys: &[&'static str]) -> Self {
+            Self {
+                previous: keys
+                    .iter()
+                    .map(|&key| (key, std::env::var(key).ok()))
+                    .collect(),
+            }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            for (key, value) in self.previous.drain(..) {
+                match value {
+                    Some(value) => unsafe { std::env::set_var(key, value) },
+                    None => unsafe { std::env::remove_var(key) },
+                }
+            }
+        }
+    }
+
     fn lock_env() -> std::sync::MutexGuard<'static, ()> {
         ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
     }
@@ -2313,6 +2339,8 @@ mod tests {
     #[test]
     fn test_coding_container_harness_capabilities_are_registered_when_flag_enabled() {
         let _lock = lock_env();
+        let _env_guard =
+            EnvVarGuard::capture(&["FEATURE_CONTAINER_SANDBOX", "FEATURE_DOCKER_CAPABILITY"]);
         unsafe { std::env::set_var("FEATURE_CONTAINER_SANDBOX", "true") };
         unsafe { std::env::remove_var("FEATURE_DOCKER_CAPABILITY") };
 
@@ -2333,13 +2361,13 @@ mod tests {
                 cap.id
             );
         }
-
-        unsafe { std::env::remove_var("FEATURE_CONTAINER_SANDBOX") };
     }
 
     #[test]
     fn test_coding_container_harness_hidden_when_flag_disabled() {
         let _lock = lock_env();
+        let _env_guard =
+            EnvVarGuard::capture(&["FEATURE_CONTAINER_SANDBOX", "FEATURE_DOCKER_CAPABILITY"]);
         unsafe { std::env::remove_var("FEATURE_CONTAINER_SANDBOX") };
         unsafe { std::env::remove_var("FEATURE_DOCKER_CAPABILITY") };
 

--- a/docs/integrations/container-sandbox.md
+++ b/docs/integrations/container-sandbox.md
@@ -24,9 +24,13 @@ Ensure Docker Engine is accessible from the server/worker. The capability commun
 
 Set `CONTAINER_SANDBOX_DOCKER_HOST` to override the default Docker host.
 
-### 2. Assign the Capability
+### 2. Enable the Feature and Assign the Capability
 
-Add the `container_sandbox` capability to a harness or use the built-in **Coding (Container)** harness which includes it by default.
+Set `FEATURE_CONTAINER_SANDBOX=true` on the server to enable the capability and built-in **Coding (Container)** harness.
+
+For legacy deployments, `FEATURE_DOCKER_CAPABILITY=true` still enables the same feature until operators switch to the new flag name.
+
+Once enabled, add the `container_sandbox` capability to a custom harness or use the built-in **Coding (Container)** harness.
 
 ### 3. Use in Sessions
 

--- a/docs/integrations/container-sandbox.md
+++ b/docs/integrations/container-sandbox.md
@@ -26,11 +26,11 @@ Set `CONTAINER_SANDBOX_DOCKER_HOST` to override the default Docker host.
 
 ### 2. Enable the Feature and Assign the Capability
 
-Set `FEATURE_CONTAINER_SANDBOX=true` on the server to enable the capability and built-in **Coding (Container)** harness.
+Set `FEATURE_CONTAINER_SANDBOX=true` anywhere capabilities are registered or executed to enable the capability and built-in **Coding (Container)** harness. In most deployments, that means both the server and any workers.
 
-For legacy deployments, `FEATURE_DOCKER_CAPABILITY=true` still enables the same feature until operators switch to the new flag name.
+For legacy deployments, `FEATURE_DOCKER_CAPABILITY=true` still enables the same feature until operators switch to the new flag name, and it must be enabled in the same places.
 
-Once enabled, add the `container_sandbox` capability to a custom harness or use the built-in **Coding (Container)** harness.
+Once the flag is enabled in the relevant processes, add the `container_sandbox` capability to a custom harness or use the built-in **Coding (Container)** harness.
 
 ### 3. Use in Sessions
 

--- a/test_cases/ui/container_sandbox/TC001_sandbox_lifecycle.md
+++ b/test_cases/ui/container_sandbox/TC001_sandbox_lifecycle.md
@@ -9,8 +9,9 @@ Verify that the Coding (Container) harness creates a container sandbox, executes
 - Server running (`just start-all` -- full mode with PostgreSQL required for leased resources)
 - User logged in
 - LLM API keys configured (Anthropic or OpenAI)
-- `FEATURE_CONTAINER_SANDBOX=true` enabled on the server
-  Legacy compatibility: `FEATURE_DOCKER_CAPABILITY=true` also enables the same feature
+- `FEATURE_CONTAINER_SANDBOX=true` enabled anywhere the capability is registered or executed
+  Typically this means both the server and any workers
+  Legacy compatibility: `FEATURE_DOCKER_CAPABILITY=true` also enables the same feature in the same places
 - Docker Engine accessible from the server (local socket or remote TCP)
 - `CONTAINER_SANDBOX_DOCKER_HOST` set if Docker is not on the default socket
 

--- a/test_cases/ui/container_sandbox/TC001_sandbox_lifecycle.md
+++ b/test_cases/ui/container_sandbox/TC001_sandbox_lifecycle.md
@@ -9,6 +9,8 @@ Verify that the Coding (Container) harness creates a container sandbox, executes
 - Server running (`just start-all` -- full mode with PostgreSQL required for leased resources)
 - User logged in
 - LLM API keys configured (Anthropic or OpenAI)
+- `FEATURE_CONTAINER_SANDBOX=true` enabled on the server
+  Legacy compatibility: `FEATURE_DOCKER_CAPABILITY=true` also enables the same feature
 - Docker Engine accessible from the server (local socket or remote TCP)
 - `CONTAINER_SANDBOX_DOCKER_HOST` set if Docker is not on the default socket
 


### PR DESCRIPTION
## What
Add an internal `container_sandbox` feature flag and gate the built-in `coding-container` harness behind it.

## Why
Current `main` already registers the `container_sandbox` capability behind a feature flag, but `InternalFeatureFlags` does not define that flag and the built-in harness list always exposes `coding-container`.

That leaves two broken states:
- with the flag disabled, `coding-container` still appears
- with the flag enabled, the harness references `container_sandbox` but the capability registry still treats the flag as unknown

## How
- add `container_sandbox` to `InternalFeatureFlags`
- let it fall back to `FEATURE_DOCKER_CAPABILITY` for legacy compatibility
- only include `coding-container` in built-in harnesses when the flag is enabled
- add regression coverage for both enabled and disabled cases

## Risk
- Low
- Main risk is hiding `coding-container` in environments that expected it without setting the flag explicitly

## Security
- Threat categories reviewed: No security-relevant code changes beyond narrowing sandbox capability exposure
- Findings and resolutions: This change reduces accidental exposure of the container sandbox harness when the feature is disabled

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
