### PR TITLE
feat(api): add raw session file downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2061,6 +2061,7 @@ dependencies = [
  "jsonwebtoken",
  "metrics",
  "metrics-exporter-prometheus",
+ "mime_guess",
  "moka",
  "parking_lot",
  "prost",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -64,6 +64,7 @@ moka.workspace = true
 zip = { version = "2", default-features = false, features = ["deflate"] }
 urlencoding = "2"
 git2.workspace = true
+mime_guess = "2"
 
 bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.1.18", features = ["scripted_tool", "jq"] }
 

--- a/crates/server/src/api/session_files.rs
+++ b/crates/server/src/api/session_files.rs
@@ -9,6 +9,7 @@
 // - POST   /fs/_/copy - Copy file
 // - POST   /fs/_/grep - Search files
 // - POST   /fs/_/stat - Get file metadata
+// - GET    /fs/_/download/*path - Download raw file bytes
 //
 // Note: Paths starting with "_" are reserved for actions and cannot be
 // used for file creation or updates.
@@ -22,12 +23,15 @@ use crate::domains::session_files::{
 use crate::storage::StorageBackend;
 use axum::{
     Json, Router,
+    body::Body,
     extract::{DefaultBodyLimit, Path, Query, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode, header},
+    response::{IntoResponse, Response},
     routing::{get, post},
 };
 use everruns_core::Caller;
 use everruns_core::{FileInfo, FileStat, GrepResult, SessionFile};
+use mime_guess::from_path;
 
 use super::common::{ListResponse, impl_auth_state};
 use crate::services::session_file::SessionFileService;
@@ -183,6 +187,64 @@ fn file_error(error: CommandError) -> (StatusCode, String) {
     }
 }
 
+fn wants_raw_file(headers: &HeaderMap) -> bool {
+    headers
+        .get(header::ACCEPT)
+        .and_then(|value| value.to_str().ok())
+        .map(|accept| {
+            accept
+                .split(',')
+                .map(|entry| entry.split(';').next().unwrap_or("").trim())
+                .any(|entry| entry.eq_ignore_ascii_case("application/octet-stream"))
+        })
+        .unwrap_or(false)
+}
+
+fn raw_file_content_type(file: &SessionFile) -> String {
+    from_path(&file.path)
+        .first_raw()
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| {
+            if file.encoding == "base64" {
+                "application/octet-stream".to_string()
+            } else {
+                "text/plain; charset=utf-8".to_string()
+            }
+        })
+}
+
+fn raw_file_response(file: SessionFile) -> Result<Response, (StatusCode, String)> {
+    let content_type = raw_file_content_type(&file);
+    let filename = file.name.clone();
+    let content = file.content.as_ref().ok_or((
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "File content missing".to_string(),
+    ))?;
+    let bytes = SessionFile::decode_content(content, &file.encoding).map_err(|error| {
+        tracing::error!(path = %file.path, %error, "Failed to decode session file content");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to decode file content".to_string(),
+        )
+    })?;
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, content_type)
+        .header(
+            header::CONTENT_DISPOSITION,
+            format!("attachment; filename=\"{}\"", filename),
+        )
+        .body(Body::from(bytes))
+        .map_err(|error| {
+            tracing::error!(path = %file.path, %error, "Failed to build raw file response");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to build file response".to_string(),
+            )
+        })
+}
+
 /// Create session files routes
 pub fn routes(state: AppState) -> Router {
     Router::new()
@@ -191,6 +253,10 @@ pub fn routes(state: AppState) -> Router {
         .route("/v1/sessions/{session_id}/fs/_/copy", post(copy_file))
         .route("/v1/sessions/{session_id}/fs/_/grep", post(grep_files))
         .route("/v1/sessions/{session_id}/fs/_/stat", post(stat_file))
+        .route(
+            "/v1/sessions/{session_id}/fs/_/download/{*path}",
+            get(download_path),
+        )
         // File operations with path
         .route(
             "/v1/sessions/{session_id}/fs",
@@ -308,8 +374,9 @@ pub async fn get_path(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path((session_id, path)): Path<(String, String)>,
+    headers: HeaderMap,
     Query(query): Query<GetQuery>,
-) -> Result<Json<GetResponse>, (StatusCode, String)> {
+) -> Result<Response, (StatusCode, String)> {
     let response = GetSessionFile {
         session_id,
         path,
@@ -318,7 +385,57 @@ pub async fn get_path(
     .execute(&state.ctx(&org))
     .await
     .map_err(file_error)?;
-    Ok(Json(response))
+
+    if wants_raw_file(&headers) {
+        return match response {
+            GetResponse::File(file) => raw_file_response(file),
+            GetResponse::Listing(_) => Err((
+                StatusCode::BAD_REQUEST,
+                "Cannot download a directory".to_string(),
+            )),
+        };
+    }
+
+    Ok(Json(response).into_response())
+}
+
+/// GET /fs/_/download/*path - Download raw file bytes
+#[utoipa::path(
+    get,
+    path = "/v1/sessions/{session_id}/fs/_/download/{path}",
+    params(
+        ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)"),
+        ("path" = String, Path, description = "File path")
+    ),
+    responses(
+        (status = 200, description = "Raw file bytes", content_type = "application/octet-stream"),
+        (status = 400, description = "Invalid session ID or path points to a directory"),
+        (status = 404, description = "File not found"),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = "filesystem"
+)]
+pub async fn download_path(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path((session_id, path)): Path<(String, String)>,
+) -> Result<Response, (StatusCode, String)> {
+    let response = GetSessionFile {
+        session_id,
+        path,
+        recursive: false,
+    }
+    .execute(&state.ctx(&org))
+    .await
+    .map_err(file_error)?;
+
+    match response {
+        GetResponse::File(file) => raw_file_response(file),
+        GetResponse::Listing(_) => Err((
+            StatusCode::BAD_REQUEST,
+            "Cannot download a directory".to_string(),
+        )),
+    }
 }
 
 /// POST /fs - Create at root (not allowed)

--- a/crates/server/src/api/session_files.rs
+++ b/crates/server/src/api/session_files.rs
@@ -194,10 +194,36 @@ fn wants_raw_file(headers: &HeaderMap) -> bool {
         .map(|accept| {
             accept
                 .split(',')
-                .map(|entry| entry.split(';').next().unwrap_or("").trim())
-                .any(|entry| entry.eq_ignore_ascii_case("application/octet-stream"))
+                .filter_map(parse_accept_entry)
+                .any(|(entry, quality)| {
+                    entry.eq_ignore_ascii_case("application/octet-stream") && quality > 0.0
+                })
         })
         .unwrap_or(false)
+}
+
+fn parse_accept_entry(entry: &str) -> Option<(&str, f32)> {
+    let mut parts = entry.split(';');
+    let media_type = parts.next()?.trim();
+    if media_type.is_empty() {
+        return None;
+    }
+
+    let mut quality = 1.0_f32;
+    for param in parts {
+        let mut key_value = param.splitn(2, '=');
+        let key = key_value.next().unwrap_or("").trim();
+        let value = key_value.next().unwrap_or("").trim();
+
+        if key.eq_ignore_ascii_case("q") {
+            if let Ok(parsed) = value.parse::<f32>() {
+                quality = parsed;
+            }
+            break;
+        }
+    }
+
+    Some((media_type, quality))
 }
 
 fn raw_file_content_type(file: &SessionFile) -> String {
@@ -213,9 +239,35 @@ fn raw_file_content_type(file: &SessionFile) -> String {
         })
 }
 
-fn raw_file_response(file: SessionFile) -> Result<Response, (StatusCode, String)> {
+fn ascii_filename_fallback(filename: &str) -> String {
+    let sanitized: String = filename
+        .chars()
+        .map(|ch| match ch {
+            '"' | '\\' | '/' | ';' => '_',
+            ' '..='~' => ch,
+            _ => '_',
+        })
+        .collect();
+    let trimmed = sanitized.trim();
+    if trimmed.is_empty() {
+        "download".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn content_disposition_value(filename: &str, attachment: bool) -> String {
+    let disposition = if attachment { "attachment" } else { "inline" };
+    let fallback = ascii_filename_fallback(filename);
+    let encoded = urlencoding::encode(filename);
+    format!("{disposition}; filename=\"{fallback}\"; filename*=UTF-8''{encoded}")
+}
+
+fn raw_file_response(
+    file: SessionFile,
+    attachment: bool,
+) -> Result<Response, (StatusCode, String)> {
     let content_type = raw_file_content_type(&file);
-    let filename = file.name.clone();
     let content = file.content.as_ref().ok_or((
         StatusCode::INTERNAL_SERVER_ERROR,
         "File content missing".to_string(),
@@ -233,7 +285,7 @@ fn raw_file_response(file: SessionFile) -> Result<Response, (StatusCode, String)
         .header(header::CONTENT_TYPE, content_type)
         .header(
             header::CONTENT_DISPOSITION,
-            format!("attachment; filename=\"{}\"", filename),
+            content_disposition_value(&file.name, attachment),
         )
         .body(Body::from(bytes))
         .map_err(|error| {
@@ -388,7 +440,7 @@ pub async fn get_path(
 
     if wants_raw_file(&headers) {
         return match response {
-            GetResponse::File(file) => raw_file_response(file),
+            GetResponse::File(file) => raw_file_response(file, false),
             GetResponse::Listing(_) => Err((
                 StatusCode::BAD_REQUEST,
                 "Cannot download a directory".to_string(),
@@ -430,7 +482,7 @@ pub async fn download_path(
     .map_err(file_error)?;
 
     match response {
-        GetResponse::File(file) => raw_file_response(file),
+        GetResponse::File(file) => raw_file_response(file, true),
         GetResponse::Listing(_) => Err((
             StatusCode::BAD_REQUEST,
             "Cannot download a directory".to_string(),
@@ -725,5 +777,37 @@ mod tests {
         // /workspacefoo is NOT a workspace path (no slash after workspace)
         assert_eq!(normalize_path("workspacefoo"), "/workspacefoo");
         assert_eq!(normalize_path("/workspacefoo"), "/workspacefoo");
+    }
+
+    #[test]
+    fn test_wants_raw_file_honors_q_zero() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::ACCEPT,
+            "application/octet-stream;q=0, application/json"
+                .parse()
+                .unwrap(),
+        );
+        assert!(!wants_raw_file(&headers));
+    }
+
+    #[test]
+    fn test_wants_raw_file_accepts_positive_quality() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::ACCEPT,
+            "application/json, application/octet-stream;q=0.5"
+                .parse()
+                .unwrap(),
+        );
+        assert!(wants_raw_file(&headers));
+    }
+
+    #[test]
+    fn test_content_disposition_value_uses_ascii_fallback_and_filename_star() {
+        let value = content_disposition_value("report \"Δ\".pdf", true);
+        assert!(value.starts_with("attachment; "));
+        assert!(value.contains("filename=\"report ___.pdf\""));
+        assert!(value.contains("filename*=UTF-8''report%20%22%CE%94%22.pdf"));
     }
 }

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -70,6 +70,7 @@ use utoipa::OpenApi;
         api::users::list_users,
         api::session_files::get_root,
         api::session_files::get_path,
+        api::session_files::download_path,
         api::session_files::create_path,
         api::session_files::update_path,
         api::session_files::delete_path,

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -1531,7 +1531,7 @@ async fn test_session_file_download_path_returns_raw_bytes() {
         raw.headers()
             .get("content-disposition")
             .and_then(|value| value.to_str().ok()),
-        Some("attachment; filename=\"report.pdf\"")
+        Some("attachment; filename=\"report.pdf\"; filename*=UTF-8''report.pdf")
     );
     assert_eq!(raw.bytes(), pdf_bytes.as_slice());
 }
@@ -1596,7 +1596,75 @@ async fn test_session_file_read_accept_octet_stream_returns_raw_bytes() {
             .and_then(|value| value.to_str().ok()),
         Some("application/octet-stream")
     );
+    assert_eq!(
+        response
+            .headers()
+            .get("content-disposition")
+            .and_then(|value| value.to_str().ok()),
+        Some("inline; filename=\"payload.bin\"; filename*=UTF-8''payload.bin")
+    );
     assert_eq!(response.bytes(), raw_bytes.as_slice());
+}
+
+#[tokio::test]
+async fn test_session_file_read_accept_octet_stream_q_zero_keeps_json_response() {
+    let server = TestServer::in_memory().await;
+
+    let agent: Agent = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": "fs-negotiate-q-zero-agent",
+                "display_name": "FS Negotiate Q Zero Agent",
+                "system_prompt": "Test"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let session: Session = server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": server.seed_base_harness_id,
+                "agent_id": agent.public_id
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let fs_url = format!("/v1/sessions/{}/fs", session.id);
+    let raw_bytes = vec![0, 159, 146, 150];
+
+    server
+        .post(
+            &format!("{}/payload.bin", fs_url),
+            json!({
+                "content": BASE64.encode(&raw_bytes),
+                "encoding": "base64"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    let response = server
+        .request_raw(
+            axum::http::Method::GET,
+            &format!("{}/payload.bin", fs_url),
+            vec![("accept", "application/octet-stream;q=0, application/json")],
+            vec![],
+        )
+        .await
+        .assert_status(StatusCode::OK);
+
+    let file: SessionFile = response.json();
+    assert_eq!(file.encoding, "base64");
+    assert_eq!(
+        file.content.as_deref(),
+        Some(BASE64.encode(&raw_bytes).as_str())
+    );
 }
 
 #[tokio::test]

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -13,6 +13,7 @@
 mod test_harness;
 
 use axum::http::StatusCode;
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use chrono::{Duration, Utc};
 use serde_json::{Value, json};
 use test_harness::TestServer;
@@ -1459,6 +1460,188 @@ async fn test_session_filesystem_list_nonexistent_directory_returns_404() {
     // List a directory that doesn't exist — should return 404, not 500
     let resp = server.get(&format!("{}/.agents/skills", fs_url)).await;
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_session_file_download_path_returns_raw_bytes() {
+    let server = TestServer::in_memory().await;
+
+    let agent: Agent = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": "fs-download-agent",
+                "display_name": "FS Download Agent",
+                "system_prompt": "Test"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let session: Session = server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": server.seed_base_harness_id,
+                "agent_id": agent.public_id
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let fs_url = format!("/v1/sessions/{}/fs", session.id);
+    let pdf_bytes = b"%PDF-1.7\n%\x80\x81\x82\x83\n".to_vec();
+
+    server
+        .post(
+            &format!("{}/report.pdf", fs_url),
+            json!({
+                "content": BASE64.encode(&pdf_bytes),
+                "encoding": "base64"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    let json_read: SessionFile = server
+        .get(&format!("{}/report.pdf", fs_url))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    assert_eq!(json_read.encoding, "base64");
+    assert_eq!(
+        json_read.content.as_deref(),
+        Some(BASE64.encode(&pdf_bytes).as_str())
+    );
+
+    let raw = server
+        .get(&format!("{}/_/download/report.pdf", fs_url))
+        .await
+        .assert_status(StatusCode::OK);
+
+    assert_eq!(
+        raw.headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok()),
+        Some("application/pdf")
+    );
+    assert_eq!(
+        raw.headers()
+            .get("content-disposition")
+            .and_then(|value| value.to_str().ok()),
+        Some("attachment; filename=\"report.pdf\"")
+    );
+    assert_eq!(raw.bytes(), pdf_bytes.as_slice());
+}
+
+#[tokio::test]
+async fn test_session_file_read_accept_octet_stream_returns_raw_bytes() {
+    let server = TestServer::in_memory().await;
+
+    let agent: Agent = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": "fs-negotiate-agent",
+                "display_name": "FS Negotiate Agent",
+                "system_prompt": "Test"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let session: Session = server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": server.seed_base_harness_id,
+                "agent_id": agent.public_id
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let fs_url = format!("/v1/sessions/{}/fs", session.id);
+    let raw_bytes = vec![0, 159, 146, 150];
+
+    server
+        .post(
+            &format!("{}/payload.bin", fs_url),
+            json!({
+                "content": BASE64.encode(&raw_bytes),
+                "encoding": "base64"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    let response = server
+        .request_raw(
+            axum::http::Method::GET,
+            &format!("{}/payload.bin", fs_url),
+            vec![("accept", "application/octet-stream")],
+            vec![],
+        )
+        .await
+        .assert_status(StatusCode::OK);
+
+    assert_eq!(
+        response
+            .headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok()),
+        Some("application/octet-stream")
+    );
+    assert_eq!(response.bytes(), raw_bytes.as_slice());
+}
+
+#[tokio::test]
+async fn test_session_file_download_path_rejects_directories() {
+    let server = TestServer::in_memory().await;
+
+    let agent: Agent = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": "fs-download-dir-agent",
+                "display_name": "FS Download Dir Agent",
+                "system_prompt": "Test"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let session: Session = server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": server.seed_base_harness_id,
+                "agent_id": agent.public_id
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let fs_url = format!("/v1/sessions/{}/fs", session.id);
+
+    server
+        .post(
+            &format!("{}/docs", fs_url),
+            json!({
+                "is_directory": true
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    let response = server.get(&format!("{}/_/download/docs", fs_url)).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
 // ============================================

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -701,6 +701,11 @@ impl TestResponse {
         String::from_utf8_lossy(&self.body).to_string()
     }
 
+    /// Get the raw response body bytes
+    pub fn bytes(&self) -> &[u8] {
+        &self.body
+    }
+
     /// Parse the body as JSON
     pub fn json<T: DeserializeOwned>(&self) -> T {
         serde_json::from_slice(&self.body)

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3766,6 +3766,52 @@
         }
       }
     },
+    "/v1/sessions/{session_id}/fs/_/download/{path}": {
+      "get": {
+        "tags": [
+          "filesystem"
+        ],
+        "summary": "GET /fs/_/download/*path - Download raw file bytes",
+        "operationId": "download_path",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "description": "Session ID (prefixed, e.g., sess_...)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "path",
+            "in": "path",
+            "description": "File path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Raw file bytes",
+            "content": {
+              "application/octet-stream": {}
+            }
+          },
+          "400": {
+            "description": "Invalid session ID or path points to a directory"
+          },
+          "404": {
+            "description": "File not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
     "/v1/sessions/{session_id}/fs/_/grep": {
       "post": {
         "tags": [

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -249,11 +249,12 @@ Virtual filesystem scoped to each session. See [session-filesystem.md](session-f
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/v1/sessions/{session_id}/fs` | List root directory |
-| GET | `/v1/sessions/{session_id}/fs/{path}` | Read file or list directory |
+| GET | `/v1/sessions/{session_id}/fs/{path}` | Read file or list directory; `Accept: application/octet-stream` returns raw file bytes |
 | POST | `/v1/sessions/{session_id}/fs/{path}` | Create file or directory |
 | PUT | `/v1/sessions/{session_id}/fs/{path}` | Update file content |
 | DELETE | `/v1/sessions/{session_id}/fs/{path}` | Delete file |
 | DELETE | `/v1/sessions/{session_id}/fs/{path}?recursive=true` | Delete directory recursively |
+| GET | `/v1/sessions/{session_id}/fs/_/download/{path}` | Download raw file bytes |
 | POST | `/v1/sessions/{session_id}/fs/_/stat` | Get file metadata |
 | POST | `/v1/sessions/{session_id}/fs/_/move` | Move/rename file |
 | POST | `/v1/sessions/{session_id}/fs/_/copy` | Copy file |

--- a/specs/session-filesystem.md
+++ b/specs/session-filesystem.md
@@ -104,6 +104,7 @@ All endpoints under `/v1/sessions/{session_id}/fs`
 | POST | `/fs/_/move` | Move/rename file |
 | POST | `/fs/_/copy` | Copy file |
 | POST | `/fs/_/grep` | Search files by content |
+| GET | `/fs/_/download/{path}` | Download raw file bytes |
 
 **Note:** Paths starting with `_` are reserved for system actions and cannot be used for file creation or updates.
 
@@ -113,6 +114,8 @@ See the OpenAPI spec (`./scripts/export-openapi.sh`) for detailed request/respon
 - Create: `POST /fs/{path}` with `{ "content": "...", "encoding": "text" }`
 - Directory: `POST /fs/{path}` with `{ "is_directory": true }`
 - Grep: `POST /fs/_/grep` with `{ "pattern": "...", "path_pattern": "*.rs" }`
+- Raw download: `GET /fs/_/download/{path}` for decoded bytes with `Content-Disposition: attachment`
+- Content negotiation: `GET /fs/{path}` still returns JSON by default, but `Accept: application/octet-stream` returns decoded raw bytes for files
 
 ### Behavior
 
@@ -127,6 +130,7 @@ See the OpenAPI spec (`./scripts/export-openapi.sh`) for detailed request/respon
 9. **Bounded diff payloads:** `edit_file` returns a unified diff for transcript/UI rendering, but large diffs are truncated and flagged to avoid oversized tool payloads.
 10. **Capability mounts:** When a session is created, files from capability mount points are automatically populated. Inline mounts are written to the database; virtual mounts (`MountSource::Virtual`) are registered in an in-memory `VirtualMountRegistry` and served without DB writes. See `specs/capabilities.md` for details.
 11. **Starter files:** Agents and harnesses can declare starter files that are copied into each new session before use. Agent starter files override harness starter files when they target the same normalized path.
+12. **Raw download behavior:** Raw file responses decode base64-backed binary files before sending bytes, infer `Content-Type` from the file path when possible, and reject directory downloads with `400 Bad Request`.
 
 ### Database Schema
 


### PR DESCRIPTION
## What
Add raw session-file download support for API clients.

The session filesystem now supports:
- `GET /v1/sessions/{session_id}/fs/_/download/{path}` for attachment-style raw bytes
- `Accept: application/octet-stream` on `GET /v1/sessions/{session_id}/fs/{path}` for content negotiation without breaking existing JSON reads

Specs and generated OpenAPI are updated, and API coverage was added for the new path, negotiated reads, and directory rejection.

## Why
Binary session files were only readable through the JSON `SessionFile` envelope, which forced clients to fetch base64 content and decode it themselves. This adds a direct raw-byte path for downloads while preserving the existing JSON contract for current clients.

Fixes EVE-387.

## How
Decode stored base64-backed file content into raw bytes at the HTTP edge, infer a response MIME type from the file path, and return an attachment response.

Validation:
- `cargo test -p everruns-server --test api_integration_test test_session_file_ -- --nocapture`
- Live smoke in `just start-dev --no-watch`: created a session file, verified both `/_/download/...` and `Accept: application/octet-stream` returned the expected PDF bytes and attachment headers
- `./scripts/export-openapi.sh`
- `just pre-push`

## Risk
- Low
- Main risk is changing `GET /fs/{path}` behavior for callers that send `Accept: application/octet-stream`; default JSON behavior remains unchanged, and directory downloads return `400`.

## Security
- Threat categories reviewed: TM-API, TM-FS
- Findings and resolutions: No new auth boundary or cross-session access path was introduced; the new route reuses existing session lookup and file-read authorization, decodes only already-stored content, and rejects directory downloads instead of attempting recursive/raw output. No threat-model update was required.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
