### PR TITLE
fix(api): return round-trippable image ids

### DIFF
--- a/crates/server/src/api/images.rs
+++ b/crates/server/src/api/images.rs
@@ -24,7 +24,6 @@ use serde::{Deserialize, Serialize};
 use std::io::Cursor;
 use std::sync::Arc;
 use utoipa::ToSchema;
-use uuid::Uuid;
 
 // ============================================
 // Constants
@@ -46,7 +45,8 @@ const ALLOWED_CONTENT_TYPES: &[&str] = &["image/png", "image/jpeg", "image/gif",
 /// Image metadata (without binary data)
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ImageInfo {
-    pub id: Uuid,
+    #[schema(value_type = String, example = "img_01933b5a00007000800000000000001")]
+    pub id: ImageId,
     pub filename: String,
     pub content_type: String,
     pub size_bytes: i64,
@@ -57,7 +57,8 @@ pub struct ImageInfo {
 /// Image upload response
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ImageUploadResponse {
-    pub id: Uuid,
+    #[schema(value_type = String, example = "img_01933b5a00007000800000000000001")]
+    pub id: ImageId,
     pub filename: String,
     pub content_type: String,
     pub size_bytes: i64,
@@ -280,7 +281,7 @@ pub async fn upload_image(
     Ok((
         StatusCode::CREATED,
         Json(ImageUploadResponse {
-            id: row.id.uuid(),
+            id: row.id,
             filename: row.filename,
             content_type: row.content_type,
             size_bytes: row.size_bytes,
@@ -320,7 +321,7 @@ pub async fn list_images(
     let images: Vec<ImageInfo> = rows
         .into_iter()
         .map(|row| ImageInfo {
-            id: row.id.uuid(),
+            id: row.id,
             filename: row.filename,
             content_type: row.content_type,
             size_bytes: row.size_bytes,
@@ -486,6 +487,7 @@ pub async fn delete_image(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_is_valid_content_type() {
@@ -538,5 +540,38 @@ mod tests {
             Some(ImageFormat::WebP)
         ));
         assert!(format_from_content_type("image/svg+xml").is_none());
+    }
+
+    #[test]
+    fn test_image_info_serializes_prefixed_id() {
+        let image_id = ImageId::from_seed(1);
+        let info = ImageInfo {
+            id: image_id,
+            filename: "upload.png".to_string(),
+            content_type: "image/png".to_string(),
+            size_bytes: 42,
+            metadata: json!({"session_id": "session_123"}),
+            created_at: Utc::now(),
+        };
+
+        let value = serde_json::to_value(info).expect("image info should serialize");
+
+        assert_eq!(value["id"], json!(image_id.to_string()));
+    }
+
+    #[test]
+    fn test_image_upload_response_serializes_prefixed_id() {
+        let image_id = ImageId::from_seed(2);
+        let response = ImageUploadResponse {
+            id: image_id,
+            filename: "upload.png".to_string(),
+            content_type: "image/png".to_string(),
+            size_bytes: 42,
+            created_at: Utc::now(),
+        };
+
+        let value = serde_json::to_value(response).expect("upload response should serialize");
+
+        assert_eq!(value["id"], json!(image_id.to_string()));
     }
 }

--- a/crates/server/src/api/images.rs
+++ b/crates/server/src/api/images.rs
@@ -45,7 +45,14 @@ const ALLOWED_CONTENT_TYPES: &[&str] = &["image/png", "image/jpeg", "image/gif",
 /// Image metadata (without binary data)
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ImageInfo {
-    #[schema(value_type = String, example = "img_01933b5a00007000800000000000001")]
+    /// ID of the uploaded image (format: img_{32-hex})
+    #[schema(
+        value_type = String,
+        pattern = "^img_[0-9a-fA-F]{32}$",
+        min_length = 36,
+        max_length = 36,
+        example = "img_01933b5a00007000800000000000001"
+    )]
     pub id: ImageId,
     pub filename: String,
     pub content_type: String,
@@ -57,7 +64,14 @@ pub struct ImageInfo {
 /// Image upload response
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ImageUploadResponse {
-    #[schema(value_type = String, example = "img_01933b5a00007000800000000000001")]
+    /// ID of the uploaded image (format: img_{32-hex})
+    #[schema(
+        value_type = String,
+        pattern = "^img_[0-9a-fA-F]{32}$",
+        min_length = 36,
+        max_length = 36,
+        example = "img_01933b5a00007000800000000000001"
+    )]
     pub id: ImageId,
     pub filename: String,
     pub content_type: String,

--- a/crates/server/src/domains/images/queries.rs
+++ b/crates/server/src/domains/images/queries.rs
@@ -11,7 +11,7 @@ pub fn parse_image_id(input: &str) -> Result<ImageId, CommandError> {
 
 pub fn row_to_image_info(row: ImageInfoRow) -> ImageInfo {
     ImageInfo {
-        id: row.id.uuid(),
+        id: row.id,
         filename: row.filename,
         content_type: row.content_type,
         size_bytes: row.size_bytes,

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -3295,3 +3295,52 @@ async fn test_delete_user_account() {
         .await
         .assert_status(StatusCode::NOT_FOUND);
 }
+
+#[tokio::test]
+async fn test_image_ids_round_trip_across_upload_list_and_get() {
+    let server = TestServer::in_memory().await;
+    let boundary = "----everruns-image-upload";
+    let content_type = format!("multipart/form-data; boundary={boundary}");
+    let image_bytes = vec![0x89, 0x50, 0x4E, 0x47];
+    let mut body = Vec::new();
+    body.extend_from_slice(
+        format!(
+            "--{boundary}\r\n\
+Content-Disposition: form-data; name=\"file\"; filename=\"upload.png\"\r\n\
+Content-Type: image/png\r\n\r\n"
+        )
+        .as_bytes(),
+    );
+    body.extend_from_slice(&image_bytes);
+    body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+
+    let upload: Value = server
+        .request_raw(
+            axum::http::Method::POST,
+            "/v1/images",
+            vec![("content-type", content_type.as_str())],
+            body,
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let image_id = upload["id"].as_str().expect("upload image id");
+    assert!(
+        image_id.starts_with("img_"),
+        "upload should return public image id, got {image_id}"
+    );
+
+    let listed: Vec<Value> = server
+        .get("/v1/images")
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    assert_eq!(listed.len(), 1, "expected uploaded image to be listed");
+    assert_eq!(listed[0]["id"], upload["id"]);
+
+    server
+        .get(&format!("/v1/images/{image_id}"))
+        .await
+        .assert_status(StatusCode::OK);
+}

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -7893,10 +7893,10 @@
           "id": {
             "type": "string",
             "description": "ID of the uploaded image (format: img_{32-hex})",
-            "pattern": "^img_[0-9a-fA-F]{32}$",
+            "example": "img_01933b5a00007000800000000000001",
             "maxLength": 36,
             "minLength": 36,
-            "example": "img_01933b5a00007000800000000000001"
+            "pattern": "^img_[0-9a-fA-F]{32}$"
           },
           "metadata": {},
           "size_bytes": {
@@ -7929,10 +7929,10 @@
           "id": {
             "type": "string",
             "description": "ID of the uploaded image (format: img_{32-hex})",
-            "pattern": "^img_[0-9a-fA-F]{32}$",
+            "example": "img_01933b5a00007000800000000000001",
             "maxLength": 36,
             "minLength": 36,
-            "example": "img_01933b5a00007000800000000000001"
+            "pattern": "^img_[0-9a-fA-F]{32}$"
           },
           "size_bytes": {
             "type": "integer",

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -7892,7 +7892,7 @@
           },
           "id": {
             "type": "string",
-            "format": "uuid"
+            "example": "img_01933b5a00007000800000000000001"
           },
           "metadata": {},
           "size_bytes": {
@@ -7924,7 +7924,7 @@
           },
           "id": {
             "type": "string",
-            "format": "uuid"
+            "example": "img_01933b5a00007000800000000000001"
           },
           "size_bytes": {
             "type": "integer",

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -7892,6 +7892,10 @@
           },
           "id": {
             "type": "string",
+            "description": "ID of the uploaded image (format: img_{32-hex})",
+            "pattern": "^img_[0-9a-fA-F]{32}$",
+            "maxLength": 36,
+            "minLength": 36,
             "example": "img_01933b5a00007000800000000000001"
           },
           "metadata": {},
@@ -7924,6 +7928,10 @@
           },
           "id": {
             "type": "string",
+            "description": "ID of the uploaded image (format: img_{32-hex})",
+            "pattern": "^img_[0-9a-fA-F]{32}$",
+            "maxLength": 36,
+            "minLength": 36,
             "example": "img_01933b5a00007000800000000000001"
           },
           "size_bytes": {


### PR DESCRIPTION
## What
Return public `img_*` IDs from `POST /v1/images` and `GET /v1/images` instead of raw UUIDs.

## Why
The image list/upload responses were not round-trippable. Clients had to transform raw UUIDs into `img_*` IDs before calling get/delete/thumbnail routes, even though those routes already required the typed public ID format.

## How
Use `ImageId` in the image response DTOs and row mappers, add regression tests for serialization and HTTP round-tripping, and update the committed OpenAPI schema examples for the image ID fields.

## Risk
- Low
- Could affect clients that incorrectly depended on the leaked raw UUID format instead of the documented public image ID contract

## Security
- Threat categories reviewed: TM-API
- Findings and resolutions: The change removes raw storage UUID leakage from public image API responses and aligns all image endpoints on the same public identifier format. No auth, permission, or new input-surface changes.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)
