### PR TITLE
fix(ci): remove unpinned cargo-binstall install script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,7 +405,7 @@ jobs:
         run: |
           if [ ! -f ~/.cargo/bin/sqlx ]; then
             if [ ! -f ~/.cargo/bin/cargo-binstall ]; then
-              curl -L --proto '=https' --tlsv1.2 -sSf --retry 3 https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+              cargo install cargo-binstall --locked
             fi
             cargo binstall sqlx-cli --no-confirm --version '~0.8'
           fi
@@ -570,7 +570,7 @@ jobs:
         run: |
           if [ ! -f ~/.cargo/bin/sqlx ]; then
             if [ ! -f ~/.cargo/bin/cargo-binstall ]; then
-              curl -L --proto '=https' --tlsv1.2 -sSf --retry 3 https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+              cargo install cargo-binstall --locked
             fi
             cargo binstall sqlx-cli --no-confirm --version '~0.8'
           fi


### PR DESCRIPTION
### Motivation
- Remove a CI supply-chain risk where the workflow executed an unpinned remote script via `curl ... | bash` to bootstrap `cargo-binstall` from the mutable `main` branch.

### Description
- Replace both `curl | bash` occurrences in `.github/workflows/ci.yml` with a reproducible fallback that runs `cargo install cargo-binstall --locked` when `~/.cargo/bin/cargo-binstall` is missing, preserving the existing `cargo binstall sqlx-cli` and cache behavior.

### Testing
- Ran `cargo fmt --check` which passed, and verified the workflow no longer contains the remote `install-from-binstall-release.sh` URL and now contains `cargo install cargo-binstall --locked` in both affected install steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c2c67e48832b9099dba258dba9c5)