### PR TITLE
fix(worker): preserve steering signals across act/failure

### DIFF
--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -1402,13 +1402,23 @@ impl DurableWorker {
             );
         let host = WorkerRuntimeHost::new(adapters);
         let pending_user_message_count = if completed_activity == "reason" {
-            store
-                .get_and_consume_signals(workflow_id)
-                .await
-                .map_err(|error| anyhow::anyhow!("Failed to consume workflow signals: {}", error))?
-                .into_iter()
-                .filter(|signal| signal.signal_type == everruns_durable::signal_types::USER_MESSAGE)
-                .count()
+            let reason_result: everruns_core::ReasonResult = serde_json::from_value(output.clone())
+                .map_err(|error| anyhow::anyhow!("Invalid reason output payload: {}", error))?;
+            if reason_result.success && !reason_result.has_tool_calls {
+                store
+                    .get_and_consume_signals(workflow_id)
+                    .await
+                    .map_err(|error| {
+                        anyhow::anyhow!("Failed to consume workflow signals: {}", error)
+                    })?
+                    .into_iter()
+                    .filter(|signal| {
+                        signal.signal_type == everruns_durable::signal_types::USER_MESSAGE
+                    })
+                    .count()
+            } else {
+                0
+            }
         } else {
             0
         };

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -697,13 +697,19 @@ async fn schedule_next_activity<S: WorkflowEventStore, A: WorkerAdapters + Clone
     output: &serde_json::Value,
 ) -> Result<()> {
     let pending_user_message_count = if completed_activity == "reason" {
-        store
-            .consume_pending_signals(workflow_id)
-            .await
-            .map_err(|error| anyhow::anyhow!("Failed to consume workflow signals: {}", error))?
-            .into_iter()
-            .filter(|signal| signal.signal_type == everruns_durable::signal_types::USER_MESSAGE)
-            .count()
+        let reason_result: everruns_core::ReasonResult = serde_json::from_value(output.clone())
+            .map_err(|error| anyhow::anyhow!("Invalid reason output payload: {}", error))?;
+        if reason_result.success && !reason_result.has_tool_calls {
+            store
+                .consume_pending_signals(workflow_id)
+                .await
+                .map_err(|error| anyhow::anyhow!("Failed to consume workflow signals: {}", error))?
+                .into_iter()
+                .filter(|signal| signal.signal_type == everruns_durable::signal_types::USER_MESSAGE)
+                .count()
+        } else {
+            0
+        }
     } else {
         0
     };


### PR DESCRIPTION
### Motivation
- Worker schedulers were consuming and discarding pending workflow signals immediately after every `reason` completion, which could drop mid-turn steering user messages when the turn continued to `act` or failed. 
- The intended behavior is to preserve queued steering messages unless the turn actually completes and the runtime decides another `reason` iteration should be scheduled.

### Description
- Parse the `ReasonResult` before consuming signals and only consume pending USER_MESSAGE signals when `reason_result.success && !reason_result.has_tool_calls` in `crates/worker/src/durable_worker.rs`.
- Apply the same conditional signal-consumption logic in `crates/worker/src/unified_worker.rs` for consistency across worker implementations.
- This ensures signals are not destructively read when the planner will schedule `act` or emit failure, preserving steering inputs for later processing.

### Testing
- Ran `cargo fmt --all` successfully.
- Ran `cargo test -p everruns-worker durable_runner::tests::start_run_steers_running_workflow -- --nocapture` and the test passed.
- Built and ran unit tests for the worker crate; the durable runner steering test completed `ok` (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaba4a1208832ba5e653ba93cc505d)