### PR TITLE
fix(server): handle NULL display_name in harness search

### DIFF
--- a/crates/server/src/storage/repositories/harnesses.rs
+++ b/crates/server/src/storage/repositories/harnesses.rs
@@ -152,7 +152,7 @@ impl Database {
     ) -> Result<Vec<HarnessRow>> {
         let (search_sql, patterns) = build_search_sql(
             search,
-            "LOWER(display_name || ' ' || name || ' ' || COALESCE(description, ''))",
+            "LOWER(COALESCE(display_name, name) || ' ' || name || ' ' || COALESCE(description, ''))",
             2,
         );
         let status_sql = if include_archived {


### PR DESCRIPTION
### Motivation
- `display_name` for harnesses is now nullable and PostgreSQL `||` string concatenation returns `NULL` if any operand is `NULL`, which made the search expression evaluate to `NULL` and excluded matching harnesses. 
- Restore correct search behavior for harnesses created without a `display_name` by ensuring the concatenation never produces `NULL`.

### Description
- Update the search expression in `list_harnesses` to use `COALESCE(display_name, name)` so `display_name` is replaced with `name` when `NULL` in `crates/server/src/storage/repositories/harnesses.rs`.
- This matches the pattern used in the agents repository and preserves searchable text from `name`/`description` when `display_name` is absent.
- Commit message: `fix(server): coalesce nullable harness display name in search`.

### Testing
- Ran `cargo fmt --all -- --check`, which succeeded.
- Verified the source change with `rg` and found the updated expression `COALESCE(display_name, name)` present in `crates/server/src/storage/repositories/harnesses.rs`.
- Attempted `cargo test -p server --no-run`, which failed because the package name is `everruns-server` not `server` (expected failure due to wrong package name).
- Started `cargo test -p everruns-server --no-run` to validate the workspace, but the full workspace compilation did not complete in this environment before the process was terminated (build in progress, tests not fully executed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaad3af21c832b825d9d90e0313df7)