### PR TITLE
fix(core): avoid UTF-8 panic when truncating AGENTS.md

### DIFF
--- a/crates/core/src/capabilities/agent_instructions.rs
+++ b/crates/core/src/capabilities/agent_instructions.rs
@@ -110,7 +110,11 @@ pub fn format_agents_md_content(content: &str) -> Option<String> {
             max_size = MAX_AGENTS_MD_SIZE,
             "AGENTS.md exceeds size limit, truncating"
         );
-        (&content[..MAX_AGENTS_MD_SIZE], true)
+        let mut truncation_idx = MAX_AGENTS_MD_SIZE;
+        while truncation_idx > 0 && !content.is_char_boundary(truncation_idx) {
+            truncation_idx -= 1;
+        }
+        (&content[..truncation_idx], true)
     } else {
         (content, false)
     };
@@ -297,6 +301,24 @@ mod tests {
         let truncation_marker = "\n\n[AGENTS.md was truncated";
         let body_end = result.find(truncation_marker).unwrap();
         assert_eq!(body_end - body_start, MAX_AGENTS_MD_SIZE);
+    }
+
+    #[test]
+    fn test_format_agents_md_content_truncation_utf8_boundary_safe() {
+        let content = "€".repeat((MAX_AGENTS_MD_SIZE / "€".len()) + 1);
+        let result = format_agents_md_content(&content).unwrap();
+
+        assert!(result.contains("truncated"));
+
+        let header = "<agent-instructions source=\"AGENTS.md\">\n";
+        let body_start = result.find(header).unwrap() + header.len();
+        let truncation_marker = "\n\n[AGENTS.md was truncated";
+        let body_end = result.find(truncation_marker).unwrap();
+        let body = &result[body_start..body_end];
+
+        assert!(body.len() <= MAX_AGENTS_MD_SIZE);
+        assert!(std::str::from_utf8(body.as_bytes()).is_ok());
+        assert_eq!(body.chars().last(), Some('€'));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The previous `format_agents_md_content` implementation used a raw byte slice `&content[..MAX_AGENTS_MD_SIZE]`, which can panic if the byte index lands inside a multi-byte UTF‑8 codepoint and crash reasoning activities (DoS vector). 
- The change prevents that panic while preserving the 32 KiB size limit and existing behavior for ASCII content.

### Description
- When truncation is needed, walk back from `MAX_AGENTS_MD_SIZE` to the nearest UTF‑8 character boundary using `is_char_boundary` and slice at that safe index instead of slicing at a fixed byte offset. 
- Added a focused unit test `test_format_agents_md_content_truncation_utf8_boundary_safe` that constructs oversized multi-byte (`€`) content and asserts the truncated output is valid UTF‑8, within the byte limit, and ends on a full character. 
- Kept the truncation warning, truncation notice text, and surrounding `<agent-instructions>` wrapping unchanged. 

### Testing
- Ran `cargo test -p everruns-core test_format_agents_md_content_truncation_utf8_boundary_safe`, and the new test passed. 
- Ran `cargo fmt --all --check`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaad3993e0832b89bd6e8a79632499)