### PR TITLE
fix(runtime): preserve session blueprint for act tools

### DIFF
--- a/crates/runtime/src/turn_strategy.rs
+++ b/crates/runtime/src/turn_strategy.rs
@@ -133,6 +133,11 @@ pub async fn plan_next_host_turn<A: RuntimeHostAdapter>(
             let response_id = reason_result.response_id.clone();
 
             if reason_result.has_tool_calls && reason_result.success {
+                let session_blueprint_id = adapter
+                    .session_store(state.org_id)
+                    .get_session(state.session_id)
+                    .await?
+                    .and_then(|session| session.blueprint_id);
                 let plan = RuntimeActPlan {
                     input: ActInput {
                         org_id: Some(state.org_id),
@@ -147,7 +152,7 @@ pub async fn plan_next_host_turn<A: RuntimeHostAdapter>(
                         tool_calls: reason_result.tool_calls,
                         tool_definitions: reason_result.tool_definitions,
                         locale: reason_result.locale,
-                        blueprint_id: None,
+                        blueprint_id: session_blueprint_id,
                         network_access: reason_result.network_access,
                     },
                     previous_response_id: response_id,

--- a/crates/runtime/tests/runtime_host_test.rs
+++ b/crates/runtime/tests/runtime_host_test.rs
@@ -938,6 +938,55 @@ async fn plan_next_host_turn_schedules_act_after_reason_tool_calls() {
 }
 
 #[tokio::test]
+async fn plan_next_host_turn_schedules_act_with_session_blueprint_id() {
+    let adapter = mock_host();
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    adapter.harness_store.add_harness(harness(harness_id)).await;
+    adapter
+        .session_store
+        .insert(Session {
+            blueprint_id: Some("blueprint.private".into()),
+            ..session(session_id, harness_id)
+        })
+        .await;
+
+    let input = turn_state(session_id, harness_id);
+    let output = serde_json::to_value(ReasonResult {
+        success: true,
+        text: "Calling a tool".into(),
+        tool_calls: vec![ToolCall {
+            id: "call_mul".into(),
+            name: "multiply".into(),
+            arguments: serde_json::json!({ "a": 6, "b": 7 }),
+        }],
+        has_tool_calls: true,
+        tool_definitions: vec![],
+        max_iterations: 8,
+        error: None,
+        usage: None,
+        response_id: Some("resp_blueprint".into()),
+        locale: Some("en-US".into()),
+        network_access: None,
+    })
+    .unwrap();
+
+    let plan = plan_next_host_turn(&adapter, "reason", &input, &output, 0)
+        .await
+        .unwrap();
+
+    match plan {
+        RuntimeTurnPlan::ScheduleAct(plan) => {
+            assert_eq!(
+                plan.input.blueprint_id.as_deref(),
+                Some("blueprint.private")
+            );
+        }
+        other => panic!("expected ScheduleAct, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn plan_next_host_turn_continues_reason_when_steering_messages_are_pending() {
     let adapter = mock_host();
     let harness_id = HarnessId::from_uuid(Uuid::now_v7());


### PR DESCRIPTION
### Motivation
- A refactor made `ActInput.blueprint_id` drive blueprint tool loading, but runtime planning always set it to `None`, causing blueprint-backed sessions to fall back to agent/harness tool registries and potentially run host/default tools.
- This is a security/regression risk (blueprint-specific tools and restrictions could be bypassed), so scheduled act payloads must carry the session blueprint when present.

### Description
- In `plan_next_host_turn` (reason branch) load the session via `adapter.session_store(...)` and copy `session.blueprint_id` into the scheduled `ActInput.blueprint_id` so runtime host tool registry selection preserves blueprint context.
- Added a regression test `plan_next_host_turn_schedules_act_with_session_blueprint_id` that creates a session with `blueprint_id` and asserts the planned `RuntimeActPlan` carries that `blueprint_id`.
- Commit message: `fix(runtime): carry session blueprint into act planning` (changes in `crates/runtime/src/turn_strategy.rs` and `crates/runtime/tests/runtime_host_test.rs`).

### Testing
- Ran the targeted test with `cargo test -p everruns-runtime plan_next_host_turn_schedules_act_with_session_blueprint_id` and it passed.
- Ran `cargo test -p everruns-runtime` (runtime crate tests), which completed successfully (runtime tests executed and passed for the new regression test).
- Ran `cargo fmt --check` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c2c64a14832b97ef6dc0f6c4b375)