### PR TITLE
fix(core): avoid double-applying capability configs

### DIFF
--- a/crates/core/src/runtime_context.rs
+++ b/crates/core/src/runtime_context.rs
@@ -223,7 +223,6 @@ async fn assemble_turn_context_with_mode(
     let runtime_agent = build_runtime_agent(
         &session,
         &effective_overlay,
-        &resolved_capability_configs,
         capability_registry,
         &prompt_ctx,
         mcp_tool_definitions,
@@ -280,7 +279,6 @@ pub fn resolve_runtime_capabilities(
 async fn build_runtime_agent(
     session: &Session,
     effective_overlay: &AgentConfigOverlay,
-    resolved_capability_configs: &[AgentCapabilityConfig],
     capability_registry: &CapabilityRegistry,
     prompt_ctx: &SystemPromptContext,
     mcp_tool_definitions: &[ToolDefinition],
@@ -323,8 +321,6 @@ async fn build_runtime_agent(
         let overlay_tools = std::mem::take(&mut overlay_for_builder.tools);
 
         RuntimeAgentBuilder::from_overlay(overlay_for_builder, capability_registry, prompt_ctx)
-            .await
-            .with_capability_configs(resolved_capability_configs, capability_registry, prompt_ctx)
             .await
             .with_locale(prompt_ctx.locale.as_deref())
             .tools(mcp_tool_definitions.iter().cloned())


### PR DESCRIPTION
### Motivation
- Prevent duplicate application of capability configs during turn-context assembly which duplicated capability system-prompt contributions and could bloat prompts or alter tool composition/ordering.

### Description
- Remove the redundant `.with_capability_configs(...)` call when constructing non-blueprint `RuntimeAgent`s so capabilities are applied only once via `RuntimeAgentBuilder::from_overlay(...)`.
- Stop passing the now-unused `resolved_capability_configs` into `build_runtime_agent` and simplify the builder plumbing accordingly.

### Testing
- Ran `cargo test -p everruns-core runtime_context -- --nocapture` and the runtime_context tests passed.
- Ran `cargo fmt --check` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaad38f344832bbc64571fbde82901)