### PR TITLE
fix(server): preserve readonly guard in write_file race recovery

### DIFF
--- a/crates/server/src/storage/session_file_store.rs
+++ b/crates/server/src/storage/session_file_store.rs
@@ -216,7 +216,29 @@ impl SessionFileStore for DbSessionFileStore {
                         || msg.contains("unique constraint")
                         || msg.contains("UNIQUE constraint")
                     {
-                        // Race: file was created concurrently; fall back to update
+                        // Race: file was created concurrently; re-check file type/readonly, then update.
+                        let existing = self
+                            .db
+                            .get_session_file(session_id.uuid(), &path)
+                            .await
+                            .store_err()?
+                            .ok_or_else(|| {
+                                AgentLoopError::store("File not found after race recovery")
+                            })?;
+
+                        if existing.is_directory {
+                            return Err(AgentLoopError::store(format!(
+                                "Cannot write to directory: {}",
+                                path
+                            )));
+                        }
+                        if existing.is_readonly {
+                            return Err(AgentLoopError::store(format!(
+                                "Cannot modify readonly file: {}",
+                                path
+                            )));
+                        }
+
                         self.db
                             .update_session_file(
                                 session_id.uuid(),
@@ -228,9 +250,7 @@ impl SessionFileStore for DbSessionFileStore {
                             )
                             .await
                             .store_err()?
-                            .ok_or_else(|| {
-                                AgentLoopError::store("File not found after race recovery")
-                            })?
+                            .ok_or_else(|| AgentLoopError::store("File not found after update"))?
                     } else {
                         return Err(AgentLoopError::store(e.to_string()));
                     }


### PR DESCRIPTION
### Motivation
- Prevent a TOCTOU race where the duplicate-key recovery path in `DbSessionFileStore::write_file` could overwrite a concurrently-created readonly file by skipping the readonly/directory guards.

### Description
- In the duplicate-key error branch of `crates/server/src/storage/session_file_store.rs`, fetch the concurrently-created row and re-validate `is_directory` and `is_readonly` before calling `update_session_file`, returning an error if the row is a directory or readonly; otherwise proceed to update as before.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Started `cargo test -p everruns-server test_normalize_path -- --nocapture`, but the full test run could not complete in this environment (build/linking exceeded available time), so the repository integration tests were not fully executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaba4ac1a0832bb0bf1fbcda4cb316)