### PR TITLE
fix(auth): restore signup harness-seed safety net via platform_definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
-### Fixed
-
-- Restore the default-org harness-seed safety net in `register` / `oauth_callback` / admin-bootstrap. PR #1462 removed it to prevent public signup from re-applying OSS harness defaults over a custom `PlatformDefinition`; this re-adds it using `state.platform_definition.built_in_harnesses()` instead of `oss_built_in_harnesses()`, so new users landing in `DEFAULT_ORG_ID` before the async seed task completes still get built-in harnesses without re-opening the override path. `BuiltinAuthBackend` now carries `platform_definition`; the `.auth()` factory signature on `ServerAppBuilder` is now `Fn(Arc<StorageBackend>, Arc<PlatformDefinition>) -> Arc<dyn AuthBackend>`. See `specs/authentication.md` "Default-Org Harness-Seed Guarantee" and threat-model entry TM-AUTH-016 (EVE-390).
-
 ## [0.8.22] - 2026-04-27
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+### Fixed
+
+- Restore the default-org harness-seed safety net in `register` / `oauth_callback` / admin-bootstrap. PR #1462 removed it to prevent public signup from re-applying OSS harness defaults over a custom `PlatformDefinition`; this re-adds it using `state.platform_definition.built_in_harnesses()` instead of `oss_built_in_harnesses()`, so new users landing in `DEFAULT_ORG_ID` before the async seed task completes still get built-in harnesses without re-opening the override path. `BuiltinAuthBackend` now carries `platform_definition`; the `.auth()` factory signature on `ServerAppBuilder` is now `Fn(Arc<StorageBackend>, Arc<PlatformDefinition>) -> Arc<dyn AuthBackend>`. See `specs/authentication.md` "Default-Org Harness-Seed Guarantee" and threat-model entry TM-AUTH-016 (EVE-390).
+
 ## [0.8.22] - 2026-04-27
 
 ### Highlights

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -132,7 +132,9 @@ struct HealthState {
 ///
 /// let auth_config = AuthConfig::from_env();
 /// ServerAppBuilder::new(ServerConfig::from_env())
-///     .auth(move |db| Arc::new(BuiltinAuthBackend::new(auth_config, db)))
+///     .auth(move |db, platform| {
+///         Arc::new(BuiltinAuthBackend::new(auth_config, db, platform))
+///     })
 ///     .routes(my_billing_routes())
 ///     .event_listener(Arc::new(MyAnalyticsListener))
 ///     .migration(|pool| async move {

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -48,7 +48,8 @@ use utoipa::OpenApi;
 // Types
 // =========================================================================
 
-type AuthFactoryFn = Box<dyn FnOnce(Arc<StorageBackend>) -> Arc<dyn AuthBackend> + Send>;
+type AuthFactoryFn =
+    Box<dyn FnOnce(Arc<StorageBackend>, Arc<PlatformDefinition>) -> Arc<dyn AuthBackend> + Send>;
 
 type MigrationFn =
     Box<dyn FnOnce(PgPool) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> + Send>;
@@ -171,11 +172,18 @@ impl ServerAppBuilder {
 
     /// Set the authentication backend factory.
     ///
-    /// The factory receives the storage backend and returns an auth backend.
-    /// If not set, the built-in auth backend is used.
+    /// The factory receives the storage backend and the active platform
+    /// definition, and returns an auth backend. If not set, the built-in
+    /// auth backend is used.
+    ///
+    /// The platform definition is forwarded so auth handlers can enforce
+    /// operator-configured defaults (e.g. the signup harness-seed safety
+    /// net in `BuiltinAuthBackend` — see EVE-390).
     pub fn auth(
         mut self,
-        factory: impl FnOnce(Arc<StorageBackend>) -> Arc<dyn AuthBackend> + Send + 'static,
+        factory: impl FnOnce(Arc<StorageBackend>, Arc<PlatformDefinition>) -> Arc<dyn AuthBackend>
+        + Send
+        + 'static,
     ) -> Self {
         self.auth_factory = Some(Box::new(factory));
         self
@@ -392,17 +400,22 @@ impl ServerAppBuilder {
         );
 
         let auth_backend = match self.auth_factory {
-            Some(factory) => factory(db.clone()),
+            Some(factory) => factory(db.clone(), platform_definition.clone()),
             None => {
                 let cfg = auth_config.clone();
                 if let Some(valkey) = valkey_client {
                     Arc::new(auth::BuiltinAuthBackend::with_valkey(
                         cfg,
                         db.clone(),
+                        platform_definition.clone(),
                         valkey,
                     ))
                 } else {
-                    Arc::new(auth::BuiltinAuthBackend::new(cfg, db.clone()))
+                    Arc::new(auth::BuiltinAuthBackend::new(
+                        cfg,
+                        db.clone(),
+                        platform_definition.clone(),
+                    ))
                 }
             }
         };

--- a/crates/server/src/auth/builtin.rs
+++ b/crates/server/src/auth/builtin.rs
@@ -7,7 +7,9 @@
 
 use async_trait::async_trait;
 use axum::Router;
-use everruns_core::{DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, OrgMembership, OrgRole};
+use everruns_core::{
+    DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, OrgMembership, OrgRole, PlatformDefinition,
+};
 use moka::future::Cache;
 use std::sync::Arc;
 use std::time::Duration;
@@ -31,12 +33,32 @@ const API_KEY_CACHE_MAX_CAPACITY: u64 = 10_000;
 
 /// Built-in authentication backend (JWT + password + OAuth + API keys).
 /// This is the default for OSS deployments.
+///
+/// HARNESS-SEED SAFETY NET (see also `specs/authentication.md`):
+/// `register` and `oauth_callback` both add new users to `DEFAULT_ORG_ID`.
+/// The background seed task (see `seed::spawn_seed_task_with_platform_definition`)
+/// provisions built-in harnesses for that org, but it runs asynchronously
+/// with a 500 ms initial delay — so a user who signs up during the startup
+/// window (cold boot, slow DB, or a partial seed failure that will
+/// self-retry) can otherwise land in an org that has no harnesses and see
+/// the chat/session UI 404.
+///
+/// PR #1462 removed an earlier safety-net call that used
+/// `oss_built_in_harnesses()`, because that could override an operator's
+/// custom `PlatformDefinition`. The fix is to keep the safety net but
+/// drive it from `platform_definition.built_in_harnesses()` instead, so a
+/// custom platform definition is never overwritten. `platform_definition`
+/// is owned by this backend for that purpose.
 #[derive(Clone)]
 pub struct BuiltinAuthBackend {
     pub config: AuthConfig,
     pub jwt_service: Arc<JwtService>,
     pub db: Arc<StorageBackend>,
     pub rate_limiter: AuthRateLimiter,
+    /// Platform-defined harness set. Used by the signup safety-net in
+    /// `register` / `oauth_callback` so a pre-seed signup still lands in an
+    /// org with the correct (operator-chosen) harnesses.
+    pub platform_definition: Arc<PlatformDefinition>,
     /// In-process cache: key_hash -> AuthUser. Avoids 4 sequential DB queries per API-key request.
     api_key_cache: Cache<String, AuthUser>,
 }
@@ -68,25 +90,36 @@ fn platform_user_from_roles(roles: &[String]) -> bool {
 
 impl BuiltinAuthBackend {
     /// Create with in-memory rate limiting (per-instance).
-    pub fn new(config: AuthConfig, db: Arc<StorageBackend>) -> Self {
+    pub fn new(
+        config: AuthConfig,
+        db: Arc<StorageBackend>,
+        platform_definition: Arc<PlatformDefinition>,
+    ) -> Self {
         let jwt_service = Arc::new(JwtService::new(config.jwt.clone()));
         Self {
             config,
             jwt_service,
             db,
             rate_limiter: AuthRateLimiter::new(),
+            platform_definition,
             api_key_cache: build_api_key_cache(),
         }
     }
 
     /// Create with Valkey-backed distributed rate limiting.
-    pub fn with_valkey(config: AuthConfig, db: Arc<StorageBackend>, valkey: ValkeyClient) -> Self {
+    pub fn with_valkey(
+        config: AuthConfig,
+        db: Arc<StorageBackend>,
+        platform_definition: Arc<PlatformDefinition>,
+        valkey: ValkeyClient,
+    ) -> Self {
         let jwt_service = Arc::new(JwtService::new(config.jwt.clone()));
         Self {
             config,
             jwt_service,
             db,
             rate_limiter: AuthRateLimiter::with_valkey(valkey),
+            platform_definition,
             api_key_cache: build_api_key_cache(),
         }
     }
@@ -518,7 +551,11 @@ mod tests {
         #[tokio::test]
         async fn validate_api_key_rejects_after_key_deleted_from_db() {
             let db = Arc::new(StorageBackend::in_memory());
-            let backend = BuiltinAuthBackend::new(AuthConfig::default(), db.clone());
+            let backend = BuiltinAuthBackend::new(
+                AuthConfig::default(),
+                db.clone(),
+                Arc::new(crate::platform::oss_platform_definition()),
+            );
             let (user_id, key_id, plaintext_key) =
                 seed_user_with_key(&db, "revoked@example.com", "Revoked User").await;
 
@@ -542,7 +579,11 @@ mod tests {
         #[tokio::test]
         async fn validate_api_key_reflects_fresh_user_state_on_revalidation() {
             let db = Arc::new(StorageBackend::in_memory());
-            let backend = BuiltinAuthBackend::new(AuthConfig::default(), db.clone());
+            let backend = BuiltinAuthBackend::new(
+                AuthConfig::default(),
+                db.clone(),
+                Arc::new(crate::platform::oss_platform_definition()),
+            );
             let (user_id, _key_id, plaintext_key) =
                 seed_user_with_key(&db, "user@example.com", "Original Name").await;
 
@@ -577,7 +618,11 @@ mod tests {
         #[tokio::test]
         async fn validate_api_key_rejects_invalid_format_without_db_lookup() {
             let db = Arc::new(StorageBackend::in_memory());
-            let backend = BuiltinAuthBackend::new(AuthConfig::default(), db.clone());
+            let backend = BuiltinAuthBackend::new(
+                AuthConfig::default(),
+                db.clone(),
+                Arc::new(crate::platform::oss_platform_definition()),
+            );
 
             let result = backend.validate_api_key("not-an-api-key").await;
             assert!(result.is_err(), "malformed key must be rejected");

--- a/crates/server/src/auth/middleware.rs
+++ b/crates/server/src/auth/middleware.rs
@@ -181,9 +181,11 @@ impl AuthState {
 
     /// Convenience: create with built-in backend (OSS default)
     pub fn builtin(config: AuthConfig, db: Arc<StorageBackend>) -> Self {
+        let platform_definition = Arc::new(crate::platform::oss_platform_definition());
         let backend = Arc::new(super::builtin::BuiltinAuthBackend::new(
             config.clone(),
             db.clone(),
+            platform_definition,
         ));
         Self {
             config,

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -411,6 +411,25 @@ pub async fn register(
             // Continue anyway - user is created, they just might not have org membership
         });
 
+    // Harness-seed safety net: the async seed task (500 ms delay, see
+    // `seed::spawn_seed_task_with_platform_definition`) may not have
+    // provisioned DEFAULT_ORG_ID's built-in harnesses yet when a user
+    // registers immediately after server startup. Re-run the provisioner
+    // using the *platform definition*'s harness set (NOT the OSS default)
+    // so a custom `PlatformDefinition` is never overridden — that was the
+    // security concern addressed by PR #1462. The call is idempotent: if
+    // seeding has already completed, every harness is "unchanged". See
+    // EVE-390 and `specs/authentication.md`.
+    if let Err(e) = crate::org_init::initialize_org_harnesses_with_definitions(
+        &state.db,
+        DEFAULT_ORG_ID,
+        state.platform_definition.built_in_harnesses(),
+    )
+    .await
+    {
+        tracing::warn!(error = %e, "Failed to ensure default org harnesses (non-fatal)");
+    }
+
     let organizations = builtin::fetch_user_organizations(&state.db, user.id)
         .await
         .unwrap_or_default();
@@ -788,6 +807,20 @@ pub async fn oauth_callback(
                 // Continue anyway
             });
 
+        // Harness-seed safety net (see equivalent comment in `register` and
+        // EVE-390). Drive the provisioner from `platform_definition`, not
+        // `oss_built_in_harnesses()`, so a custom platform definition is
+        // never overridden on OAuth signup.
+        if let Err(e) = crate::org_init::initialize_org_harnesses_with_definitions(
+            &state.db,
+            DEFAULT_ORG_ID,
+            state.platform_definition.built_in_harnesses(),
+        )
+        .await
+        {
+            tracing::warn!(error = %e, "Failed to ensure default org harnesses (non-fatal)");
+        }
+
         created_user
     };
 
@@ -957,9 +990,18 @@ async fn get_or_create_admin_user(
                 // Continue anyway
             });
 
-        // Ensure default org has built-in harnesses (safety net — background seed task
-        // may not have completed yet or may have failed silently).
-        if let Err(e) = crate::org_init::initialize_org_harnesses(&state.db, DEFAULT_ORG_ID).await {
+        // Ensure default org has built-in harnesses (safety net — background
+        // seed task may not have completed yet or may have failed silently).
+        // Drive from `platform_definition` (not `oss_built_in_harnesses()`)
+        // so operator-customized harnesses are never overridden — see
+        // EVE-390 and PR #1462.
+        if let Err(e) = crate::org_init::initialize_org_harnesses_with_definitions(
+            &state.db,
+            DEFAULT_ORG_ID,
+            state.platform_definition.built_in_harnesses(),
+        )
+        .await
+        {
             tracing::warn!(error = %e, "Failed to ensure default org harnesses (non-fatal)");
         }
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -41,7 +41,9 @@ async fn main() -> Result<()> {
     // Start server with built-in auth backend (OSS default)
     let auth_config = auth::AuthConfig::from_env();
     ServerAppBuilder::new(config)
-        .auth(move |db| Arc::new(auth::BuiltinAuthBackend::new(auth_config, db)))
+        .auth(move |db, platform| {
+            Arc::new(auth::BuiltinAuthBackend::new(auth_config, db, platform))
+        })
         .run()
         .await
 }

--- a/crates/server/tests/auth_integration_test.rs
+++ b/crates/server/tests/auth_integration_test.rs
@@ -38,7 +38,11 @@ async fn auth_router() -> (Router, Arc<StorageBackend>) {
         ..Default::default()
     };
 
-    let backend = BuiltinAuthBackend::new(config, db.clone());
+    let backend = BuiltinAuthBackend::new(
+        config,
+        db.clone(),
+        std::sync::Arc::new(everruns_server::platform::oss_platform_definition()),
+    );
     let router = auth::routes(backend);
     (router, db)
 }
@@ -509,4 +513,178 @@ async fn test_auth_config_returns_full_mode() {
     assert_eq!(body["mode"], "full");
     assert_eq!(body["password_auth_enabled"], true);
     assert_eq!(body["signup_enabled"], true);
+}
+
+// ============================================
+// Default-org harness-seed safety net (EVE-390)
+// ============================================
+//
+// Invariants under test:
+// 1. A user registering before the async seed task provisions harnesses
+//    for DEFAULT_ORG_ID still lands in an org that has the built-in
+//    harnesses (the safety net fires).
+// 2. The safety net drives from `platform_definition.built_in_harnesses()`
+//    rather than `oss_built_in_harnesses()`. A custom `PlatformDefinition`
+//    that ships only a single harness must NOT have OSS defaults re-added
+//    on signup. This preserves the fix from PR #1462 (TM-AUTH-016).
+
+use everruns_core::{
+    BuiltInHarnessDefinition, BuiltInHarnessRole, CapabilityRegistry, DEFAULT_ORG_ID,
+    DEFAULT_ORG_PUBLIC_ID, DriverRegistry, PlatformDefinition,
+};
+use everruns_server::storage::models::CreateOrganizationRow;
+
+fn single_custom_harness(name: &str) -> BuiltInHarnessDefinition {
+    BuiltInHarnessDefinition::new(
+        name,
+        "Custom",
+        "custom harness used in tests",
+        "custom system prompt",
+    )
+    // Mark this sole harness as both Default and Base so the org-settings
+    // pointers the provisioner needs can be resolved.
+    .with_roles([BuiltInHarnessRole::Default, BuiltInHarnessRole::Base])
+}
+
+fn custom_platform_definition_with_single_harness(harness_name: &str) -> PlatformDefinition {
+    let mut def = PlatformDefinition::new(
+        CapabilityRegistry::with_builtins(),
+        DriverRegistry::default(),
+    );
+    def.add_built_in_harness(single_custom_harness(harness_name));
+    def
+}
+
+async fn custom_platform_auth_router(
+    platform_definition: PlatformDefinition,
+) -> (Router, Arc<StorageBackend>) {
+    let db = Arc::new(StorageBackend::in_memory());
+
+    // Deliberately do NOT call `seed::seed_all` — this simulates the cold-boot
+    // window before the async seed task has provisioned harnesses for
+    // DEFAULT_ORG_ID. Only the org row itself is created so `register` can
+    // add the new user to it.
+    db.create_organization_with_id(
+        DEFAULT_ORG_ID,
+        CreateOrganizationRow {
+            public_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
+            name: "Default Organization".to_string(),
+            created_by: None,
+        },
+    )
+    .await
+    .expect("create default org");
+
+    let config = AuthConfig {
+        mode: AuthMode::Full,
+        jwt: JwtConfig {
+            secret: "test-secret-for-auth-integration-tests".to_string(),
+            access_token_lifetime: Duration::from_secs(900),
+            refresh_token_lifetime: Duration::from_secs(86400),
+        },
+        ..Default::default()
+    };
+
+    let backend = BuiltinAuthBackend::new(config, db.clone(), Arc::new(platform_definition));
+    let router = auth::routes(backend);
+    (router, db)
+}
+
+#[tokio::test]
+async fn test_register_safety_net_uses_platform_definition_not_oss_defaults() {
+    let custom_name = "custom-safety-net-harness";
+    let (router, db) =
+        custom_platform_auth_router(custom_platform_definition_with_single_harness(custom_name))
+            .await;
+
+    // Pre-condition: no harnesses seeded for DEFAULT_ORG_ID.
+    let pre = db
+        .list_harnesses(DEFAULT_ORG_ID, None, false)
+        .await
+        .expect("list harnesses (pre)");
+    assert!(pre.is_empty(), "default org must start with no harnesses");
+
+    // Register a fresh user.
+    let (status, _body, _cookies) = send(
+        &router,
+        "POST",
+        "/v1/auth/register",
+        Some(json!({
+            "email": "new-user@example.com",
+            "password": "super-secret-password",
+            "name": "New User",
+        })),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "register should succeed");
+
+    // Post-condition: default org now has exactly the platform-defined
+    // harness. No OSS defaults (base/generic/etc) should have been added.
+    let post = db
+        .list_harnesses(DEFAULT_ORG_ID, None, false)
+        .await
+        .expect("list harnesses (post)");
+    let names: Vec<String> = post.iter().map(|h| h.name.clone()).collect();
+    assert_eq!(
+        names,
+        vec![custom_name.to_string()],
+        "safety net must only provision the platform-defined harness set (got {:?})",
+        names
+    );
+}
+
+#[tokio::test]
+async fn test_register_safety_net_is_idempotent_when_seed_already_ran() {
+    // When the harness already exists (seed task completed first), registering
+    // must not create duplicates — the upsert is idempotent.
+    let custom_name = "custom-idempotent-harness";
+    let (router, db) =
+        custom_platform_auth_router(custom_platform_definition_with_single_harness(custom_name))
+            .await;
+
+    // Pre-provision harnesses to simulate the seed task finishing first.
+    everruns_server::org_init::initialize_org_harnesses_with_definitions(
+        &db,
+        DEFAULT_ORG_ID,
+        &[single_custom_harness(custom_name)],
+    )
+    .await
+    .expect("pre-seed");
+
+    let before = db
+        .list_harnesses(DEFAULT_ORG_ID, None, false)
+        .await
+        .expect("list harnesses (before)");
+    assert_eq!(before.len(), 1);
+    let before_id = before[0].id;
+
+    // Register — safety net must not create a second row.
+    let (status, _body, _cookies) = send(
+        &router,
+        "POST",
+        "/v1/auth/register",
+        Some(json!({
+            "email": "second-user@example.com",
+            "password": "another-secret-password",
+            "name": "Second User",
+        })),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let after = db
+        .list_harnesses(DEFAULT_ORG_ID, None, false)
+        .await
+        .expect("list harnesses (after)");
+    assert_eq!(
+        after.len(),
+        1,
+        "safety net must not duplicate harnesses on pre-seeded orgs"
+    );
+    assert_eq!(
+        after[0].id, before_id,
+        "safety net must keep the same harness row identity (idempotent upsert)"
+    );
 }

--- a/crates/server/tests/cli_auth_no_org_test.rs
+++ b/crates/server/tests/cli_auth_no_org_test.rs
@@ -42,7 +42,11 @@ async fn test_cli_exchange_no_orgs_returns_422() {
         ..Default::default()
     };
 
-    let backend = BuiltinAuthBackend::new(config.clone(), db.clone());
+    let backend = BuiltinAuthBackend::new(
+        config.clone(),
+        db.clone(),
+        std::sync::Arc::new(everruns_server::platform::oss_platform_definition()),
+    );
     let auth_state = AuthState::new(config, Arc::new(backend));
     let cli_state = CliAuthState {
         db: db.clone(),
@@ -136,7 +140,11 @@ async fn test_cli_exchange_code_is_one_time_use() {
         ..Default::default()
     };
 
-    let backend = BuiltinAuthBackend::new(config.clone(), db.clone());
+    let backend = BuiltinAuthBackend::new(
+        config.clone(),
+        db.clone(),
+        std::sync::Arc::new(everruns_server::platform::oss_platform_definition()),
+    );
     let auth_state = AuthState::new(config, Arc::new(backend));
     let cli_state = CliAuthState {
         db: db.clone(),

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -204,7 +204,11 @@ impl TestServer {
                 .to_string(),
             ..auth::AuthConfig::default()
         };
-        let auth_backend = auth::BuiltinAuthBackend::new(auth_config.clone(), db.clone());
+        let auth_backend = auth::BuiltinAuthBackend::new(
+            auth_config.clone(),
+            db.clone(),
+            std::sync::Arc::new(everruns_server::platform::oss_platform_definition()),
+        );
         let auth_state = auth::AuthState::new(auth_config.clone(), Arc::new(auth_backend.clone()));
 
         // Create runner with PostgreSQL backend

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -207,7 +207,7 @@ impl TestServer {
         let auth_backend = auth::BuiltinAuthBackend::new(
             auth_config.clone(),
             db.clone(),
-            std::sync::Arc::new(everruns_server::platform::oss_platform_definition()),
+            platform_definition.clone(),
         );
         let auth_state = auth::AuthState::new(auth_config.clone(), Arc::new(auth_backend.clone()));
 

--- a/specs/authentication.md
+++ b/specs/authentication.md
@@ -147,6 +147,18 @@ See `crates/server/migrations/001_base_schema.sql` for `users`, `api_keys`, and 
 
 For `auth=none` mode, a well-known anonymous user is seeded via `crates/server/src/seed.rs`. Constants in `crates/core/src/organization.rs`: `ANONYMOUS_USER_ID`, `ANONYMOUS_USER_EMAIL`, `ANONYMOUS_USER_NAME`. The anonymous user has admin role and belongs to the default organization.
 
+#### Default-Org Harness-Seed Guarantee
+
+The server's background seed task (`seed::spawn_seed_task_with_platform_definition`) provisions the platform-defined built-in harnesses for every organization — including `DEFAULT_ORG_ID` — using the active `PlatformDefinition`. The task runs asynchronously with a 500 ms initial delay, so there is a window on cold boot where a user could register via `register` or `oauth_callback` before `DEFAULT_ORG_ID` has its harnesses.
+
+To close that window, both handlers re-run `initialize_org_harnesses_with_definitions(db, DEFAULT_ORG_ID, platform_definition.built_in_harnesses())` as a safety net after adding the user to the default org. Invariants:
+
+- **Correctness**: every newly-signed-up user lands in an org that has built-in harnesses, even if the async seed task has not completed. The provisioner is idempotent (upsert keyed on harness name), so the second call is a no-op once seeding is done.
+- **No operator override**: the safety net drives from `state.platform_definition.built_in_harnesses()` (the operator-configured set), **not** from `oss_built_in_harnesses()`. This preserves the fix from PR #1462 — public signup cannot reintroduce OSS harnesses that a custom `PlatformDefinition` removed. Tracked as threat-model entry `TM-AUTH-016` in `specs/threat-model.md` and originally surfaced in EVE-390.
+- **Non-fatal on failure**: if the provisioner errors, the signup still succeeds (user is already created). The failure is logged at warn level so operators can diagnose seeding issues without blocking onboarding.
+
+The admin-bootstrap path (first-admin login in `login`) uses the same safety net for the same reasons.
+
 ### Security Considerations
 
 1. **JWT Secret**: Must be a secure random string (minimum 32 bytes recommended)

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -104,6 +104,7 @@ Format: `TM-<CATEGORY>-<NNN>`
 | TM-AUTH-013 | Expired API key still in use | Medium | Expiration checked on every request via DB lookup; `last_used_at` tracked | MITIGATED |
 | TM-AUTH-014 | Account enumeration via registration | Medium | Returns generic "Registration failed" for existing emails; password hash computed first for timing consistency | MITIGATED |
 | TM-AUTH-015 | JWT secret insecure default | High | Falls back to hardcoded `insecure-dev-secret-change-me` if `AUTH_JWT_SECRET` unset; no startup check in production | **OPEN** |
+| TM-AUTH-016 | OSS harness reseeding via public signup | High | The signup safety net in `register` / `oauth_callback` uses `state.platform_definition.built_in_harnesses()` via `initialize_org_harnesses_with_definitions`, **not** `oss_built_in_harnesses()`. An operator's custom `PlatformDefinition` is the source of truth — public signup cannot reintroduce OSS harnesses that were removed. Original concern tracked by PR #1462; the safety-net semantics re-added in EVE-390 preserve pre-seed correctness without re-opening the override path. | MITIGATED |
 
 ### Mitigation Details
 


### PR DESCRIPTION
## What
Restore the default-org harness-seed safety net in `register`, OAuth first-login, and admin-bootstrap login, using `state.platform_definition.built_in_harnesses()` as the source of truth.

Fixes EVE-390.

## Why
PR #1462 correctly removed an unsafe safety-net path that re-applied OSS harness defaults over custom `PlatformDefinition` values, but it also reopened a cold-boot gap: a user can sign up before the async seed task provisions `DEFAULT_ORG_ID` harnesses and land in an org with no built-in harnesses.

## How
- Thread `Arc<PlatformDefinition>` into `BuiltinAuthBackend` and the `ServerAppBuilder::auth` factory.
- Call `initialize_org_harnesses_with_definitions(db, DEFAULT_ORG_ID, state.platform_definition.built_in_harnesses())` after default-org membership is added in signup-adjacent auth paths.
- Add regression tests proving the safety net uses a custom platform definition, does not leak OSS defaults, and remains idempotent when seed already ran.
- Document the invariant in `specs/authentication.md` and threat-model entry `TM-AUTH-016`.

## Risk
- Low.
- Public signup performs an additional bounded, idempotent harness upsert/read path.
- `ServerAppBuilder::auth` has a signature bump for embedders; in-repo callers and docs are updated.
- No migrations, no dependency changes.

## Security
- Threat categories reviewed: TM-AUTH, TM-AUTHZ, TM-TOOL.
- Findings and resolutions:
  - Operator override risk: safety net now uses the active platform definition, not OSS defaults. Regression test covers this.
  - Privilege escalation risk: only built-in harness rows/settings are touched; no user/org role state is elevated.
  - DoS risk: work is bounded by the configured built-in harness list and uses existing upsert semantics.

## Validation
- `cargo fmt -p everruns-server --check`
- `cargo check -p everruns-server --tests`
- `cargo test -p everruns-server --test auth_integration_test` — 14 passed
- `cargo clippy -p everruns-server --lib --tests --all-features -- -D warnings`
- `just pre-push` — passed all 8 checks
- Smoke: direct dev-mode server with `AUTH_MODE=full`; `POST /api/v1/auth/register` returned 201, then `GET /api/v1/harnesses` with the issued token returned built-in harnesses (`platform-chat`, `coding-daytona`, `data-analyst`, `generic`, `base`). Full `just start-dev --no-watch` could not complete the proxy/UI smoke in this worktree because `apps/ui/node_modules` is missing.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
