### PR TITLE
fix(core): restore bash narration for commands arg

### DIFF
--- a/crates/core/src/tool_narration.rs
+++ b/crates/core/src/tool_narration.rs
@@ -168,7 +168,7 @@ fn ukrainian_phrase(
     let args = &tool_call.arguments;
     match tool_call.name.as_str() {
         name if is_shell_exec_tool(name) => {
-            let command = arg_str(args, &["command"])
+            let command = arg_str(args, &["commands", "command"])
                 .map(|value| format!("`{}`", truncate(value, 48)))
                 .unwrap_or_else(|| fallback_name.to_string());
             match phase {
@@ -489,7 +489,7 @@ pub fn render_tool_narration_with_locale(
 
     match tool_call.name.as_str() {
         name if is_shell_exec_tool(name) => {
-            let command = arg_str(args, &["command"])
+            let command = arg_str(args, &["commands", "command"])
                 .map(|value| format!("`{}`", truncate(value, 48)))
                 .unwrap_or_else(|| fallback_name.clone());
             generic_phrase("Running", "Ran", "Failed to run", Some(command), phase)
@@ -882,6 +882,24 @@ mod tests {
     }
 
     #[test]
+    fn renders_bash_narration_with_commands_arg() {
+        let tool_call = ToolCall {
+            id: "call_1".to_string(),
+            name: "bash".to_string(),
+            arguments: json!({ "commands": "echo hi" }),
+        };
+
+        assert_eq!(
+            render_tool_narration(None, &tool_call, ToolNarrationPhase::Started),
+            "Running `echo hi`"
+        );
+        assert_eq!(
+            render_tool_narration(None, &tool_call, ToolNarrationPhase::Completed),
+            "Ran `echo hi`"
+        );
+    }
+
+    #[test]
     fn renders_group_headline_from_multiple_tool_calls() {
         let tool_calls = vec![
             ToolCall {
@@ -963,6 +981,34 @@ mod tests {
                 Some("uk-UA"),
             ),
             "Запустив `npm test`"
+        );
+    }
+
+    #[test]
+    fn renders_ukrainian_bash_narration_with_commands_arg() {
+        let tool_call = ToolCall {
+            id: "call_1".to_string(),
+            name: "bash".to_string(),
+            arguments: json!({ "commands": "echo hi" }),
+        };
+
+        assert_eq!(
+            render_tool_narration_with_locale(
+                None,
+                &tool_call,
+                ToolNarrationPhase::Started,
+                Some("uk-UA"),
+            ),
+            "Запускаю `echo hi`"
+        );
+        assert_eq!(
+            render_tool_narration_with_locale(
+                None,
+                &tool_call,
+                ToolNarrationPhase::Completed,
+                Some("uk-UA"),
+            ),
+            "Запустив `echo hi`"
         );
     }
 


### PR DESCRIPTION
### Motivation
- A recent change made the Bash tool require the `commands` argument, but narration still looked up the legacy `command` key, causing shell tool narration to fall back to a generic tool name and lose visibility into what was executed.
- The intent is to restore observability by making narration prefer the new `commands` field while still accepting the legacy `command` key for compatibility.

### Description
- Update both the default and Ukrainian narration paths in `crates/core/src/tool_narration.rs` to extract shell commands with `arg_str(args, &["commands", "command"])` so `commands` is preferred and `command` is a fallback.
- Add unit tests `renders_bash_narration_with_commands_arg` and `renders_ukrainian_bash_narration_with_commands_arg` to cover English and Ukrainian narration when callers supply `commands`.
- Change is narration-only and contained to `crates/core/src/tool_narration.rs` without altering execution behavior.

### Testing
- Ran `cargo test -p everruns-core tool_narration` and the updated tests passed (14 passed, 0 failed) in the `everruns-core` test set.
- No other behavioral or security-impacting changes were introduced and the change is low risk as it only affects display/narration logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaad3a2770832b9422680c527319d4)