### PR TITLE
fix(server): bound turn-prefix pagination query

### DIFF
--- a/crates/server/src/domains/events/commands.rs
+++ b/crates/server/src/domains/events/commands.rs
@@ -105,6 +105,7 @@ impl Command for ListEvents {
                     .find_turn_boundary(session_id.uuid(), first_seq)
                     .await
                 && turn_seq < first_seq
+                && let Some(prefix_limit) = first_seq.checked_sub(turn_seq)
                 && let Ok(mut prefix) = q::event_service(ctx)?
                     .list(
                         session_id.uuid(),
@@ -113,7 +114,7 @@ impl Command for ListEvents {
                         &self.types,
                         &self.exclude,
                         Some(first_seq),
-                        None,
+                        Some(prefix_limit),
                     )
                     .await
             {


### PR DESCRIPTION
### Motivation
- Prevent unbounded/duplicate results when snapping page boundaries: the prefix fetch used `before_sequence` with `limit=None`, but the Postgres repository only applies `before_sequence` when `limit` is `Some`, which could return far more history than intended.

### Description
- Compute `prefix_limit = first_seq.checked_sub(turn_seq)` and pass `Some(prefix_limit)` into the prefix call to `event_service.list(...)` in `ListEvents` so the turn-boundary prefix fetch is bounded and respects the cursor.

### Testing
- Ran formatter with `cargo fmt --package everruns-server`, which succeeded. 
- Attempted `cargo test -p everruns-server --lib domains::events::commands`, but the build did not complete within the session (large dependency compile), so unit test status is inconclusive.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaad398328832b96bd4028ae333eea)