### PR TITLE
fix(auth): stop reseeding harnesses in public signup flows

### DIFF
--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -398,12 +398,6 @@ pub async fn register(
             // Continue anyway - user is created, they just might not have org membership
         });
 
-    // Ensure default org has built-in harnesses (safety net — background seed task
-    // may not have completed yet or may have failed silently).
-    if let Err(e) = crate::org_init::initialize_org_harnesses(&state.db, DEFAULT_ORG_ID).await {
-        tracing::warn!(error = %e, "Failed to ensure default org harnesses (non-fatal)");
-    }
-
     let organizations = builtin::fetch_user_organizations(&state.db, user.id)
         .await
         .unwrap_or_default();
@@ -776,12 +770,6 @@ pub async fn oauth_callback(
                 tracing::error!("Failed to add OAuth user to default org: {}", e);
                 // Continue anyway
             });
-
-        // Ensure default org has built-in harnesses (safety net — background seed task
-        // may not have completed yet or may have failed silently).
-        if let Err(e) = crate::org_init::initialize_org_harnesses(&state.db, DEFAULT_ORG_ID).await {
-            tracing::warn!(error = %e, "Failed to ensure default org harnesses (non-fatal)");
-        }
 
         created_user
     };


### PR DESCRIPTION
### Motivation
- Public signup handlers called `initialize_org_harnesses` which uses OSS `oss_built_in_harnesses()`, allowing unauthenticated registration to re-apply OSS harness definitions and potentially re-enable capabilities operators removed via a custom `PlatformDefinition`.

### Description
- Removed the safety-net call to `initialize_org_harnesses(&state.db, DEFAULT_ORG_ID)` from the password `register` handler in `crates/server/src/auth/routes.rs`.
- Removed the same unauthenticated call from the OAuth first-login user-creation path in `crates/server/src/auth/routes.rs` so OAuth signup cannot trigger OSS reseeding for the default org.
- Left the privileged/admin bootstrap path that calls `initialize_org_harnesses` intact to avoid changing admin/seed behavior.

### Testing
- Ran `cargo fmt --all`, which completed successfully. 
- Attempted `cargo test -p everruns-server register -- --nocapture` and `cargo test -p everruns-server register -- --list`, but full test execution did not complete in this environment due to long compile/test run time and toolchain/download issues (no definitive pass/fail result).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bbf9efa8832b88257a9702346cd0)