### PR TITLE
fix(ui): guard invalid schedule timezone rendering

### DIFF
--- a/apps/ui/src/__tests__/schedule-display.test.ts
+++ b/apps/ui/src/__tests__/schedule-display.test.ts
@@ -30,6 +30,12 @@ describe("schedule-display", () => {
     expect(formatScheduledDateTime("2026-04-16T15:30:00Z", "UTC")).toBe("Apr 16, 3:30 PM UTC");
   });
 
+  it("falls back to UTC when timezone is invalid", () => {
+    expect(formatScheduledDateTime("2026-04-16T15:30:00Z", "Bad/Zone")).toBe(
+      "Apr 16, 3:30 PM UTC",
+    );
+  });
+
   it("extracts background monitor titles from synthetic schedule descriptions", () => {
     expect(
       getScheduleDisplayTitle(`Monitor: Watch PR 1319

--- a/apps/ui/src/__tests__/schedule-display.test.ts
+++ b/apps/ui/src/__tests__/schedule-display.test.ts
@@ -31,9 +31,7 @@ describe("schedule-display", () => {
   });
 
   it("falls back to UTC when timezone is invalid", () => {
-    expect(formatScheduledDateTime("2026-04-16T15:30:00Z", "Bad/Zone")).toBe(
-      "Apr 16, 3:30 PM UTC",
-    );
+    expect(formatScheduledDateTime("2026-04-16T15:30:00Z", "Bad/Zone")).toBe("Apr 16, 3:30 PM UTC");
   });
 
   it("extracts background monitor titles from synthetic schedule descriptions", () => {

--- a/apps/ui/src/lib/schedule-display.ts
+++ b/apps/ui/src/lib/schedule-display.ts
@@ -105,14 +105,23 @@ export function formatScheduleCadence(input: {
 }
 
 export function formatScheduledDateTime(dateString: string, timezone = "UTC"): string {
-  return new Intl.DateTimeFormat("en-US", {
+  const options: Intl.DateTimeFormatOptions = {
     month: "short",
     day: "numeric",
     hour: "numeric",
     minute: "2-digit",
     timeZone: timezone,
     timeZoneName: "short",
-  }).format(new Date(dateString));
+  };
+
+  try {
+    return new Intl.DateTimeFormat("en-US", options).format(new Date(dateString));
+  } catch {
+    return new Intl.DateTimeFormat("en-US", {
+      ...options,
+      timeZone: "UTC",
+    }).format(new Date(dateString));
+  }
 }
 
 export function getScheduleDisplayTitle(description: string): string {


### PR DESCRIPTION
### Motivation

- The UI used unvalidated stored timezone strings directly with `Intl.DateTimeFormat`, which throws `RangeError` for invalid zones and can crash schedule and tool-activity rendering.
- Remediate a client-side availability (DoS) vector by making date formatting robust to malformed timezone values.

### Description

- Wrap `formatScheduledDateTime` in a safe `try/catch` and fall back to `UTC` when `Intl.DateTimeFormat` throws, preserving display for invalid zones (`apps/ui/src/lib/schedule-display.ts`).
- Add a unit test verifying the fallback behavior for an invalid timezone (`Bad/Zone`) (`apps/ui/src/__tests__/schedule-display.test.ts`).

### Testing

- Added a Jest test case `falls back to UTC when timezone is invalid` (committed with the change). 
- Attempted to run `npm test -- schedule-display.test.ts` in the container, but the run failed because `jest` is not installed in this environment (`sh: 1: jest: not found`); the test is expected to pass in CI where dependencies are installed. 
- No other automated tests were executed locally due to the container environment constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea806760ac832b8cf22fbaa912c42e)