### PR TITLE
feat(mcp): add read-only query tool

### DIFF
--- a/crates/server/src/api/mcp_endpoint/catalog.rs
+++ b/crates/server/src/api/mcp_endpoint/catalog.rs
@@ -11,6 +11,12 @@ pub struct CatalogContext {
     pub caller: everruns_core::permissions::Caller,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolsetMode {
+    Full,
+    ReadOnly,
+}
+
 impl CatalogContext {
     /// Convert to a domain Ctx for inventory-registered command dispatch.
     pub fn to_domain_ctx(&self) -> crate::domains::common::Ctx {
@@ -42,9 +48,12 @@ impl CatalogContext {
 }
 
 /// Build a ScriptingToolSet from inventory-registered commands only.
-pub fn build_toolset(ctx: CatalogContext) -> ScriptingToolSet {
+pub fn build_toolset(ctx: CatalogContext, mode: ToolsetMode) -> ScriptingToolSet {
     let mut builder = ScriptingToolSet::builder("everruns")
-        .short_description("Everruns API operations as bash builtins")
+        .short_description(match mode {
+            ToolsetMode::Full => "Everruns API operations as bash builtins",
+            ToolsetMode::ReadOnly => "Read-only Everruns API operations as bash builtins",
+        })
         .limits(
             bashkit::ExecutionLimits::new()
                 .max_commands(500)
@@ -56,6 +65,9 @@ pub fn build_toolset(ctx: CatalogContext) -> ScriptingToolSet {
         );
 
     for desc in inventory::iter::<crate::domains::common::CommandDescriptor> {
+        if mode == ToolsetMode::ReadOnly && !(desc.read_only)() {
+            continue;
+        }
         let def = command_descriptor_to_def(desc);
         let callback = make_inventory_callback(desc, ctx.clone());
         builder = builder.async_tool(def, callback);

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -4,10 +4,11 @@
 // - JSON-RPC 2.0 over POST /mcp (Streamable HTTP, per MCP spec)
 // - Tier 1 tools: agent_run, session_send_message, session_get_status
 //   → Direct service calls, first-class support for the agent conversation loop
-// - Tier 2 tools: discover, execute
-//   → Backed by bashkit ScriptedTool with all API operations as builtins
+// - Tier 2 tools: discover, query, execute
+//   → Backed by bashkit ScriptedTool with API operations exposed as builtins
 //   → discover: uses ScriptedTool's built-in `discover` command
-//   → execute: runs bash scripts through ScriptedTool (all API ops available as commands)
+//   → query: runs bash scripts with the read-only subset of API ops
+//   → execute: runs bash scripts with the full API surface, including writes
 // - Tier 0 tools: me, list_organizations, switch_organization
 //   → Identity & org context tools for multi-org OAuth flows
 //   → MCP clients can't set cookies, so org selection is via explicit tool calls
@@ -599,6 +600,10 @@ async fn handle_tools_call(
                     Ok(org) => tool_discover(&arguments, &org, state).await,
                     Err(e) => Err(e),
                 },
+                "query" => match resolve_org_override(&arguments, auth_user, org, state).await {
+                    Ok(org) => tool_query(&arguments, &org, state).await,
+                    Err(e) => Err(e),
+                },
                 "execute" => match resolve_org_override(&arguments, auth_user, org, state).await {
                     Ok(org) => tool_execute(&arguments, &org, state).await,
                     Err(e) => Err(e),
@@ -1047,15 +1052,28 @@ async fn tool_discover(
         format!("discover --search '{}'", query.replace('\'', "'\\''"))
     };
 
-    let toolset = build_toolset(org, state);
+    let toolset = build_toolset(org, state, catalog::ToolsetMode::Full);
     execute_script(&toolset, &command, 10_000).await
 }
 
 // ============================================================================
-// Tier 2: execute — delegates to ScriptedTool
+// Tier 2: query/execute — delegate to ScriptedTool
 // ============================================================================
 
+async fn tool_query(args: &Value, org: &ResolvedOrg, state: &AppState) -> Result<String, String> {
+    tool_script(args, org, state, catalog::ToolsetMode::ReadOnly).await
+}
+
 async fn tool_execute(args: &Value, org: &ResolvedOrg, state: &AppState) -> Result<String, String> {
+    tool_script(args, org, state, catalog::ToolsetMode::Full).await
+}
+
+async fn tool_script(
+    args: &Value,
+    org: &ResolvedOrg,
+    state: &AppState,
+    mode: catalog::ToolsetMode,
+) -> Result<String, String> {
     let command = args
         .get("commands")
         .and_then(|v| v.as_str())
@@ -1071,7 +1089,7 @@ async fn tool_execute(args: &Value, org: &ResolvedOrg, state: &AppState) -> Resu
     // callers don't hit bashkit's "expected --flag" rejection.
     let rewritten = positional::rewrite(command, positional::positional_map());
 
-    let toolset = build_toolset(org, state);
+    let toolset = build_toolset(org, state, mode);
     execute_script(&toolset, &rewritten, timeout_ms).await
 }
 
@@ -1089,8 +1107,12 @@ fn catalog_context(org: &ResolvedOrg, state: &AppState) -> catalog::CatalogConte
 
 /// Build a ScriptingToolSet for the given org context.
 /// All scripted tools dispatch inventory-registered domain commands — no HTTP.
-fn build_toolset(org: &ResolvedOrg, state: &AppState) -> ScriptingToolSet {
-    catalog::build_toolset(catalog_context(org, state))
+fn build_toolset(
+    org: &ResolvedOrg,
+    state: &AppState,
+    mode: catalog::ToolsetMode,
+) -> ScriptingToolSet {
+    catalog::build_toolset(catalog_context(org, state), mode)
 }
 
 /// Execute a script through a ScriptingToolSet and return formatted output.

--- a/crates/server/src/api/mcp_endpoint/positional.rs
+++ b/crates/server/src/api/mcp_endpoint/positional.rs
@@ -1,4 +1,4 @@
-// Positional-argument rewriter for MCP `execute` commands.
+// Positional-argument rewriter for MCP `query`/`execute` commands.
 //
 // bashkit's flag parser rejects positional arguments (`expected --flag, got: X`).
 // LLMs naturally type `get_agent <id>` instead of `get_agent --id <id>`,
@@ -14,7 +14,7 @@
 use std::collections::HashMap;
 use std::sync::OnceLock;
 
-/// Positional map shared across all `tool_execute` calls. Built once from
+/// Positional map shared across all scripted MCP calls. Built once from
 /// inventory-registered commands.
 static POSITIONAL_MAP: OnceLock<HashMap<&'static str, &'static str>> = OnceLock::new();
 

--- a/crates/server/src/api/mcp_endpoint/tool_registry.rs
+++ b/crates/server/src/api/mcp_endpoint/tool_registry.rs
@@ -52,6 +52,7 @@ pub fn tool_definitions(
         session_send_message_tool(protocol_version, org_id_description),
         session_get_status_tool(protocol_version, org_id_description),
         discover_tool(protocol_version, org_id_description),
+        query_tool(protocol_version, org_id_description),
         execute_tool(protocol_version, org_id_description),
     ]
 }
@@ -365,7 +366,7 @@ fn discover_tool(protocol_version: &str, org_id_description: &str) -> McpEndpoin
         protocol_version,
         "discover",
         "Discover Operations",
-        "Search the Everruns API catalog to find available operations. Returns matching operations with description and parameters. Use all: true to list every operation grouped by category. The discovered operations are available as bash builtins in the execute tool.",
+        "Search the Everruns API catalog to find available operations. Returns matching operations with description and parameters. Use all: true to list every operation grouped by category. Read-only operations are available as bash builtins in query; the full catalog is available in execute.",
         object_schema(
             vec![
                 (
@@ -399,12 +400,54 @@ fn discover_tool(protocol_version: &str, org_id_description: &str) -> McpEndpoin
     )
 }
 
+fn query_tool(protocol_version: &str, org_id_description: &str) -> McpEndpointToolDefinition {
+    tool(
+        protocol_version,
+        "query",
+        "Query Commands",
+        "Execute a bash script in an environment where only read-only Everruns API operations are available as built-in commands. Supports pipes, variables, loops, conditionals, jq, and direct access to safe builtins. Mutating commands are intentionally unavailable.",
+        object_schema(
+            vec![
+                (
+                    "commands",
+                    json!({
+                        "type": "string",
+                        "description": "Bash script to execute. Only read-only API operations are available as built-in commands.",
+                        "minLength": 1
+                    }),
+                ),
+                (
+                    "timeout_ms",
+                    json!({
+                        "type": "integer",
+                        "description": "Execution timeout in milliseconds (default: 30000, max: 60000).",
+                        "minimum": 1,
+                        "maximum": 60000
+                    }),
+                ),
+                (
+                    "organization_id",
+                    json!({
+                        "type": "string",
+                        "description": org_id_description,
+                        "pattern": "^org_[0-9a-f]{32}$"
+                    }),
+                ),
+            ],
+            vec!["commands"],
+        ),
+        None,
+        Some(read_only_annotations()),
+        65_000,
+    )
+}
+
 fn execute_tool(protocol_version: &str, org_id_description: &str) -> McpEndpointToolDefinition {
     tool(
         protocol_version,
         "execute",
         "Execute Commands",
-        "Execute a bash script in an environment where every Everruns API operation is a built-in command. Supports pipes, variables, loops, conditionals, jq, and direct access to the catalog builtins. Use discover first if you need to find command names.",
+        "Execute a bash script in an environment where every Everruns API operation is a built-in command, including operations with side effects. Supports pipes, variables, loops, conditionals, jq, and direct access to the full builtin set. Prefer query for read-only inspection; use execute when you need create/update/delete or other mutating operations.",
         object_schema(
             vec![
                 (

--- a/crates/server/src/domains/agents/commands.rs
+++ b/crates/server/src/domains/agents/commands.rs
@@ -823,6 +823,10 @@ impl Command for PreviewAgent {
         }
     }
 
+    fn read_only() -> bool {
+        true
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<AgentPreview, CommandError> {
         crate::services::scoped_mcp::validate_scoped_mcp_servers(&self.mcp_servers)
             .map_err(classify_anyhow)?;

--- a/crates/server/src/domains/common.rs
+++ b/crates/server/src/domains/common.rs
@@ -357,6 +357,14 @@ pub trait Command: DeserializeOwned + Send + 'static + CommandSchema {
     /// Static metadata — drives MCP catalog generation.
     fn meta() -> CommandMeta;
 
+    /// Whether this command is read-only when exposed through scripted MCP tools.
+    ///
+    /// Defaults to GET-only. Override for read-only POST-style helpers such as
+    /// previews or search operations that accept structured bodies.
+    fn read_only() -> bool {
+        matches!(Self::meta().method, "GET")
+    }
+
     /// Policy to check before execution. None = public/no auth.
     fn policy() -> Option<&'static Policy> {
         None
@@ -507,6 +515,7 @@ type DispatchFn =
 
 pub struct CommandDescriptor {
     pub meta: fn() -> CommandMeta,
+    pub read_only: fn() -> bool,
     pub positional_arg: fn() -> Option<&'static str>,
     pub param_schema: fn() -> Value,
     pub dispatch: DispatchFn,
@@ -519,6 +528,7 @@ impl CommandDescriptor {
     pub const fn of<C: Command>() -> Self {
         Self {
             meta: C::meta,
+            read_only: C::read_only,
             positional_arg: C::positional_arg,
             param_schema: <C as Command>::param_schema,
             dispatch: dispatch_for::<C>,

--- a/crates/server/src/domains/harnesses/commands.rs
+++ b/crates/server/src/domains/harnesses/commands.rs
@@ -699,6 +699,10 @@ impl Command for PreviewHarness {
         }
     }
 
+    fn read_only() -> bool {
+        true
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<HarnessPreview, CommandError> {
         let parent = match self.parent_harness_id {
             Some(parent_id) => q::resolve_effective(ctx.db.as_ref(), ctx.org_id(), parent_id)

--- a/crates/server/src/domains/session_files/commands.rs
+++ b/crates/server/src/domains/session_files/commands.rs
@@ -456,6 +456,10 @@ impl Command for GrepSessionFiles {
         }
     }
 
+    fn read_only() -> bool {
+        true
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<Vec<GrepResult>, CommandError> {
         let session_id = q::parse_session_id(&self.session_id)?;
         q::verify_session(ctx, session_id).await?;
@@ -499,6 +503,10 @@ impl Command for StatSessionFile {
             method: "POST",
             path: "/v1/sessions/{session_id}/fs/_/stat",
         }
+    }
+
+    fn read_only() -> bool {
+        true
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<FileStat, CommandError> {

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -296,7 +296,7 @@ async fn test_mcp_tools_list() {
     let tools = resp["result"]["tools"]
         .as_array()
         .expect("Expected tools array");
-    assert_eq!(tools.len(), 8, "Expected 8 MCP tools");
+    assert_eq!(tools.len(), 9, "Expected 9 MCP tools");
 
     let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
     assert!(names.contains(&"me"), "Missing me");
@@ -318,6 +318,7 @@ async fn test_mcp_tools_list() {
         "Missing session_get_status"
     );
     assert!(names.contains(&"discover"), "Missing discover");
+    assert!(names.contains(&"query"), "Missing query");
     assert!(names.contains(&"execute"), "Missing execute");
 
     // Verify each tool has inputSchema
@@ -356,6 +357,24 @@ async fn test_mcp_tools_list() {
     );
     assert!(discover.as_object().unwrap().get("outputSchema").is_none());
     assert!(discover.as_object().unwrap().get("_meta").is_none());
+
+    let query = tools.iter().find(|tool| tool["name"] == "query").unwrap();
+    assert_eq!(query["title"], "Query Commands");
+    assert_eq!(query["annotations"]["readOnlyHint"], true);
+    assert_eq!(query["annotations"]["destructiveHint"], false);
+    assert_eq!(query["annotations"]["idempotentHint"], true);
+    assert_eq!(query["annotations"]["openWorldHint"], false);
+    assert!(query.as_object().unwrap().get("outputSchema").is_none());
+    assert!(query.as_object().unwrap().get("_meta").is_none());
+
+    let execute = tools.iter().find(|tool| tool["name"] == "execute").unwrap();
+    assert_eq!(execute["title"], "Execute Commands");
+    assert_eq!(execute["annotations"]["readOnlyHint"], false);
+    assert_eq!(execute["annotations"]["destructiveHint"], true);
+    assert_eq!(execute["annotations"]["idempotentHint"], false);
+    assert_eq!(execute["annotations"]["openWorldHint"], true);
+    assert!(execute.as_object().unwrap().get("outputSchema").is_none());
+    assert!(execute.as_object().unwrap().get("_meta").is_none());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -990,8 +1009,66 @@ async fn test_mcp_discover_capabilities() {
 }
 
 // ============================================================================
-// Tier 2: execute — requires a real TCP server for HTTP callbacks
+// Tier 2: query/execute scripted tools
 // ============================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_query_list_harnesses() {
+    let server = TestServer::in_memory().await;
+    let resp = mcp_tool_call(&server, "query", json!({ "commands": "list_harnesses" })).await;
+    assert!(
+        !tool_is_error(&resp),
+        "query list_harnesses failed: {}",
+        tool_text(&resp)
+    );
+
+    let result = tool_json(&resp);
+    let harnesses = result.as_array().expect("Expected harnesses array");
+    assert!(!harnesses.is_empty(), "Should have seed harnesses");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_query_allows_read_only_post_helpers() {
+    let server = TestServer::in_memory().await;
+    let resp = mcp_tool_call(
+        &server,
+        "query",
+        json!({ "commands": "preview_agent --system_prompt 'Preview via query'" }),
+    )
+    .await;
+    assert!(
+        !tool_is_error(&resp),
+        "query preview_agent failed: {}",
+        tool_text(&resp)
+    );
+
+    let result = tool_json(&resp);
+    assert_eq!(result["system_prompt"], "Preview via query");
+    assert!(result["tools"].is_array());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_query_rejects_mutating_commands() {
+    let server = TestServer::in_memory().await;
+    let resp = mcp_tool_call(
+        &server,
+        "query",
+        json!({
+            "commands": "create_agent --name 'query-should-fail' --display_name 'Query Should Fail' --system_prompt 'nope'"
+        }),
+    )
+    .await;
+    assert!(
+        tool_is_error(&resp),
+        "query create_agent unexpectedly succeeded"
+    );
+
+    let text = tool_text(&resp);
+    assert!(
+        text.contains("create_agent"),
+        "Expected command name in error, got: {text}"
+    );
+}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mcp_execute_health_check() {

--- a/plugins/everruns/.claude-plugin/plugin.json
+++ b/plugins/everruns/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "everruns",
   "version": "0.1.0",
-  "description": "Interact with the Everruns agent platform — create and run agents, manage harnesses and sessions, browse the API catalog.",
+  "description": "Interact with the Everruns agent platform — inspect state with read-only queries, run side-effecting workflows, and manage agents, harnesses, and sessions.",
   "author": {
     "name": "Everruns",
     "url": "https://everruns.com"

--- a/plugins/everruns/.codex-plugin/plugin.json
+++ b/plugins/everruns/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "everruns",
   "version": "0.1.0",
-  "description": "Interact with the Everruns agent platform from Codex over MCP.",
+  "description": "Interact with the Everruns agent platform from Codex over MCP, with read-only `query` and full-access `execute` workflows.",
   "author": {
     "name": "Everruns",
     "url": "https://everruns.com"
@@ -20,8 +20,8 @@
   "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "Everruns",
-    "shortDescription": "Create and run Everruns agents from Codex over MCP",
-    "longDescription": "Bring the Everruns agent platform into Codex. Create and run agents, manage harnesses and sessions, browse the API catalog, and drive the full Everruns API through the bundled skill, slash commands, and MCP connection.",
+    "shortDescription": "Query or execute Everruns workflows from Codex over MCP",
+    "longDescription": "Bring the Everruns agent platform into Codex. Query Everruns state through the read-only `query` tool, use `execute` for workflows with side effects, manage harnesses and sessions, browse the API catalog, and drive the full platform through the bundled skill, slash commands, and MCP connection.",
     "developerName": "Everruns",
     "category": "Coding",
     "capabilities": [

--- a/plugins/everruns/README.md
+++ b/plugins/everruns/README.md
@@ -6,6 +6,8 @@ Claude Code and Codex.
 It wires the [Everruns](https://everruns.com) agent platform into local agent
 tools over MCP. The shared payload is the Everruns MCP server config, the
 `everruns` skill, and the slash commands for common session workflows.
+Use `query` for read-only inspection and `execute` for workflows that create,
+update, delete, or otherwise have side effects.
 
 - Product: <https://everruns.com>
 - Docs: <https://docs.everruns.com>

--- a/plugins/everruns/commands/agent-run.md
+++ b/plugins/everruns/commands/agent-run.md
@@ -3,7 +3,7 @@ description: Start a new session on an Everruns agent and send the first message
 argument-hint: "<agent_id_or_name> <message>"
 ---
 
-Start a session with `agent_run`; resolve agent name to id via `execute` if
+Start a session with `agent_run`; resolve agent name to id via `query` if
 needed. Print `session_id` and poll `session_get_status` once.
 
 Arguments: `$ARGUMENTS`

--- a/plugins/everruns/commands/discover.md
+++ b/plugins/everruns/commands/discover.md
@@ -4,6 +4,7 @@ argument-hint: "<query> | --all"
 ---
 
 Call the `discover` MCP tool. With `--all`, pass `all: true`; otherwise pass
-the text as `query`. See the `everruns` skill for examples.
+the text as `query`. Use `query` for read-only operations and `execute` for
+mutating workflows. See the `everruns` skill for examples.
 
 Arguments: `$ARGUMENTS`

--- a/plugins/everruns/commands/execute.md
+++ b/plugins/everruns/commands/execute.md
@@ -1,10 +1,11 @@
----
-description: Run a bash script against the Everruns API (every operation is a builtin)
+description: Run a bash script with full Everruns API access, including side effects
 argument-hint: "<bash script>"
 ---
 
 Call the `execute` MCP tool with the provided script as `commands`. Every
-Everruns API operation is a bash builtin; `jq` is available. See the
-`everruns` skill for the command inventory, patterns, and examples.
+Everruns API operation is a bash builtin; `jq` is available. Prefer `query`
+for read-only inspection and use `execute` when the script needs to create,
+update, delete, or trigger other side effects. See the `everruns` skill for
+the command inventory, patterns, and examples.
 
 Arguments: `$ARGUMENTS`

--- a/plugins/everruns/commands/query.md
+++ b/plugins/everruns/commands/query.md
@@ -1,0 +1,11 @@
+---
+description: Run a read-only bash script against the Everruns API
+argument-hint: "<bash script>"
+---
+
+Call the `query` MCP tool with the provided script as `commands`. Only
+read-only Everruns API operations are available as bash builtins; `jq` is
+available. Use `execute` instead when the script needs side effects. See the
+`everruns` skill for the command inventory, patterns, and examples.
+
+Arguments: `$ARGUMENTS`

--- a/plugins/everruns/skills/everruns/SKILL.md
+++ b/plugins/everruns/skills/everruns/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: everruns
-description: Reference for working with the Everruns agent platform (https://everruns.com) over MCP - core concepts, how to connect capabilities to agents and harnesses, and how to drive the API with the `discover` and `execute` tools. Use whenever the user asks about Everruns agents, harnesses, capabilities, sessions, models, or wants to call the Everruns API.
+description: Reference for working with the Everruns agent platform (https://everruns.com) over MCP - core concepts, how to connect capabilities to agents and harnesses, and how to drive the API with the `discover`, `query`, and `execute` tools. Use whenever the user asks about Everruns agents, harnesses, capabilities, sessions, models, or wants to call the Everruns API.
 ---
 
 # Everruns
 
 Everruns is a durable agentic harness engine. Docs:
 <https://docs.everruns.com>. This plugin talks to Everruns over MCP and exposes
-every API operation as a bash builtin inside the `execute` tool.
+read-only API operations as bash builtins inside `query` and the full API
+surface inside `execute`.
 
 If a user asks something Everruns-related, prefer the MCP tools over guessing.
 When the exact shape of an operation is unclear, call `discover` first.
@@ -75,15 +76,17 @@ agent-specific tools, or at the session level for one-off additions.
 | `session_send_message` | Follow-up user message in an existing session. |
 | `session_get_status` | Poll session status + latest agent message + recent events. Supports `since_event_id` for incremental polling and `event_types` to filter. |
 | `discover` | Search the API catalog. Returns operation name, category, description, parameters. |
-| `execute` | Run a bash script where every Everruns API operation is a builtin. `jq` is available. This is how you do anything beyond the fixed MCP tools above. |
+| `query` | Run a bash script where only read-only Everruns API operations are builtins. `jq` is available. Prefer this for inspection, search, preview, export, grep, and status checks. |
+| `execute` | Run a bash script where every Everruns API operation is a builtin. `jq` is available. Use this when the workflow needs side effects. |
 
-The `execute` tool is the catch-all. Prefer it over asking the user to hit the
-REST API manually.
+Default to `query` for reads. Switch to `execute` only when the workflow needs
+to create, update, delete, or trigger actions.
 
-## Using `discover` and `execute`
+## Using `discover`, `query`, and `execute`
 
-`discover` surfaces what is available; `execute` runs it. Always use
-`discover` if you are unsure which builtin to call.
+`discover` surfaces what is available, `query` runs the read-only subset, and
+`execute` runs the full catalog. Always use `discover` if you are unsure which
+builtin to call.
 
 ### Finding operations
 
@@ -97,83 +100,78 @@ discover { "all": true }
 
 ### Running operations
 
-Inside `execute`, each operation becomes a bash builtin. Pass parameters as
+Inside `query` and `execute`, each available operation becomes a bash builtin.
+Pass parameters as
 `--name value` flags. Builtins emit JSON on stdout.
 
 Rules of thumb:
 
 - Pipe through `jq` to extract fields.
 - Capture ids in shell variables so follow-up calls stay readable.
-- Prefer one `execute` call that does the whole workflow over several
-  round-trips.
+- Prefer `query` when a read-only path is enough.
+- Prefer one scripted call that does the whole workflow over several round-trips.
 - `<cmd> --help` prints usage if you are uncertain about flags.
+- If a builtin is missing in `query`, it is probably mutating; switch to `execute`.
 
 ### Examples
 
 **List agents by name.**
 
 ```bash
-list_agents | jq '.data[] | {id, name, default_model_id}'
+query { "commands": "list_agents | jq '.data[] | {id, name, default_model_id}'" }
 ```
 
 **Create a harness and an agent, then run the agent.**
 
 ```bash
-HID=$(create_harness --name "research" --system_prompt "Research assistant." | jq -r .id)
-AID=$(create_agent --name "researcher" --system_prompt "You are a careful researcher." | jq -r .id)
-agent_run --agent_id "$AID" --message "Summarize the latest MCP spec."
+execute { "commands": "HID=$(create_harness --name \"research\" --system_prompt \"Research assistant.\" | jq -r .id)\nAID=$(create_agent --name \"researcher\" --system_prompt \"You are a careful researcher.\" | jq -r .id)\nagent_run --agent_id \"$AID\" --message \"Summarize the latest MCP spec.\"" }
 ```
 
 `agent_run` uses the default harness. To pin `$HID` (or any specific harness)
 to the session, create the session directly:
 
 ```bash
-SID=$(create_session --harness_id "$HID" --agent_id "$AID" | jq -r .id)
-create_message --session_id "$SID" \
-  --message '{"role":"user","content":[{"type":"text","text":"Summarize the latest MCP spec."}]}'
+execute { "commands": "SID=$(create_session --harness_id \"$HID\" --agent_id \"$AID\" | jq -r .id)\ncreate_message --session_id \"$SID\" --message '{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"Summarize the latest MCP spec.\"}]}'" }
 ```
 
 **Attach a capability to an agent.**
 
 ```bash
-# Discover the capability id
-list_capabilities | jq '.data[] | {id, name}'
+query { "commands": "list_capabilities | jq '.data[] | {id, name}'" }
+```
 
-# Update the agent
-update_agent --id "$AID" --capabilities '[{"ref":"web_fetch"}]'
+```bash
+execute { "commands": "update_agent --id \"$AID\" --capabilities '[{\"ref\":\"web_fetch\"}]'" }
 ```
 
 **Poll a session until it idles.**
 
 ```bash
-SID=session_abc...
-while true; do
-  STATUS=$(get_session --session_id "$SID" | jq -r .status)
-  echo "status=$STATUS"
-  [ "$STATUS" = "idle" ] && break
-  sleep 2
-done
-list_messages --session_id "$SID" | jq '.data[-1]'
+query { "commands": "SID=session_abc...\nwhile true; do\n  STATUS=$(get_session --session_id \"$SID\" | jq -r .status)\n  echo \"status=$STATUS\"\n  [ \"$STATUS\" = \"idle\" ] && break\n  sleep 2\ndone\nlist_messages --session_id \"$SID\" | jq '.data[-1]'" }
 ```
 
 **Iterate over agents.**
 
 ```bash
-list_agents | jq -r '.data[].id' | while read id; do
-  get_agent --id "$id" | jq '{id, name, harness_id}'
-done
+query { "commands": "list_agents | jq -r '.data[].id' | while read id; do\n  get_agent --id \"$id\" | jq '{id, name, harness_id}'\ndone" }
 ```
 
 **Add an MCP server (becomes a virtual capability).**
 
 ```bash
-create_mcp_server --name "jira" --url "https://mcp.example.com/jira" --auth_mode oauth
+execute { "commands": "create_mcp_server --name \"jira\" --url \"https://mcp.example.com/jira\" --auth_mode oauth" }
+```
+
+### Raw builtin examples
+
+```bash
+list_agents | jq '.data[] | {id, name, default_model_id}'
 ```
 
 ### Defaults and limits
 
-- `execute` timeout defaults to 30 s, max 60 s. For long workflows, split them
-  into multiple calls.
+- `query` and `execute` time out after 30 s by default, max 60 s. For long
+  workflows, split them into multiple calls.
 - `list_*` operations default to `--limit 20` (max 100) with `--offset` for
   paging.
 - Every org-scoped operation accepts `--organization_id org_{32-hex}` to target
@@ -183,9 +181,11 @@ create_mcp_server --name "jira" --url "https://mcp.example.com/jira" --auth_mode
 
 - **401 / OAuth loop** - The host handles the OAuth 2.1 flow. If it fails,
   sign out at <https://everruns.com> and retry so a fresh client registers.
+- **`tool not found` in query** - `query` only exposes read-only builtins. If
+  the command mutates state, switch to `execute`.
 - **`tool not found` in execute** - run `discover { "all": true }` to confirm
   the builtin exists under the expected name.
-- **Operation unclear** - `<cmd> --help` inside `execute` prints usage;
+- **Operation unclear** - `<cmd> --help` inside `query` or `execute` prints usage;
   `discover { "query": "<cmd>" }` shows parameter types.
 - **Wrong org** - `me` reports the active org; pass `--organization_id`
   explicitly on each call to override.

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -48,7 +48,7 @@ SSE responses under `/api/*` must disable proxy buffering.
 |--------|------|-------------|
 | POST | `/mcp` | MCP server (Streamable HTTP transport, JSON-RPC 2.0) |
 
-Exposes Everruns as an MCP server. Tier 1 tools (`agent_run`, `session_send_message`, `session_get_status`) handle the agent conversation loop via direct service calls. Tier 2 tools (`discover`, `execute`) are backed by a bashkit `ScriptedTool` with all API operations registered as builtins — run `discover --categories` to list them, or call them directly in bash scripts via `execute`. See `crates/server/src/api/mcp_endpoint/mod.rs` for implementation.
+Exposes Everruns as an MCP server. Tier 1 tools (`agent_run`, `session_send_message`, `session_get_status`) handle the agent conversation loop via direct service calls. Tier 2 tools (`discover`, `query`, `execute`) are backed by a bashkit `ScriptedTool`: `query` exposes the read-only subset of API operations, while `execute` exposes the full catalog including writes. Run `discover --categories` to list them. See `crates/server/src/api/mcp_endpoint/mod.rs` for implementation.
 
 ### Well-Known Endpoints
 

--- a/specs/domains.md
+++ b/specs/domains.md
@@ -123,14 +123,19 @@ inventory::collect!(CommandDescriptor);
 Adding a new command: implement `Command` for a struct, add `inventory::submit!`
 at the bottom. The catalog auto-updates. No other files to touch.
 
-### MCP `execute` positional args
+### MCP `query`/`execute` positional args
 
 `Command::positional_arg()` lets a command opt in to accepting one positional
-argument under MCP's `execute` tool (bashkit). Returning `Some("id")` on
+argument under MCP's scripted MCP tools (`query` and `execute`, both backed by
+bashkit). Returning `Some("id")` on
 `get_agent` means callers can write `get_agent <id>` instead of
 `get_agent --id <id>`; the mcp_endpoint rewrites the command string at
 statement boundaries before bashkit's flag parser runs. Only opt in when the
 command has exactly one required primary-key-like parameter. See EVE-323.
+
+`Command::read_only()` controls whether the command is exposed through the
+read-only MCP `query` tool. The default is GET-only; override it for safe
+POST-style commands such as previews or structured search helpers.
 
 ## Writing a Command
 
@@ -216,10 +221,12 @@ automatic HTTP error mapping.
 ## MCP Dispatch
 
 Domain commands are exposed automatically as bash builtins inside the MCP
-`execute` tool. The MCP `build_toolset` function in
+scripted tools. The MCP `build_toolset` function in
 `crates/server/src/api/mcp_endpoint/catalog.rs` iterates inventory-registered
 descriptors:
 
+- `query` filters the command registry to commands whose `read_only()` returns
+  true; `execute` exposes the full catalog.
 - `CatalogContext::to_domain_ctx()` constructs the domain `Ctx` from the
   MCP `AppState` (db, capability_service, encryption).
 - Adding `inventory::submit! { CommandDescriptor::of::<Cmd>() }` makes the

--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -328,7 +328,7 @@ MCP clients authenticate via OAuth 2.1 Bearer tokens, which don't carry org cont
 
 ### Per-Call `organization_id` Override
 
-All org-scoped tools (`agent_run`, `session_send_message`, `session_get_status`, `execute`) accept an optional `organization_id` parameter (format: `org_{32-hex}`). When provided:
+All org-scoped tools (`agent_run`, `session_send_message`, `session_get_status`, `query`, `execute`) accept an optional `organization_id` parameter (format: `org_{32-hex}`). When provided:
 
 1. User membership is validated against the database (not stale JWT claims)
 2. A `ResolvedOrg` is constructed for the target org

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -409,7 +409,7 @@ fn authorizer(action: AuthAction) -> Authorization {
 | TM-TOOL-016 | Browserless timeout DoS | Medium | All wait/timeout values capped at 120s; prevents unbounded resource consumption | MITIGATED |
 | TM-TOOL-017 | Browserless API token in logs | Medium | CDP debug logging redacts token from WebSocket URLs before logging | MITIGATED |
 | TM-TOOL-018 | MCP server SSRF via configured server URL | High | MCP server URLs are validated on create/update and re-validated at execution time; private/internal hosts and metadata endpoints blocked | MITIGATED |
-| TM-TOOL-019 | MCP `execute` positional-arg rewrite injection | Low | Rewriter only inserts compile-time `--<flag>` tokens at statement-start boundaries, respects quotes/escapes/comments, and never modifies or reorders user bytes. Flag names come from the command registry, not user input. See EVE-323. | MITIGATED |
+| TM-TOOL-019 | MCP `query`/`execute` positional-arg rewrite injection | Low | Rewriter only inserts compile-time `--<flag>` tokens at statement-start boundaries, respects quotes/escapes/comments, and never modifies or reorders user bytes. Flag names come from the command registry, not user input. See EVE-323. | MITIGATED |
 
 ### Mitigation Details
 


### PR DESCRIPTION
## What
Add a read-only MCP `query` tool alongside `execute`, keep the same scripted input shape, and update plugin/docs copy so the two are clearly distinguished.

## Why
`execute` can trigger side effects, so clients need a separate read-only path with accurate MCP hints for inspection workflows.

## How
- add `Command::read_only()` metadata and mark safe POST-style helpers such as previews/search-like commands as query-safe overrides
- split the scripted MCP toolset into read-only `query` and full-access `execute`, and update tool descriptions/annotations accordingly
- add MCP regression tests plus plugin/spec documentation for the new tool split

## Risk
- Medium
- Main risk: a mutating builtin could leak into `query` or the hints could drift from enforcement. Mitigated by server-side filtering and dedicated tests.

## Security
- Threat categories reviewed: TM-TOOL, TM-API, TM-BASH
- Findings and resolutions:
  - New MCP surface could imply read-only behavior without real enforcement. Resolved by filtering the scripted builtin registry server-side via `Command::read_only()`.
  - Some safe read-style POST helpers still need to work in `query`. Resolved with explicit `read_only()` overrides and regression coverage.
  - The positional rewrite path applies to both scripted tools. Updated threat-model/docs wording to cover both `query` and `execute`.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
