### PR TITLE
fix(server): bound Slack users.info cache growth

### DIFF
--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -33,11 +33,11 @@ use everruns_core::progress_reporting::sync_slack_reply_mode_tags;
 use everruns_core::{App, AppStatus, Caller, SessionStrategy, SlackChannelConfig, SlackReplyMode};
 use everruns_worker::AgentRunner;
 use hmac::{Hmac, Mac};
+use moka::sync::Cache;
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::RwLock;
 
 use crate::api::messages::{CreateMessageRequest, InputContentPart, InputMessage, MessageRole};
 use crate::api::sessions::CreateSessionRequest;
@@ -185,7 +185,16 @@ struct AckResponse {
 
 /// Resolved Slack user display name.
 /// `Some(name)` = resolved, `None` = resolution failed (don't retry).
-type SlackUserCache = Arc<RwLock<HashMap<String, Option<String>>>>;
+type SlackUserCache = Cache<String, Option<String>>;
+
+/// Bound for in-memory Slack users.info cache to prevent unbounded growth.
+const SLACK_USER_CACHE_MAX_ENTRIES: u64 = 10_000;
+
+fn new_slack_user_cache() -> SlackUserCache {
+    Cache::builder()
+        .max_capacity(SLACK_USER_CACHE_MAX_ENTRIES)
+        .build()
+}
 
 /// App-scoped Slack state (no auth required).
 #[derive(Clone)]
@@ -221,7 +230,7 @@ impl SlackState {
             event_service: Arc::new(EventService::new(db.clone(), event_delivery)),
             encryption,
             db,
-            user_name_cache: Arc::new(RwLock::new(HashMap::new())),
+            user_name_cache: new_slack_user_cache(),
             delivery_dispatcher,
         }
     }
@@ -1251,11 +1260,8 @@ async fn resolve_slack_user_name_base(
     user_id: &str,
 ) -> Option<String> {
     // Check cache first
-    {
-        let cache_read = cache.read().await;
-        if let Some(cached) = cache_read.get(user_id) {
-            return cached.clone();
-        }
+    if let Some(cached) = cache.get(user_id) {
+        return cached;
     }
 
     // Call Slack API (user IDs are alphanumeric, safe to interpolate)
@@ -1305,8 +1311,7 @@ async fn resolve_slack_user_name_base(
             })
             .map(String::from);
 
-        let mut cache_write = cache.write().await;
-        cache_write.insert(user_id.to_string(), display_name.clone());
+        cache.insert(user_id.to_string(), display_name.clone());
         display_name
     } else {
         let error = body
@@ -1326,8 +1331,7 @@ async fn resolve_slack_user_name_base(
             || error == "token_revoked"
             || error == "account_inactive"
         {
-            let mut cache_write = cache.write().await;
-            cache_write.insert(user_id.to_string(), None);
+            cache.insert(user_id.to_string(), None);
         }
 
         None
@@ -1805,11 +1809,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_slack_user_name_cache_hit() {
-        let cache: SlackUserCache = Arc::new(RwLock::new(HashMap::new()));
-        cache
-            .write()
-            .await
-            .insert("U123".to_string(), Some("Alice".to_string()));
+        let cache: SlackUserCache = new_slack_user_cache();
+        cache.insert("U123".to_string(), Some("Alice".to_string()));
 
         let result = resolve_slack_user_name(&cache, "xoxb-fake", "U123").await;
         assert_eq!(result, Some("Alice".to_string()));
@@ -1818,8 +1819,8 @@ mod tests {
     #[tokio::test]
     async fn test_resolve_slack_user_name_cache_hit_none() {
         // Cached failure (e.g., missing_scope) should return None without API call
-        let cache: SlackUserCache = Arc::new(RwLock::new(HashMap::new()));
-        cache.write().await.insert("U123".to_string(), None);
+        let cache: SlackUserCache = new_slack_user_cache();
+        cache.insert("U123".to_string(), None);
 
         let result = resolve_slack_user_name(&cache, "xoxb-fake", "U123").await;
         assert_eq!(result, None);
@@ -1828,7 +1829,7 @@ mod tests {
     #[tokio::test]
     async fn test_resolve_slack_user_name_api_failure_not_cached() {
         // Network failures should not be cached (allow retry)
-        let cache: SlackUserCache = Arc::new(RwLock::new(HashMap::new()));
+        let cache: SlackUserCache = new_slack_user_cache();
 
         // Use an invalid URL-ish token that will fail network-level
         // (the function uses hardcoded slack.com URL, so with a bad token
@@ -2965,7 +2966,7 @@ mod tests {
                 .mount(&mock_server)
                 .await;
 
-            let cache: SlackUserCache = Arc::new(RwLock::new(HashMap::new()));
+            let cache: SlackUserCache = new_slack_user_cache();
             let result =
                 resolve_slack_user_name_base(&mock_server.uri(), &cache, "xoxb-test-token", "U123")
                     .await;
@@ -2973,7 +2974,7 @@ mod tests {
             assert_eq!(result, Some("Alice S.".to_string()));
 
             // Verify it was cached
-            let cached = cache.read().await.get("U123").cloned();
+            let cached = cache.get("U123");
             assert_eq!(cached, Some(Some("Alice S.".to_string())));
         }
 
@@ -2998,7 +2999,7 @@ mod tests {
                 .mount(&mock_server)
                 .await;
 
-            let cache: SlackUserCache = Arc::new(RwLock::new(HashMap::new()));
+            let cache: SlackUserCache = new_slack_user_cache();
             let result =
                 resolve_slack_user_name_base(&mock_server.uri(), &cache, "xoxb-test-token", "U123")
                     .await;
@@ -3027,7 +3028,7 @@ mod tests {
                 .mount(&mock_server)
                 .await;
 
-            let cache: SlackUserCache = Arc::new(RwLock::new(HashMap::new()));
+            let cache: SlackUserCache = new_slack_user_cache();
             let result =
                 resolve_slack_user_name_base(&mock_server.uri(), &cache, "xoxb-test-token", "U123")
                     .await;
@@ -3053,7 +3054,7 @@ mod tests {
                 .mount(&mock_server)
                 .await;
 
-            let cache: SlackUserCache = Arc::new(RwLock::new(HashMap::new()));
+            let cache: SlackUserCache = new_slack_user_cache();
             let result =
                 resolve_slack_user_name_base(&mock_server.uri(), &cache, "xoxb-test-token", "U123")
                     .await;
@@ -3071,11 +3072,8 @@ mod tests {
             let mock_server = MockServer::start().await;
 
             // No mock mounted — any actual HTTP call would fail
-            let cache: SlackUserCache = Arc::new(RwLock::new(HashMap::new()));
-            cache
-                .write()
-                .await
-                .insert("U123".to_string(), Some("Cached Alice".to_string()));
+            let cache: SlackUserCache = new_slack_user_cache();
+            cache.insert("U123".to_string(), Some("Cached Alice".to_string()));
 
             let result =
                 resolve_slack_user_name_base(&mock_server.uri(), &cache, "xoxb-test-token", "U123")
@@ -3085,13 +3083,24 @@ mod tests {
             // No HTTP call made (mock server received 0 requests)
         }
 
+        #[test]
+        fn test_slack_user_cache_is_bounded() {
+            let cache: SlackUserCache = new_slack_user_cache();
+            let inserts = (SLACK_USER_CACHE_MAX_ENTRIES as usize) + 5_000;
+            for index in 0..inserts {
+                cache.insert(format!("U{index}"), Some(format!("user-{index}")));
+            }
+
+            assert!(cache.entry_count() <= SLACK_USER_CACHE_MAX_ENTRIES);
+        }
+
         #[tokio::test]
         async fn test_resolve_user_name_cached_none_skips_api() {
             let mock_server = MockServer::start().await;
 
             // Cache a None (permanent failure like missing_scope)
-            let cache: SlackUserCache = Arc::new(RwLock::new(HashMap::new()));
-            cache.write().await.insert("U123".to_string(), None);
+            let cache: SlackUserCache = new_slack_user_cache();
+            cache.insert("U123".to_string(), None);
 
             let result =
                 resolve_slack_user_name_base(&mock_server.uri(), &cache, "xoxb-test-token", "U123")
@@ -3118,7 +3127,7 @@ mod tests {
                 .mount(&mock_server)
                 .await;
 
-            let cache: SlackUserCache = Arc::new(RwLock::new(HashMap::new()));
+            let cache: SlackUserCache = new_slack_user_cache();
             let result =
                 resolve_slack_user_name_base(&mock_server.uri(), &cache, "xoxb-test-token", "U123")
                     .await;
@@ -3126,7 +3135,7 @@ mod tests {
             assert_eq!(result, None);
 
             // Permanent error should be cached as None
-            let cached = cache.read().await.get("U123").cloned();
+            let cached = cache.get("U123");
             assert_eq!(cached, Some(None));
         }
 
@@ -3144,13 +3153,13 @@ mod tests {
                 .mount(&mock_server)
                 .await;
 
-            let cache: SlackUserCache = Arc::new(RwLock::new(HashMap::new()));
+            let cache: SlackUserCache = new_slack_user_cache();
             let result =
                 resolve_slack_user_name_base(&mock_server.uri(), &cache, "xoxb-bad-token", "U123")
                     .await;
 
             assert_eq!(result, None);
-            assert_eq!(cache.read().await.get("U123").cloned(), Some(None));
+            assert_eq!(cache.get("U123"), Some(None));
         }
 
         #[tokio::test]
@@ -3167,13 +3176,13 @@ mod tests {
                 .mount(&mock_server)
                 .await;
 
-            let cache: SlackUserCache = Arc::new(RwLock::new(HashMap::new()));
+            let cache: SlackUserCache = new_slack_user_cache();
             let result =
                 resolve_slack_user_name_base(&mock_server.uri(), &cache, "xoxb-revoked", "U123")
                     .await;
 
             assert_eq!(result, None);
-            assert_eq!(cache.read().await.get("U123").cloned(), Some(None));
+            assert_eq!(cache.get("U123"), Some(None));
         }
 
         #[tokio::test]
@@ -3191,7 +3200,7 @@ mod tests {
                 .mount(&mock_server)
                 .await;
 
-            let cache: SlackUserCache = Arc::new(RwLock::new(HashMap::new()));
+            let cache: SlackUserCache = new_slack_user_cache();
             let result =
                 resolve_slack_user_name_base(&mock_server.uri(), &cache, "xoxb-test-token", "U123")
                     .await;
@@ -3199,7 +3208,7 @@ mod tests {
             assert_eq!(result, None);
 
             // Transient error should NOT be cached (allow retry)
-            assert!(cache.read().await.get("U123").is_none());
+            assert!(cache.get("U123").is_none());
         }
 
         #[tokio::test]
@@ -3213,14 +3222,14 @@ mod tests {
                 .mount(&mock_server)
                 .await;
 
-            let cache: SlackUserCache = Arc::new(RwLock::new(HashMap::new()));
+            let cache: SlackUserCache = new_slack_user_cache();
             let result =
                 resolve_slack_user_name_base(&mock_server.uri(), &cache, "xoxb-test-token", "U123")
                     .await;
 
             assert_eq!(result, None);
             // Parse failure is transient — not cached
-            assert!(cache.read().await.get("U123").is_none());
+            assert!(cache.get("U123").is_none());
         }
 
         #[tokio::test]
@@ -3237,13 +3246,13 @@ mod tests {
                 .mount(&mock_server)
                 .await;
 
-            let cache: SlackUserCache = Arc::new(RwLock::new(HashMap::new()));
+            let cache: SlackUserCache = new_slack_user_cache();
             let result =
                 resolve_slack_user_name_base(&mock_server.uri(), &cache, "xoxb-test-token", "U123")
                     .await;
 
             assert_eq!(result, None);
-            assert_eq!(cache.read().await.get("U123").cloned(), Some(None));
+            assert_eq!(cache.get("U123"), Some(None));
         }
 
         #[tokio::test]
@@ -3260,13 +3269,13 @@ mod tests {
                 .mount(&mock_server)
                 .await;
 
-            let cache: SlackUserCache = Arc::new(RwLock::new(HashMap::new()));
+            let cache: SlackUserCache = new_slack_user_cache();
             let result =
                 resolve_slack_user_name_base(&mock_server.uri(), &cache, "xoxb-test-token", "U123")
                     .await;
 
             assert_eq!(result, None);
-            assert_eq!(cache.read().await.get("U123").cloned(), Some(None));
+            assert_eq!(cache.get("U123"), Some(None));
         }
 
         // ------------------------------------------


### PR DESCRIPTION
### Motivation
- The Slack user-name cache was an unbounded shared `HashMap` keyed by user IDs, enabling unbounded memory growth and an availability risk when many unique IDs are seen.

### Description
- Replaced the ad-hoc `Arc<RwLock<HashMap<_,_>>>` cache with a bounded `moka::sync::Cache<String, Option<String>>` and added `SLACK_USER_CACHE_MAX_ENTRIES` (10_000) and a `new_slack_user_cache()` constructor. 
- Updated `resolve_slack_user_name_base` to use `cache.get()` and `cache.insert()` while preserving existing behavior (cache successful names and permanent failures as `None`; transient errors are not cached). 
- Replaced test usage of the old `RwLock<HashMap>` with the new cache and added `test_slack_user_cache_is_bounded` that inserts more than the capacity and asserts the cache enforces the configured max entries.

### Testing
- Ran code formatting with `cargo fmt --all` (succeeded). 
- Ran the server test case with `CARGO_INCREMENTAL=0 cargo test -p everruns-server test_slack_user_cache_is_bounded -- --nocapture`, and the new bounded-growth test passed. 
- Unit and wiremock tests exercising `resolve_slack_user_name` were updated and ran as part of the test session; the targeted cache behavior checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab45ff1e4832b98290e282ead3af8)