### PR TITLE
fix(session-files): handle root virtual mount lookups

### DIFF
--- a/crates/server/src/domains/session_files/virtual_mount_registry.rs
+++ b/crates/server/src/domains/session_files/virtual_mount_registry.rs
@@ -62,6 +62,8 @@ impl VirtualMountRegistry {
             if let Some(relative) = strip_mount_prefix(path, &mount.mount_path) {
                 let lookup = if relative.is_empty() {
                     mount.mount_path.clone()
+                } else if mount.mount_path == "/" {
+                    format!("/{relative}")
                 } else {
                     format!("{}/{relative}", mount.mount_path)
                 };
@@ -260,6 +262,19 @@ mod tests {
 
         // "/mnt2/hello.txt" should NOT match mount at "/mnt"
         assert!(registry.read_file(&sid, "/mnt2/hello.txt").is_none());
+    }
+
+    #[test]
+    fn registry_read_file_root_mount() {
+        let registry = VirtualMountRegistry::new();
+        let sid = Uuid::new_v4();
+        let mut tree = VirtualFileTree::new();
+        tree.insert_text("/hello.txt", "world");
+        registry.register(sid, "/".into(), Arc::new(tree), "cap".into());
+
+        let result = registry.read_file(&sid, "/hello.txt").unwrap();
+        assert_eq!(result.content, b"world");
+        assert!(!result.is_directory);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Root-mounted virtual trees were unreadable because lookup keys were built as `//foo` which do not match stored paths like `/foo` in `VirtualFileTree`.
- This caused virtual reads to miss and fall back to DB, allowing DB files to shadow intended read-only virtual content for root mounts.

### Description
- In `VirtualMountRegistry::read_file` add a branch that, for a non-empty relative path under a `/` mount, constructs the lookup as `/{relative}` instead of `//{relative}`.
- Add a regression test `registry_read_file_root_mount` that registers a virtual tree at `/` and asserts a mounted file is readable.
- No behavior changed for non-root mounts and write protection / path validation are unchanged.

### Testing
- Ran `cargo fmt --all -- --check` which succeeded.
- Added unit test `registry_read_file_root_mount` under `crates/server/src/domains/session_files/virtual_mount_registry.rs` to lock in behavior.
- Attempted `cargo test -p everruns-server virtual_mount_registry` and targeted runs of `registry_read_file_root_mount`, but full test execution in this environment was blocked/incomplete due to long compile time and artifact locking; CI should run the full test matrix and validate the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaad3a9248832b921f05a90eebac65)