### PR TITLE
fix(core): reapply read_file hard cap after outline append

### DIFF
--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -558,7 +558,9 @@ impl Tool for ReadFileTool {
         arguments: Value,
         context: &ToolContext,
     ) -> ToolExecutionResult {
-        use crate::tool_output_sanitizer::{READ_FILE_DEFAULT_LIMIT, format_lines};
+        use crate::tool_output_sanitizer::{
+            READ_FILE_DEFAULT_LIMIT, apply_read_file_hard_cap, format_lines,
+        };
 
         let path = match arguments.get("path").and_then(|v| v.as_str()) {
             Some(p) => p,
@@ -694,7 +696,7 @@ impl Tool for ReadFileTool {
                 };
 
                 // Generate structural outline for unread portions (EVE-248)
-                let formatted = if truncated && start_line > 0 {
+                let mut formatted = if truncated && start_line > 0 {
                     let outline_items =
                         crate::outline::generate_outline(raw_content, &normalized_path);
                     if let Some(outline_text) = crate::outline::format_outline(
@@ -710,6 +712,9 @@ impl Tool for ReadFileTool {
                 } else {
                     formatted
                 };
+                // Reapply hard cap after any post-format decorations (e.g. outlines).
+                let hard_capped = apply_read_file_hard_cap(&mut formatted);
+                let truncated = truncated || hard_capped;
 
                 let mut result = json!({
                     "path": display_path,

--- a/crates/core/src/tool_output_sanitizer.rs
+++ b/crates/core/src/tool_output_sanitizer.rs
@@ -211,6 +211,19 @@ pub const READ_FILE_DEFAULT_LIMIT: usize = 2000;
 /// Hard byte cap for read_file (50 KB safety net for pathological cases like minified files).
 pub const READ_FILE_HARD_BYTE_CAP: usize = 50 * 1024;
 
+/// Apply the read_file hard byte cap to already-formatted output.
+///
+/// Returns true when truncation was applied.
+pub fn apply_read_file_hard_cap(result: &mut String) -> bool {
+    if result.len() <= READ_FILE_HARD_BYTE_CAP {
+        return false;
+    }
+
+    let cut = utf8_floor(result, READ_FILE_HARD_BYTE_CAP);
+    result.truncate(cut);
+    true
+}
+
 /// Format file content with compact line numbers: `N|content`.
 ///
 /// Applies offset/limit pagination. Returns (formatted_content, total_lines, truncated).
@@ -243,9 +256,7 @@ pub fn format_lines(content: &str, offset: usize, limit: usize) -> (String, usiz
     let truncated = end < total_lines;
 
     // Apply hard byte cap
-    if result.len() > READ_FILE_HARD_BYTE_CAP {
-        let cut = utf8_floor(&result, READ_FILE_HARD_BYTE_CAP);
-        result.truncate(cut);
+    if apply_read_file_hard_cap(&mut result) {
         return (result, total_lines, true);
     }
 
@@ -812,6 +823,15 @@ mod tests {
         assert!(truncated);
         assert!(formatted.len() <= READ_FILE_HARD_BYTE_CAP);
         // Must be valid UTF-8 (would panic on access if not)
+        assert!(formatted.is_char_boundary(formatted.len()));
+    }
+
+    #[test]
+    fn test_apply_read_file_hard_cap() {
+        let mut formatted = "x".repeat(READ_FILE_HARD_BYTE_CAP + 128);
+        let truncated = apply_read_file_hard_cap(&mut formatted);
+        assert!(truncated);
+        assert!(formatted.len() <= READ_FILE_HARD_BYTE_CAP);
         assert!(formatted.is_char_boundary(formatted.len()));
     }
 


### PR DESCRIPTION
### Motivation
- A structural outline was appended to `read_file` output after `format_lines` applied `READ_FILE_HARD_BYTE_CAP`, allowing the final response to exceed the 50 KB cap and enabling a resource-exhaustion (DoS) vector. 
- The intent is to preserve the hard byte cap for any post-format decorations (CSV header, outlines) so callers cannot force oversized responses.

### Description
- Added `apply_read_file_hard_cap(&mut String) -> bool` in `crates/core/src/tool_output_sanitizer.rs` to apply the `READ_FILE_HARD_BYTE_CAP` to an already-formatted string (UTF-8-safe). 
- Reused the helper inside `format_lines` to keep existing behavior unchanged. 
- Updated the `ReadFileTool` in `crates/core/src/capabilities/file_system.rs` to reapply the hard cap after CSV header prepend and structural outline append and to fold the result into the `truncated` flag. 
- Added a unit test `test_apply_read_file_hard_cap` to cover the new helper and kept existing `format_lines` cap tests intact.

### Testing
- Ran `cargo fmt --all` which completed successfully. 
- Ran `cargo test -p everruns-core test_apply_read_file_hard_cap` which passed. 
- Ran `cargo test -p everruns-core test_format_lines_hard_byte_cap` which passed. 
- Ran `cargo test -p everruns-core test_read_file_truncation_envelope_with_resume` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bbfc5e24832bb9d132f34643a2c5)