### PR TITLE
feat(settings): split organisations page

### DIFF
--- a/apps/ui/src/__tests__/settings-layout.test.tsx
+++ b/apps/ui/src/__tests__/settings-layout.test.tsx
@@ -30,6 +30,7 @@ describe("SettingsLayout", () => {
     );
 
     expect(screen.getByText("General")).toBeInTheDocument();
+    expect(screen.getByText("Organisations")).toBeInTheDocument();
     expect(screen.getByText("LLM Providers")).toBeInTheDocument();
     expect(screen.getByText("Members")).toBeInTheDocument();
     expect(screen.getByText("Profile")).toBeInTheDocument();
@@ -56,6 +57,7 @@ describe("SettingsLayout", () => {
     );
 
     const generalLink = screen.getByRole("link", { name: /General/i });
+    const organisationsLink = screen.getByRole("link", { name: /Organisations/i });
     const providersLink = screen.getByRole("link", { name: /LLM Providers/i });
     const membersLink = screen.getByRole("link", { name: /Members/i });
     const profileLink = screen.getByRole("link", { name: /Profile/i });
@@ -63,6 +65,7 @@ describe("SettingsLayout", () => {
     const apiKeysLink = screen.getByRole("link", { name: /API Keys/i });
 
     expect(generalLink).toHaveAttribute("href", "/settings/organisation");
+    expect(organisationsLink).toHaveAttribute("href", "/settings/organisations");
     expect(providersLink).toHaveAttribute("href", "/settings/providers");
     expect(membersLink).toHaveAttribute("href", "/settings/members");
     expect(profileLink).toHaveAttribute("href", "/settings/profile");
@@ -117,7 +120,7 @@ describe("SettingsLayout", () => {
     expect(membersLink).toHaveClass("border-accent");
   });
 
-  it("has exactly 6 navigation items", () => {
+  it("has exactly 7 navigation items", () => {
     render(
       <SettingsLayout>
         <div>Test Content</div>
@@ -125,7 +128,7 @@ describe("SettingsLayout", () => {
     );
 
     const navLinks = screen.getAllByRole("link");
-    expect(navLinks).toHaveLength(6);
+    expect(navLinks).toHaveLength(7);
   });
 
   it("groups items under correct sections", () => {
@@ -141,6 +144,7 @@ describe("SettingsLayout", () => {
     // Organisation section contains its items
     const orgSection = orgLabel.closest("div[class]")!.parentElement!;
     expect(orgSection).toHaveTextContent("General");
+    expect(orgSection).toHaveTextContent("Organisations");
     expect(orgSection).toHaveTextContent("LLM Providers");
     expect(orgSection).toHaveTextContent("Members");
     expect(orgSection).not.toHaveTextContent("Connections");
@@ -152,6 +156,7 @@ describe("SettingsLayout", () => {
     expect(personalSection).toHaveTextContent("Connections");
     expect(personalSection).toHaveTextContent("API Keys");
     expect(personalSection).not.toHaveTextContent("General");
+    expect(personalSection).not.toHaveTextContent("Organisations");
     expect(personalSection).not.toHaveTextContent("Members");
   });
 
@@ -183,11 +188,13 @@ describe("SettingsLayout", () => {
     );
 
     const generalLink = screen.getByRole("link", { name: /General/i });
+    const organisationsLink = screen.getByRole("link", { name: /Organisations/i });
     const membersLink = screen.getByRole("link", { name: /Members/i });
     const apiKeysLink = screen.getByRole("link", { name: /API Keys/i });
 
     expect(generalLink).toHaveClass("border-transparent");
     expect(generalLink).not.toHaveClass("border-accent");
+    expect(organisationsLink).toHaveClass("border-transparent");
     expect(membersLink).toHaveClass("border-transparent");
     expect(apiKeysLink).toHaveClass("border-transparent");
   });
@@ -202,6 +209,18 @@ describe("SettingsLayout", () => {
 
     const generalLink = screen.getByRole("link", { name: /General/i });
     expect(generalLink).toHaveClass("border-accent");
+  });
+
+  it("highlights active item for Organisations page", () => {
+    mockPathname.mockReturnValue("/settings/organisations");
+    render(
+      <SettingsLayout>
+        <div>Test Content</div>
+      </SettingsLayout>,
+    );
+
+    const organisationsLink = screen.getByRole("link", { name: /Organisations/i });
+    expect(organisationsLink).toHaveClass("border-accent");
   });
 
   it("highlights active item for Profile page", () => {

--- a/apps/ui/src/__tests__/settings-organisations.test.tsx
+++ b/apps/ui/src/__tests__/settings-organisations.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import OrganisationsPage from "@/app/(main)/settings/organisations/page";
+
+const mockPush = jest.fn();
+const mockSetCurrentOrg = jest.fn();
+const mockMutateAsync = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+jest.mock("@/providers/org-provider", () => ({
+  useOrg: () => ({
+    currentOrg: { public_id: "org-1", name: "Current Org", role: "owner" },
+    organizations: [
+      { public_id: "org-1", name: "Current Org", role: "owner" },
+      { public_id: "org-2", name: "Second Org", role: "member" },
+    ],
+    setCurrentOrg: mockSetCurrentOrg,
+  }),
+}));
+
+jest.mock("@/hooks/use-organizations", () => ({
+  useCreateOrganization: () => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
+}));
+
+describe("OrganisationsPage", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockSetCurrentOrg.mockClear();
+    mockMutateAsync.mockClear();
+  });
+
+  it("renders accessible organisations separately from general settings", () => {
+    render(<OrganisationsPage />);
+
+    expect(screen.getByRole("heading", { name: "Organisations" })).toBeInTheDocument();
+    expect(screen.getByText("Current Org")).toBeInTheDocument();
+    expect(screen.getByText("Second Org")).toBeInTheDocument();
+    expect(screen.getByText("org-1")).toBeInTheDocument();
+    expect(screen.getByText("org-2")).toBeInTheDocument();
+    expect(screen.getByText("Current")).toBeInTheDocument();
+  });
+
+  it("switches to another organisation", () => {
+    render(<OrganisationsPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch" }));
+
+    expect(mockSetCurrentOrg).toHaveBeenCalledWith({
+      public_id: "org-2",
+      name: "Second Org",
+      role: "member",
+    });
+  });
+
+  it("creates a new organisation and routes to setup", async () => {
+    mockMutateAsync.mockResolvedValue({ id: "org-3", name: "New Org" });
+
+    render(<OrganisationsPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Create Organisation" }));
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "New Org" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({ name: "New Org" });
+      expect(mockSetCurrentOrg).toHaveBeenCalledWith({
+        public_id: "org-3",
+        name: "New Org",
+        role: "owner",
+      });
+      expect(mockPush).toHaveBeenCalledWith("/orgs/org-3/setup");
+    });
+  });
+});

--- a/apps/ui/src/app/(main)/settings/layout.tsx
+++ b/apps/ui/src/app/(main)/settings/layout.tsx
@@ -28,6 +28,12 @@ const settingsSections: NavSection[] = [
         description: "Manage organisation settings",
       },
       {
+        name: "Organisations",
+        href: "/settings/organisations",
+        icon: Building2,
+        description: "Switch or create organisations",
+      },
+      {
         name: "LLM Providers",
         href: "/settings/providers",
         icon: Server,

--- a/apps/ui/src/app/(main)/settings/organisation/page.tsx
+++ b/apps/ui/src/app/(main)/settings/organisation/page.tsx
@@ -8,38 +8,21 @@ import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { CopyButton } from "@/components/ui/copy-button";
 import { HarnessSelect } from "@/components/harness/harness-select";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
-  useOrganization,
-  useUpdateOrganization,
-  useCreateOrganization,
-} from "@/hooks/use-organizations";
+import { useOrganization, useUpdateOrganization } from "@/hooks/use-organizations";
 import { useHarnesses } from "@/hooks";
 import { useOrg } from "@/providers/org-provider";
-import { useRouter } from "next/navigation";
-import { Building2, Save, AlertCircle, Plus, Check } from "lucide-react";
+import { Building2, Save, AlertCircle } from "lucide-react";
 
 export default function OrganisationPage() {
-  const router = useRouter();
-  const { currentOrg, organizations, setCurrentOrg } = useOrg();
+  const { currentOrg } = useOrg();
   const { data: organization, isLoading, error } = useOrganization();
   const { data: harnesses = [] } = useHarnesses();
   const updateOrganization = useUpdateOrganization();
-  const createOrganization = useCreateOrganization();
 
   const [name, setName] = useState("");
   const [defaultHarnessId, setDefaultHarnessId] = useState("");
   const [baseHarnessId, setBaseHarnessId] = useState("");
   const [hasChanges, setHasChanges] = useState(false);
-  const [createDialogOpen, setCreateDialogOpen] = useState(false);
-  const [newOrgName, setNewOrgName] = useState("");
 
   const syncHasChanges = (
     nextName: string,
@@ -88,19 +71,6 @@ export default function OrganisationPage() {
     if (e.key === "Enter" && hasChanges && name.trim() && defaultHarnessId && baseHarnessId) {
       handleSave();
     }
-  };
-
-  const handleCreateOrg = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!newOrgName.trim()) return;
-
-    const org = await createOrganization.mutateAsync({
-      name: newOrgName.trim(),
-    });
-    setCurrentOrg({ public_id: org.id, name: org.name, role: "owner" });
-    setNewOrgName("");
-    setCreateDialogOpen(false);
-    router.push(`/orgs/${org.id}/setup`);
   };
 
   if (error) {
@@ -248,93 +218,6 @@ export default function OrganisationPage() {
           </Card>
         )}
       </section>
-
-      {/* All Organisations */}
-      <section>
-        <div className="mb-6 flex items-center justify-between">
-          <div>
-            <h2 className="text-xl font-semibold">Your Organisations</h2>
-            <p className="text-sm text-muted-foreground">All organisations you are a member of.</p>
-          </div>
-          <Button onClick={() => setCreateDialogOpen(true)}>
-            <Plus className="h-4 w-4 mr-2" />
-            Create Organisation
-          </Button>
-        </div>
-
-        <div className="space-y-3">
-          {organizations.map((org) => {
-            const isCurrent = currentOrg?.public_id === org.public_id;
-            return (
-              <Card
-                key={org.public_id}
-                className={`p-4 flex items-center justify-between ${isCurrent ? "border-primary/50" : ""}`}
-              >
-                <div className="flex items-center gap-3">
-                  <div className={`p-2 ${isCurrent ? "bg-primary/10" : "bg-muted"}`}>
-                    <Building2
-                      className={`h-4 w-4 ${isCurrent ? "text-primary" : "text-muted-foreground"}`}
-                    />
-                  </div>
-                  <div>
-                    <p className="font-medium">{org.name}</p>
-                    <p className="text-xs text-muted-foreground font-mono">{org.public_id}</p>
-                  </div>
-                </div>
-                <div className="flex items-center gap-2">
-                  {isCurrent ? (
-                    <span className="flex items-center gap-1 text-sm text-primary">
-                      <Check className="h-4 w-4" />
-                      Current
-                    </span>
-                  ) : (
-                    <Button variant="outline" size="sm" onClick={() => setCurrentOrg(org)}>
-                      Switch
-                    </Button>
-                  )}
-                </div>
-              </Card>
-            );
-          })}
-        </div>
-      </section>
-
-      {/* Create Organisation Dialog */}
-      <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Create Organisation</DialogTitle>
-            <DialogDescription>
-              Create a new organisation. You will be added as a member automatically.
-            </DialogDescription>
-          </DialogHeader>
-          <form onSubmit={handleCreateOrg} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="new-org-name">Name</Label>
-              <Input
-                id="new-org-name"
-                value={newOrgName}
-                onChange={(e) => setNewOrgName(e.target.value)}
-                placeholder="Organisation name"
-                required
-              />
-            </div>
-            {createOrganization.isError && (
-              <p className="text-sm text-destructive">
-                Failed to create: {createOrganization.error.message}
-              </p>
-            )}
-            <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => setCreateDialogOpen(false)}>
-                Cancel
-              </Button>
-              <Button type="submit" disabled={createOrganization.isPending || !newOrgName.trim()}>
-                {createOrganization.isPending ? "Creating..." : "Create"}
-              </Button>
-            </DialogFooter>
-          </form>
-        </DialogContent>
-      </Dialog>
     </div>
   );
 }

--- a/apps/ui/src/app/(main)/settings/organisations/page.tsx
+++ b/apps/ui/src/app/(main)/settings/organisations/page.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Building2, Check, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useCreateOrganization } from "@/hooks/use-organizations";
+import { useOrg } from "@/providers/org-provider";
+
+export default function OrganisationsPage() {
+  const router = useRouter();
+  const { currentOrg, organizations, setCurrentOrg } = useOrg();
+  const createOrganization = useCreateOrganization();
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [newOrgName, setNewOrgName] = useState("");
+
+  const handleCreateOrg = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newOrgName.trim()) return;
+
+    const org = await createOrganization.mutateAsync({
+      name: newOrgName.trim(),
+    });
+    setCurrentOrg({ public_id: org.id, name: org.name, role: "owner" });
+    setNewOrgName("");
+    setCreateDialogOpen(false);
+    router.push(`/orgs/${org.id}/setup`);
+  };
+
+  return (
+    <div className="space-y-8">
+      <section>
+        <div className="mb-6 flex items-center justify-between gap-4">
+          <div>
+            <h2 className="text-xl font-semibold">Organisations</h2>
+            <p className="text-sm text-muted-foreground">All organisations you are a member of.</p>
+          </div>
+          <Button onClick={() => setCreateDialogOpen(true)}>
+            <Plus className="h-4 w-4 mr-2" />
+            Create Organisation
+          </Button>
+        </div>
+
+        {organizations.length === 0 ? (
+          <Card className="p-8 text-center">
+            <Building2 className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+            <h3 className="text-lg font-medium mb-2">No organisations</h3>
+            <p className="text-muted-foreground">
+              Create an organisation to start managing shared resources.
+            </p>
+          </Card>
+        ) : (
+          <div className="space-y-3">
+            {organizations.map((org) => {
+              const isCurrent = currentOrg?.public_id === org.public_id;
+              return (
+                <Card
+                  key={org.public_id}
+                  className={`p-4 flex items-center justify-between gap-4 ${isCurrent ? "border-primary/50" : ""}`}
+                >
+                  <div className="flex min-w-0 items-center gap-3">
+                    <div className={`p-2 ${isCurrent ? "bg-primary/10" : "bg-muted"}`}>
+                      <Building2
+                        className={`h-4 w-4 ${isCurrent ? "text-primary" : "text-muted-foreground"}`}
+                      />
+                    </div>
+                    <div className="min-w-0">
+                      <p className="truncate font-medium">{org.name}</p>
+                      <p className="truncate text-xs text-muted-foreground font-mono">
+                        {org.public_id}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-2">
+                    {isCurrent ? (
+                      <span className="flex items-center gap-1 text-sm text-primary">
+                        <Check className="h-4 w-4" />
+                        Current
+                      </span>
+                    ) : (
+                      <Button variant="outline" size="sm" onClick={() => setCurrentOrg(org)}>
+                        Switch
+                      </Button>
+                    )}
+                  </div>
+                </Card>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create Organisation</DialogTitle>
+            <DialogDescription>
+              Create a new organisation. You will be added as a member automatically.
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleCreateOrg} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="new-org-name">Name</Label>
+              <Input
+                id="new-org-name"
+                value={newOrgName}
+                onChange={(e) => setNewOrgName(e.target.value)}
+                placeholder="Organisation name"
+                required
+              />
+            </div>
+            {createOrganization.isError && (
+              <p className="text-sm text-destructive">
+                Failed to create: {createOrganization.error.message}
+              </p>
+            )}
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setCreateDialogOpen(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={createOrganization.isPending || !newOrgName.trim()}>
+                {createOrganization.isPending ? "Creating..." : "Create"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/ui/src/hooks/use-global-search.ts
+++ b/apps/ui/src/hooks/use-global-search.ts
@@ -183,7 +183,13 @@ const NAVIGATION_PAGES: NavigationPage[] = [
     title: "Settings > Organisation",
     href: "/settings/organisation",
     icon: Settings,
-    keywords: ["org", "team"],
+    keywords: ["org", "organization", "team"],
+  },
+  {
+    title: "Settings > Organisations",
+    href: "/settings/organisations",
+    icon: Settings,
+    keywords: ["org", "organization", "organizations", "team", "switch"],
   },
   {
     title: "Settings > Members",


### PR DESCRIPTION
## What
Move the list of organisations accessible to the user out of Settings > Organisation and into a dedicated Settings > Organisations page.

## Why
The general organisation settings page mixed editable settings with account-level organisation switching and creation. Splitting the list gives users a clearer place to switch or create organisations.

## How
- Added `/settings/organisations` with the existing organisation list, current-org badge, switch action, empty state, and create-organisation dialog.
- Removed the organisation list/create dialog from `/settings/organisation`, leaving only editable settings and organisation ID.
- Added the new settings sidebar item and global search entry, including `organization` search keywords.
- Added Jest coverage for the new page and updated settings navigation tests.

## Risk
- Low
- Settings navigation or organisation switching UI could regress if the new route is not discoverable or the existing hooks are wired incorrectly.

## Security
- Threat categories reviewed: TM-WEB, TM-TENANT, TM-AUTH, TM-AUTHZ
- Findings and resolutions: No new server endpoints, auth checks, permission checks, storage, or raw rendering paths were introduced. The page continues to use the existing `useOrg()` membership list and existing organization create/switch hooks. React renders organisation names/IDs as text, preserving existing XSS mitigations. No threat-model update needed.

## Validation
- `cd apps/ui && npm run format:check`
- `cd apps/ui && npm run lint` (passes with existing unrelated warnings)
- `cd apps/ui && npm test -- --runTestsByPath src/__tests__/settings-layout.test.tsx src/__tests__/settings-organisations.test.tsx --runInBand`
- `cd apps/ui && npm run build`
- `PORT_PREFIX=271 just start-dev --no-watch`
- Local Playwright smoke through `http://localhost:27100/settings/organisations` with dev cookie: verified Settings header, Organisations heading, Create Organisation button, Current badge, and Default Organization visible.
- `just pre-push`

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)