### PR TITLE
test(auth): regression tests for API key revalidation

### DIFF
--- a/crates/server/src/auth/builtin.rs
+++ b/crates/server/src/auth/builtin.rs
@@ -467,4 +467,120 @@ mod tests {
         assert_eq!(API_KEY_CACHE_TTL, Duration::from_secs(300));
         assert_eq!(API_KEY_CACHE_MAX_CAPACITY, 10_000);
     }
+
+    // Regression tests for the fix that dropped read-through API-key caching.
+    // See fix(auth): always revalidate API keys against DB (#1532). These tests
+    // lock in that `validate_api_key` goes to the DB on every call, so revoked
+    // keys and stale user state cannot re-authenticate via the in-process cache.
+    mod revalidation {
+        use super::super::super::backend::AuthBackend;
+        use super::super::*;
+        use crate::storage::StorageBackend;
+        use crate::storage::models::{CreateApiKeyRow, CreateUserRow, UpdateUser};
+
+        async fn seed_user_with_key(
+            db: &Arc<StorageBackend>,
+            email: &str,
+            name: &str,
+        ) -> (uuid::Uuid, uuid::Uuid, String) {
+            let user = db
+                .create_user(CreateUserRow {
+                    email: email.to_string(),
+                    name: name.to_string(),
+                    avatar_url: None,
+                    roles: vec!["user".to_string()],
+                    password_hash: None,
+                    email_verified: true,
+                    auth_provider: None,
+                    auth_provider_id: None,
+                    external_id: None,
+                })
+                .await
+                .expect("create user");
+
+            let generated = crate::auth::api_key::generate_api_key();
+            let key_row = db
+                .create_api_key(CreateApiKeyRow {
+                    user_id: user.id,
+                    name: "test-key".to_string(),
+                    key_hash: generated.key_hash.clone(),
+                    key_prefix: generated.key_prefix.clone(),
+                    scopes: vec!["*".to_string()],
+                    expires_at: None,
+                    metadata: serde_json::json!({}),
+                })
+                .await
+                .expect("create api key");
+
+            (user.id, key_row.id, generated.key)
+        }
+
+        #[tokio::test]
+        async fn validate_api_key_rejects_after_key_deleted_from_db() {
+            let db = Arc::new(StorageBackend::in_memory());
+            let backend = BuiltinAuthBackend::new(AuthConfig::default(), db.clone());
+            let (user_id, key_id, plaintext_key) =
+                seed_user_with_key(&db, "revoked@example.com", "Revoked User").await;
+
+            // First call succeeds and populates the cache.
+            let first = backend.validate_api_key(&plaintext_key).await;
+            assert!(first.is_ok(), "initial validation should succeed");
+
+            // Delete the key from the DB but do NOT invalidate the cache. Prior to
+            // the fix this would silently keep authenticating from the cache.
+            let removed = db.delete_api_key(key_id, user_id).await.expect("delete");
+            assert!(removed);
+
+            // Re-validate: must reject because revalidation always hits the DB.
+            let second = backend.validate_api_key(&plaintext_key).await;
+            assert!(
+                second.is_err(),
+                "revoked key must not authenticate even when cached"
+            );
+        }
+
+        #[tokio::test]
+        async fn validate_api_key_reflects_fresh_user_state_on_revalidation() {
+            let db = Arc::new(StorageBackend::in_memory());
+            let backend = BuiltinAuthBackend::new(AuthConfig::default(), db.clone());
+            let (user_id, _key_id, plaintext_key) =
+                seed_user_with_key(&db, "user@example.com", "Original Name").await;
+
+            let first = backend
+                .validate_api_key(&plaintext_key)
+                .await
+                .expect("first validation");
+            assert_eq!(first.name, "Original Name");
+
+            // Rename the user in the DB. With read-through caching this change
+            // would not surface until TTL expired.
+            db.update_user(
+                user_id,
+                UpdateUser {
+                    name: Some("Renamed User".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("rename user");
+
+            let second = backend
+                .validate_api_key(&plaintext_key)
+                .await
+                .expect("second validation");
+            assert_eq!(
+                second.name, "Renamed User",
+                "validate must re-read user state from DB on every call"
+            );
+        }
+
+        #[tokio::test]
+        async fn validate_api_key_rejects_invalid_format_without_db_lookup() {
+            let db = Arc::new(StorageBackend::in_memory());
+            let backend = BuiltinAuthBackend::new(AuthConfig::default(), db.clone());
+
+            let result = backend.validate_api_key("not-an-api-key").await;
+            assert!(result.is_err(), "malformed key must be rejected");
+        }
+    }
 }


### PR DESCRIPTION
## What
Add regression tests for `BuiltinAuthBackend::validate_api_key` covering the behavior locked in by #1532.

## Why
#1532 dropped read-through API-key caching so revoked keys and stale user state cannot re-authenticate. The fix shipped without tests proving the new contract, so a future refactor could silently reintroduce the TOCTOU window. Three tests under `auth::builtin::tests::revalidation` cover:
- `validate_api_key_rejects_after_key_deleted_from_db` — key deleted in DB while cache still holds the auth result must no longer authenticate.
- `validate_api_key_reflects_fresh_user_state_on_revalidation` — renaming the user in the DB surfaces on the next call (no cache staleness).
- `validate_api_key_rejects_invalid_format_without_db_lookup` — malformed keys fail fast.

I verified the tests regress against the pre-fix behavior by temporarily re-adding the cache-read path: 2 of the 3 new tests fail; with the fix in place all 3 pass.

## How
Test-only change. Uses the existing in-memory `StorageBackend` to seed a user + API key, drives `BuiltinAuthBackend::validate_api_key`, and asserts behavior after DB-side mutations. No production code touched.

## Risk
- Low
- Tests only — cannot affect runtime behavior. In-memory storage path is already exercised by the rest of the auth test module.

## Security
- Threat categories reviewed: TM-AUTH (authentication, credential lifecycle).
- Findings and resolutions: None. This PR exists to lock in the mitigation for the TM-AUTH issue fixed in #1532.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (test-only)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AnQoGgcE9v2Fq97oqH9WJV)_