### PR TITLE
test(cli): regression tests for connections set argv key leak

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -705,4 +705,76 @@ mod tests {
             panic!("Expected Connections command");
         }
     }
+
+    // Regression tests for fix(cli): avoid API key in connections set args (#1518).
+    //
+    // The old `--api-key <value>` flag leaked the provider secret into shell
+    // history and `ps` output. The fix removed the flag entirely and routed
+    // input through `--api-key-stdin` or the interactive password prompt.
+    // These tests lock in that contract at the clap-parser boundary.
+
+    #[test]
+    fn connections_set_rejects_legacy_api_key_flag() {
+        // Passing `--api-key <value>` must now fail parsing so the secret
+        // cannot end up in argv / shell history.
+        let result = Cli::try_parse_from([
+            "everruns",
+            "connections",
+            "set",
+            "daytona",
+            "--api-key",
+            "leaked_secret_value",
+        ]);
+        assert!(
+            result.is_err(),
+            "--api-key argv flag must be rejected to prevent argv/shell-history leaks"
+        );
+    }
+
+    #[test]
+    fn connections_set_defaults_api_key_stdin_to_false_for_interactive_prompt() {
+        // Without `--api-key-stdin`, the flag is false and `run` drops into
+        // the dialoguer Password prompt — the secret never touches argv.
+        let cli = Cli::try_parse_from(["everruns", "connections", "set", "daytona"]).unwrap();
+        if let Commands::Connections { command } = cli.command {
+            if let commands::connections::ConnectionsCommand::Set {
+                provider,
+                api_key_stdin,
+            } = command
+            {
+                assert_eq!(provider, "daytona");
+                assert!(
+                    !api_key_stdin,
+                    "omitting --api-key-stdin must default to interactive prompt"
+                );
+            } else {
+                panic!("Expected Set command");
+            }
+        } else {
+            panic!("Expected Connections command");
+        }
+    }
+
+    #[test]
+    fn connections_set_rejects_positional_api_key_after_provider() {
+        // A stray positional arg after `provider` must not bind to anything;
+        // clap should reject it rather than silently consuming the secret.
+        let result = Cli::try_parse_from([
+            "everruns",
+            "connections",
+            "set",
+            "daytona",
+            "leaked_secret_value",
+        ]);
+        assert!(
+            result.is_err(),
+            "extra positional args after provider must be rejected"
+        );
+    }
+
+    #[test]
+    fn connections_set_requires_provider() {
+        let result = Cli::try_parse_from(["everruns", "connections", "set"]);
+        assert!(result.is_err(), "provider arg is required");
+    }
 }


### PR DESCRIPTION
## What
Clap-parser regression tests for the argv-leak fix in #1518.

## Why
#1518 removed the `--api-key <value>` flag on `connections set` because it embedded the provider secret in shell history / `ps` output, and routed input through the interactive `dialoguer::Password` prompt or `--api-key-stdin`. The fix updated the existing positive-path parser test but did not pin the negative paths. If a future change re-added an `api_key: String` arg (the original leaky shape), nothing in the test suite would complain.

Four new tests in the existing `mod tests` block lock in the argv contract:

- **`connections_set_rejects_legacy_api_key_flag`** — invoking `connections set daytona --api-key <secret>` must fail to parse.
- **`connections_set_defaults_api_key_stdin_to_false_for_interactive_prompt`** — omitting `--api-key-stdin` keeps the flag `false`, so `run` drops into the `Password` prompt rather than any argv path.
- **`connections_set_rejects_positional_api_key_after_provider`** — an extra positional arg must be rejected rather than silently consumed.
- **`connections_set_requires_provider`** — baseline: provider name remains mandatory.

**Gap noted:** `read_provider_api_key` itself depends on `std::io::stdin()` and is not covered here. Testing that path would require threading a reader abstraction through the function. Left for a follow-up.

**Substitution note:** I originally planned this slot for `fix(daytona): harden git credential file permissions (#1509)`. That fix sequences `chmod 600` between `file_upload` and `git config` calls on `DaytonaClient`, and the daytona crate has no mock client infrastructure — testing would require a sizable scaffolding PR. The CLI argv-leak fix is a higher-leverage, low-risk coverage target given the same credential-exposure class (TM-SECRET).

## How
Test-only change. Uses `Cli::try_parse_from` as the rest of the CLI test suite does.

## Risk
- Low
- Tests only.

## Security
- Threat categories reviewed: TM-SECRET (credential handling / argv leakage).
- Findings and resolutions: None. This PR locks in the fix for the argv leak shipped in #1518.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (test-only)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AnQoGgcE9v2Fq97oqH9WJV)_