### PR TITLE
fix(server): keep auth rate limiter fail-open on valkey errors

### DIFF
--- a/crates/server/src/valkey.rs
+++ b/crates/server/src/valkey.rs
@@ -75,6 +75,8 @@ impl ValkeyClient {
     /// Check rate limit using sliding window counter.
     ///
     /// Returns `Ok(remaining)` if allowed, `Err(())` if limit exceeded.
+    ///
+    /// Fail-open behavior: Valkey command errors are logged and treated as allowed.
     /// `key`: rate limit key (e.g., `rl:login:192.168.1.1`)
     /// `limit`: max requests in the window
     /// `window_secs`: window duration in seconds
@@ -91,7 +93,7 @@ impl ValkeyClient {
 
         let window_ms = (window_secs * 1000) as i64;
 
-        let result: i64 = self
+        let result: i64 = match self
             .client
             .eval(
                 RATE_LIMIT_SCRIPT,
@@ -99,10 +101,14 @@ impl ValkeyClient {
                 vec![limit as i64, window_ms, now],
             )
             .await
-            .map_err(|e| {
+        {
+            Ok(result) => result,
+            Err(e) => {
                 // Fail open: on Valkey errors, allow the request (availability > strictness)
                 tracing::error!(error = %e, key = %key, "Valkey rate limit check failed, allowing request");
-            })?;
+                return Ok(limit);
+            }
+        };
 
         if result >= 0 {
             Ok(result as u32)


### PR DESCRIPTION
### Motivation

- The Valkey-backed limiter was intended to "fail open" on Valkey command failures, but `check_rate_limit` mapped any `eval` error into an `Err(())` which the auth middleware treated as a limit violation and returned HTTP 429, creating an auth DoS on Valkey outages.

### Description

- Changed `crates/server/src/valkey.rs::ValkeyClient::check_rate_limit` to explicitly handle `eval` errors, log the failure, and return `Ok(limit)` (allow) instead of propagating `Err(())` on command errors so operational failures follow the documented fail-open behavior.
- Kept genuine over-limit behavior unchanged: the Lua script returning a negative value still yields `Err(())` and enforces a rate limit.
- Documented the fail-open behavior in the function docstring.
- This is a minimal, localized change that preserves existing auth rate-limit handling in `crates/server/src/auth/rate_limit.rs`.

### Testing

- Ran the URL parsing unit test with `cargo test -p everruns-server test_valkey_url_parsing --lib` and it passed (`1 passed; 0 failed`).
- Ran `cargo fmt --check` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaba4a04a0832baee7e9504074698d)