### PR TITLE
fix(storage): search nested message content in event filters

### DIFF
--- a/crates/server/migrations/006_v0.8.5.sql
+++ b/crates/server/migrations/006_v0.8.5.sql
@@ -12,15 +12,27 @@
 -- Replaces `data::text ILIKE '%query%'` (sequential scan) with a tsvector
 -- generated column + GIN index for indexed full-text search.
 --
--- The search_vector is built from data->>'content' which is the main text
--- field in message-type event JSONB payloads. A partial GIN index covers
--- only message-type events (the only types searched in practice).
+-- The search_vector is built from canonical message text fields in event
+-- payloads. Message events store text under data.message.content (array of
+-- content parts), while some events carry top-level text (delta/content).
+-- A partial GIN index covers only message-type events (the only types
+-- searched in practice).
 
--- Generated tsvector column from the content field in JSONB data
+-- Generated tsvector column from canonical message text fields in JSONB data
 ALTER TABLE events
     ADD COLUMN search_vector tsvector
     GENERATED ALWAYS AS (
-        to_tsvector('english', COALESCE(data->>'content', ''))
+        to_tsvector(
+            'english',
+            COALESCE(
+                data #>> '{message,content}',
+                data #>> '{result}',
+                data->>'content',
+                data->>'delta',
+                data->>'accumulated',
+                ''
+            )
+        )
     ) STORED;
 
 -- GIN index on search_vector, scoped to message-type events
@@ -34,7 +46,7 @@ CREATE INDEX idx_events_search_vector
         'tool.completed'
     );
 
-COMMENT ON COLUMN events.search_vector IS 'Generated tsvector for full-text search on data.content (EVE-87)';
+COMMENT ON COLUMN events.search_vector IS 'Generated tsvector for full-text search on canonical event text fields (EVE-87)';
 
 -- ============================================
 -- Workflow snapshot checkpointing (EVE-86)

--- a/crates/server/src/storage/memory/events.rs
+++ b/crates/server/src/storage/memory/events.rs
@@ -286,10 +286,21 @@ impl InMemoryDatabase {
                             }
                         }
                         MessageFilter::Search(search_query) => {
-                            // Match PostgreSQL tsvector behavior: search data->>'content'
-                            let content =
-                                e.data.get("content").and_then(|v| v.as_str()).unwrap_or("");
-                            if !content
+                            // Match PostgreSQL tsvector behavior: search canonical event text
+                            // fields (message.content/result/content/delta/accumulated).
+                            let searchable = e
+                                .data
+                                .pointer("/message/content")
+                                .or_else(|| e.data.pointer("/result"))
+                                .or_else(|| e.data.get("content"))
+                                .or_else(|| e.data.get("delta"))
+                                .or_else(|| e.data.get("accumulated"))
+                                .map(|v| match v {
+                                    serde_json::Value::String(s) => s.to_string(),
+                                    _ => v.to_string(),
+                                })
+                                .unwrap_or_default();
+                            if !searchable
                                 .to_lowercase()
                                 .contains(&search_query.to_lowercase())
                             {

--- a/crates/server/src/storage/memory/tests.rs
+++ b/crates/server/src/storage/memory/tests.rs
@@ -2002,23 +2002,50 @@ async fn create_session_with_content_events(db: &InMemoryDatabase) -> SessionId 
     let events_data = vec![
         (
             "input.message",
-            serde_json::json!({"content": "Hello, how are you?"}),
+            serde_json::json!({
+                "message": {
+                    "id": "message_01933b5a00007000800000000000001",
+                    "role": "user",
+                    "content": [{"type": "text", "text": "Hello, how are you?"}]
+                }
+            }),
         ),
         (
             "output.message.completed",
-            serde_json::json!({"content": "I am doing great, thank you!"}),
+            serde_json::json!({
+                "message": {
+                    "id": "message_01933b5a00007000800000000000002",
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "I am doing great, thank you!"}]
+                }
+            }),
         ),
         (
             "input.message",
-            serde_json::json!({"content": "Tell me about Rust programming"}),
+            serde_json::json!({
+                "message": {
+                    "id": "message_01933b5a00007000800000000000003",
+                    "role": "user",
+                    "content": [{"type": "text", "text": "Tell me about Rust programming"}]
+                }
+            }),
         ),
         (
             "tool.completed",
-            serde_json::json!({"tool_name": "search", "content": "Rust is a systems language"}),
+            serde_json::json!({
+                "tool_name": "search",
+                "result": [{"type": "text", "text": "Rust is a systems language"}]
+            }),
         ),
         (
             "output.message.completed",
-            serde_json::json!({"content": "Here is information about Rust"}),
+            serde_json::json!({
+                "message": {
+                    "id": "message_01933b5a00007000800000000000004",
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "Here is information about Rust"}]
+                }
+            }),
         ),
         // Event with no content field
         ("turn.started", serde_json::json!({"turn_id": "abc123"})),


### PR DESCRIPTION
### Motivation
- Event full-text search and in-memory search were reading a non-existent top-level `data.content` key, causing message search to miss real message events stored under `data.message.content`.
- Fixing extraction to use canonical message fields restores search functionality for `input.message`, `output.message.completed`, and `tool.completed` events.

### Description
- Updated migration `crates/server/migrations/006_v0.8.5.sql` to generate `search_vector` from canonical text locations using `COALESCE(data #>> '{message,content}', data #>> '{result}', data->>'content', data->>'delta', data->>'accumulated', '')` instead of only `data->>'content'`.
- Updated in-memory filter in `crates/server/src/storage/memory/events.rs` to search the same canonical fields by inspecting `message.content`, `result`, and fallbacks (`content`, `delta`, `accumulated`), serializing JSON values to strings for matching.
- Adjusted in-memory test fixtures in `crates/server/src/storage/memory/tests.rs` to use realistic event payload shapes (`message.content` arrays and `result`) so tests reflect actual stored schema.

### Testing
- Ran formatting check with `cargo fmt --check`, which succeeded.
- Attempted targeted unit tests via `cargo test -p everruns-server test_search_filter_ -- --nocapture`, but the full build/test run did not complete within the session due to large dependency compilation (build in progress); no failing test results observed locally during the attempted run.
- Updated and committed tests that exercise `MessageFilter::Search` in-memory behavior; these tests will run in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaad3862cc832b85226b350590193e)