### PR TITLE
feat(ui): move models to building blocks

### DIFF
--- a/apps/ui/src/__tests__/middleware.test.ts
+++ b/apps/ui/src/__tests__/middleware.test.ts
@@ -43,6 +43,7 @@ describe("auth proxy", () => {
       "/evals/:path*",
       "/harnesses/:path*",
       "/mcp-servers/:path*",
+      "/models/:path*",
       "/orgs/:path*",
       "/sessions/:path*",
       "/settings/:path*",

--- a/apps/ui/src/__tests__/models-page.test.tsx
+++ b/apps/ui/src/__tests__/models-page.test.tsx
@@ -1,0 +1,182 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import ModelsPage from "@/app/(main)/models/page";
+
+const mockProviders = [
+  {
+    id: "provider-1",
+    name: "OpenAI Production",
+    provider_type: "openai",
+    status: "active",
+    api_key_set: true,
+    base_url: "https://api.openai.com/v1",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  },
+];
+
+const mockModels = [
+  {
+    id: "model-1",
+    model_id: "gpt-5.2",
+    display_name: "GPT-4",
+    provider_id: "provider-1",
+    provider_name: "OpenAI Production",
+    provider_type: "openai",
+    status: "active",
+    enabled: true,
+    capabilities: ["chat", "function_calling"],
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  },
+];
+
+const mockUseLlmProviders = jest.fn();
+const mockUseLlmModels = jest.fn();
+const mockUseCreateLlmModel = jest.fn();
+const mockUseDeleteLlmModel = jest.fn();
+
+jest.mock("@/hooks/use-llm-providers", () => ({
+  useLlmProviders: () => mockUseLlmProviders(),
+  useLlmModels: () => mockUseLlmModels(),
+  useCreateLlmModel: () => mockUseCreateLlmModel(),
+  useDeleteLlmModel: () => mockUseDeleteLlmModel(),
+}));
+
+jest.mock("@/hooks/use-organizations", () => ({
+  useOrganization: () => ({
+    data: {
+      id: "org_1",
+      name: "Test Org",
+      default_model_id: "model-1",
+      default_harness_id: null,
+      base_harness_id: null,
+      created_at: "2024-01-01",
+      updated_at: "2024-01-01",
+    },
+    isLoading: false,
+    error: null,
+  }),
+  useUpdateOrganization: () => ({
+    mutateAsync: jest.fn(),
+    isPending: false,
+  }),
+}));
+
+jest.mock("@/lib/api/llm-providers", () => ({
+  updateLlmModel: jest.fn(),
+}));
+
+jest.mock("@/lib/query-keys", () => ({
+  queryKeys: {
+    llmModels: {
+      all: ["llm-models"],
+      list: () => ["llm-models"],
+      detail: (id: string) => ["llm-models", id],
+    },
+    organizations: { all: ["organizations"], detail: (id: string) => ["organization", id] },
+  },
+}));
+
+describe("ModelsPage", () => {
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    mockUseLlmProviders.mockReturnValue({
+      data: mockProviders,
+      isLoading: false,
+      error: null,
+    });
+    mockUseLlmModels.mockReturnValue({
+      data: mockModels,
+      isLoading: false,
+      error: null,
+    });
+    mockUseCreateLlmModel.mockReturnValue({
+      mutateAsync: jest.fn(),
+      isPending: false,
+    });
+    mockUseDeleteLlmModel.mockReturnValue({
+      mutateAsync: jest.fn(),
+      isPending: false,
+    });
+  });
+
+  it("renders Models section header", () => {
+    render(<ModelsPage />, { wrapper });
+
+    expect(screen.getByText("Models")).toBeInTheDocument();
+    expect(
+      screen.getByText("Manage the models available from your configured providers."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders model rows with correct data", () => {
+    render(<ModelsPage />, { wrapper });
+
+    expect(screen.getAllByText("GPT-4").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("gpt-5.2 - OpenAI Production")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no models exist", () => {
+    mockUseLlmModels.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ModelsPage />, { wrapper });
+
+    expect(screen.getByText("No models configured")).toBeInTheDocument();
+  });
+
+  it("shows error message when models fail to load", () => {
+    mockUseLlmModels.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: new Error("Network error"),
+    });
+
+    render(<ModelsPage />, { wrapper });
+
+    expect(screen.getByText(/Failed to load models/)).toBeInTheDocument();
+  });
+
+  it("disables Add Model button when no providers exist", () => {
+    mockUseLlmProviders.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ModelsPage />, { wrapper });
+
+    expect(screen.getByRole("button", { name: /Add Model/i })).toBeDisabled();
+  });
+
+  it("shows Enabled badge and Disable button for enabled model", () => {
+    render(<ModelsPage />, { wrapper });
+
+    expect(screen.getByText("Enabled")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Disable/i })).toBeInTheDocument();
+  });
+
+  it("renders organization default model settings", () => {
+    render(<ModelsPage />, { wrapper });
+
+    expect(screen.getByText("Organization Settings")).toBeInTheDocument();
+    expect(screen.getByText("Default Model")).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/__tests__/settings-providers.test.tsx
+++ b/apps/ui/src/__tests__/settings-providers.test.tsx
@@ -165,13 +165,11 @@ describe("ProvidersPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders Models section header", () => {
+  it("does not render model management in provider settings", () => {
     render(<ProvidersPage />, { wrapper });
 
-    expect(screen.getByText("Models")).toBeInTheDocument();
-    expect(
-      screen.getByText("Manage the models available from your configured providers."),
-    ).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Models" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Add Model/i })).not.toBeInTheDocument();
   });
 
   it("renders provider cards with correct data", () => {
@@ -179,14 +177,6 @@ describe("ProvidersPage", () => {
 
     expect(screen.getByText("OpenAI Production")).toBeInTheDocument();
     expect(screen.getByText("Anthropic Dev")).toBeInTheDocument();
-  });
-
-  it("renders model rows with correct data", () => {
-    render(<ProvidersPage />, { wrapper });
-
-    // Model name may appear in both the row and org settings selector
-    expect(screen.getAllByText("GPT-4").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText("gpt-5.2 - OpenAI Production")).toBeInTheDocument();
   });
 
   it("shows loading skeleton when providers are loading", () => {
@@ -218,18 +208,6 @@ describe("ProvidersPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows empty state when no models exist", () => {
-    mockUseLlmModels.mockReturnValue({
-      data: [],
-      isLoading: false,
-      error: null,
-    });
-
-    render(<ProvidersPage />, { wrapper });
-
-    expect(screen.getByText("No models configured")).toBeInTheDocument();
-  });
-
   it("shows error message when providers fail to load", () => {
     mockUseLlmProviders.mockReturnValue({
       data: [],
@@ -242,59 +220,11 @@ describe("ProvidersPage", () => {
     expect(screen.getByText(/Failed to load providers/)).toBeInTheDocument();
   });
 
-  it("shows error message when models fail to load", () => {
-    mockUseLlmModels.mockReturnValue({
-      data: [],
-      isLoading: false,
-      error: new Error("Network error"),
-    });
-
-    render(<ProvidersPage />, { wrapper });
-
-    expect(screen.getByText(/Failed to load models/)).toBeInTheDocument();
-  });
-
   it("renders Add Provider button", () => {
     render(<ProvidersPage />, { wrapper });
 
     const addButtons = screen.getAllByRole("button", { name: /Add Provider/i });
     expect(addButtons.length).toBeGreaterThan(0);
-  });
-
-  it("renders Add Model button", () => {
-    render(<ProvidersPage />, { wrapper });
-
-    const addButtons = screen.getAllByRole("button", { name: /Add Model/i });
-    expect(addButtons.length).toBeGreaterThan(0);
-  });
-
-  it("disables Add Model button when no providers exist", () => {
-    mockUseLlmProviders.mockReturnValue({
-      data: [],
-      isLoading: false,
-      error: null,
-    });
-
-    render(<ProvidersPage />, { wrapper });
-
-    // The Add Model button in the header should be disabled
-    const addModelButtons = screen.getAllByRole("button", { name: /Add Model/i });
-    const headerButton = addModelButtons[0];
-    expect(headerButton).toBeDisabled();
-  });
-
-  it("shows Enabled badge for enabled model", () => {
-    render(<ProvidersPage />, { wrapper });
-
-    // GPT-4 is enabled
-    expect(screen.getByText("Enabled")).toBeInTheDocument();
-  });
-
-  it("shows Enable/Disable button for models", () => {
-    render(<ProvidersPage />, { wrapper });
-
-    // Enabled model should show Disable button
-    expect(screen.getByRole("button", { name: /Disable/i })).toBeInTheDocument();
   });
 
   it("shows API Key status correctly", () => {

--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -164,6 +164,7 @@ describe("Sidebar", () => {
     expect(screen.getByText("Dashboard")).toBeInTheDocument();
     expect(screen.getByText("Harnesses")).toBeInTheDocument();
     expect(screen.getByText("Agents")).toBeInTheDocument();
+    expect(screen.getByText("Models")).toBeInTheDocument();
     expect(screen.getByText("Capabilities")).toBeInTheDocument();
     expect(screen.getByText("Settings")).toBeInTheDocument();
   });
@@ -174,12 +175,14 @@ describe("Sidebar", () => {
     const dashboardLink = screen.getByRole("link", { name: "Dashboard" });
     const harnessesLink = screen.getByRole("link", { name: "Harnesses" });
     const agentsLink = screen.getByRole("link", { name: "Agents" });
+    const modelsLink = screen.getByRole("link", { name: "Models" });
     const capabilitiesLink = screen.getByRole("link", { name: "Capabilities" });
     const settingsLink = screen.getByRole("link", { name: "Settings" });
 
     expect(dashboardLink).toHaveAttribute("href", "/dashboard");
     expect(harnessesLink).toHaveAttribute("href", "/harnesses");
     expect(agentsLink).toHaveAttribute("href", "/agents");
+    expect(modelsLink).toHaveAttribute("href", "/models");
     expect(capabilitiesLink).toHaveAttribute("href", "/capabilities");
     expect(settingsLink).toHaveAttribute("href", "/settings");
   });
@@ -231,7 +234,7 @@ describe("Sidebar", () => {
     expect(dashboardLink).toHaveClass("text-[13px]");
   });
 
-  it("has exactly 6 navigation items", () => {
+  it("has exactly 7 core navigation items", () => {
     render(<Sidebar />);
 
     // Get nav links (excluding logo link)
@@ -241,12 +244,19 @@ describe("Sidebar", () => {
         (link) =>
           link.getAttribute("href") !== "/dashboard" || link.textContent?.includes("Dashboard"),
       );
-    // Filter to only nav items (Chat, Dashboard, Harnesses, Agents, Capabilities, Settings)
-    const navItems = ["Chat", "Dashboard", "Harnesses", "Agents", "Capabilities", "Settings"];
+    const navItems = [
+      "Chat",
+      "Dashboard",
+      "Harnesses",
+      "Agents",
+      "Models",
+      "Capabilities",
+      "Settings",
+    ];
     const foundNavLinks = navLinks.filter((link) =>
       navItems.some((item) => link.textContent?.includes(item)),
     );
-    expect(foundNavLinks).toHaveLength(6);
+    expect(foundNavLinks).toHaveLength(7);
   });
 
   it("renders section labels for Building Blocks and Durable Execution", () => {

--- a/apps/ui/src/app/(main)/models/page.tsx
+++ b/apps/ui/src/app/(main)/models/page.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { Cpu, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { AddModelDialog } from "@/components/models/add-model-dialog";
+import { ModelRow } from "@/components/models/model-row";
+import { ProviderIcon } from "@/components/providers/provider-icon";
+import { useLlmModels, useLlmProviders, useDeleteLlmModel } from "@/hooks/use-llm-providers";
+import { useOrganization, useUpdateOrganization } from "@/hooks/use-organizations";
+import { updateLlmModel } from "@/lib/api/llm-providers";
+import { queryKeys } from "@/lib/query-keys";
+
+export default function ModelsPage() {
+  const queryClient = useQueryClient();
+  const { data: providers = [] } = useLlmProviders();
+  const { data: models = [], isLoading: modelsLoading, error: modelsError } = useLlmModels();
+  const { data: org } = useOrganization();
+  const updateOrg = useUpdateOrganization();
+  const deleteModel = useDeleteLlmModel();
+  const [addModelOpen, setAddModelOpen] = useState(false);
+  const [togglingModelId, setTogglingModelId] = useState<string | null>(null);
+
+  const enabledModels = models.filter((model) => model.enabled);
+  const selectedDefaultModelName = org?.default_model_id
+    ? (enabledModels.find((model) => model.id === org.default_model_id)?.display_name ??
+      "Unknown model")
+    : undefined;
+
+  const handleDeleteModel = async (id: string) => {
+    if (confirm("Are you sure you want to delete this model?")) {
+      await deleteModel.mutateAsync(id);
+    }
+  };
+
+  const handleToggleEnabled = async (modelId: string, enabled: boolean) => {
+    setTogglingModelId(modelId);
+    try {
+      await updateLlmModel(modelId, { enabled });
+      await queryClient.invalidateQueries({ queryKey: queryKeys.llmModels.all });
+      if (!enabled) {
+        await queryClient.invalidateQueries({ queryKey: queryKeys.organizations.all });
+      }
+    } finally {
+      setTogglingModelId(null);
+    }
+  };
+
+  const handleSetDefaultModel = async (modelId: string) => {
+    await updateOrg.mutateAsync({ default_model_id: modelId || undefined });
+  };
+
+  return (
+    <div className="space-y-8">
+      <section>
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <h2 className="text-xl font-semibold">Models</h2>
+            <p className="text-sm text-muted-foreground">
+              Manage the models available from your configured providers.
+            </p>
+          </div>
+          <Button onClick={() => setAddModelOpen(true)} disabled={providers.length === 0}>
+            <Plus className="h-4 w-4 mr-2" />
+            Add Model
+          </Button>
+        </div>
+
+        {modelsError && (
+          <div className="bg-destructive/10 text-destructive p-4 mb-4">
+            Failed to load models: {modelsError.message}
+          </div>
+        )}
+
+        {modelsLoading ? (
+          <div className="space-y-2">
+            {[...Array(3)].map((_, index) => (
+              <Skeleton key={index} className="h-16 w-full" />
+            ))}
+          </div>
+        ) : models.length === 0 ? (
+          <Card className="p-8 text-center">
+            <Cpu className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+            <h3 className="text-lg font-medium mb-2">No models configured</h3>
+            <p className="text-muted-foreground mb-4">
+              {providers.length === 0
+                ? "Add a provider first, then add models to it."
+                : "Add models to your providers to use them with agents."}
+            </p>
+            {providers.length > 0 && (
+              <Button onClick={() => setAddModelOpen(true)}>
+                <Plus className="h-4 w-4 mr-2" />
+                Add Model
+              </Button>
+            )}
+          </Card>
+        ) : (
+          <div className="space-y-2">
+            {models.map((model) => (
+              <ModelRow
+                key={model.id}
+                model={model}
+                onDelete={handleDeleteModel}
+                onToggleEnabled={handleToggleEnabled}
+                isTogglingEnabled={togglingModelId === model.id}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {enabledModels.length > 0 && (
+        <section>
+          <div className="mb-4">
+            <h2 className="text-xl font-semibold">Organization Settings</h2>
+            <p className="text-sm text-muted-foreground">
+              Configure the default model for your organization. This is used when no model is
+              specified at the agent or session level.
+            </p>
+          </div>
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center gap-4">
+                <Label htmlFor="default-model" className="whitespace-nowrap font-medium">
+                  Default Model
+                </Label>
+                <Select
+                  value={org?.default_model_id ?? "none"}
+                  onValueChange={(value) => handleSetDefaultModel(value === "none" ? "" : value)}
+                  disabled={updateOrg.isPending}
+                >
+                  <SelectTrigger className="w-full max-w-md" id="default-model">
+                    <SelectValue placeholder="No default model">
+                      {selectedDefaultModelName}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">No default model</SelectItem>
+                    {enabledModels.map((model) => (
+                      <SelectItem key={model.id} value={model.id}>
+                        <div className="flex items-center gap-2">
+                          <ProviderIcon
+                            providerType={model.provider_type}
+                            size="sm"
+                            showBackground={false}
+                          />
+                          <span>
+                            {model.display_name} ({model.provider_name})
+                          </span>
+                        </div>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </CardContent>
+          </Card>
+        </section>
+      )}
+
+      <AddModelDialog providers={providers} open={addModelOpen} onOpenChange={setAddModelOpen} />
+    </div>
+  );
+}

--- a/apps/ui/src/app/(main)/settings/layout.tsx
+++ b/apps/ui/src/app/(main)/settings/layout.tsx
@@ -31,7 +31,7 @@ const settingsSections: NavSection[] = [
         name: "LLM Providers",
         href: "/settings/providers",
         icon: Server,
-        description: "Manage LLM providers and models",
+        description: "Manage LLM providers",
       },
       {
         name: "Members",

--- a/apps/ui/src/app/(main)/settings/providers/page.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/page.tsx
@@ -2,54 +2,34 @@
 
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
-import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger } from "@/components/ui/select";
-import { useQueryClient } from "@tanstack/react-query";
+import { Card } from "@/components/ui/card";
 import {
   useLlmProviders,
-  useLlmModels,
   useDeleteLlmProvider,
   useSyncProviderModels,
-  useDeleteLlmModel,
 } from "@/hooks/use-llm-providers";
-import { updateLlmModel } from "@/lib/api/llm-providers";
-import { useOrganization, useUpdateOrganization } from "@/hooks/use-organizations";
-import { queryKeys } from "@/lib/query-keys";
-import { Plus, Server, Cpu } from "lucide-react";
-import { ProviderIcon } from "@/components/providers/provider-icon";
+import { Plus, Server } from "lucide-react";
 import type { LlmProvider } from "@/lib/api/types";
 
 import { ProviderCard, ProviderCardSkeleton } from "./provider-card";
-import { ModelRow } from "./model-row";
-import { AddProviderDialog, SetApiKeyDialog, AddModelDialog } from "./provider-dialogs";
+import { AddProviderDialog, SetApiKeyDialog } from "./provider-dialogs";
 
 export default function ProvidersPage() {
-  const queryClient = useQueryClient();
   const {
     data: providers = [],
     isLoading: providersLoading,
     error: providersError,
   } = useLlmProviders();
-  const { data: models = [], isLoading: modelsLoading, error: modelsError } = useLlmModels();
-  const { data: org } = useOrganization();
-  const updateOrg = useUpdateOrganization();
   const deleteProvider = useDeleteLlmProvider();
-  const deleteModel = useDeleteLlmModel();
   const syncModels = useSyncProviderModels();
-  const [togglingModelId, setTogglingModelId] = useState<string | null>(null);
 
   const [addProviderOpen, setAddProviderOpen] = useState(false);
-  const [addModelOpen, setAddModelOpen] = useState(false);
   const [apiKeyProvider, setApiKeyProvider] = useState<LlmProvider | null>(null);
   const [syncingProviderId, setSyncingProviderId] = useState<string | null>(null);
   const [syncMessage, setSyncMessage] = useState<{
     type: "success" | "error";
     text: string;
   } | null>(null);
-
-  const enabledModels = models.filter((m) => m.enabled);
 
   const handleDeleteProvider = async (id: string) => {
     if (
@@ -59,30 +39,6 @@ export default function ProvidersPage() {
     ) {
       await deleteProvider.mutateAsync(id);
     }
-  };
-
-  const handleDeleteModel = async (id: string) => {
-    if (confirm("Are you sure you want to delete this model?")) {
-      await deleteModel.mutateAsync(id);
-    }
-  };
-
-  const handleToggleEnabled = async (modelId: string, enabled: boolean) => {
-    setTogglingModelId(modelId);
-    try {
-      await updateLlmModel(modelId, { enabled });
-      await queryClient.invalidateQueries({ queryKey: queryKeys.llmModels.all });
-      // If disabling, also refresh org in case it was the default
-      if (!enabled) {
-        await queryClient.invalidateQueries({ queryKey: queryKeys.organizations.all });
-      }
-    } finally {
-      setTogglingModelId(null);
-    }
-  };
-
-  const handleSetDefaultModel = async (modelId: string) => {
-    await updateOrg.mutateAsync({ default_model_id: modelId || undefined });
   };
 
   const handleSyncModels = async (providerId: string) => {
@@ -108,14 +64,12 @@ export default function ProvidersPage() {
       });
     } finally {
       setSyncingProviderId(null);
-      // Clear message after 5 seconds
       setTimeout(() => setSyncMessage(null), 5000);
     }
   };
 
   return (
     <div className="space-y-8">
-      {/* LLM Providers Section */}
       <section>
         <div className="flex items-center justify-between mb-4">
           <div>
@@ -150,8 +104,8 @@ export default function ProvidersPage() {
 
         {providersLoading ? (
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {[...Array(3)].map((_, i) => (
-              <ProviderCardSkeleton key={i} />
+            {[...Array(3)].map((_, index) => (
+              <ProviderCardSkeleton key={index} />
             ))}
           </div>
         ) : providers.length === 0 ? (
@@ -182,125 +136,12 @@ export default function ProvidersPage() {
         )}
       </section>
 
-      {/* LLM Models Section */}
-      <section>
-        <div className="flex items-center justify-between mb-4">
-          <div>
-            <h2 className="text-xl font-semibold">Models</h2>
-            <p className="text-sm text-muted-foreground">
-              Manage the models available from your configured providers.
-            </p>
-          </div>
-          <Button onClick={() => setAddModelOpen(true)} disabled={providers.length === 0}>
-            <Plus className="h-4 w-4 mr-2" />
-            Add Model
-          </Button>
-        </div>
-
-        {modelsError && (
-          <div className="bg-destructive/10 text-destructive p-4 mb-4">
-            Failed to load models: {modelsError.message}
-          </div>
-        )}
-
-        {modelsLoading ? (
-          <div className="space-y-2">
-            {[...Array(3)].map((_, i) => (
-              <Skeleton key={i} className="h-16 w-full" />
-            ))}
-          </div>
-        ) : models.length === 0 ? (
-          <Card className="p-8 text-center">
-            <Cpu className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-            <h3 className="text-lg font-medium mb-2">No models configured</h3>
-            <p className="text-muted-foreground mb-4">
-              {providers.length === 0
-                ? "Add a provider first, then add models to it."
-                : "Add models to your providers to use them with agents."}
-            </p>
-            {providers.length > 0 && (
-              <Button onClick={() => setAddModelOpen(true)}>
-                <Plus className="h-4 w-4 mr-2" />
-                Add Model
-              </Button>
-            )}
-          </Card>
-        ) : (
-          <div className="space-y-2">
-            {models.map((model) => (
-              <ModelRow
-                key={model.id}
-                model={model}
-                onDelete={handleDeleteModel}
-                onToggleEnabled={handleToggleEnabled}
-                isTogglingEnabled={togglingModelId === model.id}
-              />
-            ))}
-          </div>
-        )}
-      </section>
-
-      {/* Organization Default Model Section */}
-      {enabledModels.length > 0 && (
-        <section>
-          <div className="mb-4">
-            <h2 className="text-xl font-semibold">Organization Settings</h2>
-            <p className="text-sm text-muted-foreground">
-              Configure the default model for your organization. This is used when no model is
-              specified at the agent or session level.
-            </p>
-          </div>
-          <Card>
-            <CardContent className="pt-6">
-              <div className="flex items-center gap-4">
-                <Label htmlFor="default-model" className="whitespace-nowrap font-medium">
-                  Default Model
-                </Label>
-                <Select
-                  value={org?.default_model_id ?? "none"}
-                  onValueChange={(val) => handleSetDefaultModel(val === "none" ? "" : val)}
-                  disabled={updateOrg.isPending}
-                >
-                  <SelectTrigger className="w-full max-w-md" id="default-model">
-                    <span>
-                      {org?.default_model_id
-                        ? (enabledModels.find((m) => m.id === org.default_model_id)?.display_name ??
-                          "Unknown model")
-                        : "No default model"}
-                    </span>
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">No default model</SelectItem>
-                    {enabledModels.map((model) => (
-                      <SelectItem key={model.id} value={model.id}>
-                        <div className="flex items-center gap-2">
-                          <ProviderIcon
-                            providerType={model.provider_type}
-                            size="sm"
-                            showBackground={false}
-                          />
-                          <span>
-                            {model.display_name} ({model.provider_name})
-                          </span>
-                        </div>
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            </CardContent>
-          </Card>
-        </section>
-      )}
-
-      {/* Dialogs */}
       <AddProviderDialog open={addProviderOpen} onOpenChange={setAddProviderOpen} />
       <SetApiKeyDialog
         provider={apiKeyProvider}
         open={apiKeyProvider !== null}
         onOpenChange={(open) => !open && setApiKeyProvider(null)}
       />
-      <AddModelDialog providers={providers} open={addModelOpen} onOpenChange={setAddModelOpen} />
     </div>
   );
 }

--- a/apps/ui/src/app/(main)/settings/providers/provider-dialogs.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/provider-dialogs.tsx
@@ -13,18 +13,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import {
-  useCreateLlmProvider,
-  useUpdateLlmProvider,
-  useCreateLlmModel,
-} from "@/hooks/use-llm-providers";
+import { useCreateLlmProvider, useUpdateLlmProvider } from "@/hooks/use-llm-providers";
 import { ProviderIcon, getProviderLabel } from "@/components/providers/provider-icon";
-import type {
-  LlmProvider,
-  LlmProviderType,
-  CreateLlmProviderRequest,
-  CreateLlmModelRequest,
-} from "@/lib/api/types";
+import type { LlmProvider, LlmProviderType, CreateLlmProviderRequest } from "@/lib/api/types";
 
 const PROVIDER_TYPES: { value: LlmProviderType; label: string }[] = [
   { value: "openai", label: "OpenAI (Responses API)" },
@@ -236,111 +227,6 @@ export function SetApiKeyDialog({
             </Button>
             <Button type="submit" disabled={updateProvider.isPending || !apiKey}>
               {updateProvider.isPending ? "Saving..." : "Save API Key"}
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-export function AddModelDialog({
-  providers,
-  open,
-  onOpenChange,
-}: {
-  providers: LlmProvider[];
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-}) {
-  const [providerId, setProviderId] = useState("");
-  const [modelId, setModelId] = useState("");
-  const [displayName, setDisplayName] = useState("");
-  const [enabled, setEnabled] = useState(true);
-
-  const createModel = useCreateLlmModel(providerId);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    const data: CreateLlmModelRequest = {
-      model_id: modelId,
-      display_name: displayName,
-      enabled,
-    };
-    await createModel.mutateAsync(data);
-    onOpenChange(false);
-    setProviderId("");
-    setModelId("");
-    setDisplayName("");
-    setEnabled(true);
-  };
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Add Model</DialogTitle>
-          <DialogDescription>Add a new model to an existing provider.</DialogDescription>
-        </DialogHeader>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="provider">Provider</Label>
-            <Select value={providerId} onValueChange={setProviderId}>
-              <SelectTrigger className="w-full">
-                <span className={!providerId ? "text-muted-foreground" : ""}>
-                  {providerId
-                    ? providers.find((p) => p.id === providerId)?.name
-                    : "Select provider"}
-                </span>
-              </SelectTrigger>
-              <SelectContent>
-                {providers.map((p) => (
-                  <SelectItem key={p.id} value={p.id}>
-                    {p.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="model-id">Model ID</Label>
-            <Input
-              id="model-id"
-              value={modelId}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setModelId(e.target.value)}
-              placeholder="gpt-5.2"
-              required
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="display-name">Display Name</Label>
-            <Input
-              id="display-name"
-              value={displayName}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setDisplayName(e.target.value)}
-              placeholder="GPT-4o"
-              required
-            />
-          </div>
-          <div className="flex items-center gap-2">
-            <input
-              type="checkbox"
-              id="model-enabled"
-              checked={enabled}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEnabled(e.target.checked)}
-              className="h-4 w-4"
-            />
-            <Label htmlFor="model-enabled">Enable model (visible in UI model pickers)</Label>
-          </div>
-          <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              disabled={createModel.isPending || !providerId || !modelId || !displayName}
-            >
-              {createModel.isPending ? "Creating..." : "Create Model"}
             </Button>
           </DialogFooter>
         </form>

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -37,6 +37,7 @@ import {
   UserRound,
   Workflow,
   Cog,
+  Cpu,
 } from "lucide-react";
 import { capabilityIconMap } from "@/lib/capability-icons";
 import { useCommandPalette } from "@/hooks/use-command-palette";
@@ -91,6 +92,7 @@ export const defaultBuildingBlocksNavigation: NavigationItem[] = [
   { name: "Agents", href: "/agents", icon: Boxes },
   { name: "Agent Identities", href: "/agent-identities", icon: UserRound },
   { name: "Skills", href: "/skills", icon: BookOpen },
+  { name: "Models", href: "/models", icon: Cpu },
   { name: "Capabilities", href: "/capabilities", icon: Puzzle },
   { name: "MCP Servers", href: "/mcp-servers", icon: capabilityIconMap.mcp },
   { name: "Apps", href: "/apps", icon: Rocket, flag: "apps", experimental: true },

--- a/apps/ui/src/components/models/add-model-dialog.tsx
+++ b/apps/ui/src/components/models/add-model-dialog.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useCreateLlmModel } from "@/hooks/use-llm-providers";
+import type { CreateLlmModelRequest, LlmProvider } from "@/lib/api/types";
+
+export function AddModelDialog({
+  providers,
+  open,
+  onOpenChange,
+}: {
+  providers: LlmProvider[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [providerId, setProviderId] = useState("");
+  const [modelId, setModelId] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [enabled, setEnabled] = useState(true);
+
+  const createModel = useCreateLlmModel(providerId);
+  const selectedProviderName = providers.find((provider) => provider.id === providerId)?.name;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const data: CreateLlmModelRequest = {
+      model_id: modelId,
+      display_name: displayName,
+      enabled,
+    };
+    await createModel.mutateAsync(data);
+    onOpenChange(false);
+    setProviderId("");
+    setModelId("");
+    setDisplayName("");
+    setEnabled(true);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add Model</DialogTitle>
+          <DialogDescription>Add a new model to an existing provider.</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="provider">Provider</Label>
+            <Select value={providerId} onValueChange={setProviderId}>
+              <SelectTrigger id="provider" className="w-full">
+                <SelectValue placeholder="Select provider">{selectedProviderName}</SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                {providers.map((provider) => (
+                  <SelectItem key={provider.id} value={provider.id}>
+                    {provider.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="model-id">Model ID</Label>
+            <Input
+              id="model-id"
+              value={modelId}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setModelId(e.target.value)}
+              placeholder="gpt-5.2"
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="display-name">Display Name</Label>
+            <Input
+              id="display-name"
+              value={displayName}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setDisplayName(e.target.value)}
+              placeholder="GPT-4o"
+              required
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <Checkbox id="model-enabled" checked={enabled} onCheckedChange={setEnabled} />
+            <Label htmlFor="model-enabled">Enable model (visible in UI model pickers)</Label>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={createModel.isPending || !providerId || !modelId || !displayName}
+            >
+              {createModel.isPending ? "Creating..." : "Create Model"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/ui/src/components/models/model-row.tsx
+++ b/apps/ui/src/components/models/model-row.tsx
@@ -80,7 +80,6 @@ export function ModelRow({
           </div>
         </div>
         <div className="flex items-center gap-2">
-          {/* Profile capability badges */}
           {profile && (
             <div className="flex gap-1">
               {profile.reasoning && (
@@ -103,7 +102,6 @@ export function ModelRow({
               )}
             </div>
           )}
-          {/* Legacy capabilities (only show if no profile) */}
           {!profile && model.capabilities.length > 0 && (
             <div className="flex gap-1">
               {model.capabilities.slice(0, 2).map((cap) => (
@@ -128,7 +126,6 @@ export function ModelRow({
           >
             {model.status}
           </Badge>
-          {/* Enable / Disable toggle */}
           <Button
             variant={model.enabled ? "outline" : "default"}
             size="sm"
@@ -173,11 +170,9 @@ export function ModelRow({
         </div>
       </div>
 
-      {/* Expanded profile details */}
       {expanded && profile && (
         <div className="border-t bg-muted/30 p-4">
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm mb-3">
-            {/* Limits */}
             {profile.limits && (
               <div>
                 <div className="font-medium text-muted-foreground mb-1 flex items-center gap-1">
@@ -190,7 +185,6 @@ export function ModelRow({
               </div>
             )}
 
-            {/* Cost */}
             {profile.cost && (
               <div>
                 <div className="font-medium text-muted-foreground mb-1 flex items-center gap-1">
@@ -203,7 +197,6 @@ export function ModelRow({
               </div>
             )}
 
-            {/* Capabilities */}
             <div>
               <div className="font-medium text-muted-foreground mb-1 flex items-center gap-1">
                 <Wrench className="h-3.5 w-3.5" />
@@ -227,7 +220,6 @@ export function ModelRow({
               </div>
             </div>
 
-            {/* Info */}
             <div>
               <div className="font-medium text-muted-foreground mb-1 flex items-center gap-1">
                 <Info className="h-3.5 w-3.5" />

--- a/apps/ui/src/hooks/use-global-search.ts
+++ b/apps/ui/src/hooks/use-global-search.ts
@@ -37,6 +37,7 @@ import {
   Calendar,
   MessageCircle,
   FlaskConical,
+  Cpu,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useAgents } from "@/hooks/use-agents";
@@ -123,6 +124,12 @@ const NAVIGATION_PAGES: NavigationPage[] = [
     icon: BookOpen,
     keywords: ["ability", "tool"],
   },
+  {
+    title: "Models",
+    href: "/models",
+    icon: Cpu,
+    keywords: ["llm", "openai", "anthropic", "default model"],
+  },
   { title: "Capabilities", href: "/capabilities", icon: Puzzle },
   {
     title: "Apps",
@@ -170,7 +177,7 @@ const NAVIGATION_PAGES: NavigationPage[] = [
     title: "Settings > LLM Providers",
     href: "/settings/providers",
     icon: Settings,
-    keywords: ["openai", "anthropic", "model"],
+    keywords: ["openai", "anthropic", "credentials"],
   },
   {
     title: "Settings > Organisation",

--- a/apps/ui/src/proxy.ts
+++ b/apps/ui/src/proxy.ts
@@ -26,6 +26,7 @@ export const config = {
     "/evals/:path*",
     "/harnesses/:path*",
     "/mcp-servers/:path*",
+    "/models/:path*",
     "/orgs/:path*",
     "/sessions/:path*",
     "/settings/:path*",


### PR DESCRIPTION
## What
Move LLM model management out of Settings > LLM Providers and into a new top-level /models page under Building Blocks. Keep provider configuration in Settings.

## Why
Models are a reusable building block for agents and sessions; providers remain configuration/credential setup.

## How
- Added a /models route with model list, add model, enable/disable, delete, and organization default model controls.
- Added Models to Building Blocks navigation and command palette search.
- Trimmed Settings > LLM Providers down to provider management only.
- Added /models to the protected app proxy matcher.
- Updated focused tests for sidebar, settings providers, models, and auth proxy matching.

## Risk
- Low / Medium / High: Low
- What can break: navigation to model management or settings provider management; mitigated by targeted tests, build, pre-push, and browser smoke.

## Security
- Threat categories reviewed: TM-WEB, TM-AUTH
- Findings and resolutions: /models is a protected application route and was added to the proxy matcher. No new input parsing, credential handling, or cross-tenant data access was introduced; existing model/provider hooks and API calls are reused.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Validation:
- npm test -- --runTestsByPath src/__tests__/settings-providers.test.tsx src/__tests__/models-page.test.tsx src/__tests__/sidebar.test.tsx src/__tests__/settings-layout.test.tsx src/__tests__/middleware.test.ts
- npm run lint
- npm run build
- just pre-push
- Browser smoke via PORT_PREFIX=302 just start-dev --no-watch: /models renders from Building Blocks and /settings/providers renders provider-only UI
