### PR TITLE
fix(worker): block pending takeover with claimed tasks

### DIFF
--- a/crates/durable/src/persistence/memory.rs
+++ b/crates/durable/src/persistence/memory.rs
@@ -643,6 +643,17 @@ impl WorkflowEventStore for InMemoryWorkflowEventStore {
     }
 
     async fn try_claim_workflow_for_new_turn(&self, workflow_id: Uuid) -> Result<bool, StoreError> {
+        {
+            let tasks = self.tasks.read();
+            let has_claimed_task = tasks.values().any(|task| {
+                task.definition.workflow_id == Some(workflow_id)
+                    && task.status == TaskStatus::Claimed
+            });
+            if has_claimed_task {
+                return Ok(false);
+            }
+        }
+
         let mut workflows = self.workflows.write();
         let workflow = workflows
             .get_mut(&workflow_id)

--- a/crates/durable/src/persistence/postgres.rs
+++ b/crates/durable/src/persistence/postgres.rs
@@ -951,6 +951,29 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
             return Ok(false);
         }
 
+        let has_claimed_task = sqlx::query_scalar::<_, bool>(
+            r#"
+            SELECT EXISTS(
+                SELECT 1
+                FROM durable_task_queue
+                WHERE workflow_id = $1
+                  AND status = 'claimed'
+            )
+            "#,
+        )
+        .bind(workflow_id)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|e| {
+            error!("Failed to check claimed workflow tasks: {}", e);
+            StoreError::Database(e.to_string())
+        })?;
+
+        if has_claimed_task {
+            tx.rollback().await.ok();
+            return Ok(false);
+        }
+
         // Claim: set to running, clear transient fields
         sqlx::query(
             r#"

--- a/crates/worker/src/durable_runner.rs
+++ b/crates/worker/src/durable_runner.rs
@@ -760,6 +760,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn start_run_steers_pending_workflow_with_claimed_task() {
+        let shared = Arc::new(InMemoryWorkflowEventStore::new());
+        let workflow_id = Uuid::now_v7();
+        shared
+            .create_workflow(workflow_id, "turn_workflow", serde_json::json!({}), None)
+            .await
+            .expect("create workflow");
+        shared
+            .update_workflow_status(workflow_id, WorkflowStatus::Pending, None, None)
+            .await
+            .expect("mark pending");
+        shared
+            .enqueue_task(
+                everruns_durable::TaskDefinition {
+                    workflow_id: Some(workflow_id),
+                    activity_id: format!("input_{}", Uuid::now_v7()),
+                    activity_type: "process_input".to_string(),
+                    input: serde_json::json!({}),
+                    options: Default::default(),
+                },
+            )
+            .await
+            .expect("enqueue task");
+        let claimed = shared
+            .claim_task("worker-1", &["process_input".to_string()], 1)
+            .await
+            .expect("claim task");
+        assert_eq!(claimed.len(), 1);
+
+        let runner = DurableRunner::new_with_shared_store(shared.clone());
+        let session_id = SessionId::from_uuid(workflow_id);
+
+        runner
+            .start_run(
+                1,
+                session_id,
+                HarnessId::new(),
+                None,
+                MessageId::new(),
+                None,
+            )
+            .await
+            .expect("start_run should send steering signal");
+
+        let signals = shared
+            .consume_pending_signals(workflow_id)
+            .await
+            .expect("signals should load");
+        assert_eq!(signals.len(), 1);
+        assert_eq!(
+            signals[0].signal_type,
+            everruns_durable::signal_types::USER_MESSAGE
+        );
+
+        let additional_claimed = shared
+            .claim_task("worker-2", &["process_input".to_string()], 10)
+            .await
+            .expect("no additional process_input tasks should be available");
+        assert!(additional_claimed.is_empty());
+    }
+
+    #[tokio::test]
     async fn resume_after_tool_results_enqueues_reason() {
         let shared = Arc::new(InMemoryWorkflowEventStore::new());
         let session_id = SessionId::new();

--- a/crates/worker/src/durable_runner.rs
+++ b/crates/worker/src/durable_runner.rs
@@ -772,15 +772,13 @@ mod tests {
             .await
             .expect("mark pending");
         shared
-            .enqueue_task(
-                everruns_durable::TaskDefinition {
-                    workflow_id: Some(workflow_id),
-                    activity_id: format!("input_{}", Uuid::now_v7()),
-                    activity_type: "process_input".to_string(),
-                    input: serde_json::json!({}),
-                    options: Default::default(),
-                },
-            )
+            .enqueue_task(everruns_durable::TaskDefinition {
+                workflow_id: Some(workflow_id),
+                activity_id: format!("input_{}", Uuid::now_v7()),
+                activity_type: "process_input".to_string(),
+                input: serde_json::json!({}),
+                options: Default::default(),
+            })
             .await
             .expect("enqueue task");
         let claimed = shared


### PR DESCRIPTION
### Motivation
- `start_run` could treat a `Pending` workflow as takeover-safe and enqueue a new task while an earlier task had already been claimed, allowing parallel execution for the same workflow.
- The store cancellation API only removes pending (unclaimed) tasks, so a claimed-but-still-Pending workflow would be vulnerable to overlap.

### Description
- Add a claimed-task guard in `try_claim_workflow_for_new_turn` for the in-memory store by checking for any `TaskStatus::Claimed` tasks for the workflow and returning `Ok(false)` if found (`crates/durable/src/persistence/memory.rs`).
- Add the same guard in the Postgres store inside the claim transaction using `SELECT EXISTS(...)` to detect claimed tasks and abort the claim when present (`crates/durable/src/persistence/postgres.rs`).
- Add a regression unit test that constructs a `Pending` workflow with an enqueued and claimed `process_input` task and verifies `start_run` sends a steering signal and does not make another `process_input` task claimable (`crates/worker/src/durable_runner.rs`).

### Testing
- Ran `cargo fmt` successfully.
- Ran focused unit tests in the worker crate: `cargo test -p everruns-worker start_run_steers_pending_workflow_with_claimed_task` which passed.
- Ran the worker steering tests prefix `cargo test -p everruns-worker start_run_steers_` which passed (both the Running and Pending-with-claimed-task steering tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaad3ae3f0832b94a99e8a39eb7e91)