### PR TITLE
fix(auth): sanitize register return_to redirect

### DIFF
--- a/apps/ui/src/app/(auth)/register/page.tsx
+++ b/apps/ui/src/app/(auth)/register/page.tsx
@@ -16,6 +16,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { useAuthConfig, useRegister } from "@/hooks/use-auth";
+import { sanitizeReturnTo } from "@/lib/auth-redirect";
 import { Loader2 } from "lucide-react";
 
 export default function RegisterPage() {
@@ -30,7 +31,7 @@ export default function RegisterPage() {
   const [confirmPassword, setConfirmPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
 
-  const returnTo = searchParams.get("return_to");
+  const returnTo = sanitizeReturnTo(searchParams.get("return_to"));
 
   // Redirect if auth is not required or signup is disabled
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- The registration page previously read `return_to` directly from the query string and used it for post-signup navigation, creating an open-redirect risk to external origins.

### Description
- Import and apply `sanitizeReturnTo` from `apps/ui/src/lib/auth-redirect.ts` in `apps/ui/src/app/(auth)/register/page.tsx` so `return_to` is validated and the flow falls back to `/dashboard` when the value is missing or invalid.

### Testing
- Attempted to run the UI unit test `src/__tests__/auth-redirect.test.ts` with `npm test -- --runInBand`, but the environment lacked `jest` so the test run failed and no additional automated tests were executed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab45faf68832bb1e23b61374da9b8)