### PR TITLE
fix(evals): prevent orphaned eval runs without a target

### DIFF
--- a/crates/server/src/domains/evals/service.rs
+++ b/crates/server/src/domains/evals/service.rs
@@ -357,8 +357,6 @@ impl EvalService {
             triggered_by: "user".to_string(),
         };
 
-        let run_row = self.db.create_eval_run(caller.org_id, input).await?;
-
         // Load eval-level target for resolution
         let eval_target: Option<EvalTarget> = eval
             .target
@@ -370,10 +368,8 @@ impl EvalService {
         // target_snapshot must always store a concrete resolved target so results
         // remain reproducible and do not depend on future default changes.
         let cases = self.db.list_eval_cases(eval.id).await?;
+        let mut resolved_targets = Vec::with_capacity(cases.len());
         for case in &cases {
-            let result_uuid = Uuid::now_v7();
-            let result_public_id = EvalResultId::from_uuid(result_uuid);
-
             // Resolve target: run → case → eval. Fail if nothing resolved.
             let case_target: Option<EvalTarget> = case
                 .target
@@ -390,12 +386,19 @@ impl EvalService {
                     )
                 })?;
 
-            let resolved_json = serde_json::to_value(&resolved)?;
+            resolved_targets.push((case.id, serde_json::to_value(&resolved)?));
+        }
+
+        let run_row = self.db.create_eval_run(caller.org_id, input).await?;
+
+        for (case_id, resolved_json) in resolved_targets {
+            let result_uuid = Uuid::now_v7();
+            let result_public_id = EvalResultId::from_uuid(result_uuid);
 
             let result_input = CreateEvalCaseResultRow {
                 public_id: result_public_id.to_string(),
                 eval_run_id: run_row.id,
-                eval_case_id: case.id,
+                eval_case_id: case_id,
                 target: Some(resolved_json.clone()),
                 target_snapshot: Some(resolved_json),
                 artifacts: None,

--- a/crates/server/tests/evals_integration_test.rs
+++ b/crates/server/tests/evals_integration_test.rs
@@ -263,6 +263,55 @@ async fn test_bulk_update_run_scores_rejects_duplicate_result_ids() {
     );
 }
 
+#[tokio::test]
+async fn test_create_run_without_any_target_does_not_create_orphaned_run() {
+    let server = TestServer::in_memory().await;
+    let eval: Eval = server
+        .post(
+            "/v1/evals",
+            json!({
+                "name": "targetless eval",
+                "description": "integration test"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let _case: EvalCase = server
+        .post(
+            &format!("/v1/evals/{}/cases", eval.public_id),
+            json!({
+                "name": "targetless case",
+                "conversation": [{"content": "hello"}],
+                "scorers": [{"type": "contains", "text": "ok", "weight": 1.0}]
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let response = server
+        .post(&format!("/v1/evals/{}/runs", eval.public_id), json!({}))
+        .await;
+
+    assert_ne!(response.status(), StatusCode::CREATED);
+    let _ = response.text();
+
+    let eval_row = server
+        .db
+        .get_eval_by_public_id(TEST_ORG_ID, &eval.public_id.to_string())
+        .await
+        .expect("load eval")
+        .expect("eval exists");
+    let runs = server
+        .db
+        .list_eval_runs(eval_row.id)
+        .await
+        .expect("list runs");
+    assert_eq!(runs.len(), 0);
+}
+
 struct SeededRun {
     eval_id: String,
     run_id: String,


### PR DESCRIPTION
### Motivation
- The refactor made `EvalTarget` optional but `create_run` inserted an `eval_runs` row before resolving per-case targets, which could leave orphaned pending runs when no target was provided and block the org-default fallback.

### Description
- Precompute resolved per-case targets using the existing resolution order `run → case → eval` and return the existing error early if any case has no resolved target.
- Only insert the `eval_runs` row after all case targets are resolved, then create `eval_case_results` using the precomputed `target`/`target_snapshot` JSON values. 
- Preserve current execution behavior and background dispatch via `spawn_eval_run` for successful runs. 
- Add integration test `test_create_run_without_any_target_does_not_create_orphaned_run` to assert that failed run creation does not leave a persisted run row.

### Testing
- Ran `cargo fmt` which completed successfully. 
- Ran `cargo test -p everruns-server --test evals_integration_test test_create_run_without_any_target_does_not_create_orphaned_run` and the new integration test passed. 
- Recommend running full CI before merge to exercise the complete test matrix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaad3af53c832ba8a4b56f2f7a152c)