### PR TITLE
fix(setup): avoid top-level local in Linux NATS install

### DIFF
--- a/scripts/lib/setup.sh
+++ b/scripts/lib/setup.sh
@@ -138,8 +138,8 @@ case "$cmd" in
           ;;
         Linux)
           # Download pre-built nats-server binary (pinned version, no curl|sh)
-          local nats_version="2.11.3"
-          local arch
+          nats_version="2.11.3"
+          arch=""
           arch=$(uname -m)
           case "$arch" in
             x86_64)  arch="amd64" ;;
@@ -147,12 +147,12 @@ case "$cmd" in
             *)       arch="" ;;
           esac
           if [ -n "$arch" ] && command -v curl &> /dev/null; then
-            local nats_url="https://github.com/nats-io/nats-server/releases/download/v${nats_version}/nats-server-v${nats_version}-linux-${arch}.tar.gz"
-            local tmp_dir
+            nats_url="https://github.com/nats-io/nats-server/releases/download/v${nats_version}/nats-server-v${nats_version}-linux-${arch}.tar.gz"
+            tmp_dir=""
             tmp_dir=$(mktemp -d)
             if curl -fsSL "$nats_url" -o "$tmp_dir/nats.tar.gz" 2>/dev/null; then
               tar -xzf "$tmp_dir/nats.tar.gz" -C "$tmp_dir" 2>/dev/null
-              local nats_bin
+              nats_bin=""
               nats_bin=$(find "$tmp_dir" -name nats-server -type f | head -1)
               if [ -n "$nats_bin" ]; then
                 mkdir -p "$HOME/.local/bin"


### PR DESCRIPTION
### Motivation
- Prevent `just init` from aborting on Linux when `scripts/lib/setup.sh` is sourced with `set -euo pipefail` because top-level `local` is invalid outside a function.

### Description
- Replace top-level `local` declarations in the Linux NATS install block of `scripts/lib/setup.sh` with ordinary shell variable assignments (`nats_version`, `arch`, `nats_url`, `tmp_dir`, `nats_bin`) while preserving the original install logic and version pin.

### Testing
- Ran a syntax check with `bash -n scripts/lib/setup.sh`, which succeeded.
- Verified via `rg` that the previous top-level `local` usages for the affected NATS variables are gone.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaad3a8bec832b9de3c7f63a689992)