### PR TITLE
chore(migrations): enforce migration immutability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,19 @@ jobs:
       - name: Check Cargo.lock is up to date
         run: cargo fetch --locked
 
+  migration-immutability:
+    name: Migration Immutability
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check existing migrations are immutable
+        run: bash scripts/lib/check-migration-immutability.sh
+
   clippy:
     name: Clippy Lints
     runs-on: ubuntu-latest

--- a/crates/server/migrations/AGENTS.md
+++ b/crates/server/migrations/AGENTS.md
@@ -8,3 +8,4 @@ Key rules:
 2. **After rebase:** check for duplicate numbers, renumber to next available
 3. **Release prep:** do not squash or rename existing migrations for a release; keep authored filenames and verify ordering
 4. **Ordering:** numbers must be strictly sequential (no gaps, no duplicates) — validated by `just pre-push` and `/ship`
+5. **Immutability:** once a migration SQL file is merged to `main`, never modify, delete, or rename it. Fixes must land as a new sequential migration. CI and `just pre-push` reject modified/deleted/renamed existing migration files.

--- a/scripts/lib/check-migration-immutability.sh
+++ b/scripts/lib/check-migration-immutability.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Reject rewrites of already-merged SQL migrations.
+# New migrations are append-only: add the next NNN_*.sql file instead.
+
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+BASE_REF="${MIGRATION_IMMUTABILITY_BASE_REF:-origin/main}"
+MIGRATION_PATHSPEC="crates/server/migrations/*.sql"
+
+if ! git rev-parse --verify -q "$BASE_REF" >/dev/null; then
+  if git remote get-url origin >/dev/null 2>&1; then
+    git fetch --quiet origin main:refs/remotes/origin/main || true
+  fi
+fi
+
+if ! git rev-parse --verify -q "$BASE_REF" >/dev/null; then
+  echo "Could not resolve migration immutability base ref: $BASE_REF" >&2
+  echo "Fetch origin/main or set MIGRATION_IMMUTABILITY_BASE_REF." >&2
+  exit 1
+fi
+
+MERGE_BASE="$(git merge-base HEAD "$BASE_REF")"
+readonly MERGE_BASE
+
+if ! violations="$(
+  git diff --name-status --find-renames --diff-filter=MDR \
+    "$MERGE_BASE" HEAD -- "$MIGRATION_PATHSPEC"
+)"; then
+  echo "Failed to compare migration history against $BASE_REF." >&2
+  exit 1
+fi
+
+if [ -n "$violations" ]; then
+  echo "Existing migrations are immutable once merged to main." >&2
+  echo "Add a new sequential migration instead of modifying, deleting, or renaming an existing one." >&2
+  echo "" >&2
+  echo "$violations" >&2
+  exit 1
+fi
+
+echo "migration history immutable"

--- a/scripts/lib/pre-push.sh
+++ b/scripts/lib/pre-push.sh
@@ -13,7 +13,7 @@ echo "🔒 Running pre-push checks..."
 echo ""
 
 # 1. Rust formatting
-echo "1/7 Rust formatting"
+echo "1/8 Rust formatting"
 if cargo fmt --check 2>/dev/null; then
   pass "cargo fmt"
 else
@@ -21,7 +21,7 @@ else
 fi
 
 # 2. Clippy
-echo "2/7 Rust linting"
+echo "2/8 Rust linting"
 if cargo clippy --all-targets --all-features -- -D warnings 2>/dev/null; then
   pass "clippy"
 else
@@ -29,7 +29,7 @@ else
 fi
 
 # 3. Cargo.lock freshness
-echo "3/7 Cargo.lock freshness"
+echo "3/8 Cargo.lock freshness"
 if cargo fetch --locked 2>/dev/null; then
   pass "Cargo.lock up to date"
 else
@@ -37,7 +37,7 @@ else
 fi
 
 # 4. UI formatting (skip if node_modules missing)
-echo "4/7 UI formatting"
+echo "4/8 UI formatting"
 if [ -d "$PROJECT_ROOT/apps/ui/node_modules" ]; then
   if (cd "$PROJECT_ROOT/apps/ui" && npm run format:check 2>/dev/null); then
     pass "UI format"
@@ -49,7 +49,7 @@ else
 fi
 
 # 5. UI linting (skip if node_modules missing)
-echo "5/7 UI linting"
+echo "5/8 UI linting"
 if [ -d "$PROJECT_ROOT/apps/ui/node_modules" ]; then
   if (cd "$PROJECT_ROOT/apps/ui" && npm run lint 2>/dev/null); then
     pass "UI lint"
@@ -61,7 +61,7 @@ else
 fi
 
 # 6. Migration ordering check
-echo "6/7 Migration ordering"
+echo "6/8 Migration ordering"
 MIGRATION_DIR="$PROJECT_ROOT/crates/server/migrations"
 if [ -d "$MIGRATION_DIR" ]; then
   EXPECTED=1
@@ -83,8 +83,19 @@ else
   echo "   ⏭️  skipped (no migrations dir)"
 fi
 
-# 7. Commit author attribution check
-echo "7/7 Commit author attribution"
+# 7. Migration immutability check
+echo "7/8 Migration immutability"
+if MIGRATION_IMMUTABILITY_OUTPUT="$(
+  bash "$PROJECT_ROOT/scripts/lib/check-migration-immutability.sh" 2>&1
+)"; then
+  pass "existing migrations unchanged"
+else
+  printf '%s\n' "$MIGRATION_IMMUTABILITY_OUTPUT" | sed 's/^/   /'
+  fail "migration immutability check failed"
+fi
+
+# 8. Commit author attribution check
+echo "8/8 Commit author attribution"
 if ! resolve_commit_git_identity; then
   fail "commit identity invalid — fix git config or set GIT_USER_NAME/GIT_USER_EMAIL to a real user"
 elif OFFENDING_COMMIT="$(find_agent_like_outgoing_commit)"; then


### PR DESCRIPTION
## What
Add a migration immutability guard that rejects modified, deleted, or renamed SQL migrations relative to `origin/main`. Wire it into PR CI and `just pre-push`, and document the rule in `crates/server/migrations/AGENTS.md`.

## Why
Changing a migration after it has been applied breaks existing databases because SQLx records migration versions and checksums. The recent in-place `006` edit showed that fresh-database migration checks were not enough to catch this class of failure.

## How
- Add `scripts/lib/check-migration-immutability.sh` to fail on `M`, `D`, or `R` changes under `crates/server/migrations/*.sql`.
- Add a dedicated PR CI job for the guard.
- Add the guard to `just pre-push` after sequential migration numbering.
- State the immutable-after-main rule in migration-local `AGENTS.md`.

## Risk
- Low
- Can block legitimate emergency edits to historical migrations; the intended path is a new sequential migration. If a true emergency requires rewriting history, the guard must be consciously changed or bypassed in repo policy.

## Security
- Threat categories reviewed: No security-relevant runtime code changes.
- Findings and resolutions: The change affects repository automation and contributor instructions only. No auth, API, SQL execution, runtime, or tenant data path changes. The new shell script consumes only Git refs/pathspecs and does not execute untrusted repository file contents.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `just pre-push`
- `MIGRATION_IMMUTABILITY_BASE_REF=7aa8a2c6 bash scripts/lib/check-migration-immutability.sh` fails on the known bad `006` rewrite path
- `git diff --check`
- Verified migrations remain sequential through `024` after rebase onto latest `origin/main`