### PR TITLE
fix(server): refresh stale MCP caches in batch load

### DIFF
--- a/crates/server/src/domains/mcp_servers/service.rs
+++ b/crates/server/src/domains/mcp_servers/service.rs
@@ -184,15 +184,40 @@ impl McpServerService {
         ids: &[Uuid],
     ) -> Result<HashMap<Uuid, (McpServer, Vec<McpToolDefinition>)>> {
         let rows = self.db.get_mcp_servers_batch(caller.org_id, ids).await?;
-        Ok(rows
-            .iter()
-            .map(|row| {
-                let server = Self::row_to_mcp_server(row);
-                let tools: Vec<McpToolDefinition> =
-                    serde_json::from_value(row.cached_tools.clone()).unwrap_or_default();
-                (row.id.uuid(), (server, tools))
-            })
-            .collect())
+        let mut servers = HashMap::with_capacity(rows.len());
+
+        for row in rows {
+            let server = Self::row_to_mcp_server(&row);
+            let server_id = row.id.uuid();
+
+            let cache_fresh = if let Some(cached_at) = row.tools_cached_at {
+                let age = Utc::now().signed_duration_since(cached_at);
+                age < chrono::Duration::from_std(TOOL_CACHE_TTL)
+                    .unwrap_or(chrono::Duration::hours(1))
+            } else {
+                false
+            };
+
+            let tools = if cache_fresh {
+                serde_json::from_value(row.cached_tools.clone()).unwrap_or_default()
+            } else {
+                match self.refresh_tools(caller, server_id).await {
+                    Ok(tools) => tools,
+                    Err(err) => {
+                        tracing::warn!(
+                            server_id = %server_id,
+                            error = %err,
+                            "Failed to refresh stale MCP tool cache in batch load; returning empty tools"
+                        );
+                        Vec::new()
+                    }
+                }
+            };
+
+            servers.insert(server_id, (server, tools));
+        }
+
+        Ok(servers)
     }
 
     pub async fn list(


### PR DESCRIPTION
### Motivation

- The batched MCP server loading path read `cached_tools` directly and bypassed the staleness/refresh logic in `get_tools`, which could leave workers with stale or empty MCP tool definitions.
- Restore on-demand refresh behavior in the batch path so worker turn context sees fresh tool definitions (or fails gracefully) similar to the original per-server path.

### Description

- Updated `McpServerService::get_batch_with_tools` in `crates/server/src/domains/mcp_servers/service.rs` to check `tools_cached_at` against `TOOL_CACHE_TTL` for each server and to call `refresh_tools` for stale or missing caches.
- If `refresh_tools` fails for a server, the code logs a warning and returns an empty tool list for that server to avoid silently serving stale data.
- The change preserves the single-query batch fetch for server rows while reintroducing per-server refresh when necessary.

### Testing

- Ran formatting with `cargo fmt --all` which completed successfully.
- Attempted to run `cargo test -p everruns-server decrypt_api_key_returns_none_when_no_key_set`, but the test run did not complete within the environment/time constraints due to a full dependency build; no failing tests observed so far but full test run was not finished.
- Performed repository-level inspections (`rg`, `sed`) to confirm `build_mcp_tool_definitions` now calls the updated batch helper and that `get_tools`/`refresh_tools` remain available for individual refresh semantics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaad3afc84832bb456cada5fe41f44)