### PR TITLE
fix(commands): classify /btw LLM errors instead of returning 500

### DIFF
--- a/apps/ui/src/lib/api/types/command-types.ts
+++ b/apps/ui/src/lib/api/types/command-types.ts
@@ -30,4 +30,6 @@ export interface ExecuteCommandRequest {
 export interface CommandResult {
   success: boolean;
   message: string;
+  error_code?: string;
+  error_fields?: Record<string, unknown>;
 }

--- a/crates/core/src/command.rs
+++ b/crates/core/src/command.rs
@@ -10,6 +10,7 @@
 // system commands. The UI fetches available commands and renders autocomplete.
 
 use crate::message::Controls;
+use crate::user_facing_error::UserFacingErrorFields;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "openapi")]
@@ -77,4 +78,13 @@ pub struct CommandResult {
     pub success: bool,
     /// Human-readable message describing the result
     pub message: String,
+    /// Stable error code when `success` is false. Mirrors the codes emitted on
+    /// chat error messages so the UI can localize the copy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<String>,
+    /// Optional structured fields associated with `error_code` (provider,
+    /// model_id, retry_after, …).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<Object>))]
+    pub error_fields: Option<UserFacingErrorFields>,
 }

--- a/crates/server/src/domains/session_commands/service.rs
+++ b/crates/server/src/domains/session_commands/service.rs
@@ -22,6 +22,7 @@ use everruns_core::message::{Controls, Message, MessageRole};
 use everruns_core::runtime_context::{inspect_turn_context, resolve_runtime_capabilities};
 use everruns_core::traits::{AgentStore, HarnessStore, ImageResolver, SessionStore};
 use everruns_core::typed_id::{ModelId, SessionId};
+use everruns_core::user_facing_error::{UserFacingErrorContext, classify_runtime_error_message};
 use everruns_core::{Agent, Caller, CapabilityRegistry, DriverRegistry, Harness, ResolvedImage};
 use everruns_worker::worker_adapters::{
     AdapterAgentStore, AdapterHarnessStore, AdapterImageResolver, AdapterLlmProviderStore,
@@ -269,12 +270,12 @@ impl SessionCommandService {
             llm_messages.push(llm_msg);
         }
 
+        let provider_type_str = model.provider_type.to_string();
         let provider = ProviderConfig {
             provider_type: provider_type_from_llm(model.provider_type)?,
             api_key: model.api_key.clone(),
             base_url: model.base_url.clone(),
         };
-        let driver = self.driver_registry.create_driver(&provider)?;
 
         let mut llm_config_builder = LlmCallConfigBuilder::from(&turn_context.runtime_agent)
             .tools(vec![])
@@ -293,16 +294,23 @@ impl SessionCommandService {
             .with_metadata("command", BTW_COMMAND_NAME)
             .build();
 
-        let response = driver.chat_completion(llm_messages, &llm_config).await?;
-        let message = response.text.trim().to_string();
-        if message.is_empty() {
-            return Err(anyhow!("System command /btw returned an empty response"));
-        }
+        let context = UserFacingErrorContext::default()
+            .with_provider(provider_type_str)
+            .with_model_id(model.model.to_string());
 
-        Ok(CommandResult {
-            success: true,
-            message,
-        })
+        // Mirror the worker's ReasonAtom path: provider/runtime errors during
+        // /btw should be classified and returned as `success: false` instead of
+        // bubbling up as HTTP 500. The frontend uses `error_code` to localize.
+        match run_btw_completion(&self.driver_registry, &provider, llm_messages, &llm_config).await
+        {
+            Ok(message) => Ok(CommandResult {
+                success: true,
+                message,
+                error_code: None,
+                error_fields: None,
+            }),
+            Err(error) => Ok(classify_btw_error(error, &context)),
+        }
     }
 
     async fn resolve_model(
@@ -330,6 +338,39 @@ impl SessionCommandService {
             api_key: resolved.api_key,
             base_url: resolved.base_url,
         }))
+    }
+}
+
+async fn run_btw_completion(
+    driver_registry: &DriverRegistry,
+    provider: &ProviderConfig,
+    llm_messages: Vec<LlmMessage>,
+    llm_config: &everruns_core::llm_driver_registry::LlmCallConfig,
+) -> Result<String> {
+    let driver = driver_registry
+        .create_driver(provider)
+        .map_err(|err| anyhow!(err.to_string()))?;
+
+    let response = driver
+        .chat_completion(llm_messages, llm_config)
+        .await
+        .map_err(|err| anyhow!(err.to_string()))?;
+
+    let message = response.text.trim().to_string();
+    if message.is_empty() {
+        return Err(anyhow!("System command /btw returned an empty response"));
+    }
+    Ok(message)
+}
+
+fn classify_btw_error(error: anyhow::Error, context: &UserFacingErrorContext) -> CommandResult {
+    let chain = format!("{error:#}");
+    let classified = classify_runtime_error_message(&chain, context);
+    CommandResult {
+        success: false,
+        message: classified.fallback_message(),
+        error_code: Some(classified.code.clone()),
+        error_fields: classified.error_fields(),
     }
 }
 
@@ -404,4 +445,68 @@ async fn resolve_images(
         }
     }
     resolved
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_btw_error_maps_401_to_provider_misconfigured() {
+        let err = anyhow!("OpenAI API error (401): unauthorized");
+        let context = UserFacingErrorContext::default()
+            .with_provider("openai")
+            .with_model_id("gpt-5");
+
+        let result = classify_btw_error(err, &context);
+
+        assert!(!result.success);
+        assert_eq!(result.error_code.as_deref(), Some("provider_misconfigured"));
+        assert_eq!(
+            result.message,
+            "There is a misconfiguration with the AI provider. Please contact support."
+        );
+        let fields = result.error_fields.expect("error_fields populated");
+        assert_eq!(
+            fields.get("provider").and_then(|v| v.as_str()),
+            Some("openai")
+        );
+        assert_eq!(
+            fields.get("model_id").and_then(|v| v.as_str()),
+            Some("gpt-5")
+        );
+    }
+
+    #[test]
+    fn classify_btw_error_maps_429_to_rate_limited() {
+        let err = anyhow!("OpenAI API error (429): rate limit exceeded");
+        let context = UserFacingErrorContext::default().with_provider("openai");
+
+        let result = classify_btw_error(err, &context);
+
+        assert!(!result.success);
+        assert_eq!(result.error_code.as_deref(), Some("provider_rate_limited"));
+    }
+
+    #[test]
+    fn classify_btw_error_falls_back_to_processing_error() {
+        let err = anyhow!("something exploded");
+        let context = UserFacingErrorContext::default();
+
+        let result = classify_btw_error(err, &context);
+
+        assert!(!result.success);
+        assert_eq!(result.error_code.as_deref(), Some("processing_error"));
+    }
+
+    #[test]
+    fn classify_btw_error_handles_missing_api_key() {
+        let err = anyhow!("API key is required. Configure the API key in provider settings.");
+        let context = UserFacingErrorContext::default().with_provider("openai");
+
+        let result = classify_btw_error(err, &context);
+
+        assert!(!result.success);
+        assert_eq!(result.error_code.as_deref(), Some("provider_misconfigured"));
+    }
 }


### PR DESCRIPTION
## What
When `/btw` (the side-question slash command) hits a provider/runtime LLM error — provider misconfigured, rate-limited, model unavailable, etc. — return a graceful `CommandResult { success: false, message, error_code, error_fields }` (HTTP 200) instead of bubbling up an HTTP 500 with `{"error":"Internal server error"}`.

## Why
Closes EVE-398. The regular chat path through `ReasonAtom` already classifies the same driver errors via `classify_runtime_error_message` and surfaces a placeholder agent message with `error_code` metadata. `/btw` skipped that classification entirely, so any LLM failure produced a 500 and the UI showed a generic `"Failed to answer side question."` with no signal of what went wrong.

`CommandResult { success: bool, message: String }` already exists for graceful failures — the success path uses `success: true`. Provider-misconfigured / rate-limited cases now use `success: false` with the user-facing message and a stable `error_code`.

## How
- `crates/core/src/command.rs`: extended `CommandResult` with optional `error_code` and `error_fields` (both `#[serde(default, skip_serializing_if = "Option::is_none")]`, additive).
- `crates/server/src/domains/session_commands/service.rs`:
  - Extracted `run_btw_completion` (driver creation + chat completion + empty-response check) so all LLM failures funnel into a single classification site.
  - Added `classify_btw_error` that runs the error chain through `classify_runtime_error_message` with `UserFacingErrorContext { provider, model_id }` and returns `CommandResult { success: false, message: classified.fallback_message(), error_code, error_fields }`.
  - 4 unit tests for `classify_btw_error` covering 401, 429, missing-API-key, and unknown-error paths.
- `apps/ui/src/lib/api/types/command-types.ts`: declared the new optional fields. Existing UI logic at `chat-panel.tsx:243-249` already shows `result.message` when `result.success === false`, so no behavioral change is needed in the component.

## Risk
Low.
- Additive change to `CommandResult` (new fields are optional, skip-if-None on serialize, default-on-deserialize).
- Error path replaces a 5xx with a structured 200 response. The same classification function is already used by the worker's `ReasonAtom` path.
- Existing `test_execute_btw_returns_ephemeral_response` still passes (success path returns `success: true`).

## Validation
- `cargo fmt --check` ✅
- `cargo clippy -p everruns-core -p everruns-server --all-targets -- -D warnings` ✅
- `cargo test -p everruns-server --lib` — 1084 passed (includes 4 new `classify_btw_error_*` tests)
- `cargo test -p everruns-server --test api_integration_test test_execute_btw` — existing /btw integration test still passes
- `./scripts/lib/pre-push.sh` — all checks pass

UI smoke test was skipped: backend-only fix on a code path with full unit coverage (4 new tests for the error classifier) and the success path still has the existing integration test. The same `classify_runtime_error_message` function is the one used by `ReasonAtom`.

## Security
- Threat categories reviewed: **TM-API**, **TM-LLM**.
- TM-API: response shape changes additively. No new endpoints, no new auth path. Same caller authorization as before.
- TM-LLM: error responses now include `provider` (e.g. `"openai"`) and `model_id` in `error_fields`. These are the same fields already exposed by the regular chat error path through `UserFacingErrorContext`, so no new information leakage. Raw error chains are not returned to the client — `fallback_message()` returns a fixed user-facing string keyed by error code.
- No injection, auth bypass, dependency, or DoS surface introduced.

## Checklist
- [x] Tests added or updated (4 new unit tests in `service.rs`)
- [x] Backward compatibility considered (additive optional fields)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (n/a — new PR)