### PR TITLE
fix(ci): run rust-gated jobs when CLI E2E script changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
             rust:
               - 'crates/**'
               - 'integrations/**'
+              - 'scripts/cli-e2e-test.sh'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'


### PR DESCRIPTION
### Motivation
- Prevent a CI path-filter gap where changes to `scripts/cli-e2e-test.sh` could be merged without running Rust-gated jobs that later execute the script with secrets, creating a supply-chain/CI-secret exposure risk.

### Description
- Add `scripts/cli-e2e-test.sh` to the `rust` filter in `.github/workflows/ci.yml` so `build-binaries` and downstream jobs run when that script is modified.

### Testing
- Validated CI YAML parsing with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml')"` (OK), confirmed the single-line diff with `git diff` and committed the change as `fix(ci): run rust-gated jobs when CLI E2E script changes`, and noted `git fetch origin main` failed in this environment due to no `origin` remote configured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab45ed59c832badd9908871e97f00)