### PR TITLE
fix(server): share LLM resolver with worker service

### DIFF
--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -1212,6 +1212,7 @@ impl ServerAppBuilder {
             let grpc_runner = runner.clone();
             let grpc_addr = self.config.grpc_addr.clone();
             let grpc_platform_definition = platform_definition.clone();
+            let grpc_llm_resolver = llm_resolver.clone();
 
             let grpc_task_broadcaster = task_broadcaster.clone();
             let grpc_virtual_registry = virtual_registry.clone();
@@ -1224,6 +1225,7 @@ impl ServerAppBuilder {
                     Some(grpc_runner),
                     grpc_platform_definition.as_ref().clone(),
                     Some(grpc_virtual_registry),
+                    Some(grpc_llm_resolver),
                 );
                 if let Some(broadcaster) = grpc_task_broadcaster {
                     grpc_svc.set_task_broadcaster(broadcaster);

--- a/crates/server/src/grpc_service/mod.rs
+++ b/crates/server/src/grpc_service/mod.rs
@@ -358,7 +358,7 @@ pub struct WorkerServiceImpl {
     event_service: EventService,
     session_service: SessionService,
     session_file_service: SessionFileService,
-    llm_resolver_service: LlmResolverService,
+    llm_resolver_service: Arc<LlmResolverService>,
     mcp_server_service: McpServerService,
     capability_service: Arc<CapabilityService>,
     durable_store: Option<Arc<PostgresWorkflowEventStore>>,
@@ -400,6 +400,7 @@ impl WorkerServiceImpl {
             runner,
             platform_definition,
             None,
+            None,
         )
     }
 
@@ -412,6 +413,7 @@ impl WorkerServiceImpl {
         virtual_registry: Option<
             Arc<crate::domains::session_files::virtual_mount_registry::VirtualMountRegistry>,
         >,
+        llm_resolver_service: Option<Arc<LlmResolverService>>,
     ) -> Self {
         let capability_registry = platform_definition.capability_registry().clone();
         let session_service = {
@@ -427,7 +429,8 @@ impl WorkerServiceImpl {
         } else {
             SessionFileService::new(db.clone())
         };
-        let llm_resolver_service = LlmResolverService::new(db.clone(), encryption.clone());
+        let llm_resolver_service = llm_resolver_service
+            .unwrap_or_else(|| Arc::new(LlmResolverService::new(db.clone(), encryption.clone())));
         let mcp_server_service = McpServerService::new(db.clone(), encryption.clone());
         let capability_service = Arc::new(CapabilityService::with_registry(
             db.clone(),


### PR DESCRIPTION
### Motivation
- Prevent the gRPC worker from using stale cached LLM provider/model credentials by ensuring API and worker paths share the same `LlmResolverService` instance so `invalidate_cache()` applies to both immediately.

### Description
- `WorkerServiceImpl` now holds an `Arc<LlmResolverService>` and its `with_virtual_registry` accepts an optional shared resolver instead of always constructing a new one.
- `ServerAppBuilder` gRPC startup now passes the existing shared `llm_resolver` into the worker service so API and worker share the same cache instance.
- Preserve existing behavior by falling back to creating a local resolver when no shared resolver is provided.
- Changes applied to `crates/server/src/grpc_service/mod.rs` and `crates/server/src/app_builder.rs` to update types and wiring.

### Testing
- Ran `cargo fmt` on the modified files (`crates/server/src/grpc_service/mod.rs`, `crates/server/src/app_builder.rs`) which completed successfully.
- Attempted `cargo check`/build in the container but the full compile did not complete due to environment network/toolchain fetch limitations, so a full automated build could not be verified here.
- Verified the worker gRPC model resolution code path now calls `resolve_model`/`resolve_default_model` on the injected shared resolver by code inspection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaba4a5eb0832bb6923cf70e21670d)