### PR TITLE
fix(skills): preserve user-invocable flag on skill update

### DIFF
--- a/crates/server/src/domains/skills/commands.rs
+++ b/crates/server/src/domains/skills/commands.rs
@@ -384,8 +384,18 @@ impl Command for UpdateSkillCmd {
             input.description = Some(parsed.description);
             input.license = parsed.license;
             input.compatibility = parsed.compatibility;
+            let mut metadata_map = parsed.metadata.clone();
+            if !parsed.user_invocable {
+                metadata_map.insert("user_invocable".to_string(), serde_json::Value::Bool(false));
+            }
+            if parsed.disable_model_invocation {
+                metadata_map.insert(
+                    "disable_model_invocation".to_string(),
+                    serde_json::Value::Bool(true),
+                );
+            }
             input.metadata = Some(
-                serde_json::to_value(&parsed.metadata)
+                serde_json::to_value(&metadata_map)
                     .map_err(|e| CommandError::Internal(e.into()))?,
             );
             input.allowed_tools = parsed.allowed_tools;

--- a/crates/server/tests/skills_integration_test.rs
+++ b/crates/server/tests/skills_integration_test.rs
@@ -125,6 +125,33 @@ async fn test_update_skill() {
 }
 
 #[tokio::test]
+async fn test_update_skill_preserves_user_invocable_false() {
+    let server = TestServer::new().await;
+
+    let initial_md =
+        "---\nname: hidden-skill\ndescription: Hidden command.\nuser-invocable: false\n---\n\n# Hidden\n";
+    let create_resp = server
+        .post("/v1/skills", json!({ "skill_md": initial_md }))
+        .await
+        .assert_status(StatusCode::CREATED);
+    let skill_id = create_resp.json_value()["id"].as_str().unwrap().to_string();
+
+    let updated_md =
+        "---\nname: hidden-skill\ndescription: Updated hidden command.\nuser-invocable: false\n---\n\n# Hidden Updated\n";
+    let update_resp = server
+        .patch(
+            &format!("/v1/skills/{skill_id}"),
+            json!({ "skill_md": updated_md }),
+        )
+        .await
+        .assert_success();
+
+    let body = update_resp.json_value();
+    assert_eq!(body["description"], "Updated hidden command.");
+    assert_eq!(body["user_invocable"], false);
+}
+
+#[tokio::test]
 async fn test_update_skill_status() {
     let server = TestServer::new().await;
 

--- a/crates/server/tests/skills_integration_test.rs
+++ b/crates/server/tests/skills_integration_test.rs
@@ -128,16 +128,14 @@ async fn test_update_skill() {
 async fn test_update_skill_preserves_user_invocable_false() {
     let server = TestServer::new().await;
 
-    let initial_md =
-        "---\nname: hidden-skill\ndescription: Hidden command.\nuser-invocable: false\n---\n\n# Hidden\n";
+    let initial_md = "---\nname: hidden-skill\ndescription: Hidden command.\nuser-invocable: false\n---\n\n# Hidden\n";
     let create_resp = server
         .post("/v1/skills", json!({ "skill_md": initial_md }))
         .await
         .assert_status(StatusCode::CREATED);
     let skill_id = create_resp.json_value()["id"].as_str().unwrap().to_string();
 
-    let updated_md =
-        "---\nname: hidden-skill\ndescription: Updated hidden command.\nuser-invocable: false\n---\n\n# Hidden Updated\n";
+    let updated_md = "---\nname: hidden-skill\ndescription: Updated hidden command.\nuser-invocable: false\n---\n\n# Hidden Updated\n";
     let update_resp = server
         .patch(
             &format!("/v1/skills/{skill_id}"),


### PR DESCRIPTION
### Motivation
- Updating a skill previously re-parsed `SKILL.md` but persisted only `parsed.metadata`, which could drop the `user-invocable: false` marker and unintentionally expose hidden skills as slash commands.

### Description
- In `UpdateSkillCmd` (`crates/server/src/domains/skills/commands.rs`) build a `metadata_map` from `parsed.metadata` and re-insert `user_invocable=false` when `parsed.user_invocable` is false and `disable_model_invocation=true` when enabled before serializing to `input.metadata`.
- This aligns the update path with the create/archive paths that explicitly persist these sentinel flags.
- Added an integration regression test `test_update_skill_preserves_user_invocable_false` in `crates/server/tests/skills_integration_test.rs` that creates a skill with `user-invocable: false`, updates it, and asserts `user_invocable` remains `false`.
- Changes touch `crates/server/src/domains/skills/commands.rs` and `crates/server/tests/skills_integration_test.rs`.

### Testing
- Ran `cargo test -p everruns-server` for the new integration test which compiled successfully but the integration test failed with `PoolTimedOut` because PostgreSQL is not available in the CI-like environment; the failure is environmental and not related to the fix.
- The repository compiled and unit tests executed (many filtered out), confirming the change builds cleanly in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac60f56b4832b890790921f1dc640)