### PR TITLE
fix(ui): keep live usage updating after SSE trim cap

### DIFF
--- a/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
@@ -475,7 +475,9 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
   // Incremental token usage accumulation — O(1) per new event instead of O(n).
   // Tracks how many events have been processed so only new events are scanned.
   const usageRef = useRef({
-    processed: 0,
+    sessionId: session?.id,
+    maxSequenceProcessed: -1,
+    processedIdsWithoutSequence: new Set<string>(),
     inputTokens: 0,
     outputTokens: 0,
     cacheReadTokens: 0,
@@ -483,10 +485,12 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
     hasLlmEvents: false,
   });
 
-  // Reset accumulator when events array shrinks (session change or trimming)
-  if (events.length < usageRef.current.processed) {
+  // Reset accumulator when switching sessions.
+  if (usageRef.current.sessionId !== session?.id) {
     usageRef.current = {
-      processed: 0,
+      sessionId: session?.id,
+      maxSequenceProcessed: -1,
+      processedIdsWithoutSequence: new Set<string>(),
       inputTokens: 0,
       outputTokens: 0,
       cacheReadTokens: 0,
@@ -502,9 +506,16 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
 
     const acc = usageRef.current;
 
-    // Only scan events we haven't processed yet
-    for (let i = acc.processed; i < events.length; i++) {
-      const event = events[i];
+    // Scan only events that are newer than what we've already accumulated.
+    for (const event of events) {
+      const eventSequence = event.sequence ?? null;
+      if (eventSequence != null && eventSequence <= acc.maxSequenceProcessed) {
+        continue;
+      }
+      if (eventSequence == null && acc.processedIdsWithoutSequence.has(event.id)) {
+        continue;
+      }
+
       const llmData = getEventData(event, "llm.generation");
       if (llmData?.metadata?.usage) {
         acc.hasLlmEvents = true;
@@ -513,8 +524,13 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
         acc.cacheReadTokens += llmData.metadata.usage.cache_read_tokens ?? 0;
         acc.cacheCreationTokens += llmData.metadata.usage.cache_creation_tokens ?? 0;
       }
+
+      if (eventSequence != null) {
+        acc.maxSequenceProcessed = Math.max(acc.maxSequenceProcessed, eventSequence);
+      } else {
+        acc.processedIdsWithoutSequence.add(event.id);
+      }
     }
-    acc.processed = events.length;
 
     if (acc.hasLlmEvents) {
       return {


### PR DESCRIPTION
### Motivation
- Fix a functional regression where live token usage stopped updating once the in-memory SSE event list hit its cap and began trimming old events.
- The previous accumulator relied on `events.length` growth and therefore skipped newly appended events when the array length remained constant at the cap.

### Description
- Replace index-based `processed` tracking with event-freshness tracking by adding `maxSequenceProcessed` for sequenced events and `processedIdsWithoutSequence` for unsequenced events in `usageRef` in `apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx`.
- Reset the accumulator on session switches by tracking `sessionId` in `usageRef` so state does not carry across sessions.
- Iterate events and only accumulate usage for events that are newer than the tracked sequence or whose IDs were not seen, and update the freshness trackers as events are processed.
- Preserve existing fallback behavior of returning `session?.usage` when no streamed usage is present.

### Testing
- Ran `npm -C apps/ui run lint`, which failed in the environment due to the `oxlint` binary not being available, so lint could not be validated here.
- Repository sync (`git fetch origin main && git rebase origin/main`) could not be performed in this environment because the `origin` remote is not configured.
- No unit or integration tests were executed in this environment; change is limited to UI token-accumulation logic and should be covered by UI/behavioral tests in CI or local `just pre-push` flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaad387318832bad294256724cc2be)