### PR TITLE
fix(subagents): persist child session metadata

### DIFF
--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -331,6 +331,19 @@ impl Tool for SpawnSubagentTool {
             Ok(s) => s,
             Err(e) => return ToolExecutionResult::internal_error(e),
         };
+        let child_session = match store
+            .set_subagent_metadata(
+                child_session.id,
+                context.session_id,
+                &name,
+                &task,
+                crate::session::SubagentStatus::Running,
+            )
+            .await
+        {
+            Ok(s) => s,
+            Err(e) => return ToolExecutionResult::internal_error(e),
+        };
 
         // Register subagent in session resource registry.
         if let Some(ref registry) = context.session_resource_registry {

--- a/crates/core/src/platform_store.rs
+++ b/crates/core/src/platform_store.rs
@@ -198,6 +198,19 @@ pub trait PlatformStore: Send + Sync {
         blueprint_config: Option<&serde_json::Value>,
     ) -> Result<Session>;
 
+    /// Attach subagent metadata to an existing session.
+    ///
+    /// Used by subagent orchestration to persist parent/child linkage and
+    /// support nesting guards plus child-session lookups.
+    async fn set_subagent_metadata(
+        &self,
+        session_id: SessionId,
+        parent_session_id: SessionId,
+        subagent_name: &str,
+        subagent_task: &str,
+        subagent_status: crate::session::SubagentStatus,
+    ) -> Result<Session>;
+
     /// Get a session by ID.
     async fn get_session_by_id(&self, id: SessionId) -> Result<Option<Session>>;
 
@@ -653,6 +666,22 @@ pub mod tests {
         }
         async fn get_session_by_id(&self, _id: SessionId) -> Result<Option<Session>> {
             Ok(Some(self.session.clone()))
+        }
+        async fn set_subagent_metadata(
+            &self,
+            session_id: SessionId,
+            parent_session_id: SessionId,
+            subagent_name: &str,
+            subagent_task: &str,
+            subagent_status: crate::session::SubagentStatus,
+        ) -> Result<Session> {
+            let mut s = self.session.clone();
+            s.id = session_id;
+            s.parent_session_id = Some(parent_session_id);
+            s.subagent_name = Some(subagent_name.to_string());
+            s.subagent_task = Some(subagent_task.to_string());
+            s.subagent_status = Some(subagent_status);
+            Ok(s)
         }
         async fn delete_session(&self, _id: SessionId) -> Result<()> {
             Ok(())

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -2047,6 +2047,16 @@ mod tests {
         async fn get_session_by_id(&self, _id: SessionId) -> crate::Result<Option<crate::Session>> {
             Ok(None)
         }
+        async fn set_subagent_metadata(
+            &self,
+            _session_id: SessionId,
+            _parent_session_id: SessionId,
+            _subagent_name: &str,
+            _subagent_task: &str,
+            _subagent_status: crate::session::SubagentStatus,
+        ) -> crate::Result<crate::Session> {
+            unreachable!()
+        }
         async fn delete_session(&self, _id: SessionId) -> crate::Result<()> {
             Ok(())
         }

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -508,10 +508,12 @@ impl WorkerAdapters for DirectWorkerAdapters {
                 is_pinned: None,
                 active_schedule_count: None,
                 features: vec![],
-                parent_session_id: None,
-                subagent_name: None,
-                subagent_task: None,
-                subagent_status: None,
+                parent_session_id: r.parent_session_id,
+                subagent_name: r.subagent_name,
+                subagent_task: r.subagent_task,
+                subagent_status: r
+                    .subagent_status
+                    .map(|s| everruns_core::session::SubagentStatus::from(s.as_str())),
                 blueprint_id: r.blueprint_id,
                 blueprint_config: r.blueprint_config,
             }
@@ -1916,10 +1918,12 @@ impl DirectPlatformStore {
             is_pinned: None,
             active_schedule_count: None,
             features: vec![],
-            parent_session_id: None,
-            subagent_name: None,
-            subagent_task: None,
-            subagent_status: None,
+            parent_session_id: row.parent_session_id,
+            subagent_name: row.subagent_name,
+            subagent_task: row.subagent_task,
+            subagent_status: row
+                .subagent_status
+                .map(|s| everruns_core::session::SubagentStatus::from(s.as_str())),
             blueprint_id: row.blueprint_id,
             blueprint_config: row.blueprint_config,
         }
@@ -2635,6 +2639,40 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
             }
             None => Ok(None),
         }
+    }
+
+    async fn set_subagent_metadata(
+        &self,
+        session_id: SessionId,
+        parent_session_id: SessionId,
+        subagent_name: &str,
+        subagent_task: &str,
+        subagent_status: everruns_core::session::SubagentStatus,
+    ) -> everruns_core::error::Result<Session> {
+        let row = self
+            .db
+            .set_subagent_metadata(
+                self.org_id,
+                session_id,
+                parent_session_id,
+                subagent_name,
+                subagent_task,
+                &subagent_status.to_string(),
+            )
+            .await
+            .map_err(|e| store_error(format!("Failed to set subagent metadata: {e}")))?
+            .ok_or_else(|| store_error("Session not found"))?;
+
+        let fallback = if row.harness_id.is_none() {
+            Some(
+                org_init::base_harness_id(&self.db, self.org_id)
+                    .await
+                    .map_err(|e| store_error(format!("Failed to resolve base harness: {e}")))?,
+            )
+        } else {
+            None
+        };
+        Ok(self.row_to_session(row, fallback))
     }
 
     async fn delete_session(&self, id: SessionId) -> everruns_core::error::Result<()> {

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -544,6 +544,27 @@ impl StorageBackend {
         dispatch!(self, get_session, org_id, id)
     }
 
+    pub async fn set_subagent_metadata(
+        &self,
+        org_id: i64,
+        id: SessionId,
+        parent_session_id: SessionId,
+        subagent_name: &str,
+        subagent_task: &str,
+        subagent_status: &str,
+    ) -> Result<Option<SessionRow>> {
+        dispatch!(
+            self,
+            set_subagent_metadata,
+            org_id,
+            id,
+            parent_session_id,
+            subagent_name,
+            subagent_task,
+            subagent_status
+        )
+    }
+
     /// Get session without org scoping. For internal system use only (e.g. usage tracking).
     pub async fn get_session_unscoped(&self, id: SessionId) -> Result<Option<SessionRow>> {
         dispatch!(self, get_session_unscoped, id)

--- a/crates/server/src/storage/memory/sessions.rs
+++ b/crates/server/src/storage/memory/sessions.rs
@@ -68,6 +68,29 @@ impl InMemoryDatabase {
         Ok(None)
     }
 
+    pub async fn set_subagent_metadata(
+        &self,
+        org_id: i64,
+        id: SessionId,
+        parent_session_id: SessionId,
+        subagent_name: &str,
+        subagent_task: &str,
+        subagent_status: &str,
+    ) -> Result<Option<SessionRow>> {
+        let mut sessions = self.sessions.write();
+        let Some(session) = sessions.get_mut(&id) else {
+            return Ok(None);
+        };
+        if session.org_id != org_id {
+            return Ok(None);
+        }
+        session.parent_session_id = Some(parent_session_id);
+        session.subagent_name = Some(subagent_name.to_string());
+        session.subagent_task = Some(subagent_task.to_string());
+        session.subagent_status = Some(subagent_status.to_string());
+        Ok(Some(session.clone()))
+    }
+
     /// Get session without org scoping. For internal system use only (e.g. usage tracking).
     pub async fn get_session_unscoped(&self, id: SessionId) -> Result<Option<SessionRow>> {
         let sessions = self.sessions.read();

--- a/crates/server/src/storage/repositories/sessions.rs
+++ b/crates/server/src/storage/repositories/sessions.rs
@@ -70,6 +70,40 @@ impl Database {
         Ok(row)
     }
 
+    pub async fn set_subagent_metadata(
+        &self,
+        org_id: i64,
+        id: SessionId,
+        parent_session_id: SessionId,
+        subagent_name: &str,
+        subagent_task: &str,
+        subagent_status: &str,
+    ) -> Result<Option<SessionRow>> {
+        let row = sqlx::query_as::<_, SessionRow>(
+            r#"
+            UPDATE sessions
+            SET parent_session_id = $3,
+                subagent_name = $4,
+                subagent_task = $5,
+                subagent_status = $6
+            WHERE org_id = $1 AND id = $2
+            RETURNING id, org_id, harness_id, agent_id, agent_identity_id, owner_principal_id, resolved_owner_user_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, status, created_at, updated_at, started_at, finished_at,
+                      total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, parent_session_id, subagent_name, subagent_task, subagent_status,
+                      blueprint_id, blueprint_config
+            "#,
+        )
+        .bind(org_id)
+        .bind(id)
+        .bind(parent_session_id)
+        .bind(subagent_name)
+        .bind(subagent_task)
+        .bind(subagent_status)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
     /// Get session without org scoping. For internal system use only (e.g. usage tracking).
     pub async fn get_session_unscoped(&self, id: SessionId) -> Result<Option<SessionRow>> {
         let row = sqlx::query_as::<_, SessionRow>(

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -2935,6 +2935,19 @@ impl everruns_core::platform_store::PlatformStore for GrpcOrgAdapter {
         }
     }
 
+    async fn set_subagent_metadata(
+        &self,
+        _session_id: SessionId,
+        _parent_session_id: SessionId,
+        _subagent_name: &str,
+        _subagent_task: &str,
+        _subagent_status: everruns_core::session::SubagentStatus,
+    ) -> Result<Session> {
+        Err(AgentLoopError::store(
+            "set_subagent_metadata is not supported over grpc platform adapter",
+        ))
+    }
+
     async fn delete_session(&self, id: SessionId) -> Result<()> {
         let mut client = self.client.inner.lock().await;
         client


### PR DESCRIPTION
### Motivation

- Subagent orchestration relied on `parent_session_id` and related fields to prevent nesting and find child sessions, but those fields were dropped in session creation/mapping paths so the guards and lookups failed. 

### Description

- Added `PlatformStore::set_subagent_metadata` and invoke it from `spawn_subagent` immediately after `create_session` to attach parent/name/task/status metadata to the child session. 
- Implemented persistence for the metadata in storage backends by adding `set_subagent_metadata` to the Postgres repository (`UPDATE ... RETURNING ...`), the in-memory store mutation, and a dispatch wrapper on the storage backend. 
- Updated direct worker / platform adapters to map `parent_session_id`, `subagent_name`, `subagent_task`, and `subagent_status` from storage rows instead of forcing `None`. 
- Added a `GrpcOrgAdapter` stub implementation that returns a store error for `set_subagent_metadata` so the trait extension compiles cleanly where there is no RPC path for this update today. 

### Testing

- Ran `cargo fmt` which completed successfully. 
- Ran `cargo test -p everruns-core --test subagent_test` resulting in 14 passed, 1 failed (`test_subagent_capability_registration`), which asserts prompt text contains `spawn_subagent` and appears unrelated to metadata persistence changes. 
- Ran `cargo check -p everruns-worker` which succeeded. 
- Ran `cargo check -p everruns-server` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaba4a0800832bb990fc8eb5150ca7)