### PR TITLE
fix(durable): handle snapshot sequence zero correctly

### DIFF
--- a/crates/durable/src/engine/executor.rs
+++ b/crates/durable/src/engine/executor.rs
@@ -252,7 +252,7 @@ impl<S: WorkflowEventStore> WorkflowExecutor<S> {
         // Track the current sequence
         // For snapshot replay: snapshot_seq + events_after.len()
         // For full replay: events.len()
-        let mut current_sequence = if snapshot_seq > 0 {
+        let mut current_sequence = if let Some(snapshot_seq) = snapshot_seq {
             // We replayed events after snapshot; total = last event seq + 1
             events
                 .last()
@@ -263,7 +263,7 @@ impl<S: WorkflowEventStore> WorkflowExecutor<S> {
         };
 
         // For full replay (no snapshot), also need total event count for snapshot decisions
-        let total_event_count = if snapshot_seq > 0 {
+        let total_event_count = if let Some(snapshot_seq) = snapshot_seq {
             // snapshot_seq is 0-indexed, plus events after snapshot
             (snapshot_seq + 1 + events.len() as i32) as usize
         } else {
@@ -531,12 +531,12 @@ impl<S: WorkflowEventStore> WorkflowExecutor<S> {
     /// Load workflow state, using snapshot if available.
     ///
     /// Returns (workflow_instance, events_to_replay, snapshot_sequence).
-    /// snapshot_sequence is 0 if no snapshot was used (full replay).
+    /// `snapshot_sequence` is `None` if no snapshot was used (full replay).
     async fn load_workflow_state(
         &self,
         workflow_id: Uuid,
         workflow_info: &crate::persistence::WorkflowInfo,
-    ) -> Result<(Box<dyn AnyWorkflow>, Vec<(i32, WorkflowEvent)>, i32), ExecutorError> {
+    ) -> Result<(Box<dyn AnyWorkflow>, Vec<(i32, WorkflowEvent)>, Option<i32>), ExecutorError> {
         // Try loading a snapshot first
         let snapshot = self.store.load_latest_snapshot(workflow_id).await?;
 
@@ -584,7 +584,7 @@ impl<S: WorkflowEventStore> WorkflowExecutor<S> {
                     "restored from snapshot"
                 );
 
-                return Ok((restored, events, snap.sequence_num));
+                return Ok((restored, events, Some(snap.sequence_num)));
             }
             // Snapshot restore failed (e.g., workflow doesn't support snapshots)
             // Fall through to full replay
@@ -622,7 +622,7 @@ impl<S: WorkflowEventStore> WorkflowExecutor<S> {
             .registry
             .create(&workflow_info.workflow_type, workflow_info.input.clone())?;
 
-        Ok((workflow, events, 0))
+        Ok((workflow, events, None))
     }
 
     /// Save a snapshot if enough events have accumulated since the last one.
@@ -631,7 +631,7 @@ impl<S: WorkflowEventStore> WorkflowExecutor<S> {
         workflow_id: Uuid,
         workflow: &dyn AnyWorkflow,
         current_sequence: i32,
-        last_snapshot_seq: i32,
+        last_snapshot_seq: Option<i32>,
         total_events: usize,
     ) {
         let interval = self.config.snapshot_interval;
@@ -640,7 +640,7 @@ impl<S: WorkflowEventStore> WorkflowExecutor<S> {
         }
 
         // Only snapshot if enough events since last snapshot
-        let events_since_snapshot = if last_snapshot_seq > 0 {
+        let events_since_snapshot = if let Some(last_snapshot_seq) = last_snapshot_seq {
             current_sequence - last_snapshot_seq
         } else {
             // No previous snapshot — use total event count
@@ -1585,6 +1585,71 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(status, WorkflowStatus::Running);
+    }
+
+    #[tokio::test]
+    async fn test_snapshot_at_sequence_zero_is_treated_as_valid_snapshot() {
+        let executor = snap_executor(InMemoryWorkflowEventStore::new(), 100);
+        let workflow_id = Uuid::now_v7();
+
+        executor
+            .store()
+            .create_workflow(
+                workflow_id,
+                <SnapCounterWorkflow as crate::workflow::Workflow>::TYPE,
+                serde_json::json!({ "start": 0, "target": 10 }),
+                None,
+            )
+            .await
+            .unwrap();
+
+        executor
+            .store()
+            .append_events(
+                workflow_id,
+                0,
+                vec![
+                    WorkflowEvent::WorkflowStarted {
+                        input: serde_json::json!({ "start": 0, "target": 10 }),
+                    },
+                    WorkflowEvent::ActivityScheduled {
+                        activity_id: "increment-0".into(),
+                        activity_type: "increment".into(),
+                        input: serde_json::json!({ "value": 0 }),
+                        options: crate::workflow::ActivityOptions::default(),
+                    },
+                ],
+            )
+            .await
+            .unwrap();
+
+        executor
+            .store()
+            .save_snapshot(
+                workflow_id,
+                0,
+                serde_json::to_vec(&SnapCounterState {
+                    current: 0,
+                    target: 10,
+                    completed: false,
+                    failed: false,
+                    error_message: None,
+                })
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        executor
+            .send_signal(
+                workflow_id,
+                WorkflowSignal::new("noop", serde_json::json!({})),
+            )
+            .await
+            .unwrap();
+
+        let result = executor.process_workflow(workflow_id).await.unwrap();
+        assert_eq!(result.signals_processed, 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- `load_workflow_state` could return a valid snapshot with sequence `0`, but the executor used `0` as a sentinel for “no snapshot”, causing replay bookkeeping to undercount events and leading to `append_events` concurrency conflicts.
- Snapshots at sequence `0` must be treated as a real snapshot boundary so replay, sequence counters, and snapshot interval bookkeeping remain correct.

### Description
- Changed the snapshot sentinel semantics from `i32` to `Option<i32>` so `None` means full replay and `Some(seq)` means a restored snapshot (allowing `Some(0)`).
- Updated `process_workflow` to compute `current_sequence` and `total_event_count` from `Option<i32>` instead of `snapshot_seq > 0` checks.
- Updated `maybe_save_snapshot` to accept `Option<i32>` and correctly compute `events_since_snapshot` when the last snapshot is `Some(0)`.
- Added a regression test `test_snapshot_at_sequence_zero_is_treated_as_valid_snapshot` that saves a snapshot at sequence `0`, sends a signal, and verifies processing succeeds without sequence conflicts.

### Testing
- Ran the new regression test with `cargo test -p everruns-durable test_snapshot_at_sequence_zero_is_treated_as_valid_snapshot`, and it passed (`ok`).
- Ran the crate test suite for `everruns-durable` (unit tests) during development and observed the test run complete successfully for the added test.
- Ran `cargo fmt --all` to ensure formatting; no formatting failures occurred.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaad3877a4832b86efae70099aa07a)