### PR TITLE
test(capabilities): lock in high-risk gating for bash/fetch

### DIFF
--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -1024,3 +1024,106 @@ pub async fn preview_agent(
         tools: result.tools,
     }))
 }
+
+// Regression tests for fix(capabilities): restore high-risk levels for
+// bash/fetch (#1500). `require_admin_for_high_risk` is the HTTP-side gate
+// that enforces TM-AGENT-005: a member cannot assign `virtual_bash` or
+// `web_fetch` to an agent. The fix re-classified both capabilities as
+// High; without that classification this gate silently becomes a no-op
+// for the two most dangerous capabilities.
+#[cfg(test)]
+mod high_risk_admin_gate_tests {
+    use super::*;
+    use crate::services::CapabilityService;
+    use crate::storage::StorageBackend;
+    use everruns_core::CapabilityRegistry;
+    use std::sync::Arc;
+
+    fn capability_service() -> CapabilityService {
+        let db = Arc::new(StorageBackend::in_memory());
+        CapabilityService::with_registry(db, None, CapabilityRegistry::with_builtins())
+    }
+
+    fn org_with_role(role: OrgRole) -> ResolvedOrg {
+        ResolvedOrg {
+            org_id: 1,
+            public_id: "org_test".to_string(),
+            name: "Test".to_string(),
+            user_id: None,
+            role,
+            is_platform_user: false,
+        }
+    }
+
+    fn caps(refs: &[&str]) -> Vec<AgentCapabilityConfig> {
+        refs.iter()
+            .map(|r| AgentCapabilityConfig::new((*r).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn member_blocked_from_assigning_virtual_bash() {
+        let svc = capability_service();
+        let result = require_admin_for_high_risk(
+            &org_with_role(OrgRole::Member),
+            &caps(&["virtual_bash"]),
+            &svc,
+        );
+        let (status, body) = result.expect_err("member must not assign virtual_bash");
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert!(body.0.error.contains("virtual_bash"));
+    }
+
+    #[test]
+    fn member_blocked_from_assigning_web_fetch() {
+        let svc = capability_service();
+        let result = require_admin_for_high_risk(
+            &org_with_role(OrgRole::Member),
+            &caps(&["web_fetch"]),
+            &svc,
+        );
+        let (status, body) = result.expect_err("member must not assign web_fetch");
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert!(body.0.error.contains("web_fetch"));
+    }
+
+    #[test]
+    fn member_allowed_for_low_risk_capability() {
+        let svc = capability_service();
+        let result =
+            require_admin_for_high_risk(&org_with_role(OrgRole::Member), &caps(&["noop"]), &svc);
+        assert!(
+            result.is_ok(),
+            "low-risk capabilities must remain assignable by members"
+        );
+    }
+
+    #[test]
+    fn admin_allowed_for_virtual_bash() {
+        let svc = capability_service();
+        let result = require_admin_for_high_risk(
+            &org_with_role(OrgRole::Admin),
+            &caps(&["virtual_bash"]),
+            &svc,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn owner_allowed_for_web_fetch() {
+        let svc = capability_service();
+        let result = require_admin_for_high_risk(
+            &org_with_role(OrgRole::Owner),
+            &caps(&["web_fetch"]),
+            &svc,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn empty_capability_list_allowed_for_members() {
+        let svc = capability_service();
+        let result = require_admin_for_high_risk(&org_with_role(OrgRole::Member), &[], &svc);
+        assert!(result.is_ok());
+    }
+}

--- a/crates/server/src/services/capability.rs
+++ b/crates/server/src/services/capability.rs
@@ -483,4 +483,66 @@ mod tests {
         assert!(!is_cached(&svc, 1).await);
         assert!(is_cached(&svc, 2).await);
     }
+
+    // Regression tests for fix(capabilities): restore high-risk levels for
+    // bash/fetch (#1500). `high_risk_ids` is the admin-gating primitive used
+    // by `api::agents::require_admin_for_high_risk`, the agent domain command
+    // `check_high_risk_caps`, and the session service's high-risk guard. If a
+    // refactor again downgrades `virtual_bash` or `web_fetch` the admin gate
+    // would silently stop firing (TM-AGENT-005).
+    mod high_risk_ids_tests {
+        use super::*;
+
+        #[test]
+        fn flags_virtual_bash_as_high_risk() {
+            let svc = make_service();
+            let high = svc.high_risk_ids(&["virtual_bash"]);
+            assert_eq!(high, vec!["virtual_bash".to_string()]);
+        }
+
+        #[test]
+        fn flags_web_fetch_as_high_risk() {
+            let svc = make_service();
+            let high = svc.high_risk_ids(&["web_fetch"]);
+            assert_eq!(high, vec!["web_fetch".to_string()]);
+        }
+
+        #[test]
+        fn flags_both_bash_and_fetch_in_mixed_input() {
+            let svc = make_service();
+            let high = svc.high_risk_ids(&["noop", "virtual_bash", "web_fetch"]);
+            assert!(high.contains(&"virtual_bash".to_string()));
+            assert!(high.contains(&"web_fetch".to_string()));
+            assert!(!high.contains(&"noop".to_string()));
+            assert_eq!(high.len(), 2);
+        }
+
+        #[test]
+        fn does_not_flag_noop_capability() {
+            let svc = make_service();
+            let high = svc.high_risk_ids(&["noop"]);
+            assert!(
+                high.is_empty(),
+                "default/low-risk capabilities must not be flagged as high-risk"
+            );
+        }
+
+        #[test]
+        fn does_not_flag_unknown_capability_refs() {
+            let svc = make_service();
+            // MCP and skill capability refs are resolved externally and are always
+            // Low risk; unknown refs must not be pulled into the high-risk set.
+            let high = svc.high_risk_ids(&["mcp:example/tool", "skill:local"]);
+            assert!(
+                high.is_empty(),
+                "non-builtin refs must not appear as high-risk"
+            );
+        }
+
+        #[test]
+        fn empty_input_returns_empty() {
+            let svc = make_service();
+            assert!(svc.high_risk_ids(&[]).is_empty());
+        }
+    }
 }


### PR DESCRIPTION
## What
Regression tests for the admin-gating surface restored by #1500.

## Why
#1500 reclassified `virtual_bash` and `web_fetch` back to `RiskLevel::High` after a refactor had downgraded them, restoring TM-AGENT-005 enforcement (non-admins cannot assign command execution or outbound network capabilities). The fix updated the existing per-capability metadata asserts but did not cover the two downstream consumers of that classification — `CapabilityService::high_risk_ids` and `require_admin_for_high_risk`. Those are where a silent downgrade would actually reach users, so this PR tests them directly:

- **`services::capability::tests::high_risk_ids_tests`** (6 tests) — asserts `high_risk_ids` returns `virtual_bash` and `web_fetch` (individually and mixed), does not flag `noop`, does not flag unknown / MCP / skill refs, and handles empty input.
- **`api::agents::high_risk_admin_gate_tests`** (6 tests) — drives `require_admin_for_high_risk` across Member/Admin/Owner for both high-risk capabilities, `noop`, and the empty-capability case, verifying the 403 response shape carries the offending capability id.

I verified the tests regress by temporarily setting `virtual_bash` risk to `RiskLevel::Low`: `flags_virtual_bash_as_high_risk` and `member_blocked_from_assigning_virtual_bash` both fail, so a future accidental downgrade would now trip CI.

## How
Test-only change. Uses the existing in-memory `StorageBackend` + `CapabilityService::with_registry` + the production `CapabilityRegistry::with_builtins`. No production code touched.

## Risk
- Low
- Tests only.

## Security
- Threat categories reviewed: TM-AGENT-005 (admin gating for high-risk capabilities), TM-AUTHZ (role-based authorization).
- Findings and resolutions: None. This PR locks in the mitigation shipped in #1500.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (test-only)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AnQoGgcE9v2Fq97oqH9WJV)_