### PR TITLE
fix(evals): prevent NameError in SWE-bench score write-back

### DIFF
--- a/evals/swe-bench/swe_bench/scorer.py
+++ b/evals/swe-bench/swe_bench/scorer.py
@@ -126,6 +126,7 @@ def write_scores_back(
         sys.exit(1)
 
     print(f"Writing scores for {len(bulk_items)} results ({len(resolved_ids)} resolved)...")
+    matched = len(bulk_items)
 
     metadata = {
         "scorer": "swebench-docker-harness",


### PR DESCRIPTION
### Motivation
- Fix a NameError in `evals/swe-bench/swe_bench/scorer.py` where `metadata["total_count"]` referenced an undefined `matched`, preventing bulk score write-back to the Everruns API.

### Description
- Define `matched = len(bulk_items)` immediately before constructing the `metadata` dict in `write_scores_back`, preserving the existing metadata shape and behavior.

### Testing
- Ran `python -m py_compile evals/swe-bench/swe_bench/scorer.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaba49e7e0832b9309c4249f7b8e54)