### PR TITLE
fix(ui): stop trusting forwarded headers for SSR API origin

### DIFF
--- a/apps/ui/src/__tests__/server-query.test.ts
+++ b/apps/ui/src/__tests__/server-query.test.ts
@@ -14,14 +14,14 @@ const SECOND_ORG: OrganizationMembership = {
 };
 
 describe("server-query", () => {
-  it("uses forwarded host and proto when present", () => {
+  it("uses host header and ignores forwarded headers", () => {
     const headers = new Headers({
       host: "localhost:9100",
       "x-forwarded-host": "app.everruns.com",
       "x-forwarded-proto": "https",
     });
 
-    expect(getRequestOrigin(headers)).toBe("https://app.everruns.com");
+    expect(getRequestOrigin(headers)).toBe("http://localhost:9100");
   });
 
   it("falls back to host header when forwarded headers are missing", () => {

--- a/apps/ui/src/lib/server-query.ts
+++ b/apps/ui/src/lib/server-query.ts
@@ -23,8 +23,8 @@ export function createServerQueryClient() {
 }
 
 export function getRequestOrigin(headersList: Headers): string {
-  const host = headersList.get("x-forwarded-host") ?? headersList.get("host") ?? "localhost";
-  const proto = headersList.get("x-forwarded-proto") ?? "http";
+  const host = headersList.get("host") ?? "localhost";
+  const proto = process.env.NODE_ENV === "production" ? "https" : "http";
   return `${proto}://${host}`;
 }
 


### PR DESCRIPTION
### Motivation
- Prevent SSRF and cookie leakage by removing trust in unvalidated `x-forwarded-host`/`x-forwarded-proto` when computing the server-side API origin used for SSR prefetches.

### Description
- Modified `getRequestOrigin` in `apps/ui/src/lib/server-query.ts` to ignore `x-forwarded-*` headers and use only the request `host` with protocol derived from `NODE_ENV` (`https` in production, `http` otherwise).
- Updated the unit test in `apps/ui/src/__tests__/server-query.test.ts` to assert that forwarded headers are ignored and the `host` header is used for origin resolution.

### Testing
- Attempted to run the focused unit test with `npm --prefix apps/ui test -- --runTestsByPath src/__tests__/server-query.test.ts` but the environment lacks `jest`, so the test could not be executed (failed: `jest: not found`).
- Repository remote sync (`git fetch origin main`) could not be performed in this environment due to missing `origin` remote, so no CI or integration checks were run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c2c65cc0832bab5dbd3ea102e4bb)