### PR TITLE
fix(ui): block svg file previews

### DIFF
--- a/apps/ui/src/__tests__/file-previews.test.tsx
+++ b/apps/ui/src/__tests__/file-previews.test.tsx
@@ -312,7 +312,6 @@ describe("ImagePreview", () => {
       const img = screen.getByRole("img");
       expect(img).toHaveAttribute("src", `data:image/webp;base64,${sampleBase64}`);
     });
-
   });
 
   describe("case insensitivity", () => {

--- a/apps/ui/src/__tests__/file-previews.test.tsx
+++ b/apps/ui/src/__tests__/file-previews.test.tsx
@@ -105,8 +105,8 @@ describe("getPreviewType", () => {
       expect(getPreviewType("webp", "base64")).toBe("image");
     });
 
-    it("returns 'image' for SVG files with base64 encoding", () => {
-      expect(getPreviewType("svg", "base64")).toBe("image");
+    it("returns 'binary' for SVG files with base64 encoding", () => {
+      expect(getPreviewType("svg", "base64")).toBe("binary");
     });
   });
 
@@ -179,6 +179,7 @@ describe("canPreview", () => {
     it("returns false for binary files", () => {
       expect(canPreview("exe", "base64")).toBe(false);
       expect(canPreview("bin", "base64")).toBe(false);
+      expect(canPreview("svg", "base64")).toBe(false);
     });
 
     it("returns false for unknown file types", () => {
@@ -312,12 +313,6 @@ describe("ImagePreview", () => {
       expect(img).toHaveAttribute("src", `data:image/webp;base64,${sampleBase64}`);
     });
 
-    it("sets correct data URL for SVG", () => {
-      render(<ImagePreview content={sampleBase64} extension="svg" fileName="test.svg" />);
-
-      const img = screen.getByRole("img");
-      expect(img).toHaveAttribute("src", `data:image/svg+xml;base64,${sampleBase64}`);
-    });
   });
 
   describe("case insensitivity", () => {

--- a/apps/ui/src/components/files/file-previews.tsx
+++ b/apps/ui/src/components/files/file-previews.tsx
@@ -55,7 +55,7 @@ const CODE_EXTENSIONS = new Set([
   "svelte",
 ]);
 
-const IMAGE_EXTENSIONS = new Set(["png", "jpg", "jpeg", "gif", "webp", "svg", "bmp", "ico"]);
+const IMAGE_EXTENSIONS = new Set(["png", "jpg", "jpeg", "gif", "webp", "bmp", "ico"]);
 
 // Map file extensions to Shiki language identifiers
 const EXTENSION_TO_LANG: Record<string, string> = {
@@ -349,7 +349,6 @@ export function ImagePreview({
       jpeg: "image/jpeg",
       gif: "image/gif",
       webp: "image/webp",
-      svg: "image/svg+xml",
       bmp: "image/bmp",
       ico: "image/x-icon",
     };


### PR DESCRIPTION
### Motivation

- The Workspace image preview rendered base64 `.svg` as `data:image/svg+xml` in an `<img>` tag, which allows active SVG content to execute and enables stored XSS or data exfiltration from untrusted session files.

### Description

- Remove `svg` from the `IMAGE_EXTENSIONS` allowlist so base64 `.svg` files are classified as `binary` and not shown inline by the previewer.
- Remove the `svg: "image/svg+xml"` MIME mapping from `ImagePreview` so the component no longer constructs SVG data URLs for previews.
- Update unit tests in `apps/ui/src/__tests__/file-previews.test.tsx` to assert `getPreviewType("svg", "base64") === "binary"` and `canPreview("svg", "base64") === false`, and remove the previous expectation that SVG is rendered as a data URL.

### Testing

- Installed UI dev dependencies with `npm install --no-audit --no-fund` in `apps/ui` and ran the file-previews tests with `npm test -- --runTestsByPath src/__tests__/file-previews.test.tsx`.
- All tests in that suite passed: `58 passed, 58 total`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea80683f0c832b8692c86b42cb3b8a)