### PR TITLE
fix(media): preserve image IDs across RPC and API

### DIFF
--- a/crates/server/src/api/images.rs
+++ b/crates/server/src/api/images.rs
@@ -24,7 +24,6 @@ use serde::{Deserialize, Serialize};
 use std::io::Cursor;
 use std::sync::Arc;
 use utoipa::ToSchema;
-use uuid::Uuid;
 
 // ============================================
 // Constants
@@ -46,7 +45,8 @@ const ALLOWED_CONTENT_TYPES: &[&str] = &["image/png", "image/jpeg", "image/gif",
 /// Image metadata (without binary data)
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ImageInfo {
-    pub id: Uuid,
+    #[schema(value_type = String, example = "img_01933b5a00007000800000000000001")]
+    pub id: ImageId,
     pub filename: String,
     pub content_type: String,
     pub size_bytes: i64,
@@ -57,7 +57,8 @@ pub struct ImageInfo {
 /// Image upload response
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ImageUploadResponse {
-    pub id: Uuid,
+    #[schema(value_type = String, example = "img_01933b5a00007000800000000000001")]
+    pub id: ImageId,
     pub filename: String,
     pub content_type: String,
     pub size_bytes: i64,
@@ -280,7 +281,7 @@ pub async fn upload_image(
     Ok((
         StatusCode::CREATED,
         Json(ImageUploadResponse {
-            id: row.id.uuid(),
+            id: row.id,
             filename: row.filename,
             content_type: row.content_type,
             size_bytes: row.size_bytes,
@@ -320,7 +321,7 @@ pub async fn list_images(
     let images: Vec<ImageInfo> = rows
         .into_iter()
         .map(|row| ImageInfo {
-            id: row.id.uuid(),
+            id: row.id,
             filename: row.filename,
             content_type: row.content_type,
             size_bytes: row.size_bytes,
@@ -486,6 +487,7 @@ pub async fn delete_image(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_is_valid_content_type() {
@@ -538,5 +540,38 @@ mod tests {
             Some(ImageFormat::WebP)
         ));
         assert!(format_from_content_type("image/svg+xml").is_none());
+    }
+
+    #[test]
+    fn test_image_info_serializes_prefixed_id() {
+        let image_id = ImageId::from_seed(1);
+        let info = ImageInfo {
+            id: image_id,
+            filename: "upload.png".to_string(),
+            content_type: "image/png".to_string(),
+            size_bytes: 42,
+            metadata: json!({"session_id": "session_123"}),
+            created_at: Utc::now(),
+        };
+
+        let value = serde_json::to_value(info).expect("image info should serialize");
+
+        assert_eq!(value["id"], json!(image_id.to_string()));
+    }
+
+    #[test]
+    fn test_image_upload_response_serializes_prefixed_id() {
+        let image_id = ImageId::from_seed(2);
+        let response = ImageUploadResponse {
+            id: image_id,
+            filename: "upload.png".to_string(),
+            content_type: "image/png".to_string(),
+            size_bytes: 42,
+            created_at: Utc::now(),
+        };
+
+        let value = serde_json::to_value(response).expect("upload response should serialize");
+
+        assert_eq!(value["id"], json!(image_id.to_string()));
     }
 }

--- a/crates/server/src/domains/images/queries.rs
+++ b/crates/server/src/domains/images/queries.rs
@@ -11,7 +11,7 @@ pub fn parse_image_id(input: &str) -> Result<ImageId, CommandError> {
 
 pub fn row_to_image_info(row: ImageInfoRow) -> ImageInfo {
     ImageInfo {
-        id: row.id.uuid(),
+        id: row.id,
         filename: row.filename,
         content_type: row.content_type,
         size_bytes: row.size_bytes,

--- a/crates/server/src/grpc_service/mod.rs
+++ b/crates/server/src/grpc_service/mod.rs
@@ -645,7 +645,7 @@ impl WorkerServiceImpl {
     ) -> proto::StoredImageInfo {
         proto::StoredImageInfo {
             id: Some(proto::Uuid {
-                value: row.id.to_string(),
+                value: row.id.uuid().to_string(),
             }),
             filename: row.filename,
             content_type: row.content_type,

--- a/crates/server/src/grpc_service/tests.rs
+++ b/crates/server/src/grpc_service/tests.rs
@@ -24,6 +24,28 @@ async fn test_worker_service() -> WorkerServiceImpl {
 }
 
 #[test]
+fn test_image_info_row_to_proto_uses_raw_uuid_transport_value() {
+    let image_id = everruns_core::ImageId::new();
+    let proto = WorkerServiceImpl::image_info_row_to_proto(crate::storage::models::ImageInfoRow {
+        id: image_id,
+        org_id: everruns_core::DEFAULT_ORG_ID,
+        filename: "generated-image.png".to_string(),
+        content_type: "image/png".to_string(),
+        size_bytes: 128,
+        metadata: serde_json::json!({ "provider": "openai" }),
+        created_at: chrono::Utc::now(),
+    });
+
+    let serialized_id = proto
+        .id
+        .expect("stored image info should include an id")
+        .value;
+
+    assert_eq!(serialized_id, image_id.uuid().to_string());
+    assert_ne!(serialized_id, image_id.to_string());
+}
+
+#[test]
 fn test_interceptor_allows_when_no_token_configured() {
     let mut interceptor = GrpcAuthInterceptor::new(None);
     let request = Request::new(());

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -3295,3 +3295,52 @@ async fn test_delete_user_account() {
         .await
         .assert_status(StatusCode::NOT_FOUND);
 }
+
+#[tokio::test]
+async fn test_image_ids_round_trip_across_upload_list_and_get() {
+    let server = TestServer::in_memory().await;
+    let boundary = "----everruns-image-upload";
+    let content_type = format!("multipart/form-data; boundary={boundary}");
+    let image_bytes = vec![0x89, 0x50, 0x4E, 0x47];
+    let mut body = Vec::new();
+    body.extend_from_slice(
+        format!(
+            "--{boundary}\r\n\
+Content-Disposition: form-data; name=\"file\"; filename=\"upload.png\"\r\n\
+Content-Type: image/png\r\n\r\n"
+        )
+        .as_bytes(),
+    );
+    body.extend_from_slice(&image_bytes);
+    body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+
+    let upload: Value = server
+        .request_raw(
+            axum::http::Method::POST,
+            "/v1/images",
+            vec![("content-type", content_type.as_str())],
+            body,
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let image_id = upload["id"].as_str().expect("upload image id");
+    assert!(
+        image_id.starts_with("img_"),
+        "upload should return public image id, got {image_id}"
+    );
+
+    let listed: Vec<Value> = server
+        .get("/v1/images")
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    assert_eq!(listed.len(), 1, "expected uploaded image to be listed");
+    assert_eq!(listed[0]["id"], upload["id"]);
+
+    server
+        .get(&format!("/v1/images/{image_id}"))
+        .await
+        .assert_status(StatusCode::OK);
+}

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -3342,6 +3342,24 @@ mod tests {
     }
 
     #[test]
+    fn test_proto_stored_image_info_to_schema_roundtrips_image_id_uuid_transport() {
+        let image_id = everruns_core::ImageId::new();
+        let info = proto_stored_image_info_to_schema(proto::StoredImageInfo {
+            id: Some(proto::Uuid {
+                value: image_id.uuid().to_string(),
+            }),
+            filename: "generated-image.png".into(),
+            content_type: "image/png".into(),
+            size_bytes: 128,
+            metadata: None,
+            created_at: None,
+        })
+        .expect("stored image info should convert");
+
+        assert_eq!(info.id, image_id);
+    }
+
+    #[test]
     fn test_grpc_command_error_to_error_not_found() {
         let err = grpc_command_error_to_error(proto::CommandError {
             kind: 3,

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -7892,7 +7892,7 @@
           },
           "id": {
             "type": "string",
-            "format": "uuid"
+            "example": "img_01933b5a00007000800000000000001"
           },
           "metadata": {},
           "size_bytes": {
@@ -7924,7 +7924,7 @@
           },
           "id": {
             "type": "string",
-            "format": "uuid"
+            "example": "img_01933b5a00007000800000000000001"
           },
           "size_bytes": {
             "type": "integer",


### PR DESCRIPTION
## What
Fix image artifact ID serialization at the server/worker boundary and make the public image API consistently return typed `img_...` IDs.

## Why
`gpt_image_gen` persisted image artifacts successfully, but the worker later received a prefixed image ID where the gRPC transport expected a raw UUID, so the tool call still failed after storage succeeded.

While tracing that path, I found the adjacent image REST API was also returning raw UUIDs instead of the documented prefixed public IDs.

## How
- serialize `StoredImageInfo.id` as the underlying UUID on the internal gRPC transport boundary
- keep `ImageId` as the public REST shape for image upload/list responses and regenerate OpenAPI
- add server, worker, and API regressions for gRPC transport and image ID round-tripping

## Risk
- Low
- Touches image artifact serialization between server and worker plus the public image ID response schema

## Security
- Threat categories reviewed: TM-API, TM-TOOL
- Findings and resolutions:
  - Reviewed the REST and gRPC ID boundaries for injection, authz, and data exposure regressions; no new attack surface added.
  - Kept raw UUIDs only on the internal transport boundary and typed `img_...` IDs on the public API boundary to avoid parser drift and accidental internal-ID leakage.

## Validation
- `just pre-push`
- `CARGO_TARGET_DIR=/tmp/everruns-eve383-target cargo test -p everruns-worker --lib test_proto_stored_image_info_to_schema_roundtrips_image_id_uuid_transport`
- `CARGO_TARGET_DIR=/tmp/everruns-eve383-target cargo test -p everruns-server --lib test_image_info_row_to_proto_uses_raw_uuid_transport_value`
- `CARGO_TARGET_DIR=/tmp/everruns-eve383-target cargo test -p everruns-server --test api_integration_test test_image_ids_round_trip_across_upload_list_and_get -- --exact`
- `PORT_PREFIX=271 CARGO_TARGET_DIR=/tmp/everruns-eve383-target just start-dev --no-watch` smoke: `GET /health`, `POST /api/v1/images`, `GET /api/v1/images`, `GET /api/v1/images/{id}`

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
