### PR TITLE
feat(server): add budget usage journal and ledger

### DIFF
--- a/crates/server/migrations/020_budget_journal_ledger.sql
+++ b/crates/server/migrations/020_budget_journal_ledger.sql
@@ -1,0 +1,152 @@
+-- Generic activity journal plus rated usage ledger for budgeting and future metering.
+
+CREATE TABLE usage_journal (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    org_id BIGINT NOT NULL REFERENCES organizations(org_id),
+    kind TEXT NOT NULL,
+    source_type TEXT,
+    source_id TEXT,
+    event_id UUID REFERENCES events(id) ON DELETE SET NULL,
+    session_id UUID REFERENCES sessions(id) ON DELETE SET NULL,
+    turn_id UUID,
+    user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+    principal_id UUID REFERENCES principals(id) ON DELETE SET NULL,
+    agent_id UUID REFERENCES agents(id) ON DELETE SET NULL,
+    harness_id UUID REFERENCES harnesses(id) ON DELETE SET NULL,
+    measures JSONB NOT NULL DEFAULT '{}'::jsonb,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX idx_usage_journal_source
+    ON usage_journal(source_type, source_id)
+    WHERE source_type IS NOT NULL AND source_id IS NOT NULL;
+
+CREATE UNIQUE INDEX idx_usage_journal_kind_event
+    ON usage_journal(kind, event_id)
+    WHERE event_id IS NOT NULL;
+
+CREATE INDEX idx_usage_journal_org_created
+    ON usage_journal(org_id, created_at DESC);
+CREATE INDEX idx_usage_journal_session_created
+    ON usage_journal(session_id, created_at DESC)
+    WHERE session_id IS NOT NULL;
+CREATE INDEX idx_usage_journal_kind_created
+    ON usage_journal(kind, created_at DESC);
+
+CREATE TRIGGER prevent_usage_journal_mutation
+    BEFORE UPDATE OR DELETE ON usage_journal
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_event_mutation();
+
+CREATE TABLE usage_ledger (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    journal_id UUID NOT NULL REFERENCES usage_journal(id) ON DELETE CASCADE,
+    budget_id UUID REFERENCES budgets(id) ON DELETE SET NULL,
+    org_id BIGINT NOT NULL REFERENCES organizations(org_id),
+    session_id UUID REFERENCES sessions(id) ON DELETE SET NULL,
+    user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+    principal_id UUID REFERENCES principals(id) ON DELETE SET NULL,
+    agent_id UUID REFERENCES agents(id) ON DELETE SET NULL,
+    harness_id UUID REFERENCES harnesses(id) ON DELETE SET NULL,
+    currency TEXT NOT NULL,
+    amount DOUBLE PRECISION NOT NULL,
+    meter_source TEXT NOT NULL,
+    ref_type TEXT,
+    ref_id UUID,
+    description TEXT,
+    rating_metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX idx_usage_ledger_journal_budget_currency
+    ON usage_ledger(journal_id, budget_id, currency);
+
+CREATE INDEX idx_usage_ledger_budget_created
+    ON usage_ledger(budget_id, created_at DESC)
+    WHERE budget_id IS NOT NULL;
+CREATE INDEX idx_usage_ledger_journal_created
+    ON usage_ledger(journal_id, created_at DESC);
+CREATE INDEX idx_usage_ledger_session_created
+    ON usage_ledger(session_id, created_at DESC)
+    WHERE session_id IS NOT NULL;
+CREATE INDEX idx_usage_ledger_org_created
+    ON usage_ledger(org_id, created_at DESC);
+
+CREATE TRIGGER prevent_usage_ledger_mutation
+    BEFORE UPDATE OR DELETE ON usage_ledger
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_event_mutation();
+
+INSERT INTO usage_journal (
+    id,
+    org_id,
+    kind,
+    source_type,
+    source_id,
+    session_id,
+    measures,
+    metadata,
+    created_at
+)
+SELECT
+    uuidv7(),
+    b.org_id,
+    CASE
+        WHEN bl.amount < 0 OR bl.ref_type = 'top_up' THEN 'top_up'
+        ELSE 'legacy_budget_charge'
+    END,
+    'legacy_budget_ledger',
+    bl.id::text,
+    bl.session_id,
+    jsonb_build_object(
+        'legacy_amount', bl.amount,
+        'legacy_currency', b.currency
+    ),
+    jsonb_build_object(
+        'legacy_budget_id', bl.budget_id,
+        'legacy_ref_type', bl.ref_type,
+        'legacy_ref_id', bl.ref_id,
+        'legacy_description', bl.description
+    ),
+    bl.created_at
+FROM budget_ledger bl
+JOIN budgets b ON b.id = bl.budget_id;
+
+INSERT INTO usage_ledger (
+    id,
+    journal_id,
+    budget_id,
+    org_id,
+    session_id,
+    currency,
+    amount,
+    meter_source,
+    ref_type,
+    ref_id,
+    description,
+    rating_metadata,
+    created_at
+)
+SELECT
+    uuidv7(),
+    uj.id,
+    bl.budget_id,
+    b.org_id,
+    bl.session_id,
+    b.currency,
+    bl.amount,
+    bl.meter_source,
+    bl.ref_type,
+    bl.ref_id,
+    bl.description,
+    jsonb_build_object(
+        'ruleset_version', 'legacy-v1',
+        'backfilled_from', 'budget_ledger'
+    ),
+    bl.created_at
+FROM budget_ledger bl
+JOIN budgets b ON b.id = bl.budget_id
+JOIN usage_journal uj
+    ON uj.source_type = 'legacy_budget_ledger'
+   AND uj.source_id = bl.id::text;

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -55,7 +55,6 @@ fn name_from_path(path: &str) -> String {
 }
 
 struct DirectBudgetChecker {
-    db: Arc<StorageBackend>,
     budget_service: Arc<BudgetService>,
     org_id: i64,
     agent_id: Option<String>,
@@ -169,25 +168,10 @@ impl ProviderCredentialStore for DirectProviderCredentialStore {
 #[async_trait]
 impl BudgetChecker for DirectBudgetChecker {
     async fn check_budgets(&self, session_id: &str) -> Result<BudgetToolResponse> {
-        let session_budgets = self
-            .db
-            .list_budgets(self.org_id, Some("session"), Some(session_id))
-            .await
-            .map_err(|e| store_error(format!("Failed to list session budgets: {e}")))?;
-
-        let mut all_budgets = session_budgets;
-        if let Some(agent_id) = self.agent_id.as_deref() {
-            match self
-                .db
-                .list_budgets(self.org_id, Some("agent"), Some(agent_id))
-                .await
-            {
-                Ok(agent_budgets) => all_budgets.extend(agent_budgets),
-                Err(error) => {
-                    tracing::error!(agent_id, error = %error, "Failed to list agent budgets");
-                }
-            }
-        }
+        let all_budgets = self
+            .budget_service
+            .list_budgets_for_session_hierarchy(self.org_id, session_id, self.agent_id.as_deref())
+            .await;
 
         if all_budgets.is_empty() {
             return Ok(BudgetToolResponse {
@@ -1354,7 +1338,6 @@ impl WorkerAdapters for DirectWorkerAdapters {
     ) -> Option<Arc<dyn BudgetChecker>> {
         self.budget_service.as_ref().map(|budget_service| {
             Arc::new(DirectBudgetChecker {
-                db: self.db.clone(),
                 budget_service: budget_service.clone(),
                 org_id,
                 agent_id: agent_id.map(|id| id.to_string()),

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -3748,29 +3748,14 @@ impl WorkerService for WorkerServiceImpl {
     ) -> Result<Response<CheckBudgetsForSessionResponse>, Status> {
         let req = request.into_inner();
 
-        // Get the full budget rows for detailed response
-        let session_budgets = self
-            .db
-            .list_budgets(req.org_id, Some("session"), Some(&req.session_id))
-            .await
-            .map_err(|e| {
-                tracing::error!("Failed to list session budgets: {}", e);
-                Status::internal("Failed to list session budgets")
-            })?;
-
-        let mut all_budgets = session_budgets;
-        if let Some(ref agent_id) = req.agent_id {
-            match self
-                .db
-                .list_budgets(req.org_id, Some("agent"), Some(agent_id))
-                .await
-            {
-                Ok(agent_budgets) => all_budgets.extend(agent_budgets),
-                Err(e) => {
-                    tracing::error!("Failed to list agent budgets for {agent_id}: {e}");
-                }
-            }
-        }
+        let all_budgets = self
+            .budget_service
+            .list_budgets_for_session_hierarchy(
+                req.org_id,
+                &req.session_id,
+                req.agent_id.as_deref(),
+            )
+            .await;
 
         if all_budgets.is_empty() {
             return Ok(Response::new(CheckBudgetsForSessionResponse {

--- a/crates/server/src/services/budget.rs
+++ b/crates/server/src/services/budget.rs
@@ -13,8 +13,9 @@ use everruns_core::budget::{
 use everruns_core::events::{Event, EventData, LLM_GENERATION};
 use everruns_core::llm_model_profiles::get_model_profile;
 use everruns_core::llm_models::LlmProviderType;
-use everruns_core::typed_id::{BudgetId, SessionId};
+use everruns_core::typed_id::{AgentId, BudgetId, SessionId};
 use everruns_core::{UserFacingError, user_facing_error_codes};
+use std::collections::HashSet;
 use std::sync::Arc;
 use tracing::{error, info, instrument, warn};
 
@@ -27,6 +28,18 @@ use crate::storage::models::*;
 
 pub struct BudgetService {
     db: Arc<StorageBackend>,
+}
+
+struct BudgetScope {
+    session_subject_id: String,
+    agent_subject_id: Option<String>,
+    user_subject_id: Option<String>,
+    org_subject_id: String,
+    session_id: Option<uuid::Uuid>,
+    user_id: Option<uuid::Uuid>,
+    principal_id: Option<uuid::Uuid>,
+    agent_id: Option<uuid::Uuid>,
+    harness_id: Option<uuid::Uuid>,
 }
 
 impl BudgetService {
@@ -59,7 +72,10 @@ impl BudgetService {
     pub fn row_to_ledger_entry(row: &BudgetLedgerRow) -> LedgerEntry {
         LedgerEntry {
             id: format!("ledger_{}", row.id.to_string().replace('-', "")),
-            budget_id: BudgetId::from_uuid(row.budget_id),
+            budget_id: BudgetId::from_uuid(
+                row.budget_id
+                    .expect("budget ledger rows returned from budget APIs always have a budget_id"),
+            ),
             amount: row.amount,
             meter_source: row.meter_source.clone(),
             ref_type: row.ref_type.clone(),
@@ -68,6 +84,113 @@ impl BudgetService {
             description: row.description.clone(),
             created_at: row.created_at,
         }
+    }
+
+    async fn resolve_scope(
+        &self,
+        org_id: i64,
+        session_id: &str,
+        agent_id: Option<&str>,
+    ) -> Result<BudgetScope, anyhow::Error> {
+        if let Ok(parsed_session_id) = SessionId::parse(session_id)
+            && let Some(session) = self.db.get_session(org_id, parsed_session_id).await?
+        {
+            return Ok(Self::scope_from_session(&session, session_id, agent_id));
+        }
+
+        Ok(BudgetScope {
+            session_subject_id: session_id.to_string(),
+            agent_subject_id: agent_id.map(ToOwned::to_owned),
+            user_subject_id: None,
+            org_subject_id: everruns_core::org_public_id_from_internal(org_id),
+            session_id: SessionId::parse(session_id).ok().map(|id| id.uuid()),
+            user_id: None,
+            principal_id: None,
+            agent_id: agent_id
+                .and_then(|id| AgentId::parse(id).ok())
+                .map(|id| id.uuid()),
+            harness_id: None,
+        })
+    }
+
+    fn scope_from_session(
+        session: &SessionRow,
+        session_subject_id: &str,
+        agent_id_override: Option<&str>,
+    ) -> BudgetScope {
+        BudgetScope {
+            session_subject_id: session_subject_id.to_string(),
+            agent_subject_id: agent_id_override
+                .map(ToOwned::to_owned)
+                .or_else(|| session.agent_id.map(|id| id.to_string())),
+            user_subject_id: session.resolved_owner_user_id.map(|id| id.to_string()),
+            org_subject_id: everruns_core::org_public_id_from_internal(session.org_id),
+            session_id: Some(session.id.uuid()),
+            user_id: session.resolved_owner_user_id,
+            principal_id: Some(session.owner_principal_id.uuid()),
+            agent_id: session.agent_id.map(|id| id.uuid()),
+            harness_id: session.harness_id.map(|id| id.uuid()),
+        }
+    }
+
+    pub async fn list_budgets_for_session_hierarchy(
+        &self,
+        org_id: i64,
+        session_id: &str,
+        agent_id: Option<&str>,
+    ) -> Vec<BudgetRow> {
+        let scope = match self.resolve_scope(org_id, session_id, agent_id).await {
+            Ok(scope) => scope,
+            Err(error) => {
+                error!(
+                    session_id,
+                    error = %error,
+                    "Failed to resolve session scope for budget hierarchy"
+                );
+                return vec![];
+            }
+        };
+
+        let mut seen = HashSet::new();
+        let mut budgets = Vec::new();
+        for (subject_type, subject_id) in [
+            ("session", Some(scope.session_subject_id.as_str())),
+            ("agent", scope.agent_subject_id.as_deref()),
+            ("user", scope.user_subject_id.as_deref()),
+            ("org", Some(scope.org_subject_id.as_str())),
+        ] {
+            let Some(subject_id) = subject_id else {
+                continue;
+            };
+            match self
+                .db
+                .list_budgets(org_id, Some(subject_type), Some(subject_id))
+                .await
+            {
+                Ok(rows) => {
+                    for row in rows {
+                        if seen.insert(row.id) {
+                            budgets.push(row);
+                        }
+                    }
+                }
+                Err(error) => {
+                    error!(
+                        subject_type,
+                        subject_id,
+                        error = %error,
+                        "Failed to list budgets for hierarchy subject"
+                    );
+                }
+            }
+        }
+
+        budgets.sort_by(|a, b| {
+            a.balance
+                .partial_cmp(&b.balance)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        budgets
     }
 
     // ============================================================================
@@ -83,6 +206,7 @@ impl BudgetService {
         provider: Option<&str>,
         input_tokens: i64,
         output_tokens: i64,
+        finish_reasons: Option<&[String]>,
     ) {
         // Get session to find subject hierarchy
         let session = match self.db.get_session_unscoped(event.session_id).await {
@@ -101,19 +225,17 @@ impl BudgetService {
         };
 
         let session_public_id = event.session_id.to_string();
-        let agent_public_id = session.agent_id.map(|a| a.to_string());
+        let scope = Self::scope_from_session(&session, &session_public_id, None);
 
         // Find all active budgets in the subject hierarchy
         let budgets = match self
             .db
             .get_active_budgets_for_session(
                 session.org_id,
-                &session_public_id,
-                agent_public_id.as_deref(),
-                // TODO: user_id and org_public_id not yet available in event context;
-                // user/org-scoped budgets will require plumbing these through session/turn context
-                None,
-                None,
+                &scope.session_subject_id,
+                scope.agent_subject_id.as_deref(),
+                scope.user_subject_id.as_deref(),
+                Some(scope.org_subject_id.as_str()),
             )
             .await
         {
@@ -132,6 +254,43 @@ impl BudgetService {
         }
 
         let total_tokens = input_tokens + output_tokens;
+        let journal = match self
+            .db
+            .create_usage_journal_entry(CreateUsageJournalRow {
+                org_id: session.org_id,
+                kind: "llm_generation".to_string(),
+                source_type: Some("event".to_string()),
+                source_id: Some(event.id.to_string()),
+                event_id: Some(event.id.uuid()),
+                session_id: scope.session_id,
+                turn_id: event.context.turn_id.as_ref().map(|id| id.uuid()),
+                user_id: scope.user_id,
+                principal_id: scope.principal_id,
+                agent_id: scope.agent_id,
+                harness_id: scope.harness_id,
+                measures: serde_json::json!({
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "total_tokens": total_tokens,
+                }),
+                metadata: serde_json::json!({
+                    "model": model,
+                    "provider": provider,
+                    "finish_reasons": finish_reasons,
+                }),
+            })
+            .await
+        {
+            Ok(journal) => journal,
+            Err(error) => {
+                error!(
+                    session_id = %event.session_id,
+                    error = %error,
+                    "Failed to create usage journal row for llm generation"
+                );
+                return;
+            }
+        };
 
         // For each budget, compute the debit amount in budget currency and record it
         for budget in &budgets {
@@ -148,19 +307,38 @@ impl BudgetService {
                 continue;
             }
 
-            // Record ledger entry and get updated balance
-            let ledger_input = CreateBudgetLedgerRow {
-                budget_id: budget.id,
+            let ledger_input = CreateUsageLedgerRow {
+                journal_id: journal.id,
+                budget_id: Some(budget.id),
+                org_id: session.org_id,
+                session_id: scope.session_id,
+                user_id: scope.user_id,
+                principal_id: scope.principal_id,
+                agent_id: scope.agent_id,
+                harness_id: scope.harness_id,
+                currency: budget.currency.clone(),
                 amount: debit,
                 meter_source: "llm_tokens".into(),
                 ref_type: Some("llm_generation".into()),
                 ref_id: Some(event.id.uuid()),
-                session_id: Some(event.session_id.uuid()),
                 description: model.map(|m| format!("{} tokens on {}", total_tokens, m)),
+                rating_metadata: Some(serde_json::json!({
+                    "ruleset_version": "v1",
+                    "journal_kind": "llm_generation",
+                    "model": model,
+                    "provider": provider,
+                })),
             };
 
-            let updated_budget = match self.db.create_budget_ledger_entry(ledger_input).await {
-                Ok((_entry, budget)) => budget,
+            let updated_budget = match self.db.create_usage_ledger_entry(ledger_input).await {
+                Ok((_entry, Some(budget))) => budget,
+                Ok((_entry, None)) => {
+                    error!(
+                        "Usage ledger row for budget {} did not update a budget",
+                        budget.id
+                    );
+                    continue;
+                }
                 Err(e) => {
                     error!("Failed to record budget ledger entry: {}", e);
                     continue;
@@ -310,29 +488,9 @@ impl BudgetService {
         session_id: &str,
         agent_id: Option<&str>,
     ) -> BudgetCheckResult {
-        // Query session-scoped budgets
-        let mut all_matching = match self
-            .db
-            .list_budgets(org_id, Some("session"), Some(session_id))
-            .await
-        {
-            Ok(b) => b,
-            Err(e) => {
-                error!("Failed to check session budgets: {}", e);
-                return BudgetCheckResult::ok();
-            }
-        };
-
-        // Query agent-scoped budgets if agent_id is provided
-        if let Some(aid) = agent_id {
-            match self.db.list_budgets(org_id, Some("agent"), Some(aid)).await {
-                Ok(b) => all_matching.extend(b),
-                Err(e) => error!("Failed to check agent budgets: {}", e),
-            }
-        }
-
-        // TODO: user_id and org_public_id not yet available in event context;
-        // user/org-scoped budgets will require plumbing these through session/turn context
+        let all_matching = self
+            .list_budgets_for_session_hierarchy(org_id, session_id, agent_id)
+            .await;
 
         // Evaluate ALL matching budgets and keep the most restrictive result.
         // Priority: stop > pause > warn > continue
@@ -438,6 +596,7 @@ impl EventListener for BudgetService {
             data.metadata.provider.as_deref(),
             input_tokens,
             output_tokens,
+            data.metadata.finish_reasons.as_deref(),
         )
         .await;
     }

--- a/crates/server/src/services/budget_tests.rs
+++ b/crates/server/src/services/budget_tests.rs
@@ -9,7 +9,9 @@ mod tests {
     use crate::storage::StorageBackend;
     use crate::storage::models::*;
     use everruns_core::budget::BudgetAction;
+    use everruns_core::{AgentId, PrincipalId, org_public_id_from_internal};
     use std::sync::Arc;
+    use uuid::Uuid;
 
     fn make_db() -> Arc<StorageBackend> {
         Arc::new(StorageBackend::in_memory())
@@ -19,6 +21,38 @@ mod tests {
         let db = make_db();
         let svc = BudgetService::new(db.clone());
         (svc, db)
+    }
+
+    async fn create_session_with_owner(
+        db: &Arc<StorageBackend>,
+        org_id: i64,
+        agent_id: Option<AgentId>,
+        resolved_owner_user_id: Option<Uuid>,
+    ) -> SessionRow {
+        db.create_session(CreateSessionRow {
+            org_id,
+            harness_id: None,
+            agent_id,
+            agent_identity_id: None,
+            owner_principal_id: PrincipalId::new(),
+            resolved_owner_user_id,
+            title: Some("Budget test session".into()),
+            locale: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!({}),
+            tools: serde_json::json!([]),
+            mcp_servers: serde_json::json!([]),
+            system_prompt: None,
+            initial_files: serde_json::json!({}),
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            blueprint_id: None,
+            blueprint_config: None,
+        })
+        .await
+        .unwrap()
     }
 
     fn make_budget_row(
@@ -352,6 +386,45 @@ mod tests {
             .unwrap();
         assert_eq!(entry.amount, 3.0);
         assert_eq!(updated.balance, 7.0);
+    }
+
+    #[tokio::test]
+    async fn test_budget_ledger_entry_creates_usage_journal_link() {
+        let db = make_db();
+        let budget = db
+            .create_budget(CreateBudgetRow {
+                org_id: 1,
+                subject_type: "session".into(),
+                subject_id: "s1".into(),
+                currency: "usd".into(),
+                limit: 10.0,
+                soft_limit: None,
+                period: None,
+                metadata: None,
+            })
+            .await
+            .unwrap();
+        let (entry, _) = db
+            .create_budget_ledger_entry(CreateBudgetLedgerRow {
+                budget_id: budget.id,
+                amount: 3.0,
+                meter_source: "llm_tokens".into(),
+                ref_type: Some("llm_generation".into()),
+                ref_id: Some(uuid::Uuid::now_v7()),
+                session_id: None,
+                description: Some("test debit".into()),
+            })
+            .await
+            .unwrap();
+
+        let journal = db
+            .get_usage_journal(entry.journal_id)
+            .await
+            .unwrap()
+            .expect("journal should be created");
+        assert_eq!(journal.kind, "budget_adjustment");
+        assert_eq!(journal.org_id, budget.org_id);
+        assert_eq!(journal.measures["amount"], serde_json::json!(3.0));
     }
 
     #[tokio::test]
@@ -807,6 +880,91 @@ mod tests {
         assert_eq!(result.action, "stop");
     }
 
+    #[tokio::test]
+    async fn test_list_budgets_for_session_hierarchy_resolves_user_and_org_from_session() {
+        let (svc, db) = make_service();
+        let user_id = Uuid::now_v7();
+        let agent_id = AgentId::new();
+        let session = create_session_with_owner(&db, 1, Some(agent_id), Some(user_id)).await;
+        let session_public_id = session.id.to_string();
+        let org_public_id = org_public_id_from_internal(session.org_id);
+
+        for (subject_type, subject_id) in [
+            ("session", session_public_id.clone()),
+            ("agent", agent_id.to_string()),
+            ("user", user_id.to_string()),
+            ("org", org_public_id.clone()),
+        ] {
+            db.create_budget(CreateBudgetRow {
+                org_id: session.org_id,
+                subject_type: subject_type.into(),
+                subject_id,
+                currency: "usd".into(),
+                limit: 25.0,
+                soft_limit: None,
+                period: None,
+                metadata: None,
+            })
+            .await
+            .unwrap();
+        }
+
+        let budgets = svc
+            .list_budgets_for_session_hierarchy(session.org_id, &session_public_id, None)
+            .await;
+
+        let subjects: Vec<(&str, &str)> = budgets
+            .iter()
+            .map(|budget| (budget.subject_type.as_str(), budget.subject_id.as_str()))
+            .collect();
+        assert!(subjects.contains(&("session", session_public_id.as_str())));
+        assert!(subjects.contains(&("agent", agent_id.to_string().as_str())));
+        assert!(subjects.contains(&("user", user_id.to_string().as_str())));
+        assert!(subjects.contains(&("org", org_public_id.as_str())));
+    }
+
+    #[tokio::test]
+    async fn test_check_budgets_respects_user_budget_from_session_hierarchy() {
+        let (svc, db) = make_service();
+        let user_id = Uuid::now_v7();
+        let session = create_session_with_owner(&db, 1, None, Some(user_id)).await;
+        let session_public_id = session.id.to_string();
+
+        let budget = db
+            .create_budget(CreateBudgetRow {
+                org_id: session.org_id,
+                subject_type: "user".into(),
+                subject_id: user_id.to_string(),
+                currency: "usd".into(),
+                limit: 10.0,
+                soft_limit: None,
+                period: None,
+                metadata: None,
+            })
+            .await
+            .unwrap();
+
+        db.create_budget_ledger_entry(CreateBudgetLedgerRow {
+            budget_id: budget.id,
+            amount: 10.0,
+            meter_source: "llm_tokens".into(),
+            ref_type: None,
+            ref_id: None,
+            session_id: Some(session.id.uuid()),
+            description: None,
+        })
+        .await
+        .unwrap();
+        db.set_budget_status(budget.id, "exhausted").await.unwrap();
+
+        let result = svc
+            .check_budgets_for_session(session.org_id, &session_public_id, None)
+            .await;
+
+        assert_eq!(result.action, "stop");
+        assert_eq!(result.error_code.as_deref(), Some("budget_exhausted"));
+    }
+
     // ========================================================================
     // Set budget status + DTO conversion tests
     // ========================================================================
@@ -859,13 +1017,21 @@ mod tests {
     fn test_row_to_ledger_entry_dto() {
         let row = BudgetLedgerRow {
             id: uuid::Uuid::now_v7(),
-            budget_id: uuid::Uuid::now_v7(),
+            journal_id: uuid::Uuid::now_v7(),
+            budget_id: Some(uuid::Uuid::now_v7()),
+            org_id: 1,
+            session_id: None,
+            user_id: None,
+            principal_id: None,
+            agent_id: None,
+            harness_id: None,
+            currency: "usd".into(),
             amount: 5.5,
             meter_source: "llm_tokens".into(),
             ref_type: Some("llm_generation".into()),
             ref_id: Some(uuid::Uuid::now_v7()),
-            session_id: None,
             description: Some("test".into()),
+            rating_metadata: None,
             created_at: chrono::Utc::now(),
         };
         let dto = BudgetService::row_to_ledger_entry(&row);

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -2283,14 +2283,41 @@ impl StorageBackend {
     }
 
     // ============================================
-    // Budget Ledger
+    // Usage Journal + Ledger
     // ============================================
+
+    pub async fn create_usage_journal_entry(
+        &self,
+        input: CreateUsageJournalRow,
+    ) -> Result<UsageJournalRow> {
+        dispatch!(self, create_usage_journal_entry, input)
+    }
+
+    pub async fn get_usage_journal(&self, id: Uuid) -> Result<Option<UsageJournalRow>> {
+        dispatch!(self, get_usage_journal, id)
+    }
+
+    pub async fn create_usage_ledger_entry(
+        &self,
+        input: CreateUsageLedgerRow,
+    ) -> Result<(UsageLedgerRow, Option<BudgetRow>)> {
+        dispatch!(self, create_usage_ledger_entry, input)
+    }
 
     pub async fn create_budget_ledger_entry(
         &self,
         input: CreateBudgetLedgerRow,
     ) -> Result<(BudgetLedgerRow, BudgetRow)> {
         dispatch!(self, create_budget_ledger_entry, input)
+    }
+
+    pub async fn list_usage_ledger_for_budget(
+        &self,
+        budget_id: Uuid,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<UsageLedgerRow>> {
+        dispatch!(self, list_usage_ledger_for_budget, budget_id, limit, offset)
     }
 
     pub async fn list_budget_ledger(

--- a/crates/server/src/storage/memory/budgets.rs
+++ b/crates/server/src/storage/memory/budgets.rs
@@ -1,6 +1,7 @@
 // In-memory budget storage
 
 use anyhow::Result;
+use everruns_core::{AgentId, SessionId};
 use uuid::Uuid;
 
 use super::InMemoryDatabase;
@@ -136,41 +137,167 @@ impl InMemoryDatabase {
     }
 
     // ============================================
-    // Budget Ledger
+    // Usage Journal + Ledger
     // ============================================
+
+    pub async fn create_usage_journal_entry(
+        &self,
+        input: CreateUsageJournalRow,
+    ) -> Result<UsageJournalRow> {
+        let now = Self::now();
+        let row = UsageJournalRow {
+            id: Uuid::now_v7(),
+            org_id: input.org_id,
+            kind: input.kind,
+            source_type: input.source_type,
+            source_id: input.source_id,
+            event_id: input.event_id,
+            session_id: input.session_id,
+            turn_id: input.turn_id,
+            user_id: input.user_id,
+            principal_id: input.principal_id,
+            agent_id: input.agent_id,
+            harness_id: input.harness_id,
+            measures: input.measures,
+            metadata: input.metadata,
+            created_at: now,
+        };
+        self.usage_journal.write().insert(row.id, row.clone());
+        Ok(row)
+    }
+
+    pub async fn get_usage_journal(&self, id: Uuid) -> Result<Option<UsageJournalRow>> {
+        Ok(self.usage_journal.read().get(&id).cloned())
+    }
+
+    pub async fn create_usage_ledger_entry(
+        &self,
+        input: CreateUsageLedgerRow,
+    ) -> Result<(UsageLedgerRow, Option<BudgetRow>)> {
+        let now = Self::now();
+        let entry = UsageLedgerRow {
+            id: Uuid::now_v7(),
+            journal_id: input.journal_id,
+            budget_id: input.budget_id,
+            org_id: input.org_id,
+            session_id: input.session_id,
+            user_id: input.user_id,
+            principal_id: input.principal_id,
+            agent_id: input.agent_id,
+            harness_id: input.harness_id,
+            currency: input.currency,
+            amount: input.amount,
+            meter_source: input.meter_source,
+            ref_type: input.ref_type,
+            ref_id: input.ref_id,
+            description: input.description,
+            rating_metadata: input.rating_metadata,
+            created_at: now,
+        };
+        self.usage_ledger.write().push(entry.clone());
+
+        let updated_budget = match input.budget_id {
+            Some(budget_id) => {
+                let mut budgets = self.budgets.write();
+                let budget = budgets
+                    .get_mut(&budget_id)
+                    .ok_or_else(|| anyhow::anyhow!("Budget not found: {}", budget_id))?;
+                budget.balance -= input.amount;
+                budget.updated_at = now;
+                Some(budget.clone())
+            }
+            None => None,
+        };
+
+        Ok((entry, updated_budget))
+    }
 
     pub async fn create_budget_ledger_entry(
         &self,
         input: CreateBudgetLedgerRow,
     ) -> Result<(BudgetLedgerRow, BudgetRow)> {
-        let now = Self::now();
-        let entry_id = Uuid::now_v7();
-
-        // Update budget balance
-        let updated_budget = {
-            let mut budgets = self.budgets.write();
-            let budget = budgets
-                .get_mut(&input.budget_id)
-                .ok_or_else(|| anyhow::anyhow!("Budget not found: {}", input.budget_id))?;
-            budget.balance -= input.amount;
-            budget.updated_at = now;
-            budget.clone()
+        let budget = self
+            .get_budget_for_ledger(input.budget_id)
+            .ok_or_else(|| anyhow::anyhow!("Budget not found: {}", input.budget_id))?;
+        let (session_id, user_id, agent_id) = self.scope_from_budget(&budget, input.session_id);
+        let journal_kind = if input.amount < 0.0 || input.ref_type.as_deref() == Some("top_up") {
+            "top_up"
+        } else {
+            "budget_adjustment"
         };
+        let journal = self
+            .create_usage_journal_entry(CreateUsageJournalRow {
+                org_id: budget.org_id,
+                kind: journal_kind.to_string(),
+                source_type: Some("budget_ledger_compat".to_string()),
+                source_id: Some(Uuid::now_v7().to_string()),
+                event_id: None,
+                session_id,
+                turn_id: None,
+                user_id,
+                principal_id: None,
+                agent_id,
+                harness_id: None,
+                measures: serde_json::json!({
+                    "amount": input.amount,
+                    "currency": budget.currency,
+                }),
+                metadata: serde_json::json!({
+                    "budget_id": budget.id,
+                    "ref_type": input.ref_type,
+                    "ref_id": input.ref_id,
+                    "description": input.description,
+                }),
+            })
+            .await?;
 
-        let entry = BudgetLedgerRow {
-            id: entry_id,
-            budget_id: input.budget_id,
-            amount: input.amount,
-            meter_source: input.meter_source,
-            ref_type: input.ref_type,
-            ref_id: input.ref_id,
-            session_id: input.session_id,
-            description: input.description,
-            created_at: now,
-        };
-        self.budget_ledger.write().push(entry.clone());
+        let (entry, updated_budget) = self
+            .create_usage_ledger_entry(CreateUsageLedgerRow {
+                journal_id: journal.id,
+                budget_id: Some(budget.id),
+                org_id: budget.org_id,
+                session_id,
+                user_id,
+                principal_id: None,
+                agent_id,
+                harness_id: None,
+                currency: budget.currency.clone(),
+                amount: input.amount,
+                meter_source: input.meter_source,
+                ref_type: input.ref_type,
+                ref_id: input.ref_id,
+                description: input.description,
+                rating_metadata: Some(serde_json::json!({
+                    "ruleset_version": "v1",
+                    "compatibility_wrapper": true,
+                })),
+            })
+            .await?;
 
-        Ok((entry, updated_budget))
+        Ok((
+            entry,
+            updated_budget.expect("budget ledger compatibility path always updates a budget"),
+        ))
+    }
+
+    pub async fn list_usage_ledger_for_budget(
+        &self,
+        budget_id: Uuid,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<UsageLedgerRow>> {
+        let ledger = self.usage_ledger.read();
+        let mut entries: Vec<UsageLedgerRow> = ledger
+            .iter()
+            .filter(|e| e.budget_id == Some(budget_id))
+            .cloned()
+            .collect();
+        entries.sort_by_key(|entry| std::cmp::Reverse(entry.created_at));
+        Ok(entries
+            .into_iter()
+            .skip(offset as usize)
+            .take(limit as usize)
+            .collect())
     }
 
     pub async fn list_budget_ledger(
@@ -179,19 +306,8 @@ impl InMemoryDatabase {
         limit: i64,
         offset: i64,
     ) -> Result<Vec<BudgetLedgerRow>> {
-        let ledger = self.budget_ledger.read();
-        let mut entries: Vec<BudgetLedgerRow> = ledger
-            .iter()
-            .filter(|e| e.budget_id == budget_id)
-            .cloned()
-            .collect();
-        entries.sort_by_key(|entry| std::cmp::Reverse(entry.created_at));
-        let result = entries
-            .into_iter()
-            .skip(offset as usize)
-            .take(limit as usize)
-            .collect();
-        Ok(result)
+        self.list_usage_ledger_for_budget(budget_id, limit, offset)
+            .await
     }
 
     pub async fn set_budget_status(&self, id: Uuid, status: &str) -> Result<Option<BudgetRow>> {
@@ -203,5 +319,32 @@ impl InMemoryDatabase {
         } else {
             Ok(None)
         }
+    }
+
+    fn get_budget_for_ledger(&self, id: Uuid) -> Option<BudgetRow> {
+        self.budgets.read().get(&id).cloned()
+    }
+
+    fn scope_from_budget(
+        &self,
+        budget: &BudgetRow,
+        explicit_session_id: Option<Uuid>,
+    ) -> (Option<Uuid>, Option<Uuid>, Option<Uuid>) {
+        let session_id = explicit_session_id.or_else(|| {
+            (budget.subject_type == "session")
+                .then(|| {
+                    SessionId::parse(&budget.subject_id)
+                        .ok()
+                        .map(|id| id.uuid())
+                })
+                .flatten()
+        });
+        let user_id = (budget.subject_type == "user")
+            .then(|| Uuid::parse_str(&budget.subject_id).ok())
+            .flatten();
+        let agent_id = (budget.subject_type == "agent")
+            .then(|| AgentId::parse(&budget.subject_id).ok().map(|id| id.uuid()))
+            .flatten();
+        (session_id, user_id, agent_id)
     }
 }

--- a/crates/server/src/storage/memory/mod.rs
+++ b/crates/server/src/storage/memory/mod.rs
@@ -139,7 +139,8 @@ pub struct InMemoryDatabase {
     eval_case_results: RwLock<HashMap<Uuid, EvalCaseResultRow>>,
     // Budgets
     budgets: RwLock<HashMap<Uuid, BudgetRow>>,
-    budget_ledger: RwLock<Vec<BudgetLedgerRow>>,
+    usage_journal: RwLock<HashMap<Uuid, UsageJournalRow>>,
+    usage_ledger: RwLock<Vec<UsageLedgerRow>>,
     // OAuth clients (MCP OAuth 2.1)
     oauth_clients: RwLock<HashMap<Uuid, OAuthClientRow>>,
     oauth_authorization_codes: RwLock<HashMap<Uuid, OAuthAuthorizationCodeRow>>,
@@ -209,7 +210,8 @@ impl Default for InMemoryDatabase {
             eval_runs: RwLock::new(HashMap::new()),
             eval_case_results: RwLock::new(HashMap::new()),
             budgets: RwLock::new(HashMap::new()),
-            budget_ledger: RwLock::new(Vec::new()),
+            usage_journal: RwLock::new(HashMap::new()),
+            usage_ledger: RwLock::new(Vec::new()),
             oauth_clients: RwLock::new(HashMap::new()),
             oauth_authorization_codes: RwLock::new(HashMap::new()),
             oauth_refresh_tokens: RwLock::new(HashMap::new()),

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -1855,21 +1855,87 @@ pub struct UpdateBudgetRow {
     pub metadata: Option<serde_json::Value>,
 }
 
-/// Budget ledger entry row (maps to `budget_ledger` table).
+/// Immutable activity journal row (maps to `usage_journal` table).
 #[derive(Debug, Clone, sqlx::FromRow, serde::Serialize)]
-pub struct BudgetLedgerRow {
+pub struct UsageJournalRow {
     pub id: Uuid,
-    pub budget_id: Uuid,
+    pub org_id: i64,
+    pub kind: String,
+    pub source_type: Option<String>,
+    pub source_id: Option<String>,
+    pub event_id: Option<Uuid>,
+    pub session_id: Option<Uuid>,
+    pub turn_id: Option<Uuid>,
+    pub user_id: Option<Uuid>,
+    pub principal_id: Option<Uuid>,
+    pub agent_id: Option<Uuid>,
+    pub harness_id: Option<Uuid>,
+    pub measures: sqlx::types::JsonValue,
+    pub metadata: sqlx::types::JsonValue,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Input for creating a journal row.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct CreateUsageJournalRow {
+    pub org_id: i64,
+    pub kind: String,
+    pub source_type: Option<String>,
+    pub source_id: Option<String>,
+    pub event_id: Option<Uuid>,
+    pub session_id: Option<Uuid>,
+    pub turn_id: Option<Uuid>,
+    pub user_id: Option<Uuid>,
+    pub principal_id: Option<Uuid>,
+    pub agent_id: Option<Uuid>,
+    pub harness_id: Option<Uuid>,
+    pub measures: serde_json::Value,
+    pub metadata: serde_json::Value,
+}
+
+/// Rated ledger row (maps to `usage_ledger` table).
+#[derive(Debug, Clone, sqlx::FromRow, serde::Serialize)]
+pub struct UsageLedgerRow {
+    pub id: Uuid,
+    pub journal_id: Uuid,
+    pub budget_id: Option<Uuid>,
+    pub org_id: i64,
+    pub session_id: Option<Uuid>,
+    pub user_id: Option<Uuid>,
+    pub principal_id: Option<Uuid>,
+    pub agent_id: Option<Uuid>,
+    pub harness_id: Option<Uuid>,
+    pub currency: String,
     pub amount: f64,
     pub meter_source: String,
     pub ref_type: Option<String>,
     pub ref_id: Option<Uuid>,
-    pub session_id: Option<Uuid>,
     pub description: Option<String>,
+    pub rating_metadata: Option<sqlx::types::JsonValue>,
     pub created_at: DateTime<Utc>,
 }
 
-/// Input for creating a ledger entry.
+/// Input for creating a rated ledger row.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct CreateUsageLedgerRow {
+    pub journal_id: Uuid,
+    pub budget_id: Option<Uuid>,
+    pub org_id: i64,
+    pub session_id: Option<Uuid>,
+    pub user_id: Option<Uuid>,
+    pub principal_id: Option<Uuid>,
+    pub agent_id: Option<Uuid>,
+    pub harness_id: Option<Uuid>,
+    pub currency: String,
+    pub amount: f64,
+    pub meter_source: String,
+    pub ref_type: Option<String>,
+    pub ref_id: Option<Uuid>,
+    pub description: Option<String>,
+    pub rating_metadata: Option<serde_json::Value>,
+}
+
+/// Compatibility input for callers that still think in budget-specific postings.
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct CreateBudgetLedgerRow {
     pub budget_id: Uuid,
@@ -1880,3 +1946,6 @@ pub struct CreateBudgetLedgerRow {
     pub session_id: Option<Uuid>,
     pub description: Option<String>,
 }
+
+/// Compatibility alias for budget-scoped ledger reads.
+pub type BudgetLedgerRow = UsageLedgerRow;

--- a/crates/server/src/storage/repositories/budgets.rs
+++ b/crates/server/src/storage/repositories/budgets.rs
@@ -1,6 +1,7 @@
 // Budget storage (PostgreSQL)
 
 use anyhow::Result;
+use everruns_core::{AgentId, SessionId};
 use uuid::Uuid;
 
 use crate::storage::Database;
@@ -178,61 +179,130 @@ impl Database {
     }
 
     // ============================================
-    // Budget Ledger
+    // Usage Journal + Ledger
     // ============================================
 
-    /// Record a ledger entry and atomically update the budget balance.
-    /// Returns the updated budget row.
-    pub async fn create_budget_ledger_entry(
+    pub async fn create_usage_journal_entry(
         &self,
-        input: CreateBudgetLedgerRow,
-    ) -> Result<(BudgetLedgerRow, BudgetRow)> {
+        input: CreateUsageJournalRow,
+    ) -> Result<UsageJournalRow> {
+        let row = sqlx::query_as::<_, UsageJournalRow>(
+            r#"
+            INSERT INTO usage_journal (
+                org_id, kind, source_type, source_id, event_id, session_id, turn_id,
+                user_id, principal_id, agent_id, harness_id, measures, metadata
+            ) VALUES (
+                $1, $2, $3, $4, $5, $6, $7,
+                $8, $9, $10, $11, $12, $13
+            )
+            RETURNING id, org_id, kind, source_type, source_id, event_id, session_id, turn_id,
+                      user_id, principal_id, agent_id, harness_id, measures, metadata, created_at
+            "#,
+        )
+        .bind(input.org_id)
+        .bind(&input.kind)
+        .bind(input.source_type.as_deref())
+        .bind(input.source_id.as_deref())
+        .bind(input.event_id)
+        .bind(input.session_id)
+        .bind(input.turn_id)
+        .bind(input.user_id)
+        .bind(input.principal_id)
+        .bind(input.agent_id)
+        .bind(input.harness_id)
+        .bind(&input.measures)
+        .bind(&input.metadata)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    pub async fn get_usage_journal(&self, id: Uuid) -> Result<Option<UsageJournalRow>> {
+        let row = sqlx::query_as::<_, UsageJournalRow>(
+            r#"
+            SELECT id, org_id, kind, source_type, source_id, event_id, session_id, turn_id,
+                   user_id, principal_id, agent_id, harness_id, measures, metadata, created_at
+            FROM usage_journal
+            WHERE id = $1
+            "#,
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    /// Record a rated ledger entry and update any attached budget snapshot atomically.
+    pub async fn create_usage_ledger_entry(
+        &self,
+        input: CreateUsageLedgerRow,
+    ) -> Result<(UsageLedgerRow, Option<BudgetRow>)> {
         let mut tx = self.pool.begin().await?;
 
-        // Lock budget row
-        let _budget = sqlx::query_as::<_, BudgetRow>(
-            r#"
-            SELECT id, org_id, subject_type, subject_id, currency, "limit", soft_limit,
-                   balance, period, metadata, status, created_at, updated_at
-            FROM budgets
-            WHERE id = $1
-            FOR UPDATE
-            "#,
-        )
-        .bind(input.budget_id)
-        .fetch_one(&mut *tx)
-        .await?;
+        let updated_budget = if let Some(budget_id) = input.budget_id {
+            let _budget = sqlx::query_as::<_, BudgetRow>(
+                r#"
+                SELECT id, org_id, subject_type, subject_id, currency, "limit", soft_limit,
+                       balance, period, metadata, status, created_at, updated_at
+                FROM budgets
+                WHERE id = $1
+                FOR UPDATE
+                "#,
+            )
+            .bind(budget_id)
+            .fetch_one(&mut *tx)
+            .await?;
 
-        // Insert ledger entry
-        let entry = sqlx::query_as::<_, BudgetLedgerRow>(
+            Some(
+                sqlx::query_as::<_, BudgetRow>(
+                    r#"
+                    UPDATE budgets
+                    SET balance = balance - $2
+                    WHERE id = $1
+                    RETURNING id, org_id, subject_type, subject_id, currency, "limit", soft_limit,
+                              balance, period, metadata, status, created_at, updated_at
+                    "#,
+                )
+                .bind(budget_id)
+                .bind(input.amount)
+                .fetch_one(&mut *tx)
+                .await?,
+            )
+        } else {
+            None
+        };
+
+        let entry = sqlx::query_as::<_, UsageLedgerRow>(
             r#"
-            INSERT INTO budget_ledger (budget_id, amount, meter_source, ref_type, ref_id, session_id, description)
-            VALUES ($1, $2, $3, $4, $5, $6, $7)
-            RETURNING id, budget_id, amount, meter_source, ref_type, ref_id, session_id, description, created_at
+            INSERT INTO usage_ledger (
+                journal_id, budget_id, org_id, session_id, user_id, principal_id,
+                agent_id, harness_id, currency, amount, meter_source, ref_type,
+                ref_id, description, rating_metadata
+            ) VALUES (
+                $1, $2, $3, $4, $5, $6,
+                $7, $8, $9, $10, $11, $12,
+                $13, $14, $15
+            )
+            RETURNING id, journal_id, budget_id, org_id, session_id, user_id, principal_id,
+                      agent_id, harness_id, currency, amount, meter_source, ref_type, ref_id,
+                      description, rating_metadata, created_at
             "#,
         )
+        .bind(input.journal_id)
         .bind(input.budget_id)
+        .bind(input.org_id)
+        .bind(input.session_id)
+        .bind(input.user_id)
+        .bind(input.principal_id)
+        .bind(input.agent_id)
+        .bind(input.harness_id)
+        .bind(&input.currency)
         .bind(input.amount)
         .bind(&input.meter_source)
         .bind(input.ref_type.as_deref())
         .bind(input.ref_id)
-        .bind(input.session_id)
         .bind(input.description.as_deref())
-        .fetch_one(&mut *tx)
-        .await?;
-
-        // Update balance (subtract debit, add credit)
-        let updated_budget = sqlx::query_as::<_, BudgetRow>(
-            r#"
-            UPDATE budgets
-            SET balance = balance - $2
-            WHERE id = $1
-            RETURNING id, org_id, subject_type, subject_id, currency, "limit", soft_limit,
-                      balance, period, metadata, status, created_at, updated_at
-            "#,
-        )
-        .bind(input.budget_id)
-        .bind(input.amount)
+        .bind(&input.rating_metadata)
         .fetch_one(&mut *tx)
         .await?;
 
@@ -240,17 +310,96 @@ impl Database {
         Ok((entry, updated_budget))
     }
 
-    pub async fn list_budget_ledger(
+    /// Record a ledger entry and atomically update the budget balance.
+    /// Returns the updated budget row.
+    pub async fn create_budget_ledger_entry(
+        &self,
+        input: CreateBudgetLedgerRow,
+    ) -> Result<(BudgetLedgerRow, BudgetRow)> {
+        let budget = sqlx::query_as::<_, BudgetRow>(
+            r#"
+            SELECT id, org_id, subject_type, subject_id, currency, "limit", soft_limit,
+                   balance, period, metadata, status, created_at, updated_at
+            FROM budgets
+            WHERE id = $1
+            "#,
+        )
+        .bind(input.budget_id)
+        .fetch_one(&self.pool)
+        .await?;
+        let (session_id, user_id, agent_id) = scope_from_budget(&budget, input.session_id);
+        let journal_kind = if input.amount < 0.0 || input.ref_type.as_deref() == Some("top_up") {
+            "top_up"
+        } else {
+            "budget_adjustment"
+        };
+        let journal = self
+            .create_usage_journal_entry(CreateUsageJournalRow {
+                org_id: budget.org_id,
+                kind: journal_kind.to_string(),
+                source_type: Some("budget_ledger_compat".to_string()),
+                source_id: Some(Uuid::now_v7().to_string()),
+                event_id: None,
+                session_id,
+                turn_id: None,
+                user_id,
+                principal_id: None,
+                agent_id,
+                harness_id: None,
+                measures: serde_json::json!({
+                    "amount": input.amount,
+                    "currency": budget.currency,
+                }),
+                metadata: serde_json::json!({
+                    "budget_id": budget.id,
+                    "ref_type": input.ref_type,
+                    "ref_id": input.ref_id,
+                    "description": input.description,
+                }),
+            })
+            .await?;
+
+        let (entry, updated_budget) = self
+            .create_usage_ledger_entry(CreateUsageLedgerRow {
+                journal_id: journal.id,
+                budget_id: Some(budget.id),
+                org_id: budget.org_id,
+                session_id,
+                user_id,
+                principal_id: None,
+                agent_id,
+                harness_id: None,
+                currency: budget.currency.clone(),
+                amount: input.amount,
+                meter_source: input.meter_source,
+                ref_type: input.ref_type,
+                ref_id: input.ref_id,
+                description: input.description,
+                rating_metadata: Some(serde_json::json!({
+                    "ruleset_version": "v1",
+                    "compatibility_wrapper": true,
+                })),
+            })
+            .await?;
+
+        Ok((
+            entry,
+            updated_budget.expect("budget ledger compatibility path always updates a budget"),
+        ))
+    }
+
+    pub async fn list_usage_ledger_for_budget(
         &self,
         budget_id: Uuid,
         limit: i64,
         offset: i64,
-    ) -> Result<Vec<BudgetLedgerRow>> {
-        let rows = sqlx::query_as::<_, BudgetLedgerRow>(
+    ) -> Result<Vec<UsageLedgerRow>> {
+        let rows = sqlx::query_as::<_, UsageLedgerRow>(
             r#"
-            SELECT id, budget_id, amount, meter_source, ref_type, ref_id, session_id,
-                   description, created_at
-            FROM budget_ledger
+            SELECT id, journal_id, budget_id, org_id, session_id, user_id, principal_id,
+                   agent_id, harness_id, currency, amount, meter_source, ref_type, ref_id,
+                   description, rating_metadata, created_at
+            FROM usage_ledger
             WHERE budget_id = $1
             ORDER BY created_at DESC
             LIMIT $2 OFFSET $3
@@ -262,6 +411,16 @@ impl Database {
         .fetch_all(&self.pool)
         .await?;
         Ok(rows)
+    }
+
+    pub async fn list_budget_ledger(
+        &self,
+        budget_id: Uuid,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<BudgetLedgerRow>> {
+        self.list_usage_ledger_for_budget(budget_id, limit, offset)
+            .await
     }
 
     /// Update budget status (used by rules engine).
@@ -280,4 +439,26 @@ impl Database {
         .await?;
         Ok(row)
     }
+}
+
+fn scope_from_budget(
+    budget: &BudgetRow,
+    explicit_session_id: Option<Uuid>,
+) -> (Option<Uuid>, Option<Uuid>, Option<Uuid>) {
+    let session_id = explicit_session_id.or_else(|| {
+        (budget.subject_type == "session")
+            .then(|| {
+                SessionId::parse(&budget.subject_id)
+                    .ok()
+                    .map(|id| id.uuid())
+            })
+            .flatten()
+    });
+    let user_id = (budget.subject_type == "user")
+        .then(|| Uuid::parse_str(&budget.subject_id).ok())
+        .flatten();
+    let agent_id = (budget.subject_type == "agent")
+        .then(|| AgentId::parse(&budget.subject_id).ok().map(|id| id.uuid()))
+        .flatten();
+    (session_id, user_id, agent_id)
 }

--- a/specs/budgeting.md
+++ b/specs/budgeting.md
@@ -19,25 +19,33 @@ See source files for full definitions:
 - Service: `crates/server/src/services/budget.rs`
 - API: `crates/server/src/api/budgets.rs`
 - Capability: `crates/core/src/capabilities/budgeting.rs`
-- Migration: `crates/server/migrations/011_budgeting.sql`
+- Migrations: `crates/server/migrations/010_v0.8.9.sql`, `crates/server/migrations/020_budget_journal_ledger.sql`
 
 ## Concepts
 
 ```
 ┌─────────────────────────────────────────────────────┐
-│                    Budget                             │
-│  subject: (session | agent | user | org)             │
-│  currency: (usd | tokens | credits | custom)        │
-│  limit: f64                                          │
-│  soft_limit: Option<f64>  (pause/warn threshold)     │
-│  period: Option<Period>   (rolling/calendar)         │
-│  balance: denormalized from ledger                   │
+│                Usage Journal                        │
+│  kind: llm_generation | top_up | ...               │
+│  scope: org/user/principal/session/agent/harness    │
+│  source: event_id or synthetic source_id            │
+│  measures: raw facts JSONB                          │
+│  metadata: trace / model / provider / notes         │
 └──────────────┬──────────────────────────────────────┘
-               │ 1:N
+               │ 1:N rated postings
 ┌──────────────▼──────────────────────────────────────┐
-│                 Ledger Entry                          │
-│  budget_id, amount, meter_source, ref_id, timestamp  │
-│  (append-only — no UPDATE/DELETE)                    │
+│                 Usage Ledger                        │
+│  journal_id, budget_id?, currency, amount           │
+│  meter_source, ref_id, rating_metadata, timestamp   │
+│  (append-only — no UPDATE/DELETE)                   │
+└──────────────┬──────────────────────────────────────┘
+               │ projected into
+┌──────────────▼──────────────────────────────────────┐
+│                    Budget                           │
+│  subject: (session | agent | user | org)            │
+│  currency: (usd | tokens | credits | custom)        │
+│  limit / soft_limit / period                        │
+│  balance: denormalized current snapshot             │
 └─────────────────────────────────────────────────────┘
 
 ┌─────────────────────────┐    ┌──────────────────────┐
@@ -59,13 +67,21 @@ A spending cap bound to a **subject** (who) in a **currency** (what unit). Multi
 
 **Currencies**: Strings (not enum) — new currencies added without migrations. Built-in: `usd` (via LlmModelProfile cost lookup), `tokens` (raw count), `credits` (1 credit = 1000 tokens).
 
-**Balance**: `limit - SUM(debits) + SUM(credits)`. Denormalized on `budgets.balance`, updated atomically with each ledger insert (Postgres: `SELECT ... FOR UPDATE` in transaction; in-memory: lock + update).
+**Balance**: `limit - SUM(debits) + SUM(credits)`. Denormalized on `budgets.balance`, updated atomically with each budget-scoped ledger insert (Postgres: transaction + `SELECT ... FOR UPDATE`; in-memory: lock + update).
 
 **Status lifecycle**: `active` → `paused` (soft limit reached) → `exhausted` (balance ≤ 0) → `disabled` (soft-deleted). Budget can be resumed by top-up or limit increase.
 
-### Ledger Entry
+### Usage Journal
 
-Immutable, append-only record of consumption or credit. Positive = debit, negative = credit (top-up/refund). Protected by `prevent_event_mutation()` trigger in Postgres.
+Immutable raw activity fact. Current writers:
+- `llm_generation` from `llm.generation` events
+- synthetic adjustment rows for budget top-ups / manual compatibility writes
+
+The journal stores scope (`org_id`, `user_id`, `principal_id`, `session_id`, `agent_id`, `harness_id`) plus raw `measures` and free-form `metadata`.
+
+### Usage Ledger
+
+Immutable, append-only rated posting derived from a journal row. Positive = debit, negative = credit (top-up/refund). Each ledger row links back to `journal_id`; budget-scoped postings also carry `budget_id`. Protected by append-only triggers in Postgres.
 
 ## Evaluation Pipeline
 
@@ -78,7 +94,9 @@ llm.generation event arrives
 BudgetService.on_event() (EventListener)
   │
   ▼
-Extract tokens: input_tokens + output_tokens
+INSERT usage_journal row
+  kind=llm_generation
+  measures={input_tokens, output_tokens, total_tokens}
   │
   ▼
 Look up session → find active budgets in hierarchy
@@ -91,7 +109,8 @@ compute_debit(currency, tokens, model, provider)
   │  "credits" → tokens / 1000
   │
   ▼
-INSERT ledger entry + UPDATE budget.balance (atomic)
+INSERT usage_ledger row (journal_id -> budget_id)
+  + UPDATE budget.balance (atomic)
   │
   ▼
 evaluate_rules(budget)
@@ -106,7 +125,7 @@ Execute action (set budget status)
 
 **Post-hoc enforcement**: Budget checks happen after each metered event, not before. This avoids blocking the LLM hot path. Minor overshoot on the last generation is acceptable and expected.
 
-**Worker integration**: The worker checks `BudgetCheckResult` between atoms via gRPC. When a budget is `paused` or `exhausted`, the turn loop stops scheduling the next atom.
+**Worker integration**: The worker checks `BudgetCheckResult` between atoms via gRPC. When a budget is `paused` or `exhausted`, the turn loop stops scheduling the next atom. Current implementation resolves all four hierarchy levels (`session`, `agent`, `user`, `org`) from the session owner and org context before checking.
 
 ## Soft Enforcement: Pause
 
@@ -212,7 +231,7 @@ Everruns distinguishes two orthogonal concerns:
 
 | Concern | Capability | Source of truth | Enforcement |
 |---------|-----------|-----------------|-------------|
-| Platform-enforced limit | `budgeting` | Budgets table / ledger | Session paused/stopped automatically at exhaustion |
+| Platform-enforced limit | `budgeting` | Budgets table / usage ledger | Session paused/stopped automatically at exhaustion |
 | User-requested indicative target ("you have $7") | `self_budget` | Session cumulative usage (`get_session_info`) | None — agent adapts behavior via prompt guidance |
 
 The `self_budget` capability contributes prompt-only guidance. It ships no tools (cumulative usage is already exposed by `get_session_info` from the `session` capability, which is present in the Generic harness). The prompt:
@@ -234,7 +253,8 @@ File: `crates/core/src/capabilities/self_budget.rs`.
 | Question | Decision | Rationale |
 |----------|----------|-----------|
 | Pre-check vs post-check | Post-check (after event) | Avoids blocking hot path; minor overshoot acceptable |
-| Balance storage | Denormalized on `budgets` + append-only ledger | Fast reads; ledger is source of truth for reconciliation |
+| Raw activity vs rated usage | Split into `usage_journal` then `usage_ledger` | Preserves raw facts, enables replay/backfill, keeps pricing/rating separate |
+| Balance storage | Denormalized on `budgets` + append-only usage ledger | Fast reads; ledger is source of truth for reconciliation |
 | Currency as enum vs string | String | Extensible without migrations |
 | Budget scope | Per-subject with hierarchy | Flexible: session, agent, user, or org level |
 | Pause mechanism | Session status + turn loop yield | Reuses existing session lifecycle; non-destructive |
@@ -246,6 +266,7 @@ File: `crates/core/src/capabilities/self_budget.rs`.
 ## Future Work
 
 - **ToolCallMeter**, **DataProcessedMeter** — additional meters
+- **Externalized rating rules** — replace hardcoded Rust rating with configurable scripts/expressions
 - **Rolling/calendar period support** — balance resets on period boundary
 - **Valkey-cached balance** — for high-throughput without DB round-trip per check
 - **Budget analytics dashboard** — spend by model, by agent, over time

--- a/specs/usage-tracking.md
+++ b/specs/usage-tracking.md
@@ -55,9 +55,43 @@ Timeline:
 
 ## Data Model
 
-### llm_generations Table (Source of Truth)
+### usage_journal / usage_ledger (Generic Metering Path)
 
-Every LLM call is recorded in the `llm_generations` table:
+Budgeting and future cross-resource metering use a generic raw-fact journal plus rated ledger:
+
+```sql
+CREATE TABLE usage_journal (
+    id UUID PRIMARY KEY,
+    org_id BIGINT NOT NULL,
+    kind TEXT NOT NULL,            -- llm_generation, top_up, ...
+    event_id UUID,
+    session_id UUID,
+    user_id UUID,
+    principal_id UUID,
+    agent_id UUID,
+    harness_id UUID,
+    measures JSONB NOT NULL,       -- raw usage facts
+    metadata JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE usage_ledger (
+    id UUID PRIMARY KEY,
+    journal_id UUID NOT NULL REFERENCES usage_journal(id),
+    budget_id UUID,                -- set for budget-scoped postings
+    org_id BIGINT NOT NULL,
+    currency TEXT NOT NULL,        -- usd, tokens, credits, ...
+    amount DOUBLE PRECISION NOT NULL,
+    meter_source TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL
+);
+```
+
+`usage_journal` captures raw facts. `usage_ledger` stores rated postings derived from those facts. Budget balances are projections over budget-scoped ledger rows.
+
+### llm_generations Table (LLM Analytics Projection)
+
+LLM analytics still maintain a specialized `llm_generations` table for token-centric querying and denormalized session/agent totals:
 
 ```sql
 CREATE TABLE llm_generations (
@@ -94,10 +128,12 @@ total_cache_creation_tokens BIGINT DEFAULT 0
 ### Data Flow
 
 ```
-LLM Response → llm.generation event → Trigger:
-  1. INSERT into llm_generations (source of truth)
-  2. UPDATE sessions totals
-  3. UPDATE agents totals
+LLM Response → llm.generation event → Listeners:
+  1. INSERT into usage_journal (raw metering fact)
+  2. Rate into usage_ledger when budgets/metering apply
+  3. INSERT into llm_generations (LLM analytics projection)
+  4. UPDATE sessions totals
+  5. UPDATE agents totals
 ```
 
 ## API Response


### PR DESCRIPTION
## What
Add a generic `usage_journal` and `usage_ledger` pipeline for budgeting, then project budget balance/status from that ledger instead of writing directly to a budget-specific journal.

## Why
The previous model mixed raw usage facts with budget-specific accounting. This split preserves immutable source facts, keeps rated postings generic, and makes replay/backfill or future externalized rating logic possible.

## How
- Add migration `020_budget_journal_ledger.sql` with append-only `usage_journal` and `usage_ledger` tables plus backfill from legacy `budget_ledger`
- Add storage models/backends/repositories for journal and ledger, while keeping compatibility wrappers for existing budget write paths
- Update `BudgetService` to write `llm_generation` journal rows, emit rated ledger rows, and resolve session/agent/user/org hierarchy from the real session context
- Update worker-side budget checks to use the same hierarchy helper
- Update budgeting and usage-tracking specs, and add tests for journal linkage plus user/org hierarchy resolution

## Risk
- Medium
- Main risk is migration/runtime behavior in PostgreSQL because new tables are introduced and legacy budget history is backfilled into the new schema. Existing budget API behavior is preserved through compatibility wrappers.

## Security
- Threat categories reviewed: TM-TENANT, TM-API, TM-SQL, TM-DOS
- Findings and resolutions:
  - TM-TENANT: hierarchy resolution now derives user/org scope from the persisted session row instead of trusting only caller-provided IDs; repository reads remain org-scoped
  - TM-API / TM-SQL: all new writes use existing typed models and parameterized sqlx queries; no dynamic SQL or new external input surfaces were added
  - TM-DOS: added indexes for journal/ledger lookup paths used by budget checks and ledger listing to keep the new reads bounded

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
