### PR TITLE
fix(ci): restore Linux formula URL on AMD x86_64

### DIFF
--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -132,7 +132,9 @@ jobs:
 
             on_linux do
               depends_on arch: :x86_64
-              if Hardware::CPU.intel?
+              if Hardware::CPU.arm?
+                odie "Linux ARM is not supported by this formula"
+              else
                 url "${BASE_URL}/everruns-x86_64-unknown-linux-gnu.tar.gz"
                 sha256 "${SHA_LINUX}"
               end


### PR DESCRIPTION
### Motivation
- Fix Homebrew formula generation that omitted the Linux `url`/`sha256` on AMD x86_64 because the Linux stanza was incorrectly guarded by `Hardware::CPU.intel?`, producing an invalid formula for non-Intel x86_64 Linux users.

### Description
- Update `.github/workflows/cli-binaries.yml` to make the generated `on_linux` block explicitly `odie` on ARM and emit the existing x86_64 `url`/`sha256` in the `else` branch so both Intel and AMD x86_64 receive a download URL.

### Testing
- Verified the workflow YAML parses with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cli-binaries.yml"); puts "ok"'` which succeeded, and an attempted `PyYAML` parse (`python -c 'import yaml'`) failed because `PyYAML` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaad3add34832bb78d8bd72446b87d)