### PR TITLE
test(slack): cross-org recovery app lookup rejection

### DIFF
--- a/crates/server/src/slack_delivery.rs
+++ b/crates/server/src/slack_delivery.rs
@@ -1342,4 +1342,163 @@ mod tests {
             assert!(result.unwrap_err().to_string().contains("unknown"));
         }
     }
+
+    // Regression tests for fix(slack): scope recovery app lookup to session org (#1502).
+    //
+    // Pre-fix `SlackDeliveryDispatcher::recover` resolved `slack:app:*` tags
+    // through an unscoped app lookup, allowing a session in org B to recover
+    // using org A's Slack bot token and post messages as that app. The fix
+    // routes the lookup through `get_by_public_id(..., session.org_id, ...)`,
+    // which returns None for cross-org tags. These tests pin the cross-tenant
+    // rejection.
+    mod recovery_scoping_tests {
+        use super::*;
+        use crate::storage::StorageBackend;
+        use crate::storage::models::{CreateAppRow, CreateSessionRow, UpdateSession};
+        use everruns_core::PrincipalId;
+        use everruns_core::typed_id::{AgentId, HarnessId};
+        use tokio::sync::broadcast;
+
+        const ORG_APP_OWNER: i64 = 10;
+        const ORG_ATTACKER: i64 = 20;
+        const LEGIT_APP_PUBLIC_ID: &str = "app_legit_test";
+
+        async fn seed_slack_app(db: &StorageBackend, org_id: i64, public_id: &str) {
+            db.create_app(
+                org_id,
+                CreateAppRow {
+                    public_id: public_id.to_string(),
+                    name: "Legit Slack App".to_string(),
+                    description: None,
+                    harness_id: uuid::Uuid::nil(),
+                    agent_id: Some(uuid::Uuid::nil()),
+                    agent_identity_id: None,
+                    owner_principal_id: PrincipalId::from_seed(1),
+                    resolved_owner_user_id: None,
+                    channel_type: Some("slack".to_string()),
+                    channel_config: serde_json::json!({
+                        "signing_secret": "sig",
+                        "bot_token": "xoxb-secret-bot-token",
+                        "session_strategy": "per_thread",
+                        "reply_mode": "all_messages",
+                    }),
+                    channel_config_encrypted: None,
+                },
+            )
+            .await
+            .expect("seed slack app");
+        }
+
+        async fn seed_active_session_with_slack_tag(
+            db: &StorageBackend,
+            org_id: i64,
+            app_public_id: &str,
+        ) -> everruns_core::typed_id::SessionId {
+            use crate::storage::models::CreateEventRow;
+
+            let session = db
+                .create_session(CreateSessionRow {
+                    org_id,
+                    harness_id: Some(HarnessId::from_uuid(uuid::Uuid::nil())),
+                    agent_id: Some(AgentId::from_uuid(uuid::Uuid::nil())),
+                    agent_identity_id: None,
+                    owner_principal_id: PrincipalId::from_seed(1),
+                    resolved_owner_user_id: None,
+                    title: Some("recovery test".to_string()),
+                    locale: None,
+                    tags: vec![format!("slack:app:{app_public_id}")],
+                    model_id: None,
+                    capabilities: serde_json::json!([]),
+                    tools: serde_json::json!([]),
+                    mcp_servers: serde_json::json!({}),
+                    system_prompt: None,
+                    initial_files: serde_json::Value::Array(vec![]),
+                    hints: None,
+                    max_iterations: None,
+                    blueprint_id: None,
+                    blueprint_config: None,
+                    network_access: None,
+                })
+                .await
+                .expect("create session");
+
+            db.update_session(
+                org_id,
+                session.id,
+                UpdateSession {
+                    status: Some("active".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("activate session");
+
+            // Seed an input.message event so recover() has enough context to
+            // reach the `register()` call under the pre-fix (unscoped) lookup.
+            // Without this, recover() would exit via the "no events" branch
+            // and the test couldn't distinguish pre- and post-fix behavior.
+            db.create_event(CreateEventRow {
+                session_id: session.id,
+                event_type: "input.message".to_string(),
+                ts: chrono::Utc::now(),
+                context: serde_json::json!({}),
+                data: serde_json::json!({
+                    "message": {
+                        "id": "msg_test_input",
+                        "metadata": {
+                            "slack_channel": "C_TEST",
+                            "slack_ts": "1234.5678",
+                        },
+                    },
+                }),
+                metadata: None,
+                tags: None,
+            })
+            .await
+            .expect("seed input.message");
+
+            session.id
+        }
+
+        fn build_dispatcher(db: Arc<StorageBackend>) -> Arc<SlackDeliveryDispatcher> {
+            // `recover` is independent of the event loop; we only need the
+            // dispatcher struct with a valid broadcast receiver so `start`
+            // can wire the event loop.
+            let (_tx, rx) = broadcast::channel::<EventNotificationPayload>(16);
+            SlackDeliveryDispatcher::start(db, rx)
+        }
+
+        #[tokio::test]
+        async fn recover_ignores_cross_org_slack_app_tag() {
+            let db = Arc::new(StorageBackend::in_memory());
+            seed_slack_app(&db, ORG_APP_OWNER, LEGIT_APP_PUBLIC_ID).await;
+            // Attacker session sits in a different org but tags a real app's public id.
+            seed_active_session_with_slack_tag(&db, ORG_ATTACKER, LEGIT_APP_PUBLIC_ID).await;
+
+            let dispatcher = build_dispatcher(db);
+            dispatcher.recover(None).await;
+
+            assert_eq!(
+                dispatcher.active_delivery_count().await,
+                0,
+                "cross-org slack:app:* tag must not register a delivery during recovery"
+            );
+        }
+
+        #[tokio::test]
+        async fn recover_ignores_session_with_unknown_app_tag() {
+            let db = Arc::new(StorageBackend::in_memory());
+            // No app exists with this public id anywhere.
+            seed_active_session_with_slack_tag(&db, ORG_ATTACKER, "app_does_not_exist").await;
+
+            let dispatcher = build_dispatcher(db);
+            dispatcher.recover(None).await;
+
+            assert_eq!(
+                dispatcher.active_delivery_count().await,
+                0,
+                "missing slack:app:* lookup must not leak recovery to any app"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## What
Integration test for `SlackDeliveryDispatcher::recover` covering the multi-tenant guarantee introduced by #1502.

## Why
#1502 replaced an unscoped `get_by_public_id_unscoped` in startup Slack recovery with an org-scoped `get_by_public_id(session.org_id, ...)`, preventing a forged `slack:app:<id>` tag on a session in org B from silently recovering using org A's bot token. The fix shipped without tests, so a refactor that reintroduced the unscoped lookup would not trip CI. This PR adds a `recovery_scoping_tests` submodule inside `slack_delivery::tests` with:

- **`recover_ignores_cross_org_slack_app_tag`** — seeds a legitimate Slack app in org A and an attacker session in org B tagged with that app's public id, plus an `input.message` event so recovery would otherwise reach `register()`. Asserts `active_delivery_count() == 0` after `recover()`. Verified locally to fail against the pre-fix `get_by_public_id_unscoped` call (the attacker session gets registered), and to pass under the current fix.
- **`recover_ignores_session_with_unknown_app_tag`** — baseline coverage for the "tag references an app that does not exist" path.

The session manifest-endpoint scope fix (#1534) is not covered here; it deserves a separate PR with handler-level setup. Noted for follow-up.

## How
Test-only change. Uses the in-memory `StorageBackend`, a local broadcast channel, and `SlackDeliveryDispatcher::start`. No production code touched.

## Risk
- Low
- Tests only — cannot affect runtime behavior.

## Security
- Threat categories reviewed: TM-AUTHZ (multi-tenant isolation), TM-API (Slack delivery surface).
- Findings and resolutions: None. This PR exists to lock in the cross-tenant mitigation from #1502.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (test-only)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AnQoGgcE9v2Fq97oqH9WJV)_