### PR TITLE
fix(core): enforce web_fetch file-download runtime guard

### DIFF
--- a/crates/core/src/capabilities/web_fetch.rs
+++ b/crates/core/src/capabilities/web_fetch.rs
@@ -263,6 +263,7 @@ impl FileSaver for SessionFileSaver {
 /// the session filesystem (SessionFileStore) via the SessionFileSaver adapter.
 pub struct WebFetchTool {
     fetchkit_tool: fetchkit::Tool,
+    enable_save_to_file: bool,
     /// Cached description from ToolBuilder (owned copy of fetchkit's &str for our Tool trait)
     description: String,
 }
@@ -278,6 +279,7 @@ impl WebFetchTool {
         let description = fetchkit_tool.description().to_string();
         Self {
             fetchkit_tool,
+            enable_save_to_file,
             description,
         }
     }
@@ -430,6 +432,12 @@ impl Tool for WebFetchTool {
             Err(e) => return e,
         };
 
+        if request.save_to_file.is_some() && !self.enable_save_to_file {
+            return ToolExecutionResult::tool_error(
+                "File download is disabled for this capability",
+            );
+        }
+
         // THREAT[TM-AGENT-018]: Enforce network access list
         if let Some(ref acl) = context.network_access
             && !acl.is_url_allowed(&request.url)
@@ -499,6 +507,7 @@ mod tests {
         let description = fetchkit_tool.description().to_string();
         WebFetchTool {
             fetchkit_tool,
+            enable_save_to_file: true,
             description,
         }
     }
@@ -1821,6 +1830,50 @@ mod tests {
         } else {
             panic!("Expected tool error, got: {:?}", result);
         }
+    }
+
+    #[tokio::test]
+    async fn test_save_to_file_disabled_by_config_returns_error() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/file.txt"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("content"))
+            .mount(&mock_server)
+            .await;
+
+        let tool = WebFetchTool::new(false, None);
+        let file_store = Arc::new(MockFileStore::new());
+        let session_id = SessionId::new();
+        let context = ToolContext::with_file_store(session_id, file_store.clone());
+
+        let result = tool
+            .execute_with_context(
+                serde_json::json!({
+                    "url": format!("{}/file.txt", mock_server.uri()),
+                    "save_to_file": "/downloads/file.txt"
+                }),
+                &context,
+            )
+            .await;
+
+        if let ToolExecutionResult::ToolError(msg) = result {
+            assert!(
+                msg.contains("disabled"),
+                "Expected file download disabled error, got: {}",
+                msg
+            );
+        } else {
+            panic!("Expected tool error, got: {:?}", result);
+        }
+
+        assert!(
+            file_store
+                .get_file(session_id, "/downloads/file.txt")
+                .await
+                .is_none(),
+            "File should not be written when save_to_file is disabled",
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Runtime capability config (`enable_file_download`) was used to build schema/prompt metadata but was not enforced at execution time, allowing crafted `save_to_file` arguments to write to the session file store.

### Description
- Add `enable_save_to_file: bool` to `WebFetchTool` and persist the constructor `enable_save_to_file` flag from `ToolBuilder` into the tool instance.
- Enforce the runtime gate in `WebFetchTool::execute_with_context` by returning a `ToolExecutionResult::tool_error` when `save_to_file` is present but `enable_save_to_file` is `false`.
- Update `tool_for_wiremock` and the `WebFetchTool` constructor usages to initialize the new field.
- Add a regression test `test_save_to_file_disabled_by_config_returns_error` that asserts an error is returned and no file is written when file downloads are disabled.

### Testing
- Ran `cargo fmt --all` to format changes successfully.
- Ran `cargo test -p everruns-core test_save_to_file_disabled_by_config_returns_error` and the new test passed (`ok`).
- Ran `cargo test -p everruns-core test_web_fetch_tool_schema_save_to_file_gated_by_config` and `cargo test -p everruns-core test_web_fetch_tools_with_config_enables_file_download`, and both tests passed (`ok`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea84effc18832b9f79c0caa5fbfeeb)