### PR TITLE
feat(openai): stream image generation progress

### DIFF
--- a/apps/ui/src/__tests__/capability-settings-editor.test.tsx
+++ b/apps/ui/src/__tests__/capability-settings-editor.test.tsx
@@ -20,11 +20,11 @@ describe("CapabilitySettingsEditor", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Medium")).toBeInTheDocument();
     expect(screen.getByText(/Balanced quality and latency/i)).toBeInTheDocument();
-    expect(screen.getByText("1 Preview")).toBeInTheDocument();
-    expect(screen.getByText(/Streams one in-progress preview/i)).toBeInTheDocument();
+    expect(screen.getByText("1 Progress Update")).toBeInTheDocument();
+    expect(screen.getByText(/Emits one in-progress status update/i)).toBeInTheDocument();
   });
 
-  it("shows the configured legacy model, quality, and preview descriptions", () => {
+  it("shows the configured legacy model, quality, and progress update descriptions", () => {
     render(
       <CapabilitySettingsEditor
         capabilityId="gpt_image_gen"
@@ -36,7 +36,7 @@ describe("CapabilitySettingsEditor", () => {
     expect(screen.getByText("GPT Image 1")).toBeInTheDocument();
     expect(screen.getByText(/Legacy fallback/i)).toBeInTheDocument();
     expect(screen.getByText(/Highest fidelity, but materially slower/i)).toBeInTheDocument();
-    expect(screen.getByText("3 Previews")).toBeInTheDocument();
-    expect(screen.getByText(/Maximum preview feedback/i)).toBeInTheDocument();
+    expect(screen.getByText("3 Progress Updates")).toBeInTheDocument();
+    expect(screen.getByText(/Maximum status feedback/i)).toBeInTheDocument();
   });
 });

--- a/apps/ui/src/__tests__/capability-settings-editor.test.tsx
+++ b/apps/ui/src/__tests__/capability-settings-editor.test.tsx
@@ -20,13 +20,15 @@ describe("CapabilitySettingsEditor", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Medium")).toBeInTheDocument();
     expect(screen.getByText(/Balanced quality and latency/i)).toBeInTheDocument();
+    expect(screen.getByText("1 Preview")).toBeInTheDocument();
+    expect(screen.getByText(/Streams one in-progress preview/i)).toBeInTheDocument();
   });
 
-  it("shows the configured legacy model and high-quality descriptions", () => {
+  it("shows the configured legacy model, quality, and preview descriptions", () => {
     render(
       <CapabilitySettingsEditor
         capabilityId="gpt_image_gen"
-        config={{ model: "gpt-image-1", default_quality: "high" }}
+        config={{ model: "gpt-image-1", default_quality: "high", partial_images: 3 }}
         onChange={jest.fn()}
       />,
     );
@@ -34,5 +36,7 @@ describe("CapabilitySettingsEditor", () => {
     expect(screen.getByText("GPT Image 1")).toBeInTheDocument();
     expect(screen.getByText(/Legacy fallback/i)).toBeInTheDocument();
     expect(screen.getByText(/Highest fidelity, but materially slower/i)).toBeInTheDocument();
+    expect(screen.getByText("3 Previews")).toBeInTheDocument();
+    expect(screen.getByText(/Maximum preview feedback/i)).toBeInTheDocument();
   });
 });

--- a/apps/ui/src/components/agents/capability-settings-editor.tsx
+++ b/apps/ui/src/components/agents/capability-settings-editor.tsx
@@ -216,23 +216,24 @@ const GPT_IMAGE_PARTIAL_IMAGE_OPTIONS: Array<{
 }> = [
   {
     value: 1,
-    label: "1 Preview",
-    description: "Default. Streams one in-progress preview for single-image requests.",
+    label: "1 Progress Update",
+    description: "Default. Emits one in-progress status update for single-image requests.",
   },
   {
     value: 0,
     label: "Off",
-    description: "Disable preview streaming and only wait for the final image.",
+    description: "Disable progress updates and only wait for the final image.",
   },
   {
     value: 2,
-    label: "2 Previews",
-    description: "Show two in-progress previews. More responsive, but slightly higher token cost.",
+    label: "2 Progress Updates",
+    description:
+      "Emit two in-progress status updates. More responsive, with slightly higher token cost.",
   },
   {
     value: 3,
-    label: "3 Previews",
-    description: "Maximum preview feedback. Highest extra token cost.",
+    label: "3 Progress Updates",
+    description: "Maximum status feedback. Highest extra token cost.",
   },
 ];
 
@@ -332,7 +333,7 @@ function GptImageGenEditor({ config, onChange, disabled }: GptImageGenEditorProp
           htmlFor="gpt-image-partial-images"
           className="text-xs font-normal text-muted-foreground"
         >
-          Preview Updates
+          Progress Updates
         </Label>
         <Select
           value={String(selectedPartialImages)}

--- a/apps/ui/src/components/agents/capability-settings-editor.tsx
+++ b/apps/ui/src/components/agents/capability-settings-editor.tsx
@@ -23,10 +23,12 @@ export interface DockerContainerConfig {
 
 type GptImageGenModel = "gpt-image-2" | "gpt-image-1";
 type GptImageGenQuality = "low" | "medium" | "high" | "auto";
+type GptImageGenPartialImages = 0 | 1 | 2 | 3;
 
 export interface GptImageGenConfig {
   model?: GptImageGenModel;
   default_quality?: GptImageGenQuality;
+  partial_images?: GptImageGenPartialImages;
 }
 
 export type CapabilityConfig = DockerContainerConfig | GptImageGenConfig | Record<string, unknown>;
@@ -161,6 +163,7 @@ function DockerContainerEditor({ config, onChange, disabled }: DockerContainerEd
 
 const DEFAULT_GPT_IMAGE_MODEL: GptImageGenModel = "gpt-image-2";
 const DEFAULT_GPT_IMAGE_QUALITY: GptImageGenQuality = "medium";
+const DEFAULT_GPT_IMAGE_PARTIAL_IMAGES: GptImageGenPartialImages = 1;
 
 const GPT_IMAGE_MODEL_OPTIONS: Array<{
   value: GptImageGenModel;
@@ -206,6 +209,33 @@ const GPT_IMAGE_QUALITY_OPTIONS: Array<{
   },
 ];
 
+const GPT_IMAGE_PARTIAL_IMAGE_OPTIONS: Array<{
+  value: GptImageGenPartialImages;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: 1,
+    label: "1 Preview",
+    description: "Default. Streams one in-progress preview for single-image requests.",
+  },
+  {
+    value: 0,
+    label: "Off",
+    description: "Disable preview streaming and only wait for the final image.",
+  },
+  {
+    value: 2,
+    label: "2 Previews",
+    description: "Show two in-progress previews. More responsive, but slightly higher token cost.",
+  },
+  {
+    value: 3,
+    label: "3 Previews",
+    description: "Maximum preview feedback. Highest extra token cost.",
+  },
+];
+
 interface GptImageGenEditorProps {
   config: GptImageGenConfig;
   onChange: (config: Record<string, unknown>) => void;
@@ -215,12 +245,16 @@ interface GptImageGenEditorProps {
 function GptImageGenEditor({ config, onChange, disabled }: GptImageGenEditorProps) {
   const selectedModel = config.model || DEFAULT_GPT_IMAGE_MODEL;
   const selectedQuality = config.default_quality || DEFAULT_GPT_IMAGE_QUALITY;
+  const selectedPartialImages = config.partial_images ?? DEFAULT_GPT_IMAGE_PARTIAL_IMAGES;
   const selectedOption =
     GPT_IMAGE_MODEL_OPTIONS.find((option) => option.value === selectedModel) ??
     GPT_IMAGE_MODEL_OPTIONS[0];
   const selectedQualityOption =
     GPT_IMAGE_QUALITY_OPTIONS.find((option) => option.value === selectedQuality) ??
     GPT_IMAGE_QUALITY_OPTIONS[0];
+  const selectedPartialImagesOption =
+    GPT_IMAGE_PARTIAL_IMAGE_OPTIONS.find((option) => option.value === selectedPartialImages) ??
+    GPT_IMAGE_PARTIAL_IMAGE_OPTIONS[0];
 
   const handleModelChange = (value: string) => {
     const newConfig = { ...config };
@@ -238,6 +272,17 @@ function GptImageGenEditor({ config, onChange, disabled }: GptImageGenEditorProp
       newConfig.default_quality = value as GptImageGenQuality;
     } else {
       delete newConfig.default_quality;
+    }
+    onChange(newConfig);
+  };
+
+  const handlePartialImagesChange = (value: string) => {
+    const parsedValue = Number(value) as GptImageGenPartialImages;
+    const newConfig = { ...config };
+    if (parsedValue !== DEFAULT_GPT_IMAGE_PARTIAL_IMAGES) {
+      newConfig.partial_images = parsedValue;
+    } else {
+      delete newConfig.partial_images;
     }
     onChange(newConfig);
   };
@@ -280,6 +325,32 @@ function GptImageGenEditor({ config, onChange, disabled }: GptImageGenEditorProp
           </SelectContent>
         </Select>
         <p className="text-xs text-muted-foreground">{selectedQualityOption.description}</p>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label
+          htmlFor="gpt-image-partial-images"
+          className="text-xs font-normal text-muted-foreground"
+        >
+          Preview Updates
+        </Label>
+        <Select
+          value={String(selectedPartialImages)}
+          onValueChange={handlePartialImagesChange}
+          disabled={disabled}
+        >
+          <SelectTrigger id="gpt-image-partial-images" className="w-full">
+            <SelectValue>{selectedPartialImagesOption.label}</SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            {GPT_IMAGE_PARTIAL_IMAGE_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={String(option.value)}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">{selectedPartialImagesOption.description}</p>
       </div>
     </div>
   );

--- a/crates/core/src/observation/otel.rs
+++ b/crates/core/src/observation/otel.rs
@@ -687,39 +687,37 @@ impl OtelEventListener {
                     "gen_ai.tool.call.result" = tracing::field::Empty,
                 )
             }
+        } else if let Some(parent_span) = &parent_span {
+            tracing::info_span!(
+                parent: parent_span,
+                "gen_ai.execute_tool",
+                "otel.name" = %span_name,
+                "otel.kind" = "internal",
+                "gen_ai.operation.name" = gen_ai::operation::EXECUTE_TOOL,
+                "gen_ai.tool.name" = %data.tool_call.name,
+                "gen_ai.tool.type" = gen_ai::tool_type::FUNCTION,
+                "gen_ai.tool.call.id" = %data.tool_call.id,
+                "gen_ai.conversation.id" = %event.session_id,
+                "tool.success" = tracing::field::Empty,
+                "tool.status" = tracing::field::Empty,
+                "duration_ms" = tracing::field::Empty,
+                "error.type" = tracing::field::Empty,
+            )
         } else {
-            if let Some(parent_span) = &parent_span {
-                tracing::info_span!(
-                    parent: parent_span,
-                    "gen_ai.execute_tool",
-                    "otel.name" = %span_name,
-                    "otel.kind" = "internal",
-                    "gen_ai.operation.name" = gen_ai::operation::EXECUTE_TOOL,
-                    "gen_ai.tool.name" = %data.tool_call.name,
-                    "gen_ai.tool.type" = gen_ai::tool_type::FUNCTION,
-                    "gen_ai.tool.call.id" = %data.tool_call.id,
-                    "gen_ai.conversation.id" = %event.session_id,
-                    "tool.success" = tracing::field::Empty,
-                    "tool.status" = tracing::field::Empty,
-                    "duration_ms" = tracing::field::Empty,
-                    "error.type" = tracing::field::Empty,
-                )
-            } else {
-                tracing::info_span!(
-                    "gen_ai.execute_tool",
-                    "otel.name" = %span_name,
-                    "otel.kind" = "internal",
-                    "gen_ai.operation.name" = gen_ai::operation::EXECUTE_TOOL,
-                    "gen_ai.tool.name" = %data.tool_call.name,
-                    "gen_ai.tool.type" = gen_ai::tool_type::FUNCTION,
-                    "gen_ai.tool.call.id" = %data.tool_call.id,
-                    "gen_ai.conversation.id" = %event.session_id,
-                    "tool.success" = tracing::field::Empty,
-                    "tool.status" = tracing::field::Empty,
-                    "duration_ms" = tracing::field::Empty,
-                    "error.type" = tracing::field::Empty,
-                )
-            }
+            tracing::info_span!(
+                "gen_ai.execute_tool",
+                "otel.name" = %span_name,
+                "otel.kind" = "internal",
+                "gen_ai.operation.name" = gen_ai::operation::EXECUTE_TOOL,
+                "gen_ai.tool.name" = %data.tool_call.name,
+                "gen_ai.tool.type" = gen_ai::tool_type::FUNCTION,
+                "gen_ai.tool.call.id" = %data.tool_call.id,
+                "gen_ai.conversation.id" = %event.session_id,
+                "tool.success" = tracing::field::Empty,
+                "tool.status" = tracing::field::Empty,
+                "duration_ms" = tracing::field::Empty,
+                "error.type" = tracing::field::Empty,
+            )
         };
 
         let mut spans = self.active_spans.lock().unwrap();

--- a/crates/openai/src/image_capability.rs
+++ b/crates/openai/src/image_capability.rs
@@ -43,7 +43,7 @@ For straightforward image requests, avoid unrelated metadata or bookkeeping tool
 When the user asks for multiple new images, make one `generate_image` call per requested concept unless they explicitly ask for a batch in one call.
 Unless the user says otherwise, set `save_to_session_fs` to true, keep `persist_artifact` enabled, and save under `/workspace/.outputs/images`.
 Prefer PNG output and rely on the capability default quality unless the user requests a specific quality.
-For single-image requests, streaming preview updates may arrive before the final image; wait for the completed tool result before describing the finished output.
+For single-image requests, streaming progress updates may arrive before the final image; wait for the completed tool result before describing the finished output.
 Do not stop at writing prompts, suggesting external tools, or describing environment limitations unless an actual image tool call fails.
 
 Store per-session OpenAI overrides in `secret_store` under `OPENAI_API_KEY` and optionally `OPENAI_BASE_URL`.
@@ -645,7 +645,7 @@ fn initial_progress_message(action: &str, count: usize, partial_images: Option<u
     if count > 1 {
         format!("{action} {count} images...")
     } else if partial_images.unwrap_or(0) > 0 {
-        format!("{action} image and waiting for preview...")
+        format!("{action} image and waiting for progress updates...")
     } else {
         format!("{action} image...")
     }
@@ -661,8 +661,9 @@ async fn emit_stream_progress(
     let message = match event {
         ImageApiStreamEvent::PartialImage {
             partial_image_index,
+            ..
         } => format!(
-            "{action} preview {} of {}...",
+            "{action} progress update {} of {}...",
             partial_image_index + 1,
             expected_previews
         ),

--- a/crates/openai/src/image_capability.rs
+++ b/crates/openai/src/image_capability.rs
@@ -1,5 +1,6 @@
 use crate::images::{
-    EditImageInput, EditImageRequest, GenerateImageRequest, ImageApiImage, OpenAiImageClient,
+    EditImageInput, EditImageRequest, GenerateImageRequest, ImageApiImage, ImageApiStreamEvent,
+    OpenAiImageClient,
 };
 use async_trait::async_trait;
 use base64::Engine;
@@ -18,6 +19,7 @@ const GPT_IMAGE_GEN_CAPABILITY_ID: &str = "gpt_image_gen";
 // keeping the legacy GPT Image 1 path available as an explicit opt-in.
 const DEFAULT_OPENAI_IMAGE_MODEL: ImageGenerationModel = ImageGenerationModel::GptImage2;
 const DEFAULT_OPENAI_IMAGE_QUALITY: ImageGenerationQuality = ImageGenerationQuality::Medium;
+const DEFAULT_OPENAI_IMAGE_PARTIAL_IMAGES: u8 = 1;
 const DEFAULT_OUTPUT_DIR: &str = "/workspace/.outputs/images";
 const DEFAULT_GENERATE_PREFIX: &str = "generated-image";
 const DEFAULT_EDIT_PREFIX: &str = "edited-image";
@@ -41,6 +43,7 @@ For straightforward image requests, avoid unrelated metadata or bookkeeping tool
 When the user asks for multiple new images, make one `generate_image` call per requested concept unless they explicitly ask for a batch in one call.
 Unless the user says otherwise, set `save_to_session_fs` to true, keep `persist_artifact` enabled, and save under `/workspace/.outputs/images`.
 Prefer PNG output and rely on the capability default quality unless the user requests a specific quality.
+For single-image requests, streaming preview updates may arrive before the final image; wait for the completed tool result before describing the finished output.
 Do not stop at writing prompts, suggesting external tools, or describing environment limitations unless an actual image tool call fails.
 
 Store per-session OpenAI overrides in `secret_store` under `OPENAI_API_KEY` and optionally `OPENAI_BASE_URL`.
@@ -214,24 +217,51 @@ impl Tool for GenerateImageTool {
             Ok(client) => client,
             Err(result) => return result,
         };
+        let partial_images = resolve_partial_images(args.common.count(), &capability_config);
+        let request = GenerateImageRequest {
+            model: model.to_string(),
+            prompt: args.prompt.clone(),
+            size: args.common.size.clone(),
+            quality: Some(resolve_quality(
+                args.common.quality.as_deref(),
+                capability_config.default_quality,
+            )),
+            background: args.common.background.clone(),
+            output_format: args.common.format.clone(),
+            stream: partial_images.map(|_| true),
+            partial_images,
+            count: args.common.count(),
+        };
 
-        let response = match client
-            .generate(GenerateImageRequest {
-                model: model.to_string(),
-                prompt: args.prompt.clone(),
-                size: args.common.size.clone(),
-                quality: Some(resolve_quality(
-                    args.common.quality.as_deref(),
-                    capability_config.default_quality,
-                )),
-                background: args.common.background.clone(),
-                output_format: args.common.format.clone(),
-                count: args.common.count(),
-            })
-            .await
-        {
-            Ok(response) => response,
-            Err(error) => return ToolExecutionResult::internal_error_msg(format!("{error:#}")),
+        context
+            .emit_progress(
+                self.name(),
+                &initial_progress_message("Generating", args.common.count(), partial_images),
+            )
+            .await;
+
+        let response = if let Some(expected_previews) = partial_images {
+            match client
+                .generate_with_events(request, |event| async {
+                    emit_stream_progress(
+                        context,
+                        self.name(),
+                        "Generating",
+                        expected_previews,
+                        event,
+                    )
+                    .await;
+                })
+                .await
+            {
+                Ok(response) => response,
+                Err(error) => return ToolExecutionResult::internal_error_msg(format!("{error:#}")),
+            }
+        } else {
+            match client.generate(request).await {
+                Ok(response) => response,
+                Err(error) => return ToolExecutionResult::internal_error_msg(format!("{error:#}")),
+            }
         };
 
         materialize_outputs(
@@ -352,25 +382,46 @@ impl Tool for EditImageTool {
             Ok(client) => client,
             Err(result) => return result,
         };
+        let partial_images = resolve_partial_images(args.common.count(), &capability_config);
+        let request = EditImageRequest {
+            model: model.to_string(),
+            prompt: args.prompt.clone(),
+            images: sources,
+            size: args.common.size.clone(),
+            quality: Some(resolve_quality(
+                args.common.quality.as_deref(),
+                capability_config.default_quality,
+            )),
+            background: args.common.background.clone(),
+            output_format: args.common.format.clone(),
+            stream: partial_images.map(|_| true),
+            partial_images,
+            count: args.common.count(),
+        };
 
-        let response = match client
-            .edit(EditImageRequest {
-                model: model.to_string(),
-                prompt: args.prompt.clone(),
-                images: sources,
-                size: args.common.size.clone(),
-                quality: Some(resolve_quality(
-                    args.common.quality.as_deref(),
-                    capability_config.default_quality,
-                )),
-                background: args.common.background.clone(),
-                output_format: args.common.format.clone(),
-                count: args.common.count(),
-            })
-            .await
-        {
-            Ok(response) => response,
-            Err(error) => return ToolExecutionResult::internal_error_msg(format!("{error:#}")),
+        context
+            .emit_progress(
+                self.name(),
+                &initial_progress_message("Editing", args.common.count(), partial_images),
+            )
+            .await;
+
+        let response = if let Some(expected_previews) = partial_images {
+            match client
+                .edit_with_events(request, |event| async {
+                    emit_stream_progress(context, self.name(), "Editing", expected_previews, event)
+                        .await;
+                })
+                .await
+            {
+                Ok(response) => response,
+                Err(error) => return ToolExecutionResult::internal_error_msg(format!("{error:#}")),
+            }
+        } else {
+            match client.edit(request).await {
+                Ok(response) => response,
+                Err(error) => return ToolExecutionResult::internal_error_msg(format!("{error:#}")),
+            }
         };
 
         materialize_outputs(
@@ -519,6 +570,8 @@ struct GptImageGenCapabilityConfig {
     model: ImageGenerationModel,
     #[serde(default = "default_openai_image_quality")]
     default_quality: ImageGenerationQuality,
+    #[serde(default = "default_openai_image_partial_images")]
+    partial_images: u8,
 }
 
 impl Default for GptImageGenCapabilityConfig {
@@ -526,6 +579,7 @@ impl Default for GptImageGenCapabilityConfig {
         Self {
             model: default_openai_image_model(),
             default_quality: default_openai_image_quality(),
+            partial_images: default_openai_image_partial_images(),
         }
     }
 }
@@ -536,6 +590,10 @@ fn default_openai_image_model() -> ImageGenerationModel {
 
 fn default_openai_image_quality() -> ImageGenerationQuality {
     DEFAULT_OPENAI_IMAGE_QUALITY
+}
+
+fn default_openai_image_partial_images() -> u8 {
+    DEFAULT_OPENAI_IMAGE_PARTIAL_IMAGES
 }
 
 fn resolve_quality(
@@ -561,9 +619,56 @@ fn parse_capability_config(
         return Ok(GptImageGenCapabilityConfig::default());
     }
 
-    serde_json::from_value::<GptImageGenCapabilityConfig>(config.clone()).map_err(|error| {
-        ToolExecutionResult::tool_error(format!("Invalid gpt_image_gen config: {error}"))
-    })
+    let parsed =
+        serde_json::from_value::<GptImageGenCapabilityConfig>(config.clone()).map_err(|error| {
+            ToolExecutionResult::tool_error(format!("Invalid gpt_image_gen config: {error}"))
+        })?;
+
+    if parsed.partial_images > 3 {
+        return Err(ToolExecutionResult::tool_error(
+            "Invalid gpt_image_gen config: partial_images must be between 0 and 3",
+        ));
+    }
+
+    Ok(parsed)
+}
+
+fn resolve_partial_images(count: usize, config: &GptImageGenCapabilityConfig) -> Option<u8> {
+    if count == 1 && config.partial_images > 0 {
+        Some(config.partial_images)
+    } else {
+        None
+    }
+}
+
+fn initial_progress_message(action: &str, count: usize, partial_images: Option<u8>) -> String {
+    if count > 1 {
+        format!("{action} {count} images...")
+    } else if partial_images.unwrap_or(0) > 0 {
+        format!("{action} image and waiting for preview...")
+    } else {
+        format!("{action} image...")
+    }
+}
+
+async fn emit_stream_progress(
+    context: &ToolContext,
+    tool_name: &str,
+    action: &str,
+    expected_previews: u8,
+    event: ImageApiStreamEvent,
+) {
+    let message = match event {
+        ImageApiStreamEvent::PartialImage {
+            partial_image_index,
+        } => format!(
+            "{action} preview {} of {}...",
+            partial_image_index + 1,
+            expected_previews
+        ),
+        ImageApiStreamEvent::Completed { .. } => format!("{action} final image..."),
+    };
+    context.emit_progress(tool_name, &message).await;
 }
 
 async fn build_client(context: &ToolContext) -> Result<OpenAiImageClient, ToolExecutionResult> {
@@ -1109,17 +1214,20 @@ mod tests {
         let config = parse_capability_config(&json!({})).unwrap();
         assert_eq!(config.model, ImageGenerationModel::GptImage2);
         assert_eq!(config.default_quality, ImageGenerationQuality::Medium);
+        assert_eq!(config.partial_images, 1);
     }
 
     #[test]
     fn capability_config_accepts_legacy_model_override() {
         let config = parse_capability_config(&json!({
             "model": "gpt-image-1",
-            "default_quality": "low"
+            "default_quality": "low",
+            "partial_images": 2
         }))
         .unwrap();
         assert_eq!(config.model, ImageGenerationModel::GptImage1);
         assert_eq!(config.default_quality, ImageGenerationQuality::Low);
+        assert_eq!(config.partial_images, 2);
     }
 
     #[test]
@@ -1127,11 +1235,13 @@ mod tests {
         let config = parse_capability_config(&json!({
             "model": "gpt-image-1",
             "default_quality": "high",
+            "partial_images": 3,
             "future_field": true
         }))
         .unwrap();
         assert_eq!(config.model, ImageGenerationModel::GptImage1);
         assert_eq!(config.default_quality, ImageGenerationQuality::High);
+        assert_eq!(config.partial_images, 3);
     }
 
     #[test]
@@ -1143,6 +1253,20 @@ mod tests {
         match error {
             ToolExecutionResult::ToolError(message) => {
                 assert!(message.contains("Invalid gpt_image_gen config"));
+            }
+            other => panic!("expected tool error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn capability_config_rejects_invalid_partial_image_count() {
+        let result = parse_capability_config(&json!({
+            "partial_images": 4
+        }));
+        let error = result.unwrap_err();
+        match error {
+            ToolExecutionResult::ToolError(message) => {
+                assert!(message.contains("partial_images must be between 0 and 3"));
             }
             other => panic!("expected tool error, got {other:?}"),
         }
@@ -1162,6 +1286,18 @@ mod tests {
             resolve_quality(None, ImageGenerationQuality::Medium),
             "medium"
         );
+    }
+
+    #[test]
+    fn resolve_partial_images_defaults_single_image_requests() {
+        let config = GptImageGenCapabilityConfig::default();
+        assert_eq!(resolve_partial_images(1, &config), Some(1));
+    }
+
+    #[test]
+    fn resolve_partial_images_disables_preview_streaming_for_batches() {
+        let config = GptImageGenCapabilityConfig::default();
+        assert_eq!(resolve_partial_images(3, &config), None);
     }
 
     #[test]

--- a/crates/openai/src/images.rs
+++ b/crates/openai/src/images.rs
@@ -1,7 +1,10 @@
 use anyhow::{Context, Result, anyhow};
+use eventsource_stream::Eventsource;
+use futures::{StreamExt, future::Future};
 use reqwest::multipart::{Form, Part};
 use reqwest::{Client, RequestBuilder, Url};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
 const DEFAULT_OPENAI_IMAGE_TIMEOUT_SECS: u64 = 300;
@@ -43,39 +46,29 @@ impl OpenAiImageClient {
         parse_image_response(response).await
     }
 
+    pub async fn generate_with_events<F, Fut>(
+        &self,
+        request: GenerateImageRequest,
+        on_event: F,
+    ) -> Result<ImageApiResponse>
+    where
+        F: FnMut(ImageApiStreamEvent) -> Fut + Send,
+        Fut: Future<Output = ()> + Send,
+    {
+        let url = image_endpoint_url(self.base_url.as_deref(), "images/generations")?;
+        let response = self
+            .apply_auth(self.client.post(url.clone()), url.as_str())
+            .json(&request)
+            .send()
+            .await
+            .context("failed to call OpenAI image generation API")?;
+
+        parse_image_stream_response(response, on_event).await
+    }
+
     pub async fn edit(&self, request: EditImageRequest) -> Result<ImageApiResponse> {
         let url = image_endpoint_url(self.base_url.as_deref(), "images/edits")?;
-        let image_field_name = if request.images.len() > 1 {
-            "image[]"
-        } else {
-            "image"
-        };
-
-        let mut form = Form::new()
-            .text("model", request.model)
-            .text("prompt", request.prompt)
-            .text("n", request.count.to_string());
-
-        if let Some(size) = request.size {
-            form = form.text("size", size);
-        }
-        if let Some(quality) = request.quality {
-            form = form.text("quality", quality);
-        }
-        if let Some(background) = request.background {
-            form = form.text("background", background);
-        }
-        if let Some(output_format) = request.output_format {
-            form = form.text("output_format", output_format);
-        }
-
-        for image in request.images {
-            let part = Part::bytes(image.data)
-                .file_name(image.filename)
-                .mime_str(&image.content_type)
-                .context("invalid source image content type")?;
-            form = form.part(image_field_name.to_string(), part);
-        }
+        let form = build_edit_image_form(request)?;
 
         let response = self
             .apply_auth(self.client.post(url.clone()), url.as_str())
@@ -85,6 +78,28 @@ impl OpenAiImageClient {
             .context("failed to call OpenAI image edit API")?;
 
         parse_image_response(response).await
+    }
+
+    pub async fn edit_with_events<F, Fut>(
+        &self,
+        request: EditImageRequest,
+        on_event: F,
+    ) -> Result<ImageApiResponse>
+    where
+        F: FnMut(ImageApiStreamEvent) -> Fut + Send,
+        Fut: Future<Output = ()> + Send,
+    {
+        let url = image_endpoint_url(self.base_url.as_deref(), "images/edits")?;
+        let form = build_edit_image_form(request)?;
+
+        let response = self
+            .apply_auth(self.client.post(url.clone()), url.as_str())
+            .multipart(form)
+            .send()
+            .await
+            .context("failed to call OpenAI image edit API")?;
+
+        parse_image_stream_response(response, on_event).await
     }
 
     fn apply_auth(&self, request: RequestBuilder, api_url: &str) -> RequestBuilder {
@@ -108,6 +123,10 @@ pub struct GenerateImageRequest {
     pub background: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "output_format")]
     pub output_format: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub partial_images: Option<u8>,
     #[serde(rename = "n")]
     pub count: usize,
 }
@@ -121,6 +140,8 @@ pub struct EditImageRequest {
     pub quality: Option<String>,
     pub background: Option<String>,
     pub output_format: Option<String>,
+    pub stream: Option<bool>,
+    pub partial_images: Option<u8>,
     pub count: usize,
 }
 
@@ -141,6 +162,54 @@ pub struct ImageApiImage {
     pub b64_json: String,
     #[serde(default)]
     pub revised_prompt: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImageApiStreamEvent {
+    PartialImage { partial_image_index: usize },
+    Completed { completed_image_count: usize },
+}
+
+fn build_edit_image_form(request: EditImageRequest) -> Result<Form> {
+    let image_field_name = if request.images.len() > 1 {
+        "image[]"
+    } else {
+        "image"
+    };
+
+    let mut form = Form::new()
+        .text("model", request.model)
+        .text("prompt", request.prompt)
+        .text("n", request.count.to_string());
+
+    if let Some(size) = request.size {
+        form = form.text("size", size);
+    }
+    if let Some(quality) = request.quality {
+        form = form.text("quality", quality);
+    }
+    if let Some(background) = request.background {
+        form = form.text("background", background);
+    }
+    if let Some(output_format) = request.output_format {
+        form = form.text("output_format", output_format);
+    }
+    if let Some(stream) = request.stream {
+        form = form.text("stream", stream.to_string());
+    }
+    if let Some(partial_images) = request.partial_images {
+        form = form.text("partial_images", partial_images.to_string());
+    }
+
+    for image in request.images {
+        let part = Part::bytes(image.data)
+            .file_name(image.filename)
+            .mime_str(&image.content_type)
+            .context("invalid source image content type")?;
+        form = form.part(image_field_name.to_string(), part);
+    }
+
+    Ok(form)
 }
 
 fn image_endpoint_url(base_url: Option<&str>, endpoint: &str) -> Result<Url> {
@@ -184,6 +253,77 @@ async fn parse_image_response(response: reqwest::Response) -> Result<ImageApiRes
         .context("failed to decode OpenAI image API response")
 }
 
+async fn parse_image_stream_response<F, Fut>(
+    response: reqwest::Response,
+    mut on_event: F,
+) -> Result<ImageApiResponse>
+where
+    F: FnMut(ImageApiStreamEvent) -> Fut + Send,
+    Fut: Future<Output = ()> + Send,
+{
+    let status = response.status();
+    if !status.is_success() {
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "<unreadable response body>".to_string());
+        return Err(anyhow!("OpenAI image API returned {status}: {body}"));
+    }
+
+    let mut images = Vec::new();
+    let mut event_stream = response.bytes_stream().eventsource();
+
+    while let Some(event) = event_stream.next().await {
+        let event = event.context("failed to read OpenAI image stream event")?;
+        if event.data == "[DONE]" {
+            break;
+        }
+
+        let payload: Value = serde_json::from_str(&event.data)
+            .context("failed to decode OpenAI image stream event")?;
+        let Some(event_type) = payload.get("type").and_then(Value::as_str) else {
+            tracing::debug!("Ignoring OpenAI image stream payload without type");
+            continue;
+        };
+
+        match event_type {
+            "image_generation.partial_image" => {
+                let partial_image_index = payload
+                    .get("partial_image_index")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0) as usize;
+                on_event(ImageApiStreamEvent::PartialImage {
+                    partial_image_index,
+                })
+                .await;
+            }
+            "image_generation.completed" => {
+                let image = serde_json::from_value::<ImageApiImage>(payload)
+                    .context("failed to decode OpenAI completed image event")?;
+                images.push(image);
+                on_event(ImageApiStreamEvent::Completed {
+                    completed_image_count: images.len(),
+                })
+                .await;
+            }
+            other => {
+                tracing::debug!(
+                    event_type = other,
+                    "Ignoring unknown OpenAI image stream event"
+                );
+            }
+        }
+    }
+
+    if images.is_empty() {
+        return Err(anyhow!(
+            "OpenAI image stream ended before any completed image events were received"
+        ));
+    }
+
+    Ok(ImageApiResponse { data: images })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -221,6 +361,8 @@ mod tests {
                 quality: Some("high".to_string()),
                 background: Some("transparent".to_string()),
                 output_format: Some("png".to_string()),
+                stream: None,
+                partial_images: None,
                 count: 1,
             })
             .await
@@ -258,11 +400,70 @@ mod tests {
                 quality: Some("medium".to_string()),
                 background: Some("opaque".to_string()),
                 output_format: Some("png".to_string()),
+                stream: None,
+                partial_images: None,
                 count: 1,
             })
             .await
             .unwrap();
 
         assert_eq!(response.data.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn generate_with_events_streams_partial_and_completed_images() {
+        let server = MockServer::start().await;
+        let stream_body = concat!(
+            "data: {\"type\":\"image_generation.partial_image\",\"partial_image_index\":0}\n\n",
+            "data: {\"type\":\"image_generation.completed\",\"b64_json\":\"aGVsbG8=\",\"revised_prompt\":\"otter\"}\n\n",
+            "data: [DONE]\n\n"
+        );
+        Mock::given(method("POST"))
+            .and(path("/v1/images/generations"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(stream_body),
+            )
+            .mount(&server)
+            .await;
+
+        let client =
+            OpenAiImageClient::new("sk-test", Some(format!("{}/v1", server.uri()))).unwrap();
+        let mut events = Vec::new();
+        let response = client
+            .generate_with_events(
+                GenerateImageRequest {
+                    model: "gpt-image-2".to_string(),
+                    prompt: "otter".to_string(),
+                    size: Some("1024x1024".to_string()),
+                    quality: Some("medium".to_string()),
+                    background: Some("opaque".to_string()),
+                    output_format: Some("png".to_string()),
+                    stream: Some(true),
+                    partial_images: Some(1),
+                    count: 1,
+                },
+                |event| {
+                    events.push(event);
+                    async {}
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            events,
+            vec![
+                ImageApiStreamEvent::PartialImage {
+                    partial_image_index: 0
+                },
+                ImageApiStreamEvent::Completed {
+                    completed_image_count: 1
+                },
+            ]
+        );
+        assert_eq!(response.data.len(), 1);
+        assert_eq!(response.data[0].revised_prompt.as_deref(), Some("otter"));
     }
 }

--- a/crates/openai/src/images.rs
+++ b/crates/openai/src/images.rs
@@ -166,8 +166,14 @@ pub struct ImageApiImage {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ImageApiStreamEvent {
-    PartialImage { partial_image_index: usize },
-    Completed { completed_image_count: usize },
+    PartialImage {
+        partial_image_index: usize,
+        b64_json: Option<String>,
+        revised_prompt: Option<String>,
+    },
+    Completed {
+        completed_image_count: usize,
+    },
 }
 
 fn build_edit_image_form(request: EditImageRequest) -> Result<Form> {
@@ -292,8 +298,18 @@ where
                     .get("partial_image_index")
                     .and_then(Value::as_u64)
                     .unwrap_or(0) as usize;
+                let b64_json = payload
+                    .get("b64_json")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned);
+                let revised_prompt = payload
+                    .get("revised_prompt")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned);
                 on_event(ImageApiStreamEvent::PartialImage {
                     partial_image_index,
+                    b64_json,
+                    revised_prompt,
                 })
                 .await;
             }
@@ -414,7 +430,7 @@ mod tests {
     async fn generate_with_events_streams_partial_and_completed_images() {
         let server = MockServer::start().await;
         let stream_body = concat!(
-            "data: {\"type\":\"image_generation.partial_image\",\"partial_image_index\":0}\n\n",
+            "data: {\"type\":\"image_generation.partial_image\",\"partial_image_index\":0,\"b64_json\":\"cHJldmlldw==\",\"revised_prompt\":\"otter sketch\"}\n\n",
             "data: {\"type\":\"image_generation.completed\",\"b64_json\":\"aGVsbG8=\",\"revised_prompt\":\"otter\"}\n\n",
             "data: [DONE]\n\n"
         );
@@ -456,7 +472,9 @@ mod tests {
             events,
             vec![
                 ImageApiStreamEvent::PartialImage {
-                    partial_image_index: 0
+                    partial_image_index: 0,
+                    b64_json: Some("cHJldmlldw==".to_string()),
+                    revised_prompt: Some("otter sketch".to_string()),
                 },
                 ImageApiStreamEvent::Completed {
                     completed_image_count: 1
@@ -465,5 +483,73 @@ mod tests {
         );
         assert_eq!(response.data.len(), 1);
         assert_eq!(response.data[0].revised_prompt.as_deref(), Some("otter"));
+    }
+
+    #[tokio::test]
+    async fn edit_with_events_streams_partial_and_completed_images() {
+        let server = MockServer::start().await;
+        let stream_body = concat!(
+            "data: {\"type\":\"image_generation.partial_image\",\"partial_image_index\":0,\"b64_json\":\"cHJldmlldw==\"}\n\n",
+            "data: {\"type\":\"image_generation.completed\",\"b64_json\":\"ZmluYWw=\",\"revised_prompt\":\"edited otter\"}\n\n",
+            "data: [DONE]\n\n"
+        );
+        Mock::given(method("POST"))
+            .and(path("/v1/images/edits"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(stream_body),
+            )
+            .mount(&server)
+            .await;
+
+        let client =
+            OpenAiImageClient::new("sk-test", Some(format!("{}/v1", server.uri()))).unwrap();
+        let mut events = Vec::new();
+        let response = client
+            .edit_with_events(
+                EditImageRequest {
+                    model: "gpt-image-2".to_string(),
+                    prompt: "edit otter".to_string(),
+                    images: vec![EditImageInput {
+                        filename: "source.png".to_string(),
+                        content_type: "image/png".to_string(),
+                        data: vec![1, 2, 3],
+                    }],
+                    size: Some("1024x1024".to_string()),
+                    quality: Some("medium".to_string()),
+                    background: Some("opaque".to_string()),
+                    output_format: Some("png".to_string()),
+                    stream: Some(true),
+                    partial_images: Some(1),
+                    count: 1,
+                },
+                |event| {
+                    events.push(event);
+                    async {}
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            events,
+            vec![
+                ImageApiStreamEvent::PartialImage {
+                    partial_image_index: 0,
+                    b64_json: Some("cHJldmlldw==".to_string()),
+                    revised_prompt: None,
+                },
+                ImageApiStreamEvent::Completed {
+                    completed_image_count: 1
+                },
+            ]
+        );
+        assert_eq!(response.data.len(), 1);
+        assert_eq!(response.data[0].b64_json, "ZmluYWw=");
+        assert_eq!(
+            response.data[0].revised_prompt.as_deref(),
+            Some("edited otter")
+        );
     }
 }

--- a/docs/capabilities/openai-image-generation.md
+++ b/docs/capabilities/openai-image-generation.md
@@ -26,7 +26,7 @@ If you need the previous generation model for compatibility, set `"model": "gpt-
 
 The default quality is `medium`. That keeps latency and reliability reasonable for `gpt-image-2` while still producing polished outputs.
 
-The default `partial_images` value is `1`. For single-image requests, the capability streams one preview frame and emits `tool.progress` updates while waiting for the final image. Set it to `0` to disable preview streaming, or up to `3` for more feedback at higher token cost.
+The default `partial_images` value is `1`. For single-image requests, the capability emits `tool.progress` status updates while waiting for the final image. Set it to `0` to disable progress updates, or up to `3` for more feedback at higher token cost.
 
 This capability resolves credentials server-side, persists durable image artifacts, and can also write generated outputs into the session filesystem under `/workspace/.outputs/images/`.
 
@@ -95,8 +95,8 @@ Both tools return:
 
 - Transparent background requires `png` or `webp` output
 - High quality can take substantially longer than medium or low on `gpt-image-2`
-- Single-image requests stream preview progress by default; multi-image batches still wait for the final response
-- Each streamed preview adds extra image output tokens on the OpenAI side, so higher `partial_images` values trade cost for better perceived latency
+- Single-image requests emit progress updates by default; multi-image batches still wait for the final response
+- Each additional streamed update adds extra image output tokens on the OpenAI side, so higher `partial_images` values trade cost for better perceived latency
 - `generate_image` and `edit_image` stay fully exposed even when OpenAI `tool_search` is enabled, so large tool lists do not defer their schemas
 - Session file edits must be `png`, `jpg`, `jpeg`, or `webp`
 - Edit sources larger than 50 MB are rejected before the API call

--- a/docs/capabilities/openai-image-generation.md
+++ b/docs/capabilities/openai-image-generation.md
@@ -17,13 +17,16 @@ Capability config supports both model selection and a default quality used when 
 ```json
 {
   "model": "gpt-image-2",
-  "default_quality": "medium"
+  "default_quality": "medium",
+  "partial_images": 1
 }
 ```
 
 If you need the previous generation model for compatibility, set `"model": "gpt-image-1"`.
 
 The default quality is `medium`. That keeps latency and reliability reasonable for `gpt-image-2` while still producing polished outputs.
+
+The default `partial_images` value is `1`. For single-image requests, the capability streams one preview frame and emits `tool.progress` updates while waiting for the final image. Set it to `0` to disable preview streaming, or up to `3` for more feedback at higher token cost.
 
 This capability resolves credentials server-side, persists durable image artifacts, and can also write generated outputs into the session filesystem under `/workspace/.outputs/images/`.
 
@@ -92,6 +95,8 @@ Both tools return:
 
 - Transparent background requires `png` or `webp` output
 - High quality can take substantially longer than medium or low on `gpt-image-2`
+- Single-image requests stream preview progress by default; multi-image batches still wait for the final response
+- Each streamed preview adds extra image output tokens on the OpenAI side, so higher `partial_images` values trade cost for better perceived latency
 - `generate_image` and `edit_image` stay fully exposed even when OpenAI `tool_search` is enabled, so large tool lists do not defer their schemas
 - Session file edits must be `png`, `jpg`, `jpeg`, or `webp`
 - Edit sources larger than 50 MB are rejected before the API call

--- a/test_cases/agents/image_generation/TC001_funny_images_with_artifacts.md
+++ b/test_cases/agents/image_generation/TC001_funny_images_with_artifacts.md
@@ -49,6 +49,7 @@ This case is based on the successful 2026-04-23 live run captured after fixing t
 
 5. Inspect the session messages and event stream:
    - confirm the agent emitted three `generate_image` tool calls
+   - confirm each tool call emitted at least one `tool.progress` update while the image was rendering
    - confirm each tool call completed successfully
    - confirm the final assistant message is present
 
@@ -67,6 +68,7 @@ This case is based on the successful 2026-04-23 live run captured after fixing t
 
 - Session reaches `idle`
 - Event stream includes `turn.started`, `reason.completed`, `turn.completed`, and `session.idled`
+- For each single-image `generate_image` call, the event stream includes at least one `tool.progress` status such as `Generating image and waiting for preview...` or `Generating preview 1 of 1...`
 - No `tool.error`, `internal_error`, or equivalent failure event appears
 
 ### Tool Planning

--- a/test_cases/agents/image_generation/TC001_funny_images_with_artifacts.md
+++ b/test_cases/agents/image_generation/TC001_funny_images_with_artifacts.md
@@ -68,7 +68,7 @@ This case is based on the successful 2026-04-23 live run captured after fixing t
 
 - Session reaches `idle`
 - Event stream includes `turn.started`, `reason.completed`, `turn.completed`, and `session.idled`
-- For each single-image `generate_image` call, the event stream includes at least one `tool.progress` status such as `Generating image and waiting for preview...` or `Generating preview 1 of 1...`
+- For each single-image `generate_image` call, the event stream includes at least one `tool.progress` status such as `Generating image and waiting for progress updates...` or `Generating progress update 1 of 1...`
 - No `tool.error`, `internal_error`, or equivalent failure event appears
 
 ### Tool Planning


### PR DESCRIPTION
## What
Add streamed progress feedback for OpenAI image generation and editing.

## Why
`gpt-image-2` calls can take a long time, and the existing capability stayed visually silent until the final image arrived. Users had no indication that the tool was still working.

## How
- Added SSE-based image event handling in the OpenAI image client for `image_generation.partial_image` and `image_generation.completed`.
- Updated `generate_image` and `edit_image` to emit `tool.progress` messages during single-image requests and to keep the final tool result/artifact contract unchanged.
- Added capability config for preview count (`partial_images`, default `1`), exposed it in the UI, and updated docs/manual test coverage.
- Carried a minimal clippy cleanup in `crates/core/src/observation/otel.rs` because latest `origin/main` failed the required local gate without it.

## Risk
- Medium
- This changes runtime behavior for OpenAI image tools by enabling streamed previews on single-image requests. Main risks are extra provider cost from streamed progress events, event parsing mismatches, or regressions in tool completion semantics.

## Security
- Threat categories reviewed: TM-TOOL, TM-LLM, TM-DOS, TM-WEB
- Findings and resolutions:
  - `TM-TOOL`: progress is emitted through the existing `tool.progress` channel; tool authority and result routing do not change.
  - `TM-LLM`: final artifacts/results still come only from completed image events, and invalid `partial_images` config values are rejected (`0..=3` only).
  - `TM-DOS`: preview streaming is bounded to single-image requests and capped progress-update count, limiting extra event volume and token cost.
  - `TM-WEB`: UI changes are bounded selectors only; no new raw HTML/script surface was introduced.
- No new threat-model entry was required because this extends an existing OpenAI tool path without introducing a new trust boundary.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `cargo test -p everruns-openai image_capability -- --nocapture`
- `cd apps/ui && ./node_modules/.bin/jest --runTestsByPath src/__tests__/capability-settings-editor.test.tsx`
- `just pre-push`
- Live smoke on `PORT_PREFIX=294 doppler --project everruns-dev --config dev run -- just start-dev --no-watch`
  - Session: `session_019dbdc7fd1479918985446444e567c6`
  - Observed `tool.progress` messages:
    - `Generating image and waiting for progress updates...`
    - `Generating progress update 1 of 1...`
    - `Generating final image...`
  - Final artifact: `img_019dbdc916147522ad03510281042c9c`
  - Final file: `/workspace/.outputs/images/raccoon_earnings_presentation.png`

