### PR TITLE
fix(durable): bind correct params when resetting workflow pending

### DIFF
--- a/crates/durable/src/persistence/postgres.rs
+++ b/crates/durable/src/persistence/postgres.rs
@@ -514,33 +514,42 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
                 WorkflowStatus::Pending => (None, None),
             };
 
-        let query = if reset_to_pending {
-            // Clear all transient fields when resetting for a new turn
-            r#"
-            UPDATE durable_workflow_instances
-            SET status = $2,
-                result = NULL,
-                error = NULL,
-                started_at = NULL,
-                completed_at = NULL
-            WHERE id = $1
-            "#
-        } else {
-            r#"
-            UPDATE durable_workflow_instances
-            SET status = $2,
-                result = COALESCE($3, result),
-                error = COALESCE($4, error),
-                started_at = COALESCE($5, started_at),
-                completed_at = COALESCE($6, completed_at)
-            WHERE id = $1
-            "#
-        };
-
         let result = result.map(sanitize_json_null_bytes);
         let error_json = error_json.map(sanitize_json_null_bytes);
 
-        sqlx::query(query)
+        if reset_to_pending {
+            // Clear all transient fields when resetting for a new turn.
+            sqlx::query(
+                r#"
+                UPDATE durable_workflow_instances
+                SET status = $2,
+                    result = NULL,
+                    error = NULL,
+                    started_at = NULL,
+                    completed_at = NULL
+                WHERE id = $1
+                "#,
+            )
+            .bind(workflow_id)
+            .bind(&status_str)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| {
+                error!("Failed to update workflow status: {}", e);
+                StoreError::Database(e.to_string())
+            })?;
+        } else {
+            sqlx::query(
+                r#"
+                UPDATE durable_workflow_instances
+                SET status = $2,
+                    result = COALESCE($3, result),
+                    error = COALESCE($4, error),
+                    started_at = COALESCE($5, started_at),
+                    completed_at = COALESCE($6, completed_at)
+                WHERE id = $1
+                "#,
+            )
             .bind(workflow_id)
             .bind(&status_str)
             .bind(&result)
@@ -553,6 +562,7 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
                 error!("Failed to update workflow status: {}", e);
                 StoreError::Database(e.to_string())
             })?;
+        }
 
         debug!(%workflow_id, %status_str, "updated workflow status");
         Ok(())


### PR DESCRIPTION
### Motivation
- Fix a bind-count mismatch in `PostgresStore::update_workflow_status` where the reset-to-`Pending` SQL only uses `$1`/`$2` but the code bound six parameters, causing Postgres errors and breaking multi-turn workflow reuse.
- Bring Postgres behavior in line with the in-memory store by clearing transient fields when resetting to `Pending` while preserving existing semantics for other transitions.

### Description
- Split `update_workflow_status` execution into two explicit SQL branches so each statement only binds the parameters it references.
- For the reset-to-`Pending` branch, execute an `UPDATE` that clears `result`, `error`, `started_at`, and `completed_at` and bind only `workflow_id` and `status`.
- For non-pending transitions, retain the `COALESCE($3..$6, ...)` update and bind `result`, `error`, `started_at`, and `completed_at` as before.
- Preserve existing transient-field clearing semantics for `Pending` and unchanged behavior for other status transitions.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p everruns-durable --lib` and all tests passed (`170 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac611c730832bb3d1e6679ee25399)