### PR TITLE
fix(ui): avoid global chat init when flag disabled

### DIFF
--- a/apps/ui/src/__tests__/global-chat-page.test.tsx
+++ b/apps/ui/src/__tests__/global-chat-page.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import GlobalChatPage from "@/app/(main)/chat/page";
+import { useFeatureFlag } from "@/providers/feature-flags-provider";
+import { useGlobalChat } from "@/hooks/use-global-chat";
+
+jest.mock("@/providers/feature-flags-provider", () => ({
+  useFeatureFlag: jest.fn(),
+}));
+
+jest.mock("@/hooks/use-global-chat", () => ({
+  useGlobalChat: jest.fn(),
+}));
+
+jest.mock("@/components/chat/chat-panel", () => ({
+  ChatPanel: () => <div>chat-panel</div>,
+}));
+
+jest.mock("@/app/(main)/sessions/[sessionId]/session-context", () => ({
+  SessionProvider: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock("@/components/ui/experimental-badge", () => ({
+  ExperimentalPageBadge: () => <div>badge</div>,
+}));
+
+const mockUseFeatureFlag = jest.mocked(useFeatureFlag);
+const mockUseGlobalChat = jest.mocked(useGlobalChat);
+
+describe("GlobalChatPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not initialize global chat when feature flag is disabled", () => {
+    mockUseFeatureFlag.mockReturnValue(false);
+
+    render(<GlobalChatPage />);
+
+    expect(screen.getByText("Global Chat is not enabled")).toBeInTheDocument();
+    expect(mockUseGlobalChat).not.toHaveBeenCalled();
+  });
+
+  it("initializes global chat when feature flag is enabled", () => {
+    mockUseFeatureFlag.mockReturnValue(true);
+    mockUseGlobalChat.mockReturnValue({
+      sessionId: "session_123",
+      isLoading: false,
+      error: null,
+    });
+
+    render(<GlobalChatPage />);
+
+    expect(mockUseGlobalChat).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("chat-panel")).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/app/(main)/chat/page.tsx
+++ b/apps/ui/src/app/(main)/chat/page.tsx
@@ -7,20 +7,8 @@ import { useGlobalChat } from "@/hooks/use-global-chat";
 import { useFeatureFlag } from "@/providers/feature-flags-provider";
 import { ExperimentalPageBadge } from "@/components/ui/experimental-badge";
 
-export default function GlobalChatPage() {
-  const globalChatEnabled = useFeatureFlag("global_chat");
+function GlobalChatEnabledContent() {
   const { sessionId, isLoading, error } = useGlobalChat();
-
-  if (!globalChatEnabled) {
-    return (
-      <div className="flex h-full items-center justify-center">
-        <div className="text-center text-muted-foreground">
-          <p className="text-lg font-medium">Global Chat is not enabled</p>
-          <p className="text-sm">This feature is currently disabled.</p>
-        </div>
-      </div>
-    );
-  }
 
   if (isLoading || !sessionId) {
     return (
@@ -54,4 +42,21 @@ export default function GlobalChatPage() {
       </SessionProvider>
     </div>
   );
+}
+
+export default function GlobalChatPage() {
+  const globalChatEnabled = useFeatureFlag("global_chat");
+
+  if (!globalChatEnabled) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="text-center text-muted-foreground">
+          <p className="text-lg font-medium">Global Chat is not enabled</p>
+          <p className="text-sm">This feature is currently disabled.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return <GlobalChatEnabledContent />;
 }


### PR DESCRIPTION
### Motivation

- The chat route invoked `useGlobalChat()` unconditionally which caused `POST /v1/sessions/chat` to run even when the `global_chat` feature flag was disabled, creating backend sessions unintentionally.
- The goal is to ensure feature flags suppress both UI and side effects produced by hooks that perform backend calls.

### Description

- Split the page into a flag gate and an enabled-only component by introducing `GlobalChatEnabledContent` and keeping `useGlobalChat()` inside it so the hook is only invoked when `useFeatureFlag("global_chat")` returns true.
- Kept the disabled-path UI rendering in `GlobalChatPage` so no hook or network side effects run when the flag is off.
- Added a focused unit test `src/__tests__/global-chat-page.test.tsx` that asserts the disabled path does not call `useGlobalChat()` and the enabled path does call it and renders chat content.

### Testing

- Added the unit test file `apps/ui/src/__tests__/global-chat-page.test.tsx` which covers disabled/enabled flag behavior in the UI provider mocks.
- Attempted to run the focused test locally with `npm test -- --runTestsByPath src/__tests__/global-chat-page.test.tsx`, but the environment lacks `jest` so the run failed with `sh: 1: jest: not found` (test execution did not complete locally).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac5fbacd0832ba0ef722ce258b8c9)