### PR TITLE
fix(migrations): backfill owner for legacy org memberships

### DIFF
--- a/crates/server/migrations/023_backfill_org_owner_role.sql
+++ b/crates/server/migrations/023_backfill_org_owner_role.sql
@@ -1,0 +1,20 @@
+-- Backfill role for organizations created before role-based memberships existed.
+-- Choose a deterministic owner (earliest membership) only when an org has no owner/admin.
+WITH orgs_without_privileged_roles AS (
+    SELECT om.org_id
+    FROM organization_members om
+    GROUP BY om.org_id
+    HAVING COUNT(*) FILTER (WHERE om.role IN ('owner', 'admin')) = 0
+), first_member_per_org AS (
+    SELECT DISTINCT ON (om.org_id)
+        om.org_id,
+        om.user_id
+    FROM organization_members om
+    JOIN orgs_without_privileged_roles o ON o.org_id = om.org_id
+    ORDER BY om.org_id, om.created_at ASC, om.user_id ASC
+)
+UPDATE organization_members om
+SET role = 'owner'
+FROM first_member_per_org f
+WHERE om.org_id = f.org_id
+  AND om.user_id = f.user_id;


### PR DESCRIPTION
### Motivation
- A prior migration added a non-null `role` with default `'member'` to `organization_members`, which can leave pre-role organizations with no `owner`/`admin` and therefore unable to perform admin-gated membership operations.
- This change restores admin capability for legacy orgs by deterministically promoting one existing member to `owner` only when an org has no privileged roles.

### Description
- Add a forward migration `crates/server/migrations/023_backfill_org_owner_role.sql` that updates exactly one `organization_members` row per org to `role = 'owner'` when the org currently has no `owner` or `admin`.
- The migration selects a deterministic winner per org using the earliest `created_at` then `user_id`, and leaves orgs that already have `owner`/`admin` untouched.

### Testing
- Ran `cargo fmt --check`, which passed.
- Ran the migration ordering check script (ensures sequential migrations) which confirmed sequencing through `023` and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eacc14206c832b8551337a18aa6851)