### PR TITLE
fix(auth): always revalidate API keys against DB

### DIFF
--- a/crates/server/src/auth/builtin.rs
+++ b/crates/server/src/auth/builtin.rs
@@ -1,7 +1,9 @@
 // Built-in authentication backend (JWT + password + OAuth + API keys)
 // Decision: Default for OSS. All existing behavior preserved.
-// Decision: API key auth results cached in-process (moka, 5-min TTL) to avoid
-// 4 sequential DB queries per request. Invalidated on key deletion.
+// Decision: API key auth cache is write-only for now. Read-through caching of
+// AuthUser introduced a TOCTOU authorization window for key expiry and
+// membership/role changes. We keep inserts + invalidation hooks so follow-up
+// work can safely reintroduce cache reads with fresh-state guarantees.
 
 use async_trait::async_trait;
 use axum::Router;
@@ -105,7 +107,7 @@ impl BuiltinAuthBackend {
         self.api_key_cache.entry_count()
     }
 
-    /// Validate API key against DB (4 sequential queries). Called on cache miss.
+    /// Validate API key against DB (4 sequential queries).
     async fn validate_api_key_from_db(&self, key_hash: &str) -> Result<AuthUser, AuthError> {
         let api_key_row = self
             .db
@@ -236,12 +238,8 @@ impl AuthBackend for BuiltinAuthBackend {
 
         let key_hash = hash_api_key(key);
 
-        // Check cache first — avoids 4 sequential DB queries on hit
-        if let Some(cached) = self.api_key_cache.get(&key_hash).await {
-            tracing::trace!("API key auth cache hit");
-            return Ok(cached);
-        }
-
+        // Security: always validate against DB to enforce real-time key expiry
+        // and org membership/role changes.
         let auth_user = self.validate_api_key_from_db(&key_hash).await?;
 
         // Populate cache


### PR DESCRIPTION
### Motivation
- Prevent a TOCTOU/staleness authorization window introduced by returning cached `AuthUser` for API-key requests, which allowed revoked/expired keys or membership/role changes to remain effective until cache TTL expiry.

### Description
- Remove the cache read fast-path from `BuiltinAuthBackend::validate_api_key` so every API-key request runs the DB-backed validation (`validate_api_key_from_db`) and enforces expiry and org membership/role checks in real time.
- Preserve cache writes and invalidation APIs (`api_key_cache.insert`, `invalidate_api_key_cache`, `invalidate_all_api_key_cache`) and add a top-of-file note documenting that the cache is now write-only pending a safe reintroduction of read-through caching.
- Update commit/PR metadata with conventional-commit title `fix(auth): always revalidate API keys against DB`.

### Testing
- Ran `cargo fmt --all`, which completed successfully.
- Attempted `cargo test -p everruns-server auth::builtin::tests::test_cache_constants -- --exact`; compilation and tests were started in this environment but the full test run did not complete due to long-running compile time in the sandbox (build progress observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaba4aa308832baa8da617fcfeef36)