### PR TITLE
chore(release): prepare v0.8.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.8.21] - 2026-04-25
+
+### Highlights
+
+- **Hotfix: bound migration 024 input to fit `to_tsvector` 1 MiB cap** - The v0.8.20 search-vector rebuild migration crashed dev startup with `string is too long for tsvector (3108640 bytes, max 1048575 bytes)` because individual event rows can carry tool results, accumulated streaming text, or message-content arrays well beyond Postgres' 1 MiB tsvector input limit. The canonical-text expression is now wrapped in `LEFT(..., 250000)` so any single row's contribution stays under tsvector's hard cap. Search relevance is dominated by early tokens, so the truncation has negligible effect on the index's usefulness.
+- **GPT-5.5 / GPT-5.5 Pro** - New OpenAI model entries are wired into the LLM driver registry ([#1593](https://github.com/everruns/everruns/pull/1593)).
+
+### What's Changed
+
+- fix(migrations): bound migration 024 input to 250 000 chars so to_tsvector stays within Postgres' 1 MiB cap by [@chaliy](https://github.com/chaliy)
+- feat(llm): add GPT-5.5 and GPT-5.5 Pro ([#1593](https://github.com/everruns/everruns/pull/1593)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.8.20] - 2026-04-25
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,11 +1577,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.8.20"
+version = "0.8.21"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "anyhow",
  "base64",
@@ -1627,14 +1627,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "async-trait",
  "base64",
@@ -1655,7 +1655,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1777,7 +1777,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "async-trait",
  "base64",
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "async-trait",
  "base64",
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "async-trait",
  "base64",
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-pi"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1928,7 +1928,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -1945,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1955,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1977,11 +1977,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.8.20"
+version = "0.8.21"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2015,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "aes-gcm",
  "ag-ui-core",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.20"
+version = "0.8.21"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "everruns-ui",
-      "version": "0.8.20",
+      "version": "0.8.21",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@openuidev/react-lang": "^0.1.3",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "private": true,
   "exports": {
     "./route-manifest": "./src/lib/ui-route-manifest.ts",

--- a/crates/server/migrations/024_event_search_vector_canonical_fields.sql
+++ b/crates/server/migrations/024_event_search_vector_canonical_fields.sql
@@ -31,18 +31,30 @@ ALTER TABLE events DROP COLUMN search_vector;
 --   data.content           - legacy / non-message events with top-level text
 --   data.delta             - streaming deltas
 --   data.accumulated       - accumulated streaming text
+--
+-- The canonical text is bounded with `LEFT(..., 250000)` because Postgres'
+-- `to_tsvector` rejects inputs exceeding 1 MiB ("string is too long for
+-- tsvector ... max 1048575 bytes") and individual rows can carry tool
+-- results, accumulated streaming text, or stringified message-content
+-- arrays well beyond that. 250 000 chars is a safe upper bound across
+-- realistic UTF-8 inputs (250k chars * 4 worst-case bytes/char = 1 MB),
+-- and search relevance is dominated by early tokens, so the truncation
+-- has negligible effect on the index's usefulness.
 ALTER TABLE events
     ADD COLUMN search_vector tsvector
     GENERATED ALWAYS AS (
         to_tsvector(
             'english',
-            COALESCE(
-                data #>> '{message,content}',
-                data #>> '{result}',
-                data->>'content',
-                data->>'delta',
-                data->>'accumulated',
-                ''
+            LEFT(
+                COALESCE(
+                    data #>> '{message,content}',
+                    data #>> '{result}',
+                    data->>'content',
+                    data->>'delta',
+                    data->>'accumulated',
+                    ''
+                ),
+                250000
             )
         )
     ) STORED;

--- a/crates/server/migrations/024_event_search_vector_canonical_fields.sql
+++ b/crates/server/migrations/024_event_search_vector_canonical_fields.sql
@@ -37,9 +37,10 @@ ALTER TABLE events DROP COLUMN search_vector;
 -- tsvector ... max 1048575 bytes") and individual rows can carry tool
 -- results, accumulated streaming text, or stringified message-content
 -- arrays well beyond that. 250 000 chars is a safe upper bound across
--- realistic UTF-8 inputs (250k chars * 4 worst-case bytes/char = 1 MB),
--- and search relevance is dominated by early tokens, so the truncation
--- has negligible effect on the index's usefulness.
+-- realistic UTF-8 inputs (250000 chars * 4 worst-case bytes/char =
+-- 1000000 bytes, which stays below the 1048575-byte limit), and search
+-- relevance is dominated by early tokens, so the truncation has
+-- negligible effect on the index's usefulness.
 ALTER TABLE events
     ADD COLUMN search_vector tsvector
     GENERATED ALWAYS AS (


### PR DESCRIPTION
## Release v0.8.21

Hotfix on top of v0.8.20.

### Why

v0.8.20's migration 024 (search_vector rebuild from canonical fields) crashes dev startup:

```
ERROR ... Database migration failed - check migration files and database state
       error=while executing migration 24: error returned from database:
             string is too long for tsvector (3108640 bytes, max 1048575 bytes)
```

Postgres' `to_tsvector` rejects inputs over 1 MiB. The canonical-text COALESCE in migration 024 — `data #>> '{message,content}'`, `data #>> '{result}'`, `data->>'content'`, `data->>'delta'`, `data->>'accumulated'` — can carry tool results, accumulated streaming output, and stringified message-content arrays well beyond that on real data. v0.8.5..v0.8.18's migration 006 used `data->>'content'` only, which is bounded by ordinary message size and never tripped the cap; the broadened canonical formula does.

Confirmed against `dev.everruns.com` after the v0.8.20 saas adopt rolled out: the v0.8.20 image crash-loops on migration 24 with the above error.

### Fix

Wrap the COALESCE in `LEFT(..., 250000)` inside migration 024 so the input string is bounded to 250 000 chars (worst-case 1 MB UTF-8, which stays under the 1 048 575-byte tsvector cap). Search relevance is dominated by early tokens; the truncation has negligible effect on the GIN index's usefulness.

Migration 024 was never successfully applied anywhere (dev rolled back, prod hasn't deployed v0.8.20, CI uses fresh DBs), so editing 024's content in v0.8.21 does not regress the migration-checksum invariant. `crates/server/tests/migration_history_test.rs` only locks 016/017 and is unaffected.

### Security

Reviewed against `specs/threat-model.md`:

- **TM-SQL / TM-DOS** — The migration adds a defensive `LEFT(..., 250000)` cap on tsvector input. This *improves* the DoS posture: the previous unbounded form crashes server startup on realistic event payloads (tool results, accumulated streaming text, large message-content arrays). The bound operates on COALESCE'd JSONB-derived text only; it introduces no SQL-injection surface.
- **TM-AUTH / TM-AUTHZ / TM-API / TM-TOOL / TM-LLM / TM-TENANT / TM-FS / TM-BASH / TM-WEB** — Not touched. The remaining changes are version bumps in `Cargo.toml`/`Cargo.lock`/`apps/ui/package.json`/`apps/ui/package-lock.json` and a `CHANGELOG.md` entry.

No new dependencies; no auth/authz/API/tool/network surface changes.

### Checklist
- [x] Migration 024 capped via `LEFT(..., 250000)` (the only schema change in this release)
- [x] Migration sequence 001-024 still contiguous
- [x] `Cargo.toml`, `apps/ui/package.json` bumped to 0.8.21
- [x] `Cargo.lock`, `apps/ui/package-lock.json` regenerated
- [x] `CHANGELOG.md` updated with `[0.8.21] - 2026-04-25`
- [x] Security review against `specs/threat-model.md`
- [ ] CI green

### Post-merge
Auto-tag will create `v0.8.21`.