### PR TITLE
fix(dev): bind Caddy admin API to localhost

### DIFF
--- a/local/Caddyfile
+++ b/local/Caddyfile
@@ -1,7 +1,7 @@
 # Local development reverse proxy
 # Unifies API and UI behind a single port.
 {
-	admin :{$CADDY_ADMIN_PORT:2019}
+	admin localhost:{$CADDY_ADMIN_PORT:2019}
 }
 
 # Recommended:


### PR DESCRIPTION
### Motivation
- Prevent exposing the unauthenticated Caddy admin API on all interfaces in local development by restricting the admin listener to loopback.

### Description
- Updated `local/Caddyfile` to change `admin :{$CADDY_ADMIN_PORT:2019}` to `admin localhost:{$CADDY_ADMIN_PORT:2019}` so the admin endpoint binds to `localhost` only.

### Testing
- Ran `caddy validate --config local/Caddyfile --adapter caddyfile` and the configuration validated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab45f006c832baf31d9885386b229)