### PR TITLE
fix(server): preserve activity type in NATS notifications

### DIFF
--- a/crates/server/src/nats_task_notifications.rs
+++ b/crates/server/src/nats_task_notifications.rs
@@ -21,6 +21,14 @@ use crate::task_notifications::{TaskNotificationPayload, WorkerSubscription};
 /// NATS subject prefix for task availability notifications
 const NATS_TASK_SUBJECT_PREFIX: &str = "task.available";
 
+fn activity_type_from_message(subject: &str, payload: &[u8], prefix: &str) -> String {
+    std::str::from_utf8(payload)
+        .ok()
+        .filter(|activity_type| !activity_type.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| subject.strip_prefix(prefix).unwrap_or(subject).to_string())
+}
+
 /// NATS-backed task notification broadcaster.
 /// Same public API as `TaskNotificationBroadcaster` — drop-in replacement.
 pub struct NatsTaskNotificationBroadcaster {
@@ -175,10 +183,8 @@ impl NatsTaskNotificationBroadcaster {
                     msg = subscription.next() => {
                         match msg {
                             Some(msg) => {
-                                let activity_type = msg.subject
-                                    .strip_prefix(&prefix)
-                                    .unwrap_or(&msg.subject)
-                                    .to_string();
+                                let activity_type =
+                                    activity_type_from_message(&msg.subject, &msg.payload, &prefix);
 
                                 debug!(activity_type = %activity_type, "NATS task notification received");
 
@@ -202,6 +208,30 @@ impl NatsTaskNotificationBroadcaster {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::activity_type_from_message;
+
+    #[test]
+    fn uses_payload_activity_type_when_available() {
+        let activity_type = activity_type_from_message(
+            "task.available.email_send_batch",
+            b"email.send batch",
+            "task.available.",
+        );
+
+        assert_eq!(activity_type, "email.send batch");
+    }
+
+    #[test]
+    fn falls_back_to_subject_suffix_when_payload_invalid() {
+        let activity_type =
+            activity_type_from_message("task.available.foo", &[0xFF], "task.available.");
+
+        assert_eq!(activity_type, "foo");
     }
 }
 

--- a/crates/server/src/nats_task_notifications.rs
+++ b/crates/server/src/nats_task_notifications.rs
@@ -211,6 +211,12 @@ impl NatsTaskNotificationBroadcaster {
     }
 }
 
+impl Drop for NatsTaskNotificationBroadcaster {
+    fn drop(&mut self) {
+        let _ = self.shutdown_tx.try_send(());
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::activity_type_from_message;
@@ -232,11 +238,5 @@ mod tests {
             activity_type_from_message("task.available.foo", &[0xFF], "task.available.");
 
         assert_eq!(activity_type, "foo");
-    }
-}
-
-impl Drop for NatsTaskNotificationBroadcaster {
-    fn drop(&mut self) {
-        let _ = self.shutdown_tx.try_send(());
     }
 }


### PR DESCRIPTION
### Motivation
- The NATS publisher sanitized `activity_type` into the subject, but the listener rebuilt `activity_type` from the sanitized subject suffix which remapped values containing `.`, `*`, `>`, or spaces and caused worker subscription mismatches and dropped notifications.

### Description
- Added `activity_type_from_message(subject, payload, prefix)` which prefers the UTF-8 `payload` value when non-empty and falls back to the subject suffix only when the payload is invalid or empty.
- Updated the NATS listener to use the new helper so the original `activity_type` (payload) is the canonical source of truth.
- Kept the existing sanitized subject publishing behavior unchanged to preserve compatibility with NATS subject constraints.
- Added focused unit tests validating payload-first decoding and the subject-suffix fallback.

### Testing
- Ran the module unit tests with `cargo test -p everruns-server --lib nats_task_notifications::tests` and both new tests passed.
- Ran `cargo fmt --check` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaad3a64a8832b9cb8ca5416746bc1)