### PR TITLE
fix(server): reject scoped MCP names with reserved delimiter

### DIFF
--- a/crates/server/src/services/scoped_mcp.rs
+++ b/crates/server/src/services/scoped_mcp.rs
@@ -94,6 +94,12 @@ pub fn validate_scoped_mcp_servers(servers: &ScopedMcpServers) -> Result<()> {
         validate_safe_url(&server.url)
             .map_err(|e| anyhow!("Invalid scoped MCP server URL for '{name}': {e}"))?;
         let prefix = sanitize_mcp_server_name(name);
+        if prefix.contains("__") {
+            return Err(anyhow!(
+                "Scoped MCP server name '{name}' is invalid after sanitization: \
+                 consecutive underscores are reserved for MCP tool prefix delimiters"
+            ));
+        }
         if !sanitized.insert(prefix) {
             return Err(anyhow!(
                 "Scoped MCP server names must be unique after sanitization"
@@ -271,6 +277,22 @@ mod tests {
             error
                 .to_string()
                 .contains("must be unique after sanitization")
+        );
+    }
+
+    #[test]
+    fn validate_scoped_mcp_servers_rejects_reserved_delimiter_after_sanitization() {
+        let mut servers = ScopedMcpServers::default();
+        servers.insert(
+            "admin__foo".to_string(),
+            scoped_server("https://one.example.com/mcp"),
+        );
+
+        let error = validate_scoped_mcp_servers(&servers).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("reserved for MCP tool prefix delimiters")
         );
     }
 


### PR DESCRIPTION
### Motivation
- Prevent prefix-truncation attacks where a scoped MCP server name that sanitizes to a string containing `__` can cause tool-name parsing to drop part of the prefix and fall back to an unintended org-managed MCP server.

### Description
- Extend `validate_scoped_mcp_servers` to return an error when `sanitize_mcp_server_name(name)` contains `__`, thereby reserving `__` as the internal MCP tool-prefix delimiter, and add the unit test `validate_scoped_mcp_servers_rejects_reserved_delimiter_after_sanitization` to cover this path.

### Testing
- Ran `cargo test -p everruns-server --lib validate_scoped_mcp_servers_rejects_reserved_delimiter_after_sanitization` and the new test passed, and ran `cargo fmt --check` which also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bbf992c0832b9ee125591429a2f9)