### PR TITLE
fix(daytona): reject traversal segments in default clone path

### DIFF
--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -1613,7 +1613,10 @@ fn extract_owner_repo(url: &str) -> Option<String> {
     if !url.contains("://") && !url.starts_with("git@") && url.contains('/') && !url.contains(' ') {
         let trimmed = url.trim_end_matches(".git");
         let parts: Vec<&str> = trimmed.splitn(3, '/').collect();
-        if parts.len() == 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+        if parts.len() == 2
+            && is_valid_owner_repo_segment(parts[0])
+            && is_valid_owner_repo_segment(parts[1])
+        {
             return Some(trimmed.to_string());
         }
     }
@@ -1627,7 +1630,10 @@ fn extract_owner_repo(url: &str) -> Option<String> {
         if let Some(path) = rest.split_once('/').map(|(_, p)| p) {
             let path = path.trim_end_matches(".git").trim_end_matches('/');
             let parts: Vec<&str> = path.splitn(3, '/').collect();
-            if parts.len() == 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+            if parts.len() == 2
+                && is_valid_owner_repo_segment(parts[0])
+                && is_valid_owner_repo_segment(parts[1])
+            {
                 return Some(path.to_string());
             }
         }
@@ -1639,12 +1645,19 @@ fn extract_owner_repo(url: &str) -> Option<String> {
     {
         let path = path.trim_end_matches(".git").trim_end_matches('/');
         let parts: Vec<&str> = path.splitn(3, '/').collect();
-        if parts.len() == 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+        if parts.len() == 2
+            && is_valid_owner_repo_segment(parts[0])
+            && is_valid_owner_repo_segment(parts[1])
+        {
             return Some(path.to_string());
         }
     }
 
     None
+}
+
+fn is_valid_owner_repo_segment(segment: &str) -> bool {
+    !segment.is_empty() && segment != "." && segment != ".."
 }
 
 /// Resolve GitHub token lazily from user connections, with session secret fallback.
@@ -2655,6 +2668,14 @@ mod tests {
     #[test]
     fn test_extract_owner_repo_with_spaces() {
         assert_eq!(extract_owner_repo("user /repo"), None);
+    }
+
+    #[test]
+    fn test_extract_owner_repo_rejects_traversal_segments() {
+        assert_eq!(extract_owner_repo("../repo"), None);
+        assert_eq!(extract_owner_repo("user/.."), None);
+        assert_eq!(extract_owner_repo("https://github.com/../repo"), None);
+        assert_eq!(extract_owner_repo("git@github.com:user/../.git"), None);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The default clone destination used `extract_owner_repo` raw segments which allowed `.`/`..` components and enabled path traversal out of the sandbox workspace when `path` was omitted.
- Prevent constructing unsafe targets like `/sandbox/../etc` by validating parsed owner/repo segments before using them in the default path.

### Description
- Add `is_valid_owner_repo_segment(segment: &str)` to reject `.` and `..` and empty segments.
- Update `extract_owner_repo` to call `is_valid_owner_repo_segment` for both owner and repo parts in shorthand, HTTPS, and SSH parsing branches so traversal-like inputs are not accepted.
- Add regression test `test_extract_owner_repo_rejects_traversal_segments` that asserts traversal-style inputs are rejected.
- Change is confined to `integrations/daytona/src/tools.rs` and preserves the existing fallback logic (when extraction fails the code still uses the repo name).

### Testing
- Ran `cargo test -p everruns-integrations-daytona test_extract_owner_repo -- --nocapture` and the test suite for the package passed (new test and existing extract tests OK).
- Ran `cargo fmt --check` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaba4a95bc832b823468b8b7ebdb90)