### PR TITLE
fix(ui): sync org cookie on automatic org fallback

### DIFF
--- a/apps/ui/src/__tests__/org-provider.test.tsx
+++ b/apps/ui/src/__tests__/org-provider.test.tsx
@@ -244,7 +244,6 @@ describe("OrgProvider", () => {
     expect(mockPush).not.toHaveBeenCalled();
   });
 
-
   it("syncs cookie when current org auto-falls back after org list refresh", async () => {
     storageMap.set("everruns_current_org", SECOND_ORG.public_id);
     mockInitialOrgId = SECOND_ORG.public_id;

--- a/apps/ui/src/__tests__/org-provider.test.tsx
+++ b/apps/ui/src/__tests__/org-provider.test.tsx
@@ -244,6 +244,33 @@ describe("OrgProvider", () => {
     expect(mockPush).not.toHaveBeenCalled();
   });
 
+
+  it("syncs cookie when current org auto-falls back after org list refresh", async () => {
+    storageMap.set("everruns_current_org", SECOND_ORG.public_id);
+    mockInitialOrgId = SECOND_ORG.public_id;
+    mockUser = { organizations: [DEFAULT_ORG, SECOND_ORG] };
+    mockAuthLoading = false;
+
+    const { result, rerender } = renderHook(() => useOrg(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.currentOrg?.public_id).toBe(SECOND_ORG.public_id);
+    });
+
+    mockSwitchOrg.mockClear();
+
+    // Simulate membership update removing current org; provider should
+    // auto-fallback and resync cookie for the new org.
+    mockUser = { organizations: [DEFAULT_ORG] };
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.currentOrg?.public_id).toBe(DEFAULT_ORG.public_id);
+    });
+
+    expect(mockSwitchOrg).toHaveBeenCalledWith(DEFAULT_ORG.public_id);
+  });
+
   it("restores org from localStorage on init", () => {
     storageMap.set("everruns_current_org", SECOND_ORG.public_id);
     mockUser = { organizations: [DEFAULT_ORG, SECOND_ORG] };

--- a/apps/ui/src/providers/org-provider.tsx
+++ b/apps/ui/src/providers/org-provider.tsx
@@ -151,7 +151,13 @@ export function OrgProvider({ children, initialOrgId = null }: OrgProviderProps)
         return;
       }
       const defaultOrg = organizations.find((org) => org.public_id === DEFAULT_ORG_PUBLIC_ID);
-      setCurrentOrgState(defaultOrg ?? organizations[0]);
+      const nextOrg = defaultOrg ?? organizations[0];
+      setCurrentOrgState(nextOrg);
+      // Keep server-side org cookie in sync for non-explicit org changes
+      // (e.g. membership removal, login org-list refresh).
+      void switchOrgApi(nextOrg.public_id).catch((error) => {
+        console.warn("Failed to sync org cookie after automatic org update:", error);
+      });
     } else {
       // Org found in list — clear the explicit flag since we're in sync.
       if (explicitOrgRef.current === currentOrg?.public_id) {

--- a/apps/ui/src/providers/org-provider.tsx
+++ b/apps/ui/src/providers/org-provider.tsx
@@ -127,7 +127,13 @@ export function OrgProvider({ children, initialOrgId = null }: OrgProviderProps)
     // Fall back to default org or first available org
     if (organizations.length > 0) {
       const defaultOrg = organizations.find((org) => org.public_id === DEFAULT_ORG_PUBLIC_ID);
-      setCurrentOrgState(defaultOrg ?? organizations[0]);
+      const nextOrg = defaultOrg ?? organizations[0];
+      setCurrentOrgState(nextOrg);
+      // Keep server-side org cookie in sync for non-explicit org changes
+      // (e.g. membership removal, login org-list refresh).
+      void switchOrgApi(nextOrg.public_id).catch((error) => {
+        console.warn("Failed to sync org cookie after automatic org update:", error);
+      });
     }
 
     setIsInitialized(true);


### PR DESCRIPTION
### Motivation
- Automatic updates to `currentOrg` (e.g., after login or membership changes) could update client state without syncing the server-side `everruns_org` cookie, leaving the browser scoped to the old org and causing mis-scoped or 404 responses.
- The change restores cookie sync for non-explicit fallback paths to keep server scoping consistent with the UI state.

### Description
- In `apps/ui/src/providers/org-provider.tsx`, when the provider selects the initial fallback org, call `switchOrgApi(nextOrg.public_id)` fire-and-forget so the server cookie is kept in sync with the client on automatic fallback. 
- Added a regression test in `apps/ui/src/__tests__/org-provider.test.tsx` that starts on one org, simulates an org-list refresh that removes the active org, and asserts `switchOrg` is invoked for the fallback org.
- Retained existing behavior for explicit user-initiated switches (they remain atomic and await `switchOrgApi`).

### Testing
- Added a unit test `it("syncs cookie when current org auto-falls back after org list refresh")` under `apps/ui/src/__tests__/org-provider.test.tsx` (not executed in this environment).
- Attempted to run `cd apps/ui && npm test -- org-provider.test.tsx` but it failed with `jest: not found` so tests could not be executed here (exit 127).
- `git fetch origin main` also failed in this environment due to no configured `origin` remote, so no remote merge verification was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaad3a3b08832b9b5217c93d9b87bd)