### PR TITLE
fix(server): clamp turn context message limits

### DIFF
--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -5,6 +5,16 @@ use super::*;
 
 const COMMAND_API_VERSION_V1: &str = "v1";
 const MAX_EXECUTE_COMMAND_PARAMS_BYTES: usize = 1024 * 1024;
+const DEFAULT_TURN_CONTEXT_MESSAGE_LIMIT: i32 = 200;
+const MAX_TURN_CONTEXT_MESSAGE_LIMIT: i32 = 5_000;
+
+fn normalize_turn_context_message_limit(requested_limit: Option<i32>, default_limit: i32) -> i32 {
+    let normalized_default = default_limit.clamp(1, MAX_TURN_CONTEXT_MESSAGE_LIMIT);
+    requested_limit
+        .filter(|&l| l > 0)
+        .unwrap_or(normalized_default)
+        .clamp(1, MAX_TURN_CONTEXT_MESSAGE_LIMIT)
+}
 
 fn command_error_kind(error: &crate::domains::common::CommandError) -> i32 {
     match error {
@@ -143,16 +153,14 @@ impl WorkerService for WorkerServiceImpl {
         let default_limit: i32 = std::env::var("TURN_CONTEXT_MESSAGE_LIMIT")
             .ok()
             .and_then(|v| v.parse().ok())
-            .unwrap_or(200);
-        let message_limit = req
-            .message_limit
-            .filter(|&l| l > 0)
-            .unwrap_or(default_limit);
+            .unwrap_or(DEFAULT_TURN_CONTEXT_MESSAGE_LIMIT);
+        let message_limit = normalize_turn_context_message_limit(req.message_limit, default_limit);
+        let fetch_limit = message_limit.saturating_add(1);
 
         // Fetch one extra to detect truncation
         let events = self
             .event_service
-            .list_message_events_limited(session_id, Some(message_limit + 1))
+            .list_message_events_limited(session_id, Some(fetch_limit))
             .await
             .map_err(|e| {
                 tracing::error!("Failed to list messages: {}", e);
@@ -3911,5 +3919,39 @@ fn proto_to_workflow_status(status: DurableWorkflowStatus) -> WorkflowStatus {
         DurableWorkflowStatus::Cancelled => WorkflowStatus::Cancelled,
         DurableWorkflowStatus::ContinuedAsNew => WorkflowStatus::ContinuedAsNew,
         DurableWorkflowStatus::Unspecified => WorkflowStatus::Pending,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DEFAULT_TURN_CONTEXT_MESSAGE_LIMIT, MAX_TURN_CONTEXT_MESSAGE_LIMIT,
+        normalize_turn_context_message_limit,
+    };
+
+    #[test]
+    fn normalize_turn_context_message_limit_uses_clamped_default() {
+        assert_eq!(
+            normalize_turn_context_message_limit(None, DEFAULT_TURN_CONTEXT_MESSAGE_LIMIT),
+            DEFAULT_TURN_CONTEXT_MESSAGE_LIMIT
+        );
+        assert_eq!(
+            normalize_turn_context_message_limit(None, i32::MAX),
+            MAX_TURN_CONTEXT_MESSAGE_LIMIT
+        );
+    }
+
+    #[test]
+    fn normalize_turn_context_message_limit_rejects_non_positive_values() {
+        assert_eq!(normalize_turn_context_message_limit(Some(0), 123), 123);
+        assert_eq!(normalize_turn_context_message_limit(Some(-50), 123), 123);
+    }
+
+    #[test]
+    fn normalize_turn_context_message_limit_clamps_large_values() {
+        assert_eq!(
+            normalize_turn_context_message_limit(Some(i32::MAX), 123),
+            MAX_TURN_CONTEXT_MESSAGE_LIMIT
+        );
     }
 }

--- a/crates/server/src/storage/memory/events.rs
+++ b/crates/server/src/storage/memory/events.rs
@@ -184,12 +184,14 @@ impl InMemoryDatabase {
             .cloned()
             .collect();
         result.sort_by_key(|e| e.sequence);
-        if let Some(limit) = limit {
+        if let Some(limit) = limit.filter(|limit| *limit > 0) {
             let len = result.len();
             let limit = limit as usize;
             if len > limit {
                 result = result.split_off(len - limit);
             }
+        } else if limit.is_some() {
+            result.clear();
         }
         Ok(result)
     }

--- a/crates/server/src/storage/repositories/events.rs
+++ b/crates/server/src/storage/repositories/events.rs
@@ -273,7 +273,7 @@ impl Database {
         session_id: SessionId,
         limit: Option<i32>,
     ) -> Result<Vec<EventRow>> {
-        let rows = if let Some(limit) = limit {
+        let rows = if let Some(limit) = limit.filter(|limit| *limit > 0) {
             // Subquery: get most recent N by sequence DESC, then re-order ASC
             sqlx::query_as::<_, EventRow>(
                 r#"
@@ -292,6 +292,8 @@ impl Database {
             .bind(limit as i64)
             .fetch_all(&self.pool)
             .await?
+        } else if limit.is_some() {
+            Vec::new()
         } else {
             // Safety cap when no explicit limit — prevents unbounded result sets.
             const MESSAGE_SAFETY_LIMIT: i64 = 5_000;


### PR DESCRIPTION
### Motivation
- Closing a DoS vector where a client-provided `message_limit` could overflow when computing `message_limit + 1`, producing negative or unbounded SQL `LIMIT` values and allowing unbounded message loading or internal errors.

### Description
- Add `normalize_turn_context_message_limit(requested_limit, default_limit)` and constants `DEFAULT_TURN_CONTEXT_MESSAGE_LIMIT` and `MAX_TURN_CONTEXT_MESSAGE_LIMIT` to enforce a safe range (1..=5000) for turn-context message limits.
- Use `saturating_add(1)` when fetching one extra row for truncation detection to avoid overflow when incrementing the normalized limit.
- Harden storage backends by treating explicitly provided non-positive limits as empty results instead of passing invalid values into SQL or in-memory logic (`list_message_events_limited` in both repository and in-memory implementations).
- Add focused unit tests for normalization behavior covering missing/defaults, non-positive values, and huge inputs.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran targeted unit tests with `cargo test -p everruns-server normalize_turn_context_message_limit --lib` and the three new tests passed.
- Verified the modified code compiles as part of the server crate during test execution (no regressions observed in the exercised units).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab45eda38832ba168b783d44fdde7)