### PR TITLE
fix(commands): enforce session view policy on command execution

### DIFF
--- a/crates/server/src/api/commands.rs
+++ b/crates/server/src/api/commands.rs
@@ -16,6 +16,7 @@ use axum::{
 };
 
 use super::common::{ApiPolicyResultExt, ApiResult, impl_auth_state};
+use everruns_core::Caller;
 use everruns_core::command::{CommandDescriptor, CommandResult, ExecuteCommandRequest};
 use everruns_core::typed_id::SessionId;
 use serde::Serialize;
@@ -76,9 +77,10 @@ async fn list_session_commands(
     org: ResolvedOrg,
     Path(session_id): Path<SessionId>,
 ) -> ApiResult<CommandsResponse> {
+    let caller = Caller::from(&org);
     let mut commands = state
         .command_service
-        .list_system_commands(org.org_id, session_id)
+        .list_system_commands(&caller, session_id)
         .await
         .map_policy_or_internal("list session system commands")?;
 
@@ -103,9 +105,10 @@ async fn execute_session_command(
     Path(session_id): Path<SessionId>,
     Json(req): Json<ExecuteCommandRequest>,
 ) -> ApiResult<CommandResult> {
+    let caller = Caller::from(&org);
     let result = state
         .command_service
-        .execute(org.org_id, session_id, req)
+        .execute(&caller, session_id, req)
         .await
         .map_policy_or_internal("execute session command")?;
     Ok(Json(result))

--- a/crates/server/src/domains/session_commands/service.rs
+++ b/crates/server/src/domains/session_commands/service.rs
@@ -8,6 +8,7 @@
 
 use crate::direct_worker_adapters::DirectWorkerAdapters;
 use crate::domains::mcp_servers::McpServerService;
+use crate::domains::sessions::SESSION_VIEW;
 use crate::errors::{BadRequestError, ResourceNotFoundError};
 use crate::services::{EventService, LlmResolverService};
 use crate::storage::StorageBackend;
@@ -22,7 +23,8 @@ use everruns_core::message::{Controls, Message, MessageRole};
 use everruns_core::runtime_context::{inspect_turn_context, resolve_runtime_capabilities};
 use everruns_core::traits::{AgentStore, HarnessStore, ImageResolver, SessionStore};
 use everruns_core::typed_id::{ModelId, SessionId};
-use everruns_core::{Agent, CapabilityRegistry, DriverRegistry, Harness, ResolvedImage};
+use everruns_core::{Agent, Caller, CapabilityRegistry, DriverRegistry, Harness, ResolvedImage};
+use everruns_macros::policy;
 use everruns_worker::worker_adapters::{
     AdapterAgentStore, AdapterHarnessStore, AdapterImageResolver, AdapterLlmProviderStore,
     AdapterMessageRetriever, AdapterSessionFileStore, AdapterSessionStore,
@@ -76,13 +78,15 @@ impl SessionCommandService {
         self
     }
 
+    #[policy(SESSION_VIEW)]
     pub async fn list_system_commands(
         &self,
-        org_id: i64,
+        caller: &Caller,
         session_id: SessionId,
     ) -> Result<Vec<CommandDescriptor>> {
-        let (harness_chain, agent, session) =
-            self.load_session_components(org_id, session_id).await?;
+        let (harness_chain, agent, session) = self
+            .load_session_components(caller.org_id, session_id)
+            .await?;
         let resolved = resolve_runtime_capabilities(
             &harness_chain,
             agent.as_ref(),
@@ -106,13 +110,14 @@ impl SessionCommandService {
         Ok(commands)
     }
 
+    #[policy(SESSION_VIEW)]
     pub async fn execute(
         &self,
-        org_id: i64,
+        caller: &Caller,
         session_id: SessionId,
         req: ExecuteCommandRequest,
     ) -> Result<CommandResult> {
-        let commands = self.list_system_commands(org_id, session_id).await?;
+        let commands = self.list_system_commands(caller, session_id).await?;
         let command = commands
             .iter()
             .find(|command| command.name == req.name)
@@ -124,7 +129,7 @@ impl SessionCommandService {
             })?;
 
         match command.name.as_str() {
-            BTW_COMMAND_NAME => self.execute_btw(org_id, session_id, req).await,
+            BTW_COMMAND_NAME => self.execute_btw(caller.org_id, session_id, req).await,
             _ => Err(BadRequestError::new(format!(
                 "Unsupported system command: /{}",
                 command.name


### PR DESCRIPTION
### Motivation
- Close an authorization bypass where `/v1/sessions/{id}/commands` and `/v1/sessions/{id}/commands/execute` forwarded only `org_id` into the service layer and could expose session-derived context (e.g. `/btw`) to callers that should be denied `SESSION_VIEW` by custom permission resolvers.

### Description
- Build a `Caller` from `ResolvedOrg` in the commands API handlers and pass `&Caller` into the session command service via `list_system_commands` and `execute` instead of raw `org_id`.
- Add `#[policy(SESSION_VIEW)]` to `SessionCommandService::list_system_commands` and `SessionCommandService::execute` so policy enforcement runs in the service layer.
- Keep data access using `caller.org_id` and preserve existing command resolution and execution logic (no behavioral changes beyond authorization checks).

### Testing
- Ran `cargo fmt --all`, which completed successfully to ensure formatting consistency. 
- Attempted to run `cargo test -p everruns-server test_execute_btw_returns_ephemeral_response -- --nocapture`, but the full build/test did not complete in this environment due to long dependency compilation/toolchain install; the integration test exercising `/btw` already exists (`test_execute_btw_returns_ephemeral_response`) and the change is intended to be covered by it when CI runs. 
- Verified repository diffs and code references (`rg`, `git diff`) to ensure all call sites were updated and the patch was committed as `fix(commands): enforce session view policy on command execution`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b0158a94832b9e667a534b7e5564)