### PR TITLE
fix(evals): require session manage permission to run evals

### DIFF
--- a/crates/server/src/domains/evals/service.rs
+++ b/crates/server/src/domains/evals/service.rs
@@ -29,10 +29,22 @@ pub const EVAL_VIEW: Policy = Policy {
     rules: &[Rule::UserHasPermission(Permission::OrgAgentsManage)],
 };
 
-/// Policy: Manage evals (create, update, run).
+/// Policy: Manage evals (create, update, metadata operations).
 pub const EVAL_MANAGE: Policy = Policy {
     id: "eval.manage",
     rules: &[Rule::UserHasPermission(Permission::OrgAgentsManage)],
+};
+
+/// Policy: Start eval runs.
+///
+/// Runs create real sessions in the background eval runner, so require both
+/// eval-management and session-management permissions.
+pub const EVAL_RUN: Policy = Policy {
+    id: "eval.run",
+    rules: &[
+        Rule::UserHasPermission(Permission::OrgAgentsManage),
+        Rule::UserHasPermission(Permission::OrgSessionsManage),
+    ],
 };
 
 pub struct EvalService {
@@ -328,7 +340,7 @@ impl EvalService {
     // Eval Run
     // ============================================
 
-    #[policy(EVAL_MANAGE)]
+    #[policy(EVAL_RUN)]
     pub async fn create_run(
         &self,
         caller: &Caller,


### PR DESCRIPTION
### Motivation
- A background eval runner creates real sessions using an internal caller, which allowed users with only `OrgAgentsManage` to indirectly create sessions and execute workflows, causing an authorization bypass.
- The fix enforces that launching eval runs requires both eval-management and session-management permissions so run creation cannot be used to bypass `SESSION_MANAGE` checks.

### Description
- Add a new `EVAL_RUN` policy that requires both `Permission::OrgAgentsManage` and `Permission::OrgSessionsManage` in `crates/server/src/domains/evals/service.rs`.
- Keep `EVAL_MANAGE` for metadata operations and change `create_run` to use `#[policy(EVAL_RUN)]` so run launches are gated by the stricter policy.
- Update the `EVAL_MANAGE` doc comment to clarify it now covers metadata operations only.

### Testing
- Ran `cargo fmt --all` and formatting completed successfully.
- Ran `cargo check -p everruns-server` and the package type-checked successfully with no errors.
- Verified the modified file `crates/server/src/domains/evals/service.rs` compiles as part of the checked package and the new policy compiles cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c6b28e18832ba684858fcd8652fa)