### PR TITLE
fix(ci): avoid exposing PAT in homebrew tap clone

### DIFF
--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -166,9 +166,25 @@ jobs:
 
           # Fetch the GitHub PAT from Doppler (has push access to homebrew-tap)
           GH_PAT=$(doppler secrets get GITHUB_TOKEN --plain)
+          echo "::add-mask::${GH_PAT}"
+
+          # Use askpass instead of embedding credentials in the clone URL
+          ASKPASS_SCRIPT="$(mktemp)"
+          cat > "${ASKPASS_SCRIPT}" <<'EOF'
+          #!/usr/bin/env sh
+          case "$1" in
+            *Username*) echo "x-access-token" ;;
+            *Password*) echo "${GH_PAT}" ;;
+          esac
+          EOF
+          chmod 700 "${ASKPASS_SCRIPT}"
+          trap 'rm -f "${ASKPASS_SCRIPT}"' EXIT
+          export GH_PAT
+          export GIT_ASKPASS="${ASKPASS_SCRIPT}"
+          export GIT_TERMINAL_PROMPT=0
 
           # Clone the tap repo
-          git clone "https://x-access-token:${GH_PAT}@github.com/everruns/homebrew-tap.git" tap
+          git clone "https://github.com/everruns/homebrew-tap.git" tap
           cp everruns.rb tap/Formula/everruns.rb
 
           cd tap


### PR DESCRIPTION
### Motivation
- Prevent accidental disclosure of the Doppler-fetched GitHub PAT that was previously embedded in the `git clone` URL in the `cli-binaries` workflow, which can leak to CI logs on error.

### Description
- Add `::add-mask::` for the fetched PAT and switch authentication to a temporary `GIT_ASKPASS` script while cloning `https://github.com/everruns/homebrew-tap.git` so the token is not present in the remote URL, and ensure the askpass script is cleaned up with a `trap`.

### Testing
- Ran `just pre-push` locally (formatting step completed successfully and linting steps started in the session but full run output did not complete in this environment). 
- Ran `git diff --check HEAD~1..HEAD`, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaad3aed78832bb612b26c3cbd5444)