### PR TITLE
chore(release): prepare v0.8.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.8.20] - 2026-04-25
+
+### Highlights
+
+- **Hotfix: restore migration 006 checksum** - Migration `006_v0.8.5.sql` was edited in-place by [#1566](https://github.com/everruns/everruns/pull/1566) to broaden `events.search_vector` coverage to nested message text. Modifying an applied migration breaks startup against existing databases because sqlx tracks per-migration checksums in `_sqlx_migrations`. v0.8.20 reverts migration 006 to its original v0.8.18 form and re-delivers the search-vector update as a new additive migration `024_event_search_vector_canonical_fields.sql`. Restores deploys against dev/prod databases.
+- **UI: SVG previews behind sandboxed iframe** - SVG file previews are restored under a sandboxed iframe so user-supplied vectors can't break out into the host page ([#1587](https://github.com/everruns/everruns/pull/1587)).
+
+### What's Changed
+
+- fix(migrations): restore migration 006 checksum; re-deliver search_vector via additive 024 by [@chaliy](https://github.com/chaliy)
+- fix(ui): restore SVG previews behind sandboxed iframe ([#1587](https://github.com/everruns/everruns/pull/1587)) by [@chaliy](https://github.com/chaliy)
+- chore(plugin): rename everruns dev plugin by [@chaliy](https://github.com/chaliy)
+- feat(ui): move models to building blocks by [@chaliy](https://github.com/chaliy)
+
 ## [0.8.19] - 2026-04-24
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,11 +1577,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.8.19"
+version = "0.8.20"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "anyhow",
  "base64",
@@ -1627,14 +1627,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "async-trait",
  "base64",
@@ -1655,7 +1655,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1777,7 +1777,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "async-trait",
  "base64",
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "async-trait",
  "base64",
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "async-trait",
  "base64",
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-pi"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1928,7 +1928,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -1945,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1955,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1977,11 +1977,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.8.19"
+version = "0.8.20"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2015,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "aes-gcm",
  "ag-ui-core",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.19"
+version = "0.8.20"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.19",
+  "version": "0.8.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "everruns-ui",
-      "version": "0.8.19",
+      "version": "0.8.20",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@openuidev/react-lang": "^0.1.3",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.19",
+  "version": "0.8.20",
   "private": true,
   "exports": {
     "./route-manifest": "./src/lib/ui-route-manifest.ts",

--- a/crates/server/migrations/006_v0.8.5.sql
+++ b/crates/server/migrations/006_v0.8.5.sql
@@ -12,27 +12,15 @@
 -- Replaces `data::text ILIKE '%query%'` (sequential scan) with a tsvector
 -- generated column + GIN index for indexed full-text search.
 --
--- The search_vector is built from canonical message text fields in event
--- payloads. Message events store text under data.message.content (array of
--- content parts), while some events carry top-level text (delta/content).
--- A partial GIN index covers only message-type events (the only types
--- searched in practice).
+-- The search_vector is built from data->>'content' which is the main text
+-- field in message-type event JSONB payloads. A partial GIN index covers
+-- only message-type events (the only types searched in practice).
 
--- Generated tsvector column from canonical message text fields in JSONB data
+-- Generated tsvector column from the content field in JSONB data
 ALTER TABLE events
     ADD COLUMN search_vector tsvector
     GENERATED ALWAYS AS (
-        to_tsvector(
-            'english',
-            COALESCE(
-                data #>> '{message,content}',
-                data #>> '{result}',
-                data->>'content',
-                data->>'delta',
-                data->>'accumulated',
-                ''
-            )
-        )
+        to_tsvector('english', COALESCE(data->>'content', ''))
     ) STORED;
 
 -- GIN index on search_vector, scoped to message-type events
@@ -46,7 +34,7 @@ CREATE INDEX idx_events_search_vector
         'tool.completed'
     );
 
-COMMENT ON COLUMN events.search_vector IS 'Generated tsvector for full-text search on canonical event text fields (EVE-87)';
+COMMENT ON COLUMN events.search_vector IS 'Generated tsvector for full-text search on data.content (EVE-87)';
 
 -- ============================================
 -- Workflow snapshot checkpointing (EVE-86)

--- a/crates/server/migrations/024_event_search_vector_canonical_fields.sql
+++ b/crates/server/migrations/024_event_search_vector_canonical_fields.sql
@@ -1,0 +1,59 @@
+-- Rebuild events.search_vector with canonical message text fields.
+--
+-- Migration 006 (v0.8.5) seeded a generated tsvector column from
+-- `data->>'content'` only. PR #1566 ("fix(storage): search nested message
+-- content in event filters") needed to also cover `data.message.content`,
+-- `data.result`, `data.delta`, and `data.accumulated`, and was originally
+-- delivered by editing migration 006 in place. That broke startup against
+-- already-deployed databases because sqlx tracks each migration's checksum
+-- in `_sqlx_migrations` and refuses to run when an applied migration's
+-- content changes (see specs/migrations.md, specs/release-process.md
+-- "Migration Handling").
+--
+-- This migration restores the contract by:
+--   1. Reverting migration 006 to its original v0.8.18 form (so the
+--      checksum on disk matches the checksum recorded in databases that
+--      already applied 006).
+--   2. Dropping and re-creating `events.search_vector` and its supporting
+--      partial GIN index here, with the canonical fields, as an additive
+--      migration that all environments will apply cleanly.
+
+-- Drop the existing generated column. The partial GIN index on it is
+-- removed automatically via CASCADE.
+ALTER TABLE events DROP COLUMN search_vector;
+
+-- Recreate the generated tsvector column from canonical message text
+-- fields in the JSONB payload. Coalesce in priority order:
+--   data.message.content   - chat-style messages (array stringified)
+--   data.result            - tool/function results
+--   data.content           - legacy / non-message events with top-level text
+--   data.delta             - streaming deltas
+--   data.accumulated       - accumulated streaming text
+ALTER TABLE events
+    ADD COLUMN search_vector tsvector
+    GENERATED ALWAYS AS (
+        to_tsvector(
+            'english',
+            COALESCE(
+                data #>> '{message,content}',
+                data #>> '{result}',
+                data->>'content',
+                data->>'delta',
+                data->>'accumulated',
+                ''
+            )
+        )
+    ) STORED;
+
+-- Recreate the partial GIN index on the new column, scoped to the same
+-- event types as the original.
+CREATE INDEX idx_events_search_vector
+    ON events USING GIN (search_vector)
+    WHERE event_type IN (
+        'input.message',
+        'output.message.completed',
+        'output.message.delta',
+        'tool.completed'
+    );
+
+COMMENT ON COLUMN events.search_vector IS 'Generated tsvector for full-text search on canonical event text fields (EVE-87)';

--- a/crates/server/migrations/024_event_search_vector_canonical_fields.sql
+++ b/crates/server/migrations/024_event_search_vector_canonical_fields.sql
@@ -18,8 +18,10 @@
 --      partial GIN index here, with the canonical fields, as an additive
 --      migration that all environments will apply cleanly.
 
--- Drop the existing generated column. The partial GIN index on it is
--- removed automatically via CASCADE.
+-- Drop the existing partial GIN index, then the generated column it
+-- referenced. Done explicitly (rather than relying on `DROP COLUMN`'s
+-- automatic dependency cleanup) so the dependency is obvious in review.
+DROP INDEX IF EXISTS idx_events_search_vector;
 ALTER TABLE events DROP COLUMN search_vector;
 
 -- Recreate the generated tsvector column from canonical message text


### PR DESCRIPTION
## Release v0.8.20

Hotfix release. Restores deploy to environments that already applied migration 006 from v0.8.5..v0.8.18.

### Why

PR [#1566](https://github.com/everruns/everruns/pull/1566) edited `crates/server/migrations/006_v0.8.5.sql` in place to broaden `events.search_vector` to nested message text. SQLx persists each migration's checksum in `_sqlx_migrations`; when the on-disk content of an already-applied migration changes, server startup aborts:

```
ERROR ... Database migration failed - check migration files and database state
       error=migration 6 was previously applied but has been modified
```

The dev environment (and any deployed prod environment that already ran migration 6 from v0.8.5..v0.8.18) cannot start v0.8.19. Confirmed against `dev.everruns.com` after the v0.8.19 saas adopt rolled out: server containers crash-looped with the above error.

### Fix

- Revert `crates/server/migrations/006_v0.8.5.sql` to its v0.8.18 content byte-for-byte (so the on-disk checksum matches what's recorded in `_sqlx_migrations`).
- Add `crates/server/migrations/024_event_search_vector_canonical_fields.sql` that drops + re-creates `events.search_vector` and its partial GIN index with the canonical-fields formula from #1566 (`data #>> '{message,content}'`, `data #>> '{result}'`, `data->>'content'`, `data->>'delta'`, `data->>'accumulated'`).

This is the migration handling the `specs/release-process.md` "Migration Handling" section calls out: don't modify applied migrations; deliver schema changes additively.

### Checklist
- [x] Migration 006 restored to v0.8.18 form (verified via `diff` against `v0.8.18:crates/server/migrations/006_v0.8.5.sql`)
- [x] Migration 024 added; sequence 001-024 contiguous, no dupes
- [x] `Cargo.toml`, `apps/ui/package.json` bumped to 0.8.20
- [x] `Cargo.lock`, `apps/ui/package-lock.json` regenerated
- [x] `CHANGELOG.md` updated with `[0.8.20] - 2026-04-25`
- [ ] CI green

### Post-merge
Auto-tag workflow will create `v0.8.20` from the squash-merge commit message.

### Acknowledged limitation

The new migration runs `DROP COLUMN search_vector` then `ADD COLUMN ... GENERATED ALWAYS AS (...) STORED`, which rewrites the column on every event row. On large `events` tables this is O(rows) and locks the table for the duration. For dev this is fine; for prod operators who already deployed v0.8.18 with the small index, this is the unavoidable cost of getting the index back to a single canonical form. No long-term breaking effect.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUF5ghprzoirkE5bB7Nqsy)_