### PR TITLE
fix(sprites): validate sprite names when loading state

### DIFF
--- a/integrations/sprites/src/state.rs
+++ b/integrations/sprites/src/state.rs
@@ -92,6 +92,8 @@ pub async fn get_sprite_state(
     context: &ToolContext,
     sprite_name: &str,
 ) -> Result<SpriteState, ToolExecutionResult> {
+    validate_sprite_name(sprite_name)?;
+
     let storage = context
         .storage_store
         .as_ref()
@@ -121,6 +123,8 @@ pub async fn save_sprite_state(
     context: &ToolContext,
     state: &SpriteState,
 ) -> Result<(), ToolExecutionResult> {
+    validate_sprite_name(&state.sprite_name)?;
+
     let storage = context
         .storage_store
         .as_ref()
@@ -144,6 +148,8 @@ pub async fn delete_sprite_state(
     context: &ToolContext,
     sprite_name: &str,
 ) -> Result<(), ToolExecutionResult> {
+    validate_sprite_name(sprite_name)?;
+
     let storage = context
         .storage_store
         .as_ref()

--- a/integrations/sprites/tests/tool_integration.rs
+++ b/integrations/sprites/tests/tool_integration.rs
@@ -635,6 +635,29 @@ async fn test_create_sprite_rejects_uppercase_name() {
     }
 }
 
+#[tokio::test]
+async fn test_exec_rejects_path_traversal_name() {
+    let tool = get_tool("sprites_exec");
+    let session_id = SessionId::new();
+    let store = Arc::new(MockStorageStore::new());
+    let context = ToolContext::with_storage_store(session_id, store)
+        .with_connection_resolver(sprites_resolver());
+
+    let result = tool
+        .execute_with_context(
+            json!({"sprite_name": "../account", "command": "pwd"}),
+            &context,
+        )
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(msg) => {
+            assert!(msg.contains("lowercase"), "Got: {msg}");
+        }
+        other => panic!("Expected ToolError, got: {other:?}"),
+    }
+}
+
 // ============================================================================
 // Service URL and checkpoint tool tests
 // ============================================================================


### PR DESCRIPTION
### Motivation

- Non-create Sprites tools loaded sprite state from session secrets using the raw `sprite_name`, which allowed forged secret keys containing traversal segments (e.g. `../`) to influence API paths and reach unintended endpoints.
- Enforce a single validation boundary so all tools using persisted sprite state cannot be tricked into constructing unsafe Sprites API paths.

### Description

- Added `validate_sprite_name(...)` checks at the start of `get_sprite_state`, `save_sprite_state`, and `delete_sprite_state` in `integrations/sprites/src/state.rs` to reject invalid/traversal-style names before touching secrets or downstream API flows.
- Added an integration regression test `test_exec_rejects_path_traversal_name` in `integrations/sprites/tests/tool_integration.rs` that asserts `sprites_exec` rejects a traversal-style name like `../account`.
- Change is narrowly scoped to input validation at the state boundary and does not alter behavior for valid sprite names or the Sprites API client.

### Testing

- Ran the package tests for the Sprites integration with `cargo test -p everruns-integrations-sprites test_exec_rejects_path_traversal_name` and the new test passed (`test_exec_rejects_path_traversal_name` OK).
- Ran the `tool_integration` tests in the package and the suite executed with the new test included (1 new test executed and passed).
- Ran `cargo fmt` to apply formatting fixes prior to testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b01471d4832b914766588190d7aa)