### PR TITLE
refactor(services): drop deprecated shims for moved modules

### DIFF
--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -16,12 +16,6 @@
 //
 // Anything with a clear single owner belongs under `domains/<owner>/`. See
 // `specs/domains.md` for the "shared services" rule.
-//
-// BACKWARDS COMPATIBILITY: the `services` module is `pub`, so downstream
-// wrapper crates may have imported the now-moved modules from here. The
-// `pub use ... as <old_name>` lines below re-export them under their old
-// paths with `#[deprecated]` so existing imports still compile with a
-// compiler warning. Drop these in the next breaking release.
 
 pub mod capability;
 pub mod event;
@@ -36,44 +30,3 @@ pub use llm_resolver::{LlmResolverService, ResolvedModel};
 pub use model_sync::{ModelSyncService, SyncResult};
 pub use principal::{PrincipalService, row_to_principal};
 pub use usage_tracking::UsageTrackingListener;
-
-// --- Deprecated re-exports of moved modules ---
-// Each module moved to its single owning domain. Import from the new path;
-// these aliases will be removed in a future release.
-
-#[deprecated(
-    since = "0.8.19",
-    note = "moved to `crate::domains::evals::runner`; update your imports"
-)]
-pub use crate::domains::evals::runner as eval_runner;
-
-#[deprecated(
-    since = "0.8.19",
-    note = "moved to `crate::domains::session_files::virtual_mount_registry`; update your imports"
-)]
-pub use crate::domains::session_files::virtual_mount_registry;
-
-#[deprecated(
-    since = "0.8.19",
-    note = "moved to `crate::domains::mcp_servers::scoped_mcp`; update your imports"
-)]
-pub use crate::domains::mcp_servers::scoped_mcp;
-
-#[deprecated(
-    since = "0.8.19",
-    note = "moved to `crate::domains::session_resources::leased_resource`; update your imports"
-)]
-pub use crate::domains::session_resources::leased_resource;
-
-#[deprecated(
-    since = "0.8.19",
-    note = "moved to `crate::domains::capabilities::validation`; update your imports"
-)]
-pub use crate::domains::capabilities::validation as capability_validation;
-
-#[deprecated(
-    since = "0.8.19",
-    note = "LeasedResourceService moved to `crate::domains::session_resources`"
-)]
-#[allow(deprecated)]
-pub use leased_resource::LeasedResourceService;


### PR DESCRIPTION
## What

Follow-up to #1483. Removes the `#[deprecated]` re-exports in `services/mod.rs` that were put in place to give downstream SaaS wrapper crates time to migrate to the new domain paths for the 5 modules moved in #1483 (`eval_runner`, `virtual_mount_registry`, `scoped_mcp`, `leased_resource`, `capability_validation` + `LeasedResourceService`).

## Why

The shims were intentionally temporary. After #1483 landed, the `services/` surface exists solely to host the six genuinely shared modules (`capability`, `event`, `llm_resolver`, `model_sync`, `principal`, `usage_tracking`) per the rule in `specs/domains.md`. The deprecated aliases diluted that message and would bitrot — better to land them while the move is fresh in memory.

A full grep across `crates/` and `integrations/` for the deprecated paths returns zero hits, so no internal caller breaks.

## How

- Delete the `#[deprecated]` re-export block from `services/mod.rs`.
- Keep the documentation header that enumerates what remains and why.
- No other files touched.

## Risk

- **Low.** Pure deletion of compatibility shims; the target modules at their new paths are untouched. 1017 lib tests + 8 security integration tests + full `pre-push` (fmt, clippy, lockfile, migrations) pass locally.
- Downstream wrapper crates that imported from the old `crate::services::*` paths will now see unresolved-import errors. The previous deprecation warnings pointed at the exact new path, so fixing is mechanical. Since everruns is still pre-1.0 (0.8.x), this sits within the expected churn envelope.

## Security

No security-relevant code changes — module layout only; all enforcement paths, policy checks, and resolver threading remain untouched.

## Checklist
- [x] Tests added or updated — existing test suite unchanged; 1017 lib tests + 8 security integration tests pass.
- [x] Backward compatibility considered — deprecated shims were explicit compat scaffolding; no-op internally.
- [x] Security review performed against relevant threat model categories — no security-relevant changes.
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FvMcyZL66vqTxip713UY8n)_