### PR TITLE
fix(server): cancel SSE pg_notify listener on disconnect

### DIFF
--- a/crates/server/src/api/events.rs
+++ b/crates/server/src/api/events.rs
@@ -35,6 +35,7 @@ use futures::{
 };
 use std::{convert::Infallible, sync::Arc, time::Duration};
 use tokio::sync::broadcast;
+use tokio::task::JoinHandle;
 use tokio::time::Instant;
 use uuid::Uuid;
 
@@ -310,11 +311,12 @@ pub async fn stream_sse(
 
     // Legacy PG polling waker (used only when EventDelivery subscription unavailable)
     let event_waker = Arc::new(tokio::sync::Notify::new());
+    let mut pg_notify_listener_task: Option<JoinHandle<()>> = None;
     if let (false, Some(broadcaster)) = (use_push, &state.event_broadcaster) {
         let mut rx = broadcaster.subscribe();
         let waker = event_waker.clone();
         let target_session = session_id;
-        tokio::spawn(async move {
+        let task = tokio::spawn(async move {
             loop {
                 match rx.recv().await {
                     Ok(payload) if payload.session_id == target_session => {
@@ -329,6 +331,7 @@ pub async fn stream_sse(
                 }
             }
         });
+        pg_notify_listener_task = Some(task);
     }
 
     // Shared subscription wrapped in Arc<Mutex> for use inside the stream
@@ -614,6 +617,7 @@ pub async fn stream_sse(
     let guarded_stream = GuardedStream {
         inner: Box::pin(stream),
         _guard: sse_guard,
+        notification_task: pg_notify_listener_task,
     };
 
     let keep_alive = KeepAlive::new()
@@ -626,6 +630,15 @@ pub async fn stream_sse(
 struct GuardedStream<S> {
     inner: std::pin::Pin<Box<S>>,
     _guard: super::sse::SseConnectionGuard,
+    notification_task: Option<JoinHandle<()>>,
+}
+
+impl<S> Drop for GuardedStream<S> {
+    fn drop(&mut self) {
+        if let Some(task) = self.notification_task.take() {
+            task.abort();
+        }
+    }
 }
 
 impl<S: Stream> Stream for GuardedStream<S> {


### PR DESCRIPTION
### Motivation

- Prevent unbounded server-side task growth from legacy per-connection pg_notify listener tasks that outlived SSE connections and enabled resource-exhaustion DoS.

### Description

- Retain the `tokio::spawn` `JoinHandle` for the legacy pg_notify listener started for SSE fallback paths.  
- Attach the optional handle to the `GuardedStream` used for SSE connections so the stream owns the listener for the connection.  
- Implement `Drop` for `GuardedStream` and `abort()` the listener task when the stream is dropped to ensure deterministic cancellation on client disconnect.  
- No change to normal EventDelivery push-path behavior or polling semantics is introduced.

### Testing

- Ran formatting: `cargo fmt --all` which completed successfully.  
- Verified formatting check: `cargo fmt --all --check` completed successfully.  
- Attempted targeted test run: `cargo test -p server stream_sse -- --nocapture` failed because the crate name is `everruns-server` (wrong package spec).  
- Started `cargo test -p everruns-server stream_sse -- --nocapture`; compilation began but the run was not completed in this environment due to long build time, so tests could not be fully executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8067ada8832bb386b7cb1912a1b7)