### PR TITLE
fix(storage): preserve forward in-memory event catch-up window

### DIFF
--- a/crates/server/src/storage/memory/events.rs
+++ b/crates/server/src/storage/memory/events.rs
@@ -95,11 +95,22 @@ impl InMemoryDatabase {
 
         result.sort_by_key(|e| e.sequence);
 
-        // Apply limit: take last N events (backward pagination).
-        // Safety cap of 10 000 when no explicit limit to prevent unbounded results.
-        let effective_limit = limit.map(|l| l as usize).unwrap_or(10_000);
-        if result.len() > effective_limit {
-            result = result.split_off(result.len() - effective_limit);
+        // Apply limit.
+        // - Explicit limit keeps backward pagination behavior (most recent N).
+        // - Implicit safety cap (no explicit limit) keeps forward catch-up semantics:
+        //   return the earliest rows first so callers can advance cursors safely.
+        const FORWARD_SAFETY_LIMIT: usize = 10_000;
+        if let Some(limit) = limit {
+            let limit = limit as usize;
+            if result.len() > limit {
+                result = result.split_off(result.len() - limit);
+            }
+        } else if result.len() > FORWARD_SAFETY_LIMIT {
+            if since_id.is_some() || since_sequence.is_some() {
+                result.truncate(FORWARD_SAFETY_LIMIT);
+            } else {
+                result = result.split_off(result.len() - FORWARD_SAFETY_LIMIT);
+            }
         }
 
         Ok(result)

--- a/crates/server/src/storage/memory/tests.rs
+++ b/crates/server/src/storage/memory/tests.rs
@@ -649,7 +649,7 @@ async fn test_list_events_default_cap_keeps_earliest_forward_window() {
     }
 
     let all_events = db
-        .list_events(session_id, None, None, &[], &[], None, None)
+        .list_events(session_id, None, None, &[], &[], Some(20_000), None)
         .await
         .unwrap();
     assert!(all_events.len() > 10_000);

--- a/crates/server/src/storage/memory/tests.rs
+++ b/crates/server/src/storage/memory/tests.rs
@@ -649,7 +649,7 @@ async fn test_list_events_default_cap_keeps_earliest_forward_window() {
     }
 
     let all_events = db
-        .list_events(session_id, None, None, &[], &[], Some(20_000), None)
+        .list_events(session_id, None, None, &[], &[], None, Some(20_000))
         .await
         .unwrap();
     assert!(all_events.len() > 10_000);

--- a/crates/server/src/storage/memory/tests.rs
+++ b/crates/server/src/storage/memory/tests.rs
@@ -629,6 +629,53 @@ async fn test_list_events_since_id_takes_precedence_over_since_sequence() {
 }
 
 #[tokio::test]
+async fn test_list_events_default_cap_keeps_earliest_forward_window() {
+    let db = InMemoryDatabase::new();
+    let session_id = create_session_with_events(&db).await;
+
+    // Add enough events so forward catch-up exceeds the implicit 10k safety cap.
+    for _ in 0..10_010 {
+        db.create_event(CreateEventRow {
+            session_id,
+            event_type: "output.message.delta".to_string(),
+            ts: Utc::now(),
+            context: serde_json::json!({}),
+            data: serde_json::json!({}),
+            metadata: None,
+            tags: None,
+        })
+        .await
+        .unwrap();
+    }
+
+    let all_events = db
+        .list_events(session_id, None, None, &[], &[], None, None)
+        .await
+        .unwrap();
+    assert!(all_events.len() > 10_000);
+
+    // Simulate SSE catch-up by querying with since_id and no explicit limit.
+    let second_event_id = all_events[1].id;
+    let events = db
+        .list_events(
+            session_id,
+            None,
+            Some(second_event_id),
+            &[],
+            &[],
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(events.len(), 10_000);
+    // Forward path must return the earliest page after the cursor, not the newest page.
+    assert_eq!(events[0].sequence, all_events[2].sequence);
+    assert_eq!(events.last().unwrap().sequence, all_events[10_001].sequence);
+}
+
+#[tokio::test]
 async fn test_list_events_with_limit() {
     let db = InMemoryDatabase::new();
     let session_id = create_session_with_events(&db).await;


### PR DESCRIPTION
### Motivation
- The in-memory `list_events` implicit 10k cap previously kept the newest N rows which causes forward (SSE catch-up) queries using `since_id`/`since_sequence` to skip older undelivered events.

### Description
- Update `crates/server/src/storage/memory/events.rs` so explicit `limit: Some(_)` preserves backward-pagination behavior (keep most recent N), while implicit cap (`limit: None`) preserves forward catch-up semantics by keeping the earliest page when `since_id`/`since_sequence` is used (`FORWARD_SAFETY_LIMIT = 10_000`).
- When no cursor is provided and no explicit limit, the original behavior of returning the most recent N rows is retained.
- Add a regression test `test_list_events_default_cap_keeps_earliest_forward_window` in `crates/server/src/storage/memory/tests.rs` that creates >10k events and verifies `since_id` + no explicit limit returns the earliest forward window.

### Testing
- Ran `cargo fmt --check` which succeeded.
- Added unit test `test_list_events_default_cap_keeps_earliest_forward_window` under `crates/server/src/storage/memory/tests.rs`.
- Attempted to run `cargo test -p everruns-server test_list_events_default_cap_keeps_earliest_forward_window`, but the compile/test run in this environment downloaded and built many dependencies and was terminated before completing, so the test could not be executed to completion here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaad39804c832ba109335052f139f1)