### PR TITLE
test(server): cover owner-scoped connection resolution

### DIFF
--- a/crates/server/specs/user-connections.md
+++ b/crates/server/specs/user-connections.md
@@ -101,7 +101,11 @@ Connections are **user-scoped**. The installation represents the user's/org's gr
 
 **Visibility:** Connections are private to the user who created them. Other org members cannot list, view, or manage another user's connections via the API. The `GET /v1/user/connections` endpoint only returns the authenticated user's own connections.
 
-**Token resolution:** Although connections are private, the lazy token resolver (`UserConnectionResolver`) can resolve tokens across org members for tool execution. When a tool needs a GitHub token, the resolver finds any org member who has connected GitHub. This means a user's installation may be used to serve tool requests in sessions belonging to the same org, but the connection itself remains invisible to other users.
+**Token resolution:** Although connections are private, the lazy token resolver (`UserConnectionResolver`) may use a connection for tool execution without exposing the connection object through the API, but it is scoped to the session's resolved owner. A session can use:
+- an `agent_identity_connection` attached to that session's `agent_identity_id`, or
+- a `user_connection` owned by `sessions.resolved_owner_user_id`
+
+It must not fall back to another org member's connection. If the resolved owner has not connected the provider, tool execution returns guidance to connect the provider in Settings.
 
 ### Lazy Token Resolution
 

--- a/crates/server/src/storage/connection_resolver.rs
+++ b/crates/server/src/storage/connection_resolver.rs
@@ -23,7 +23,7 @@ use crate::auth::oauth::GitHubAppService;
 ///
 /// Session-based lookup priority:
 /// 1. If the session has an `agent_identity_id`, resolves from `agent_identity_connections`.
-/// 2. Falls back to `user_connections` via org membership.
+/// 2. Falls back to `user_connections` for the session's resolved owner user.
 ///
 /// Leased-resource cleanup additionally uses explicit owner-user lookups so
 /// the same provider identity that created a resource can delete it later.

--- a/crates/server/src/storage/memory/tests.rs
+++ b/crates/server/src/storage/memory/tests.rs
@@ -261,6 +261,185 @@ async fn test_events_sequence() {
 }
 
 #[tokio::test]
+async fn test_session_connection_resolution_uses_resolved_owner_user() {
+    let db = InMemoryDatabase::new();
+
+    let owner = db
+        .create_user(CreateUserRow {
+            email: format!("owner-{}@example.com", Uuid::now_v7()),
+            name: "Owner".to_string(),
+            avatar_url: None,
+            roles: vec!["user".to_string()],
+            password_hash: None,
+            email_verified: true,
+            auth_provider: None,
+            auth_provider_id: None,
+            external_id: None,
+        })
+        .await
+        .unwrap();
+    let other = db
+        .create_user(CreateUserRow {
+            email: format!("other-{}@example.com", Uuid::now_v7()),
+            name: "Other".to_string(),
+            avatar_url: None,
+            roles: vec!["user".to_string()],
+            password_hash: None,
+            email_verified: true,
+            auth_provider: None,
+            auth_provider_id: None,
+            external_id: None,
+        })
+        .await
+        .unwrap();
+
+    db.add_organization_member(DEFAULT_ORG_ID, owner.id, "member")
+        .await
+        .unwrap();
+    db.add_organization_member(DEFAULT_ORG_ID, other.id, "member")
+        .await
+        .unwrap();
+
+    let session = db
+        .create_session(CreateSessionRow {
+            org_id: DEFAULT_ORG_ID,
+            harness_id: None,
+            agent_id: None,
+            agent_identity_id: None,
+            owner_principal_id: everruns_core::PrincipalId::from_seed(42),
+            resolved_owner_user_id: Some(owner.id),
+            title: Some("connection-owner-scope".to_string()),
+            locale: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+            mcp_servers: serde_json::json!({}),
+            system_prompt: None,
+            initial_files: serde_json::Value::Array(vec![]),
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            blueprint_id: None,
+            blueprint_config: None,
+        })
+        .await
+        .unwrap();
+
+    db.upsert_user_connection(CreateUserConnectionRow {
+        user_id: other.id,
+        provider: "gitlab".to_string(),
+        connection_type: "oauth".to_string(),
+        provider_user_id: Some("other-gitlab".to_string()),
+        provider_username: Some("other".to_string()),
+        access_token_encrypted: Some(b"other-token".to_vec()),
+        refresh_token_encrypted: None,
+        scopes: Some("api".to_string()),
+        expires_at: None,
+        installation_id: None,
+        provider_metadata: Some(serde_json::json!({ "user": "other" })),
+    })
+    .await
+    .unwrap();
+    db.upsert_user_connection(CreateUserConnectionRow {
+        user_id: other.id,
+        provider: "github".to_string(),
+        connection_type: "oauth".to_string(),
+        provider_user_id: Some("other-github".to_string()),
+        provider_username: Some("other".to_string()),
+        access_token_encrypted: None,
+        refresh_token_encrypted: None,
+        scopes: Some("contents:read".to_string()),
+        expires_at: None,
+        installation_id: Some(222),
+        provider_metadata: None,
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(
+        db.get_connection_token_for_session(session.id, "gitlab")
+            .await
+            .unwrap(),
+        None
+    );
+    assert_eq!(
+        db.get_connection_metadata_for_session(session.id, "gitlab")
+            .await
+            .unwrap(),
+        None
+    );
+    assert_eq!(
+        db.get_connection_user_for_session(session.id, "gitlab")
+            .await
+            .unwrap(),
+        None
+    );
+    assert_eq!(
+        db.get_installation_id_for_session(session.id, "github")
+            .await
+            .unwrap(),
+        None
+    );
+
+    db.upsert_user_connection(CreateUserConnectionRow {
+        user_id: owner.id,
+        provider: "gitlab".to_string(),
+        connection_type: "oauth".to_string(),
+        provider_user_id: Some("owner-gitlab".to_string()),
+        provider_username: Some("owner".to_string()),
+        access_token_encrypted: Some(b"owner-token".to_vec()),
+        refresh_token_encrypted: None,
+        scopes: Some("api".to_string()),
+        expires_at: None,
+        installation_id: None,
+        provider_metadata: Some(serde_json::json!({ "user": "owner" })),
+    })
+    .await
+    .unwrap();
+    db.upsert_user_connection(CreateUserConnectionRow {
+        user_id: owner.id,
+        provider: "github".to_string(),
+        connection_type: "oauth".to_string(),
+        provider_user_id: Some("owner-github".to_string()),
+        provider_username: Some("owner".to_string()),
+        access_token_encrypted: None,
+        refresh_token_encrypted: None,
+        scopes: Some("contents:read".to_string()),
+        expires_at: None,
+        installation_id: Some(111),
+        provider_metadata: None,
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(
+        db.get_connection_token_for_session(session.id, "gitlab")
+            .await
+            .unwrap(),
+        Some(b"owner-token".to_vec())
+    );
+    assert_eq!(
+        db.get_connection_metadata_for_session(session.id, "gitlab")
+            .await
+            .unwrap(),
+        Some(serde_json::json!({ "user": "owner" }))
+    );
+    assert_eq!(
+        db.get_connection_user_for_session(session.id, "gitlab")
+            .await
+            .unwrap(),
+        Some(owner.id)
+    );
+    assert_eq!(
+        db.get_installation_id_for_session(session.id, "github")
+            .await
+            .unwrap(),
+        Some(111)
+    );
+}
+
+#[tokio::test]
 async fn test_unpin_session_is_scoped_by_org() {
     let db = InMemoryDatabase::new();
     let user_id = Uuid::now_v7();

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -22,9 +22,9 @@ use everruns_server::org_init;
 use everruns_server::storage::{
     CreateAgentCapabilityRow, CreateAgentRow, CreateEventRow, CreateHarnessRow, CreateImageRow,
     CreateLlmModelRow, CreateLlmProviderRow, CreateMcpServerRow, CreateOrganizationRow,
-    CreatePrincipalRow, CreateSessionFileRow, CreateSessionRow, Database, StorageBackend,
-    UpdateAgent, UpdateLlmModel, UpdateLlmProvider, UpdateOrganization, UpdateOrganizationSettings,
-    UpdateSession, UpdateSessionFile,
+    CreatePrincipalRow, CreateSessionFileRow, CreateSessionRow, CreateUserConnectionRow,
+    CreateUserRow, Database, StorageBackend, UpdateAgent, UpdateLlmModel, UpdateLlmProvider,
+    UpdateOrganization, UpdateOrganizationSettings, UpdateSession, UpdateSessionFile,
 };
 use test_harness::get_database_url;
 
@@ -61,6 +61,46 @@ async fn create_test_principal(
         })
         .await
         .expect("Failed to create test principal")
+        .id
+}
+
+async fn create_test_user(
+    backend: &StorageBackend,
+    label: &str,
+) -> everruns_server::storage::UserRow {
+    backend
+        .create_user(CreateUserRow {
+            email: format!("{label}-{}@example.com", Uuid::now_v7()),
+            name: format!("Test {label}"),
+            avatar_url: None,
+            roles: vec!["user".to_string()],
+            password_hash: None,
+            email_verified: true,
+            auth_provider: None,
+            auth_provider_id: None,
+            external_id: None,
+        })
+        .await
+        .expect("Failed to create test user")
+}
+
+async fn create_test_user_principal(
+    backend: &StorageBackend,
+    org_id: i64,
+    user_id: Uuid,
+) -> everruns_core::PrincipalId {
+    backend
+        .create_principal(CreatePrincipalRow {
+            id: everruns_core::PrincipalId::new(),
+            org_id,
+            kind: "user".to_string(),
+            subject_id: Some(user_id),
+            parent_principal_id: None,
+            resolved_user_id: Some(user_id),
+            metadata: json!({ "source": "repository_integration_test", "kind": "user" }),
+        })
+        .await
+        .expect("Failed to create user principal")
         .id
 }
 
@@ -250,6 +290,174 @@ async fn test_agent_get_by_name() {
 
     // Cleanup
     backend.delete_agent(TEST_ORG_ID, agent.id).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_session_connection_resolution_uses_resolved_owner_user() {
+    let backend = create_test_backend().await;
+
+    let owner = create_test_user(&backend, "owner").await;
+    let other = create_test_user(&backend, "other").await;
+
+    backend
+        .add_organization_member(TEST_ORG_ID, owner.id, "member")
+        .await
+        .expect("Failed to add owner to org");
+    backend
+        .add_organization_member(TEST_ORG_ID, other.id, "member")
+        .await
+        .expect("Failed to add other user to org");
+
+    let owner_principal_id = create_test_user_principal(&backend, TEST_ORG_ID, owner.id).await;
+    let session = backend
+        .create_session(CreateSessionRow {
+            org_id: TEST_ORG_ID,
+            harness_id: None,
+            agent_id: None,
+            agent_identity_id: None,
+            owner_principal_id,
+            resolved_owner_user_id: Some(owner.id),
+            title: Some(format!("connection-owner-scope-{}", Uuid::now_v7())),
+            locale: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+            mcp_servers: serde_json::json!({}),
+            system_prompt: None,
+            initial_files: serde_json::Value::Array(vec![]),
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            blueprint_id: None,
+            blueprint_config: None,
+        })
+        .await
+        .expect("Failed to create session");
+
+    backend
+        .upsert_user_connection(CreateUserConnectionRow {
+            user_id: other.id,
+            provider: "gitlab".to_string(),
+            connection_type: "oauth".to_string(),
+            provider_user_id: Some("other-gitlab".to_string()),
+            provider_username: Some("other".to_string()),
+            access_token_encrypted: Some(b"other-token".to_vec()),
+            refresh_token_encrypted: None,
+            scopes: Some("api".to_string()),
+            expires_at: None,
+            installation_id: None,
+            provider_metadata: Some(serde_json::json!({ "user": "other" })),
+        })
+        .await
+        .expect("Failed to insert other user's OAuth connection");
+    backend
+        .upsert_user_connection(CreateUserConnectionRow {
+            user_id: other.id,
+            provider: "github".to_string(),
+            connection_type: "oauth".to_string(),
+            provider_user_id: Some("other-github".to_string()),
+            provider_username: Some("other".to_string()),
+            access_token_encrypted: None,
+            refresh_token_encrypted: None,
+            scopes: Some("contents:read".to_string()),
+            expires_at: None,
+            installation_id: Some(222),
+            provider_metadata: None,
+        })
+        .await
+        .expect("Failed to insert other user's GitHub installation");
+
+    assert_eq!(
+        backend
+            .get_connection_token_for_session(session.id, "gitlab")
+            .await
+            .expect("Failed to resolve connection token"),
+        None
+    );
+    assert_eq!(
+        backend
+            .get_connection_metadata_for_session(session.id, "gitlab")
+            .await
+            .expect("Failed to resolve connection metadata"),
+        None
+    );
+    assert_eq!(
+        backend
+            .get_connection_user_for_session(session.id, "gitlab")
+            .await
+            .expect("Failed to resolve connection owner"),
+        None
+    );
+    assert_eq!(
+        backend
+            .get_installation_id_for_session(session.id, "github")
+            .await
+            .expect("Failed to resolve GitHub installation"),
+        None
+    );
+
+    backend
+        .upsert_user_connection(CreateUserConnectionRow {
+            user_id: owner.id,
+            provider: "gitlab".to_string(),
+            connection_type: "oauth".to_string(),
+            provider_user_id: Some("owner-gitlab".to_string()),
+            provider_username: Some("owner".to_string()),
+            access_token_encrypted: Some(b"owner-token".to_vec()),
+            refresh_token_encrypted: None,
+            scopes: Some("api".to_string()),
+            expires_at: None,
+            installation_id: None,
+            provider_metadata: Some(serde_json::json!({ "user": "owner" })),
+        })
+        .await
+        .expect("Failed to insert owner OAuth connection");
+    backend
+        .upsert_user_connection(CreateUserConnectionRow {
+            user_id: owner.id,
+            provider: "github".to_string(),
+            connection_type: "oauth".to_string(),
+            provider_user_id: Some("owner-github".to_string()),
+            provider_username: Some("owner".to_string()),
+            access_token_encrypted: None,
+            refresh_token_encrypted: None,
+            scopes: Some("contents:read".to_string()),
+            expires_at: None,
+            installation_id: Some(111),
+            provider_metadata: None,
+        })
+        .await
+        .expect("Failed to insert owner GitHub installation");
+
+    assert_eq!(
+        backend
+            .get_connection_token_for_session(session.id, "gitlab")
+            .await
+            .expect("Failed to resolve owner connection token"),
+        Some(b"owner-token".to_vec())
+    );
+    assert_eq!(
+        backend
+            .get_connection_metadata_for_session(session.id, "gitlab")
+            .await
+            .expect("Failed to resolve owner connection metadata"),
+        Some(serde_json::json!({ "user": "owner" }))
+    );
+    assert_eq!(
+        backend
+            .get_connection_user_for_session(session.id, "gitlab")
+            .await
+            .expect("Failed to resolve owner connection user"),
+        Some(owner.id)
+    );
+    assert_eq!(
+        backend
+            .get_installation_id_for_session(session.id, "github")
+            .await
+            .expect("Failed to resolve owner GitHub installation"),
+        Some(111)
+    );
 }
 
 // ============================================


### PR DESCRIPTION
## What
- Add regression coverage proving session connection resolution uses the resolved owner user, not another org member.
- Update the user-connections spec and resolver comment to match the already-merged owner-scoped behavior.

## Why
- The original finding was real on commit `582c8c39`, but the underlying code path was already fixed by PR #1487.
- The repo still documented the old cross-org-member behavior and lacked a focused regression test, which makes the security boundary easier to drift.

## How
- Add an in-memory storage test that verifies another org member's OAuth token and GitHub installation are ignored until the session owner connects the provider.
- Add the same regression coverage to the Postgres repository integration suite.
- Rewrite the spec/comment text so session resolution is explicitly limited to `agent_identity_connections` or `sessions.resolved_owner_user_id`.

## Risk
- Low
- Changes are limited to tests, comments, and spec text; no runtime logic changed.

## Security
- Threat categories reviewed: No security-relevant code changes; this PR only adds regression coverage and aligns documentation with the existing mitigation from PR #1487.
- Findings and resolutions: corrected stale documentation that still described cross-org-member token resolution, and added tests to catch any regression back to that behavior.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)