### PR TITLE
chore(release): prepare v0.8.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Highlights
 
-- **App invocation channels** - Apps can now be invoked via schedules and webhooks, expanding deployment options beyond agents and chat channels ([#1431](https://github.com/everruns/everruns/pull/1431), [#1415](https://github.com/everruns/everruns/pull/1415))
+- **App invocation channels** - Apps can now be invoked via schedules and webhooks, expanding deployment options beyond agents and chat channels ([#1431](https://github.com/everruns/everruns/pull/1431))
+- **Draft apps** - Apps can be created and saved without committing to an agent or channel, enabling staged authoring ([#1415](https://github.com/everruns/everruns/pull/1415))
 - **Budget usage journal & ledger** - New extensible budgeting backbone tracks LLM and tool usage with a journal and ledger for fine-grained cost accounting ([#1434](https://github.com/everruns/everruns/pull/1434))
 - **MCP read-only query tool & metadata** - Standardized MCP server tool metadata and added a read-only query tool for safe data access ([#1435](https://github.com/everruns/everruns/pull/1435), [#1418](https://github.com/everruns/everruns/pull/1418))
 - **Claude Code MCP plugin** - New Everruns MCP plugin and marketplace entry for direct integration with Claude Code ([#1406](https://github.com/everruns/everruns/pull/1406))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.8.18] - 2026-04-22
+
+### Highlights
+
+- **App invocation channels** - Apps can now be invoked via schedules and webhooks, expanding deployment options beyond agents and chat channels ([#1431](https://github.com/everruns/everruns/pull/1431), [#1415](https://github.com/everruns/everruns/pull/1415))
+- **Budget usage journal & ledger** - New extensible budgeting backbone tracks LLM and tool usage with a journal and ledger for fine-grained cost accounting ([#1434](https://github.com/everruns/everruns/pull/1434))
+- **MCP read-only query tool & metadata** - Standardized MCP server tool metadata and added a read-only query tool for safe data access ([#1435](https://github.com/everruns/everruns/pull/1435), [#1418](https://github.com/everruns/everruns/pull/1418))
+- **Claude Code MCP plugin** - New Everruns MCP plugin and marketplace entry for direct integration with Claude Code ([#1406](https://github.com/everruns/everruns/pull/1406))
+- **SWE-bench Lite eval harness** - Added evaluation harness for benchmarking against SWE-bench Lite ([#1394](https://github.com/everruns/everruns/pull/1394))
+- **Prompt cache request metadata** - LLM driver now propagates prompt cache metadata for improved observability and tuning ([#1398](https://github.com/everruns/everruns/pull/1398))
+
+### What's Changed
+
+- feat(daytona): standardize exec output contract ([#1390](https://github.com/everruns/everruns/pull/1390)) by [@chaliy](https://github.com/chaliy)
+- fix(daytona): suffix sandbox names on create ([#1396](https://github.com/everruns/everruns/pull/1396)) by [@chaliy](https://github.com/chaliy)
+- fix(integrations): scope sandbox resources to sessions ([#1397](https://github.com/everruns/everruns/pull/1397)) by [@chaliy](https://github.com/chaliy)
+- fix(runtime): unify overlay capability execution path by [@chaliy](https://github.com/chaliy)
+- chore(ci): codify integration live-test policy ([#1399](https://github.com/everruns/everruns/pull/1399)) by [@chaliy](https://github.com/chaliy)
+- feat(evals): add SWE-bench Lite evaluation harness ([#1394](https://github.com/everruns/everruns/pull/1394)) by [@chaliy](https://github.com/chaliy)
+- feat(llm): add prompt cache request metadata ([#1398](https://github.com/everruns/everruns/pull/1398)) by [@chaliy](https://github.com/chaliy)
+- fix(ci): stop doc-only pushes from triggering paid live tests ([#1405](https://github.com/everruns/everruns/pull/1405)) by [@chaliy](https://github.com/chaliy)
+- feat(embedding): add vendor-neutral error-reporting hooks for wrappers by [@chaliy](https://github.com/chaliy)
+- fix(core): redesign Braintrust REST delivery ([#1403](https://github.com/everruns/everruns/pull/1403)) by [@chaliy](https://github.com/chaliy)
+- fix(core): unify exec presentation contract ([#1402](https://github.com/everruns/everruns/pull/1402)) by [@chaliy](https://github.com/chaliy)
+- test(integrations): add Gemini and Daytona regression coverage ([#1400](https://github.com/everruns/everruns/pull/1400)) by [@chaliy](https://github.com/chaliy)
+- test(mcp): add argument and notification contract matrix by [@chaliy](https://github.com/chaliy)
+- fix(ci): scope live jobs to real integration changes ([#1407](https://github.com/everruns/everruns/pull/1407)) by [@chaliy](https://github.com/chaliy)
+- fix(browserless): attach page target for CDP v2 ([#1410](https://github.com/everruns/everruns/pull/1410)) by [@chaliy](https://github.com/chaliy)
+- feat(claude-code-plugin): add Everruns MCP plugin and marketplace ([#1406](https://github.com/everruns/everruns/pull/1406)) by [@chaliy](https://github.com/chaliy)
+- test(scripts): formalize shell helper CI coverage ([#1409](https://github.com/everruns/everruns/pull/1409)) by [@chaliy](https://github.com/chaliy)
+- fix(deno): resolve sandbox A records explicitly by [@chaliy](https://github.com/chaliy)
+- chore(maintenance): require Claude Code plugin freshness review by [@chaliy](https://github.com/chaliy)
+- refactor(errors): use structured runtime error metadata ([#1414](https://github.com/everruns/everruns/pull/1414)) by [@chaliy](https://github.com/chaliy)
+- feat(apps): allow draft apps without agent or channel ([#1415](https://github.com/everruns/everruns/pull/1415)) by [@chaliy](https://github.com/chaliy)
+- feat(mcp): standardize server tool metadata ([#1418](https://github.com/everruns/everruns/pull/1418)) by [@chaliy](https://github.com/chaliy)
+- fix(server): enable bashkit jq feature for MCP execute tool ([#1419](https://github.com/everruns/everruns/pull/1419)) by [@chaliy](https://github.com/chaliy)
+- refactor(server): move request types from api/ to domains/*/types.rs ([#1416](https://github.com/everruns/everruns/pull/1416)) by [@chaliy](https://github.com/chaliy)
+- refactor(server): use bashkit async_tool for MCP catalog callbacks ([#1420](https://github.com/everruns/everruns/pull/1420)) by [@chaliy](https://github.com/chaliy)
+- feat(core): add observational bashkit hooks for virtual_bash ([#1421](https://github.com/everruns/everruns/pull/1421)) by [@chaliy](https://github.com/chaliy)
+- feat(core): unify reading-tool truncation envelope ([#1422](https://github.com/everruns/everruns/pull/1422)) by [@chaliy](https://github.com/chaliy)
+- chore(release): remove migration squash requirement ([#1423](https://github.com/everruns/everruns/pull/1423)) by [@chaliy](https://github.com/chaliy)
+- fix(ci): pin deno live tests to ams ([#1417](https://github.com/everruns/everruns/pull/1417)) by [@chaliy](https://github.com/chaliy)
+- fix(plugins): share everruns plugin root ([#1424](https://github.com/everruns/everruns/pull/1424)) by [@chaliy](https://github.com/chaliy)
+- refactor(server): migrate remaining API domains to commands by [@chaliy](https://github.com/chaliy)
+- fix(sprites): align live API and CI token checks ([#1426](https://github.com/everruns/everruns/pull/1426)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump astro from 6.1.3 to 6.1.8 in /apps/docs in the npm_and_yarn group across 1 directory ([#1427](https://github.com/everruns/everruns/pull/1427)) by [@dependabot](https://github.com/dependabot)
+- fix(session-sandbox): harden managed sandbox e2e ([#1428](https://github.com/everruns/everruns/pull/1428)) by [@chaliy](https://github.com/chaliy)
+- refactor(mcp): remove static catalog and handlers ([#1430](https://github.com/everruns/everruns/pull/1430)) by [@chaliy](https://github.com/chaliy)
+- fix(api-keys): use expiry presets and drop key quota ([#1432](https://github.com/everruns/everruns/pull/1432)) by [@chaliy](https://github.com/chaliy)
+- feat(server): add budget usage journal and ledger ([#1434](https://github.com/everruns/everruns/pull/1434)) by [@chaliy](https://github.com/chaliy)
+- feat(mcp): add read-only query tool ([#1435](https://github.com/everruns/everruns/pull/1435)) by [@chaliy](https://github.com/chaliy)
+- fix(media): preserve image IDs across RPC and API ([#1438](https://github.com/everruns/everruns/pull/1438)) by [@chaliy](https://github.com/chaliy)
+- fix(server): gate coding-container behind container sandbox flag by [@chaliy](https://github.com/chaliy)
+- test(agents): add image generation artifact case ([#1439](https://github.com/everruns/everruns/pull/1439)) by [@chaliy](https://github.com/chaliy)
+- feat(commands): add btw capability ([#1437](https://github.com/everruns/everruns/pull/1437)) by [@chaliy](https://github.com/chaliy)
+- feat(apps): add schedule and webhook invocation channels ([#1431](https://github.com/everruns/everruns/pull/1431)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.8.17] - 2026-04-19
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -153,7 +153,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1395,7 +1395,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1520,7 +1520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1577,11 +1577,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.8.17"
+version = "0.8.18"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "anyhow",
  "base64",
@@ -1627,14 +1627,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "async-trait",
  "base64",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1759,7 +1759,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1775,7 +1775,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "async-trait",
  "base64",
@@ -1796,7 +1796,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "async-trait",
  "base64",
@@ -1836,7 +1836,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "async-trait",
  "base64",
@@ -1851,7 +1851,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1895,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-pi"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1910,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -1943,7 +1943,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1953,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1975,11 +1975,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.8.17"
+version = "0.8.18"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "aes-gcm",
  "ag-ui-core",
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3005,7 +3005,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3025,7 +3025,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3427,7 +3427,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4171,7 +4171,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4965,7 +4965,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5003,7 +5003,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5563,7 +5563,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5577,7 +5577,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -5640,11 +5640,11 @@ dependencies = [
  "rustls",
  "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5665,9 +5665,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -6134,7 +6134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6543,7 +6543,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6949,7 +6949,7 @@ dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -6958,7 +6958,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -7847,7 +7847,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8338,9 +8338,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.17"
+version = "0.8.18"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.17",
+  "version": "0.8.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "everruns-ui",
-      "version": "0.8.17",
+      "version": "0.8.18",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@openuidev/react-lang": "^0.1.3",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.17",
+  "version": "0.8.18",
   "private": true,
   "exports": {
     "./route-manifest": "./src/lib/ui-route-manifest.ts",


### PR DESCRIPTION
## Release v0.8.18

This PR prepares the v0.8.18 patch release.

### Highlights

- **App invocation channels** - Apps can now be invoked via schedules and webhooks (#1431, #1415)
- **Budget usage journal & ledger** - New extensible budgeting backbone (#1434)
- **MCP read-only query tool & metadata** - (#1435, #1418)
- **Claude Code MCP plugin** - (#1406)
- **SWE-bench Lite eval harness** - (#1394)
- **Prompt cache request metadata** - (#1398)

### Checklist
- [x] Bumped Cargo.toml workspace version to 0.8.18
- [x] Bumped apps/ui/package.json version to 0.8.18
- [x] Updated CHANGELOG.md
- [x] Regenerated Cargo.lock and apps/ui/package-lock.json
- [x] Migrations sequential (001..022, no gaps/duplicates)
- [ ] CI passes

### Post-merge
After merging, the release workflow will automatically:
- Create git tag `v0.8.18`
- Create GitHub Release with notes from CHANGELOG.md
- Trigger Docker image build with version tag