### PR TITLE
fix(skills): preserve disable-model-invocation on update

### DIFF
--- a/crates/server/src/domains/skills/commands.rs
+++ b/crates/server/src/domains/skills/commands.rs
@@ -380,12 +380,23 @@ impl Command for UpdateSkillCmd {
                 )));
             }
 
+            let mut metadata_map = parsed.metadata.clone();
+            if !parsed.user_invocable {
+                metadata_map.insert("user_invocable".to_string(), serde_json::Value::Bool(false));
+            }
+            if parsed.disable_model_invocation {
+                metadata_map.insert(
+                    "disable_model_invocation".to_string(),
+                    serde_json::Value::Bool(true),
+                );
+            }
+
             input.name = Some(parsed.name);
             input.description = Some(parsed.description);
             input.license = parsed.license;
             input.compatibility = parsed.compatibility;
             input.metadata = Some(
-                serde_json::to_value(&parsed.metadata)
+                serde_json::to_value(&metadata_map)
                     .map_err(|e| CommandError::Internal(e.into()))?,
             );
             input.allowed_tools = parsed.allowed_tools;

--- a/crates/server/tests/skills_integration_test.rs
+++ b/crates/server/tests/skills_integration_test.rs
@@ -125,6 +125,49 @@ async fn test_update_skill() {
 }
 
 #[tokio::test]
+async fn test_update_skill_preserves_disable_model_invocation_flag() {
+    let server = TestServer::new().await;
+
+    let skill_md = "---
+name: model-invocation-flag-test
+description: Test disable-model-invocation persistence.
+disable-model-invocation: true
+---
+
+# Test
+";
+    let create_resp = server
+        .post("/v1/skills", json!({ "skill_md": skill_md }))
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    let created_body = create_resp.json_value();
+    assert_eq!(created_body["disable_model_invocation"], true);
+
+    let skill_id = created_body["id"].as_str().unwrap().to_string();
+
+    let updated_md = "---
+name: model-invocation-flag-test
+description: Updated description.
+disable-model-invocation: true
+---
+
+# Updated
+";
+    let update_resp = server
+        .patch(
+            &format!("/v1/skills/{skill_id}"),
+            json!({ "skill_md": updated_md }),
+        )
+        .await
+        .assert_success();
+
+    let updated_body = update_resp.json_value();
+    assert_eq!(updated_body["description"], "Updated description.");
+    assert_eq!(updated_body["disable_model_invocation"], true);
+}
+
+#[tokio::test]
 async fn test_update_skill_status() {
     let server = TestServer::new().await;
 


### PR DESCRIPTION
### Motivation
- Creating a skill persisted the `disable_model_invocation` frontmatter flag into the DB metadata but updating a skill rebuilt metadata from `parsed.metadata` only, which omits the frontmatter flags and caused the flag to be dropped on edits.
- This silently reverted explicit invocation controls after SKILL.md edits and made `disable-model-invocation` ineffective on updates.

### Description
- In the skill update path, build `metadata_map` from `parsed.metadata` and re-insert frontmatter-derived flags (`user_invocable = false` and `disable_model_invocation = true`) before serializing into `input.metadata` so update behavior matches create/archive paths.
- Modified `crates/server/src/domains/skills/commands.rs` to preserve these flags when `skill_md` is provided.
- Added an integration test in `crates/server/tests/skills_integration_test.rs` that creates a skill with `disable-model-invocation: true`, updates it via `skill_md`, and asserts the flag remains `true` after update.

### Testing
- Added `test_update_skill_preserves_disable_model_invocation_flag` integration test to cover create+update persistence of the flag; the test is included in the change.
- Ran `cargo fmt --all` to apply formatting checks in this environment.
- Attempted to run `cargo test -p everruns-server test_update_skill_preserves_disable_model_invocation_flag -- --exact`, but the test run did not complete in this session due to lengthy toolchain/dependency installation; the test has been added and should be run in CI or a full local environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaad3884bc832ba618bcef5092fff7)