### PR TITLE
fix(auth): fail fast on AUTH_MODE=external + built-in OAuth config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+### What's Changed
+
+- fix(auth): fail fast on `AUTH_MODE=external` + built-in OAuth provider config. The platform's own OAuth flow is disabled in External mode (the third-party provider handles identity), so accidentally configuring both used to surface as silent 401s on `/v1/auth/oauth/{provider}` and `/v1/auth/callback/{provider}` at request time. `AuthConfig::validate()` now runs inside `AuthConfig::from_env()` and panics at startup with a clear message naming the conflicting mode and the specific env vars (`AUTH_GOOGLE_CLIENT_ID/SECRET`, `AUTH_GITHUB_CLIENT_ID/SECRET`). The repo-access GitHub App config (`GITHUB_APP_ID` / `GITHUB_APP_PRIVATE_KEY`) is unaffected. See `specs/authentication.md` (External Mode and OAuth Providers).
+
 ## [0.8.22] - 2026-04-27
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### What's Changed
 
-- fix(auth): fail fast on `AUTH_MODE=external` + built-in OAuth provider config. The platform's own OAuth flow is disabled in External mode (the third-party provider handles identity), so accidentally configuring both used to surface as silent 401s on `/v1/auth/oauth/{provider}` and `/v1/auth/callback/{provider}` at request time. `AuthConfig::validate()` now runs inside `AuthConfig::from_env()` and panics at startup with a clear message naming the conflicting mode and the specific env vars (`AUTH_GOOGLE_CLIENT_ID/SECRET`, `AUTH_GITHUB_CLIENT_ID/SECRET`). The repo-access GitHub App config (`GITHUB_APP_ID` / `GITHUB_APP_PRIVATE_KEY`) is unaffected. See `specs/authentication.md` (External Mode and OAuth Providers).
+- fix(auth): fail fast on `AUTH_MODE=external` + built-in OAuth provider config. The platform's own OAuth flow is disabled in External mode (the third-party provider handles identity), so accidentally configuring both used to surface as silent 401s on `/v1/auth/oauth/{provider}` and `/v1/auth/callback/{provider}` at request time. `AuthConfig::validate()` now runs inside `AuthConfig::from_env()` and panics at startup with a clear message naming the conflicting mode and the specific env vars (`AUTH_GOOGLE_CLIENT_ID`, `AUTH_GOOGLE_CLIENT_SECRET`, `AUTH_GITHUB_CLIENT_ID`, `AUTH_GITHUB_CLIENT_SECRET`). The repo-access GitHub App config (`GITHUB_APP_ID` / `GITHUB_APP_PRIVATE_KEY`) is unaffected. See `specs/authentication.md` (External Mode and OAuth Providers).
 
 ## [0.8.22] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
-### What's Changed
-
-- fix(auth): fail fast on `AUTH_MODE=external` + built-in OAuth provider config. The platform's own OAuth flow is disabled in External mode (the third-party provider handles identity), so accidentally configuring both used to surface as silent 401s on `/v1/auth/oauth/{provider}` and `/v1/auth/callback/{provider}` at request time. `AuthConfig::validate()` now runs inside `AuthConfig::from_env()` and panics at startup with a clear message naming the conflicting mode and the specific env vars (`AUTH_GOOGLE_CLIENT_ID`, `AUTH_GOOGLE_CLIENT_SECRET`, `AUTH_GITHUB_CLIENT_ID`, `AUTH_GITHUB_CLIENT_SECRET`). The repo-access GitHub App config (`GITHUB_APP_ID` / `GITHUB_APP_PRIVATE_KEY`) is unaffected. See `specs/authentication.md` (External Mode and OAuth Providers).
-
 ## [0.8.22] - 2026-04-27
 
 ### Highlights

--- a/crates/server/src/auth/config.rs
+++ b/crates/server/src/auth/config.rs
@@ -1,6 +1,18 @@
 // Authentication configuration loaded from environment variables.
 // Decision: Follow Langfuse pattern with AUTH_ prefix for all auth config
 // Decision: Default to "none" mode for local development
+//
+// Trust boundary (External mode + OAuth providers): when `AUTH_MODE=external`
+// the platform delegates user identity to a third-party provider (PropelAuth,
+// Auth0, Clerk, etc.) and the built-in OAuth flow is intentionally disabled.
+// Pre-#1492 the runtime quietly hid configured providers and returned 401 on
+// `/oauth/redirect` and `/oauth/callback`. That made hybrid deployments fail
+// silently — operators saw 401s only at request time. We now fail fast at
+// startup: `AuthConfig::validate()` rejects `mode == External` when any
+// OAuth provider config is present, with a clear message that names both
+// the conflicting mode and the specific providers. Operators must remove
+// `google`/`github` config or change `AUTH_MODE` before the server starts.
+// See `specs/authentication.md` (External Mode and OAuth Providers).
 
 use std::time::Duration;
 
@@ -296,7 +308,7 @@ impl AuthConfig {
             .map(|mins: u64| Duration::from_secs(mins * 60))
             .unwrap_or_else(|| Duration::from_secs(30 * 24 * 60 * 60));
 
-        Self {
+        let config = Self {
             mode,
             base_url,
             frontend_url,
@@ -308,7 +320,47 @@ impl AuthConfig {
             disable_password_auth,
             disable_signup,
             session_max_age,
+        };
+
+        // Fail fast on conflicting auth-config combinations so operators see
+        // the problem at startup instead of as silent 401s at request time.
+        // See top-of-file decision comment for rationale.
+        if let Err(err) = config.validate() {
+            panic!("{err}");
         }
+        config
+    }
+
+    /// Validate cross-field invariants on the assembled config. Returns a
+    /// human-readable error message that operators can paste into a chat
+    /// channel without further translation.
+    ///
+    /// Currently enforces:
+    /// - `mode == External` is incompatible with any built-in OAuth provider
+    ///   (`google` or `github`). External mode delegates identity to a
+    ///   third-party provider; configuring both at once is ambiguous and
+    ///   was the source of the silent 401s in #1492.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.mode == AuthMode::External {
+            let mut configured: Vec<&str> = Vec::new();
+            if self.google.is_some() {
+                configured.push("AUTH_GOOGLE_CLIENT_ID/SECRET");
+            }
+            if self.github.is_some() {
+                configured.push("AUTH_GITHUB_CLIENT_ID/SECRET");
+            }
+            if !configured.is_empty() {
+                return Err(format!(
+                    "AUTH_MODE=external is incompatible with built-in OAuth providers \
+                     ({}). External mode delegates identity to a third-party provider; \
+                     remove the OAuth env vars or change AUTH_MODE to 'full' to use the \
+                     built-in OAuth flow. See specs/authentication.md (External Mode and \
+                     OAuth Providers).",
+                    configured.join(", ")
+                ));
+            }
+        }
+        Ok(())
     }
 
     /// Check if authentication is enabled
@@ -515,6 +567,119 @@ mod tests {
             !config.signup_enabled(),
             "Admin mode should never allow signup"
         );
+    }
+
+    fn make_google_config() -> GoogleOAuthConfig {
+        GoogleOAuthConfig {
+            base: OAuthProviderConfig {
+                client_id: "id".to_string(),
+                client_secret: "secret".to_string(),
+                redirect_uri: "https://example.com/callback".to_string(),
+            },
+            allowed_domains: None,
+        }
+    }
+
+    fn make_github_config() -> GitHubOAuthConfig {
+        GitHubOAuthConfig {
+            base: OAuthProviderConfig {
+                client_id: "id".to_string(),
+                client_secret: "secret".to_string(),
+                redirect_uri: "https://example.com/callback".to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn test_validate_external_mode_with_google_oauth_rejected() {
+        let config = AuthConfig {
+            mode: AuthMode::External,
+            google: Some(make_google_config()),
+            ..Default::default()
+        };
+        let err = config.validate().expect_err("expected validation error");
+        assert!(err.contains("AUTH_MODE=external"), "got: {err}");
+        assert!(err.contains("AUTH_GOOGLE_CLIENT_ID"), "got: {err}");
+    }
+
+    #[test]
+    fn test_validate_external_mode_with_github_oauth_rejected() {
+        let config = AuthConfig {
+            mode: AuthMode::External,
+            github: Some(make_github_config()),
+            ..Default::default()
+        };
+        let err = config.validate().expect_err("expected validation error");
+        assert!(err.contains("AUTH_MODE=external"), "got: {err}");
+        assert!(err.contains("AUTH_GITHUB_CLIENT_ID"), "got: {err}");
+    }
+
+    #[test]
+    fn test_validate_external_mode_with_both_providers_lists_both() {
+        let config = AuthConfig {
+            mode: AuthMode::External,
+            google: Some(make_google_config()),
+            github: Some(make_github_config()),
+            ..Default::default()
+        };
+        let err = config.validate().expect_err("expected validation error");
+        assert!(err.contains("AUTH_GOOGLE_CLIENT_ID"), "got: {err}");
+        assert!(err.contains("AUTH_GITHUB_CLIENT_ID"), "got: {err}");
+    }
+
+    #[test]
+    fn test_validate_external_mode_without_oauth_passes() {
+        // External mode without any built-in OAuth config is the supported
+        // setup — third-party provider handles identity, no conflict.
+        let config = AuthConfig {
+            mode: AuthMode::External,
+            ..Default::default()
+        };
+        config.validate().expect("expected validation to pass");
+    }
+
+    #[test]
+    fn test_validate_full_mode_with_oauth_passes() {
+        // Full mode IS the built-in OAuth mode — providers are required there.
+        let config = AuthConfig {
+            mode: AuthMode::Full,
+            google: Some(make_google_config()),
+            github: Some(make_github_config()),
+            ..Default::default()
+        };
+        config.validate().expect("expected validation to pass");
+    }
+
+    #[test]
+    fn test_validate_admin_mode_with_oauth_passes() {
+        // Admin mode doesn't surface OAuth either, but the validator only
+        // catches the External-mode conflict — Admin + configured OAuth is
+        // unusual but harmless (login goes through admin credentials).
+        let config = AuthConfig {
+            mode: AuthMode::Admin,
+            google: Some(make_google_config()),
+            ..Default::default()
+        };
+        config.validate().expect("expected validation to pass");
+    }
+
+    #[test]
+    fn test_validate_github_connection_does_not_conflict_with_external() {
+        // The repo-access GitHub App (GITHUB_APP_ID / GITHUB_APP_PRIVATE_KEY)
+        // is unrelated to the login OAuth flow — it's a per-user connection
+        // for repo access. Operators running External mode can still wire
+        // the GitHub App for repo features.
+        let config = AuthConfig {
+            mode: AuthMode::External,
+            github_connection: Some(GitHubConnectionConfig {
+                app_id: "1".to_string(),
+                private_key: "key".to_string(),
+                app_slug: "everruns".to_string(),
+                setup_url: "https://example.com/setup".to_string(),
+            }),
+            ..Default::default()
+        };
+        config.validate().expect("expected validation to pass");
     }
 
     // TM-AUTH-002: Verify the insecure hardcoded fallback is removed

--- a/crates/server/src/auth/config.rs
+++ b/crates/server/src/auth/config.rs
@@ -6,13 +6,15 @@
 // the platform delegates user identity to a third-party provider (PropelAuth,
 // Auth0, Clerk, etc.) and the built-in OAuth flow is intentionally disabled.
 // Pre-#1492 the runtime quietly hid configured providers and returned 401 on
-// `/oauth/redirect` and `/oauth/callback`. That made hybrid deployments fail
-// silently — operators saw 401s only at request time. We now fail fast at
-// startup: `AuthConfig::validate()` rejects `mode == External` when any
-// OAuth provider config is present, with a clear message that names both
-// the conflicting mode and the specific providers. Operators must remove
-// `google`/`github` config or change `AUTH_MODE` before the server starts.
-// See `specs/authentication.md` (External Mode and OAuth Providers).
+// `/v1/auth/oauth/{provider}` and `/v1/auth/callback/{provider}` (the login
+// OAuth handlers — distinct from the MCP `/oauth/...` handlers). That made
+// hybrid deployments fail silently — operators saw 401s only at request
+// time. We now fail fast at startup: `AuthConfig::validate()` rejects
+// `mode == External` when any OAuth provider config is present, with a clear
+// message that names both the conflicting mode and the specific providers.
+// Operators must remove `google`/`github` config or change `AUTH_MODE`
+// before the server starts. See `specs/authentication.md` (External Mode
+// and OAuth Providers).
 
 use std::time::Duration;
 
@@ -344,19 +346,19 @@ impl AuthConfig {
         if self.mode == AuthMode::External {
             let mut configured: Vec<&str> = Vec::new();
             if self.google.is_some() {
-                configured.push("AUTH_GOOGLE_CLIENT_ID/SECRET");
+                configured.push("AUTH_GOOGLE_CLIENT_ID, AUTH_GOOGLE_CLIENT_SECRET");
             }
             if self.github.is_some() {
-                configured.push("AUTH_GITHUB_CLIENT_ID/SECRET");
+                configured.push("AUTH_GITHUB_CLIENT_ID, AUTH_GITHUB_CLIENT_SECRET");
             }
             if !configured.is_empty() {
                 return Err(format!(
                     "AUTH_MODE=external is incompatible with built-in OAuth providers \
                      ({}). External mode delegates identity to a third-party provider; \
-                     remove the OAuth env vars or change AUTH_MODE to 'full' to use the \
-                     built-in OAuth flow. See specs/authentication.md (External Mode and \
-                     OAuth Providers).",
-                    configured.join(", ")
+                     remove the OAuth env vars or set AUTH_MODE=full to use the built-in \
+                     OAuth flow. See specs/authentication.md (External Mode and OAuth \
+                     Providers).",
+                    configured.join("; ")
                 ));
             }
         }
@@ -640,7 +642,10 @@ mod tests {
 
     #[test]
     fn test_validate_full_mode_with_oauth_passes() {
-        // Full mode IS the built-in OAuth mode — providers are required there.
+        // Full mode supports built-in OAuth when providers are configured;
+        // that combination must validate successfully. (Full mode is also
+        // valid without OAuth — password / API-key auth still work — and
+        // that case is covered by `test_full_mode_password_auth`.)
         let config = AuthConfig {
             mode: AuthMode::Full,
             google: Some(make_google_config()),

--- a/crates/server/src/auth/config.rs
+++ b/crates/server/src/auth/config.rs
@@ -5,7 +5,7 @@
 // Trust boundary (External mode + OAuth providers): when `AUTH_MODE=external`
 // the platform delegates user identity to a third-party provider (PropelAuth,
 // Auth0, Clerk, etc.) and the built-in OAuth flow is intentionally disabled.
-// Pre-#1492 the runtime quietly hid configured providers and returned 401 on
+// Since #1492 the runtime quietly hides configured providers and returns 401 on
 // `/v1/auth/oauth/{provider}` and `/v1/auth/callback/{provider}` (the login
 // OAuth handlers — distinct from the MCP `/oauth/...` handlers). That made
 // hybrid deployments fail silently — operators saw 401s only at request

--- a/specs/authentication.md
+++ b/specs/authentication.md
@@ -111,7 +111,7 @@ To prevent silent 401s for hybrid deployments that accidentally configure both a
 
 The error names both the conflicting mode and the specific env vars, and points operators to remove the OAuth env vars or switch `AUTH_MODE=full`. The repo-access GitHub App config (`GITHUB_APP_ID` / `GITHUB_APP_PRIVATE_KEY`) is **not** affected — it powers per-user repo connections, not the login flow, so External mode + GitHub App is supported.
 
-This is a fail-fast validation: operators see the misconfiguration at deploy time, not as a 401 on `/oauth/redirect` after rollout. See `crates/server/src/auth/config.rs::validate` for the implementation and the top-of-file decision comment.
+This is a fail-fast validation: operators see the misconfiguration at deploy time, not during a built-in OAuth login attempt on `/v1/auth/oauth/{provider}` or its callback `/v1/auth/callback/{provider}` after rollout. See `crates/server/src/auth/config.rs::validate` for the implementation and the top-of-file decision comment.
 
 ### OAuth Providers
 

--- a/specs/authentication.md
+++ b/specs/authentication.md
@@ -100,6 +100,19 @@ The login page accepts exactly one public query parameter for auth resume:
 
 Implementations: `apps/ui/src/lib/auth-redirect.ts` (`sanitizeReturnTo`) and `apps/ui/src/app/(auth)/login/page.tsx`.
 
+### External Mode and OAuth Providers
+
+`AUTH_MODE=external` and the built-in OAuth flow are mutually exclusive. External mode delegates user identity to a third-party provider (PropelAuth, Auth0, Clerk, etc.); the platform's own OAuth handlers (`/v1/auth/oauth/{provider}`, `/v1/auth/callback/{provider}`) are disabled.
+
+To prevent silent 401s for hybrid deployments that accidentally configure both at once, `AuthConfig::validate()` runs at startup (inside `AuthConfig::from_env()`) and **panics with a clear message** when `AUTH_MODE=external` and any of the following are set:
+
+- `AUTH_GOOGLE_CLIENT_ID` / `AUTH_GOOGLE_CLIENT_SECRET`
+- `AUTH_GITHUB_CLIENT_ID` / `AUTH_GITHUB_CLIENT_SECRET`
+
+The error names both the conflicting mode and the specific env vars, and points operators to remove the OAuth env vars or switch `AUTH_MODE=full`. The repo-access GitHub App config (`GITHUB_APP_ID` / `GITHUB_APP_PRIVATE_KEY`) is **not** affected — it powers per-user repo connections, not the login flow, so External mode + GitHub App is supported.
+
+This is a fail-fast validation: operators see the misconfiguration at deploy time, not as a 401 on `/oauth/redirect` after rollout. See `crates/server/src/auth/config.rs::validate` for the implementation and the top-of-file decision comment.
+
 ### OAuth Providers
 
 When configured, supports OAuth2 with:


### PR DESCRIPTION
## What

Fail fast when `AUTH_MODE=external` is combined with built-in Google or GitHub OAuth provider config.

`AuthConfig::validate()` now runs inside `AuthConfig::from_env()` and panics at startup with a clear operator-facing message naming the conflicting mode and concrete env vars:

- `AUTH_GOOGLE_CLIENT_ID` / `AUTH_GOOGLE_CLIENT_SECRET`
- `AUTH_GITHUB_CLIENT_ID` / `AUTH_GITHUB_CLIENT_SECRET`

The repo-access GitHub App config (`GITHUB_APP_ID` / `GITHUB_APP_PRIVATE_KEY`) is intentionally unaffected because it powers per-user repo connections, not the login flow.

## Why

`AUTH_MODE=external` delegates identity to a third-party provider. The platform's own OAuth login handlers are disabled in that mode, so configuring both surfaces as runtime 401s after rollout. Startup validation gives operators a clear deploy-time failure instead.

Fixes EVE-394.

## How

- Add `AuthConfig::validate()` for cross-field auth config invariants.
- Call validation from `AuthConfig::from_env()` after assembling provider config.
- Add focused auth config tests for rejected and supported combinations.
- Document the rule in `specs/authentication.md`.

## Risk

- Low.
- This rejects a config combination that already could not use built-in OAuth in External mode.
- No schema or API response shape changes.

## Validation

- `cargo test -p everruns-server --lib auth::config::` — 17 passed.
- `just pre-push` — passed. UI format/lint skipped because `apps/ui/node_modules` is not installed in this worktree.
- Startup smoke: `AUTH_MODE=external` + Google OAuth env vars against `target/debug/everruns-server` exits immediately with `AUTH_MODE=external is incompatible with built-in OAuth providers ...`.
- Post-rebase migration duplicate check: none.

## Security

- Threat categories reviewed: TM-AUTH.
- No new auth bypass surface. The change moves an existing invalid auth-mode/provider combination from request-time failure to startup failure.
- Panic message names env-var identifiers only, never secret values.
- GitHub App config remains allowed in External mode because it is not part of login authentication.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Review comments addressed
