### PR TITLE
fix(server): restrict client tool definitions to client_side

### DIFF
--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -21,7 +21,7 @@ use everruns_core::capability_types::AgentCapabilityConfig;
 use everruns_core::typed_id::{AgentId, AgentIdentityId, HarnessId, ModelId};
 use everruns_core::{
     BuiltInHarnessRole, Caller, PlatformDefinition, ResourceConfigResponse, ScopedMcpServers,
-    Session, evaluate_policies_with,
+    Session, ToolDefinition, evaluate_policies_with,
 };
 use everruns_worker::AgentRunner;
 
@@ -80,8 +80,8 @@ pub struct CreateSessionRequest {
     pub capabilities: Vec<AgentCapabilityConfig>,
     /// Client-side tools for this session (additive to agent tools).
     /// These tools are sent to the LLM but executed by the client.
-    #[serde(default)]
-    pub tools: Vec<everruns_core::ToolDefinition>,
+    #[serde(default, deserialize_with = "deserialize_client_side_tools")]
+    pub tools: Vec<ToolDefinition>,
     /// Remote MCP servers scoped to this session only.
     #[serde(default, rename = "mcpServers", alias = "mcp_servers")]
     pub mcp_servers: ScopedMcpServers,
@@ -108,6 +108,22 @@ pub struct CreateSessionRequest {
     /// Maximum number of LLM iterations per turn for this session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_iterations: Option<usize>,
+}
+
+fn deserialize_client_side_tools<'de, D>(deserializer: D) -> Result<Vec<ToolDefinition>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let tools = Vec::<ToolDefinition>::deserialize(deserializer)?;
+    if tools
+        .iter()
+        .any(|tool| !matches!(tool, ToolDefinition::ClientSide(_)))
+    {
+        return Err(serde::de::Error::custom(
+            "tools must contain only client_side definitions",
+        ));
+    }
+    Ok(tools)
 }
 
 /// Response from cancel turn endpoint
@@ -685,6 +701,30 @@ mod tests {
         let req: CreateSessionRequest = serde_json::from_str(&json).unwrap();
         assert_eq!(req.capabilities[0].capability_id(), "current_time");
         assert_eq!(req.capabilities[1].capability_id(), "web_fetch");
+    }
+
+    #[test]
+    fn test_create_session_request_rejects_builtin_tools() {
+        let json = format!(
+            r#"{{
+                "harness_id": "{}",
+                "tools": [
+                    {{
+                        "type": "builtin",
+                        "name": "read_file",
+                        "description": "Read file",
+                        "parameters": {{"type": "object"}}
+                    }}
+                ]
+            }}"#,
+            TEST_HARNESS_ID
+        );
+
+        let err = serde_json::from_str::<CreateSessionRequest>(&json).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("tools must contain only client_side definitions")
+        );
     }
 
     #[test]

--- a/crates/server/src/domains/agents/types.rs
+++ b/crates/server/src/domains/agents/types.rs
@@ -56,7 +56,7 @@ pub struct CreateAgentRequest {
     pub initial_files: Vec<InitialFile>,
     /// Client-side tools for this agent.
     /// These tools are sent to the LLM but executed by the client, not the server.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_client_side_tools")]
     pub tools: Vec<ToolDefinition>,
     /// Remote MCP servers scoped to this agent.
     #[serde(default, rename = "mcpServers", alias = "mcp_servers")]
@@ -110,7 +110,11 @@ pub struct UpdateAgentRequest {
     pub status: Option<AgentStatus>,
     /// Client-side tools for this agent.
     /// Replaces existing tools if provided.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_client_side_tools",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub tools: Option<Vec<ToolDefinition>>,
     /// Remote MCP servers scoped to this agent.
     #[serde(
@@ -197,4 +201,86 @@ pub struct ImportAgentQuery {
     /// When set, the request body is ignored.
     #[serde(rename = "from-example")]
     pub from_example: Option<String>,
+}
+
+fn deserialize_client_side_tools<'de, D>(deserializer: D) -> Result<Vec<ToolDefinition>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let tools = Vec::<ToolDefinition>::deserialize(deserializer)?;
+    if tools
+        .iter()
+        .any(|tool| !matches!(tool, ToolDefinition::ClientSide(_)))
+    {
+        return Err(serde::de::Error::custom(
+            "tools must contain only client_side definitions",
+        ));
+    }
+    Ok(tools)
+}
+
+fn deserialize_optional_client_side_tools<'de, D>(
+    deserializer: D,
+) -> Result<Option<Vec<ToolDefinition>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let tools = Option::<Vec<ToolDefinition>>::deserialize(deserializer)?;
+    if let Some(tools) = &tools
+        && tools
+            .iter()
+            .any(|tool| !matches!(tool, ToolDefinition::ClientSide(_)))
+    {
+        return Err(serde::de::Error::custom(
+            "tools must contain only client_side definitions",
+        ));
+    }
+    Ok(tools)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CreateAgentRequest, UpdateAgentRequest};
+
+    #[test]
+    fn create_agent_request_rejects_builtin_tools() {
+        let json = r#"{
+            "name": "test-agent",
+            "system_prompt": "You are helpful",
+            "tools": [
+                {
+                    "type": "builtin",
+                    "name": "read_file",
+                    "description": "Read file",
+                    "parameters": {"type": "object"}
+                }
+            ]
+        }"#;
+
+        let err = serde_json::from_str::<CreateAgentRequest>(json).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("tools must contain only client_side definitions")
+        );
+    }
+
+    #[test]
+    fn update_agent_request_rejects_builtin_tools() {
+        let json = r#"{
+            "tools": [
+                {
+                    "type": "builtin",
+                    "name": "web_fetch",
+                    "description": "Fetch",
+                    "parameters": {"type": "object"}
+                }
+            ]
+        }"#;
+
+        let err = serde_json::from_str::<UpdateAgentRequest>(json).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("tools must contain only client_side definitions")
+        );
+    }
 }


### PR DESCRIPTION
### Motivation
- Client-provided `tools` fields were deserialized as `ToolDefinition` (which includes `Builtin`), allowing callers to request server-side builtin tools and bypass capability gating.
- The intent is that these API fields only accept client-side tools which are executed by the client, so inputs must be validated to prevent privilege escalation.

### Description
- Added strict serde deserializers that validate `tools` payloads accept only `ToolDefinition::ClientSide` and return a JSON deserialization error for non-client-side variants.
- Wired the validators into `CreateSessionRequest.tools` in `crates/server/src/api/sessions.rs` via `deserialize_client_side_tools`.
- Wired the validators into `CreateAgentRequest.tools` and `UpdateAgentRequest.tools` in `crates/server/src/domains/agents/types.rs` via `deserialize_client_side_tools` and `deserialize_optional_client_side_tools`.
- Added unit tests asserting `builtin` tool definitions are rejected for session create and agent create/update request shapes.

### Testing
- Ran `cargo fmt` successfully to format changes.
- Ran unit tests in the server crate for the new validations; `cargo test -p everruns-server rejects_builtin_tools` ran and the added tests passed (`test_create_session_request_rejects_builtin_tools`, `create_agent_request_rejects_builtin_tools`, `update_agent_request_rejects_builtin_tools`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa538c504832baddc82d0272ed4f1)