### PR TITLE
feat(server): emit one INFO log per HTTP request with request_id, status, latency

### DIFF
--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -1178,6 +1178,15 @@ impl ServerAppBuilder {
         // creating the span above. See specs/correlation-ids.md.
         let app = app.layer(RequestIdLayer);
 
+        // Per-request access log: applied as route_layer so axum's MatchedPath
+        // extractor is available for low-cardinality `route` labels. Emits one
+        // tracing event per request with method, route, status, latency_ms,
+        // and request_id (DEBUG for /health and /metrics, WARN for 5xx,
+        // INFO otherwise). See EVE-399 / specs/correlation-ids.md.
+        let app = app.route_layer(axum::middleware::from_fn(
+            crate::middleware::http_access_log_layer,
+        ));
+
         // HTTP request duration histogram: applied as route_layer so axum's
         // MatchedPath extractor is available for low-cardinality path labels.
         let app = if prometheus_handle.is_some() {

--- a/crates/server/src/middleware/access_log.rs
+++ b/crates/server/src/middleware/access_log.rs
@@ -1,0 +1,246 @@
+// HTTP access log middleware
+//
+// Emits one structured tracing event per HTTP request with method, matched
+// route, status, latency, and the correlation `request_id` set by
+// `RequestIdLayer`. Mirrors the field set so a single
+// `request_id=<x>` grep returns the wire-side line plus every child span
+// (LLM calls, DB queries, durable activities) that runs under the
+// per-request span built by `TraceLayer` in `app_builder.rs`.
+//
+// Decisions:
+// - Uses `MatchedPath` (e.g. `/v1/sessions/{id}`) instead of the raw URI to
+//   keep log/index cardinality bounded. Falls back to `unmatched` for 404s
+//   so scanners cannot blow up downstream indexes.
+// - Must be applied as `route_layer` so axum populates `MatchedPath` before
+//   this middleware runs.
+// - Health and metrics endpoints are downgraded to DEBUG to keep INFO
+//   clean. Operators can promote them with `RUST_LOG`.
+// - 5xx responses log at WARN; everything else logs at INFO (or DEBUG for
+//   noise paths). The fields are identical regardless of level.
+
+use crate::middleware::request_id::RequestId;
+use axum::extract::MatchedPath;
+use axum::middleware::Next;
+use axum::response::Response;
+
+const NOISE_PATHS: &[&str] = &["/health", "/metrics"];
+
+/// Axum middleware that emits one tracing event per HTTP request.
+///
+/// Apply with `route_layer(axum::middleware::from_fn(http_access_log_layer))`
+/// so `MatchedPath` is available for the route field.
+pub async fn http_access_log_layer(
+    matched_path: Option<MatchedPath>,
+    req: axum::extract::Request,
+    next: Next,
+) -> Response {
+    let method = req.method().clone();
+    let route = matched_path
+        .map(|mp| mp.as_str().to_owned())
+        .unwrap_or_else(|| "unmatched".to_owned());
+    let request_id = req
+        .extensions()
+        .get::<RequestId>()
+        .map(|r| r.0.clone())
+        .unwrap_or_default();
+
+    let start = std::time::Instant::now();
+    let response = next.run(req).await;
+    let latency_ms = start.elapsed().as_millis() as u64;
+    let status = response.status().as_u16();
+
+    let is_noise = NOISE_PATHS.iter().any(|p| route == *p);
+
+    if status >= 500 {
+        tracing::warn!(
+            method = %method,
+            route = %route,
+            status = status,
+            latency_ms = latency_ms,
+            request_id = %request_id,
+            "http request failed",
+        );
+    } else if is_noise {
+        tracing::debug!(
+            method = %method,
+            route = %route,
+            status = status,
+            latency_ms = latency_ms,
+            request_id = %request_id,
+            "http request",
+        );
+    } else {
+        tracing::info!(
+            method = %method,
+            route = %route,
+            status = status,
+            latency_ms = latency_ms,
+            request_id = %request_id,
+            "http request",
+        );
+    }
+
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::routing::get;
+    use std::sync::{Arc, Mutex};
+    use tower::ServiceExt;
+    use tracing::subscriber::with_default;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::{Layer, Registry};
+
+    /// A tracing layer that captures every event into a shared buffer so
+    /// tests can assert on field values.
+    #[derive(Clone, Default)]
+    struct CaptureLayer {
+        events: Arc<Mutex<Vec<CapturedEvent>>>,
+    }
+
+    #[derive(Clone, Debug)]
+    struct CapturedEvent {
+        level: tracing::Level,
+        fields: std::collections::HashMap<String, String>,
+    }
+
+    impl<S> Layer<S> for CaptureLayer
+    where
+        S: tracing::Subscriber,
+    {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            let mut visitor = FieldVisitor::default();
+            event.record(&mut visitor);
+            self.events.lock().unwrap().push(CapturedEvent {
+                level: *event.metadata().level(),
+                fields: visitor.fields,
+            });
+        }
+    }
+
+    #[derive(Default)]
+    struct FieldVisitor {
+        fields: std::collections::HashMap<String, String>,
+    }
+
+    impl tracing::field::Visit for FieldVisitor {
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            self.fields
+                .insert(field.name().to_string(), format!("{:?}", value));
+        }
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+        fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+        fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+        fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+    }
+
+    fn build_app() -> Router {
+        async fn ok() -> &'static str {
+            "ok"
+        }
+        async fn boom() -> (StatusCode, &'static str) {
+            (StatusCode::INTERNAL_SERVER_ERROR, "kaboom")
+        }
+        Router::new()
+            .route("/users/{id}", get(ok))
+            .route("/health", get(ok))
+            .route("/boom", get(boom))
+            .route_layer(axum::middleware::from_fn(http_access_log_layer))
+    }
+
+    fn run_request(app: Router, uri: &str, request_id: &str) -> CaptureLayer {
+        let capture = CaptureLayer::default();
+        let subscriber = Registry::default().with(capture.clone());
+        with_default(subscriber, || {
+            let req = Request::builder()
+                .uri(uri)
+                .extension(RequestId(request_id.to_string()))
+                .body(Body::empty())
+                .unwrap();
+            futures::executor::block_on(async {
+                app.oneshot(req).await.unwrap();
+            });
+        });
+        capture
+    }
+
+    #[test]
+    fn emits_info_event_with_method_route_status_latency_request_id() {
+        let capture = run_request(build_app(), "/users/42", "req-abc");
+        let events = capture.events.lock().unwrap().clone();
+        assert_eq!(events.len(), 1, "expected exactly one event");
+        let evt = &events[0];
+        assert_eq!(evt.level, tracing::Level::INFO);
+        assert_eq!(evt.fields.get("method").map(String::as_str), Some("GET"));
+        assert_eq!(
+            evt.fields.get("route").map(String::as_str),
+            Some("/users/{id}")
+        );
+        assert_eq!(evt.fields.get("status").map(String::as_str), Some("200"));
+        assert!(evt.fields.contains_key("latency_ms"));
+        assert_eq!(
+            evt.fields.get("request_id").map(String::as_str),
+            Some("req-abc")
+        );
+    }
+
+    #[test]
+    fn downgrades_health_to_debug() {
+        let capture = run_request(build_app(), "/health", "req-health");
+        let events = capture.events.lock().unwrap().clone();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].level, tracing::Level::DEBUG);
+        assert_eq!(
+            events[0].fields.get("route").map(String::as_str),
+            Some("/health")
+        );
+    }
+
+    #[test]
+    fn upgrades_5xx_to_warn_with_same_request_id() {
+        let capture = run_request(build_app(), "/boom", "req-boom");
+        let events = capture.events.lock().unwrap().clone();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].level, tracing::Level::WARN);
+        assert_eq!(
+            events[0].fields.get("status").map(String::as_str),
+            Some("500")
+        );
+        assert_eq!(
+            events[0].fields.get("request_id").map(String::as_str),
+            Some("req-boom")
+        );
+    }
+
+    #[test]
+    fn unmatched_route_does_not_log_via_route_layer() {
+        // Documented behaviour: `route_layer` only fires on matched routes
+        // (axum requires this so `MatchedPath` is populated). 404s for
+        // unmatched paths therefore do not produce an access-log line — the
+        // TraceLayer span around the request still emits its own record.
+        let capture = run_request(build_app(), "/totally/unknown/path", "req-404");
+        let events = capture.events.lock().unwrap().clone();
+        assert!(events.is_empty(), "expected no events for unmatched route");
+    }
+}

--- a/crates/server/src/middleware/access_log.rs
+++ b/crates/server/src/middleware/access_log.rs
@@ -9,8 +9,11 @@
 //
 // Decisions:
 // - Uses `MatchedPath` (e.g. `/v1/sessions/{id}`) instead of the raw URI to
-//   keep log/index cardinality bounded. Falls back to `unmatched` for 404s
-//   so scanners cannot blow up downstream indexes.
+//   keep log/index cardinality bounded. Falls back to `unmatched` only when
+//   `MatchedPath` is unavailable while this middleware still runs (e.g. a
+//   fallback handler), so mis-wired usage cannot blow up downstream indexes.
+//   Note: completely unmatched paths (404s outside any route) do not fire
+//   this middleware at all because `route_layer` only runs on matched routes.
 // - Must be applied as `route_layer` so axum populates `MatchedPath` before
 //   this middleware runs.
 // - Health and metrics endpoints are downgraded to DEBUG to keep INFO

--- a/crates/server/src/middleware/mod.rs
+++ b/crates/server/src/middleware/mod.rs
@@ -1,2 +1,4 @@
+pub mod access_log;
 pub mod request_id;
+pub use access_log::http_access_log_layer;
 pub use request_id::{RequestId, RequestIdLayer};

--- a/specs/correlation-ids.md
+++ b/specs/correlation-ids.md
@@ -60,14 +60,17 @@ The W3C `traceparent` / `tracestate` headers are handled automatically by the OT
 ## Middleware Stack Position
 
 ```
-RequestIdLayer      ← outermost: extracts/generates request_id, stores in extensions, echoes in response
-  TraceLayer        ← reads request_id from extensions, creates span with request_id + session_id fields
+RequestIdLayer            ← outermost: extracts/generates request_id, stores in extensions, echoes in response
+  TraceLayer              ← reads request_id from extensions, creates span with request_id + session_id fields
     CORS
     Security headers
-      Handlers      ← record session_id on span; extract RequestId extension for CreateMessageContext
+      route_layer:        ← inner layers, run only for matched routes (MatchedPath populated)
+        http_access_log_layer  ← emits one INFO/WARN/DEBUG event per request with method, route, status, latency_ms, request_id
+        prometheus http_metrics_layer  ← records HTTP request duration histogram with matched-path labels
+        Handlers          ← record session_id on span; extract RequestId extension for CreateMessageContext
 ```
 
-The `RequestIdLayer` must sit outside `TraceLayer` so the span has the ID when it is created.
+The `RequestIdLayer` must sit outside `TraceLayer` so the span has the ID when it is created. The `http_access_log_layer` and prometheus middleware sit inside as `route_layer` so axum's `MatchedPath` extractor is populated before they run; this means completely unmatched paths (404 outside any route) are not logged via the access-log middleware but are still wrapped by the outer `TraceLayer` span.
 
 ---
 

--- a/specs/correlation-ids.md
+++ b/specs/correlation-ids.md
@@ -43,6 +43,8 @@ All HTTP request spans include:
 
 The `RequestIdLayer` Tower middleware (see `crates/server/src/middleware/request_id.rs`) generates or extracts the request ID and stores it in request extensions. The `TraceLayer` reads it from extensions when creating the per-request span so it is present on every log line emitted within the request.
 
+In addition, the `http_access_log_layer` middleware (see `crates/server/src/middleware/access_log.rs`) emits one tracing event per HTTP request with `method`, `route` (matched-path template, low-cardinality), `status`, `latency_ms`, and `request_id`. The level is `INFO` for normal responses, `DEBUG` for noise endpoints (`/health`, `/metrics`), and `WARN` for 5xx. This guarantees a single grep on `request_id=<x>` returns the wire-side line plus every child span emitted under the request span. The middleware is applied as a `route_layer` so axum's `MatchedPath` extractor is populated; unmatched (404) requests are not logged via this middleware (the surrounding `TraceLayer` span still emits its own record for them).
+
 ### Durable Execution
 
 The `request_id` is stored in `DurableTurnInput` and propagated across all durable tasks (reason, act, tool execution) so worker logs carry the originating request ID even when executed asynchronously in a separate worker process.
@@ -74,6 +76,7 @@ The `RequestIdLayer` must sit outside `TraceLayer` so the span has the ID when i
 | Component | File |
 |---|---|
 | `RequestIdLayer` Tower middleware | `crates/server/src/middleware/request_id.rs` |
+| `http_access_log_layer` middleware | `crates/server/src/middleware/access_log.rs` |
 | Middleware wiring + custom `TraceLayer` span | `crates/server/src/app_builder.rs` |
 | `request_id` in `CreateMessageContext` | `crates/server/src/services/message.rs` |
 | `request_id` in `AgentRunner::start_run` | `crates/worker/src/runner.rs` |


### PR DESCRIPTION
## What
Add an axum middleware (`http_access_log_layer`) that emits one structured tracing event per HTTP request with `method`, `route` (matched-path template, low-cardinality), `status`, `latency_ms`, and `request_id`. INFO for normal responses, DEBUG for noise endpoints (`/health`, `/metrics`), WARN for 5xx.

## Why
Closes EVE-399. The OSS axum server already carries a `request_id` end-to-end (see `specs/correlation-ids.md` and `RequestIdLayer`), but never wrote it to the application log on the wire side. As a result, `grep request_id=<x>` over server logs returned zero rows even when the response carried that ID in the `X-Request-ID` header. With this middleware in place, the same triage becomes a single grep that returns the full causal chain (HTTP edge + child spans + durable activities).

## How
- New `crates/server/src/middleware/access_log.rs` — `http_access_log_layer` axum middleware.
  - Uses `Option<MatchedPath>` for low-cardinality `route` labels (e.g. `/v1/sessions/{id}` rather than `/v1/sessions/sess_abc`). Falls back to `unmatched` only when `MatchedPath` isn't available while the middleware still runs (e.g. a fallback handler) — completely unmatched paths don't reach this middleware at all because `route_layer` only fires on matched routes.
  - Reads `request_id` from the existing `RequestId` request extension populated by `RequestIdLayer`.
  - 5xx → WARN; `/health` and `/metrics` → DEBUG; everything else → INFO. Operators can promote levels via `RUST_LOG`.
- `crates/server/src/middleware/mod.rs` — re-export.
- `crates/server/src/app_builder.rs` — apply as `route_layer` next to the existing prometheus middleware (inside the existing `TraceLayer` span).
- `specs/correlation-ids.md` — document the new middleware in **Where IDs Appear**, in the implementation table, and in the **Middleware Stack Position** diagram.
- 4 unit tests covering: full INFO path, DEBUG-downgrade for `/health`, WARN-upgrade for 5xx (with matching `request_id`), and the documented gap that 404s on unmatched paths don't fire `route_layer` middleware.

## Risk
Low.
- Pure addition: a new middleware in front of handlers. No existing routes change.
- Per-request overhead: one `tracing::info!` event with five fields. Smaller than the prometheus histogram already running next to it.
- 404s for completely unmatched paths are not logged via this middleware (axum populates `MatchedPath` only for matched routes, and `route_layer` only fires for matched routes). The surrounding `TraceLayer` span still emits its own record for them. Documented in the new test and spec.

## Validation
- `cargo fmt --check` ✅
- `cargo clippy -p everruns-server --all-targets --all-features -- -D warnings` ✅
- `cargo test -p everruns-server --lib middleware::access_log` — 4 passed
- `./scripts/lib/pre-push.sh` — all checks pass
- Implementation verified against `specs/correlation-ids.md` (request_id propagation contract).

A full `just start-dev` smoke test was skipped: the change is a tracing middleware whose behaviour is fully exercised by the unit tests (level + fields per response class) and the existing prometheus middleware sits at the same layer position. Production logging level is opt-in via `RUST_LOG`, so default behaviour is unchanged for operators who don't enable INFO.

## Security
- Threat categories reviewed: **TM-API**, **TM-LLM**, **TM-DOS**.
- TM-API: emits log fields (method, route, status, latency_ms, request_id). `route` uses the matched template, so user-supplied path segments (IDs, query strings) are not written to logs by this middleware.
- TM-LLM / sensitive payload: only metadata is logged. Request and response bodies are never touched.
- TM-DOS: middleware allocates a small `String` for the route per request; latency is measured with `Instant::now()`. No unbounded loops, no per-request resource accumulation. Equivalent to the prometheus middleware already in production.
- No new auth checks, no new endpoints, no new dependencies. `request_id` itself is opaque (UUID v4 by default; client-supplied values are length-capped at 256 chars by `RequestIdLayer`), so logging it cannot leak credentials.

## Checklist
- [x] Tests added or updated (4 new unit tests in `middleware/access_log.rs`)
- [x] Backward compatibility considered (purely additive — new tracing event behind `RUST_LOG`)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (Copilot suggestions on `access_log.rs` and `correlation-ids.md` applied in `dbd8e2e`)