### PR TITLE
fix(authz): enforce command policy on every caller via Command::run

### DIFF
--- a/crates/server/src/api/agent_identities.rs
+++ b/crates/server/src/api/agent_identities.rs
@@ -49,6 +49,7 @@ impl AppState {
             self.db.clone(),
             self.capability_service.clone(),
             None,
+            self.auth.permission_resolver.clone(),
         )
     }
 }
@@ -98,7 +99,7 @@ pub async fn create_agent_identity(
     Json(req): Json<CreateAgentIdentityRequest>,
 ) -> Result<(StatusCode, Json<AgentIdentity>), (StatusCode, Json<ErrorResponse>)> {
     let identity = crate::domains::agent_identities::CreateAgentIdentity(req)
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     Ok((StatusCode::CREATED, Json(identity)))
 }
@@ -112,7 +113,7 @@ pub async fn list_agent_identities(
         search: query.search,
         include_archived: query.include_archived.unwrap_or(false),
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
     Ok(Json(ListResponse::new(identities)))
 }
@@ -123,7 +124,7 @@ pub async fn get_agent_identity(
     Path(identity_id): Path<String>,
 ) -> Result<Json<AgentIdentity>, (StatusCode, Json<ErrorResponse>)> {
     let identity = crate::domains::agent_identities::GetAgentIdentity { id: identity_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     Ok(Json(identity))
 }
@@ -138,7 +139,7 @@ pub async fn update_agent_identity(
         id: identity_id,
         req,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
     Ok(Json(identity))
 }
@@ -149,7 +150,7 @@ pub async fn delete_agent_identity(
     Path(identity_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     crate::domains::agent_identities::DeleteAgentIdentity { id: identity_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     Ok(StatusCode::NO_CONTENT)
 }
@@ -160,7 +161,7 @@ pub async fn destroy_agent_identity(
     Path(identity_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     crate::domains::agent_identities::DestroyAgentIdentity { id: identity_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -148,6 +148,7 @@ impl AppState {
             self.db.clone(),
             self.capability_service.clone(),
             None,
+            self.auth.permission_resolver.clone(),
         )
     }
 }
@@ -178,7 +179,7 @@ pub async fn check_agent_name(
         name: query.name,
         exclude_id: query.exclude_id,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
     Ok(Json(CheckAgentNameResponse {
         available: result.available,
@@ -272,7 +273,7 @@ pub async fn create_agent(
     Json(req): Json<CreateAgentRequest>,
 ) -> Result<(StatusCode, Json<WithUrls<Agent>>), (StatusCode, Json<ErrorResponse>)> {
     let agent = crate::domains::agents::CreateAgent(req)
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     let builder = UrlBuilder::from_auth_config(&state.auth.config);
     Ok((StatusCode::CREATED, Json(builder.wrap(agent))))
@@ -300,7 +301,7 @@ pub async fn list_agents(
         offset: query.offset,
         limit: query.limit,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
 
     let builder = UrlBuilder::from_auth_config(&state.auth.config);
@@ -336,7 +337,7 @@ pub async fn get_agent(
     let agent = crate::domains::agents::GetAgent {
         id: agent_id_or_name,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
     let builder = UrlBuilder::from_auth_config(&state.auth.config);
     Ok(Json(builder.wrap(agent)))
@@ -365,7 +366,7 @@ pub async fn update_agent(
     Json(req): Json<UpdateAgentRequest>,
 ) -> ApiResult<WithUrls<Agent>> {
     let agent = crate::domains::agents::UpdateAgentCmd { id: agent_id, req }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     let builder = UrlBuilder::from_auth_config(&state.auth.config);
     Ok(Json(builder.wrap(agent)))
@@ -392,7 +393,7 @@ pub async fn delete_agent(
     Path(agent_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     crate::domains::agents::DeleteAgent { id: agent_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     Ok(StatusCode::NO_CONTENT)
 }
@@ -403,7 +404,7 @@ pub async fn destroy_agent(
     Path(agent_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     crate::domains::agents::DestroyAgent { id: agent_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     Ok(StatusCode::NO_CONTENT)
 }
@@ -432,7 +433,7 @@ pub async fn copy_agent(
     Path(agent_id): Path<String>,
 ) -> Result<(StatusCode, Json<WithUrls<Agent>>), (StatusCode, Json<ErrorResponse>)> {
     let agent = crate::domains::agents::CopyAgent { id: agent_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     let builder = UrlBuilder::from_auth_config(&state.auth.config);
     Ok((StatusCode::CREATED, Json(builder.wrap(agent))))
@@ -473,7 +474,7 @@ pub async fn upsert_agent(
             id: agent_id.to_string(),
             req,
         }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
         (result.agent, result.was_created)
     } else {
@@ -488,7 +489,7 @@ pub async fn upsert_agent(
         }
         // Name-based upsert: try create, if name taken → update
         let create_result = crate::domains::agents::CreateAgent(req.clone())
-            .execute(&state.ctx(&org))
+            .run(&state.ctx(&org))
             .await;
         match create_result {
             Ok(agent) => (agent, true),
@@ -520,7 +521,7 @@ pub async fn upsert_agent(
                     id: existing.public_id.to_string(),
                     req: update_req,
                 }
-                .execute(&state.ctx(&org))
+                .run(&state.ctx(&org))
                 .await?;
                 (agent, false)
             }
@@ -570,7 +571,7 @@ pub async fn export_agent(
     let agent = crate::domains::agents::GetAgent {
         id: agent_id.to_string(),
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
 
     let markdown = agent_to_markdown(&agent);
@@ -703,7 +704,7 @@ async fn import_from_example(
                 name: candidate.clone(),
                 exclude_id: None,
             }
-            .execute(&state.ctx(&org))
+            .run(&state.ctx(&org))
             .await?;
             let available = result.available;
 
@@ -733,7 +734,7 @@ async fn import_from_example(
     };
 
     let agent = crate::domains::agents::CreateAgent(req)
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
 
     let builder = UrlBuilder::from_auth_config(&state.auth.config);
@@ -835,7 +836,7 @@ async fn import_from_file(
             id: id.to_string(),
             req: request,
         }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
 
         let status = if result.was_created {
@@ -847,7 +848,7 @@ async fn import_from_file(
         Ok((status, Json(builder.wrap(result.agent))))
     } else {
         let agent = crate::domains::agents::CreateAgent(request)
-            .execute(&state.ctx(&org))
+            .run(&state.ctx(&org))
             .await?;
 
         Ok((StatusCode::CREATED, Json(builder.wrap(agent))))
@@ -1015,7 +1016,7 @@ pub async fn preview_agent(
         tools: req.tools,
         mcp_servers: req.mcp_servers,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
 
     Ok(Json(AgentPreviewResponse {

--- a/crates/server/src/api/apps.rs
+++ b/crates/server/src/api/apps.rs
@@ -58,6 +58,7 @@ impl AppState {
             self.db.clone(),
             self.capability_service.clone(),
             self.encryption.clone(),
+            self.auth.permission_resolver.clone(),
         )
         .with_workflow_store(self.workflow_store.clone())
     }
@@ -126,7 +127,7 @@ pub async fn create_app(
     Json(req): Json<CreateAppRequest>,
 ) -> Result<(StatusCode, Json<WithUrls<App>>), (StatusCode, Json<ErrorResponse>)> {
     let app = crate::domains::apps::CreateApp(req)
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
 
     let builder = UrlBuilder::from_auth_config(&state.auth.config);
@@ -153,7 +154,7 @@ pub async fn list_apps(
         search: query.search,
         include_archived: query.include_archived.unwrap_or(false),
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
 
     let builder = UrlBuilder::from_auth_config(&state.auth.config);
@@ -179,7 +180,7 @@ pub async fn get_app(
     Path(app_id): Path<String>,
 ) -> ApiResult<WithUrls<App>> {
     let app = crate::domains::apps::GetApp { id: app_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
 
     let builder = UrlBuilder::from_auth_config(&state.auth.config);
@@ -207,7 +208,7 @@ pub async fn update_app(
     Json(req): Json<UpdateAppRequest>,
 ) -> ApiResult<WithUrls<App>> {
     let app = crate::domains::apps::UpdateAppCmd { id: app_id, req }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
 
     let builder = UrlBuilder::from_auth_config(&state.auth.config);
@@ -233,7 +234,7 @@ pub async fn delete_app(
     Path(app_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     crate::domains::apps::DeleteApp { id: app_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     Ok(StatusCode::NO_CONTENT)
 }
@@ -244,7 +245,7 @@ pub async fn destroy_app(
     Path(app_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     crate::domains::apps::DestroyApp { id: app_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     Ok(StatusCode::NO_CONTENT)
 }
@@ -268,7 +269,7 @@ pub async fn publish_app(
     Path(app_id): Path<String>,
 ) -> ApiResult<WithUrls<App>> {
     let app = crate::domains::apps::PublishApp { id: app_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
 
     let builder = UrlBuilder::from_auth_config(&state.auth.config);
@@ -294,7 +295,7 @@ pub async fn unpublish_app(
     Path(app_id): Path<String>,
 ) -> ApiResult<WithUrls<App>> {
     let app = crate::domains::apps::UnpublishApp { id: app_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
 
     let builder = UrlBuilder::from_auth_config(&state.auth.config);
@@ -313,7 +314,7 @@ pub async fn add_channel(
     Json(req): Json<AddChannelRequest>,
 ) -> Result<(StatusCode, Json<AppChannel>), (StatusCode, Json<ErrorResponse>)> {
     let channel = crate::domains::apps::AddChannel { app_id, req }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     Ok((StatusCode::CREATED, Json(channel)))
 }
@@ -330,7 +331,7 @@ pub async fn update_channel(
         channel_id,
         req,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
     Ok(Json(channel))
 }
@@ -342,7 +343,7 @@ pub async fn delete_channel(
     Path((app_id, channel_id)): Path<(String, String)>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     crate::domains::apps::DeleteChannel { app_id, channel_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/server/src/api/audit_logs.rs
+++ b/crates/server/src/api/audit_logs.rs
@@ -46,6 +46,7 @@ impl AppState {
             self.db.clone(),
             self.capability_service.clone(),
             None,
+            self.auth.permission_resolver.clone(),
         )
     }
 }
@@ -89,7 +90,7 @@ async fn list_audit_logs(
         domain: query.domain,
         action: query.action,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
 
     Ok(Json(ListResponse::new(items)))

--- a/crates/server/src/api/budgets.rs
+++ b/crates/server/src/api/budgets.rs
@@ -50,7 +50,12 @@ impl AppState {
     }
 
     fn ctx(&self, org: &ResolvedOrg) -> Ctx {
-        Ctx::minimal(Caller::from(org), self.db.clone(), None)
+        Ctx::minimal(
+            Caller::from(org),
+            self.db.clone(),
+            None,
+            self.auth.permission_resolver.clone(),
+        )
     }
 }
 
@@ -138,7 +143,7 @@ async fn create_budget(
     State(state): State<AppState>,
     Json(req): Json<CreateBudgetRequest>,
 ) -> Result<(StatusCode, Json<WithUrls<Budget>>), ApiError> {
-    let row = CreateBudget(req).execute(&state.ctx(&org)).await?;
+    let row = CreateBudget(req).run(&state.ctx(&org)).await?;
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
     Ok((StatusCode::CREATED, Json(urls.wrap(row))))
 }
@@ -148,7 +153,7 @@ async fn get_budget(
     State(state): State<AppState>,
     Path(budget_id): Path<String>,
 ) -> Result<Json<WithUrls<Budget>>, ApiError> {
-    let row = GetBudget { budget_id }.execute(&state.ctx(&org)).await?;
+    let row = GetBudget { budget_id }.run(&state.ctx(&org)).await?;
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
     Ok(Json(urls.wrap(row)))
 }
@@ -162,7 +167,7 @@ async fn list_budgets(
         subject_type: query.subject_type,
         subject_id: query.subject_id,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
     Ok(Json(urls.wrap_vec(budgets)))
@@ -181,7 +186,7 @@ async fn update_budget(
         status: req.status,
         metadata: req.metadata,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
     Ok(Json(urls.wrap(row)))
@@ -192,7 +197,7 @@ async fn delete_budget(
     State(state): State<AppState>,
     Path(budget_id): Path<String>,
 ) -> Result<StatusCode, ApiError> {
-    DeleteBudget { budget_id }.execute(&state.ctx(&org)).await?;
+    DeleteBudget { budget_id }.run(&state.ctx(&org)).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -207,7 +212,7 @@ async fn top_up(
         amount: req.amount,
         description: req.description,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
     Ok(Json(urls.wrap(row)))
@@ -225,7 +230,7 @@ async fn list_ledger(
             limit: query.limit,
             offset: query.offset,
         }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?,
     ))
 }
@@ -235,9 +240,7 @@ async fn check_budget(
     State(state): State<AppState>,
     Path(budget_id): Path<String>,
 ) -> Result<Json<BudgetCheckResult>, ApiError> {
-    Ok(Json(
-        CheckBudget { budget_id }.execute(&state.ctx(&org)).await?,
-    ))
+    Ok(Json(CheckBudget { budget_id }.run(&state.ctx(&org)).await?))
 }
 
 // ============================================================================
@@ -250,7 +253,7 @@ async fn list_session_budgets(
     Path(session_id): Path<String>,
 ) -> Result<Json<Vec<WithUrls<Budget>>>, ApiError> {
     let budgets = ListSessionBudgets { session_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
     Ok(Json(urls.wrap_vec(budgets)))
@@ -263,7 +266,7 @@ async fn check_session_budgets(
 ) -> Result<Json<BudgetCheckResult>, ApiError> {
     Ok(Json(
         CheckSessionBudgets { session_id }
-            .execute(&state.ctx(&org))
+            .run(&state.ctx(&org))
             .await?,
     ))
 }
@@ -276,7 +279,7 @@ async fn resume_session(
     Ok(Json(
         serde_json::to_value(
             ResumeSessionBudgets { session_id }
-                .execute(&state.ctx(&org))
+                .run(&state.ctx(&org))
                 .await?,
         )
         .map_err(|e| {

--- a/crates/server/src/api/capabilities.rs
+++ b/crates/server/src/api/capabilities.rs
@@ -44,6 +44,7 @@ impl AppState {
             self.db.clone(),
             self.service.clone(),
             None,
+            self.auth.permission_resolver.clone(),
         )
     }
 }
@@ -89,7 +90,7 @@ pub async fn list_capabilities(
         offset: query.offset,
         limit: query.limit,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await
     .map_err(|e| e.status())?;
 
@@ -119,7 +120,7 @@ pub async fn get_capability(
     Path(capability_id): Path<String>,
 ) -> Result<Json<WithUrls<CapabilityInfo>>, StatusCode> {
     let capability = crate::domains::capabilities::GetCapability { id: capability_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await
         .map_err(|e| e.status())?;
 

--- a/crates/server/src/api/evals.rs
+++ b/crates/server/src/api/evals.rs
@@ -58,8 +58,13 @@ impl AppState {
     }
 
     fn ctx(&self, org: &ResolvedOrg) -> Ctx {
-        Ctx::minimal(Caller::from(org), self.db.clone(), None)
-            .with_eval_service(self.service.clone())
+        Ctx::minimal(
+            Caller::from(org),
+            self.db.clone(),
+            None,
+            self.auth.permission_resolver.clone(),
+        )
+        .with_eval_service(self.service.clone())
     }
 }
 
@@ -263,7 +268,7 @@ async fn create_eval(
     State(state): State<AppState>,
     Json(req): Json<CreateEvalRequest>,
 ) -> Result<(StatusCode, Json<Eval>), (StatusCode, Json<ErrorResponse>)> {
-    let eval = CreateEval(req).execute(&state.ctx(&org)).await?;
+    let eval = CreateEval(req).run(&state.ctx(&org)).await?;
     Ok((StatusCode::CREATED, Json(eval)))
 }
 
@@ -276,7 +281,7 @@ async fn list_evals(
         search: query.search,
         include_archived: query.include_archived.unwrap_or(false),
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
     Ok(Json(ListResponse::new(evals)))
 }
@@ -286,7 +291,7 @@ async fn get_eval(
     State(state): State<AppState>,
     Path(eval_id): Path<String>,
 ) -> ApiResult<Eval> {
-    let eval = GetEval { eval_id }.execute(&state.ctx(&org)).await?;
+    let eval = GetEval { eval_id }.run(&state.ctx(&org)).await?;
     Ok(Json(eval))
 }
 
@@ -296,9 +301,7 @@ async fn update_eval(
     Path(eval_id): Path<String>,
     Json(req): Json<UpdateEvalRequest>,
 ) -> ApiResult<Eval> {
-    let eval = UpdateEval { eval_id, req }
-        .execute(&state.ctx(&org))
-        .await?;
+    let eval = UpdateEval { eval_id, req }.run(&state.ctx(&org)).await?;
     Ok(Json(eval))
 }
 
@@ -307,7 +310,7 @@ async fn delete_eval(
     State(state): State<AppState>,
     Path(eval_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    DeleteEval { eval_id }.execute(&state.ctx(&org)).await?;
+    DeleteEval { eval_id }.run(&state.ctx(&org)).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -322,7 +325,7 @@ async fn create_case(
     Json(req): Json<CreateEvalCaseRequest>,
 ) -> Result<(StatusCode, Json<EvalCase>), (StatusCode, Json<ErrorResponse>)> {
     let case = CreateEvalCase { eval_id, req }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     Ok((StatusCode::CREATED, Json(case)))
 }
@@ -332,7 +335,7 @@ async fn list_cases(
     State(state): State<AppState>,
     Path(eval_id): Path<String>,
 ) -> ApiResult<ListResponse<EvalCase>> {
-    let cases = ListEvalCases { eval_id }.execute(&state.ctx(&org)).await?;
+    let cases = ListEvalCases { eval_id }.run(&state.ctx(&org)).await?;
     Ok(Json(ListResponse::new(cases)))
 }
 
@@ -342,7 +345,7 @@ async fn get_case(
     Path((eval_id, case_id)): Path<(String, String)>,
 ) -> ApiResult<EvalCase> {
     let case = GetEvalCase { eval_id, case_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     Ok(Json(case))
 }
@@ -358,7 +361,7 @@ async fn update_case(
         case_id,
         req,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
     Ok(Json(case))
 }
@@ -369,7 +372,7 @@ async fn delete_case(
     Path((eval_id, case_id)): Path<(String, String)>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     DeleteEvalCase { eval_id, case_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     Ok(StatusCode::NO_CONTENT)
 }
@@ -384,9 +387,7 @@ async fn create_run(
     Path(eval_id): Path<String>,
     Json(req): Json<CreateEvalRunRequest>,
 ) -> Result<(StatusCode, Json<EvalRun>), (StatusCode, Json<ErrorResponse>)> {
-    let run = CreateEvalRun { eval_id, req }
-        .execute(&state.ctx(&org))
-        .await?;
+    let run = CreateEvalRun { eval_id, req }.run(&state.ctx(&org)).await?;
     Ok((StatusCode::CREATED, Json(run)))
 }
 
@@ -395,7 +396,7 @@ async fn list_runs(
     State(state): State<AppState>,
     Path(eval_id): Path<String>,
 ) -> ApiResult<ListResponse<EvalRun>> {
-    let runs = ListEvalRuns { eval_id }.execute(&state.ctx(&org)).await?;
+    let runs = ListEvalRuns { eval_id }.run(&state.ctx(&org)).await?;
     Ok(Json(ListResponse::new(runs)))
 }
 
@@ -404,9 +405,7 @@ async fn get_run(
     State(state): State<AppState>,
     Path((eval_id, run_id)): Path<(String, String)>,
 ) -> ApiResult<EvalRun> {
-    let run = GetEvalRun { eval_id, run_id }
-        .execute(&state.ctx(&org))
-        .await?;
+    let run = GetEvalRun { eval_id, run_id }.run(&state.ctx(&org)).await?;
     Ok(Json(run))
 }
 
@@ -416,7 +415,7 @@ async fn export_run_artifacts(
     Path((eval_id, run_id)): Path<(String, String)>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
     let export = ExportEvalRunArtifacts { eval_id, run_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     let body = Body::from(Bytes::from(export.body));
 
@@ -436,7 +435,7 @@ async fn cancel_run(
     Path((eval_id, run_id)): Path<(String, String)>,
 ) -> ApiResult<EvalRun> {
     let run = CancelEvalRun { eval_id, run_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     Ok(Json(run))
 }
@@ -453,7 +452,7 @@ async fn update_result_scores(
         result_id,
         req,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
     Ok(Json(result))
 }
@@ -469,7 +468,7 @@ async fn bulk_update_run_scores(
         run_id,
         req,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
     Ok(Json(ListResponse::new(results)))
 }

--- a/crates/server/src/api/events.rs
+++ b/crates/server/src/api/events.rs
@@ -143,9 +143,14 @@ impl AppState {
     }
 
     fn ctx(&self, org: &ResolvedOrg) -> Ctx {
-        Ctx::minimal(Caller::from(org), self.db.clone(), None)
-            .with_session_service(self.session_service.clone())
-            .with_event_service(self.event_service.clone())
+        Ctx::minimal(
+            Caller::from(org),
+            self.db.clone(),
+            None,
+            self.auth.permission_resolver.clone(),
+        )
+        .with_session_service(self.session_service.clone())
+        .with_event_service(self.event_service.clone())
     }
 }
 
@@ -688,7 +693,7 @@ pub async fn list_events(
         limit: query.limit,
         before_sequence: query.before_sequence,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
 
     // Build response with optional X-Total-Count header

--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -64,6 +64,7 @@ impl AppState {
             self.db.clone(),
             self.capability_service.clone(),
             None,
+            self.auth.permission_resolver.clone(),
         )
     }
 }
@@ -137,7 +138,7 @@ pub async fn check_harness_name(
         name: query.name,
         exclude_id: query.exclude_id,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
     Ok(Json(CheckNameResponse {
         available: result.available,
@@ -163,7 +164,7 @@ pub async fn create_harness(
     Json(req): Json<CreateHarnessRequest>,
 ) -> Result<(StatusCode, Json<WithUrls<Harness>>), (StatusCode, Json<ErrorResponse>)> {
     let harness = crate::domains::harnesses::CreateHarness(req)
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
     Ok((StatusCode::CREATED, Json(urls.wrap(harness))))
@@ -190,7 +191,7 @@ pub async fn list_harnesses(
         search: query.search,
         include_archived: query.include_archived.unwrap_or(false),
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
 
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
@@ -224,7 +225,7 @@ pub async fn get_harness(
     let harness = crate::domains::harnesses::GetHarness {
         id: harness_id_or_name,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
     Ok(Json(urls.wrap(harness)))
@@ -257,7 +258,7 @@ pub async fn update_harness(
         id: harness_id,
         req,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
     Ok(Json(urls.wrap(harness)))
@@ -285,7 +286,7 @@ pub async fn delete_harness(
     Path(harness_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     crate::domains::harnesses::DeleteHarness { id: harness_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     Ok(StatusCode::NO_CONTENT)
 }
@@ -296,7 +297,7 @@ pub async fn destroy_harness(
     Path(harness_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     crate::domains::harnesses::DestroyHarness { id: harness_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     Ok(StatusCode::NO_CONTENT)
 }
@@ -326,7 +327,7 @@ pub async fn copy_harness(
     Path(harness_id): Path<String>,
 ) -> Result<(StatusCode, Json<WithUrls<Harness>>), (StatusCode, Json<ErrorResponse>)> {
     let harness = crate::domains::harnesses::CopyHarness { id: harness_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
     Ok((StatusCode::CREATED, Json(urls.wrap(harness))))
@@ -354,7 +355,7 @@ pub async fn preview_harness(
         capabilities: req.capabilities,
         mcp_servers: req.mcp_servers,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
 
     Ok(Json(HarnessPreviewResponse {

--- a/crates/server/src/api/llm_models.rs
+++ b/crates/server/src/api/llm_models.rs
@@ -53,8 +53,13 @@ impl AppState {
     }
 
     fn ctx(&self, org: &ResolvedOrg) -> Ctx {
-        Ctx::minimal(Caller::from(org), self.db.clone(), None)
-            .with_llm_model_service(self.service.clone())
+        Ctx::minimal(
+            Caller::from(org),
+            self.db.clone(),
+            None,
+            self.auth.permission_resolver.clone(),
+        )
+        .with_llm_model_service(self.service.clone())
     }
 }
 
@@ -158,7 +163,7 @@ pub async fn create_model(
         enabled: req.enabled,
         is_favorite: req.is_favorite,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
 
     let builder = UrlBuilder::from_auth_config(&state.auth.config);
@@ -184,7 +189,7 @@ pub async fn list_provider_models(
     Path(provider_id): Path<String>,
 ) -> ApiResult<ListResponse<WithUrls<LlmModel>>> {
     let models = ListProviderModels { provider_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
 
     let builder = UrlBuilder::from_auth_config(&state.auth.config);
@@ -213,7 +218,7 @@ pub async fn list_all_models(
         include_stale: query.include_stale,
         favorites_only: query.favorites_only,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
 
     let builder = UrlBuilder::from_auth_config(&state.auth.config);
@@ -239,7 +244,7 @@ pub async fn get_model(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> ApiResult<WithUrls<LlmModelWithProvider>> {
-    let model = GetModel { id }.execute(&state.ctx(&org)).await?;
+    let model = GetModel { id }.run(&state.ctx(&org)).await?;
 
     let builder = UrlBuilder::from_auth_config(&state.auth.config);
     Ok(Json(builder.wrap(model)))
@@ -275,7 +280,7 @@ pub async fn update_model(
         is_favorite: req.is_favorite,
         status: req.status,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
 
     let builder = UrlBuilder::from_auth_config(&state.auth.config);
@@ -301,7 +306,7 @@ pub async fn delete_model(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    DeleteModel { id }.execute(&state.ctx(&org)).await?;
+    DeleteModel { id }.run(&state.ctx(&org)).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/crates/server/src/api/llm_providers.rs
+++ b/crates/server/src/api/llm_providers.rs
@@ -58,9 +58,14 @@ impl AppState {
     }
 
     fn ctx(&self, org: &ResolvedOrg) -> Ctx {
-        Ctx::minimal(Caller::from(org), self.db.clone(), None)
-            .with_llm_provider_service(self.service.clone())
-            .with_model_sync_service(self.sync_service.clone())
+        Ctx::minimal(
+            Caller::from(org),
+            self.db.clone(),
+            None,
+            self.auth.permission_resolver.clone(),
+        )
+        .with_llm_provider_service(self.service.clone())
+        .with_model_sync_service(self.sync_service.clone())
     }
 }
 
@@ -148,7 +153,7 @@ pub async fn create_provider(
         base_url: req.base_url,
         api_key: req.api_key,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
 
     let builder = UrlBuilder::from_auth_config(&state.auth.config);
@@ -168,7 +173,7 @@ pub async fn list_providers(
     org: ResolvedOrg,
     State(state): State<AppState>,
 ) -> ApiResult<ListResponse<WithUrls<LlmProvider>>> {
-    let providers = ListProviders.execute(&state.ctx(&org)).await?;
+    let providers = ListProviders.run(&state.ctx(&org)).await?;
 
     let builder = UrlBuilder::from_auth_config(&state.auth.config);
     Ok(Json(ListResponse::new(providers).with_urls(&builder)))
@@ -193,7 +198,7 @@ pub async fn get_provider(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> ApiResult<WithUrls<LlmProvider>> {
-    let provider = GetProvider { id }.execute(&state.ctx(&org)).await?;
+    let provider = GetProvider { id }.run(&state.ctx(&org)).await?;
 
     let builder = UrlBuilder::from_auth_config(&state.auth.config);
     Ok(Json(builder.wrap(provider)))
@@ -228,7 +233,7 @@ pub async fn update_provider(
         api_key: req.api_key,
         status: req.status,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
 
     let builder = UrlBuilder::from_auth_config(&state.auth.config);
@@ -254,7 +259,7 @@ pub async fn delete_provider(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    DeleteProvider { id }.execute(&state.ctx(&org)).await?;
+    DeleteProvider { id }.run(&state.ctx(&org)).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -281,9 +286,7 @@ pub async fn sync_models(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> ApiResult<SyncModelsResponse> {
-    Ok(Json(
-        SyncProviderModels { id }.execute(&state.ctx(&org)).await?,
-    ))
+    Ok(Json(SyncProviderModels { id }.run(&state.ctx(&org)).await?))
 }
 
 /// GET /v1/llm-providers/config

--- a/crates/server/src/api/mcp_endpoint/catalog.rs
+++ b/crates/server/src/api/mcp_endpoint/catalog.rs
@@ -41,6 +41,7 @@ impl CatalogContext {
             self.state.db.clone(),
             self.state.capability_service.clone(),
             self.state.encryption.clone(),
+            self.state.auth.permission_resolver.clone(),
         )
         .with_session_service(self.state.session_service.clone())
         .with_message_service(self.state.message_service.clone())

--- a/crates/server/src/api/mcp_servers.rs
+++ b/crates/server/src/api/mcp_servers.rs
@@ -74,6 +74,7 @@ impl AppState {
             self.db.clone(),
             self.capability_service.clone(),
             self.encryption.clone(),
+            self.auth.permission_resolver.clone(),
         )
     }
 }
@@ -143,7 +144,7 @@ pub async fn create_mcp_server(
     Json(req): Json<CreateMcpServerRequest>,
 ) -> Result<(StatusCode, Json<WithUrls<McpServer>>), (StatusCode, Json<ErrorResponse>)> {
     let server = crate::domains::mcp_servers::CreateMcpServer(req)
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
 
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
@@ -170,7 +171,7 @@ pub async fn list_mcp_servers(
         search: query.search,
         include_archived: query.include_archived.unwrap_or(false),
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
 
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
@@ -198,7 +199,7 @@ pub async fn get_mcp_server(
     Path(server_id): Path<String>,
 ) -> ApiResult<WithUrls<McpServer>> {
     let server = crate::domains::mcp_servers::GetMcpServer { id: server_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
 
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
@@ -228,7 +229,7 @@ pub async fn update_mcp_server(
     Json(req): Json<UpdateMcpServerRequest>,
 ) -> ApiResult<WithUrls<McpServer>> {
     let server = crate::domains::mcp_servers::UpdateMcpServerCmd { id: server_id, req }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
 
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
@@ -256,7 +257,7 @@ pub async fn delete_mcp_server(
     Path(server_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     crate::domains::mcp_servers::DeleteMcpServer { id: server_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     Ok(StatusCode::NO_CONTENT)
 }
@@ -267,7 +268,7 @@ pub async fn destroy_mcp_server(
     Path(server_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     crate::domains::mcp_servers::DestroyMcpServer { id: server_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/server/src/api/messages.rs
+++ b/crates/server/src/api/messages.rs
@@ -191,9 +191,14 @@ impl AppState {
     }
 
     fn ctx(&self, org: &ResolvedOrg) -> Ctx {
-        Ctx::minimal(Caller::from(org), self.db.clone(), None)
-            .with_session_service(self.session_service.clone())
-            .with_message_service(self.message_service.clone())
+        Ctx::minimal(
+            Caller::from(org),
+            self.db.clone(),
+            None,
+            self.auth.permission_resolver.clone(),
+        )
+        .with_session_service(self.session_service.clone())
+        .with_message_service(self.message_service.clone())
     }
 }
 
@@ -250,7 +255,7 @@ pub async fn create_message(
         external_actor: req.external_actor,
         request_id,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
 
     Ok((StatusCode::CREATED, Json(message)))
@@ -276,9 +281,7 @@ pub async fn list_messages(
     State(state): State<AppState>,
     Path(session_id): Path<String>,
 ) -> ApiResult<ListResponse<Message>> {
-    let messages = ListMessages { session_id }
-        .execute(&state.ctx(&org))
-        .await?;
+    let messages = ListMessages { session_id }.run(&state.ctx(&org)).await?;
 
     Ok(Json(ListResponse::new(messages)))
 }
@@ -311,7 +314,7 @@ pub async fn export_session_jsonl(
     let export = ExportSessionMessages {
         session_id: session_id.clone(),
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
     let filename = format!("{}.jsonl", session_id);
     Ok((

--- a/crates/server/src/api/notifications.rs
+++ b/crates/server/src/api/notifications.rs
@@ -74,7 +74,12 @@ pub struct AppState {
 
 impl AppState {
     fn ctx(&self, org: &ResolvedOrg) -> Ctx {
-        Ctx::minimal(Caller::from(org), self.db.clone(), None)
+        Ctx::minimal(
+            Caller::from(org),
+            self.db.clone(),
+            None,
+            self.auth.permission_resolver.clone(),
+        )
     }
 }
 
@@ -127,7 +132,7 @@ pub async fn list_notifications(
     require_user_id(&org)?;
     Ok(Json(
         ListNotifications { limit: query.limit }
-            .execute(&state.ctx(&org))
+            .run(&state.ctx(&org))
             .await?,
     ))
 }
@@ -140,7 +145,7 @@ pub async fn mark_notification_viewed(
     require_user_id(&org)?;
     Ok(Json(
         MarkNotificationViewed { notification_id }
-            .execute(&state.ctx(&org))
+            .run(&state.ctx(&org))
             .await?,
     ))
 }

--- a/crates/server/src/api/schedules.rs
+++ b/crates/server/src/api/schedules.rs
@@ -80,8 +80,13 @@ impl ScheduleAppState {
             is_platform_user: auth.0.is_platform_user,
             is_internal: false,
         };
-        Ok(Ctx::minimal(caller, self.db.clone(), None)
-            .with_workflow_store(Some(self.get_store()?.clone())))
+        Ok(Ctx::minimal(
+            caller,
+            self.db.clone(),
+            None,
+            self.auth.permission_resolver.clone(),
+        )
+        .with_workflow_store(Some(self.get_store()?.clone())))
     }
 }
 
@@ -426,7 +431,7 @@ pub async fn create_schedule(
     State(state): State<ScheduleAppState>,
     Json(req): Json<CreateScheduleRequest>,
 ) -> Result<(StatusCode, Json<ScheduleResponse>), (StatusCode, Json<ErrorResponse>)> {
-    let schedule = CreateSchedule(req).execute(&state.ctx(&auth)?).await?;
+    let schedule = CreateSchedule(req).run(&state.ctx(&auth)?).await?;
     Ok((StatusCode::CREATED, Json(schedule)))
 }
 
@@ -458,7 +463,7 @@ pub async fn list_schedules(
         offset: query.offset,
         limit: query.limit,
     }
-    .execute(&state.ctx(&auth)?)
+    .run(&state.ctx(&auth)?)
     .await?;
     Ok(Json(schedules))
 }
@@ -483,9 +488,7 @@ pub async fn get_schedule(
     State(state): State<ScheduleAppState>,
     Path(schedule_id): Path<Uuid>,
 ) -> ApiResult<ScheduleResponse> {
-    let schedule = GetSchedule { schedule_id }
-        .execute(&state.ctx(&auth)?)
-        .await?;
+    let schedule = GetSchedule { schedule_id }.run(&state.ctx(&auth)?).await?;
     Ok(Json(schedule))
 }
 
@@ -513,7 +516,7 @@ pub async fn update_schedule(
     Json(req): Json<UpdateScheduleRequest>,
 ) -> ApiResult<ScheduleResponse> {
     let schedule = UpdateScheduleCmd { schedule_id, req }
-        .execute(&state.ctx(&auth)?)
+        .run(&state.ctx(&auth)?)
         .await?;
     Ok(Json(schedule))
 }
@@ -539,7 +542,7 @@ pub async fn delete_schedule(
     Path(schedule_id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     DeleteSchedule { schedule_id }
-        .execute(&state.ctx(&auth)?)
+        .run(&state.ctx(&auth)?)
         .await?;
     Ok(StatusCode::NO_CONTENT)
 }
@@ -565,7 +568,7 @@ pub async fn pause_schedule(
     Path(schedule_id): Path<Uuid>,
 ) -> ApiResult<ScheduleResponse> {
     let schedule = PauseSchedule { schedule_id }
-        .execute(&state.ctx(&auth)?)
+        .run(&state.ctx(&auth)?)
         .await?;
     Ok(Json(schedule))
 }
@@ -591,7 +594,7 @@ pub async fn resume_schedule(
     Path(schedule_id): Path<Uuid>,
 ) -> ApiResult<ScheduleResponse> {
     let schedule = ResumeSchedule { schedule_id }
-        .execute(&state.ctx(&auth)?)
+        .run(&state.ctx(&auth)?)
         .await?;
     Ok(Json(schedule))
 }
@@ -617,7 +620,7 @@ pub async fn trigger_schedule(
     Path(schedule_id): Path<Uuid>,
 ) -> ApiResult<TriggerResponse> {
     let response = TriggerSchedule { schedule_id }
-        .execute(&state.ctx(&auth)?)
+        .run(&state.ctx(&auth)?)
         .await?;
     Ok(Json(response))
 }
@@ -652,7 +655,7 @@ pub async fn list_schedule_executions(
         offset: query.offset,
         limit: query.limit,
     }
-    .execute(&state.ctx(&auth)?)
+    .run(&state.ctx(&auth)?)
     .await?;
     Ok(Json(executions))
 }
@@ -678,7 +681,7 @@ pub async fn get_execution(
     Path(execution_id): Path<Uuid>,
 ) -> ApiResult<ScheduleExecutionResponse> {
     let execution = GetExecution { execution_id }
-        .execute(&state.ctx(&auth)?)
+        .run(&state.ctx(&auth)?)
         .await?;
     Ok(Json(execution))
 }
@@ -704,7 +707,7 @@ pub async fn get_schedule_stats(
     Path(schedule_id): Path<Uuid>,
 ) -> ApiResult<ScheduleStatsResponse> {
     let stats = GetScheduleStats { schedule_id }
-        .execute(&state.ctx(&auth)?)
+        .run(&state.ctx(&auth)?)
         .await?;
     Ok(Json(stats))
 }

--- a/crates/server/src/api/session_databases.rs
+++ b/crates/server/src/api/session_databases.rs
@@ -84,8 +84,13 @@ impl AppState {
     }
 
     fn ctx(&self, org: &ResolvedOrg) -> Ctx {
-        Ctx::minimal(Caller::from(org), self.db.clone(), None)
-            .with_sqldb_store(self.sqldb_store.clone())
+        Ctx::minimal(
+            Caller::from(org),
+            self.db.clone(),
+            None,
+            self.auth.permission_resolver.clone(),
+        )
+        .with_sqldb_store(self.sqldb_store.clone())
     }
 }
 
@@ -129,7 +134,7 @@ pub async fn list_databases(
     let items = ListSessionDatabases {
         session_id: session_id.to_string(),
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await
     .map_err(|e| e.status())?;
     Ok(Json(ListResponse::new(items)))
@@ -160,7 +165,7 @@ pub async fn create_database(
         session_id: session_id.to_string(),
         name: req.name,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await
     .map_err(|e| e.status())?;
 
@@ -192,7 +197,7 @@ pub async fn get_database(
             session_id: session_id.to_string(),
             name,
         }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await
         .map_err(|e| e.status())?,
     ))
@@ -222,7 +227,7 @@ pub async fn delete_database(
         session_id: session_id.to_string(),
         name,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await
     .map_err(|e| e.status())?;
     Ok(StatusCode::NO_CONTENT)
@@ -253,7 +258,7 @@ pub async fn get_schema(
             session_id: session_id.to_string(),
             name,
         }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await
         .map_err(|e| e.status())?,
     ))

--- a/crates/server/src/api/session_files.rs
+++ b/crates/server/src/api/session_files.rs
@@ -167,9 +167,14 @@ impl AppState {
     }
 
     fn ctx(&self, org: &ResolvedOrg) -> Ctx {
-        Ctx::minimal(Caller::from(org), self.db.clone(), None)
-            .with_session_file_service(self.file_service.clone())
-            .with_event_service(self.event_service.clone())
+        Ctx::minimal(
+            Caller::from(org),
+            self.db.clone(),
+            None,
+            self.auth.permission_resolver.clone(),
+        )
+        .with_session_file_service(self.file_service.clone())
+        .with_event_service(self.event_service.clone())
     }
 }
 
@@ -398,7 +403,7 @@ pub async fn get_root(
         session_id,
         recursive: query.recursive,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await
     .map_err(file_error)?;
     Ok(Json(response))
@@ -433,7 +438,7 @@ pub async fn get_path(
         path,
         recursive: query.recursive,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await
     .map_err(file_error)?;
 
@@ -476,7 +481,7 @@ pub async fn download_path(
         path,
         recursive: false,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await
     .map_err(file_error)?;
 
@@ -525,7 +530,7 @@ pub async fn create_path(
         path,
         req,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await
     .map_err(file_error)?;
     Ok((StatusCode::CREATED, Json(file)))
@@ -559,7 +564,7 @@ pub async fn update_path(
         path,
         req,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await
     .map_err(file_error)?;
     Ok(Json(file))
@@ -601,7 +606,7 @@ pub async fn delete_path(
         path,
         recursive: query.recursive,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await
     .map_err(file_error)?;
     Ok(Json(response))
@@ -631,7 +636,7 @@ pub async fn move_file(
     Json(req): Json<MoveFileRequest>,
 ) -> Result<Json<SessionFile>, (StatusCode, String)> {
     let file = MoveSessionFile { session_id, req }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await
         .map_err(file_error)?;
     Ok(Json(file))
@@ -661,7 +666,7 @@ pub async fn copy_file(
     Json(req): Json<CopyFileRequest>,
 ) -> Result<(StatusCode, Json<SessionFile>), (StatusCode, String)> {
     let file = CopySessionFile { session_id, req }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await
         .map_err(file_error)?;
     Ok((StatusCode::CREATED, Json(file)))
@@ -689,7 +694,7 @@ pub async fn grep_files(
     Json(req): Json<GrepRequest>,
 ) -> Result<Json<ListResponse<GrepResult>>, (StatusCode, String)> {
     let results = GrepSessionFiles { session_id, req }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await
         .map_err(file_error)?;
     Ok(Json(ListResponse::new(results)))
@@ -718,7 +723,7 @@ pub async fn stat_file(
     Json(req): Json<StatRequest>,
 ) -> Result<Json<FileStat>, (StatusCode, String)> {
     let stat = StatSessionFile { session_id, req }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await
         .map_err(file_error)?;
     Ok(Json(stat))

--- a/crates/server/src/api/session_resources.rs
+++ b/crates/server/src/api/session_resources.rs
@@ -40,7 +40,12 @@ impl AppState {
     }
 
     fn ctx(&self, org: &ResolvedOrg) -> Ctx {
-        Ctx::minimal(Caller::from(org), self.db.clone(), None)
+        Ctx::minimal(
+            Caller::from(org),
+            self.db.clone(),
+            None,
+            self.auth.permission_resolver.clone(),
+        )
     }
 }
 
@@ -71,7 +76,7 @@ pub async fn list_resources(
         ListSessionResources {
             session_id: session_id.to_string(),
         }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?,
     ))
 }

--- a/crates/server/src/api/session_sandbox.rs
+++ b/crates/server/src/api/session_sandbox.rs
@@ -118,9 +118,14 @@ impl AppState {
     }
 
     fn ctx(&self, org: &ResolvedOrg) -> Ctx {
-        Ctx::minimal(Caller::from(org), self.db.clone(), None)
-            .with_session_service(self.session_service.clone())
-            .with_session_sandbox_service(self.session_sandbox_service.clone())
+        Ctx::minimal(
+            Caller::from(org),
+            self.db.clone(),
+            None,
+            self.auth.permission_resolver.clone(),
+        )
+        .with_session_service(self.session_service.clone())
+        .with_session_sandbox_service(self.session_sandbox_service.clone())
     }
 }
 
@@ -154,7 +159,7 @@ pub async fn get_sandbox(
 ) -> ApiResult<GetSessionSandboxResponse> {
     Ok(Json(
         GetSessionSandbox { session_id }
-            .execute(&state.ctx(&org))
+            .run(&state.ctx(&org))
             .await?,
     ))
 }
@@ -184,7 +189,7 @@ pub async fn manage_sandbox(
             session_id,
             action: body.action,
         }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?,
     ))
 }

--- a/crates/server/src/api/session_storage.rs
+++ b/crates/server/src/api/session_storage.rs
@@ -83,7 +83,12 @@ impl AppState {
     }
 
     fn ctx(&self, org: &ResolvedOrg) -> Ctx {
-        Ctx::minimal(Caller::from(org), self.db.clone(), self.encryption.clone())
+        Ctx::minimal(
+            Caller::from(org),
+            self.db.clone(),
+            self.encryption.clone(),
+            self.auth.permission_resolver.clone(),
+        )
     }
 }
 
@@ -123,7 +128,7 @@ pub async fn list_keys(
     let items = ListSessionStorage {
         session_id: session_id.to_string(),
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await
     .map_err(|e| e.status())?;
     Ok(Json(ListResponse::new(items)))
@@ -152,7 +157,7 @@ pub async fn list_secrets(
     let items = ListSessionSecrets {
         session_id: session_id.to_string(),
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await
     .map_err(|e| e.status())?;
     Ok(Json(ListResponse::new(items)))
@@ -191,7 +196,7 @@ pub async fn batch_set_secrets(
             session_id: session_id.to_string(),
             secrets: body.secrets,
         }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?,
     ))
 }

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -232,13 +232,18 @@ impl AppState {
     }
 
     fn ctx(&self, org: &ResolvedOrg) -> Ctx {
-        Ctx::minimal(Caller::from(org), self.db.clone(), None)
-            .with_session_service(self.session_service.clone())
-            .with_event_service(Arc::new(self.event_service.clone()))
-            .with_runner(self.runner.clone())
-            .with_fallback_harness_name(self.fallback_default_harness_name.clone())
-            .with_chat_harness_name(self.chat_harness_name.clone())
-            .with_chat_session_title(self.chat_session_title.clone())
+        Ctx::minimal(
+            Caller::from(org),
+            self.db.clone(),
+            None,
+            self.auth.permission_resolver.clone(),
+        )
+        .with_session_service(self.session_service.clone())
+        .with_event_service(Arc::new(self.event_service.clone()))
+        .with_runner(self.runner.clone())
+        .with_fallback_harness_name(self.fallback_default_harness_name.clone())
+        .with_chat_harness_name(self.chat_harness_name.clone())
+        .with_chat_session_title(self.chat_session_title.clone())
     }
 }
 
@@ -318,7 +323,7 @@ pub async fn create_session(
     Json(req): Json<CreateSessionRequest>,
 ) -> Result<(StatusCode, Json<WithUrls<Session>>), (StatusCode, Json<ErrorResponse>)> {
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
-    let session = CreateSession(req).execute(&state.ctx(&org)).await?;
+    let session = CreateSession(req).run(&state.ctx(&org)).await?;
 
     Ok((StatusCode::CREATED, Json(urls.wrap(session))))
 }
@@ -347,7 +352,7 @@ pub async fn get_or_create_chat_session(
     let session = GetOrCreateChatSession {
         locale: payload.and_then(|Json(body)| body.locale),
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
 
     Ok(Json(urls.wrap(session)))
@@ -376,7 +381,7 @@ pub async fn list_sessions(
         offset: query.offset,
         limit: query.limit,
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
 
     Ok(Json(
@@ -398,7 +403,7 @@ pub async fn get_session_stats(
     org: ResolvedOrg,
     State(state): State<AppState>,
 ) -> ApiResult<SessionStatsResponse> {
-    Ok(Json(GetSessionStats.execute(&state.ctx(&org)).await?))
+    Ok(Json(GetSessionStats.run(&state.ctx(&org)).await?))
 }
 
 /// GET /v1/sessions/{session_id} - Get session
@@ -422,7 +427,7 @@ pub async fn get_session(
     Path(session_id): Path<String>,
 ) -> ApiResult<WithUrls<Session>> {
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
-    let session = GetSession { session_id }.execute(&state.ctx(&org)).await?;
+    let session = GetSession { session_id }.run(&state.ctx(&org)).await?;
 
     Ok(Json(urls.wrap(session)))
 }
@@ -451,7 +456,7 @@ pub async fn update_session(
 ) -> ApiResult<WithUrls<Session>> {
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
     let session = UpdateSessionCmd { session_id, req }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
 
     Ok(Json(urls.wrap(session)))
@@ -477,9 +482,7 @@ pub async fn delete_session(
     State(state): State<AppState>,
     Path(session_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    DeleteSession { session_id }
-        .execute(&state.ctx(&org))
-        .await?;
+    DeleteSession { session_id }.run(&state.ctx(&org)).await?;
 
     Ok(StatusCode::NO_CONTENT)
 }
@@ -513,7 +516,7 @@ pub async fn pin_session(
             }),
         ));
     }
-    PinSession { session_id }.execute(&state.ctx(&org)).await?;
+    PinSession { session_id }.run(&state.ctx(&org)).await?;
 
     Ok(StatusCode::NO_CONTENT)
 }
@@ -547,9 +550,7 @@ pub async fn unpin_session(
             }),
         ));
     }
-    UnpinSession { session_id }
-        .execute(&state.ctx(&org))
-        .await?;
+    UnpinSession { session_id }.run(&state.ctx(&org)).await?;
 
     Ok(StatusCode::NO_CONTENT)
 }
@@ -582,9 +583,7 @@ pub async fn cancel_turn(
     Path(session_id): Path<String>,
 ) -> ApiResult<CancelTurnResponse> {
     Ok(Json(
-        CancelSession { session_id }
-            .execute(&state.ctx(&org))
-            .await?,
+        CancelSession { session_id }.run(&state.ctx(&org)).await?,
     ))
 }
 

--- a/crates/server/src/api/skills.rs
+++ b/crates/server/src/api/skills.rs
@@ -86,6 +86,7 @@ impl AppState {
             self.db.clone(),
             self.capability_service.clone(),
             None,
+            self.auth.permission_resolver.clone(),
         )
     }
 }
@@ -162,7 +163,7 @@ pub async fn create_skill(
     Json(req): Json<CreateSkillRequest>,
 ) -> Result<(StatusCode, Json<WithUrls<Skill>>), (StatusCode, Json<ErrorResponse>)> {
     let skill = crate::domains::skills::CreateSkill(req)
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
 
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
@@ -260,7 +261,7 @@ pub async fn list_skills(
         search: query.search,
         include_archived: query.include_archived.unwrap_or(false),
     }
-    .execute(&state.ctx(&org))
+    .run(&state.ctx(&org))
     .await?;
 
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
@@ -286,7 +287,7 @@ pub async fn get_skill(
     Path(skill_id): Path<String>,
 ) -> ApiResult<WithUrls<Skill>> {
     let skill = crate::domains::skills::GetSkill { id: skill_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
 
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
@@ -312,7 +313,7 @@ pub async fn get_skill_content(
     Path(skill_id): Path<String>,
 ) -> ApiResult<SkillContent> {
     let content = crate::domains::skills::GetSkillContent { id: skill_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
 
     Ok(Json(content))
@@ -338,7 +339,7 @@ pub async fn update_skill(
     Json(req): Json<UpdateSkillRequest>,
 ) -> ApiResult<WithUrls<Skill>> {
     let skill = crate::domains::skills::UpdateSkillCmd { id: skill_id, req }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
 
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
@@ -364,7 +365,7 @@ pub async fn delete_skill(
     Path(skill_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     crate::domains::skills::DeleteSkill { id: skill_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     Ok(StatusCode::NO_CONTENT)
 }
@@ -375,7 +376,7 @@ pub async fn destroy_skill(
     Path(skill_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     crate::domains::skills::DestroySkill { id: skill_id }
-        .execute(&state.ctx(&org))
+        .run(&state.ctx(&org))
         .await?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1760,11 +1760,15 @@ impl DirectPlatformStore {
     }
 
     fn command_ctx(&self) -> crate::domains::common::Ctx {
+        // Internal gRPC/worker path — uses DefaultPermissionResolver so
+        // internal ops are never subject to SaaS custom restrictions.
+        // `Caller::internal` already carries role:Owner + is_internal.
         crate::domains::common::Ctx::new(
             Caller::internal(self.org_id),
             self.db.clone(),
             self.capability_service.clone(),
             self.encryption.clone(),
+            std::sync::Arc::new(everruns_core::DefaultPermissionResolver),
         )
         .with_workflow_store(self.workflow_store.clone())
     }

--- a/crates/server/src/domains/agents/commands.rs
+++ b/crates/server/src/domains/agents/commands.rs
@@ -834,6 +834,10 @@ impl Command for PreviewAgent {
         true
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::agents::AGENT_VIEW)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<AgentPreview, CommandError> {
         crate::services::scoped_mcp::validate_scoped_mcp_servers(&self.mcp_servers)
             .map_err(classify_anyhow)?;

--- a/crates/server/src/domains/audit_logs/commands.rs
+++ b/crates/server/src/domains/audit_logs/commands.rs
@@ -137,7 +137,13 @@ mod tests {
         .unwrap();
 
         let capability_service = Arc::new(CapabilityService::new(db.clone(), None));
-        Ctx::new(caller_with_role(role), db, capability_service, None)
+        Ctx::new(
+            caller_with_role(role),
+            db,
+            capability_service,
+            None,
+            Arc::new(everruns_core::DefaultPermissionResolver),
+        )
     }
 
     #[tokio::test]

--- a/crates/server/src/domains/budgets/commands.rs
+++ b/crates/server/src/domains/budgets/commands.rs
@@ -114,6 +114,10 @@ impl Command for ListBudgets {
         }
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&BUDGET_VIEW)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<Vec<Budget>, CommandError> {
         let rows = ctx
             .db
@@ -150,6 +154,10 @@ impl Command for GetBudget {
 
     fn positional_arg() -> Option<&'static str> {
         Some("budget_id")
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&BUDGET_VIEW)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<Budget, CommandError> {
@@ -356,6 +364,10 @@ impl Command for ListBudgetLedger {
         }
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&BUDGET_VIEW)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<Vec<LedgerEntry>, CommandError> {
         let budget_id = q::parse_budget_id(&self.budget_id)?;
         ctx.db
@@ -390,6 +402,10 @@ impl Command for CheckBudget {
             method: "GET",
             path: "/v1/budgets/{budget_id}/check",
         }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&BUDGET_VIEW)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<BudgetCheckResult, CommandError> {
@@ -435,6 +451,10 @@ impl Command for ListSessionBudgets {
         Some("session_id")
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&BUDGET_VIEW)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<Vec<Budget>, CommandError> {
         let rows = ctx
             .db
@@ -467,6 +487,10 @@ impl Command for CheckSessionBudgets {
 
     fn positional_arg() -> Option<&'static str> {
         Some("session_id")
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&BUDGET_VIEW)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<BudgetCheckResult, CommandError> {
@@ -553,7 +577,13 @@ mod tests {
     fn ctx_for_role(role: OrgRole) -> Ctx {
         let db = Arc::new(StorageBackend::in_memory());
         let capability_service = Arc::new(CapabilityService::new(db.clone(), None));
-        Ctx::new(caller_with_role(role), db, capability_service, None)
+        Ctx::new(
+            caller_with_role(role),
+            db,
+            capability_service,
+            None,
+            Arc::new(everruns_core::DefaultPermissionResolver),
+        )
     }
 
     #[tokio::test]

--- a/crates/server/src/domains/budgets/commands.rs
+++ b/crates/server/src/domains/budgets/commands.rs
@@ -1,5 +1,5 @@
 use super::types::CreateBudgetRequest;
-use super::{BUDGET_MANAGE, queries as q};
+use super::{BUDGET_MANAGE, BUDGET_VIEW, queries as q};
 use crate::domains::common::*;
 use crate::storage::models::{CreateBudgetLedgerRow, CreateBudgetRow, UpdateBudgetRow};
 use everruns_core::Policy;

--- a/crates/server/src/domains/budgets/mod.rs
+++ b/crates/server/src/domains/budgets/mod.rs
@@ -12,8 +12,16 @@ pub mod types;
 pub use commands::*;
 pub use service::*;
 
-/// Policy: Manage budgets (create, update, top-up, delete, resume).
+/// Policy: Manage budgets. Budgets control spending limits; treated as a
+/// settings-level concern so only Owner/Admin can modify.
 pub const BUDGET_MANAGE: Policy = Policy {
     id: "budget.manage",
     rules: &[Rule::UserHasPermission(Permission::OrgSettingsManage)],
+};
+
+/// Policy: View budgets. Any caller with settings view, which every role
+/// receives today.
+pub const BUDGET_VIEW: Policy = Policy {
+    id: "budget.view",
+    rules: &[Rule::UserHasPermission(Permission::OrgSettingsView)],
 };

--- a/crates/server/src/domains/common.rs
+++ b/crates/server/src/domains/common.rs
@@ -198,8 +198,9 @@ impl Ctx {
     ///
     /// `permission_resolver` is required — pass `auth.permission_resolver`
     /// from `AuthState` so SaaS-custom resolvers are honored during
-    /// enforcement. Use `Ctx::with_default_resolver` only in tests that
-    /// don't care about the resolver.
+    /// enforcement. In tests that don't care about the resolver, use
+    /// `Ctx::minimal_for_test`; use `with_permission_resolver` when a test
+    /// needs to override the resolver explicitly.
     pub fn new(
         caller: Caller,
         db: Arc<StorageBackend>,

--- a/crates/server/src/domains/common.rs
+++ b/crates/server/src/domains/common.rs
@@ -6,7 +6,9 @@
 use crate::storage::StorageBackend;
 use axum::Json;
 use axum::http::StatusCode;
-use everruns_core::{Caller, Policy, PolicyError};
+#[cfg(test)]
+use everruns_core::DefaultPermissionResolver;
+use everruns_core::{Caller, PermissionResolver, Policy, PolicyError};
 use everruns_durable::WorkflowEventStore;
 use serde::{Serialize, de::DeserializeOwned};
 use serde_json::Value;
@@ -152,6 +154,11 @@ pub struct CommandMeta {
 #[derive(Clone)]
 pub struct Ctx {
     pub caller: Caller,
+    // SECURITY: Threaded through every caller (HTTP/MCP/gRPC/platform) so
+    // `Command::run` evaluates policies against the active (possibly
+    // SaaS-custom) resolver. Never bypass via `Policy::evaluate` — that
+    // hardcodes `DefaultPermissionResolver`.
+    pub permission_resolver: Arc<dyn PermissionResolver>,
     pub db: Arc<StorageBackend>,
     pub capability_service: Arc<crate::services::CapabilityService>,
     pub encryption: Option<Arc<crate::storage::encryption::EncryptionService>>,
@@ -188,14 +195,21 @@ impl Ctx {
     /// `encryption` may be `None` for domains that never need it (agents,
     /// harnesses, skills). Domains that encrypt secrets (apps, mcp_servers)
     /// must pass `Some`.
+    ///
+    /// `permission_resolver` is required — pass `auth.permission_resolver`
+    /// from `AuthState` so SaaS-custom resolvers are honored during
+    /// enforcement. Use `Ctx::with_default_resolver` only in tests that
+    /// don't care about the resolver.
     pub fn new(
         caller: Caller,
         db: Arc<StorageBackend>,
         capability_service: Arc<crate::services::CapabilityService>,
         encryption: Option<Arc<crate::storage::encryption::EncryptionService>>,
+        permission_resolver: Arc<dyn PermissionResolver>,
     ) -> Self {
         Self {
             caller,
+            permission_resolver,
             db,
             capability_service,
             encryption,
@@ -224,10 +238,37 @@ impl Ctx {
         caller: Caller,
         db: Arc<StorageBackend>,
         encryption: Option<Arc<crate::storage::encryption::EncryptionService>>,
+        permission_resolver: Arc<dyn PermissionResolver>,
     ) -> Self {
         let capability_service =
             Arc::new(crate::services::CapabilityService::new(db.clone(), None));
-        Self::new(caller, db, capability_service, encryption)
+        Self::new(
+            caller,
+            db,
+            capability_service,
+            encryption,
+            permission_resolver,
+        )
+    }
+
+    /// Test-only convenience: construct a minimal Ctx with the OSS default
+    /// resolver. Production code must never use this — route
+    /// `AuthState.permission_resolver` through `Ctx::new` instead so SaaS
+    /// overrides take effect.
+    #[cfg(test)]
+    pub fn minimal_for_test(
+        caller: Caller,
+        db: Arc<StorageBackend>,
+        encryption: Option<Arc<crate::storage::encryption::EncryptionService>>,
+    ) -> Self {
+        Self::minimal(caller, db, encryption, Arc::new(DefaultPermissionResolver))
+    }
+
+    /// Override the permission resolver. Primarily for tests; production
+    /// code should pass the resolver to `Ctx::new` directly.
+    pub fn with_permission_resolver(mut self, resolver: Arc<dyn PermissionResolver>) -> Self {
+        self.permission_resolver = resolver;
+        self
     }
 
     pub fn with_session_service(
@@ -395,7 +436,32 @@ pub trait Command: DeserializeOwned + Send + 'static + CommandSchema {
     }
 
     /// Execute the command. Validation + business logic + persistence.
+    ///
+    /// SECURITY: Do not call this directly from HTTP/MCP/gRPC adapters —
+    /// it skips the policy check. Use `Command::run` instead. `execute`
+    /// stays public to allow one command to compose another (already
+    /// authorized through its own `run`) without re-paying policy cost.
     fn execute(self, ctx: &Ctx) -> impl Future<Output = Result<Self::Output, CommandError>> + Send;
+
+    /// Public entry point. Evaluates `policy()` against the active
+    /// `PermissionResolver` (from `Ctx`) and then delegates to `execute`.
+    ///
+    /// Every caller — HTTP adapters, MCP dispatch, gRPC `ExecuteCommand`,
+    /// platform capability — goes through this. If you're adding a new
+    /// caller and want to skip policy, stop: write a new command.
+    fn run(self, ctx: &Ctx) -> impl Future<Output = Result<Self::Output, CommandError>> + Send
+    where
+        Self: Sized,
+    {
+        async move {
+            if let Some(policy) = Self::policy() {
+                policy
+                    .evaluate_with(ctx.permission_resolver.as_ref(), &ctx.caller)
+                    .map_err(|e| CommandError::Forbidden(e.message))?;
+            }
+            self.execute(ctx).await
+        }
+    }
 }
 
 pub trait CommandSchema {
@@ -528,6 +594,9 @@ pub struct CommandDescriptor {
     pub read_only: fn() -> bool,
     pub positional_arg: fn() -> Option<&'static str>,
     pub param_schema: fn() -> Value,
+    // SECURITY: Exposed so the policy-coverage test can assert every
+    // mutating command declares a policy; do not drop.
+    pub policy: fn() -> Option<&'static Policy>,
     pub dispatch: DispatchFn,
 }
 
@@ -541,6 +610,7 @@ impl CommandDescriptor {
             read_only: C::read_only,
             positional_arg: C::positional_arg,
             param_schema: <C as Command>::param_schema,
+            policy: C::policy,
             dispatch: dispatch_for::<C>,
         }
     }
@@ -551,17 +621,11 @@ fn dispatch_for<C: Command>(
     ctx: &Ctx,
 ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + '_>> {
     Box::pin(async move {
-        // Policy check
-        if let Some(policy) = C::policy() {
-            policy
-                .evaluate(&ctx.caller)
-                .map_err(|e| CommandError::Forbidden(e.message))?;
-        }
-
         let cmd: C =
             serde_json::from_value(params).map_err(|e| CommandError::BadRequest(e.to_string()))?;
 
-        let result = cmd.execute(ctx).await?;
+        // `run` handles the policy check using the active resolver in `ctx`.
+        let result = cmd.run(ctx).await?;
 
         serde_json::to_string(&result).map_err(|e| CommandError::Internal(e.into()))
     })

--- a/crates/server/src/domains/evals/commands.rs
+++ b/crates/server/src/domains/evals/commands.rs
@@ -35,6 +35,10 @@ impl Command for CreateEval {
         }
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::evals::EVAL_MANAGE)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<Eval, CommandError> {
         q::service(ctx)
             .create(&ctx.caller, self.0)
@@ -135,6 +139,10 @@ impl Command for UpdateEval {
         }
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::evals::EVAL_MANAGE)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<Eval, CommandError> {
         let eval_id = q::parse_eval_id(&self.eval_id)?;
         q::service(ctx)
@@ -163,6 +171,10 @@ impl Command for DeleteEval {
             method: "DELETE",
             path: "/v1/evals/{eval_id}",
         }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::evals::EVAL_MANAGE)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<bool, CommandError> {
@@ -199,6 +211,10 @@ impl Command for CreateEvalCase {
             method: "POST",
             path: "/v1/evals/{eval_id}/cases",
         }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::evals::EVAL_MANAGE)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<EvalCase, CommandError> {
@@ -294,6 +310,10 @@ impl Command for UpdateEvalCase {
         }
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::evals::EVAL_MANAGE)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<EvalCase, CommandError> {
         let eval_id = q::parse_eval_id(&self.eval_id)?;
         let case_id = q::parse_case_id(&self.case_id)?;
@@ -331,6 +351,10 @@ impl Command for DeleteEvalCase {
         }
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::evals::EVAL_MANAGE)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<bool, CommandError> {
         let eval_id = q::parse_eval_id(&self.eval_id)?;
         let case_id = q::parse_case_id(&self.case_id)?;
@@ -366,6 +390,10 @@ impl Command for CreateEvalRun {
             method: "POST",
             path: "/v1/evals/{eval_id}/runs",
         }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::evals::EVAL_MANAGE)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<EvalRun, CommandError> {
@@ -501,6 +529,10 @@ impl Command for CancelEvalRun {
         }
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::evals::EVAL_MANAGE)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<EvalRun, CommandError> {
         let eval_id = q::parse_eval_id(&self.eval_id)?;
         let run_id = q::parse_run_id(&self.run_id)?;
@@ -534,6 +566,10 @@ impl Command for UpdateEvalResultScores {
             method: "PATCH",
             path: "/v1/evals/{eval_id}/runs/{run_id}/results/{result_id}/scores",
         }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::evals::EVAL_MANAGE)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<EvalCaseResult, CommandError> {
@@ -575,6 +611,10 @@ impl Command for BulkUpdateEvalRunScores {
             method: "PATCH",
             path: "/v1/evals/{eval_id}/runs/{run_id}/scores",
         }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::evals::EVAL_MANAGE)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<Vec<EvalCaseResult>, CommandError> {

--- a/crates/server/src/domains/messages/commands.rs
+++ b/crates/server/src/domains/messages/commands.rs
@@ -34,6 +34,10 @@ impl Command for CreateMessage {
         }
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::sessions::SESSION_MANAGE)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<Message, CommandError> {
         let mut req = crate::api::messages::CreateMessageRequest {
             message: self.message,

--- a/crates/server/src/domains/notifications/commands.rs
+++ b/crates/server/src/domains/notifications/commands.rs
@@ -76,6 +76,10 @@ impl Command for MarkNotificationViewed {
         Some("notification_id")
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&super::NOTIFICATION_ACCESS)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<Notification, CommandError> {
         let user_id = require_user_id(ctx)?;
         let notification_id: NotificationId = self

--- a/crates/server/src/domains/notifications/mod.rs
+++ b/crates/server/src/domains/notifications/mod.rs
@@ -2,6 +2,8 @@
 //
 // See specs/domains.md for the pattern.
 
+use everruns_core::{OrgRole, Policy, Rule};
+
 pub mod commands;
 pub mod queries;
 pub mod service;
@@ -9,3 +11,11 @@ pub mod types;
 
 pub use commands::*;
 pub use service::*;
+
+/// Policy: Access the authenticated caller's own notifications. Requires
+/// any org role (i.e., the caller must be a member of the org). The
+/// notification handler further scopes by `caller.user_id`.
+pub const NOTIFICATION_ACCESS: Policy = Policy {
+    id: "notification.access",
+    rules: &[Rule::UserHasRole(OrgRole::Member)],
+};

--- a/crates/server/src/domains/organizations/commands.rs
+++ b/crates/server/src/domains/organizations/commands.rs
@@ -102,7 +102,7 @@ mod tests {
         .await
         .expect("seed test data");
 
-        let ctx = Ctx::minimal(
+        let ctx = Ctx::minimal_for_test(
             Caller {
                 org_id: DEFAULT_ORG_ID,
                 org_public_id: "org_00000000000000000000000000000001".to_string(),

--- a/crates/server/src/domains/schedules/commands.rs
+++ b/crates/server/src/domains/schedules/commands.rs
@@ -35,6 +35,10 @@ impl Command for CreateSchedule {
         }
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&super::SCHEDULE_MANAGE)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<ScheduleResponse, CommandError> {
         q::ensure_platform_user(ctx)?;
         let store = q::store(ctx)?;
@@ -187,6 +191,10 @@ impl Command for UpdateScheduleCmd {
         }
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&super::SCHEDULE_MANAGE)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<ScheduleResponse, CommandError> {
         q::ensure_platform_user(ctx)?;
         let store = q::store(ctx)?;
@@ -255,6 +263,10 @@ impl Command for DeleteSchedule {
         }
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&super::SCHEDULE_MANAGE)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<bool, CommandError> {
         q::ensure_platform_user(ctx)?;
         q::store(ctx)?
@@ -283,6 +295,10 @@ impl Command for PauseSchedule {
             method: "POST",
             path: "/v1/durable/schedules/{schedule_id}/pause",
         }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&super::SCHEDULE_MANAGE)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<ScheduleResponse, CommandError> {
@@ -330,6 +346,10 @@ impl Command for ResumeSchedule {
             method: "POST",
             path: "/v1/durable/schedules/{schedule_id}/resume",
         }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&super::SCHEDULE_MANAGE)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<ScheduleResponse, CommandError> {
@@ -380,6 +400,10 @@ impl Command for TriggerSchedule {
             method: "POST",
             path: "/v1/durable/schedules/{schedule_id}/trigger",
         }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&super::SCHEDULE_MANAGE)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<TriggerResponse, CommandError> {

--- a/crates/server/src/domains/schedules/commands.rs
+++ b/crates/server/src/domains/schedules/commands.rs
@@ -108,6 +108,10 @@ impl Command for ListSchedules {
         }
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&super::SCHEDULE_VIEW)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<SchedulesListResponse, CommandError> {
         q::ensure_platform_user(ctx)?;
         let store = q::store(ctx)?;
@@ -157,6 +161,10 @@ impl Command for GetSchedule {
 
     fn positional_arg() -> Option<&'static str> {
         Some("schedule_id")
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&super::SCHEDULE_VIEW)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<ScheduleResponse, CommandError> {
@@ -479,6 +487,10 @@ impl Command for ListScheduleExecutions {
         }
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&super::SCHEDULE_VIEW)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<ScheduleExecutionsListResponse, CommandError> {
         q::ensure_platform_user(ctx)?;
         let store = q::store(ctx)?;
@@ -537,6 +549,10 @@ impl Command for GetExecution {
         Some("execution_id")
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&super::SCHEDULE_VIEW)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<ScheduleExecutionResponse, CommandError> {
         q::ensure_platform_user(ctx)?;
         let execution = q::store(ctx)?
@@ -565,6 +581,10 @@ impl Command for GetScheduleStats {
             method: "GET",
             path: "/v1/durable/schedules/{schedule_id}/stats",
         }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&super::SCHEDULE_VIEW)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<ScheduleStatsResponse, CommandError> {

--- a/crates/server/src/domains/schedules/mod.rs
+++ b/crates/server/src/domains/schedules/mod.rs
@@ -1,7 +1,23 @@
 // Durable schedules domain — commands, queries, and types.
 
+use everruns_core::{Policy, Rule};
+
 pub mod commands;
 pub mod queries;
 pub mod types;
 
 pub use commands::*;
+
+/// Policy: Manage durable schedules. Gated on platform-user auth — matches
+/// the axum `PlatformUser` extractor on these routes. Defense in depth so
+/// MCP/gRPC paths also enforce.
+pub const SCHEDULE_MANAGE: Policy = Policy {
+    id: "schedule.manage",
+    rules: &[Rule::IsPlatformUser],
+};
+
+/// Policy: View durable schedules.
+pub const SCHEDULE_VIEW: Policy = Policy {
+    id: "schedule.view",
+    rules: &[Rule::IsPlatformUser],
+};

--- a/crates/server/src/domains/session_databases/commands.rs
+++ b/crates/server/src/domains/session_databases/commands.rs
@@ -71,6 +71,10 @@ impl Command for CreateSessionDatabaseCmd {
         }
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::sessions::SESSION_MANAGE)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<DatabaseInfoResponse, CommandError> {
         let session_id = q::parse_owned_session_id(&self.session_id)?;
         q::verify_session_ownership(&ctx.db, ctx.org_id(), session_id).await?;
@@ -151,6 +155,10 @@ impl Command for DeleteSessionDatabase {
             method: "DELETE",
             path: "/v1/sessions/{session_id}/databases/{name}",
         }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::sessions::SESSION_MANAGE)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<DeleteSessionDatabaseResult, CommandError> {

--- a/crates/server/src/domains/session_files/commands.rs
+++ b/crates/server/src/domains/session_files/commands.rs
@@ -189,6 +189,10 @@ impl Command for CreateSessionFile {
         }
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::sessions::SESSION_MANAGE)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<SessionFile, CommandError> {
         let session_id = q::parse_session_id(&self.session_id)?;
         q::verify_session(ctx, session_id).await?;
@@ -277,6 +281,10 @@ impl Command for UpdateSessionFile {
         }
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::sessions::SESSION_MANAGE)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<SessionFile, CommandError> {
         let session_id = q::parse_session_id(&self.session_id)?;
         q::verify_session(ctx, session_id).await?;
@@ -344,6 +352,10 @@ impl Command for DeleteSessionFile {
         }
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::sessions::SESSION_MANAGE)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<DeleteResponse, CommandError> {
         let session_id = q::parse_session_id(&self.session_id)?;
         q::verify_session(ctx, session_id).await?;
@@ -376,6 +388,10 @@ impl Command for MoveSessionFile {
             method: "POST",
             path: "/v1/sessions/{session_id}/fs/_/move",
         }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::sessions::SESSION_MANAGE)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<SessionFile, CommandError> {
@@ -415,6 +431,10 @@ impl Command for CopySessionFile {
             method: "POST",
             path: "/v1/sessions/{session_id}/fs/_/copy",
         }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::sessions::SESSION_MANAGE)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<SessionFile, CommandError> {
@@ -458,6 +478,10 @@ impl Command for GrepSessionFiles {
 
     fn read_only() -> bool {
         true
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::sessions::SESSION_VIEW)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<Vec<GrepResult>, CommandError> {
@@ -507,6 +531,10 @@ impl Command for StatSessionFile {
 
     fn read_only() -> bool {
         true
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::sessions::SESSION_VIEW)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<FileStat, CommandError> {

--- a/crates/server/src/domains/session_sandbox/commands.rs
+++ b/crates/server/src/domains/session_sandbox/commands.rs
@@ -425,7 +425,7 @@ mod tests {
     }
 
     fn test_ctx(db: Arc<StorageBackend>, sandbox_service: Arc<SessionSandboxService>) -> Ctx {
-        Ctx::minimal(Caller::internal(DEFAULT_ORG_ID), db.clone(), None)
+        Ctx::minimal_for_test(Caller::internal(DEFAULT_ORG_ID), db.clone(), None)
             .with_session_service(Arc::new(SessionService::new(db)))
             .with_session_sandbox_service(sandbox_service)
     }

--- a/crates/server/src/domains/session_storage/commands.rs
+++ b/crates/server/src/domains/session_storage/commands.rs
@@ -124,6 +124,10 @@ impl Command for BatchSetSessionSecrets {
         }
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::sessions::SESSION_MANAGE)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<BatchSetSecretsResponse, CommandError> {
         let session_id = q::parse_owned_session_id(&self.session_id)?;
         q::verify_session_ownership(&ctx.db, ctx.org_id(), session_id).await?;

--- a/crates/server/src/domains/sessions/commands.rs
+++ b/crates/server/src/domains/sessions/commands.rs
@@ -48,6 +48,10 @@ impl Command for CreateSession {
         }
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&super::SESSION_MANAGE)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<Session, CommandError> {
         let mut req = self.0;
         req.locale =
@@ -238,6 +242,10 @@ impl Command for GetSession {
         Some("session_id")
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&super::SESSION_VIEW)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<Session, CommandError> {
         let session_id = q::parse_session_id(&self.session_id)?;
         q::get_session(ctx, session_id, ctx.caller.user_id).await
@@ -264,6 +272,10 @@ impl Command for UpdateSessionCmd {
             method: "PATCH",
             path: "/v1/sessions/{session_id}",
         }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&super::SESSION_MANAGE)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<Session, CommandError> {
@@ -297,6 +309,10 @@ impl Command for DeleteSession {
             method: "DELETE",
             path: "/v1/sessions/{session_id}",
         }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&super::SESSION_MANAGE)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<bool, CommandError> {
@@ -333,6 +349,10 @@ impl Command for GetOrCreateChatSession {
             method: "POST",
             path: "/v1/sessions/chat",
         }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&super::SESSION_MANAGE)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<Session, CommandError> {
@@ -411,6 +431,10 @@ impl Command for PinSession {
         }
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&super::SESSION_MANAGE)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<bool, CommandError> {
         let user_id = ctx.caller.user_id.ok_or_else(|| {
             CommandError::Forbidden("Authentication required to pin sessions".to_string())
@@ -444,6 +468,10 @@ impl Command for UnpinSession {
         }
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&super::SESSION_MANAGE)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<bool, CommandError> {
         let user_id = ctx.caller.user_id.ok_or_else(|| {
             CommandError::Forbidden("Authentication required to unpin sessions".to_string())
@@ -474,6 +502,10 @@ impl Command for CancelSession {
             method: "POST",
             path: "/v1/sessions/{session_id}/cancel",
         }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&super::SESSION_MANAGE)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<CancelTurnResponse, CommandError> {

--- a/crates/server/src/domains/sessions/service.rs
+++ b/crates/server/src/domains/sessions/service.rs
@@ -1170,7 +1170,13 @@ mod tests {
 
     fn test_ctx(caller: Caller, db: Arc<StorageBackend>) -> Ctx {
         let capability_service = Arc::new(CapabilityService::new(db.clone(), None));
-        Ctx::new(caller, db, capability_service, None)
+        Ctx::new(
+            caller,
+            db,
+            capability_service,
+            None,
+            Arc::new(everruns_core::DefaultPermissionResolver),
+        )
     }
 
     fn build_create_request(

--- a/crates/server/src/domains/system/commands.rs
+++ b/crates/server/src/domains/system/commands.rs
@@ -41,7 +41,7 @@ mod tests {
     #[tokio::test]
     async fn health_check_dispatch_accepts_empty_object_params() {
         let db = Arc::new(StorageBackend::in_memory());
-        let ctx = Ctx::minimal(
+        let ctx = Ctx::minimal_for_test(
             Caller {
                 org_id: DEFAULT_ORG_ID,
                 org_public_id: "org_00000000000000000000000000000001".to_string(),

--- a/crates/server/src/domains/tool_results/commands.rs
+++ b/crates/server/src/domains/tool_results/commands.rs
@@ -31,6 +31,10 @@ impl Command for SubmitToolResults {
         Some("session_id")
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::sessions::SESSION_MANAGE)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<SubmitToolResultsResponse, CommandError> {
         if self.tool_results.is_empty() {
             return Err(CommandError::bad_request("tool_results must not be empty"));

--- a/crates/server/src/grpc_service/mod.rs
+++ b/crates/server/src/grpc_service/mod.rs
@@ -527,11 +527,14 @@ impl WorkerServiceImpl {
 
     /// Build a domain command context for the given org.
     fn domain_ctx(&self, org_id: i64) -> crate::domains::common::Ctx {
+        // Internal gRPC path — uses DefaultPermissionResolver so internal
+        // ops are not subject to SaaS custom restrictions.
         crate::domains::common::Ctx::new(
             everruns_core::Caller::internal(org_id),
             self.db.clone(),
             self.capability_service.clone(),
             self.encryption.clone(),
+            Arc::new(everruns_core::DefaultPermissionResolver),
         )
         .with_workflow_store(
             self.durable_store

--- a/crates/server/tests/command_policy_enforcement_test.rs
+++ b/crates/server/tests/command_policy_enforcement_test.rs
@@ -1,0 +1,254 @@
+//! Security integration tests for command policy enforcement.
+//!
+//! Ensures that `Command::run()` — the single entry point for every caller
+//! kind (HTTP, MCP, gRPC, platform capability) — evaluates `Command::policy()`
+//! against the `PermissionResolver` carried in `Ctx`. Without enforcement at
+//! this layer, HTTP requests would bypass role-based restrictions and SaaS
+//! custom resolvers would never be consulted during write operations.
+//!
+//! Covers:
+//!  1. Role-based denial (Member cannot manage harnesses; default resolver).
+//!  2. Role-based success (Member can view; Owner can manage).
+//!  3. A custom `PermissionResolver` plugged into `Ctx` overrides the default
+//!     role map (including denying an Owner) — the SaaS enforcement contract.
+//!  4. `dispatch()` (MCP + gRPC `ExecuteCommand`) enforces identically.
+//!  5. Inventory coverage: every mutating command declares `policy()`.
+//!
+//! Run with: cargo test -p everruns-server --test command_policy_enforcement_test
+
+use std::sync::Arc;
+
+use everruns_core::{
+    Caller, DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, DefaultPermissionResolver, OrgRole, Permission,
+    PermissionResolver,
+};
+use everruns_server::domains::common::{Command, CommandError, Ctx, catalog_entries, dispatch};
+use everruns_server::domains::harnesses::types::CreateHarnessRequest;
+use everruns_server::domains::harnesses::{CreateHarness, ListHarnesses};
+use everruns_server::services::CapabilityService;
+use everruns_server::storage::StorageBackend;
+use uuid::Uuid;
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+fn caller_with_role(role: OrgRole) -> Caller {
+    Caller {
+        org_id: DEFAULT_ORG_ID,
+        org_public_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
+        user_id: Some(Uuid::nil()),
+        role,
+        is_platform_user: false,
+        is_internal: false,
+    }
+}
+
+fn make_ctx(caller: Caller, resolver: Arc<dyn PermissionResolver>) -> Ctx {
+    let db = Arc::new(StorageBackend::in_memory());
+    let capability_service = Arc::new(CapabilityService::new(db.clone(), None));
+    Ctx::new(caller, db, capability_service, None, resolver)
+}
+
+fn minimal_harness(name: &str) -> CreateHarnessRequest {
+    CreateHarnessRequest {
+        name: name.to_string(),
+        display_name: None,
+        description: None,
+        system_prompt: "test prompt".to_string(),
+        parent_harness_id: None,
+        default_model_id: None,
+        tags: Vec::new(),
+        capabilities: Vec::new(),
+        initial_files: Vec::new(),
+        mcp_servers: Default::default(),
+        network_access: None,
+    }
+}
+
+/// Denies every permission — models a SaaS tier that blocks all writes.
+struct DenyAllResolver;
+
+impl PermissionResolver for DenyAllResolver {
+    fn has_permission(&self, _caller: &Caller, _permission: &Permission) -> bool {
+        false
+    }
+    fn caller_permissions(&self, _caller: &Caller) -> Vec<Permission> {
+        Vec::new()
+    }
+}
+
+/// Grants only harness read — models a read-only SaaS tier.
+struct HarnessReadOnlyResolver;
+
+impl PermissionResolver for HarnessReadOnlyResolver {
+    fn has_permission(&self, _caller: &Caller, permission: &Permission) -> bool {
+        matches!(permission, Permission::OrgHarnessesView)
+    }
+    fn caller_permissions(&self, _caller: &Caller) -> Vec<Permission> {
+        vec![Permission::OrgHarnessesView]
+    }
+}
+
+// ============================================================================
+// 1. Role-based enforcement via Command::run (the HTTP path)
+// ============================================================================
+
+#[tokio::test]
+async fn run_blocks_member_from_manage_command() {
+    // Members have OrgHarnessesView but not OrgHarnessesManage. Create must fail.
+    let ctx = make_ctx(
+        caller_with_role(OrgRole::Member),
+        Arc::new(DefaultPermissionResolver),
+    );
+    let err = CreateHarness(minimal_harness("member-denied"))
+        .run(&ctx)
+        .await
+        .expect_err("Member must not be allowed to create harnesses");
+    assert!(
+        matches!(err, CommandError::Forbidden(_)),
+        "expected Forbidden, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn run_allows_member_view_command() {
+    let ctx = make_ctx(
+        caller_with_role(OrgRole::Member),
+        Arc::new(DefaultPermissionResolver),
+    );
+    ListHarnesses {
+        search: None,
+        include_archived: false,
+    }
+    .run(&ctx)
+    .await
+    .expect("Member should be allowed to list harnesses");
+}
+
+#[tokio::test]
+async fn run_allows_owner_manage_command() {
+    let ctx = make_ctx(
+        caller_with_role(OrgRole::Owner),
+        Arc::new(DefaultPermissionResolver),
+    );
+    CreateHarness(minimal_harness("owner-allowed"))
+        .run(&ctx)
+        .await
+        .expect("Owner should be allowed to create harnesses");
+}
+
+// ============================================================================
+// 2. Custom PermissionResolver (the SaaS enforcement contract) fires during
+//    run() — not only at /config endpoints.
+// ============================================================================
+
+#[tokio::test]
+async fn run_honors_custom_resolver_denying_owner_write() {
+    // Owner role would normally pass — SaaS resolver denies. This is the
+    // exact property SaaS enforcement depends on (billing tier, etc.).
+    let ctx = make_ctx(caller_with_role(OrgRole::Owner), Arc::new(DenyAllResolver));
+    let err = CreateHarness(minimal_harness("saas-denied"))
+        .run(&ctx)
+        .await
+        .expect_err("Custom resolver must block Owner write");
+    assert!(
+        matches!(err, CommandError::Forbidden(_)),
+        "expected Forbidden, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn run_honors_read_only_resolver() {
+    // Owner with read-only resolver: read works, write blocked.
+    let ctx = make_ctx(
+        caller_with_role(OrgRole::Owner),
+        Arc::new(HarnessReadOnlyResolver),
+    );
+
+    ListHarnesses {
+        search: None,
+        include_archived: false,
+    }
+    .run(&ctx)
+    .await
+    .expect("Read-only resolver must allow view");
+
+    let err = CreateHarness(minimal_harness("ro-create"))
+        .run(&ctx)
+        .await
+        .expect_err("Read-only resolver must block create");
+    assert!(matches!(err, CommandError::Forbidden(_)));
+}
+
+// ============================================================================
+// 3. dispatch() path (MCP / gRPC ExecuteCommand) enforces identically.
+// ============================================================================
+
+#[tokio::test]
+async fn dispatch_blocks_member_from_manage_command() {
+    let ctx = make_ctx(
+        caller_with_role(OrgRole::Member),
+        Arc::new(DefaultPermissionResolver),
+    );
+    let params = serde_json::json!({
+        "name": "dispatch-member",
+        "system_prompt": "test prompt",
+    });
+    let err = dispatch("create_harness", params, &ctx)
+        .await
+        .expect_err("dispatch must enforce Command::policy()");
+    assert!(
+        matches!(err, CommandError::Forbidden(_)),
+        "expected Forbidden from dispatch, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn dispatch_honors_custom_resolver() {
+    let ctx = make_ctx(caller_with_role(OrgRole::Owner), Arc::new(DenyAllResolver));
+    let params = serde_json::json!({
+        "name": "dispatch-saas",
+        "system_prompt": "test prompt",
+    });
+    let err = dispatch("create_harness", params, &ctx)
+        .await
+        .expect_err("dispatch must consult custom resolver");
+    assert!(matches!(err, CommandError::Forbidden(_)));
+}
+
+// ============================================================================
+// 4. Inventory coverage — every non-GET command declares policy(). Catches
+//    new write commands that forget enforcement. Keep ALLOWED_PUBLIC tiny
+//    and justify each entry.
+// ============================================================================
+
+#[test]
+fn every_non_readonly_command_declares_policy() {
+    use everruns_server::domains::common::CommandDescriptor;
+
+    let mut missing: Vec<&'static str> = Vec::new();
+    for desc in inventory::iter::<CommandDescriptor> {
+        let meta = (desc.meta)();
+        let has_policy = (desc.policy)().is_some();
+        let is_get = meta.method == "GET";
+        if !is_get && !has_policy && !ALLOWED_PUBLIC.contains(&meta.name) {
+            missing.push(meta.name);
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "These mutating commands are missing a policy() declaration. \
+         Every non-GET command must enforce authorization. Missing: {missing:?}"
+    );
+    assert!(
+        !catalog_entries().is_empty(),
+        "command catalog is empty — is inventory registration broken?"
+    );
+}
+
+/// Commands intentionally exposed without a policy (public reads, probes).
+/// Keep tiny; justify every entry in a comment.
+const ALLOWED_PUBLIC: &[&str] = &[
+    // (none today)
+];

--- a/specs/domains.md
+++ b/specs/domains.md
@@ -55,13 +55,32 @@ pub trait Command: DeserializeOwned + Send + 'static {
     /// Static metadata — drives MCP catalog generation.
     fn meta() -> CommandMeta;
 
-    /// Policy checked before execute(). None = no auth required.
+    /// Policy checked by `run()` before `execute()`. None = public/no auth.
     fn policy() -> Option<&'static Policy> { None }
 
     /// Execute the command. All validation and business logic lives here.
+    /// SECURITY: Do not call directly from HTTP/MCP/gRPC adapters — it skips
+    /// the policy check. Use `run()` instead. `execute` stays public so one
+    /// command can compose another already-authorized command.
     async fn execute(self, ctx: &Ctx) -> Result<Self::Output, CommandError>;
+
+    /// Public entry point. Every caller (HTTP adapter, MCP dispatch, gRPC
+    /// `ExecuteCommand`, platform capability) goes through here.
+    ///
+    /// Evaluates `policy()` against `ctx.permission_resolver` (so SaaS
+    /// custom resolvers apply), then delegates to `execute`.
+    async fn run(self, ctx: &Ctx) -> Result<Self::Output, CommandError>;
 }
 ```
+
+### Enforcement contract
+
+Policy enforcement is performed **once**, at `Command::run`. Every caller kind (HTTP, MCP, gRPC `ExecuteCommand`, platform capability) routes through `run`, which evaluates `Command::policy()` against the `PermissionResolver` carried in `Ctx`. See `specs/permissions.md` for the full model.
+
+- HTTP adapters: `CreateAgent(req).run(&ctx).await` (never `.execute(...)`).
+- MCP and gRPC `ExecuteCommand` use `domains::common::dispatch()`, which calls `run` internally.
+- Every non-GET command must declare `policy()`; `crates/server/tests/command_policy_enforcement_test.rs` verifies this at test time by iterating `inventory::iter::<CommandDescriptor>`.
+- `Ctx::new` requires the resolver as its fifth argument, so constructing a `Ctx` without a resolver is a compile error. Tests use `Ctx::minimal_for_test` which defaults to `DefaultPermissionResolver`.
 
 ### CommandMeta
 
@@ -278,28 +297,23 @@ the logic. Once all callers are migrated, the service file is removed.
 
 ### Status
 
-**Migrated (commands + queries + MCP wired):**
-- `agents`, `harnesses`, `apps`, `mcp_servers`, `agent_identities`, `skills`,
-  `capabilities`, `audit_logs`
+All user-facing domains have been migrated. The 30 directories under `crates/server/src/domains/` each own their HTTP/MCP/gRPC surface via commands. Several domains retain an internal `service.rs` alongside `commands.rs` for orchestration that spans multiple commands — that's intentional and not a migration backlog.
 
-**Pending migration:**
-- `sessions`, `budgets`, `messages`, `events`, `harnesses` (sessions),
-  `llm_models`, `llm_providers`, `schedules`, `notifications`,
-  `session_files`, `session_databases`, `session_storage`,
-  `session_resources`, `session_sandbox`, `evals`
+**Fully migrated (commands + queries only):** `agents`, `harnesses`, `apps`, `mcp_servers`, `agent_identities`, `skills`, `capabilities`, `audit_logs`, `schedules`, `events`, `images`, `tool_results`, `users`, `organizations`, `system`, `session_databases`, `session_storage`.
+
+**Commands + internal `service.rs`:** `sessions`, `messages`, `budgets`, `evals`, `llm_models`, `llm_providers`, `notifications`, `session_files`, `session_sandbox`, `session_resources`.
+
+**Internal-only (no user-facing commands):** `session_git`, `session_commands`, `session_schedules`.
 
 ### Migration order for new domains
 
-1. Create `domains/{name}/` with `mod.rs`, `commands.rs`, `queries.rs`, `types.rs`
-2. Move request types into `types.rs` (initially re-export from `api/`)
-3. Extract shared DB helpers from `services/{name}.rs` into `queries.rs`
-4. Implement `Command` for each user-facing operation in `commands.rs`,
-   each with `inventory::submit! { CommandDescriptor::of::<Cmd>() }`
-5. Wire HTTP adapter to call commands via `cmd.execute(&ctx).await`
-   (MCP integration is automatic via inventory)
-6. If orchestration still needs to be shared, keep it as a helper under
-   `domains/{name}/` (for example `service.rs` or `helpers.rs`)
-7. Once all callers migrated, delete the old top-level `services/{name}.rs`
+1. Create `domains/{name}/` with `mod.rs`, `commands.rs`, `queries.rs`, `types.rs`.
+2. Move request types into `types.rs`.
+3. Put shared DB helpers in `queries.rs`.
+4. Implement `Command` for each user-facing operation in `commands.rs`, each with `inventory::submit! { CommandDescriptor::of::<Cmd>() }`. Declare `policy()` for every non-GET command — the inventory coverage test enforces this.
+5. Wire the HTTP adapter to call `cmd.run(&ctx).await` (not `.execute(...)`). MCP and gRPC integration are automatic via inventory.
+6. Thread `self.auth.permission_resolver.clone()` into the adapter's `ctx()` method so SaaS custom resolvers apply during enforcement.
+7. If orchestration needs to be shared across commands, keep it as a helper under `domains/{name}/` (for example `service.rs`).
 
 ### Cross-Org Resource Resolution (`domains/org_resolver.rs`)
 

--- a/specs/permissions.md
+++ b/specs/permissions.md
@@ -67,9 +67,37 @@ Built-in OSS auth preserves previous behavior by deriving `is_platform_user` fro
 
 ## Enforcement
 
-### Service Layer
+### Command Runner (Primary Enforcement Point)
 
-Services receive a `Caller` context (replacing raw `org_id`). Policy checks happen at the start of each service method. See `crates/core/src/permissions.rs` for the `Caller` struct definition.
+Every user-facing operation is a domain `Command` (`crates/server/src/domains/common.rs`). Each command declares its policy statically via `Command::policy()`. All four caller kinds — HTTP adapters, MCP dispatch, gRPC `ExecuteCommand`, and platform capability — invoke commands through **`Command::run`**, which evaluates `policy()` against the `PermissionResolver` carried in `Ctx` before delegating to `execute()`:
+
+```rust
+impl Command for CreateAgent {
+    fn policy() -> Option<&'static Policy> { Some(&AGENT_MANAGE) }
+    async fn execute(self, ctx: &Ctx) -> Result<Agent, CommandError> { ... }
+}
+```
+
+**Key properties:**
+
+- `Command::run` is the single public entry point. `execute` is the business-logic hook and must not be called directly from HTTP/MCP/gRPC adapters — doing so skips policy evaluation. A command may call another command's `execute` as an already-authorized composition.
+- `dispatch()` (used by MCP and gRPC `ExecuteCommand`) routes through `run` — enforcement is identical across HTTP and RPC paths.
+- The resolver is threaded through `Ctx::new` from `AuthState.permission_resolver`. Internal callers (`Caller::internal`) use `DefaultPermissionResolver` so SaaS-custom restrictions never block internal ops.
+
+**Inventory coverage test.** `crates/server/tests/command_policy_enforcement_test.rs` iterates `inventory::iter::<CommandDescriptor>` and asserts every non-GET command declares a policy. New mutating commands that forget `policy()` fail the build.
+
+### Legacy `#[policy]` Macro (Being Retired)
+
+The `#[policy(...)]` attribute macro (`crates/macros/src/lib.rs`) is the historical enforcement mechanism — it injects `POLICY.evaluate(caller)?;` at the top of a service method. Some hybrid domains still use it (`sessions`, `mcp_servers`, `llm_models`, `llm_providers`, `evals`) as defense in depth alongside `Command::run`. Remove it as each service is absorbed into `commands.rs` / `queries.rs`.
+
+**Key behaviors of the macro** (preserved for existing usage):
+
+- Accepts a path to a `Policy` constant (e.g., `HARNESS_MANAGE`).
+- Compile error if no `caller: &Caller` parameter is found.
+- Multiple `#[policy]` attributes stack.
+- Uses `DefaultPermissionResolver` directly; custom resolvers are **not** consulted by the macro.
+
+Because the macro hardcodes `DefaultPermissionResolver`, it breaks the SaaS enforcement contract for any caller it's the primary check for. `Command::run` uses `evaluate_with(ctx.permission_resolver, &caller)` and is the only path that honors custom resolvers during enforcement.
 
 ### Durable Ownership
 
@@ -82,17 +110,7 @@ Policy evaluation and durable ownership are separate concerns.
 
 ### Policy Evaluation
 
-See `crates/core/src/permissions.rs` for evaluation logic. Policies support both default and custom resolvers via `evaluate()` / `evaluate_with()`. Config endpoints can use `evaluate_policies_with(resolver, caller, policies)` when they need policy results derived from a custom resolver instead of the default role map.
-
-### Declarative Enforcement via `#[policy]` Macro
-
-The `#[policy(...)]` attribute macro (in `crates/macros/src/lib.rs`) injects `POLICY.evaluate(caller)?;` at the top of the function body. It finds the `caller: &Caller` parameter by type automatically.
-
-**Key behaviors:**
-- Accepts a path to a `Policy` constant (e.g., `HARNESS_MANAGE`)
-- Compile error if no `&Caller` parameter found
-- Multiple `#[policy]` attributes can be stacked for multiple independent checks
-- Uses `DefaultPermissionResolver`; custom resolvers are opt-in at explicit call sites
+See `crates/core/src/permissions.rs` for evaluation logic. Policies support both default and custom resolvers via `evaluate()` / `evaluate_with()`. The command runner always uses `evaluate_with(ctx.permission_resolver, caller)` so custom resolvers (SaaS billing-tier, per-user grants, external RBAC) apply uniformly across HTTP/MCP/gRPC/platform. Config endpoints use `evaluate_policies_with(resolver, caller, policies)` for UI-facing policy hints.
 
 ### Error Mapping
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -215,9 +215,11 @@ ApiError::Forbidden("No access")         // ✗ Reveals resource exists
 | TM-AUTHZ-001 | Default Owner role grants full access | Medium | By design for phase 1; all users are Owners. Future phases will assign roles via admin UI/invitation flow | **BY DESIGN** |
 | TM-AUTHZ-002 | Policy bypass via internal Caller | Medium | `Caller::internal()` bypasses policies with Owner role; only used in gRPC service (worker ↔ server), not HTTP-accessible | MITIGATED |
 | TM-AUTHZ-003 | Policy error reveals permission names | Low | 403 response includes policy ID and required permission; acceptable for debugging, no internal state leaked | **ACCEPTED** |
-| TM-AUTHZ-004 | Missing policy on service method | Medium | Compile-time enforcement via `#[policy]` macro; code review required to ensure coverage | MITIGATED |
+| TM-AUTHZ-004 | Missing policy on mutating command | Medium | Every caller (HTTP/MCP/gRPC/platform) routes through `Command::run` which evaluates `Command::policy()`. Inventory coverage test (`crates/server/tests/command_policy_enforcement_test.rs`) asserts every non-GET command declares a policy — a missing declaration fails the build | MITIGATED |
 | TM-AUTHZ-005 | Anonymous app channel reaches draft or disabled app config | High | Public AG-UI ingress requires `AppStatus::Published`, an enabled `ag_ui` channel, and `anonymous=true`; otherwise returns 403/400 before session creation | MITIGATED |
 | TM-AUTHZ-006 | Anonymous webhook reaches draft or disabled app channel | High | Public webhook ingress requires `AppStatus::Published`, a `webhook` channel, `enabled=true`, and the per-channel token before creating or reusing a session | MITIGATED |
+| TM-AUTHZ-007 | HTTP callers bypass declared command policy | High | Before the command runner, HTTP adapters called `Command::execute` directly, skipping `Command::policy()`. Now all adapters call `Command::run`, which enforces policy using `ctx.permission_resolver.evaluate_with`. Tests: `run_blocks_member_from_manage_command`, `dispatch_blocks_member_from_manage_command` | MITIGATED |
+| TM-AUTHZ-008 | SaaS custom `PermissionResolver` bypassed during enforcement | High | Legacy `#[policy]` macro calls `Policy::evaluate(caller)` which hardcodes `DefaultPermissionResolver`, ignoring custom resolvers. `Command::run` now threads `ctx.permission_resolver` (from `AuthState`) into `evaluate_with`, so billing-tier / per-user grant resolvers apply uniformly. Tests: `run_honors_custom_resolver_denying_owner_write`, `dispatch_honors_custom_resolver` | MITIGATED |
 
 ### Mitigation Details
 
@@ -226,6 +228,12 @@ Phase 1 assigns `OrgRole::Owner` as the default for all users. This means no per
 
 **TM-AUTHZ-002 — Internal Caller:**
 `Caller::internal(org_id)` is used exclusively in `grpc_service.rs` for worker-to-server calls. The gRPC endpoint requires a bearer token in production (`TM-DURABLE-002`). HTTP handlers always construct `Caller` from `ResolvedOrg` with the user's actual role.
+
+**TM-AUTHZ-004 — Command Runner as Single Enforcement Point:**
+`Command::run` (`crates/server/src/domains/common.rs`) evaluates `Command::policy()` against the active `PermissionResolver` before dispatching to `execute`. HTTP adapters call `run`; MCP and gRPC `ExecuteCommand` route through `dispatch()` which calls `run`. Coverage is enforced by iterating `inventory::iter::<CommandDescriptor>` in a test, so new mutating commands that forget `policy()` fail the build. The legacy `#[policy]` attribute macro remains in a few service methods as defense in depth but is slated for removal as services are absorbed into commands.
+
+**TM-AUTHZ-007 / TM-AUTHZ-008 — Historical gap:**
+Prior to the command runner, only MCP/gRPC `dispatch` evaluated `Command::policy()`, and the evaluation used `Policy::evaluate` (default resolver only). HTTP adapters called `Command::execute` directly, so role-based restrictions and SaaS custom resolvers were not enforced on HTTP writes for fully-migrated domains. The runner closes both gaps in a single code path.
 
 ## 4. API Security (TM-API)
 


### PR DESCRIPTION
## What

Close a policy-enforcement gap across the command layer by adding `Command::run` as the single public entry point for every caller kind (HTTP / MCP / gRPC `ExecuteCommand` / platform capability), and threading the active `PermissionResolver` from `AuthState` through `Ctx` so SaaS custom resolvers actually fire during enforcement.

## Why

Two gaps existed:

1. **HTTP bypassed `Command::policy()`.** Only `dispatch_for` (used by MCP and gRPC) evaluated the declared policy before calling `execute()`. HTTP adapters called `.execute()` directly, so on fully-migrated domains (`agents`, `apps`, `skills`, `capabilities`, `agent_identities`, `audit_logs`, …) the `policy()` declaration was never enforced over HTTP. Cross-tenant reads were still blocked by `org_id` SQL scoping, but role-based and subscription-based restrictions were effectively not applied to HTTP writes.
2. **SaaS `PermissionResolver` was never consulted during enforcement.** Both the MCP/gRPC check and the legacy `#[policy]` service macro called `Policy::evaluate(caller)`, which hardcodes `DefaultPermissionResolver`. Wrappers that inject a custom resolver (billing-tier, per-user grants, external RBAC) saw it only in `/v1/{resource}/config` UI hints — never during enforcement.

Both tracked as `TM-AUTHZ-007` (HTTP bypass) and `TM-AUTHZ-008` (custom resolver ignored) in `specs/threat-model.md`.

## How

- **`Command::run`** — new default trait method. Evaluates `policy()` via `ctx.permission_resolver.evaluate_with(caller)` and delegates to `execute`. `execute` stays public so one command can compose another (already-authorized) command without re-paying the policy cost.
- **`Ctx.permission_resolver: Arc<dyn PermissionResolver>`** — required field. HTTP adapters pass `self.auth.permission_resolver.clone()` from `AuthState`; internal paths (`Caller::internal` in gRPC / direct worker adapters) pass `DefaultPermissionResolver` so internal ops are never subject to SaaS custom restrictions. `Ctx::new` now has a fifth required argument so omitting the resolver is a compile error.
- **`dispatch_for` routes through `run`.** A single enforcement path for MCP and gRPC. No behavior change except that it now uses the resolver in `Ctx` rather than the default-only `Policy::evaluate`.
- **HTTP adapters** updated from `.execute(&state.ctx(&org))` to `.run(&state.ctx(&org))` across every `api/*.rs`.
- **`policy()` added to every mutating command that lacked one** in hybrid domains (sessions, messages, session_files, session_databases, session_storage, tool_results, evals, budgets, schedules, notifications, agents/harnesses previews). Introduced three new domain policies where none existed: `SCHEDULE_MANAGE` (IsPlatformUser), `BUDGET_MANAGE` (OrgSettingsManage), `NOTIFICATION_ACCESS` (any member).
- **Inventory coverage test** (`command_policy_enforcement_test::every_non_readonly_command_declares_policy`) iterates `inventory::iter::<CommandDescriptor>` and fails the build if any non-GET command is missing `policy()`. `CommandDescriptor` now exposes `policy: fn() -> Option<&'static Policy>` to support this.

## Risk

- **Medium.** Permission enforcement surface touched across 50 files.
- Role-based restrictions now actually take effect for HTTP writes on fully-migrated domains. In the default OSS configuration every user is an `Owner` (`TM-AUTHZ-001` — BY DESIGN), so in practice behavior is unchanged for OSS installs.
- SaaS wrappers using a custom `PermissionResolver` will see their resolver consulted during enforcement for the first time. That is the intended contract, but any mismatch between the resolver's view of the world and existing caller permissions could surface as a 403 where none fired before. Recommend wrappers review their resolver before deploying.
- `#[policy]` macro usages on hybrid service methods are retained as defense in depth; they're now redundant and can be removed in a follow-up.

## Security

- **Threat categories reviewed:** TM-AUTHZ (primary), spot-checked TM-AUTH (no auth surface touched), TM-TENANT (org scoping unchanged), TM-API (no input-validation changes), TM-CRYPTO (not touched).
- **Findings and resolutions:**
  - `TM-AUTHZ-004` tightened: compile-time coverage via the inventory test replaces the weaker "code review required" note.
  - `TM-AUTHZ-007` (HTTP bypasses `Command::policy`) — new entry, **MITIGATED**. `run_blocks_member_from_manage_command` asserts.
  - `TM-AUTHZ-008` (custom `PermissionResolver` bypassed during enforcement) — new entry, **MITIGATED**. `run_honors_custom_resolver_denying_owner_write` and `dispatch_honors_custom_resolver` assert.
  - `TM-AUTHZ-002` (internal caller bypasses policies) unchanged — internal `Ctx` continues to use `DefaultPermissionResolver` so SaaS restrictions don't accidentally block internal workers.
- No new attack surface introduced. `permission_resolver` is already an `Arc<dyn>` on `AuthState`; it's now also on `Ctx`. No serialization boundary, no new endpoints, no new secrets.

## Checklist
- [x] Tests added or updated — `crates/server/tests/command_policy_enforcement_test.rs` (8 tests: role-based denial/success, custom-resolver denial, dispatch-path enforcement, inventory coverage)
- [x] Backward compatibility considered — HTTP contract unchanged; `#[policy]` retained as defense in depth; `execute` remains public for command composition
- [x] Security review performed against relevant threat model categories — primary: TM-AUTHZ; see "Security" section above
- [ ] All review comments addressed (code change or written reasoning)