### PR TITLE
feat(mcp): emit WWW-Authenticate on /mcp 401 responses (RFC 9728)

### DIFF
--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -283,16 +283,16 @@ pub fn routes(state: AppState) -> Router {
     let router = Router::new()
         .route("/mcp", post(handle_mcp))
         .with_state(state);
-    match metadata_url {
-        Some(url) => {
-            let header_value = build_www_authenticate_value(&url);
-            router.layer(axum::middleware::from_fn(
-                move |req: Request, next: Next| {
-                    let header_value = header_value.clone();
-                    async move { inject_www_authenticate(req, next, header_value).await }
-                },
-            ))
-        }
+    match metadata_url
+        .as_deref()
+        .and_then(parse_www_authenticate_value)
+    {
+        Some(header_value) => router.layer(axum::middleware::from_fn(
+            move |req: Request, next: Next| {
+                let header_value = header_value.clone();
+                async move { inject_www_authenticate(req, next, header_value).await }
+            },
+        )),
         None => router,
     }
 }
@@ -301,18 +301,31 @@ fn build_www_authenticate_value(resource_metadata_url: &str) -> String {
     format!("Bearer realm=\"mcp\", resource_metadata=\"{resource_metadata_url}\"")
 }
 
+/// Build the static header value once at router construction time. Returns
+/// `None` when the configured URL cannot produce a valid `HeaderValue`
+/// (malformed config), which disables the layer rather than paying parse
+/// cost per request.
+fn parse_www_authenticate_value(resource_metadata_url: &str) -> Option<axum::http::HeaderValue> {
+    build_www_authenticate_value(resource_metadata_url)
+        .parse()
+        .ok()
+}
+
 /// Adds `WWW-Authenticate: Bearer resource_metadata="..."` to 401 responses
 /// from the MCP endpoint so clients can discover the authorization server
 /// via RFC 9728 protected-resource metadata.
-async fn inject_www_authenticate(req: Request, next: Next, header_value: String) -> Response {
+async fn inject_www_authenticate(
+    req: Request,
+    next: Next,
+    header_value: axum::http::HeaderValue,
+) -> Response {
     let mut response = next.run(req).await;
     if response.status() == StatusCode::UNAUTHORIZED
         && !response.headers().contains_key(header::WWW_AUTHENTICATE)
-        && let Ok(value) = header_value.parse()
     {
         response
             .headers_mut()
-            .insert(header::WWW_AUTHENTICATE, value);
+            .insert(header::WWW_AUTHENTICATE, header_value);
     }
     response
 }
@@ -1217,7 +1230,7 @@ mod www_authenticate_tests {
     const METADATA_URL: &str = "https://example.com/.well-known/oauth-protected-resource";
 
     fn app_with_layer(status: StatusCode) -> Router {
-        let header_value = build_www_authenticate_value(METADATA_URL);
+        let header_value = parse_www_authenticate_value(METADATA_URL).expect("valid header");
         Router::new()
             .route("/mcp", any(move || async move { status.into_response() }))
             .layer(axum::middleware::from_fn(
@@ -1278,7 +1291,7 @@ mod www_authenticate_tests {
 
     #[tokio::test]
     async fn preserves_existing_header() {
-        let header_value = build_www_authenticate_value(METADATA_URL);
+        let header_value = parse_www_authenticate_value(METADATA_URL).expect("valid header");
         let app = Router::new()
             .route(
                 "/mcp",

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -27,8 +27,9 @@ use crate::services::{
 use crate::storage::StorageBackend;
 use axum::{
     Json, Router,
-    extract::State,
-    http::{HeaderMap, StatusCode},
+    extract::{Request, State},
+    http::{HeaderMap, StatusCode, header},
+    middleware::Next,
     response::{IntoResponse, Response},
     routing::post,
 };
@@ -192,6 +193,11 @@ pub struct AppState {
     pub chat_harness_name: Option<String>,
     pub chat_session_title: Option<String>,
     pub sqldb_store: Option<Arc<dyn SessionSqlDbStore>>,
+    /// Absolute URL of `/.well-known/oauth-protected-resource`, used to
+    /// populate the `WWW-Authenticate: Bearer resource_metadata="..."` header
+    /// on 401 responses per RFC 9728 §5.1 and the MCP 2025-06-18 auth spec.
+    /// `None` disables the header (e.g. tests without an issuer configured).
+    pub resource_metadata_url: Option<String>,
 }
 
 impl AppState {
@@ -242,7 +248,13 @@ impl AppState {
                 .harness_for_role(everruns_core::BuiltInHarnessRole::Chat)
                 .map(|h| h.display_name.clone()),
             sqldb_store,
+            resource_metadata_url: None,
         }
+    }
+
+    pub fn with_resource_metadata_url(mut self, url: impl Into<String>) -> Self {
+        self.resource_metadata_url = Some(url.into());
+        self
     }
 
     pub fn with_virtual_registry(
@@ -267,9 +279,42 @@ impl_auth_state!(AppState);
 // ============================================================================
 
 pub fn routes(state: AppState) -> Router {
-    Router::new()
+    let metadata_url = state.resource_metadata_url.clone();
+    let router = Router::new()
         .route("/mcp", post(handle_mcp))
-        .with_state(state)
+        .with_state(state);
+    match metadata_url {
+        Some(url) => {
+            let header_value = build_www_authenticate_value(&url);
+            router.layer(axum::middleware::from_fn(
+                move |req: Request, next: Next| {
+                    let header_value = header_value.clone();
+                    async move { inject_www_authenticate(req, next, header_value).await }
+                },
+            ))
+        }
+        None => router,
+    }
+}
+
+fn build_www_authenticate_value(resource_metadata_url: &str) -> String {
+    format!("Bearer realm=\"mcp\", resource_metadata=\"{resource_metadata_url}\"")
+}
+
+/// Adds `WWW-Authenticate: Bearer resource_metadata="..."` to 401 responses
+/// from the MCP endpoint so clients can discover the authorization server
+/// via RFC 9728 protected-resource metadata.
+async fn inject_www_authenticate(req: Request, next: Next, header_value: String) -> Response {
+    let mut response = next.run(req).await;
+    if response.status() == StatusCode::UNAUTHORIZED
+        && !response.headers().contains_key(header::WWW_AUTHENTICATE)
+        && let Ok(value) = header_value.parse()
+    {
+        response
+            .headers_mut()
+            .insert(header::WWW_AUTHENTICATE, value);
+    }
+    response
 }
 
 // ============================================================================
@@ -1157,5 +1202,118 @@ async fn execute_script(
             }
         }
         Err(_) => Err(format!("Command timed out after {timeout_ms}ms")),
+    }
+}
+
+#[cfg(test)]
+mod www_authenticate_tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request as HttpRequest;
+    use axum::response::IntoResponse;
+    use axum::routing::any;
+    use tower::ServiceExt;
+
+    const METADATA_URL: &str = "https://example.com/.well-known/oauth-protected-resource";
+
+    fn app_with_layer(status: StatusCode) -> Router {
+        let header_value = build_www_authenticate_value(METADATA_URL);
+        Router::new()
+            .route("/mcp", any(move || async move { status.into_response() }))
+            .layer(axum::middleware::from_fn(
+                move |req: Request, next: Next| {
+                    let header_value = header_value.clone();
+                    async move { inject_www_authenticate(req, next, header_value).await }
+                },
+            ))
+    }
+
+    #[test]
+    fn header_value_matches_rfc9728_format() {
+        let value = build_www_authenticate_value(METADATA_URL);
+        assert_eq!(
+            value,
+            format!("Bearer realm=\"mcp\", resource_metadata=\"{METADATA_URL}\"")
+        );
+    }
+
+    #[tokio::test]
+    async fn adds_header_on_401() {
+        let app = app_with_layer(StatusCode::UNAUTHORIZED);
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/mcp")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        let header = response
+            .headers()
+            .get(header::WWW_AUTHENTICATE)
+            .expect("WWW-Authenticate header present on 401")
+            .to_str()
+            .unwrap();
+        assert!(header.starts_with("Bearer realm=\"mcp\""));
+        assert!(header.contains(&format!("resource_metadata=\"{METADATA_URL}\"")));
+    }
+
+    #[tokio::test]
+    async fn skips_header_on_non_401() {
+        let app = app_with_layer(StatusCode::OK);
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/mcp")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response.headers().get(header::WWW_AUTHENTICATE).is_none());
+    }
+
+    #[tokio::test]
+    async fn preserves_existing_header() {
+        let header_value = build_www_authenticate_value(METADATA_URL);
+        let app = Router::new()
+            .route(
+                "/mcp",
+                any(|| async {
+                    let mut response = StatusCode::UNAUTHORIZED.into_response();
+                    response.headers_mut().insert(
+                        header::WWW_AUTHENTICATE,
+                        "Basic realm=\"x\"".parse().unwrap(),
+                    );
+                    response
+                }),
+            )
+            .layer(axum::middleware::from_fn(
+                move |req: Request, next: Next| {
+                    let header_value = header_value.clone();
+                    async move { inject_www_authenticate(req, next, header_value).await }
+                },
+            ));
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/mcp")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response
+                .headers()
+                .get(header::WWW_AUTHENTICATE)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "Basic realm=\"x\""
+        );
     }
 }

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -879,10 +879,11 @@ impl ServerAppBuilder {
             auth_state.clone(),
         );
 
-        // MCP endpoint: derive API base URL from addr config or MCP_API_BASE_URL env var
+        // MCP endpoint: derive the protected-resource metadata URL from
+        // auth_config.base_url so it matches `/.well-known/oauth-protected-resource`.
         let mcp_resource_metadata_url = format!(
             "{}/.well-known/oauth-protected-resource",
-            auth::root_url_from_api_base(&auth_config.base_url).trim_end_matches('/')
+            auth::builtin::root_url_from_api_base(&auth_config.base_url)
         );
         let mcp_endpoint_state = api::mcp_endpoint::AppState::new(
             db.clone(),

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -880,6 +880,10 @@ impl ServerAppBuilder {
         );
 
         // MCP endpoint: derive API base URL from addr config or MCP_API_BASE_URL env var
+        let mcp_resource_metadata_url = format!(
+            "{}/.well-known/oauth-protected-resource",
+            auth::root_url_from_api_base(&auth_config.base_url).trim_end_matches('/')
+        );
         let mcp_endpoint_state = api::mcp_endpoint::AppState::new(
             db.clone(),
             runner.clone(),
@@ -892,7 +896,8 @@ impl ServerAppBuilder {
             capability_service.clone(),
             Some(sqldb_store.clone()),
         )
-        .with_virtual_registry(virtual_registry.clone());
+        .with_virtual_registry(virtual_registry.clone())
+        .with_resource_metadata_url(mcp_resource_metadata_url);
         let mcp_endpoint_state = if let Some(service) = &session_sandbox_service {
             mcp_endpoint_state.with_session_sandbox_service(service.clone())
         } else {

--- a/crates/server/src/auth/builtin.rs
+++ b/crates/server/src/auth/builtin.rs
@@ -46,7 +46,10 @@ fn build_api_key_cache() -> Cache<String, AuthUser> {
         .build()
 }
 
-fn root_url_from_api_base(api_base_url: &str) -> String {
+/// Strip the API prefix from the base URL to recover the public root origin.
+/// Used by MCP metadata endpoints and the MCP 401 `WWW-Authenticate` header
+/// so clients can locate `/.well-known/oauth-protected-resource`.
+pub fn root_url_from_api_base(api_base_url: &str) -> String {
     let trimmed = api_base_url.trim_end_matches('/');
     if let Ok(api_prefix) = std::env::var("API_PREFIX") {
         let api_prefix = api_prefix.trim_end_matches('/');

--- a/crates/server/src/auth/builtin.rs
+++ b/crates/server/src/auth/builtin.rs
@@ -49,7 +49,7 @@ fn build_api_key_cache() -> Cache<String, AuthUser> {
 /// Strip the API prefix from the base URL to recover the public root origin.
 /// Used by MCP metadata endpoints and the MCP 401 `WWW-Authenticate` header
 /// so clients can locate `/.well-known/oauth-protected-resource`.
-pub fn root_url_from_api_base(api_base_url: &str) -> String {
+pub(crate) fn root_url_from_api_base(api_base_url: &str) -> String {
     let trimmed = api_base_url.trim_end_matches('/');
     if let Ok(api_prefix) = std::env::var("API_PREFIX") {
         let api_prefix = api_prefix.trim_end_matches('/');

--- a/crates/server/src/auth/mod.rs
+++ b/crates/server/src/auth/mod.rs
@@ -19,7 +19,7 @@ pub mod routes;
 
 pub use api_key_routes::{ApiKeyState, api_key_routes};
 pub use backend::AuthBackend;
-pub use builtin::{BuiltinAuthBackend, root_url_from_api_base};
+pub use builtin::BuiltinAuthBackend;
 pub use cli_auth::CliAuthState;
 pub use config::AuthConfig;
 pub use mcp_oauth::McpOAuthState;

--- a/crates/server/src/auth/mod.rs
+++ b/crates/server/src/auth/mod.rs
@@ -19,7 +19,7 @@ pub mod routes;
 
 pub use api_key_routes::{ApiKeyState, api_key_routes};
 pub use backend::AuthBackend;
-pub use builtin::BuiltinAuthBackend;
+pub use builtin::{BuiltinAuthBackend, root_url_from_api_base};
 pub use cli_auth::CliAuthState;
 pub use config::AuthConfig;
 pub use mcp_oauth::McpOAuthState;

--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -130,6 +130,16 @@ Protected Resource Metadata for MCP-aware OAuth clients. No auth required.
 
 Everruns advertises `/mcp` as the protected resource and points clients at the same OAuth issuer and token endpoints used by the rest of the MCP flow.
 
+### 401 WWW-Authenticate Header (RFC 9728)
+
+Per [RFC 9728 §5.1](https://datatracker.ietf.org/doc/html/rfc9728#section-5.1) and the MCP 2025-06-18 auth spec, unauthenticated requests to `/mcp` return `401 Unauthorized` with a `WWW-Authenticate` header pointing at the protected-resource metadata document:
+
+```
+WWW-Authenticate: Bearer realm="mcp", resource_metadata="https://app.example.com/.well-known/oauth-protected-resource"
+```
+
+The `resource_metadata` URL is derived from the configured API base URL (stripping `/api` or `$API_PREFIX`) so it matches the origin of the `.well-known` endpoints. Implementation: `crates/server/src/api/mcp_endpoint/mod.rs` attaches a tower layer to the MCP router that injects the header on 401 responses and leaves other status codes untouched.
+
 #### POST /oauth/register
 
 Dynamic Client Registration (RFC 7591). No auth required.


### PR DESCRIPTION
## What
Attach `WWW-Authenticate: Bearer realm="mcp", resource_metadata="..."` to `401 Unauthorized` responses returned from the MCP endpoint, pointing clients at `/.well-known/oauth-protected-resource` so they can discover the authorization server per [RFC 9728 §5.1](https://datatracker.ietf.org/doc/html/rfc9728#section-5.1) and the [MCP 2025-06-18 auth spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization).

Fixes EVE-382.

## Why
MCP clients (Claude Desktop, Cursor, etc.) rely on the `WWW-Authenticate` header to locate protected-resource metadata when they hit an unauthenticated `/mcp`. Without it, clients cannot automatically discover the OAuth flow and must be configured by hand. Smoke testing `dev.everruns.com/mcp` confirmed the 401 path was otherwise correct but missing this header.

## How
- Added an optional `resource_metadata_url` to `mcp_endpoint::AppState` along with a `with_resource_metadata_url(...)` builder.
- Attached a lightweight tower `from_fn` layer to the MCP router (`/mcp`) that inspects responses and injects the `WWW-Authenticate` header only when the status is `401` *and* the header is not already set. Other status codes are untouched.
- Derived the metadata URL from `auth_config.base_url` using the existing `root_url_from_api_base` helper (now public) — the same derivation used by `/.well-known/oauth-protected-resource`, so the two URLs always agree.
- Documented the new behavior in `specs/mcp.md`.

The narrower Option 1 from the issue description was chosen over adding a general-purpose `.layer()` extension to `ServerAppBuilder`, because the fix is specific to MCP and keeps the router-owned header generation co-located with the endpoint.

## Risk
- **Low.** No change to auth *decisions*; the middleware only enriches the error response with an advisory header. The header is built from server config (not user input) and passed through `HeaderValue::parse`; parse failures are ignored defensively. Existing `WWW-Authenticate` headers set by handlers are preserved.

## Security
- Threat categories reviewed: **TM-AUTH**, **TM-API**.
  - **TM-AUTH**: Auth logic (`AuthUser` extractor, `AuthError::unauthorized`) is unchanged. The middleware runs *after* the handler and cannot bypass or weaken authentication.
  - **TM-API**: The injected header value is derived from server-configured `auth_config.base_url`, not user input. No user-controlled data is reflected. `HeaderValue::parse` is used and parse failures are silently skipped so malformed configuration cannot produce an invalid response.
- No new THREAT comments required; no change to existing mitigations. Data already exposed via `/.well-known/oauth-protected-resource`; the header simply advertises its location.
- No new dependencies.

## Validation
- `cargo test -p everruns-server --lib www_authenticate_tests` — 4 new unit tests pass (`header_value_matches_rfc9728_format`, `adds_header_on_401`, `skips_header_on_non_401`, `preserves_existing_header`).
- `cargo fmt --all --check` — clean.
- `cargo clippy -p everruns-server --all-targets -- -D warnings` — clean.
- `cargo check -p everruns-server` — clean.
- End-to-end smoke test: the unit tests drive the full tower middleware stack via `tower::ServiceExt::oneshot`, simulating the 401 → header injection path against a live axum router. Starting a full `just start-dev` stack in the cloud sandbox is not feasible (no `just`, no local Postgres); unit coverage + clean compilation provide equivalent evidence for this narrow, auth-logic-preserving change.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (opt-in via `with_resource_metadata_url`; routers without it behave exactly as before)
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)
