### PR TITLE
feat(openai): make gpt-image-2 image generation reliable

### DIFF
--- a/apps/ui/src/__tests__/capability-settings-editor.test.tsx
+++ b/apps/ui/src/__tests__/capability-settings-editor.test.tsx
@@ -18,18 +18,21 @@ describe("CapabilitySettingsEditor", () => {
     expect(
       screen.getByText(/Uses OpenAI's current ChatGPT Images 2.0 API model/i),
     ).toBeInTheDocument();
+    expect(screen.getByText("Medium")).toBeInTheDocument();
+    expect(screen.getByText(/Balanced quality and latency/i)).toBeInTheDocument();
   });
 
-  it("shows the legacy GPT Image 1 description when configured", () => {
+  it("shows the configured legacy model and high-quality descriptions", () => {
     render(
       <CapabilitySettingsEditor
         capabilityId="gpt_image_gen"
-        config={{ model: "gpt-image-1" }}
+        config={{ model: "gpt-image-1", default_quality: "high" }}
         onChange={jest.fn()}
       />,
     );
 
     expect(screen.getByText("GPT Image 1")).toBeInTheDocument();
     expect(screen.getByText(/Legacy fallback/i)).toBeInTheDocument();
+    expect(screen.getByText(/Highest fidelity, but materially slower/i)).toBeInTheDocument();
   });
 });

--- a/apps/ui/src/__tests__/capability-settings-editor.test.tsx
+++ b/apps/ui/src/__tests__/capability-settings-editor.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import {
+  CapabilitySettingsEditor,
+  hasCapabilitySettings,
+} from "@/components/agents/capability-settings-editor";
+
+describe("CapabilitySettingsEditor", () => {
+  it("exposes settings for OpenAI image generation", () => {
+    expect(hasCapabilitySettings("gpt_image_gen")).toBe(true);
+  });
+
+  it("shows ChatGPT Images 2.0 as the default image model", () => {
+    render(
+      <CapabilitySettingsEditor capabilityId="gpt_image_gen" config={{}} onChange={jest.fn()} />,
+    );
+
+    expect(screen.getByText("ChatGPT Images 2.0")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Uses OpenAI's current ChatGPT Images 2.0 API model/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the legacy GPT Image 1 description when configured", () => {
+    render(
+      <CapabilitySettingsEditor
+        capabilityId="gpt_image_gen"
+        config={{ model: "gpt-image-1" }}
+        onChange={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText("GPT Image 1")).toBeInTheDocument();
+    expect(screen.getByText(/Legacy fallback/i)).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/components/agents/capability-settings-editor.tsx
+++ b/apps/ui/src/components/agents/capability-settings-editor.tsx
@@ -2,10 +2,18 @@
 
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import type { CapabilityId } from "@/lib/api/types";
 
 // Known capability IDs that have configurable settings
 const DOCKER_CONTAINER_ID = "docker_container";
+const GPT_IMAGE_GEN_ID = "gpt_image_gen";
 
 // Type definitions for capability-specific configs
 export interface DockerContainerConfig {
@@ -13,7 +21,13 @@ export interface DockerContainerConfig {
   working_dir?: string;
 }
 
-export type CapabilityConfig = DockerContainerConfig | Record<string, unknown>;
+type GptImageGenModel = "gpt-image-2" | "gpt-image-1";
+
+export interface GptImageGenConfig {
+  model?: GptImageGenModel;
+}
+
+export type CapabilityConfig = DockerContainerConfig | GptImageGenConfig | Record<string, unknown>;
 
 interface CapabilitySettingsEditorProps {
   /** The capability ID */
@@ -46,6 +60,14 @@ export function CapabilitySettingsEditor({
           disabled={disabled}
         />
       );
+    case GPT_IMAGE_GEN_ID:
+      return (
+        <GptImageGenEditor
+          config={config as GptImageGenConfig}
+          onChange={onChange}
+          disabled={disabled}
+        />
+      );
     default:
       // No settings editor for this capability
       return null;
@@ -56,7 +78,7 @@ export function CapabilitySettingsEditor({
  * Check if a capability has configurable settings
  */
 export function hasCapabilitySettings(capabilityId: CapabilityId): boolean {
-  return capabilityId === DOCKER_CONTAINER_ID;
+  return capabilityId === DOCKER_CONTAINER_ID || capabilityId === GPT_IMAGE_GEN_ID;
 }
 
 // ============================================================================
@@ -126,6 +148,75 @@ function DockerContainerEditor({ config, onChange, disabled }: DockerContainerEd
         <p className="text-xs text-muted-foreground">
           Default working directory inside the container
         </p>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// OpenAI Image Generation Config Editor
+// ============================================================================
+
+const DEFAULT_GPT_IMAGE_MODEL: GptImageGenModel = "gpt-image-2";
+
+const GPT_IMAGE_MODEL_OPTIONS: Array<{
+  value: GptImageGenModel;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: "gpt-image-2",
+    label: "ChatGPT Images 2.0",
+    description: "Default. Uses OpenAI's current ChatGPT Images 2.0 API model (`gpt-image-2`).",
+  },
+  {
+    value: "gpt-image-1",
+    label: "GPT Image 1",
+    description: "Legacy fallback if you need the previous image model.",
+  },
+];
+
+interface GptImageGenEditorProps {
+  config: GptImageGenConfig;
+  onChange: (config: Record<string, unknown>) => void;
+  disabled?: boolean;
+}
+
+function GptImageGenEditor({ config, onChange, disabled }: GptImageGenEditorProps) {
+  const selectedModel = config.model || DEFAULT_GPT_IMAGE_MODEL;
+  const selectedOption =
+    GPT_IMAGE_MODEL_OPTIONS.find((option) => option.value === selectedModel) ??
+    GPT_IMAGE_MODEL_OPTIONS[0];
+
+  const handleModelChange = (value: string) => {
+    const newConfig = { ...config };
+    if (value !== DEFAULT_GPT_IMAGE_MODEL) {
+      newConfig.model = value as GptImageGenModel;
+    } else {
+      delete newConfig.model;
+    }
+    onChange(newConfig);
+  };
+
+  return (
+    <div className="space-y-3 pt-2">
+      <div className="space-y-1.5">
+        <Label htmlFor="gpt-image-model" className="text-xs font-normal text-muted-foreground">
+          Image Model
+        </Label>
+        <Select value={selectedModel} onValueChange={handleModelChange} disabled={disabled}>
+          <SelectTrigger id="gpt-image-model" className="w-full">
+            <SelectValue>{selectedOption.label}</SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            {GPT_IMAGE_MODEL_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">{selectedOption.description}</p>
       </div>
     </div>
   );

--- a/apps/ui/src/components/agents/capability-settings-editor.tsx
+++ b/apps/ui/src/components/agents/capability-settings-editor.tsx
@@ -22,9 +22,11 @@ export interface DockerContainerConfig {
 }
 
 type GptImageGenModel = "gpt-image-2" | "gpt-image-1";
+type GptImageGenQuality = "low" | "medium" | "high" | "auto";
 
 export interface GptImageGenConfig {
   model?: GptImageGenModel;
+  default_quality?: GptImageGenQuality;
 }
 
 export type CapabilityConfig = DockerContainerConfig | GptImageGenConfig | Record<string, unknown>;
@@ -158,6 +160,7 @@ function DockerContainerEditor({ config, onChange, disabled }: DockerContainerEd
 // ============================================================================
 
 const DEFAULT_GPT_IMAGE_MODEL: GptImageGenModel = "gpt-image-2";
+const DEFAULT_GPT_IMAGE_QUALITY: GptImageGenQuality = "medium";
 
 const GPT_IMAGE_MODEL_OPTIONS: Array<{
   value: GptImageGenModel;
@@ -176,6 +179,33 @@ const GPT_IMAGE_MODEL_OPTIONS: Array<{
   },
 ];
 
+const GPT_IMAGE_QUALITY_OPTIONS: Array<{
+  value: GptImageGenQuality;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: "medium",
+    label: "Medium",
+    description: "Default. Balanced quality and latency for ChatGPT Images 2.0.",
+  },
+  {
+    value: "low",
+    label: "Low",
+    description: "Fastest and cheapest. Best when throughput matters more than fidelity.",
+  },
+  {
+    value: "high",
+    label: "High",
+    description: "Highest fidelity, but materially slower on `gpt-image-2`.",
+  },
+  {
+    value: "auto",
+    label: "Auto",
+    description: "Let OpenAI choose the quality dynamically.",
+  },
+];
+
 interface GptImageGenEditorProps {
   config: GptImageGenConfig;
   onChange: (config: Record<string, unknown>) => void;
@@ -184,9 +214,13 @@ interface GptImageGenEditorProps {
 
 function GptImageGenEditor({ config, onChange, disabled }: GptImageGenEditorProps) {
   const selectedModel = config.model || DEFAULT_GPT_IMAGE_MODEL;
+  const selectedQuality = config.default_quality || DEFAULT_GPT_IMAGE_QUALITY;
   const selectedOption =
     GPT_IMAGE_MODEL_OPTIONS.find((option) => option.value === selectedModel) ??
     GPT_IMAGE_MODEL_OPTIONS[0];
+  const selectedQualityOption =
+    GPT_IMAGE_QUALITY_OPTIONS.find((option) => option.value === selectedQuality) ??
+    GPT_IMAGE_QUALITY_OPTIONS[0];
 
   const handleModelChange = (value: string) => {
     const newConfig = { ...config };
@@ -194,6 +228,16 @@ function GptImageGenEditor({ config, onChange, disabled }: GptImageGenEditorProp
       newConfig.model = value as GptImageGenModel;
     } else {
       delete newConfig.model;
+    }
+    onChange(newConfig);
+  };
+
+  const handleQualityChange = (value: string) => {
+    const newConfig = { ...config };
+    if (value !== DEFAULT_GPT_IMAGE_QUALITY) {
+      newConfig.default_quality = value as GptImageGenQuality;
+    } else {
+      delete newConfig.default_quality;
     }
     onChange(newConfig);
   };
@@ -217,6 +261,25 @@ function GptImageGenEditor({ config, onChange, disabled }: GptImageGenEditorProp
           </SelectContent>
         </Select>
         <p className="text-xs text-muted-foreground">{selectedOption.description}</p>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="gpt-image-quality" className="text-xs font-normal text-muted-foreground">
+          Default Quality
+        </Label>
+        <Select value={selectedQuality} onValueChange={handleQualityChange} disabled={disabled}>
+          <SelectTrigger id="gpt-image-quality" className="w-full">
+            <SelectValue>{selectedQualityOption.label}</SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            {GPT_IMAGE_QUALITY_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">{selectedQualityOption.description}</p>
       </div>
     </div>
   );

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -217,6 +217,7 @@ impl ToolExecutionResult {
                     tool_name = %tool_name,
                     tool_call_id = %tool_call_id,
                     error = %err.message,
+                    error_chain = %err.chain_string(),
                     "Tool internal error (details hidden from LLM)"
                 );
 
@@ -271,6 +272,19 @@ impl ToolInternalError {
             message: message.into(),
             source: None,
         }
+    }
+
+    pub fn chain_string(&self) -> String {
+        let mut parts = vec![self.message.clone()];
+        let mut current = <Self as std::error::Error>::source(self);
+        while let Some(source) = current {
+            let message = source.to_string();
+            if parts.last() != Some(&message) {
+                parts.push(message);
+            }
+            current = source.source();
+        }
+        parts.join(": ")
     }
 }
 

--- a/crates/openai/src/image_capability.rs
+++ b/crates/openai/src/image_capability.rs
@@ -611,28 +611,6 @@ async fn resolve_client_config(
         if let Some(api_key) = api_key {
             return Ok(ResolvedClientConfig { api_key, base_url });
         }
-
-        if let Some(base_url) = base_url {
-            let Some(provider_store) = &context.provider_credential_store else {
-                return Err(ToolExecutionResult::tool_error(
-                    "OpenAI credentials are not configured. Store OPENAI_API_KEY via secret_store or configure an OpenAI provider.",
-                ));
-            };
-
-            return match provider_store
-                .get_default_provider_credentials("openai")
-                .await
-            {
-                Ok(Some(credentials)) => Ok(ResolvedClientConfig {
-                    api_key: credentials.api_key,
-                    base_url: Some(base_url),
-                }),
-                Ok(None) => Err(ToolExecutionResult::tool_error(
-                    "OpenAI credentials are not configured. Store OPENAI_API_KEY via secret_store or configure an OpenAI provider.",
-                )),
-                Err(error) => Err(ToolExecutionResult::internal_error(error)),
-            };
-        }
     }
 
     let Some(provider_store) = &context.provider_credential_store else {

--- a/crates/openai/src/image_capability.rs
+++ b/crates/openai/src/image_capability.rs
@@ -1157,6 +1157,16 @@ mod tests {
     }
 
     #[test]
+    fn capability_config_ignores_unknown_fields() {
+        let config = parse_capability_config(&json!({
+            "model": "gpt-image-1",
+            "future_field": true
+        }))
+        .unwrap();
+        assert_eq!(config.model, ImageGenerationModel::GptImage1);
+    }
+
+    #[test]
     fn capability_config_rejects_unknown_model_override() {
         let result = parse_capability_config(&json!({
             "model": "chatgpt-image-latest"

--- a/crates/openai/src/image_capability.rs
+++ b/crates/openai/src/image_capability.rs
@@ -1157,16 +1157,6 @@ mod tests {
     }
 
     #[test]
-    fn capability_config_ignores_unknown_fields() {
-        let config = parse_capability_config(&json!({
-            "model": "gpt-image-1",
-            "future_field": true
-        }))
-        .unwrap();
-        assert_eq!(config.model, ImageGenerationModel::GptImage1);
-    }
-
-    #[test]
     fn capability_config_rejects_unknown_model_override() {
         let result = parse_capability_config(&json!({
             "model": "chatgpt-image-latest"

--- a/crates/openai/src/image_capability.rs
+++ b/crates/openai/src/image_capability.rs
@@ -6,7 +6,7 @@ use base64::Engine;
 use everruns_core::ImageId;
 use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin};
 use everruns_core::session_file::SessionFile;
-use everruns_core::tool_types::ToolHints;
+use everruns_core::tool_types::{DeferrablePolicy, ToolDefinition, ToolHints};
 use everruns_core::tools::{Tool, ToolExecutionResult, ToolResultImage};
 use everruns_core::traits::{CreateStoredImage, ToolContext};
 use serde::Deserialize;
@@ -14,7 +14,10 @@ use serde_json::{Value, json};
 use std::sync::LazyLock;
 
 const GPT_IMAGE_GEN_CAPABILITY_ID: &str = "gpt_image_gen";
-const OPENAI_IMAGE_MODEL: &str = "gpt-image-1";
+// Default to OpenAI's ChatGPT Images 2.0 API model (`gpt-image-2`), while
+// keeping the legacy GPT Image 1 path available as an explicit opt-in.
+const DEFAULT_OPENAI_IMAGE_MODEL: ImageGenerationModel = ImageGenerationModel::GptImage2;
+const DEFAULT_OPENAI_IMAGE_QUALITY: ImageGenerationQuality = ImageGenerationQuality::Medium;
 const DEFAULT_OUTPUT_DIR: &str = "/workspace/.outputs/images";
 const DEFAULT_GENERATE_PREFIX: &str = "generated-image";
 const DEFAULT_EDIT_PREFIX: &str = "edited-image";
@@ -32,9 +35,17 @@ inventory::submit! {
 
 static SYSTEM_PROMPT: LazyLock<String> = LazyLock::new(|| {
     r#"Use `generate_image` for raster image generation and `edit_image` to transform existing images.
+If the user asks for image generation or editing and those tools are present in the tool list, call them directly.
+Do not claim the tools are unavailable when `generate_image` or `edit_image` are listed as available tools.
+For straightforward image requests, avoid unrelated metadata or bookkeeping tools before the image tool call.
+When the user asks for multiple new images, make one `generate_image` call per requested concept unless they explicitly ask for a batch in one call.
+Unless the user says otherwise, set `save_to_session_fs` to true, keep `persist_artifact` enabled, and save under `/workspace/.outputs/images`.
+Prefer PNG output and rely on the capability default quality unless the user requests a specific quality.
+Do not stop at writing prompts, suggesting external tools, or describing environment limitations unless an actual image tool call fails.
 
 Store per-session OpenAI overrides in `secret_store` under `OPENAI_API_KEY` and optionally `OPENAI_BASE_URL`.
-When saving files, write under `/workspace/.outputs/images` unless the user requests another directory."#
+When saving files, write under `/workspace/.outputs/images` unless the user requests another directory.
+Prefer medium quality unless the user explicitly asks for higher fidelity."#
         .to_string()
 });
 
@@ -70,7 +81,31 @@ impl Capability for GptImageGenCapability {
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
-        vec![Box::new(GenerateImageTool), Box::new(EditImageTool)]
+        self.tools_with_config(&json!({}))
+    }
+
+    fn tools_with_config(&self, config: &Value) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(GenerateImageTool {
+                config: config.clone(),
+            }),
+            Box::new(EditImageTool {
+                config: config.clone(),
+            }),
+        ]
+    }
+
+    fn tool_definitions(&self) -> Vec<ToolDefinition> {
+        self.tools()
+            .into_iter()
+            .map(|tool| {
+                let mut definition = tool.to_definition();
+                if let ToolDefinition::Builtin(builtin) = &mut definition {
+                    builtin.deferrable = DeferrablePolicy::Never;
+                }
+                definition
+            })
+            .collect()
     }
 
     fn dependencies(&self) -> Vec<&'static str> {
@@ -78,7 +113,9 @@ impl Capability for GptImageGenCapability {
     }
 }
 
-pub struct GenerateImageTool;
+pub struct GenerateImageTool {
+    config: Value,
+}
 
 #[async_trait]
 impl Tool for GenerateImageTool {
@@ -91,7 +128,7 @@ impl Tool for GenerateImageTool {
     }
 
     fn description(&self) -> &str {
-        "Generate raster images with OpenAI's GPT Image API and optionally persist them as artifacts or session files."
+        "Server-side image generation tool. Call this directly for user image requests; it generates the image in this session and can persist results as artifacts or session files."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -107,7 +144,7 @@ impl Tool for GenerateImageTool {
                 "quality": {
                     "type": "string",
                     "enum": ["low", "medium", "high", "auto"],
-                    "description": "Generation quality. Defaults to auto."
+                    "description": "Generation quality. Defaults to the capability default quality (medium unless overridden)."
                 },
                 "background": {
                     "type": "string",
@@ -167,6 +204,11 @@ impl Tool for GenerateImageTool {
         if let Err(message) = validate_output_options(&args.common) {
             return ToolExecutionResult::tool_error(message);
         }
+        let capability_config = match parse_capability_config(&self.config) {
+            Ok(config) => config,
+            Err(result) => return result,
+        };
+        let model = capability_config.model.as_str();
 
         let client = match build_client(context).await {
             Ok(client) => client,
@@ -175,10 +217,13 @@ impl Tool for GenerateImageTool {
 
         let response = match client
             .generate(GenerateImageRequest {
-                model: OPENAI_IMAGE_MODEL.to_string(),
+                model: model.to_string(),
                 prompt: args.prompt.clone(),
                 size: args.common.size.clone(),
-                quality: args.common.quality.clone(),
+                quality: Some(resolve_quality(
+                    args.common.quality.as_deref(),
+                    capability_config.default_quality,
+                )),
                 background: args.common.background.clone(),
                 output_format: args.common.format.clone(),
                 count: args.common.count(),
@@ -186,7 +231,7 @@ impl Tool for GenerateImageTool {
             .await
         {
             Ok(response) => response,
-            Err(error) => return ToolExecutionResult::internal_error_msg(error.to_string()),
+            Err(error) => return ToolExecutionResult::internal_error_msg(format!("{error:#}")),
         };
 
         materialize_outputs(
@@ -194,6 +239,7 @@ impl Tool for GenerateImageTool {
             &args.prompt,
             None,
             &args.common,
+            model,
             response.data,
             args.common
                 .filename_prefix
@@ -204,7 +250,9 @@ impl Tool for GenerateImageTool {
     }
 }
 
-pub struct EditImageTool;
+pub struct EditImageTool {
+    config: Value,
+}
 
 #[async_trait]
 impl Tool for EditImageTool {
@@ -217,7 +265,7 @@ impl Tool for EditImageTool {
     }
 
     fn description(&self) -> &str {
-        "Edit one or more source images from a stored image artifact and/or a session file path."
+        "Server-side image editing tool. Call this directly when the user wants an existing image revised using a stored artifact and/or a session file path."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -241,7 +289,7 @@ impl Tool for EditImageTool {
                 "quality": {
                     "type": "string",
                     "enum": ["low", "medium", "high", "auto"],
-                    "description": "Generation quality. Defaults to auto."
+                    "description": "Generation quality. Defaults to the capability default quality (medium unless overridden)."
                 },
                 "background": {
                     "type": "string",
@@ -290,6 +338,11 @@ impl Tool for EditImageTool {
         if let Err(message) = validate_output_options(&args.common) {
             return ToolExecutionResult::tool_error(message);
         }
+        let capability_config = match parse_capability_config(&self.config) {
+            Ok(config) => config,
+            Err(result) => return result,
+        };
+        let model = capability_config.model.as_str();
 
         let sources = match collect_edit_sources(context, &args).await {
             Ok(sources) => sources,
@@ -302,11 +355,14 @@ impl Tool for EditImageTool {
 
         let response = match client
             .edit(EditImageRequest {
-                model: OPENAI_IMAGE_MODEL.to_string(),
+                model: model.to_string(),
                 prompt: args.prompt.clone(),
                 images: sources,
                 size: args.common.size.clone(),
-                quality: args.common.quality.clone(),
+                quality: Some(resolve_quality(
+                    args.common.quality.as_deref(),
+                    capability_config.default_quality,
+                )),
                 background: args.common.background.clone(),
                 output_format: args.common.format.clone(),
                 count: args.common.count(),
@@ -314,7 +370,7 @@ impl Tool for EditImageTool {
             .await
         {
             Ok(response) => response,
-            Err(error) => return ToolExecutionResult::internal_error_msg(error.to_string()),
+            Err(error) => return ToolExecutionResult::internal_error_msg(format!("{error:#}")),
         };
 
         materialize_outputs(
@@ -325,6 +381,7 @@ impl Tool for EditImageTool {
                 "path": args.path,
             })),
             &args.common,
+            model,
             response.data,
             args.common
                 .filename_prefix
@@ -416,11 +473,97 @@ struct ResolvedClientConfig {
     base_url: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+enum ImageGenerationModel {
+    #[serde(rename = "gpt-image-2")]
+    GptImage2,
+    #[serde(rename = "gpt-image-1")]
+    GptImage1,
+}
+
+impl ImageGenerationModel {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::GptImage2 => "gpt-image-2",
+            Self::GptImage1 => "gpt-image-1",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+enum ImageGenerationQuality {
+    #[serde(rename = "low")]
+    Low,
+    #[serde(rename = "medium")]
+    Medium,
+    #[serde(rename = "high")]
+    High,
+    #[serde(rename = "auto")]
+    Auto,
+}
+
+impl ImageGenerationQuality {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Auto => "auto",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct GptImageGenCapabilityConfig {
+    #[serde(default = "default_openai_image_model")]
+    model: ImageGenerationModel,
+    #[serde(default = "default_openai_image_quality")]
+    default_quality: ImageGenerationQuality,
+}
+
+impl Default for GptImageGenCapabilityConfig {
+    fn default() -> Self {
+        Self {
+            model: default_openai_image_model(),
+            default_quality: default_openai_image_quality(),
+        }
+    }
+}
+
+fn default_openai_image_model() -> ImageGenerationModel {
+    DEFAULT_OPENAI_IMAGE_MODEL
+}
+
+fn default_openai_image_quality() -> ImageGenerationQuality {
+    DEFAULT_OPENAI_IMAGE_QUALITY
+}
+
+fn resolve_quality(
+    explicit_quality: Option<&str>,
+    default_quality: ImageGenerationQuality,
+) -> String {
+    explicit_quality
+        .unwrap_or(default_quality.as_str())
+        .to_string()
+}
+
 fn parse_arguments<T: for<'de> Deserialize<'de>>(
     arguments: Value,
 ) -> Result<T, ToolExecutionResult> {
     serde_json::from_value(arguments)
         .map_err(|error| ToolExecutionResult::tool_error(format!("Invalid arguments: {error}")))
+}
+
+fn parse_capability_config(
+    config: &Value,
+) -> Result<GptImageGenCapabilityConfig, ToolExecutionResult> {
+    if config.is_null() {
+        return Ok(GptImageGenCapabilityConfig::default());
+    }
+
+    serde_json::from_value::<GptImageGenCapabilityConfig>(config.clone()).map_err(|error| {
+        ToolExecutionResult::tool_error(format!("Invalid gpt_image_gen config: {error}"))
+    })
 }
 
 async fn build_client(context: &ToolContext) -> Result<OpenAiImageClient, ToolExecutionResult> {
@@ -430,7 +573,7 @@ async fn build_client(context: &ToolContext) -> Result<OpenAiImageClient, ToolEx
     };
 
     OpenAiImageClient::new(config.api_key, config.base_url)
-        .map_err(|error| ToolExecutionResult::internal_error_msg(error.to_string()))
+        .map_err(|error| ToolExecutionResult::internal_error_msg(format!("{error:#}")))
 }
 
 async fn resolve_client_config(
@@ -445,7 +588,11 @@ async fn resolve_client_config(
         .await
         {
             Ok(api_key) => api_key,
-            Err(error) => return Err(ToolExecutionResult::internal_error_msg(error.to_string())),
+            Err(error) => {
+                return Err(ToolExecutionResult::internal_error_msg(format!(
+                    "{error:#}"
+                )));
+            }
         };
         let base_url = match get_first_secret(
             storage_store.as_ref(),
@@ -455,13 +602,17 @@ async fn resolve_client_config(
         .await
         {
             Ok(base_url) => base_url,
-            Err(error) => return Err(ToolExecutionResult::internal_error_msg(error.to_string())),
+            Err(error) => {
+                return Err(ToolExecutionResult::internal_error_msg(format!(
+                    "{error:#}"
+                )));
+            }
         };
         if let Some(api_key) = api_key {
             return Ok(ResolvedClientConfig { api_key, base_url });
         }
 
-        if base_url.is_some() {
+        if let Some(base_url) = base_url {
             let Some(provider_store) = &context.provider_credential_store else {
                 return Err(ToolExecutionResult::tool_error(
                     "OpenAI credentials are not configured. Store OPENAI_API_KEY via secret_store or configure an OpenAI provider.",
@@ -474,7 +625,7 @@ async fn resolve_client_config(
             {
                 Ok(Some(credentials)) => Ok(ResolvedClientConfig {
                     api_key: credentials.api_key,
-                    base_url: credentials.base_url,
+                    base_url: Some(base_url),
                 }),
                 Ok(None) => Err(ToolExecutionResult::tool_error(
                     "OpenAI credentials are not configured. Store OPENAI_API_KEY via secret_store or configure an OpenAI provider.",
@@ -626,6 +777,7 @@ async fn materialize_outputs(
     prompt: &str,
     source: Option<Value>,
     common: &CommonImageArgs,
+    model: &str,
     images: Vec<ImageApiImage>,
     filename_prefix: String,
 ) -> ToolExecutionResult {
@@ -661,7 +813,7 @@ async fn materialize_outputs(
                     data: bytes.clone(),
                     metadata: json!({
                         "provider": "openai",
-                        "model": OPENAI_IMAGE_MODEL,
+                        "model": model,
                         "prompt": prompt,
                         "revised_prompt": image.revised_prompt,
                     }),
@@ -717,7 +869,7 @@ async fn materialize_outputs(
     ToolExecutionResult::success_with_images(
         json!({
             "provider": "openai",
-            "model": OPENAI_IMAGE_MODEL,
+            "model": model,
             "prompt": prompt,
             "count": rendered_results.len(),
             "source": source,
@@ -972,5 +1124,83 @@ mod tests {
             resolved.base_url,
             Some("https://provider.example/v1".to_string())
         );
+    }
+
+    #[test]
+    fn capability_config_defaults_to_gpt_image_2() {
+        let config = parse_capability_config(&json!({})).unwrap();
+        assert_eq!(config.model, ImageGenerationModel::GptImage2);
+        assert_eq!(config.default_quality, ImageGenerationQuality::Medium);
+    }
+
+    #[test]
+    fn capability_config_accepts_legacy_model_override() {
+        let config = parse_capability_config(&json!({
+            "model": "gpt-image-1",
+            "default_quality": "low"
+        }))
+        .unwrap();
+        assert_eq!(config.model, ImageGenerationModel::GptImage1);
+        assert_eq!(config.default_quality, ImageGenerationQuality::Low);
+    }
+
+    #[test]
+    fn capability_config_ignores_unknown_fields() {
+        let config = parse_capability_config(&json!({
+            "model": "gpt-image-1",
+            "default_quality": "high",
+            "future_field": true
+        }))
+        .unwrap();
+        assert_eq!(config.model, ImageGenerationModel::GptImage1);
+        assert_eq!(config.default_quality, ImageGenerationQuality::High);
+    }
+
+    #[test]
+    fn capability_config_rejects_unknown_model_override() {
+        let result = parse_capability_config(&json!({
+            "model": "chatgpt-image-latest"
+        }));
+        let error = result.unwrap_err();
+        match error {
+            ToolExecutionResult::ToolError(message) => {
+                assert!(message.contains("Invalid gpt_image_gen config"));
+            }
+            other => panic!("expected tool error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_quality_prefers_explicit_argument() {
+        assert_eq!(
+            resolve_quality(Some("high"), ImageGenerationQuality::Medium),
+            "high"
+        );
+    }
+
+    #[test]
+    fn resolve_quality_uses_capability_default_when_omitted() {
+        assert_eq!(
+            resolve_quality(None, ImageGenerationQuality::Medium),
+            "medium"
+        );
+    }
+
+    #[test]
+    fn system_prompt_marks_image_tools_as_directly_invokable() {
+        let prompt = GptImageGenCapability.system_prompt_addition().unwrap();
+        assert!(prompt.contains("call them directly"));
+        assert!(prompt.contains("Do not claim the tools are unavailable"));
+        assert!(prompt.contains("Do not stop at writing prompts"));
+    }
+
+    #[test]
+    fn image_tools_are_never_deferred_for_tool_search() {
+        for definition in GptImageGenCapability.tool_definitions() {
+            let ToolDefinition::Builtin(builtin) = definition else {
+                panic!("expected builtin tool definition");
+            };
+            assert_eq!(builtin.deferrable, DeferrablePolicy::Never);
+        }
     }
 }

--- a/crates/openai/src/images.rs
+++ b/crates/openai/src/images.rs
@@ -4,6 +4,8 @@ use reqwest::{Client, RequestBuilder, Url};
 use serde::{Deserialize, Serialize};
 
 const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
+const DEFAULT_OPENAI_IMAGE_TIMEOUT_SECS: u64 = 300;
+const OPENAI_IMAGE_TIMEOUT_ENV: &str = "OPENAI_IMAGE_TIMEOUT_SECS";
 
 #[derive(Debug, Clone)]
 pub struct OpenAiImageClient {
@@ -14,9 +16,14 @@ pub struct OpenAiImageClient {
 
 impl OpenAiImageClient {
     pub fn new(api_key: impl Into<String>, base_url: Option<String>) -> Result<Self> {
+        let timeout_secs = std::env::var(OPENAI_IMAGE_TIMEOUT_ENV)
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(DEFAULT_OPENAI_IMAGE_TIMEOUT_SECS);
         Ok(Self {
             client: Client::builder()
-                .timeout(std::time::Duration::from_secs(120))
+                .timeout(std::time::Duration::from_secs(timeout_secs))
                 .build()
                 .context("failed to build OpenAI image client")?,
             api_key: api_key.into(),

--- a/docs/capabilities/openai-image-generation.md
+++ b/docs/capabilities/openai-image-generation.md
@@ -10,7 +10,13 @@ description: Generate and edit raster images with OpenAI's GPT Image API, persis
 | **Features** | None |
 | **Dependencies** | [`session_file_system`](/capabilities/file-system/), [`session_storage`](/capabilities/session-storage/) |
 
-Generate new raster images and edit existing ones with OpenAI's `gpt-image-1` model.
+Generate new raster images and edit existing ones with OpenAI's ChatGPT Images 2.0 API model, `gpt-image-2`, by default.
+
+If you need the previous generation model for compatibility, set capability config to:
+
+```json
+{ "model": "gpt-image-1" }
+```
 
 This capability resolves credentials server-side, persists durable image artifacts, and can also write generated outputs into the session filesystem under `/workspace/.outputs/images/`.
 

--- a/docs/capabilities/openai-image-generation.md
+++ b/docs/capabilities/openai-image-generation.md
@@ -12,11 +12,18 @@ description: Generate and edit raster images with OpenAI's GPT Image API, persis
 
 Generate new raster images and edit existing ones with OpenAI's ChatGPT Images 2.0 API model, `gpt-image-2`, by default.
 
-If you need the previous generation model for compatibility, set capability config to:
+Capability config supports both model selection and a default quality used when the tool call does not specify one:
 
 ```json
-{ "model": "gpt-image-1" }
+{
+  "model": "gpt-image-2",
+  "default_quality": "medium"
+}
 ```
+
+If you need the previous generation model for compatibility, set `"model": "gpt-image-1"`.
+
+The default quality is `medium`. That keeps latency and reliability reasonable for `gpt-image-2` while still producing polished outputs.
 
 This capability resolves credentials server-side, persists durable image artifacts, and can also write generated outputs into the session filesystem under `/workspace/.outputs/images/`.
 
@@ -40,7 +47,7 @@ Generate one or more images from a prompt.
 |---|---|---|---|
 | `prompt` | string | yes | Image generation prompt |
 | `size` | enum | no | `1024x1024`, `1536x1024`, `1024x1536`, `auto` |
-| `quality` | enum | no | `low`, `medium`, `high`, `auto` |
+| `quality` | enum | no | `low`, `medium`, `high`, `auto`. Defaults to capability `default_quality`, which defaults to `medium` |
 | `background` | enum | no | `transparent`, `opaque`, `auto` |
 | `format` | enum | no | `png`, `jpeg`, `webp` |
 | `count` | integer | no | Number of images to generate (1-10) |
@@ -59,7 +66,7 @@ Edit one or more existing images using a prompt.
 | `image_id` | string | conditional | Durable image artifact ID to use as an edit source |
 | `path` | string | conditional | Session filesystem path to use as an edit source |
 | `size` | enum | no | `1024x1024`, `1536x1024`, `1024x1536`, `auto` |
-| `quality` | enum | no | `low`, `medium`, `high`, `auto` |
+| `quality` | enum | no | `low`, `medium`, `high`, `auto`. Defaults to capability `default_quality`, which defaults to `medium` |
 | `background` | enum | no | `transparent`, `opaque`, `auto` |
 | `format` | enum | no | `png`, `jpeg`, `webp` |
 | `count` | integer | no | Number of images to produce (1-10) |
@@ -84,6 +91,8 @@ Both tools return:
 ## Notes
 
 - Transparent background requires `png` or `webp` output
+- High quality can take substantially longer than medium or low on `gpt-image-2`
+- `generate_image` and `edit_image` stay fully exposed even when OpenAI `tool_search` is enabled, so large tool lists do not defer their schemas
 - Session file edits must be `png`, `jpg`, `jpeg`, or `webp`
 - Edit sources larger than 50 MB are rejected before the API call
 - Saved workspace files are written as base64-encoded binary files

--- a/test_cases/agents/image_generation/TC001_funny_images_with_artifacts.md
+++ b/test_cases/agents/image_generation/TC001_funny_images_with_artifacts.md
@@ -9,7 +9,7 @@ This case is based on the real 2026-04-22 live run captured in `EVE-385`. It exi
 ## Preconditions
 
 - Control-plane running (`just start-dev` or `just start-all`)
-- OpenAI credentials configured so `gpt_image_gen` can call `gpt-image-1`
+- OpenAI credentials configured so `gpt_image_gen` can call `gpt-image-2` (default)
 - OpenAI `gpt-5.4` model available in the org
 - Agent can enable these capabilities:
   - `gpt_image_gen`

--- a/test_cases/agents/image_generation/TC001_funny_images_with_artifacts.md
+++ b/test_cases/agents/image_generation/TC001_funny_images_with_artifacts.md
@@ -4,7 +4,7 @@
 
 Verify that an agent using `gpt_image_gen` can complete a three-image generation request end to end: plan three `generate_image` calls, persist durable `img_*` artifacts, mirror each image into the session filesystem, and finish with a coherent final reply instead of an internal-error message.
 
-This case is based on the real 2026-04-22 live run captured in `EVE-385`. It exists to preserve the intended contract independently of the regressions tracked in `EVE-383` and `EVE-384`.
+This case is based on the successful 2026-04-23 live run captured after fixing the regressions tracked in `EVE-383`, `EVE-384`, and the tool-search exposure issue discovered during validation.
 
 ## Preconditions
 
@@ -76,9 +76,10 @@ This case is based on the real 2026-04-22 live run captured in `EVE-385`. It exi
   - `save_to_session_fs: true`
   - `persist_artifact: true`
   - `format: png`
-  - `size: 1536x1024`
-  - `quality: high`
+  - `quality: medium`
   - `background: opaque`
+- Every call uses a supported GPT Image size
+- For the recorded 2026-04-23 fixture, each call used `size: 1024x1024`
 - The three calls target the three requested joke concepts and use distinct filename prefixes
 
 ### Final Reply
@@ -117,14 +118,18 @@ This case is based on the real 2026-04-22 live run captured in `EVE-385`. It exi
 | Tool-call mismatch | Fewer than 3 `generate_image` calls, wrong output format/size/quality, or `persist_artifact` / `save_to_session_fs` omitted |
 | Collapsed concepts | Images are duplicates or do not clearly map to raccoon-boardroom, knight-cubicle, and cat-diner concepts |
 
-## Recorded Fixture Evidence (2026-04-22)
+## Recorded Fixture Evidence (2026-04-23)
 
-- Agent id: `agent_019db2ecc0017331a0ec8fe20dff9ad6`
-- Session id: `session_019db2ed04fb71eda72ce6eb262b41b1`
+- Agent id: `agent_019db8af118f71719bf264c49a115f7e`
+- Session id: `session_019db8af119f7f62afd2db111617d7b5`
 - Recorded image artifacts:
-  - `funny_raccoon_boardroom.png` -> `img_019db2ee211d7398ad2ba9871e3f466d`
-  - `funny_knight_cubicle.png` -> `img_019db2ee1c8d7adaaad316c1ee169016`
-  - `funny_cat_diner.png` -> `img_019db2ee35e974e78c0151b472e2ab49`
+  - `funny_raccoon_boardroom.png` -> `img_019db8b0235e7af3afa7ef32ed53af03`
+  - `funny_knight_cubicle.png` -> `img_019db8b021037a70a5cc4954c0538c43`
+  - `funny_cat_diner.png` -> `img_019db8b0203972409d6fe60863c4d569`
+- Recorded tool-call defaults:
+  - `quality: medium`
+  - `size: 1024x1024`
+  - `tool_search.enabled: true`, with `generate_image` still invoked successfully
 - Recorded prompt themes:
   - raccoon boardroom: polished comedic corporate satire with a raccoon presenting quarterly earnings to pigeons
   - knight cubicle: polished comedic fantasy-vs-office contrast with a knight trapped in a beige cubicle during standup


### PR DESCRIPTION
## What
Default the `gpt_image_gen` capability to OpenAI's `gpt-image-2` model and make image generation reliable by default.

## Why
The capability was still hardcoded to `gpt-image-1`, and live validation showed the new image flow was fragile in practice: the agent could choose expensive `high` quality requests that exceeded the client timeout, and internal errors hid the real cause.

## How
- Defaulted empty `gpt_image_gen` config to `gpt-image-2` and added capability-level `default_quality`, with `medium` as the default and `gpt-image-1` preserved as an explicit legacy override.
- Increased the OpenAI image client timeout to 300s, improved internal error-chain logging, and ensured image tools are not deferred behind `tool_search` so the model always sees the full schema.
- Added UI support for the quality/model settings, updated docs and the manual agent test case, and covered config parsing / quality resolution / credential precedence with Rust and Jest tests.
- Fixed the post-rebase trust-boundary regression so a session-only `OPENAI_BASE_URL` is ignored when execution falls back to provider credentials.

## Risk
- Medium
- This changes default image behavior, request latency budget, tool registration behavior, and OpenAI credential resolution. The main risk is changing how agents plan image calls or which base URL is used. Mitigated with targeted Rust tests, UI coverage, `just pre-push`, and a live OpenAI-backed smoke test.

## Security
- Threat categories reviewed: TM-TOOL, TM-LLM, TM-DOS
- Findings and resolutions:
  - `TM-TOOL`: image tools now opt out of deferred loading so the model sees the full schema; this reduces hidden-tool planning failures rather than expanding tool authority.
  - `TM-LLM`: capability config remains bounded to known model/quality values, invalid values are rejected, and the provider/session credential precedence bug was fixed so session-controlled base URLs cannot override provider credentials without a session API key.
  - `TM-DOS`: the timeout increase is intentional to accommodate valid `gpt-image-2` runtimes, while the new default quality drops from agent-selected `high` to capability default `medium` to keep latency and failure rates bounded.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
