### PR TITLE
fix(discovery): add homepage link headers

### DIFF
--- a/apps/docs/public/_headers
+++ b/apps/docs/public/_headers
@@ -1,0 +1,2 @@
+/
+  Link: </api/>; rel="service-doc"; type="text/html"

--- a/apps/ui/src/__tests__/middleware.test.ts
+++ b/apps/ui/src/__tests__/middleware.test.ts
@@ -31,8 +31,25 @@ describe("auth proxy", () => {
     expect(response.headers.get("location")).toBeNull();
   });
 
+  it("adds agent discovery Link headers to the homepage", () => {
+    const request = {
+      cookies: { has: () => false },
+      nextUrl: new URL("http://localhost/"),
+      url: "http://localhost/",
+    } as Parameters<typeof proxy>[0];
+
+    const response = proxy(request);
+
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+    expect(response.headers.get("location")).toBeNull();
+    expect(response.headers.get("link")).toBe(
+      '</api-doc/openapi.json>; rel="service-desc"; type="application/json", <https://docs.everruns.com/api/>; rel="service-doc"; type="text/html"',
+    );
+  });
+
   it("protects the main application routes", () => {
     expect(config.matcher).toEqual([
+      "/",
       "/agent-identities/:path*",
       "/agents/:path*",
       "/apps/:path*",

--- a/apps/ui/src/proxy.ts
+++ b/apps/ui/src/proxy.ts
@@ -2,10 +2,21 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { getLoginRedirectPath } from "@/lib/auth-redirect";
 
+const HOMEPAGE_DISCOVERY_LINKS = [
+  '</api-doc/openapi.json>; rel="service-desc"; type="application/json"',
+  '<https://docs.everruns.com/api/>; rel="service-doc"; type="text/html"',
+].join(", ");
+
 // Decision: proxy only enforces cookie presence for protected app routes.
 // AuthProvider remains the source of truth for config bootstrap, user loading,
 // token refresh, and auth-unavailable fallback UI.
 export function proxy(request: NextRequest) {
+  if (request.nextUrl.pathname === "/") {
+    const response = NextResponse.next();
+    response.headers.set("Link", HOMEPAGE_DISCOVERY_LINKS);
+    return response;
+  }
+
   if (request.cookies.has("access_token")) {
     return NextResponse.next();
   }
@@ -16,6 +27,7 @@ export function proxy(request: NextRequest) {
 
 export const config = {
   matcher: [
+    "/",
     "/agent-identities/:path*",
     "/agents/:path*",
     "/apps/:path*",

--- a/specs/documentation.md
+++ b/specs/documentation.md
@@ -111,6 +111,10 @@ Cloudflare Pages dashboard configuration:
 - Set output directory: `dist`
 - Pin Node.js from `apps/docs/.node-version` (currently `22.16.0`) so Pages builds do not depend on dashboard defaults; any override must stay at `20.19.1+` or `22.12+` to satisfy Astro 6 toolchain requirements
 
+The docs homepage advertises agent-discoverable API resources with RFC 8288
+`Link` response headers from `apps/docs/public/_headers`. The header points to
+the docs API reference.
+
 ### Development
 
 ```bash


### PR DESCRIPTION
## What
Add RFC 8288 `Link` response headers for agent discovery on the app homepage and docs homepage.

## Why
Agent readiness scanners reported no `Link` headers on the homepage, making useful API/docs resources harder for agents to discover.

## How
- Add a Next proxy branch for `/` that emits `service-desc` and `service-doc` links before auth gating.
- Add a Cloudflare Pages `_headers` rule for the docs homepage that points to the docs API reference.
- Add focused proxy test coverage and document the docs deployment behavior.

## Risk
- Low
- Homepage `/` still redirects to `/dashboard`; risk is limited to response header metadata and Cloudflare Pages header config.

## Security
- Threat categories reviewed: TM-WEB
- Findings and resolutions: No auth, authorization, tenant data, secrets, or input-processing paths changed. Headers expose only existing public documentation and API descriptor locations. No threat model update needed.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `npm test -- --runTestsByPath src/__tests__/middleware.test.ts`
- `npm run lint` (existing warnings only)
- `npm run format:check -- src/proxy.ts src/__tests__/middleware.test.ts`
- `npm run check` in `apps/docs` (existing hints only)
- `npm run build` in `apps/docs`
- `curl -sSI http://localhost:9120/` smoke test verified app homepage `Link` headers
- `cat apps/docs/dist/_headers` verified docs homepage header output
- `just pre-push`