### PR TITLE
fix(ui): avoid render-phase state updates in command and file views

### DIFF
--- a/apps/ui/src/components/chat/command-autocomplete.tsx
+++ b/apps/ui/src/components/chat/command-autocomplete.tsx
@@ -30,12 +30,10 @@ export function CommandAutocomplete({
       cmd.name.toLowerCase().includes(query) || cmd.description.toLowerCase().includes(query),
   );
 
-  // Reset selection when filter changes — derived inline, no effect needed.
-  const prevQueryRef = useRef(query);
-  if (prevQueryRef.current !== query) {
-    prevQueryRef.current = query;
+  // Reset selection when filter changes.
+  useEffect(() => {
     setSelectedIndex(0);
-  }
+  }, [query]);
 
   // Scroll selected item into view
   useEffect(() => {

--- a/apps/ui/src/components/command-palette.tsx
+++ b/apps/ui/src/components/command-palette.tsx
@@ -95,12 +95,10 @@ export function CommandPalette() {
     }
   }, [open]);
 
-  // Reset selected index when query changes — derived inline, no effect needed.
-  const prevQueryRef = useRef(query);
-  if (prevQueryRef.current !== query) {
-    prevQueryRef.current = query;
+  // Reset selected index when query changes.
+  useEffect(() => {
     setSelectedIndex(0);
-  }
+  }, [query]);
 
   const navigate = useCallback(
     (result: SearchResult) => {

--- a/apps/ui/src/components/files/file-browser.tsx
+++ b/apps/ui/src/components/files/file-browser.tsx
@@ -129,10 +129,14 @@ export function FileBrowser({
   const createDir = useCreateDirectory();
   const deleteFile = useDeleteFile();
 
-  // Sync root files into loadedDirs inline — no effect needed for derived state.
-  if (rootFiles && loadedDirs.get("/workspace") !== rootFiles) {
-    setLoadedDirs((prev) => new Map(prev).set("/workspace", rootFiles));
-  }
+  // Sync root files into loadedDirs when root data changes.
+  useEffect(() => {
+    if (!rootFiles) return;
+    setLoadedDirs((prev) => {
+      if (prev.get("/workspace") === rootFiles) return prev;
+      return new Map(prev).set("/workspace", rootFiles);
+    });
+  }, [rootFiles]);
 
   // Auto-refresh when Workspace tab becomes active (component remounts on tab switch)
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- A recent refactor moved derived-state synchronization into render time, introducing guarded `setState` calls during render that can cause "Too many re-renders" when derived inputs are referentially unstable; this change restores effect-based syncing to avoid render-phase updates.

### Description
- `CommandAutocomplete`: reset `selectedIndex` in a `useEffect` keyed by `query` instead of calling `setSelectedIndex` during render.
- `CommandPalette`: reset `selectedIndex` in a `useEffect` keyed by `query` instead of performing the update inline during render.
- `FileBrowser`: move syncing of `rootFiles` into `loadedDirs` into a `useEffect` keyed by `rootFiles` and return the previous `Map` when the entry is already identical to avoid unnecessary updates.
- Behavior is preserved; changes simply move derived-state updates into lifecycle effects to prevent render-phase state changes.

### Testing
- Ran `cd apps/ui && npm ci --ignore-scripts` which completed successfully.
- Ran `cd apps/ui && npm run lint` which completed with warnings but no errors.
- Ran `cd apps/ui && npm test -- --runInBand` and all test suites passed (67 suites, 657 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaad394d5c832b88722b394413f80b)