### PR TITLE
fix(sessions): scope unpin to caller org

### DIFF
--- a/crates/server/src/domains/sessions/service.rs
+++ b/crates/server/src/domains/sessions/service.rs
@@ -958,11 +958,11 @@ impl SessionService {
             .await
     }
 
-    /// Unpin a session for a user. `_caller` kept for signature symmetry;
-    /// authorization is enforced at `Command::run` via `UnpinSession::policy`.
-    pub async fn unpin(&self, _caller: &Caller, user_id: Uuid, session_id: Uuid) -> Result<bool> {
+    /// Unpin a session for a user in the caller's current org.
+    /// Authorization is enforced at `Command::run` via `UnpinSession::policy`.
+    pub async fn unpin(&self, caller: &Caller, user_id: Uuid, session_id: Uuid) -> Result<bool> {
         self.db
-            .unpin_session(user_id, SessionId::from_uuid(session_id))
+            .unpin_session(user_id, SessionId::from_uuid(session_id), caller.org_id)
             .await
     }
 

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -639,8 +639,13 @@ impl StorageBackend {
         dispatch!(self, pin_session, user_id, session_id, org_id)
     }
 
-    pub async fn unpin_session(&self, user_id: Uuid, session_id: SessionId) -> Result<bool> {
-        dispatch!(self, unpin_session, user_id, session_id)
+    pub async fn unpin_session(
+        &self,
+        user_id: Uuid,
+        session_id: SessionId,
+        org_id: i64,
+    ) -> Result<bool> {
+        dispatch!(self, unpin_session, user_id, session_id, org_id)
     }
 
     pub async fn list_pinned_session_ids(

--- a/crates/server/src/storage/memory/sessions.rs
+++ b/crates/server/src/storage/memory/sessions.rs
@@ -318,9 +318,21 @@ impl InMemoryDatabase {
         Ok(())
     }
 
-    pub async fn unpin_session(&self, user_id: Uuid, session_id: SessionId) -> Result<bool> {
+    pub async fn unpin_session(
+        &self,
+        user_id: Uuid,
+        session_id: SessionId,
+        org_id: i64,
+    ) -> Result<bool> {
         let mut pins = self.pinned_sessions.write();
-        Ok(pins.remove(&(user_id, session_id)).is_some())
+        let key = (user_id, session_id);
+        let Some((pinned_org_id, _)) = pins.get(&key) else {
+            return Ok(false);
+        };
+        if *pinned_org_id != org_id {
+            return Ok(false);
+        }
+        Ok(pins.remove(&key).is_some())
     }
 
     pub async fn list_pinned_session_ids(

--- a/crates/server/src/storage/memory/tests.rs
+++ b/crates/server/src/storage/memory/tests.rs
@@ -260,6 +260,60 @@ async fn test_events_sequence() {
     assert_eq!(events[2].sequence, 3);
 }
 
+#[tokio::test]
+async fn test_unpin_session_is_scoped_by_org() {
+    let db = InMemoryDatabase::new();
+    let user_id = Uuid::now_v7();
+
+    let session = db
+        .create_session(CreateSessionRow {
+            org_id: DEFAULT_ORG_ID,
+            harness_id: None,
+            agent_id: None,
+            agent_identity_id: None,
+            owner_principal_id: everruns_core::PrincipalId::from_seed(1),
+            resolved_owner_user_id: Some(user_id),
+            title: Some("Pinned Session".to_string()),
+            locale: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+            mcp_servers: serde_json::json!({}),
+            system_prompt: None,
+            initial_files: serde_json::Value::Array(vec![]),
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            blueprint_id: None,
+            blueprint_config: None,
+        })
+        .await
+        .unwrap();
+
+    db.pin_session(user_id, session.id, DEFAULT_ORG_ID)
+        .await
+        .unwrap();
+
+    let removed_wrong_org = db
+        .unpin_session(user_id, session.id, DEFAULT_ORG_ID + 1)
+        .await
+        .unwrap();
+    assert!(!removed_wrong_org);
+
+    let pinned_after_wrong_org = db
+        .list_pinned_session_ids(user_id, DEFAULT_ORG_ID)
+        .await
+        .unwrap();
+    assert_eq!(pinned_after_wrong_org, vec![session.id]);
+
+    let removed_correct_org = db
+        .unpin_session(user_id, session.id, DEFAULT_ORG_ID)
+        .await
+        .unwrap();
+    assert!(removed_correct_org);
+}
+
 /// Helper: create an agent + session for event filter tests.
 async fn create_session_with_events(db: &InMemoryDatabase) -> SessionId {
     let agent = db

--- a/crates/server/src/storage/repositories/sessions.rs
+++ b/crates/server/src/storage/repositories/sessions.rs
@@ -378,16 +378,22 @@ impl Database {
         Ok(())
     }
 
-    /// Unpin a session for a user
-    pub async fn unpin_session(&self, user_id: Uuid, session_id: SessionId) -> Result<bool> {
+    /// Unpin a session for a user in an org
+    pub async fn unpin_session(
+        &self,
+        user_id: Uuid,
+        session_id: SessionId,
+        org_id: i64,
+    ) -> Result<bool> {
         let result = sqlx::query(
             r#"
             DELETE FROM pinned_sessions
-            WHERE user_id = $1 AND session_id = $2
+            WHERE user_id = $1 AND session_id = $2 AND org_id = $3
             "#,
         )
         .bind(user_id)
         .bind(session_id)
+        .bind(org_id)
         .execute(&self.pool)
         .await?;
         Ok(result.rows_affected() > 0)


### PR DESCRIPTION
### Motivation
- The unpin flow previously deleted pinned rows using only `(user_id, session_id)`, allowing an authenticated user to remove their pin for a session in a different org if they knew the session ID.
- Pins are intended to be scoped per-org according to the pinned_sessions schema and listing logic, so unpin must enforce org boundaries.

### Description
- Thread `org_id` through `SessionService::unpin` -> `StorageBackend::unpin_session` -> repository to ensure unpin is executed in the caller's org (`crates/server/src/domains/sessions/service.rs`, `crates/server/src/storage/backend.rs`).
- Updated the PostgreSQL repository `DELETE` query to include `AND org_id = $3` so rows are only removed in the correct org (`crates/server/src/storage/repositories/sessions.rs`).
- Updated in-memory storage to check the stored pin's org before removing it so the in-memory backend matches DB semantics (`crates/server/src/storage/memory/sessions.rs`).
- Added an in-memory regression test `test_unpin_session_is_scoped_by_org` that verifies wrong-org unpin is rejected and same-org unpin succeeds (`crates/server/src/storage/memory/tests.rs`).

### Testing
- Ran `cargo fmt --all` which completed successfully to ensure formatting consistency.
- Added unit test `test_unpin_session_is_scoped_by_org` in the in-memory tests to cover the regression and verify behavior in the memory backend.
- Attempted `cargo test -p everruns-server test_unpin_session_is_scoped_by_org`, but a full local test run could not complete in this environment due to lengthy toolchain/dependency fetch and compile time; the test was added and will be executed by CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab45ef9a8832b821060af37011e4a)