### PR TITLE
feat(multitenancy): auto-select owning org from direct resource links

### DIFF
--- a/apps/ui/src/hooks/create-crud-hooks.ts
+++ b/apps/ui/src/hooks/create-crud-hooks.ts
@@ -10,6 +10,7 @@ import {
 } from "@tanstack/react-query";
 import type { CrudApi } from "@/lib/api/crud";
 import { useOrg } from "@/providers/org-provider";
+import { useResourceOrgFallback } from "./use-resource-org-fallback";
 
 interface UseCrudListOptions {
   includeArchived?: boolean;
@@ -88,12 +89,21 @@ export function createCrudHooks<TItem, TCreate, TUpdate>({
   }
 
   function useDetail(id: string | undefined) {
-    return useOrgScopedQuery({
+    const query = useOrgScopedQuery({
       queryKey: queryKeys.detail(id ?? ""),
       queryFn: () => api.get(id!),
       enabled: !!id,
       staleTime,
     });
+    // Cross-org fallback: if the current org doesn't own this resource but
+    // another org the caller belongs to does, switch and retry transparently.
+    // See specs/multitenancy.md (Cross-Org Resource Resolution).
+    useResourceOrgFallback({
+      resourceId: id,
+      error: query.error,
+      isLoading: query.isLoading,
+    });
+    return query;
   }
 
   function useCreate(): UseMutationResult<TItem, Error, TCreate> {

--- a/apps/ui/src/hooks/use-agent-identities.ts
+++ b/apps/ui/src/hooks/use-agent-identities.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/api/agent-identities";
 import { useOrg } from "@/providers/org-provider";
 import type { CreateAgentIdentityRequest, UpdateAgentIdentityRequest } from "@/lib/api/types";
+import { useResourceOrgFallback } from "./use-resource-org-fallback";
 
 const agentIdentityKeys = {
   all: ["agent-identities"] as const,
@@ -37,6 +38,11 @@ export function useAgentIdentity(identityId: string | undefined) {
     queryKey: [...agentIdentityKeys.detail(identityId ?? ""), org],
     queryFn: () => getAgentIdentity(identityId!),
     enabled: !!org && !!identityId,
+  });
+  useResourceOrgFallback({
+    resourceId: identityId,
+    error: query.error,
+    isLoading: orgLoading || query.isLoading,
   });
   return { ...query, isLoading: orgLoading || query.isLoading };
 }

--- a/apps/ui/src/hooks/use-resource-org-fallback.ts
+++ b/apps/ui/src/hooks/use-resource-org-fallback.ts
@@ -1,0 +1,73 @@
+// Cross-org resource fallback.
+// See specs/multitenancy.md (Cross-Org Resource Resolution).
+//
+// When a user follows a direct link to a top-level entity (session, agent,
+// app, ...) that lives in an org they are a member of but have not currently
+// selected, the entity API returns 404. This hook detects that condition,
+// asks the backend which of the caller's orgs owns the id, and triggers an
+// org switch that stays on the current page so the detail view re-fetches
+// against the right org instead of redirecting to the list.
+
+"use client";
+
+import { useEffect, useRef } from "react";
+import { ApiError } from "@/lib/api/client";
+import { resolveOrgForResource } from "@/lib/api/resolver";
+import { useOrg } from "@/providers/org-provider";
+
+interface Options {
+  /** Prefixed public id from the current route (e.g. `session_019db...`). */
+  resourceId: string | undefined;
+  /**
+   * The resource query's error (React Query's `error` field). The hook only
+   * reacts when it looks like a genuine 404 against the current org.
+   */
+  error: unknown;
+  /** True while the resource query is in flight. */
+  isLoading: boolean;
+}
+
+function is404(error: unknown): boolean {
+  return error instanceof ApiError && error.status === 404;
+}
+
+/**
+ * Attempt to recover from a 404 on an entity detail route by switching to the
+ * owning org (if the caller is a member of it).
+ *
+ * Calling sites keep their existing "not found" fallback UI — if the resolver
+ * can't recover, nothing changes. If it can, `setCurrentOrg` is invoked with
+ * `stayOnPage: true`, React Query invalidates, and the detail query re-runs
+ * in the new org context.
+ */
+export function useResourceOrgFallback({ resourceId, error, isLoading }: Options): void {
+  const { currentOrg, organizations, setCurrentOrg, isSwitching } = useOrg();
+  const attemptedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!resourceId || !currentOrg || isLoading || isSwitching) return;
+    if (!is404(error)) return;
+    // Only try once per resource id per mount to avoid ping-pong if the
+    // target org also returns 404.
+    if (attemptedRef.current === resourceId) return;
+    attemptedRef.current = resourceId;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const result = await resolveOrgForResource(resourceId);
+        if (cancelled || !result) return;
+        if (result.org_id === currentOrg.public_id) return;
+        const target = organizations.find((o) => o.public_id === result.org_id);
+        if (!target) return;
+        setCurrentOrg(target, { stayOnPage: true });
+      } catch (e) {
+        console.warn("Failed to resolve owning org for resource:", e);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [resourceId, error, isLoading, isSwitching, currentOrg, organizations, setCurrentOrg]);
+}

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -27,6 +27,7 @@ import { useOrg } from "@/providers/org-provider";
 import { useLocale } from "@/providers/locale-provider";
 import { createReconnectTracker } from "@/lib/sse-reconnect";
 import { createEventStream, type EventStreamLike } from "@/lib/event-stream";
+import { useResourceOrgFallback } from "./use-resource-org-fallback";
 
 /**
  * Fetch paginated sessions for an organization.
@@ -79,6 +80,15 @@ export function useSession(
     queryFn: () => getSession(sessionId!),
     enabled: !!org && !!sessionId,
     refetchInterval: options?.refetchInterval,
+  });
+
+  // Cross-org fallback: auto-switch to the owning org when the user follows a
+  // direct link to a session in another org they are a member of.
+  // See specs/multitenancy.md (Cross-Org Resource Resolution).
+  useResourceOrgFallback({
+    resourceId: sessionId,
+    error: query.error,
+    isLoading: orgLoading || query.isLoading,
   });
 
   // Include org loading state so pages show skeleton while org initializes

--- a/apps/ui/src/lib/api/resolver.ts
+++ b/apps/ui/src/lib/api/resolver.ts
@@ -1,0 +1,30 @@
+// Cross-org resource resolver client.
+// See specs/multitenancy.md (Cross-Org Resource Resolution).
+
+import { ApiError, api } from "./client";
+
+export interface ResolveOrgResult {
+  org_id: string;
+  org_name: string;
+}
+
+/**
+ * Resolve the owning organization for a prefixed resource ID.
+ *
+ * Returns `null` when the backend answers 404 — either the id is unknown, its
+ * prefix is not registered, or the resource lives in an org the caller is not
+ * a member of. Any other error is thrown.
+ */
+export async function resolveOrgForResource(id: string): Promise<ResolveOrgResult | null> {
+  try {
+    const response = await api.get<ResolveOrgResult>(
+      `/v1/resolve-org?id=${encodeURIComponent(id)}`,
+    );
+    return response.data;
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) {
+      return null;
+    }
+    throw error;
+  }
+}

--- a/apps/ui/src/providers/org-provider.tsx
+++ b/apps/ui/src/providers/org-provider.tsx
@@ -57,13 +57,23 @@ function getEntityListPath(pathname: string): string | null {
   return null;
 }
 
+export interface SetCurrentOrgOptions {
+  /**
+   * When true, skip the default "redirect entity detail to list" behaviour and
+   * stay on the current page after the switch. Used by the cross-org resource
+   * resolver — after switching to the owning org, the current detail URL is
+   * valid and should not be redirected away from.
+   */
+  stayOnPage?: boolean;
+}
+
 export interface OrgContextValue {
   /** Currently selected organization */
   currentOrg: OrganizationMembership | null;
   /** All organizations the user belongs to */
   organizations: OrganizationMembership[];
   /** Set the current organization (awaits server cookie sync before committing) */
-  setCurrentOrg: (org: OrganizationMembership) => void;
+  setCurrentOrg: (org: OrganizationMembership, options?: SetCurrentOrgOptions) => void;
   /** Check if current user has at least the given role in the current org */
   hasRole: (role: OrgRole) => boolean;
   /** Loading state */
@@ -161,7 +171,7 @@ export function OrgProvider({ children, initialOrgId = null }: OrgProviderProps)
 
   // Atomic org switch: await cookie sync → commit state → invalidate queries
   const setCurrentOrg = useCallback(
-    (org: OrganizationMembership) => {
+    (org: OrganizationMembership, options?: SetCurrentOrgOptions) => {
       // Skip if already on this org
       if (currentOrg?.public_id === org.public_id) return;
 
@@ -171,6 +181,7 @@ export function OrgProvider({ children, initialOrgId = null }: OrgProviderProps)
 
       const switchId = ++switchCounterRef.current;
       setIsSwitching(true);
+      const stayOnPage = options?.stayOnPage === true;
 
       // Await server cookie before committing client state
       switchOrgApi(org.public_id)
@@ -181,10 +192,14 @@ export function OrgProvider({ children, initialOrgId = null }: OrgProviderProps)
           localStorage.setItem(ORG_STORAGE_KEY, org.public_id);
           // Invalidate all org-scoped queries so stale data is refetched
           void queryClient.invalidateQueries();
-          // Redirect entity detail pages to their list page to avoid 404
-          const listPath = getEntityListPath(pathname);
-          if (listPath) {
-            router.push(listPath);
+          // Redirect entity detail pages to their list page to avoid 404,
+          // unless the caller has opted out (e.g. cross-org resource
+          // resolver, where the detail URL is valid in the new org).
+          if (!stayOnPage) {
+            const listPath = getEntityListPath(pathname);
+            if (listPath) {
+              router.push(listPath);
+            }
           }
         })
         .catch((error) => {

--- a/apps/ui/src/providers/org-provider.tsx
+++ b/apps/ui/src/providers/org-provider.tsx
@@ -35,11 +35,14 @@ export function hasPermission(currentRole: OrgRole, requiredRole: OrgRole): bool
 }
 
 // Entity detail route prefixes — when on a detail page under one of these,
-// org switch redirects to the list page to avoid a 404.
+// org switch redirects to the list page to avoid a 404. MUST stay in sync
+// with the dynamic [id] routes under apps/ui/src/app/(main)/.
 const ENTITY_PREFIXES = [
+  "/agent-identities/",
   "/agents/",
   "/apps/",
   "/capabilities/",
+  "/evals/",
   "/harnesses/",
   "/sessions/",
   "/durable/schedules/",

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -31,6 +31,7 @@ pub mod messages;
 pub mod notifications;
 pub mod organizations;
 pub mod prometheus;
+pub mod resolver;
 pub mod schedules;
 pub mod session_databases;
 pub mod session_files;

--- a/crates/server/src/api/resolver.rs
+++ b/crates/server/src/api/resolver.rs
@@ -89,16 +89,31 @@ pub async fn resolve_org(
 
     // Gate: only reveal the org if the caller is already a member. Without
     // this filter the endpoint would be a generic resource→org oracle.
-    let memberships = state
+    // THREAT[TM-TENANT-010]: membership gate — DO NOT remove.
+    let is_member = state
         .db
-        .list_user_organizations(auth.id)
+        .is_organization_member(owning_org_id, auth.id)
         .await
         .map_err(|e| {
             tracing::error!("resolve-org membership lookup failed: {e}");
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
+    if !is_member {
+        return Err(StatusCode::NOT_FOUND);
+    }
 
-    let Some(org) = memberships.into_iter().find(|o| o.org_id == owning_org_id) else {
+    // Only load the org record once membership is established.
+    let Some(org) = state
+        .db
+        .get_organization(owning_org_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("resolve-org org lookup failed: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+    else {
+        // Theoretically unreachable (membership implies the org exists),
+        // but treat a vanished row as 404 rather than 500.
         return Err(StatusCode::NOT_FOUND);
     };
 

--- a/crates/server/src/api/resolver.rs
+++ b/crates/server/src/api/resolver.rs
@@ -1,0 +1,115 @@
+// Cross-org resource resolution endpoint.
+//
+// Lets the UI recover from a direct link into a resource owned by another
+// org the caller is a member of. The API's 404-on-cross-org behaviour is
+// preserved for every resource route — this endpoint is the only place that
+// leaks an org_id across org boundaries, and only to orgs the caller
+// already belongs to. See specs/multitenancy.md (Cross-Org Resource
+// Resolution).
+
+use std::sync::Arc;
+
+use axum::{
+    Json, Router,
+    extract::{Query, State},
+    http::StatusCode,
+    routing::get,
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use super::common::impl_auth_state;
+use crate::auth::middleware::{AuthState, AuthUser};
+use crate::domains::org_resolver;
+use crate::storage::StorageBackend;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub db: Arc<StorageBackend>,
+    pub auth: AuthState,
+}
+
+impl_auth_state!(AppState);
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ResolveOrgQuery {
+    /// Prefixed public ID of a top-level entity (e.g. a session, agent, app).
+    #[schema(example = "session_019db85695a8785e87e8203109109343")]
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct ResolveOrgResponse {
+    /// Public ID of the organization that owns the resource.
+    pub org_id: String,
+    /// Organization name (for UX messaging).
+    pub org_name: String,
+}
+
+/// GET /v1/resolve-org — resolve the owning org for a resource id.
+///
+/// Returns the owning organization only when it is one the authenticated
+/// caller already belongs to. For every other case (unknown id, unknown
+/// prefix, resource belongs to a non-member org) the endpoint returns 404 —
+/// this preserves the existing org-enumeration guarantee documented in
+/// specs/multitenancy.md.
+#[utoipa::path(
+    get,
+    path = "/v1/resolve-org",
+    params(
+        ("id" = String, Query, description = "Prefixed public ID of the resource")
+    ),
+    responses(
+        (status = 200, description = "Owning org resolved", body = ResolveOrgResponse),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Unknown id, unknown prefix, or caller is not a member of the owning org")
+    ),
+    tag = "users"
+)]
+pub async fn resolve_org(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Query(query): Query<ResolveOrgQuery>,
+) -> Result<Json<ResolveOrgResponse>, StatusCode> {
+    let trimmed = query.id.trim();
+    if trimmed.is_empty() {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    let owning_org_id = org_resolver::resolve_resource_org(&state.db, trimmed)
+        .await
+        .map_err(|e| {
+            tracing::error!("resolve-org lookup failed: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    let Some(owning_org_id) = owning_org_id else {
+        return Err(StatusCode::NOT_FOUND);
+    };
+
+    // Gate: only reveal the org if the caller is already a member. Without
+    // this filter the endpoint would be a generic resource→org oracle.
+    let memberships = state
+        .db
+        .list_user_organizations(auth.id)
+        .await
+        .map_err(|e| {
+            tracing::error!("resolve-org membership lookup failed: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    let Some(org) = memberships.into_iter().find(|o| o.org_id == owning_org_id) else {
+        return Err(StatusCode::NOT_FOUND);
+    };
+
+    Ok(Json(ResolveOrgResponse {
+        org_id: org.public_id,
+        org_name: org.name,
+    }))
+}
+
+pub fn routes(state: AppState) -> Router {
+    Router::new()
+        .route("/v1/resolve-org", get(resolve_org))
+        .with_state(state)
+}

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -808,6 +808,10 @@ impl ServerAppBuilder {
             db: db.clone(),
             auth: auth_state.clone(),
         };
+        let resolver_state = api::resolver::AppState {
+            db: db.clone(),
+            auth: auth_state.clone(),
+        };
         let durable_store: Option<Arc<dyn WorkflowEventStore + Send + Sync>> =
             if let Some(ref shared_store) = shared_durable_store {
                 tracing::info!("Using shared in-memory workflow event store for DEV MODE");
@@ -969,6 +973,7 @@ impl ServerAppBuilder {
             .merge(api::session_storage::routes(session_storage_state))
             .merge(api::session_databases::routes(session_databases_state))
             .merge(api::users::routes(users_state))
+            .merge(api::resolver::routes(resolver_state))
             .merge(api::durable::routes(durable_state))
             .merge(schedules_state)
             .merge(api::images::routes(images_state))

--- a/crates/server/src/domains/mod.rs
+++ b/crates/server/src/domains/mod.rs
@@ -20,6 +20,7 @@ pub mod llm_providers;
 pub mod mcp_servers;
 pub mod messages;
 pub mod notifications;
+pub mod org_resolver;
 pub mod organizations;
 pub mod schedules;
 pub mod session_commands;

--- a/crates/server/src/domains/org_resolver.rs
+++ b/crates/server/src/domains/org_resolver.rs
@@ -1,0 +1,167 @@
+// Cross-org resource resolution.
+//
+// Every top-level entity that has a dedicated UI detail route MUST register a
+// resolver here so the UI can auto-switch the caller's active org when they
+// follow a direct link to a resource owned by a different (but still member)
+// org. The API keeps returning 404 for cross-org access — only the UI calls
+// the gated /v1/resolve-org endpoint to recover. See
+// specs/multitenancy.md (Cross-Org Resource Resolution).
+//
+// Adding a new top entity: implement a storage method
+// `get_<entity>_organization_id(public_id: &str) -> Result<Option<i64>>` and
+// add an `inventory::submit!` block below. The HTTP endpoint dispatches by
+// the prefix component of the ID (`session_...`, `agent_...`, etc.) so no
+// other wiring is required.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use anyhow::Result;
+use everruns_core::typed_id::SessionId;
+
+use crate::storage::StorageBackend;
+
+/// Resolver function signature: given a storage handle and a prefixed
+/// public ID, return the owning `org_id` without any caller-side scoping.
+pub type ResolveFn = for<'a> fn(
+    &'a StorageBackend,
+    &'a str,
+) -> Pin<Box<dyn Future<Output = Result<Option<i64>>> + Send + 'a>>;
+
+/// Resolves the owning organization for a top-level entity ID.
+///
+/// The dispatch key is the prefix component of a prefixed public ID
+/// (e.g. `session`, `agent`, `app`). At runtime the resolver endpoint
+/// iterates `inventory::iter::<ResourceOrgResolver>` looking for a match.
+pub struct ResourceOrgResolver {
+    /// ID prefix without the trailing underscore (e.g. `"session"`).
+    pub prefix: &'static str,
+    /// Resolver function. MUST NOT apply caller-side scoping — the endpoint
+    /// gates the result against the caller's org memberships.
+    pub resolve: ResolveFn,
+}
+
+inventory::collect!(ResourceOrgResolver);
+
+/// Resolve the owning org for a prefixed public ID, regardless of caller.
+///
+/// Returns `Ok(None)` if the prefix is unknown or the resource doesn't
+/// exist. Callers MUST filter the returned `org_id` against the user's
+/// memberships before revealing it to the client.
+pub async fn resolve_resource_org(db: &StorageBackend, id: &str) -> Result<Option<i64>> {
+    let prefix = match id.split_once('_') {
+        Some((p, _)) if !p.is_empty() => p,
+        _ => return Ok(None),
+    };
+    for entry in inventory::iter::<ResourceOrgResolver> {
+        if entry.prefix == prefix {
+            return (entry.resolve)(db, id).await;
+        }
+    }
+    Ok(None)
+}
+
+// ============================================================================
+// Registered resolvers (one per top-level entity with a detail UI route).
+// ============================================================================
+
+inventory::submit! {
+    ResourceOrgResolver {
+        prefix: "session",
+        resolve: |db, id| Box::pin(async move {
+            let Ok(session_id) = id.parse::<SessionId>() else {
+                return Ok(None);
+            };
+            db.get_session_organization_id(session_id).await
+        }),
+    }
+}
+
+inventory::submit! {
+    ResourceOrgResolver {
+        prefix: "agent",
+        resolve: |db, id| Box::pin(async move { db.get_agent_organization_id(id).await }),
+    }
+}
+
+inventory::submit! {
+    ResourceOrgResolver {
+        prefix: "harness",
+        resolve: |db, id| Box::pin(async move { db.get_harness_organization_id(id).await }),
+    }
+}
+
+inventory::submit! {
+    ResourceOrgResolver {
+        prefix: "app",
+        resolve: |db, id| Box::pin(async move { db.get_app_organization_id(id).await }),
+    }
+}
+
+inventory::submit! {
+    ResourceOrgResolver {
+        prefix: "skill",
+        resolve: |db, id| Box::pin(async move { db.get_skill_organization_id(id).await }),
+    }
+}
+
+inventory::submit! {
+    ResourceOrgResolver {
+        prefix: "mcp",
+        resolve: |db, id| Box::pin(async move { db.get_mcp_server_organization_id(id).await }),
+    }
+}
+
+inventory::submit! {
+    ResourceOrgResolver {
+        prefix: "identity",
+        resolve: |db, id| Box::pin(async move { db.get_agent_identity_organization_id(id).await }),
+    }
+}
+
+inventory::submit! {
+    ResourceOrgResolver {
+        prefix: "eval",
+        resolve: |db, id| Box::pin(async move { db.get_eval_organization_id(id).await }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_registered_prefix_is_nonempty_and_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for entry in inventory::iter::<ResourceOrgResolver> {
+            assert!(!entry.prefix.is_empty());
+            assert!(!entry.prefix.contains('_'));
+            assert!(
+                seen.insert(entry.prefix),
+                "duplicate resolver prefix: {}",
+                entry.prefix
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_rejects_missing_prefix() {
+        let db = StorageBackend::in_memory();
+        assert!(
+            resolve_resource_org(&db, "not-an-id")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(resolve_resource_org(&db, "").await.unwrap().is_none());
+        assert!(resolve_resource_org(&db, "_").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_returns_none_for_unknown_prefix() {
+        let db = StorageBackend::in_memory();
+        let result =
+            resolve_resource_org(&db, "unknownprefix_00000000000000000000000000000001").await;
+        assert!(result.unwrap().is_none());
+    }
+}

--- a/crates/server/src/domains/org_resolver.rs
+++ b/crates/server/src/domains/org_resolver.rs
@@ -142,6 +142,13 @@ mod tests {
                 entry.prefix
             );
         }
+        // Guard against a missing `inventory::submit!` silently passing CI.
+        // Must stay in sync with the registrations above.
+        assert!(
+            seen.len() >= 8,
+            "expected at least 8 resolvers, found {}",
+            seen.len()
+        );
     }
 
     #[tokio::test]

--- a/crates/server/src/domains/org_resolver.rs
+++ b/crates/server/src/domains/org_resolver.rs
@@ -164,4 +164,52 @@ mod tests {
             resolve_resource_org(&db, "unknownprefix_00000000000000000000000000000001").await;
         assert!(result.unwrap().is_none());
     }
+
+    #[tokio::test]
+    async fn resolve_agent_returns_owning_org_id() {
+        use crate::storage::models::CreateAgentRow;
+
+        let db = StorageBackend::in_memory();
+
+        // Seed an agent in org 1 and another in org 42. Mirrors the
+        // cross-org situation: a user currently in one org follows a link
+        // to a resource owned by another.
+        let agent_one = CreateAgentRow {
+            public_id: "agent_00000000000000000000000000000001".to_string(),
+            name: "one".to_string(),
+            display_name: None,
+            description: None,
+            system_prompt: String::new(),
+            default_model_id: None,
+            tags: vec![],
+            initial_files: serde_json::json!([]),
+            tools: serde_json::json!([]),
+            mcp_servers: serde_json::json!([]),
+            network_access: None,
+            max_iterations: None,
+        };
+        let mut agent_two = agent_one.clone();
+        agent_two.public_id = "agent_00000000000000000000000000000042".to_string();
+        agent_two.name = "two".to_string();
+
+        db.create_agent(1, agent_one).await.unwrap();
+        db.create_agent(42, agent_two).await.unwrap();
+
+        // Known id → known owning org.
+        let org = resolve_resource_org(&db, "agent_00000000000000000000000000000001")
+            .await
+            .unwrap();
+        assert_eq!(org, Some(1));
+
+        let org = resolve_resource_org(&db, "agent_00000000000000000000000000000042")
+            .await
+            .unwrap();
+        assert_eq!(org, Some(42));
+
+        // Same prefix, unknown id → None (never leaks a guessed org).
+        let org = resolve_resource_org(&db, "agent_00000000000000000000000000000099")
+            .await
+            .unwrap();
+        assert!(org.is_none());
+    }
 }

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -1872,6 +1872,44 @@ impl StorageBackend {
         dispatch!(self, get_session_organization_id, session_id)
     }
 
+    // ============================================
+    // Cross-Org Resource Resolution
+    //
+    // Lookup-by-public_id helpers that return the owning org without requiring
+    // the caller to know it. Used only by the authenticated
+    // GET /v1/resolve-org endpoint, which gates the result by the caller's
+    // org memberships to preserve the 404-vs-403 enumeration guarantee.
+    // See specs/multitenancy.md (Cross-Org Resource Resolution).
+    // ============================================
+
+    pub async fn get_agent_organization_id(&self, public_id: &str) -> Result<Option<i64>> {
+        dispatch!(self, get_agent_organization_id, public_id)
+    }
+
+    pub async fn get_harness_organization_id(&self, public_id: &str) -> Result<Option<i64>> {
+        dispatch!(self, get_harness_organization_id, public_id)
+    }
+
+    pub async fn get_app_organization_id(&self, public_id: &str) -> Result<Option<i64>> {
+        dispatch!(self, get_app_organization_id, public_id)
+    }
+
+    pub async fn get_skill_organization_id(&self, public_id: &str) -> Result<Option<i64>> {
+        dispatch!(self, get_skill_organization_id, public_id)
+    }
+
+    pub async fn get_mcp_server_organization_id(&self, public_id: &str) -> Result<Option<i64>> {
+        dispatch!(self, get_mcp_server_organization_id, public_id)
+    }
+
+    pub async fn get_agent_identity_organization_id(&self, public_id: &str) -> Result<Option<i64>> {
+        dispatch!(self, get_agent_identity_organization_id, public_id)
+    }
+
+    pub async fn get_eval_organization_id(&self, public_id: &str) -> Result<Option<i64>> {
+        dispatch!(self, get_eval_organization_id, public_id)
+    }
+
     pub async fn upsert_leased_resource(
         &self,
         input: UpsertLeasedResourceRow,

--- a/crates/server/src/storage/memory/agent_identities.rs
+++ b/crates/server/src/storage/memory/agent_identities.rs
@@ -45,6 +45,14 @@ impl InMemoryDatabase {
             .cloned())
     }
 
+    /// Look up the owning org for an agent identity by its public id.
+    pub async fn get_agent_identity_organization_id(&self, public_id: &str) -> Result<Option<i64>> {
+        let Ok(id) = public_id.parse::<AgentIdentityId>() else {
+            return Ok(None);
+        };
+        Ok(self.agent_identities.read().get(&id).map(|r| r.org_id))
+    }
+
     pub async fn list_agent_identities(
         &self,
         org_id: i64,

--- a/crates/server/src/storage/memory/agents.rs
+++ b/crates/server/src/storage/memory/agents.rs
@@ -124,6 +124,16 @@ impl InMemoryDatabase {
             .cloned())
     }
 
+    /// Look up the owning org for an agent by its public_id (cross-org resolver).
+    pub async fn get_agent_organization_id(&self, public_id: &str) -> Result<Option<i64>> {
+        Ok(self
+            .agents
+            .read()
+            .values()
+            .find(|a| a.public_id == public_id)
+            .map(|a| a.org_id))
+    }
+
     pub async fn get_agent_by_public_id(
         &self,
         org_id: i64,

--- a/crates/server/src/storage/memory/apps.rs
+++ b/crates/server/src/storage/memory/apps.rs
@@ -57,6 +57,16 @@ impl InMemoryDatabase {
         Ok(apps.values().find(|a| a.public_id == public_id).cloned())
     }
 
+    /// Look up the owning org for an app by its public_id (cross-org resolver).
+    pub async fn get_app_organization_id(&self, public_id: &str) -> Result<Option<i64>> {
+        Ok(self
+            .apps
+            .read()
+            .values()
+            .find(|a| a.public_id == public_id)
+            .map(|a| a.org_id))
+    }
+
     pub async fn list_apps(
         &self,
         org_id: i64,

--- a/crates/server/src/storage/memory/evals.rs
+++ b/crates/server/src/storage/memory/evals.rs
@@ -45,6 +45,16 @@ impl InMemoryDatabase {
             .cloned())
     }
 
+    /// Look up the owning org for an eval by its public_id (cross-org resolver).
+    pub async fn get_eval_organization_id(&self, public_id: &str) -> Result<Option<i64>> {
+        Ok(self
+            .evals
+            .read()
+            .values()
+            .find(|e| e.public_id == public_id)
+            .map(|e| e.org_id))
+    }
+
     pub async fn list_evals(
         &self,
         org_id: i64,

--- a/crates/server/src/storage/memory/harnesses.rs
+++ b/crates/server/src/storage/memory/harnesses.rs
@@ -112,6 +112,14 @@ impl InMemoryDatabase {
             .cloned())
     }
 
+    /// Look up the owning org for a harness by its prefixed public id.
+    pub async fn get_harness_organization_id(&self, public_id: &str) -> Result<Option<i64>> {
+        let Ok(id) = public_id.parse::<HarnessId>() else {
+            return Ok(None);
+        };
+        Ok(self.harnesses.read().get(&id).map(|h| h.org_id))
+    }
+
     pub async fn get_harness_by_name(&self, org_id: i64, name: &str) -> Result<Option<HarnessRow>> {
         Ok(self
             .harnesses

--- a/crates/server/src/storage/memory/mcp_servers.rs
+++ b/crates/server/src/storage/memory/mcp_servers.rs
@@ -130,6 +130,14 @@ impl InMemoryDatabase {
             .cloned())
     }
 
+    /// Look up the owning org for an MCP server by its public id.
+    pub async fn get_mcp_server_organization_id(&self, public_id: &str) -> Result<Option<i64>> {
+        let Ok(id) = public_id.parse::<McpServerId>() else {
+            return Ok(None);
+        };
+        Ok(self.mcp_servers.read().get(&id).map(|s| s.org_id))
+    }
+
     /// Batch fetch multiple MCP servers by IDs.
     pub async fn get_mcp_servers_batch(
         &self,

--- a/crates/server/src/storage/memory/skills.rs
+++ b/crates/server/src/storage/memory/skills.rs
@@ -154,6 +154,16 @@ impl InMemoryDatabase {
             .cloned())
     }
 
+    /// Look up the owning org for a skill by its public_id (cross-org resolver).
+    pub async fn get_skill_organization_id(&self, public_id: &str) -> Result<Option<i64>> {
+        Ok(self
+            .skills
+            .read()
+            .values()
+            .find(|s| s.public_id == public_id)
+            .map(|s| s.org_id))
+    }
+
     pub async fn get_skill_by_name(&self, org_id: i64, name: &str) -> Result<Option<SkillRow>> {
         Ok(self
             .skills

--- a/crates/server/src/storage/repositories/agent_identities.rs
+++ b/crates/server/src/storage/repositories/agent_identities.rs
@@ -35,6 +35,20 @@ impl Database {
         Ok(row)
     }
 
+    /// Look up the owning org for an agent identity by its public id. See
+    /// specs/multitenancy.md (Cross-Org Resource Resolution).
+    pub async fn get_agent_identity_organization_id(&self, public_id: &str) -> Result<Option<i64>> {
+        let Ok(id) = public_id.parse::<AgentIdentityId>() else {
+            return Ok(None);
+        };
+        let row: Option<(i64,)> =
+            sqlx::query_as("SELECT org_id FROM agent_identities WHERE id = $1 LIMIT 1")
+                .bind(id)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.map(|(org_id,)| org_id))
+    }
+
     pub async fn get_agent_identity(
         &self,
         org_id: i64,

--- a/crates/server/src/storage/repositories/agents.rs
+++ b/crates/server/src/storage/repositories/agents.rs
@@ -116,6 +116,19 @@ impl Database {
         Ok(row)
     }
 
+    /// Look up the owning org for an agent by its public_id, without scoping
+    /// to a caller-supplied org. Used exclusively by the cross-org resolver
+    /// (see specs/multitenancy.md). Callers MUST gate the result on user
+    /// membership before revealing it — this method does NOT.
+    pub async fn get_agent_organization_id(&self, public_id: &str) -> Result<Option<i64>> {
+        let row: Option<(i64,)> =
+            sqlx::query_as("SELECT org_id FROM agents WHERE public_id = $1 LIMIT 1")
+                .bind(public_id)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.map(|(org_id,)| org_id))
+    }
+
     pub async fn get_agent_by_public_id(
         &self,
         org_id: i64,

--- a/crates/server/src/storage/repositories/apps.rs
+++ b/crates/server/src/storage/repositories/apps.rs
@@ -57,6 +57,17 @@ impl Database {
         Ok(row)
     }
 
+    /// Look up the owning org for an app by its public_id. See
+    /// specs/multitenancy.md (Cross-Org Resource Resolution).
+    pub async fn get_app_organization_id(&self, public_id: &str) -> Result<Option<i64>> {
+        let row: Option<(i64,)> =
+            sqlx::query_as("SELECT org_id FROM apps WHERE public_id = $1 LIMIT 1")
+                .bind(public_id)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.map(|(org_id,)| org_id))
+    }
+
     /// Lookup app by public_id without org scoping (for unauthenticated webhooks).
     pub async fn get_app_by_public_id_unscoped(&self, public_id: &str) -> Result<Option<AppRow>> {
         let row = sqlx::query_as::<_, AppRow>(

--- a/crates/server/src/storage/repositories/evals.rs
+++ b/crates/server/src/storage/repositories/evals.rs
@@ -33,6 +33,17 @@ impl Database {
         Ok(row)
     }
 
+    /// Look up the owning org for an eval by its public_id. See
+    /// specs/multitenancy.md (Cross-Org Resource Resolution).
+    pub async fn get_eval_organization_id(&self, public_id: &str) -> Result<Option<i64>> {
+        let row: Option<(i64,)> =
+            sqlx::query_as("SELECT org_id FROM evals WHERE public_id = $1 LIMIT 1")
+                .bind(public_id)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.map(|(org_id,)| org_id))
+    }
+
     pub async fn get_eval_by_public_id(
         &self,
         org_id: i64,

--- a/crates/server/src/storage/repositories/harnesses.rs
+++ b/crates/server/src/storage/repositories/harnesses.rs
@@ -97,6 +97,21 @@ impl Database {
         Ok(row)
     }
 
+    /// Look up the owning org for a harness by its public_id, without scoping
+    /// to a caller-supplied org. See specs/multitenancy.md (Cross-Org Resource
+    /// Resolution). Gating by membership happens at the resolver endpoint.
+    pub async fn get_harness_organization_id(&self, public_id: &str) -> Result<Option<i64>> {
+        let Ok(id) = public_id.parse::<HarnessId>() else {
+            return Ok(None);
+        };
+        let row: Option<(i64,)> =
+            sqlx::query_as("SELECT org_id FROM harnesses WHERE id = $1 LIMIT 1")
+                .bind(id.uuid())
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.map(|(org_id,)| org_id))
+    }
+
     pub async fn get_harness(&self, org_id: i64, id: HarnessId) -> Result<Option<HarnessRow>> {
         let row = sqlx::query_as::<_, HarnessRow>(
             r#"

--- a/crates/server/src/storage/repositories/mcp_servers.rs
+++ b/crates/server/src/storage/repositories/mcp_servers.rs
@@ -6,6 +6,7 @@ use super::super::models::*;
 use super::Database;
 use super::build_search_sql;
 use anyhow::Result;
+use everruns_core::typed_id::McpServerId;
 use uuid::Uuid;
 
 impl Database {
@@ -90,6 +91,20 @@ impl Database {
         .await?;
 
         Ok(row)
+    }
+
+    /// Look up the owning org for an MCP server by its public id. See
+    /// specs/multitenancy.md (Cross-Org Resource Resolution).
+    pub async fn get_mcp_server_organization_id(&self, public_id: &str) -> Result<Option<i64>> {
+        let Ok(id) = public_id.parse::<McpServerId>() else {
+            return Ok(None);
+        };
+        let row: Option<(i64,)> =
+            sqlx::query_as("SELECT org_id FROM mcp_servers WHERE id = $1 LIMIT 1")
+                .bind(id.uuid())
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.map(|(org_id,)| org_id))
     }
 
     pub async fn get_mcp_server(&self, org_id: i64, id: Uuid) -> Result<Option<McpServerRow>> {

--- a/crates/server/src/storage/repositories/skills.rs
+++ b/crates/server/src/storage/repositories/skills.rs
@@ -37,6 +37,17 @@ impl Database {
         Ok(row)
     }
 
+    /// Look up the owning org for a skill by its public_id. See
+    /// specs/multitenancy.md (Cross-Org Resource Resolution).
+    pub async fn get_skill_organization_id(&self, public_id: &str) -> Result<Option<i64>> {
+        let row: Option<(i64,)> =
+            sqlx::query_as("SELECT org_id FROM skills WHERE public_id = $1 LIMIT 1")
+                .bind(public_id)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.map(|(org_id,)| org_id))
+    }
+
     pub async fn get_skill(&self, org_id: i64, id: Uuid) -> Result<Option<SkillRow>> {
         let row = sqlx::query_as::<_, SkillRow>(
             r#"

--- a/specs/domains.md
+++ b/specs/domains.md
@@ -301,6 +301,19 @@ the logic. Once all callers are migrated, the service file is removed.
    `domains/{name}/` (for example `service.rs` or `helpers.rs`)
 7. Once all callers migrated, delete the old top-level `services/{name}.rs`
 
+### Cross-Org Resource Resolution (`domains/org_resolver.rs`)
+
+`domains/org_resolver.rs` is an inventory-registry module, not a `Command`
+domain. Every top-level entity with a dedicated UI detail route MUST
+register an `inventory::submit! { ResourceOrgResolver { prefix, resolve } }`
+block there so the UI can auto-switch orgs on direct links. See
+`specs/multitenancy.md` (Cross-Org Resource Resolution) for the full
+contract. When introducing a new such entity, add:
+
+1. A storage method `get_<entity>_organization_id(public_id: &str) -> Result<Option<i64>>`
+   (PG + in-memory).
+2. One `inventory::submit!` block in `domains/org_resolver.rs`.
+
 ### When NOT to use this pattern
 
 - **Internal-only logic** with no user-facing API surface (e.g. `llm_resolver`,

--- a/specs/multitenancy.md
+++ b/specs/multitenancy.md
@@ -593,6 +593,81 @@ The settings page (`/settings/organisation`) has two sections:
 1. **Current Organisation:** Edit name, view org ID (existing)
 2. **Your Organisations:** Lists all orgs the user belongs to with switch buttons. Current org highlighted with a "Current" badge.
 
+## Cross-Org Resource Resolution
+
+Users who belong to multiple organisations routinely follow direct links
+(shared URLs, bookmarks, external notifications) that point at a resource
+owned by one of their orgs but not the one currently selected. With strict
+org scoping (see the Query Rules above) the entity API returns 404 for that
+resource and the UI shows a "not found" screen — a recurring papercut.
+
+### Contract
+
+| Layer                | Behaviour                                                                                                                |
+|----------------------|--------------------------------------------------------------------------------------------------------------------------|
+| Entity APIs          | UNCHANGED — still return 404 for resources in other orgs. Preserves the enumeration guarantee on lines 127–128.          |
+| `GET /v1/resolve-org`| Authenticated endpoint. Given a prefixed public ID, returns the owning org ONLY when the caller is a member of that org. |
+| UI                   | On 404 from an entity detail fetch, calls the resolver and, if a member-owned org is returned, switches and retries.     |
+
+Because the resolver reveals only orgs the caller already belongs to, the
+set of answers it can produce is a subset of the information the caller can
+learn by manually switching between their own orgs. No new information
+leaks across org boundaries.
+
+### Endpoint
+
+```
+GET /v1/resolve-org?id=<prefixed_public_id>
+→ 200 { "org_id": "org_xxx", "org_name": "Acme Corp" }
+→ 404 — unknown id, unknown prefix, or owning org is not a caller membership
+```
+
+### Domain trait (`ResourceOrgResolver`)
+
+Every top-level entity with a dedicated UI detail route MUST register an
+`inventory::submit! { ResourceOrgResolver { ... } }` block in
+`crates/server/src/domains/org_resolver.rs`. Each entry pairs an ID prefix
+(e.g. `"session"`) with a function that looks up the owning `org_id`. The
+endpoint dispatches by prefix; adding a new top entity requires:
+
+1. A storage method `get_<entity>_organization_id(public_id: &str) -> Result<Option<i64>>`
+   on the PG and in-memory backends (no caller-side org scoping).
+2. One `inventory::submit!` block in `domains/org_resolver.rs`.
+3. Nothing else — the resolver endpoint picks up the new prefix on startup,
+   and any entity-detail React hook built on `useDetail` automatically gets
+   the fallback.
+
+Existing registrations cover: `session`, `agent`, `harness`, `app`,
+`skill`, `mcp`, `identity`, `eval`.
+
+### UI integration
+
+- `lib/api/resolver.ts::resolveOrgForResource(id)` wraps the endpoint.
+- `hooks/use-resource-org-fallback.ts` is the single React hook that reacts
+  to a 404 on a detail query, calls the resolver, and invokes
+  `setCurrentOrg(target, { stayOnPage: true })` when the owner is a
+  membership. The `stayOnPage` option skips the default org-switch redirect
+  that would otherwise send the user back to the list page.
+- It is wired into `useDetail` (shared CRUD factory) and the bespoke
+  `useSession` / `useAgentIdentity` hooks so every top-level detail route
+  gets the fallback for free.
+
+### Invariants
+
+- The fallback fires **at most once per resource id per mount** (tracked
+  via a ref inside the hook) to avoid ping-pong when the new org also 404s.
+- The entity API's 404 behaviour is never relaxed. The only cross-org
+  information disclosure happens through `GET /v1/resolve-org`, which is
+  membership-gated.
+- The resolver endpoint MUST NOT be reached before authentication; it
+  requires an `AuthUser` extractor.
+
+### When to add a new entity to the resolver
+
+If you add a new top-level entity with a dedicated UI detail route
+(`apps/ui/src/app/(main)/<entity>/[id]/...`), add it to the resolver
+registry. Entities without a detail route do not need to register.
+
 ## Future Considerations
 
 **Not in scope for v1:**

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -180,6 +180,7 @@ Re-encryption CLI tool implemented at `crates/server/src/bin/reencrypt_secrets.r
 | TM-TENANT-007 | Durable tasks cross-org | Medium | gRPC `GetTurnContext` validates org_id in request matches record in DB | MITIGATED |
 | TM-TENANT-008 | User listing cross-org | High | `GET /v1/users` returns all system users without org filtering; uses `AuthUser` not `ResolvedOrg` | **OPEN** |
 | TM-TENANT-009 | AG-UI thread ID collision crosses app session boundaries | High | AG-UI session routing tags include both `ag_ui:app:{app_id}` and `ag_ui:thread:{thread_id}` so a shared thread UUID cannot attach to another app's session | MITIGATED |
+| TM-TENANT-010 | Cross-org resource→org oracle via `/v1/resolve-org` | Medium | Endpoint requires `AuthUser` and answers only when the owning org is a membership of the caller (`is_organization_member` check before returning any identity). Unknown ids, unknown prefixes, and non-member owners all produce 404 — identical to what the entity APIs would return. Attacker learns nothing they couldn't already learn by manually switching between their own orgs. See specs/multitenancy.md (Cross-Org Resource Resolution). | MITIGATED |
 
 ### Mitigation Details
 

--- a/test_cases/ui/cross_org_resolution/TC001_auto_switch_org_from_link.md
+++ b/test_cases/ui/cross_org_resolution/TC001_auto_switch_org_from_link.md
@@ -1,0 +1,92 @@
+# TC001: Auto-Switch Organisation from Direct Resource Link
+
+## Description
+
+Verify that following a direct link to a top-level resource (session, agent,
+app, harness, eval, agent identity) owned by an organisation the user is a
+member of but has **not** currently selected causes the UI to transparently
+switch to the owning org and render the resource — instead of showing a
+"not found" screen.
+
+Covers the cross-org resource resolution behaviour described in
+`specs/multitenancy.md` (Cross-Org Resource Resolution). The API's
+`GET /v1/<resource>/<id>` continues to return 404 for cross-org access; the
+recovery happens only in the UI via the authenticated
+`GET /v1/resolve-org` endpoint, which only reveals orgs the caller already
+belongs to.
+
+## Preconditions
+
+- User is authenticated.
+- User is a member of at least two organisations — call them **Org A** and
+  **Org B**.
+- Org A has at least one visible session. Capture its ID (for example
+  `session_019db85695a8785e87e8203109109343`) and its URL, e.g.
+  `/sessions/session_019db85695a8785e87e8203109109343/chat`.
+- The browser's currently selected org (the `everruns_org` cookie + sidebar
+  switcher) is **Org B** — NOT the owner of the captured session.
+
+## Test Data
+
+| Field                  | Value                                                      |
+|------------------------|------------------------------------------------------------|
+| Owning org             | Org A                                                      |
+| Currently selected org | Org B                                                      |
+| Direct link            | `/sessions/<session_id_owned_by_A>/chat`                   |
+| Expected result        | Page renders the session; sidebar shows Org A as selected. |
+
+## Steps
+
+1. Confirm the sidebar org switcher shows **Org B** as current.
+2. Navigate the browser directly to the captured URL
+   `/sessions/<session_id_owned_by_A>/chat` (e.g. paste into the address bar
+   and press Enter, or click an external link that points there).
+3. Wait for the page to settle (loading skeleton disappears).
+
+## Expected Result
+
+- The sidebar org switcher now shows **Org A** as the current organisation.
+- The session detail page renders normally — chat view, title, metadata are
+  all visible.
+- The URL in the address bar is unchanged (still the original
+  `/sessions/<id>/chat` — no redirect to `/sessions`).
+- No "Session not found" error is displayed.
+- Opening DevTools → Network, the sequence of requests shows (order may vary
+  slightly):
+  1. `GET /api/v1/sessions/<id>` → **404** (still Org B context).
+  2. `GET /api/v1/resolve-org?id=<session_id>` → **200** with
+     `{ "org_id": "<Org A public_id>", "org_name": "<Org A name>" }`.
+  3. `POST /api/v1/users/me/switch-org` with Org A's public id → **200**.
+  4. `GET /api/v1/sessions/<id>` → **200** (now Org A context).
+
+## Negative Variants (should each keep the existing 404 behaviour)
+
+The following variants verify the enumeration guarantee is preserved:
+
+1. **Unknown session ID** — navigate to
+   `/sessions/session_00000000000000000000000000000000/chat`. Expected: page
+   shows "Session not found" and `GET /api/v1/resolve-org?id=...` returns
+   **404**. No org switch occurs.
+2. **Session owned by a non-member org** — log in as a user who is NOT a
+   member of the session's owning org and open its direct link. Expected:
+   page shows "Session not found" and `GET /api/v1/resolve-org?id=...`
+   returns **404**. No org switch occurs.
+3. **Logged-out user** — sign out, then open the direct link. Expected: the
+   user is redirected to login (standard auth flow). No call to
+   `/v1/resolve-org`.
+
+## Cross-Resource Coverage
+
+Repeat step 2 with each of the following direct URL shapes to confirm the
+fallback works for every top-level entity with a detail route. Each case
+should switch to the owning org and render the detail view — the fallback is
+installed once in the shared CRUD detail hook (`useDetail`) and in
+`useSession` / `useAgentIdentity`, so all of the below should behave
+identically.
+
+- `/agents/<agent_id>`
+- `/agent-identities/<identity_id>`
+- `/apps/<app_id>`
+- `/evals/<eval_id>`
+- `/harnesses/<harness_id>`
+- `/sessions/<session_id>/chat`


### PR DESCRIPTION
## What

When a user opens a direct link to a top-level entity (session, agent, app, harness, agent identity, eval) that lives in an org they belong to but have not currently selected, the UI now transparently switches to the owning org and renders the resource — instead of showing "not found".

Example: `https://dev.everruns.com/sessions/session_019db85695a8785e87e8203109109343/chat` when the user is currently viewing Org B but the session lives in Org A (of which they are also a member) now Just Works, instead of rendering the `Session not found` fallback.

## Why

Users who belong to multiple orgs routinely share URLs, bookmarks, and follow external notifications that point at resources owned by whichever org they were in at the time. With strict org scoping the entity API returns 404 and the UI shows a "not found" screen — a recurring papercut. This change makes cross-org direct links self-healing without relaxing the API's cross-org isolation.

## How

Design keeps the entity API's 404 behaviour unchanged. Recovery happens only in the UI via a new authenticated endpoint that reveals an org only when the caller is already a member of it. Because the set of answers is a subset of what a user can learn by manually switching between their own orgs, no new cross-org information leaks.

- **Domain trait** (`crates/server/src/domains/org_resolver.rs`): new `ResourceOrgResolver` inventory registry. Every top entity with a dedicated UI detail route adds one `inventory::submit!` block here. Registered for session, agent, harness, app, skill, mcp, identity, eval. Adding a future entity is a two-line change (one storage method + one submit block).
- **Storage methods**: new `get_<entity>_organization_id(public_id: &str) -> Result<Option<i64>>` on `StorageBackend`, its Postgres repository, and the in-memory backend for the 7 entities that didn't already have one (sessions was the only pre-existing one).
- **HTTP endpoint** (`GET /v1/resolve-org?id=<prefixed_id>`, `api/resolver.rs`): authenticated. Resolves the owning org via the trait, then gates the response on `is_organization_member(owning_org_id, user_id)`. Only loads the org record after membership is established.
- **Frontend**: new `lib/api/resolver.ts::resolveOrgForResource`. `setCurrentOrg` grew a `{ stayOnPage }` option so the cross-org auto-switch doesn't redirect to the list page (the current URL is valid in the new org). A new `hooks/use-resource-org-fallback.ts` reacts to 404s on detail queries and is wired into the shared `useDetail` (CRUD factory), `useSession`, and `useAgentIdentity` so every existing top-level detail route picks up the behaviour automatically.
- **Spec**: new "Cross-Org Resource Resolution" section in `specs/multitenancy.md` laying out the contract. Note in `specs/domains.md` making the trait the norm for new top-level entities with a detail route.
- **Threat model**: new `TM-TENANT-010` entry (medium severity, MITIGATED) documenting the deliberate disclosure and the membership gate. `THREAT[TM-TENANT-010]` marker placed at the gate so a future refactor can't silently delete it.
- **Test case**: `test_cases/ui/cross_org_resolution/TC001_auto_switch_org_from_link.md` covering the happy path, three negative variants (unknown id, non-member org, logged-out), and the full list of cross-resource routes that share the fallback.

## Risk

- **Low**.
- What can break:
  - The one cross-org disclosure is a new surface. It is gated by `is_organization_member`; an unauthenticated or non-member caller receives 404 exactly as they would from every entity route today.
  - The frontend fallback fires only on 404 responses on detail queries and dedupes per resource id per mount. If the target org also 404s, the UI falls through to the existing "not found" screen — identical to today.
  - The resolver endpoint participates in the existing API per-IP rate limiter.

## Security

- Threat categories reviewed: **TM-TENANT** (tenant isolation — this change explicitly operates across orgs, by design), **TM-API** (new endpoint input validation), **TM-AUTH** (endpoint extracts `AuthUser`, so unauthenticated calls get 401).
- Findings and resolutions:
  - Added `TM-TENANT-010` to `specs/threat-model.md`: "Cross-org resource→org oracle via `/v1/resolve-org`" (medium, MITIGATED). Mitigation: membership gate via `is_organization_member` before revealing any identity; unknown ids, unknown prefixes, and non-member owners all produce identical 404s.
  - No SQL injection surface: sqlx parameter binding for every new storage method.
  - No information-in-errors regression: endpoint returns only `{ org_id, org_name }` on success (data the caller is entitled to) and 404 otherwise.
  - No new dependencies.
  - Existing `TM-TENANT-001`, `TM-TENANT-002` guarantees for the entity APIs are untouched.

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features --lib --bins` all green (1003 server tests).
- New unit tests in `domains/org_resolver.rs`: prefix registry is non-empty/unique, empty/unknown-prefix ids resolve to `None`, and a seeded in-memory database with agents in two orgs resolves to the correct owner for each id.
- End-to-end smoke test against a locally-running `everruns-server` with `AUTH_MODE=none`:
  - `GET /api/v1/resolve-org?id=agent_019db...` (known agent in caller's org) → `200 {"org_id":"org_...","org_name":"Default Organization"}`.
  - Unknown id, unknown prefix, empty id, non-existent session id all → `404`.

## Checklist

- [x] Tests added or updated (new resolver unit tests + manual UI test case).
- [x] Backward compatibility considered (entity APIs behave identically; new endpoint is additive).
- [x] Security review performed against relevant threat model categories (TM-TENANT, TM-API, TM-AUTH); new `TM-TENANT-010` entry added.
- [ ] All review comments addressed (code change or written reasoning) — will be checked after CI runs.

---
_Generated by [Claude Code](https://claude.ai/code/session_015iigvjwtRfXnUqmqTFw4iF)_